### PR TITLE
fix(gateway): scope terminal config per routed profile in multiplexed gateway

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1520,11 +1520,74 @@ class SecondaryPortBindingConfigError(MultiplexConfigError):
     """A secondary profile conflicts with the multiplexer's shared listener."""
 
 
+def _resolve_profile_terminal_config(profile_home: "Path") -> Optional[Dict[str, Any]]:
+    """Read the ``terminal:`` section from a profile's own config.yaml.
+
+    Returns a flat dict of terminal settings suitable for
+    ``set_terminal_config_scope``, or ``None`` when the profile has no
+    terminal section (in which case the gateway-starting profile's env vars
+    remain the fallback).
+
+    This is a read-only, side-effect-free operation: it does NOT mutate
+    ``os.environ`` or the process-global config cache.
+    """
+    from hermes_constants import get_hermes_home
+
+    try:
+        from hermes_cli.config import read_raw_config
+    except Exception:
+        return None
+
+    saved_home = None
+    try:
+        # Temporarily override HERMES_HOME so read_raw_config loads the
+        # target profile's config.yaml instead of the default profile's.
+        from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+
+        saved_home = set_hermes_home_override(str(profile_home))
+        cfg = read_raw_config()
+        terminal = cfg.get("terminal") if isinstance(cfg, dict) else None
+        if not isinstance(terminal, dict):
+            return None
+
+        # Flatten to the keys the terminal tool expects.
+        # The _get_scoped_env_config function reads these raw config.yaml keys.
+        result: Dict[str, Any] = {}
+        for k, v in terminal.items():
+            if isinstance(v, (str, int, float, bool, list, dict)) or v is None:
+                result[k] = v
+
+        # Expand ${ENV_VAR} references that may appear in values.
+        try:
+            from hermes_cli.config import _expand_env_vars
+
+            expanded = _expand_env_vars({"terminal": result})
+            if isinstance(expanded, dict):
+                result = expanded.get("terminal", result)  # type: ignore[assignment]
+        except Exception:
+            pass
+
+        return result
+    except Exception:
+        logger.debug(
+            "Failed to resolve terminal config for profile %s", profile_home, exc_info=True
+        )
+        return None
+    finally:
+        if saved_home is not None:
+            try:
+                from hermes_constants import reset_hermes_home_override
+
+                reset_hermes_home_override(saved_home)
+            except Exception:
+                pass
+
+
 @_contextmanager
 def _profile_runtime_scope(profile_home: "Path"):
-    """Scope config/skills/memory AND credentials to a profile for one turn.
+    """Scope config/skills/memory AND credentials AND terminal to a profile for one turn.
 
-    Combines the two seams the multiplexer needs:
+    Combines the three seams the multiplexer needs:
       1. ``set_hermes_home_override`` — redirects ``get_hermes_home()`` (config,
          skills, memory, SOUL, sessions) to the profile's home. Contextvar, so
          it propagates into the agent worker thread via ``copy_context()``.
@@ -1532,6 +1595,10 @@ def _profile_runtime_scope(profile_home: "Path"):
          authoritative credential source, so ``get_secret`` reads this profile's
          keys and never the process-global ``os.environ`` (which in a
          multiplexer may hold another profile's values).
+      3. ``set_terminal_config_scope`` — installs the profile's ``terminal:``
+         config section so terminal/file tools use the routed profile's backend
+         (docker/ssh/etc.) instead of inheriting the gateway-starting profile's
+         process-global ``TERMINAL_*`` env vars. See issue #68559.
 
     Only used on the multiplexed inbound path. Single-profile gateways never
     enter this scope, so their behavior is unchanged. Loading the profile's
@@ -1545,12 +1612,27 @@ def _profile_runtime_scope(profile_home: "Path"):
         set_secret_scope,
         reset_secret_scope,
     )
+    from tools.terminal_tool import (
+        set_terminal_config_scope,
+        reset_terminal_config_scope,
+    )
 
     home_token = set_hermes_home_override(str(profile_home))
     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+
+    # Resolve the profile's terminal config from its own config.yaml.
+    # This does NOT mutate os.environ; it returns an isolated dict that the
+    # terminal tool reads via ContextVar, so concurrent routed profile turns
+    # remain isolated.  See issue #68559.
+    terminal_cfg = _resolve_profile_terminal_config(profile_home)
+    terminal_token = (
+        set_terminal_config_scope(terminal_cfg) if terminal_cfg is not None else None
+    )
     try:
         yield
     finally:
