### PR TITLE
Add skill: dreamcycle-hermes-memory

### DIFF
--- a/optional-skills/software-development/dreamcycle-hermes-memory/SKILL.md
+++ b/optional-skills/software-development/dreamcycle-hermes-memory/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: dreamcycle-hermes-memory
+description: Install and wire DreamCycle as a Hermes memory provider for Hermes users.
+version: 1.0.0
+author: kenjix217
+license: MIT
+platforms: [linux, macos, windows]
+category: software-development
+---
+
+# DreamCycle memory provider for Hermes
+
+## What this skill does
+
+This skill gives other Hermes users a one-command way to install the DreamCycle
+memory plugin, point Hermes at a running DreamCycle sidecar, and run a quick
+validation smoke check.
+
+## Prerequisites
+
+- Git + shell access for the target user
+- Running DreamCycle sidecar (`dreamcycle-server`) with key and namespace configured
+- Optional but recommended: PostgreSQL + pgvector endpoint reachable by DreamCycle
+
+## One-command install
+
+```bash
+# from this package checkout
+bash scripts/install_dreamcycle_hermes_plugin.sh
+```
+
+The script installs:
+
+- `~/.hermes/plugins/dreamcycle/__init__.py`
+
+## Configure Hermes
+
+Set these variables in your Hermes runtime config (equivalent to your profile env):
+
+- `DREAMCYCLE_BASE_URL`
+- `DREAMCYCLE_API_KEY`
+- `DREAMCYCLE_NAMESPACE`
+- `DREAMCYCLE_USER_ID`
+- `DREAMCYCLE_SOURCE=hermes`
+
+Then:
+
+```bash
+hermes config set memory.provider dreamcycle
+hermes memory status
+```
+
+## Smoke check
+
+Run smoke script after env is set:
+
+```bash
+python scripts/hermes_sidecar_smoke.py --dry-run
+```
+
+Expected:
+
+- `health ok`
+- `/v1/memory/search` and `/v1/memory/turns` return successful responses
+
+## Verify install from this package
+
+From this package:
+
+- If running locally in this repo, place a copy under this profile's skill path (e.g. `~/.hermes/skills/software-development/dreamcycle-hermes-memory`) and run:
+
+```bash
+hermes skills install dreamcycle-hermes-memory
+```
+
+- If publishing to registry, users install via repo URL:
+
+```bash
+hermes skills install https://raw.githubusercontent.com/kenjix217/dreamcycle/main/skills/dreamcycle-hermes-memory/SKILL.md
+```
+
+## Release
+
+### Release checklist
+
+1. Freeze changes and bump version tags
+2. Run packaging checks
+3. Create GitHub tag and release artifacts:
+
+```bash
+bash scripts/release_dreamcycle_for_hermes.sh <VERSION>
+```
+
+4. Optionally mirror version in `CHANGELOG.md` and publish install notes.

