### PR TITLE
fix(gateway): --replace takes over live platform-lock holders once and reaps orphaned children

### DIFF
--- a/contributors/emails/jaretbottoms@gmail.com
+++ b/contributors/emails/jaretbottoms@gmail.com
@@ -1,0 +1,2 @@
+jbbottoms
+# PR #65178 salvage (gateway: --replace platform-lock takeover)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2448,6 +2448,12 @@ class BasePlatformAdapter(ABC):
         self._fatal_error_message: Optional[str] = None
         self._fatal_error_retryable = True
         self._fatal_error_handler: Optional[Callable[["BasePlatformAdapter"], Awaitable[None] | None]] = None
+        # Cross-HERMES_HOME token takeover is armed by GatewayRunner only for
+        # an adapter's initial connect during an explicit ``gateway run
+        # --replace`` startup.  Ordinary starts and every reconnect fail safe
+        # through the existing retryable conflict path.
+        self._platform_lock_takeover_allowed = False
+        self._platform_lock_takeover_attempted = False
         
         # Track active message handlers per session for interrupt support.
         # _active_sessions stores the per-session interrupt Event; _session_tasks
@@ -2847,8 +2853,18 @@ class BasePlatformAdapter(ABC):
             await result
 
     def _acquire_platform_lock(self, scope: str, identity: str, resource_desc: str) -> bool:
-        """Acquire a scoped lock for this adapter. Returns True on success."""
-        from gateway.status import acquire_scoped_lock
+        """Acquire a scoped lock for this adapter. Returns True on success.
+
+        A live cross-HERMES_HOME holder may be replaced only when the runner
+        explicitly arms this adapter for its initial ``--replace`` connect.
+        The status module validates PID/start-time/home ownership, places the
+        marker in the target's home, and performs the bounded termination.
+        """
+        from gateway.status import (
+            acquire_scoped_lock,
+            take_over_scoped_lock_holder,
+        )
+
         self._platform_lock_scope = scope
         self._platform_lock_identity = identity
         acquired, existing = acquire_scoped_lock(
@@ -2856,6 +2872,42 @@ class BasePlatformAdapter(ABC):
         )
         if acquired:
             return True
+
+        takeover_allowed = bool(
+            getattr(self, "_platform_lock_takeover_allowed", False)
+        )
+        takeover_attempted = bool(
+            getattr(self, "_platform_lock_takeover_attempted", False)
+        )
+        if takeover_allowed and not takeover_attempted and isinstance(existing, dict):
+            # Consume the authority before doing any I/O: one adapter connect
+            # gets at most one termination attempt, even if lock re-acquire or
+            # later initialization fails.
+            self._platform_lock_takeover_allowed = False
+            self._platform_lock_takeover_attempted = True
+            owner_pid = take_over_scoped_lock_holder(existing)
+            if owner_pid is not None:
+                logger.warning(
+                    "[%s] %s was held by gateway PID %d — explicit --replace "
+                    "handoff completed",
+                    self.name,
+                    resource_desc,
+                    owner_pid,
+                )
+                acquired, existing = acquire_scoped_lock(
+                    scope,
+                    identity,
+                    metadata={"platform": self.platform.value},
+                )
+                if acquired:
+                    logger.info(
+                        "[%s] Acquired %s after taking over PID %d",
+                        self.name,
+                        resource_desc,
+                        owner_pid,
+                    )
+                    return True
+
         owner_pid = existing.get('pid') if isinstance(existing, dict) else None
         message = (
             f'{resource_desc} already in use'

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22509,6 +22509,17 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 write_takeover_marker(existing_pid)
             except Exception as e:
                 logger.debug("Could not write takeover marker: %s", e)
+            # Snapshot the old gateway's child processes BEFORE signalling it:
+            # once it exits, orphans are reparented and can no longer be found
+            # by a parent walk. On POSIX, adapter subprocesses that outlive
+            # the gateway keep holding scoped token locks and block the
+            # replacement (Windows terminate_pid(force=True) already
+            # tree-kills via taskkill /T). Best-effort — [] on any failure.
+            try:
+                from gateway.status import _snapshot_gateway_children
+                _old_gateway_children = _snapshot_gateway_children(existing_pid)
+            except Exception:
+                _old_gateway_children = []
             try:
                 terminate_pid(existing_pid, force=False)
             except ProcessLookupError:
@@ -22572,6 +22583,21 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                     except Exception:
                         pass
                     return False
+            # Old gateway confirmed dead — reap any orphaned child processes
+            # it left behind (POSIX; mirrors Windows taskkill /T tree-kill).
+            # Orphaned adapter subprocesses would otherwise keep holding
+            # scoped token locks against us. Best-effort, never raises.
+            try:
+                from gateway.status import reap_gateway_children
+                reap_gateway_children(
+                    _old_gateway_children, parent_pid=existing_pid
+                )
+            except Exception:
+                logger.debug(
+                    "Child reap for replaced gateway PID %d failed",
+                    existing_pid,
+                    exc_info=True,
+                )
             remove_pid_file()
             # remove_pid_file() is a no-op when the PID doesn't match.
             # Force-unlink to cover the old-process-crashed case.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3096,6 +3096,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _loop_heartbeat_task: Optional["asyncio.Task"] = None
     _gateway_started_at: float = 0.0
     _shutdown_watchdog_done: Optional["threading.Event"] = None
+    _platform_lock_takeover_on_start: bool = False
 
     def __init__(self, config: Optional[GatewayConfig] = None):
         global _gateway_runner_ref
@@ -3255,6 +3256,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # with the synthetic resume turns for the same session.  The queued
         # events drain only after all startup resume tasks have finished.
         self._startup_restore_in_progress = False
+        # Set by start_gateway() only for an explicit ``--replace`` launch.
+        # _connect_initial_adapter_with_timeout scopes it to each adapter's
+        # cold-start connect and removes it before any reconnect can run.
+        self._platform_lock_takeover_on_start = False
         self._startup_restore_queue: List[MessageEvent] = []
         self._startup_restore_tasks: List[asyncio.Task] = []
         # LRU cache of live SessionSources keyed by session_key. Used by
@@ -3839,6 +3844,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             raise TimeoutError(
                 f"{platform.value} connect timed out after {timeout:g}s"
             ) from exc
+
+    async def _connect_initial_adapter_with_timeout(self, adapter, platform) -> bool:
+        """Connect one cold-start adapter with tightly scoped replace intent.
+
+        The capability is visible only while this initial connect is awaited.
+        Reconnects call ``_connect_adapter_with_timeout`` directly and adapters
+        also default to deny, so a later network recovery can never evict a
+        healthy token holder.
+        """
+        adapter._platform_lock_takeover_allowed = bool(
+            self._platform_lock_takeover_on_start
+        )
+        try:
+            return await self._connect_adapter_with_timeout(adapter, platform)
+        finally:
+            adapter._platform_lock_takeover_allowed = False
 
     @property
     def should_exit_cleanly(self) -> bool:
@@ -7696,7 +7717,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 error_message=None,
             )
             try:
