### PR TITLE
fix(auxiliary): route MiniMax OAuth via runtime credentials

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4904,6 +4904,58 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
+    # ── MiniMax OAuth (PKCE bearer → Anthropic Messages API) ─────────
+    # Reuse the main runtime resolver instead of the registry default: the
+    # persisted OAuth state may select a region-specific inference endpoint.
+    # Keep the credential callable so long-lived auxiliary/MoA clients observe
+    # token refreshes persisted by this process or a sibling process.
+    if provider == "minimax-oauth":
+        try:
+            from hermes_cli.auth import AuthError, resolve_minimax_oauth_runtime_credentials
+
+            creds = resolve_minimax_oauth_runtime_credentials(as_token_provider=True)
+        except (AuthError, ImportError) as exc:
+            logger.debug("Auxiliary minimax-oauth: %s", exc)
+            return None, None
+
+        token_provider = creds.get("api_key")
+        base_url = str(creds.get("base_url") or "").strip().rstrip("/")
+        if not callable(token_provider) or not base_url:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth credentials are incomplete"
+            )
+            return None, None
+
+        final_model = _normalize_resolved_model(
+            model or _get_aux_model_for_provider(provider) or "MiniMax-M2.7",
+            provider,
+        )
+        try:
+            from agent.anthropic_adapter import build_anthropic_client
+
+            real_client = build_anthropic_client(token_provider, base_url)
+        except ImportError:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth requires the anthropic SDK"
+            )
+            return None, None
+
+        sync_client = AnthropicAuxiliaryClient(
+            real_client,
+            final_model,
+            token_provider,
+            base_url,
+            # MiniMax uses OAuth for bearer authentication, but it is a
+            # third-party Anthropic-compatible endpoint.  ``is_oauth=True``
+            # means *native Anthropic/Claude Code wire compatibility* here;
+            # enabling it would inject Claude Code identity and rewrite tool
+            # names.  The callable token provider already handles auth.
+            is_oauth=False,
+        )
+        if async_mode:
+            return AsyncAnthropicAuxiliaryClient(sync_client), final_model
+        return sync_client, final_model
+
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
         custom_base = ""

--- a/docs/diagnosis/aux-title-minimax-401.md
+++ b/docs/diagnosis/aux-title-minimax-401.md
@@ -1,0 +1,51 @@
+# MiniMax OAuth auxiliary routing
+
+## Symptom
+
+When `minimax-oauth` is selected for an auxiliary task or a MoA reference,
+`resolve_provider_client()` returns `(None, None)` and the request may fall
+through to another provider or surface a misleading missing-API-key error.
+The main MiniMax OAuth conversation path remains functional.
+
+## Root cause
+
+`hermes_cli.auth.PROVIDER_REGISTRY` registers `minimax-oauth` with
+`auth_type="oauth_minimax"`, while the generic OAuth dispatch in
+`agent/auxiliary_client.py` handles only `oauth_device_code` and
+`oauth_external`. The auxiliary resolver therefore never reaches the working
+MiniMax OAuth runtime credential path.
+
+## Fix
+
+Add a first-class `minimax-oauth` branch beside the other named OAuth
+providers. It calls
+`resolve_minimax_oauth_runtime_credentials(as_token_provider=True)` and uses:
+
+- the callable token provider, so every request can observe persisted refreshes;
+- the runtime-resolved base URL, including a persisted region-specific endpoint;
+- `build_anthropic_client()` and `AnthropicAuxiliaryClient`, matching MiniMax's
+  Anthropic Messages transport;
+- `is_oauth=False`, because that wrapper flag means native Anthropic/Claude
+  Code wire transforms, not generic bearer authentication. The callable token
+  provider supplies the MiniMax OAuth bearer independently.
+
+The branch intentionally runs before the generic `ProviderConfig` dispatch.
+No environment API key or synthetic `MINIMAX-OAUTH_API_KEY` is introduced.
+
+## Regression coverage
+
+`TestResolveMiniMaxOAuthForAux` verifies that:
+
+1. a callable token provider and a persisted regional URL reach the Anthropic
+   client unchanged;
+2. the returned wrapper preserves the requested model without enabling Claude
+   Code identity/tool-name transforms;
+3. the actual request-builder call receives `is_oauth=False`;
+4. a missing login returns `(None, None)` rather than falling through to a
+   fabricated API-key path.
+
+Run:
+
+```bash
+scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/test_minimax_oauth.py tests/run_agent/test_moa_loop_mode.py -q
+```

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -604,6 +604,109 @@ class TestResolveXaiOAuthForAux:
         )
 
 
