### PR TITLE
fix(profiles): keep profile.yaml when exporting the default profile

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -235,7 +235,7 @@ _DEFAULT_EXPORT_EXCLUDE_ROOT = frozenset({
 # (#58394). Add new artifacts here when introduced in ``hermes_constants``.
 _DEFAULT_EXPORT_INCLUDE_ROOT = frozenset({
     # Configuration / persona
-    "config.yaml", "SOUL.md", "MEMORY.md", "USER.md", "todo.json",
+    "config.yaml", "profile.yaml", "SOUL.md", "MEMORY.md", "USER.md", "todo.json",
     "system_prompt.md", "AGENTS.md", "CLAUDE.md", ".cursorrules",
     # User-facing skill, cron, and session artifacts
     "skills", "cron", "scripts", "sessions",

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1192,6 +1192,32 @@ class TestExportImport:
         assert imported.is_dir()
         assert (imported / "marker.txt").read_text() == "hello"
 
+    def test_export_default_profile_keeps_profile_metadata(self, profile_env, tmp_path):
+        """``profile.yaml`` must survive ``export_profile("default")``.
+
+        The default profile's export is filtered by a root allow-list (its home
+        IS ``$HERMES_HOME``, which in Docker/cwd deployments holds arbitrary
+        unrelated files). ``profile.yaml`` holds the role description the kanban
+        decomposer routes on, so dropping it silently exports an agent that has
+        forgotten what it is for. Named profiles use a different, blacklist-based
+        filter and were never affected.
+        """
+        from hermes_cli.profiles import _get_default_hermes_home, write_profile_meta
+
+        default_home = _get_default_hermes_home()
+        write_profile_meta(default_home, description="a useful researcher")
+        assert (default_home / "profile.yaml").is_file()
+
+        archive_path = tmp_path / "export" / "default.tar.gz"
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+        export_profile("default", str(archive_path))
+
+        with tarfile.open(str(archive_path)) as tar:
+            names = tar.getnames()
+        assert "default/profile.yaml" in names, (
+            f"profile.yaml was dropped from the default profile export; got {names}"
+        )
+
     def test_import_to_existing_name_raises(self, profile_env, tmp_path):
         create_profile("coder", no_alias=True)
         profile_dir = get_profile_dir("coder")


### PR DESCRIPTION
## What does this PR do?

`export_profile("default")` silently drops `profile.yaml` from the archive.

The default profile's home *is* `$HERMES_HOME`, which in Docker/cwd deployments sits alongside arbitrary unrelated user files. So its export is filtered through a root-level allow-list (`_DEFAULT_EXPORT_INCLUDE_ROOT`, added in #58394) rather than a blacklist. `profile.yaml` was never added to that list.

That file holds the profile's role description and the `description_auto` flag. The kanban decomposer builds its assignee roster from those descriptions (`kanban_decompose._build_roster`) and routes tasks by matching against them — so a default profile that is exported and re-imported comes back without the metadata that tells the system what it is for, and stops being routed work.

The failure is invisible: the command succeeds, the archive is created, and every other artifact is present.

Named profiles were never affected — their export path uses a blacklist that only strips `auth.json` and `.env`.

## Related Issue

No existing issue — found while working with profile metadata. I searched open and merged issues/PRs for `profile.yaml export`, `profile export description` and related terms and found no duplicate. Happy to open one first if you'd prefer that order.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py` — add `"profile.yaml"` to `_DEFAULT_EXPORT_INCLUDE_ROOT`.
- `tests/hermes_cli/test_profiles.py` — add `TestExportImport::test_export_default_profile_keeps_profile_metadata`, asserting on the archive member list (so it pins the export filter itself rather than a round-trip that could pass for other reasons).

## How to Test

Reproduce on `main`:

```python
from pathlib import Path
import os, tarfile
from hermes_cli import profiles as P

home = Path(os.environ["HERMES_HOME"])
(home / "SOUL.md").write_text("I am a research agent.")
P.write_profile_meta(home, description="Researches papers and writes summaries")

P.export_profile("default", "/tmp/exported.tar.gz")
with tarfile.open("/tmp/exported.tar.gz") as t:
    print(sorted(n for n in t.getnames() if n.count("/") == 1))
```

- **Before:** `['default/SOUL.md']` — the description is gone.
- **After:** `['default/SOUL.md', 'default/profile.yaml']`

Or via the test:

```bash
pytest tests/hermes_cli/test_profiles.py -k keeps_profile_metadata -q   # passes
git stash push hermes_cli/profiles.py                                    # remove the fix
pytest tests/hermes_cli/test_profiles.py -k keeps_profile_metadata -q   # fails
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (1 commit, 2 files)
- [x] I've added tests for my changes, and verified the test fails without the fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **see note**

### Note on the test run

I did not complete a full `pytest tests/ -q` locally — it was still at 17% after ten minutes on this machine, and it already showed failures unrelated to this change, so a raw pass/fail count from it would not have been meaningful either way.

What I ran instead was the delta on the affected suites, against a clean `main` for comparison:

```
tests/hermes_cli/test_profiles.py
tests/hermes_cli/test_profile_describer.py
tests/hermes_cli/test_profile_distribution.py
tests/hermes_cli/test_kanban_decompose.py

main (0.19.0):  243 passed, 0 failed
this branch:    244 passed, 0 failed   (+1 = the new regression test)
```

Happy to run anything more specific you'd like to see. Flagging it rather than ticking the box, since a one-word change to a frozenset of filenames can't plausibly affect unrelated suites and I'd rather not imply a green full run I didn't observe.
