### PR TITLE
fix(tui): bound post-kill cleanup in Windows git probe to prevent agent init timeout

### DIFF
--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+import pytest
 from types import SimpleNamespace
 
 
@@ -38,34 +39,160 @@ def _spawns(captured, *needles):
 def test_tui_gateway_git_probe_hides_git_windows(monkeypatch):
     from tui_gateway import git_probe
 
-    captured = []
+    spawns = []
 
-    def fake_run(cmd, **kwargs):
-        captured.append((cmd, kwargs))
-        return _Completed(stdout="main\n")
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            if _is_probe(cmd):
+                spawns.append((cmd, kwargs))
+            self.returncode = 0
+
+        def communicate(self, timeout=None):
+            return ("main\n", "")
+
+        def kill(self):  # pragma: no cover - never reached on the fast path
+            raise AssertionError("kill() must not run when git returns in time")
 
     monkeypatch.setattr(git_probe, "IS_WINDOWS", True)
     monkeypatch.setattr(git_probe, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
-    monkeypatch.setattr(git_probe.subprocess, "run", fake_run)
+    monkeypatch.setattr(git_probe.subprocess, "Popen", _FakePopen)
 
     assert git_probe.run_git("C:/repo", "branch", "--show-current") == "main"
 
-    git_calls = _spawns(captured, "branch", "--show-current")
-    assert git_calls == [
-        (
-            ["git", "-C", "C:/repo", "branch", "--show-current"],
-            {
-                "capture_output": True,
-                "text": True,
-                "encoding": "utf-8",
-                "errors": "replace",
-                "timeout": git_probe._GIT_TIMEOUT,
-                "check": False,
-                "stdin": subprocess.DEVNULL,
-                "creationflags": _CREATE_NO_WINDOW,
-            },
-        )
-    ]
+    git_calls = _spawns(spawns, "branch", "--show-current")
+    assert len(git_calls) == 1, git_calls
+    cmd, kwargs = git_calls[0]
+    assert cmd == ["git", "-C", "C:/repo", "branch", "--show-current"]
+    assert kwargs["creationflags"] == _CREATE_NO_WINDOW
+    assert kwargs["stdin"] == subprocess.DEVNULL
+    assert kwargs["stdout"] == subprocess.PIPE
+    assert kwargs["stderr"] == subprocess.PIPE
+    assert kwargs["text"] is True
+    assert kwargs["encoding"] == "utf-8"
+    assert kwargs["errors"] == "replace"
+
+
+def _is_probe(cmd) -> bool:
+    """True only for the ``git -C <cwd> branch --show-current`` spawn under test.
+
+    Patching ``git_probe.subprocess.Popen`` is process-wide (it is the
+    shared ``subprocess`` module), so the import-time update-check daemon
+    thread started by an earlier test can route its own ``git ... origin``
+    call through these mocks. Gating every record/side-effect on this predicate
+    keeps a stray daemon spawn from polluting the assertions.
+    """
+    return bool(cmd) and cmd[:2] == ["git", "-C"] and "branch" in cmd
+
+
+def test_tui_gateway_git_probe_timeout_returns_empty(monkeypatch):
+    """A hung git is killed, bounded cleanup runs, and run_git returns ""."""
+    from tui_gateway import git_probe
+
+    events = []
+
+    class _HangingPopen:
+        def __init__(self, cmd, **kwargs):
+            self._probe = _is_probe(cmd)
+            self.returncode = None
+
+        def communicate(self, timeout=None):
+            if not self._probe:
+                return ("", "")
+            events.append(f"comm:{timeout}")
+            if timeout == git_probe._GIT_TIMEOUT:
+                raise subprocess.TimeoutExpired(cmd="git", timeout=timeout)
+            return ("", "")  # bounded post-kill drain succeeds
+
+        def kill(self):
+            if self._probe:
+                events.append("kill")
+
+    monkeypatch.setattr(git_probe, "IS_WINDOWS", False)
+    monkeypatch.setattr(git_probe.subprocess, "Popen", _HangingPopen)
+
+    assert git_probe.run_git("C:/repo", "branch", "--show-current") == ""
+    assert events == [f"comm:{git_probe._GIT_TIMEOUT}", "kill", "comm:1"]
+
+
+@pytest.mark.parametrize(
+    "cleanup_exc",
+    [
+        subprocess.TimeoutExpired(cmd="git", timeout=1),
+        OSError("pipe closed"),
+        ValueError("I/O operation on closed file"),
+    ],
+)
+def test_tui_gateway_git_probe_timeout_cleanup_failure_is_swallowed(monkeypatch, cleanup_exc):
+    """If the bounded cleanup itself raises, run_git swallows it and returns ""."""
+    from tui_gateway import git_probe
+
+    class _StuckPopen:
+        def __init__(self, cmd, **kwargs):
+            self._probe = _is_probe(cmd)
+            self.returncode = None
+            self._calls = 0
+
+        def communicate(self, timeout=None):
+            if not self._probe:
+                return ("", "")
+            self._calls += 1
+            if self._calls == 1:
+                raise subprocess.TimeoutExpired(cmd="git", timeout=timeout)
+            raise cleanup_exc
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(git_probe, "IS_WINDOWS", False)
+    monkeypatch.setattr(git_probe.subprocess, "Popen", _StuckPopen)
+
+    assert git_probe.run_git("C:/repo", "branch", "--show-current") == ""
+
+
+def test_tui_gateway_git_probe_nonzero_returncode_returns_empty(monkeypatch):
+    """git finishes within budget but exits non-zero -> ""."""
+    from tui_gateway import git_probe
+
+    class _FailPopen:
+        def __init__(self, cmd, **kwargs):
+            self.returncode = 1 if _is_probe(cmd) else 0
+
+        def communicate(self, timeout=None):
+            return ("garbage-should-not-leak\n", "fatal: not a repo")
+
+        def kill(self):  # pragma: no cover
+            pass
+
+    monkeypatch.setattr(git_probe, "IS_WINDOWS", False)
+    monkeypatch.setattr(git_probe.subprocess, "Popen", _FailPopen)
+
+    assert git_probe.run_git("C:/repo", "branch", "--show-current") == ""
+
+
+def test_tui_gateway_git_probe_no_hide_flags_off_windows(monkeypatch):
+    """Off Windows, creationflags must NOT be passed."""
+    from tui_gateway import git_probe
+
+    spawns = []
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            if _is_probe(cmd):
+                spawns.append((cmd, kwargs))
+            self.returncode = 0
+
+        def communicate(self, timeout=None):
+            return ("main\n", "")
+
+        def kill(self):  # pragma: no cover
+            pass
+
+    monkeypatch.setattr(git_probe, "IS_WINDOWS", False)
+    monkeypatch.setattr(git_probe.subprocess, "Popen", _FakePopen)
+
+    assert git_probe.run_git("C:/repo", "branch", "--show-current") == "main"
+    assert len(spawns) == 1, spawns
+    assert "creationflags" not in spawns[0][1]
 
 
 def test_tui_gateway_fuzzy_file_listing_hides_git_windows(monkeypatch):

--- a/tui_gateway/git_probe.py
+++ b/tui_gateway/git_probe.py
@@ -49,20 +49,36 @@ def run_git(cwd: str, *args: str) -> str:
         return ""
     _popen_kwargs = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {}
     try:
-        result = subprocess.run(
+        proc = subprocess.Popen(
             ["git", "-C", cwd, *args],
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
             text=True,
             encoding="utf-8",
             errors="replace",
-            timeout=_GIT_TIMEOUT,
-            check=False,
-            stdin=subprocess.DEVNULL,
             **_popen_kwargs,
         )
-        return result.stdout.strip() if result.returncode == 0 else ""
-    except Exception:
+    except (OSError, subprocess.SubprocessError):
         return ""
+    try:
+        stdout, _ = proc.communicate(timeout=_GIT_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        # Bounded post-kill cleanup: on Windows, a process spawned CONCURRENTLY
+        # by another thread can inherit duplicates of this pipe's handles, so
+        # the pipe never reaches EOF even though git is already dead.
+        # subprocess.run()'s cleanup then joins the reader threads forever.
+        # A bounded second communicate() abandons the pipes after a grace
+        # period; the orphaned reader threads are daemonic and cost nothing.
+        try:
+            proc.communicate(timeout=1)
+        except (subprocess.TimeoutExpired, OSError, ValueError):
+            pass
+        return ""
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return stdout.strip() if proc.returncode == 0 else ""
 
 
 def branch(cwd: str) -> str:


### PR DESCRIPTION
Fixes #68609.

## Problem

On Windows, `tui_gateway/git_probe.py::run_git()` uses `subprocess.run(timeout=1.5)` whose post-timeout cleanup joins pipe reader threads unboundedly when a descendant `git.exe` retains captured stdout/stderr handles in Suspended state. Because `_session_info()` (which calls `git_probe.branch()`) runs synchronously inside `_build()` before `ready.set()` at `server.py:1722`, the build thread never signals readiness, and `_wait_agent()` returns error 5032 after 30s — the Desktop shows `agent initialization timed out`.

Confirmed by py-spy stacks showing both profile build threads blocked in `threading.Thread.join` inside `_communicate`, with 16 orphaned suspended `git.exe` processes on the system.

## Fix

Replace `subprocess.run()` with `Popen` + bounded `communicate(timeout=_GIT_TIMEOUT)` + bounded post-kill `communicate(timeout=1)` that abandons pipes after a grace period. Consistent with the approach in PR #66038 for `agent/coding_context.py`.

## Tests

- Updated existing `test_tui_gateway_git_probe_hides_git_windows` from `subprocess.run` to `Popen` mock
- Added 5 new tests:
  - `test_tui_gateway_git_probe_timeout_returns_empty` — verifies event ordering: communicate → kill → bounded communicate
  - `test_tui_gateway_git_probe_timeout_cleanup_failure_is_swallowed` (parametrized: TimeoutExpired, OSError, ValueError)
  - `test_tui_gateway_git_probe_nonzero_returncode_returns_empty`
  - `test_tui_gateway_git_probe_no_hide_flags_off_windows`

All 21 tests in `test_windows_subprocess_no_window_flags.py` pass.