### PR TITLE
fix(whatsapp): randomize browser fingerprint instead of hardcoded value

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -87,6 +87,38 @@ const DOCUMENT_CACHE_DIR = process.env.HERMES_DOCUMENT_CACHE_DIR
 const AUDIO_CACHE_DIR = process.env.HERMES_AUDIO_CACHE_DIR
   || path.join(process.env.HOME || '~', '.hermes', 'audio_cache');
 
+// Browser fingerprint pool for makeWASocket().
+//
+// The browser tuple [appName, browserName, version] is sent to WhatsApp as
+// part of the connection handshake. Using a hardcoded value like
+// ['Hermes Agent', 'Chrome', '120.0'] means every Hermes deployment
+// worldwide presents the identical wire fingerprint — trivially clusterable
+// by WhatsApp's anti-spam ML classifier.
+//
+// Instead, pick at random from a pool of realistic browser tuples on each
+// connection. The pool covers the common OS/browser combinations a linked
+// device would actually present, with real version strings.
+const BROWSER_POOL = Object.freeze([
+  ['Mac OS', 'Chrome', '120.0.6099.109'],
+  ['Mac OS', 'Chrome', '121.0.6167.85'],
+  ['Mac OS', 'Safari', '17.2.1'],
+  ['Mac OS', 'Firefox', '122.0'],
+  ['Windows', 'Chrome', '120.0.6099.130'],
+  ['Windows', 'Chrome', '121.0.6167.85'],
+  ['Windows', 'Edge', '120.0.2210.91'],
+  ['Windows', 'Firefox', '122.0'],
+  ['Linux', 'Chrome', '120.0.6099.62'],
+  ['Linux', 'Firefox', '122.0'],
+  ['Linux', 'Chrome', '121.0.6167.85'],
+  ['Mac OS', 'Chrome', '119.0.6045.105'],
+  ['Windows', 'Chrome', '119.0.6045.105'],
+  ['Mac OS', 'Safari', '17.1.2'],
+]);
+
+function pickBrowserFingerprint() {
+  return BROWSER_POOL[Math.floor(Math.random() * BROWSER_POOL.length)];
+}
+
 // Self-hash of this script file.  Reported in /health so the Python gateway
 // can detect a running bridge that predates the current bridge.js and
 // restart it instead of silently reusing stale code (stale-bridge trap:
@@ -395,7 +427,7 @@ async function startSocket() {
     auth: state,
     logger,
     printQRInTerminal: false,
-    browser: ['Hermes Agent', 'Chrome', '120.0'],
+    browser: pickBrowserFingerprint(),
     syncFullHistory: false,
     markOnlineOnConnect: false,
     // Required for Baileys 7.x: without this, incoming messages that need


### PR DESCRIPTION
## Summary

The browser tuple `[appName, browserName, version]` is sent to WhatsApp as part of the Baileys connection handshake. The hardcoded value `['Hermes Agent', 'Chrome', '120.0']` meant **every Hermes deployment worldwide presented the identical wire fingerprint** — trivially clusterable by WhatsApp's anti-spam ML classifier.

This replaces it with a random pick from a pool of 14 realistic browser tuples (Mac/Win/Linux × Chrome/Safari/Firefox/Edge) on each connection.

## Problem

WhatsApp's anti-bot detection systems cluster accounts by their connection fingerprint. The `browser` field in `makeWASocket()` is one of the most visible signals:

\`\`\`javascript
// Before (every Hermes user, every connection):
browser: ['Hermes Agent', 'Chrome', '120.0'],
\`\`\`

Issues:
1. **`'Hermes Agent'` as appName** — no real WhatsApp linked device reports this name. It's a dead giveaway that the connection is from a bot framework.
2. **`'120.0'` as version** — not a valid Chrome version string (real Chrome uses `120.0.6099.109` etc.)
3. **Identical across all deployments** — every Hermes instance globally presents the same fingerprint, making the entire user base clusterable as a single bot network.

## Fix

A frozen pool of 14 realistic browser tuples covering the common OS/browser combinations a linked device would actually present, with real version strings:

\`\`\`javascript
const BROWSER_POOL = Object.freeze([
  ['Mac OS', 'Chrome', '120.0.6099.109'],
  ['Mac OS', 'Chrome', '121.0.6167.85'],
  ['Mac OS', 'Safari', '17.2.1'],
  // ... 11 more
]);

function pickBrowserFingerprint() {
  return BROWSER_POOL[Math.floor(Math.random() * BROWSER_POOL.length)];
}
\`\`\`

A new fingerprint is picked on each `startSocket()` call — so reconnects also get a new identity.

## Scope

- **No new dependencies** — the pool is a frozen array in `bridge.js`
- **No config changes** — no env vars, no `config.yaml` keys
- **No behavioral changes** — same Baileys API, same socket flow
- **1 file changed, +33/-1 lines**

## Testing

- [x] `node --check bridge.js` — syntax passes
- [x] Bridge starts and picks a random fingerprint each run (verified across 3 runs)
- [x] Python tests: `102 passed, 1 skipped` across 8 WhatsApp test files
- [x] Node tests: `21 passed, 0 failed` across 5 bridge test files
- **Tested on**: Windows 10, Node 24.16.0, Python 3.11.13

## Related

- Similar fingerprint randomization is used by [baileys-antiban](https://github.com/kobie3717/baileys-antiban) (`STEALTH_BROWSER_POOL`) and other anti-detection libraries