### PR TITLE
fix(desktop): drop the decorative top-up credits bar

### DIFF
--- a/apps/desktop/src/app/settings/billing/use-billing-state.test.ts
+++ b/apps/desktop/src/app/settings/billing/use-billing-state.test.ts
@@ -351,20 +351,15 @@ describe('deriveBillingView', () => {
     })
   })
 
-  it('renders top-up balance as a full ok bar when credits remain', () => {
+  it('renders top-up balance as a bare amount — no bar (no denominator exists)', () => {
     const view = deriveBillingView(okBilling(postTrainBillingState), okSubscription(postTrainSubscriptionState))
+    const topup = view.usageRows.find(row => row.id === 'topup_credits')
 
-    expect(view.usageRows.find(row => row.id === 'topup_credits')).toMatchObject({
-      bar: {
-        state: 'ok',
-        tone: 'topup',
-        value: 1
-      },
-      value: '$75'
-    })
+    expect(topup?.value).toBe('$75')
+    expect(topup?.bar).toBeUndefined()
   })
 
-  it('renders zero top-up balance as an empty neutral bar', () => {
+  it('renders zero top-up balance without a bar too', () => {
     const view = deriveBillingView(
       okBilling({
         ...todayBillingState,
@@ -378,14 +373,10 @@ describe('deriveBillingView', () => {
       undefined
     )
 
-    expect(view.usageRows.find(row => row.id === 'topup_credits')).toMatchObject({
-      bar: {
-        state: 'neutral',
-        tone: 'topup',
-        value: 0
-      },
-      value: '$0'
-    })
+    const topup = view.usageRows.find(row => row.id === 'topup_credits')
+
+    expect(topup?.value).toBe('$0')
+    expect(topup?.bar).toBeUndefined()
   })
 })
 

--- a/apps/desktop/src/app/settings/billing/use-billing-state.ts
+++ b/apps/desktop/src/app/settings/billing/use-billing-state.ts
@@ -459,18 +459,10 @@ function deriveUsageRows(
   })
 
   const topupValue = topupCreditsValue(billing, usage)
-  const topupRemaining = topupCreditsAmount(billing, usage)
 
+  // No bar: top-ups have no denominator (the wire carries only the current
+  // balance, and the pool is open-ended), so a fill fraction would be fiction.
   rows.push({
-    bar:
-      topupRemaining != null
-        ? {
-            label: 'Top-up credits remaining',
-            state: topupRemaining > 0 ? 'ok' : 'neutral',
-            tone: 'topup',
-            value: topupRemaining > 0 ? 1 : 0
-          }
-        : undefined,
     caption: 'Does not expire',
     id: 'topup_credits',
     title: 'Top-up credits',
@@ -533,14 +525,6 @@ function topupCreditsValue(billing: BillingStateResponse, usage?: UsageModelData
   )
 }
 
-function topupCreditsAmount(billing: BillingStateResponse, usage?: UsageModelData): null | number {
-  return (
-    parseAmount(usage?.topup_bar?.remaining_display) ??
-    parseAmount(usage?.topup_remaining_display) ??
-    parseAmount(billing.balance_usd) ??
-    parseAmount(billing.balance_display)
-  )
-}
 
 function buyCreditsDisabledReason(billing: BillingStateResponse): null | string {
   if (!billing.is_admin) {


### PR DESCRIPTION
The Usage card showed a progress bar for top-up credits that was always 100% full (or empty at $0) — its value was literally `remaining > 0 ? 1 : 0`. There is no denominator to show: the billing state carries only the current balance, and top-ups are open-ended rather than an allowance, so any fill fraction would be invented.

Now the row shows the amount and "Does not expire" with no bar. Subscription credits and the monthly spend cap keep their bars — those have real denominators (monthly credits, cap limit).

Verification: desktop billing suite 57 tests (bar-assertions replaced with no-bar assertions), `tsc --noEmit` clean.