### PR TITLE
fix(agent): gate durable-session prompt restore on a managed-context fingerprint

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1371,7 +1371,18 @@ def compress_context(
                 # in-place keeps and rotation has already reassigned to the new id):
                 # refresh the stored system prompt and reset the flush cursor so the
                 # next turn re-bases its append diff.
-                agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
+                # Persist the context fingerprint alongside the prompt: a
+                # NULL fingerprint reads as "legacy/stale inputs" to
+                # _restore_or_build_system_prompt (#68563), which would force
+                # a rebuild — and a guaranteed prefix-cache miss — on the
+                # first turn after every compression boundary.
+                from agent.conversation_loop import _compute_current_context_fingerprint
+
+                agent._session_db.update_system_prompt(
+                    agent.session_id,
+                    new_system_prompt,
+                    _compute_current_context_fingerprint(agent),
+                )
                 if in_place:
                     agent._last_flushed_db_idx = 0
                 else:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1200,10 +1200,22 @@ def compress_context(
             and getattr(agent, "_memory_manager", None) is None
             and _cached_prompt_reflects_builtin_memory(agent, cached_system_prompt)
         ):
+            # No build happens on this branch — cached_system_prompt is
+            # reused verbatim — so there's no TOCTOU window to guard: a
+            # single fingerprint read (not the pre/post pair
+            # build_prompt_with_fingerprint uses) is sufficient (#68563
+            # follow-up review finding #1).
+            from agent.conversation_loop import compute_current_context_fingerprint
+
             new_system_prompt = cached_system_prompt
             agent._cached_system_prompt = cached_system_prompt
+            new_system_prompt_fingerprint = compute_current_context_fingerprint(agent)
         else:
-            new_system_prompt = agent._build_system_prompt(system_message)
+            from agent.conversation_loop import build_prompt_with_fingerprint
+
+            new_system_prompt, new_system_prompt_fingerprint = build_prompt_with_fingerprint(
+                agent, system_message
+            )
             agent._cached_system_prompt = new_system_prompt
 
         if agent._session_db:
@@ -1371,17 +1383,15 @@ def compress_context(
                 # in-place keeps and rotation has already reassigned to the new id):
                 # refresh the stored system prompt and reset the flush cursor so the
                 # next turn re-bases its append diff.
-                # Persist the context fingerprint alongside the prompt: a
-                # NULL fingerprint reads as "legacy/stale inputs" to
+                # Persist the context fingerprint computed above alongside the
+                # prompt: a NULL fingerprint reads as "legacy/stale inputs" to
                 # _restore_or_build_system_prompt (#68563), which would force
                 # a rebuild — and a guaranteed prefix-cache miss — on the
                 # first turn after every compression boundary.
-                from agent.conversation_loop import _compute_current_context_fingerprint
-
                 agent._session_db.update_system_prompt(
                     agent.session_id,
                     new_system_prompt,
-                    _compute_current_context_fingerprint(agent),
+                    new_system_prompt_fingerprint,
                 )
                 if in_place:
                     agent._last_flushed_db_idx = 0

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -302,6 +302,48 @@ def _try_refresh_nous_paid_entitlement_credentials(agent) -> bool:
         return False
 
 
+def _compute_current_context_fingerprint(agent) -> Optional[str]:
+    """SHA-256 fingerprint of the CURRENT managed context inputs (SOUL.md,
+    AGENTS.md, CLAUDE.md, .hermes.md, .cursorrules) that feed the system
+    prompt — see ``agent.prompt_builder.compute_context_fingerprint``.
+
+    Used by :func:`_restore_or_build_system_prompt` to detect when a
+    persisted ``system_prompt`` is stale relative to what these files look
+    like right now, even though the cheap Model/Provider check in
+    ``_stored_prompt_matches_runtime`` still passes (issue #68563) — e.g.
+    SOUL.md was edited after the durable gateway session's prompt was
+    cached, so the stale identity kept being served forever.
+
+    Returns ``None`` on any failure (I/O error, unreadable HERMES_HOME,
+    etc.). Per the issue's contract, a fingerprint bug must never break
+    sessions: ``None`` means "inconclusive" and callers fall back to the
+    pre-existing runtime-identity-only check.
+    """
+    try:
+        from agent.prompt_builder import compute_context_fingerprint
+        from agent.runtime_cwd import resolve_context_cwd
+
+        context_length = None
+        compressor = getattr(agent, "context_compressor", None)
+        cc_len = getattr(compressor, "context_length", None) if compressor is not None else None
+        if isinstance(cc_len, int) and cc_len > 0:
+            context_length = cc_len
+
+        return compute_context_fingerprint(
+            cwd=resolve_context_cwd(),
+            context_length=context_length,
+            allow_install_tree_fallback=getattr(agent, "platform", None) in ("cli", "tui"),
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to compute system-prompt input fingerprint for session "
+            "%s: %s. Falling back to the runtime-identity check only "
+            "(issue #68563 guard fails open).",
+            getattr(agent, "session_id", None), exc,
+        )
+        return None
+
+
 def _restore_or_build_system_prompt(agent, system_message, conversation_history):
     """Restore the cached system prompt from the session DB or build it fresh.
 
@@ -328,14 +370,27 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     log that silently broke prefix-cache reuse on the gateway path
     (which constructs a fresh ``AIAgent`` per turn and depends on this
     DB roundtrip).
+
+    Issue #68563: a stored prompt matching the Model/Provider check alone
+    is not enough — durable gateway sessions can outlive edits to managed
+    context inputs (SOUL.md, AGENTS.md, ...), and those never got
+    re-injected because nothing ever compared them. The restore is now
+    additionally gated on ``system_prompt_fingerprint`` (a SHA-256 over
+    those inputs, see ``agent.prompt_builder.compute_context_fingerprint``)
+    matching the current one. A NULL stored fingerprint (legacy session
+    predating this column, or a prior fingerprint-compute failure) counts
+    as a mismatch, triggering a one-time rebuild that persists the
+    fingerprint going forward — self-healing.
     """
     stored_prompt = None
+    stored_fingerprint = None
     stored_state = "missing"
     if conversation_history and agent._session_db:
         try:
             session_row = agent._session_db.get_session(agent.session_id)
             if session_row is not None:
                 raw_prompt = session_row.get("system_prompt")
+                stored_fingerprint = session_row.get("system_prompt_fingerprint")
                 if raw_prompt is None:
                     stored_state = "null"
                 elif raw_prompt == "":
@@ -351,20 +406,40 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                 agent.session_id, exc,
             )
 
-    if stored_prompt and _stored_prompt_matches_runtime(agent, stored_prompt):
-        # Continuing session — reuse the exact system prompt from the
-        # previous turn so the Anthropic cache prefix matches.
-        agent._cached_system_prompt = stored_prompt
-        return
+    # Computed unconditionally (even on a legitimate first build) so it can
+    # be persisted alongside the prompt snapshot below. Fail-open: a compute
+    # failure returns None, which _never_ blocks a restore on its own — see
+    # the fingerprint_ok check next.
+    current_fingerprint = _compute_current_context_fingerprint(agent)
+
     if stored_prompt:
-        stored_state = "stale_runtime"
-        logger.info(
-            "Stored system prompt for session %s has stale runtime identity; "
-            "rebuilding for model=%s provider=%s.",
-            agent.session_id,
-            getattr(agent, "model", "") or "",
-            getattr(agent, "provider", "") or "",
-        )
+        if _stored_prompt_matches_runtime(agent, stored_prompt):
+            fingerprint_ok = current_fingerprint is None or stored_fingerprint == current_fingerprint
+            if fingerprint_ok:
+                # Continuing session — reuse the exact system prompt from
+                # the previous turn so the Anthropic cache prefix matches.
+                agent._cached_system_prompt = stored_prompt
+                return
+            stored_state = "stale_inputs"
+            logger.info(
+                "Stored system prompt for session %s has a stale managed-"
+                "context-input fingerprint (SOUL.md/AGENTS.md/CLAUDE.md/"
+                ".hermes.md/.cursorrules changed since last persisted, or "
+                "this is a legacy session predating fingerprinting); "
+                "rebuilding for model=%s provider=%s.",
+                agent.session_id,
+                getattr(agent, "model", "") or "",
+                getattr(agent, "provider", "") or "",
+            )
+        else:
+            stored_state = "stale_runtime"
+            logger.info(
+                "Stored system prompt for session %s has stale runtime identity; "
+                "rebuilding for model=%s provider=%s.",
+                agent.session_id,
+                getattr(agent, "model", "") or "",
+                getattr(agent, "provider", "") or "",
+            )
 
     if conversation_history and stored_state in ("null", "empty"):
         # Continuing session whose stored prompt is unusable.  The
@@ -416,7 +491,9 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # subsequent turn).
     if agent._session_db:
         try:
-            agent._session_db.update_system_prompt(agent.session_id, agent._cached_system_prompt)
+            agent._session_db.update_system_prompt(
+                agent.session_id, agent._cached_system_prompt, current_fingerprint
+            )
         except Exception as exc:
             logger.warning(
                 "Session DB update_system_prompt failed for session %s: "

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -302,17 +302,26 @@ def _try_refresh_nous_paid_entitlement_credentials(agent) -> bool:
         return False
 
 
-def _compute_current_context_fingerprint(agent) -> Optional[str]:
+def compute_current_context_fingerprint(agent) -> Optional[str]:
     """SHA-256 fingerprint of the CURRENT managed context inputs (SOUL.md,
     AGENTS.md, CLAUDE.md, .hermes.md, .cursorrules) that feed the system
     prompt — see ``agent.prompt_builder.compute_context_fingerprint``.
 
-    Used by :func:`_restore_or_build_system_prompt` to detect when a
-    persisted ``system_prompt`` is stale relative to what these files look
-    like right now, even though the cheap Model/Provider check in
-    ``_stored_prompt_matches_runtime`` still passes (issue #68563) — e.g.
-    SOUL.md was edited after the durable gateway session's prompt was
-    cached, so the stale identity kept being served forever.
+    Public (not ``_``-prefixed): called from
+    :func:`_restore_or_build_system_prompt` and :func:`build_prompt_with_fingerprint`
+    in this module, and imported cross-module from
+    ``agent.conversation_compression`` and ``tui_gateway.server`` to keep
+    their own ``update_system_prompt`` persists in sync with this guard
+    (issue #68563 follow-up review finding #3 — no more reaching into a
+    private helper from other modules).
+
+    Threads the SAME gates ``agent.system_prompt.build_system_prompt_parts``
+    uses to decide whether SOUL.md / the project-context chain can reach
+    the rendered prompt at all (``agent.load_soul_identity``,
+    ``agent.skip_context_files``) through to
+    ``compute_context_fingerprint``'s ``include_soul`` /
+    ``include_project_context`` — a file that can never appear in this
+    agent's prompt must not be able to invalidate its cache (finding #2).
 
     Returns ``None`` on any failure (I/O error, unreadable HERMES_HOME,
     etc.). Per the issue's contract, a fingerprint bug must never break
@@ -329,10 +338,15 @@ def _compute_current_context_fingerprint(agent) -> Optional[str]:
         if isinstance(cc_len, int) and cc_len > 0:
             context_length = cc_len
 
+        skip_context_files = bool(getattr(agent, "skip_context_files", False))
+        load_soul_identity = bool(getattr(agent, "load_soul_identity", False))
+
         return compute_context_fingerprint(
             cwd=resolve_context_cwd(),
             context_length=context_length,
             allow_install_tree_fallback=getattr(agent, "platform", None) in ("cli", "tui"),
+            include_soul=load_soul_identity or not skip_context_files,
+            include_project_context=not skip_context_files,
         )
     except Exception as exc:
         logger.warning(
@@ -342,6 +356,43 @@ def _compute_current_context_fingerprint(agent) -> Optional[str]:
             getattr(agent, "session_id", None), exc,
         )
         return None
+
+
+def build_prompt_with_fingerprint(agent, system_message) -> tuple[str, Optional[str]]:
+    """Build a fresh system prompt and its input fingerprint as a single
+    persist-ready unit (issue #68563 follow-up review finding #1 — TOCTOU).
+
+    The prompt build and the fingerprint computation are two SEPARATE
+    filesystem reads. If an edit (e.g. to SOUL.md) lands between them, the
+    persisted pair would pair an OLD prompt with a NEW fingerprint — a
+    later restore would see that fingerprint "match" a freshly-recomputed
+    one and serve the now-stale prompt forever, silently reopening
+    #68563 through the very fix meant to close it.
+
+    Guards with a pre/post digest check bracketing the build:
+    ``compute_current_context_fingerprint`` runs once immediately before
+    ``agent._build_system_prompt`` and once immediately after. They agree
+    unless something changed mid-build, in which case the returned
+    fingerprint is ``None`` — a NULL fingerprint reads as legacy/stale to
+    the restore guard, triggering one safe rebuild next turn instead of
+    silently persisting a mismatched pair.
+
+    Used at all three ``update_system_prompt`` call sites that perform a
+    fresh build: :func:`_restore_or_build_system_prompt` here,
+    ``agent.conversation_compression`` (the fresh-build branch — the
+    cached-prompt branch there does its own single post-check fingerprint
+    since no build happens between reads), and
+    ``tui_gateway.server._persist_live_session_system_prompt``.
+    """
+    pre_fingerprint = compute_current_context_fingerprint(agent)
+    prompt = agent._build_system_prompt(system_message)
+    post_fingerprint = compute_current_context_fingerprint(agent)
+    fingerprint = (
+        pre_fingerprint
+        if pre_fingerprint is not None and pre_fingerprint == post_fingerprint
+        else None
+    )
+    return prompt, fingerprint
 
 
 def _restore_or_build_system_prompt(agent, system_message, conversation_history):
@@ -406,11 +457,12 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                 agent.session_id, exc,
             )
 
-    # Computed unconditionally (even on a legitimate first build) so it can
-    # be persisted alongside the prompt snapshot below. Fail-open: a compute
+    # Informs the reuse-vs-rebuild DECISION below only. Fail-open: a compute
     # failure returns None, which _never_ blocks a restore on its own — see
-    # the fingerprint_ok check next.
-    current_fingerprint = _compute_current_context_fingerprint(agent)
+    # the fingerprint_ok check next. NOT what gets persisted on a rebuild —
+    # that comes from build_prompt_with_fingerprint's own pre/post pair,
+    # bracketing the actual build call (issue #68563 TOCTOU follow-up).
+    current_fingerprint = compute_current_context_fingerprint(agent)
 
     if stored_prompt:
         if _stored_prompt_matches_runtime(agent, stored_prompt):
@@ -456,7 +508,9 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
 
     # First turn of a new session (or recovering from a broken stored
     # prompt) — build from scratch.
-    agent._cached_system_prompt = agent._build_system_prompt(system_message)
+    agent._cached_system_prompt, built_fingerprint = build_prompt_with_fingerprint(
+        agent, system_message
+    )
 
     # Plugin hook: on_session_start — fired once when a brand-new
     # session is created (not on continuation).  Plugins can use this
@@ -492,7 +546,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     if agent._session_db:
         try:
             agent._session_db.update_system_prompt(
-                agent.session_id, agent._cached_system_prompt, current_fingerprint
+                agent.session_id, agent._cached_system_prompt, built_fingerprint
             )
         except Exception as exc:
             logger.warning(

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -4,6 +4,7 @@ All functions are stateless. AIAgent._build_system_prompt() calls these to
 assemble pieces, then combines them with memory and ephemeral prompts.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -2075,3 +2076,77 @@ def build_context_files_prompt(
     if not sections:
         return ""
     return "# Project Context\n\nThe following project context files have been loaded and should be followed:\n\n" + "\n".join(sections)
+
+
+def compute_context_fingerprint(
+    cwd: Optional[str] = None,
+    context_length: Optional[int] = None,
+    allow_install_tree_fallback: bool = False,
+) -> str:
+    """SHA-256 fingerprint over every managed context input the builder can
+    inject into the system prompt: SOUL.md, .hermes.md/HERMES.md,
+    AGENTS.md/agents.md, CLAUDE.md/claude.md, and .cursorrules (+
+    .cursor/rules/*.mdc).
+
+    Used by the gateway durable-session restore guard
+    (``agent.conversation_loop._stored_prompt_matches_runtime``) to detect
+    when a persisted ``system_prompt`` is stale relative to what these
+    files look like RIGHT NOW, even when the cheap Model/Provider check
+    still matches (issue #68563) — e.g. SOUL.md was edited after the
+    session's system prompt was cached, so the stale identity kept being
+    served forever.
+
+    Reuses the exact loader helpers ``build_context_files_prompt`` uses so
+    the fingerprint always reflects what a real rebuild would inject.
+    Deliberately does NOT short-circuit on the project-context priority
+    chain the way ``build_context_files_prompt`` does: every candidate
+    source is probed independently and keyed by its own identifier, so a
+    file appearing/disappearing changes the fingerprint even when it is
+    shadowed by a higher-priority file in the rendered prompt. That is
+    intentionally more conservative than the rendered prompt — a spurious
+    one-time rebuild is harmless, a missed drift is not.
+
+    Must NOT be fed volatile per-turn data (timestamps, credit/token
+    counts, session ids) — those belong in the volatile prompt tier, not
+    here; mixing them in would make every turn look "stale".
+
+    Raises on unexpected failures (e.g. an unreadable HERMES_HOME); callers
+    that need the fail-open behavior from the issue's contract ("a
+    fingerprint bug must never break sessions") must catch and treat a
+    failure as a mismatch-tolerant no-op, not swallow it here.
+    """
+    if cwd is None:
+        cwd = os.getcwd()
+        cwd_is_fallback = True
+    else:
+        cwd_is_fallback = False
+    cwd_path = Path(cwd).resolve()
+
+    from agent.runtime_cwd import _is_install_tree
+
+    project_context_disabled = (
+        cwd_is_fallback
+        and not allow_install_tree_fallback
+        and _is_install_tree(cwd_path)
+    )
+
+    # (source-identifier, content) pairs, in a stable order. The identifier
+    # is hashed alongside the content so an absent file (content == "") is
+    # still a distinct, addressable slot in the digest — that's what makes
+    # add/remove detectable even for a shadowed lower-priority candidate.
+    entries = [("SOUL.md", load_soul_md(context_length) or "")]
+    if project_context_disabled:
+        entries.append(("project_context:disabled", "1"))
+    else:
+        entries.append((".hermes.md/HERMES.md", _load_hermes_md(cwd_path, context_length)))
+        entries.append(("AGENTS.md/agents.md", _load_agents_md(cwd_path, context_length)))
+        entries.append(("CLAUDE.md/claude.md", _load_claude_md(cwd_path, context_length)))
+        entries.append((".cursorrules", _load_cursorrules(cwd_path, context_length)))
+
+    hasher = hashlib.sha256()
+    for source_id, content in entries:
+        hasher.update(source_id.encode("utf-8"))
+        hasher.update(b"\x00")
+        hasher.update(content.encode("utf-8"))
+        hasher.update(b"\x01")
+    return hasher.hexdigest()

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2082,6 +2082,8 @@ def compute_context_fingerprint(
     cwd: Optional[str] = None,
     context_length: Optional[int] = None,
     allow_install_tree_fallback: bool = False,
+    include_soul: bool = True,
+    include_project_context: bool = True,
 ) -> str:
     """SHA-256 fingerprint over every managed context input the builder can
     inject into the system prompt: SOUL.md, .hermes.md/HERMES.md,
@@ -2089,22 +2091,34 @@ def compute_context_fingerprint(
     .cursor/rules/*.mdc).
 
     Used by the gateway durable-session restore guard
-    (``agent.conversation_loop._stored_prompt_matches_runtime``) to detect
-    when a persisted ``system_prompt`` is stale relative to what these
-    files look like RIGHT NOW, even when the cheap Model/Provider check
-    still matches (issue #68563) — e.g. SOUL.md was edited after the
-    session's system prompt was cached, so the stale identity kept being
-    served forever.
+    (``agent.conversation_loop.build_prompt_with_fingerprint`` /
+    ``compute_current_context_fingerprint``) to detect when a persisted
+    ``system_prompt`` is stale relative to what these files look like RIGHT
+    NOW, even when the cheap Model/Provider check still matches (issue
+    #68563) — e.g. SOUL.md was edited after the session's system prompt was
+    cached, so the stale identity kept being served forever.
 
     Reuses the exact loader helpers ``build_context_files_prompt`` uses so
     the fingerprint always reflects what a real rebuild would inject.
-    Deliberately does NOT short-circuit on the project-context priority
-    chain the way ``build_context_files_prompt`` does: every candidate
-    source is probed independently and keyed by its own identifier, so a
-    file appearing/disappearing changes the fingerprint even when it is
-    shadowed by a higher-priority file in the rendered prompt. That is
-    intentionally more conservative than the rendered prompt — a spurious
-    one-time rebuild is harmless, a missed drift is not.
+
+    Project-context candidates (.hermes.md, AGENTS.md, CLAUDE.md,
+    .cursorrules) follow the SAME first-match-wins priority chain as
+    ``build_context_files_prompt``: only the WINNING candidate's content
+    feeds the digest. The other three still contribute an existence-only
+    flag ("0"/"1", never their content) so a lower-priority file appearing
+    or disappearing still changes the fingerprint — it could become the
+    winner later — while editing the CONTENT of a file that is currently
+    shadowed and can never reach this agent's rendered prompt does not
+    (issue #68563 follow-up review finding #2: hashing shadowed content
+    caused spurious rebuilds).
+
+    ``include_soul`` / ``include_project_context`` mirror the same
+    ``agent.load_soul_identity`` / ``agent.skip_context_files`` gates
+    ``agent.system_prompt.build_system_prompt_parts`` honors when deciding
+    whether SOUL.md or the project-context chain can reach the prompt at
+    all. When a tier is excluded there, its fingerprint slot is a constant
+    sentinel rather than file content — editing a file that this agent's
+    prompt can never render must not invalidate the cache.
 
     Must NOT be fed volatile per-turn data (timestamps, credit/token
     counts, session ids) — those belong in the volatile prompt tier, not
@@ -2115,33 +2129,51 @@ def compute_context_fingerprint(
     fingerprint bug must never break sessions") must catch and treat a
     failure as a mismatch-tolerant no-op, not swallow it here.
     """
-    if cwd is None:
-        cwd = os.getcwd()
-        cwd_is_fallback = True
+    entries: list = []
+
+    if include_soul:
+        entries.append(("SOUL.md", load_soul_md(context_length) or ""))
     else:
-        cwd_is_fallback = False
-    cwd_path = Path(cwd).resolve()
+        # SOUL.md can never reach this agent's rendered prompt (skip_
+        # context_files without load_soul_identity falls back to the
+        # hardcoded DEFAULT_AGENT_IDENTITY) — a constant slot so edits to
+        # the file never trigger a spurious rebuild.
+        entries.append(("SOUL.md:excluded", "1"))
 
-    from agent.runtime_cwd import _is_install_tree
-
-    project_context_disabled = (
-        cwd_is_fallback
-        and not allow_install_tree_fallback
-        and _is_install_tree(cwd_path)
-    )
-
-    # (source-identifier, content) pairs, in a stable order. The identifier
-    # is hashed alongside the content so an absent file (content == "") is
-    # still a distinct, addressable slot in the digest — that's what makes
-    # add/remove detectable even for a shadowed lower-priority candidate.
-    entries = [("SOUL.md", load_soul_md(context_length) or "")]
-    if project_context_disabled:
-        entries.append(("project_context:disabled", "1"))
+    if not include_project_context:
+        entries.append(("project_context:excluded", "1"))
     else:
-        entries.append((".hermes.md/HERMES.md", _load_hermes_md(cwd_path, context_length)))
-        entries.append(("AGENTS.md/agents.md", _load_agents_md(cwd_path, context_length)))
-        entries.append(("CLAUDE.md/claude.md", _load_claude_md(cwd_path, context_length)))
-        entries.append((".cursorrules", _load_cursorrules(cwd_path, context_length)))
+        if cwd is None:
+            cwd = os.getcwd()
+            cwd_is_fallback = True
+        else:
+            cwd_is_fallback = False
+        cwd_path = Path(cwd).resolve()
+
+        from agent.runtime_cwd import _is_install_tree
+
+        if (
+            cwd_is_fallback
+            and not allow_install_tree_fallback
+            and _is_install_tree(cwd_path)
+        ):
+            entries.append(("project_context:install_tree_fallback_disabled", "1"))
+        else:
+            candidates = [
+                (".hermes.md/HERMES.md", _load_hermes_md(cwd_path, context_length)),
+                ("AGENTS.md/agents.md", _load_agents_md(cwd_path, context_length)),
+                ("CLAUDE.md/claude.md", _load_claude_md(cwd_path, context_length)),
+                (".cursorrules", _load_cursorrules(cwd_path, context_length)),
+            ]
+            # First-match-wins, same as build_context_files_prompt's `or` chain.
+            selected_id = next((sid for sid, content in candidates if content), None)
+            for source_id, content in candidates:
+                if source_id == selected_id:
+                    entries.append((source_id, content))
+                else:
+                    # Shadowed (or simply absent) — only its existence flips
+                    # the fingerprint, never its content.
+                    entries.append((source_id, "1" if content else "0"))
 
     hasher = hashlib.sha256()
     for source_id, content in entries:

--- a/contributors/emails/sora.bluesky.dev@gmail.com
+++ b/contributors/emails/sora.bluesky.dev@gmail.com
@@ -1,0 +1,1 @@
+Sora-bluesky

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -853,6 +853,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     model TEXT,
     model_config TEXT,
     system_prompt TEXT,
+    system_prompt_fingerprint TEXT,
     parent_session_id TEXT,
     started_at REAL NOT NULL,
     ended_at REAL,
@@ -2865,12 +2866,32 @@ class SessionDB:
             )
         self._execute_write(_do)
 
-    def update_system_prompt(self, session_id: str, system_prompt: str) -> None:
-        """Store the full assembled system prompt snapshot."""
+    def update_system_prompt(
+        self,
+        session_id: str,
+        system_prompt: str,
+        fingerprint: Optional[str] = None,
+    ) -> None:
+        """Store the full assembled system prompt snapshot and, optionally,
+        its input fingerprint (SHA-256 over SOUL.md/AGENTS.md/etc. — see
+        ``agent.prompt_builder.compute_context_fingerprint``).
+
+        Both columns are written in the SAME UPDATE statement so they can
+        never be observed out of sync: a failed write leaves neither column
+        changed, and a successful write updates both atomically (issue
+        #68563 — the restore guard compares the fingerprint alongside the
+        prompt and must never see a fingerprint that describes a different
+        prompt than the one actually stored).
+
+        ``fingerprint`` defaults to ``None`` (column stays/becomes NULL) so
+        existing callers that only ever persisted the prompt keep working
+        unchanged.
+        """
         def _do(conn):
             conn.execute(
-                "UPDATE sessions SET system_prompt = ? WHERE id = ?",
-                (system_prompt, session_id),
+                "UPDATE sessions SET system_prompt = ?, "
+                "system_prompt_fingerprint = ? WHERE id = ?",
+                (system_prompt, fingerprint, session_id),
             )
         self._execute_write(_do)
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -18,6 +18,7 @@ from agent.prompt_builder import (
     build_skills_system_prompt,
     build_nous_subscription_prompt,
     build_context_files_prompt,
+    compute_context_fingerprint,
     CONTEXT_FILE_MAX_CHARS,
     _dynamic_context_file_max_chars,
     _get_context_file_max_chars,
@@ -1706,3 +1707,116 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 
 
+
+
+# =========================================================================
+# compute_context_fingerprint (issue #68563)
+# =========================================================================
+
+
+class TestComputeContextFingerprint:
+    """SHA-256 fingerprint over every managed context input the prompt
+    builder can inject (SOUL.md, .hermes.md, AGENTS.md, CLAUDE.md,
+    .cursorrules), keyed by source identifier — used by the gateway
+    durable-session restore guard to detect when a stored ``system_prompt``
+    is stale relative to the CURRENT files on disk, even though the
+    Model/Provider lines still match (issue #68563).
+    """
+
+    def test_returns_a_sha256_hexdigest(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        fp = compute_context_fingerprint(cwd=str(tmp_path))
+        assert isinstance(fp, str)
+        assert len(fp) == 64
+        int(fp, 16)  # raises ValueError if not hex
+
+    def test_deterministic_for_identical_inputs(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        (tmp_path / "AGENTS.md").write_text("Use Ruff for linting.")
+        fp1 = compute_context_fingerprint(cwd=str(tmp_path))
+        fp2 = compute_context_fingerprint(cwd=str(tmp_path))
+        assert fp1 == fp2
+
+    def test_changes_when_soul_md_content_changes(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        (hermes_home / "SOUL.md").write_text("Be concise.", encoding="utf-8")
+        fp1 = compute_context_fingerprint(cwd=str(tmp_path))
+        (hermes_home / "SOUL.md").write_text("Be verbose.", encoding="utf-8")
+        fp2 = compute_context_fingerprint(cwd=str(tmp_path))
+        assert fp1 != fp2
+
+    def test_changes_when_agents_md_content_changes(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        (tmp_path / "AGENTS.md").write_text("Version 1.")
+        fp1 = compute_context_fingerprint(cwd=str(tmp_path))
+        (tmp_path / "AGENTS.md").write_text("Version 2.")
+        fp2 = compute_context_fingerprint(cwd=str(tmp_path))
+        assert fp1 != fp2
+
+    def test_changes_when_agents_md_is_added(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        fp_before = compute_context_fingerprint(cwd=str(tmp_path))
+        (tmp_path / "AGENTS.md").write_text("New project rules.")
+        fp_after = compute_context_fingerprint(cwd=str(tmp_path))
+        assert fp_before != fp_after
+
+    def test_changes_when_agents_md_is_removed(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        agents_md = tmp_path / "AGENTS.md"
+        agents_md.write_text("Project rules.")
+        fp_before = compute_context_fingerprint(cwd=str(tmp_path))
+        agents_md.unlink()
+        fp_after = compute_context_fingerprint(cwd=str(tmp_path))
+        assert fp_before != fp_after
+
+    def test_lower_priority_file_addition_changes_fingerprint_even_when_shadowed(
+        self, tmp_path, monkeypatch
+    ):
+        """AGENTS.md always wins over .cursorrules in the assembled prompt,
+        but the fingerprint must still change when .cursorrules appears —
+        the source-identity slot for a lower-priority candidate flips from
+        absent to present even though it never reaches the actual prompt.
+        This is deliberately more conservative than the rendered prompt: a
+        spurious one-time rebuild is harmless, a missed drift is not.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        (tmp_path / "AGENTS.md").write_text("Agent guidelines.")
+        fp_before = compute_context_fingerprint(cwd=str(tmp_path))
+        (tmp_path / ".cursorrules").write_text("Cursor rules - shadowed by AGENTS.md.")
+        fp_after = compute_context_fingerprint(cwd=str(tmp_path))
+        # Sanity: the actual rendered prompt is unaffected by the shadowed file.
+        rendered_before = "Agent guidelines" in build_context_files_prompt(
+            cwd=str(tmp_path), skip_soul=True
+        )
+        assert rendered_before
+        assert fp_before != fp_after
+
+    def test_unrelated_directory_does_not_affect_fingerprint(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        fp_a = compute_context_fingerprint(cwd=str(dir_a))
+        fp_b = compute_context_fingerprint(cwd=str(dir_b))
+        assert fp_a == fp_b
+
+    def test_install_tree_fallback_skip_mirrors_build_context_files_prompt(
+        self, monkeypatch, tmp_path
+    ):
+        """When cwd falls back into the install tree (no explicit cwd, not
+        CLI/TUI), discovery is skipped exactly like
+        ``build_context_files_prompt`` — the fingerprint must not react to
+        files inside that tree, matching what actually gets rendered.
+        """
+        import agent.runtime_cwd as rt
+
+        monkeypatch.setattr(rt, "_PACKAGE_ROOT", tmp_path.resolve())
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        monkeypatch.chdir(tmp_path)
+        fp_before = compute_context_fingerprint(cwd=None, allow_install_tree_fallback=False)
+        (tmp_path / "AGENTS.md").write_text("Never give up on the right solution.")
+        fp_after = compute_context_fingerprint(cwd=None, allow_install_tree_fallback=False)
+        assert fp_before == fp_after

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1771,15 +1771,13 @@ class TestComputeContextFingerprint:
         fp_after = compute_context_fingerprint(cwd=str(tmp_path))
         assert fp_before != fp_after
 
-    def test_lower_priority_file_addition_changes_fingerprint_even_when_shadowed(
-        self, tmp_path, monkeypatch
-    ):
+    def test_shadowed_file_addition_changes_fingerprint(self, tmp_path, monkeypatch):
         """AGENTS.md always wins over .cursorrules in the assembled prompt,
-        but the fingerprint must still change when .cursorrules appears —
-        the source-identity slot for a lower-priority candidate flips from
-        absent to present even though it never reaches the actual prompt.
-        This is deliberately more conservative than the rendered prompt: a
-        spurious one-time rebuild is harmless, a missed drift is not.
+        but the fingerprint must still change when .cursorrules APPEARS —
+        the existence flag for a lower-priority candidate flips from "0" to
+        "1" even though its content never reaches the actual prompt. It
+        could become the winner later (e.g. if AGENTS.md is later removed),
+        so add/remove must stay visible to the digest.
         """
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
         (tmp_path / "AGENTS.md").write_text("Agent guidelines.")
@@ -1792,6 +1790,82 @@ class TestComputeContextFingerprint:
         )
         assert rendered_before
         assert fp_before != fp_after
+
+    def test_shadowed_file_content_edit_does_not_change_fingerprint(
+        self, tmp_path, monkeypatch
+    ):
+        """Editing the CONTENT of a file that is currently shadowed by a
+        higher-priority candidate must NOT invalidate the cache — that
+        content can never reach this session's rendered prompt while
+        AGENTS.md exists (issue #68563 follow-up review finding #2: the
+        original implementation over-conservatively hashed shadowed
+        content too, causing spurious rebuilds on every edit to a file the
+        agent never actually reads).
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        (tmp_path / "AGENTS.md").write_text("Agent guidelines.")
+        (tmp_path / ".cursorrules").write_text("Cursor rules v1 - shadowed by AGENTS.md.")
+        fp_before = compute_context_fingerprint(cwd=str(tmp_path))
+        (tmp_path / ".cursorrules").write_text("Cursor rules v2 - still shadowed.")
+        fp_after = compute_context_fingerprint(cwd=str(tmp_path))
+        assert fp_before == fp_after
+
+    def test_shadowed_file_removal_changes_fingerprint(self, tmp_path, monkeypatch):
+        """Symmetric to the addition case: removing a shadowed candidate
+        also flips its existence flag and must change the digest."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        (tmp_path / "AGENTS.md").write_text("Agent guidelines.")
+        cursorrules = tmp_path / ".cursorrules"
+        cursorrules.write_text("Cursor rules - shadowed by AGENTS.md.")
+        fp_before = compute_context_fingerprint(cwd=str(tmp_path))
+        cursorrules.unlink()
+        fp_after = compute_context_fingerprint(cwd=str(tmp_path))
+        assert fp_before != fp_after
+
+    def test_selected_candidate_content_edit_changes_fingerprint(
+        self, tmp_path, monkeypatch
+    ):
+        """The WINNING candidate's content must still be hashed in full —
+        only shadowed candidates are reduced to an existence flag."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        agents_md = tmp_path / "AGENTS.md"
+        agents_md.write_text("Version 1.")
+        fp_before = compute_context_fingerprint(cwd=str(tmp_path))
+        agents_md.write_text("Version 2.")
+        fp_after = compute_context_fingerprint(cwd=str(tmp_path))
+        assert fp_before != fp_after
+
+    def test_include_project_context_false_ignores_all_project_files(
+        self, tmp_path, monkeypatch
+    ):
+        """When the agent's own ``skip_context_files`` gate would prevent
+        the project-context chain from ever being loaded, the fingerprint
+        must not react to those files at all — editing a file that can
+        never reach this agent's prompt must not invalidate the cache
+        (issue #68563 follow-up review finding #2)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        fp_before = compute_context_fingerprint(
+            cwd=str(tmp_path), include_project_context=False
+        )
+        (tmp_path / "AGENTS.md").write_text("New project rules.")
+        fp_after = compute_context_fingerprint(
+            cwd=str(tmp_path), include_project_context=False
+        )
+        assert fp_before == fp_after
+
+    def test_include_soul_false_ignores_soul_md(self, tmp_path, monkeypatch):
+        """Mirrors the project-context gate for SOUL.md: when the agent
+        would never load it (skip_context_files without
+        load_soul_identity, which falls back to a hardcoded identity
+        constant), editing SOUL.md must not invalidate the cache."""
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        (hermes_home / "SOUL.md").write_text("Be concise.", encoding="utf-8")
+        fp_before = compute_context_fingerprint(cwd=str(tmp_path), include_soul=False)
+        (hermes_home / "SOUL.md").write_text("Be verbose.", encoding="utf-8")
+        fp_after = compute_context_fingerprint(cwd=str(tmp_path), include_soul=False)
+        assert fp_before == fp_after
 
     def test_unrelated_directory_does_not_affect_fingerprint(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -11,6 +11,15 @@ instead of rebuilding).  Covers:
       - Row has system_prompt=NULL → WARNING + fresh build
       - Row has system_prompt="" → WARNING + fresh build
       - DB write fails → WARNING (subsequent turns will miss cache)
+  * Managed-context-input fingerprint gate (issue #68563):
+      - stale fingerprint → INFO + fresh build, even with matching runtime
+      - NULL/legacy fingerprint → treated as a mismatch, self-heals
+      - fingerprint compute failure → fails open (runtime check only)
+
+Real filesystem-based fingerprint computation is patched out via the
+``_FP`` sentinel + the ``fixed_fingerprint`` autouse fixture below, so
+these tests stay hermetic and don't depend on this checkout's actual
+SOUL.md/AGENTS.md contents.
 """
 
 from __future__ import annotations
@@ -20,7 +29,33 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import agent.conversation_loop as conversation_loop
 from agent.conversation_loop import _restore_or_build_system_prompt
+
+# Sentinel current-fingerprint value used across tests unless a test
+# overrides ``conversation_loop._compute_current_context_fingerprint``
+# itself (e.g. to simulate drift or a compute failure).
+_FP = "fingerprint-current"
+
+# Captured before the autouse fixture below ever patches the module
+# attribute, so the one test that exercises the REAL helper (failure →
+# fail-open) can restore it deliberately.
+_real_compute_current_context_fingerprint = (
+    conversation_loop._compute_current_context_fingerprint
+)
+
+
+@pytest.fixture(autouse=True)
+def fixed_fingerprint(monkeypatch):
+    """Make ``_compute_current_context_fingerprint`` deterministic.
+
+    Without this, the helper would hit the real filesystem (SOUL.md,
+    AGENTS.md, ...) via ``agent.prompt_builder.compute_context_fingerprint``,
+    making these tests depend on this checkout's actual files.
+    """
+    monkeypatch.setattr(
+        conversation_loop, "_compute_current_context_fingerprint", lambda agent: _FP
+    )
 
 
 def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
@@ -46,7 +81,7 @@ class TestStoredPromptReuse:
         """Continuing session with a stored prompt → reuse byte-for-byte."""
         stored = "Stored prompt from turn 1 — byte-identical reuse"
         db = MagicMock()
-        db.get_session.return_value = {"system_prompt": stored}
+        db.get_session.return_value = {"system_prompt": stored, "system_prompt_fingerprint": _FP}
         agent = _make_agent(session_db=db)
 
         with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
@@ -62,7 +97,7 @@ class TestStoredPromptReuse:
         """Non-ASCII bytes in the stored prompt are not mangled."""
         stored = "Stored prompt with unicode: ☤ ⚗ ◆ — and emoji 🦊"
         db = MagicMock()
-        db.get_session.return_value = {"system_prompt": stored}
+        db.get_session.return_value = {"system_prompt": stored, "system_prompt_fingerprint": _FP}
         agent = _make_agent(session_db=db)
 
         _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
@@ -105,7 +140,7 @@ class TestStoredPromptReuse:
         )
         agent._build_system_prompt.assert_called_once_with(None)
         db.update_system_prompt.assert_called_once_with(
-            agent.session_id, agent._cached_system_prompt
+            agent.session_id, agent._cached_system_prompt, _FP
         )
         assert any("stale runtime identity" in r.getMessage() for r in caplog.records)
 
@@ -128,8 +163,8 @@ class TestLegitimateFreshBuild:
         db.get_session.assert_not_called()
         agent._build_system_prompt.assert_called_once_with(None)
         assert agent._cached_system_prompt == "BUILT_PROMPT"
-        # Persisted to DB
-        db.update_system_prompt.assert_called_once_with(agent.session_id, "BUILT_PROMPT")
+        # Persisted to DB, alongside the current input fingerprint
+        db.update_system_prompt.assert_called_once_with(agent.session_id, "BUILT_PROMPT", _FP)
         assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
 
     def test_no_db_skips_persistence(self):
@@ -249,7 +284,7 @@ class TestPromptStabilityInvariant:
             "Session ID: 20260517_153500_abc123\n"
         )
         db = MagicMock()
-        db.get_session.return_value = {"system_prompt": stored}
+        db.get_session.return_value = {"system_prompt": stored, "system_prompt_fingerprint": _FP}
         agent = _make_agent(session_db=db)
 
         _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
@@ -259,6 +294,119 @@ class TestPromptStabilityInvariant:
         assert agent._cached_system_prompt == stored
         # Byte-level check
         assert agent._cached_system_prompt.encode("utf-8") == stored.encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Managed-context-input fingerprint gate (issue #68563)
+# ---------------------------------------------------------------------------
+
+
+class TestFingerprintGate:
+    def test_stale_fingerprint_rebuilds_despite_matching_runtime(self, caplog, monkeypatch):
+        """SOUL.md (etc.) changed since this durable session's prompt was
+        cached — the Model/Provider lines still match, but the stored
+        prompt no longer reflects the current managed context inputs, so it
+        must NOT be reused verbatim (the core bug in #68563)."""
+        stored = "You are Hermes Agent.\n\nModel: test-model\nProvider: openrouter"
+        db = MagicMock()
+        db.get_session.return_value = {
+            "system_prompt": stored,
+            "system_prompt_fingerprint": "fingerprint-OLD",
+        }
+        agent = _make_agent(session_db=db)
+        monkeypatch.setattr(
+            conversation_loop, "_compute_current_context_fingerprint", lambda a: "fingerprint-NEW"
+        )
+
+        with caplog.at_level(logging.INFO, logger="agent.conversation_loop"):
+            _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        agent._build_system_prompt.assert_called_once_with(None)
+        assert agent._cached_system_prompt == "BUILT_PROMPT"
+        db.update_system_prompt.assert_called_once_with(
+            agent.session_id, "BUILT_PROMPT", "fingerprint-NEW"
+        )
+        assert any("stale" in r.getMessage().lower() for r in caplog.records)
+
+    def test_null_stored_fingerprint_is_treated_as_mismatch_and_self_heals(self, caplog):
+        """Legacy session predating this column (system_prompt_fingerprint
+        is NULL) → treated as stale even though the prompt itself and the
+        runtime identity both look fine. Rebuilding persists the
+        fingerprint, so the NEXT restore on this session is a clean hit."""
+        stored = "You are Hermes Agent.\n\nModel: test-model\nProvider: openrouter"
+        db = MagicMock()
+        db.get_session.return_value = {
+            "system_prompt": stored,
+            "system_prompt_fingerprint": None,
+        }
+        agent = _make_agent(session_db=db)
+
+        with caplog.at_level(logging.INFO, logger="agent.conversation_loop"):
+            _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        agent._build_system_prompt.assert_called_once_with(None)
+        db.update_system_prompt.assert_called_once_with(agent.session_id, "BUILT_PROMPT", _FP)
+
+    def test_fingerprint_compute_failure_fails_open_and_reuses_stored_prompt(
+        self, caplog, monkeypatch
+    ):
+        """A bug/IO error while computing the CURRENT fingerprint must never
+        break the session — fall back to the pre-existing runtime-identity
+        check alone, exactly like before this feature existed."""
+        stored = "You are Hermes Agent.\n\nModel: test-model\nProvider: openrouter"
+        db = MagicMock()
+        db.get_session.return_value = {
+            "system_prompt": stored,
+            "system_prompt_fingerprint": "fingerprint-OLD",
+        }
+        agent = _make_agent(session_db=db)
+        monkeypatch.setattr(
+            conversation_loop, "_compute_current_context_fingerprint", lambda a: None
+        )
+
+        _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+        db.update_system_prompt.assert_not_called()
+
+    def test_compute_current_context_fingerprint_failure_logs_warning_and_returns_none(
+        self, monkeypatch, caplog
+    ):
+        """Unit-level check of the helper itself: an exception from
+        ``compute_context_fingerprint`` must be caught, logged at WARNING,
+        and surfaced to the caller as ``None`` (fail open)."""
+
+        monkeypatch.setattr(
+            conversation_loop,
+            "_compute_current_context_fingerprint",
+            _real_compute_current_context_fingerprint,
+        )
+
+        def _boom(*a, **kw):
+            raise OSError("disk full")
+
+        # Patch the sys.modules-cached module object directly rather than
+        # via monkeypatch's dotted-string form: the latter resolves through
+        # the ``agent`` package's own ``prompt_builder`` attribute (see
+        # ``_pytest.monkeypatch.resolve``), which can go stale relative to
+        # sys.modules if an earlier test reloads the submodule in place
+        # (e.g. TestPromptBuilderImports in test_prompt_builder.py) without
+        # updating the parent package's attribute to match. The lazy
+        # ``from agent.prompt_builder import ...`` inside the real helper
+        # resolves via sys.modules, so that's what must be patched.
+        import importlib as _importlib
+
+        prompt_builder_module = _importlib.import_module("agent.prompt_builder")
+        monkeypatch.setattr(prompt_builder_module, "compute_context_fingerprint", _boom)
+        agent = _make_agent()
+
+        with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
+            result = conversation_loop._compute_current_context_fingerprint(agent)
+
+        assert result is None
+        warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("Failed to compute" in m and "disk full" in m for m in warnings)
 
 
 if __name__ == "__main__":

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -33,28 +33,28 @@ import agent.conversation_loop as conversation_loop
 from agent.conversation_loop import _restore_or_build_system_prompt
 
 # Sentinel current-fingerprint value used across tests unless a test
-# overrides ``conversation_loop._compute_current_context_fingerprint``
+# overrides ``conversation_loop.compute_current_context_fingerprint``
 # itself (e.g. to simulate drift or a compute failure).
 _FP = "fingerprint-current"
 
 # Captured before the autouse fixture below ever patches the module
-# attribute, so the one test that exercises the REAL helper (failure →
-# fail-open) can restore it deliberately.
+# attribute, so tests that exercise the REAL helper (failure → fail-open;
+# the end-to-end SOUL.md drift test) can restore it deliberately.
 _real_compute_current_context_fingerprint = (
-    conversation_loop._compute_current_context_fingerprint
+    conversation_loop.compute_current_context_fingerprint
 )
 
 
 @pytest.fixture(autouse=True)
 def fixed_fingerprint(monkeypatch):
-    """Make ``_compute_current_context_fingerprint`` deterministic.
+    """Make ``compute_current_context_fingerprint`` deterministic.
 
     Without this, the helper would hit the real filesystem (SOUL.md,
     AGENTS.md, ...) via ``agent.prompt_builder.compute_context_fingerprint``,
     making these tests depend on this checkout's actual files.
     """
     monkeypatch.setattr(
-        conversation_loop, "_compute_current_context_fingerprint", lambda agent: _FP
+        conversation_loop, "compute_current_context_fingerprint", lambda agent: _FP
     )
 
 
@@ -68,6 +68,12 @@ def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
     agent.platform = "cli"
     agent._session_db = session_db
     agent._build_system_prompt = MagicMock(return_value=prebuilt_prompt)
+    # Explicit (a bare MagicMock() attribute is truthy by default, which
+    # would silently disable SOUL.md/project-context inclusion in the REAL
+    # compute_current_context_fingerprint — only exercised directly by a
+    # couple of tests below, but worth pinning down for all of them).
+    agent.skip_context_files = False
+    agent.load_soul_identity = False
     return agent
 
 
@@ -315,7 +321,7 @@ class TestFingerprintGate:
         }
         agent = _make_agent(session_db=db)
         monkeypatch.setattr(
-            conversation_loop, "_compute_current_context_fingerprint", lambda a: "fingerprint-NEW"
+            conversation_loop, "compute_current_context_fingerprint", lambda a: "fingerprint-NEW"
         )
 
         with caplog.at_level(logging.INFO, logger="agent.conversation_loop"):
@@ -361,7 +367,7 @@ class TestFingerprintGate:
         }
         agent = _make_agent(session_db=db)
         monkeypatch.setattr(
-            conversation_loop, "_compute_current_context_fingerprint", lambda a: None
+            conversation_loop, "compute_current_context_fingerprint", lambda a: None
         )
 
         _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
@@ -379,7 +385,7 @@ class TestFingerprintGate:
 
         monkeypatch.setattr(
             conversation_loop,
-            "_compute_current_context_fingerprint",
+            "compute_current_context_fingerprint",
             _real_compute_current_context_fingerprint,
         )
 
@@ -402,11 +408,147 @@ class TestFingerprintGate:
         agent = _make_agent()
 
         with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
-            result = conversation_loop._compute_current_context_fingerprint(agent)
+            result = conversation_loop.compute_current_context_fingerprint(agent)
 
         assert result is None
         warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
         assert any("Failed to compute" in m and "disk full" in m for m in warnings)
+
+
+# ---------------------------------------------------------------------------
+# Prompt/fingerprint TOCTOU guard (issue #68563 follow-up review finding #1)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPromptWithFingerprint:
+    def test_returns_none_fingerprint_when_pre_post_digests_disagree(self, monkeypatch):
+        """An edit landing between the pre-build and post-build fingerprint
+        reads must not produce a fingerprint that gets attached to the (now
+        stale) prompt — persist NULL instead, which the restore guard
+        safely treats as legacy/stale and rebuilds once next turn."""
+        values = iter(["fingerprint-before", "fingerprint-after"])
+        monkeypatch.setattr(
+            conversation_loop,
+            "compute_current_context_fingerprint",
+            lambda a: next(values),
+        )
+        agent = _make_agent()
+
+        prompt, fingerprint = conversation_loop.build_prompt_with_fingerprint(agent, None)
+
+        assert prompt == "BUILT_PROMPT"
+        assert fingerprint is None
+
+    def test_returns_the_fingerprint_when_pre_post_digests_agree(self, monkeypatch):
+        """Nothing changed mid-build → the (single, stable) digest is
+        returned and safe to persist."""
+        monkeypatch.setattr(
+            conversation_loop,
+            "compute_current_context_fingerprint",
+            lambda a: "fingerprint-stable",
+        )
+        agent = _make_agent()
+
+        prompt, fingerprint = conversation_loop.build_prompt_with_fingerprint(agent, None)
+
+        assert prompt == "BUILT_PROMPT"
+        assert fingerprint == "fingerprint-stable"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real SOUL.md drift through the real code path (issue #68563
+# follow-up review finding #4)
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndSoulMdDrift:
+    def test_soul_md_edit_forces_one_rebuild_then_reuses_until_next_edit(
+        self, tmp_path, monkeypatch
+    ):
+        """No fingerprint mocking here — real SOUL.md reads, real SessionDB.
+
+        1. First turn (no history): fresh build, persists prompt + fingerprint.
+        2. Restore with no edits: reused verbatim (byte-identical, no rebuild).
+        3. Edit SOUL.md on disk, restore again: MUST rebuild and persist a
+           new prompt + a DIFFERENT fingerprint.
+        4. Restore once more with no further edits: reused verbatim again.
+        """
+        monkeypatch.setattr(
+            conversation_loop,
+            "compute_current_context_fingerprint",
+            _real_compute_current_context_fingerprint,
+        )
+
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        (hermes_home / "SOUL.md").write_text("Be concise.", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)  # no AGENTS.md/etc here — only SOUL.md varies
+
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session(session_id="e2e-session", source="cli")
+
+            build_count = {"n": 0}
+
+            def _fake_build(system_message):
+                build_count["n"] += 1
+                return f"PROMPT v{build_count['n']}"
+
+            agent = MagicMock()
+            agent._cached_system_prompt = None
+            agent.session_id = "e2e-session"
+            agent.model = "test-model"
+            agent.provider = "openrouter"
+            agent.platform = "cli"
+            agent.skip_context_files = False
+            agent.load_soul_identity = False
+            agent.context_compressor = None
+            agent._session_db = db
+            agent._build_system_prompt = _fake_build
+
+            # 1. First turn — legitimate first build.
+            _restore_or_build_system_prompt(agent, None, [])
+            assert agent._cached_system_prompt == "PROMPT v1"
+            assert build_count["n"] == 1
+            row = db.get_session("e2e-session")
+            assert row["system_prompt"] == "PROMPT v1"
+            fp1 = row["system_prompt_fingerprint"]
+            assert fp1 is not None
+
+            # 2. Fresh "AIAgent" (gateway pattern) restores with no edits.
+            agent._cached_system_prompt = None
+            _restore_or_build_system_prompt(
+                agent, None, [{"role": "user", "content": "hi"}]
+            )
+            assert agent._cached_system_prompt == "PROMPT v1"
+            assert build_count["n"] == 1  # reused — no rebuild
+
+            # 3. Edit SOUL.md — the fingerprint drifts, forcing a rebuild.
+            (hermes_home / "SOUL.md").write_text("Be verbose.", encoding="utf-8")
+            agent._cached_system_prompt = None
+            _restore_or_build_system_prompt(
+                agent, None, [{"role": "user", "content": "hi"}]
+            )
+            assert agent._cached_system_prompt == "PROMPT v2"
+            assert build_count["n"] == 2
+            row2 = db.get_session("e2e-session")
+            assert row2["system_prompt"] == "PROMPT v2"
+            fp2 = row2["system_prompt_fingerprint"]
+            assert fp2 is not None
+            assert fp2 != fp1
+
+            # 4. No further edits — reuses the NEW pair verbatim.
+            agent._cached_system_prompt = None
+            _restore_or_build_system_prompt(
+                agent, None, [{"role": "user", "content": "hi"}]
+            )
+            assert agent._cached_system_prompt == "PROMPT v2"
+            assert build_count["n"] == 2  # still just the one rebuild
+        finally:
+            db.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -235,6 +235,26 @@ class TestSessionLifecycle:
         session = db.get_session("s1")
         assert session["system_prompt"] == "You are a helpful assistant."
 
+    def test_update_system_prompt_defaults_fingerprint_to_null(self, db):
+        """Backward-compat callers that don't pass a fingerprint (issue
+        #68563) must leave the column NULL, not raise."""
+        db.create_session(session_id="s1", source="cli")
+        db.update_system_prompt("s1", "You are a helpful assistant.")
+
+        session = db.get_session("s1")
+        assert session["system_prompt_fingerprint"] is None
+
+    def test_update_system_prompt_persists_fingerprint_atomically(self, db):
+        """The prompt snapshot and its input fingerprint are written in the
+        SAME UPDATE statement (issue #68563) so they can never be observed
+        out of sync with each other."""
+        db.create_session(session_id="s1", source="cli")
+        db.update_system_prompt("s1", "You are a helpful assistant.", "abc123fingerprint")
+
+        session = db.get_session("s1")
+        assert session["system_prompt"] == "You are a helpful assistant."
+        assert session["system_prompt_fingerprint"] == "abc123fingerprint"
+
     def test_update_token_counts(self, db):
         db.create_session(session_id="s1", source="cli")
         db.update_token_counts("s1", input_tokens=200, output_tokens=100)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5552,7 +5552,7 @@ def test_config_set_model_switches_agent_without_touching_env(monkeypatch):
         def update_session_meta(self, _session_id, model_config_json, _model=None):
             self.model_config = model_config_json
 
-        def update_system_prompt(self, _session_id, system_prompt):
+        def update_system_prompt(self, _session_id, system_prompt, fingerprint=None):
             self.system_prompt = system_prompt
 
         def append_message(self, session_id, role, content=None, **_kwargs):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2838,7 +2838,16 @@ def _persist_live_session_system_prompt(session: dict | None) -> None:
     try:
         prompt = agent._build_system_prompt(None)
         agent._cached_system_prompt = prompt
-        db.update_system_prompt(getattr(agent, "session_id", None) or session_key, prompt)
+        # Include the context fingerprint so the next restore doesn't treat
+        # this freshly-persisted prompt as legacy/stale (#68563) and rebuild
+        # it — that would waste the prefix cache right after a model switch.
+        from agent.conversation_loop import _compute_current_context_fingerprint
+
+        db.update_system_prompt(
+            getattr(agent, "session_id", None) or session_key,
+            prompt,
+            _compute_current_context_fingerprint(agent),
+        )
     except Exception:
         logger.debug("failed to persist live session system prompt", exc_info=True)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2836,17 +2836,20 @@ def _persist_live_session_system_prompt(session: dict | None) -> None:
         return
 
     try:
-        prompt = agent._build_system_prompt(None)
+        # Build + fingerprint as one persist-ready unit: a plain build-then-
+        # fingerprint sequence has a TOCTOU window (an edit landing between
+        # the two reads would tag a stale prompt with a fresh-looking
+        # fingerprint, reopening #68563 through its own fix) — see
+        # agent.conversation_loop.build_prompt_with_fingerprint.
+        from agent.conversation_loop import build_prompt_with_fingerprint
+
+        prompt, fingerprint = build_prompt_with_fingerprint(agent, None)
         agent._cached_system_prompt = prompt
-        # Include the context fingerprint so the next restore doesn't treat
-        # this freshly-persisted prompt as legacy/stale (#68563) and rebuild
-        # it — that would waste the prefix cache right after a model switch.
-        from agent.conversation_loop import _compute_current_context_fingerprint
 
         db.update_system_prompt(
             getattr(agent, "session_id", None) or session_key,
             prompt,
-            _compute_current_context_fingerprint(agent),
+            fingerprint,
         )
     except Exception:
         logger.debug("failed to persist live session system prompt", exc_info=True)


### PR DESCRIPTION
Fixes #68563.

## Problem

Gateway durable sessions persist and reuse the assembled `sessions.system_prompt`, but the restore guard (`_stored_prompt_matches_runtime`) only compares the `Model:` / `Provider:` lines. Edits to managed prompt inputs — `SOUL.md`, `.hermes.md`/`HERMES.md`, `AGENTS.md`, `CLAUDE.md`, `.cursorrules` — therefore never reach an existing durable session: the stale prompt is served forever.

## Fix (implements the contract suggested in the issue)

| Issue contract | Implementation |
|---|---|
| Persist a non-model-visible fingerprint of the inputs used to assemble the prompt | `compute_context_fingerprint()` (agent/prompt_builder.py): SHA-256 over the managed context inputs, computed with the same loader helpers the prompt build uses. Stored in a new nullable `sessions.system_prompt_fingerprint` column (auto-added by the existing column-reconcile loop). |
| Reuse the exact stored prompt only when both runtime identity and the fingerprint match | `_restore_or_build_system_prompt` now requires `_stored_prompt_matches_runtime` AND fingerprint equality. A NULL stored fingerprint (legacy session) is a mismatch → one-time self-healing rebuild. New `stale_inputs` log state mirrors the existing `stale_runtime` one. |
| Persist the new fingerprint only after the prompt snapshot write succeeds | Prompt + fingerprint are written in a single `UPDATE` (`update_system_prompt(session_id, prompt, fingerprint=None)`); failures leave the pair unwritten and the next turn rebuilds. |
| Preserve prefix-cache stability when inputs are unchanged | Unchanged inputs ⇒ identical fingerprint ⇒ stored prompt reused byte-for-byte. The fingerprint is also carried through the compression-boundary and live-model-switch persist paths so those don't NULL it and force a guaranteed cache miss. |

Hardening from adversarial review, folded in:

- **Prompt/fingerprint TOCTOU**: `build_prompt_with_fingerprint()` computes the fingerprint before and after the build and persists it only when the two agree — a context-file edit racing the build persists NULL instead of a mismatched pair (safe rebuild next turn).
- **No spurious invalidation from shadowed files**: only the first-match-wins project-context candidate contributes content to the digest; shadowed candidates contribute an existence flag, so editing a file that cannot appear in this agent's prompt does not break the prefix cache — while add/remove of any candidate still invalidates. `agent.skip_context_files` / `load_soul_identity` are honored.
- **Fail-open**: any failure computing the current fingerprint logs a WARNING and falls back to today's runtime-identity-only check — a fingerprint bug can never break sessions.

## Relationship to #28078

#28078 targets the same stale-SOUL.md symptom but is scoped to SOUL.md refresh for cached gateway agents and is currently in conflict with main (`mergeable_state: dirty`, last updated 2026-07-13). This PR implements the broader fingerprint contract from #68563 across all managed context inputs on the durable-session restore path. If maintainers prefer rebasing #28078, I'm happy to close this in its favor (also stated on the issue).

## Known limitations (deliberate scope decisions)

- The context-file loaders fail-empty on I/O errors (pre-existing behavior shared with the prompt build itself), so a transient read error hashes as "absent" and costs one spurious rebuild rather than surfacing as an error. Loader-level error signaling would touch every prompt-build path and is left for a follow-up.
- An older binary downgrade can update `system_prompt` without touching the fingerprint column; combined with an input revert this could accept a mismatched pair. Judged out of scope (double-edge: downgrade + revert), noted for completeness.

## Tests

- RED-first TDD; 672 tests across the touched suites pass (`tests/agent/test_prompt_builder.py`, `tests/agent/test_system_prompt_restore.py`, `tests/test_hermes_state.py`, `tests/test_tui_gateway_server.py`, `tests/gateway/test_compress_command.py`, `tests/gateway/test_agent_cache.py`).
- New coverage: fingerprint semantics (shadowed edit vs add/remove, flag handling), stale/legacy/fail-open restore paths, TOCTOU pre/post-digest, schema column + single-UPDATE atomicity, and an end-to-end test with a real `HERMES_HOME`: persist → no-edit reuse → real SOUL.md edit → rebuild with new pair → reuse again.
- Pre-existing Windows-only failures (sqlite temp-file teardown `WinError 32`, one mtime-resolution flake) reproduce identically on clean `upstream/main` and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
