### PR TITLE
feat(background-review): surface unified diff preview in self-improvement summary

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -281,10 +281,17 @@ def summarize_background_review_actions(
             continue
         message = data.get("message", "")
         target = data.get("target", "")
+        diff_preview = data.get("diff_preview", "")
         if "created" in message.lower():
-            actions.append(message)
+            action = message
+            if diff_preview:
+                action = f"{message}\n{diff_preview}"
+            actions.append(action)
         elif "updated" in message.lower():
-            actions.append(message)
+            action = message
+            if diff_preview:
+                action = f"{message}\n{diff_preview}"
+            actions.append(action)
         elif "added" in message.lower() or (target and "add" in message.lower()):
             label = "Memory" if target == "memory" else "User profile" if target == "user" else target
             actions.append(f"{label} updated")
@@ -294,6 +301,13 @@ def summarize_background_review_actions(
         elif "removed" in message.lower() or "replaced" in message.lower():
             label = "Memory" if target == "memory" else "User profile" if target == "user" else target
             actions.append(f"{label} updated")
+        elif "patched" in message.lower() or "written" in message.lower():
+            # skill_manage patch/create/edit/write_file — surface the diff
+            # so the user can see what actually changed, not just a count.
+            action = message
+            if diff_preview:
+                action = f"{message}\n{diff_preview}"
+            actions.append(action)
     return actions
 
 

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -313,3 +313,59 @@ def test_background_review_fork_skips_external_memory_plugins(monkeypatch):
         "the fork leaks harness prompts into the user's real memory "
         "namespace via on_turn_start / prefetch_all / sync_all."
     )
+
+
+def test_background_review_surfaces_diff_preview_for_skill_patches():
+    """Skill patch/create/edit actions must include a diff preview.
+
+    Users complained that the self-improvement summary only showed
+    "Patched SKILL.md in skill 'X' (1 replacement)" with no indication
+    of what actually changed.  The skill_manage tool now returns a
+    ``diff_preview`` field in its result JSON; summarize_background_review_actions
+    must surface that diff alongside the action message.
+    """
+    import json
+
+    from agent.background_review import summarize_background_review_actions
+
+    review_messages = [
+        {
+            "role": "tool",
+            "tool_call_id": "call_patch",
+            "content": json.dumps({
+                "success": True,
+                "message": "Patched SKILL.md in skill 'my-skill' (1 replacement).",
+                "diff_preview": "--- a/SKILL.md\n+++ b/SKILL.md\n@@ -1,3 +1,3 @@\n-old line\n+new line\n",
+            }),
+        },
+    ]
+
+    actions = summarize_background_review_actions(review_messages, prior_snapshot=[])
+
+    assert len(actions) == 1, actions
+    action = actions[0]
+    assert "Patched SKILL.md in skill 'my-skill'" in action
+    assert "new line" in action, "diff_preview must be surfaced in the action summary"
+    assert "-old line" in action, "removed lines must appear in the diff"
+
+
+def test_background_review_memory_actions_have_no_diff_preview():
+    """Memory actions without diff_preview must still work (backward compat)."""
+    import json
+
+    from agent.background_review import summarize_background_review_actions
+
+    review_messages = [
+        {
+            "role": "tool",
+            "tool_call_id": "call_mem",
+            "content": json.dumps({
+                "success": True,
+                "message": "Entry added",
+                "target": "memory",
+            }),
+        },
+    ]
+
+    actions = summarize_background_review_actions(review_messages, prior_snapshot=[])
+    assert actions == ["Memory updated"]

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -111,6 +111,41 @@ SKILLS_DIR = HERMES_HOME / "skills"
 MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
 
+# Cap on the unified-diff preview returned in tool results so the
+# background-review summary stays compact (issue: user wants to see
+# what changed, not just "1 replacement").
+_DIFF_PREVIEW_MAX_CHARS = 600
+
+
+def _build_diff_preview(
+    original: str,
+    updated: str,
+    label: str = "SKILL.md",
+) -> str:
+    """Return a compact unified-diff preview of a skill-file edit.
+
+    Returns an empty string when there is no original (new file) or
+    when the diff would exceed ``_DIFF_PREVIEW_MAX_CHARS`` (truncated
+    with a ``… (truncated)`` marker).
+    """
+    import difflib
+
+    if original is None:
+        original = ""
+    if original == updated:
+        return ""
+    diff_lines = list(difflib.unified_diff(
+        original.splitlines(keepends=True),
+        updated.splitlines(keepends=True),
+        fromfile=f"a/{label}",
+        tofile=f"b/{label}",
+        n=1,
+    ))
+    diff = "".join(diff_lines)
+    if len(diff) > _DIFF_PREVIEW_MAX_CHARS:
+        diff = diff[:_DIFF_PREVIEW_MAX_CHARS].rstrip() + "\n… (truncated)"
+    return diff
+
 
 def _containing_skills_root(skill_path: Path) -> Path:
     """Return the skills root directory (local or external_dirs entry) that
@@ -529,6 +564,7 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
         "message": f"Skill '{name}' created.",
         "path": str(skill_dir.relative_to(SKILLS_DIR)),
         "skill_md": str(skill_md),
+        "diff_preview": _build_diff_preview(None, content, "SKILL.md"),
     }
     if category:
         result["category"] = category
@@ -557,7 +593,6 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     # Back up original content for rollback
     original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
     _atomic_write_text(skill_md, content)
-
     # Security scan — roll back on block
     scan_error = _security_scan_skill(existing["path"])
     if scan_error:
@@ -569,6 +604,7 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
         "success": True,
         "message": f"Skill '{name}' updated.",
         "path": str(existing["path"]),
+        "diff_preview": _build_diff_preview(original_content, content, "SKILL.md"),
     }
 
 
@@ -660,9 +696,11 @@ def _patch_skill(
         _atomic_write_text(target, original_content)
         return {"success": False, "error": scan_error}
 
+    target_label = "SKILL.md" if not file_path else file_path
     return {
         "success": True,
         "message": f"Patched {'SKILL.md' if not file_path else file_path} in skill '{name}' ({match_count} replacement{'s' if match_count > 1 else ''}).",
+        "diff_preview": _build_diff_preview(original_content, new_content, target_label),
     }
 
 
@@ -772,6 +810,7 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
         "success": True,
         "message": f"File '{file_path}' written to skill '{name}'.",
         "path": str(target),
+        "diff_preview": _build_diff_preview(original_content, file_content, file_path),
     }
 
 


### PR DESCRIPTION
## What does this PR do?

The self-improvement review summary only showed action counts like `Patched SKILL.md in skill X (1 replacement)` with no indication of what actually changed — users had no way to see what the background review agent modified in their skills.

This PR surfaces a compact unified-diff preview alongside the action message, so the user can immediately see what was added/removed without digging into the skill files.

**Before:**
```
💾 Self-improvement review: Patched SKILL.md in skill prd-quality-review (1 replacement)
```

**After:**
```
💾 Self-improvement review: Patched SKILL.md in skill prd-quality-review (1 replacement).
--- a/SKILL.md
+++ b/SKILL.md
@@ -42,7 +42,7 @@
-- 需求背景/功能/验收条件为段落（非 bullet）
+- 需求背景/功能/验收条件为段落，关联 FR/优先级为 bullet
```

## Related Issue

No existing issue — discovered during user feedback that the summary was opaque.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/skill_manager_tool.py`: Added `_build_diff_preview()` helper (compact unified diff via `difflib`, truncated to 600 chars with `… (truncated)` marker) and `diff_preview` field in the result JSON of all 4 write actions: `patch`, `create`, `edit`, `write_file`.
- `agent/background_review.py`: `summarize_background_review_actions()` now reads `diff_preview` from tool results and appends it to the action string for skill-manage actions (`created`/`updated`/`patched`/`written`). Memory actions without `diff_preview` are unaffected (backward compat).
- `tests/run_agent/test_background_review.py`: 2 new tests — `test_background_review_surfaces_diff_preview_for_skill_patches` verifies a patch action surfaces the diff (`-old line`/`+new line` appear in the summary), `test_background_review_memory_actions_have_no_diff_preview` verifies memory-only actions still produce `"Memory updated"`.

## How to Test

1. `venv/bin/python -m pytest tests/run_agent/test_background_review.py tests/tools/test_skill_manager_tool.py -o "addopts=" -q` → 97 passed
2. Trigger a background review that patches a skill (any session where the review agent updates a skill) and verify the `💾 Self-improvement review:` line now includes the unified diff
3. Verify memory-only reviews still show `Memory updated` without any diff

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run `pytest tests/ -q` and all tests pass (97 passed for the two relevant test files)
- [x] I have added tests for my changes (2 new tests)
- [x] I have tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I have updated relevant documentation — N/A (internal behavior change, no new config keys or user-facing commands)
- [x] I have updated `cli-config.yaml.example` — N/A (no new config keys)
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture or workflow changes)
- [x] I have considered cross-platform impact — N/A (pure Python stdlib `difflib`, no platform-specific code)
- [x] I have updated tool descriptions/schemas — N/A (no tool schema changes, `diff_preview` is an additive field in the result JSON that the background review consumer reads internally)

## Screenshots / Logs

```
$ venv/bin/python -m pytest tests/run_agent/test_background_review.py tests/tools/test_skill_manager_tool.py -o addopts= -q
97 passed, 1 warning in 2.34s
```