### PR TITLE
fix(kanban): auto-REINDEX index corruption, backup retention cap, periodic WAL checkpoint, repair CLI

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -880,6 +880,25 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_gc.add_argument("--log-retention-days", type=int, default=30,
                       help="Delete worker log files older than N days (default: 30)")
 
+    # --- repair ---
+    p_repair = sub.add_parser(
+        "repair",
+        help="Check kanban.db integrity and auto-repair index-only corruption",
+        description=(
+            "Runs PRAGMA integrity_check on the board's DB and reports the "
+            "result. When the failure consists only of index-scoped errors "
+            "('wrong # of entries in index <name>' / 'row N missing from "
+            "index <name>'), the corrupt file is quarantined to a "
+            ".corrupt.<hash>.bak sibling first and the damaged indexes are "
+            "rebuilt with REINDEX — the same narrow auto-repair the "
+            "connect-time guard applies. Any other corruption class is "
+            "reported and left untouched (fail-closed). Exits 0 when the DB "
+            "is healthy or was repaired, non-zero when it is still corrupt."
+        ),
+    )
+    p_repair.add_argument("--json", action="store_true",
+                          help="Emit the repair report as JSON")
+
     kanban_parser.set_defaults(_kanban_parser=kanban_parser)
     return kanban_parser
 
@@ -950,6 +969,12 @@ def kanban_command(args: argparse.Namespace) -> int:
     # schema creation; `create` / `list` / every other command would
     # error out on a fresh install.
     with board_scope:
+        # `repair` must dispatch BEFORE the auto-init below: on a corrupt DB
+        # init_db() itself raises KanbanDbCorruptError, which would turn
+        # every `hermes kanban repair` into "could not initialize database"
+        # without ever reaching the repair path.
+        if action == "repair":
+            return _cmd_repair(args)
         try:
             kb.init_db()
         except Exception as exc:
@@ -2884,6 +2909,76 @@ def _cmd_gc(args: argparse.Namespace) -> int:
     print(f"GC complete: {removed_ws} workspace(s), "
           f"{removed_events} event row(s), {removed_logs} log file(s) removed")
     return 0
+
+
+def _cmd_repair(args: argparse.Namespace) -> int:
+    """Check DB integrity and apply the narrow index-REINDEX auto-repair.
+
+    Dispatched BEFORE the auto ``kb.init_db()`` in :func:`kanban_command`
+    (init itself refuses corrupt DBs), so this is reachable on exactly the
+    boards that need it. Exit codes: 0 = healthy / repaired / no DB file,
+    1 = still corrupt (non-index corruption, or REINDEX did not produce a
+    clean re-check).
+    """
+    try:
+        report = kb.repair_db()
+    except Exception as exc:  # locked/busy probe, unexpected I/O
+        print(f"kanban repair: {exc}", file=sys.stderr)
+        return 1
+
+    if getattr(args, "json", False):
+        print(json.dumps({
+            "status": report.status,
+            "db_path": str(report.db_path),
+            "messages": report.messages,
+            "post_repair_messages": report.post_repair_messages,
+            "backup_path": (
+                str(report.backup_path) if report.backup_path else None
+            ),
+            "reindexed": report.reindexed,
+        }, indent=2))
+        return 0 if report.status in {"ok", "repaired", "missing"} else 1
+
+    if report.status == "missing":
+        print(f"No kanban DB at {report.db_path} — nothing to repair.")
+        return 0
+    if report.status == "ok":
+        print(f"{report.db_path}: integrity_check ok — no repair needed.")
+        return 0
+    if report.status == "repaired":
+        print(f"{report.db_path}: repaired.")
+        print(f"  reindexed: {', '.join(report.reindexed)}")
+        if report.backup_path:
+            print(f"  pre-repair backup: {report.backup_path}")
+        print("  integrity_check now ok.")
+        return 0
+    # still corrupt
+    print(f"{report.db_path}: CORRUPT.", file=sys.stderr)
+    for line in (report.messages or [])[:10]:
+        print(f"  {line}", file=sys.stderr)
+    if report.reindexed:
+        print(
+            f"  REINDEX ({', '.join(report.reindexed)}) attempted but "
+            f"integrity_check is still failing:",
+            file=sys.stderr,
+        )
+        for line in (report.post_repair_messages or [])[:10]:
+            print(f"    {line}", file=sys.stderr)
+    else:
+        print(
+            "  Not an index-only failure — automatic REINDEX repair does "
+            "not apply (fail-closed).",
+            file=sys.stderr,
+        )
+    if report.backup_path:
+        print(f"  corrupt copy quarantined at: {report.backup_path}",
+              file=sys.stderr)
+    print(
+        "  Recover manually (e.g. `sqlite3 kanban.db \".recover\"` into a "
+        "fresh file) or move the file aside to start a new board.",
+        file=sys.stderr,
+    )
+    return 1
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1286,6 +1286,14 @@ _INIT_LOCK = threading.RLock()
 _SQLITE_HEADER = b"SQLite format 3\x00"
 DEFAULT_BUSY_TIMEOUT_MS = 120_000
 
+# Maximum number of ``<db>.corrupt.<hash>.bak`` quarantine files retained per
+# board DB. Content-addressing already dedupes identical corrupt bytes, but
+# repeatedly-mutating corruption (partial repairs, further damage between
+# dispatcher retries) mints a new fingerprint each time; without a cap a user
+# accumulated 124 backups. Oldest-by-mtime files beyond the cap are pruned
+# right after each new backup is created.
+_CORRUPT_BACKUP_RETENTION = 10
+
 # Bounded acquire for the cross-process init lock (#36644). The original bare
 # blocking flock had no timeout, so a wedged holder blocked the dispatcher's
 # next-tick connect forever. We retry a non-blocking acquire up to this
