### PR TITLE
fix(desktop): stop model-switch markers duplicating user messages

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -327,6 +327,57 @@ describe('preserveLocalPendingTurnMessages', () => {
 
     expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
   })
+
+  // Issue #67603: the gateway persists model-switch markers as role=user
+  // (tui_gateway/server.py), so the authoritative transcript carries one more
+  // user row than the live view. Naive role-ordinal pairing then misses the
+  // committed copy of the optimistic turn and appends it again at the end —
+  // the duplicated user bubble at the bottom of the chat.
+  it('does not duplicate the optimistic turn when a stored [System:] marker shifts user ordinals', () => {
+    const previous = [
+      msg('1-user', 'user', 'first'),
+      msg('2-assistant', 'assistant', 'first answer'),
+      msg('user-optimistic', 'user', 'new question'),
+      msg('assistant-stream-1', 'assistant', 'partial answer', { pending: true })
+    ]
+
+    const next = [
+      msg('1-user-stored', 'user', 'first'),
+      msg('2-assistant-stored', 'assistant', 'first answer'),
+      msg(
+        '3-marker-stored',
+        'user',
+        '[System: The active model for this chat has changed to k3 via provider kimi. ' +
+          'From this point forward, use this runtime metadata when answering questions about what model/provider is active.]'
+      ),
+      msg('4-user-stored', 'user', 'new question'),
+      msg('5-assistant-stored', 'assistant', 'complete answer')
+    ]
+
+    expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
+  })
+
+  it('still keeps a genuinely uncommitted optimistic turn when a marker is present', () => {
+    const previous = [
+      msg('1-user', 'user', 'first'),
+      msg('2-assistant', 'assistant', 'first answer'),
+      msg('user-optimistic', 'user', 'new question')
+    ]
+
+    // Server projection lags: marker is persisted, the new turn is not.
+    const next = [
+      msg('1-user-stored', 'user', 'first'),
+      msg('2-assistant-stored', 'assistant', 'first answer'),
+      msg('3-marker-stored', 'user', '[System: The active model for this chat has changed to k3.]')
+    ]
+
+    expect(preserveLocalPendingTurnMessages(next, previous).map(message => message.id)).toEqual([
+      '1-user-stored',
+      '2-assistant-stored',
+      '3-marker-stored',
+      'user-optimistic'
+    ])
+  })
 })
 
 describe('appendLiveSessionProjection', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -234,7 +234,17 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
  * Authoritative rows use different ids, so match by role ordinal. A matching
  * user row is considered committed only when its visible text also matches;
  * any authoritative assistant at the same ordinal supersedes the local stream.
+ *
+ * Gateway bookkeeping markers (e.g. the model-switch notice written by
+ * tui_gateway/server.py) are persisted as role=user but are not user turns.
+ * They must not take part in ordinal pairing on either side: a stored marker
+ * between two real user turns shifts every later user ordinal, the optimistic
+ * row then misses its committed copy and is appended a second time at the end
+ * of the transcript — the duplicated user bubble of #67603.
  */
+const isGatewaySystemMarker = (message: ChatMessage): boolean =>
+  message.role === 'user' && chatMessageText(message).trimStart().startsWith('[System:')
+
 export function preserveLocalPendingTurnMessages(
   nextMessages: ChatMessage[],
   previousMessages: ChatMessage[]
@@ -247,6 +257,10 @@ export function preserveLocalPendingTurnMessages(
   const nextRoleCounts = new Map<ChatMessage['role'], number>()
 
   for (const message of nextMessages) {
+    if (isGatewaySystemMarker(message)) {
+      continue
+    }
+
     const ordinal = nextRoleCounts.get(message.role) ?? 0
     nextRoleCounts.set(message.role, ordinal + 1)
     nextByRoleOrdinal.set(`${message.role}:${ordinal}`, message)
@@ -257,6 +271,10 @@ export function preserveLocalPendingTurnMessages(
   const preserved: ChatMessage[] = []
 
   for (const message of previousMessages) {
+    if (isGatewaySystemMarker(message)) {
+      continue
+    }
+
     const ordinal = previousRoleCounts.get(message.role) ?? 0
     previousRoleCounts.set(message.role, ordinal + 1)
 


### PR DESCRIPTION
## Summary

Fixes #67603 — Desktop duplicates a user message and stacks the copy at the bottom of the chat after a mid-session model switch.

## Root cause

The gateway persists model-switch notices as `role=user` (`tui_gateway/server.py`, `_append_model_switch_marker`) — deliberately, because strict OpenAI-compatible providers reject non-leading system messages (#48338). The authoritative transcript therefore contains one more user row than the live renderer state.

`preserveLocalPendingTurnMessages` (`apps/desktop/src/app/session/hooks/use-session-actions/utils.ts`) pairs local optimistic rows with the authoritative transcript **by role ordinal** (`user:N`). A stored `[System:]` marker between two real user turns shifts every later user ordinal: the optimistic row (`user-<ts>`) no longer matches its committed copy (`nextByRoleOrdinal` returns the marker, text mismatch), so it is treated as uncommitted and appended **a second time** at the end of the transcript — exactly the reported "same user message rendered twice, stacked at the bottom". DB inspection confirms the transcript itself holds only one copy (reported in #67603 and reproduced independently on Windows, v0.19.0: 1 DB row + 1 stored `[System:]` marker in the affected session).

## Fix

Skip gateway bookkeeping markers (`role=user` rows whose text starts with `[System:`) when building the role-ordinal maps on **both** sides of the pairing, so ordinals count real user turns only. Sibling paths assessed: `reconcileResumeMessages` uses the same ordinal scheme but its grafts are guarded by exact text equality, so shifted user ordinals are benign there (user rows carry no reasoning parts); `preserveLocalAssistantErrors` matches by id/text, not ordinals.

## Test plan

- [x] New regression test reproduces #67603 exactly: stored transcript with a `[System:]` marker + live optimistic turn → **fails before** the fix (optimistic user row appended as duplicate), **passes after** (`toBe(next)`, nothing appended)
- [x] Companion test: a genuinely uncommitted optimistic turn is still kept when a marker is present (no over-correction)
- [x] `vitest run src/app/session/hooks/use-session-actions/utils.test.ts src/lib/chat-messages.test.ts` → 61/61 pass
- [x] `tsc -p . --noEmit` clean
- [x] Full desktop suite: only pre-existing environment-dependent failures (electron git-worktree-ops, packaging scripts, platform paths) — identical set fails on clean `main` without this change
