### PR TITLE
fix(plugins): give block directives precedence

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2131,8 +2131,9 @@ def _get_pre_tool_call_directive_details(
     - ``rule_key`` is optional and only honored for ``approve`` directives. It
       lets plugins choose the allowlist grain for `[a]lways` approvals.
 
-    The first valid directive wins. Invalid or irrelevant hook return values
-    are silently ignored so existing observer-only hooks are unaffected.
+    The first valid block wins; otherwise the first valid approve wins. Invalid
+    or irrelevant hook return values are silently ignored so existing
+    observer-only hooks are unaffected.
     """
     allowed = getattr(_thread_tool_whitelist, "allowed", None)
     if allowed is not None and tool_name not in allowed:
@@ -2154,6 +2155,9 @@ def _get_pre_tool_call_directive_details(
         middleware_trace=list(middleware_trace or []),
     )
 
+    first_block: Optional[_PreToolCallDirective] = None
+    first_approve: Optional[_PreToolCallDirective] = None
+
     for result in hook_results:
         if not isinstance(result, dict):
             continue
@@ -2170,9 +2174,17 @@ def _get_pre_tool_call_directive_details(
         rule_key = rule_key.strip() if isinstance(rule_key, str) else None
         if not rule_key:
             rule_key = None
-        return _PreToolCallDirective(action=action, message=message, rule_key=rule_key)
+        directive = _PreToolCallDirective(
+            action=action,
+            message=message,
+            rule_key=rule_key,
+        )
+        if action == "block" and first_block is None:
+            first_block = directive
+        elif action == "approve" and first_approve is None:
+            first_approve = directive
 
-    return _PreToolCallDirective()
+    return first_block or first_approve or _PreToolCallDirective()
 
 
 def get_pre_tool_call_directive(

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -890,17 +890,117 @@ class TestPreToolCallDirective:
         )
         assert get_pre_tool_call_directive("terminal", {}) == (None, None)
 
-    def test_first_directive_wins_across_actions(self, monkeypatch):
+    @pytest.mark.parametrize(
+        "results, expected_message",
+        [
+            (
+                [
+                    {
+                        "action": "approve",
+                        "message": "gate first",
+                        "rule_key": "terminal:ssh",
+                    },
+                    {"action": "block", "message": "veto second"},
+                ],
+                "veto second",
+            ),
+            (
+                [
+                    {"action": "block", "message": "veto first"},
+                    {"action": "approve", "message": "gate second"},
+                ],
+                "veto first",
+            ),
+        ],
+    )
+    def test_block_takes_precedence_over_approve_regardless_of_order(
+        self, monkeypatch, results, expected_message
+    ):
         from hermes_cli.plugins import get_pre_tool_call_directive
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: results,
+        )
+
+        assert get_pre_tool_call_directive("terminal", {}) == (
+            "block",
+            expected_message,
+        )
+
+    def test_first_approve_wins_when_no_valid_block_exists(self, monkeypatch):
+        from hermes_cli.plugins import _get_pre_tool_call_directive_details
+
         monkeypatch.setattr(
             "hermes_cli.plugins.invoke_hook",
             lambda hook_name, **kwargs: [
-                {"action": "approve", "message": "gate first"},
-                {"action": "block", "message": "block second"},
+                {
+                    "action": "approve",
+                    "message": "first gate",
+                    "rule_key": " terminal:ssh ",
+                },
+                {
+                    "action": "approve",
+                    "message": "second gate",
+                    "rule_key": "terminal:local",
+                },
             ],
         )
+
+        directive = _get_pre_tool_call_directive_details("terminal", {})
+        assert directive.action == "approve"
+        assert directive.message == "first gate"
+        assert directive.rule_key == "terminal:ssh"
+
+    def test_invalid_block_does_not_suppress_valid_approve(self, monkeypatch):
+        from hermes_cli.plugins import get_pre_tool_call_directive
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "block", "message": ""},
+                {"action": "approve", "message": "valid gate"},
+            ],
+        )
+
         assert get_pre_tool_call_directive("terminal", {}) == (
-            "approve", "gate first")
+            "approve",
+            "valid gate",
+        )
+
+    def test_invalid_approve_does_not_suppress_valid_block(self, monkeypatch):
+        from hermes_cli.plugins import get_pre_tool_call_directive
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "review", "message": "not a directive"},
+                {"action": "block", "message": "valid veto"},
+            ],
+        )
+
+        assert get_pre_tool_call_directive("terminal", {}) == (
+            "block",
+            "valid veto",
+        )
+
+    def test_hook_results_are_obtained_once(self, monkeypatch):
+        from hermes_cli.plugins import get_pre_tool_call_directive
+
+        calls = 0
+
+        def _invoke(hook_name, **kwargs):
+            nonlocal calls
+            calls += 1
+            return [
+                {"action": "approve", "message": "gate"},
+                {"action": "block", "message": "veto"},
+            ]
+
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _invoke)
+
+        assert get_pre_tool_call_directive("terminal", {}) == ("block", "veto")
+        assert calls == 1
 
     def test_shim_ignores_approve(self, monkeypatch):
         """Back-compat shim only reports block, never approve."""
@@ -930,6 +1030,29 @@ class TestResolvePreToolBlock:
         monkeypatch.setattr(
             "hermes_cli.plugins.invoke_hook", lambda hook_name, **kwargs: [])
         assert resolve_pre_tool_block("terminal", {}) is None
+
+    def test_block_suppresses_approval_gate(self, monkeypatch):
+        from hermes_cli.plugins import resolve_pre_tool_block
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "approve", "message": "gate first"},
+                {"action": "block", "message": "veto second"},
+            ],
+        )
+
+        gate_calls = 0
+
+        def _approve(*args, **kwargs):
+            nonlocal gate_calls
+            gate_calls += 1
+            return {"approved": True, "message": None}
+
+        monkeypatch.setattr("tools.approval.request_tool_approval", _approve)
+
+        assert resolve_pre_tool_block("write_file", {}) == "veto second"
+        assert gate_calls == 0
 
     def test_approve_denied_blocks(self, monkeypatch):
         from hermes_cli.plugins import resolve_pre_tool_block


### PR DESCRIPTION
## Summary

- make valid `block` directives take precedence over valid `approve` directives regardless of plugin registration order
- preserve first-wins ordering among directives with the same action
- preserve existing validation, approval fail-closed behavior, callback invocation, and public helper signatures

## Problem

`_get_pre_tool_call_directive_details()` returned the first valid directive from the collected `pre_tool_call` hook results. If an approval-policy plugin was registered before a blocking policy plugin, an earlier `approve` could mask a later `block`:

```text
approve, block -> approve
block, approve -> block
```

That makes policy composition depend on plugin discovery order and allows adding an approval hook to weaken an existing veto.

## Fix

Collect the first valid block and first valid approve from the already-materialized hook results, then return:

1. the first valid block, when any block exists;
2. otherwise the first valid approve;
3. otherwise no directive.

All callbacks are still invoked once by `invoke_hook()` before selection. A selected block bypasses the human approval prompt; approve-only behavior remains unchanged and fail-closed.

## Tests

Added regression coverage for:

- block precedence in both registration orders
- first block and first approve ordering
- approve `rule_key` preservation
- malformed block/approve results
- single hook-result collection
- suppression of the approval gate when a block exists

Focused canonical test runs on the submitted commit:

```text
tests/hermes_cli/test_plugins.py: 122 passed
tests/tools/test_approval_plugin_hooks.py: 21 passed
tests/run_agent/ -k "tool or plugin or approval": 554 passed
tests/agent/ -k "tool or plugin or approval": 670 passed
```

Ruff lint, `compileall`, and `git diff --check` also pass.

## Baseline limitation

The complete upstream suite is not green in this host environment. A prior full run produced unrelated dependency/environment failures that were reproduced by failure class on an unchanged worktree at the same base. This change does not touch those systems, and the affected plugin/approval/dispatch slices above pass on the submitted commit.
