### PR TITLE
fix(sanitization): close truncated tool-call args by nesting, not by count

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2940,7 +2940,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 if arguments and arguments.strip():
                     try:
                         json.loads(arguments)
-                    except json.JSONDecodeError:
+                    except ValueError:
+                        # ValueError, not JSONDecodeError: CPython >= 3.11
+                        # raises a bare ValueError from json.loads when an
+                        # integer literal exceeds sys.get_int_max_str_digits().
+                        # JSONDecodeError subclasses ValueError, so this still
+                        # catches every malformed-JSON case.
                         # Attempt repair before flagging as truncated.
                         # Models like GLM-5.1 via Ollama produce trailing
                         # commas, unclosed brackets, Python None, etc.

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -182,6 +182,60 @@ def _escape_invalid_chars_in_json_strings(raw: str) -> str:
     return "".join(out)
 
 
+def _close_unclosed_json_structures(raw: str) -> str:
+    """Close a truncated JSON payload, honouring nesting order.
+
+    Walks ``raw`` tracking string and escape state, pushing ``{``/``[`` onto a
+    stack and popping on the matching closer, then appends whatever the stack
+    still holds in LIFO (innermost-first) order.
+
+    This replaces a ``str.count`` deficit calculation that appended *all*
+    missing ``}`` before *all* missing ``]`` regardless of actual nesting, and
+    that counted delimiters appearing inside string *values*.  Either made the
+    repair emit invalid JSON for payloads it could otherwise close, which then
+    degraded to the ``"{}"`` last resort and dropped the model's arguments
+    entirely (#35151).
+
+    A payload that ends *inside* a string value is returned unchanged: there
+    the truncation cut a value rather than the structure around it, and
+    inventing a closing quote would hand the tool a plausible-looking but
+    silently incomplete argument (the failure #62948 reports).  Those stay
+    unrepairable on purpose so the caller routes them through the
+    partial-stream/truncation path instead of executing them.
+    """
+    stack: list[str] = []
+    in_string = False
+    escaped = False
+    for ch in raw:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch in "{[":
+            stack.append(ch)
+        elif ch == "}" and stack and stack[-1] == "{":
+            stack.pop()
+        elif ch == "]" and stack and stack[-1] == "[":
+            stack.pop()
+
+    if in_string or not stack:
+        return raw
+
+    # A comma the truncation left dangling would sit right in front of the
+    # closer we are about to append ("[1, 2," -> "[1, 2,]").
+    tail = raw.rstrip()
+    while tail.endswith(","):
+        tail = tail[:-1].rstrip()
+
+    return tail + "".join("}" if ch == "{" else "]" for ch in reversed(stack))
+
+
 def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     """Attempt to repair malformed tool_call argument JSON.
 
@@ -224,19 +278,14 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     fixed = raw_stripped
     # 1. Strip trailing commas before } or ]
     fixed = re.sub(r',\s*([}\]])', r'\1', fixed)
-    # 2. Close unclosed structures
-    open_curly = fixed.count('{') - fixed.count('}')
-    open_bracket = fixed.count('[') - fixed.count(']')
-    if open_curly > 0:
-        fixed += '}' * open_curly
-    if open_bracket > 0:
-        fixed += ']' * open_bracket
+    # 2. Close unclosed structures, innermost first (string-aware)
+    fixed = _close_unclosed_json_structures(fixed)
     # 3. Remove excess closing braces/brackets (bounded to 50 iterations)
     for _ in range(50):
         try:
             json.loads(fixed)
             break
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, ValueError):
             if fixed.endswith('}') and fixed.count('}') > fixed.count('{'):
                 fixed = fixed[:-1]
             elif fixed.endswith(']') and fixed.count(']') > fixed.count('['):
@@ -251,7 +300,7 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
             tool_name, raw_stripped[:80], fixed[:80],
         )
         return fixed
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, ValueError):
         pass
 
     # Repair pass 4: escape unescaped control chars inside JSON strings,

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -182,6 +182,46 @@ def _escape_invalid_chars_in_json_strings(raw: str) -> str:
     return "".join(out)
 
 
+def _strip_trailing_commas(raw: str) -> str:
+    r"""Drop commas that sit directly before a closing brace or bracket.
+
+    String-aware replacement for a ``re.sub(r',\s*([}\]])', r'\1', ...)``
+    pass.  The regex had no notion of string boundaries, so a comma inside a
+    string *value* followed by ``]`` or ``}`` was rewritten too: the payload
+    ``{"sep": ", ]", ...}`` had its separator silently changed to ``"]"``.
+    On its own that produced JSON that still failed to parse and degraded to
+    ``"{}"``, but paired with a nesting-aware closer it parses cleanly and the
+    corrupted value reaches the tool.
+    """
+    out: list[str] = []
+    in_string = False
+    escaped = False
+    pending: int | None = None  # index in `out` of a comma awaiting a verdict
+    for ch in raw:
+        if in_string:
+            out.append(ch)
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if pending is not None:
+            if ch.isspace():
+                out.append(ch)
+                continue
+            if ch in "}]":
+                del out[pending:]  # drop the comma and any whitespace after it
+            pending = None
+        if ch == '"':
+            in_string = True
+        elif ch == ",":
+            pending = len(out)
+        out.append(ch)
+    return "".join(out)
+
+
 def _close_unclosed_json_structures(raw: str) -> str:
     """Close a truncated JSON payload, honouring nesting order.
 
