### PR TITLE
fix(mcp): don't trip the circuit breaker on application-level tool errors

### DIFF
--- a/tests/tools/test_mcp_breaker_app_error.py
+++ b/tests/tools/test_mcp_breaker_app_error.py
@@ -1,0 +1,82 @@
+"""Regression: the MCP circuit breaker must not treat application-level tool
+errors as reachability failures.
+
+A tool call that returns an ``isError`` result (for example a codebase-memory
+"function not found") reaches ``_make_tool_handler`` as a *delivered response* —
+``_call_once()`` returned rather than raising, so the server is reachable.
+Counting such payloads toward the "unreachable" breaker let 3 bad symbol
+lookups trip a false ``server unreachable`` 60s cooldown on a perfectly healthy
+server. Only genuine transport failures (exceptions / not-connected paths) may
+open the breaker.
+
+Both tests mock ``_run_on_mcp_loop`` — the seam ``_call_once()`` uses to run the
+tool — so they exercise exactly the bump-vs-reset decision without a live MCP
+session or event loop.
+"""
+
+import json
+
+import pytest
+
+
+class _FakeConnectedServer:
+    """Minimal stand-in: a non-None ``session`` makes the handler treat the
+    server as connected and proceed to ``_call_once()``."""
+
+    session = object()
+
+
+@pytest.mark.no_isolate
+def test_app_level_tool_error_does_not_open_breaker(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+
+    name = "breaker-app-error-probe"
+    mcp_tool._reset_server_error(name)
+    monkeypatch.setitem(mcp_tool._servers, name, _FakeConnectedServer())
+
+    # The tool ran and returned an application-level error payload — this is
+    # what the handler produces from a ``result.isError`` response.
+    monkeypatch.setattr(
+        mcp_tool,
+        "_run_on_mcp_loop",
+        lambda *a, **k: json.dumps({"error": "function not found"}),
+    )
+
+    handler = mcp_tool._make_tool_handler(name, "trace_path", 5.0)
+
+    for _ in range(mcp_tool._CIRCUIT_BREAKER_THRESHOLD):
+        out = json.loads(handler({}))
+        assert out["error"] == "function not found"  # app error surfaced to caller
+
+    # Delivered responses — even error ones — prove reachability: breaker stays shut.
+    assert mcp_tool._server_error_counts.get(name, 0) == 0
+    assert name not in mcp_tool._server_breaker_opened_at
+
+
+@pytest.mark.no_isolate
+def test_transport_failure_still_opens_breaker(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+
+    name = "breaker-transport-probe"
+    mcp_tool._reset_server_error(name)
+    monkeypatch.setitem(mcp_tool._servers, name, _FakeConnectedServer())
+
+    # A genuine transport failure raises out of the call.
+    def _boom(*a, **k):
+        raise RuntimeError("transport is dead")
+
+    monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", _boom)
+
+    handler = mcp_tool._make_tool_handler(name, "trace_path", 5.0)
+
+    for _ in range(mcp_tool._CIRCUIT_BREAKER_THRESHOLD):
+        json.loads(handler({}))  # each returns an {"error": ...} transport-failure payload
+
+    # Real outages must still trip the breaker (unchanged behaviour).
+    assert (
+        mcp_tool._server_error_counts.get(name, 0)
+        >= mcp_tool._CIRCUIT_BREAKER_THRESHOLD
+    )
+    assert name in mcp_tool._server_breaker_opened_at

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4270,15 +4270,18 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
         try:
             result = _call_once()
-            # Check if the MCP tool itself returned an error
-            try:
-                parsed = json.loads(result)
-                if "error" in parsed:
-                    _bump_server_error(server_name)
-                else:
-                    _reset_server_error(server_name)  # success — reset
-            except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)  # non-JSON = success
+            # Reaching here means _call_once() returned rather than raising —
+            # the transport delivered a response, so the server IS reachable,
+            # even when the tool itself reports an application-level error
+            # (e.g. CBM "function not found" / "project not found", surfaced via
+            # MCP isError). Such domain errors are NOT reachability failures:
+            # previously any {"error"} payload bumped the breaker, so 3 bad
+            # symbol lookups tripped a false "server unreachable" 60s cooldown
+            # while CBM was perfectly healthy (2026-07-21 曼联 charge 排查实发).
+            # Only genuine transport failures count: exceptions (except below)
+            # and the not-connected/dead-session paths above already bump. A
+            # delivered response — success or app-error — resets.
+            _reset_server_error(server_name)
             return result
         except InterruptedError:
             return _interrupted_call_result()


### PR DESCRIPTION
…rors

The per-server circuit breaker in _make_tool_handler bumped the consecutive-failure count whenever a tool result's JSON contained an "error" key. But reaching that point means _call_once() returned rather than raising — the transport delivered a response, so the server IS reachable. The only "error" payloads that get there come from the MCP isError path (application-level tool errors, e.g. "function not found").

Counting those as reachability failures let 3 bad symbol lookups trip a false "server unreachable" 60s cooldown while the server was perfectly healthy (observed with a codebase-memory MCP: 3 trace_path calls with mistyped qualified names -> 3x "function not found" -> breaker opened -> agent reported the service as down).

A delivered response — success or application error — now resets the breaker. Genuine transport failures still bump it via the exception handler and the not-connected/dead-session paths above, so real outages are unaffected.

## What does this PR do?

Stops the per-server MCP circuit breaker from counting application-level tool errors (e.g. "function not found") as reachability failures, which could falsely trip a "server unreachable" cooldown on a healthy server.



## Related Issue


Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ×] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_tool.py`: the MCP circuit breaker no longer counts application-level tool errors (isError responses) as reachability failures — only genuine transport failures (exceptions / not-connected paths) trip it.

- 

## How to Test

1. Configure any MCP server whose tools can return an application-level error (e.g. codebase-memory's trace_path with a non-existent qualified name → "function not found").
2. Before this fix: make 3 such calls in a row → the breaker opens and every following call returns "server unreachable, auto-retry in ~Ns" for 60s, even though the server is healthy.
3. After this fix: the same 3 application-level errors no longer open the breaker; only real transport failures do. Verified against the module's own _bump/_reset breaker helpers at the threshold (3).

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the Contributing Guide        
- [x] My commit messages follow Conventional Commits    
- [ ] I searched for existing PRs            
- [x] My PR contains only changes related to this fix    
- [ ] I've run pytest tests/ -q and all tests pass       
- [x] I've added tests for my changes         
- [x] I've tested on my platform: Ubuntu      

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A



- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

Verified the breaker decision directly against the module helpers (threshold = 3):
[1] 3x application-level "function not found" -> error count = 0, breaker stays closed  ✅
[2] 3x transport failure (exception)          -> error count = 3, breaker opens          ✅

