### PR TITLE
feat(slack): add a single-socket ingress sidecar

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -77,6 +77,13 @@ class GatewayAuthorizationMixin:
         """Resolve the live adapter for an inbound ``SessionSource``."""
         if source is None:
             return None
+        # Relay-delivered events preserve their underlying platform for session
+        # keying and authorization, but responses must leave through the one
+        # process-level RelayAdapter.  Never consult a profile adapter map here:
+        # multiplex mode intentionally owns one relay connection per process.
+        if getattr(source, "delivered_via_relay", False) is True:
+            adapters = getattr(self, "adapters", None) or {}
+            return adapters.get(Platform.RELAY)
         # ``getattr`` guards test fixtures that build a bare source via
         # SimpleNamespace and omit ``profile`` (see AGENTS.md pitfall #17).
         return self._authorization_adapter(

--- a/gateway/relay/__init__.py
+++ b/gateway/relay/__init__.py
@@ -45,6 +45,31 @@ def relay_url() -> Optional[str]:
     return None
 
 
+def relay_authorization_is_upstream() -> bool:
+    """Whether relay inbound may bypass local platform authorization.
+
+    Team Gateway remains trusted by default for backwards compatibility. Local
+    ingress connectors set ``gateway.relay_authorization_is_upstream: false`` in
+    config.yaml so Slack's normal allowlist/pairing logic remains authoritative.
+    This is intentionally config-only: it is behavioral policy, not a secret.
+    """
+    try:
+        from gateway.run import _load_gateway_config  # late import to avoid cycle
+
+        gateway = _load_gateway_config().get("gateway") or {}
+        value = gateway.get("relay_authorization_is_upstream", True)
+    except Exception:  # noqa: BLE001 - config absence must preserve old behaviour
+        return True
+    if isinstance(value, bool):
+        return value
+    normalized = str(value).strip().lower()
+    if normalized in {"false", "0", "no", "off"}:
+        return False
+    if normalized in {"true", "1", "yes", "on"}:
+        return True
+    return True
+
+
 def relay_platform_identities() -> list[tuple[str, str]]:
     """The (platform, bot_id) pairs this gateway fronts over the relay (Phase 1.5).
 
@@ -815,6 +840,7 @@ def register_relay_adapter(force: bool = False, url: Optional[str] = None) -> bo
                 identities=relay_platform_identities(),
                 gateway_id=gateway_id,
                 upgrade_secret=upgrade_secret,
+                authorization_is_upstream=relay_authorization_is_upstream(),
                 # Phase 5 §5.3: re-dial + re-handshake after an unexpected socket
                 # close so a gateway that went idle/suspended re-establishes its
                 # relay socket — which triggers the connector's buffered-flip drain

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -513,6 +513,37 @@ class RelayAdapter(BasePlatformAdapter):
             error=result.get("error"),
         )
 
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Proxy an edit through the same scoped underlying-platform route."""
+        if self._transport is None:
+            return SendResult(success=False, error="no transport")
+        result = await self._transport.send_outbound(
+            {
+                "op": "edit",
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "finalize": bool(finalize),
+                "metadata": self._with_scope(chat_id, metadata),
+            },
+            platform=self._platform_by_chat.get(str(chat_id)),
+        )
+        return SendResult(
+            success=bool(result.get("success")),
+            message_id=result.get("message_id"),
+            error=result.get("error"),
+            retryable=bool(result.get("retryable", False)),
+            retry_after=result.get("retry_after"),
+        )
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         # Proxied to the connector (it owns the platform connection / cache).
         if self._transport is None:

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -129,7 +129,9 @@ def _render_relay_context(context: Any) -> Optional[str]:
     return f"[Recent channel messages]\n{body}"
 
 
-def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
+def _event_from_wire(
+    raw: Dict[str, Any], *, authorization_is_upstream: bool = True
+) -> MessageEvent:
     """Rebuild a MessageEvent from the connector's normalized inbound payload.
 
     The connector emits SessionSource as the snake_case wire form (§3); map it
@@ -167,19 +169,20 @@ def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
         # config/credential scope — the same field the /p/<profile>/ HTTP
         # prefix and per-credential polling adapters already set.
         profile=src.get("profile"),
-        # Authentic upstream-trust signal: this event arrived over the
-        # per-instance-authenticated relay WS, so the connector already resolved
-        # it to this instance's owner-bound author. ``platform`` is the
-        # UNDERLYING platform (e.g. discord), not ``relay`` — authz keys the
-        # upstream-trust decision off THIS flag, not off ``platform`` (which
-        # would miss because the relay adapter is registered under
-        # ``Platform.RELAY``). Stamped here, never read off the wire.
-        delivered_via_upstream_relay=True,
+        # Transport routing and authorization trust are separate internal
+        # signals. Every event rebuilt here exits through RelayAdapter, but a
+        # local connector may opt out of upstream auth delegation so the normal
+        # platform allowlist/pairing checks still run.
+        delivered_via_relay=True,
+        delivered_via_upstream_relay=authorization_is_upstream is True,
     )
     try:
         msg_type = MessageType(raw.get("message_type", "text"))
     except ValueError:
         msg_type = MessageType.TEXT
+    metadata = raw.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
 
     return MessageEvent(
         text=raw.get("text", ""),
@@ -188,15 +191,21 @@ def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
         message_id=raw.get("message_id"),
         reply_to_message_id=raw.get("reply_to_message_id"),
         media_urls=raw.get("media_urls") or [],
-        # Surrounding channel/group CONTEXT the connector attached for this
-        # addressed turn (design relay-channel-context): a read-only, oldest→
-        # newest list of nearby non-addressed messages (Model A pull / Model B
-        # buffer). Rendered into the existing ``channel_context`` field — the
-        # same read-only injection path history-backfill already uses
-        # (run.py prepends it ahead of the trigger message). Absent / empty on a
-        # connector that doesn't send it, a dm, or a no-context platform, so
-        # this is purely additive and byte-identical to today when unset.
-        channel_context=_render_relay_context(raw.get("context")),
+        media_types=raw.get("media_types") or [],
+        reply_to_text=raw.get("reply_to_text"),
+        reply_to_author_id=raw.get("reply_to_author_id"),
+        reply_to_author_name=raw.get("reply_to_author_name"),
+        reply_to_is_own_message=bool(raw.get("reply_to_is_own_message", False)),
+        auto_skill=raw.get("auto_skill"),
+        channel_prompt=raw.get("channel_prompt"),
+        metadata=metadata,
+        # A local platform adapter may already have rendered its context string;
+        # remote connectors use the normalized context-array form.
+        channel_context=(
+            raw.get("channel_context")
+            if isinstance(raw.get("channel_context"), str)
+            else _render_relay_context(raw.get("context"))
+        ),
     )
 
 
@@ -262,6 +271,7 @@ class WebSocketRelayTransport:
         outbound_timeout_s: float = _OUTBOUND_TIMEOUT_S,
         gateway_id: Optional[str] = None,
         upgrade_secret: Optional[str] = None,
+        authorization_is_upstream: bool = True,
         reconnect: bool = False,
         reconnect_backoff_s: float = 1.0,
         reconnect_max_backoff_s: float = 30.0,
@@ -291,6 +301,7 @@ class WebSocketRelayTransport:
         # (dev/test, or a connector that doesn't enforce auth).
         self._gateway_id = gateway_id
         self._upgrade_secret = upgrade_secret
+        self._authorization_is_upstream = authorization_is_upstream is True
 
         # Phase 5 §5.3: a NET-NEW reconnect supervisor. The base transport's
         # _read_loop just ends on socket close ("reconnection is caller policy");
@@ -714,7 +725,10 @@ class WebSocketRelayTransport:
                 self._descriptor_ready.set_result(descriptor)
         elif ftype == "inbound":
             if self._inbound is not None:
-                event = _event_from_wire(frame.get("event", {}))
+                event = _event_from_wire(
+                    frame.get("event", {}),
+                    authorization_is_upstream=self._authorization_is_upstream,
+                )
                 await self._inbound(event)
                 # Phase 5 §5.3: a buffered delivery (replayed on reconnect) carries
                 # a bufferId; ack it after the handler has durably taken it so the

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -191,6 +191,13 @@ class SessionSource:
     auto_thread_created: bool = False
     auto_thread_initial_name: Optional[str] = None
 
+    # Internal, wire-INVISIBLE transport signal: True when this event arrived
+    # through a RelayAdapter. It selects relay egress while preserving the
+    # underlying platform for session keys and platform-specific authorization.
+    # This is distinct from upstream authorization: an on-device ingress may use the
+    # relay transport while intentionally keeping Gateway allowlist/pairing checks.
+    delivered_via_relay: bool = False
+
     # Internal, wire-INVISIBLE trust signal: True when this event was delivered
     # to the gateway over the per-instance-authenticated relay WebSocket (the
     # Team Gateway connector). The connector authenticates the gateway's socket

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4490,6 +4490,11 @@ def cmd_slack(args):
 
         return slack_manifest_command(args)
 
+    if sub == "ingress":
+        from hermes_cli.slack_cli import slack_ingress_command
+
+        return slack_ingress_command(args)
+
     print(f"Unknown slack subcommand: {sub}", file=sys.stderr)
     return 1
 

--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -17,10 +17,127 @@ for reinstall when scopes/commands change.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sys
 from pathlib import Path
+from typing import Any
+
+
+def _slack_ingress_settings(config: dict[str, Any] | None) -> dict[str, Any]:
+    """Normalize bounded ingress policy settings from ``config.yaml``."""
+    root = config if isinstance(config, dict) else {}
+    ingress: dict[str, Any] = {}
+    slack = root.get("slack")
+    if isinstance(slack, dict) and isinstance(slack.get("ingress"), dict):
+        ingress = slack["ingress"]
+    else:
+        platforms = root.get("platforms")
+        platform_slack = platforms.get("slack") if isinstance(platforms, dict) else None
+        extra = platform_slack.get("extra") if isinstance(platform_slack, dict) else None
+        if isinstance(extra, dict) and isinstance(extra.get("ingress"), dict):
+            ingress = extra["ingress"]
+
+    try:
+        ttl_days = float(ingress.get("follow_ttl_days", 30))
+        max_threads = int(ingress.get("max_followed_threads", 10_000))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Slack ingress TTL and thread cap must be numeric") from exc
+    if ttl_days <= 0 or max_threads <= 0:
+        raise ValueError("Slack ingress TTL and thread cap must be positive")
+
+    def _tokens(value: Any, *, strip_colons: bool = False) -> set[str]:
+        if isinstance(value, str):
+            values = value.split(",")
+        elif isinstance(value, (list, tuple, set)):
+            values = value
+        else:
+            values = ()
+        result: set[str] = set()
+        for item in values:
+            token = str(item).strip()
+            if strip_colons:
+                token = token.strip(":").lower()
+            if token:
+                result.add(token)
+        return result
+
+    return {
+        "ttl_seconds": ttl_days * 24 * 60 * 60,
+        "max_threads": max_threads,
+        "reaction_user_ids": _tokens(ingress.get("reaction_user_ids")),
+        "reaction_names": _tokens(
+            ingress.get("reaction_names"), strip_colons=True
+        ),
+    }
+
+
+def slack_ingress_command(args) -> int:
+    """Run the machine-singleton Slack ingress/Relay sidecar."""
+    from gateway.config import Platform, load_gateway_config
+    from hermes_cli.config import load_config
+    from hermes_constants import get_default_hermes_root, get_hermes_home
+    from plugins.platforms.slack.adapter import SlackAdapter
+    from plugins.platforms.slack.ingress import (
+        FollowStore,
+        SlackIngressPolicy,
+        SlackIngressServer,
+    )
+
+    hermes_home = get_hermes_home()
+    try:
+        settings = _slack_ingress_settings(load_config())
+        gateway_config = load_gateway_config()
+        slack_config = gateway_config.platforms.get(Platform.SLACK)
+        if slack_config is not None and slack_config.enabled:
+            raise RuntimeError(
+                "set slack.enabled: false before starting the ingress sidecar; "
+                "the Gateway and sidecar must not both own Slack Socket Mode"
+            )
+        if slack_config is None or not slack_config.token:
+            raise RuntimeError(
+                "SLACK_BOT_TOKEN is required for `hermes slack ingress`"
+            )
+        state_path = Path(
+            getattr(args, "state", None) or hermes_home / "slack-ingress.db"
+        ).expanduser()
+        policy = SlackIngressPolicy(
+            FollowStore(
+                state_path,
+                ttl_seconds=settings["ttl_seconds"],
+                max_threads=settings["max_threads"],
+            ),
+            reaction_user_ids=settings["reaction_user_ids"],
+            reaction_names=settings["reaction_names"],
+        )
+        server = SlackIngressServer(
+            SlackAdapter(slack_config),
+            policy,
+            host=str(getattr(args, "host", "127.0.0.1")),
+            port=int(getattr(args, "port", 8791)),
+            lock_path=get_default_hermes_root() / "slack-ingress.lock",
+        )
+
+        async def _serve() -> None:
+            await server.start()
+            print(
+                f"Slack ingress listening at {server.url}/relay; "
+                "Slack connects only after the Gateway Relay handshake.",
+                file=sys.stderr,
+            )
+            try:
+                await server.wait_closed()
+            finally:
+                await server.stop()
+
+        asyncio.run(_serve())
+    except KeyboardInterrupt:
+        return 0
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"Slack ingress failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
 
 
 def _build_full_manifest(
@@ -86,6 +203,7 @@ def _build_full_manifest(
         "im:write",
         "mpim:history",
         "mpim:read",
+        "reactions:read",
         "users:read",
     ]
 
@@ -95,6 +213,7 @@ def _build_full_manifest(
         "message.groups",
         "message.im",
         "message.mpim",
+        "reaction_added",
     ]
 
     if messaging_experience == "assistant":

--- a/hermes_cli/subcommands/slack.py
+++ b/hermes_cli/subcommands/slack.py
@@ -20,6 +20,32 @@ def build_slack_parser(subparsers, *, cmd_slack: Callable) -> None:
         description="Slack integration helpers for Hermes.",
     )
     slack_sub = slack_parser.add_subparsers(dest="slack_command")
+    slack_ingress = slack_sub.add_parser(
+        "ingress",
+        help="Run the loopback Slack Socket Mode ingress sidecar",
+        description=(
+            "Run the sole Slack Socket Mode owner and expose the local Relay "
+            "endpoint used by a Slack-disabled Hermes Gateway. Slack connects "
+            "only while that Relay client is connected."
+        ),
+    )
+    slack_ingress.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Loopback listener host (default: 127.0.0.1)",
+    )
+    slack_ingress.add_argument(
+        "--port",
+        type=int,
+        default=8791,
+        help="Relay listener port (default: 8791; use 0 for an ephemeral port)",
+    )
+    slack_ingress.add_argument(
+        "--state",
+        default=None,
+        metavar="PATH",
+        help="SQLite state path (default: $HERMES_HOME/slack-ingress.db)",
+    )
     slack_manifest = slack_sub.add_parser(
         "manifest",
         help="Print or write a Slack app manifest with every gateway command "

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -502,6 +502,60 @@ class SlackAdapter(BasePlatformAdapter):
         self._socket_watchdog_task: Optional[asyncio.Task] = None
         self._socket_reconnect_lock = asyncio.Lock()
         self._socket_watchdog_interval_s = 15.0
+        # Optional out-of-process ingress admission hook. When installed it is
+        # authoritative: the connector, not this adapter's legacy participation
+        # caches/session lookup, decides whether an event reaches Hermes.
+        self._external_admission_handler: Optional[Any] = None
+        self._external_reaction_handler: Optional[Any] = None
+
+    def set_external_admission_handler(self, handler: Optional[Any]) -> None:
+        """Install an authoritative async/sync raw-event admission callback."""
+        self._external_admission_handler = handler
+
+    def set_external_reaction_handler(self, handler: Optional[Any]) -> None:
+        """Install the optional sidecar reaction trigger callback."""
+        self._external_reaction_handler = handler
+
+    async def _handle_reaction_added(
+        self, event: dict, body: Optional[dict] = None
+    ) -> None:
+        handler = self._external_reaction_handler
+        if handler is None:
+            return
+        result = handler(event, body=body)
+        if asyncio.iscoroutine(result):
+            await result
+
+    async def dispatch_reaction_trigger(
+        self, event: dict, *, body: Optional[dict] = None
+    ) -> None:
+        """Turn an admitted message reaction into a one-shot thread trigger."""
+        item = event.get("item")
+        if not isinstance(item, dict) or item.get("type") != "message":
+            return
+        channel_id = str(item.get("channel") or "")
+        message_ts = str(item.get("ts") or "")
+        user_id = str(event.get("user") or "")
+        team_id = self._event_team_id(event, body)
+        bot_user_id = self._team_bot_user_ids.get(team_id) or self._bot_user_id or ""
+        if not channel_id or not message_ts or not user_id or not bot_user_id:
+            return
+        reaction = str(event.get("reaction") or "").strip().strip(":")
+        event_ts = str(event.get("event_ts") or event.get("ts") or time.time())
+        synthetic = {
+            "text": (
+                f"[Slack reaction trigger :{reaction}:] <@{bot_user_id}> "
+                "Respond to the reacted message using its thread context."
+            ),
+            "user": user_id,
+            "channel": channel_id,
+            "channel_type": "im" if channel_id.startswith("D") else "channel",
+            "team": team_id,
+            "ts": event_ts,
+            "thread_ts": message_ts,
+            "_slack_ingress_reaction_trigger": True,
+        }
+        await self._handle_slack_message(synthetic, body)
 
     def _start_socket_mode_handler(self) -> None:
         """Start the Slack Socket Mode background task."""
@@ -1148,13 +1202,11 @@ class SlackAdapter(BasePlatformAdapter):
             async def handle_file_change(event, say):
                 pass
 
-            # Reactions are useful lightweight acknowledgements in Slack, but
-            # Hermes does not currently need to route them into the agent loop.
-            # Ack the events explicitly so high-traffic channels do not fill
-            # gateway.error.log with Slack Bolt "Unhandled request" warnings.
+            # Reactions stay no-op in direct mode. An out-of-process ingress may
+            # install a policy hook for owner-only emoji triggers.
             @self._app.event("reaction_added")
-            async def handle_reaction_added(event, say):
-                pass
+            async def handle_reaction_added(event, say, body):
+                await self._handle_reaction_added(event, body)
 
             @self._app.event("reaction_removed")
             async def handle_reaction_removed(event, say):
@@ -3356,6 +3408,7 @@ class SlackAdapter(BasePlatformAdapter):
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
 
+        external_admission = self._external_admission_handler
         if not is_one_to_one_dm and bot_uid:
             # Check allowed channels — if set, only respond in these channels (whitelist)
             allowed_channels = self._slack_allowed_channels()
@@ -3365,6 +3418,26 @@ class SlackAdapter(BasePlatformAdapter):
                 )
                 return
 
+        if external_admission is not None:
+            try:
+                admitted = external_admission(
+                    event,
+                    body=payload,
+                    team_id=str(team_id or ""),
+                    bot_user_id=str(bot_uid or ""),
+                    is_one_to_one_dm=is_one_to_one_dm,
+                )
+                if asyncio.iscoroutine(admitted):
+                    admitted = await admitted
+            except Exception:
+                logger.warning(
+                    "[Slack] External ingress admission failed closed",
+                    exc_info=True,
+                )
+                return
+            if admitted is not True:
+                return
+        elif not is_one_to_one_dm and bot_uid:
             if channel_id in self._slack_free_response_channels():
                 pass  # Free-response channel — always process
             elif not self._slack_require_mention():
@@ -3399,7 +3472,11 @@ class SlackAdapter(BasePlatformAdapter):
             # Skipped in strict mode: strict_mention=true bots must be
             # re-mentioned every turn, so remembering the thread would
             # defeat the feature (and re-enable agent-to-agent ack loops).
-            if event_thread_ts and not self._slack_strict_mention():
+            if (
+                external_admission is None
+                and event_thread_ts
+                and not self._slack_strict_mention()
+            ):
                 self._mentioned_threads.add(event_thread_ts)
                 if len(self._mentioned_threads) > self._MENTIONED_THREADS_MAX:
                     to_remove = list(self._mentioned_threads)[

--- a/plugins/platforms/slack/ingress.py
+++ b/plugins/platforms/slack/ingress.py
@@ -1,0 +1,653 @@
+"""Slack Socket Mode ingress primitives.
+
+This module owns the small, durable thread-follow index used by the optional
+out-of-process Slack ingress.  The actual connector is built on top of these
+primitives below; keeping the store independent makes its lifetime and bounds
+straightforward to test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sqlite3
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Callable
+
+from gateway.platforms.base import MessageEvent, SendResult
+from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
+
+try:
+    import websockets
+except ImportError:  # pragma: no cover - surfaced by start()
+    websockets = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+
+
+class FollowStore:
+    """Bounded SQLite index of Slack threads that should auto-forward.
+
+    Rows expire after ``ttl_seconds`` of inactivity.  ``max_threads`` is a hard
+    LRU cap so a busy workspace cannot grow this state without bound.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        ttl_seconds: float,
+        max_threads: int,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        if max_threads <= 0:
+            raise ValueError("max_threads must be positive")
+        self.path = Path(path).expanduser()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.ttl_seconds = float(ttl_seconds)
+        self.max_threads = int(max_threads)
+        self._clock = clock
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path, timeout=5.0)
+        conn.execute("PRAGMA busy_timeout = 5000")
+        return conn
+
+    def _initialize(self) -> None:
+        with self._connect() as conn:
+            conn.execute("PRAGMA journal_mode = WAL")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS followed_threads (
+                    team_id TEXT NOT NULL,
+                    channel_id TEXT NOT NULL,
+                    thread_ts TEXT NOT NULL,
+                    last_seen REAL NOT NULL,
+                    PRIMARY KEY (team_id, channel_id, thread_ts)
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS followed_threads_last_seen "
+                "ON followed_threads(last_seen)"
+            )
+
+    def _prune(self, conn: sqlite3.Connection, *, now: float) -> None:
+        conn.execute(
+            "DELETE FROM followed_threads WHERE last_seen < ?",
+            (now - self.ttl_seconds,),
+        )
+        row = conn.execute("SELECT COUNT(*) FROM followed_threads").fetchone()
+        overflow = int(row[0]) - self.max_threads if row else 0
+        if overflow > 0:
+            conn.execute(
+                """
+                DELETE FROM followed_threads
+                WHERE rowid IN (
+                    SELECT rowid FROM followed_threads
+                    ORDER BY last_seen ASC, rowid ASC
+                    LIMIT ?
+                )
+                """,
+                (overflow,),
+            )
+
+    def follow(
+        self,
+        team_id: str,
+        channel_id: str,
+        thread_ts: str,
+        *,
+        seen_at: float | None = None,
+    ) -> None:
+        now = self._clock() if seen_at is None else float(seen_at)
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO followed_threads(team_id, channel_id, thread_ts, last_seen)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(team_id, channel_id, thread_ts)
+                DO UPDATE SET last_seen = excluded.last_seen
+                """,
+                (str(team_id), str(channel_id), str(thread_ts), now),
+            )
+            self._prune(conn, now=self._clock())
+
+    def is_followed(self, team_id: str, channel_id: str, thread_ts: str) -> bool:
+        now = self._clock()
+        with self._connect() as conn:
+            self._prune(conn, now=now)
+            row = conn.execute(
+                """
+                SELECT 1 FROM followed_threads
+                WHERE team_id = ? AND channel_id = ? AND thread_ts = ?
+                """,
+                (str(team_id), str(channel_id), str(thread_ts)),
+            ).fetchone()
+        return row is not None
+
+    def unfollow(self, team_id: str, channel_id: str, thread_ts: str) -> bool:
+        """Delete a follow route and report whether one existed."""
+        with self._connect() as conn:
+            result = conn.execute(
+                """
+                DELETE FROM followed_threads
+                WHERE team_id = ? AND channel_id = ? AND thread_ts = ?
+                """,
+                (str(team_id), str(channel_id), str(thread_ts)),
+            )
+        return bool(result.rowcount)
+
+    def touch_if_followed(self, team_id: str, channel_id: str, thread_ts: str) -> bool:
+        """Refresh an active follow row atomically and report whether it existed."""
+        now = self._clock()
+        with self._connect() as conn:
+            self._prune(conn, now=now)
+            result = conn.execute(
+                """
+                UPDATE followed_threads SET last_seen = ?
+                WHERE team_id = ? AND channel_id = ? AND thread_ts = ?
+                """,
+                (now, str(team_id), str(channel_id), str(thread_ts)),
+            )
+        return bool(result.rowcount)
+
+    def count(self) -> int:
+        now = self._clock()
+        with self._connect() as conn:
+            self._prune(conn, now=now)
+            row = conn.execute("SELECT COUNT(*) FROM followed_threads").fetchone()
+        return int(row[0]) if row else 0
+
+
+class SlackIngressPolicy:
+    """Admission and control policy applied before an event reaches Gateway."""
+
+    def __init__(
+        self,
+        store: FollowStore,
+        *,
+        reaction_user_ids: set[str] | None = None,
+        reaction_names: set[str] | None = None,
+    ) -> None:
+        self.store = store
+        self.reaction_user_ids = {
+            str(user_id).strip()
+            for user_id in (reaction_user_ids or set())
+            if str(user_id).strip()
+        }
+        self.reaction_names = {
+            str(name).strip().strip(":").lower()
+            for name in (reaction_names or set())
+            if str(name).strip().strip(":")
+        }
+        self._control_commands: dict[str, Callable[..., None]] = {}
+        self.register_control_command("/mute", self._mute)
+
+    def register_control_command(
+        self, command: str, handler: Callable[..., None]
+    ) -> None:
+        """Register a sidecar-local command that is consumed before forwarding."""
+        normalized = command.strip().lower()
+        if not normalized.startswith("/") or any(ch.isspace() for ch in normalized):
+            raise ValueError("control command must be one slash-prefixed token")
+        self._control_commands[normalized] = handler
+
+    def _mute(
+        self,
+        *,
+        team_id: str,
+        channel_id: str,
+        thread_ts: str,
+        event: dict,
+    ) -> None:
+        del event
+        self.store.unfollow(team_id, channel_id, thread_ts)
+
+    def _consume_control_command(
+        self,
+        text: str,
+        mention: str,
+        *,
+        team_id: str,
+        channel_id: str,
+        thread_ts: str,
+        event: dict,
+    ) -> bool:
+        if not mention:
+            return False
+        stripped = text.lstrip()
+        if not stripped.startswith(mention):
+            return False
+        remainder = stripped[len(mention) :].lstrip()
+        command = remainder.split(maxsplit=1)[0].lower() if remainder else ""
+        handler = self._control_commands.get(command)
+        if handler is None:
+            return False
+        handler(
+            team_id=team_id,
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            event=event,
+        )
+        return True
+
+    def admit_reaction(self, event: dict[str, Any]) -> bool:
+        """Admit one configured owner reaction without mutating follow state."""
+        item = event.get("item")
+        if not isinstance(item, dict) or item.get("type") != "message":
+            return False
+        user_id = str(event.get("user") or "")
+        reaction = str(event.get("reaction") or "").strip().strip(":").lower()
+        return bool(
+            self.reaction_user_ids
+            and self.reaction_names
+            and user_id in self.reaction_user_ids
+            and reaction in self.reaction_names
+            and item.get("channel")
+            and item.get("ts")
+        )
+
+    def admit(
+        self,
+        event: dict,
+        *,
+        team_id: str,
+        bot_user_id: str,
+        is_one_to_one_dm: bool,
+    ) -> bool:
+        channel_id = str(event.get("channel") or "")
+        ts = str(event.get("ts") or "")
+        text = str(event.get("text") or "")
+        incoming_thread_ts = str(event.get("thread_ts") or "")
+        thread_ts = incoming_thread_ts or ts
+        mention = f"<@{bot_user_id}>" if bot_user_id else ""
+
+        # Control commands are sidecar-local state transitions. They run before
+        # TTL refresh/admission and are never delivered to Gateway or the LLM.
+        if self._consume_control_command(
+            text,
+            mention,
+            team_id=team_id,
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            event=event,
+        ):
+            return False
+
+        if is_one_to_one_dm:
+            return True
+        is_root = not incoming_thread_ts or incoming_thread_ts == ts
+        if not is_root and self.store.touch_if_followed(team_id, channel_id, thread_ts):
+            return True
+        if is_root and mention and text.lstrip().startswith(mention):
+            self.store.follow(team_id, channel_id, ts)
+            return True
+        if mention and mention in text:
+            return True
+        return False
+
+
+def message_event_to_wire(event: MessageEvent) -> dict[str, Any]:
+    """Serialize a normalized event for ``WebSocketRelayTransport``.
+
+    The transport deliberately accepts a plain JSON object.  Keep this mapping
+    explicit so new MessageEvent fields are not accidentally exposed, while
+    retaining the Slack context needed for feature parity with the direct
+    adapter.
+    """
+    source = event.source.to_dict() if event.source is not None else {}
+    return {
+        "text": event.text,
+        "message_type": event.message_type.value,
+        "source": source,
+        "message_id": event.message_id,
+        "media_urls": list(event.media_urls),
+        "media_types": list(event.media_types),
+        "reply_to_message_id": event.reply_to_message_id,
+        "reply_to_text": event.reply_to_text,
+        "reply_to_author_id": event.reply_to_author_id,
+        "reply_to_author_name": event.reply_to_author_name,
+        "reply_to_is_own_message": event.reply_to_is_own_message,
+        "auto_skill": event.auto_skill,
+        "channel_prompt": event.channel_prompt,
+        "channel_context": event.channel_context,
+        "metadata": dict(event.metadata),
+    }
+
+
+class _SingleInstanceLock:
+    """Process-wide advisory lock; the OS releases it after abnormal exit."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path).expanduser()
+        self._handle: Any = None
+
+    def acquire(self) -> None:
+        if self._handle is not None:
+            return
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        handle = self.path.open("a+", encoding="utf-8")
+        try:
+            handle.seek(0)
+            if not handle.read(1):
+                handle.seek(0)
+                handle.write(" ")
+                handle.flush()
+            handle.seek(0)
+            if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+                import msvcrt
+
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            handle.close()
+            raise RuntimeError(
+                f"Slack ingress sidecar is already running on this machine ({self.path})"
+            ) from exc
+        handle.seek(0)
+        handle.truncate()
+        handle.write(str(os.getpid()))
+        handle.flush()
+        self._handle = handle
+
+    def release(self) -> None:
+        handle = self._handle
+        self._handle = None
+        if handle is None:
+            return
+        try:
+            if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+                import msvcrt
+
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            handle.close()
+
+
+class SlackIngressServer:
+    """Sole Slack Socket Mode owner and local Relay WebSocket server.
+
+    ``slack_adapter`` is the existing production SlackAdapter. Reusing it keeps
+    Slack normalization, files, thread context, formatting, and Web API egress
+    identical to direct mode; only admission and delivery to Hermes move here.
+    """
+
+    def __init__(
+        self,
+        slack_adapter: Any,
+        policy: SlackIngressPolicy,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 8791,
+        lock_path: str | Path | None = None,
+    ) -> None:
+        if host not in {"127.0.0.1", "::1", "localhost"}:
+            raise ValueError("Slack ingress currently supports loopback binding only")
+        if lock_path is None:
+            from hermes_constants import get_default_hermes_root
+
+            lock_path = get_default_hermes_root() / "slack-ingress.lock"
+        self.slack_adapter = slack_adapter
+        self.policy = policy
+        self.host = host
+        self.port = int(port)
+        self._instance_lock = _SingleInstanceLock(lock_path)
+        self._server: Any = None
+        self._gateway: Any = None
+        self._send_lock = asyncio.Lock()
+        self._slack_connection_lock = asyncio.Lock()
+        self._slack_connected = False
+        self._descriptor = CapabilityDescriptor(
+            contract_version=CONTRACT_VERSION,
+            platform="slack",
+            label="Slack",
+            max_message_length=39_000,
+            supports_draft_streaming=False,
+            supports_edit=True,
+            supports_threads=False,
+            markdown_dialect="slack",
+            len_unit="chars",
+            emoji="💬",
+            platform_hint="You are on Slack.",
+            pii_safe=False,
+            supports_context=True,
+        )
+
+    @property
+    def url(self) -> str:
+        if self._server is None or not self._server.sockets:
+            raise RuntimeError("Slack ingress server is not running")
+        port = int(self._server.sockets[0].getsockname()[1])
+        return f"http://{self.host}:{port}"
+
+    async def start(self, *, connect_slack: bool = False) -> None:
+        if websockets is None:
+            raise RuntimeError("Slack ingress requires the 'websockets' package")
+        if connect_slack:
+            raise ValueError("Slack may connect only after a Relay handshake")
+        if self._server is not None:
+            return
+        self._instance_lock.acquire()
+        try:
+            self.slack_adapter.set_external_admission_handler(self._admit_slack_event)
+            self.slack_adapter.set_external_reaction_handler(
+                self._handle_slack_reaction
+            )
+            self.slack_adapter.set_message_handler(self.forward_event)
+            self._server = await websockets.serve(
+                self._handle_connection, self.host, self.port
+            )
+        except BaseException:
+            self._instance_lock.release()
+            raise
+
+    async def _ensure_slack_connected(self) -> None:
+        async with self._slack_connection_lock:
+            if self._slack_connected:
+                return
+            connected = await self.slack_adapter.connect()
+            if connected is False:
+                raise RuntimeError("Slack Socket Mode connection failed")
+            self._slack_connected = True
+
+    async def _disconnect_slack(self) -> None:
+        async with self._slack_connection_lock:
+            if not self._slack_connected:
+                return
+            self._slack_connected = False
+            await self.slack_adapter.disconnect()
+
+    async def stop(self) -> None:
+        try:
+            gateway = self._gateway
+            self._gateway = None
+            if gateway is not None:
+                try:
+                    await gateway.close()
+                except Exception:
+                    pass
+            try:
+                await self._disconnect_slack()
+            finally:
+                if self._server is not None:
+                    self._server.close()
+                    await self._server.wait_closed()
+                    self._server = None
+        finally:
+            self._instance_lock.release()
+
+    async def wait_closed(self) -> None:
+        if self._server is None:
+            raise RuntimeError("Slack ingress server is not running")
+        await self._server.wait_closed()
+
+    def _admit_slack_event(
+        self,
+        event: dict,
+        *,
+        body: Any = None,
+        team_id: str,
+        bot_user_id: str,
+        is_one_to_one_dm: bool,
+    ) -> bool:
+        del body
+        if event.get("_slack_ingress_reaction_trigger") is True:
+            return True
+        return self.policy.admit(
+            event,
+            team_id=team_id,
+            bot_user_id=bot_user_id,
+            is_one_to_one_dm=is_one_to_one_dm,
+        )
+
+    async def _handle_slack_reaction(
+        self, event: dict[str, Any], *, body: Any = None
+    ) -> None:
+        if self._gateway is None or not self.policy.admit_reaction(event):
+            return
+        await self.slack_adapter.dispatch_reaction_trigger(event, body=body)
+
+    async def forward_event(self, event: MessageEvent) -> None:
+        gateway = self._gateway
+        if gateway is None:
+            logger.warning(
+                "Slack ingress dropped admitted event: Gateway is disconnected"
+            )
+            return
+        await self._send_frame(
+            gateway,
+            {"type": "inbound", "event": message_event_to_wire(event)},
+        )
+
+    async def _handle_connection(self, websocket: Any) -> None:
+        request = getattr(websocket, "request", None)
+        path = getattr(request, "path", "/relay")
+        if str(path).split("?", 1)[0] != "/relay":
+            await websocket.close(code=4404, reason="relay endpoint not found")
+            return
+        if self._gateway is not None:
+            await websocket.close(code=4429, reason="Gateway already connected")
+            return
+        self._gateway = websocket
+        try:
+            async for payload in websocket:
+                if isinstance(payload, bytes):
+                    payload = payload.decode("utf-8")
+                for line in str(payload).splitlines():
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        frame = json.loads(line)
+                    except json.JSONDecodeError:
+                        logger.warning("Slack ingress ignored malformed relay frame")
+                        continue
+                    if isinstance(frame, dict):
+                        await self._handle_frame(websocket, frame)
+        finally:
+            if self._gateway is websocket:
+                self._gateway = None
+                await self._disconnect_slack()
+
+    async def _handle_frame(self, websocket: Any, frame: dict[str, Any]) -> None:
+        frame_type = frame.get("type")
+        if frame_type == "hello":
+            try:
+                await self._ensure_slack_connected()
+            except Exception as exc:
+                logger.error("Slack ingress handshake could not connect Slack: %s", exc)
+                await websocket.close(code=4503, reason="Slack connection failed")
+                return
+            await self._send_frame(
+                websocket,
+                {"type": "descriptor", "descriptor": asdict(self._descriptor)},
+            )
+            return
+        if frame_type == "outbound":
+            request_id = str(frame.get("requestId") or "")
+            result = await self._execute_outbound(frame.get("action") or {})
+            await self._send_frame(
+                websocket,
+                {
+                    "type": "outbound_result",
+                    "requestId": request_id,
+                    "result": result,
+                },
+            )
+            return
+        if frame_type == "going_idle":
+            await self._send_frame(websocket, {"type": "going_idle_ack"})
+
+    async def _execute_outbound(self, action: dict[str, Any]) -> dict[str, Any]:
+        op = str(action.get("op") or "")
+        try:
+            if op == "send":
+                result = await self.slack_adapter.send(
+                    str(action.get("chat_id") or ""),
+                    str(action.get("content") or ""),
+                    reply_to=action.get("reply_to"),
+                    metadata=action.get("metadata") or {},
+                )
+                return self._send_result(result)
+            if op == "edit":
+                result = await self.slack_adapter.edit_message(
+                    str(action.get("chat_id") or ""),
+                    str(action.get("message_id") or ""),
+                    str(action.get("content") or ""),
+                    finalize=bool(action.get("finalize", False)),
+                    metadata=action.get("metadata") or {},
+                )
+                return self._send_result(result)
+            if op == "typing":
+                method = (
+                    self.slack_adapter.send_typing
+                    if action.get("active", True)
+                    else self.slack_adapter.stop_typing
+                )
+                await method(
+                    str(action.get("chat_id") or ""),
+                    metadata=action.get("metadata") or {},
+                )
+                return {"success": True}
+            if op == "get_chat_info":
+                info = await self.slack_adapter.get_chat_info(
+                    str(action.get("chat_id") or "")
+                )
+                return {"success": True, "chat_info": info}
+            return {"success": False, "error": f"unsupported Slack relay op: {op}"}
+        except Exception as exc:  # noqa: BLE001 - result must correlate every request
+            logger.warning("Slack ingress outbound failed: %s", exc, exc_info=True)
+            return {"success": False, "error": str(exc)}
+
+    @staticmethod
+    def _send_result(result: SendResult) -> dict[str, Any]:
+        return {
+            "success": bool(result.success),
+            "message_id": result.message_id,
+            "error": result.error,
+            "retryable": bool(result.retryable),
+            "retry_after": result.retry_after,
+            "continuation_message_ids": list(result.continuation_message_ids),
+        }
+
+    async def _send_frame(self, websocket: Any, frame: dict[str, Any]) -> None:
+        payload = json.dumps(frame, ensure_ascii=False, separators=(",", ":")) + "\n"
+        async with self._send_lock:
+            await websocket.send(payload)

--- a/tests/gateway/relay/test_relay_adapter.py
+++ b/tests/gateway/relay/test_relay_adapter.py
@@ -111,6 +111,39 @@ async def test_send_without_transport_returns_failure():
     assert result.error == "no transport"
 
 
+@pytest.mark.asyncio
+async def test_edit_proxies_with_scope_and_platform():
+    t = _CaptureTransport()
+    a = RelayAdapter(PlatformConfig(), make_desc(platform="slack"), transport=t)
+    event = _make_event(chat_id="chan-1", scope_id="team-1")
+    event.source.platform = Platform.SLACK
+    event.source.user_id = "user-1"
+    a._capture_scope(event)
+
+    result = await a.edit_message(
+        "chan-1",
+        "message-1",
+        "updated",
+        finalize=True,
+        metadata={"thread_id": "root-1"},
+    )
+
+    assert result.success is True
+    assert t.sent_platform == "slack"
+    assert t.sent == {
+        "op": "edit",
+        "chat_id": "chan-1",
+        "message_id": "message-1",
+        "content": "updated",
+        "finalize": True,
+        "metadata": {
+            "thread_id": "root-1",
+            "scope_id": "team-1",
+            "user_id": "user-1",
+        },
+    }
+
+
 class _CaptureTransport:
     """Minimal RelayTransport stand-in that records the outbound action."""
 

--- a/tests/gateway/relay/test_relay_registration.py
+++ b/tests/gateway/relay/test_relay_registration.py
@@ -64,3 +64,16 @@ def test_create_adapter_yields_relay_adapter():
     assert isinstance(adapter, RelayAdapter)
     # Placeholder descriptor until handshake negotiates the real one.
     assert adapter.descriptor.platform == "relay"
+
+
+def test_registration_can_keep_authorization_local(monkeypatch):
+    monkeypatch.setattr(
+        "gateway.relay.relay_authorization_is_upstream",
+        lambda: False,
+    )
+    register_relay_adapter(url="ws://127.0.0.1:9999")
+
+    adapter = platform_registry.create_adapter("relay", PlatformConfig())
+
+    assert adapter is not None
+    assert adapter._transport._authorization_is_upstream is False

--- a/tests/gateway/relay/test_slack_ingress_sidecar.py
+++ b/tests/gateway/relay/test_slack_ingress_sidecar.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.relay.adapter import RelayAdapter
+from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
+from gateway.relay.ws_transport import WebSocketRelayTransport
+from gateway.session import SessionSource
+from plugins.platforms.slack.ingress import (
+    FollowStore,
+    SlackIngressPolicy,
+    SlackIngressServer,
+)
+
+
+class _FakeSlackAdapter:
+    def __init__(self) -> None:
+        self.admission_handler = None
+        self.reaction_handler = None
+        self.dispatch_reaction_trigger = AsyncMock()
+        self.message_handler = None
+        self.sent: list[dict] = []
+        self.connected = False
+        self.connect_calls = 0
+        self.connected_event = asyncio.Event()
+        self.disconnected_event = asyncio.Event()
+
+    def set_external_admission_handler(self, handler) -> None:
+        self.admission_handler = handler
+
+    def set_external_reaction_handler(self, handler) -> None:
+        self.reaction_handler = handler
+
+    def set_message_handler(self, handler) -> None:
+        self.message_handler = handler
+
+    async def connect(self) -> bool:
+        self.connect_calls += 1
+        self.connected = True
+        self.disconnected_event.clear()
+        self.connected_event.set()
+        return True
+
+    async def disconnect(self) -> None:
+        self.connected = False
+        self.connected_event.clear()
+        self.disconnected_event.set()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append({
+            "chat_id": chat_id,
+            "content": content,
+            "reply_to": reply_to,
+            "metadata": dict(metadata or {}),
+        })
+        return SendResult(success=True, message_id="200.1")
+
+    async def edit_message(
+        self, chat_id, message_id, content, *, finalize=False, metadata=None
+    ) -> SendResult:
+        return SendResult(success=True, message_id=message_id)
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def stop_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {"name": "general", "type": "group"}
+
+
+def test_default_sidecar_lock_is_shared_across_profiles(tmp_path, monkeypatch):
+    profile_home = tmp_path / "hermes-root" / "profiles" / "work"
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    sidecar = SlackIngressServer(
+        _FakeSlackAdapter(),
+        SlackIngressPolicy(
+            FollowStore(tmp_path / "state.db", ttl_seconds=60, max_threads=100)
+        ),
+        host="127.0.0.1",
+        port=0,
+    )
+
+    assert sidecar._instance_lock.path == (
+        tmp_path / "hermes-root" / "slack-ingress.lock"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_start_releases_machine_lock(tmp_path, monkeypatch):
+    import plugins.platforms.slack.ingress as ingress_module
+
+    lock_path = tmp_path / "slack-ingress.lock"
+    first = SlackIngressServer(
+        _FakeSlackAdapter(),
+        SlackIngressPolicy(
+            FollowStore(tmp_path / "first.db", ttl_seconds=60, max_threads=100)
+        ),
+        host="127.0.0.1",
+        port=0,
+        lock_path=lock_path,
+    )
+    second = SlackIngressServer(
+        _FakeSlackAdapter(),
+        SlackIngressPolicy(
+            FollowStore(tmp_path / "second.db", ttl_seconds=60, max_threads=100)
+        ),
+        host="127.0.0.1",
+        port=0,
+        lock_path=lock_path,
+    )
+    real_serve = ingress_module.websockets.serve
+    monkeypatch.setattr(
+        ingress_module.websockets,
+        "serve",
+        AsyncMock(side_effect=asyncio.CancelledError()),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await first.start()
+
+    monkeypatch.setattr(ingress_module.websockets, "serve", real_serve)
+    await second.start()
+    await second.stop()
+
+
+@pytest.mark.asyncio
+async def test_only_one_sidecar_can_own_slack_for_a_profile(tmp_path):
+    lock_path = tmp_path / "slack-ingress.lock"
+    first = SlackIngressServer(
+        _FakeSlackAdapter(),
+        SlackIngressPolicy(
+            FollowStore(tmp_path / "first.db", ttl_seconds=60, max_threads=100)
+        ),
+        host="127.0.0.1",
+        port=0,
+        lock_path=lock_path,
+    )
+    second = SlackIngressServer(
+        _FakeSlackAdapter(),
+        SlackIngressPolicy(
+            FollowStore(tmp_path / "second.db", ttl_seconds=60, max_threads=100)
+        ),
+        host="127.0.0.1",
+        port=0,
+        lock_path=lock_path,
+    )
+
+    await first.start()
+    try:
+        with pytest.raises(RuntimeError, match="already running"):
+            await second.start()
+    finally:
+        await first.stop()
+
+    await second.start()
+    await second.stop()
+
+
+@pytest.mark.asyncio
+async def test_sidecar_closes_listener_and_releases_lock_when_slack_disconnect_fails(
+    tmp_path,
+):
+    lock_path = tmp_path / "slack-ingress.lock"
+    slack = _FakeSlackAdapter()
+    first = SlackIngressServer(
+        slack,
+        SlackIngressPolicy(
+            FollowStore(tmp_path / "first.db", ttl_seconds=60, max_threads=100)
+        ),
+        host="127.0.0.1",
+        port=0,
+        lock_path=lock_path,
+    )
+    second = SlackIngressServer(
+        _FakeSlackAdapter(),
+        SlackIngressPolicy(
+            FollowStore(tmp_path / "second.db", ttl_seconds=60, max_threads=100)
+        ),
+        host="127.0.0.1",
+        port=0,
+        lock_path=lock_path,
+    )
+
+    await first.start()
+    first._slack_connected = True
+    slack.disconnect = AsyncMock(side_effect=RuntimeError("disconnect failed"))
+
+    with pytest.raises(RuntimeError, match="disconnect failed"):
+        await first.stop()
+    assert first._server is None
+
+    await second.start()
+    await second.stop()
+
+
+@pytest.mark.asyncio
+async def test_slack_ingress_round_trips_over_production_relay(tmp_path):
+    slack = _FakeSlackAdapter()
+    store = FollowStore(
+        tmp_path / "ingress.db",
+        ttl_seconds=30 * 24 * 60 * 60,
+        max_threads=10_000,
+    )
+    sidecar = SlackIngressServer(
+        slack,
+        SlackIngressPolicy(
+            store,
+            reaction_user_ids={"U_OWNER"},
+            reaction_names={"eyes"},
+        ),
+        host="127.0.0.1",
+        port=0,
+    )
+    await sidecar.start(connect_slack=False)
+    assert slack.connected is False
+
+    placeholder = CapabilityDescriptor(
+        contract_version=CONTRACT_VERSION,
+        platform="slack",
+        label="Slack",
+        max_message_length=39_000,
+        supports_draft_streaming=False,
+        supports_edit=True,
+        supports_threads=False,
+        markdown_dialect="slack",
+        len_unit="chars",
+    )
+    transport = WebSocketRelayTransport(
+        sidecar.url,
+        "slack",
+        "U_BOT",
+        authorization_is_upstream=False,
+    )
+    relay = RelayAdapter(PlatformConfig(enabled=True), placeholder, transport=transport)
+    received = asyncio.Event()
+    inbound: list[MessageEvent] = []
+
+    async def _capture(event: MessageEvent) -> None:
+        inbound.append(event)
+        received.set()
+
+    relay.set_message_handler(_capture)
+    try:
+        assert await relay.connect() is True
+        await asyncio.wait_for(slack.connected_event.wait(), timeout=2)
+        assert slack.connected is True
+        assert slack.connect_calls == 1
+        assert slack.reaction_handler is not None
+
+        duplicate_transport = WebSocketRelayTransport(
+            sidecar.url,
+            "slack",
+            "U_DUPLICATE",
+            authorization_is_upstream=False,
+        )
+        duplicate_relay = RelayAdapter(
+            PlatformConfig(enabled=True),
+            placeholder,
+            transport=duplicate_transport,
+        )
+        try:
+            with pytest.raises(Exception, match="4429"):
+                await duplicate_relay.connect()
+        finally:
+            await duplicate_relay.disconnect()
+        assert slack.connect_calls == 1
+
+        reaction = {
+            "type": "reaction_added",
+            "user": "U_OTHER",
+            "reaction": "eyes",
+            "item": {"type": "message", "channel": "C1", "ts": "100.1"},
+        }
+        await slack.reaction_handler(reaction, body={"team_id": "T1"})
+        slack.dispatch_reaction_trigger.assert_not_awaited()
+        reaction["user"] = "U_OWNER"
+        await slack.reaction_handler(reaction, body={"team_id": "T1"})
+        slack.dispatch_reaction_trigger.assert_awaited_once_with(
+            reaction, body={"team_id": "T1"}
+        )
+
+        await sidecar.forward_event(
+            MessageEvent(
+                text="plain follow-up",
+                message_type=MessageType.TEXT,
+                source=SessionSource(
+                    platform=Platform.SLACK,
+                    chat_id="C1",
+                    chat_type="group",
+                    user_id="U1",
+                    thread_id="100.1",
+                    scope_id="T1",
+                    message_id="100.2",
+                ),
+                message_id="100.2",
+                reply_to_message_id="100.1",
+                metadata={"slack_team_id": "T1", "slack_thread_ts": "100.1"},
+            )
+        )
+        await asyncio.wait_for(received.wait(), timeout=2)
+
+        assert inbound[0].source.platform is Platform.SLACK
+        assert inbound[0].source.delivered_via_relay is True
+        assert inbound[0].source.delivered_via_upstream_relay is False
+
+        result = await relay.send(
+            "C1",
+            "Hermes reply",
+            reply_to="100.2",
+            metadata={"thread_id": "100.1", "slack_team_id": "T1"},
+        )
+        assert result.success is True
+        assert slack.sent == [
+            {
+                "chat_id": "C1",
+                "content": "Hermes reply",
+                "reply_to": "100.2",
+                "metadata": {
+                    "thread_id": "100.1",
+                    "slack_team_id": "T1",
+                    "scope_id": "T1",
+                    "user_id": "U1",
+                },
+            }
+        ]
+    finally:
+        await relay.disconnect()
+        await asyncio.wait_for(slack.disconnected_event.wait(), timeout=2)
+        assert slack.connected is False
+        await sidecar.stop()

--- a/tests/gateway/test_relay_upstream_authz.py
+++ b/tests/gateway/test_relay_upstream_authz.py
@@ -242,7 +242,37 @@ def test_event_from_wire_sets_relay_delivery_marker():
         }
     )
     assert event.source.platform is Platform.DISCORD
+    assert event.source.delivered_via_relay is True
     assert event.source.delivered_via_upstream_relay is True
+
+
+def test_local_relay_delivery_does_not_bypass_platform_allowlist(monkeypatch):
+    """A local Slack ingress uses relay for transport, not for authorization."""
+    from gateway.relay.ws_transport import _event_from_wire
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+    runner, relay_adapter = _make_runner(
+        platform=Platform.RELAY,
+        authorization_is_upstream=True,
+    )
+    event = _event_from_wire(
+        {
+            "text": "hello!",
+            "source": {
+                "platform": "slack",
+                "chat_id": "C1",
+                "chat_type": "group",
+                "user_id": "U1",
+            },
+        },
+        authorization_is_upstream=False,
+    )
+
+    assert event.source.delivered_via_relay is True
+    assert event.source.delivered_via_upstream_relay is False
+    assert runner._adapter_for_source(event.source) is relay_adapter
+    assert runner._is_user_authorized(event.source) is False
 
 
 def test_event_from_wire_stamps_routed_profile():

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2107,6 +2107,46 @@ class TestIncomingAudioHandling:
 
 class TestMessageRouting:
     @pytest.mark.asyncio
+    async def test_external_reaction_handler_receives_raw_event_and_body(self, adapter):
+        handler = AsyncMock()
+        adapter.set_external_reaction_handler(handler)
+        event = {
+            "type": "reaction_added",
+            "user": "U_OWNER",
+            "reaction": "eyes",
+            "item": {"type": "message", "channel": "C1", "ts": "500.1"},
+        }
+        body = {"team_id": "T1", "event_id": "Ev1"}
+
+        await adapter._handle_reaction_added(event, body)
+
+        handler.assert_awaited_once_with(event, body=body)
+
+    @pytest.mark.asyncio
+    async def test_reaction_trigger_becomes_one_shot_thread_mention(self, adapter):
+        adapter._handle_slack_message = AsyncMock()
+        event = {
+            "type": "reaction_added",
+            "user": "U_OWNER",
+            "reaction": "eyes",
+            "event_ts": "500.2",
+            "item": {"type": "message", "channel": "C1", "ts": "500.1"},
+        }
+        body = {"team_id": "T1", "event_id": "Ev1"}
+
+        await adapter.dispatch_reaction_trigger(event, body=body)
+
+        synthetic, forwarded_body = adapter._handle_slack_message.await_args.args
+        assert synthetic["user"] == "U_OWNER"
+        assert synthetic["channel"] == "C1"
+        assert synthetic["thread_ts"] == "500.1"
+        assert synthetic["ts"] == "500.2"
+        assert "<@U_BOT>" in synthetic["text"]
+        assert not synthetic["text"].lstrip().startswith("<@U_BOT>")
+        assert synthetic["_slack_ingress_reaction_trigger"] is True
+        assert forwarded_body is body
+
+    @pytest.mark.asyncio
     async def test_dm_processed_without_mention(self, adapter):
         """DM messages should be processed without requiring a bot mention."""
         event = {
@@ -2131,6 +2171,46 @@ class TestMessageRouting:
         }
         await adapter._handle_slack_message(event)
         adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_external_admission_denial_overrides_legacy_thread_gates(self, adapter):
+        root_ts = "1234567890.000000"
+        adapter._bot_message_ts.add(root_ts)
+        adapter._mentioned_threads.add(root_ts)
+        admission = AsyncMock(return_value=False)
+        adapter.set_external_admission_handler(admission)
+        event = {
+            "text": "humans keep talking",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "thread_ts": root_ts,
+            "ts": "1234567890.000001",
+        }
+
+        await adapter._handle_slack_message(event, {"team_id": "T123"})
+
+        admission.assert_awaited_once()
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_external_admission_does_not_mutate_legacy_follow_state(self, adapter):
+        root_ts = "1234567890.000000"
+        admission = AsyncMock(return_value=True)
+        adapter.set_external_admission_handler(admission)
+        event = {
+            "text": "<@U_BOT> answer only this turn",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "thread_ts": root_ts,
+            "ts": "1234567890.000001",
+        }
+
+        await adapter._handle_slack_message(event, {"team_id": "T123"})
+
+        adapter.handle_message.assert_awaited_once()
+        assert root_ts not in adapter._mentioned_threads
 
     @pytest.mark.asyncio
     async def test_channel_mention_strips_bot_id(self, adapter):

--- a/tests/gateway/test_slack_ingress.py
+++ b/tests/gateway/test_slack_ingress.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+from plugins.platforms.slack.ingress import (
+    FollowStore,
+    SlackIngressPolicy,
+    message_event_to_wire,
+)
+
+
+def test_follow_store_prunes_expired_and_oldest_rows(tmp_path):
+    store = FollowStore(
+        tmp_path / "follow.db",
+        ttl_seconds=100,
+        max_threads=2,
+        clock=lambda: 1_000.0,
+    )
+
+    store.follow("T1", "C1", "expired", seen_at=800.0)
+    store.follow("T1", "C1", "older", seen_at=950.0)
+    store.follow("T1", "C1", "newer", seen_at=975.0)
+    store.follow("T1", "C1", "newest", seen_at=990.0)
+
+    assert store.is_followed("T1", "C1", "expired") is False
+    assert store.is_followed("T1", "C1", "older") is False
+    assert store.is_followed("T1", "C1", "newer") is True
+    assert store.is_followed("T1", "C1", "newest") is True
+    assert store.count() == 2
+
+
+def test_root_mention_starts_following_the_new_thread(tmp_path):
+    store = FollowStore(
+        tmp_path / "follow.db",
+        ttl_seconds=100,
+        max_threads=10,
+        clock=lambda: 1_000.0,
+    )
+    policy = SlackIngressPolicy(store)
+
+    admitted = policy.admit(
+        {"channel": "C1", "ts": "100.1", "text": "  <@B1> hello"},
+        team_id="T1",
+        bot_user_id="B1",
+        is_one_to_one_dm=False,
+    )
+
+    assert admitted is True
+    assert store.is_followed("T1", "C1", "100.1") is True
+
+
+def test_followed_thread_messages_refresh_the_idle_ttl(tmp_path):
+    now = [1_000.0]
+    store = FollowStore(
+        tmp_path / "follow.db",
+        ttl_seconds=100,
+        max_threads=10,
+        clock=lambda: now[0],
+    )
+    store.follow("T1", "C1", "100.1", seen_at=950.0)
+    policy = SlackIngressPolicy(store)
+
+    now[0] = 1_040.0
+    admitted = policy.admit(
+        {
+            "channel": "C1",
+            "ts": "104.1",
+            "thread_ts": "100.1",
+            "text": "plain follow-up",
+        },
+        team_id="T1",
+        bot_user_id="B1",
+        is_one_to_one_dm=False,
+    )
+    now[0] = 1_120.0
+
+    assert admitted is True
+    assert store.is_followed("T1", "C1", "100.1") is True
+
+
+def test_untracked_thread_mention_is_one_shot(tmp_path):
+    store = FollowStore(
+        tmp_path / "follow.db",
+        ttl_seconds=100,
+        max_threads=10,
+        clock=lambda: 1_000.0,
+    )
+    policy = SlackIngressPolicy(store)
+
+    mentioned = policy.admit(
+        {
+            "channel": "C1",
+            "ts": "200.2",
+            "thread_ts": "200.1",
+            "text": "<@B1> answer this only",
+        },
+        team_id="T1",
+        bot_user_id="B1",
+        is_one_to_one_dm=False,
+    )
+    later_plain = policy.admit(
+        {
+            "channel": "C1",
+            "ts": "200.3",
+            "thread_ts": "200.1",
+            "text": "humans keep talking",
+        },
+        team_id="T1",
+        bot_user_id="B1",
+        is_one_to_one_dm=False,
+    )
+
+    assert mentioned is True
+    assert store.is_followed("T1", "C1", "200.1") is False
+    assert later_plain is False
+
+
+def test_message_event_to_wire_preserves_slack_context_and_media():
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C1",
+        chat_name="general",
+        chat_type="group",
+        user_id="U1",
+        user_name="Alice",
+        thread_id="100.1",
+        scope_id="T1",
+        message_id="100.2",
+    )
+    event = MessageEvent(
+        text="summarize this",
+        message_type=MessageType.DOCUMENT,
+        source=source,
+        message_id="100.2",
+        media_urls=["/tmp/report.pdf"],
+        media_types=["application/pdf"],
+        reply_to_message_id="100.1",
+        reply_to_text="parent",
+        reply_to_author_id="U2",
+        reply_to_author_name="Bob",
+        channel_prompt="channel rules",
+        auto_skill=["one", "two"],
+        metadata={"slack_team_id": "T1", "slack_thread_ts": "100.1"},
+    )
+
+    wire = message_event_to_wire(event)
+
+    assert wire["message_type"] == "document"
+    assert wire["source"]["platform"] == "slack"
+    assert wire["source"]["scope_id"] == "T1"
+    assert wire["media_urls"] == ["/tmp/report.pdf"]
+    assert wire["media_types"] == ["application/pdf"]
+    assert wire["reply_to_text"] == "parent"
+    assert wire["reply_to_author_id"] == "U2"
+    assert wire["reply_to_author_name"] == "Bob"
+    assert wire["channel_prompt"] == "channel rules"
+    assert wire["auto_skill"] == ["one", "two"]
+    assert wire["metadata"]["slack_thread_ts"] == "100.1"
+
+    from gateway.relay.ws_transport import _event_from_wire
+
+    rebuilt = _event_from_wire(wire, authorization_is_upstream=False)
+    assert rebuilt.media_types == ["application/pdf"]
+    assert rebuilt.reply_to_text == "parent"
+    assert rebuilt.reply_to_author_id == "U2"
+    assert rebuilt.reply_to_author_name == "Bob"
+    assert rebuilt.channel_prompt == "channel rules"
+    assert rebuilt.auto_skill == ["one", "two"]
+    assert rebuilt.metadata["slack_thread_ts"] == "100.1"
+
+
+def test_mute_removes_follow_before_any_gateway_delivery(tmp_path):
+    store = FollowStore(
+        tmp_path / "follow.db",
+        ttl_seconds=100,
+        max_threads=10,
+        clock=lambda: 1_000.0,
+    )
+    store.follow("T1", "C1", "300.1")
+    policy = SlackIngressPolicy(store)
+
+    mute_admitted = policy.admit(
+        {
+            "channel": "C1",
+            "ts": "300.2",
+            "thread_ts": "300.1",
+            "text": "<@B1> /mute",
+        },
+        team_id="T1",
+        bot_user_id="B1",
+        is_one_to_one_dm=False,
+    )
+    later_plain = policy.admit(
+        {
+            "channel": "C1",
+            "ts": "300.3",
+            "thread_ts": "300.1",
+            "text": "this must stay outside Gateway",
+        },
+        team_id="T1",
+        bot_user_id="B1",
+        is_one_to_one_dm=False,
+    )
+
+    assert mute_admitted is False
+    assert store.is_followed("T1", "C1", "300.1") is False
+    assert later_plain is False
+
+
+def test_control_commands_are_extensible_and_consumed_locally(tmp_path):
+    store = FollowStore(
+        tmp_path / "follow.db",
+        ttl_seconds=100,
+        max_threads=10,
+    )
+    policy = SlackIngressPolicy(store)
+    seen = []
+
+    def _pause(**context):
+        seen.append(context)
+
+    policy.register_control_command("/pause", _pause)
+    admitted = policy.admit(
+        {
+            "channel": "C1",
+            "ts": "400.2",
+            "thread_ts": "400.1",
+            "text": "<@B1> /pause later",
+        },
+        team_id="T1",
+        bot_user_id="B1",
+        is_one_to_one_dm=False,
+    )
+
+    assert admitted is False
+    assert seen[0]["team_id"] == "T1"
+    assert seen[0]["channel_id"] == "C1"
+    assert seen[0]["thread_ts"] == "400.1"
+    assert seen[0]["event"]["ts"] == "400.2"
+
+
+def test_reaction_trigger_requires_owner_allowed_emoji_and_message_item(tmp_path):
+    store = FollowStore(
+        tmp_path / "follow.db",
+        ttl_seconds=100,
+        max_threads=10,
+    )
+    policy = SlackIngressPolicy(
+        store,
+        reaction_user_ids={"U_OWNER"},
+        reaction_names={"eyes"},
+    )
+    base = {
+        "type": "reaction_added",
+        "user": "U_OWNER",
+        "reaction": "eyes",
+        "item": {"type": "message", "channel": "C1", "ts": "500.1"},
+    }
+
+    assert policy.admit_reaction(base) is True
+    assert policy.admit_reaction({**base, "user": "U_OTHER"}) is False
+    assert policy.admit_reaction({**base, "reaction": "thumbsup"}) is False
+    assert (
+        policy.admit_reaction({**base, "item": {"type": "file", "file": "F1"}}) is False
+    )
+    assert store.count() == 0

--- a/tests/hermes_cli/test_slack_cli.py
+++ b/tests/hermes_cli/test_slack_cli.py
@@ -2,7 +2,8 @@
 
 import argparse
 
-from hermes_cli.slack_cli import _build_full_manifest
+from hermes_cli.main import cmd_slack
+from hermes_cli.slack_cli import _build_full_manifest, _slack_ingress_settings
 from hermes_cli.subcommands.slack import build_slack_parser
 
 
@@ -12,6 +13,106 @@ def _parse_slack_args(argv):
     subparsers = parser.add_subparsers(dest="command")
     build_slack_parser(subparsers, cmd_slack=lambda _args: 0)
     return parser.parse_args(argv)
+
+
+class TestSlackIngressArgparse:
+    def test_ingress_defaults_to_loopback(self):
+        args = _parse_slack_args(["slack", "ingress"])
+        assert args.slack_command == "ingress"
+        assert args.host == "127.0.0.1"
+        assert args.port == 8791
+        assert args.state is None
+
+    def test_ingress_accepts_operational_overrides(self):
+        args = _parse_slack_args(
+            [
+                "slack",
+                "ingress",
+                "--host",
+                "localhost",
+                "--port",
+                "9001",
+                "--state",
+                "/tmp/slack.db",
+            ]
+        )
+        assert args.host == "localhost"
+        assert args.port == 9001
+        assert args.state == "/tmp/slack.db"
+
+    def test_ingress_policy_settings_come_from_config(self):
+        settings = _slack_ingress_settings(
+            {
+                "slack": {
+                    "ingress": {
+                        "follow_ttl_days": 7,
+                        "max_followed_threads": 321,
+                        "reaction_user_ids": ["U_OWNER", "U_OWNER", ""],
+                        "reaction_names": [":eyes:", "bookmark"],
+                    }
+                }
+            }
+        )
+
+        assert settings == {
+            "ttl_seconds": 7 * 24 * 60 * 60,
+            "max_threads": 321,
+            "reaction_user_ids": {"U_OWNER"},
+            "reaction_names": {"eyes", "bookmark"},
+        }
+
+    def test_ingress_policy_settings_have_bounded_defaults(self):
+        settings = _slack_ingress_settings({})
+        assert settings["ttl_seconds"] == 30 * 24 * 60 * 60
+        assert settings["max_threads"] == 10_000
+        assert settings["reaction_user_ids"] == set()
+        assert settings["reaction_names"] == set()
+
+    def test_ingress_dispatches_to_runtime_command(self, monkeypatch):
+        import hermes_cli.slack_cli as slack_cli
+
+        called = []
+        monkeypatch.setattr(
+            slack_cli,
+            "slack_ingress_command",
+            lambda args: called.append(args) or 17,
+        )
+        args = _parse_slack_args(["slack", "ingress"])
+
+        assert cmd_slack(args) == 17
+        assert called == [args]
+
+    def test_ingress_refuses_direct_slack_gateway_ownership(
+        self, monkeypatch, capsys
+    ):
+        import gateway.config as gateway_config_module
+        import hermes_cli.config as cli_config
+        import hermes_cli.slack_cli as slack_cli
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        monkeypatch.setattr(cli_config, "load_config", lambda: {})
+        monkeypatch.setattr(
+            gateway_config_module,
+            "load_gateway_config",
+            lambda: GatewayConfig(
+                platforms={
+                    Platform.SLACK: PlatformConfig(
+                        enabled=True,
+                        token="xoxb-test",
+                    )
+                }
+            ),
+        )
+        monkeypatch.setattr(
+            slack_cli.asyncio,
+            "run",
+            lambda coroutine: coroutine.close(),
+        )
+
+        assert slack_cli.slack_ingress_command(
+            _parse_slack_args(["slack", "ingress"])
+        ) == 1
+        assert "slack.enabled: false" in capsys.readouterr().err
 
 
 class TestSlackManifestArgparse:
@@ -68,6 +169,14 @@ class TestSlackFullManifest:
         # mpim:read mirrors im:read for conversations.info classification.
         assert "mpim:history" in bot_scopes
         assert "mpim:read" in bot_scopes
+
+    def test_reaction_trigger_subscription_is_included(self):
+        manifest = _build_full_manifest("Hermes", "Your Hermes agent on Slack")
+
+        bot_scopes = manifest["oauth_config"]["scopes"]["bot"]
+        bot_events = manifest["settings"]["event_subscriptions"]["bot_events"]
+        assert "reactions:read" in bot_scopes
+        assert "reaction_added" in bot_events
 
     def test_group_dm_surface_present_without_assistant_mode(self):
         """Dropping assistant mode must not strip the group-DM surface."""

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -79,6 +79,7 @@ Navigate to **Features → OAuth & Permissions** in the sidebar. Scroll to **Sco
 | `im:write` | Open and manage DMs |
 | `mpim:history` | Read group direct message (multi-person DM) history |
 | `mpim:read` | View basic group DM info |
+| `reactions:read` | Receive configured one-shot emoji triggers |
 | `users:read` | Look up user information |
 | `files:read` | Read and download attached files, including voice notes/audio |
 | `files:write` | Upload files (images, audio, documents) |
@@ -132,6 +133,7 @@ This step is critical — it controls what messages the bot can see.
 | `message.channels` | **Yes** | Bot receives messages in **public** channels it's added to |
 | `message.groups` | **Recommended** | Bot receives messages in **private** channels it's invited to |
 | `app_mention` | **Yes** | Prevents Bolt SDK errors when bot is @mentioned |
+| `reaction_added` | **Optional** | Enables configured owner-only one-shot emoji triggers |
 
 4. Click **Save Changes** at the bottom of the page
 
@@ -217,6 +219,54 @@ hermes gateway              # Foreground
 hermes gateway install      # Install as a user service
 sudo hermes gateway install --system   # Linux only: boot-time system service
 ```
+
+### Optional: single-Socket ingress sidecar
+
+For a Mac that may run or restart more than one Hermes process, the ingress
+sidecar can be the sole owner of Slack Socket Mode. The Gateway talks to it over
+one loopback Relay connection and never opens Slack directly.
+
+```yaml title="~/.hermes/config.yaml"
+slack:
+  enabled: false
+  ingress:
+    follow_ttl_days: 30
+    max_followed_threads: 10000
+    reaction_user_ids: ["U01ABC2DEF3"]
+    reaction_names: ["eyes"]
+
+gateway:
+  relay_url: "http://127.0.0.1:8791"
+  relay_authorization_is_upstream: false
+```
+
+Keep `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, and `SLACK_ALLOWED_USERS` in
+`~/.hermes/.env`, then run the sidecar before starting or restarting Gateway:
+
+```bash
+hermes slack ingress
+# In another terminal:
+hermes gateway restart
+```
+
+The safety invariants are enforced rather than advisory:
+
+- one ingress sidecar per machine, even across profiles or alternate ports;
+- one Slack Socket owner per app token, including direct Gateway processes;
+- one active Gateway Relay connection; a second is closed with code `4429`;
+- Slack connects only after Relay handshake and disconnects with Relay;
+- followed threads expire after the configured inactivity TTL and are also
+  bounded by `max_followed_threads`;
+- a root message beginning with `@Hermes` follows that thread; a mention inside
+  an existing thread is one-shot unless the thread is already followed;
+- `@Hermes /mute` is consumed by the sidecar, deletes the follow route, and is
+  never sent to Gateway or the LLM;
+- configured reactions trigger one turn without creating or refreshing a
+  follow route.
+
+The generated manifest includes `reactions:read` and `reaction_added`. If you
+apply those additions to an existing Slack app, reinstall the app when Slack
+prompts you.
 
 :::tip Codex reasoning-effort safety
 For Codex-backed Slack peer-agent channels, prefer `agent.reasoning_effort: high` or lower. `xhigh`


### PR DESCRIPTION
## Summary

- add a machine-singleton Slack ingress sidecar that owns one Socket Mode connection and bridges one active Gateway over loopback Relay
- add bounded, durable thread-follow policy with root-mention follow, one-shot existing-thread mentions/reactions, and sidecar-local `@Hermes /mute`
- preserve Slack authorization while routing Relay-delivered replies/edits through the underlying Slack adapter, plus CLI/config docs and lifecycle safeguards

## Conversation Log
> 이번 세션에서 사용자가 요청한 내용들입니다.

- 여러 Slack Gateway Socket 연결 때문에 메시지 응답이 유실되는 문제를 근본적으로 해결해 달라고 요청
- Mac 전체에서 Sidecar와 Slack Socket 연결을 각각 하나로 제한하고, Gateway Relay도 하나만 허용하도록 요청
- 루트 멘션은 thread follow, 기존 thread 멘션과 emoji reaction은 one-shot으로 처리하고 상태/메모리를 TTL과 cap으로 제한하도록 요청
- `@Hermes /mute`는 Gateway나 LLM으로 보내지 않고 Sidecar에서 즉시 소비하도록 요청
- 설계 설명보다 실제 구현과 테스트, 실행 가능한 검증 절차를 우선해 달라고 요청

## Test plan

- [x] `scripts/run_tests.sh tests/gateway/test_slack_ingress.py tests/gateway/relay/test_slack_ingress_sidecar.py tests/gateway/relay/test_relay_adapter.py tests/gateway/relay/test_relay_registration.py tests/gateway/test_relay_upstream_authz.py tests/gateway/test_slack.py tests/hermes_cli/test_slack_cli.py --file-retries 0 -q` — **325 passed**
- [x] Ruff lint and format checks for all changed Python files
- [x] `git diff --check` and staged secret-pattern scan (only a fake `xoxb-test` test token matched)
- [x] isolated real CLI process: listener opened on loopback, Relay-unconnected state had zero external established connections, and shutdown released the listener/OS lock
- [x] full repository suite attempted (~43k tests); failures were confined to unrelated environment/baseline files (macOS systemd/abstract-socket cases, credential environment, subprocess/file-descriptor pressure). Representative failures reproduced unchanged on a detached `origin/main` worktree.
