### PR TITLE
fix(state): FTS read-path corruption detection, search self-heal, and REINDEX repair strategy

### DIFF
--- a/contributors/emails/chenjin@hermes.local
+++ b/contributors/emails/chenjin@hermes.local
@@ -1,0 +1,2 @@
+Enough1122
+# PR #66906 salvage

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -579,6 +579,36 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
             return "; ".join(problems[:3])
         conn.execute("SELECT COUNT(*) FROM sessions").fetchone()
 
+        # FTS5 read probe: run a representative MATCH query against the
+        # messages_fts* virtual tables. The FTS *write* probe above catches
+        # the corruption class where base tables read fine but writes fail
+        # through the triggers (#50502). It does NOT catch partial FTS5
+        # index corruption — bad shadow-table segments where reads still
+        # parse but MATCH / snippet / rank queries error out with
+        # "database disk image is malformed". session_search, /resume title
+        # resolution, and any feature relying on FTS5 discovery then break
+        # silently because the official repair tool's check-only path
+        # reports the DB as healthy. #66724.
+        try:
+            for fts_table in ("messages_fts", "messages_fts_trigram"):
+                # No-op queries against the actual FTS5 APIs the search
+                # tools use. The trigram table is included because it backs
+                # the title-resolution path; either corruption mode would
+                # break session recall without this probe. Empty MATCH
+                # string is the safest probe — every FTS5 index accepts it
+                # without requiring populated content.
+                conn.execute(
+                    f"SELECT 1 FROM {fts_table} WHERE {fts_table} MATCH '' LIMIT 1"
+                ).fetchone()
+        except sqlite3.OperationalError as exc:
+            msg = str(exc).lower()
+            if "no such table" in msg or "no such column" in msg:
+                # FTS5 not built yet (brand new file mid-init) — not the
+                # corruption class we probe.
+                pass
+            else:
+                return f"fts5 read probe failed on {fts_table}: {exc}"
+
         # FTS write probe: drive a row through the messages_fts* triggers in a
         # transaction that is always rolled back, so a corrupt FTS index that
         # rejects writes is caught even though reads look healthy. The probe is

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -598,13 +598,31 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
                 # No-op queries against the actual FTS5 APIs the search
                 # tools use. The trigram table is included because it backs
                 # the title-resolution path; either corruption mode would
-                # break session recall without this probe. Empty MATCH
-                # string is the safest probe — every FTS5 index accepts it
-                # without requiring populated content.
+                # break session recall without this probe. MATCH '""' is
+                # the empty phrase-token probe — FTS5 rejects MATCH ''
+                # outright ("fts5: syntax error"), but a quoted empty
+                # phrase parses, scans zero rows, and exercises the same
+                # shadow-table read path the search tools use.
                 conn.execute(
-                    f"SELECT 1 FROM {fts_table} WHERE {fts_table} MATCH '' LIMIT 1"
+                    f"SELECT 1 FROM {fts_table} WHERE {fts_table} MATCH '\"\"' LIMIT 1"
                 ).fetchone()
             except sqlite3.OperationalError as exc:
