### PR TITLE
fix(kanban): reject reason-shaped positionals in unblock before mutating

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -18,6 +18,7 @@ import argparse
 import contextlib
 import json
 import os
+import re
 import shlex
 import sys
 import time
@@ -2141,10 +2142,45 @@ def _cmd_schedule(args: argparse.Namespace) -> int:
     return 0 if not failed else 1
 
 
+# Task ids are ``t_`` + hex (see kanban_db._new_task_id). Length is left
+# unconstrained on purpose: ids have been 4, 8 and 12 hex chars across
+# versions, and a length rule would make tasks created by an older Hermes
+# unreachable. The shape alone is enough to tell an id from a reason phrase.
+_TASK_ID_SHAPE_RE = re.compile(r"^t_[0-9a-fA-F]+$")
+
+
+def _reject_non_task_ids(ids: list[str], command: str) -> bool:
+    """Print guidance and return True when any argument isn't a task id.
+
+    ``block`` takes its reason positionally while ``unblock`` requires
+    ``--reason`` (bulk syntax owns the positionals), so passing the reason
+    positionally to ``unblock`` is an easy mistake for humans and agents
+    alike. Caught before the first write, the command is a no-op instead of
+    partially mutating whichever ids happened to sort after the bad one.
+    """
+    bad = [tid for tid in ids if not _TASK_ID_SHAPE_RE.match(tid)]
+    if not bad:
+        return False
+    for tid in bad:
+        print(f"not a task id: {tid!r}", file=sys.stderr)
+    good = [tid for tid in ids if _TASK_ID_SHAPE_RE.match(tid)]
+    if len(bad) == 1 and good:
+        # The classic shape: one reason phrase followed by real ids.
+        print(
+            f"Did you mean: hermes kanban {command} --reason {bad[0]!r} "
+            + " ".join(good),
+            file=sys.stderr,
+        )
+    print("No tasks were modified.", file=sys.stderr)
+    return True
+
+
 def _cmd_unblock(args: argparse.Namespace) -> int:
     ids = list(args.task_ids or [])
     if not ids:
         print("at least one task_id is required", file=sys.stderr)
+        return 1
+    if _reject_non_task_ids(ids, "unblock"):
         return 1
     reason = getattr(args, "reason", None)
     if reason is not None:

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -565,3 +565,85 @@ def test_run_slash_board_override_does_not_change_boards_show_current(kanban_hom
     out = kc.run_slash("--board beta boards show")
 
     assert "Current board: alpha" in out
+
+
+# ---------------------------------------------------------------------------
+# unblock: reject reason-looking positional args before mutating anything
+# ---------------------------------------------------------------------------
+
+
+def _blocked_task(title: str = "real task") -> str:
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title=title)
+        kb.block_task(conn, tid, reason="waiting")
+    return tid
+
+
+def test_unblock_rejects_reason_shaped_positional_without_mutating(kanban_home, capsys):
+    """A reason passed positionally must not be treated as a task id.
+
+    ``block`` takes its reason positionally while ``unblock`` requires
+    ``--reason``, so this is an easy mistake. Previously the phrase was
+    treated as an id and the command still unblocked whichever real ids
+    followed it — a partial mutation the user never asked for.
+    """
+    tid = _blocked_task()
+
+    rc = kc._cmd_unblock(
+        argparse.Namespace(task_ids=["skill external_dirs fixed; retry review", tid], reason=None)
+    )
+
+    assert rc == 1
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, tid).status == "blocked", "the valid id must NOT be unblocked"
+
+    err = capsys.readouterr().err
+    assert "not a task id" in err
+    assert "--reason" in err, "should point at the correct syntax"
+    assert "No tasks were modified" in err
+
+
+def test_unblock_with_reason_flag_no_longer_raises_on_bad_positional(kanban_home):
+    """With ``--reason`` set, the pre-check also prevents an unhandled crash.
+
+    ``add_comment`` raises ValueError for an unknown task, so the bad
+    positional used to escape as a traceback before any id was processed.
+    """
+    tid = _blocked_task()
+
+    rc = kc._cmd_unblock(argparse.Namespace(task_ids=["some reason text", tid], reason="a note"))
+
+    assert rc == 1
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_unblock_still_works_for_valid_ids(kanban_home):
+    """The guard must not get in the way of the normal path, single or bulk."""
+    first, second = _blocked_task("one"), _blocked_task("two")
+
+    rc = kc._cmd_unblock(argparse.Namespace(task_ids=[first, second], reason="done waiting"))
+
+    assert rc == 0
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, first).status in {"ready", "todo"}
+        assert kb.get_task(conn, second).status in {"ready", "todo"}
+
+
+def test_unblock_accepts_legacy_short_task_ids(kanban_home):
+    """Ids have been 4, 8 and 12 hex chars across versions.
+
+    The guard checks shape, not length, so a task created by an older
+    Hermes stays reachable. A length rule would strand those tasks.
+    """
+    with kb.connect_closing() as conn:
+        legacy = "t_abcd"  # 2-hex-byte era
+        conn.execute(
+            "INSERT INTO tasks (id, title, status, created_at) VALUES (?,?,?,?)",
+            (legacy, "legacy", "blocked", 0),
+        )
+        conn.commit()
+
+    rc = kc._cmd_unblock(argparse.Namespace(task_ids=[legacy], reason=None))
+
+    assert rc == 0, "a legacy short id must not be rejected as malformed"


