### PR TITLE
fix(gateway): bound the post-kill cleanup in the Windows git probe

### DIFF
--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -35,37 +35,153 @@ def _spawns(captured, *needles):
     ]
 
 
+def _is_branch_probe(cmd) -> bool:
+    """True only for the ``git -C <cwd> branch --show-current`` spawn under
+    test. Patching ``git_probe.subprocess.Popen`` is process-wide (shared
+    ``subprocess`` module), so unrelated daemon spawns must stay benign."""
+    return bool(cmd) and cmd[:2] == ["git", "-C"] and cmd[-2:] == ["branch", "--show-current"]
+
+
 def test_tui_gateway_git_probe_hides_git_windows(monkeypatch):
     from tui_gateway import git_probe
 
-    captured = []
+    spawns = []
 
-    def fake_run(cmd, **kwargs):
-        captured.append((cmd, kwargs))
-        return _Completed(stdout="main\n")
+    class _FakePopen:
+        """Fast-path stand-in: git returns within the budget."""
+
+        def __init__(self, cmd, **kwargs):
+            if _is_branch_probe(cmd):
+                spawns.append((cmd, kwargs))
+            self.returncode = 0
+
+        def communicate(self, timeout=None):
+            return ("main\n", "")
+
+        def kill(self):  # pragma: no cover - never reached on the fast path
+            raise AssertionError("kill() must not run when git returns in time")
 
     monkeypatch.setattr(git_probe, "IS_WINDOWS", True)
     monkeypatch.setattr(git_probe, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
-    monkeypatch.setattr(git_probe.subprocess, "run", fake_run)
+    monkeypatch.setattr(git_probe.subprocess, "Popen", _FakePopen)
 
     assert git_probe.run_git("C:/repo", "branch", "--show-current") == "main"
 
-    git_calls = _spawns(captured, "branch", "--show-current")
-    assert git_calls == [
-        (
-            ["git", "-C", "C:/repo", "branch", "--show-current"],
-            {
-                "capture_output": True,
-                "text": True,
-                "encoding": "utf-8",
-                "errors": "replace",
-                "timeout": git_probe._GIT_TIMEOUT,
-                "check": False,
-                "stdin": subprocess.DEVNULL,
-                "creationflags": _CREATE_NO_WINDOW,
-            },
-        )
-    ]
+    git_calls = [(c, k) for c, k in spawns]
+    assert len(git_calls) == 1, git_calls
+    cmd, kwargs = git_calls[0]
+    assert cmd == ["git", "-C", "C:/repo", "branch", "--show-current"]
+    # The full spawn contract must survive the run()->Popen rewrite.
+    assert kwargs["creationflags"] == _CREATE_NO_WINDOW
+    assert kwargs["stdin"] == subprocess.DEVNULL
+    assert kwargs["stdout"] == subprocess.PIPE
+    assert kwargs["stderr"] == subprocess.PIPE
+    assert kwargs["text"] is True
+    assert kwargs["encoding"] == "utf-8"
+    assert kwargs["errors"] == "replace"
+
+
+def test_tui_gateway_git_probe_no_hide_flags_off_windows(monkeypatch):
+    from tui_gateway import git_probe
+
+    spawns = []
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            if _is_branch_probe(cmd):
+                spawns.append((cmd, kwargs))
+            self.returncode = 0
+
+        def communicate(self, timeout=None):
+            return ("main\n", "")
+
+        def kill(self):  # pragma: no cover
+            pass
+
+    monkeypatch.setattr(git_probe, "IS_WINDOWS", False)
+    monkeypatch.setattr(git_probe.subprocess, "Popen", _FakePopen)
+
+    assert git_probe.run_git("/repo", "branch", "--show-current") == "main"
+    assert len(spawns) == 1, spawns
+    assert "creationflags" not in spawns[0][1]
+
+
+def test_tui_gateway_git_probe_nonzero_returncode_returns_empty(monkeypatch):
+    from tui_gateway import git_probe
+
+    class _FailPopen:
+        def __init__(self, cmd, **kwargs):
+            self.returncode = 1 if _is_branch_probe(cmd) else 0
+
+        def communicate(self, timeout=None):
+            return ("garbage-should-not-leak\n", "fatal: not a repo")
+
+        def kill(self):  # pragma: no cover
+            pass
+
+    monkeypatch.setattr(git_probe, "IS_WINDOWS", False)
+    monkeypatch.setattr(git_probe.subprocess, "Popen", _FailPopen)
+
+    assert git_probe.run_git("/repo", "branch", "--show-current") == ""
+
+
+def test_tui_gateway_git_probe_timeout_kills_and_returns_empty(monkeypatch):
+    """A hung git is killed and cleaned up with a *bounded* second
+    communicate(), and the probe returns "" — never subprocess.run()'s
+    unbounded post-kill reader-thread join, which on Windows deadlocks when
+    a suspended descendant git.exe retains the captured handles and blocks
+    Desktop agent initialization behind it (issue #68609)."""
+    from tui_gateway import git_probe
+
+    events = []
+
+    class _HangingPopen:
+        def __init__(self, cmd, **kwargs):
+            self._probe = _is_branch_probe(cmd)
+            self.returncode = None
+
+        def communicate(self, timeout=None):
+            if not self._probe:
+                return ("", "")
+            events.append(f"comm:{timeout}")
+            if timeout == git_probe._GIT_TIMEOUT:
+                raise subprocess.TimeoutExpired(cmd="git", timeout=timeout)
+            return ("", "")  # bounded post-kill drain succeeds
+
+        def kill(self):
+            if self._probe:
+                events.append("kill")
+
+    monkeypatch.setattr(git_probe, "IS_WINDOWS", False)
+    monkeypatch.setattr(git_probe.subprocess, "Popen", _HangingPopen)
+
+    assert git_probe.run_git("/repo", "branch", "--show-current") == ""
+    assert events == [f"comm:{git_probe._GIT_TIMEOUT}", "kill", "comm:1"]
+
+
+def test_tui_gateway_git_probe_timeout_cleanup_failure_is_swallowed(monkeypatch):
+    """If the bounded cleanup itself still times out (descendant keeps the
+    handles), run_git abandons the pipes and honours the empty-string
+    failure contract instead of hanging."""
+    from tui_gateway import git_probe
+
+    class _StuckPopen:
+        def __init__(self, cmd, **kwargs):
+            self._probe = _is_branch_probe(cmd)
+            self.returncode = None
+
+        def communicate(self, timeout=None):
+            if not self._probe:
+                return ("", "")
+            raise subprocess.TimeoutExpired(cmd="git", timeout=timeout or 0)
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(git_probe, "IS_WINDOWS", False)
+    monkeypatch.setattr(git_probe.subprocess, "Popen", _StuckPopen)
+
+    assert git_probe.run_git("/repo", "branch", "--show-current") == ""
 
 
 def test_tui_gateway_fuzzy_file_listing_hides_git_windows(monkeypatch):

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -159,6 +159,66 @@ def test_tui_gateway_git_probe_timeout_kills_and_returns_empty(monkeypatch):
     assert events == [f"comm:{git_probe._GIT_TIMEOUT}", "kill", "comm:1"]
 
 
+def test_tui_gateway_git_probe_kill_failure_still_fails_open(monkeypatch):
+    """kill() raising (access denied, already-reaped) must not escape —
+    run_git's contract is '' on ANY failure."""
+    from tui_gateway import git_probe
+
+    class _UnkillablePopen:
+        def __init__(self, cmd, **kwargs):
+            self._probe = _is_branch_probe(cmd)
+            self.returncode = None
+            self.pid = 4242
+
+        def communicate(self, timeout=None):
+            if not self._probe:
+                return ("", "")
+            if timeout == git_probe._GIT_TIMEOUT:
+                raise subprocess.TimeoutExpired(cmd="git", timeout=timeout)
+            return ("", "")
+
+        def kill(self):
+            if self._probe:
+                raise OSError("access denied")
+
+    monkeypatch.setattr(git_probe, "IS_WINDOWS", False)
+    monkeypatch.setattr(git_probe.subprocess, "Popen", _UnkillablePopen)
+
+    assert git_probe.run_git("/repo", "branch", "--show-current") == ""
+
+
+def test_tui_gateway_git_probe_nontimeout_failure_kills_child(monkeypatch):
+    """A non-timeout communicate() failure must still terminate the child
+    (not leave it running) and fail open."""
+    from tui_gateway import git_probe
+
+    events = []
+
+    class _BrokenPipePopen:
+        def __init__(self, cmd, **kwargs):
+            self._probe = _is_branch_probe(cmd)
+            self.returncode = None
+            self.pid = 4242
+
+        def communicate(self, timeout=None):
+            if not self._probe:
+                return ("", "")
+            if timeout == git_probe._GIT_TIMEOUT:
+                raise ValueError("I/O operation on closed file")
+            events.append("drain")
+            return ("", "")
+
+        def kill(self):
+            if self._probe:
+                events.append("kill")
+
+    monkeypatch.setattr(git_probe, "IS_WINDOWS", False)
+    monkeypatch.setattr(git_probe.subprocess, "Popen", _BrokenPipePopen)
+
+    assert git_probe.run_git("/repo", "branch", "--show-current") == ""
+    assert events == ["kill", "drain"]
+
+
 def test_tui_gateway_git_probe_timeout_cleanup_failure_is_swallowed(monkeypatch):
     """If the bounded cleanup itself still times out (descendant keeps the
     handles), run_git abandons the pipes and honours the empty-string

--- a/tui_gateway/git_probe.py
+++ b/tui_gateway/git_probe.py
@@ -64,7 +64,7 @@ def run_git(cwd: str, *args: str) -> str:
     try:
         stdout, _ = proc.communicate(timeout=_GIT_TIMEOUT)
     except subprocess.TimeoutExpired:
-        proc.kill()
+        _kill_process_tree(proc)
         # Bounded post-kill cleanup instead of subprocess.run()'s unbounded
         # communicate(): on Windows, killing the PATH-resolved git launcher
         # can leave a suspended descendant git.exe holding duplicates of the
@@ -82,8 +82,49 @@ def run_git(cwd: str, *args: str) -> str:
             pass
         return ""
     except Exception:
+        # Non-timeout communicate() failure (decode error, torn-down pipe):
+        # still terminate the child and drain bounded — leaving it running
+        # would leak the same suspended-descendant class this fix targets.
+        _kill_process_tree(proc)
+        try:
+            proc.communicate(timeout=1)
+        except Exception:
+            pass
         return ""
     return stdout.strip() if proc.returncode == 0 else ""
+
+
+def _kill_process_tree(proc) -> None:
+    """Best-effort terminate *proc* and, on Windows, its descendants.
+
+    ``proc.kill()`` alone only terminates the PATH-resolved launcher; a
+    suspended descendant ``git.exe`` can survive holding duplicates of the
+    captured pipe handles, which keeps the pipes from reaching EOF and leaks
+    two reader threads + the process per fired timeout (issue #68609).
+    ``taskkill /T /F`` takes the whole tree down so the bounded drain that
+    follows can actually reach EOF. All failures are swallowed — this is
+    cleanup on an already-failing path, and ``run_git``'s contract is to
+    fail open to ``""``. The taskkill spawn itself cannot re-enter this
+    deadlock class: no pipes are captured (DEVNULL), so there are no reader
+    threads for its own timeout cleanup to join.
+    """
+    try:
+        proc.kill()
+    except OSError:
+        pass
+    if IS_WINDOWS:
+        try:
+            subprocess.run(
+                ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL,
+                timeout=2,
+                check=False,
+                creationflags=windows_hide_flags(),
+            )
+        except Exception:
+            pass
 
 
 def branch(cwd: str) -> str:

--- a/tui_gateway/git_probe.py
+++ b/tui_gateway/git_probe.py
@@ -49,20 +49,41 @@ def run_git(cwd: str, *args: str) -> str:
         return ""
     _popen_kwargs = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {}
     try:
-        result = subprocess.run(
+        proc = subprocess.Popen(
             ["git", "-C", cwd, *args],
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
             text=True,
             encoding="utf-8",
             errors="replace",
-            timeout=_GIT_TIMEOUT,
-            check=False,
-            stdin=subprocess.DEVNULL,
             **_popen_kwargs,
         )
-        return result.stdout.strip() if result.returncode == 0 else ""
     except Exception:
         return ""
+    try:
+        stdout, _ = proc.communicate(timeout=_GIT_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        # Bounded post-kill cleanup instead of subprocess.run()'s unbounded
+        # communicate(): on Windows, killing the PATH-resolved git launcher
+        # can leave a suspended descendant git.exe holding duplicates of the
+        # captured stdout/stderr handles, so the pipes never reach EOF —
+        # run()'s cleanup then joins its reader threads forever. This call
+        # site sits on the Desktop agent-build path (_start_agent_build →
+        # _session_info → branch()), where the unbounded join turned an
+        # optional branch label into "agent initialization timed out"
+        # (issue #68609; same deadlock class as #66037). A bounded second
+        # communicate() abandons the pipes after a grace period; the
+        # orphaned daemonic reader threads cost nothing.
+        try:
+            proc.communicate(timeout=1)
+        except (subprocess.TimeoutExpired, OSError, ValueError):
+            pass
+        return ""
+    except Exception:
+        return ""
+    return stdout.strip() if proc.returncode == 0 else ""
 
 
 def branch(cwd: str) -> str:


### PR DESCRIPTION
Fixes #68609.

## Problem

`run_git()` (tui_gateway/git_probe.py) used `subprocess.run(timeout=1.5)`. On Windows, when the timeout fires, `run()`'s post-kill cleanup calls an **unbounded** `communicate()` that joins the pipe reader threads. Killing the PATH-resolved git launcher can leave a suspended descendant `git.exe` holding duplicates of the captured stdout/stderr handles, so the pipes never reach EOF and the join blocks indefinitely.

This call site sits on the Desktop agent-build path: `_start_agent_build._build → _session_info → branch() → run_git`, and `ready.set()` is only reached after `_session_info()` — so an optional branch label became a hard dependency for session readiness, and `_wait_agent(timeout=30)` surfaced it as `agent initialization timed out` (the reporter's py-spy stacks show both profile backends blocked in exactly this frame).

Same deadlock class as #66037 (`agent/coding_context.py`), whose fix #66038 is still open and covers only that call site.

## Fix

Bounded `Popen` flow mirroring #66038 so the two call sites stay coherent, plus the tree-termination the issue's proposed fix asks for:

- Bounded initial `communicate(timeout=_GIT_TIMEOUT)`.
- On timeout: `_kill_process_tree()` — `proc.kill()` **and, on Windows, best-effort `taskkill /T /F`** so the suspended descendant that holds the pipe writers dies too, letting the drain actually reach EOF instead of leaking a process + two reader threads per fired timeout. The taskkill spawn cannot re-enter this deadlock class: it captures no pipes (DEVNULL), so its own timeout cleanup has no reader threads to join.
- Bounded 1s post-kill drain; if pipes are still held, abandon them (daemonic reader threads).
- Fail open to `""` on **every** path: `kill()` raising (an exception inside an `except` handler bypasses the sibling handler — this was a real gap), and non-timeout `communicate()` failures now also terminate the child instead of leaving it running.

Normal-path contract is preserved byte-for-byte: PIPE/DEVNULL, `text` + UTF-8 `errors="replace"` decoding, nonzero-returncode → `""`, `creationflags` hidden-window flags on Windows only.

## Verification

- 21 tests in `tests/test_windows_subprocess_no_window_flags.py` pin the bounded-flow semantics: spawn-contract parity on/off Windows, nonzero returncode, wait→kill→bounded-drain ordering, kill-failure fail-open, non-timeout-failure kill, cleanup-failure swallowing. RED-first (the ordering/fail-open tests fail against the `subprocess.run` implementation).
- **Real-machine reproduction (Windows 11, outside the test harness):** with a launcher whose descendant inherits the captured pipe handles (modeling the suspended `git.exe`), the pre-fix `subprocess.run()` flow blocks until the descendant exits — measured **20.3s for a 20s sleeper, i.e. unbounded** — while the fixed flow returns `""` bounded (timeout + ≤2s tree-kill + ≤1s drain).
- An in-suite E2E variant of that reproduction was built and deliberately **not** included: under the pytest process tree the inherited-handle hold does not reproduce (the descendant's duplicated writers get released ~1.3s after the kill by some harness layer; persists even with `live_system_guard_bypass`), which made it a false-green regression test. The mock tests pin the semantics instead; the reproduction script is preserved in the commit message trail.

## Deliberate scope decisions

- **Readiness decoupling** (the issue's item 5 — don't make agent readiness depend synchronously on git metadata) is left for a follow-up: it changes `_start_agent_build` semantics and deserves its own review. This PR removes the unbounded hang that made the dependency fatal.
- **Failure caching/backoff for `branch()`** (its two-probe fallback doubles the cost when a repo is in this state) is likewise noted for follow-up; with the tree-kill in place each occurrence is bounded to a few seconds and no longer leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
