### PR TITLE
fix(desktop): add profile activation button to Profiles settings view

### DIFF
--- a/apps/desktop/src/app/profiles/index.test.tsx
+++ b/apps/desktop/src/app/profiles/index.test.tsx
@@ -8,12 +8,13 @@ import type { ProfileInfo } from '@/types/hermes'
 
 import { ProfilesView } from './index'
 
-// These tests pin the invariant this whole area exists to hold: the Manage
+// These tests pin the invariants this whole area exists to hold: the Manage
 // Profiles page and the sidebar rail share ONE set of profile dialogs, so both
 // "New Profile" entry points render the same modal (SOUL.md included), and
 // deleting the profile the gateway is on re-homes to default instead of
 // stranding it on a dead backend. The drift that motivated the fix got in
-// precisely because nothing rendered this view.
+// precisely because nothing rendered this view. The switch-to-profile button
+// tests pin the activation affordance added in #68667.
 
 afterEach(cleanup)
 
@@ -58,7 +59,7 @@ vi.mock('@/store/profile', () => ({
 }))
 
 // The one non-default profile these tests act on. Its name doubles as the row's
-// accessible name, so the delete helper queries by it rather than a literal.
+// accessible name, so the helpers query by it rather than a literal.
 const NAMED_PROFILE = 'work'
 
 function makeProfile(name: string, isDefault = false): ProfileInfo {
@@ -85,10 +86,12 @@ function realClick(el: HTMLElement) {
 // so the first paint is the loader and the rows commit a microtask later. Flush
 // that inside act() so the rows exist before anything queries them, and so the
 // mount setState isn't left unwrapped.
-async function renderProfilesView() {
+async function renderProfilesView(onClose = vi.fn()) {
   await act(async () => {
-    render(<ProfilesView onClose={vi.fn()} />)
+    render(<ProfilesView onClose={onClose} />)
   })
+
+  return onClose
 }
 
 // PanelListRow labels BOTH the row's select target and its kebab with the
@@ -109,6 +112,21 @@ async function deleteTheNamedProfile() {
   await act(async () => {
     fireEvent.click(confirm)
   })
+}
+
+// The row's select target is the plain RowButton (data-slot="row-button", no
+// aria-expanded), while the kebab trigger is a menu button carrying the same
+// accessible name. Disambiguate by slot rather than by name/expanded.
+function selectNamedProfileRow() {
+  const rowButton = screen
+    .getAllByRole('button', { name: NAMED_PROFILE })
+    .find(button => button.closest('[data-slot="row-button"]'))
+
+  if (!rowButton) {
+    throw new Error(`No row button found for profile "${NAMED_PROFILE}"`)
+  }
+
+  fireEvent.click(rowButton)
 }
 
 describe('ProfilesView', () => {
@@ -151,5 +169,40 @@ describe('ProfilesView', () => {
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull())
     expect(selectProfile).not.toHaveBeenCalled()
     expect(setActiveProfile).not.toHaveBeenCalled()
+  })
+
+  it('renders "Switch to <name>" for an inactive profile and activates it on click', async () => {
+    vi.mocked(refreshProfiles).mockResolvedValue([makeProfile('default', true), makeProfile(NAMED_PROFILE)])
+    activeGateway.set('default')
+    const onClose = vi.fn()
+
+    await renderProfilesView(onClose)
+    selectNamedProfileRow()
+
+    const switchButton = await screen.findByRole('button', { name: `Switch to ${NAMED_PROFILE}` })
+    expect(switchButton).toBeTruthy()
+
+    fireEvent.click(switchButton)
+
+    expect(selectProfile).toHaveBeenCalledWith(NAMED_PROFILE)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('omits the switch button when viewing the currently active profile', async () => {
+    vi.mocked(refreshProfiles).mockResolvedValue([makeProfile('default', true), makeProfile(NAMED_PROFILE)])
+    activeGateway.set(NAMED_PROFILE)
+
+    await renderProfilesView()
+    selectNamedProfileRow()
+
+    // Confirm the detail panel actually switched to the named profile — its
+    // header is an h3 with the profile name. Without this, the absence query
+    // below would pass even if the row click never landed (the panel would
+    // still show "default", whose switch button says "Switch to default").
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 3, name: NAMED_PROFILE })).toBeTruthy()
+    })
+
+    expect(screen.queryByRole('button', { name: `Switch to ${NAMED_PROFILE}` })).toBeNull()
   })
 })

--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -9,11 +9,11 @@ import { Codicon } from '@/components/ui/codicon'
 import { getProfileSoul, type ProfileInfo, updateProfileSoul } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { displayPath } from '@/lib/display-path'