@@ -264,20 +304,23 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     # the most common local-model repair case (#12068).
     try:
         parsed = json.loads(raw_stripped, strict=False)
-        reserialised = json.dumps(parsed, separators=(",", ":"))
+        # allow_nan=False: json.loads turns 1e999 into inf, and the default
+        # dumps would re-emit a bare ``Infinity`` token, which is not JSON.
+        # Raising here drops us into the repair passes instead.
+        reserialised = json.dumps(parsed, separators=(",", ":"), allow_nan=False)
         if reserialised != raw_stripped:
             logger.warning(
                 "Repaired unescaped control chars in tool_call arguments for %s",
                 tool_name,
             )
         return reserialised
-    except (json.JSONDecodeError, TypeError, ValueError):
+    except (json.JSONDecodeError, TypeError, ValueError, RecursionError):
         pass
 
     # Attempt common JSON repairs
     fixed = raw_stripped
-    # 1. Strip trailing commas before } or ]
-    fixed = re.sub(r',\s*([}\]])', r'\1', fixed)
+    # 1. Strip trailing commas before } or ] (string-aware)
+    fixed = _strip_trailing_commas(fixed)
     # 2. Close unclosed structures, innermost first (string-aware)
     fixed = _close_unclosed_json_structures(fixed)
     # 3. Remove excess closing braces/brackets (bounded to 50 iterations)
@@ -285,7 +328,7 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
         try:
             json.loads(fixed)
             break
-        except (json.JSONDecodeError, ValueError):
+        except (json.JSONDecodeError, ValueError, RecursionError):
             if fixed.endswith('}') and fixed.count('}') > fixed.count('{'):
                 fixed = fixed[:-1]
             elif fixed.endswith(']') and fixed.count(']') > fixed.count('['):
@@ -300,7 +343,7 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
             tool_name, raw_stripped[:80], fixed[:80],
         )
         return fixed
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError, RecursionError):
         pass
 
     # Repair pass 4: escape unescaped control chars inside JSON strings,
@@ -315,7 +358,7 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
                 tool_name, raw_stripped[:80], escaped[:80],
             )
             return escaped
-    except (json.JSONDecodeError, TypeError, ValueError):
+    except (json.JSONDecodeError, TypeError, ValueError, RecursionError):
         pass
 
     # Last resort: replace with empty object so the API request doesn't

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -27,6 +27,15 @@ logger = logging.getLogger(__name__)
 # scrubbing.
 _SURROGATE_RE = re.compile(r'[\ud800-\udfff]')
 