@@ -1567,6 +1575,54 @@ class KanbanDbCorruptError(RuntimeError):
         )
 
 
+def _prune_corrupt_backups(
+    parent: Path, base_name: str, keep: Optional[Path] = None,
+) -> None:
+    """Cap the number of retained ``<db>.corrupt.<hash>.bak`` files.
+
+    Content-addressed backups dedupe identical corrupt bytes, but a board
+    whose file keeps changing between corruption events (partial repairs,
+    ongoing damage, fleets of retrying dispatchers) can still accumulate
+    backups without bound — a user reported 124 of them. After creating a
+    new backup we keep only the ``_CORRUPT_BACKUP_RETENTION`` most recent
+    (by mtime) and delete the rest, including their copied ``-wal``/``-shm``
+    sidecars. ``keep`` (the just-created backup) is never pruned regardless
+    of its mtime — ``shutil.copy2`` preserves the source file's timestamp,
+    which may be older than existing backups. Best-effort: prune failures
+    never mask the corruption error the caller is about to raise.
+    """
+    try:
+        backups = [
+            candidate
+            for candidate in parent.glob(f"{base_name}.corrupt.*.bak")
+            if candidate.is_file() and candidate != keep
+        ]
+    except OSError:
+        return
+    budget = _CORRUPT_BACKUP_RETENTION - (1 if keep is not None else 0)
+    budget = max(budget, 0)
+    if len(backups) <= budget:
+        return
+
+    def _mtime(item: Path) -> float:
+        try:
+            return item.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    backups.sort(key=_mtime, reverse=True)
+    for stale in backups[budget:]:
+        for victim in (
+            stale,
+            stale.with_name(stale.name + "-wal"),
+            stale.with_name(stale.name + "-shm"),
+        ):
+            try:
+                victim.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
 def _backup_corrupt_db(path: Path) -> Optional[Path]:
     """Copy a corrupt DB (and its WAL/SHM sidecars) to a content-addressed backup.
 
@@ -1607,6 +1663,9 @@ def _backup_corrupt_db(path: Path) -> Optional[Path]:
             shutil.copy2(resolved, candidate)
         except OSError:
             return None
+        # A NEW backup landed on disk — enforce the retention cap so
+        # mutating-corruption loops can't accumulate quarantines forever.
+        _prune_corrupt_backups(parent, base_name, keep=candidate)
     for suffix in ("-wal", "-shm"):
         sidecar = parent / (base_name + suffix)
         if sidecar.parent != parent or not sidecar.exists():

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1505,6 +1505,52 @@ def _dispatch_tick_lock(db_path: Path):
                 handle.close()
 
 
+# Periodic WAL checkpoint state for the dispatcher tick path. The kanban
+# connections run with ``wal_autocheckpoint=100``, but a passive
+# autocheckpoint can be starved forever on a busy multi-process board (any
+# reader with an open snapshot blocks the WAL reset), letting the -wal file
+# grow without bound between gateway restarts. Once per coarse interval the
+# dispatcher — the board's single writer during a tick, and holding the
+# dispatch flock — issues an explicit ``wal_checkpoint(TRUNCATE)``.
+# Best-effort: a busy/locked checkpoint is logged at DEBUG and retried next
+# interval. Keyed per resolved DB path so multi-board dispatchers checkpoint
+# each board on its own clock.
+_WAL_CHECKPOINT_INTERVAL_SECONDS = 300.0
+_LAST_WAL_CHECKPOINT: dict[str, float] = {}
+_WAL_CHECKPOINT_LOCK = threading.Lock()
+
+
+def _maybe_checkpoint_wal(conn: sqlite3.Connection, db_path: Path) -> None:
+    """Run ``PRAGMA wal_checkpoint(TRUNCATE)`` at a coarse interval.
+
+    Called from the dispatcher tick while the board's dispatch lock is
+    held. No-ops (cheaply) until ``_WAL_CHECKPOINT_INTERVAL_SECONDS`` has
+    elapsed since this process last checkpointed this board. Never raises:
+    the checkpoint is pure hygiene and must not fail a dispatch tick.
+    """
+    try:
+        key = str(db_path.resolve())
+    except OSError:
+        key = str(db_path)
+    now = time.monotonic()
+    with _WAL_CHECKPOINT_LOCK:
+        last = _LAST_WAL_CHECKPOINT.get(key)
+        if last is not None and (now - last) < _WAL_CHECKPOINT_INTERVAL_SECONDS:
+            return
+        # Claim the slot before doing the work so concurrent ticks (other
+        # threads in this process) don't double-checkpoint on the boundary.
+        _LAST_WAL_CHECKPOINT[key] = now
+    try:
+        row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        _log.debug(
+            "kanban WAL checkpoint (TRUNCATE) on %s -> %s "
+            "(busy, wal_frames, checkpointed_frames)",
+            key, tuple(row) if row is not None else None,
+        )
+    except sqlite3.Error as exc:
+        _log.debug("kanban WAL checkpoint on %s skipped: %s", key, exc)
+
+
 def _looks_like_tls_record_at(data: bytes, offset: int) -> bool:
     """Return True for a TLS record header at ``data[offset:]``."""
     if len(data) < offset + 5:
@@ -7669,7 +7715,7 @@ def dispatch_once(
     with _dispatch_tick_lock(db_path) as held:
         if not held:
             return DispatchResult(skipped_locked=True)
-        return _dispatch_once_locked(
+        result = _dispatch_once_locked(
             conn,
             spawn_fn=spawn_fn,
             ttl_seconds=ttl_seconds,
@@ -7682,6 +7728,10 @@ def dispatch_once(
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
         )
+        # Still under the dispatch lock: opportunistically truncate the WAL
+        # at a coarse interval so it cannot grow unbounded between restarts.
+        _maybe_checkpoint_wal(conn, db_path)
+        return result
 
 
 def _dispatch_once_locked(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1621,15 +1621,111 @@ def _backup_corrupt_db(path: Path) -> Optional[Path]:
     return candidate
 
 
+# Repairable integrity_check error classes. Both shapes are *index-scoped*:
+# the table b-tree is intact and only a secondary index disagrees with it,
+# which REINDEX rebuilds losslessly from the table data. The index name is
+# parsed generically from the message — no hardcoded index list. Any other
+# integrity_check message (page corruption, "database disk image is
+# malformed", freelist damage, …) is NOT repairable this way and keeps the
+# fail-closed behavior.
+_REPAIRABLE_INDEX_ERROR_PATTERNS = (
+    re.compile(r"^wrong # of entries in index (?P<index>.+)$"),
+    re.compile(r"^row \d+ missing from index (?P<index>.+)$"),
+)
+
+
+def _integrity_messages_ok(messages: list[str]) -> bool:
+    """True iff ``PRAGMA integrity_check`` output is the single ``ok`` row."""
+    return len(messages) == 1 and messages[0].strip().lower() == "ok"
+
+
+def _run_integrity_check(conn: sqlite3.Connection) -> list[str]:
+    """Return all ``PRAGMA integrity_check`` message rows as strings."""
+    rows = conn.execute("PRAGMA integrity_check").fetchall()
+    return [str(row[0]) for row in rows if row is not None and row[0] is not None]
+
+
+def _repairable_index_names(messages: list[str]) -> Optional[list[str]]:
+    """Return the distinct index names iff EVERY message is index-repairable.
+
+    ``None`` when any line falls outside the repairable index-class errors
+    (or when there are no messages at all) — the caller must then fail
+    closed exactly as before. Order of first appearance is preserved so the
+    REINDEX pass is deterministic.
+    """
+    names: list[str] = []
+    saw_any = False
+    for raw in messages:
+        message = (raw or "").strip()
+        if not message:
+            continue
+        for pattern in _REPAIRABLE_INDEX_ERROR_PATTERNS:
+            match = pattern.match(message)
+            if match:
+                break
+        else:
+            return None
+        saw_any = True
+        name = match.group("index").strip()
+        if name and name not in names:
+            names.append(name)
+    if not saw_any or not names:
+        return None
+    return names
+
+
+def _attempt_index_reindex_repair(
+    path: Path, index_names: list[str],
+) -> tuple[bool, list[str]]:
+    """REINDEX the named indexes, then re-run ``PRAGMA integrity_check``.
+
+    Tries a per-index ``REINDEX "<name>"`` first (cheapest, most targeted);
+    if any per-index statement fails — e.g. the parsed name does not resolve
+    because integrity_check reported an internal/auto index — falls back to
+    a bare ``REINDEX`` of the whole database. Returns
+    ``(clean, post_repair_messages)``; never raises. Callers must hold the
+    board's cross-process init flock so no other process connects mid-repair.
+    """
+    try:
+        conn = _sqlite_connect(path)
+    except sqlite3.Error as exc:
+        return False, [f"could not reopen for REINDEX: {exc}"]
+    try:
+        try:
+            for name in index_names:
+                escaped = name.replace('"', '""')
+                conn.execute(f'REINDEX "{escaped}"')
+        except sqlite3.Error:
+            # Per-index rebuild failed (unresolvable parsed name, auto
+            # index, …) — bare REINDEX rebuilds every index in the DB.
+            conn.execute("REINDEX")
+        messages = _run_integrity_check(conn)
+    except sqlite3.Error as exc:
+        return False, [f"REINDEX failed: {exc}"]
+    finally:
+        conn.close()
+    return _integrity_messages_ok(messages), messages
+
+
 def _guard_existing_db_is_healthy(path: Path) -> None:
     """Run ``PRAGMA integrity_check`` on an existing non-empty DB file.
 
     Opens the probe in read/write mode so SQLite can recover or
     checkpoint a healthy WAL/hot-journal DB before we declare it
