### PR TITLE
fix(gateway): detect stale gateway_state.json in status output (TTL + PID liveness)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -935,6 +935,52 @@ def read_runtime_status(path: Optional[Path] = None) -> Optional[dict[str, Any]]
     return _read_json_file(path or _get_runtime_status_path())
 
 
+# Max age of a persisted ``gateway_state.json`` snapshot before its liveness
+# claim is treated as suspect.  A healthy gateway rewrites the file (advancing
+# ``updated_at``) far more often than this; a record older than the TTL whose
+# PID is also dead almost certainly outlived an ungracefully-killed writer
+# (taskkill /F, OOM, power loss) that never ran its shutdown handler.
+_RUNTIME_STATUS_STALE_TTL_S = 120
+
+
+def runtime_status_is_stale(
+    record: Optional[dict[str, Any]],
+    ttl_s: int = _RUNTIME_STATUS_STALE_TTL_S,
+) -> bool:
+    """Return True when the runtime-status snapshot is older than ``ttl_s``.
+
+    Delegates to the existing :func:`_marker_is_stale` on the record's
+    ``updated_at`` timestamp.  A missing or unparseable timestamp is treated as
+    stale (the freshness signal is absent, so it cannot vouch for the record).
+    """
+    if not isinstance(record, dict):
+        return True
+    return _marker_is_stale(record.get("updated_at") or "", ttl_s)
+
+
+def runtime_status_pid_is_live(record: Optional[dict[str, Any]]) -> bool:
+    """Return True when the PID recorded in the snapshot is still alive.
+
+    Uses the existing no-kill :func:`_pid_exists` probe and the same
+    ``start_time`` PID-reuse guard as :func:`get_runtime_status_running_pid`:
+    when both the recorded and live start-times are known they must match, so a
+    recycled PID (same number, different process) is not mistaken for the
+    original.  Degrades to ``False`` when the record has no usable PID.
+    """
+    pid = _pid_from_record(record)
+    if pid is None or not _pid_exists(pid):
+        return False
+    recorded_start = (record or {}).get("start_time")
+    current_start = _get_process_start_time(pid)
+    if (
+        recorded_start is not None
+        and current_start is not None
+        and current_start != recorded_start
+    ):
+        return False
+    return True
+
+
 def parse_active_agents(raw: Any) -> int:
     """Coerce a persisted ``active_agents`` value to a clamped non-negative int.
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5357,7 +5357,11 @@ def _platform_status(platform: dict) -> str:
 def _runtime_health_lines() -> list[str]:
     """Summarize the latest persisted gateway runtime health state."""
     try:
-        from gateway.status import read_runtime_status
+        from gateway.status import (
+            read_runtime_status,
+            runtime_status_is_stale,
+            runtime_status_pid_is_live,
+        )
     except Exception:
         return []
 
@@ -5376,6 +5380,22 @@ def _runtime_health_lines() -> list[str]:
         if pdata.get("state") == "fatal":
             message = pdata.get("error_message") or "unknown error"
             lines.append(f"⚠ {platform}: {message}")
+
+    # A persisted snapshot that still claims liveness can outlive an
+    # ungracefully-killed gateway (taskkill /F, OOM, power loss) whose shutdown
+    # handler never ran.  When the record is past its freshness TTL AND the
+    # recorded PID is gone, the file is contradicting reality — surface that
+    # explicitly instead of rendering the misleading live-state summary.
+    if (
+        gateway_state in ("running", "starting", "draining")
+        and runtime_status_is_stale(state)
+        and not runtime_status_pid_is_live(state)
+    ):
+        lines.append(
+            f"⚠ Stale gateway_state.json: recorded state '{gateway_state}' but the "
+            "recorded process is gone (likely an ungraceful shutdown)"
+        )
+        return lines
 
     if gateway_state == "startup_failed" and exit_reason:
         lines.append(f"⚠ Last startup issue: {exit_reason}")

--- a/tests/hermes_cli/test_gateway_runtime_health.py
+++ b/tests/hermes_cli/test_gateway_runtime_health.py
@@ -1,4 +1,117 @@
+from datetime import datetime, timedelta, timezone
+
 from hermes_cli.gateway import _runtime_health_lines
+
+
+def _iso_age(seconds_ago: float) -> str:
+    """ISO-8601 UTC timestamp ``seconds_ago`` in the past (drives _marker_is_stale)."""
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)).isoformat()
+
+
+_STALE_LINE_PREFIX = "⚠ Stale gateway_state.json:"
+
+
+def _stale_lines(lines):
+    return [ln for ln in lines if ln.startswith(_STALE_LINE_PREFIX)]
+
+
+def test_runtime_health_lines_flags_stale_running_with_dead_pid(monkeypatch):
+    """Stale updated_at + dead PID + 'running' -> contradiction line, no draining line."""
+    from gateway import status as status_mod
+
+    monkeypatch.setattr(
+        "gateway.status.read_runtime_status",
+        lambda: {
+            "gateway_state": "running",
+            "pid": 4242,
+            "start_time": 111,
+            "updated_at": _iso_age(600),  # well past the 120s TTL -> stale
+            "active_agents": 0,
+        },
+    )
+    # Recorded PID is gone (ungraceful kill); no real process is touched.
+    monkeypatch.setattr(status_mod, "_pid_exists", lambda pid: False)
+    monkeypatch.setattr(status_mod, "_get_process_start_time", lambda pid: None)
+
+    lines = _runtime_health_lines()
+
+    stale = _stale_lines(lines)
+    assert len(stale) == 1, lines
+    assert "recorded state 'running'" in stale[0]
+    assert "recorded process is gone" in stale[0]
+    # The misleading live-state summary must be suppressed.
+    assert not any("draining" in ln.lower() for ln in lines), lines
+
+
+def test_runtime_health_lines_no_warning_for_fresh_running_with_live_pid(monkeypatch):
+    """Fresh updated_at + live PID + 'running' -> no contradiction line."""
+    from gateway import status as status_mod
+
+    monkeypatch.setattr(
+        "gateway.status.read_runtime_status",
+        lambda: {
+            "gateway_state": "running",
+            "pid": 4242,
+            "start_time": 111,
+            "updated_at": _iso_age(5),  # fresh, within the 120s TTL
+            "active_agents": 2,
+        },
+    )
+    monkeypatch.setattr(status_mod, "_pid_exists", lambda pid: True)
+    # start_time matches the record -> not a recycled PID.
+    monkeypatch.setattr(status_mod, "_get_process_start_time", lambda pid: 111)
+
+    lines = _runtime_health_lines()
+
+    assert _stale_lines(lines) == [], lines
+
+
+def test_runtime_health_lines_no_warning_for_stale_running_but_live_pid(monkeypatch):
+    """Stale updated_at but PID still live (long-idle gateway) -> no false positive."""
+    from gateway import status as status_mod
+
+    monkeypatch.setattr(
+        "gateway.status.read_runtime_status",
+        lambda: {
+            "gateway_state": "running",
+            "pid": 4242,
+            "start_time": 111,
+            "updated_at": _iso_age(600),  # stale timestamp...
+            "active_agents": 0,
+        },
+    )
+    # ...but the recorded process is genuinely alive (start_time matches).
+    monkeypatch.setattr(status_mod, "_pid_exists", lambda pid: pid == 4242)
+    monkeypatch.setattr(status_mod, "_get_process_start_time", lambda pid: 111)
+
+    lines = _runtime_health_lines()
+
+    # Guard requires BOTH stale AND dead PID; live PID must suppress the warning.
+    assert _stale_lines(lines) == [], lines
+
+
+def test_runtime_health_lines_treats_missing_updated_at_as_stale(monkeypatch):
+    """Missing updated_at (degrade path) + dead PID + 'running' -> contradiction line."""
+    from gateway import status as status_mod
+
+    monkeypatch.setattr(
+        "gateway.status.read_runtime_status",
+        lambda: {
+            "gateway_state": "running",
+            "pid": 4242,
+            "start_time": 111,
+            # no "updated_at" -> runtime_status_is_stale must treat as stale
+            "active_agents": 0,
+        },
+    )
+    monkeypatch.setattr(status_mod, "_pid_exists", lambda pid: False)
+    monkeypatch.setattr(status_mod, "_get_process_start_time", lambda pid: None)
+
+    lines = _runtime_health_lines()
+
+    stale = _stale_lines(lines)
+    assert len(stale) == 1, lines
+    assert "recorded state 'running'" in stale[0]
 
 
 def test_runtime_health_lines_include_fatal_platform_and_startup_reason(monkeypatch):


### PR DESCRIPTION
## Summary
`hermes gateway status` no longer reports a dead gateway as running: runtime-health lines now validate `gateway_state.json` freshness (updated_at TTL) and lock-holder PID liveness instead of trusting the file verbatim.

Salvages #51361 by @Cossackx (authorship preserved).

## Changes
- `hermes_cli/gateway.py` `_runtime_health_lines`: TTL check on `updated_at` + PID liveness before reporting state
- `gateway/status.py`: shared staleness helper

## Validation
`scripts/run_tests.sh tests/hermes_cli/test_gateway_runtime_health.py` — 7 passed; `tests/gateway/test_status.py` — 99 passed.

## Infographic

![gateway-status-state-ttl](https://v3b.fal.media/files/b/0aa32559/LZJnbKAvUA719Tzm1GxPb_ULtMLxZG.png)