+# The only characters JSON permits as whitespace between tokens (RFC 8259
+# section 2).  Python's ``str.isspace()`` / bare ``str.rstrip()`` are
+# Unicode-aware and also match U+001C-U+001F, U+0085, U+00A0, U+2028 and
+# friends -- all of which are *illegal* outside a JSON string.  Treating them
+# as skippable whitespace lets the repair passes delete them and hand back a
+# payload that parses, turning input JSON rightly rejects into an executed
+# tool call.  Every whitespace test in the repair path uses this instead.
+_JSON_WHITESPACE = " \t\n\r"
+
 
 def _sanitize_surrogates(text: str) -> str:
     """Replace lone surrogate code points with U+FFFD (replacement character).
@@ -208,7 +217,7 @@ def _strip_trailing_commas(raw: str) -> str:
                 in_string = False
             continue
         if pending is not None:
-            if ch.isspace():
+            if ch in _JSON_WHITESPACE:
                 out.append(ch)
                 continue
             if ch in "}]":
@@ -267,13 +276,15 @@ def _close_unclosed_json_structures(raw: str) -> str:
     if in_string or not stack:
         return raw
 
-    # A comma the truncation left dangling would sit right in front of the
-    # closer we are about to append ("[1, 2," -> "[1, 2,]").
-    tail = raw.rstrip()
-    while tail.endswith(","):
-        tail = tail[:-1].rstrip()
-
-    return tail + "".join("}" if ch == "{" else "]" for ch in reversed(stack))
+    # Note: a comma the truncation left dangling is deliberately NOT trimmed.
+    # ``{"a": [1, 2,`` ends on a comma, which is the model promising another
+    # element that never arrived -- trimming it would append the closer and
+    # present a short list as a complete one.  Leaving the comma in place makes
+    # the result unparseable, so the payload falls through to ``"{}"`` and the
+    # caller's truncation path, same as before this change.  A *stray* trailing
+    # comma in otherwise-complete JSON (``{"a": [1, 2,]}``) is a different case
+    # and is still handled by ``_strip_trailing_commas``.
+    return raw + "".join("}" if ch == "{" else "]" for ch in reversed(stack))
 
 
 def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -287,6 +287,58 @@ def _close_unclosed_json_structures(raw: str) -> str:
     return raw + "".join("}" if ch == "{" else "]" for ch in reversed(stack))
 
 
+def _unmatched_trailing_closer_index(raw: str) -> int:
+    """Index of a trailing ``}``/``]`` that closes nothing, or -1.
+
+    Companion to :func:`_close_unclosed_json_structures` for the opposite
+    problem: a payload carrying one closer too many.  Shares the same
+    string/escape tracking, so a delimiter inside a string *value* is not
+    mistaken for structure -- the ``str.count`` version this replaces saw the
+    brace in ``{"s":"{","x":[1]}}`` and concluded the braces were balanced, so
+    it never removed the genuinely excess ``}`` and a recoverable payload
+    degraded to ``"{}"``.
+
+    Only reports a closer that is the payload's LAST token.  An excess closer
+    in the middle (``{"a": [1]]}``) is deliberately left alone: the caller
+    repairs by dropping the character it is told about, and dropping the tail
+    there would take a legitimate closer with it and mangle the payload.  Those
+    stay unparseable and fall through to ``"{}"``, exactly as before.
+    """
+    stack: list[str] = []
+    in_string = False
+    escaped = False
+    unmatched = -1
+    last_token = -1
+    for i, ch in enumerate(raw):
+        if in_string:
+            last_token = i
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch in _JSON_WHITESPACE:
+            continue
+        last_token = i
+        if ch == '"':
+            in_string = True
+        elif ch in "{[":
+            stack.append(ch)
+        elif ch == "}":
+            if stack and stack[-1] == "{":
+                stack.pop()
+            else:
+                unmatched = i
+        elif ch == "]":
+            if stack and stack[-1] == "[":
+                stack.pop()
+            else:
+                unmatched = i
+    return unmatched if unmatched >= 0 and unmatched == last_token else -1
+
+
 def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     """Attempt to repair malformed tool_call argument JSON.
 