-    corrupt. If the file is malformed, copy it (and any WAL/SHM
-    sidecars) to a timestamped backup and raise
-    :class:`KanbanDbCorruptError` so callers cannot silently recreate
-    the schema on top of a damaged DB.
+    corrupt.
+
+    **Narrow auto-repair:** when the integrity failure consists *only* of
+    index-scoped errors (``wrong # of entries in index <name>`` / ``row N
+    missing from index <name>``), the table b-trees are intact and REINDEX
+    rebuilds the damaged indexes losslessly. In that case we take the
+    corrupt backup FIRST (same content-addressed quarantine as the
+    fail-closed path), run REINDEX under the caller-held init flock,
+    re-run ``integrity_check``, and proceed only if it comes back clean.
+    Anything else — page corruption, ``malformed`` images, a REINDEX that
+    does not produce a clean re-check — fails closed exactly as before:
+    copy the file (and any WAL/SHM sidecars) to a backup and raise
+    :class:`KanbanDbCorruptError` so callers cannot silently recreate the
+    schema on top of a damaged DB.
 
     Transient lock/busy errors (``sqlite3.OperationalError``) are NOT
     treated as corruption; they propagate raw so the caller sees a
@@ -1660,14 +1756,18 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
     if str(resolved) in _INITIALIZED_PATHS:
         return
     reason: Optional[str] = None
