### PR TITLE
fix(desktop): create a project from a folder in one step

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/project-dialog.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.test.tsx
@@ -1,8 +1,14 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type * as Nanostores from 'nanostores'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ProjectDialog } from './project-dialog'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  createProject.mockResolvedValue({ id: 'p_created' })
+  pickProjectFolder.mockResolvedValue('/Users/test/my-folder')
+})
 
 afterEach(cleanup)
 
@@ -35,16 +41,20 @@ vi.mock('@/i18n', () => ({
 
 // $projectDialog is a real nanostore atom in the app; recreate it here so
 // useStore behaves identically without pulling in the rest of the projects
-// store (backend calls, project list, etc.) which is irrelevant to the Tip fix.
+// store (backend calls, project list, etc.) which is irrelevant to the dialog
+// interactions under test.
 // vi.mock factories are hoisted above the rest of the file, so the atom must
 // be created inside vi.hoisted to exist by the time the factory runs.
-const { $projectDialog } = vi.hoisted(() => {
+const { $projectDialog, createProject, enterProject, pickProjectFolder } = vi.hoisted(() => {
   const { atom } = require('nanostores') as typeof Nanostores
 
   return {
     $projectDialog: atom<{ mode: 'create' | 'rename' | 'add-folder'; name?: string; projectId?: string } | null>({
       mode: 'create'
-    })
+    }),
+    createProject: vi.fn(),
+    enterProject: vi.fn(),
+    pickProjectFolder: vi.fn()
   }
 })
 
@@ -52,9 +62,10 @@ vi.mock('@/store/projects', () => ({
   $projectDialog,
   addProjectFolder: vi.fn(),
   closeProjectDialog: vi.fn(),
-  createProject: vi.fn(),
+  createProject,
+  enterProject,
   generateProjectIdea: vi.fn(),
-  pickProjectFolder: vi.fn(async () => '/Users/test/my-folder'),
+  pickProjectFolder,
   renameProject: vi.fn()
 }))
 
@@ -69,6 +80,39 @@ vi.mock('@/lib/project-idea-templates', () => ({
 const tipTrigger = (el: HTMLElement) => el.closest('[data-slot="tooltip-trigger"]')
 
 describe('ProjectDialog', () => {
+  it('creates from the folder basename and enters the created project when the name is empty', async () => {
+    render(<ProjectDialog />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add folder' }))
+
+    await screen.findByDisplayValue('my-folder')
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => {
+      expect(createProject).toHaveBeenCalledWith({
+        folders: ['/Users/test/my-folder'],
+        idea: undefined,
+        name: 'my-folder',
+        use: true
+      })
+      expect(enterProject).toHaveBeenCalledWith('p_created')
+    })
+  })
+
+  it('keeps an explicit project name when a folder is selected', async () => {
+    render(<ProjectDialog />)
+
+    fireEvent.change(screen.getByPlaceholderText('Project name'), { target: { value: 'My project' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add folder' }))
+
+    await screen.findByRole('button', { name: 'Remove folder' })
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => {
+      expect(createProject).toHaveBeenCalledWith(expect.objectContaining({ name: 'My project' }))
+    })
+  })
+
   it('wraps the "shuffle idea" button in a Tip', () => {
     render(<ProjectDialog />)
 

--- a/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
@@ -24,10 +24,13 @@ import {
   addProjectFolder,
   closeProjectDialog,
   createProject,
+  enterProject,
   generateProjectIdea,
   pickProjectFolder,
   renameProject
 } from '@/store/projects'
+
+import { baseName } from './projects/workspace-groups'
 
 // Single dialog mounted once in the sidebar; it renders create / rename /
 // add-folder flows driven by the $projectDialog atom. Folders are chosen via
@@ -46,6 +49,8 @@ export function ProjectDialog() {
   const [generatingIdea, setGeneratingIdea] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const nameRef = useRef<HTMLInputElement>(null)
+
+  const resolvedName = name.trim() || (folders[0] ? (baseName(folders[0]) ?? '') : '')
 
   useEffect(() => {
     if (open) {
@@ -104,6 +109,14 @@ export function ProjectDialog() {
       }
 
       setFolders(prev => (prev.includes(dir) ? prev : [...prev, dir]))
+
+      if (mode === 'create') {
+        const base = baseName(dir)
+
+        if (base) {
+          setName(prev => (prev.trim() ? prev : base))
+        }
+      }
     } catch (err) {
       notifyError(err, p.createFailed)
     }
@@ -123,8 +136,14 @@ export function ProjectDialog() {
 
     // A project owns sessions by folder (cwd-prefix), so creation requires at
     // least one — a folder-less project couldn't hold a session anyway.
-    if (mode === 'create' && trimmed && folders.length) {
-      await runSubmit(() => createProject({ folders, idea: idea.trim() || undefined, name: trimmed, use: true }))
+    if (mode === 'create' && folders.length && resolvedName) {
+      await runSubmit(async () => {
+        const created = await createProject({ folders, idea: idea.trim() || undefined, name: resolvedName, use: true })
+
+        if (created) {
+          enterProject(created.id)
+        }
+      })
     }
   }
 
@@ -291,7 +310,7 @@ export function ProjectDialog() {
               {t.common.cancel}
             </Button>
             <Button
-              disabled={submitting || !name.trim() || (mode === 'create' && folders.length === 0)}
+              disabled={submitting || !resolvedName || (mode === 'create' && folders.length === 0)}
               onClick={() => void submit()}
               type="button"
             >


### PR DESCRIPTION
## What does this PR do?

When a folder is picked in the New Project dialog and no name was typed, auto-fill it from the folder's name.

This PR supersedes #63732 and #53057 — it is simpler and aligned with `DESIGN.md`.

## Related Issue

Fixes #53004

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/project-dialog.tsx`
- `apps/desktop/src/app/chat/sidebar/project-dialog.test.tsx`

## How to Test

1. `+` to create new Project
2. add folder
3. `Create` button is clickable without specifying the name of the project
4. Project is created named after the folder and activated
5. `cmd+N` will create a session inside that project

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2

> This is a desktop-only change, so I did not run the Python pytest suite. I ran the focused ProjectDialog Vitest suite, ESLint, desktop typecheck, and a packaged macOS build.

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