+                # Use the canonical capability classifier instead of a
+                # hand-rolled substring check. On SQLite builds without the
+                # fts5 module, the legacy messages_fts table may exist on
+                # disk (from a prior build that had FTS5) and MATCH queries
+                # against it raise OperationalError("no such module: fts5");
+                # the substring check below would misclassify that as
+                # corruption and send the DB into the repair path, whose
+                # final fallback deletes the messages_fts% schema
+                # (hermes_state.py:645-723). The supported degraded-runtime
+                # path (SessionDB._is_fts5_unavailable_error + the
+                # regression suite in tests/test_hermes_state.py:600-632)
+                # treats both "no such module: fts5" and
+                # "no such tokenizer: trigram" as the capability error.
+                if SessionDB._is_fts5_unavailable_error(exc):
+                    # Degraded runtime — not the corruption class we probe.
+                    continue
                 msg = str(exc).lower()
                 if "no such table" in msg or "no such column" in msg:
                     # FTS5 not built yet (brand new file mid-init) — not the

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5684,15 +5684,47 @@ class SessionDB:
                     LIMIT ? OFFSET ?
                 """
                 tri_params.extend([limit, offset])
-                with self._lock:
-                    try:
+                try:
+                    with self._lock:
                         tri_cursor = self._conn.execute(tri_sql, tri_params)
-                    except sqlite3.OperationalError:
-                        # Trigram query failed at runtime — fall through to LIKE.
-                        pass
-                    else:
                         matches = [dict(row) for row in tri_cursor.fetchall()]
                         _trigram_succeeded = True
+                except sqlite3.OperationalError:
+                    # Trigram query failed at runtime — fall through to LIKE.
+                    pass
+                except sqlite3.DatabaseError as exc:
+                    # Same corruption class the main FTS5 MATCH branch
+                    # self-heals above: a corrupt trigram shadow table raises
+                    # malformed / "fts5: corrupt structure record", which is a
+                    # DatabaseError (parent of the OperationalError syntax arm
+                    # caught first). Rebuild once outside the lock — the lock
+                    # is released here so rebuild_fts() can re-acquire it —
+                    # and retry the trigram query. If the rebuild is refused
+                    # (already attempted / FTS disabled / different error
+                    # class) or the retry fails again, fall through to the
+                    # LIKE substring path, which reads only the canonical
+                    # messages table, so CJK search stays available.
+                    if self._try_runtime_fts_rebuild(exc):
+                        try:
+                            with self._lock:
+                                tri_cursor = self._conn.execute(
+                                    tri_sql, tri_params
+                                )
+                                matches = [
+                                    dict(row) for row in tri_cursor.fetchall()
+                                ]
+                                _trigram_succeeded = True
+                        except sqlite3.DatabaseError:
+                            logger.warning(
+                                "Trigram FTS search still failing after "
+                                "in-place rebuild; falling back to LIKE."
+                            )
+                    else:
+                        logger.warning(
+                            "Trigram FTS search hit a corruption error (%s) "
+                            "and no in-place rebuild was possible; falling "
+                            "back to LIKE.", exc,
+                        )
             if not _trigram_succeeded:
                 # Short / mixed CJK query, trigram unavailable, or trigram
                 # <3 CJK chars. Fall back to LIKE substring search.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5741,13 +5741,26 @@ class SessionDB:
                     like_cursor = self._conn.execute(like_sql, like_params)
                     matches = [dict(row) for row in like_cursor.fetchall()]
         else:
-            with self._lock:
-                try:
+            try:
+                with self._lock:
                     cursor = self._conn.execute(sql, params)
-                except sqlite3.OperationalError:
-                    # FTS5 query syntax error despite sanitization — return empty
-                    return []
-                else:
+                    matches = [dict(row) for row in cursor.fetchall()]
+            except sqlite3.OperationalError:
+                # FTS5 query syntax error despite sanitization — return empty
+                return []
+            except sqlite3.DatabaseError as exc:
+                # A corrupt FTS index raises the malformed / "fts5: corrupt
+                # structure record" class on the MATCH read, the same class the
+                # write path self-heals (#66296). OperationalError (query
+                # syntax) is a subclass caught above; this arm is the corruption
+                # parent. Rebuild the index in place once — the lock is released
+                # here, so rebuild_fts() can re-acquire it — and retry, so
+                # search self-heals for read-only sessions (cron/CLI history
+                # search) that never trigger a write to repair it first.
+                if not self._try_runtime_fts_rebuild(exc):
+                    raise
+                with self._lock:
+                    cursor = self._conn.execute(sql, params)
                     matches = [dict(row) for row in cursor.fetchall()]
 
         # Add surrounding context (1 message before + after each match).

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -748,6 +748,29 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
     except sqlite3.DatabaseError as exc:
         logger.warning("state.db FTS in-place rebuild pass failed: %s", exc)
 
+    # ── Strategy 0.5: rebuild stale B-tree indexes (#63386) ──
+    # PRAGMA integrity_check can report "wrong # of entries in index" when a
+    # B-tree index (e.g. idx_sessions_handoff_state) falls out of sync with its
+    # base table. REINDEX rewrites the index b-tree from the canonical table
+    # rows using the existing index definition, fixing the mismatch without
+    # touching data or FTS schema.
+    try:
+        conn = sqlite3.connect(str(db_path), isolation_level=None)
+        try:
+            conn.execute("REINDEX")
+            conn.commit()
+        finally:
+            conn.close()
+        if _db_opens_cleanly(db_path) is None:
+            report["repaired"] = True
+            report["strategy"] = "reindex_btree"
+            logger.warning(
+                "state.db B-tree indexes rebuilt via REINDEX: %s", db_path
+            )
+            return report
+    except sqlite3.DatabaseError as exc:
+        logger.warning("state.db REINDEX pass failed: %s", exc)
+
     # ── Strategy 1: de-duplicate sqlite_master (keeps FTS index) ──
     try:
         conn = sqlite3.connect(str(db_path), isolation_level=None)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -580,17 +580,21 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         conn.execute("SELECT COUNT(*) FROM sessions").fetchone()
 
         # FTS5 read probe: run a representative MATCH query against the
-        # messages_fts* virtual tables. The FTS *write* probe above catches
+        # messages_fts* virtual tables. The FTS *write* probe below catches
         # the corruption class where base tables read fine but writes fail
         # through the triggers (#50502). It does NOT catch partial FTS5
         # index corruption — bad shadow-table segments where reads still
         # parse but MATCH / snippet / rank queries error out with
-        # "database disk image is malformed". session_search, /resume title
-        # resolution, and any feature relying on FTS5 discovery then break
-        # silently because the official repair tool's check-only path
-        # reports the DB as healthy. #66724.
-        try:
-            for fts_table in ("messages_fts", "messages_fts_trigram"):
+        # "database disk image is malformed" (a `sqlite3.DatabaseError`,
+        # not `OperationalError`). session_search, /resume title resolution,
+        # and any feature relying on FTS5 discovery then break silently
+        # because the official repair tool's check-only path reports the
+        # DB as healthy. #66724.
+        # Catch the full sqlite3 exception hierarchy (not just
+        # OperationalError) so the malformed-shadow-table class is reported
+        # rather than letting it crash the caller.
+        for fts_table in ("messages_fts", "messages_fts_trigram"):
+            try:
                 # No-op queries against the actual FTS5 APIs the search
                 # tools use. The trigram table is included because it backs
                 # the title-resolution path; either corruption mode would
@@ -600,13 +604,18 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
                 conn.execute(
                     f"SELECT 1 FROM {fts_table} WHERE {fts_table} MATCH '' LIMIT 1"
                 ).fetchone()
-        except sqlite3.OperationalError as exc:
-            msg = str(exc).lower()
-            if "no such table" in msg or "no such column" in msg:
-                # FTS5 not built yet (brand new file mid-init) — not the
-                # corruption class we probe.
-                pass
-            else:
+            except sqlite3.OperationalError as exc:
+                msg = str(exc).lower()
+                if "no such table" in msg or "no such column" in msg:
+                    # FTS5 not built yet (brand new file mid-init) — not the
+                    # corruption class we probe.
+                    continue
+                return f"fts5 read probe failed on {fts_table}: {exc}"
+            except sqlite3.DatabaseError as exc:
+                # This is the corruption class #66724 actually wants caught:
+                # partial shadow-table damage where MATCH / snippet / rank
+                # queries raise DatabaseError("database disk image is malformed")
+                # while reads of the FTS5 table itself parse fine.
                 return f"fts5 read probe failed on {fts_table}: {exc}"
 
         # FTS write probe: drive a row through the messages_fts* triggers in a

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -93,6 +93,29 @@ class TestRuntimeFtsRebuild:
         raw.close()
         assert len(hits) == 1
 
+    def test_search_messages_self_heals_after_fts_corruption(self, db, tmp_path):
+        """A read-only session that only SEARCHES (no write after corruption)
+        must self-heal too. The MATCH read raises the corruption class
+        (DatabaseError / 'fts5: corrupt structure record'), NOT the
+        OperationalError that search_messages caught — so before this fix the
+        search crashed until a write or restart rebuilt the index.
+        """
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "a searchable needle here")
+
+        _corrupt_fts(tmp_path / "state.db")
+        # Injected via a raw connection, so no write on THIS instance has
+        # consumed the one-shot rebuild yet.
+        assert db._fts_runtime_rebuild_attempted is False
+
+        results = db.search_messages("needle")
+
+        assert db._fts_runtime_rebuild_attempted is True  # the search rebuilt it
+        assert results  # non-empty: the rebuilt index matched the query
+        assert any("needle" in (r.get("snippet") or "") for r in results)
+
     def test_rebuild_is_one_shot_per_instance(self, db, tmp_path):
         if not db._fts_enabled:
             pytest.skip("FTS5 unavailable in this build")

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -38,6 +38,16 @@ def _corrupt_fts(db_path):
     raw.close()
 
 
+def _corrupt_trigram_fts(db_path):
+    raw = sqlite3.connect(str(db_path))
+    raw.execute(
+        "UPDATE messages_fts_trigram_data "
+        "SET block = X'DEADBEEFDEADBEEFDEADBEEFDEADBEEF'"
+    )
+    raw.commit()
+    raw.close()
+
+
 def _message_contents(db_path):
     raw = sqlite3.connect(str(db_path))
     rows = raw.execute("SELECT content FROM messages ORDER BY id").fetchall()
@@ -115,6 +125,57 @@ class TestRuntimeFtsRebuild:
         assert db._fts_runtime_rebuild_attempted is True  # the search rebuilt it
         assert results  # non-empty: the rebuilt index matched the query
         assert any("needle" in (r.get("snippet") or "") for r in results)
+
+    def test_trigram_search_self_heals_after_fts_corruption(self, db, tmp_path):
+        """The CJK/trigram MATCH branch has the same read-corruption exposure
+        as the main FTS5 branch: it caught only OperationalError (query
+        syntax), so a corrupt trigram shadow table raised DatabaseError
+        straight out of search_messages. It must self-heal via the shared
+        one-shot rebuild and answer from the rebuilt trigram index.
+        """
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        if not db._trigram_available:
+            pytest.skip("trigram tokenizer unavailable in this build")
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "关于大别山项目的进展报告")
+
+        _corrupt_trigram_fts(tmp_path / "state.db")
+        assert db._fts_runtime_rebuild_attempted is False
+
+        # >=3 CJK chars per token → routed to the trigram branch.
+        results = db.search_messages("大别山项目")
+
+        assert db._fts_runtime_rebuild_attempted is True  # search rebuilt it
+        assert results
+        # The rebuilt trigram index answered (trigram snippets use >>> <<<),
+        # i.e. we did not silently degrade to the LIKE fallback.
+        assert any(">>>" in (r.get("snippet") or "") for r in results)
+
+    def test_trigram_search_falls_back_to_like_when_rebuild_consumed(
+        self, db, tmp_path
+    ):
+        """When the one-shot rebuild was already consumed, a corrupt trigram
+        index must NOT crash search_messages — it degrades to the LIKE
+        substring fallback, which reads only the canonical messages table.
+        """
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        if not db._trigram_available:
+            pytest.skip("trigram tokenizer unavailable in this build")
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "关于大别山项目的进展报告")
+
+        # Consume the one-shot guard, then corrupt again.
+        _corrupt_trigram_fts(tmp_path / "state.db")
+        db.append_message("s1", "user", "seed to trigger write-path heal")
+        assert db._fts_runtime_rebuild_attempted is True
+        _corrupt_trigram_fts(tmp_path / "state.db")
+
+        # Before the fix this raised sqlite3.DatabaseError.
+        results = db.search_messages("大别山项目")
+        assert results  # LIKE fallback found the canonical row
+        assert any("大别山项目" in (r.get("snippet") or "") for r in results)
 
     def test_rebuild_is_one_shot_per_instance(self, db, tmp_path):
         if not db._fts_enabled:

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -487,33 +487,100 @@ def test_repair_noop_db_uses_already_healthy_shortcut(tmp_path):
     assert report["strategy"] == "already_healthy"
 
 
-def test_repair_rebuilds_stale_btree_indexes(tmp_path, monkeypatch):
-    """repair_state_db_schema uses REINDEX for 'wrong # of entries in index'.
+def _corrupt_btree_index(db_path: Path, index_name: str) -> None:
+    """Make a real B-tree index stale so integrity_check reports
+    'wrong # of entries in index <name>'.
 
-    When PRAGMA integrity_check reports a stale B-tree index (e.g.
-    idx_sessions_handoff_state), the FTS-rebuild and dedup strategies don't
-    help — REINDEX rewrites the index b-tree from the canonical table rows.
+    writable_schema hack: temporarily rewrite the index definition in
+    sqlite_master to a partial index (``WHERE 0``), REINDEX so its b-tree is
+    rebuilt EMPTY, then restore the original full definition. The stored
+    b-tree now has zero entries while the schema says it must cover every
+    row — exactly the on-disk state issue #63386 reported for
+    idx_sessions_handoff_state, produced without any mocking.
+    """
+    raw = sqlite3.connect(str(db_path))
+    orig_sql = raw.execute(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name=?",
+        (index_name,),
+    ).fetchone()[0]
+
+    def _set_index_sql(conn, sql):
+        conn.execute("PRAGMA writable_schema=ON")
+        conn.execute(
+            "UPDATE sqlite_master SET sql=? WHERE type='index' AND name=?",
+            (sql, index_name),
+        )
+        ver = conn.execute("PRAGMA schema_version").fetchone()[0]
+        conn.execute(f"PRAGMA schema_version={ver + 1}")
+        conn.execute("PRAGMA writable_schema=OFF")
+        conn.commit()
+
+    _set_index_sql(raw, orig_sql + " WHERE 0")
+    raw.close()
+
+    # Fresh connection so the doctored schema is re-parsed, then rebuild the
+    # index under the WHERE 0 definition — empty b-tree on disk.
+    raw = sqlite3.connect(str(db_path))
+    raw.execute(f"REINDEX {index_name}")
+    raw.commit()
+    # Restore the original (full) definition: schema and b-tree now disagree.
+    _set_index_sql(raw, orig_sql)
+    raw.close()
+
+
+def test_repair_rebuilds_stale_btree_indexes(tmp_path):
+    """repair_state_db_schema repairs a REAL stale B-tree index via REINDEX.
+
+    End-to-end, no mocks: a genuinely stale index (empty b-tree under a full
+    index definition — the #63386 'wrong # of entries in index' class) is
+    detected by the real _db_opens_cleanly, repaired by Strategy 0.5
+    (REINDEX), and the DB verifies clean afterwards with real integrity
+    checks.
     """
     db_path = tmp_path / "state.db"
     _build_healthy_db(db_path)
 