+        if terminal_token is not None:
+            reset_terminal_config_scope(terminal_token)
         reset_secret_scope(secret_token)
         reset_hermes_home_override(home_token)
 

--- a/tests/gateway/test_68559_terminal_config_scope.py
+++ b/tests/gateway/test_68559_terminal_config_scope.py
@@ -1,0 +1,151 @@
+"""Regression tests for issue #68559: multiplexed gateway terminal backend routing.
+
+These tests prove that when a routed profile turn executes under
+``_profile_runtime_scope``, the terminal tool reads the routed profile's
+``terminal:`` configuration rather than the gateway-starting profile's
+process-global ``TERMINAL_*`` environment variables.
+"""
+import os
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+
+class TestTerminalConfigScope:
+    """Context-local terminal config scope works in isolation."""
+
+    def test_scope_overrides_env_vars(self, monkeypatch):
+        """When a terminal config scope is active, _get_env_config reads from it."""
+        from tools.terminal_tool import (
+            _get_env_config,
+            set_terminal_config_scope,
+            reset_terminal_config_scope,
+        )
+
+        # Set process-global env vars to a known \"wrong\" value
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.delenv("TERMINAL_DOCKER_IMAGE", raising=False)
+
+        # Activate a scoped config that says \"docker\"
+        scoped = {
+            "backend": "docker",
+            "docker_image": "alpine:latest",
+        }
+        token = set_terminal_config_scope(scoped)
+        try:
+            cfg = _get_env_config()
+            assert cfg["env_type"] == "docker", (
+                f"Expected 'docker' from scope, got {cfg['env_type']}"
+            )
+            assert cfg["docker_image"] == "alpine:latest", (
+                f"Expected 'alpine:latest' from scope, got {cfg['docker_image']}"
+            )
+        finally:
+            reset_terminal_config_scope(token)
+
+    def test_no_scope_falls_back_to_env_vars(self, monkeypatch):
+        """Without an active scope, the legacy env-var path is used."""
+        from tools.terminal_tool import _get_env_config
+
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "example.com")
+
+        cfg = _get_env_config()
+        assert cfg["env_type"] == "ssh"
+        assert cfg["ssh_host"] == "example.com"
+
+    def test_scope_isolation_concurrent(self):
+        """Simulating two profile scopes don't interfere (single-threaded proof)."""
+        from tools.terminal_tool import (
+            _get_env_config,
+            set_terminal_config_scope,
+            reset_terminal_config_scope,
+        )
+
+        # Profile A: docker
+        token_a = set_terminal_config_scope({
+            "backend": "docker",
+            "docker_image": "python:3.11",
+        })
+        cfg_a = _get_env_config()
+        assert cfg_a["env_type"] == "docker"
+
+        # Profile B: ssh (nested scope)
+        token_b = set_terminal_config_scope({
+            "backend": "ssh",
+            "ssh_host": "remote.example.com",
+        })
+        cfg_b = _get_env_config()
+        assert cfg_b["env_type"] == "ssh"
+        assert cfg_b["ssh_host"] == "remote.example.com"
+
+        # After B's scope ends, A's scope is still active
+        reset_terminal_config_scope(token_b)
+        cfg_a_again = _get_env_config()
+        assert cfg_a_again["env_type"] == "docker"
+
+        reset_terminal_config_scope(token_a)
+
+
+class TestProfileRuntimeScopeTerminalConfig:
+    """_profile_runtime_scope installs terminal config for routed profiles."""
+
+    @pytest.fixture
+    def tmp_hermes_home(self, tmp_path, monkeypatch):
+        """Create a temporary HERMES_HOME with a config.yaml containing terminal settings."""
+        home = tmp_path / "hermes"
+        home.mkdir()
+        config = home / "config.yaml"
+        config.write_text(
+            "terminal:\n"
+            "  backend: docker\n"
+            "  docker_image: nikolaik/python-nodejs:python3.11-nodejs20\n"
+            "  container_cpu: 2.0\n"
+        )
+        # Ensure no process-global TERMINAL_* env vars pollute the test
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("TERMINAL_DOCKER_IMAGE", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        return home
+
+    def test_profile_runtime_scope_applies_terminal_config(self, tmp_hermes_home):
+        """_profile_runtime_scope installs the profile's terminal config."""
+        from gateway.run import _profile_runtime_scope
+        from tools.terminal_tool import _get_env_config, _get_terminal_config_scope
+
+        profile_home = Path(tmp_hermes_home)
+
+        # Before entering scope: no terminal config scope active
+        assert _get_terminal_config_scope() is None
+
+        with _profile_runtime_scope(profile_home):
+            # Inside scope: terminal config should come from the profile's config.yaml
+            scoped = _get_terminal_config_scope()
+            assert scoped is not None, "Terminal config scope should be active"
+            assert scoped.get("backend") == "docker"
+            assert scoped.get("docker_image") == "nikolaik/python-nodejs:python3.11-nodejs20"
+
+            # _get_env_config should read from the scoped config
+            cfg = _get_env_config()
+            assert cfg["env_type"] == "docker", (
+                f"Expected 'docker' from profile config, got {cfg['env_type']}"
+            )
+
+        # After exiting scope: terminal config scope is cleared
+        assert _get_terminal_config_scope() is None
+
+    def test_profile_runtime_scope_no_terminal_section(self, tmp_path, monkeypatch):
+        """Profile without terminal section doesn't break _profile_runtime_scope."""
+        home = tmp_path / "hermes"
+        home.mkdir()
+        config = home / "config.yaml"
+        config.write_text("agent:\n  max_turns: 10\n")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        from gateway.run import _profile_runtime_scope
+        from tools.terminal_tool import _get_terminal_config_scope
+
+        with _profile_runtime_scope(Path(home)):
+            # No terminal section → no scope installed → None
+            assert _get_terminal_config_scope() is None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -42,6 +42,7 @@ import threading
 import atexit
 import shutil
 import subprocess
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
@@ -1309,6 +1310,37 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
 # optimization: after the first attempt either TERMINAL_ENV is set (bridge
 # succeeded — merged config always carries terminal.backend) or the import
 # failed and retrying every call would be wasted work.
+# --- Per-scope terminal configuration (ContextVar) ---------------------------
+# Allows the gateway multiplexer to override terminal settings for a routed
+# profile turn without mutating os.environ, which is process-global and unsafe
+# for concurrent multi-profile execution.  See issue #68559.
+_terminal_config_scope: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
+    "terminal_config_scope", default=None
+)
+
+
+def set_terminal_config_scope(terminal_cfg: Dict[str, Any]) -> Any:
+    """Install a context-local terminal-config override for the current scope.
+
+    Returns an opaque token that must be passed to ``reset_terminal_config_scope``
+    to restore the previous scope.  This is the terminal analogue of
+    ``set_secret_scope`` / ``set_hermes_home_override`` used in
+    ``_profile_runtime_scope``.
+    """
+    return _terminal_config_scope.set(terminal_cfg)
+
+
+def reset_terminal_config_scope(token: Any) -> None:
+    """Restore the previous terminal-config scope using the opaque token."""
+    _terminal_config_scope.reset(token)
+
+
+def _get_terminal_config_scope() -> Optional[Dict[str, Any]]:
+    """Return the current context-local terminal config override, or None."""
+    return _terminal_config_scope.get()
+
+
+# --- Terminal config bridge fallback -----------------------------------------
 _terminal_config_bridge_attempted = False
 
 