@@ -334,18 +386,17 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     fixed = _strip_trailing_commas(fixed)
     # 2. Close unclosed structures, innermost first (string-aware)
     fixed = _close_unclosed_json_structures(fixed)
-    # 3. Remove excess closing braces/brackets (bounded to 50 iterations)
+    # 3. Remove excess closing braces/brackets (bounded to 50 iterations),
+    #    string-aware so a delimiter inside a value is not counted as structure
     for _ in range(50):
         try:
             json.loads(fixed)
             break
         except (json.JSONDecodeError, ValueError, RecursionError):
-            if fixed.endswith('}') and fixed.count('}') > fixed.count('{'):
-                fixed = fixed[:-1]
-            elif fixed.endswith(']') and fixed.count(']') > fixed.count('['):
-                fixed = fixed[:-1]
-            else:
+            drop = _unmatched_trailing_closer_index(fixed)
+            if drop < 0:
                 break
+            fixed = fixed[:drop] + fixed[drop + 1:]
 
     try:
         json.loads(fixed)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -102,7 +102,12 @@ def _parse_tool_arguments(raw_arguments: Any) -> tuple[dict, Optional[str]]:
     """Parse model-emitted arguments without repairing or coercing them."""
     try:
         arguments = json.loads(raw_arguments)
-    except (json.JSONDecodeError, TypeError):
+    except (ValueError, TypeError):
+        # ValueError rather than JSONDecodeError: CPython >= 3.11 raises a
+        # bare ValueError from json.loads for integer literals longer than
+        # sys.get_int_max_str_digits().  JSONDecodeError subclasses
+        # ValueError, so malformed JSON is still covered and this parser
+        # stays fail-closed instead of propagating.
         arguments = None
     if isinstance(arguments, dict):
         return arguments, None

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -77,7 +77,10 @@ class TestRepairToolCallArguments:
         assert _repair_tool_call_arguments("totally not json", "t") == "{}"
 
     def test_unrepairable_partial_returns_empty_object(self):
-        # Truncated in the middle of a string key — bracket closing won't help
+        # Truncated in the middle of a string value — deliberately NOT closed.
+        # Inventing a terminator would hand the tool a silently incomplete
+        # argument, so this stays unrepairable and routes to the partial-stream
+        # path instead (#62948).
         assert _repair_tool_call_arguments('{"truncated": "val', "t") == "{}"
 
     # -- Valid JSON passthrough (this path is via except, but still works) --
@@ -139,4 +142,72 @@ class TestRepairToolCallArguments:
         result = _repair_tool_call_arguments(raw, "t")
         parsed = json.loads(result)
         assert "line" in parsed["msg"]
