### PR TITLE
feat(tools): add raw parameter to read_file for execute_code sandbox

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -292,9 +292,9 @@ _TOOL_STUBS = {
     ),
     "read_file": (
         "read_file",
-        "path: str, offset: int = 1, limit: int = 500",
-        '"""Read a file (1-indexed lines). Returns dict with "content" and "total_lines"."""',
-        '{"path": path, "offset": offset, "limit": limit}',
+        "path: str, offset: int = 1, limit: int = 500, raw: bool = True",
+        '"""Read a file (1-indexed lines). Returns dict with "content" and "total_lines". raw=True strips line number prefixes."""',
+        '{"path": path, "offset": offset, "limit": limit, "raw": raw}',
     ),
     "write_file": (
         "write_file",

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -895,7 +895,7 @@ class ShellFileOperations(FileOperations):
         ext = os.path.splitext(path)[1].lower()
         return ext in IMAGE_EXTENSIONS
     
-    def _add_line_numbers(self, content: str, start_line: int = 1) -> str:
+    def _add_line_numbers(self, content: str, start_line: int = 1, raw: bool = False) -> str:
         """Add line numbers to content in ``LINE_NUM|CONTENT`` format.
 
         The gutter uses a compact ``<n>|`` prefix (e.g. ``34|foo``) rather
@@ -909,6 +909,8 @@ class ShellFileOperations(FileOperations):
         while dropping line numbers entirely regressed line-referencing
         (the model hand-counted and was off-by-one, 3/4) — so we keep the
         numbers, just not the padding.
+
+        When ``raw=True``, return the content as-is without line numbers.
         """
         from tools.tool_output_limits import get_max_line_length
         max_line_length = get_max_line_length()
@@ -918,7 +920,10 @@ class ShellFileOperations(FileOperations):
             # Truncate long lines
             if len(line) > max_line_length:
                 line = line[:max_line_length] + "... [truncated]"
-            numbered.append(f"{i}|{line}")
+            if raw:
+                numbered.append(line)
+            else:
+                numbered.append(f"{i}|{line}")
         return '\n'.join(numbered)
     
     def _expand_path(self, path: str) -> str:
@@ -1082,7 +1087,7 @@ class ShellFileOperations(FileOperations):
     # READ Implementation
     # =========================================================================
     
-    def read_file(self, path: str, offset: int = 1, limit: int = 500) -> ReadResult:
+    def read_file(self, path: str, offset: int = 1, limit: int = 500, raw: bool = False) -> ReadResult:
         """
         Read a file with pagination, binary detection, and line numbers.
         
@@ -1090,6 +1095,7 @@ class ShellFileOperations(FileOperations):
             path: File path (absolute or relative to cwd)
             offset: Line number to start from (1-indexed, default 1)
             limit: Maximum lines to return (default 500, max 2000)
+            raw: If True, return content without line number prefixes (default False)
         
         Returns:
             ReadResult with content, metadata, or error info
@@ -1172,7 +1178,7 @@ class ShellFileOperations(FileOperations):
             hint = f"Use offset={end_line + 1} to continue reading (showing {offset}-{end_line} of {total_lines} lines)"
         
         return ReadResult(
-            content=self._add_line_numbers(read_output, offset),
+            content=self._add_line_numbers(read_output, offset, raw=raw),
             total_lines=total_lines,
             file_size=file_size,
             truncated=truncated,

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1106,7 +1106,7 @@ def clear_file_ops_cache(task_id: str = None):
             _file_ops_cache.clear()
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = "default") -> str:
+def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = "default", raw: bool = False) -> str:
     """Read a file with pagination and line numbers."""
     try:
         offset, limit = normalize_read_pagination(offset, limit)
@@ -1142,7 +1142,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 end_line = offset + limit - 1
                 page_text = "\n".join(lines[offset - 1:end_line])
                 result_dict = {
-                    "content": file_ops._add_line_numbers(page_text, offset) if page_text else "",
+                    "content": file_ops._add_line_numbers(page_text, offset, raw=raw) if page_text else "",
                     "total_lines": total_lines,
                     "file_size": os.path.getsize(_resolved),
                     "truncated": total_lines > end_line,
@@ -1211,7 +1211,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # file hasn't been modified since, return a lightweight stub
         # instead of re-sending the same content.  Saves context tokens.
         resolved_str = str(_resolved)
-        dedup_key = (resolved_str, offset, limit)
+        dedup_key = (resolved_str, offset, limit, raw)
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
                 "last_key": None, "consecutive": 0,
@@ -1268,7 +1268,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
 
         # ── Perform the read ──────────────────────────────────────────
         file_ops = _get_file_ops(task_id)
-        result = file_ops.read_file(path, offset, limit)
+        result = file_ops.read_file(path, offset, limit, raw=raw)
         result_dict = result.to_dict()
 
         # ── Character-count guard ─────────────────────────────────────
@@ -1952,7 +1952,8 @@ READ_FILE_SCHEMA = {
         "properties": {
             "path": {"type": "string", "description": "Path to the file to read (absolute, relative, or ~/path)"},
             "offset": {"type": "integer", "description": "Line number to start reading from (1-indexed, default: 1)", "default": 1, "minimum": 1},
-            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 500, max: 2000)", "default": 500, "maximum": 2000}
+            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 500, max: 2000)", "default": 500, "maximum": 2000},
+            "raw": {"type": "boolean", "description": "If true, return content without LINE_NUM| prefixes (default: false)", "default": False}
         },
         "required": ["path"]
     }
@@ -2049,7 +2050,7 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid, raw=args.get("raw", False))
 
 
 def _handle_write_file(args, **kw):


### PR DESCRIPTION
## Summary

Add `raw` parameter to `read_file` that strips `LINE_NUM|CONTENT` line number prefixes when `raw=True`. The `execute_code` sandbox uses `raw=True` by default so `json.loads()` and similar parsing don't break on numbered prefixes.

## Changes

- `file_operations.py`: `_add_line_numbers()` and `read_file()` accept `raw` parameter
- `code_execution_tool.py`: `_TOOL_STUBS` for `read_file` defaults to `raw=True`

## Motivation

When an agent uses `execute_code` to call `read_file` from `hermes_tools`, the sandbox stub returns line-numbered content (`LINE_NUM|CONTENT`). This breaks `json.loads()` and other structured parsing. The `raw` flag lets the sandbox get clean content.