### PR TITLE
fix: guard BaseEnvironment.__del__ against shutdown crash and gate KANBAN_GUIDANCE on HERMES_KANBAN_TASK

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1417,9 +1417,17 @@ def init_agent(
     # Resolving the ~835-token block once here avoids re-running the
     # membership test + reference on every system-prompt rebuild
     # (init + each context compression).
+    #
+    # Gate on HERMES_KANBAN_TASK specifically, not just kanban_show tool
+    # presence: profiles with "kanban" in their toolsets config enable the
+    # kanban tool surface for orchestrator mode, but non-dispatched cron
+    # agents should not receive the kanban lifecycle protocol (#68592).
+    import os
     from agent.prompt_builder import KANBAN_GUIDANCE
     agent._kanban_worker_guidance = (
-        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
+        KANBAN_GUIDANCE
+        if os.environ.get("HERMES_KANBAN_TASK") and "kanban_show" in agent.valid_tool_names
+        else ""
     )
 
     # Check tool requirements

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1175,6 +1175,21 @@ class BaseEnvironment(ABC):
         self.cleanup()
 
     def __del__(self):
+        # During interpreter shutdown, builtins and the import machinery may
+        # already be partially torn down.  Remote backends (SSH, Modal,
+        # Daytona) call sync_back from cleanup(), which uses open() and
+        # fcntl — both unreliable after atexit handlers have fired.
+        # Skip cleanup entirely when the interpreter is shutting down.
+        #
+        # sys is imported lazily here because importing it at module level
+        # would add an unconditional import for every environment backend,
+        # and this guard is only needed during the rare __del__ path.
+        try:
+            import sys as _sys
+            if _sys.meta_path is None:
+                return  # interpreter is shutting down
+        except Exception:
+            return  # can't determine state — safest to skip
         try:
             self.cleanup()
         except Exception:


### PR DESCRIPTION
Two independent bug fixes in this PR:

## Fix 1: BaseEnvironment.__del__ crashes during interpreter shutdown (#68531)

**The problem:** When a remote backend (SSH, Modal, Daytona) environment object is garbage-collected during interpreter shutdown, `cleanup()` calls `sync_back` which uses `open()` and `fcntl` — both unreliable after `atexit` handlers have fired. The result is a multi-second stall with repeated `name 'open' is not defined` errors.

**The fix:** Check `sys.meta_path` before running `cleanup()` in `__del__`. When the interpreter is shutting down, `sys.meta_path` is set to `None`, which is a reliable indicator that builtins and the import machinery are already partially torn down. In that case, skip cleanup entirely.

`sys` is imported lazily inside `__del__` to avoid adding an unconditional import for every environment backend when this guard is only needed during the rare `__del__` path.

## Fix 2: Cron agents without HERMES_KANBAN_TASK get mandatory kanban_show protocol (#68592)

**The problem:** `_check_kanban_mode()` in `kanban_tools.py` returns `True` when either `HERMES_KANBAN_TASK` is set OR the profile has `kanban` in its toolsets config. The `KANBAN_GUIDANCE` injection in `agent_init.py` only checked whether `kanban_show` was in `valid_tool_names` — which is true for both cases. This meant cron agents on profiles with the kanban toolset enabled received the kanban lifecycle protocol even though they weren't dispatched as kanban workers, causing `kanban_show()` to fail with `task_id is required` every run.

**The fix:** Gate the `KANBAN_GUIDANCE` injection on `HERMES_KANBAN_TASK` specifically, not just `kanban_show` tool presence. Profiles with `kanban` in their toolsets still get the kanban tool surface for orchestrator mode, but only dispatcher-spawned workers (with `HERMES_KANBAN_TASK` set) receive the lifecycle protocol guidance.

Fixes #68531, fixes #68592