### PR TITLE
fix: recover named credentials for custom fallbacks

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1335,6 +1335,10 @@ def restore_primary_runtime(agent) -> bool:
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
         agent._client_kwargs = dict(rt["client_kwargs"])
+        # Header isolation belongs to the active custom fallback only. Clear it
+        # before any primary pool re-selection can rebuild the restored client.
+        agent._custom_fallback_header_isolation = False
+        agent._custom_fallback_headers = {}
         agent._use_prompt_caching = rt["use_prompt_caching"]
         # Default to native layout when the restored snapshot predates the
         # native-vs-proxy split (older sessions saved before this PR).

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -106,6 +106,7 @@ OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
 from agent.credential_pool import load_pool
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
+from agent.secret_scope import get_secret
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_float, model_forces_max_completion_tokens, normalize_proxy_env_vars
@@ -4674,6 +4675,7 @@ def resolve_provider_client(
     main_runtime: Optional[Dict[str, Any]] = None,
     is_vision: bool = False,
     task: Optional[str] = None,
+    apply_user_default_headers: bool = True,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Central router: given a provider name and optional model, return a
     configured client with the correct auth, base URL, and API format.
@@ -4701,6 +4703,9 @@ def resolve_provider_client(
             "codex_responses", or None (auto-detect).  When set to
             "codex_responses", the client is wrapped in
             CodexAuxiliaryClient to route through the Responses API.
+        apply_user_default_headers: Whether to merge model-level default
+            headers. Disable for fallback routes whose endpoint identity is
+            outside the primary model's credential boundary.
 
     Returns:
         (client, resolved_model) or (None, None) if auth is unavailable.
@@ -4962,7 +4967,11 @@ def resolve_provider_client(
                         extra["default_headers"] = dict(_ph_custom.default_headers)
                 except Exception:
                     pass
-            _merged_custom = _apply_user_default_headers(extra.get("default_headers"))
+            _merged_custom = (
+                _apply_user_default_headers(extra.get("default_headers"))
+                if apply_user_default_headers
+                else extra.get("default_headers")
+            )
             if _merged_custom:
                 extra["default_headers"] = _merged_custom
             client = _create_openai_client(api_key=custom_key, base_url=_clean_base, **extra)
@@ -4990,7 +4999,10 @@ def resolve_provider_client(
 
     # ── Named custom providers (config.yaml providers dict / custom_providers list) ───
     try:
-        from hermes_cli.runtime_provider import _get_named_custom_provider
+        from hermes_cli.runtime_provider import (
+            _get_named_custom_provider,
+            _normalize_base_url_for_match,
+        )
         # When the raw requested name is an alias (``kimi`` → ``kimi-coding``)
         # and the user defined a ``custom_providers`` entry under that alias
         # name, the custom entry is the intended target — the built-in alias
@@ -5004,11 +5016,19 @@ def resolve_provider_client(
         if custom_entry is None:
             custom_entry = _get_named_custom_provider(provider)
         if custom_entry:
-            custom_base = (custom_entry.get("base_url") or "").strip()
-            custom_key = (custom_entry.get("api_key") or "").strip()
+            configured_base = (custom_entry.get("base_url") or "").strip()
+            custom_base = (explicit_base_url or configured_base).strip()
+            endpoint_matches_config = (
+                not explicit_base_url
+                or _normalize_base_url_for_match(explicit_base_url)
+                == _normalize_base_url_for_match(configured_base)
+            )
+            custom_key = (explicit_api_key or "").strip()
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
-            if not custom_key and custom_key_env:
-                custom_key = os.getenv(custom_key_env, "").strip()
+            if not custom_key and endpoint_matches_config:
+                custom_key = (custom_entry.get("api_key") or "").strip()
+                if not custom_key and custom_key_env:
+                    custom_key = (get_secret(custom_key_env, "") or "").strip()
             custom_key = custom_key or "no-key-required"
             if custom_key == "no-key-required":
                 logger.warning(
@@ -5041,7 +5061,14 @@ def resolve_provider_client(
                     raw_base_for_wrap = custom_base
                 _clean_base2, _dq2 = _extract_url_query_params(openai_base)
                 _extra2 = {"default_query": _dq2} if _dq2 else {}
-                _headers2 = _apply_user_default_headers(_extra2.get("default_headers"))
+                configured_headers = custom_entry.get("extra_headers")
+                if endpoint_matches_config and isinstance(configured_headers, dict):
+                    _extra2["default_headers"] = dict(configured_headers)
+                _headers2 = (
+                    _apply_user_default_headers(_extra2.get("default_headers"))
+                    if apply_user_default_headers
+                    else _extra2.get("default_headers")
+                )
                 if _headers2:
                     _extra2["default_headers"] = _headers2
                 logger.debug(
@@ -5066,7 +5093,13 @@ def resolve_provider_client(
                         _fallback_base = _to_openai_base_url(custom_base)
                         _fb_clean, _fb_dq = _extract_url_query_params(_fallback_base)
                         _fb_extra = {"default_query": _fb_dq} if _fb_dq else {}
-                        _fb_headers = _apply_user_default_headers(_fb_extra.get("default_headers"))
+                        if endpoint_matches_config and isinstance(configured_headers, dict):
+                            _fb_extra["default_headers"] = dict(configured_headers)
+                        _fb_headers = (
+                            _apply_user_default_headers(_fb_extra.get("default_headers"))
+                            if apply_user_default_headers
+                            else _fb_extra.get("default_headers")
+                        )
                         if _fb_headers:
                             _fb_extra["default_headers"] = _fb_headers
                         client = _create_openai_client(api_key=custom_key, base_url=_fb_clean, **_fb_extra)
@@ -5083,11 +5116,11 @@ def resolve_provider_client(
                 # _wrap_if_needed reads the closed-over `api_mode` (the task-level
                 # override). Named-provider entry api_mode=codex_responses also
                 # flows through here.
-                if entry_api_mode == "codex_responses" and not isinstance(
+                if not raw_codex and entry_api_mode == "codex_responses" and not isinstance(
                     client, CodexAuxiliaryClient
                 ):
                     client = CodexAuxiliaryClient(client, final_model)
-                else:
+                elif not raw_codex:
                     client = _wrap_if_needed(client, final_model, raw_base_for_wrap, custom_key)
                 return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                         else (client, final_model))

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -34,6 +34,7 @@ from agent.turn_context import substitute_api_content
 from agent.gemini_native_adapter import is_native_gemini_base_url
 from agent.model_metadata import is_local_endpoint
 from agent.message_content import flatten_message_text
+from agent.secret_scope import get_secret
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
@@ -1633,22 +1634,99 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # endpoints (e.g. Ollama Cloud) resolve correctly instead of
         # falling through to OpenRouter defaults.
         fb_base_url_hint = (fb.get("base_url") or "").strip() or None
+        if fb_base_url_hint:
+            from hermes_cli.runtime_provider import is_valid_http_provider_base_url
+
+            if not is_valid_http_provider_base_url(fb_base_url_hint):
+                unavailable.add(fb_key)
+                logger.warning(
+                    "Fallback skip: refusing malformed or non-HTTP(S) base_url"
+                )
+                return agent._try_activate_fallback(reason)
         fb_api_key_hint = (fb.get("api_key") or "").strip() or None
+        fb_api_mode_hint = (
+            fb.get("api_mode") or fb.get("transport") or ""
+        ).strip() or None
+        fb_custom_entry = None
+        fb_custom_headers = {}
         if not fb_api_key_hint:
             # key_env and api_key_env are both documented aliases (see
             # _normalize_custom_provider_entry in hermes_cli/config.py).
             fb_key_env = (fb.get("key_env") or fb.get("api_key_env") or "").strip()
             if fb_key_env:
-                fb_api_key_hint = os.getenv(fb_key_env, "").strip() or None
+                fb_api_key_hint = (get_secret(fb_key_env, "") or "").strip() or None
         # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
         # when no explicit key is in the fallback config. Host match
         # (not substring) — see GHSA-76xc-57q6-vm5m.
         if fb_base_url_hint and base_url_host_matches(fb_base_url_hint, "ollama.com") and not fb_api_key_hint:
-            fb_api_key_hint = os.getenv("OLLAMA_API_KEY") or None
+            fb_api_key_hint = get_secret("OLLAMA_API_KEY") or None
+        if fb_provider == "custom" and fb_base_url_hint and not fb_api_key_hint:
+            # A bare custom fallback has no credential identity. Recover it only
+            # when exactly one enabled named provider owns the endpoint; shared
+            # URLs may represent different tenants, keys, or transports.
+            from hermes_cli.runtime_provider import find_custom_provider_identities
+
+            custom_identities = find_custom_provider_identities(fb_base_url_hint)
+            if len(custom_identities) == 1:
+                fb_provider = custom_identities[0]
+                from hermes_cli.runtime_provider import _get_named_custom_provider
+
+                fb_custom_entry = _get_named_custom_provider(fb_provider) or {}
+                if not fb_api_mode_hint:
+                    fb_api_mode_hint = (
+                        fb_custom_entry.get("api_mode") or ""
+                    ).strip() or None
+            elif len(custom_identities) > 1:
+                logger.warning(
+                    "Custom fallback endpoint matches %d named providers; "
+                    "refusing to guess credentials. Set provider to "
+                    "custom:<name> explicitly.",
+                    len(custom_identities),
+                )
+                fb_api_key_hint = "no-key-required"
+            else:
+                # An anonymous endpoint has no credential identity. Fail closed
+                # instead of inheriting a primary/global key across hosts.
+                # Authenticated endpoints must declare key_env/api_key or a
+                # unique custom:<name> provider.
+                logger.warning(
+                    "Bare custom fallback has no named provider identity; "
+                    "refusing to inherit global credentials. Set provider to "
+                    "custom:<name> or configure api_key/key_env explicitly."
+                )
+                fb_api_key_hint = "no-key-required"
+        if fb_provider.lower().startswith("custom:"):
+            from hermes_cli.config import normalize_extra_headers
+            from hermes_cli.runtime_provider import (
+                _get_named_custom_provider,
+                _normalize_base_url_for_match,
+            )
+
+            if fb_custom_entry is None:
+                fb_custom_entry = _get_named_custom_provider(fb_provider) or {}
+            configured_base = str(fb_custom_entry.get("base_url") or "").strip()
+            endpoint_matches_config = (
+                not fb_base_url_hint
+                or _normalize_base_url_for_match(fb_base_url_hint)
+                == _normalize_base_url_for_match(configured_base)
+            )
+            if endpoint_matches_config:
+                fb_custom_headers = normalize_extra_headers(
+                    fb_custom_entry.get("extra_headers")
+                )
+            if not fb_api_mode_hint:
+                fb_api_mode_hint = (
+                    fb_custom_entry.get("api_mode") or ""
+                ).strip() or None
         fb_client, _resolved_fb_model = resolve_provider_client(
-            fb_provider, model=fb_model, raw_codex=True,
+            fb_provider,
+            model=fb_model,
+            raw_codex=True,
             explicit_base_url=fb_base_url_hint,
-            explicit_api_key=fb_api_key_hint)
+            explicit_api_key=fb_api_key_hint or "",
+            api_mode=fb_api_mode_hint or "",
+            apply_user_default_headers=not fb_provider.lower().startswith("custom"),
+        )
         if fb_client is None:
             logger.warning(
                 "Fallback to %s failed: provider not configured",
@@ -1666,10 +1744,12 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             )
 
         # Determine api_mode from provider / base URL / model
-        fb_api_mode = "chat_completions"
+        fb_api_mode = fb_api_mode_hint or "chat_completions"
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
+        if fb_api_mode_hint:
+            pass
+        elif fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
         elif (
             fb_provider == "anthropic"
@@ -1714,6 +1794,10 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         agent.provider = fb_provider
         agent.base_url = fb_base_url
         agent.api_mode = fb_api_mode
+        agent._custom_fallback_header_isolation = (
+            fb_provider.lower().startswith("custom")
+        )
+        agent._custom_fallback_headers = dict(fb_custom_headers)
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True
@@ -1785,9 +1869,12 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             # _create_request_openai_client) drop the headers,
             # causing 403s from providers like Kimi Coding that
             # require a User-Agent sentinel.
-            fb_headers = getattr(fb_client, "_custom_headers", None)
-            if not fb_headers:
-                fb_headers = getattr(fb_client, "default_headers", None)
+            if agent._custom_fallback_header_isolation:
+                fb_headers = fb_custom_headers
+            else:
+                fb_headers = getattr(fb_client, "_custom_headers", None)
+                if not fb_headers:
+                    fb_headers = getattr(fb_client, "default_headers", None)
             agent._client_kwargs = {
                 "api_key": fb_client.api_key,
                 "base_url": fb_base_url,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import re
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
@@ -39,6 +39,7 @@ from hermes_cli.auth import (
 )
 from hermes_cli.config import (
     get_compatible_custom_providers,
+    is_provider_enabled,
     load_config,
     normalize_extra_headers,
 )
@@ -659,7 +660,6 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
     # First check providers: dict (new-style user-defined providers)
     providers = config.get("providers")
     if isinstance(providers, dict):
-        from hermes_cli.config import is_provider_enabled
         for ep_name, entry in providers.items():
             if not isinstance(entry, dict):
                 continue
@@ -796,55 +796,88 @@ def has_named_custom_provider(requested_provider: str) -> bool:
         return False
 
 
-def find_custom_provider_identity(base_url: str) -> Optional[str]:
-    """Map an endpoint URL back to its canonical ``custom:<name>`` menu key.
+def find_custom_provider_identities(base_url: Optional[str]) -> list[str]:
+    """Return every enabled ``custom:<name>`` entry owning *base_url*.
 
-    Returns the ``custom:<normalized-name>`` slug of the first ``providers:``
-    / ``custom_providers:`` entry whose base_url matches, or ``None`` when no
-    entry owns the URL.
-
-    Session persistence stores the agent's *resolved* provider, and for every
-    named custom endpoint that is the literal string ``"custom"`` — the entry
-    name is lost, and the api_key is deliberately never persisted. The
-    endpoint URL is the one durable fact that survives the round-trip, so
-    this reverse lookup lets persist/rebuild paths recover the entry identity
-    (and with it key_env/api_key/api_mode resolution via
-    :func:`_get_named_custom_provider`) instead of failing with
-    ``auth_unavailable`` or silently rebuilding with placeholder credentials.
+    Callers that select credentials from a bare custom endpoint must require a
+    single candidate. Multiple named providers may deliberately share one URL
+    while using different tenant keys or transports, so choosing the first
+    match would cross a credential boundary.
     """
     target = _normalize_base_url_for_match(base_url)
     if not target:
-        return None
+        return []
     try:
         config = load_config()
     except Exception:
-        return None
+        return []
+
+    identities: list[str] = []
+
+    def _add_identity(name: object) -> None:
+        normalized = _normalize_custom_provider_name(str(name or ""))
+        if not normalized:
+            return
+        identity = f"custom:{normalized}"
+        identities.append(identity)
 
     providers = config.get("providers")
     if isinstance(providers, dict):
         for ep_name, entry in providers.items():
-            if not isinstance(entry, dict):
+            if not isinstance(entry, dict) or not is_provider_enabled(entry):
                 continue
             entry_url = (
                 entry.get("api") or entry.get("url") or entry.get("base_url") or ""
             )
             if _normalize_base_url_for_match(entry_url) == target:
-                return f"custom:{_normalize_custom_provider_name(str(ep_name))}"
+                _add_identity(ep_name)
 
+    custom_providers = config.get("custom_providers")
+    if isinstance(custom_providers, list):
+        for raw_entry in custom_providers:
+            if not isinstance(raw_entry, dict) or not is_provider_enabled(raw_entry):
+                continue
+            try:
+                entries = get_compatible_custom_providers(
+                    {"custom_providers": [raw_entry]}
+                )
+            except Exception:
+                entries = []
+            for entry in entries:
+                name = entry.get("name")
+                if not isinstance(name, str) or not name.strip():
+                    continue
+                if _normalize_base_url_for_match(entry.get("base_url")) == target:
+                    _add_identity(name)
+
+    return identities
+
+
+def find_custom_provider_identity(base_url: Optional[str]) -> Optional[str]:
+    """Map an endpoint URL to its unique canonical ``custom:<name>`` key.
+
+    Return ``None`` when no provider or multiple providers own the endpoint;
+    callers must not guess a credential identity for shared URLs.
+    """
+    identities = find_custom_provider_identities(base_url)
+    return identities[0] if len(identities) == 1 else None
+
+
+def is_valid_http_provider_base_url(value: Optional[str]) -> bool:
+    """Return whether *value* is a credential-safe HTTP(S) provider URL."""
+    raw = str(value or "").strip()
+    if not raw:
+        return False
     try:
-        custom_providers = get_compatible_custom_providers(config)
-    except Exception:
-        custom_providers = None
-    for entry in custom_providers or []:
-        if not isinstance(entry, dict):
-            continue
-        name = entry.get("name")
-        if not isinstance(name, str) or not name.strip():
-            continue
-        if _normalize_base_url_for_match(entry.get("base_url")) == target:
-            return f"custom:{_normalize_custom_provider_name(name)}"
-
-    return None
+        parsed = urlparse(raw)
+        return bool(
+            parsed.scheme.lower() in {"http", "https"}
+            and parsed.hostname
+            and parsed.username is None
+            and parsed.password is None
+        )
+    except ValueError:
+        return False
 
 
 def canonical_custom_identity(
@@ -878,11 +911,15 @@ def canonical_custom_identity(
     ``None`` (caller keeps whatever it had — bare ``"custom"`` only as a last
     resort, e.g. a genuine ad-hoc endpoint with no config entry).
     """
-    # 1. Reverse-lookup by endpoint URL.
+    # 1. Reverse-lookup by endpoint URL. Ambiguity is terminal: falling
+    # through to config.model.provider would silently choose one tenant for a
+    # shared URL.
     if base_url:
-        identity = find_custom_provider_identity(base_url)
-        if identity:
-            return identity
+        identities = find_custom_provider_identities(base_url)
+        if len(identities) == 1:
+            return identities[0]
+        if len(identities) > 1:
+            return None
 
     # 2. Fall back to the configured provider when it names a real entry.
     candidate = str(config_provider or "").strip()
@@ -911,7 +948,34 @@ def canonical_custom_identity(
 
 
 def _normalize_base_url_for_match(value) -> str:
-    return str(value or "").strip().rstrip("/").lower()
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    try:
+        parsed = urlparse(raw)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return raw.rstrip("/")
+    if not parsed.scheme or not hostname or parsed.username or parsed.password:
+        return raw.rstrip("/")
+
+    normalized_host = hostname.lower()
+    if ":" in normalized_host:
+        normalized_host = f"[{normalized_host}]"
+    netloc = normalized_host
+    if port is not None:
+        netloc = f"{netloc}:{port}"
+    return urlunparse(
+        (
+            parsed.scheme.lower(),
+            netloc,
+            parsed.path.rstrip("/"),
+            parsed.params,
+            parsed.query,
+            parsed.fragment,
+        )
+    )
 
 
 def _custom_provider_request_overrides(custom_provider: Dict[str, Any]) -> Dict[str, Any]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -4696,16 +4696,29 @@ class AIAgent:
             else:
                 self._client_kwargs.pop("default_headers", None)
 
-        # User-configured overrides win over URL/profile defaults — keep them
-        # applied across credential swaps and client rebuilds, not just at
-        # first construction.
-        self._apply_user_default_headers()
+        isolated_custom_fallback = getattr(
+            self, "_custom_fallback_header_isolation", False
+        )
+        if isolated_custom_fallback:
+            fallback_headers = getattr(self, "_custom_fallback_headers", {})
+            if fallback_headers:
+                merged = dict(self._client_kwargs.get("default_headers") or {})
+                merged.update(fallback_headers)
+                self._client_kwargs["default_headers"] = merged
+        else:
+            # User-configured overrides win over URL/profile defaults — keep them
+            # applied across credential swaps and client rebuilds, not just at
+            # first construction.
+            self._apply_user_default_headers()
 
         # Per-provider extra HTTP headers (providers.<name>.extra_headers /
         # custom_providers[].extra_headers) — applied last so the most
         # specific config level survives credential swaps and rebuilds too.
         # SECURITY: values may carry credentials — never log them.
-        if self.api_mode not in ("anthropic_messages", "bedrock_converse"):
+        if (
+            not isolated_custom_fallback
+            and self.api_mode not in ("anthropic_messages", "bedrock_converse")
+        ):
             try:
                 from hermes_cli.config import (
                     apply_custom_provider_extra_headers_to_client_kwargs,

--- a/tests/agent/test_restore_primary_pool_reselect.py
+++ b/tests/agent/test_restore_primary_pool_reselect.py
@@ -133,6 +133,37 @@ class TestRestorePrimaryPoolReselect:
         assert agent.api_key == "rotated-key-entry-2"
         assert agent._client_kwargs["api_key"] == "rotated-key-entry-2"
 
+    def test_restore_clears_custom_fallback_headers_before_pool_reselect(self):
+        entries = [
+            _make_entry("entry-1", "original-key-entry-1", priority=0),
+            _make_entry("entry-2", "rotated-key-entry-2", priority=1),
+        ]
+        pool = _build_mock_pool(entries)
+        pool._mark_exhausted(pool._entries[0], 401)
+        pool._current_id = "entry-2"
+        agent = self._make_agent(pool)
+        agent._custom_fallback_header_isolation = True
+        agent._custom_fallback_headers = {
+            "X-Fallback-Auth": "fallback-header-value"
+        }
+        isolation_seen_during_rebuild = []
+
+        def _capture_header_state(_base_url):
+            isolation_seen_during_rebuild.append(
+                (
+                    agent._custom_fallback_header_isolation,
+                    dict(agent._custom_fallback_headers),
+                )
+            )
+
+        agent._apply_client_headers_for_base_url.side_effect = _capture_header_state
+
+        assert agent._restore_primary_runtime() is True
+
+        assert isolation_seen_during_rebuild == [(False, {})]
+        assert agent._custom_fallback_header_isolation is False
+        assert agent._custom_fallback_headers == {}
+
     def test_restore_uses_freshest_available_entry(self):
         """When multiple entries are available, restore should select the pool's best pick."""
         entries = [

--- a/tests/hermes_cli/test_custom_provider_identity.py
+++ b/tests/hermes_cli/test_custom_provider_identity.py
@@ -97,3 +97,91 @@ def test_identity_resolves_back_through_named_lookup(monkeypatch):
     assert entry is not None
     assert entry["base_url"] == "https://api.mimo.example/v1"
     assert entry["api_key"] == "sk-entry"
+
+
+def test_candidate_lookup_preserves_case_sensitive_paths(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {"name": "tenant-upper", "base_url": "https://gateway.example/TenantA"},
+                {"name": "tenant-lower", "base_url": "https://gateway.example/tenanta"},
+            ]
+        },
+    )
+
+    assert rp.find_custom_provider_identities("https://GATEWAY.example/tenanta/") == [
+        "custom:tenant-lower"
+    ]
+
+
+def test_candidate_lookup_returns_all_shared_endpoint_identities(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "model": {"provider": "custom:tenant-b"},
+            "custom_providers": [
+                {"name": "tenant-a", "base_url": "https://gateway.example/v1"},
+                {"name": "tenant-b", "base_url": "https://gateway.example/v1/"},
+            ]
+        },
+    )
+
+    assert rp.find_custom_provider_identities("https://gateway.example/v1") == [
+        "custom:tenant-a",
+        "custom:tenant-b",
+    ]
+    assert rp.find_custom_provider_identity("https://gateway.example/v1") is None
+    assert rp.canonical_custom_identity(base_url="https://gateway.example/v1") is None
+
+
+def test_normalized_name_collision_is_ambiguous(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {"name": "Tenant A", "base_url": "https://gateway.example/v1"},
+                {"name": "tenant-a", "base_url": "https://gateway.example/v1"},
+            ]
+        },
+    )
+
+    assert rp.find_custom_provider_identities("https://gateway.example/v1") == [
+        "custom:tenant-a",
+        "custom:tenant-a",
+    ]
+    assert rp.find_custom_provider_identity("https://gateway.example/v1") is None
+
+
+def test_candidate_lookup_skips_disabled_provider_blocks(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "disabled": {
+                    "enabled": False,
+                    "api": "https://gateway.example/v1",
+                },
+                "enabled": {
+                    "api": "https://gateway.example/v1",
+                },
+            },
+            "custom_providers": [
+                {
+                    "name": "legacy-disabled",
+                    "enabled": False,
+                    "base_url": "https://legacy-disabled.example/v1",
+                    "api_key": "must-not-resolve",
+                }
+            ],
+        },
+    )
+
+    assert rp.find_custom_provider_identities("https://gateway.example/v1") == [
+        "custom:enabled"
+    ]
+    assert rp.find_custom_provider_identities("https://legacy-disabled.example/v1") == []

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -7,6 +7,8 @@ advancement through multiple providers.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit
 
 
@@ -181,6 +183,364 @@ class TestFallbackChainAdvancement:
         ):
             assert agent._try_activate_fallback() is True
             assert mock_rpc.call_args.kwargs["explicit_api_key"] == "env-secret"
+
+    @pytest.mark.parametrize(
+        "fallback_url",
+        [
+            "ftp://collector.invalid/v1",
+            "https:///missing-host/v1",
+            "https://trusted.example@collector.invalid/v1",
+        ],
+        ids=("non-http-scheme", "missing-host", "userinfo"),
+    )
+    def test_rejects_malformed_credential_bearing_fallback_url(
+        self, fallback_url
+    ):
+        agent = _make_agent(
+            fallback_model=[
+                {
+                    "provider": "custom",
+                    "model": "fallback-model",
+                    "base_url": fallback_url,
+                    "api_key": "explicit-fallback-key",
+                }
+            ]
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(
+                _mock_client(
+                    base_url=fallback_url,
+                    api_key="explicit-fallback-key",
+                ),
+                "fallback-model",
+            ),
+        ) as mock_rpc:
+            assert agent._try_activate_fallback() is False
+
+        mock_rpc.assert_not_called()
+
+    def test_bare_custom_fallback_recovers_named_provider_from_base_url(
+        self, tmp_path, monkeypatch
+    ):
+        """A persisted bare custom fallback must recover its named identity.
+
+        Exercise the real config, reverse-lookup, named-provider, and client
+        construction path. The unrelated primary key must never reach the
+        fallback endpoint.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("OPENAI_API_KEY", "primary-provider-key")
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  default: primary-model\n"
+            "custom_providers:\n"
+            "  - name: fallback-example\n"
+            "    base_url: http://127.0.0.1:1/v1\n"
+            "    api_key: named-provider-key\n",
+            encoding="utf-8",
+        )
+        agent = _make_agent(
+            fallback_model=[
+                {
+                    "provider": "custom",
+                    "model": "fallback-model",
+                    "base_url": "http://127.0.0.1:1/v1",
+                }
+            ]
+        )
+
+        assert agent._try_activate_fallback() is True
+
+        assert getattr(agent, "provider") == "custom:fallback-example"
+        assert agent.api_key == "named-provider-key"
+        assert agent.client is not None
+        assert agent.client.api_key == "named-provider-key"
+        assert str(agent.client.base_url).rstrip("/") == "http://127.0.0.1:1/v1"
+
+    def test_named_fallback_key_env_uses_active_secret_scope(
+        self, tmp_path, monkeypatch
+    ):
+        from agent import secret_scope
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("FALLBACK_API_KEY", "foreign-process-key")
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  default: primary-model\n"
+            "custom_providers:\n"
+            "  - name: fallback-example\n"
+            "    base_url: http://127.0.0.1:1/v1\n"
+            "    key_env: FALLBACK_API_KEY\n",
+            encoding="utf-8",
+        )
+        agent = _make_agent(
+            fallback_model=[
+                {
+                    "provider": "custom",
+                    "model": "fallback-model",
+                    "base_url": "http://127.0.0.1:1/v1",
+                }
+            ]
+        )
+
+        secret_scope.set_multiplex_active(True)
+        token = secret_scope.set_secret_scope(
+            {"FALLBACK_API_KEY": "active-profile-key"}
+        )
+        try:
+            assert agent._try_activate_fallback() is True
+        finally:
+            secret_scope.reset_secret_scope(token)
+            secret_scope.set_multiplex_active(False)
+
+        assert getattr(agent, "provider") == "custom:fallback-example"
+        assert agent.api_key == "active-profile-key"
+        assert agent.client is not None
+        assert agent.client.api_key == "active-profile-key"
+
+    def test_recovered_named_fallback_preserves_explicit_api_mode(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  default: primary-model\n"
+            "custom_providers:\n"
+            "  - name: native-anthropic\n"
+            "    base_url: https://generic-relay.example/v1\n"
+            "    api_key: named-provider-key\n"
+            "    api_mode: anthropic_messages\n",
+            encoding="utf-8",
+        )
+        agent = _make_agent(
+            fallback_model=[
+                {
+                    "provider": "custom",
+                    "model": "claude-test",
+                    "base_url": "https://generic-relay.example/v1",
+                }
+            ]
+        )
+
+        with patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=MagicMock(),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert getattr(agent, "provider") == "custom:native-anthropic"
+        assert getattr(agent, "api_mode") == "anthropic_messages"
+        assert agent.client is None
+
+    def test_recovered_codex_responses_fallback_keeps_raw_main_client(
+        self, tmp_path, monkeypatch
+    ):
+        from agent.auxiliary_client import CodexAuxiliaryClient
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  default: primary-model\n"
+            "custom_providers:\n"
+            "  - name: responses-relay\n"
+            "    base_url: https://responses-relay.example/v1\n"
+            "    api_key: named-provider-key\n"
+            "    api_mode: codex_responses\n",
+            encoding="utf-8",
+        )
+        agent = _make_agent(
+            fallback_model=[
+                {
+                    "provider": "custom",
+                    "model": "responses-model",
+                    "base_url": "https://responses-relay.example/v1",
+                }
+            ]
+        )
+
+        assert agent._try_activate_fallback() is True
+        assert getattr(agent, "api_mode") == "codex_responses"
+        assert agent.client is not None
+        assert not isinstance(agent.client, CodexAuxiliaryClient)
+        assert hasattr(agent.client, "responses")
+
+    def test_custom_fallback_header_isolation_survives_client_rebuild(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  default: primary-model\n"
+            "  default_headers:\n"
+            "    X-Primary-Auth: primary-header-value\n"
+            "custom_providers:\n"
+            "  - name: fallback-example\n"
+            "    base_url: https://fallback.example/v1\n"
+            "    api_key: named-provider-key\n"
+            "    extra_headers:\n"
+            "      X-Fallback-Auth: fallback-header-value\n",
+            encoding="utf-8",
+        )
+        agent = _make_agent(
+            fallback_model=[
+                {
+                    "provider": "custom",
+                    "model": "fallback-model",
+                    "base_url": "https://fallback.example/v1",
+                }
+            ]
+        )
+
+        assert agent._try_activate_fallback() is True
+        assert agent._client_kwargs["default_headers"] == {
+            "X-Fallback-Auth": "fallback-header-value"
+        }
+
+        agent._apply_client_headers_for_base_url("https://fallback.example/v1")
+
+        assert agent._client_kwargs["default_headers"] == {
+            "X-Fallback-Auth": "fallback-header-value"
+        }
+
+    @pytest.mark.parametrize(
+        ("provider_config", "fallback_url"),
+        [
+            (
+                "custom_providers:\n"
+                "  - name: other\n"
+                "    base_url: http://127.0.0.1:1/v1\n"
+                "    api_key: other-provider-key\n",
+                "http://127.0.0.1:2/v1",
+            ),
+            (
+                "custom_providers:\n"
+                "  - name: tenant-a\n"
+                "    base_url: http://127.0.0.1:1/v1\n"
+                "    api_key: tenant-a-key\n"
+                "  - name: tenant-b\n"
+                "    base_url: http://127.0.0.1:1/v1\n"
+                "    api_key: tenant-b-key\n",
+                "http://127.0.0.1:1/v1",
+            ),
+            (
+                "providers:\n"
+                "  disabled-tenant:\n"
+                "    enabled: false\n"
+                "    api: http://127.0.0.1:1/v1\n"
+                "    api_key: disabled-provider-key\n",
+                "http://127.0.0.1:1/v1",
+            ),
+        ],
+        ids=("unknown", "shared", "disabled"),
+    )
+    def test_bare_custom_fallback_without_unique_identity_fails_closed(
+        self, tmp_path, monkeypatch, provider_config, fallback_url
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("OPENAI_API_KEY", "primary-provider-key")
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  default: primary-model\n"
+            "  extra_headers:\n"
+            "    Authorization: Bearer primary-header-secret\n"
+            + provider_config,
+            encoding="utf-8",
+        )
+        agent = _make_agent(
+            fallback_model=[
+                {
+                    "provider": "custom",
+                    "model": "fallback-model",
+                    "base_url": fallback_url,
+                }
+            ]
+        )
+
+        assert agent._try_activate_fallback() is True
+        assert getattr(agent, "provider") == "custom"
+        assert agent.api_key == "no-key-required"
+        assert agent.client is not None
+        assert agent.client.api_key == "no-key-required"
+        assert "primary-header-secret" not in repr(agent.client.default_headers)
+
+    def test_custom_fallback_explicit_key_env_beats_named_provider(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("MY_FALLBACK_KEY", "explicit-fallback-key")
+        monkeypatch.setenv("OPENAI_API_KEY", "primary-provider-key")
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  default: primary-model\n"
+            "custom_providers:\n"
+            "  - name: fallback-example\n"
+            "    base_url: http://127.0.0.1:1/v1\n"
+            "    api_key: named-provider-key\n",
+            encoding="utf-8",
+        )
+        agent = _make_agent(
+            fallback_model=[
+                {
+                    "provider": "custom",
+                    "model": "fallback-model",
+                    "base_url": "http://127.0.0.1:1/v1",
+                    "key_env": "MY_FALLBACK_KEY",
+                }
+            ]
+        )
+
+        assert agent._try_activate_fallback() is True
+        assert getattr(agent, "provider") == "custom"
+        assert agent.api_key == "explicit-fallback-key"
+        assert agent.client is not None
+        assert agent.client.api_key == "explicit-fallback-key"
+
+    def test_named_custom_fallback_explicit_key_beats_configured_key(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  default: primary-model\n"
+            "custom_providers:\n"
+            "  - name: fallback-example\n"
+            "    base_url: http://127.0.0.1:1/v1\n"
+            "    api_key: configured-key\n",
+            encoding="utf-8",
+        )
+        agent = _make_agent(
+            fallback_model=[
+                {
+                    "provider": "custom:fallback-example",
+                    "model": "fallback-model",
+                    "base_url": "http://127.0.0.1:1/v1",
+                    "api_key": "explicit-fallback-key",
+                }
+            ]
+        )
+
+        assert agent._try_activate_fallback() is True
+        assert agent.api_key == "explicit-fallback-key"
+        assert agent.client is not None
+        assert agent.client.api_key == "explicit-fallback-key"
 
     def test_anthropic_host_custom_provider_uses_anthropic_messages(self):
         """A custom provider on the native api.anthropic.com host (no


### PR DESCRIPTION
## Summary

Conversation-time fallback entries can be persisted as bare `provider: custom` records with a `base_url` but no inline key. That loses the named custom-provider identity, so fallback activation can reuse unrelated primary/global credentials and fail with HTTP 401.

This change:

- recovers `custom:<name>` only when exactly one enabled provider owns the normalized endpoint
- resolves named `key_env` values through the active secret scope
- fails closed for unknown, disabled-only, shared, or normalized-name-colliding endpoints instead of forwarding unrelated keys or model-level credential headers
- keeps explicit fallback credentials ahead of named-provider credentials
- preserves named-provider `api_mode`, including a raw main-loop client for `codex_responses`
- preserves only the uniquely matched provider's `extra_headers` across credential rotation/client rebuilds
- clears fallback header-isolation state before restoring and rotating the primary runtime
- rejects explicit fallback URLs before credential resolution unless they are HTTP(S), include a hostname, and contain no userinfo

The endpoint comparison treats scheme/host case-insensitively while preserving path case. This PR intentionally scopes behavior changes to conversation-time fallback activation; setup-time and auxiliary-task fallback routing are unchanged.

## Security properties

- No primary/global API key is inherited by an unidentified custom endpoint.
- No primary `model.default_headers` are copied to a custom fallback endpoint.
- Shared endpoints and normalized provider-name collisions are treated as ambiguous.
- Disabled providers cannot supply fallback identity.
- A named provider's credentials or headers are not reused when an explicit endpoint override points elsewhere.
- Primary runtime restoration clears custom-fallback header state before any pool-driven credential swap.
- Malformed, non-HTTP(S), hostless, and userinfo-bearing fallback URLs never reach client construction.

## Tests

Focused regression suite:

```text
108 passed
```

Covered files:

- `tests/agent/test_restore_primary_pool_reselect.py`
- `tests/run_agent/test_provider_fallback.py`
- `tests/run_agent/test_fallback_credential_isolation.py`
- `tests/hermes_cli/test_custom_provider_identity.py`
- `tests/agent/test_auxiliary_named_custom_providers.py`
- `tests/tui_gateway/test_custom_provider_session_persistence.py`

Runtime-provider resolution suite:

```text
151 passed
```

Additional checks:

- Ruff on changed Python files: PASS
- Windows footgun scan: PASS
- `compileall` on changed runtime modules: PASS
- `git diff --check`: PASS
- authenticated bare-custom fallback smoke against two configured OpenAI-compatible endpoints: PASS
- independent Codex security/correctness review after fixes: APPROVE

The repository-wide test runner did not complete within a prior 600-second local limit, so this PR does not claim a full-suite result.