-    _reason = "wrong # of entries in index idx_sessions_handoff_state"
-    _call_count = {"n": 0}
-    _real_check = hermes_state._db_opens_cleanly
+    _corrupt_btree_index(db_path, "idx_messages_session")
 
-    def _simulated_check(path):
-        _call_count["n"] += 1
-        # initial health check + post-Strategy-0 check report corruption;
-        # after REINDEX (Strategy 0.5) the DB is healthy.
-        if _call_count["n"] <= 2:
-            return _reason
-        return _real_check(path)
+    # The real detector must see the real corruption...
+    reason = hermes_state._db_opens_cleanly(db_path)
+    assert reason is not None
+    assert "wrong # of entries in index idx_messages_session" in reason
 
-    monkeypatch.setattr(hermes_state, "_db_opens_cleanly", _simulated_check)
-
+    # ...and the real repair ladder must fix it via REINDEX.
     report = repair_state_db_schema(db_path)
     assert report["repaired"] is True
     assert report["strategy"] == "reindex_btree"
+
+    # Post-repair the DB is genuinely healthy: detector and raw
+    # integrity_check both agree, and the repaired index answers queries.
+    assert hermes_state._db_opens_cleanly(db_path) is None
+    raw = sqlite3.connect(str(db_path))
+    assert raw.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    n = raw.execute(
+        "SELECT count(*) FROM messages INDEXED BY idx_messages_session "
+        "WHERE session_id IS NOT NULL"
+    ).fetchone()[0]
+    raw.close()
+    assert n == 10  # every row visible through the rebuilt index
+
+
+def test_repair_stale_btree_index_preserves_rows(tmp_path):
+    """The REINDEX strategy is non-destructive: sessions/messages survive."""
+    db_path = tmp_path / "state.db"
+    sid = _build_healthy_db(db_path)
+    _corrupt_btree_index(db_path, "idx_messages_session")
+
+    report = repair_state_db_schema(db_path, backup=False)
+    assert report["strategy"] == "reindex_btree"
+
+    db = SessionDB(db_path=db_path)
+    try:
+        msgs = db.get_messages(sid)
+        assert len(msgs) == 10
+        assert msgs[0]["content"] == "hello world 0"
+    finally:
+        db.close()
 
 
 def test_select_cached_agent_history_prefers_longer_live_transcript():

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -256,6 +256,160 @@ def test_repair_on_clean_db_is_noop(tmp_path):
     conn.close()
 
 