### PR DESCRIPTION
## What does this PR do?

Fixes the sharp edge reported in #68613: `hermes kanban unblock` treats a reason-looking positional argument as a task id and partially mutates state.

`block` takes its reason positionally, while `unblock` reserves the positionals for bulk ids and requires `--reason`. Passing the reason positionally to `unblock` is therefore an easy mistake — and because ids were validated only by attempting the write, the command mutated as it iterated.

While reproducing it I found the failure is worse than reported, and depends on whether `--reason` is set:

**Without `--reason`** — the reported behaviour. The bad argument errors, then the real ids are unblocked anyway:

```
cannot unblock some reason text (not blocked/scheduled?)
Unblocked t_d23f4470          <- mutated despite the invalid argument
```

**With `--reason`** — an unhandled traceback. `add_comment` raises `ValueError` for an unknown task, so the bad positional escapes before any id is processed:

```
ValueError: unknown task skill external_dirs fixed; retry review
```

Both paths now fail fast, before the first write:

```
not a task id: 'skill external_dirs fixed; retry review'
Did you mean: hermes kanban unblock --reason 'skill external_dirs fixed; retry review' t_e17f5dd2
No tasks were modified.
```

This is the first option the reporter suggested ("fail fast before mutating any later valid ids"), plus the targeted hint they offered as an alternative. Bulk syntax and `--reason` are unchanged.

## Related Issue

Fixes #68613

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban.py` — add `_TASK_ID_SHAPE_RE` and `_reject_non_task_ids()`; call it from `_cmd_unblock` before opening the connection.
- `tests/hermes_cli/test_kanban_cli.py` — 4 tests: the reported no-`--reason` path, the `--reason` traceback path, the normal single/bulk path still working, and a legacy short id still being accepted.

### One design note

The check is deliberately **shape-only** — `t_` followed by hex, any length — rather than reusing the `t_[a-f0-9]{8,}` pattern in `kanban_db._TASK_ID_PROSE_RE`.

`_new_task_id` has generated 2-hex-byte ids historically and `kanban_create` uses 12, so a minimum-length rule would classify tasks created by an older Hermes as malformed and make them permanently un-unblockable. Shape alone is enough to separate an id from a reason phrase, and there's a test pinning that (`test_unblock_accepts_legacy_short_task_ids`).

`block` is not affected — its reason is a positional it consumes itself.

## How to Test

```bash
# Given a blocked task t_<hex>:
hermes kanban unblock "some reason text" t_<hex>
```

**Before:** the real task is unblocked anyway (or, with `--reason`, a `ValueError` traceback).
**After:** exit 1, nothing modified, and the corrected command is suggested.

Tests:

```bash
pytest tests/hermes_cli/test_kanban_cli.py -k unblock -q          # 5 passed
git stash push hermes_cli/kanban.py                                # remove the fix
pytest tests/hermes_cli/test_kanban_cli.py -k unblock -q          # 2 failed (one via the ValueError)
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (1 commit, 2 files)
- [x] I've added tests for my changes, and verified they fail without the fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **see note**

### Note on the test run

I didn't complete a full `pytest tests/ -q` locally — it was still at 17% after ten minutes on this machine and already showed failures unrelated to this change, so a raw count from it wouldn't have been meaningful.

Instead, the kanban suites run against a clean `main` for comparison:

```
tests/hermes_cli/test_kanban_cli.py
tests/hermes_cli/test_kanban_db.py
tests/hermes_cli/test_kanban_block_kinds.py
tests/hermes_cli/test_kanban_core_functionality.py
tests/hermes_cli/test_kanban_blocked_sticky.py

main (0.19.0):  467 passed, 0 failed
this branch:    471 passed, 0 failed   (+4 = the new tests)
```

Happy to run anything more specific.
