### PR TITLE
fix(desktop): guard gateway-open resume against active fresh-draft transition (#68594)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -259,6 +259,79 @@ describe('useRouteResume', () => {
     expect(resumeSession).toHaveBeenCalledTimes(1)
     expect(resumeSession).toHaveBeenCalledWith('session-1', true)
   })
+
+  it("does not re-resume the old session when the new profile gateway opens before /new commits (#68594)", () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const startFreshSessionDraft = vi.fn()
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: "runtime-a" }
+    const creatingSessionRef = { current: false }
+    const runtimeIdByStoredSessionIdRef = { current: new Map([["session-a", "runtime-a"]]) }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: "session-a" }
+
+    const { rerender } = render(
+      <RouteResumeHarness
+        activeSessionId="runtime-a"
+        activeSessionIdRef={activeSessionIdRef}
+        creatingSessionRef={creatingSessionRef}
+        currentView="chat"
+        freshDraftReady={false}
+        gatewayState="open"
+        locationPathname="/session-a"
+        resumeSession={resumeSession}
+        routedSessionId="session-a"
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId="session-a"
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    expect(resumeSession).not.toHaveBeenCalled()
+
+    // Profile switch: clear refs, set freshDraftReady, close profile A gateway.
+    activeSessionIdRef.current = null
+    selectedStoredSessionIdRef.current = null
+    rerender(
+      <RouteResumeHarness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        creatingSessionRef={creatingSessionRef}
+        currentView="chat"
+        freshDraftReady
+        gatewayState="closed"
+        locationPathname="/session-a"
+        resumeSession={resumeSession}
+        routedSessionId="session-a"
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId={null}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    // Profile B gateway opens before React Router commits /new.
+    rerender(
+      <RouteResumeHarness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        creatingSessionRef={creatingSessionRef}
+        currentView="chat"
+        freshDraftReady
+        gatewayState="open"
+        locationPathname="/session-a"
+        resumeSession={resumeSession}
+        routedSessionId="session-a"
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId={null}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    // Must NOT resume session-a: the fresh draft transition is active.
+    expect(resumeSession).not.toHaveBeenCalled()
+  })
+
 })
 
 describe('useRouteResume bounded auto-retry after a failed resume', () => {
@@ -472,3 +545,4 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     expect($resumeExhaustedSessionId.get()).toBeNull()
   })
 })
+

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -140,7 +140,7 @@ export function useRouteResume({
       // we're stranded on a routed session that never loaded. The first two
       // guard against a transient /:sid re-resume during "new chat" state clears
       // before the pathname updates from /:sid -> /.
-      const shouldResume = pathnameChanged || gatewayBecameOpen || stuckOnRoutedSession
+      const shouldResume = pathnameChanged || (gatewayBecameOpen && !freshDraftReady) || stuckOnRoutedSession
 
       // On a reconnect (gatewayBecameOpen) re-resume even when the route looks
       // `alreadyActive`: the cached runtime id can be stale once the gateway


### PR DESCRIPTION
## Summary

Fixes #68594 — Desktop profile switch can bounce back to the previous profile because `useRouteResume()` treats the target profile gateway opening as a resume command for the old routed session before React Router commits the `/new` pathname.

## Root cause

In `apps/desktop/src/app/session/hooks/use-route-resume.ts` line 143, `gatewayBecameOpen` was not guarded by the existing `freshDraftReady` discriminator, unlike the `stuckOnRoutedSession` guard on line 137 which already uses it.

During a profile switch:
1. `selectProfile()` calls `startFreshSessionDraft()` which sets `freshDraftReady=true` and clears active/selected refs synchronously
2. The target profile gateway opens asynchronously
3. React Router has not yet committed `/new` — pathname is still `/:sessionA`
4. `gatewayBecameOpen` alone triggers `resumeSession(sessionA)`, which re-selects profile A

## Fix

```diff
- const shouldResume = pathnameChanged || gatewayBecameOpen || stuckOnRoutedSession
+ const shouldResume = pathnameChanged || (gatewayBecameOpen \&\& !freshDraftReady) || stuckOnRoutedSession
```

This is consistent with the existing pattern on line 137. Reconnect behavior is preserved because `freshDraftReady` is `false` during normal reconnects.

## Changes

- `apps/desktop/src/app/session/hooks/use-route-resume.ts` — one-line fix
- `apps/desktop/src/app/session/hooks/use-route-resume.test.tsx` — regression test

## Validation

- 13/13 tests pass (12 existing + 1 new regression test)
- Existing reconnect test (`freshDraftReady=false`) continues passing
- Existing `/new` transition test (`gatewayState="open"` throughout) continues passing
- The affected hook blob (`588f614a533ff5b5732d9b4fcff3fe5fc65560e1`) is identical between the reporter's installed build and `origin/main`