+# ── FTS read-corruption class (#66724) ───────────────────────────────────
+# Even when writes succeed, partial FTS5 shadow-table damage makes MATCH /
+# snippet / rank queries fail with DatabaseError("database disk image is
+# malformed") while plain reads of the FTS5 table still parse. The read
+# probe in _db_opens_cleanly must surface this corruption class as a reason
+# so the repair path triggers, but it must NOT misclassify the supported
+# degraded-runtime path (no fts5 module / no trigram tokenizer) as
+# corruption — doing so would route a healthy degraded DB through the
+# repair fallback that deletes the messages_fts% schema.
+
+
+def _corrupt_fts_shadow_segments(db_path: Path) -> None:
+    """Overwrite the FTS5 shadow b-tree blocks for ``messages_fts`` only.
+
+    Distinct from ``_corrupt_fts_index_data`` which targets the writes-side
+    trigger path; this targets the MATCH query path so the read probe is
+    what fires.
+    """
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    conn.execute("UPDATE messages_fts_data SET block = X'BADC0FFEE0DDF00D'")
+    conn.close()
+
+
+def test_fts_read_corruption_detected_by_read_probe(tmp_path):
+    """Partial shadow-table damage is caught by the FTS5 read probe.
+
+    Without the read probe, ``_db_opens_cleanly`` reports the DB healthy
+    even though ``session_search`` and ``/resume`` title resolution fail
+    with ``database disk image is malformed`` — the exact silent-fail
+    behavior reported in #66724.
+    """
+    from hermes_state import _db_opens_cleanly
+
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    assert _db_opens_cleanly(db_path) is None
+
+    _corrupt_fts_shadow_segments(db_path)
+
+    reason = _db_opens_cleanly(db_path)
+    assert reason is not None
+    assert "messages_fts" in reason
+    assert "malformed" in reason.lower() or "database disk image" in reason.lower()
+
+
+def test_fts_read_corruption_repaired_in_place(tmp_path):
+    """``repair_state_db_schema`` rebuilds the FTS index so reads resume."""
+    from hermes_state import _db_opens_cleanly
+
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    _corrupt_fts_shadow_segments(db_path)
+
+    assert _db_opens_cleanly(db_path) is not None  # unhealthy before
+
+    report = repair_state_db_schema(db_path)
+    assert report["repaired"] is True
+    assert _db_opens_cleanly(db_path) is None  # healthy after rebuild
+
+    # Search back online.
+    db = SessionDB(db_path=db_path)
+    try:
+        hits = db._conn.execute(
+            "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'pizza'"
+        ).fetchone()[0]
+        assert hits >= 5
+    finally:
+        db.close()
+
+
+# ── Degraded-runtime compatibility (regression for #66906 review) ────────
+# The read probe must NOT misclassify a supported degraded runtime (no
+# fts5 module / no trigram tokenizer) as corruption. If it did, a healthy
+# degraded DB would be sent into the repair path, whose final fallback
+# deletes the messages_fts% schema — breaking the very FTS tables that
+# may have been inherited from a prior build that did have FTS5.
+
+
+class _NoFts5RuntimeCursor(sqlite3.Cursor):
+    """Simulate a runtime without the fts5 module: fts5 table exists but
+    MATCH queries raise the canonical capability error."""
+
+    def execute(self, sql, parameters=()):
+        probe = sql.strip()
+        if "MATCH" in probe and '""' in probe and "messages_fts " in probe:
+            raise sqlite3.OperationalError("no such module: fts5")
+        return super().execute(sql, parameters)
+
+
+class _NoFts5RuntimeConnection(sqlite3.Connection):
+    def cursor(self, factory=None):
+        return super().cursor(factory or _NoFts5RuntimeCursor)
+
+
+class _NoTrigramRuntimeCursor(sqlite3.Cursor):
+    """Simulate a runtime with FTS5 but without the trigram tokenizer."""
+
+    def execute(self, sql, parameters=()):
+        probe = sql.strip()
+        if "MATCH" in probe and '""' in probe and "messages_fts_trigram" in probe:
+            raise sqlite3.OperationalError("no such tokenizer: trigram")
+        return super().execute(sql, parameters)
+
+
+class _NoTrigramRuntimeConnection(sqlite3.Connection):
+    def cursor(self, factory=None):
+        return super().cursor(factory or _NoTrigramRuntimeCursor)
+
+
+def test_fts_read_probe_returns_none_when_fts5_module_missing(tmp_path, monkeypatch):
+    """Capability error on MATCH must not surface as corruption.
+
+    Simulates a healthy DB on a SQLite build without the fts5 module:
+    the messages_fts table exists (from a previous init on a build with
+    fts5) and MATCH queries raise the canonical "no such module: fts5".
+    _db_opens_cleanly must NOT classify this as corruption — otherwise
+    repair would be triggered and its final fallback would delete the
+    messages_fts% schema, breaking the search feature entirely.
+    """
+    from hermes_state import _db_opens_cleanly
+
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+
+    real_connect = sqlite3.connect
+
+    def connect_no_fts5(*args, **kwargs):
+        kwargs["factory"] = _NoFts5RuntimeConnection
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr("hermes_state.sqlite3.connect", connect_no_fts5)
+
+    # Healthy degraded DB → probe returns None. Repair path must NOT fire.
+    assert _db_opens_cleanly(db_path) is None
+
+
+def test_fts_read_probe_returns_none_when_trigram_missing(tmp_path, monkeypatch):
+    """Capability error on trigram MATCH must not surface as corruption."""
+    from hermes_state import _db_opens_cleanly
+
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+
+    real_connect = sqlite3.connect
+
+    def connect_no_trigram(*args, **kwargs):
+        kwargs["factory"] = _NoTrigramRuntimeConnection
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr("hermes_state.sqlite3.connect", connect_no_trigram)
+
+    assert _db_opens_cleanly(db_path) is None
+
+
 # ── FTS write-corruption class (#50502) ──────────────────────────────────
 # A readable state.db can still reject every message write through the
 # messages_fts* triggers when the FTS index is corrupt. Plain

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -487,6 +487,35 @@ def test_repair_noop_db_uses_already_healthy_shortcut(tmp_path):
     assert report["strategy"] == "already_healthy"
 
 
