### PR TITLE
fix: harden cron, Telegram, and session maintenance

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1152,7 +1152,18 @@ def build_environment_hints() -> str:
         else:
             host_lines.append(f"Host: {platform.system()} ({platform.release()})")
 
-        host_lines.append(f"User home directory: {os.path.expanduser('~')}")
+        from hermes_constants import get_subprocess_home
+
+        account_home = os.path.expanduser("~")
+        terminal_home = get_subprocess_home() or account_home
+        hermes_home = get_hermes_home()
+        host_lines.append(f"User home directory: {account_home}")
+        host_lines.append(f"Terminal HOME: {terminal_home}")
+        host_lines.append(
+            f"Hermes state directory: {hermes_home} ($HERMES_HOME). "
+            "For Hermes skills/scripts/state use $HERMES_HOME; do not derive it "
+            "from $HOME or ~/.hermes when they differ."
+        )
         try:
             host_lines.append(f"Current working directory: {resolve_agent_cwd()}")
         except OSError:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -294,6 +294,15 @@ SILENT_MARKER = "[SILENT]"
 # "I considered staying [SILENT] but here is the summary…" must deliver).
 _CRON_SILENCE_TOKENS = frozenset({"[SILENT]", "SILENT", "NO_REPLY", "NO REPLY"})
 
+# Back-compat for existing Gmail Inbox Zero cron prompts that predate the
+# [SILENT] contract and returned a human no-op line.  Treat these as silence
+# only when they are the whole final response; a report that merely mentions
+# the phrase still delivers.
+_CRON_WHOLE_RESPONSE_SILENCE_PHRASES = frozenset({
+    "GMAIL: НОВЫХ ДЕЙСТВИЙ НЕТ",
+    "GMAIL: NO NEW ACTIONS",
+})
+
 
 def _is_cron_silence_response(text: str) -> bool:
     """Return True when a cron final response should suppress delivery.
@@ -315,6 +324,9 @@ def _is_cron_silence_response(text: str) -> bool:
 
     # Whole response is exactly a token.
     if _is_token(stripped):
+        return True
+    normalized_whole = " ".join(stripped.upper().rstrip(".!。 ").split())
+    if normalized_whole in _CRON_WHOLE_RESPONSE_SILENCE_PHRASES:
         return True
     # Marker on its own first or last line (trailing/leading note on a
     # separate line — e.g. "2 deals filtered\n\n[SILENT]").

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -303,6 +303,11 @@ _CRON_WHOLE_RESPONSE_SILENCE_PHRASES = frozenset({
     "GMAIL: NO NEW ACTIONS",
 })
 
+# Internal status discriminator for the one failed-run class whose no-tools
+# fallback text remains safe and useful to deliver verbatim.  Do not broaden
+# this to arbitrary failures with a partial ``final_response``.
+_MAX_ITERATION_FAILURE_PREFIX = "Agent reached the iteration limit before task completion"
+
 
 def _is_cron_silence_response(text: str) -> bool:
     """Return True when a cron final response should suppress delivery.
@@ -3543,10 +3548,15 @@ def run_job(
                 or "agent reported failure"
             )
             raise RuntimeError(_err_text)
+        material_failure_error = None
         if max_iteration_summary:
+            material_failure_error = (
+                f"{_MAX_ITERATION_FAILURE_PREFIX} "
+                f"({turn_exit_reason}); fallback response preserved for delivery."
+            )
             logger.warning(
                 "Job '%s' reached the iteration limit but produced a final fallback response; "
-                "delivering the response instead of failing the cron run",
+                "preserving the response for delivery while marking the run failed",
                 job_name,
             )
 
@@ -3594,6 +3604,9 @@ def run_job(
 {logged_response}
 """
         
+        if material_failure_error:
+            logger.info("Job '%s' completed with a material failure", job_name)
+            return False, output, final_response, material_failure_error
         logger.info("Job '%s' completed successfully", job_name)
         return True, output, final_response, None
         
@@ -3828,10 +3841,24 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                     "(tool subprocess was killed mid-flight)."
                 )
 
-            # Deliver the final response to the origin/target chat.
-            # If the agent responded with [SILENT], skip delivery (but
-            # output is already saved above).  Failed jobs always deliver.
-            deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
+            # Deliver the final response to the origin/target chat.  A materially
+            # failed run may still carry a useful no-tools fallback report (for
+            # example after max-iteration exhaustion); preserve that report for
+            # delivery while keeping ``success=False`` for status accounting.
+            # Other failed jobs use the concise failure summary.  If the agent
+            # responded with [SILENT], skip delivery (but output is already saved
+            # above); genuine failed jobs without fallback text always deliver.
+            preserve_max_iteration_fallback = (
+                not success
+                and bool(final_response.strip())
+                and isinstance(error, str)
+                and error.startswith(_MAX_ITERATION_FAILURE_PREFIX)
+            )
+            deliver_content = (
+                final_response
+                if success or preserve_max_iteration_fallback
+                else _summarize_cron_failure_for_delivery(job, error)
+            )
             # Treat whitespace-only final responses the same as empty
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.

--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -12,9 +12,10 @@ import logging
 import os
 import time
 import uuid
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterator, Optional, Set
 
 from hermes_constants import get_hermes_home
 
@@ -155,6 +156,29 @@ def _read_entries(path: Path) -> list[dict[str, Any]]:
     if not isinstance(entries, list):
         return []
     return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def _read_entries_strict(path: Path) -> list[dict[str, Any]]:
+    """Read the live registry, failing closed on corruption.
+
+    Normal lease acquisition remains tolerant of a corrupt diagnostic file so
+    users are not locked out. Destructive maintenance must use this strict
+    variant because silently treating corruption as an empty protection set
+    could finalize an active session.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        return []
+    except Exception as exc:
+        raise RuntimeError(f"active session registry is unreadable: {path}") from exc
+    entries = data.get("entries") if isinstance(data, dict) else data
+    if not isinstance(entries, list) or not all(
+        isinstance(entry, dict) for entry in entries
+    ):
+        raise RuntimeError(f"active session registry is malformed: {path}")
+    return entries
 
 
 def _write_entries(path: Path, entries: list[dict[str, Any]]) -> None:
@@ -355,3 +379,24 @@ def active_session_registry_snapshot() -> list[dict[str, Any]]:
         entries = _prune_dead(_read_entries(state_path))
         _write_entries(state_path, entries)
         return entries
+
+
+@contextmanager
+def locked_active_session_ids() -> Iterator[Set[str]]:
+    """Yield live leased session IDs while holding the cross-process lock.
+
+    Intended for destructive maintenance that must prevent a new lease from
+    appearing between candidate discovery and the database transaction.
+    Registry corruption raises instead of degrading to an empty set.
+    """
+    state_path = _state_path()
+    with _FileLock(_lock_path()):
+        raw_entries = _read_entries_strict(state_path)
+        entries = _prune_dead(raw_entries)
+        if entries != raw_entries:
+            _write_entries(state_path, entries)
+        yield {
+            str(entry.get("session_id"))
+            for entry in entries
+            if str(entry.get("session_id") or "").strip()
+        }

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14295,6 +14295,29 @@ def main():
         help="Reclaim disk space: merge FTS5 segments + VACUUM (no data change)",
     )
 
