### PR TITLE
fix(mcp): stdio discovery cooldown, message-less transport classification, zero-connected retry latch

### DIFF
--- a/contributors/emails/borje@dqsverige.se
+++ b/contributors/emails/borje@dqsverige.se
@@ -1,0 +1,2 @@
+diffen77
+# PR #66547 salvage

--- a/contributors/emails/fazerluga@gmail.com
+++ b/contributors/emails/fazerluga@gmail.com
@@ -1,0 +1,2 @@
+fazerluga-creator
+# PR #66981 salvage

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -25,12 +25,35 @@ def _has_configured_mcp_servers() -> bool:
 
 
 def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
-    """Spawn one shared background MCP discovery thread for this process."""
+    """Spawn one shared background MCP discovery thread for this process.
+
+    If the first background discovery run exits without connecting any MCP
+    server (for example after startup cancellation / OOM restart), later calls
+    are allowed to retry instead of permanently pinning the process in a
+    "discovery already started" state with zero MCP tools.
+    """
     global _mcp_discovery_started, _mcp_discovery_thread
 
     with _mcp_discovery_lock:
         if _mcp_discovery_started:
-            return
+            thread = _mcp_discovery_thread
+            if thread is not None and thread.is_alive():
+                return
+            try:
+                from tools.mcp_tool import get_mcp_status
+
+                status = get_mcp_status() or []
+                if any(entry.get("connected") for entry in status):
+                    return
+            except Exception:
+                return
+            logger.warning(
+                "Background MCP discovery previously exited with no connected "
+                "servers; retrying discovery thread"
+            )
+            _mcp_discovery_started = False
+            _mcp_discovery_thread = None
+
         _mcp_discovery_started = True
         if not _has_configured_mcp_servers():
             return
@@ -38,8 +61,21 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
         def _discover() -> None:
             try:
                 _discover_mcp_tools_without_interactive_oauth()
+                try:
+                    from tools.mcp_tool import get_mcp_status
+                    status = get_mcp_status() or []
+                    if not any(entry.get("connected") for entry in status):
+                        logger.warning(
+                            "Background MCP discovery completed with zero connected servers"
+                        )
+                except Exception:
+                    logger.debug("Failed to inspect MCP status after background discovery", exc_info=True)
             except Exception:
                 logger.debug("Background MCP tool discovery failed", exc_info=True)