+def test_repair_rebuilds_stale_btree_indexes(tmp_path, monkeypatch):
+    """repair_state_db_schema uses REINDEX for 'wrong # of entries in index'.
+
+    When PRAGMA integrity_check reports a stale B-tree index (e.g.
+    idx_sessions_handoff_state), the FTS-rebuild and dedup strategies don't
+    help — REINDEX rewrites the index b-tree from the canonical table rows.
+    """
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+
+    _reason = "wrong # of entries in index idx_sessions_handoff_state"
+    _call_count = {"n": 0}
+    _real_check = hermes_state._db_opens_cleanly
+
+    def _simulated_check(path):
+        _call_count["n"] += 1
+        # initial health check + post-Strategy-0 check report corruption;
+        # after REINDEX (Strategy 0.5) the DB is healthy.
+        if _call_count["n"] <= 2:
+            return _reason
+        return _real_check(path)
+
+    monkeypatch.setattr(hermes_state, "_db_opens_cleanly", _simulated_check)
+
+    report = repair_state_db_schema(db_path)
+    assert report["repaired"] is True
+    assert report["strategy"] == "reindex_btree"
+
+
 def test_select_cached_agent_history_prefers_longer_live_transcript():
     """Gateway guard keeps the live transcript when persisted history lags."""
     from gateway.run import _select_cached_agent_history


### PR DESCRIPTION
## Summary
`hermes sessions repair --check-only` can no longer report a corrupt state.db as healthy while session_search fails: the integrity probe now exercises a real FTS5 MATCH read, the search path self-heals FTS corruption at runtime (including the CJK/trigram branch), and the repair ladder gains a REINDEX strategy for corrupt B-tree indexes — with a real corrupted-index test fixture, no mocks.

Salvages #66906 by @Enough1122, #66420 by @Frowtek, #63398 by @liuhao1024 (authorship preserved).

## Changes
- `hermes_state.py` `_db_opens_cleanly`: FTS5 MATCH read probe + DatabaseError classification (#66906)
- `search_messages`: one-shot FTS rebuild self-heal on the read path (#66420), extended to the CJK/trigram branch with graceful LIKE fallback
- `repair_state_db_schema`: REINDEX strategy for 'wrong # of entries in index' (#63398), tested against a genuinely corrupted index (writable_schema fixture), end-to-end

## Validation
Targeted state-db suite: 482 passed, 0 failed. Fixes #66724.

## Infographic

![state-db-corruption-detection](https://v3b.fal.media/files/b/0aa3255b/-2ezLZmedMCLcKwVMznVL_8laf6MR0.png)