+
+    # -- Nesting-aware closing (#35151) --
+    # Closing by delimiter count appended every missing '}' before every
+    # missing ']', so a payload whose innermost open structure was an array
+    # got its closers in the wrong order, stayed invalid, and fell through to
+    # the "{}" last resort.
+
+    def test_unclosed_array_inside_object_closes_innermost_first(self):
+        result = _repair_tool_call_arguments('{"items": [1, 2, 3', "t")
+        assert json.loads(result) == {"items": [1, 2, 3]}
+
+    def test_deeply_nested_mixed_truncation(self):
+        raw = '{"a": {"b": [{"c": [1, 2'
+        result = _repair_tool_call_arguments(raw, "t")
+        assert json.loads(result) == {"a": {"b": [{"c": [1, 2]}]}}
+
+    def test_object_inside_array_closes_innermost_first(self):
+        result = _repair_tool_call_arguments('{"edits": [{"line": 1', "t")
+        assert json.loads(result) == {"edits": [{"line": 1}]}
+
+    def test_delimiters_inside_string_values_are_not_counted(self):
+        """Braces in a *completed* string value must not skew the deficit.
+
+        Counting raw '{' characters saw braces belonging to the content, so
+        the computed deficit was wrong in either direction — here it hid the
+        still-open array and produced '...[1, 2}]'.
+        """
+        raw = '{"content": "if x: {y}", "items": [1, 2'
+        result = _repair_tool_call_arguments(raw, "write_file")
+        assert json.loads(result) == {"content": "if x: {y}", "items": [1, 2]}
+
+    def test_truncation_inside_string_is_left_unrepairable(self):
+        """Structure may be closed; a cut-off *value* may not.
+
+        Closing the quote here would produce well-formed JSON carrying a
+        truncated value, which the caller would then execute as if complete.
+        """
+        assert _repair_tool_call_arguments('{"path": "x.txt", "content": "hel', "write_file") == "{}"
+
+    def test_truncation_inside_nested_string_is_left_unrepairable(self):
+        assert _repair_tool_call_arguments('{"a": [1, {"b": "partial', "t") == "{}"
+
+    def test_dangling_comma_before_appended_closer(self):
+        result = _repair_tool_call_arguments('{"a": [1, 2,', "t")
+        assert json.loads(result) == {"a": [1, 2]}
+
+    def test_balanced_payload_is_left_alone(self):
+        """The closing pass must be a no-op when nothing is open."""
+        raw = '{"a": [1, 2], "b": {"c": 3},}'
+        result = _repair_tool_call_arguments(raw, "t")
+        assert json.loads(result) == {"a": [1, 2], "b": {"c": 3}}
+
+    # -- Never-raises contract --
+
+    def test_long_numeric_literal_does_not_raise(self):
+        """CPython >= 3.11 raises a bare ValueError, not JSONDecodeError.
+
+        ``int`` parsing past ``sys.get_int_max_str_digits()`` (4300 by default)
+        raises ValueError from inside ``json.loads``.  Two handlers here caught
+        only JSONDecodeError, so a digit run-on escaped a function the callers
+        rely on never raising.
+        """
+        result = _repair_tool_call_arguments('{"n": ' + "9" * 5000, "t")
+        json.loads(result)  # must not raise
+
+    def test_long_numeric_literal_in_closed_object_does_not_raise(self):
+        result = _repair_tool_call_arguments('{"n": ' + "9" * 5000 + ",}", "t")
+        json.loads(result)
 

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -230,6 +230,31 @@ class TestRepairToolCallArguments:
         result = _repair_tool_call_arguments('{"a": [1, 2,], "b": {"c": 3,},}', "t")
         assert json.loads(result) == {"a": [1, 2], "b": {"c": 3}}
 
+    # -- Excess-closer trimming is string-aware too --
+
+    def test_excess_trailing_closer_with_delimiter_inside_string(self):
+        """A brace inside a value made raw counts look balanced.
+
+        The excess `}` was therefore never removed and a payload one character
+        from valid degraded to "{}".
+        """
+        result = _repair_tool_call_arguments('{"s":"{","x":[1]}}', "t")
+        assert json.loads(result) == {"s": "{", "x": [1]}
+
+    def test_excess_trailing_closer_with_closing_delimiter_in_string(self):
+        result = _repair_tool_call_arguments('{"s":"}", "x":[1]}}', "t")
+        assert json.loads(result) == {"s": "}", "x": [1]}
+
+    def test_excess_closer_mid_payload_is_left_unrepairable(self):
+        """Only a trailing excess closer is dropped.
+
+        In `{"a": [1]]}` the stray `]` is not the last token, so trimming the
+        tail would remove the legitimate `}` and mangle the payload.  It stays
+        unparseable and falls through to "{}" instead.
+        """
+        assert _repair_tool_call_arguments('{"a": [1]]}', "t") == "{}"
+        assert _repair_tool_call_arguments('{"a": [1, 2]], "b": 3}', "t") == "{}"
+
     # -- Never-raises contract --
 
     def test_pathological_nesting_does_not_raise(self):

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -194,7 +194,42 @@ class TestRepairToolCallArguments:
         result = _repair_tool_call_arguments(raw, "t")
         assert json.loads(result) == {"a": [1, 2], "b": {"c": 3}}
 
