### PR TITLE
fix(gateway): auto-detect image paths typed in message text

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15817,7 +15817,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # non-image) sent alongside an image in the same message gets
                 # mis-routed here as an image and the provider 400s.
                 if _event_media_is_image(event, i):
-                    image_paths.append(path)
+                    # Attached media that is already a remote URL must ride the
+                    # URL collection, not the local-path one: native attachment
+                    # embeds local files as base64 but passes URLs through
+                    # verbatim, so a URL left in image_paths would be dropped
+                    # by build_native_content_parts' Path.exists() check.
+                    if str(path).startswith(("http://", "https://")):
+                        image_urls.append(path)
+                    else:
+                        image_paths.append(path)
                 # MessageType.AUDIO = audio file attachment (e.g. .mp3, .m4a) — never STT
                 # MessageType.VOICE = voice message (Opus/OGG) — always STT
                 if event.message_type == MessageType.AUDIO:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5330,17 +5330,19 @@ class TurnRunner:
         _approval_session_token = set_current_session_key(_approval_session_key)
         register_gateway_notify(_approval_session_key, _approval_notify_sync)
         try:
-            # If _prepare_inbound_message_text buffered image paths for native
-            # attachment, wrap the user turn as an OpenAI-style multimodal
-            # content list. Consume-and-clear so subsequent turns on the same
-            # runner instance don't re-attach stale images.
+            # If _prepare_inbound_message_text buffered image paths/URLs for
+            # native attachment, wrap the user turn as an OpenAI-style
+            # multimodal content list. Consume-and-clear so subsequent turns on
+            # the same runner instance don't re-attach stale images.
             _native_imgs = self._runner._consume_pending_native_image_paths(ctx.session_key)