@@ -1347,14 +1379,263 @@ def _ensure_terminal_env_bridged() -> None:
 
 
 def _get_env_config() -> Dict[str, Any]:
-    """Get terminal environment configuration from environment variables."""
-    # Default image with Python and Node.js for maximum compatibility
+    """Get terminal configuration, respecting per-scope overrides.
+
+    When a context-local terminal config scope is active (set via
+    ``set_terminal_config_scope`` by ``_profile_runtime_scope`` during
+    multiplexed gateway routing), all terminal settings come from the
+    scoped configuration dict — not from process-global ``os.environ``.
+
+    When no scope is active, falls back to the legacy environment-variable
+    path for backward compatibility with CLI/TUI/launchers.
+
+    See issue #68559.
+    """
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
+
+    # --- Scoped path: multiplexed gateway routing --------------------------
+    scoped_cfg = _get_terminal_config_scope()
+    if scoped_cfg is not None:
+        return _get_scoped_env_config(scoped_cfg, default_image)
+
+    # --- Legacy path: process-global env vars ------------------------------
     _ensure_terminal_env_bridged()
+    return _get_env_config_from_envvars(default_image)
+
+
+# Map of config.yaml key → canonical output key used by the terminal tool.
+# The legacy env-var names are embedded in the _get_env_config_from_envvars impl.
+_TERMINAL_CONFIG_KEY_MAP = {
+    "backend": "env_type",
+    "cwd": "cwd",
+    "timeout": "timeout",
+    "lifetime_seconds": "lifetime_seconds",
+    "docker_image": "docker_image",
+    "docker_forward_env": "docker_forward_env",
+    "singularity_image": "singularity_image",
+    "modal_image": "modal_image",
+    "daytona_image": "daytona_image",
+    "ssh_host": "ssh_host",
+    "ssh_user": "ssh_user",
+    "ssh_port": "ssh_port",
+    "ssh_key": "ssh_key",
+    "container_cpu": "container_cpu",
+    "container_memory": "container_memory",
+    "container_disk": "container_disk",
+    "container_persistent": "container_persistent",
+    "docker_volumes": "docker_volumes",
+    "docker_env": "docker_env",
+    "docker_extra_args": "docker_extra_args",
+    "docker_mount_cwd_to_workspace": "docker_mount_cwd_to_workspace",
+    "docker_network": "docker_network",
+    "docker_run_as_host_user": "docker_run_as_host_user",
+    "docker_persist_across_processes": "docker_persist_across_processes",
+    "docker_orphan_reaper": "docker_orphan_reaper",
+    "sandbox_dir": "sandbox_dir",
+    "persistent_shell": "persistent_shell",
+    "modal_mode": "modal_mode",
+    "home_mode": "home_mode",
+}
+
+# Default values for scoped config resolution
+_SCOPED_DEFAULTS: Dict[str, Any] = {
+    "env_type": "local",
+    "modal_mode": "auto",
+    "docker_image": "nikolaik/python-nodejs:python3.11-nodejs20",
+    "docker_forward_env": [],
+    "singularity_image": None,  # derived below
+    "modal_image": "nikolaik/python-nodejs:python3.11-nodejs20",
+    "daytona_image": "nikolaik/python-nodejs:python3.11-nodejs20",
+    "cwd": None,  # resolved below
+    "host_cwd": None,
+    "docker_mount_cwd_to_workspace": False,
+    "timeout": 180,
+    "lifetime_seconds": 300,
+    "ssh_host": "",
+    "ssh_user": "",
+    "ssh_port": 22,
+    "ssh_key": "",
+    "ssh_persistent": True,
+    "local_persistent": False,
+    "container_cpu": 1.0,
+    "container_memory": 5120,
+    "container_disk": 51200,
+    "container_persistent": True,
+    "docker_volumes": [],
+    "docker_env": {},
+    "docker_run_as_host_user": False,
+    "docker_network": True,
+    "docker_extra_args": [],
+    "docker_persist_across_processes": True,
+    "docker_orphan_reaper": True,
+    "sandbox_dir": None,
+    "persistent_shell": None,
+    "home_mode": False,
+}
+
+
+def _bool_from_scoped(val: Any, default: bool = False) -> bool:
+    """Convert a scoped config value (str, bool, int) to a boolean."""
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, (int, float)):
+        return bool(val)
+    return str(val).strip().lower() in {"true", "1", "yes"}
+
+
+def _int_from_scoped(val: Any, default: int) -> int:
+    """Convert a scoped config value to an integer."""
+    try:
+        return int(val)
+    except (ValueError, TypeError):
+        return default
+
+
+def _float_from_scoped(val: Any, default: float) -> float:
+    """Convert a scoped config value to a float."""
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return default
+
+
+def _get_scoped_env_config(scoped_cfg: Dict[str, Any], default_image: str) -> Dict[str, Any]:
+    """Build terminal config dict from a scoped configuration.
+
+    This mirrors the logic of ``_get_env_config_from_envvars`` but reads
+    from a dict instead of from environment variables.
+    """
+    env_type = str(scoped_cfg.get("backend", "local")).strip().lower() or "local"
+    container_backend = env_type in _CONTAINER_BACKENDS
+    docker_backend = env_type == "docker"
+
+    # Container resource defaults
+    if container_backend:
+        container_cpu = _float_from_scoped(scoped_cfg.get("container_cpu"), 1.0)
+        container_memory = _int_from_scoped(scoped_cfg.get("container_memory"), 5120)
+        container_disk = _int_from_scoped(scoped_cfg.get("container_disk"), 51200)
+    else:
+        container_cpu = 1.0
+        container_memory = 5120
+        container_disk = 51200
+
+    # Docker-specific collections
+    if docker_backend:
+        docker_forward_env = scoped_cfg.get("docker_forward_env", [])
+        docker_volumes = scoped_cfg.get("docker_volumes", [])
+        docker_env = scoped_cfg.get("docker_env", {})
+        docker_extra_args = scoped_cfg.get("docker_extra_args", [])
+        if isinstance(docker_forward_env, str):
+            try:
+                docker_forward_env = json.loads(docker_forward_env)
+            except json.JSONDecodeError:
+                docker_forward_env = []
+        if isinstance(docker_volumes, str):
+            try:
+                docker_volumes = json.loads(docker_volumes)
+            except json.JSONDecodeError:
+                docker_volumes = []
+        if isinstance(docker_env, str):
+            try:
+                docker_env = json.loads(docker_env)
+            except json.JSONDecodeError:
+                docker_env = {}
+        if isinstance(docker_extra_args, str):
+            try:
+                docker_extra_args = json.loads(docker_extra_args)
+            except json.JSONDecodeError:
+                docker_extra_args = []
+    else:
+        docker_forward_env = []
+        docker_volumes = []
+        docker_env = {}
+        docker_extra_args = []
+
+    # CWD resolution
+    if env_type == "local":
+        default_cwd = _safe_getcwd()
+    elif env_type == "ssh":
+        default_cwd = "~"
+    else:
+        default_cwd = "/root"
+
+    mount_docker_cwd = _bool_from_scoped(scoped_cfg.get("docker_mount_cwd_to_workspace"), False)
+    raw_cwd = scoped_cfg.get("cwd")
+
+    if raw_cwd is not None:
+        cwd = str(raw_cwd)
+    else:
+        cwd = default_cwd
+
+    if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
+        cwd = os.path.expanduser(cwd)
+
+    host_cwd = None
+    if docker_backend and mount_docker_cwd:
+        docker_cwd_source = str(scoped_cfg.get("cwd", "")) or _safe_getcwd()
+        candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
+        if (
+            any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
+            or (os.path.isabs(candidate) and os.path.isdir(candidate) and not candidate.startswith(("/workspace", "/root")))
+        ):
+            host_cwd = candidate
+            cwd = "/workspace"
+    elif container_backend and cwd:
+        if _is_unusable_container_cwd(cwd) and cwd != default_cwd:
+            logger.info("Ignoring cwd=%r for %s backend "
+                        "(host/relative path won't work in sandbox). Using %r instead.",
+                        cwd, env_type, default_cwd)
+            cwd = default_cwd
+
+    singularity_image = scoped_cfg.get("singularity_image")
+    if singularity_image is None:
+        singularity_image = f"docker://{scoped_cfg.get('docker_image', default_image)}"
+
+    return {
+        "env_type": env_type,
+        "modal_mode": coerce_modal_mode(scoped_cfg.get("modal_mode", "auto")),
+        "docker_image": scoped_cfg.get("docker_image", default_image),
+        "docker_forward_env": docker_forward_env if isinstance(docker_forward_env, list) else [],
+        "singularity_image": singularity_image,
+        "modal_image": scoped_cfg.get("modal_image", default_image),
+        "daytona_image": scoped_cfg.get("daytona_image", default_image),
+        "cwd": cwd,
+        "host_cwd": host_cwd,
+        "docker_mount_cwd_to_workspace": mount_docker_cwd,
+        "timeout": _int_from_scoped(scoped_cfg.get("timeout"), 180),
+        "lifetime_seconds": _int_from_scoped(scoped_cfg.get("lifetime_seconds"), 300),
+        "ssh_host": str(scoped_cfg.get("ssh_host", "")),
+        "ssh_user": str(scoped_cfg.get("ssh_user", "")),
+        "ssh_port": _int_from_scoped(scoped_cfg.get("ssh_port"), 22),
+        "ssh_key": str(scoped_cfg.get("ssh_key", "")),
+        "ssh_persistent": _bool_from_scoped(
+            scoped_cfg.get("ssh_persistent"),
+            scoped_cfg.get("persistent_shell", True),
+        ),
+        "local_persistent": _bool_from_scoped(scoped_cfg.get("local_persistent"), False),
+        "container_cpu": container_cpu,
+        "container_memory": container_memory,
+        "container_disk": container_disk,
+        "container_persistent": _bool_from_scoped(scoped_cfg.get("container_persistent"), True),
+        "docker_volumes": docker_volumes if isinstance(docker_volumes, list) else [],
+        "docker_env": docker_env if isinstance(docker_env, dict) else {},
+        "docker_run_as_host_user": _bool_from_scoped(scoped_cfg.get("docker_run_as_host_user"), False),
+        "docker_network": _bool_from_scoped(scoped_cfg.get("docker_network"), True),
+        "docker_extra_args": docker_extra_args if isinstance(docker_extra_args, list) else [],
+        "docker_persist_across_processes": _bool_from_scoped(scoped_cfg.get("docker_persist_across_processes"), True),
+        "docker_orphan_reaper": _bool_from_scoped(scoped_cfg.get("docker_orphan_reaper"), True),
+        "sandbox_dir": scoped_cfg.get("sandbox_dir"),
+        "persistent_shell": scoped_cfg.get("persistent_shell"),
+        "home_mode": _bool_from_scoped(scoped_cfg.get("home_mode"), False),
+    }
+
+
+def _get_env_config_from_envvars(default_image: str) -> Dict[str, Any]:
+    """Legacy env-var-based terminal config (backward-compatible path)."""
     env_type = os.getenv("TERMINAL_ENV", "local")