+    # -- String-aware trailing-comma strip --
+    # The comma strip used a regex with no notion of string boundaries, so a
+    # comma inside a string value followed by ']' or '}' was rewritten too.
+    # Alone that produced JSON that still failed to parse (-> "{}"); combined
+    # with a nesting-aware closer it parses cleanly and the corrupted value
+    # reaches the tool.
+
+    def test_comma_and_bracket_inside_string_value_survive(self):
+        result = _repair_tool_call_arguments('{"sep": ", ]", "files": ["a"', "t")
+        assert json.loads(result) == {"sep": ", ]", "files": ["a"]}
+
+    def test_comma_and_brace_inside_string_value_survive(self):
+        result = _repair_tool_call_arguments('{"msg": "end ,}", "n": [1', "t")
+        assert json.loads(result) == {"msg": "end ,}", "n": [1]}
+
+    def test_trailing_comma_strip_still_applies_outside_strings(self):
+        result = _repair_tool_call_arguments('{"a": [1, 2,], "b": {"c": 3,},}', "t")
+        assert json.loads(result) == {"a": [1, 2], "b": {"c": 3}}
+
     # -- Never-raises contract --
+
+    def test_pathological_nesting_does_not_raise(self):
+        """RecursionError is not a ValueError.
+
+        json.loads recurses per nesting level, so a repetition-loop payload
+        raises RecursionError out of a function documented as never raising.
+        """
+        assert _repair_tool_call_arguments("[" * 100_000, "t") == "{}"
+
+    def test_overflowing_float_is_not_laundered_into_infinity(self):
+        """json.loads turns 1e999 into inf; a default dumps re-emits the bare
+        token ``Infinity``, which is not valid JSON."""
+        result = _repair_tool_call_arguments('{"n": 1e999}', "t")
+        assert "Infinity" not in result
+        json.loads(result)
+
 
     def test_long_numeric_literal_does_not_raise(self):
         """CPython >= 3.11 raises a bare ValueError, not JSONDecodeError.

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -184,9 +184,26 @@ class TestRepairToolCallArguments:
     def test_truncation_inside_nested_string_is_left_unrepairable(self):
         assert _repair_tool_call_arguments('{"a": [1, {"b": "partial', "t") == "{}"
 
-    def test_dangling_comma_before_appended_closer(self):
-        result = _repair_tool_call_arguments('{"a": [1, 2,', "t")
-        assert json.loads(result) == {"a": [1, 2]}
+    def test_truncation_after_a_comma_is_left_unrepairable(self):
+        """A dangling comma is the model promising an element that never came.
+
+        Appending the closer would present a short list as a complete one, so
+        this stays unparseable and falls through to "{}" (and the caller's
+        truncation path) rather than executing.
+        """
+        assert _repair_tool_call_arguments('{"a": [1, 2,', "t") == "{}"
+
+    def test_json_illegal_whitespace_is_not_treated_as_whitespace(self):
+        """Only space/tab/LF/CR are JSON whitespace (RFC 8259 s2).
+
+        Python's str.isspace()/rstrip() also match U+001C-U+001F, U+0085,
+        U+00A0, U+2028 -- all illegal outside a JSON string.  Skipping them
+        would delete them and hand back a payload that parses, turning input
+        JSON rightly rejects into an executed tool call.
+        """
+        for cp in (0x1C, 0x1F, 0x85, 0xA0, 0x2028, 0x0B):
+            raw = '{"command":"echo X",' + chr(cp) + "}"
+            assert _repair_tool_call_arguments(raw, "t") == "{}", f"U+{cp:04X}"
 
     def test_balanced_payload_is_left_alone(self):
         """The closing pass must be a no-op when nothing is open."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2868,6 +2868,33 @@ class TestConcurrentToolExecution:
         assert [m["tool_call_id"] for m in messages] == ["c1", "c2"]
         assert "tool was not executed" in messages[0]["content"].lower()
 