-            if _native_imgs:
+            _native_urls = self._runner._consume_pending_native_image_urls(ctx.session_key)
+            if _native_imgs or _native_urls:
                 try:
                     from agent.image_routing import build_native_content_parts
                     _parts, _skipped = build_native_content_parts(
                         ctx.message,
                         _native_imgs,
+                        image_urls=_native_urls,
                     )
                     if _skipped:
                         logger.warning(
@@ -15734,12 +15736,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         preprocessing pipeline so sender attribution, image enrichment, STT,
         document notes, reply context, and @ references all behave the same.
 
-        Side effect: buffers per-session native image paths when the active
-        model supports native vision AND the user has images attached. The
-        caller consumes and clears that session-scoped buffer at the
-        ``run_conversation`` site to build a multimodal user turn. When the
-        list is empty, the ``_enrich_message_with_vision`` text path has
-        already run and images are represented in-text.
+        Side effect: buffers per-session native image paths and URLs when the
+        active model supports native vision AND the user has images attached
+        (via attachments or typed text references). The caller consumes and
+        clears that session-scoped buffer at the ``run_conversation`` site to
+        build a multimodal user turn. When the buffer is empty, the
+        ``_enrich_message_with_vision`` text path has already run and images
+        are represented in-text.
         """
         history = history or []
         _pending_stt_prepared = hasattr(event, "_gateway_pending_stt_text")
@@ -15748,6 +15751,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _pending_stt_prepared
             else event.text
         ) or ""
+        # Snapshot the user's OWN text before sender-prefix / channel-context
+        # composition below.  The text image-reference scan must run against
+        # this raw snapshot: ``channel_context`` carries historical backfill /
+        # relay reference messages that must never attach images to the
+        # current trigger.
+        _raw_inbound_text = message_text
         _group_sessions_per_user = getattr(self.config, "group_sessions_per_user", True)
         _thread_sessions_per_user = getattr(self.config, "thread_sessions_per_user", False)
         # Prefer the already resolved session key from the caller so this write
@@ -15757,6 +15766,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Reset only this session's per-call buffer; other sessions may be
         # concurrently preparing multimodal turns on the same runner.
         self._consume_pending_native_image_paths(session_key)
+        self._consume_pending_native_image_urls(session_key)
 
         _is_shared_multi_user = is_shared_multi_user_session(
             source,
@@ -15794,10 +15804,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # remains safe when ``event.media_urls`` is empty (no inner block runs).
         audio_file_paths: list[str] = []
         video_paths: list[str] = []
+        image_paths: list[str] = []
+        image_urls: list[str] = []
+        audio_paths: list[str] = []
 
         if event.media_urls:
-            image_paths = []
-            audio_paths = []
             for i, path in enumerate(event.media_urls):
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
                 # Classify images per-attachment: trust this attachment's own
@@ -15816,91 +15827,117 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if mtype.startswith("video/") or (not mtype and event.message_type == MessageType.VIDEO):
                     video_paths.append(path)
 
-            if image_paths:
-                # Decide routing: native (attach pixels) vs text (vision_analyze
-                # pre-run + prepend description).  See agent/image_routing.py.
-                # Offload to a worker thread: the decision does blocking network
-                # I/O — a models.dev fetch on cache miss, and the Ollama
-                # ``/api/show`` capability probe for local servers — whose
-                # request timeout would otherwise stall the whole gateway event
-                # loop (every session) while a single image is routed.
-                _img_mode = await asyncio.to_thread(
-                    self._decide_image_input_mode,
-                    source=source,
-                    session_key=session_key,
+        # Scan the user's own message text — NOT the composed
+        # ``message_text``, which at this point already includes
+        # ``event.channel_context`` (history backfill / relay
+        # reference context) — for local image paths and HTTP image
+        # URLs typed as plain text (e.g. "/tmp/screenshot.png").
+        # Mirrors the CLI/kanban-worker path in cli.py:15906.
+        # References already present via event.media_urls are skipped
+        # to avoid double-processing.  Local paths and remote URLs are
+        # kept separate: native attachment embeds local files as
+        # base64 data URLs but passes URLs through verbatim (see
+        # build_native_content_parts).
+        try:
+            from agent.image_routing import extract_image_refs
+            _text_paths, _text_urls = extract_image_refs(_raw_inbound_text)
+            _existing = {str(p) for p in image_paths} | {u for u in image_urls}
+            for _p in _text_paths:
+                if str(_p) not in _existing:
+                    _existing.add(str(_p))
+                    image_paths.append(_p)
+            for _u in _text_urls:
+                if _u not in _existing:
+                    _existing.add(_u)
+                    image_urls.append(_u)
+        except Exception:
+            logger.debug("image_refs: text scan failed", exc_info=True)
+
+        if image_paths or image_urls:
+            # Decide routing: native (attach pixels) vs text (vision_analyze
+            # pre-run + prepend description).  See agent/image_routing.py.
+            # Offload to a worker thread: the decision does blocking network
+            # I/O — a models.dev fetch on cache miss, and the Ollama
+            # ``/api/show`` capability probe for local servers — whose
+            # request timeout would otherwise stall the whole gateway event
+            # loop (every session) while a single image is routed.
+            _img_mode = await asyncio.to_thread(
+                self._decide_image_input_mode,
+                source=source,
+                session_key=session_key,
+            )
+            if _img_mode == "native":
+                # Defer attachment to the run_conversation call site.
+                _native_state = self._session_state(session_key)
+                _native_state.persistent.native_image_paths = list(image_paths)
+                _native_state.persistent.native_image_urls = list(image_urls)
+                logger.info(
+                    "Image routing: native (model supports vision). %d image(s) will be attached inline.",
+                    len(image_paths) + len(image_urls),
                 )
-                if _img_mode == "native":
-                    # Defer attachment to the run_conversation call site.
-                    self._session_state(
-                        session_key
-                    ).persistent.native_image_paths = list(image_paths)
-                    logger.info(
-                        "Image routing: native (model supports vision). %d image(s) will be attached inline.",
-                        len(image_paths),
-                    )
-                else:
-                    logger.info(
-                        "Image routing: text (mode=%s). Pre-analyzing %d image(s) via vision_analyze.",
-                        _img_mode, len(image_paths),
-                    )
-                    # Vision enrichment runs before AIAgent.run_conversation(),
-                    # so bind this session's resolved runtime explicitly rather
-                    # than consulting process-global compatibility mirrors.
-                    vision_runtime = None
-                    try:
-                        turn_model, runtime_kwargs = self._resolve_session_agent_runtime(
-                            source=source,
-                            session_key=session_key,
-                        )
-                        vision_runtime = dict(runtime_kwargs or {})
-                        vision_runtime["model"] = turn_model
-                    except Exception:
-                        logger.debug(
-                            "vision enrichment: session runtime resolution failed",
-                            exc_info=True,
-                        )
-
-                    from agent.auxiliary_client import scoped_runtime_main
-
-                    with scoped_runtime_main(vision_runtime):
-                        message_text = await self._enrich_message_with_vision(
-                            message_text,
-                            image_paths,
-                        )
-
-            if audio_paths:
-                message_text, _successful_transcripts = await self._enrich_message_with_transcription(
-                    message_text,
-                    audio_paths,
+            else:
+                logger.info(
+                    "Image routing: text (mode=%s). Pre-analyzing %d image(s) via vision_analyze.",
+                    _img_mode, len(image_paths) + len(image_urls),
                 )
-                # Echo each successful transcript back to the user immediately
-                # when configured. Lets users verify STT quality in real-time,
-                # while allowing quiet STT for users who only want the agent to
-                # receive the transcription.
-                if _successful_transcripts and self._should_echo_stt_transcripts():
-                    _echo_adapter = self._adapter_for_source(source)
-                    _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
-                    if _echo_adapter:
-                        for _tx in _successful_transcripts:
-                            try:
-                                await _echo_adapter.send(
-                                    source.chat_id,
-                                    f'🎙️ "{_tx}"',
-                                    metadata=_echo_meta,
-                                )
-                            except Exception as _echo_exc:
-                                logger.debug(
-                                    "Transcript echo failed (non-fatal): %s", _echo_exc,
-                                )
-                # NOTE: Previously, when transcription failed (e.g. no STT
-                # provider configured), the gateway also emitted a hardcoded
-                # English notice via `_stt_adapter.send()`. That bypassed the
-                # LLM and produced two replies — one pre-canned English clip
-                # (which TTS then spoke aloud, in the wrong language) and one
-                # correct, localized LLM reply from the enriched message text.
-                # The enrichment step now leaves a single neutral marker in the
-                # prompt, so the LLM produces one coherent reply in the user's
-                # language. The hardcoded send has therefore been removed.
+                # Vision enrichment runs before AIAgent.run_conversation(),
+                # so bind this session's resolved runtime explicitly rather
+                # than consulting process-global compatibility mirrors.
+                vision_runtime = None
+                try:
+                    turn_model, runtime_kwargs = self._resolve_session_agent_runtime(
+                        source=source,
+                        session_key=session_key,
+                    )
+                    vision_runtime = dict(runtime_kwargs or {})
+                    vision_runtime["model"] = turn_model
+                except Exception:
+                    logger.debug(
+                        "vision enrichment: session runtime resolution failed",
+                        exc_info=True,
+                    )
+
+                from agent.auxiliary_client import scoped_runtime_main
+
+                with scoped_runtime_main(vision_runtime):
+                    message_text = await self._enrich_message_with_vision(
+                        message_text,
+                        image_paths + image_urls,
+                    )
+
+        if audio_paths:
+            message_text, _successful_transcripts = await self._enrich_message_with_transcription(
+                message_text,
+                audio_paths,
+            )
+            # Echo each successful transcript back to the user immediately
+            # when configured. Lets users verify STT quality in real-time,
+            # while allowing quiet STT for users who only want the agent to
+            # receive the transcription.
+            if _successful_transcripts and self._should_echo_stt_transcripts():
+                _echo_adapter = self._adapter_for_source(source)
+                _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
+                if _echo_adapter:
+                    for _tx in _successful_transcripts:
+                        try:
+                            await _echo_adapter.send(
+                                source.chat_id,
+                                f'🎙️ "{_tx}"',
+                                metadata=_echo_meta,
+                            )
+                        except Exception as _echo_exc:
+                            logger.debug(
+                                "Transcript echo failed (non-fatal): %s", _echo_exc,
+                            )
+            # NOTE: Previously, when transcription failed (e.g. no STT
+            # provider configured), the gateway also emitted a hardcoded
+            # English notice via `_stt_adapter.send()`. That bypassed the
+            # LLM and produced two replies — one pre-canned English clip
+            # (which TTS then spoke aloud, in the wrong language) and one
+            # correct, localized LLM reply from the enriched message text.
+            # The enrichment step now leaves a single neutral marker in the
+            # prompt, so the LLM produces one coherent reply in the user's
+            # language. The hardcoded send has therefore been removed.
 
         if audio_file_paths:
             from tools.credential_files import to_agent_visible_cache_path as _to_agent_path
@@ -16173,6 +16210,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         paths = list(state.persistent.native_image_paths)
         state.persistent.native_image_paths = []
         return paths
+
+    def _consume_pending_native_image_urls(self, session_key: str) -> List[str]:
+        state = self._peek_session_state(session_key)
+        if state is None or not state.persistent.native_image_urls:
+            return []
+        urls = list(state.persistent.native_image_urls)
+        state.persistent.native_image_urls = []
+        return urls
 
     def _cache_session_source(self, session_key: str, source) -> None:
         if not session_key or source is None:

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -140,6 +140,11 @@ class PersistentState:
     update_prompt_pending: bool = False
     # Image paths staged for native (inline) attachment; consumed one-shot.
     native_image_paths: List[str] = field(default_factory=list)
+    # Remote image URLs staged for native (inline) attachment; consumed
+    # one-shot.  Kept separate from ``native_image_paths`` because native
+    # attachment treats the two differently: local paths are embedded as
+    # base64 data URLs, remote URLs are passed through verbatim.
+    native_image_urls: List[str] = field(default_factory=list)
     # Legacy runner-level pending message text (write-mostly; flushed to
     # disk on shutdown — see #72680).  NOTE: distinct from the adapter-level
     # ``_pending_messages`` (Dict[str, MessageEvent]) in gateway/base.py,
@@ -396,6 +401,9 @@ LEGACY_FIELD_SPECS: Dict[str, _FieldSpec] = {
     ),
     "_pending_native_image_paths_by_session": _FieldSpec(
         "persistent", "native_image_paths", list, _present_nonzero
+    ),
+    "_pending_native_image_urls_by_session": _FieldSpec(
+        "persistent", "native_image_urls", list, _present_nonzero
     ),
     "_pending_messages": _FieldSpec(
         "persistent", "pending_command_text", lambda: None, _present_not_none

--- a/tests/gateway/test_text_image_path_detection.py
+++ b/tests/gateway/test_text_image_path_detection.py
@@ -199,7 +199,12 @@ async def test_text_image_paths_deduplicated_with_media_urls(tmp_path, monkeypat
 
 @pytest.mark.asyncio
 async def test_text_url_deduplicated_with_media_url():
-    """A URL already present in event.media_urls is not double-buffered."""
+    """A URL already present in event.media_urls is buffered exactly once.
+
+    Attached media that is already a remote URL rides the URL collection
+    (native attachment passes URLs through verbatim), so the same URL found
+    by the text scan is deduplicated against it.
+    """
     url = "https://example.com/dup.png"
     runner = _make_runner()
     source = _source("chat-10")
@@ -221,11 +226,11 @@ async def test_text_url_deduplicated_with_media_url():
     key = build_session_key(source)
     paths = runner._consume_pending_native_image_paths(key)
     urls = runner._consume_pending_native_image_urls(key)
-    # Buffered exactly once, via the media classification path (URLs in the
-    # media collection stay in the local-path bucket like any other
-    # attachment; only TEXT-scan URLs use the URL bucket).
-    assert paths.count(url) == 1
-    assert urls == []
+    # Buffered exactly once, via the URL collection — not doubled across the
+    # path and URL buckets, and not dropped into the local-path bucket where
+    # native attachment would reject it as a non-file.
+    assert paths == []
+    assert urls.count(url) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_text_image_path_detection.py
+++ b/tests/gateway/test_text_image_path_detection.py
@@ -1,0 +1,289 @@
+"""Gateway auto-detects local image paths typed in message text.
+
+Regression tests for https://github.com/NousResearch/hermes-agent/issues/40533
+"""
+
+import pytest
+from unittest.mock import patch
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+def _make_runner() -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+    )
+    runner.adapters = {}
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    runner._decide_image_input_mode = lambda **_: "native"
+    return runner
+
+
+def _source(chat_id: str) -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type="private",
+        user_name=f"user-{chat_id}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_text_image_path_detected_and_buffered(tmp_path):
+    """A local image path typed in message text is auto-detected and buffered."""
+    img = tmp_path / "shot.png"
+    img.write_bytes(b"\x89PNG")
+
+    runner = _make_runner()
+    source = _source("chat-1")
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(text=f"see {img}", source=source),
+        source=source,
+        history=[],
+    )
+
+    key = build_session_key(source)
+    paths = runner._consume_pending_native_image_paths(key)
+    assert str(img) in paths
+
+
+@pytest.mark.asyncio
+async def test_text_http_image_url_detected_and_buffered():
+    """An HTTP image URL typed in message text is buffered as a URL, not a path."""
+    runner = _make_runner()
+    source = _source("chat-2")
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(
+            text="look at https://example.com/photo.jpg",
+            source=source,
+        ),
+        source=source,
+        history=[],
+    )
+
+    key = build_session_key(source)
+    assert runner._consume_pending_native_image_paths(key) == []
+    urls = runner._consume_pending_native_image_urls(key)
+    assert "https://example.com/photo.jpg" in urls
+
+
+@pytest.mark.asyncio
+async def test_native_url_typed_in_text_becomes_content_part():
+    """A typed HTTP URL survives native routing as an image_url content part.
+
+    Regression for the review finding that URLs were appended to the local-path
+    collection: ``build_native_content_parts`` skips non-files, so the URL was
+    silently dropped in native mode.  The URL must travel the ``image_urls``
+    parameter and reach the model as a real content part.
+    """
+    runner = _make_runner()
+    source = _source("chat-7")
+    url = "https://example.com/photo.jpg"
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(text=f"see {url}", source=source),
+        source=source,
+        history=[],
+    )
+
+    key = build_session_key(source)
+    paths = runner._consume_pending_native_image_paths(key)
+    urls = runner._consume_pending_native_image_urls(key)
+    assert paths == []
+    assert urls == [url]
+
+    # Mirror the run_conversation consume site (gateway/run.py).
+    from agent.image_routing import build_native_content_parts
+    parts, skipped = build_native_content_parts("see", paths, image_urls=urls)
+    assert url not in skipped
+    assert any(
+        p.get("type") == "image_url"
+        and p.get("image_url", {}).get("url") == url
+        for p in parts
+    )
+
+
+@pytest.mark.asyncio
+async def test_url_only_message_still_routes_native():
+    """A URL-only message (no local paths) still takes the routing path."""
+    runner = _make_runner()
+    source = _source("chat-9")
+    url = "https://example.com/pic.png"
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(text=url, source=source),
+        source=source,
+        history=[],
+    )
+
+    key = build_session_key(source)
+    assert runner._consume_pending_native_image_paths(key) == []
+    assert runner._consume_pending_native_image_urls(key) == [url]
+
+
+@pytest.mark.asyncio
+async def test_channel_context_references_not_attached(tmp_path):
+    """Image references that exist only in channel_context are NOT attached.
+
+    Regression for the review finding that the scan ran on composed
+    ``message_text``, which already includes ``event.channel_context`` — a
+    historical channel/thread reference could become an attachment for a
+    different trigger message.
+    """
+    hist_img = tmp_path / "historical.png"
+    hist_img.write_bytes(b"\x89PNG")
+    runner = _make_runner()
+    source = _source("chat-8")
+    text_url = "https://example.com/current.jpg"
+
+    event = MessageEvent(
+        text=f"see {text_url}",
+        source=source,
+        channel_context=(
+            "[Recent channel messages]\n"
+            "Alice: look at https://example.com/old.png\n"
+            f"Bob: check {hist_img}"
+        ),
+    )
+
+    await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    key = build_session_key(source)
+    # Neither the historical URL nor the historical (existing) local path may
+    # ride along with the current trigger message.
+    assert runner._consume_pending_native_image_paths(key) == []
+    urls = runner._consume_pending_native_image_urls(key)
+    assert urls == [text_url]
+    assert "https://example.com/old.png" not in urls
+
+
+@pytest.mark.asyncio
+async def test_text_image_paths_deduplicated_with_media_urls(tmp_path, monkeypatch):
+    """Paths found in text are skipped if already present in event.media_urls."""
+    img = tmp_path / "dup.png"
+    img.write_bytes(b"\x89PNG")
+
+    runner = _make_runner()
+    source = _source("chat-3")
+
+    event = MessageEvent(
+        text=f"here is {img}",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=[str(img)],
+        media_types=["image/png"],
+    )
+
+    await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    key = build_session_key(source)
+    paths = runner._consume_pending_native_image_paths(key)
+    # Should appear exactly once, not twice
+    assert paths.count(str(img)) == 1
+
+
+@pytest.mark.asyncio
+async def test_text_url_deduplicated_with_media_url():
+    """A URL already present in event.media_urls is not double-buffered."""
+    url = "https://example.com/dup.png"
+    runner = _make_runner()
+    source = _source("chat-10")
+
+    event = MessageEvent(
+        text=f"see {url}",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=[url],
+        media_types=["image/png"],
+    )
+
+    await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    key = build_session_key(source)
+    paths = runner._consume_pending_native_image_paths(key)
+    urls = runner._consume_pending_native_image_urls(key)
+    # Buffered exactly once, via the media classification path (URLs in the
+    # media collection stay in the local-path bucket like any other
+    # attachment; only TEXT-scan URLs use the URL bucket).
+    assert paths.count(url) == 1
+    assert urls == []
+
+
+@pytest.mark.asyncio
+async def test_text_with_no_image_paths_unchanged():
+    """Message text with no image references passes through normally."""
+    runner = _make_runner()
+    source = _source("chat-4")
+
+    result = await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="just a plain message", source=source),
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert "just a plain message" in result
+    # No image paths should be buffered
+    key = build_session_key(source)
+    assert runner._consume_pending_native_image_paths(key) == []
+    assert runner._consume_pending_native_image_urls(key) == []
+
+
+@pytest.mark.asyncio
+async def test_text_image_path_in_code_block_ignored():
+    """Image paths inside backtick code blocks are NOT auto-detected."""
+    runner = _make_runner()
+    source = _source("chat-5")
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(
+            text="run `convert /tmp/image.png` to fix it",
+            source=source,
+        ),
+        source=source,
+        history=[],
+    )
+
+    key = build_session_key(source)
+    paths = runner._consume_pending_native_image_paths(key)
+    # Paths in backticks should be ignored by extract_image_refs
+    assert "/tmp/image.png" not in paths
+
+
+@pytest.mark.asyncio
+async def test_extract_image_refs_failure_is_non_fatal(caplog):
+    """If extract_image_refs raises, the message still processes normally."""
+    runner = _make_runner()
+    source = _source("chat-6")
+
+    with patch(
+        "agent.image_routing.extract_image_refs",
+        side_effect=RuntimeError("boom"),
+    ):
+        result = await runner._prepare_inbound_message_text(
+            event=MessageEvent(text="hello", source=source),
+            source=source,
+            history=[],
+        )
+
+    assert result is not None
+    assert "hello" in result


### PR DESCRIPTION
## Summary

Gateway sessions now scan `event.text` for local image paths and HTTP image URLs via `extract_image_refs()` — the same function the CLI and kanban-worker paths already use. Before this change, typing a path like `/tmp/screenshot.png` in a Telegram/Discord/Signal chat sent it as plain text and the model never saw the pixels.

## What changed

- **`gateway/run.py` — `_prepare_inbound_message_text()`**: After processing `event.media_urls`, a new block calls `extract_image_refs()` on the **raw inbound text** (snapshotted before sender-prefix / channel-context composition, so historical backfill/relay references can never be attached to the current trigger). Found paths are deduplicated against already-attached media and fed into the existing image-routing pipeline (native or text-mode enrichment).
- **Local paths and remote URLs stay separate through native routing**: text-scan URLs buffer in the new per-session `persistent.native_image_urls` field (`gateway/session_state.py`) alongside `native_image_paths`, and the `run_conversation` site passes them to `build_native_content_parts(..., image_urls=...)` — `image_paths` is only ever local files, which native attachment embeds as base64. Attached media that is already an http(s) URL rides the same URL collection instead of the local-path bucket.
- `image_paths`, `image_urls`, and `audio_paths` initialization moved outside the `if event.media_urls:` block so the text-scan step can append to them, and the routing decision runs even when the message has no attachments.
- **New test file**: `tests/gateway/test_text_image_path_detection.py` — 10 tests covering:
  - Local path detection and buffering
  - HTTP URL detection and buffering (separate URL collection)
  - Native URL content part (URL reaches the model as `image_url`, not skipped)
  - URL-only messages still route
  - References that exist only in `channel_context` are excluded
  - Deduplication with `event.media_urls` (paths and URLs)
  - Plain text passthrough (no false positives)
  - Paths inside backtick code blocks are ignored
  - Graceful failure if `extract_image_refs` raises

## Notes

- The fix mirrors the existing CLI pattern at `cli.py:15906` which uses `extract_image_refs` for kanban task bodies.
- The text scan runs even when `event.media_urls` is empty — this is the primary use case (user types a path, no attachment).
- Paths/URLs already present in `event.media_urls` are skipped to avoid double-processing.
- The `extract_image_refs` import is deferred and wrapped in try/except to avoid blocking message processing if the import fails.
- Rebased on current `main` (the branch predates the `SessionState` refactor; the native image buffer now lives in `persistent.native_image_paths`).

Closes #40533