-    
+
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
-    container_backend = env_type in {"docker", "singularity", "modal", "daytona"}
+    container_backend = env_type in _CONTAINER_BACKENDS
     docker_backend = env_type == "docker"
 
     # Docker/container-only env vars may be bridged from config.yaml even when


### PR DESCRIPTION
## 背景

修复 #68559: 多路复用网关忽略路由 profile 的 terminal backend 配置，Docker profile 继承了本地 backend

## 根因分析

多路复用网关启动时，将默认 profile 的 `terminal.*` 配置桥接到进程全局 `TERMINAL_*` 环境变量。`_profile_runtime_scope()` 在路由到二级 profile 时只切换了 `hermes_home` 和 `secret_scope`，但没有切换 terminal 配置。`tools.terminal_tool._get_env_config()` 从 `os.environ` 读取，导致被路由的 profile 继承了网关启动 profile 的 terminal backend 设置。

当默认 profile 使用 `local` backend、被路由的 profile 配置为 `docker` 时，这构成了**安全边界失效**：本应被 Docker 沙箱隔离的 profile 实际获得了主机终端访问权限。

## 修复方式

1. **tools/terminal_tool.py**: 引入 ContextVar 类型的终端配置作用域（`_terminal_config_scope`），并提供 `set_terminal_config_scope()` / `reset_terminal_config_scope()` 辅助函数。重构 `_get_env_config()`：作用域激活时从作用域 dict 读取，否则回退到旧版环境变量路径。

2. **gateway/run.py**: 在 `_profile_runtime_scope()` 中，进入路由 profile 作用域时同时安装该 profile 的 terminal 配置（从 profile 自身的 `config.yaml` 读取），退出时清理。新增 `_resolve_profile_terminal_config()` 辅助函数。

3. **不变量保证**:
   - 不修改 `os.environ`（进程全局）
   - ContextVar 随 `copy_context()` 传播到 agent worker 线程
   - 嵌套作用域正确恢复
   - 无 terminal 段的 profile 不影响现有行为

## 测试

- 新增 `tests/gateway/test_68559_terminal_config_scope.py`，5 个测试全部通过
- 现有 multiplex 测试（`test_multiplex_credential_isolation.py`）10 个测试全部通过

## 验证

- [x] 代码变更已在本地验证
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更
- [x] 向后兼容：无作用域时完全走旧版环境变量路径

Closes #68559