+    messages: list[str] = []
     try:
         probe = _sqlite_connect(resolved)
         try:
-            row = probe.execute("PRAGMA integrity_check").fetchone()
+            messages = _run_integrity_check(probe)
         finally:
             probe.close()
-        if not row or (row[0] or "").lower() != "ok":
-            reason = f"integrity_check returned {row[0] if row else '<no row>'!r}"
+        if not _integrity_messages_ok(messages):
+            reason = (
+                f"integrity_check returned "
+                f"{messages[0] if messages else '<no row>'!r}"
+            )
     except sqlite3.OperationalError:
         # Lock contention, busy, transient IO — not corruption. Let it propagate.
         raise
@@ -1675,7 +1775,30 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
         reason = f"sqlite refused to open file: {exc}"
     if reason is None:
         return
+    # Quarantine FIRST — both the repair path and the fail-closed path
+    # preserve the pre-touch bytes before anything mutates the file.
     backup = _backup_corrupt_db(resolved)
+    index_names = _repairable_index_names(messages)
+    if index_names:
+        _log.warning(
+            "kanban DB %s failed integrity_check with index-only errors "
+            "(%s); pre-repair backup at %s — attempting REINDEX auto-repair.",
+            resolved, ", ".join(index_names),
+            backup if backup is not None else "<backup failed>",
+        )
+        repaired, post = _attempt_index_reindex_repair(resolved, index_names)
+        if repaired:
+            _log.warning(
+                "kanban DB %s auto-repaired via REINDEX (%s); "
+                "integrity_check now clean. Pre-repair copy kept at %s.",
+                resolved, ", ".join(index_names),
+                backup if backup is not None else "<backup failed>",
+            )
+            return
+        reason = (
+            f"{reason}; REINDEX auto-repair attempted but integrity_check "
+            f"still returned {post[0] if post else '<no row>'!r}"
+        )
     raise KanbanDbCorruptError(resolved, backup, reason)
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1907,6 +1907,112 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
     raise KanbanDbCorruptError(resolved, backup, reason)
 
 
