### PR TITLE
fix(cli): finalize one-shot worker sessions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1319,10 +1319,29 @@ def _notify_single_query_session_finalize(cli, *, reason: str = "shutdown") -> N
         _single_query_finalize_attempted_session_ids.add(session_id)
 
 
+def _close_single_query_agent(cli) -> None:
+    """Close the agent-owned state.db session before a one-shot process exits.
+
+    ``chat -q`` does not enter the interactive CLI shutdown path, so resource
+    cleanup alone never calls :meth:`AIAgent.close`.  This is also deliberately
+    safe from the Kanban SIGTERM handler: ``end_session`` is autocommitted and
+    must happen before that handler uses ``os._exit`` to avoid orphaning a
+    worker process.
+    """
+    agent = getattr(cli, "agent", None)
+    close = getattr(agent, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:
+            logger.debug("single-query agent close failed", exc_info=True)
+
+
 def _finalize_single_query(cli) -> None:
     """Close one-shot CLI resources before releasing the active session lease."""
     try:
         _notify_single_query_session_finalize(cli)
+        _close_single_query_agent(cli)
         _run_cleanup(notify_session_finalize=False)
     finally:
         cli._release_active_session()
@@ -15855,6 +15874,11 @@ def main(
         # the flush against any rare blocking-I/O case (the reporter measured
         # flush in <1ms; the alarm is a failsafe, not the common path).
         if os.environ.get("HERMES_KANBAN_TASK"):
+            # This path deliberately bypasses ``finally`` via os._exit() to
+            # prevent a stuck worker thread from being reparented. Persist the
+            # agent-owned session end marker first; otherwise every killed
+            # Kanban worker leaves an ``ended_at IS NULL`` row in state.db.
+            _close_single_query_agent(cli)
             try:
                 import signal as _sig_mod
                 if hasattr(_sig_mod, "SIGALRM"):

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -85,6 +85,7 @@ def test_kanban_sigterm_closes_agent_before_hard_exit(monkeypatch):
     monkeypatch.setattr(cli, "_arm_exit_watchdog_on_shutdown_signal", lambda: None)
     monkeypatch.setattr(cli.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(signal, "signal", lambda sig, handler: handlers.__setitem__(sig, handler))
+    monkeypatch.setattr(signal, "alarm", lambda _seconds: None)
     monkeypatch.setattr(cli.os, "_exit", lambda code: (_ for _ in ()).throw(SystemExit(code)))
 
     with pytest.raises(SystemExit):

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -13,7 +13,10 @@ def reset_single_query_finalize_state(monkeypatch):
 
 def test_finalize_single_query_runs_cleanup_without_reemitting_finalize_before_release(monkeypatch):
     calls = []
-    fake_cli = SimpleNamespace(_release_active_session=lambda: calls.append(("release", {})))
+    fake_cli = SimpleNamespace(
+        agent=SimpleNamespace(close=lambda: calls.append(("close", {}))),
+        _release_active_session=lambda: calls.append(("release", {})),
+    )
 
     def cleanup(**kwargs):
         calls.append(("cleanup", kwargs))
@@ -29,9 +32,69 @@ def test_finalize_single_query_runs_cleanup_without_reemitting_finalize_before_r
 
     assert calls == [
         ("finalize", {}),
+        ("close", {}),
         ("cleanup", {"notify_session_finalize": False}),
         ("release", {}),
     ]
+
+
+def test_worker_crash_finalizer_closes_owned_agent_session(tmp_path):
+    """Kanban's os._exit signal path must persist an end marker first."""
+    import threading
+
+    from hermes_state import SessionDB
+    from run_agent import AIAgent
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id="worker-session", source="cli")
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "worker-session"
+    agent._active_children = []
+    agent._active_children_lock = threading.Lock()
+    agent.client = None
+    agent._session_db = db
+    agent._end_session_on_close = True
+
+    cli._close_single_query_agent(SimpleNamespace(agent=agent))
+
+    row = db.get_session("worker-session")
+    assert row["ended_at"] is not None
+    assert row["end_reason"] == "agent_close"
+
+
+def test_kanban_sigterm_closes_agent_before_hard_exit(monkeypatch):
+    """The dispatcher worker SIGTERM path cannot skip session finalization."""
+    import signal
+
+    calls = []
+    handlers = {}
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.agent = SimpleNamespace(
+                interrupt=lambda reason: calls.append(("interrupt", reason)),
+                close=lambda: calls.append("close"),
+            )
+
+        def _claim_active_session(self, *_args, **_kwargs):
+            return False
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker")
+    monkeypatch.setattr(cli, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli, "_arm_exit_watchdog_on_shutdown_signal", lambda: None)
+    monkeypatch.setattr(cli.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(signal, "signal", lambda sig, handler: handlers.__setitem__(sig, handler))
+    monkeypatch.setattr(cli.os, "_exit", lambda code: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit):
+        cli.main(query="hello", toolsets="terminal")
+
+    with pytest.raises(SystemExit) as exc_info:
+        handlers[signal.SIGTERM](signal.SIGTERM, None)
+
+    assert exc_info.value.code == 0
+    assert calls == [("interrupt", f"received signal {signal.SIGTERM}"), "close"]
 
 
 def test_finalize_single_query_releases_session_when_cleanup_fails(monkeypatch):


### PR DESCRIPTION
## Summary
- close the owned `AIAgent` before one-shot CLI cleanup releases its active-session lease
- finalize the agent before Kanban SIGTERM uses `os._exit(0)`, persisting `ended_at` for worker sessions
- cover the normal one-shot and SIGTERM paths with the scoped session-finalization regression tests

## Verification
- `scripts/run_tests.sh tests/cli/test_single_query_session_finalize.py tests/cli/test_session_boundary_hooks.py tests/tools/test_zombie_process_cleanup.py tests/gateway/test_session_boundary_hooks.py` (33 passed)
- `git diff --check origin/main...HEAD`
- scope: `cli.py`, `tests/cli/test_single_query_session_finalize.py`

No merge, runtime update, restart, or deployment.