-                success = await self._connect_adapter_with_timeout(adapter, platform)
+                success = await self._connect_initial_adapter_with_timeout(
+                    adapter, platform
+                )
                 if await self._abort_startup_if_shutdown_requested(adapter, platform):
                     return True
                 if success:
@@ -7804,6 +7827,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return True
         except Exception as e:
             logger.error("Secondary-profile adapter startup failed: %s", e, exc_info=True)
+        finally:
+            # Startup authority is one phase, not a persistent runner mode.
+            # From this point onward every adapter retry is non-evicting.
+            self._platform_lock_takeover_on_start = False
 
         # A platform we skipped on the primary for a missing credential was
         # supposed to be picked up by a secondary profile that owns the token.
@@ -9502,7 +9529,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             try:
                 with _profile_runtime_scope(profile_home):
-                    success = await self._connect_adapter_with_timeout(adapter, platform)
+                    success = await self._connect_initial_adapter_with_timeout(
+                        adapter, platform
+                    )
                 if success:
                     profile_map[platform] = adapter
                     connected += 1
@@ -22634,6 +22663,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             logging.getLogger().setLevel(_stderr_level)
 
     runner = GatewayRunner(config)
+    # ``--replace`` is explicit startup authority, not a durable reconnect
+    # policy. GatewayRunner scopes this bit to cold adapter connects and clears
+    # it before the background reconnect watcher starts.
+    runner._platform_lock_takeover_on_start = bool(replace)
     
     # Track whether an unexpected signal initiated the shutdown. When an
     # unexpected SIGTERM kills the gateway, we exit non-zero so service

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -142,6 +142,18 @@ def _get_process_hermes_home() -> Path:
     return _get_platform_default_hermes_home()
 
 
+def _canonical_hermes_home(path: Path | str) -> Path:
+    """Return a stable absolute HERMES_HOME path for persisted identity data."""
+    return Path(path).expanduser().resolve(strict=False)
+
+
+def _same_hermes_home(left: Path | str, right: Path | str) -> bool:
+    """Compare HERMES_HOME paths with the host platform's case semantics."""
+    return os.path.normcase(str(_canonical_hermes_home(left))) == os.path.normcase(
+        str(_canonical_hermes_home(right))
+    )
+
+
 def _get_pid_path() -> Path:
     """Return the path to the gateway PID file, respecting HERMES_HOME."""
     home = _get_process_hermes_home()
@@ -499,6 +511,11 @@ def _build_pid_record() -> dict:
         "kind": _GATEWAY_KIND,
         "argv": list(sys.argv),
         "start_time": _get_process_start_time(os.getpid()),
+        # Scoped credential locks are machine-global rather than
+        # HERMES_HOME-local.  Persist the owning gateway's process home so an
+        # explicit cross-profile --replace can place its planned-takeover
+        # marker where the target process will actually read it.
+        "hermes_home": str(_canonical_hermes_home(_get_process_hermes_home())),
     }
 
 
@@ -1266,10 +1283,14 @@ _PLANNED_STOP_MARKER_FILENAME = ".gateway-planned-stop.json"
 _PLANNED_STOP_MARKER_TTL_S = 60
 
 
-def _get_takeover_marker_path() -> Path:
-    """Return the path to the --replace takeover marker file."""
-    home = _get_process_hermes_home()
-    return home / _TAKEOVER_MARKER_FILENAME
+def _get_takeover_marker_path(hermes_home: Optional[Path] = None) -> Path:
+    """Return the path to the --replace takeover marker file.
+
+    ``hermes_home`` is supplied only for a verified cross-home handoff.  The
+    target process always consumes the marker from its own process-level home.
+    """
+    home = hermes_home or _get_process_hermes_home()
+    return _canonical_hermes_home(home) / _TAKEOVER_MARKER_FILENAME
 
 
 def _get_planned_stop_marker_path() -> Path:
@@ -1316,21 +1337,24 @@ def _consume_pid_marker_for_self(
             pass
         return False
 
-    # Cross-profile guard (#29092): reject markers written by a gateway
-    # running under a different HERMES_HOME. When two profile gateway
-    # services share the same default ~/.hermes (HERMES_HOME not set
-    # distinctly), the marker path resolves to the same file for both. A
-    # --replace from profile B could land in profile A's marker, match on
-    # PID + start_time by coincidence of a shared PID namespace, and make
-    # profile A exit 0 — only to be revived by systemd Restart=always,
-    # which then races the replacer again, flapping indefinitely. The
-    # field is absent in markers written by older Hermes versions; treat
-    # absent as "same home" so old markers and single-profile setups are
-    # unaffected. Leave a mismatched marker in place so the correct
-    # profile can still consume it.
-    replacer_home = record.get("replacer_hermes_home")
-    if replacer_home is not None and replacer_home != str(_get_process_hermes_home()):
-        return False
+    # Cross-profile guard (#29092): new markers explicitly name the verified
+    # TARGET home.  That permits a deliberate cross-HERMES_HOME --replace while
+    # ensuring a marker accidentally written into another profile's directory
+    # is ignored.  Legacy markers have no target field, so retain the original
+    # same-replacer-home rule for backwards compatibility.
+    our_home = _get_process_hermes_home()
+    target_home = record.get("target_hermes_home")
+    if target_home is not None:
+        if not isinstance(target_home, str) or not _same_hermes_home(
+            target_home, our_home
+        ):
+            return False
+    else:
+        replacer_home = record.get("replacer_hermes_home")
+        if replacer_home is not None and not _same_hermes_home(
+            replacer_home, our_home
+        ):
+            return False
 
     our_pid = os.getpid()
     our_start_time = _get_process_start_time(our_pid)
@@ -1361,27 +1385,45 @@ def _consume_pid_marker_for_self(
     return matches
 
 
-def write_takeover_marker(target_pid: int) -> bool:
+def write_takeover_marker(
+    target_pid: int,
+    *,
+    target_home: Optional[Path] = None,
+    target_start_time: Any = _UNSET,
+) -> bool:
     """Record that ``target_pid`` is being replaced by the current process.
 
     Captures the target's ``start_time`` so that PID reuse after the
     target exits cannot later match the marker. Also records the
     replacer's PID and a UTC timestamp for TTL-based staleness checks.
 
-    Returns True on successful write, False on any failure. The caller
-    should proceed with the SIGTERM even if the write fails (the marker
-    is a best-effort signal, not a correctness requirement).
+    A verified scoped-lock handoff supplies ``target_home`` and the already
+    validated ``target_start_time`` so the marker is written into the target
+    gateway's HERMES_HOME rather than the replacer's.  Same-home callers omit
+    both arguments and preserve the historical behavior.
+
+    Returns True on successful write, False on any failure. Historical
+    same-home callers may treat the marker as best effort. Cross-home callers
+    must fail closed because the target's supervisor could otherwise revive it
+    without recognizing the handoff.
     """
     try:
-        target_start_time = _get_process_start_time(target_pid)
+        marker_home = _canonical_hermes_home(
+            target_home or _get_process_hermes_home()
+        )
+        if target_start_time is _UNSET:
+            target_start_time = _get_process_start_time(target_pid)
         record = {
             "target_pid": target_pid,
             "target_start_time": target_start_time,
+            "target_hermes_home": str(marker_home),
             "replacer_pid": os.getpid(),
-            "replacer_hermes_home": str(_get_process_hermes_home()),
+            "replacer_hermes_home": str(
+                _canonical_hermes_home(_get_process_hermes_home())
+            ),
             "written_at": _utc_now_iso(),
         }
-        _write_json_file(_get_takeover_marker_path(), record)
+        _write_json_file(_get_takeover_marker_path(marker_home), record)
         return True
     except (OSError, PermissionError):
         return False
@@ -1406,12 +1448,180 @@ def consume_takeover_marker_for_self() -> bool:
     )
 
 
-def clear_takeover_marker() -> None:
+def clear_takeover_marker(target_home: Optional[Path] = None) -> None:
     """Remove the takeover marker unconditionally. Safe to call repeatedly."""
     try:
-        _get_takeover_marker_path().unlink(missing_ok=True)
+        _get_takeover_marker_path(target_home).unlink(missing_ok=True)
     except OSError:
         pass
+
+
+def _validated_scoped_lock_gateway_owner(
+    record: dict[str, Any],
+) -> Optional[tuple[int, int, Path]]:
+    """Resolve a live scoped-lock owner to a verified gateway identity.
+
+    A machine-global scoped-lock file is only a claim; it is not sufficient
+    authority to terminate a process or choose a marker destination.  Require
+    the lock record, the target HERMES_HOME's gateway PID record, and the live
+    OS process to agree on PID, start-time fingerprint, gateway identity, and
+    process home.  Missing legacy metadata fails closed and leaves the normal
+    retryable lock-conflict path in charge.
+    """
+    if not isinstance(record, dict) or not _record_looks_like_gateway(record):
+        return None
+
+    try:
+        owner_pid = int(record["pid"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if owner_pid <= 0 or owner_pid == os.getpid():
+        return None
+
+    owner_start_time = record.get("start_time")
+    if not isinstance(owner_start_time, int) or isinstance(owner_start_time, bool):
+        return None
+
+    raw_home = record.get("hermes_home")
+    if not isinstance(raw_home, str) or not raw_home.strip():
+        return None
+    if not Path(raw_home).expanduser().is_absolute():
+        return None
+    target_home = _canonical_hermes_home(raw_home)
+
+    if not _pid_exists(owner_pid):
+        return None
+    live_start_time = _get_process_start_time(owner_pid)
+    if live_start_time is None or live_start_time != owner_start_time:
+        return None
+
+    live_cmdline = _read_process_cmdline(owner_pid)
+    if live_cmdline is not None and not looks_like_gateway_runtime_command_line(
+        live_cmdline
+    ):
+        return None
+
+    pid_record = _read_json_file(target_home / "gateway.pid")
+    if not isinstance(pid_record, dict) or not _record_looks_like_gateway(pid_record):
+        return None
+    try:
+        pid_record_pid = int(pid_record["pid"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if pid_record_pid != owner_pid or pid_record.get("start_time") != owner_start_time:
+        return None
+
+    pid_record_home = pid_record.get("hermes_home")
+    if not isinstance(pid_record_home, str) or not _same_hermes_home(
+        pid_record_home, target_home
+    ):
+        return None
+
+    return owner_pid, owner_start_time, target_home
+
+
+def _scoped_lock_owner_state(owner_pid: int, owner_start_time: int) -> str:
+    """Return ``same``, ``exited``, or ``unknown`` for a validated owner."""
+    if not _pid_exists(owner_pid):
+        return "exited"
+    live_start_time = _get_process_start_time(owner_pid)
+    if live_start_time is None:
+        return "unknown"
+    if live_start_time != owner_start_time:
+        # The original owner exited and the OS recycled its PID.  Never signal
+        # the replacement process.
+        return "exited"
+    return "same"
+
+
+def _wait_for_scoped_lock_owner_exit(
+    owner_pid: int,
+    owner_start_time: int,
+    *,
+    attempts: int,
+    delay: float,
+) -> tuple[bool, bool]:
+    """Return ``(exited, safe_to_force)`` after bounded identity-aware waits."""
+    for _ in range(max(0, attempts)):
+        state = _scoped_lock_owner_state(owner_pid, owner_start_time)
+        if state == "exited":
+            return True, False
+        if state == "unknown":
+            return False, False
+        time.sleep(max(0.0, delay))
+    return False, _scoped_lock_owner_state(owner_pid, owner_start_time) == "same"
+
+
+def take_over_scoped_lock_holder(
+    record: dict[str, Any],
+    *,
+    graceful_attempts: int = 20,
+    force_attempts: int = 20,
+) -> Optional[int]:
+    """Terminate one verified scoped-lock holder for explicit ``--replace``.
+
+    Returns the original owner PID only after that exact PID/start-time identity
+    has exited (or ``terminate_pid`` reports it already gone).  Validation or
+    marker-write failure returns ``None`` without signalling anything.  This is
+    deliberately stricter than the same-home PID-file replacement path: a
+    cross-home handoff must place a consumable marker in the target's home or a
+    service supervisor could revive the target and start a flap loop.
+    """
+    owner = _validated_scoped_lock_gateway_owner(record)
+    if owner is None:
+        return None
+    owner_pid, owner_start_time, target_home = owner
+
+    if not write_takeover_marker(
+        owner_pid,
+        target_home=target_home,
+        target_start_time=owner_start_time,
+    ):
+        return None
+
+    try:
+        state = _scoped_lock_owner_state(owner_pid, owner_start_time)
+        if state == "exited":
+            return owner_pid
+        if state != "same":
+            return None
+
+        try:
+            terminate_pid(owner_pid, force=False)
+        except ProcessLookupError:
+            return owner_pid
+        except (PermissionError, OSError):
+            return None
+
+        exited, safe_to_force = _wait_for_scoped_lock_owner_exit(
+            owner_pid,
+            owner_start_time,
+            attempts=graceful_attempts,
+            delay=0.5,
+        )
+        if exited:
+            return owner_pid
+        if not safe_to_force:
+            return None
+
+        try:
+            terminate_pid(owner_pid, force=True)
+        except ProcessLookupError:
+            return owner_pid
+        except (PermissionError, OSError):
+            return None
+
+        exited, _ = _wait_for_scoped_lock_owner_exit(
+            owner_pid,
+            owner_start_time,
+            attempts=force_attempts,
+            delay=0.25,
+        )
+        return owner_pid if exited else None
+    finally:
+        # The target normally consumes its marker from the signal handler.
+        # Clean up any remainder after an already-gone/forced/failed handoff.
+        clear_takeover_marker(target_home)
 
 
 def write_planned_stop_marker(target_pid: int) -> bool:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1552,6 +1552,108 @@ def _wait_for_scoped_lock_owner_exit(
     return False, _scoped_lock_owner_state(owner_pid, owner_start_time) == "same"
 
 
+def _snapshot_gateway_children(pid: int) -> list:
+    """Best-effort snapshot of ``pid``'s live descendants (POSIX only).
+
+    Must be taken while the old gateway is still alive: once the parent
+    exits, its children are reparented (to init or a subreaper) and can no
+    longer be discovered by a parent walk.  Returns ``[]`` on Windows —
+    ``terminate_pid(force=True)`` there already tree-kills via
+    ``taskkill /T`` — and on any error (missing psutil, process already
+    gone, access denied).  Never raises.
+    """
+    if _IS_WINDOWS:
+        return []
+    try:
+        import psutil  # type: ignore
+
+        return psutil.Process(int(pid)).children(recursive=True)
+    except Exception:
+        logger.debug(
+            "Could not snapshot children of gateway PID %d", pid, exc_info=True
+        )
+        return []
+
+
+def reap_gateway_children(children: list, *, parent_pid: int, timeout: float = 5.0) -> int:
+    """Best-effort reap of a dead gateway's orphaned descendants (POSIX).
+
+    Mirrors the Windows ``taskkill /T`` tree-kill for the POSIX ``--replace``
+    paths: adapter subprocesses that survive their parent keep holding scoped
+    token locks and block the replacement gateway.  Call only AFTER the main
+    gateway PID is confirmed dead, with a ``children`` snapshot taken via
+    :func:`_snapshot_gateway_children` while it was still alive.
+
+    Safety properties:
+    - ``psutil.Process.is_running()`` is identity-aware (PID + create time),
+      so a recycled child PID is never signalled.
+    - A child whose current ppid still equals ``parent_pid`` is skipped: that
+      means the parent is in fact alive (caller raced or was mocked) and the
+      child is not an orphan.
+    - SIGTERM first, bounded wait, SIGKILL only for survivors.
+    - Never raises; returns the number of children signalled.
+    """
+    if _IS_WINDOWS or not children:
+        return 0
+    reaped = 0
+    try:
+        import psutil  # type: ignore
+
+        live = []
+        for child in children:
+            try:
+                if not child.is_running():
+                    continue
+                if child.status() == psutil.STATUS_ZOMBIE:
+                    continue
+                if child.ppid() == parent_pid:
+                    # Parent still alive — this is not an orphan; leave it.
+                    logger.debug(
+                        "Skipping child PID %d of old gateway %d: parent "
+                        "still appears alive",
+                        child.pid,
+                        parent_pid,
+                    )
+                    continue
+                child.terminate()
+                live.append(child)
+            except psutil.NoSuchProcess:
+                continue
+            except Exception:
+                logger.debug(
+                    "Could not terminate child PID %s of old gateway %d",
+                    getattr(child, "pid", "?"),
+                    parent_pid,
+                    exc_info=True,
+                )
+        if not live:
+            return 0
+        gone, alive = psutil.wait_procs(live, timeout=max(0.0, timeout))
+        reaped = len(gone)
+        for child in alive:
+            try:
+                child.kill()
+                reaped += 1
+            except Exception:
+                logger.debug(
+                    "Could not force-kill child PID %s of old gateway %d",
+                    getattr(child, "pid", "?"),
+                    parent_pid,
+                    exc_info=True,
+                )
+        if reaped:
+            logger.info(
+                "Reaped %d orphaned child process(es) of replaced gateway PID %d.",
+                reaped,
+                parent_pid,
+            )
+    except Exception:
+        logger.debug(
+            "Child reap for replaced gateway PID %d failed", parent_pid, exc_info=True
+        )
+    return reaped
+
+
 def take_over_scoped_lock_holder(
     record: dict[str, Any],
     *,
@@ -1566,12 +1668,42 @@ def take_over_scoped_lock_holder(
     deliberately stricter than the same-home PID-file replacement path: a
     cross-home handoff must place a consumable marker in the target's home or a
     service supervisor could revive the target and start a flap loop.
+
+    On POSIX, after the owner is confirmed dead, its previously snapshotted
+    child processes are reaped best-effort (see :func:`reap_gateway_children`)
+    so orphaned adapter subprocesses cannot keep holding token locks.
     """
     owner = _validated_scoped_lock_gateway_owner(record)
     if owner is None:
         return None
     owner_pid, owner_start_time, target_home = owner
 
+    # Snapshot descendants while the owner is still alive — after it exits
+    # they are reparented and undiscoverable (POSIX; [] on Windows where
+    # taskkill /T already tree-kills).
+    owner_children = _snapshot_gateway_children(owner_pid)
+
+    replaced = _terminate_scoped_lock_owner_once(
+        owner_pid,
+        owner_start_time,
+        target_home,
+        graceful_attempts=graceful_attempts,
+        force_attempts=force_attempts,
+    )
+    if replaced is not None:
+        reap_gateway_children(owner_children, parent_pid=owner_pid)
+    return replaced
+
+
+def _terminate_scoped_lock_owner_once(
+    owner_pid: int,
+    owner_start_time: int,
+    target_home: Path,
+    *,
+    graceful_attempts: int = 20,
+    force_attempts: int = 20,
+) -> Optional[int]:
+    """Marker-write + bounded identity-aware termination of a verified owner."""
     if not write_takeover_marker(
         owner_pid,
         target_home=target_home,

--- a/tests/gateway/test_replace_child_reap.py
+++ b/tests/gateway/test_replace_child_reap.py
@@ -1,0 +1,372 @@
+"""Tests for --replace child-process reaping (POSIX taskkill /T parity).
+
+On Windows, ``terminate_pid(force=True)`` tree-kills via ``taskkill /T``.
+On POSIX, ``--replace`` historically signalled only the recorded gateway PID,
+so adapter subprocesses that survived their parent kept holding scoped token
+locks and blocked the replacement gateway.  ``_snapshot_gateway_children`` /
+``reap_gateway_children`` close that gap: the replacer snapshots the old
+gateway's descendants while it is still alive, and reaps them (best-effort,
+identity-aware) only after the main PID is confirmed dead.
+
+Also asserts the takeover/reap machinery stays gated on explicit --replace.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway import status
+from gateway.config import GatewayConfig
+
+
+class _FakeChild:
+    """Minimal psutil.Process stand-in for reap tests."""
+
+    def __init__(self, pid, *, running=True, ppid=1, zombie=False):
+        self.pid = pid
+        self._running = running
+        self._ppid = ppid
+        self._zombie = zombie
+        self.terminated = False
+        self.killed = False
+
+    def is_running(self):
+        return self._running
+
+    def status(self):
+        return "zombie" if self._zombie else "sleeping"
+
+    def ppid(self):
+        return self._ppid
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+
+
+def _fake_psutil(monkeypatch, *, wait_gone=None, wait_alive=None):
+    """Install a stub psutil module for gateway.status's local imports."""
+    fake = MagicMock()
+    fake.STATUS_ZOMBIE = "zombie"
+    fake.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
+    fake.wait_procs = MagicMock(
+        side_effect=lambda live, timeout: (
+            wait_gone if wait_gone is not None else list(live),
+            wait_alive if wait_alive is not None else [],
+        )
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake)
+    return fake
+
+
+class TestReapGatewayChildren:
+    def test_reaps_orphaned_children_sigterm_then_wait(self, monkeypatch):
+        monkeypatch.setattr(status, "_IS_WINDOWS", False)
+        fake = _fake_psutil(monkeypatch)
+        orphans = [_FakeChild(101, ppid=1), _FakeChild(102, ppid=1)]
+
+        reaped = status.reap_gateway_children(orphans, parent_pid=42)
+
+        assert reaped == 2
+        assert all(c.terminated for c in orphans)
+        assert not any(c.killed for c in orphans)
+        fake.wait_procs.assert_called_once()
+
+    def test_survivors_of_sigterm_get_sigkill(self, monkeypatch):
+        monkeypatch.setattr(status, "_IS_WINDOWS", False)
+        stubborn = _FakeChild(103, ppid=1)
+        _fake_psutil(monkeypatch, wait_gone=[], wait_alive=[stubborn])
+
+        reaped = status.reap_gateway_children([stubborn], parent_pid=42)
+
+        assert stubborn.terminated
+        assert stubborn.killed
+        assert reaped == 1
+
+    def test_child_still_parented_to_live_parent_is_skipped(self, monkeypatch):
+        """If a child's ppid still equals the old gateway PID, the parent is
+        alive and the child is not an orphan — never signal it."""
+        monkeypatch.setattr(status, "_IS_WINDOWS", False)
+        _fake_psutil(monkeypatch)
+        child = _FakeChild(104, ppid=42)
+
+        reaped = status.reap_gateway_children([child], parent_pid=42)
+
+        assert reaped == 0
+        assert not child.terminated
+        assert not child.killed
+
+    def test_dead_and_zombie_children_are_skipped(self, monkeypatch):
+        monkeypatch.setattr(status, "_IS_WINDOWS", False)
+        _fake_psutil(monkeypatch)
+        dead = _FakeChild(105, running=False)
+        zombie = _FakeChild(106, zombie=True)
+
+        assert status.reap_gateway_children([dead, zombie], parent_pid=42) == 0
+        assert not dead.terminated and not zombie.terminated
+
+    def test_noop_on_windows_and_empty_snapshot(self, monkeypatch):
+        monkeypatch.setattr(status, "_IS_WINDOWS", True)
+        child = _FakeChild(107, ppid=1)
+        assert status.reap_gateway_children([child], parent_pid=42) == 0
+        assert not child.terminated
+
+        monkeypatch.setattr(status, "_IS_WINDOWS", False)
+        assert status.reap_gateway_children([], parent_pid=42) == 0
+
+    def test_never_raises_when_psutil_explodes(self, monkeypatch):
+        monkeypatch.setattr(status, "_IS_WINDOWS", False)
+        fake = _fake_psutil(monkeypatch)
+        fake.wait_procs.side_effect = RuntimeError("boom")
+        child = _FakeChild(108, ppid=1)
+
+        # Must swallow and return best-effort count, not raise.
+        assert status.reap_gateway_children([child], parent_pid=42) == 0
+
+
+class TestSnapshotGatewayChildren:
+    def test_snapshot_walks_descendants_recursively(self, monkeypatch):
+        monkeypatch.setattr(status, "_IS_WINDOWS", False)
+        fake = _fake_psutil(monkeypatch)
+        kids = [_FakeChild(201), _FakeChild(202)]
+        fake.Process.return_value.children.return_value = kids
+
+        assert status._snapshot_gateway_children(42) == kids
+        fake.Process.assert_called_once_with(42)
+        fake.Process.return_value.children.assert_called_once_with(recursive=True)
+
+    def test_snapshot_returns_empty_on_windows_or_error(self, monkeypatch):
+        monkeypatch.setattr(status, "_IS_WINDOWS", True)
+        assert status._snapshot_gateway_children(42) == []
+
+        monkeypatch.setattr(status, "_IS_WINDOWS", False)
+        fake = _fake_psutil(monkeypatch)
+        fake.Process.side_effect = RuntimeError("gone")
+        assert status._snapshot_gateway_children(42) == []
+
+
+class TestScopedLockTakeoverReapsChildren:
+    """take_over_scoped_lock_holder reaps the dead owner's orphans (POSIX)."""
+
+    @staticmethod
+    def _owner_record(target_home: Path, *, pid: int = 4242, start_time: int = 123):
+        target_home.mkdir(parents=True, exist_ok=True)
+        record = {
+            "pid": pid,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            "start_time": start_time,
+            "hermes_home": str(target_home),
+        }
+        (target_home / "gateway.pid").write_text(json.dumps(record))
+        return record
+
+    def _verified_owner_env(self, tmp_path, monkeypatch, *, alive_polls):
+        replacer_home = tmp_path / "replacer"
+        target_home = tmp_path / "target"
+        replacer_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(replacer_home))
+        record = self._owner_record(target_home)
+        alive = iter(alive_polls)
+        monkeypatch.setattr(status, "_pid_exists", lambda _pid: next(alive))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda _pid: 123)
+        monkeypatch.setattr(
+            status,
+            "_read_process_cmdline",
+            lambda _pid: "python -m hermes_cli.main gateway run",
+        )
+        return record
+
+    def test_successful_takeover_snapshots_then_reaps(self, tmp_path, monkeypatch):
+        record = self._verified_owner_env(
+            tmp_path, monkeypatch, alive_polls=[True, True, False]
+        )
+        kids = [_FakeChild(301, ppid=1)]
+        events = []
+        monkeypatch.setattr(
+            status,
+            "_snapshot_gateway_children",
+            lambda pid: events.append(("snapshot", pid)) or kids,
+        )
+        monkeypatch.setattr(
+            status,
+            "reap_gateway_children",
+            lambda children, *, parent_pid, timeout=5.0: events.append(
+                ("reap", parent_pid, children)
+            )
+            or len(children),
+        )
+        monkeypatch.setattr(
+            status,
+            "terminate_pid",
+            lambda pid, *, force=False: events.append(("terminate", pid, force)),
+        )
+
+        assert status.take_over_scoped_lock_holder(record, graceful_attempts=1) == 4242
+        # Snapshot taken while owner alive, BEFORE terminate; reap after exit.
+        assert events == [
+            ("snapshot", 4242),
+            ("terminate", 4242, False),
+            ("reap", 4242, kids),
+        ]
+
+    def test_failed_takeover_does_not_reap(self, tmp_path, monkeypatch):
+        # Owner never exits; safe_to_force stays False via unknown start time.
+        record = self._verified_owner_env(
+            tmp_path, monkeypatch, alive_polls=[True] * 50
+        )
+        monkeypatch.setattr(status, "_snapshot_gateway_children", lambda pid: [])
+        starts = iter([123, 123] + [None] * 50)
+        monkeypatch.setattr(
+            status, "_get_process_start_time", lambda _pid: next(starts)
+        )
+        reap = MagicMock()
+        monkeypatch.setattr(status, "reap_gateway_children", reap)
+        monkeypatch.setattr(status, "terminate_pid", lambda pid, *, force=False: None)
+        monkeypatch.setattr(status.time, "sleep", lambda _s: None)
+
+        assert (
+            status.take_over_scoped_lock_holder(
+                record, graceful_attempts=1, force_attempts=1
+            )
+            is None
+        )
+        reap.assert_not_called()
+
+    def test_unverified_holder_is_never_snapshotted_or_signalled(
+        self, tmp_path, monkeypatch
+    ):
+        """A non-gateway lock record fails identity validation: no snapshot,
+        no terminate, no reap — regardless of --replace intent upstream."""
+        record = {"pid": 4242, "kind": "something-else", "start_time": 123}
+        snapshot = MagicMock()
+        terminate = MagicMock()
+        reap = MagicMock()
+        monkeypatch.setattr(status, "_snapshot_gateway_children", snapshot)
+        monkeypatch.setattr(status, "terminate_pid", terminate)
+        monkeypatch.setattr(status, "reap_gateway_children", reap)
+
+        assert status.take_over_scoped_lock_holder(record) is None
+        snapshot.assert_not_called()
+        terminate.assert_not_called()
+        reap.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_replace_reaps_old_gateway_children_posix(
+    monkeypatch, tmp_path
+):
+    """--replace snapshots the old gateway's children before SIGTERM and
+    reaps them after the main PID is confirmed dead (POSIX path)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    events = []
+    kids = [_FakeChild(401, ppid=1)]
+
+    class _CleanExitRunner:
+        def __init__(self, config):
+            self.config = config
+            self.should_exit_cleanly = True
+            self.exit_reason = None
+            self.exit_code = None
+            self.adapters = {}
+
+        async def start(self):
+            assert self._platform_lock_takeover_on_start is True
+            return True
+
+        async def stop(self):
+            return None
+
+    _pid_state = {"alive": True}
+    monkeypatch.setattr(
+        "gateway.status.get_running_pid",
+        lambda: 42 if _pid_state["alive"] else None,
+    )
+    monkeypatch.setattr(
+        "gateway.status.remove_pid_file",
+        lambda: _pid_state.update(alive=False),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_all_scoped_locks", lambda **kwargs: 0
+    )
+    monkeypatch.setattr(
+        "gateway.status._snapshot_gateway_children",
+        lambda pid: events.append(("snapshot", pid)) or kids,
+    )
+    monkeypatch.setattr(
+        "gateway.status.reap_gateway_children",
+        lambda children, *, parent_pid, timeout=5.0: events.append(
+            ("reap", parent_pid, children)
+        )
+        or len(children),
+    )
+
+    def _mock_terminate_pid(pid, force=False):
+        events.append(("terminate", pid, force))
+        _pid_state["alive"] = False
+
+    monkeypatch.setattr("gateway.status.terminate_pid", _mock_terminate_pid)
+    monkeypatch.setattr(
+        "gateway.status._pid_exists", lambda pid: _pid_state["alive"]
+    )
+    monkeypatch.setattr("gateway.run.os.getpid", lambda: 100)
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr(
+        "hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path
+    )
+    monkeypatch.setattr(
+        "hermes_logging._add_rotating_handler", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr("gateway.run.GatewayRunner", _CleanExitRunner)
+
+    from gateway.run import start_gateway
+
+    ok = await start_gateway(config=GatewayConfig(), replace=True, verbosity=None)
+
+    assert ok is True
+    # Snapshot precedes the SIGTERM; reap runs only after the PID is dead.
+    assert events == [
+        ("snapshot", 42),
+        ("terminate", 42, False),
+        ("reap", 42, kids),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_without_replace_never_touches_old_gateway(
+    monkeypatch, tmp_path
+):
+    """Without --replace an existing gateway aborts startup: no takeover
+    authority is armed, no snapshot/terminate/reap ever runs."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    snapshot = MagicMock()
+    terminate = MagicMock()
+    reap = MagicMock()
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 42)
+    monkeypatch.setattr("gateway.status._snapshot_gateway_children", snapshot)
+    monkeypatch.setattr("gateway.status.terminate_pid", terminate)
+    monkeypatch.setattr("gateway.status.reap_gateway_children", reap)
+    monkeypatch.setattr("gateway.run.os.getpid", lambda: 100)
+
+    class _RunnerShouldNotStart:
+        def __init__(self, config):
+            raise AssertionError("must not start while another gateway runs")
+
+    monkeypatch.setattr("gateway.run.GatewayRunner", _RunnerShouldNotStart)
+
+    from gateway.run import start_gateway
+
+    ok = await start_gateway(config=GatewayConfig(), replace=False, verbosity=None)
+
+    assert ok is False
+    snapshot.assert_not_called()
+    terminate.assert_not_called()
+    reap.assert_not_called()

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -156,6 +156,7 @@ async def test_start_gateway_verbosity_imports_redacting_formatter(monkeypatch, 
             self.adapters = {}
 
         async def start(self):
+            assert self._platform_lock_takeover_on_start is False
             return True
 
         async def stop(self):
@@ -191,6 +192,7 @@ async def test_start_gateway_replace_force_uses_terminate_pid(monkeypatch, tmp_p
             self.adapters = {}
 
         async def start(self):
+            assert self._platform_lock_takeover_on_start is True
             return True
 
         async def stop(self):

--- a/tests/gateway/test_stale_platform_lock_retryable.py
+++ b/tests/gateway/test_stale_platform_lock_retryable.py
@@ -1,5 +1,6 @@
-"""Regression test for #54167 — stale platform lock must be retryable.
+"""Regression tests for platform-lock acquire behavior.
 
+#54167 — stale platform lock must be retryable.
 When a gateway process is killed (SIGKILL, crash) during Telegram
 initialization, the scoped lock file survives. On next startup,
 ``acquire_scoped_lock()`` detects the stale lock and deletes it, but may
@@ -11,10 +12,11 @@ process grab the lock first).
 so the reconnect watcher can retry after a delay — not permanently kill
 the platform.
 
-Contract asserted here
-----------------------
-``_set_fatal_error`` is called with ``retryable=True`` when lock
-acquisition fails, regardless of the reason.
+#65176 — a live gateway token conflict may attempt one-shot takeover only
+during the initial connect of an explicit ``gateway run --replace`` startup.
+``gateway run --replace`` only kills same-HERMES_HOME PID-file holders.
+A normal start or reconnect must retain the retryable conflict behavior and
+must never evict the active holder.
 """
 
 from typing import Any, Dict
@@ -23,6 +25,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from gateway.platforms.base import BasePlatformAdapter
+from gateway.run import GatewayRunner
 
 
 class _StubAdapter(BasePlatformAdapter):
@@ -54,6 +57,8 @@ def adapter():
     obj._fatal_error_handler = None
     obj._platform_lock_scope = None
     obj._platform_lock_identity = None
+    obj._platform_lock_takeover_allowed = False
+    obj._platform_lock_takeover_attempted = False
     obj._status_write_logged = None
     return obj
 
@@ -71,3 +76,130 @@ def test_stale_lock_failure_is_retryable(adapter):
     assert result is False
     assert adapter._fatal_error_retryable is True
     assert adapter._fatal_error_code == "telegram-bot-token_lock"
+
+
+def test_explicit_replace_takeover_reacquires_lock_once(adapter):
+    """Initial explicit --replace may hand off and re-acquire once (#65176)."""
+    existing = {
+        "pid": 4242,
+        "kind": "hermes-gateway",
+        "argv": ["hermes", "gateway", "run"],
+        "start_time": 123,
+    }
+    acquire = MagicMock(side_effect=[(False, existing), (True, None)])
+    adapter._platform_lock_takeover_allowed = True
+
+    with patch("gateway.status.acquire_scoped_lock", acquire), patch(
+        "gateway.status.take_over_scoped_lock_holder",
+        return_value=4242,
+    ) as takeover, patch.object(
+        adapter, "_write_runtime_status_safe"
+    ):
+        result = adapter._acquire_platform_lock(
+            "telegram-bot-token", "test-token", "Telegram bot token"
+        )
+
+    assert result is True
+    assert adapter._platform_lock_takeover_allowed is False
+    assert adapter._platform_lock_takeover_attempted is True
+    takeover.assert_called_once_with(existing)
+    assert acquire.call_count == 2
+
+
+def test_normal_connect_conflict_never_attempts_takeover(adapter):
+    """A normal start/reconnect cannot evict the current token holder."""
+    existing = {
+        "pid": 5555,
+        "kind": "hermes-gateway",
+        "argv": ["hermes", "gateway", "run"],
+        "start_time": 123,
+    }
+    with patch(
+        "gateway.status.acquire_scoped_lock",
+        return_value=(False, existing),
+    ), patch(
+        "gateway.status.take_over_scoped_lock_holder",
+    ) as takeover, patch.object(
+        adapter, "_write_runtime_status_safe"
+    ):
+        result = adapter._acquire_platform_lock(
+            "telegram-bot-token", "test-token", "Telegram bot token"
+        )
+
+    assert result is False
+    takeover.assert_not_called()
+    assert adapter._platform_lock_takeover_attempted is False
+    assert adapter._fatal_error_retryable is True
+
+
+def test_failed_explicit_takeover_consumes_authority(adapter):
+    """A failed handoff is not retried by a later acquire on the same adapter."""
+    existing = {
+        "pid": 7777,
+        "kind": "hermes-gateway",
+        "argv": ["hermes", "gateway", "run"],
+        "start_time": 456,
+    }
+    adapter._platform_lock_takeover_allowed = True
+
+    with patch(
+        "gateway.status.acquire_scoped_lock",
+        return_value=(False, existing),
+    ), patch(
+        "gateway.status.take_over_scoped_lock_holder",
+        return_value=None,
+    ) as takeover, patch.object(
+        adapter, "_write_runtime_status_safe"
+    ):
+        first = adapter._acquire_platform_lock(
+            "telegram-bot-token", "test-token", "Telegram bot token"
+        )
+        second = adapter._acquire_platform_lock(
+            "telegram-bot-token", "test-token", "Telegram bot token"
+        )
+
+    assert first is False
+    assert second is False
+    assert adapter._platform_lock_takeover_allowed is False
+    assert adapter._platform_lock_takeover_attempted is True
+    takeover.assert_called_once_with(existing)
+
+
+@pytest.mark.asyncio
+async def test_runner_scopes_replace_intent_to_initial_connect():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._platform_lock_takeover_on_start = True
+    adapter = MagicMock()
+    adapter._platform_lock_takeover_allowed = False
+    seen = []
+
+    async def connect(current_adapter, _platform):
+        seen.append(current_adapter._platform_lock_takeover_allowed)
+        return True
+
+    runner._connect_adapter_with_timeout = connect
+
+    assert await runner._connect_initial_adapter_with_timeout(
+        adapter, MagicMock(value="telegram")
+    ) is True
+    assert seen == [True]
+    assert adapter._platform_lock_takeover_allowed is False
+
+
+@pytest.mark.asyncio
+async def test_runner_clears_replace_intent_when_initial_connect_raises():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._platform_lock_takeover_on_start = True
+    adapter = MagicMock()
+    adapter._platform_lock_takeover_allowed = False
+
+    async def connect(_adapter, _platform):
+        raise RuntimeError("connect failed")
+
+    runner._connect_adapter_with_timeout = connect
+
+    with pytest.raises(RuntimeError, match="connect failed"):
+        await runner._connect_initial_adapter_with_timeout(
+            adapter, MagicMock(value="telegram")
+        )
+    assert adapter._platform_lock_takeover_allowed is False

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1295,6 +1295,155 @@ class TestTakeoverMarker:
         assert not marker_path.exists()
 
 
+class TestScopedLockTakeover:
+    """Cross-home takeover requires explicit, corroborated process identity."""
+
+    @staticmethod
+    def _owner_record(target_home: Path, *, pid: int = 4242, start_time: int = 123):
+        target_home.mkdir(parents=True, exist_ok=True)
+        record = {
+            "pid": pid,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            "start_time": start_time,
+            "hermes_home": str(target_home),
+        }
+        (target_home / "gateway.pid").write_text(json.dumps(record))
+        return record
+
+    def test_verified_distinct_home_handoff_marks_target_before_sigterm(
+        self, tmp_path, monkeypatch
+    ):
+        replacer_home = tmp_path / "replacer"
+        target_home = tmp_path / "target"
+        replacer_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(replacer_home))
+        record = self._owner_record(target_home)
+
+        alive = iter([True, True, False])
+        monkeypatch.setattr(status, "_pid_exists", lambda _pid: next(alive))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda _pid: 123)
+        monkeypatch.setattr(
+            status,
+            "_read_process_cmdline",
+            lambda _pid: "python -m hermes_cli.main gateway run",
+        )
+        calls = []
+
+        def terminate(pid, *, force=False):
+            marker_path = target_home / ".gateway-takeover.json"
+            assert marker_path.exists()
+            payload = json.loads(marker_path.read_text())
+            assert payload["target_hermes_home"] == str(target_home)
+            assert payload["replacer_hermes_home"] == str(replacer_home)
+            calls.append((pid, force))
+
+        monkeypatch.setattr(status, "terminate_pid", terminate)
+
+        owner_pid = status.take_over_scoped_lock_holder(
+            record, graceful_attempts=1
+        )
+
+        assert owner_pid == 4242
+        assert calls == [(4242, False)]
+        assert not (target_home / ".gateway-takeover.json").exists()
+        assert not (replacer_home / ".gateway-takeover.json").exists()
+
+    def test_handoff_rejects_uncorroborated_target_home(self, tmp_path, monkeypatch):
+        target_home = tmp_path / "target"
+        record = self._owner_record(target_home)
+        # The lock claims target_home, but that home's PID record names a
+        # different process identity.
+        bad_pid_record = dict(record, pid=9999)
+        (target_home / "gateway.pid").write_text(json.dumps(bad_pid_record))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda _pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda _pid: 123)
+        monkeypatch.setattr(
+            status,
+            "_read_process_cmdline",
+            lambda _pid: "python -m hermes_cli.main gateway run",
+        )
+        calls = []
+        monkeypatch.setattr(
+            status, "terminate_pid", lambda *args, **kwargs: calls.append(args)
+        )
+
+        assert status.take_over_scoped_lock_holder(record) is None
+        assert calls == []
+        assert not (target_home / ".gateway-takeover.json").exists()
+
+    def test_handoff_requires_marker_write_before_termination(
+        self, tmp_path, monkeypatch
+    ):
+        target_home = tmp_path / "target"
+        record = self._owner_record(target_home)
+        monkeypatch.setattr(status, "_pid_exists", lambda _pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda _pid: 123)
+        monkeypatch.setattr(
+            status,
+            "_read_process_cmdline",
+            lambda _pid: "python -m hermes_cli.main gateway run",
+        )
+        monkeypatch.setattr(status, "write_takeover_marker", lambda *a, **k: False)
+        calls = []
+        monkeypatch.setattr(
+            status, "terminate_pid", lambda *args, **kwargs: calls.append(args)
+        )
+
+        assert status.take_over_scoped_lock_holder(record) is None
+        assert calls == []
+
+    def test_pid_reuse_after_sigterm_is_never_force_killed(
+        self, tmp_path, monkeypatch
+    ):
+        target_home = tmp_path / "target"
+        record = self._owner_record(target_home)
+        monkeypatch.setattr(status, "_pid_exists", lambda _pid: True)
+        starts = iter([123, 123, 999])
+        monkeypatch.setattr(
+            status, "_get_process_start_time", lambda _pid: next(starts)
+        )
+        monkeypatch.setattr(
+            status,
+            "_read_process_cmdline",
+            lambda _pid: "python -m hermes_cli.main gateway run",
+        )
+        calls = []
+        monkeypatch.setattr(
+            status,
+            "terminate_pid",
+            lambda pid, *, force=False: calls.append((pid, force)),
+        )
+
+        assert status.take_over_scoped_lock_holder(
+            record, graceful_attempts=1
+        ) == 4242
+        assert calls == [(4242, False)]
+
+    def test_target_accepts_verified_cross_home_marker(self, tmp_path, monkeypatch):
+        replacer_home = tmp_path / "replacer"
+        target_home = tmp_path / "target"
+        replacer_home.mkdir()
+        target_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(replacer_home))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda _pid: 100)
+
+        assert status.write_takeover_marker(
+            os.getpid(),
+            target_home=target_home,
+            target_start_time=100,
+        ) is True
+        assert not (replacer_home / ".gateway-takeover.json").exists()
+        assert (target_home / ".gateway-takeover.json").exists()
+
+        # The target process reads its own home.  A differing replacer home is
+        # valid only because the marker explicitly names this target home.
+        monkeypatch.setenv("HERMES_HOME", str(target_home))
+        assert status.consume_takeover_marker_for_self() is True
+        assert not (target_home / ".gateway-takeover.json").exists()
+
+
 class TestPlannedStopMarker:
     """Tests for intentional service/manual gateway stop markers."""
 


### PR DESCRIPTION
## Summary
`hermes gateway start --replace` now resolves platform token conflicts automatically: a one-shot, identity-verified takeover of a live scoped-lock holder at cold connect, plus POSIX child-process reaping after the old gateway PID dies — no more manual SIGKILL for the #65176 Telegram-token crash loop.

Salvages the takeover fix from #65178 by @jbbottoms (authorship preserved; PR's unrelated workflow/self-credit commits excluded).

## Changes
- `gateway/status.py` + `gateway/platforms/base.py` + `gateway/run.py`: one-shot takeover armed only by explicit `--replace`, scoped to initial cold connects; holder verified (PID alive + start_time fingerprint + cmdline looks-like-gateway + corroborating gateway.pid in the claimed HERMES_HOME) before `terminate_pid`; fails closed on any mismatch
- POSIX: after the replaced gateway's main PID is confirmed dead, its children are reaped best-effort (mirrors Windows `taskkill /T`), so orphaned adapters can't keep holding token locks

## Validation
135 gateway tests green, covering: takeover exactly once under --replace, never without it, never on reconnect, never on unverified records, PID-reuse never force-killed, child-reap ordering + failure paths.

Closes #65176.

## Infographic

![gateway-replace-takeover](https://v3b.fal.media/files/b/0aa32553/-98w2UBRW_DQtFaO63nUv_SXiFAY9J.png)
