### PR TITLE
fix(dashboard): ship web_dist in sdists and recover from a missing bundle instead of hard-failing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 graft skills
 graft optional-skills
 graft optional-mcps
+graft hermes_cli/web_dist
 graft locales
 # Bundled plugin manifests (plugin.yaml / plugin.yml). Without these the
 # PluginManager scan (hermes_cli/plugins.py) finds zero plugins on installs

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12675,10 +12675,25 @@ def cmd_dashboard(args):
             else PROJECT_ROOT / "hermes_cli" / "web_dist"
         )
         if not (_dist_root / "index.html").exists():
-            print(f"✗ --skip-build was passed but no web dist found at: {_dist_root}")
-            print("  Pre-build first:  npm install --workspace web && npm run build -w web")
-            print("  Or drop --skip-build to build automatically.")
-            sys.exit(1)
+            # The caller promised a pre-built dist but there isn't one.
+            # Instead of hard-failing (issue #59288 — desktop launches with
+            # --build-mode skip after a wipe of web_dist), warn and attempt
+            # ONE recovery build through the normal build path. Only the
+            # default dist location is recoverable: a custom HERMES_WEB_DIST
+            # points at a caller-managed directory the build cannot populate.
+            _recoverable = "HERMES_WEB_DIST" not in os.environ
+            if _recoverable:
+                print(f"⚠ --skip-build was passed but no web dist found at: {_dist_root}")
+                print("  Attempting one recovery build of the web UI...")
+                _build_web_ui(PROJECT_ROOT / "web", fatal=True)
+            if not (_dist_root / "index.html").exists():
+                print(f"✗ --skip-build was passed but no web dist found at: {_dist_root}")
+                if _recoverable:
+                    print("  The recovery build did not produce a usable dist.")
+                print("  Pre-build first:  npm install --workspace web && npm run build -w web")
+                print("  Or drop --skip-build to build automatically.")
+                sys.exit(1)
+            print("  ✓ Recovery build produced a web dist")
         print(f"→ Skipping web UI build (--skip-build); using dist at {_dist_root}")
     else:
         # HERMES_WEB_DIST is set without --skip-build: the build is skipped

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17907,7 +17907,18 @@ def mount_spa(application: FastAPI):
         ``__HERMES_AUTH_REQUIRED__`` flag lets the SPA pick the right
         auth scheme for /api/pty and /api/ws (ticket vs token).
         """
-        html = _index_path.read_text(encoding="utf-8")
+        try:
+            html = _index_path.read_text(encoding="utf-8")
+        except OSError:
+            # The dist dir existed at mount time but index.html is missing or
+            # unreadable now (partial build, wiped dist, permissions). Without
+            # this guard every request raises FileNotFoundError (500). Return
+            # the same JSON 404 payload mount_spa uses for a fully-missing
+            # dist so clients get a clear, consistent signal.
+            return JSONResponse(
+                {"error": "Frontend not built. Run: cd web && npm run build"},
+                status_code=404,
+            )
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
         gated_js = "true" if gated else "false"

--- a/tests/hermes_cli/test_dashboard_web_dist_validation.py
+++ b/tests/hermes_cli/test_dashboard_web_dist_validation.py
@@ -134,3 +134,115 @@ def test_env_dist_tilde_expanded_for_web_server(main_mod, monkeypatch, tmp_path)
 
     import os
     assert os.environ["HERMES_WEB_DIST"] == str(dist)
+
+
+# ---------------------------------------------------------------------------
+# --skip-build recovery (issue #59288): a missing dist under --skip-build
+# should warn and attempt ONE recovery build via _build_web_ui before the
+# fatal exit, instead of hard-failing immediately.
+# ---------------------------------------------------------------------------
+
+
+def test_skip_build_missing_dist_attempts_one_recovery_build(
+    main_mod, monkeypatch, tmp_path, capsys
+):
+    """--skip-build + missing index.html triggers exactly one recovery build;
+    when the build produces a dist, the server starts."""
+    _wire_common(main_mod, monkeypatch)
+    monkeypatch.delenv("HERMES_WEB_DIST", raising=False)
+    project_root = tmp_path / "proj"
+    dist = project_root / "hermes_cli" / "web_dist"
+    dist.mkdir(parents=True)
+    monkeypatch.setattr(main_mod, "PROJECT_ROOT", project_root)
+
+    started = []
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.web_server",
+        types.SimpleNamespace(start_server=lambda **k: started.append(k)),
+    )
+
+    builds = []
+
+    def fake_build(web_dir, *, fatal=False):
+        builds.append((web_dir, fatal))
+        (dist / "index.html").write_text("<html></html>", encoding="utf-8")
+        return True
+
+    monkeypatch.setattr(main_mod, "_build_web_ui", fake_build)
+
+    main_mod.cmd_dashboard(_args(skip_build=True))
+
+    assert len(builds) == 1  # exactly ONE recovery build
+    assert builds[0][0] == project_root / "web"
+    assert len(started) == 1
+    out = capsys.readouterr().out
+    assert "recovery build" in out.lower()
+
+
+def test_skip_build_recovery_build_failure_preserves_fatal_exit(
+    main_mod, monkeypatch, tmp_path, capsys
+):
+    """When the recovery build also fails to produce a dist, the original
+    fatal path is preserved: exit 1, clear message, server never starts."""
+    _wire_common(main_mod, monkeypatch)
+    monkeypatch.delenv("HERMES_WEB_DIST", raising=False)
+    project_root = tmp_path / "proj"
+    (project_root / "hermes_cli" / "web_dist").mkdir(parents=True)
+    monkeypatch.setattr(main_mod, "PROJECT_ROOT", project_root)
+
+    started = []
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.web_server",
+        types.SimpleNamespace(start_server=lambda **k: started.append(k)),
+    )
+
+    builds = []
+    monkeypatch.setattr(
+        main_mod,
+        "_build_web_ui",
+        lambda web_dir, *, fatal=False: builds.append(web_dir) or False,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.cmd_dashboard(_args(skip_build=True))
+
+    assert exc.value.code == 1
+    assert len(builds) == 1  # attempted once, never retried
+    assert started == []
+    out = capsys.readouterr().out
+    assert "--skip-build was passed but no web dist found" in out
+    assert "recovery build did not produce a usable dist" in out
+
+
+def test_skip_build_custom_env_dist_missing_does_not_attempt_recovery(
+    main_mod, monkeypatch, tmp_path, capsys
+):
+    """A custom HERMES_WEB_DIST is caller-managed: the recovery build writes
+    to the default dist location and cannot populate it, so the env-var +
+    --skip-build combination keeps the immediate fatal exit with no build."""
+    _wire_common(main_mod, monkeypatch)
+    empty_dist = tmp_path / "custom_dist"
+    empty_dist.mkdir()
+    monkeypatch.setenv("HERMES_WEB_DIST", str(empty_dist))
+
+    started = []
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.web_server",
+        types.SimpleNamespace(start_server=lambda **k: started.append(k)),
+    )
+    builds = []
+    monkeypatch.setattr(
+        main_mod, "_build_web_ui", lambda *a, **k: builds.append(a) or True
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.cmd_dashboard(_args(skip_build=True))
+
+    assert exc.value.code == 1
+    assert builds == []
+    assert started == []
+    out = capsys.readouterr().out
+    assert "--skip-build was passed but no web dist found" in out

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -9179,3 +9179,56 @@ class TestDesktopCronTicker:
 
         with self._client():
             assert not called.wait(0.5), "ticker must not run outside the desktop app"
+
+
+class TestServeIndexMissingIndex:
+    """_serve_index must not raise per-request when index.html vanishes
+    (partial build, wiped dist) after mount_spa saw an existing dist dir.
+    It should return the same JSON 404 payload mount_spa emits for a
+    fully-missing dist."""
+
+    @staticmethod
+    def _client_with_dist(tmp_path, monkeypatch, *, write_index: bool):
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+        import hermes_cli.web_server as ws
+
+        dist = tmp_path / "web_dist"
+        (dist / "assets").mkdir(parents=True)
+        if write_index:
+            (dist / "index.html").write_text(
+                "<html><head></head><body>SPA</body></html>", encoding="utf-8"
+            )
+        monkeypatch.setattr(ws, "WEB_DIST", dist)
+        monkeypatch.delenv("HERMES_SERVE_HEADLESS", raising=False)
+        spa_app = FastAPI()
+        ws.mount_spa(spa_app)
+        return TestClient(spa_app), dist
+
+    def test_missing_index_inside_existing_dist_returns_json_404(
+        self, tmp_path, monkeypatch
+    ):
+        client, _dist = self._client_with_dist(
+            tmp_path, monkeypatch, write_index=False
+        )
+        for route in ("/", "/chat"):
+            resp = client.get(route)
+            assert resp.status_code == 404
+            assert resp.json()["error"] == (
+                "Frontend not built. Run: cd web && npm run build"
+            )
+
+    def test_index_deleted_after_mount_returns_json_404(self, tmp_path, monkeypatch):
+        client, dist = self._client_with_dist(tmp_path, monkeypatch, write_index=True)
+        assert client.get("/chat").status_code == 200  # healthy first
+        (dist / "index.html").unlink()
+        resp = client.get("/chat")
+        assert resp.status_code == 404
+        assert "Frontend not built" in resp.json()["error"]
+        # And recovers once the index reappears (e.g. a rebuild finished).
+        (dist / "index.html").write_text(
+            "<html><head></head><body>SPA-rebuilt</body></html>", encoding="utf-8"
+        )
+        resp = client.get("/chat")
+        assert resp.status_code == 200
+        assert "SPA-rebuilt" in resp.text

--- a/tests/test_wheel_locales_e2e.py
+++ b/tests/test_wheel_locales_e2e.py
@@ -55,7 +55,10 @@ def test_installed_wheel_renders_i18n_strings(tmp_path):
     #    same-version no-op.
     venv_dir = tmp_path / "venv"
     venv.create(venv_dir, with_pip=True)
-    vpy = venv_dir / "bin" / "python"
+    if sys.platform == "win32":
+        vpy = venv_dir / "Scripts" / "python.exe"
+    else:
+        vpy = venv_dir / "bin" / "python"
     subprocess.run([str(vpy), "-m", "pip", "install", "-q", "pyyaml"], check=True, timeout=300)
     subprocess.run(
         [str(vpy), "-m", "pip", "install", "-q", "--no-deps", "--force-reinstall", wheel],
@@ -75,7 +78,11 @@ def test_installed_wheel_renders_i18n_strings(tmp_path):
         "and s != 'gateway.status.header') else 1)"
     )
     env = {k: v for k, v in os.environ.items() if k not in ("PYTHONPATH", "HERMES_BUNDLED_LOCALES")}
-    env["PATH"] = f"{venv_dir / 'bin'}:{env['PATH']}"
+    env["PYTHONIOENCODING"] = "utf-8"
+    if sys.platform == "win32":
+        env["PATH"] = f"{venv_dir / 'Scripts'}{os.pathsep}{env['PATH']}"
+    else:
+        env["PATH"] = f"{venv_dir / 'bin'}{os.pathsep}{env['PATH']}"
     env["VIRTUAL_ENV"] = str(venv_dir)
     run = subprocess.run(
         [str(vpy), "-c", probe],
@@ -135,3 +142,54 @@ def test_built_sdist_ships_locale_catalogs(tmp_path):
     assert any(m.endswith("/locales/en.yaml") for m in catalogs), (
         f"sdist missing locales/en.yaml; shipped: {catalogs[:5]}"
     )
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(300)
+def test_built_sdist_ships_web_dist(tmp_path):
+    """The sdist must carry hermes_cli/web_dist/ too.
+
+    MANIFEST.in `graft hermes_cli/web_dist` is what puts the frontend assets
+    in the source distribution tarball. This test builds the sdist and asserts
+    that index.html exists inside it.
+    """
+    # Create a dummy index.html in hermes_cli/web_dist if it doesn't exist
+    # so that the sdist build actually has files to bundle.
+    web_dist_dir = REPO_ROOT / "hermes_cli" / "web_dist"
+    dummy_index = web_dist_dir / "index.html"
+    created_dummy = False
+    if not dummy_index.exists():
+        web_dist_dir.mkdir(parents=True, exist_ok=True)
+        with open(dummy_index, "w", encoding="utf-8") as f:
+            f.write("<html><body>Dummy Dashboard</body></html>")
+        created_dummy = True
+
+    try:
+        sdist_dir = tmp_path / "sdist"
+        build = subprocess.run(
+            ["uv", "build", "--sdist", "--out-dir", str(sdist_dir), "."],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+        assert build.returncode == 0, f"uv build --sdist failed:\n{build.stderr}"
+        tarballs = glob.glob(str(sdist_dir / "*.tar.gz"))
+        assert tarballs, "no sdist produced"
+
+        with tarfile.open(tarballs[0]) as tf:
+            names = tf.getnames()
+            web_assets = [m for m in names if "hermes_cli/web_dist/" in m]
+
+        assert any(m.endswith("/hermes_cli/web_dist/index.html") for m in web_assets), (
+            f"sdist missing hermes_cli/web_dist/index.html; shipped files in web_dist: {web_assets}"
+        )
+    finally:
+        if created_dummy and dummy_index.exists():
+            try:
+                dummy_index.unlink()
+                # Clean up directory if it's empty
+                if not any(web_dist_dir.iterdir()):
+                    web_dist_dir.rmdir()
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary
A missing dashboard bundle is no longer fatal: sdists now ship `web_dist` (wheel already did), `--skip-build` with no dist attempts one recovery build instead of exiting, and `_serve_index` returns the JSON 404 instead of raising per-request when index.html vanishes.

Salvages the MANIFEST graft + sdist test from #29661 by @aniruddhaadak80 (authorship preserved; its misleading 404-message change excluded per prior review).

## Changes
- `MANIFEST.in`: graft `hermes_cli/web_dist` + sdist regression test (real `uv build --sdist`)
- `hermes_cli/main.py` `cmd_dashboard`: `--skip-build` + missing index.html → warn + ONE `_build_web_ui` recovery attempt; fatal exit preserved if that also fails; custom `HERMES_WEB_DIST` stays fail-fast
- `hermes_cli/web_server.py` `_serve_index`: OSError → same JSON 404 as the missing-dist path; auto-recovers when the file reappears

## Validation
sdist graft integration test green; 6 dashboard-validation + 2 serve-index tests green.

Fixes #59288.

## Infographic

![web-dist-recovery](https://v3b.fal.media/files/b/0aa3257b/NvXZqMdFzBxMlkxkS1VsM_SbzbF2IB.png)
