### PR TITLE
docs(links): update moved torchtune repo URL in torchtitan skill

### DIFF
--- a/optional-skills/mlops/torchtitan/references/checkpoint.md
+++ b/optional-skills/mlops/torchtitan/references/checkpoint.md
@@ -153,7 +153,7 @@ load_step = 500  # Resume from step 500
 
 ## Interoperability with TorchTune
 
-Checkpoints saved with `last_save_model_only = true` can be loaded directly into [torchtune](https://github.com/pytorch/torchtune) for fine-tuning.
+Checkpoints saved with `last_save_model_only = true` can be loaded directly into [torchtune](https://github.com/meta-pytorch/torchtune) for fine-tuning.
 
 ## Full Configuration Example
 


### PR DESCRIPTION
### Problem

The torchtitan skill's checkpointing reference links torchtune at its former location, which now permanently redirects:

```
$ curl -sI https://github.com/pytorch/torchtune
HTTP/1.1 301 Moved Permanently
Location: https://github.com/meta-pytorch/torchtune
```

PyTorch moved the project out of the `pytorch` org into `meta-pytorch`. The new location is a direct 200:

```
$ curl -sI https://github.com/meta-pytorch/torchtune
HTTP/1.1 200 OK
```

### Fix

Point the interoperability reference at the canonical URL GitHub itself redirects to.

```diff
 ## Interoperability with TorchTune

-Checkpoints saved with `last_save_model_only = true` can be loaded directly into [torchtune](https://github.com/pytorch/torchtune) for fine-tuning.
+Checkpoints saved with `last_save_model_only = true` can be loaded directly into [torchtune](https://github.com/meta-pytorch/torchtune) for fine-tuning.
```

Docs-only, no runtime or behavior change. The replacement is exactly the `Location` header returned by the old URL, so there is no ambiguity about the destination.

This URL occurs in exactly one file across the whole repo — no generated website mirror carries it — so the fix is complete in a single line.