+    sessions_reconcile_telegram = sessions_subparsers.add_parser(
+        "reconcile-telegram-orphans",
+        help="Safely finalize old unowned Telegram group sessions",
+        description=(
+            "Find unended Telegram group sessions that are old, unrouted, and "
+            "not protected by a live process lease. Defaults to dry-run. "
+            "--apply creates and verifies an online state.db backup before a "
+            "single transactional update."
+        ),
+    )
+    sessions_reconcile_telegram.add_argument(
+        "--min-age-hours",
+        type=float,
+        default=1.0,
+        metavar="HOURS",
+        help="Only consider sessions at least HOURS old (default: 1)",
+    )
+    sessions_reconcile_telegram.add_argument(
+        "--apply",
+        action="store_true",
+        help="Create a verified backup and finalize the current candidates",
+    )
+
     sessions_repair = sessions_subparsers.add_parser(
         "repair",
         help="Repair a malformed state.db schema so hidden sessions reappear",
@@ -15048,6 +15071,45 @@ def main():
 
             relaunch(["--resume", selected_id])
             return  # won't reach here after execvp
+
+        elif action == "reconcile-telegram-orphans":
+            from hermes_cli.session_reconcile import reconcile_telegram_group_orphans
+
+            min_age_hours = getattr(args, "min_age_hours", 1.0)
+            if min_age_hours < 0:
+                print("Error: --min-age-hours must be non-negative.")
+                db.close()
+                return
+            try:
+                report = reconcile_telegram_group_orphans(
+                    db,
+                    sessions_dir=get_hermes_home() / "sessions",
+                    min_age_seconds=min_age_hours * 3600,
+                    apply=bool(getattr(args, "apply", False)),
+                )
+            except Exception as exc:
+                print(f"Error: Telegram orphan reconciliation failed closed: {exc}")
+                db.close()
+                return
+
+            candidates = report["candidate_ids"]
+            if candidates:
+                print(f"Candidate Telegram group sessions: {len(candidates)}")
+                for session_id in candidates:
+                    print(f"  {session_id}")
+            else:
+                print("No orphaned Telegram group sessions found.")
+
+            if report["dry_run"]:
+                print("Dry run — no session state changed and no backup was created.")
+            else:
+                backup_path = report.get("backup_path")
+                if backup_path:
+                    print(f"Verified backup: {backup_path}")
+                print(
+                    f"Finalized {len(report['finalized_ids'])} session(s) "
+                    "with end_reason=orphan_reconcile."
+                )
 
         elif action == "optimize":
             db_path = db.db_path

--- a/hermes_cli/session_reconcile.py
+++ b/hermes_cli/session_reconcile.py
@@ -1,0 +1,82 @@
+"""Safe reconciliation of orphaned Telegram group sessions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Set
+
+from hermes_cli.active_sessions import locked_active_session_ids
+from hermes_state import SessionDB
+
+
+def _legacy_routed_session_ids(sessions_file: Path) -> Set[str]:
+    """Read legacy sessions.json references, failing closed on malformed data."""
+    try:
+        data = json.loads(sessions_file.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return set()
+    except Exception as exc:
+        raise RuntimeError(
+            f"legacy session route registry is unreadable: {sessions_file}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            f"legacy session route registry is malformed: {sessions_file}"
+        )
+
+    routed: Set[str] = set()
+    for key, entry in data.items():
+        if str(key).startswith("_"):
+            continue
+        if not isinstance(entry, dict) or not entry.get("session_id"):
+            raise RuntimeError(
+                f"legacy session route registry is malformed: {sessions_file}"
+            )
+        routed.add(str(entry["session_id"]))
+    return routed
+
+
+def reconcile_telegram_group_orphans(
+    db: SessionDB,
+    *,
+    sessions_dir: Path,
+    min_age_seconds: float = 3600.0,
+    apply: bool = False,
+) -> Dict[str, Any]:
+    """Preview or safely finalize unowned Telegram group sessions.
+
+    The cross-process lease lock stays held from protection discovery through
+    backup and the transactional database update. Canonical state.db routes are
+    re-read by ``SessionDB`` within the same write transaction; the legacy JSON
+    mirror is also treated as a protected source. Apply always creates and
+    verifies a fresh online backup first.
+    """
+    sessions_dir = Path(sessions_dir)
+    with locked_active_session_ids() as leased_ids:
+        legacy_routed_ids = _legacy_routed_session_ids(
+            sessions_dir / "sessions.json"
+        )
+        protected_ids = set(leased_ids) | legacy_routed_ids
+        preview = db.reconcile_orphaned_telegram_group_sessions(
+            protected_session_ids=protected_ids,
+            min_age_seconds=min_age_seconds,
+            apply=False,
+        )
+        if not apply:
+            return {**preview, "backup_path": None}
+        if not preview["candidate_ids"]:
+            return {
+                "candidate_ids": [],
+                "finalized_ids": [],
+                "dry_run": False,
+                "backup_path": None,
+            }
+
+        backup_path = db.create_verified_backup("telegram-orphan-reconcile")
+        result = db.reconcile_orphaned_telegram_group_sessions(
+            protected_session_ids=protected_ids,
+            min_age_seconds=min_age_seconds,
+            apply=True,
+        )
+        return {**result, "backup_path": str(backup_path)}

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -17,6 +17,7 @@ Key design decisions:
 import asyncio
 import json
 import logging
+import os
 import random
 import re
 import sqlite3
@@ -2373,6 +2374,146 @@ class SessionDB:
                 (time.time(), end_reason, session_id),
             )
         self._execute_write(_do)
+
+    def create_verified_backup(self, purpose: str = "maintenance") -> Path:
+        """Create and integrity-check a consistent online SQLite backup.
+
+        ``sqlite3.Connection.backup`` includes committed WAL contents and is safe
+        while other readers are connected.  The destination is placed beside the
+        source DB so restore remains a single-file rollback operation.
+        """
+        if self.read_only:
+            raise RuntimeError("cannot back up a read-only SessionDB handle")
+        safe_purpose = re.sub(r"[^a-zA-Z0-9_-]+", "-", purpose).strip("-")
+        safe_purpose = safe_purpose or "maintenance"
+        stamp = time.strftime("%Y%m%d_%H%M%S", time.localtime())
+        destination = self.db_path.with_name(
+            f"{self.db_path.name}.backup-{safe_purpose}-{stamp}-{time.time_ns()}"
+        )
+        destination.parent.mkdir(parents=True, exist_ok=True)
+
+        source = self._conn
+        if source is None:
+            raise RuntimeError("session database is closed")
+        target = sqlite3.connect(str(destination))
+        try:
+            os.chmod(destination, 0o600)
+            with self._lock:
+                source.backup(target)
+            result = target.execute("PRAGMA integrity_check").fetchone()
+            if not result or result[0] != "ok":
+                raise sqlite3.DatabaseError(
+                    f"backup integrity_check failed: {result[0] if result else 'no result'}"
+                )
+        except BaseException:
+            target.close()
+            try:
+                destination.unlink()
+            except OSError:
+                pass
+            raise
+        else:
+            target.close()
+        return destination
+
+    def reconcile_orphaned_telegram_group_sessions(
+        self,
+        *,
+        protected_session_ids: Any = (),
+        min_age_seconds: float = 3600.0,
+        apply: bool = False,
+    ) -> Dict[str, Any]:
+        """Find or finalize stale Telegram group sessions with no live owner.
+
+        A candidate must be an old, unended Telegram ``group`` row and must be
+        absent from both the transactional ``gateway_routing`` registry and the
+        caller-supplied protected IDs (live process/lease and legacy-route
+        snapshots).  Route JSON is parsed fail-closed: corrupt registry state
+        aborts the operation rather than risking a false orphan classification.
+
+        Apply mode runs discovery and finalization in one ``BEGIN IMMEDIATE``
+        transaction.  Every UPDATE repeats the immutable candidate predicates;
+        any error rolls back the complete batch.
+        """
+        if self.read_only and apply:
+            raise RuntimeError("cannot reconcile sessions through a read-only handle")
+        try:
+            minimum_age = float(min_age_seconds)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("min_age_seconds must be a non-negative number") from exc
+        if minimum_age < 0:
+            raise ValueError("min_age_seconds must be a non-negative number")
+
+        protected = {
+            str(session_id)
+            for session_id in (protected_session_ids or ())
+            if str(session_id or "").strip()
+        }
+        cutoff = time.time() - minimum_age
+
+        def _reconcile(conn: sqlite3.Connection) -> Dict[str, Any]:
+            current_protected = set(protected)
+            routing_rows = conn.execute(
+                "SELECT scope, session_key, entry_json FROM gateway_routing"
+            ).fetchall()
+            for route in routing_rows:
+                try:
+                    entry = json.loads(route["entry_json"])
+                    routed_session_id = entry.get("session_id") if isinstance(entry, dict) else None
+                except (TypeError, ValueError, json.JSONDecodeError) as exc:
+                    raise ValueError(
+                        "malformed gateway routing entry; refusing orphan reconciliation"
+                    ) from exc
+                if not routed_session_id:
+                    raise ValueError(
+                        "malformed gateway routing entry; refusing orphan reconciliation"
+                    )
+                current_protected.add(str(routed_session_id))
+
+            rows = conn.execute(
+                """SELECT id
+                     FROM sessions
+                    WHERE source = 'telegram'
+                      AND chat_type = 'group'
+                      AND ended_at IS NULL
+                      AND started_at <= ?
+                    ORDER BY id""",
+                (cutoff,),
+            ).fetchall()
+            candidate_ids = [
+                str(row["id"])
+                for row in rows
+                if str(row["id"]) not in current_protected
+            ]
+            finalized_ids: List[str] = []
+            if apply:
+                ended_at = time.time()
+                for session_id in candidate_ids:
+                    cursor = conn.execute(
+                        """UPDATE sessions
+                              SET ended_at = ?, end_reason = 'orphan_reconcile'
+                            WHERE id = ?
+                              AND source = 'telegram'
+                              AND chat_type = 'group'
+                              AND ended_at IS NULL
+                              AND started_at <= ?""",
+                        (ended_at, session_id, cutoff),
+                    )
+                    if cursor.rowcount == 1:
+                        finalized_ids.append(session_id)
+            return {
+                "candidate_ids": candidate_ids,
+                "finalized_ids": finalized_ids,
+                "dry_run": not apply,
+            }
+
+        if apply:
+            return self._execute_write(_reconcile)
+        with self._lock:
+            conn = self._conn
+            if conn is None:
+                raise RuntimeError("session database is closed")
+            return _reconcile(conn)
 
     def reopen_session(self, session_id: str) -> None:
         """Clear ended_at/end_reason so a session can be resumed."""

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1190,6 +1190,32 @@ class TelegramAdapter(BasePlatformAdapter):
     def _is_thread_not_found_error(error: Exception) -> bool:
         return "thread not found" in str(error).lower()
 
+    @staticmethod
+    def _is_stale_edit_placeholder_error(error: object) -> bool:
+        """Whether Telegram confirmed that an edit target no longer exists."""
+        text = str(error).lower()
+        return (
+            "message to edit not found" in text
+            or "message_id_invalid" in text
+        )
+
+    def _stale_edit_placeholder_result(
+        self, error: object, message_id: object
+    ) -> SendResult:
+        """Return a quiet terminal result for a deleted/expired placeholder."""
+        safe_error = _redact_telegram_error_text(error)
+        logger.debug(
+            "[%s] Progress edit target %s is stale; disabling edits for it",
+            self.name,
+            message_id,
+        )
+        return SendResult(
+            success=False,
+            error=safe_error,
+            retryable=False,
+            error_kind="not_found",
+        )
+
     def _prune_stale_dm_topic_binding(
         self, chat_id: Any, thread_id: Any,
     ) -> None:
@@ -1883,6 +1909,8 @@ class TelegramAdapter(BasePlatformAdapter):
             # error must not be mistaken for a failed edit).
             await self._bot.do_api_request("editMessageText", api_kwargs=payload)
         except Exception as exc:
+            if self._is_stale_edit_placeholder_error(exc):
+                return self._stale_edit_placeholder_result(exc, message_id)
             if self._is_rich_fallback_error(exc):
                 if self._is_rich_capability_error(exc):
                     self._rich_send_disabled = True
@@ -4473,6 +4501,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 # "Message is not modified" is a no-op, not an error
                 if "not modified" in str(fmt_err).lower():
                     return SendResult(success=True, message_id=message_id)
+                if self._is_stale_edit_placeholder_error(fmt_err):
+                    return self._stale_edit_placeholder_result(fmt_err, message_id)
                 # Fallback: strip MarkdownV2 escapes and retry as clean plain text
                 safe_format_error = _redact_telegram_error_text(fmt_err)
                 logger.warning(
@@ -4492,6 +4522,8 @@ class TelegramAdapter(BasePlatformAdapter):
             # "Message is not modified" — content identical, treat as success
             if "not modified" in err_str:
                 return SendResult(success=True, message_id=message_id)
+            if self._is_stale_edit_placeholder_error(e):
+                return self._stale_edit_placeholder_result(e, message_id)
             # Reactive split-and-deliver: parse_mode formatting can inflate
             # the payload past the limit even when the raw text was under
             # (e.g. MarkdownV2 escapes).  Same fix as the pre-flight path.
@@ -4648,6 +4680,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                 except Exception as fmt_err:
                     if "not modified" not in str(fmt_err).lower():
+                        if self._is_stale_edit_placeholder_error(fmt_err):
+                            return self._stale_edit_placeholder_result(
+                                fmt_err, message_id
+                            )
                         logger.warning(
                             "[%s] Overflow split: MarkdownV2 first-chunk edit "
                             "failed, falling back to plain text: %s",
@@ -4670,6 +4706,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 # First chunk identical to current text — fall through to
                 # send continuations.
                 pass
+            elif self._is_stale_edit_placeholder_error(e):
+                return self._stale_edit_placeholder_result(e, message_id)
             else:
                 logger.error(
                     "[%s] Overflow split: first-chunk edit failed: %s",

--- a/skills/productivity/maps/SKILL.md
+++ b/skills/productivity/maps/SKILL.md
@@ -39,12 +39,13 @@ functionality is covered by the `nearby` command below, with the same
 
 Python 3.8+ (stdlib only — no pip installs needed).
 
-Script path: `~/.hermes/skills/maps/scripts/maps_client.py`
+Script path: `${HERMES_HOME:-$HOME/.hermes}/skills/maps/scripts/maps_client.py`.
+`HERMES_HOME` is authoritative because terminal `$HOME` may be sandboxed.
 
 ## Commands
 
 ```bash
-MAPS=~/.hermes/skills/maps/scripts/maps_client.py
+MAPS="${HERMES_HOME:-$HOME/.hermes}/skills/maps/scripts/maps_client.py"
 ```
 
 ### search — Geocode a place name
@@ -187,9 +188,10 @@ current.
 ## Verification
 
 ```bash
-python3 ~/.hermes/skills/maps/scripts/maps_client.py search "Statue of Liberty"
+MAPS="${HERMES_HOME:-$HOME/.hermes}/skills/maps/scripts/maps_client.py"
+python3 "$MAPS" search "Statue of Liberty"
 # Should return lat ~40.689, lon ~-74.044
 
-python3 ~/.hermes/skills/maps/scripts/maps_client.py nearby --near "Times Square" --category restaurant --limit 3
+python3 "$MAPS" nearby --near "Times Square" --category restaurant --limit 3
 # Should return a list of restaurants within ~500m of Times Square
 ```

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1229,6 +1229,30 @@ class TestEnvironmentHints:
         assert "hostname" not in result
         assert "WSL" not in result
 
+    def test_local_hint_distinguishes_sandbox_home_from_hermes_home(
+        self, monkeypatch, tmp_path
+    ):
+        """Account-global paths must not be derived from a profile HOME sandbox."""
+        import agent.prompt_builder as _pb
+        import hermes_constants as _hc
+
+        hermes_home = tmp_path / ".hermes"
+        sandbox_home = hermes_home / "home"
+        real_home = tmp_path / "account"
+        sandbox_home.mkdir(parents=True)
+        real_home.mkdir()
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(_hc, "is_container", lambda: True)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HOME", str(real_home))
+
+        result = _pb.build_environment_hints()
+
+        assert f"Terminal HOME: {sandbox_home}" in result
+        assert f"Hermes state directory: {hermes_home}" in result
+        assert "do not derive it from $HOME or ~/.hermes" in result
+
     def test_build_environment_hints_on_windows_local(self, monkeypatch):
         import agent.prompt_builder as _pb
         import sys

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1486,13 +1486,14 @@ class TestRunJobSessionPersistence:
         assert error is None
         assert final_response == "all good"
 
-    def test_run_job_delivers_max_iteration_fallback_summary(self, tmp_path):
-        """Cron should deliver a usable max-iteration fallback summary.
+    def test_run_job_marks_max_iteration_fallback_failed_without_discarding_report(
+        self, tmp_path
+    ):
+        """Iteration exhaustion is a failed run even when fallback text is usable.
 
-        A cron run can exhaust the iteration budget, get a final text summary
-        from the no-tools fallback call, and still have ``completed=False`` in
-        the generic agent result. That should not make cron raise the report
-        text as a RuntimeError.
+        Cron must preserve the no-tools fallback report for delivery while
+        returning ``success=False`` so ``last_status`` cannot become a false
+        green.
         """
         job = {
             "id": "summary-job",
@@ -1527,11 +1528,10 @@ class TestRunJobSessionPersistence:
 
             success, output, final_response, error = run_job(job)
 
-        assert success is True
-        assert error is None
+        assert success is False
+        assert error is not None and "iteration limit" in error.lower()
         assert final_response == "final fallback report"
         assert "final fallback report" in output
-        assert "(FAILED)" not in output
 
     def test_tick_skips_due_jobs_while_dispatch_is_paused(self, tmp_path):
         """The drain gate runs before advancing a due job's schedule."""
@@ -2663,6 +2663,51 @@ class TestSilentDelivery:
         assert not sil("[SILENT")  # malformed open-bracket is not the sentinel
         assert not sil("")
         assert not sil("   \n\t ")
+
+    def test_iteration_limit_failure_delivers_fallback_and_marks_failed(self):
+        """Fallback text stays deliverable without turning the run green."""
+        job = self._make_job()
+        fallback = "partial report from the no-tools fallback"
+        error = "Agent reached the iteration limit before task completion"
+        with patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch(
+                 "cron.scheduler.run_job",
+                 return_value=(False, "# output", fallback, error),
+             ), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run") as mark_mock:
+            from cron.scheduler import tick
+            tick(verbose=False)
+
+        deliver_mock.assert_called_once()
+        assert deliver_mock.call_args.args[0]["id"] == "monitor-job"
+        assert deliver_mock.call_args.args[1] == fallback
+        assert deliver_mock.call_args.kwargs == {"adapters": None, "loop": None}
+        mark_mock.assert_called_once_with(
+            "monitor-job", False, error, delivery_error=deliver_mock.return_value
+        )
+
+    def test_non_iteration_failure_does_not_deliver_raw_final_response(self):
+        """Only the recognized max-iteration fallback bypasses failure summary."""
+        job = self._make_job()
+        raw_response = "raw partial response that must not be delivered"
+        error = "provider request failed"
+        with patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch(
+                 "cron.scheduler.run_job",
+                 return_value=(False, "# output", raw_response, error),
+             ), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+
+        deliver_mock.assert_called_once()
+        delivered = deliver_mock.call_args.args[1]
+        assert delivered != raw_response
+        assert error in delivered
 
     def test_failed_job_always_delivers(self):
         """Failed jobs deliver regardless of [SILENT] in output."""

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2653,10 +2653,13 @@ class TestSilentDelivery:
         assert sil("NO_REPLY")
         assert sil("NO REPLY")
         assert sil("Summary.\nSILENT")
+        assert sil("Gmail: новых действий нет.")
+        assert sil(" gmail: no new actions ")
         # Deliver: real content, mid-sentence quotes, bare words, junk.
         assert not sil("Daily report: 4 PRs merged.")
         assert not sil("I stayed [SILENT] but here is the report: 3 items.")
         assert not sil("Silent retry succeeded after 2 attempts.")
+        assert not sil("Processed 2 emails. Gmail: новых действий нет.")
         assert not sil("[SILENT")  # malformed open-bracket is not the sentinel
         assert not sil("")
         assert not sil("   \n\t ")

--- a/tests/gateway/test_telegram_progress_edit_transient.py
+++ b/tests/gateway/test_telegram_progress_edit_transient.py
@@ -17,10 +17,15 @@ Two layers are tested:
 
 from __future__ import annotations
 
+import asyncio
+import logging
+from unittest.mock import AsyncMock
 
 import pytest
 
+from gateway.config import Platform
 from gateway.platforms.base import SendResult
+from plugins.platforms.telegram.adapter import TelegramAdapter
 
 
 # ---------------------------------------------------------------------------
@@ -179,3 +184,59 @@ def test_flood_control_sets_can_edit_false():
         SendResult(success=False, error="flood_control:30.0", retryable=False),
     ]
     assert _simulate_progress_loop(results) is False
+
+
+# ---------------------------------------------------------------------------
+# 4. Real adapter lifecycle — a deleted/expired placeholder is terminal
+# ---------------------------------------------------------------------------
+
+def test_message_not_found_stops_markdown_fallback_without_error_noise(caplog):
+    """A stale placeholder is one idempotent failure, not two noisy edits."""
+    adapter = TelegramAdapter.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter._bot = AsyncMock()
+    adapter._bot.edit_message_text.side_effect = Exception(
+        "Bad Request: Message to edit not found"
+    )
+    adapter._rich_messages_enabled = False
+    adapter._last_overflow_preview = {}
+
+    with caplog.at_level(
+        logging.DEBUG, logger="plugins.platforms.telegram.adapter"
+    ):
+        result = asyncio.run(
+            adapter.edit_message(
+                chat_id="-100123", message_id="42", content="done", finalize=True
+            )
+        )
+
+    assert result.success is False
+    assert result.retryable is False
+    assert result.error_kind == "not_found"
+    assert adapter._bot.edit_message_text.await_count == 1
+    assert not [record for record in caplog.records if record.levelno >= logging.WARNING]
+
+
+def test_other_edit_errors_keep_existing_fallback_and_error_logging(caplog):
+    """The stale-placeholder special case must not hide unrelated edit errors."""
+    adapter = TelegramAdapter.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter._bot = AsyncMock()
+    adapter._bot.edit_message_text.side_effect = Exception(
+        "Bad Request: message can't be edited"
+    )
+    adapter._rich_messages_enabled = False
+    adapter._last_overflow_preview = {}
+
+    with caplog.at_level(
+        logging.DEBUG, logger="plugins.platforms.telegram.adapter"
+    ):
+        result = asyncio.run(
+            adapter.edit_message(
+                chat_id="-100123", message_id="42", content="done", finalize=True
+            )
+        )
+
+    assert result.success is False
+    assert adapter._bot.edit_message_text.await_count == 2
+    assert any(record.levelno >= logging.ERROR for record in caplog.records)

--- a/tests/hermes_cli/test_session_reconcile.py
+++ b/tests/hermes_cli/test_session_reconcile.py
@@ -1,0 +1,196 @@
+"""Operational safety tests for the Telegram orphan reconciliation service."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import active_sessions
+from hermes_cli.session_reconcile import reconcile_telegram_group_orphans
+from hermes_state import SessionDB
+
+
+def _open_group(db: SessionDB, session_id: str) -> None:
+    db.create_session(
+        session_id,
+        "telegram",
+        chat_type="group",
+        chat_id=f"chat-{session_id}",
+        session_key=f"key-{session_id}",
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = ?",
+        (time.time() - 7200, session_id),
+    )
+    db._conn.commit()
+
+
+def test_apply_holds_live_lease_protection_and_creates_verified_backup(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    sessions_dir = home / "sessions"
+    sessions_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: int(pid) == os.getpid())
+    monkeypatch.setattr(active_sessions, "_process_start_time", lambda _pid: 100.0)
+
+    db = SessionDB(home / "state.db")
+    lease = None
+    try:
+        for session_id in ("orphan", "leased", "legacy-routed"):
+            _open_group(db, session_id)
+        (sessions_dir / "sessions.json").write_text(
+            json.dumps(
+                {
+                    "telegram:legacy": {
+                        "session_id": "legacy-routed",
+                        "session_key": "telegram:legacy",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        lease, message = active_sessions.try_acquire_active_session(
+            session_id="leased",
+            surface="gateway:telegram",
+            config={"max_concurrent_sessions": 1},
+        )
+        assert message is None
+
+        report = reconcile_telegram_group_orphans(
+            db,
+            sessions_dir=sessions_dir,
+            min_age_seconds=3600,
+            apply=True,
+        )
+
+        assert report["finalized_ids"] == ["orphan"]
+        assert report["backup_path"]
+        actual_backup = Path(report["backup_path"])
+        assert actual_backup.exists()
+        assert db.get_session("leased")["ended_at"] is None
+        assert db.get_session("legacy-routed")["ended_at"] is None
+
+        backup = SessionDB(actual_backup, read_only=True)
+        try:
+            assert backup.get_session("orphan")["ended_at"] is None
+        finally:
+            backup.close()
+    finally:
+        if lease is not None:
+            lease.release()
+        db.close()
+
+
+def test_dry_run_does_not_create_backup_or_modify_state(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    sessions_dir = home / "sessions"
+    sessions_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    db = SessionDB(home / "state.db")
+    try:
+        _open_group(db, "orphan")
+        report = reconcile_telegram_group_orphans(
+            db,
+            sessions_dir=sessions_dir,
+            min_age_seconds=3600,
+            apply=False,
+        )
+        assert report["candidate_ids"] == ["orphan"]
+        assert report["backup_path"] is None
+        assert db.get_session("orphan")["ended_at"] is None
+        assert list(home.glob("state.db.backup-*")) == []
+    finally:
+        db.close()
+
+
+def test_corrupt_live_lease_registry_fails_closed_before_backup(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    sessions_dir = home / "sessions"
+    runtime = home / "runtime"
+    sessions_dir.mkdir(parents=True)
+    runtime.mkdir(parents=True)
+    (runtime / "active_sessions.json").write_text("{broken", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    db = SessionDB(home / "state.db")
+    try:
+        _open_group(db, "orphan")
+        with pytest.raises(RuntimeError, match="active session registry"):
+            reconcile_telegram_group_orphans(
+                db,
+                sessions_dir=sessions_dir,
+                min_age_seconds=3600,
+                apply=True,
+            )
+        assert db.get_session("orphan")["ended_at"] is None
+        assert list(home.glob("state.db.backup-*")) == []
+    finally:
+        db.close()
+
+
+def test_cli_defaults_to_dry_run_then_applies_with_backup(tmp_path):
+    home = tmp_path / ".hermes"
+    (home / "sessions").mkdir(parents=True)
+    db = SessionDB(home / "state.db")
+    try:
+        _open_group(db, "cli-orphan")
+    finally:
+        db.close()
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(home)
+    command = [
+        sys.executable,
+        "-m",
+        "hermes_cli.main",
+        "sessions",
+        "reconcile-telegram-orphans",
+        "--min-age-hours",
+        "1",
+    ]
+    dry_run = subprocess.run(
+        command,
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=30,
+    )
+    assert "Candidate Telegram group sessions: 1" in dry_run.stdout
+    assert "Dry run" in dry_run.stdout
+    assert list(home.glob("state.db.backup-*")) == []
+
+    applied = subprocess.run(
+        [*command, "--apply"],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=30,
+    )
+    assert "Verified backup:" in applied.stdout
+    assert "Finalized 1 session(s)" in applied.stdout
+    assert len(list(home.glob("state.db.backup-*"))) == 1
+
+    verified = subprocess.run(
+        command,
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=30,
+    )
+    assert "No orphaned Telegram group sessions found." in verified.stdout
+    reopened = SessionDB(home / "state.db")
+    try:
+        assert reopened.get_session("cli-orphan")["end_reason"] == "orphan_reconcile"
+    finally:
+        reopened.close()

--- a/tests/hermes_state/test_telegram_orphan_reconcile.py
+++ b/tests/hermes_state/test_telegram_orphan_reconcile.py
@@ -1,0 +1,131 @@
+"""Safety contracts for transactional Telegram group orphan reconciliation."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _open_group(db: SessionDB, session_id: str, *, source: str = "telegram", age: float = 7200) -> None:
+    db.create_session(
+        session_id,
+        source,
+        session_key=f"route:{session_id}",
+        chat_id=f"chat:{session_id}",
+        chat_type="group",
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = ?",
+        (time.time() - age, session_id),
+    )
+    db._conn.commit()
+
+
+def test_reconcile_only_finalizes_old_unrouted_unprotected_telegram_groups(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        for session_id in ("orphan", "routed", "leased", "fresh", "discord"):
+            _open_group(
+                db,
+                session_id,
+                source="discord" if session_id == "discord" else "telegram",
+                age=10 if session_id == "fresh" else 7200,
+            )
+        db.create_session("dm", "telegram", chat_type="dm", chat_id="dm-chat")
+        db.save_gateway_routing_entry(
+            "telegram:group:routed",
+            json.dumps({"session_id": "routed"}),
+            scope="/profile/sessions",
+        )
+
+        preview = db.reconcile_orphaned_telegram_group_sessions(
+            protected_session_ids={"leased"},
+            min_age_seconds=3600,
+            apply=False,
+        )
+        assert preview == {
+            "candidate_ids": ["orphan"],
+            "finalized_ids": [],
+            "dry_run": True,
+        }
+        assert db.get_session("orphan")["ended_at"] is None
+
+        applied = db.reconcile_orphaned_telegram_group_sessions(
+            protected_session_ids={"leased"},
+            min_age_seconds=3600,
+            apply=True,
+        )
+        assert applied == {
+            "candidate_ids": ["orphan"],
+            "finalized_ids": ["orphan"],
+            "dry_run": False,
+        }
+        assert db.get_session("orphan")["end_reason"] == "orphan_reconcile"
+        for protected in ("routed", "leased", "fresh", "discord", "dm"):
+            assert db.get_session(protected)["ended_at"] is None
+
+        second = db.reconcile_orphaned_telegram_group_sessions(
+            protected_session_ids={"leased"},
+            min_age_seconds=3600,
+            apply=True,
+        )
+        assert second["candidate_ids"] == []
+        assert second["finalized_ids"] == []
+    finally:
+        db.close()
+
+
+def test_reconcile_fails_closed_on_malformed_route_and_rolls_back(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        _open_group(db, "orphan-a")
+        _open_group(db, "orphan-b")
+        db.save_gateway_routing_entry("broken", "{not-json", scope="scope")
+
+        with pytest.raises(ValueError, match="malformed gateway routing"):
+            db.reconcile_orphaned_telegram_group_sessions(
+                protected_session_ids=set(), min_age_seconds=3600, apply=True
+            )
+        assert db.get_session("orphan-a")["ended_at"] is None
+        assert db.get_session("orphan-b")["ended_at"] is None
+
+        db._conn.execute("DELETE FROM gateway_routing")
+        db._conn.execute(
+            """CREATE TRIGGER abort_orphan_b
+               BEFORE UPDATE OF ended_at ON sessions
+               WHEN NEW.id = 'orphan-b' AND NEW.ended_at IS NOT NULL
+               BEGIN SELECT RAISE(ABORT, 'test rollback'); END"""
+        )
+        db._conn.commit()
+
+        with pytest.raises(sqlite3.IntegrityError, match="test rollback"):
+            db.reconcile_orphaned_telegram_group_sessions(
+                protected_session_ids=set(), min_age_seconds=3600, apply=True
+            )
+        assert db.get_session("orphan-a")["ended_at"] is None
+        assert db.get_session("orphan-b")["ended_at"] is None
+    finally:
+        db.close()
+
+
+def test_online_backup_is_consistent_and_restorable(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        _open_group(db, "orphan")
+        backup_path = db.create_verified_backup("telegram-orphan-reconcile")
+        assert backup_path.exists()
+        assert backup_path.stat().st_mode & 0o777 == 0o600
+
+        restored = SessionDB(backup_path, read_only=True)
+        try:
+            assert restored.get_session("orphan")["ended_at"] is None
+            assert restored._conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        finally:
+            restored.close()
+    finally:
+        db.close()

--- a/tests/skills/test_maps_skill_paths.py
+++ b/tests/skills/test_maps_skill_paths.py
@@ -1,0 +1,44 @@
+"""Path-safety contracts for the bundled maps skill."""
+
+import os
+import subprocess
+from pathlib import Path
+
+
+SKILL_MD = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "productivity"
+    / "maps"
+    / "SKILL.md"
+)
+
+
+def test_maps_helper_uses_hermes_home_under_sandbox_home(tmp_path):
+    """Operational commands must not expand ~/.hermes beneath profile HOME."""
+    content = SKILL_MD.read_text(encoding="utf-8")
+    assignment = next(
+        line for line in content.splitlines() if line.startswith("MAPS=")
+    )
+
+    assert "~/.hermes/skills/maps" not in content
+
+    hermes_home = tmp_path / ".hermes"
+    sandbox_home = hermes_home / "home"
+    sandbox_home.mkdir(parents=True)
+    env = {
+        "HOME": str(sandbox_home),
+        "HERMES_HOME": str(hermes_home),
+        "PATH": os.environ.get("PATH", ""),
+    }
+    result = subprocess.run(
+        ["bash", "-c", f'{assignment}\nprintf "%s" "$MAPS"'],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.stdout == str(
+        hermes_home / "skills" / "maps" / "scripts" / "maps_client.py"
+    )

--- a/tests/test_subprocess_home_isolation.py
+++ b/tests/test_subprocess_home_isolation.py
@@ -236,6 +236,21 @@ class TestMakeRunEnvHomeInjection:
 
         assert result["HOME"] == "/home/user"
 
+    def test_unset_process_env_still_exports_canonical_hermes_home(
+        self, tmp_path, monkeypatch
+    ):
+        """Children need $HERMES_HOME even when the parent uses the default root."""
+        account_home = tmp_path / "account"
+        account_home.mkdir()
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setenv("HOME", str(account_home))
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        from tools.environments.local import _make_run_env
+        result = _make_run_env({})
+
+        assert result["HERMES_HOME"] == str(account_home / ".hermes")
+
     def test_context_override_bridges_to_subprocess_env(self, tmp_path, monkeypatch):
         monkeypatch.setattr(hermes_constants, "is_container", lambda: True)
         root = tmp_path / "root"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -390,11 +390,16 @@ def _is_hermes_internal_secret(key: str) -> bool:
 
 
 def _inject_context_hermes_home(env: dict) -> None:
-    """Bridge the context-local Hermes home override into subprocess env."""
-    try:
-        from hermes_constants import get_hermes_home_override
+    """Expose the canonical active Hermes root to subprocesses.
 
-        value = get_hermes_home_override()
+    Context-local profile overrides win.  Otherwise export the default root as
+    well: a child may legitimately receive a sandboxed ``HOME`` and must not
+    reconstruct account-global state as ``$HOME/.hermes``.
+    """
+    try:
+        from hermes_constants import get_hermes_home, get_hermes_home_override
+
+        value = get_hermes_home_override() or str(get_hermes_home())
         if value:
             env["HERMES_HOME"] = value
     except Exception:


### PR DESCRIPTION
## Summary
- mark max-iteration cron fallbacks failed while preserving their useful delivery
- export canonical HERMES_HOME under sandboxed HOME
- stop retrying vanished Telegram progress placeholders
- add transactional, backup-aware Telegram group orphan reconciliation CLI

## Safety
- reconciliation defaults to dry-run
- apply excludes routed/leased/active sessions and creates a verified mode-0600 SQLite backup
- no live state was mutated and no Gateway was restarted

## Tests
- focused after rebase: 454 passed, 0 failed
- broader targeted: 2,153 passed, 0 failed (`-m 'not asyncio'`)
- config suites: 160 passed, 0 failed