+            finally:
+                with _mcp_discovery_lock:
+                    global _mcp_discovery_thread, _mcp_discovery_started
+                    _mcp_discovery_thread = None
 
         thread = threading.Thread(
             target=_discover,

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -222,3 +222,76 @@ def test_init_agent_waits_for_mcp_discovery_before_agent_build(monkeypatch):
     monkeypatch.setattr(cli_mod, "AIAgent", _fake_agent)
 
     assert cli._init_agent() is True
+
+
+def _retry_logger():
+    return types.SimpleNamespace(
+        debug=lambda *_a, **_k: None,
+        warning=lambda *_a, **_k: None,
+    )
+
+
+def _install_retry_stubs(monkeypatch, *, connected: bool, calls: dict):
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(
+            read_raw_config=lambda: {"mcp_servers": {"demo": {"transport": "stdio"}}},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_oauth",
+        types.SimpleNamespace(suppress_interactive_oauth=lambda: nullcontext()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(
+            discover_mcp_tools=lambda: calls.__setitem__("mcp", calls["mcp"] + 1),
+            get_mcp_status=lambda: [{"connected": connected}],
+        ),
+    )
+
+
+def test_background_discovery_retries_after_dead_thread_with_zero_connected(monkeypatch):
+    """A finished discovery run that connected nothing must not pin the
+    process in a 'discovery already started' state: the next call should be
+    allowed to retry (e.g. after startup cancellation or an OOM restart)."""
+    calls = {"mcp": 0}
+    _install_retry_stubs(monkeypatch, connected=False, calls=calls)
+
+    mcp_startup.start_background_mcp_discovery(
+        logger=_retry_logger(), thread_name="test-mcp-retry-1"
+    )
+    thread = mcp_startup._mcp_discovery_thread
+    if thread is not None:
+        thread.join(timeout=1.0)
+    assert calls["mcp"] == 1
+
+    mcp_startup.start_background_mcp_discovery(
+        logger=_retry_logger(), thread_name="test-mcp-retry-2"
+    )
+    thread = mcp_startup._mcp_discovery_thread
+    if thread is not None:
+        thread.join(timeout=1.0)
+    assert calls["mcp"] == 2
+
+
+def test_background_discovery_does_not_retry_when_servers_connected(monkeypatch):
+    """Once at least one MCP server is connected, repeat calls stay no-ops."""
+    calls = {"mcp": 0}
+    _install_retry_stubs(monkeypatch, connected=True, calls=calls)
+
+    mcp_startup.start_background_mcp_discovery(
+        logger=_retry_logger(), thread_name="test-mcp-noretry-1"
+    )
+    thread = mcp_startup._mcp_discovery_thread
+    if thread is not None:
+        thread.join(timeout=1.0)
+    assert calls["mcp"] == 1
+
+    mcp_startup.start_background_mcp_discovery(
+        logger=_retry_logger(), thread_name="test-mcp-noretry-2"
+    )
+    assert calls["mcp"] == 1

--- a/tests/test_tui_entry_mcp_owner.py
+++ b/tests/test_tui_entry_mcp_owner.py
@@ -1,0 +1,48 @@
+"""Regression tests: the stdio TUI consults the shared MCP discovery owner.
+
+The stdio ``hermes --tui`` path used to spawn its own discovery thread and
+``wait_for_mcp_discovery`` only ever joined that local handle. Now the spawn
+goes through ``hermes_cli.mcp_startup.start_background_mcp_discovery`` (single
+owner, restart-after-zero-connected semantics), so the entry-side wait must
+fall through to the shared owner when no local thread exists.
+"""
+
+import threading
+import time
+
+from hermes_cli import mcp_startup
+from tui_gateway import entry
+
+
+def test_wait_falls_through_to_shared_owner(monkeypatch):
+    monkeypatch.setattr(entry, "_mcp_discovery_thread", None)
+    thread = threading.Thread(target=lambda: time.sleep(0.05), daemon=True)
+    thread.start()
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", thread)
+
+    start = time.monotonic()
+    entry.wait_for_mcp_discovery(timeout=2.0)
+    elapsed = time.monotonic() - start
+
+    assert not thread.is_alive()
+    assert elapsed >= 0.04
+
+
+def test_wait_noop_when_no_owner_has_a_thread(monkeypatch):
+    monkeypatch.setattr(entry, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+
+    start = time.monotonic()
+    entry.wait_for_mcp_discovery(timeout=2.0)
+
+    assert time.monotonic() - start < 0.5
+
+
+def test_wait_still_joins_entry_local_thread(monkeypatch):
+    thread = threading.Thread(target=lambda: time.sleep(0.05), daemon=True)
+    thread.start()
+    monkeypatch.setattr(entry, "_mcp_discovery_thread", thread)
+
+    entry.wait_for_mcp_discovery(timeout=2.0)
+
+    assert not thread.is_alive()

--- a/tests/test_tui_entry_mcp_owner.py
+++ b/tests/test_tui_entry_mcp_owner.py
@@ -16,6 +16,13 @@ from tui_gateway import entry
 
 def test_wait_falls_through_to_shared_owner(monkeypatch):
     monkeypatch.setattr(entry, "_mcp_discovery_thread", None)
+    # The fall-through to the shared owner only exists for the stdio TUI,
+    # which arms this flag in main(); other surfaces call the startup wait
+    # directly from _make_agent and must NOT be waited twice.
+    monkeypatch.setattr(entry, "_mcp_discovery_enabled", True)
+    monkeypatch.setattr(
+        mcp_startup, "start_background_mcp_discovery", lambda **kw: None
+    )
     thread = threading.Thread(target=lambda: time.sleep(0.05), daemon=True)
     thread.start()
     monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", thread)

--- a/tests/test_tui_entry_mcp_owner.py
+++ b/tests/test_tui_entry_mcp_owner.py
@@ -46,3 +46,45 @@ def test_wait_still_joins_entry_local_thread(monkeypatch):
     entry.wait_for_mcp_discovery(timeout=2.0)
 
     assert not thread.is_alive()
+
+
+def test_wait_reinvokes_shared_spawn_when_discovery_enabled(monkeypatch):
+    """The TUI wait path must give the shared owner a retry opportunity.
+
+    start_background_mcp_discovery() allows a retry after a run that
+    connected zero servers — but only when it is CALLED again. main() calls
+    it exactly once, so the per-agent-build wait must re-invoke the
+    idempotent spawn when this process is MCP-enabled.
+    """
+    monkeypatch.setattr(entry, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(entry, "_mcp_discovery_enabled", True)
+
+    calls = []
+
+    def _fake_start(*, logger, thread_name):
+        calls.append(thread_name)
+
+    monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", _fake_start)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+
+    entry.wait_for_mcp_discovery(timeout=0.1)
+
+    assert calls == ["tui-mcp-discovery"]
+
+
+def test_wait_skips_spawn_when_discovery_not_enabled(monkeypatch):
+    """Non-MCP sessions must not import/spawn discovery on the wait path."""
+    monkeypatch.setattr(entry, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(entry, "_mcp_discovery_enabled", False)
+
+    calls = []
+
+    def _fake_start(*, logger, thread_name):
+        calls.append(thread_name)
+
+    monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", _fake_start)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+
+    entry.wait_for_mcp_discovery(timeout=0.1)
+
+    assert calls == []

--- a/tests/tools/test_mcp_bridge_single_failure.py
+++ b/tests/tools/test_mcp_bridge_single_failure.py
@@ -1,0 +1,132 @@
+"""Regression test for #50394.
+
+A single failing stdio MCP server must not churn the whole MCP bridge.
+
+Root cause: a server that fails to connect is never recorded in
+``_servers`` (``start()`` raises before the ``_servers[name] = server``
+line in ``_discover_and_register_server``). Without a post-failure
+cooldown, every subsequent ``register_mcp_servers`` pass (one per agent
+worker session) re-spawns the failing server from scratch -- a restart
+storm that destabilises the healthy co-located servers. The fix arms a
+per-server exponential backoff so a chronically failing server is retried
+on a schedule, isolated from the rest of the bridge.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+import tools.mcp_tool as mcp_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_mcp_state():
+    """Snapshot and restore the module-level MCP state around each test."""
+    snapshot = (
+        dict(mcp_mod._servers),
+        set(mcp_mod._server_connecting),
+        dict(mcp_mod._server_connect_errors),
+        dict(mcp_mod._server_connect_retry_after),
+        dict(mcp_mod._server_connect_failures),
+    )
+    mcp_mod._servers.clear()
+    mcp_mod._server_connecting.clear()
+    mcp_mod._server_connect_errors.clear()
+    mcp_mod._server_connect_retry_after.clear()
+    mcp_mod._server_connect_failures.clear()
+    try:
+        yield
+    finally:
+        (servers, connecting, errs, retry_after, failures) = snapshot
+        mcp_mod._servers.clear(); mcp_mod._servers.update(servers)
+        mcp_mod._server_connecting.clear(); mcp_mod._server_connecting.update(connecting)
+        mcp_mod._server_connect_errors.clear(); mcp_mod._server_connect_errors.update(errs)
+        mcp_mod._server_connect_retry_after.clear(); mcp_mod._server_connect_retry_after.update(retry_after)
+        mcp_mod._server_connect_failures.clear(); mcp_mod._server_connect_failures.update(failures)
+
+
+class TestConnectCooldownHelpers:
+    def test_failure_arms_exponential_backoff(self):
+        now = 1000.0
+        with patch("tools.mcp_tool.time.monotonic", return_value=now):
+            mcp_mod._record_connect_failure("bad")
+            d1 = mcp_mod._server_connect_retry_after["bad"]
+            mcp_mod._record_connect_failure("bad")
+            d2 = mcp_mod._server_connect_retry_after["bad"]
+        assert d1 == now + mcp_mod._CONNECT_RETRY_BASE_BACKOFF_SEC
+        assert d2 == now + mcp_mod._CONNECT_RETRY_BASE_BACKOFF_SEC * 2
+        assert mcp_mod._server_connect_failures["bad"] == 2
+
+    def test_backoff_is_capped(self):
+        for _ in range(50):
+            mcp_mod._record_connect_failure("bad")
+        deadline = mcp_mod._server_connect_retry_after["bad"]
+        assert deadline <= mcp_mod.time.monotonic() + mcp_mod._CONNECT_RETRY_MAX_BACKOFF_SEC + 1
+
+    def test_cooldown_active_then_clears(self):
+        now = 5000.0
+        with patch("tools.mcp_tool.time.monotonic", return_value=now):
+            mcp_mod._record_connect_failure("bad")
+            assert mcp_mod._connect_cooldown_active("bad") is True
+        later = now + mcp_mod._CONNECT_RETRY_MAX_BACKOFF_SEC + 1
+        with patch("tools.mcp_tool.time.monotonic", return_value=later):
+            assert mcp_mod._connect_cooldown_active("bad") is False
+        mcp_mod._clear_connect_failure("bad")
+        assert "bad" not in mcp_mod._server_connect_retry_after
+        assert "bad" not in mcp_mod._server_connect_failures
+
+    def test_unknown_server_not_in_cooldown(self):
+        assert mcp_mod._connect_cooldown_active("never-seen") is False
+
+
+@pytest.mark.skipif(not mcp_mod._MCP_AVAILABLE, reason="mcp SDK not installed")
+class TestRegisterMcpServersIsolation:
+    """register_mcp_servers must not re-spawn a server still in cooldown."""
+
+    def _run_with_mocked_connect(self, attempts):
+        async def fake_connect(name, config):
+            attempts.append(name)
+            if name == "bad":
+                raise ConnectionError("exec: bad: not found")
+            server = mcp_mod.MCPServerTask(name)
+            server._registered_tool_names = []
+            server._tools = []
+            return server
+
+        return patch("tools.mcp_tool._connect_server", side_effect=fake_connect)
+
+    def test_failing_server_skipped_on_second_pass(self):
+        attempts = []
+        cfg = {
+            "good": {"command": "good-cmd"},
+            "bad": {"command": "bad-cmd"},
+        }
+        with self._run_with_mocked_connect(attempts), \
+                patch("tools.mcp_tool._register_server_tools", return_value=[]), \
+                patch("tools.mcp_tool._filter_suspicious_mcp_servers", side_effect=lambda x: x):
+            mcp_mod.register_mcp_servers(cfg)
+            assert "good" in mcp_mod._servers
+            assert "bad" not in mcp_mod._servers
+            assert mcp_mod._connect_cooldown_active("bad") is True
+            assert "bad" in attempts
+
+            attempts.clear()
+            mcp_mod.register_mcp_servers(cfg)
+            assert "bad" not in attempts, (
+                "failing server was re-spawned despite active cooldown -- "
+                "restart storm not isolated (#50394)"
+            )
+
+    def test_cooldown_expiry_allows_retry(self):
+        attempts = []
+        cfg = {"bad": {"command": "bad-cmd"}}
+        with self._run_with_mocked_connect(attempts), \
+                patch("tools.mcp_tool._register_server_tools", return_value=[]), \
+                patch("tools.mcp_tool._filter_suspicious_mcp_servers", side_effect=lambda x: x):
+            mcp_mod.register_mcp_servers(cfg)
+            assert mcp_mod._connect_cooldown_active("bad") is True
+
+            mcp_mod._server_connect_retry_after["bad"] = mcp_mod.time.monotonic() - 1
+            attempts.clear()
+            mcp_mod.register_mcp_servers(cfg)
+            assert "bad" in attempts, "elapsed cooldown should permit a retry"

--- a/tests/tools/test_mcp_bridge_single_failure.py
+++ b/tests/tools/test_mcp_bridge_single_failure.py
@@ -130,3 +130,43 @@ class TestRegisterMcpServersIsolation:
             attempts.clear()
             mcp_mod.register_mcp_servers(cfg)
             assert "bad" in attempts, "elapsed cooldown should permit a retry"
+
+
+class TestShutdownClearsCooldownState:
+    """shutdown_mcp_servers must drop cooldown state on EVERY path.
+
+    A server that failed to connect is never recorded in ``_servers``, so
+    the empty-``_servers`` fast path is the most common state in which
+    stale cooldown entries exist. The original #50394 fix only cleared the
+    maps inside the async ``_shutdown`` coroutine, which the fast path
+    (and the loop-not-running path) never executes.
+    """
+
+    def test_fast_path_clears_cooldown_state(self):
+        mcp_mod._record_connect_failure("bad")
+        assert mcp_mod._server_connect_retry_after
+        assert not mcp_mod._servers  # precondition: fast path taken
+
+        with patch("tools.mcp_tool._stop_mcp_loop"):
+            mcp_mod.shutdown_mcp_servers()
+
+        assert mcp_mod._server_connect_retry_after == {}
+        assert mcp_mod._server_connect_failures == {}
+
+    def test_loop_not_running_path_clears_cooldown_state(self):
+        mcp_mod._record_connect_failure("bad")
+
+        class _DeadServer:
+            name = "dead"
+
+            async def shutdown(self):  # pragma: no cover - never awaited
+                pass
+
+        mcp_mod._servers["dead"] = _DeadServer()  # type: ignore[assignment]
+        # _mcp_loop is None in this test process, so the async _shutdown
+        # coroutine is never scheduled; only the final sweep can clear.
+        with patch("tools.mcp_tool._stop_mcp_loop"):
+            mcp_mod.shutdown_mcp_servers()
+
+        assert mcp_mod._server_connect_retry_after == {}
+        assert mcp_mod._server_connect_failures == {}

--- a/tests/tools/test_mcp_resource_content.py
+++ b/tests/tools/test_mcp_resource_content.py
@@ -239,10 +239,14 @@ class TestErrorPathResourceText:
             finally:
                 loop.close()
 
-        with mock_patch.dict(mcp_tool._servers, {"test-server": fake_server}), \
-             mock_patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_fake_run_on_mcp_loop):
-            fake_session.call_tool = AsyncMock()
-            yield fake_session, mcp_tool._make_tool_handler("test-server", "my-tool", 30.0)
+        mcp_tool._reset_server_error("test-server")
+        try:
+            with mock_patch.dict(mcp_tool._servers, {"test-server": fake_server}), \
+                 mock_patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_fake_run_on_mcp_loop):
+                fake_session.call_tool = AsyncMock()
+                yield fake_session, mcp_tool._make_tool_handler("test-server", "my-tool", 30.0)
+        finally:
+            mcp_tool._reset_server_error("test-server")
 
     def test_error_embedded_resource_text_surfaced(self, _handler):
         from unittest.mock import AsyncMock

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1518,7 +1518,14 @@ class TestToolsetInjection:
             broken_fixed = True
             call_count = 0
 
-            # Second call: should retry broken, skip good
+            # The failed server is now serving a post-failure backoff
+            # (#50394: prevents a tight re-spawn storm across the frequent
+            # per-worker-session discovery passes). Expire that cooldown to
+            # simulate the retry window having elapsed.
+            import tools.mcp_tool as _mcp_mod
+            _mcp_mod._server_connect_retry_after.pop("broken", None)
+
+            # Next call after the cooldown: should retry broken, skip good
             result2 = discover_mcp_tools()
             assert "mcp__good__ping" in result2
             assert "mcp__broken__ping" in result2

--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -121,27 +121,28 @@ def test_is_session_expired_rejects_mixed_group_with_user_interruption():
     assert _is_session_expired_error(exc) is False
 
 
-def test_exception_tree_finds_interruption_beyond_recursion_limit():
-    """Arbitrarily deep wrapper trees must not overflow Python's call stack."""
+def test_is_session_expired_finds_closed_resource_beyond_recursion_limit():
+    """The full classifier must handle arbitrarily deep transport wrappers."""
     import sys
 
-    from tools.mcp_tool import _exception_tree_contains_interruption
+    from anyio import ClosedResourceError
+    from tools.mcp_tool import _is_session_expired_error
 
     class NestedException(Exception):
         exceptions: tuple[BaseException, ...]
 
-    exc = InterruptedError("cancel")
+    exc = ClosedResourceError()
     for _ in range(sys.getrecursionlimit() + 100):
         wrapper = NestedException("wrapped")
         wrapper.exceptions = (exc,)
         exc = wrapper
 
-    assert _exception_tree_contains_interruption(exc) is True
+    assert _is_session_expired_error(exc) is True
 
 
-def test_exception_tree_handles_cyclic_exceptions_graph():
-    """Malformed exception graphs may contain cycles and must terminate safely."""
-    from tools.mcp_tool import _exception_tree_contains_interruption
+def test_is_session_expired_handles_cyclic_graph_without_transport_error():
+    """A cyclic non-transport graph must terminate and classify false."""
+    from tools.mcp_tool import _is_session_expired_error
 
     class CyclicException(Exception):
         exceptions: tuple[BaseException, ...]
@@ -151,7 +152,23 @@ def test_exception_tree_handles_cyclic_exceptions_graph():
     first.exceptions = (second,)
     second.exceptions = (first,)
 
-    assert _exception_tree_contains_interruption(first) is False
+    assert _is_session_expired_error(first) is False
+
+
+def test_is_session_expired_finds_transport_error_in_cyclic_graph():
+    """Cycle detection must not prevent scanning reachable transport errors."""
+    from anyio import ClosedResourceError
+    from tools.mcp_tool import _is_session_expired_error
+
+    class CyclicException(Exception):
+        exceptions: tuple[BaseException, ...]
+
+    first = CyclicException("first")
+    second = CyclicException("second")
+    first.exceptions = (second, ClosedResourceError())
+    second.exceptions = (first,)
+
+    assert _is_session_expired_error(first) is True
 
 
 def test_is_session_expired_rejects_empty_message():

--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -178,6 +178,83 @@ def test_is_session_expired_rejects_empty_message():
     assert _is_session_expired_error(Exception()) is False
 
 
+def test_is_session_expired_follows_cause_chain():
+    """A transport close reachable only via ``__cause__`` must classify."""
+    from anyio import ClosedResourceError
+    from tools.mcp_tool import _is_session_expired_error
+
+    try:
+        try:
+            raise ClosedResourceError()
+        except ClosedResourceError as inner:
+            raise RuntimeError("MCP request failed") from inner
+    except RuntimeError as exc:
+        assert _is_session_expired_error(exc) is True
+
+
+def test_is_session_expired_follows_context_chain():
+    """Implicit ``__context__`` chaining must also be scanned."""
+    from anyio import BrokenResourceError
+    from tools.mcp_tool import _is_session_expired_error
+
+    try:
+        try:
+            raise BrokenResourceError()
+        except BrokenResourceError:
+            raise RuntimeError("while handling transport write")
+    except RuntimeError as exc:
+        assert _is_session_expired_error(exc) is True
+
+
+def test_is_session_expired_interruption_in_cause_chain_wins():
+    """User cancellation buried in the chain overrides transport signals."""
+    from anyio import ClosedResourceError
+    from tools.mcp_tool import _is_session_expired_error
+
+    root = InterruptedError("cancel")
+    mid = ClosedResourceError()
+    mid.__cause__ = root
+    top = RuntimeError("transport is closed")
+    top.__cause__ = mid
+    assert _is_session_expired_error(top) is False
+
+
+def test_is_session_expired_handles_cyclic_cause_context_chain():
+    """Cycles through __cause__/__context__ must terminate (visited set)."""
+    from tools.mcp_tool import _is_session_expired_error
+
+    a = RuntimeError("a")
+    b = RuntimeError("b")
+    a.__cause__ = b
+    b.__context__ = a  # cycle back through the other link
+    assert _is_session_expired_error(a) is False
+
+    from anyio import ClosedResourceError
+
+    c = RuntimeError("c")
+    d = ClosedResourceError()
+    c.__cause__ = d
+    d.__context__ = c  # cycle, but transport error is reachable
+    assert _is_session_expired_error(c) is True
+
+
+def test_is_session_expired_traversal_is_budget_bounded():
+    """Pathologically long chains stop at the node budget without spinning."""
+    import tools.mcp_tool as mcp_mod
+    from tools.mcp_tool import _is_session_expired_error
+
+    exc: BaseException = RuntimeError("leaf")
+    for i in range(mcp_mod._EXC_TRAVERSAL_MAX_NODES * 2):
+        wrapper = RuntimeError(f"layer {i}")
+        wrapper.__cause__ = exc
+        exc = wrapper
+
+    # Terminates quickly and classifies false (no transport signal within
+    # budget). The exact outcome past the budget is unspecified; the
+    # invariant under test is termination.
+    assert _is_session_expired_error(exc) is False
+
+
 # ---------------------------------------------------------------------------
 # Handler integration — verify the recovery plumbing wires end-to-end
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -121,6 +121,39 @@ def test_is_session_expired_rejects_mixed_group_with_user_interruption():
     assert _is_session_expired_error(exc) is False
 
 
+def test_exception_tree_finds_interruption_beyond_recursion_limit():
+    """Arbitrarily deep wrapper trees must not overflow Python's call stack."""
+    import sys
+
+    from tools.mcp_tool import _exception_tree_contains_interruption
+
+    class NestedException(Exception):
+        exceptions: tuple[BaseException, ...]
+
+    exc = InterruptedError("cancel")
+    for _ in range(sys.getrecursionlimit() + 100):
+        wrapper = NestedException("wrapped")
+        wrapper.exceptions = (exc,)
+        exc = wrapper
+
+    assert _exception_tree_contains_interruption(exc) is True
+
+
+def test_exception_tree_handles_cyclic_exceptions_graph():
+    """Malformed exception graphs may contain cycles and must terminate safely."""
+    from tools.mcp_tool import _exception_tree_contains_interruption
+
+    class CyclicException(Exception):
+        exceptions: tuple[BaseException, ...]
+
+    first = CyclicException("first")
+    second = CyclicException("second")
+    first.exceptions = (second,)
+    second.exceptions = (first,)
+
+    assert _exception_tree_contains_interruption(first) is False
+
+
 def test_is_session_expired_rejects_empty_message():
     """Bare exceptions with no message shouldn't match."""
     from tools.mcp_tool import _is_session_expired_error

--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -10,6 +10,7 @@ Before the #13383 fix, this class of failure fell through as a plain
 tool error with no recovery path, so every subsequent call on the
 affected MCP server failed until the gateway was manually restarted.
 """
+import asyncio
 import json
 import threading
 from unittest.mock import MagicMock
@@ -90,6 +91,36 @@ def test_is_session_expired_rejects_interrupted_error():
     assert _is_session_expired_error(InterruptedError("Invalid or expired session")) is False
 
 
+def test_is_session_expired_detects_message_less_anyio_transport_failures():
+    """Recognized stream failures have no text for marker matching."""
+    from anyio import BrokenResourceError, EndOfStream
+    from tools.mcp_tool import _is_session_expired_error
+
+    assert _is_session_expired_error(BrokenResourceError()) is True
+    assert _is_session_expired_error(EndOfStream()) is True
+
+
+def test_is_session_expired_detects_wrapped_closed_resource():
+    """AnyIO task groups may wrap a message-less transport close."""
+    from anyio import ClosedResourceError
+    from tools.mcp_tool import _is_session_expired_error
+
+    exc = ExceptionGroup("MCP transport failed", [ClosedResourceError()])
+    assert _is_session_expired_error(exc) is True
+
+
+def test_is_session_expired_rejects_mixed_group_with_user_interruption():
+    """Cancellation anywhere in the tree takes precedence over transport loss."""
+    from anyio import ClosedResourceError
+    from tools.mcp_tool import _is_session_expired_error
+
+    exc = ExceptionGroup(
+        "cancelled MCP transport",
+        [InterruptedError("cancel"), ClosedResourceError()],
+    )
+    assert _is_session_expired_error(exc) is False
+
+
 def test_is_session_expired_rejects_empty_message():
     """Bare exceptions with no message shouldn't match."""
     from tools.mcp_tool import _is_session_expired_error
@@ -158,6 +189,86 @@ def _install_stub_server(name: str = "wpcom"):
     # reconnect readiness probe (``srv.session is not None``).
     server.session = MagicMock()
     return server, reconnect_flag
+
+
+@pytest.mark.parametrize(
+    "transport_config, expected_route",
+    [
+        ({"command": "librarian-mcp"}, "stdio"),
+        ({"url": "https://neo4j.example.test/mcp", "skip_preflight": True}, "http"),
+    ],
+    ids=["stdio", "http"],
+)
+def test_call_tool_handler_rebuilds_configured_server_transport(
+    monkeypatch, tmp_path, transport_config, expected_route
+):
+    """The real server run loop selects and rebuilds its configured transport."""
+    from anyio import ClosedResourceError
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask, _make_tool_handler
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    mcp_tool._ensure_mcp_loop()
+    transport_ready = threading.Event()
+    routes = []
+    configs = []
+    sessions = []
+    call_count = {"n": 0}
+
+    class _Session:
+        async def call_tool(self, *args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise ClosedResourceError
+            result = MagicMock()
+            result.isError = False
+            result.content = [MagicMock(type="text", text="reconnected")]
+            result.structuredContent = None
+            return result
+
+    class _LifecycleTask(MCPServerTask):
+        async def _serve_transport(self, route, config):
+            routes.append(route)
+            configs.append(dict(config))
+            self.session = _Session()
+            sessions.append(self.session)
+            self._ready.set()
+            transport_ready.set()
+            return await self._wait_for_lifecycle_event()
+
+        async def _run_stdio(self, config):
+            return await self._serve_transport("stdio", config)
+
+        async def _run_http(self, config):
+            return await self._serve_transport("http", config)
+
+    server = _LifecycleTask("resumed")
+    mcp_tool._servers["resumed"] = server
+    mcp_tool._server_error_counts.pop("resumed", None)
+    mcp_tool._server_breaker_opened_at.pop("resumed", None)
+    loop = mcp_tool._mcp_loop
+    assert loop is not None
+    run_future = asyncio.run_coroutine_threadsafe(
+        server.run(transport_config), loop
+    )
+
+    try:
+        assert transport_ready.wait(3), "server lifecycle did not establish transport"
+        handler = _make_tool_handler("resumed", "health", 10.0)
+        parsed = json.loads(handler({}))
+
+        assert parsed == {"result": "reconnected"}
+        assert call_count["n"] == 2
+        assert routes == [expected_route, expected_route]
+        assert configs == [transport_config, transport_config]
+        assert len(sessions) == 2
+        assert sessions[0] is not sessions[1]
+    finally:
+        loop.call_soon_threadsafe(server._shutdown_event.set)
+        run_future.result(timeout=5)
+        mcp_tool._servers.pop("resumed", None)
+        mcp_tool._server_error_counts.pop("resumed", None)
+        mcp_tool._server_breaker_opened_at.pop("resumed", None)
 
 
 def test_call_tool_handler_reconnects_on_session_expired(monkeypatch, tmp_path):
@@ -268,16 +379,19 @@ def test_session_expired_retry_waits_for_new_session(monkeypatch, tmp_path):
 
     server._reconnect_event = _ReconnectAdapter()
     mcp_tool._servers["hindsight"] = server
-    mcp_tool._server_error_counts.pop("hindsight", None)
+    mcp_tool._server_error_counts["hindsight"] = 7
+    mcp_tool._server_breaker_opened_at["hindsight"] = 123.0
 
     try:
         handler = _make_tool_handler("hindsight", "get_bank", 10.0)
         parsed = json.loads(handler({}))
         assert parsed.get("result") == "bank ok", parsed
         assert mcp_tool._server_error_counts.get("hindsight", 0) == 0
+        assert "hindsight" not in mcp_tool._server_breaker_opened_at
     finally:
         mcp_tool._servers.pop("hindsight", None)
         mcp_tool._server_error_counts.pop("hindsight", None)
+        mcp_tool._server_breaker_opened_at.pop("hindsight", None)
 
 
 def test_call_tool_handler_non_session_expired_error_falls_through(

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3584,22 +3584,6 @@ _SESSION_EXPIRED_MARKERS: tuple = (
 )
 
 
-def _exception_tree_contains_interruption(exc: BaseException) -> bool:
-    """Return whether ``exc`` or any nested exception is user cancellation."""
-    stack = [exc]
-    seen: set[int] = set()
-    while stack:
-        current = stack.pop()
-        identity = id(current)
-        if identity in seen:
-            continue
-        seen.add(identity)
-        if isinstance(current, InterruptedError):
-            return True
-        stack.extend(getattr(current, "exceptions", ()))
-    return False
-
-
 def _is_session_expired_error(exc: BaseException) -> bool:
     """Return True if ``exc`` looks like an MCP transport session expiry.
 
@@ -3614,35 +3598,50 @@ def _is_session_expired_error(exc: BaseException) -> bool:
     ``streamablehttp_client`` + ``ClientSession`` pair, which is
     exactly what ``MCPServerTask._reconnect_event`` triggers.
     """
-    if _exception_tree_contains_interruption(exc):
-        return False
-
     # AnyIO's stream exceptions are commonly message-less. In particular,
     # ``str(ClosedResourceError()) == ""``, so marker matching alone misses the
-    # exact failure emitted by both MCP stdio and HTTP transports. Match the
-    # SDK's transport-closed exception types before inspecting text.
+    # exact failure emitted by both MCP stdio and HTTP transports.
     try:
         from anyio import BrokenResourceError, ClosedResourceError, EndOfStream
 
-        if isinstance(exc, (BrokenResourceError, ClosedResourceError, EndOfStream)):
-            return True
+        transport_error_types = (
+            BrokenResourceError,
+            ClosedResourceError,
+            EndOfStream,
+        )
     except ImportError:  # pragma: no cover - AnyIO is supplied by the MCP SDK
-        pass
+        transport_error_types = ()
 
-    # AnyIO task groups can wrap the transport exception in an
-    # ExceptionGroup whose own string omits the message-less leaf details.
-    nested = getattr(exc, "exceptions", ())
-    if nested and any(_is_session_expired_error(child) for child in nested):
-        return True
+    # ExceptionGroup trees can be arbitrarily deep or even cyclic when custom
+    # exceptions expose ``exceptions``. Traverse once, iteratively, and inspect
+    # every reachable node so user interruption always overrides transport
+    # markers or types found elsewhere in the graph.
+    stack = [exc]
+    seen: set[int] = set()
+    transport_error_found = False
+    while stack:
+        current = stack.pop()
+        identity = id(current)
+        if identity in seen:
+            continue
+        seen.add(identity)
 
-    # Exception messages vary across SDK versions + server
-    # implementations, so match on a small allow-list of stable
-    # substrings rather than exception type.  Kept narrow to avoid
-    # false positives on unrelated server errors.
-    msg = str(exc).lower()
-    if not msg:
-        return False
-    return any(marker in msg for marker in _SESSION_EXPIRED_MARKERS)
+        if isinstance(current, InterruptedError):
+            return False
+        if isinstance(current, transport_error_types):
+            transport_error_found = True
+
+        # Exception messages vary across SDK versions + server
+        # implementations, so match on a small allow-list of stable
+        # substrings rather than exception type. Kept narrow to avoid
+        # false positives on unrelated server errors.
+        msg = str(current).lower()
+        if msg and any(marker in msg for marker in _SESSION_EXPIRED_MARKERS):
+            transport_error_found = True
+
+        stack.extend(getattr(current, "exceptions", ()))
+
+    return transport_error_found
 
 
 def _handle_session_expired_and_retry(

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5780,8 +5780,16 @@ def shutdown_mcp_servers():
     with _lock:
         servers_snapshot = list(_servers.values())
 
-    # Fast path: nothing to shut down.
+    # Fast path: nothing to shut down. The connect-cooldown maps can still
+    # be populated here — a server that failed to connect is never recorded
+    # in ``_servers`` (that is the very premise of the #50394 cooldown), so
+    # "no live servers" is the MOST likely state in which stale backoff
+    # entries exist. Clear them so a post-shutdown restart re-attempts every
+    # configured server immediately.
     if not servers_snapshot:
+        with _lock:
+            _server_connect_retry_after.clear()
+            _server_connect_failures.clear()
         _stop_mcp_loop()
         return
 
@@ -5817,6 +5825,14 @@ def shutdown_mcp_servers():
                 future.result(timeout=15)
             except BaseException as exc:
                 logger.debug("Error during MCP shutdown: %s", exc)
+
+    # Unconditional final sweep: whether the async ``_shutdown`` ran,
+    # timed out, or was never scheduled (loop already stopped), a full
+    # shutdown must leave no stale connect-cooldown state behind — the
+    # next start should re-attempt every server immediately (#50394).
+    with _lock:
+        _server_connect_retry_after.clear()
+        _server_connect_failures.clear()
 
     _stop_mcp_loop()
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3170,6 +3170,61 @@ _servers: Dict[str, MCPServerTask] = {}
 _server_connecting: set[str] = set()
 _server_connect_errors: Dict[str, str] = {}
 
+# Connection-retry cooldown (per-server isolation against restart storms).
+#
+# A single stdio MCP server that fails to spawn (bad PATH, ``exec: not
+# found``, crash-on-start) is never recorded in ``_servers`` -- ``start()``
+# raises and ``_discover_and_register_server`` aborts before the
+# ``_servers[name] = server`` line. Without a cooldown, EVERY subsequent
+# ``discover_mcp_tools()`` (one per agent worker session, i.e. every few
+# seconds) sees the server as "not connected" and re-spawns it from
+# scratch. That is the restart storm in #50394: the failing server is
+# re-attempted on the shared MCP event loop on every worker session, the
+# subprocesses pile up unreaped, and the churn destabilises the healthy
+# co-located servers (their tools intermittently surface as
+# "Unknown tool").
+#
+# Fix: after a failed connection attempt, stamp a monotonic
+# ``retry_after`` deadline with exponential backoff. ``register_mcp_servers``
+# skips a server whose cooldown has not elapsed, so a chronically failing
+# server is retried on a backoff schedule instead of on every worker
+# session -- isolating it from the rest of the bridge. A successful
+# connection clears the state.
+_server_connect_retry_after: Dict[str, float] = {}   # name -> monotonic deadline
+_server_connect_failures: Dict[str, int] = {}        # name -> consecutive failures
+_CONNECT_RETRY_BASE_BACKOFF_SEC = 30.0
+_CONNECT_RETRY_MAX_BACKOFF_SEC = 600.0
+
+
+def _record_connect_failure(server_name: str) -> None:
+    """Stamp an exponential-backoff cooldown after a failed connect.
+
+    Called (under ``_lock``) when a server fails its discovery/connect
+    attempt. The cooldown grows geometrically with the consecutive
+    failure count and is capped at :data:`_CONNECT_RETRY_MAX_BACKOFF_SEC`,
+    so a permanently-broken server settles into infrequent retries
+    rather than a tight respawn loop.
+    """
+    n = _server_connect_failures.get(server_name, 0) + 1
+    _server_connect_failures[server_name] = n
+    backoff = min(
+        _CONNECT_RETRY_BASE_BACKOFF_SEC * (2 ** (n - 1)),
+        _CONNECT_RETRY_MAX_BACKOFF_SEC,
+    )
+    _server_connect_retry_after[server_name] = time.monotonic() + backoff
+
+
+def _clear_connect_failure(server_name: str) -> None:
+    """Clear the connect-cooldown state after a successful connection."""
+    _server_connect_failures.pop(server_name, None)
+    _server_connect_retry_after.pop(server_name, None)
+
+
+def _connect_cooldown_active(server_name: str) -> bool:
+    """Return True if ``server_name`` is still within its retry cooldown."""
+    deadline = _server_connect_retry_after.get(server_name)
+    return deadline is not None and time.monotonic() < deadline
+
 # Circuit breaker: consecutive error counts per server.  After
 # _CIRCUIT_BREAKER_THRESHOLD consecutive failures, the handler returns
 # a "server unreachable" message that tells the model to stop retrying,
@@ -5186,7 +5241,15 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         new_servers = {
             k: v
             for k, v in servers.items()
-            if k not in _servers and _parse_boolish(v.get("enabled", True), default=True)
+            if k not in _servers
+            and _parse_boolish(v.get("enabled", True), default=True)
+            # Skip a server still serving its post-failure backoff. Without
+            # this, a server that fails to connect (and is therefore never
+            # recorded in ``_servers``) would be re-spawned on every worker
+            # session's discovery pass -- the #50394 restart storm. The
+            # cooldown is cleared automatically on the next successful
+            # connect or by a manual /mcp refresh.
+            and not _connect_cooldown_active(k)
         }
         # Cached entries with no live session are parked or mid-reconnect.
         # Their tools are deregistered, so nothing else can reach
@@ -5235,6 +5298,11 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                 with _lock:
                     _server_connecting.discard(name)
                     _server_connect_errors[name] = message
+                    # Arm the per-server backoff so the next discovery pass
+                    # doesn't immediately re-spawn this failing server
+                    # (#50394). Isolated to this server -- healthy servers
+                    # in the same batch are unaffected.
+                    _record_connect_failure(name)
                 logger.warning(
                     "Failed to connect to MCP server '%s'%s: %s",
                     name,
@@ -5245,6 +5313,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                 with _lock:
                     _server_connecting.discard(name)
                     _server_connect_errors.pop(name, None)
+                    _clear_connect_failure(name)
 
     # Per-server timeouts are handled inside _discover_and_register_server.
     # The outer timeout is generous: 120s total for parallel discovery.
@@ -5728,6 +5797,11 @@ def shutdown_mcp_servers():
                 )
         with _lock:
             _servers.clear()
+            # Drop connect-retry cooldowns too: a full shutdown/restart
+            # should re-attempt every server immediately, not honour a
+            # stale per-server backoff from before the restart (#50394).
+            _server_connect_retry_after.clear()
+            _server_connect_failures.clear()
 
     with _lock:
         loop = _mcp_loop

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3584,6 +3584,16 @@ _SESSION_EXPIRED_MARKERS: tuple = (
 )
 
 
+def _exception_tree_contains_interruption(exc: BaseException) -> bool:
+    """Return whether ``exc`` or any nested exception is user cancellation."""
+    if isinstance(exc, InterruptedError):
+        return True
+    return any(
+        _exception_tree_contains_interruption(child)
+        for child in getattr(exc, "exceptions", ())
+    )
+
+
 def _is_session_expired_error(exc: BaseException) -> bool:
     """Return True if ``exc`` looks like an MCP transport session expiry.
 
@@ -3598,8 +3608,27 @@ def _is_session_expired_error(exc: BaseException) -> bool:
     ``streamablehttp_client`` + ``ClientSession`` pair, which is
     exactly what ``MCPServerTask._reconnect_event`` triggers.
     """
-    if isinstance(exc, InterruptedError):
+    if _exception_tree_contains_interruption(exc):
         return False
+
+    # AnyIO's stream exceptions are commonly message-less. In particular,
+    # ``str(ClosedResourceError()) == ""``, so marker matching alone misses the
+    # exact failure emitted by both MCP stdio and HTTP transports. Match the
+    # SDK's transport-closed exception types before inspecting text.
+    try:
+        from anyio import BrokenResourceError, ClosedResourceError, EndOfStream
+
+        if isinstance(exc, (BrokenResourceError, ClosedResourceError, EndOfStream)):
+            return True
+    except ImportError:  # pragma: no cover - AnyIO is supplied by the MCP SDK
+        pass
+
+    # AnyIO task groups can wrap the transport exception in an
+    # ExceptionGroup whose own string omits the message-less leaf details.
+    nested = getattr(exc, "exceptions", ())
+    if nested and any(_is_session_expired_error(child) for child in nested):
+        return True
+
     # Exception messages vary across SDK versions + server
     # implementations, so match on a small allow-list of stable
     # substrings rather than exception type.  Kept narrow to avoid
@@ -3677,10 +3706,10 @@ def _handle_session_expired_and_retry(
         try:
             parsed = json.loads(result)
             if "error" not in parsed:
-                _server_error_counts[server_name] = 0
+                _reset_server_error(server_name)
                 return result
         except (json.JSONDecodeError, TypeError):
-            _server_error_counts[server_name] = 0
+            _reset_server_error(server_name)
             return result
     except Exception as retry_exc:
         logger.warning(

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3583,6 +3583,15 @@ _SESSION_EXPIRED_MARKERS: tuple = (
     "end of file",
 )
 
+# Upper bound on exception-graph nodes inspected by
+# ``_is_session_expired_error``. The visited-identity set already breaks
+# cycles across ``exceptions`` / ``__cause__`` / ``__context__``; the
+# budget additionally bounds pathological acyclic graphs (e.g. deeply
+# chained retries) so classification always terminates promptly. Kept
+# comfortably above ``sys.getrecursionlimit()`` so legitimately deep
+# wrapper stacks (task-group nesting) are still fully scanned.
+_EXC_TRAVERSAL_MAX_NODES = 10_000
+
 
 def _is_session_expired_error(exc: BaseException) -> bool:
     """Return True if ``exc`` looks like an MCP transport session expiry.
@@ -3613,18 +3622,29 @@ def _is_session_expired_error(exc: BaseException) -> bool:
         transport_error_types = ()
 
     # ExceptionGroup trees can be arbitrarily deep or even cyclic when custom
-    # exceptions expose ``exceptions``. Traverse once, iteratively, and inspect
-    # every reachable node so user interruption always overrides transport
-    # markers or types found elsewhere in the graph.
-    stack = [exc]
+    # exceptions expose ``exceptions``, and chained exceptions
+    # (``raise X from Y`` / implicit ``__context__``) can likewise form
+    # cycles when handlers re-raise previously seen exceptions. Traverse
+    # once, iteratively, with an identity-visited set AND a bounded node
+    # budget so classification can never spin, and inspect every reachable
+    # node so user interruption always overrides transport markers or types
+    # found elsewhere in the graph. The chain traversal matters for real
+    # failures: SDK wrappers often raise a generic RuntimeError *from* the
+    # message-less ClosedResourceError, leaving the transport signal only
+    # reachable via ``__cause__``.
+    stack: "list[BaseException | None]" = [exc]
     seen: set[int] = set()
     transport_error_found = False
-    while stack:
+    budget = _EXC_TRAVERSAL_MAX_NODES
+    while stack and budget > 0:
         current = stack.pop()
+        if current is None:
+            continue
         identity = id(current)
         if identity in seen:
             continue
         seen.add(identity)
+        budget -= 1
 
         if isinstance(current, InterruptedError):
             return False
@@ -3640,6 +3660,8 @@ def _is_session_expired_error(exc: BaseException) -> bool:
             transport_error_found = True
 
         stack.extend(getattr(current, "exceptions", ()))
+        stack.append(getattr(current, "__cause__", None))
+        stack.append(getattr(current, "__context__", None))
 
     return transport_error_found
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3586,12 +3586,18 @@ _SESSION_EXPIRED_MARKERS: tuple = (
 
 def _exception_tree_contains_interruption(exc: BaseException) -> bool:
     """Return whether ``exc`` or any nested exception is user cancellation."""
-    if isinstance(exc, InterruptedError):
-        return True
-    return any(
-        _exception_tree_contains_interruption(child)
-        for child in getattr(exc, "exceptions", ())
-    )
+    stack = [exc]
+    seen: set[int] = set()
+    while stack:
+        current = stack.pop()
+        identity = id(current)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        if isinstance(current, InterruptedError):
+            return True
+        stack.extend(getattr(current, "exceptions", ()))
+    return False
 
 
 def _is_session_expired_error(exc: BaseException) -> bool:

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -223,15 +223,25 @@ def wait_for_mcp_discovery(timeout: "float | None" = None) -> None:
     CLI path via ``hermes_cli.mcp_startup``); ``timeout`` overrides it.
     """
     thread = _mcp_discovery_thread
-    if thread is None or not thread.is_alive():
-        return
-    try:
-        from hermes_cli.mcp_startup import _resolve_discovery_timeout
+    if thread is not None and thread.is_alive():
+        try:
+            from hermes_cli.mcp_startup import _resolve_discovery_timeout
 
-        bound = _resolve_discovery_timeout(timeout)
+            bound = _resolve_discovery_timeout(timeout)
+        except Exception:
+            bound = timeout if timeout is not None else 0.75
+        thread.join(timeout=bound)
+        return
+    # The stdio TUI spawns discovery via the shared owner (see main()); wait
+    # on it so the first agent build still catches fast servers.
+    try:
+        from hermes_cli.mcp_startup import (
+            wait_for_mcp_discovery as _startup_wait,
+        )
+
+        _startup_wait(timeout)
     except Exception:
-        bound = timeout if timeout is not None else 0.75
-    thread.join(timeout=bound)
+        pass
 
 
 def mcp_discovery_in_flight() -> bool:
@@ -328,29 +338,23 @@ def main():
         # discovery (still backgrounded, so it can't block startup).
         _has_mcp_servers = True
     if _has_mcp_servers:
-        def _discover_mcp_background() -> None:
-            try:
-                from hermes_cli.mcp_startup import (
-                    _discover_mcp_tools_without_interactive_oauth,
-                )
+        # Spawn via the shared owner in hermes_cli.mcp_startup instead of
+        # a hand-rolled thread, so the stdio TUI gets the same restart
+        # semantics as every other surface: a discovery run that completed
+        # with zero connected servers may be retried by a later spawn call
+        # instead of latching the process into a no-MCP-tools state.
+        # wait_for_mcp_discovery/mcp_discovery_in_flight/
+        # join_mcp_discovery below already consult that owner.
+        try:
+            from hermes_cli.mcp_startup import start_background_mcp_discovery
 
-                _discover_mcp_tools_without_interactive_oauth()
-            except Exception:
-                logger.warning(
-                    "Background MCP tool discovery failed", exc_info=True
-                )
-
-        import threading as _mcp_threading
-        _mcp_thread = _mcp_threading.Thread(
-            target=_discover_mcp_background,
-            name="tui-mcp-discovery",
-            daemon=True,
-        )
-        _mcp_thread.start()
-        # Publish the handle so the first agent build can briefly wait for
-        # already-spawning fast servers to land (see wait_for_mcp_discovery).
-        global _mcp_discovery_thread
-        _mcp_discovery_thread = _mcp_thread
+            start_background_mcp_discovery(
+                logger=logger, thread_name="tui-mcp-discovery"
+            )
+        except Exception:
+            logger.warning(
+                "Background MCP tool discovery failed to start", exc_info=True
+            )
 
     if not write_json({
         "jsonrpc": "2.0",

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -29,6 +29,17 @@ logger = logging.getLogger(__name__)
 # the agent snapshots its tool list (see wait_for_mcp_discovery).
 _mcp_discovery_thread = None
 
+# True once main() decided this TUI process has MCP servers configured and
+# spawned discovery through the shared owner. Lets wait_for_mcp_discovery
+# re-invoke the (idempotent) spawn on later agent builds so the
+# retry-after-zero-connected allowance in
+# hermes_cli.mcp_startup.start_background_mcp_discovery can actually fire for
+# the stdio TUI — without this, main()'s single spawn is the only call and a
+# first run that connected nothing latches the process MCP-less. Kept as a
+# flag (rather than re-probing config) so non-MCP sessions never pay the
+# tools.mcp_tool import on the per-agent-build wait path.
+_mcp_discovery_enabled = False
+
 
 def _install_sidecar_publisher() -> None:
     """Mirror every dispatcher emit to the dashboard sidebar via WS.
@@ -233,7 +244,22 @@ def wait_for_mcp_discovery(timeout: "float | None" = None) -> None:
         thread.join(timeout=bound)
         return
     # The stdio TUI spawns discovery via the shared owner (see main()); wait
-    # on it so the first agent build still catches fast servers.
+    # on it so the first agent build still catches fast servers. Re-invoke
+    # the idempotent spawn first: if the previous run finished with zero
+    # connected servers, start_background_mcp_discovery's
+    # retry-after-zero-connected allowance kicks off a fresh discovery run
+    # here instead of leaving the TUI latched MCP-less for the session.
+    if _mcp_discovery_enabled:
+        try:
+            from hermes_cli.mcp_startup import start_background_mcp_discovery
+
+            start_background_mcp_discovery(
+                logger=logger, thread_name="tui-mcp-discovery"
+            )
+        except Exception:
+            logger.debug(
+                "TUI MCP discovery retry-spawn failed", exc_info=True
+            )
     try:
         from hermes_cli.mcp_startup import (
             wait_for_mcp_discovery as _startup_wait,
@@ -345,6 +371,8 @@ def main():
         # instead of latching the process into a no-MCP-tools state.
         # wait_for_mcp_discovery/mcp_discovery_in_flight/
         # join_mcp_discovery below already consult that owner.
+        global _mcp_discovery_enabled
+        _mcp_discovery_enabled = True
         try:
             from hermes_cli.mcp_startup import start_background_mcp_discovery
 

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -249,17 +249,23 @@ def wait_for_mcp_discovery(timeout: "float | None" = None) -> None:
     # connected servers, start_background_mcp_discovery's
     # retry-after-zero-connected allowance kicks off a fresh discovery run
     # here instead of leaving the TUI latched MCP-less for the session.
-    if _mcp_discovery_enabled:
-        try:
-            from hermes_cli.mcp_startup import start_background_mcp_discovery
+    # Only the stdio TUI (which spawned discovery through the shared owner)
+    # should delegate to the startup wait here — for every other surface
+    # (dashboard /api/ws) _make_agent already calls
+    # hermes_cli.mcp_startup.wait_for_mcp_discovery directly, and delegating
+    # unconditionally would make that bounded wait run twice per agent build.
+    if not _mcp_discovery_enabled:
+        return
+    try:
+        from hermes_cli.mcp_startup import start_background_mcp_discovery
 
-            start_background_mcp_discovery(
-                logger=logger, thread_name="tui-mcp-discovery"
-            )
-        except Exception:
-            logger.debug(
-                "TUI MCP discovery retry-spawn failed", exc_info=True
-            )
+        start_background_mcp_discovery(
+            logger=logger, thread_name="tui-mcp-discovery"
+        )
+    except Exception:
+        logger.debug(
+            "TUI MCP discovery retry-spawn failed", exc_info=True
+        )
     try:
         from hermes_cli.mcp_startup import (
             wait_for_mcp_discovery as _startup_wait,


### PR DESCRIPTION
## Summary
Three MCP reliability fixes: failed stdio servers stop being re-spawned on every discovery pass (cooldown), message-less anyio ClosedResource/BrokenResource errors are classified correctly instead of bypassing the reconnect classifier, and background discovery can retry after a run that connected nothing (CLI latch + the TUI's own discovery thread).

Salvages #50589 by @trevorgordon981, #66547 by @diffen77, #66981 by @fazerluga-creator (authorship preserved).

## Changes
- `tools/mcp_tool.py`: stdio failure cooldown (#50589) + follow-up: cooldown state now resets on the empty-`_servers` shutdown fast path too
- Exception classifier handles message-less closed-transport types (#66547) + follow-up: cause/context traversal is cycle-guarded (visited set, bounded depth)
- `hermes_cli/mcp_startup.py`: one-shot latch allows retry after zero-connected runs (#66981) + follow-up: same allowance for the TUI discovery thread (`tui_gateway/entry.py`)

## Validation
Targeted MCP + startup + TUI-entry suites green (see per-file tests in the diff).

## Infographic

![mcp-discovery-classifier-fixes](https://v3b.fal.media/files/b/0aa3259a/hriiPwKU3hQ8RDexEpwOC_zwheL7ix.png)
