### PR TITLE
fix(registry): filter kwargs to handler signature in dispatch() (#68318)

### DIFF
--- a/tools/registry.py
+++ b/tools/registry.py
@@ -624,11 +624,24 @@ class ToolRegistry:
         if not entry:
             return json.dumps({"error": f"Unknown tool: {name}"})
         try:
+            # Filter kwargs to only those the handler signature accepts.
+            # Plugin handlers written to the legacy contract ``def
+            # handle_xxx(args: dict)`` do not declare ``task_id`` or
+            # ``session_id`` parameters.  Passing unknown keyword args
+            # raises TypeError, breaking every pre-v0.19 plugin.
+            # See: NousResearch/hermes-agent#68318
+            import inspect
+            try:
+                sig = inspect.signature(entry.handler)
+                accepted = set(sig.parameters)
+                filtered = {k: v for k, v in kwargs.items() if k in accepted}
+            except (ValueError, TypeError):
+                filtered = {}
             if entry.is_async:
                 from model_tools import _run_async
-                result = _run_async(entry.handler(args, **kwargs))
+                result = _run_async(entry.handler(args, **filtered))
             else:
-                result = entry.handler(args, **kwargs)
+                result = entry.handler(args, **filtered)
             return self._normalize_handler_result(name, result)
         except Exception as e:
             logger.exception("Tool %s dispatch error: %s", name, e)


### PR DESCRIPTION
## Problem

Every plugin handler using the legacy contract  crashes in v0.19.0 with:



This affects **all** user-installed plugins and bundled plugins (e.g. kasio-notion with 11 tools). Built-in core tools are unaffected because their handlers were updated to accept the new kwargs.

## Root Cause

 passes  (containing , ) directly to the handler. Legacy plugin handlers only accept .

## Fix

Inspect the handler's signature and only forward kwargs that the handler declares. This preserves backward compatibility with pre-v0.19 plugins while still passing kwargs to handlers that accept them.

## Testing

- 376 tests pass (1 pre-existing Discord backfill failure unrelated to this change)
- Plugin handlers with legacy signature  no longer crash
- Plugin handlers with new signature  still receive kwargs
