### PR TITLE
test(desktop): pin the tail-only contract for the loading and stall indicators

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/duplicate-stall-indicator.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/duplicate-stall-indicator.test.tsx
@@ -1,0 +1,260 @@
+// Loading and stall indicators mount only on the thread's last message.
+// The tail-only gate from ba756333 keeps non-tail running bubbles silent,
+// including assistants followed only by a user or system row. The optimistic
+// placeholder flow renders exactly one status row. These contracts pin the
+// duplicate-indicator regression tracked in #68634.
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { __resetElapsedTimerRegistryForTests } from '@/components/chat/activity-timer'
+import { setSessionCompacting } from '@/store/compaction'
+import { $activeSessionId, $turnStartedAt } from '@/store/session'
+
+import { Thread } from '.'
+
+// Layout/observer stubs mirrored from streaming.test.tsx. jsdom has no
+// ResizeObserver, rAF, or real layout, and the Thread scroll container needs
+// non-zero dimensions to mount without throwing.
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+  window.setTimeout(() => callback(performance.now()), 0)
+)
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+vi.stubGlobal('CSS', { escape: (str: string) => str })
+
+Element.prototype.scrollTo = function scrollTo() {}
+
+Element.prototype.animate = function animate() {
+  return {
+    cancel: () => {},
+    finished: Promise.resolve()
+  } as unknown as Animation
+}
+
+function stubOffsetDimension(
+  prop: 'offsetHeight' | 'offsetWidth',
+  clientProp: 'clientHeight' | 'clientWidth',
+  fallback: number
+) {
+  const previous = Object.getOwnPropertyDescriptor(HTMLElement.prototype, prop)
+
+  Object.defineProperty(HTMLElement.prototype, prop, {
+    configurable: true,
+    get() {
+      return previous?.get?.call(this) || (this as HTMLElement)[clientProp] || fallback
+    }
+  })
+}
+
+stubOffsetDimension('offsetWidth', 'clientWidth', 800)
+stubOffsetDimension('offsetHeight', 'clientHeight', 600)
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+const sessionId = 'session-68634'
+
+function userMessage(id: string, text: string): ThreadMessage {
+  return {
+    id,
+    role: 'user',
+    content: [{ type: 'text', text }],
+    attachments: [],
+    createdAt,
+    metadata: { custom: {} }
+  } as ThreadMessage
+}
+
+// This shape mirrors the `/steer` note appended by appendSessionTextMessage
+// in apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts.
+function systemMessage(id: string, text: string): ThreadMessage {
+  return {
+    id,
+    role: 'system',
+    content: [{ type: 'text', text }],
+    createdAt,
+    metadata: { custom: {} }
+  } as ThreadMessage
+}
+
+function runningAssistantMessage(id: string, text: string): ThreadMessage {
+  return {
+    id,
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+    status: { type: 'running' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as ThreadMessage
+}
+
+function Harness({ messages, isRunning = false }: { messages: ThreadMessage[]; isRunning?: boolean }) {
+  // isRunning: false at the runtime level. Per-message `status: {type:
+  // 'running'}` is what drives StreamStallIndicator mounting.
+  // Passing isRunning: true makes useExternalStoreRuntime auto-append a
+  // synthetic empty trailing assistant placeholder whenever the last message
+  // is not already a running assistant, such as the trailing user prompt
+  // cases below. That is the real production flow. The isRunning:true tests
+  // prove that the placeholder is treated as the tail and renders its own
+  // loading row while the real bubble's stall row stays silent.
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages,
+    isRunning,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
+describe('StreamStallIndicator tail gating (#68634)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    __resetElapsedTimerRegistryForTests()
+    $activeSessionId.set(sessionId)
+    $turnStartedAt.set(Date.now())
+    setSessionCompacting(sessionId, true)
+  })
+
+  afterEach(() => {
+    cleanup()
+    setSessionCompacting(sessionId, false)
+    $activeSessionId.set(null)
+    $turnStartedAt.set(null)
+    __resetElapsedTimerRegistryForTests()
+    vi.useRealTimers()
+  })
+
+  it('renders exactly one indicator, on the later bubble, when two assistant bubbles are running with content', () => {
+    const { container } = render(
+      <Harness
+        messages={[
+          userMessage('user-1', 'Summarize this thread for me'),
+          runningAssistantMessage('assistant-1', 'Working on it'),
+          userMessage('user-2', 'hola?'),
+          runningAssistantMessage('assistant-2', 'On it too')
+        ]}
+      />
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+
+    const indicators = screen.getAllByRole('status', { name: 'Summarizing thread' })
+    expect(indicators.length).toBe(1)
+
+    const roots = container.querySelectorAll('[data-slot="aui_assistant-message-root"]')
+    expect(roots.length).toBe(2)
+    // The second assistant root is also the thread's any-role tail.
+    expect(roots[0]?.querySelector('[data-slot="aui_stream-stall"]')).toBeNull()
+    expect(roots[1]?.querySelector('[data-slot="aui_stream-stall"]')).not.toBeNull()
+  })
+
+  it('keeps a running assistant silent when a queued user prompt trails it and the runtime is idle', () => {
+    const { container } = render(
+      <Harness
+        messages={[
+          userMessage('user-1', 'Summarize this thread for me'),
+          runningAssistantMessage('assistant-1', 'Working on it'),
+          userMessage('user-2', 'hola?')
+        ]}
+      />
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+
+    expect(container.querySelector('[data-slot="aui_response-loading"]')).toBeNull()
+    expect(container.querySelector('[data-slot="aui_stream-stall"]')).toBeNull()
+  })
+
+  it('keeps a running assistant silent when a steer system note trails it and the runtime is idle', () => {
+    const { container } = render(
+      <Harness
+        messages={[
+          userMessage('user-1', 'Summarize this thread for me'),
+          runningAssistantMessage('assistant-1', 'Working on it'),
+          systemMessage('system-steer-1', 'steer:focus on the errors')
+        ]}
+      />
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+
+    expect(container.querySelector('[data-slot="aui_response-loading"]')).toBeNull()
+    expect(container.querySelector('[data-slot="aui_stream-stall"]')).toBeNull()
+  })
+
+  // In the production flow, isRunning: true with a trailing queued user prompt
+  // makes the runtime append an empty optimistic assistant placeholder after
+  // the real running bubble. The placeholder renders ResponseLoadingIndicator.
+  // During compaction, that row carries the same accessible label as the stall
+  // indicator. The real non-tail bubble must remain silent so there is exactly
+  // one status row.
+  it('still renders the indicator when the runtime appends an optimistic placeholder (isRunning:true)', () => {
+    render(
+      <Harness
+        isRunning
+        messages={[
+          userMessage('user-1', 'Summarize this thread for me'),
+          runningAssistantMessage('assistant-1', 'Working on it'),
+          userMessage('user-2', 'hola?')
+        ]}
+      />
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+
+    const indicators = screen.getAllByRole('status', { name: 'Summarizing thread' })
+    expect(indicators.length).toBe(1)
+    // The surviving row belongs to the placeholder, while the real running
+    // bubble's stall row stays silent.
+    expect(document.querySelectorAll('[data-slot="aui_response-loading"]').length).toBe(1)
+    expect(document.querySelectorAll('[data-slot="aui_stream-stall"]').length).toBe(0)
+  })
+
+  // Outside compaction, the placeholder uses the plain loading label and the
+  // real bubble's stall row must remain silent after the stall threshold.
+  it('keeps a single status row for the placeholder outside compaction (isRunning:true)', () => {
+    setSessionCompacting(sessionId, false)
+
+    render(
+      <Harness
+        isRunning
+        messages={[
+          userMessage('user-1', 'Summarize this thread for me'),
+          runningAssistantMessage('assistant-1', 'Working on it'),
+          userMessage('user-2', 'hola?')
+        ]}
+      />
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+
+    expect(document.querySelectorAll('[data-slot="aui_response-loading"]').length).toBe(1)
+    expect(document.querySelectorAll('[data-slot="aui_stream-stall"]').length).toBe(0)
+  })
+})


### PR DESCRIPTION
Repurposed to tests only, after measuring the original fix against current main.

The bug this PR set out to fix (#68634, duplicated "Summarizing thread" rows) was addressed on main by ba756333, which mounts the loading and stall indicators only on the thread's any-role tail. Re-running my five regression cases against current main: the duplicate cases pass, and the two cases I had written as "indicator disappears behind a trailing user/system row" fail because main intentionally silences a running-status bubble that is not the tail while the runtime is idle. That is the stranded-bubble state ba756333's settle layers leave behind, not a live stream, and reshaping the mount gate to walk back to the last assistant message would re-show a spinner above newer content in exactly that state. So I am not shipping that.

What remains is the coverage: five tests pinning the contract as it stands. Exactly one indicator with two running bubbles. Silence for a non-tail running bubble behind a trailing user or system row. Exactly one status row (the placeholder's) in the isRunning flow, during and outside compaction. Mutation-checked: relaxing the gate to a last-assistant walk fails the silence cases, and removing the gate fails all five.
