### PR TITLE
fix(skills): force UTF-8 on hub lock/taps/cache JSON I/O

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -2,6 +2,7 @@
 
 import json
 import time
+from pathlib import Path
 from typing import List, Optional
 from unittest.mock import patch, MagicMock
 
@@ -1401,6 +1402,72 @@ class TestHubLockFile:
         names = {e["name"] for e in installed}
         assert names == {"s1", "s2"}
 
+    def test_load_survives_non_utf8_locale_default(self, tmp_path, monkeypatch):
+        """#68369: bare locale read_text fails; HubLockFile forces UTF-8."""
+        lock_file = tmp_path / "lock.json"
+        payload = json.dumps(
+            {
+                "version": 1,
+                "installed": {
+                    "my-skill": {
+                        "source": "github",
+                        "identifier": "owner/repo/—skill",
+                    }
+                },
+            },
+            ensure_ascii=False,
+            indent=2,
+        ).encode("utf-8") + b"\n"
+        lock_file.write_bytes(payload)
+
+        real_read_text = Path.read_text
+
+        def locale_default_read_text(self, *args, encoding=None, errors=None, **kwargs):
+            # Simulate Chinese Windows / non-UTF-8 preferred encoding:
+            # bare Path.read_text() (encoding=None) must not succeed on this file.
+            if encoding is None:
+                raise UnicodeDecodeError(
+                    "gbk", self.read_bytes(), 0, 1, "simulated non-utf8 locale"
+                )
+            return real_read_text(self, *args, encoding=encoding, errors=errors, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", locale_default_read_text)
+        with pytest.raises(UnicodeDecodeError):
+            lock_file.read_text()
+        data = HubLockFile(path=lock_file).load()
+        assert data["installed"]["my-skill"]["identifier"] == "owner/repo/—skill"
+
+    def test_load_passes_utf8_encoding(self, tmp_path, monkeypatch):
+        lock_file = tmp_path / "lock.json"
+        lock_file.write_text('{"version": 1, "installed": {}}', encoding="utf-8")
+        calls = []
+        real_read_text = Path.read_text
+
+        def spy_read_text(self, *args, **kwargs):
+            calls.append(kwargs)
+            return real_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", spy_read_text)
+        HubLockFile(path=lock_file).load()
+        assert calls, "expected Path.read_text to be called"
+        assert any(c.get("encoding") == "utf-8" for c in calls)
+
+    def test_save_roundtrip_non_ascii_utf8(self, tmp_path):
+        lock = HubLockFile(path=tmp_path / "lock.json")
+        lock.record_install(
+            name="demo-skill",
+            source="github",
+            identifier="owner/repo/—skill",
+            trust_level="community",
+            scan_verdict="pass",
+            skill_hash="h",
+            install_path="demo-skill",
+            files=["SKILL.md"],
+        )
+        raw = (tmp_path / "lock.json").read_bytes()
+        assert "—".encode("utf-8") in raw
+        reloaded = HubLockFile(path=tmp_path / "lock.json").load()
+        assert reloaded["installed"]["demo-skill"]["identifier"] == "owner/repo/—skill"
 
 # ---------------------------------------------------------------------------
 # TapsManager
@@ -1425,6 +1492,29 @@ class TestTapsManager:
         taps_file.write_text("bad json")
         mgr = TapsManager(path=taps_file)
         assert mgr.load() == []
+
+    def test_load_survives_non_utf8_locale_default(self, tmp_path, monkeypatch):
+        taps_file = tmp_path / "taps.json"
+        payload = json.dumps(
+            {"taps": [{"repo": "owner/—repo", "path": "skills/"}]},
+            ensure_ascii=False,
+        ).encode("utf-8") + b"\n"
+        taps_file.write_bytes(payload)
+
+        real_read_text = Path.read_text
+
+        def locale_default_read_text(self, *args, encoding=None, errors=None, **kwargs):
+            if encoding is None:
+                raise UnicodeDecodeError(
+                    "gbk", self.read_bytes(), 0, 1, "simulated non-utf8 locale"
+                )
+            return real_read_text(self, *args, encoding=encoding, errors=errors, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", locale_default_read_text)
+        with pytest.raises(UnicodeDecodeError):
+            taps_file.read_text()
+        taps = TapsManager(path=taps_file).load()
+        assert taps[0]["repo"] == "owner/—repo"
 
     def test_add_new_tap(self, tmp_path):
         mgr = TapsManager(path=tmp_path / "taps.json")

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1134,8 +1134,8 @@ class GitHubSource(SkillSource):
             stat = cache_file.stat()
             if time.time() - stat.st_mtime > INDEX_CACHE_TTL:
                 return None
-            return json.loads(cache_file.read_text())
-        except (OSError, json.JSONDecodeError):
+            return json.loads(cache_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
             return None
 
     def _write_cache(self, key: str, data: list) -> None:
@@ -1144,7 +1144,10 @@ class GitHubSource(SkillSource):
         index_cache_dir.mkdir(parents=True, exist_ok=True)
         cache_file = index_cache_dir / f"{key}.json"
         try:
-            cache_file.write_text(json.dumps(data, ensure_ascii=False))
+            cache_file.write_text(
+                json.dumps(data, ensure_ascii=False),
+                encoding="utf-8",
+            )
         except OSError as e:
             logger.debug("Could not write cache: %s", e)
 
@@ -3345,8 +3348,8 @@ def _read_index_cache(key: str) -> Optional[Any]:
         stat = cache_file.stat()
         if time.time() - stat.st_mtime > INDEX_CACHE_TTL:
             return None
-        return json.loads(cache_file.read_text())
-    except (OSError, json.JSONDecodeError):
+        return json.loads(cache_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         return None
 
 
@@ -3360,12 +3363,18 @@ def _write_index_cache(key: str, data: Any) -> None:
     ignore_file = _hub_dir() / ".ignore"
     if not ignore_file.exists():
         try:
-            ignore_file.write_text("# Exclude hub internals from search tools\n*\n")
+            ignore_file.write_text(
+                "# Exclude hub internals from search tools\n*\n",
+                encoding="utf-8",
+            )
         except OSError:
             pass
     cache_file = index_cache_dir / f"{key}.json"
     try:
-        cache_file.write_text(json.dumps(data, ensure_ascii=False, default=str))
+        cache_file.write_text(
+            json.dumps(data, ensure_ascii=False, default=str),
+            encoding="utf-8",
+        )
     except OSError as e:
         logger.debug("Could not write cache: %s", e)
 
@@ -3399,13 +3408,19 @@ class HubLockFile:
         if not self.path.exists():
             return {"version": 1, "installed": {}}
         try:
-            return json.loads(self.path.read_text())
-        except (json.JSONDecodeError, OSError):
+            # Always UTF-8: save() writes ensure_ascii=False JSON. Bare
+            # read_text() uses the locale encoding (e.g. GBK on Chinese
+            # Windows) and crashes skills check on valid lock files (#68369).
+            return json.loads(self.path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
             return {"version": 1, "installed": {}}
 
     def save(self, data: dict) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+        self.path.write_text(
+            json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
 
     def record_install(
         self,
@@ -3473,14 +3488,18 @@ class TapsManager:
         if not self.path.exists():
             return []
         try:
-            data = json.loads(self.path.read_text())
+            # Match HubLockFile: hub state JSON is always UTF-8.
+            data = json.loads(self.path.read_text(encoding="utf-8"))
             return data.get("taps", [])
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
             return []
 
     def save(self, taps: List[dict]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps({"taps": taps}, indent=2) + "\n")
+        self.path.write_text(
+            json.dumps({"taps": taps}, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
 
     def add(self, repo: str, path: str = "skills/") -> bool:
         """Add a tap. Returns False if already exists."""
@@ -3793,8 +3812,10 @@ def _load_hermes_index() -> Optional[dict]:
         try:
             age = time.time() - hermes_index_cache_file.stat().st_mtime
             if age < HERMES_INDEX_TTL:
-                return json.loads(hermes_index_cache_file.read_text())
-        except (OSError, json.JSONDecodeError):
+                return json.loads(
+                    hermes_index_cache_file.read_text(encoding="utf-8")
+                )
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
             pass
 
     # Fetch from docs site.
@@ -3847,7 +3868,7 @@ def _load_hermes_index() -> Optional[dict]:
     # Cache locally
     try:
         hermes_index_cache_file.parent.mkdir(parents=True, exist_ok=True)
-        hermes_index_cache_file.write_text(json.dumps(data))
+        hermes_index_cache_file.write_text(json.dumps(data), encoding="utf-8")
     except OSError:
         pass
 
@@ -3859,8 +3880,8 @@ def _load_stale_index_cache() -> Optional[dict]:
     hermes_index_cache_file = _hermes_index_cache_file()
     if hermes_index_cache_file.exists():
         try:
-            return json.loads(hermes_index_cache_file.read_text())
-        except (OSError, json.JSONDecodeError):
+            return json.loads(hermes_index_cache_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
             pass
     return None
 


### PR DESCRIPTION
## Summary

`HubLockFile.save()` writes JSON with `ensure_ascii=False` (real Unicode), but `load()` used bare `Path.read_text()` which decodes with the process locale encoding. On Chinese Windows that is GBK/cp936, so a valid UTF-8 `lock.json` crashes `hermes skills check` with `UnicodeDecodeError`.

## Fix

- Force `encoding="utf-8"` on hub state JSON read/write paths:
  - `HubLockFile.load` / `save`
  - `TapsManager.load` / `save`
  - index cache helpers that pair `ensure_ascii=False` writes with bare reads
  - Hermes skills-index cache read/write
- Catch `UnicodeDecodeError` alongside existing JSON/OS errors so a truly corrupt file still degrades safely

## Test plan

- [x] `TestHubLockFile` — locale-default bare read fails, UTF-8 load succeeds
- [x] `TestHubLockFile` — `Path.read_text` called with `encoding="utf-8"`
- [x] `TestHubLockFile` — non-ASCII identifier round-trip
- [x] `TestTapsManager` — same locale-default survival for taps.json
- [x] Existing HubLockFile / TapsManager suite green (21 tests)

Closes #68369