-import { AlertTriangle, Save } from '@/lib/icons'
+import { AlertTriangle, LogIn, Save } from '@/lib/icons'
 import { profileColorSoft, resolveProfileColor } from '@/lib/profile-color'
 import { normalize } from '@/lib/text'
 import { notify, notifyError } from '@/store/notifications'
-import { $profileColors, refreshProfiles } from '@/store/profile'
+import { $activeGatewayProfile, $profileColors, normalizeProfileKey, refreshProfiles, selectProfile } from '@/store/profile'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import {
@@ -48,6 +48,7 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
   const [createOpen, setCreateOpen] = useState(false)
   const [pendingRename, setPendingRename] = useState<null | ProfileInfo>(null)
   const [pendingDelete, setPendingDelete] = useState<null | ProfileInfo>(null)
+  const gatewayProfile = useStore($activeGatewayProfile)
 
   const refresh = useCallback(async () => {
     try {
@@ -152,7 +153,12 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
             </PanelList>
 
             {selected ? (
-              <ProfileDetail key={selected.name} profile={selected} />
+              <ProfileDetail
+                isActive={normalizeProfileKey(selected.name) === normalizeProfileKey(gatewayProfile)}
+                key={selected.name}
+                onClose={onClose}
+                profile={selected}
+              />
             ) : (
               <PanelEmpty description={p.selectPrompt} icon="account" />
             )}
@@ -246,7 +252,15 @@ function ProfileGlyph({ color, isDefault, name }: { color: null | string; isDefa
   )
 }
 
-function ProfileDetail({ profile }: { profile: ProfileInfo }) {
+function ProfileDetail({
+  isActive,
+  onClose,
+  profile
+}: {
+  isActive: boolean
+  onClose: () => void
+  profile: ProfileInfo
+}) {
   const { t } = useI18n()
   const p = t.profiles
 
@@ -266,6 +280,19 @@ function ProfileDetail({ profile }: { profile: ProfileInfo }) {
             {displayPath(profile.path)}
           </p>
         </div>
+
+        {!isActive && (
+          <Button
+            onClick={() => {
+              selectProfile(profile.name)
+              onClose()
+            }}
+            size="sm"
+          >
+            <LogIn />
+            {p.switchToProfile(profile.name)}
+          </Button>
+        )}
 
         <PanelMeta
           rows={[


### PR DESCRIPTION
## Summary

Add a "Switch to \<name\>" button in the **ProfileDetail** panel of the Profiles settings page, so users can activate a profile directly from the management view without needing to discover the sidebar ProfileRail.

Fixes #39971

## Why

The Profiles page (`/profiles`) lets users create, rename, delete profiles, and edit their SOUL.md — but there's no way to **switch** to a profile from there. Users must go back to the sidebar's ProfileRail (colored squares at the bottom) to change the active profile. This is unintuitive, especially for users who navigate to Profiles specifically to manage their setup.

## Changes

**File:** `apps/desktop/src/app/profiles/index.tsx` (+31 lines, −4 lines)

- Import `LogIn` icon and `$activeGatewayProfile`, `normalizeProfileKey`, `selectProfile` from the profile store
- In `ProfilesView`, read the current active gateway profile via `useStore($activeGatewayProfile)`
- Pass `isActive` and `onClose` props to `ProfileDetail`
- In `ProfileDetail`, render a primary "Switch to \<name\>" button (using the existing `switchToProfile` i18n key) when the viewed profile is not the current active one
- Clicking the button calls `selectProfile(name)` and closes the overlay, landing the user on a fresh chat in the selected profile

## Behavior

| Scenario | Button shown? |
|----------|--------------|
| Viewing the currently active profile | No |
| Viewing a different profile | Yes — primary button with "Switch to \<name\>" |

## Verification

- `npx eslint src/app/profiles/index.tsx` — 0 errors
- `npx tsc --noEmit` — no new errors (pre-existing type mismatch in `incremental-external-store-runtime.ts`)
- `npm run build` — succeeds
- `npx vitest run src/store/profile.test.ts` — 11/11 passed

## Notes

- Uses `selectProfile()` (not `switchProfile()`) — the same function used by the sidebar profile switcher, which handles session refresh and gateway activation correctly.
- The row click behavior is unchanged — it still selects the profile for the detail panel. The activation is an explicit button click to prevent accidental session refreshes when browsing profile details.
- PR #41818 proposed the same fix but was based on an older code structure (OverlaySplitLayout). This PR adapts to the current Panel-based UI.