+class TestResolveMiniMaxOAuthForAux:
+    """MiniMax OAuth must use its refreshable PKCE state in auxiliary paths."""
+
+    def test_builds_refreshable_anthropic_client(self):
+        from agent.auxiliary_client import AnthropicAuxiliaryClient, resolve_provider_client
+
+        token_provider = MagicMock(name="minimax_token_provider")
+        real_client = MagicMock(name="anthropic_client")
+        with (
+            patch(
+                "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+                return_value={
+                    "provider": "minimax-oauth",
+                    "api_key": token_provider,
+                    "base_url": "https://api.minimaxi.com/anthropic/",
+                    "source": "oauth",
+                },
+            ) as mock_resolve,
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                return_value=real_client,
+            ) as mock_build,
+        ):
+            client, model = resolve_provider_client(
+                "minimax-oauth", "MiniMax-M2.7"
+            )
+
+        mock_resolve.assert_called_once_with(as_token_provider=True)
+        mock_build.assert_called_once_with(
+            token_provider, "https://api.minimaxi.com/anthropic"
+        )
+        assert isinstance(client, AnthropicAuxiliaryClient)
+        assert client._real_client is real_client
+        assert client.api_key is token_provider
+        assert client.base_url == "https://api.minimaxi.com/anthropic"
+        assert client.chat.completions._is_oauth is False
+        assert model == "MiniMax-M2.7"
+
+    def test_request_shape_does_not_enable_claude_code_oauth(self):
+        """MiniMax bearer auth must not activate native Anthropic transforms."""
+        token_provider = MagicMock(name="minimax_token_provider")
+        real_client = MagicMock(name="anthropic_client")
+        normalized = SimpleNamespace(
+            content="ok",
+            tool_calls=[],
+            reasoning=None,
+            finish_reason="stop",
+        )
+        with (
+            patch(
+                "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+                return_value={
+                    "provider": "minimax-oauth",
+                    "api_key": token_provider,
+                    "base_url": "https://api.minimaxi.com/anthropic/",
+                    "source": "oauth",
+                },
+            ),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                return_value=real_client,
+            ),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_kwargs",
+                return_value={"model": "MiniMax-M2.7", "messages": [], "max_tokens": 16},
+            ) as mock_kwargs,
+            patch(
+                "agent.anthropic_adapter.create_anthropic_message",
+                return_value=SimpleNamespace(usage=None),
+            ),
+            patch("agent.transports.get_transport") as mock_transport,
+        ):
+            mock_transport.return_value.normalize_response.return_value = normalized
+            client, _ = resolve_provider_client("minimax-oauth", "MiniMax-M2.7")
+            client.chat.completions.create(
+                model="MiniMax-M2.7",
+                messages=[{"role": "user", "content": "hello"}],
+                max_tokens=16,
+            )
+
+        assert mock_kwargs.call_args.kwargs["is_oauth"] is False
+
+    def test_missing_login_does_not_fall_through_to_fake_api_key(self):
+        from agent.auxiliary_client import resolve_provider_client
+        from hermes_cli.auth import AuthError
+
+        with patch(
+            "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+            side_effect=AuthError(
+                "not logged in",
+                provider="minimax-oauth",
+                code="not_logged_in",
+                relogin_required=True,
+            ),
+        ):
+            client, model = resolve_provider_client(
+                "minimax-oauth", "MiniMax-M2.7"
+            )
+
+        assert client is None
+        assert model is None
+
+
 class TestAnthropicOAuthFlag:
     """Test that OAuth tokens get is_oauth=True in auxiliary Anthropic client."""
 


### PR DESCRIPTION
## Summary

Salvages the confirmed MiniMax OAuth auxiliary-routing fix from #40122 on current `main`, while preserving the original contributor as the commit author.

The original PR's premise still holds, but its registry-default endpoint approach was stale. This version implements the maintainer-requested current-head integration:

- resolves credentials through `resolve_minimax_oauth_runtime_credentials(as_token_provider=True)`;
- preserves the callable per-request refresh path;
- uses the persisted runtime base URL, including region-specific MiniMax endpoints;
- builds the documented Anthropic Messages transport with `is_oauth=False`;
  this flag controls native Claude Code identity/tool-name transforms, not
  generic bearer authentication, which remains handled by the callable token;
- returns cleanly when OAuth login state is absent instead of falling through to a fabricated API-key route.

## Regression coverage

`TestResolveMiniMaxOAuthForAux` verifies:

1. callable token-provider propagation;
2. persisted regional base-URL propagation;
3. third-party request shape with Claude Code OAuth transforms disabled;
4. requested-model preservation and missing-login behavior.

## Verification

```text
scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/test_minimax_oauth.py tests/run_agent/test_moa_loop_mode.py tests/run_agent/test_anthropic_third_party_oauth_guard.py -q
4 files, 393 tests passed, 0 failed (100% complete)
```

A live MiniMax OAuth MoA-reference canary from this branch resolved
`AnthropicAuxiliaryClient` with `MiniMax-M3` and returned a non-empty response
with `failed=false`. No response text or credentials are included here.

Full MoA canary through the `default` preset returned the expected arithmetic
result and persisted a trace with non-empty outputs for all four references.
Mission Control correlated the corrected M3 request-shape canary as
`prompt_id=a31d38264630`, global `status=ok`,
`minimax-oauth / MiniMax-M3 / status=ok`, and aggregator `status=ok`.
`/api/healthz` remained `status=ok`; a public-payload scan found none of
`access_token`, `refresh_token`, `api_key`, `authorization`, or bearer headers.

## Provenance

- Original contributor/commit: @ubxty, #40122
- Current-head integration follows the maintainer review on #40122 requesting the runtime credential resolver and persisted regional URL.

Fixes #21521
Fixes #36091
