### PR TITLE
fix(tui-gateway): wrap stderr prints in try/except to prevent BrokenPipeError crash loop

### DIFF
--- a/tests/tui_gateway/test_broken_pipe_resilience.py
+++ b/tests/tui_gateway/test_broken_pipe_resilience.py
@@ -1,0 +1,66 @@
+"""Tests for the TUI gateway's broken-pipe resilience (#68614).
+
+When the TUI parent closes its stdout/stderr pipe (session recovery, UI
+recycling), the gateway child's diagnostic prints to stderr raise
+``BrokenPipeError``. In the signal handler and exit logger those prints sit
+outside any guard, so the exception propagates and kills the child — which
+the TUI parent immediately respawns, producing a visible crash loop.
+
+These tests assert the invariant: ``_log_signal`` and ``_log_exit`` must not
+raise when stderr is a broken pipe. They exercise the real functions with a
+real closed-pipe stderr, not a mock.
+
+Note: the pipe setup runs inside the test body, not a fixture — pytest's
+default capture re-installs ``sys.stderr`` after fixture setup, which would
+silently undo the patch before the test body runs.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import sys
+import threading
+
+import pytest
+
+
+def _broken_stderr(monkeypatch):
+    """Point sys.stderr at a pipe whose read end is closed (EPIPE on write)."""
+    r, w = os.pipe()
+    os.close(r)  # read end gone → writes raise BrokenPipeError
+    monkeypatch.setattr(sys, "stderr", os.fdopen(w, "w"))
+
+
+def test_log_exit_survives_broken_stderr(monkeypatch):
+    """_log_exit must not raise when stderr is a broken pipe."""
+    from tui_gateway import entry
+
+    _broken_stderr(monkeypatch)
+    entry._log_exit("test-reason")  # must not raise
+
+
+def test_log_signal_survives_broken_stderr(monkeypatch):
+    """_log_signal must not raise when stderr is a broken pipe."""
+    from tui_gateway import entry
+
+    _broken_stderr(monkeypatch)
+    # Keep the handler from actually exiting or arming the grace timer.
+    monkeypatch.setattr(entry, "_shutdown_grace_seconds", lambda: 0.0)
+    real_timer = threading.Timer
+    monkeypatch.setattr(threading, "Timer", lambda *a, **k: real_timer(0.0, lambda: None))
+    monkeypatch.setattr(entry.sys, "exit", lambda code: None)
+
+    entry._log_signal(signal.SIGTERM, None)  # must not raise
+
+
+def test_record_crash_survives_broken_stderr(monkeypatch):
+    """The panic hook must not raise when stderr is a broken pipe.
+
+    This is the worst place for a broken pipe to kill the child: the crash
+    reporter itself would die before the user sees anything.
+    """
+    from tui_gateway import server
+
+    _broken_stderr(monkeypatch)
+    server._record_crash("test", ValueError, ValueError("boom"), None)  # must not raise

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -115,7 +115,10 @@ def _log_signal(signum: int, frame) -> None:
                 f.write("".join(traceback.format_stack(sys._current_frames().get(tid))))
     except Exception:
         pass
-    print(f"[gateway-signal] {name}", file=sys.stderr, flush=True)
+    try:
+        print(f"[gateway-signal] {name}", file=sys.stderr, flush=True)
+    except OSError:
+        pass  # stderr pipe already closed — nothing to do
 
     import threading as _threading
 
@@ -203,7 +206,10 @@ def _log_exit(reason: str) -> None:
             )
     except Exception:
         pass
-    print(f"[gateway-exit] {reason}", file=sys.stderr, flush=True)
+    try:
+        print(f"[gateway-exit] {reason}", file=sys.stderr, flush=True)
+    except OSError:
+        pass
 
 
 def wait_for_mcp_discovery(timeout: "float | None" = None) -> None:

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -20,7 +20,7 @@ from tui_gateway._stdin_recovery import handle_spurious_eof
 
 from tui_gateway import server
 from tui_gateway.event_replay import replay_epoch
-from tui_gateway.server import _CRASH_LOG, dispatch, resolve_skin, write_json
+from tui_gateway.server import _CRASH_LOG, _stderr_write, dispatch, resolve_skin, write_json
 from tui_gateway.transport import TeeTransport
 
 logger = logging.getLogger(__name__)
@@ -98,7 +98,7 @@ def _log_signal(signum: int, frame) -> None:
             f.write("".join(traceback.format_stack(sys._current_frames().get(tid))))
 
     _append_crash_log(f"{name} received · {time.strftime('%Y-%m-%d %H:%M:%S')}", _dump)
-    print(f"[gateway-signal] {name}", file=sys.stderr, flush=True)
+    _stderr_write(f"[gateway-signal] {name}")
     # ``os._exit`` skips atexit but breaks the mid-flush deadlock; the crash log is the trail.
     timer = threading.Timer(_shutdown_grace_seconds(), lambda: os._exit(0))
     timer.daemon = True
@@ -138,7 +138,7 @@ _install_signal("SIGINT", signal.SIG_IGN)
 def _log_exit(reason: str) -> None:
     """Record why the gateway exits (every path is a silent sys.exit(0) otherwise)."""
     _append_crash_log(f"gateway exit · {time.strftime('%Y-%m-%d %H:%M:%S')} · reason={reason}")
-    print(f"[gateway-exit] {reason}", file=sys.stderr, flush=True)
+    _stderr_write(f"[gateway-exit] {reason}")
 
 
 def wait_for_mcp_discovery(timeout: "float | None" = None) -> None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -47,6 +47,18 @@ load_hermes_dotenv(hermes_home=_hermes_home, project_env=Path(__file__).parent.p
 _CRASH_LOG = os.path.join(_hermes_home, "logs", "tui_gateway_crash.log")
 
 
+def _stderr_write(text: str) -> None:
+    """Best-effort stderr write that never raises.
+
+    The TUI parent can close its stderr pipe mid-session (session recovery, UI
+    recycling); a plain ``print(file=sys.stderr)`` then raises BrokenPipeError
+    and kills the child — worst of all inside the panic hook, where the crash
+    reporter itself would die. All diagnostic stderr writes go through here.
+    """
+    with contextlib.suppress(OSError):
+        print(text, file=sys.stderr, flush=True)
+
+
 def _record_crash(kind: str, exc_type, exc_value, exc_tb, *, thread_name: str | None = None) -> None:
     import traceback
     trace = "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
@@ -59,7 +71,7 @@ def _record_crash(kind: str, exc_type, exc_value, exc_tb, *, thread_name: str | 
     # The first line is what the user sees (gateway.stderr Activity line); the rest stays in the log.
     first = str(exc_value).strip().splitlines()[0] if str(exc_value).strip() else exc_type.__name__
     who = f"thread {thread_name} raised " if thread_name is not None else ""
-    print(f"[gateway-crash] {who}{exc_type.__name__}: {first}", file=sys.stderr, flush=True)
+    _stderr_write(f"[gateway-crash] {who}{exc_type.__name__}: {first}")
 
 
 def _panic_hook(exc_type, exc_value, exc_tb):
@@ -1764,7 +1776,7 @@ def _gui_surface_toolsets(platform: str) -> set[str]:
 
 
 def _tui_notice(text: str) -> None:
-    print(text, file=sys.stderr, flush=True)
+    _stderr_write(text)
 
 
 def _resolve_explicit_toolsets(explicit: list[str], validate_toolset) -> list[str] | None | bool:


### PR DESCRIPTION
## Problem

The TUI gateway child enters a crash loop when the TUI parent closes its stdout/stderr pipe (e.g. during session recovery or UI recycling). The child's diagnostic prints to stderr then raise `BrokenPipeError` (a subclass of `OSError`). Those prints sit outside any guard, so the exception propagates as an unhandled exception and kills the child. The TUI parent respawns it immediately, creating a visible crash loop ("gateway exited — recovering your session").

Current `main` ignores `SIGPIPE` (`SIG_IGN`) so `write_json` sees `BrokenPipeError` and exits via `_log_exit`; `_log_signal` handles `SIGTERM`/`SIGHUP`/`SIGBREAK`. Both helpers print to stderr unguarded, and the panic hook in `server.py` (`_record_crash`) does too — the worst place for a broken pipe to kill the child, since the crash reporter itself would die.

## Fix

Add `_stderr_write()` in `tui_gateway/server.py` — a best-effort stderr write that suppresses `OSError` — and route every diagnostic stderr write through it:

- `_log_signal`, `_log_exit` (`tui_gateway/entry.py`)
- `_record_crash`, `_tui_notice` (`tui_gateway/server.py`)

The crash log file writing was already protected; this extends the same defensive pattern to the stderr prints.

## Tests

New `tests/tui_gateway/test_broken_pipe_resilience.py` asserts the invariant: `_log_signal`, `_log_exit` and `_record_crash` must not raise when stderr is a broken pipe. Proven red on unfixed code, green with the fix.

## Evidence

The crash log (`tui_gateway_crash.log`) showed repeated `unhandled exception` entries with `BrokenPipeError` at the stderr print, and the child respawned multiple times in a short window.