+@dataclass
+class RepairResult:
+    """Outcome of :func:`repair_db` for CLI/status reporting.
+
+    ``status`` is one of:
+
+    * ``"ok"``        — integrity_check was already clean; nothing done.
+    * ``"repaired"``  — index-only errors found, REINDEX applied, re-check
+      clean. ``backup_path`` holds the pre-repair quarantine copy.
+    * ``"corrupt"``   — still corrupt: either a non-index error class
+      (fail-closed, no repair attempted) or a REINDEX whose re-check did
+      not come back clean.
+    * ``"missing"``   — no DB file (or zero-byte placeholder); nothing to do.
+    """
+
+    status: str
+    db_path: Path
+    messages: list[str] = field(default_factory=list)
+    post_repair_messages: list[str] = field(default_factory=list)
+    backup_path: Optional[Path] = None
+    reindexed: list[str] = field(default_factory=list)
+
+
+def repair_db(
+    db_path: Optional[Path] = None,
+    *,
+    board: Optional[str] = None,
+) -> RepairResult:
+    """Probe a kanban DB and apply the narrow index-REINDEX repair if needed.
+
+    Shares the exact policy of :func:`_guard_existing_db_is_healthy`: only
+    integrity failures composed *entirely* of index-scoped errors are
+    repairable; the corrupt bytes are quarantined via
+    :func:`_backup_corrupt_db` BEFORE any mutation; the REINDEX runs under
+    the board's cross-process init flock; and anything else stays corrupt
+    (fail-closed) for the caller to surface. Unlike the guard this never
+    raises :class:`KanbanDbCorruptError` — it returns a structured
+    :class:`RepairResult` so ``hermes kanban repair`` can report and choose
+    its own exit code.
+
+    Transient ``sqlite3.OperationalError`` (locked/busy) still propagates
+    raw, exactly like the guard: a locked healthy DB is not corruption and
+    must not be quarantined.
+    """
+    if db_path is not None:
+        path = db_path
+    else:
+        path = kanban_db_path(board=board)
+    try:
+        resolved = path.resolve()
+    except OSError:
+        resolved = path
+    try:
+        if not resolved.exists() or resolved.stat().st_size == 0:
+            return RepairResult(status="missing", db_path=resolved)
+    except OSError:
+        return RepairResult(status="missing", db_path=resolved)
+
+    with _cross_process_init_lock(resolved):
+        messages: list[str] = []
+        try:
+            probe = _sqlite_connect(resolved)
+            try:
+                messages = _run_integrity_check(probe)
+            finally:
+                probe.close()
+        except sqlite3.OperationalError:
+            # Locked/busy — not corruption; let the caller report it raw.
+            raise
+        except sqlite3.DatabaseError as exc:
+            # Same quarantine the connect-time guard takes for a file
+            # sqlite refuses to open at all (e.g. malformed page 1).
+            return RepairResult(
+                status="corrupt",
+                db_path=resolved,
+                messages=[f"sqlite refused to open file: {exc}"],
+                backup_path=_backup_corrupt_db(resolved),
+            )
+        if _integrity_messages_ok(messages):
+            return RepairResult(status="ok", db_path=resolved, messages=messages)
+
+        # Quarantine FIRST — identical policy to the connect-time guard.
+        backup = _backup_corrupt_db(resolved)
+        index_names = _repairable_index_names(messages)
+        if not index_names:
+            return RepairResult(
+                status="corrupt",
+                db_path=resolved,
+                messages=messages,
+                backup_path=backup,
+            )
+        repaired, post = _attempt_index_reindex_repair(resolved, index_names)
+        # The file changed on disk; force the next connect() in this process
+        # to re-probe instead of trusting the stale healthy-path cache.
+        with _INIT_LOCK:
+            _INITIALIZED_PATHS.discard(str(resolved))
+        return RepairResult(
+            status="repaired" if repaired else "corrupt",
+            db_path=resolved,
+            messages=messages,
+            post_repair_messages=post,
+            backup_path=backup,
+            reindexed=index_names,
+        )
+
+
 def connect(
     db_path: Optional[Path] = None,
     *,

--- a/tests/hermes_cli/test_kanban_db_repair.py
+++ b/tests/hermes_cli/test_kanban_db_repair.py
@@ -194,3 +194,83 @@ def test_repaired_db_connects_normally_afterwards(tmp_path):
     finally:
         conn.close()
     assert set(tmp_path.glob("kanban.db.corrupt.*.bak")) == before
+
+
+# ---------------------------------------------------------------------------
+# Corrupt-backup retention cap
+# ---------------------------------------------------------------------------
+
+def test_corrupt_backup_retention_cap_prunes_oldest(tmp_path, monkeypatch):
+    """Mutating corruption can't accumulate quarantine files forever.
+
+    Regression for the field report of 124 ``.corrupt.*.bak`` files: each
+    distinct corrupt byte-state mints a new content-addressed backup, so a
+    board whose file keeps changing between failures grows one backup per
+    mutation. The cap keeps only the newest ``_CORRUPT_BACKUP_RETENTION``.
+    """
+    monkeypatch.setattr(kb, "_CORRUPT_BACKUP_RETENTION", 3)
+    db_path = tmp_path / "kanban.db"
+    _write_page_corrupt_db(db_path)
+
+    minted: list[Path] = []
+    for i in range(8):
+        # Mutate the corrupt bytes → new sha → new backup each round.
+        with db_path.open("r+b") as fh:
+            fh.seek(200)
+            fh.write(bytes([i]) * 16)
+        kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+        with pytest.raises(kb.KanbanDbCorruptError) as excinfo:
+            kb.connect(db_path=db_path)
+        assert excinfo.value.backup_path is not None
+        minted.append(excinfo.value.backup_path)
+        # The just-created backup always survives its own prune pass.
+        assert excinfo.value.backup_path.exists()
+
+    remaining = sorted(tmp_path.glob("kanban.db.corrupt.*.bak"))
+    assert len(remaining) == 3, (
+        f"expected retention cap of 3, found {len(remaining)}: {remaining}"
+    )
+    # The newest backup (this round's) is among the survivors.
+    assert minted[-1] in remaining
+
+
+def test_corrupt_backup_retention_prunes_sidecar_copies(tmp_path, monkeypatch):
+    """Pruned backups take their copied -wal/-shm sidecars with them."""
+    monkeypatch.setattr(kb, "_CORRUPT_BACKUP_RETENTION", 1)
+    db_path = tmp_path / "kanban.db"
+    _write_page_corrupt_db(db_path)
+
+    # Fabricate an old backup + sidecars that the next prune should remove.
+    import os
+    stale = tmp_path / "kanban.db.corrupt.deadbeef00000000.bak"
+    stale.write_bytes(b"old corrupt bytes")
+    (tmp_path / (stale.name + "-wal")).write_bytes(b"wal")
+    (tmp_path / (stale.name + "-shm")).write_bytes(b"shm")
+    past = 1_000_000_000
+    os.utime(stale, (past, past))
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with pytest.raises(kb.KanbanDbCorruptError) as excinfo:
+        kb.connect(db_path=db_path)
+    fresh = excinfo.value.backup_path
+    assert fresh is not None and fresh.exists()
+
+    assert not stale.exists()
+    assert not (tmp_path / (stale.name + "-wal")).exists()
+    assert not (tmp_path / (stale.name + "-shm")).exists()
+
+
+def test_identical_corrupt_bytes_still_reuse_one_backup(tmp_path):
+    """The retention cap must not break content-addressed dedupe."""
+    db_path = tmp_path / "kanban.db"
+    _write_page_corrupt_db(db_path)
+
+    backups: set[Path] = set()
+    for _ in range(5):
+        kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+        with pytest.raises(kb.KanbanDbCorruptError) as excinfo:
+            kb.connect(db_path=db_path)
+        assert excinfo.value.backup_path is not None
+        backups.add(excinfo.value.backup_path)
+    assert len(backups) == 1
+    assert len(list(tmp_path.glob("kanban.db.corrupt.*.bak"))) == 1

--- a/tests/hermes_cli/test_kanban_db_repair.py
+++ b/tests/hermes_cli/test_kanban_db_repair.py
@@ -274,3 +274,105 @@ def test_identical_corrupt_bytes_still_reuse_one_backup(tmp_path):
         backups.add(excinfo.value.backup_path)
     assert len(backups) == 1
     assert len(list(tmp_path.glob("kanban.db.corrupt.*.bak"))) == 1
+
+
+# ---------------------------------------------------------------------------
+# Periodic WAL checkpoint on the dispatcher tick path
+# ---------------------------------------------------------------------------
+
+class _ConnProxy:
+    """Delegating wrapper so tests can observe/deny wal_checkpoint PRAGMAs.
+
+    ``sqlite3.Connection`` is an immutable C type — its methods cannot be
+    monkeypatched — so the spy wraps the connection object instead.
+    """
+
+    def __init__(self, conn, recorded, fail_checkpoint=False):
+        self._conn = conn
+        self._recorded = recorded
+        self._fail_checkpoint = fail_checkpoint
+
+    def execute(self, sql, *args, **kwargs):
+        if "wal_checkpoint" in str(sql).lower():
+            self._recorded.append(str(sql))
+            if self._fail_checkpoint:
+                raise sqlite3.OperationalError("database is locked")
+        return self._conn.execute(sql, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+
+def test_dispatch_tick_runs_wal_checkpoint_at_interval(tmp_path, monkeypatch):
+    """First tick checkpoints; ticks inside the interval don't; after the
+    interval elapses the next tick checkpoints again."""
+    db_path = tmp_path / "kanban.db"
+    _build_board_db(db_path, tasks=1)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    # Fresh per-path clock so previous tests can't have claimed the slot.
+    monkeypatch.setattr(kb, "_LAST_WAL_CHECKPOINT", {})
+
+    executed: list[str] = []
+    conn = kb.connect(db_path=db_path)
+    proxy = _ConnProxy(conn, executed)
+    try:
+        kb.dispatch_once(proxy, spawn_fn=lambda *a, **k: None, dry_run=True)
+        assert len(executed) == 1, "first tick should checkpoint"
+
+        kb.dispatch_once(proxy, spawn_fn=lambda *a, **k: None, dry_run=True)
+        kb.dispatch_once(proxy, spawn_fn=lambda *a, **k: None, dry_run=True)
+        assert len(executed) == 1, "ticks inside the interval must not checkpoint"
+
+        # Age the per-path timestamp past the interval → next tick fires.
+        key = str(db_path.resolve())
+        kb._LAST_WAL_CHECKPOINT[key] -= (
+            kb._WAL_CHECKPOINT_INTERVAL_SECONDS + 1.0
+        )
+        kb.dispatch_once(proxy, spawn_fn=lambda *a, **k: None, dry_run=True)
+        assert len(executed) == 2, "tick after the interval should checkpoint"
+        assert all("TRUNCATE" in sql.upper() for sql in executed)
+    finally:
+        conn.close()
+
+
+def test_wal_checkpoint_failure_never_fails_the_tick(tmp_path, monkeypatch):
+    """A busy/erroring checkpoint is best-effort: logged, never raised."""
+    db_path = tmp_path / "kanban.db"
+    _build_board_db(db_path, tasks=1)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setattr(kb, "_LAST_WAL_CHECKPOINT", {})
+
+    executed: list[str] = []
+    conn = kb.connect(db_path=db_path)
+    proxy = _ConnProxy(conn, executed, fail_checkpoint=True)
+    try:
+        result = kb.dispatch_once(
+            proxy, spawn_fn=lambda *a, **k: None, dry_run=True,
+        )
+        assert not result.skipped_locked
+        assert executed, "checkpoint was attempted (and failed) this tick"
+    finally:
+        conn.close()
+
+
+def test_wal_checkpoint_truncates_wal_file(tmp_path, monkeypatch):
+    """End-to-end: the checkpoint actually truncates the -wal sidecar."""
+    db_path = tmp_path / "kanban.db"
+    _build_board_db(db_path, tasks=1)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setattr(kb, "_LAST_WAL_CHECKPOINT", {})
+
+    conn = kb.connect(db_path=db_path)
+    try:
+        # Generate WAL frames.
+        for i in range(30):
+            kb.create_task(conn, title=f"wal-{i}")
+        wal = tmp_path / "kanban.db-wal"
+        assert wal.exists() and wal.stat().st_size > 0
+
+        kb.dispatch_once(conn, spawn_fn=lambda *a, **k: None, dry_run=True)
+        assert wal.stat().st_size == 0, (
+            "wal_checkpoint(TRUNCATE) should reset the -wal file to 0 bytes"
+        )
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_kanban_db_repair.py
+++ b/tests/hermes_cli/test_kanban_db_repair.py
@@ -1,0 +1,196 @@
+"""Tests for kanban DB corruption repair, backup retention, WAL checkpointing,
+and the ``hermes kanban repair`` CLI verb."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+def _build_board_db(db_path: Path, tasks: int = 12) -> None:
+    """Create a real board DB with data so indexes have entries."""
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db(db_path=db_path)
+    with kb.connect(db_path=db_path) as conn:
+        for i in range(tasks):
+            kb.create_task(conn, title=f"task-{i}")
+    conn.close()
+    # Force the next connect() to re-run the health guard.
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+
+def _corrupt_index(db_path: Path, index_name: str) -> None:
+    """Make ``index_name`` disagree with its table → 'wrong # of entries'.
+
+    writable_schema approach: temporarily rewrite the index's schema SQL to
+    a partial index matching no rows, REINDEX under that lie (emptying the
+    index b-tree), then restore the original SQL. integrity_check now sees a
+    non-partial index whose b-tree is missing every row — exactly the
+    index-scoped corruption class ('wrong # of entries in index <name>' +
+    'row N missing from index <name>') with intact table b-trees.
+    """
+    conn = sqlite3.connect(db_path, isolation_level=None)
+    original_sql = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = ?", (index_name,)
+    ).fetchone()[0]
+    lie = original_sql + " WHERE 0"
+    conn.execute("PRAGMA writable_schema=ON")
+    conn.execute(
+        "UPDATE sqlite_master SET sql = ? WHERE name = ?", (lie, index_name)
+    )
+    conn.execute("PRAGMA writable_schema=OFF")
+    conn.close()
+    # New connection so the rewritten schema is what REINDEX parses.
+    conn = sqlite3.connect(db_path, isolation_level=None)
+    conn.execute(f'REINDEX "{index_name}"')
+    conn.execute("PRAGMA writable_schema=ON")
+    conn.execute(
+        "UPDATE sqlite_master SET sql = ? WHERE name = ?",
+        (original_sql, index_name),
+    )
+    conn.execute("PRAGMA writable_schema=OFF")
+    conn.close()
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+
+def _write_page_corrupt_db(path: Path) -> bytes:
+    """Valid SQLite header, garbage pages — NON-index corruption class."""
+    header = b"SQLite format 3\x00" + b"\x10\x00\x02\x02\x00\x40\x20\x20"
+    header += b"\x00\x00\x00\x0c\x00\x00\x23\x46\x00\x00\x00\x00"
+    header = header.ljust(100, b"\x00")
+    blob = header + b"definitely not a valid sqlite page \x00\x01\x02\x03" * 64
+    path.write_bytes(blob)
+    kb._INITIALIZED_PATHS.discard(str(path.resolve()))
+    return blob
+
+
+def _integrity_messages(db_path: Path) -> list[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return [r[0] for r in conn.execute("PRAGMA integrity_check").fetchall()]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Index-error parsing (generic, no hardcoded index names)
+# ---------------------------------------------------------------------------
+
+def test_repairable_index_names_parses_generically():
+    messages = [
+        "wrong # of entries in index idx_anything_at_all",
+        "row 3 missing from index idx_anything_at_all",
+        "wrong # of entries in index some_other_index",
+    ]
+    assert kb._repairable_index_names(messages) == [
+        "idx_anything_at_all", "some_other_index",
+    ]
+
+
+@pytest.mark.parametrize("messages", [
+    [],
+    ["ok"],
+    ["database disk image is malformed"],
+    ["*** in database main ***", "Page 5: btreeInitPage() returns error code 11"],
+    # Mixed: one repairable line + one non-index line → NOT repairable.
+    ["wrong # of entries in index idx_tasks_status",
+     "database disk image is malformed"],
+])
+def test_repairable_index_names_rejects_non_index_classes(messages):
+    assert kb._repairable_index_names(messages) is None
+
+
+# ---------------------------------------------------------------------------
+# Narrow auto-repair in the connect-time guard
+# ---------------------------------------------------------------------------
+
+def test_connect_auto_repairs_index_only_corruption(tmp_path, caplog):
+    """Index-only integrity errors are REINDEXed and connect proceeds."""
+    import logging
+
+    db_path = tmp_path / "kanban.db"
+    _build_board_db(db_path)
+    _corrupt_index(db_path, "idx_tasks_status")
+
+    # Precondition: the fixture really produced the index-scoped class.
+    messages = _integrity_messages(db_path)
+    assert any(m.startswith("wrong # of entries in index") for m in messages)
+    assert kb._repairable_index_names(messages) == ["idx_tasks_status"]
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.kanban_db"):
+        conn = kb.connect(db_path=db_path)
+    try:
+        # DB is clean again and data survived.
+        row = conn.execute("PRAGMA integrity_check").fetchone()
+        assert row[0] == "ok"
+        titles = {t.title for t in kb.list_tasks(conn)}
+        assert "task-0" in titles and "task-11" in titles
+    finally:
+        conn.close()
+    assert "auto-repaired via REINDEX" in caplog.text
+
+    # The corrupt bytes were quarantined BEFORE the repair mutated the file.
+    backups = list(tmp_path.glob("kanban.db.corrupt.*.bak"))
+    assert len(backups) == 1
+    backup_messages_db = backups[0]
+    # The backup still exhibits the pre-repair corruption.
+    pre = _integrity_messages(backup_messages_db)
+    assert any(m.startswith("wrong # of entries in index") for m in pre)
+
+
+def test_connect_still_fails_closed_on_page_corruption(tmp_path):
+    """Non-index corruption keeps the exact fail-closed contract."""
+    db_path = tmp_path / "kanban.db"
+    original = _write_page_corrupt_db(db_path)
+
+    with pytest.raises(kb.KanbanDbCorruptError) as excinfo:
+        kb.connect(db_path=db_path)
+
+    err = excinfo.value
+    assert err.backup_path is not None and err.backup_path.exists()
+    # No repair was attempted: original bytes untouched on the live path.
+    assert db_path.read_bytes() == original
+
+
+def test_guard_fails_closed_when_reindex_does_not_clean(tmp_path, monkeypatch):
+    """If the post-REINDEX re-check is not clean, raise exactly as today."""
+    db_path = tmp_path / "kanban.db"
+    _build_board_db(db_path)
+    _corrupt_index(db_path, "idx_tasks_status")
+
+    monkeypatch.setattr(
+        kb, "_attempt_index_reindex_repair",
+        lambda path, names: (False, ["wrong # of entries in index idx_tasks_status"]),
+    )
+    with pytest.raises(kb.KanbanDbCorruptError) as excinfo:
+        kb.connect(db_path=db_path)
+    assert "REINDEX auto-repair attempted" in str(excinfo.value)
+    assert excinfo.value.backup_path is not None
+    assert excinfo.value.backup_path.exists()
+
+
+def test_repaired_db_connects_normally_afterwards(tmp_path):
+    """After one auto-repair, subsequent connects are ordinary fast-path."""
+    db_path = tmp_path / "kanban.db"
+    _build_board_db(db_path)
+    _corrupt_index(db_path, "idx_tasks_status")
+
+    conn = kb.connect(db_path=db_path)
+    conn.close()
+    # Second connect: healthy cache path, no new backups minted.
+    before = set(tmp_path.glob("kanban.db.corrupt.*.bak"))
+    conn = kb.connect(db_path=db_path)
+    try:
+        kb.create_task(conn, title="post-repair")
+        assert "post-repair" in {t.title for t in kb.list_tasks(conn)}
+    finally:
+        conn.close()
+    assert set(tmp_path.glob("kanban.db.corrupt.*.bak")) == before

--- a/tests/hermes_cli/test_kanban_db_repair.py
+++ b/tests/hermes_cli/test_kanban_db_repair.py
@@ -3,6 +3,7 @@ and the ``hermes kanban repair`` CLI verb."""
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 
@@ -376,3 +377,133 @@ def test_wal_checkpoint_truncates_wal_file(tmp_path, monkeypatch):
         )
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# repair_db() API + `hermes kanban repair` CLI verb
+# ---------------------------------------------------------------------------
+
+def _run_kanban_cli(argv: list[str]) -> int:
+    """Drive the real argparse surface exactly like `hermes kanban …`."""
+    import argparse
+
+    from hermes_cli import kanban as kc
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    args = parser.parse_args(["kanban", *argv])
+    return kc.kanban_command(args)
+
+
+@pytest.fixture
+def cli_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME so kanban_db_path() resolves inside tmp_path."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return home
+
+
+def test_repair_db_reports_ok_on_healthy_board(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    _build_board_db(db_path)
+    report = kb.repair_db(db_path=db_path)
+    assert report.status == "ok"
+    assert report.messages == ["ok"]
+    assert report.backup_path is None
+
+
+def test_repair_db_missing_file(tmp_path):
+    report = kb.repair_db(db_path=tmp_path / "nope.db")
+    assert report.status == "missing"
+
+
+def test_repair_db_repairs_index_corruption_with_backup_first(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    _build_board_db(db_path)
+    _corrupt_index(db_path, "idx_tasks_status")
+
+    report = kb.repair_db(db_path=db_path)
+    assert report.status == "repaired"
+    assert report.reindexed == ["idx_tasks_status"]
+    assert report.backup_path is not None and report.backup_path.exists()
+    # Backup captured the PRE-repair bytes (still corrupt in the copy).
+    assert any(
+        m.startswith("wrong # of entries in index")
+        for m in _integrity_messages(report.backup_path)
+    )
+    # Live DB is clean and data intact.
+    assert _integrity_messages(db_path) == ["ok"]
+    conn = kb.connect(db_path=db_path)
+    try:
+        assert "task-0" in {t.title for t in kb.list_tasks(conn)}
+    finally:
+        conn.close()
+
+
+def test_repair_db_fail_closed_on_page_corruption(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    original = _write_page_corrupt_db(db_path)
+    report = kb.repair_db(db_path=db_path)
+    assert report.status == "corrupt"
+    assert report.reindexed == []
+    assert report.backup_path is not None and report.backup_path.exists()
+    # No REINDEX mutation happened on the live file.
+    assert db_path.read_bytes() == original
+
+
+def test_cli_repair_ok_exit_zero(cli_home, capsys):
+    kb.init_db()
+    rc = _run_kanban_cli(["repair"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "integrity_check ok" in out
+
+
+def test_cli_repair_repairs_and_exits_zero(cli_home, capsys):
+    db_path = kb.kanban_db_path()
+    _build_board_db(db_path)
+    _corrupt_index(db_path, "idx_tasks_status")
+
+    rc = _run_kanban_cli(["repair"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "repaired" in out
+    assert "idx_tasks_status" in out
+    assert "pre-repair backup" in out
+    assert _integrity_messages(db_path) == ["ok"]
+
+
+def test_cli_repair_still_corrupt_exits_nonzero(cli_home, capsys):
+    db_path = kb.kanban_db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    _write_page_corrupt_db(db_path)
+
+    rc = _run_kanban_cli(["repair"])
+    err = capsys.readouterr().err
+    assert rc != 0
+    assert "CORRUPT" in err
+    assert "fail-closed" in err
+
+
+def test_cli_repair_json_shape(cli_home, capsys):
+    db_path = kb.kanban_db_path()
+    _build_board_db(db_path)
+    _corrupt_index(db_path, "idx_tasks_status")
+
+    rc = _run_kanban_cli(["repair", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["status"] == "repaired"
+    assert payload["reindexed"] == ["idx_tasks_status"]
+    assert payload["backup_path"]
+    assert Path(payload["backup_path"]).exists()
+
+
+def test_cli_repair_missing_db_exits_zero(cli_home, capsys):
+    rc = _run_kanban_cli(["repair"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "nothing to repair" in out


### PR DESCRIPTION
## Summary
kanban.db index-class corruption ("wrong # of entries in index") now auto-repairs via REINDEX instead of hard-failing the board, corrupt-backup files are capped at 10, the dispatcher checkpoints the WAL periodically, and `hermes kanban repair` gives operators a store-specific recovery command.

## Changes
- `hermes_cli/kanban_db.py` `_guard_existing_db_is_healthy`: when integrity_check reports ONLY index-scoped errors (index name parsed generically), back up first, REINDEX under the init flock, re-verify; every other corruption class stays fail-closed
- Backup retention cap (10 per board, oldest pruned)
- `PRAGMA wal_checkpoint(TRUNCATE)` best-effort on the dispatcher tick (>=5min interval)
- `hermes kanban repair`: integrity report + the same narrow repair path; nonzero exit if still corrupt

## Validation
25 new tests with real corrupted SQLite fixtures (repairable index shape + garbage-page fail-closed). Full kanban sweep: 1033 passed.

Addresses the still-open halves of #34385 and #53819.

## Infographic

![kanban-db-repair-and-checkpoint](https://v3b.fal.media/files/b/0aa32566/y3KYTmLPSdWyX2U1V_wAS_Aftu9aCm.png)