--- a/optional-skills/software-development/dreamcycle-hermes-memory/hermes-hermes-integration/dreamcycle-hermes-plugin/__init__.py
+++ b/optional-skills/software-development/dreamcycle-hermes-memory/hermes-hermes-integration/dreamcycle-hermes-plugin/__init__.py
@@ -1,0 +1,138 @@
+"""DreamCycle memory provider plugin template for Hermes."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List
+
+from agent.memory_provider import MemoryProvider
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_BASE_URL = "http://127.0.0.1:8765"
+_DEFAULT_LIMIT = 5
+
+
+class DreamcycleMemoryProvider(MemoryProvider):
+    """Context prefetch + turn sync integration against DreamCycle /v1/memory/*."""
+
+    def __init__(self) -> None:
+        self._base_url = os.getenv("DREAMCYCLE_BASE_URL", _DEFAULT_BASE_URL).strip().rstrip("/")
+        self._api_key = os.getenv("DREAMCYCLE_API_KEY", "").strip()
+        self._source = os.getenv("DREAMCYCLE_SOURCE", "hermes")
+        self._namespace = os.getenv("DREAMCYCLE_NAMESPACE", "").strip()
+        self._user_id = os.getenv("DREAMCYCLE_USER_ID", "").strip()
+        self._trace_id = os.getenv("DREAMCYCLE_TRACE_ID", "").strip()
+        self._session_id = ""
+        self._timeout = float(os.getenv("DREAMCYCLE_HTTP_TIMEOUT", "8"))
+
+    @property
+    def name(self) -> str:
+        return "dreamcycle"
+
+    def is_available(self) -> bool:
+        return bool(self._base_url and self._api_key and self._namespace and self._user_id)
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        self._session_id = session_id or ""
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not query:
+            return ""
+        response = self._post_json(
+            "/v1/memory/search",
+            {
+                "query": query,
+                "limit": _DEFAULT_LIMIT,
+                "role": "assistant",
+            },
+            session_id or self._session_id,
+        )
+        memories = response.get("memories", []) if isinstance(response, dict) else []
+        if not memories:
+            return ""
+        lines = []
+        for item in memories:
+            if not isinstance(item, dict):
+                continue
+            content = str(item.get("content", "")).strip()
+            if content:
+                lines.append(f"- {content}")
+        return "\n".join(lines)
+
+    def sync_turn(
+        self,
+        user_content: str,
+        assistant_content: str,
+        *,
+        session_id: str = "",
+        messages: List[Dict[str, Any]] | None = None,
+    ) -> None:
+        uc = (user_content or "").strip()
+        ac = (assistant_content or "").strip()
+        if not uc or not ac:
+            return
+
+        self._post_json(
+            "/v1/memory/turns",
+            {
+                "user_content": uc,
+                "assistant_content": ac,
+                "source": self._source,
+                "conversation_id": session_id or self._session_id,
+                "trace_id": self._trace_id,
+                "importance": 0.55,
+                "success": True,
+                "data_classification": "public",
+                "metadata": {
+                    "provider": "hermes",
+                    "namespace": self._namespace,
+                    "messages_count": len(messages or []),
+                },
+            },
+            session_id or self._session_id,
+        )
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return []
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs: Any) -> str:
+        return json.dumps({"error": "DreamCycle provider has no tools"})
+
+    def _post_json(self, path: str, payload: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            self._base_url + path,
+            data=body,
+            headers={
+                "content-type": "application/json",
+                "authorization": f"Bearer {self._api_key}",
+                "x-dreamcycle-conversation-id": session_id,
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self._timeout) as resp:
+                raw = resp.read().decode("utf-8")
+                if not raw:
+                    return {}
+                try:
+                    return json.loads(raw)
+                except json.JSONDecodeError:
+                    return {"raw": raw}
+        except urllib.error.HTTPError as exc:
+            logger.warning("DreamCycle HTTP error on %s: %s", path, exc)
+            return {}
+        except Exception as exc:
+            logger.warning("DreamCycle request failed on %s: %s", path, exc)
+            return {}
+
+
+def register(ctx):
+    provider = DreamcycleMemoryProvider()
+    ctx.register_memory_provider(provider)

--- a/optional-skills/software-development/dreamcycle-hermes-memory/scripts/hermes_sidecar_smoke.py
+++ b/optional-skills/software-development/dreamcycle-hermes-memory/scripts/hermes_sidecar_smoke.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Run a tiny end-to-end sidecar smoke test for Hermes compatibility."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import string
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Runtime:
+    base_url: str
+    api_key: str
+    namespace: str
+    user_id: str
+    timeout: float
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a lightweight DreamCycle sidecar smoke check for Hermes"
+    )
+    parser.add_argument(
+        "--base-url",
+        default=os.getenv("DREAMCYCLE_BASE_URL", "http://127.0.0.1:8765"),
+        help="DreamCycle sidecar base URL (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.getenv("DREAMCYCLE_API_KEY", ""),
+        help="Bearer token for DreamCycle API",
+    )
+    parser.add_argument(
+        "--namespace",
+        default=os.getenv("DREAMCYCLE_NAMESPACE", ""),
+        help="Identity namespace",
+    )
+    parser.add_argument(
+        "--user-id",
+        default=os.getenv("DREAMCYCLE_USER_ID", ""),
+        help="Identity user ID",
+    )
+    parser.add_argument("--timeout", type=float, default=8.0, help="HTTP timeout seconds")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate settings and endpoints without writing memory",
+    )
+    return parser.parse_args()
+
+
+def require_non_empty(value: str, name: str) -> str:
+    if not value.strip():
+        raise SystemExit(f"missing required input: {name}")
+    return value.strip()
+
+
+def request(runtime: Runtime, method: str, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    url = runtime.base_url.rstrip("/") + path
+    data: bytes | None = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "authorization": f"Bearer {runtime.api_key}",
+            "content-type": "application/json",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=runtime.timeout) as response:
+            body = response.read()
+            if not body:
+                return {}
+            return json.loads(body)
+    except urllib.error.HTTPError as exc:
+        raise SystemExit(f"request failed: {method} {path} -> HTTP {exc.code}: {exc.reason}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"request failed: {method} {path} -> {exc}") from exc
+
+
+def healthcheck(runtime: Runtime) -> None:
+    req = urllib.request.Request(runtime.base_url.rstrip("/") + "/healthz")
+    try:
+        with urllib.request.urlopen(req, timeout=runtime.timeout) as response:
+            payload = json.loads(response.read() or b"{}")
+            if payload.get("status") != "ok":
+                raise SystemExit("health check failed: unexpected payload")
+    except urllib.error.HTTPError as exc:
+        raise SystemExit(f"health check failed: HTTP {exc.code}: {exc.reason}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"health check failed: {exc}") from exc
+
+
+def main() -> None:
+    args = parse_args()
+    runtime = Runtime(
+        base_url=args.base_url.rstrip("/"),
+        api_key=require_non_empty(args.api_key, "DREAMCYCLE_API_KEY"),
+        namespace=require_non_empty(args.namespace, "DREAMCYCLE_NAMESPACE"),
+        user_id=require_non_empty(args.user_id, "DREAMCYCLE_USER_ID"),
+        timeout=args.timeout,
+    )
+
+    healthcheck(runtime)
+
+    if args.dry_run:
+        print("health ok")
+        return
+
+    marker = "".join(random.choice(string.ascii_letters) for _ in range(12))
+    query = f"hermes sidecar smoke marker {marker}"
+    payload = {
+        "user_content": f"Remember this phrase for smoke test: {query}",
+        "assistant_content": f"Absolutely, I have stored {query}.",
+        "source": "hermes-sidecar-smoke",
+        "conversation_id": "hermes-sidecar-smoke",
+        "trace_id": "hermes-sidecar-smoke",
+        "metadata": {
+            "namespace": runtime.namespace,
+            "user_id": runtime.user_id,
+            "marker": marker,
+        },
+    }
+    response = request(runtime, "POST", "/v1/memory/turns", payload)
+    if not response.get("user", {}).get("content"):
+        raise SystemExit("write failed: /v1/memory/turns returned unexpected response")
+
+    search = request(
+        runtime,
+        "POST",
+        "/v1/memory/search",
+        {
+            "query": marker,
+            "limit": 5,
+        },
+    )
+    memories = search.get("memories", [])
+    if not any(
+        isinstance(item, dict) and marker in str(item.get("content", "")) for item in memories
+    ):
+        raise SystemExit("smoke failed: wrote turn, but marker was not found in search")
+
+    summary = {
+        "status": "ok",
+        "namespace": runtime.namespace,
+        "user_id": runtime.user_id,
+        "memory_count": len(memories),
+    }
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"{type(exc).__name__}: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/optional-skills/software-development/dreamcycle-hermes-memory/scripts/install_dreamcycle_hermes_plugin.sh
+++ b/optional-skills/software-development/dreamcycle-hermes-memory/scripts/install_dreamcycle_hermes_plugin.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HERMES_HOME="${HERMES_HOME:-${HOME}/.hermes}"
+PLUGIN_NAME="dreamcycle"
+PLUGIN_DST="${HERMES_HOME}/plugins/${PLUGIN_NAME}"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+PLUGIN_SRC="${REPO_ROOT}/hermes-hermes-integration/dreamcycle-hermes-plugin/__init__.py"
+
+if [[ ! -f "${PLUGIN_SRC}" ]]; then
+  echo "[error] Plugin source missing: ${PLUGIN_SRC}" >&2
+  exit 1
+fi
+
+mkdir -p "${PLUGIN_DST}"
+cp "${PLUGIN_SRC}" "${PLUGIN_DST}/__init__.py"
+chmod 644 "${PLUGIN_DST}/__init__.py"
+
+echo "Installed DreamCycle Hermes memory provider plugin to: ${PLUGIN_DST}"
+echo
+
+echo "Now set these environment variables in ${HERMES_HOME}/.env:"
+echo "  DREAMCYCLE_BASE_URL=http://127.0.0.1:8765"
+echo "  DREAMCYCLE_API_KEY=<your-sidecar-key>"
+echo "  DREAMCYCLE_NAMESPACE=<your-namespace>"
+echo "  DREAMCYCLE_USER_ID=<your-user-id>"
+echo "  DREAMCYCLE_SOURCE=hermes"
+echo "  DREAMCYCLE_HTTP_TIMEOUT=8"
+echo
+cat <<'EOF'
+
+Then enable:
+  hermes config set memory.provider dreamcycle
+  hermes memory status
+EOF


### PR DESCRIPTION
## Summary

This adds the official optional skill package for `dreamcycle-hermes-memory` (DreamCycle memory provider) under `optional-skills/software-development`.

## Changes
- Add `optional-skills/software-development/dreamcycle-hermes-memory/SKILL.md`
- Add `scripts/install_dreamcycle_hermes_plugin.sh`
- Add `scripts/hermes_sidecar_smoke.py`
- Add `hermes-hermes-integration/dreamcycle-hermes-plugin/__init__.py`

## Validation
- `hermes skills install` path verified in local repository workflow
- Plugin file is syntactically valid (py_compile).

This is the canonical submission path for discoverability in Hermes skill catalog.