+    def test_concurrent_long_numeric_literal_rejected_without_crash(self, agent):
+        """A >4300-digit literal must fail closed, not propagate.
+
+        _parse_tool_arguments guarded on (JSONDecodeError, TypeError); CPython
+        >= 3.11 raises a bare ValueError from json.loads past
+        sys.get_int_max_str_digits(), so the parser raised instead of
+        returning its structured error and the sibling call never ran.
+        """
+        tc1 = _mock_tool_call(
+            name="web_search", arguments='{"n": ' + "9" * 5000 + "}", call_id="c1"
+        )
+        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"ok"}', call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        seen_args = []
+
+        def fake_handle(name, args, task_id, **kwargs):
+            seen_args.append((kwargs["tool_call_id"], args))
+            return "ok"
+
+        with patch("run_agent.handle_function_call", side_effect=fake_handle):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert seen_args == [("c2", {"q": "ok"})]
+        assert [m["tool_call_id"] for m in messages] == ["c1", "c2"]
+        assert "tool was not executed" in messages[0]["content"].lower()
+
     def test_concurrent_preserves_order_despite_timing(self, agent):
         """Even if tools finish in different order, messages should be in original order."""
         import time as _time
@@ -7474,6 +7501,41 @@ class TestStreamingApiCall:
         assert tc[0].function.name == "write_file"
         assert tc[0].function.arguments == '{"path":"x.txt","content":"hel'
         assert resp.choices[0].finish_reason == "length"
