### PR TITLE
fix(gateway): respect reset boundaries during recovery (#68539)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2301,36 +2301,53 @@ class SessionDB:
         chat_type: Optional[str] = None,
         thread_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
-        """Find the latest recoverable gateway session for a routing peer.
+        """Find the latest gateway session for a routing peer if recoverable.
 
         ``sessions.json`` is the fast routing index, but it can be missing or
-        pruned after process-level restart bugs.  New gateway sessions persist
+        pruned after process-level restart bugs. New gateway sessions persist
         the deterministic ``session_key`` on the durable session row so the
-        mapping can be rebuilt exactly.  Rows ended only by older gateway
-        cleanup's ``agent_close`` bug or a mistaken TUI ``ws_orphan_reap``
-        (dashboard viewer disconnect before #60609) are treated as recoverable;
-        explicit conversation boundaries such as /new, /resume switches, and
-        compression splits are not.
+        mapping can be rebuilt exactly. The newest matching row is selected
+        *before* checking whether it is recoverable: an intentional boundary
+        such as ``session_reset`` must block fallback to an older live row for
+        the same peer (#68539). Rows ended only by older gateway cleanup's
+        ``agent_close`` bug or a mistaken TUI ``ws_orphan_reap`` (dashboard
+        viewer disconnect before #60609) remain recoverable, as do live rows.
         """
         if not session_key:
             return None
         with self._lock:
+
+            def _recoverable(row):
+                if row is None:
+                    return None
+                if row["ended_at"] is not None and row["end_reason"] not in (
+                    "agent_close",
+                    "ws_orphan_reap",
+                ):
+                    return None
+                if not (row["message_count"] or 0):
+                    has_message = self._conn.execute(
+                        "SELECT 1 FROM messages WHERE session_id = ? LIMIT 1",
+                        (row["id"],),
+                    ).fetchone()
+                    if has_message is None:
+                        return None
+                return dict(row)
+
             row = self._conn.execute(
                 """
                 SELECT * FROM sessions
                 WHERE session_key = ?
                   AND source = ?
-                  AND (ended_at IS NULL OR end_reason IN ('agent_close', 'ws_orphan_reap'))
-                  AND (COALESCE(message_count, 0) > 0 OR EXISTS (
-                      SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
-                  ))
-                ORDER BY started_at DESC
+                ORDER BY started_at DESC, rowid DESC
                 LIMIT 1
                 """,
                 (session_key, source),
             ).fetchone()
+            # An exact-key row is authoritative even when it is not recoverable:
+            # do not let the legacy peer-tuple fallback search behind a reset.
             if row is not None:
-                return dict(row)
+                return _recoverable(row)
 
             # Conservative fallback for rows created by current code but with a
             # temporarily-missing exact key: still require the complete peer
@@ -2345,16 +2362,12 @@ class SessionDB:
                   AND COALESCE(chat_id, '') = COALESCE(?, '')
                   AND COALESCE(chat_type, '') = COALESCE(?, '')
                   AND COALESCE(thread_id, '') = COALESCE(?, '')
-                  AND (ended_at IS NULL OR end_reason IN ('agent_close', 'ws_orphan_reap'))
-                  AND (COALESCE(message_count, 0) > 0 OR EXISTS (
-                      SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
-                  ))
-                ORDER BY started_at DESC
+                ORDER BY started_at DESC, rowid DESC
                 LIMIT 1
                 """,
                 (source, user_id, chat_id, chat_type, thread_id),
             ).fetchone()
-        return dict(row) if row else None
+            return _recoverable(row)
 
     def end_session(self, session_id: str, end_reason: str) -> None:
         """Mark a session as ended.

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 
 from gateway.config import GatewayConfig, Platform, SessionResetPolicy
 from gateway.session import SessionEntry, SessionSource, SessionStore
+from hermes_state import SessionDB
 
 
 # ---------------------------------------------------------------------------
@@ -136,6 +137,44 @@ class TestPruneStaleSessionsLocked:
         assert store._entries[key].session_id == "sid_child"
         db.find_latest_gateway_session_for_peer.assert_called_once()
         db.reopen_session.assert_called_once_with("sid_child")
+
+    def test_reset_boundary_does_not_recover_older_session_for_peer(self, tmp_path):
+        """Startup pruning must not search past an intentional reset boundary.
+
+        The durable recovery query deliberately excludes ``session_reset`` rows.
+        If startup pruning invokes it for a routing entry that points at such a
+        row, the query can return an older live session for the same peer and
+        silently restore the context that the user reset. Exercise the real
+        SessionDB query here rather than mocking its result.
+        """
+        key = "agent:main:telegram:dm:5140768830"
+        db = SessionDB(tmp_path / "state.db")
+        peer = {
+            "user_id": "5140768830",
+            "session_key": key,
+            "chat_id": "5140768830",
+            "chat_type": "dm",
+        }
+        db.create_session("sid_before_reset", "telegram", **peer)
+        db.append_message("sid_before_reset", "user", "private old context")
+        db.create_session("sid_reset", "telegram", **peer)
+        db.append_message("sid_reset", "user", "/new")
+        db.end_session("sid_reset", "session_reset")
+
+        store = _make_store_with_db(tmp_path / "sessions", db)
+        stale_entry = _make_entry_with_origin(key, "sid_reset")
+        store._entries[key] = stale_entry
+
+        # Model restart startup followed by the peer's first incoming message.
+        store._prune_stale_sessions_locked()
+        assert stale_entry.origin is not None
+        current = store.get_or_create_session(stale_entry.origin)
+
+        assert current.session_id not in {"sid_before_reset", "sid_reset"}
+        assert store._entries[key].session_id == current.session_id
+        reset_row = db.get_session("sid_reset")
+        assert reset_row is not None
+        assert reset_row["end_reason"] == "session_reset"
 
     def test_prunes_stale_entry_when_recovery_only_finds_same_ended_session(self, tmp_path):
         key = "agent:main:telegram:dm:5140768830"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5822,6 +5822,55 @@ def test_gateway_session_peer_round_trip_and_recovery(db):
     assert recovered["id"] == "gw-session"
 
 
+@pytest.mark.parametrize(
+    "persisted_session_key",
+    ["agent:main:telegram:dm:chat-1", None],
+    ids=["exact-key", "peer-fallback"],
+)
+def test_gateway_session_recovery_does_not_cross_newer_reset_boundary(
+    db, persisted_session_key
+):
+    peer = {
+        "user_id": "user-1",
+        "session_key": persisted_session_key,
+        "chat_id": "chat-1",
+        "chat_type": "dm",
+    }
+    db.create_session("gw-before-reset", "telegram", **peer)
+    db.append_message("gw-before-reset", "user", "old context")
+    db.create_session("gw-reset", "telegram", **peer)
+    db.append_message("gw-reset", "user", "/new")
+    db.end_session("gw-reset", "session_reset")
+
+    assert db.find_latest_gateway_session_for_peer(
+        source="telegram",
+        user_id="user-1",
+        session_key="agent:main:telegram:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+    ) is None
+
+
+def test_gateway_session_recovery_does_not_skip_newer_empty_session(db):
+    peer = {
+        "user_id": "user-1",
+        "session_key": "agent:main:telegram:dm:chat-1",
+        "chat_id": "chat-1",
+        "chat_type": "dm",
+    }
+    db.create_session("gw-with-history", "telegram", **peer)
+    db.append_message("gw-with-history", "user", "old context")
+    db.create_session("gw-empty", "telegram", **peer)
+
+    assert db.find_latest_gateway_session_for_peer(
+        source="telegram",
+        user_id="user-1",
+        session_key="agent:main:telegram:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+    ) is None
+
+
 def test_gateway_session_recovery_reopens_ws_orphan_reap_rows(db):
     """Rows wrongly ended by the TUI ws-orphan reaper must be recoverable (#63207)."""
     db.create_session(


### PR DESCRIPTION
## Bug Description

After an intentional gateway `session_reset`, startup recovery could discard the reset row in SQL and repoint the peer to an older live session. The next message then resumed stale context that the reset was meant to discard.

Fixes #68539

## Root Cause

`find_latest_gateway_session_for_peer()` filtered for recoverable rows before ordering. A newer reset-ended row therefore disappeared from consideration, allowing an ancient never-ended row for the same peer to become the apparent latest session.

## Fix

- Select the newest matching durable row before evaluating recovery eligibility.
- Treat an exact `session_key` row as authoritative, even when it is not recoverable, so peer-tuple fallback cannot search behind a reset boundary.
- Apply the same newest-row-first rule to legacy peer-tuple fallback.
- Preserve recovery for live, `agent_close`, and `ws_orphan_reap` rows with message history.

## How to Verify

1. Seed an older live gateway session and a newer `session_reset` row for the same peer.
2. Run startup stale-route pruning and then route the peer's first inbound message.
3. Confirm a fresh session is created instead of recovering either old session.

## Test Plan

- [x] Added a production-path regression test using a real `SessionDB`
- [x] Added exact-key, legacy-fallback, and empty-history boundary tests
- [x] Verified the four regressions fail without the production change
- [x] Ran nearby state and gateway session suites: **462 passed**
- [x] `ruff check` and `git diff --check` pass

## Risk Assessment

Medium — this changes durable gateway recovery ordering, but only at the existing recovery boundary. Focused coverage verifies intentional reset and empty-history boundaries while retaining legitimate live and cleanup-ended recovery paths.