+
+    def test_long_numeric_literal_does_not_escape_streaming_builder(self, agent):
+        # CPython >= 3.11 raises a bare ValueError (not JSONDecodeError) from
+        # json.loads when an integer literal exceeds
+        # sys.get_int_max_str_digits().  The streaming builder validated the
+        # accumulated arguments inside a JSONDecodeError-only guard, so a digit
+        # run-on propagated out of the response builder and killed the turn
+        # before the repair helper could run.
+        chunks = [
+            _make_chunk(tool_calls=[_make_tc_delta(0, "call_1", "calc", '{"n": ' + "9" * 5000 + "}")]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
+        agent.client.chat.completions.create.return_value = iter(chunks)
+
+        resp = agent._interruptible_streaming_api_call({"messages": []})
+
+        assert resp is not None
+        assert resp.choices[0].message.tool_calls is not None
+
+    def test_nested_array_truncation_is_repaired_in_streaming_path(self, agent):
+        # End-to-end counterpart to the helper-level nesting tests: closing by
+        # delimiter count emitted '...3}]' here and degraded to "{}", dropping
+        # the arguments.  The stream ends with an explicit finish_reason so
+        # this is a repairable malformation, not a mid-stream drop.
+        chunks = [
+            _make_chunk(tool_calls=[_make_tc_delta(0, "call_1", "search", '{"items": [1, 2, 3')]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
+        agent.client.chat.completions.create.return_value = iter(chunks)
+
+        resp = agent._interruptible_streaming_api_call({"messages": []})
+
+        tc = resp.choices[0].message.tool_calls
+        assert tc is not None and len(tc) == 1
+        assert json.loads(tc[0].function.arguments) == {"items": [1, 2, 3]}
 
     def test_ollama_reused_index_separate_tool_calls(self, agent):
         """Ollama sends every tool call at index 0 with different ids.


### PR DESCRIPTION

## What

`_repair_tool_call_arguments` decided where JSON structures open and close by *counting* delimiters. Counting cannot see nesting order, and counts every `{` or `]` inside a string **value** as structure. Both make the repair emit invalid JSON for payloads it could otherwise recover, which then degrade to the `"{}"` last resort — dropping the model's arguments entirely.

```python
_repair_tool_call_arguments('{"items": [1, 2, 3')
# before: '{"items": [1, 2, 3}]'   -> still invalid -> "{}"
#  after: '{"items": [1, 2, 3]}'
```

All three passes that reasoned about delimiters now share one string- and escape-aware scan:

| pass | was | now |
|---|---|---|
| strip trailing commas | `re.sub(r',\s*([}\]])', ...)` | string-aware scan |
| close unclosed structures | `str.count` deficit, all `}` then all `]` | LIFO stack, innermost first |
| trim excess closers | `str.count` deficit | string-aware, trailing token only |

Two ways the function could break its documented never-raises contract are also fixed. Since CPython 3.11, `json.loads` raises a bare `ValueError` on an integer literal past `sys.get_int_max_str_digits()`; two of four guards caught only `JSONDecodeError`, and — as review correctly pointed out — the two *callers* pre-validate with `json.loads` before ever reaching the helper, so guarding the helper alone was not enough. Both call sites now catch it. `json.loads` also recurses per nesting level, so `"[" * 100000` (a repetition-loop payload from exactly the local models this function serves) raised `RecursionError` straight out; that is now contained.

## What this deliberately refuses to repair

Repaired arguments may be **executed**, so anything that would invent a value fails closed to `"{}"` and routes to the existing truncation path instead.

- **Truncation inside a string value.** `{"path":"x.txt","content":"hel` — closing the quote yields well-formed JSON carrying a silently incomplete value. The existing test asserting this (`test_unrepairable_partial_returns_empty_object`) and `TestStreamingApiCall::test_truncated_tool_call_args_no_finish_reason_routes_to_stub` are unchanged.
- **Truncation immediately after a comma.** `{"a": [1, 2,` — the distinction is whether the last value is complete. `[1, 2` has a complete final value and only needs its container closed. `[1, 2,` does not: the comma is the model promising a next value that never arrived, so completing it would present a short list as a whole one. This is narrower than the previous behaviour on that input, and intentionally so.
- **An excess closer that is not the last token.** `{"a": [1]]}` — trimming works from the tail and would remove a legitimate closer. Unchanged from before.
- **JSON-illegal characters posing as whitespace.** JSON permits only space, tab, LF and CR between tokens (RFC 8259 §2). `str.isspace()`, bare `str.rstrip()` and a regex `\s` on a `str` pattern all additionally match U+001C–U+001F, U+0085, U+00A0 and U+2028. Treating those as skippable deleted them and returned a payload that parses, so `{"command":"echo X",\x1c}` became an executable call. All whitespace tests in the repair path now use an explicit `_JSON_WHITESPACE`.

## Behaviour

| input | before | after |
|---|---|---|
| `{"items": [1, 2, 3` | `{}` | `{"items": [1, 2, 3]}` |
| `{"edits": [{"line": 1` | `{}` | `{"edits": [{"line": 1}]}` |
| `{"a": {"b": [{"c": [1, 2` | `{}` | `{"a": {"b": [{"c": [1, 2]}]}}` |
| `{"sep": ", ]", "files": ["a"` | `{}` | `{"sep": ", ]", "files": ["a"]}` |
| `{"s":"{","x":[1]}}` | `{}` | `{"s":"{","x":[1]}` |
| `{"n": ` + `9`×5000 | **raises `ValueError`** | `{}` |
| `"[" × 100000` | **raises `RecursionError`** | `{}` |
| `{"command":"echo X",\x1c}` | **executed** | `{}` |
| `{"a": [1, 2,` | `{"a": [1, 2]}` | `{}` |
| `{"path":"x.txt","content":"hel` | `{}` | `{}` |
| balanced input | unchanged | unchanged |

## Tests

17 cases added to `tests/run_agent/test_repair_tool_call_arguments.py` and 3 to `tests/run_agent/test_run_agent.py` covering the caller boundaries. Each fails without its corresponding change. `tests/run_agent`: 2131 passed, 2 failed — both `test_provider_parity` failures reproduce on an unmodified checkout of this commit's parent. `ruff` clean.

## Related

Refs #35151, #62948. Those report the symptom: arguments replaced with `{}`. The mitigation on main — treating a `{}` result as truncated rather than forwarding it — stopped the silent execution but left the repair itself wrong, so recoverable payloads still fail. This fixes the repair underneath that mitigation; the two compose. Note `agent/conversation_loop.py:1107` assigns the repair result directly with no `{}` check, unlike the `chat_completion_helpers.py` site; that path is history normalisation rather than execution, so it is not addressed here.

Non-finite numbers (`1e999`, `NaN`, `Infinity`) still reach tools through pass 3's plain `json.loads` and `tool_executor._parse_tool_arguments`, and lone surrogate escapes still pass through a module that carries `_sanitize_surrogates` for that hazard. Both predate this change and need a policy applied at every parse boundary rather than inside the repair passes; happy to follow up with those separately.
