### PR TITLE
feat(openrouter): add policy-aware catalog and ZDR controls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7636,6 +7636,23 @@ def _build_call_kwargs(
         ):
             kwargs["_reasoning_config"] = dict(reasoning_config)
 
+    # Auxiliary calls bypass ChatCompletionsTransport and invoke the SDK
+    # directly. Enforce the same request-time privacy control here, after all
+    # caller/profile merges, so explicit ``zdr: false`` cannot weaken it.
+    from agent.openrouter_zdr import enforce_openrouter_zdr
+
+    _provider_norm = _normalize_aux_provider(provider)
+    _is_openrouter = (
+        _provider_norm == "openrouter"
+        or base_url_host_matches(effective_base, "openrouter.ai")
+        or "(openrouter)" in str(provider or "").strip().lower()
+    )
+    enforce_openrouter_zdr(
+        kwargs,
+        is_openrouter=_is_openrouter,
+        base_url=effective_base,
+    )
+
     return kwargs
 
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -192,6 +192,7 @@ def _provider_preferences_for_agent(agent) -> Dict[str, Any]:
         preferences["require_parameters"] = True
     if agent.provider_data_collection:
         preferences["data_collection"] = agent.provider_data_collection
+
     return preferences
 
 
@@ -218,6 +219,24 @@ def _merge_nous_portal_messages_extra_body(agent, anthropic_kwargs: dict) -> dic
     except Exception as exc:  # noqa: BLE001 — never block a turn on tagging
         logger.debug("Nous Portal extra_body merge failed: %s", exc)
     return anthropic_kwargs
+
+
+def _enforce_summary_openrouter_zdr(agent, api_kwargs: dict) -> None:
+    """Apply OpenRouter ZDR to direct iteration-limit summary calls."""
+    from agent.openrouter_zdr import enforce_openrouter_zdr
+
+    try:
+        is_openrouter = (
+            (agent.provider or "").strip().lower() == "openrouter"
+            or agent._is_openrouter_url()
+        )
+    except Exception:
+        is_openrouter = False
+    enforce_openrouter_zdr(
+        api_kwargs,
+        is_openrouter=is_openrouter,
+        base_url=getattr(agent, "base_url", None),
+    )
 
 
 def _env_float(name: str, default: float) -> float:
@@ -2298,6 +2317,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 _summary_result = _tsum.normalize_response(summary_response, strip_tool_prefix=agent._is_anthropic_oauth)
                 final_response = (_summary_result.content or "").strip()
             else:
+                _enforce_summary_openrouter_zdr(agent, summary_kwargs)
                 summary_client = agent._ensure_primary_openai_client(
                     reason="iteration_limit_summary"
                 )
@@ -2360,6 +2380,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 if summary_extra_body:
                     summary_kwargs["extra_body"] = summary_extra_body
 
+                _enforce_summary_openrouter_zdr(agent, summary_kwargs)
                 summary_client = agent._ensure_primary_openai_client(
                     reason="iteration_limit_summary_retry"
                 )

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -230,8 +230,18 @@ def _enforce_summary_openrouter_zdr(agent, api_kwargs: dict) -> None:
             (agent.provider or "").strip().lower() == "openrouter"
             or agent._is_openrouter_url()
         )
-    except Exception:
-        is_openrouter = False
+    except Exception as exc:
+        # Preserve enforcement when the canonical OpenRouter host is still
+        # identifiable even if the agent-specific detector fails.
+        is_openrouter = base_url_host_matches(
+            str(getattr(agent, "base_url", None) or ""), "openrouter.ai"
+        )
+        logger.warning(
+            "OpenRouter detection failed for a summary request; "
+            "host fallback selected is_openrouter=%s: %s",
+            is_openrouter,
+            exc,
+        )
     enforce_openrouter_zdr(
         api_kwargs,
         is_openrouter=is_openrouter,

--- a/agent/openrouter_zdr.py
+++ b/agent/openrouter_zdr.py
@@ -1,0 +1,43 @@
+"""Shared request-time Zero Data Retention enforcement for OpenRouter."""
+
+from typing import Any
+
+
+def enforce_openrouter_zdr(
+    api_kwargs: dict[str, Any],
+    *,
+    is_openrouter: bool,
+    base_url: Any = None,
+) -> None:
+    """Force ``provider.zdr=true`` on a final OpenRouter request payload.
+
+    Call this at the last kwargs boundary before ``chat.completions.create`` so
+    request overrides cannot weaken the defense-in-depth setting. Native Gemini
+    uses a different wire schema and must never receive OpenRouter fields.
+    """
+    if not is_openrouter:
+        return
+    try:
+        from agent.gemini_native_adapter import is_native_gemini_base_url
+
+        if is_native_gemini_base_url(base_url):
+            return
+    except Exception:
+        # Prefer privacy enforcement over compatibility if native-Gemini
+        # detection itself is unavailable.
+        pass
+    try:
+        from hermes_cli.config import openrouter_zdr_enabled
+
+        if not openrouter_zdr_enabled():
+            return
+    except Exception:
+        return
+
+    raw_extra = api_kwargs.get("extra_body")
+    extra_body = dict(raw_extra) if isinstance(raw_extra, dict) else {}
+    raw_provider = extra_body.get("provider")
+    provider = dict(raw_provider) if isinstance(raw_provider, dict) else {}
+    provider["zdr"] = True
+    extra_body["provider"] = provider
+    api_kwargs["extra_body"] = extra_body

--- a/agent/openrouter_zdr.py
+++ b/agent/openrouter_zdr.py
@@ -1,6 +1,10 @@
 """Shared request-time Zero Data Retention enforcement for OpenRouter."""
 
+import logging
 from typing import Any
+
+
+logger = logging.getLogger(__name__)
 
 
 def enforce_openrouter_zdr(
@@ -31,8 +35,14 @@ def enforce_openrouter_zdr(
 
         if not openrouter_zdr_enabled():
             return
-    except Exception:
-        return
+    except Exception as exc:
+        # The request is already known to target OpenRouter. If config state
+        # cannot be read, prefer the privacy-preserving restriction over a
+        # silent fail-open request.
+        logger.warning(
+            "Unable to read the OpenRouter ZDR setting; enforcing ZDR fail closed: %s",
+            exc,
+        )
 
     raw_extra = api_kwargs.get("extra_body")
     extra_body = dict(raw_extra) if isinstance(raw_extra, dict) else {}

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -15,6 +15,7 @@ from agent.lmstudio_reasoning import resolve_lmstudio_effort
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
+from agent.openrouter_zdr import enforce_openrouter_zdr
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
 
@@ -507,6 +508,11 @@ class ChatCompletionsTransport(ProviderTransport):
         if overrides:
             api_kwargs.update(overrides)
 
+        enforce_openrouter_zdr(
+            api_kwargs,
+            is_openrouter=bool(is_openrouter),
+            base_url=params.get("base_url"),
+        )
         return api_kwargs
 
     def _build_kwargs_from_profile(self, profile, model, sanitized, tools, params):
@@ -625,6 +631,12 @@ class ChatCompletionsTransport(ProviderTransport):
                 else:
                     api_kwargs[k] = v
 
+        try:
+            from agent.gemini_native_adapter import is_native_gemini_base_url
+
+            _native_gemini = is_native_gemini_base_url(params.get("base_url"))
+        except Exception:
+            _native_gemini = False
         if extra_body:
             # Native Gemini (generativelanguage.googleapis.com, non-/openai)
             # speaks Google's REST schema, not OpenAI's. OpenAI-style extra_body
@@ -636,11 +648,6 @@ class ChatCompletionsTransport(ProviderTransport):
             # Gemini base_url — typical when only Google credentials are set and
             # a fallback/aux call lands on Gemini. The native client only reads
             # thinking_config from extra_body, so drop everything else here.
-            try:
-                from agent.gemini_native_adapter import is_native_gemini_base_url
-                _native_gemini = is_native_gemini_base_url(params.get("base_url"))
-            except Exception:
-                _native_gemini = False
             if _native_gemini:
                 extra_body = {
                     k: v for k, v in extra_body.items()
@@ -649,6 +656,14 @@ class ChatCompletionsTransport(ProviderTransport):
             if extra_body:
                 api_kwargs["extra_body"] = extra_body
 
+        enforce_openrouter_zdr(
+            api_kwargs,
+            is_openrouter=(
+                bool(params.get("is_openrouter"))
+                or getattr(profile, "name", "") == "openrouter"
+            ),
+            base_url=params.get("base_url"),
+        )
         return api_kwargs
 
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:

--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -328,6 +328,24 @@ describe('ModelSettings', () => {
     )
   })
 
+  it('cancels a pending ZDR disable when the profile changes', async () => {
+    getHermesConfigRecord.mockResolvedValueOnce({
+      agent: { reasoning_effort: 'medium', service_tier: 'normal' },
+      openrouter: { zdr: true, response_cache: true }
+    })
+    await renderModelSettings()
+    const zdrSwitch = await screen.findByRole('switch', { name: 'Enforce OpenRouter Zero Data Retention' })
+    await waitFor(() => expect(zdrSwitch.getAttribute('data-state')).toBe('checked'))
+
+    fireEvent.click(zdrSwitch)
+    expect(await screen.findByText('Disable request-time ZDR?')).toBeTruthy()
+
+    act(() => profileSwitchHandler?.())
+
+    await waitFor(() => expect(screen.queryByText('Disable request-time ZDR?')).toBeNull())
+    expect(saveHermesConfig).not.toHaveBeenCalled()
+  })
+
   it('renders the auxiliary task rows', async () => {
     await renderModelSettings()
 

--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -263,7 +263,7 @@ describe('ModelSettings', () => {
     await renderModelSettings()
     await waitFor(() => expect(getHermesConfigRecord).toHaveBeenCalled())
 
-    const fastSwitch = await screen.findByRole('switch')
+    const fastSwitch = await screen.findByRole('switch', { name: 'Fast' })
     fireEvent.click(fastSwitch)
 
     await waitFor(() =>
@@ -289,7 +289,43 @@ describe('ModelSettings', () => {
     await renderModelSettings()
     await waitFor(() => expect(getHermesConfigRecord).toHaveBeenCalled())
 
-    expect(screen.queryByRole('switch')).toBeNull()
+    expect(screen.queryByRole('switch', { name: 'Fast' })).toBeNull()
+  })
+
+  it('persists OpenRouter ZDR as a profile-wide config setting', async () => {
+    await renderModelSettings()
+    await waitFor(() => expect(getHermesConfigRecord).toHaveBeenCalled())
+
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enforce OpenRouter Zero Data Retention' }))
+
+    await waitFor(() =>
+      expect(saveHermesConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ openrouter: expect.objectContaining({ zdr: true }) })
+      )
+    )
+  })
+
+  it('requires confirmation before disabling OpenRouter ZDR', async () => {
+    getHermesConfigRecord.mockResolvedValueOnce({
+      agent: { reasoning_effort: 'medium', service_tier: 'normal' },
+      openrouter: { zdr: true, response_cache: true }
+    })
+    await renderModelSettings()
+    const zdrSwitch = await screen.findByRole('switch', { name: 'Enforce OpenRouter Zero Data Retention' })
+    await waitFor(() => expect(zdrSwitch.getAttribute('data-state')).toBe('checked'))
+
+    fireEvent.click(zdrSwitch)
+    expect(saveHermesConfig).not.toHaveBeenCalled()
+    expect(await screen.findByText('Disable request-time ZDR?')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Disable ZDR' }))
+    await waitFor(() =>
+      expect(saveHermesConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          openrouter: expect.objectContaining({ zdr: false, response_cache: true })
+        })
+      )
+    )
   })
 
   it('renders the auxiliary task rows', async () => {

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -209,6 +210,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   // place — mirrors the onboarding ApiKeyForm but scoped to the model picker.
   const [apiKeyDraft, setApiKeyDraft] = useState('')
   const [activating, setActivating] = useState(false)
+  const [confirmDisableZdr, setConfirmDisableZdr] = useState(false)
 
   // Deep link from the vision Capabilities detail (?tab=config:model&aux=vision):
   // scroll the auxiliary task row into view and flash it once the list loads.
@@ -512,6 +514,27 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   const effortValue = rawEffort === 'false' || rawEffort === 'disabled' ? 'none' : rawEffort || DEFAULT_REASONING_EFFORT
 
   const fastOn = isFastTier(getNested(config ?? {}, 'agent.service_tier'))
+  const openRouterZdrOn = getNested(config ?? {}, 'openrouter.zdr') === true
+
+  const writeOpenRouterZdr = useCallback(
+    async (enabled: boolean) => {
+      if (!config) {
+        return
+      }
+
+      const prev = config
+      const next = setNested(config, 'openrouter.zdr', enabled)
+      setConfig(next)
+
+      try {
+        await saveHermesConfig(next)
+      } catch (err) {
+        setConfig(prev)
+        throw err
+      }
+    },
+    [config, setConfig]
+  )
 
   // Persist a single agent.* default by round-tripping the whole config record
   // (PUT /api/config replaces it) — optimistic, with rollback on failure.
@@ -756,6 +779,29 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
 
   return (
     <div className="grid gap-6">
+      <section className="flex items-center justify-between gap-4 rounded-md border border-border px-3 py-2.5">
+        <div className="min-w-0">
+          <div className="text-sm font-medium">OpenRouter Zero Data Retention</div>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {openRouterZdrOn
+              ? 'Hermes forces provider.zdr=true on every OpenRouter request for this profile.'
+              : 'OpenRouter account policy applies without a request-time ZDR requirement.'}
+          </p>
+        </div>
+        <Switch
+          aria-label="Enforce OpenRouter Zero Data Retention"
+          checked={openRouterZdrOn}
+          disabled={!config}
+          onCheckedChange={enabled => {
+            if (enabled) {
+              void writeOpenRouterZdr(true).catch(err => notifyError(err, 'Failed to enable OpenRouter ZDR'))
+            } else {
+              setConfirmDisableZdr(true)
+            }
+          }}
+        />
+      </section>
+
       <section>
         <p className="mb-3 text-xs text-muted-foreground">{m.appliesDesc}</p>
         <div className="flex flex-wrap items-center gap-2">
@@ -1275,6 +1321,16 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
           </div>
         </section>
       )}
+      <ConfirmDialog
+        cancelLabel="Keep enabled"
+        confirmLabel="Disable ZDR"
+        description="Hermes will stop requiring Zero Data Retention on each OpenRouter request. Account and guardrail policies still apply, but eligible providers may retain prompts or use them for training."
+        destructive
+        onClose={() => setConfirmDisableZdr(false)}
+        onConfirm={() => writeOpenRouterZdr(false)}
+        open={confirmDisableZdr}
+        title="Disable request-time ZDR?"
+      />
     </div>
   )
 }

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -210,7 +210,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   // place — mirrors the onboarding ApiKeyForm but scoped to the model picker.
   const [apiKeyDraft, setApiKeyDraft] = useState('')
   const [activating, setActivating] = useState(false)
-  const [confirmDisableZdr, setConfirmDisableZdr] = useState(false)
+  const [confirmDisableZdrEpoch, setConfirmDisableZdrEpoch] = useState<number | null>(null)
 
   // Deep link from the vision Capabilities detail (?tab=config:model&aux=vision):
   // scroll the auxiliary task row into view and flash it once the list loads.
@@ -288,6 +288,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
     setSelectedProvider('')
     setSelectedModel('')
     setApiKeyDraft('')
+    setConfirmDisableZdrEpoch(null)
     void refresh({ replaceSelection: true })
   })
 
@@ -517,8 +518,8 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   const openRouterZdrOn = getNested(config ?? {}, 'openrouter.zdr') === true
 
   const writeOpenRouterZdr = useCallback(
-    async (enabled: boolean) => {
-      if (!config) {
+    async (enabled: boolean, expectedEpoch = profileEpoch.current) => {
+      if (!config || profileEpoch.current !== expectedEpoch) {
         return
       }
 
@@ -527,9 +528,18 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
       setConfig(next)
 
       try {
+        // The profile cannot change between this synchronous guard and the API
+        // call, so the write is bound to the profile that initiated the intent.
+        if (profileEpoch.current !== expectedEpoch) {
+          return
+        }
+
         await saveHermesConfig(next)
       } catch (err) {
-        setConfig(prev)
+        if (profileEpoch.current === expectedEpoch) {
+          setConfig(prev)
+        }
+
         throw err
       }
     },
@@ -796,7 +806,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
             if (enabled) {
               void writeOpenRouterZdr(true).catch(err => notifyError(err, 'Failed to enable OpenRouter ZDR'))
             } else {
-              setConfirmDisableZdr(true)
+              setConfirmDisableZdrEpoch(profileEpoch.current)
             }
           }}
         />
@@ -1326,9 +1336,18 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
         confirmLabel="Disable ZDR"
         description="Hermes will stop requiring Zero Data Retention on each OpenRouter request. Account and guardrail policies still apply, but eligible providers may retain prompts or use them for training."
         destructive
-        onClose={() => setConfirmDisableZdr(false)}
-        onConfirm={() => writeOpenRouterZdr(false)}
-        open={confirmDisableZdr}
+        onClose={() => setConfirmDisableZdrEpoch(null)}
+        onConfirm={async () => {
+          const expectedEpoch = confirmDisableZdrEpoch
+          setConfirmDisableZdrEpoch(null)
+
+          if (expectedEpoch === null || profileEpoch.current !== expectedEpoch) {
+            return
+          }
+
+          await writeOpenRouterZdr(false, expectedEpoch)
+        }}
+        open={confirmDisableZdrEpoch !== null}
         title="Disable request-time ZDR?"
       />
     </div>

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -191,6 +191,7 @@ model:
 # See: https://openrouter.ai/docs/guides/features/response-caching
 #
 # openrouter:
+#   zdr: false                   # Require Zero Data Retention endpoints (default: false)
 #   response_cache: true         # Enable response caching (default: true)
 #   response_cache_ttl: 300      # Cache TTL in seconds, 1-86400 (default: 300)
 

--- a/contributors/emails/wpinner@protonmail.com
+++ b/contributors/emails/wpinner@protonmail.com
@@ -1,0 +1,2 @@
+wwpinner
+# PR #68679

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -246,12 +246,12 @@ _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
 # managed_scope), and the env snapshot invalidates it when a referenced ${VAR}
 # changes value (late .env load, in-process rotation — #58514).
 _LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, int, int, Dict[str, Any], Dict[str, Optional[str]]]] = {}
-# User-config path -> resolved managed config path used to build its cached
-# effective config. The path is separate from the fixed-shape tuple for
-# backward compatibility with tests/helpers that inspect cache entries.
-# Managed files in different directories can legitimately share identical
-# (mtime_ns, size), so metadata alone cannot safely identify the policy source.
-_LOAD_CONFIG_MANAGED_PATH_BY_USER_PATH: Dict[str, str] = {}
+# User-config path -> resolved managed target identity used to build its cached
+# effective config. Kept separate from the fixed-shape tuple for backward
+# compatibility with tests/helpers that inspect cache entries. The canonical
+# target path plus device/inode catches both directory changes and stable-link
+# retargets even when target files share identical (mtime_ns, size).
+_LOAD_CONFIG_MANAGED_IDENTITY_BY_USER_PATH: Dict[str, Tuple[str, int, int]] = {}
 # Path -> (mtime_ns, size) for a user config that the canonical loader could
 # not parse/merge. The effective config may be defaults or last-known-good,
 # but privacy-sensitive readers must be able to distinguish that degraded
@@ -3348,12 +3348,24 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
 
         managed_dir = managed_scope.get_managed_dir()
         managed_cfg_path = (managed_dir / "config.yaml") if managed_dir else None
-        managed_path_key = str(managed_cfg_path) if managed_cfg_path else ""
+        if managed_cfg_path is not None:
+            try:
+                managed_target_path = str(managed_cfg_path.resolve(strict=False))
+            except OSError:
+                managed_target_path = str(managed_cfg_path.absolute())
+        else:
+            managed_target_path = ""
         try:
             mst = managed_cfg_path.stat() if managed_cfg_path else None
             managed_sig = (mst.st_mtime_ns, mst.st_size) if mst else (0, 0)
+            managed_identity = (
+                managed_target_path,
+                mst.st_dev if mst else 0,
+                mst.st_ino if mst else 0,
+            )
         except OSError:
             managed_sig = (0, 0)
+            managed_identity = (managed_target_path, 0, 0)
 
         # Combined cache signature: user file + managed file. None only when the
         # user config is absent AND no managed file exists (nothing to cache on).
@@ -3374,8 +3386,8 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             cached is not None
             and cache_sig is not None
             and cached[:4] == cache_sig
-            and _LOAD_CONFIG_MANAGED_PATH_BY_USER_PATH.get(path_key)
-            == managed_path_key
+            and _LOAD_CONFIG_MANAGED_IDENTITY_BY_USER_PATH.get(path_key)
+            == managed_identity
         ):
             # File signatures match, but the cached expansion is only valid if
             # every ${VAR} it was expanded against still has the same value.
@@ -3442,8 +3454,8 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                             cache_sig[2], cache_sig[3],
                             lkg_copy, _empty_env,
                         )
-                        _LOAD_CONFIG_MANAGED_PATH_BY_USER_PATH[path_key] = (
-                            managed_path_key
+                        _LOAD_CONFIG_MANAGED_IDENTITY_BY_USER_PATH[path_key] = (
+                            managed_identity
                         )
                     return copy.deepcopy(lkg_copy) if want_deepcopy else lkg_copy
 
@@ -3473,7 +3485,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             if managed_config:
                 _env_ref_snapshot(managed_config, env_snapshot)
             _LOAD_CONFIG_CACHE[path_key] = (*cache_sig, cached_copy, env_snapshot)
-            _LOAD_CONFIG_MANAGED_PATH_BY_USER_PATH[path_key] = managed_path_key
+            _LOAD_CONFIG_MANAGED_IDENTITY_BY_USER_PATH[path_key] = managed_identity
             # On the readonly path return the same cached object subsequent
             # calls will see — keeps "two readonly calls return the same
             # object" invariant that callers may rely on for identity checks.
@@ -3481,7 +3493,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                 return cached_copy
         else:
             _LOAD_CONFIG_CACHE.pop(path_key, None)
-            _LOAD_CONFIG_MANAGED_PATH_BY_USER_PATH.pop(path_key, None)
+            _LOAD_CONFIG_MANAGED_IDENTITY_BY_USER_PATH.pop(path_key, None)
         # First-load result is a fresh dict (not aliased to the cache); safe
         # to return directly. For the deepcopy=True path this is the
         # canonical "freshly-built mutable result" the function has always

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -246,6 +246,12 @@ _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
 # managed_scope), and the env snapshot invalidates it when a referenced ${VAR}
 # changes value (late .env load, in-process rotation — #58514).
 _LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, int, int, Dict[str, Any], Dict[str, Optional[str]]]] = {}
+# User-config path -> resolved managed config path used to build its cached
+# effective config. The path is separate from the fixed-shape tuple for
+# backward compatibility with tests/helpers that inspect cache entries.
+# Managed files in different directories can legitimately share identical
+# (mtime_ns, size), so metadata alone cannot safely identify the policy source.
+_LOAD_CONFIG_MANAGED_PATH_BY_USER_PATH: Dict[str, str] = {}
 # Path -> (mtime_ns, size) for a user config that the canonical loader could
 # not parse/merge. The effective config may be defaults or last-known-good,
 # but privacy-sensitive readers must be able to distinguish that degraded
@@ -3342,6 +3348,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
 
         managed_dir = managed_scope.get_managed_dir()
         managed_cfg_path = (managed_dir / "config.yaml") if managed_dir else None
+        managed_path_key = str(managed_cfg_path) if managed_cfg_path else ""
         try:
             mst = managed_cfg_path.stat() if managed_cfg_path else None
             managed_sig = (mst.st_mtime_ns, mst.st_size) if mst else (0, 0)
@@ -3363,7 +3370,13 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             cache_sig = None
 
         cached = _LOAD_CONFIG_CACHE.get(path_key)
-        if cached is not None and cache_sig is not None and cached[:4] == cache_sig:
+        if (
+            cached is not None
+            and cache_sig is not None
+            and cached[:4] == cache_sig
+            and _LOAD_CONFIG_MANAGED_PATH_BY_USER_PATH.get(path_key)
+            == managed_path_key
+        ):
             # File signatures match, but the cached expansion is only valid if
             # every ${VAR} it was expanded against still has the same value.
             # Without this, a load_config() that ran before load_hermes_dotenv()
@@ -3429,6 +3442,9 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                             cache_sig[2], cache_sig[3],
                             lkg_copy, _empty_env,
                         )
+                        _LOAD_CONFIG_MANAGED_PATH_BY_USER_PATH[path_key] = (
+                            managed_path_key
+                        )
                     return copy.deepcopy(lkg_copy) if want_deepcopy else lkg_copy
 
         normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
@@ -3457,6 +3473,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             if managed_config:
                 _env_ref_snapshot(managed_config, env_snapshot)
             _LOAD_CONFIG_CACHE[path_key] = (*cache_sig, cached_copy, env_snapshot)
+            _LOAD_CONFIG_MANAGED_PATH_BY_USER_PATH[path_key] = managed_path_key
             # On the readonly path return the same cached object subsequent
             # calls will see — keeps "two readonly calls return the same
             # object" invariant that callers may rely on for identity checks.
@@ -3464,6 +3481,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                 return cached_copy
         else:
             _LOAD_CONFIG_CACHE.pop(path_key, None)
+            _LOAD_CONFIG_MANAGED_PATH_BY_USER_PATH.pop(path_key, None)
         # First-load result is a fresh dict (not aliased to the cache); safe
         # to return directly. For the deepcopy=True path this is the
         # canonical "freshly-built mutable result" the function has always

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3152,6 +3152,17 @@ def load_config_readonly() -> Dict[str, Any]:
     return _load_config_impl(want_deepcopy=False)
 
 
+def openrouter_zdr_enabled() -> bool:
+    """Return whether request-time OpenRouter ZDR enforcement is enabled.
+
+    The mtime-keyed read-only cache lets profile config changes apply to the
+    next request without rebuilding an active conversation.
+    """
+    config = load_config_readonly()
+    openrouter = config.get("openrouter")
+    return isinstance(openrouter, dict) and openrouter.get("zdr") is True
+
+
 def write_platform_config_field(
     platform_key: str,
     field_key: str,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -246,6 +246,12 @@ _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
 # managed_scope), and the env snapshot invalidates it when a referenced ${VAR}
 # changes value (late .env load, in-process rotation — #58514).
 _LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, int, int, Dict[str, Any], Dict[str, Optional[str]]]] = {}
+# Path -> (mtime_ns, size) for a user config that the canonical loader could
+# not parse/merge. The effective config may be defaults or last-known-good,
+# but privacy-sensitive readers must be able to distinguish that degraded
+# state from an explicit setting. Entries are signature-bound so fixing or
+# replacing the file invalidates the failure without a separate reset hook.
+_CONFIG_LOAD_FAILURE_BY_PATH: Dict[str, Tuple[int, int]] = {}
 # (path, mtime_ns, size) -> cached raw yaml dict. Same pattern as
 # _LOAD_CONFIG_CACHE but for read_raw_config() — used when callers want
 # the user's on-disk values without defaults merged in.
@@ -3156,11 +3162,28 @@ def openrouter_zdr_enabled() -> bool:
     """Return whether request-time OpenRouter ZDR enforcement is enabled.
 
     The mtime-keyed read-only cache lets profile config changes apply to the
-    next request without rebuilding an active conversation.
+    next request without rebuilding an active conversation.  This accessor is
+    intentionally strict because its result controls a privacy boundary:
+    unreadable/unparseable YAML and malformed ``openrouter``/``zdr`` values
+    raise so the final request guard can enforce ZDR fail closed instead of
+    mistaking loader defaults for an explicit opt-out.
     """
-    config = load_config_readonly()
+    with _CONFIG_LOCK:
+        config = load_config_readonly()
+        config_path = get_config_path()
+        if str(config_path) in _CONFIG_LOAD_FAILURE_BY_PATH:
+            raise RuntimeError(
+                f"OpenRouter ZDR state is unknown because {config_path} "
+                "could not be parsed"
+            )
+
     openrouter = config.get("openrouter")
-    return isinstance(openrouter, dict) and openrouter.get("zdr") is True
+    if not isinstance(openrouter, dict):
+        raise ValueError("effective openrouter config must be a mapping")
+    zdr = openrouter.get("zdr")
+    if not isinstance(zdr, bool):
+        raise ValueError("effective openrouter.zdr must be a boolean")
+    return zdr
 
 
 def write_platform_config_field(
@@ -3302,6 +3325,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             user_sig: Optional[Tuple[int, int]] = (st.st_mtime_ns, st.st_size)
         except FileNotFoundError:
             user_sig = None
+            _CONFIG_LOAD_FAILURE_BY_PATH.pop(path_key, None)
 
         # Managed scope: fold the managed config file's (mtime, size) into the
         # cache signature so editing /etc/hermes/config.yaml invalidates the
@@ -3356,7 +3380,9 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                     user_config.pop("max_turns", None)
 
                 config = _deep_merge(config, user_config)
+                _CONFIG_LOAD_FAILURE_BY_PATH.pop(path_key, None)
             except Exception as e:
+                _CONFIG_LOAD_FAILURE_BY_PATH[path_key] = user_sig
                 # Last-known-good fallback (port of openai/codex#31188's
                 # invariant: a parse failure in a policy/config file must not
                 # silently replace the effective policy with an empty/default

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3177,6 +3177,14 @@ def openrouter_zdr_enabled() -> bool:
                 "could not be parsed"
             )
 
+        from hermes_cli import managed_scope
+
+        if managed_scope.managed_config_load_degraded():
+            raise RuntimeError(
+                "OpenRouter ZDR state is unknown because the managed config "
+                "could not be parsed"
+            )
+
     openrouter = config.get("openrouter")
     if not isinstance(openrouter, dict):
         raise ValueError("effective openrouter config must be a mapping")

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -734,6 +734,9 @@ DEFAULT_CONFIG = {
     #   See: https://openrouter.ai/docs/guides/features/response-caching
     # response_cache_ttl: how long cached responses remain valid, in seconds (1-86400).
     #   Default 300 (5 minutes). Only used when response_cache is enabled.
+    # zdr: require Zero Data Retention on every OpenRouter inference request.
+    #   Enforced at the final request boundary so request overrides and delegated
+    #   provider changes cannot weaken a profile-wide privacy requirement.
     # min_coding_score: knob for the openrouter/pareto-code router (0.0-1.0).
     #   Only applied when model.model is "openrouter/pareto-code". Higher
     #   values route to stronger (more expensive) coders; lower values open
@@ -745,6 +748,7 @@ DEFAULT_CONFIG = {
     "openrouter": {
         "response_cache": True,
         "response_cache_ttl": 300,
+        "zdr": False,
         "min_coding_score": 0.65,
     },
 

--- a/hermes_cli/managed_scope.py
+++ b/hermes_cli/managed_scope.py
@@ -36,6 +36,11 @@ _CACHE_LOCK = threading.Lock()
 # path_key -> (mtime_ns, size, parsed)
 _CONFIG_CACHE: Dict[str, tuple] = {}
 _ENV_CACHE: Dict[str, tuple] = {}
+# path_key -> (mtime_ns, size), or None when even stat/read failed. This does
+# not change managed scope's startup-safe fail-open merge semantics; it lets
+# security-sensitive request guards detect that current administrator policy
+# is degraded and choose a stricter local behavior.
+_CONFIG_FAILURE_BY_PATH: Dict[str, Optional[tuple[int, int]]] = {}
 
 
 def _under_pytest() -> bool:
@@ -76,30 +81,57 @@ def invalidate_managed_cache() -> None:
     with _CACHE_LOCK:
         _CONFIG_CACHE.clear()
         _ENV_CACHE.clear()
+        _CONFIG_FAILURE_BY_PATH.clear()
 
 
-def _cached_read(path: Path, cache: Dict[str, tuple], parse):
+def _cached_read(
+    path: Path,
+    cache: Dict[str, tuple],
+    parse,
+    *,
+    failure_cache: Optional[Dict[str, Optional[tuple[int, int]]]] = None,
+):
     """Shared (mtime_ns, size)-keyed read. Returns a deepcopy of the parsed value.
 
     Returns ``None`` when the file is absent or fails to parse (fail-open). A
     parse failure is logged LOUDLY — the admin needs to know their policy isn't
     being applied — but never raises, so a malformed managed file can't brick
-    startup.
+    startup. ``failure_cache`` records only the current degraded file state for
+    security-sensitive consumers; normal managed-overlay behavior is unchanged.
     """
+    path_key = str(path)
     try:
         st = path.stat()
-    except OSError:
-        return None  # absent
+    except FileNotFoundError:
+        if failure_cache is not None:
+            with _CACHE_LOCK:
+                failure_cache.pop(path_key, None)
+        return None
+    except OSError as exc:
+        if failure_cache is not None:
+            with _CACHE_LOCK:
+                failure_cache[path_key] = None
+        logger.warning(
+            "managed scope: failed to access %s: %s — IGNORING this managed file. "
+            "Admin policy from this file is NOT being applied. Fix and restart.",
+            path,
+            exc,
+        )
+        return None
     key = (st.st_mtime_ns, st.st_size)
-    path_key = str(path)
     with _CACHE_LOCK:
         hit = cache.get(path_key)
         if hit is not None and hit[:2] == key:
+            if failure_cache is not None:
+                failure_cache.pop(path_key, None)
             return copy.deepcopy(hit[2])
     try:
         with open(path, encoding="utf-8") as f:
             parsed = parse(f)
     except Exception as exc:  # noqa: BLE001 — fail-open, but LOUD
+        if failure_cache is not None:
+            with _CACHE_LOCK:
+                failure_cache[path_key] = key
         logger.warning(
             "managed scope: failed to parse %s: %s — IGNORING this managed file. "
             "Admin policy from this file is NOT being applied. Fix and restart.",
@@ -109,6 +141,15 @@ def _cached_read(path: Path, cache: Dict[str, tuple], parse):
         return None
     with _CACHE_LOCK:
         cache[path_key] = (key[0], key[1], copy.deepcopy(parsed))
+        if failure_cache is not None:
+            failure_cache.pop(path_key, None)
+    return parsed
+
+
+def _parse_managed_config(f) -> dict:
+    parsed = yaml.safe_load(f) or {}
+    if not isinstance(parsed, dict):
+        raise ValueError("managed config root must be a mapping")
     return parsed
 
 
@@ -120,9 +161,26 @@ def load_managed_config() -> dict:
     parsed = _cached_read(
         managed_dir / "config.yaml",
         _CONFIG_CACHE,
-        lambda f: yaml.safe_load(f) or {},
+        _parse_managed_config,
+        failure_cache=_CONFIG_FAILURE_BY_PATH,
     )
     return parsed if isinstance(parsed, dict) else {}
+
+
+def managed_config_load_degraded() -> bool:
+    """Return whether the current managed config exists but cannot be trusted.
+
+    The ordinary overlay remains startup-safe and fail-open. Privacy/security
+    boundaries can call this after loading effective config and enforce a local
+    fail-closed policy while the administrator repairs the managed file.
+    """
+    managed_dir = get_managed_dir()
+    if managed_dir is None:
+        return False
+    config_path = managed_dir / "config.yaml"
+    load_managed_config()  # refresh signature-bound success/failure state
+    with _CACHE_LOCK:
+        return str(config_path) in _CONFIG_FAILURE_BY_PATH
 
 
 def load_managed_env() -> Dict[str, str]:

--- a/hermes_cli/managed_scope.py
+++ b/hermes_cli/managed_scope.py
@@ -33,14 +33,15 @@ logger = logging.getLogger(__name__)
 _DEFAULT_MANAGED_DIR = Path("/etc/hermes")
 
 _CACHE_LOCK = threading.Lock()
-# path_key -> (mtime_ns, size, parsed)
+# canonical target path -> (mtime_ns, size, device, inode, parsed)
 _CONFIG_CACHE: Dict[str, tuple] = {}
 _ENV_CACHE: Dict[str, tuple] = {}
-# path_key -> (mtime_ns, size), or None when even stat/read failed. This does
+# canonical target path -> (mtime_ns, size, device, inode), or None when even
+# stat/read failed. This
 # not change managed scope's startup-safe fail-open merge semantics; it lets
 # security-sensitive request guards detect that current administrator policy
 # is degraded and choose a stricter local behavior.
-_CONFIG_FAILURE_BY_PATH: Dict[str, Optional[tuple[int, int]]] = {}
+_CONFIG_FAILURE_BY_PATH: Dict[str, Optional[tuple[int, int, int, int]]] = {}
 
 
 def _under_pytest() -> bool:
@@ -84,14 +85,22 @@ def invalidate_managed_cache() -> None:
         _CONFIG_FAILURE_BY_PATH.clear()
 
 
+def _cache_path_key(path: Path) -> str:
+    """Canonical target identity seam for symlink-safe managed caches."""
+    try:
+        return str(path.resolve(strict=False))
+    except OSError:
+        return str(path.absolute())
+
+
 def _cached_read(
     path: Path,
     cache: Dict[str, tuple],
     parse,
     *,
-    failure_cache: Optional[Dict[str, Optional[tuple[int, int]]]] = None,
+    failure_cache: Optional[Dict[str, Optional[tuple[int, int, int, int]]]] = None,
 ):
-    """Shared (mtime_ns, size)-keyed read. Returns a deepcopy of the parsed value.
+    """Target-identity-keyed read. Returns a deepcopy of the parsed value.
 
     Returns ``None`` when the file is absent or fails to parse (fail-open). A
     parse failure is logged LOUDLY — the admin needs to know their policy isn't
@@ -99,7 +108,7 @@ def _cached_read(
     startup. ``failure_cache`` records only the current degraded file state for
     security-sensitive consumers; normal managed-overlay behavior is unchanged.
     """
-    path_key = str(path)
+    path_key = _cache_path_key(path)
     try:
         st = path.stat()
     except FileNotFoundError:
@@ -118,13 +127,13 @@ def _cached_read(
             exc,
         )
         return None
-    key = (st.st_mtime_ns, st.st_size)
+    key = (st.st_mtime_ns, st.st_size, st.st_dev, st.st_ino)
     with _CACHE_LOCK:
         hit = cache.get(path_key)
-        if hit is not None and hit[:2] == key:
+        if hit is not None and hit[:4] == key:
             if failure_cache is not None:
                 failure_cache.pop(path_key, None)
-            return copy.deepcopy(hit[2])
+            return copy.deepcopy(hit[4])
     try:
         with open(path, encoding="utf-8") as f:
             parsed = parse(f)
@@ -140,7 +149,7 @@ def _cached_read(
         )
         return None
     with _CACHE_LOCK:
-        cache[path_key] = (key[0], key[1], copy.deepcopy(parsed))
+        cache[path_key] = (*key, copy.deepcopy(parsed))
         if failure_cache is not None:
             failure_cache.pop(path_key, None)
     return parsed
@@ -180,7 +189,7 @@ def managed_config_load_degraded() -> bool:
     config_path = managed_dir / "config.yaml"
     load_managed_config()  # refresh signature-bound success/failure state
     with _CACHE_LOCK:
-        return str(config_path) in _CONFIG_FAILURE_BY_PATH
+        return _cache_path_key(config_path) in _CONFIG_FAILURE_BY_PATH
 
 
 def load_managed_env() -> Dict[str, str]:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1704,11 +1704,13 @@ def switch_model(
             "message": f"Could not validate `{new_model}`: {e}",
         }
 
-    # Override rejection if model is in the user's saved provider config.
-    # API /v1/models may not list cloud/aliased models even though the server supports them.
+    # Override rejection if a model is declared for a non-authoritative custom
+    # provider. OpenRouter's authenticated /models/user catalog is authoritative
+    # and must never be bypassed by a stale local declaration.
     if not validation.get("accepted"):
         override = False
-        if user_providers:
+        authoritative_openrouter = str(target_provider).strip().lower() == "openrouter"
+        if user_providers and not authoritative_openrouter:
             from hermes_cli.config import is_provider_enabled
             # user_providers is a dict: {provider_slug: config_dict}
             for slug, cfg in user_providers.items():
@@ -1719,8 +1721,14 @@ def switch_model(
                         override = True
                         break
         # Also check custom_providers list — models declared there should be accepted
-        # even if the remote /v1/models endpoint doesn't list them.
-        if not override and custom_providers and isinstance(custom_providers, list):
+        # even if the remote /v1/models endpoint doesn't list them. Never soften
+        # an authoritative OpenRouter policy rejection.
+        if (
+            not override
+            and not authoritative_openrouter
+            and custom_providers
+            and isinstance(custom_providers, list)
+        ):
             for entry in custom_providers:
                 if not isinstance(entry, dict):
                     continue

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2219,10 +2219,13 @@ def list_authenticated_providers(
 
         # Unified pathway: route through cached_provider_model_ids() so the
         # /model picker sees the SAME list `hermes model` would build, with
-        # disk caching to keep the picker open snappy. Falls back to the
-        # curated static list when the live fetcher returns nothing.
+        # disk caching to keep the picker open snappy.
         model_ids = cached_provider_model_ids(hermes_id)
-        if not model_ids:
+        # OpenRouter's authenticated /models/user response is authoritative.
+        # Curated/static entries only order and describe IDs already present in
+        # that verified set; they must not become an offline authorization
+        # fallback. Other providers retain their ordinary fallback behavior.
+        if not model_ids and hermes_id != "openrouter":
             model_ids = curated.get(hermes_id, [])
             if hermes_id in _MODELS_DEV_PREFERRED:
                 model_ids = _merge_with_models_dev(hermes_id, model_ids)
@@ -2234,6 +2237,13 @@ def list_authenticated_providers(
             configured = user_providers.get(hermes_id)
             if isinstance(configured, dict):
                 configured_models = _declared_model_ids(configured.get("models"))
+        if hermes_id == "openrouter":
+            verified_by_lower = {model_id.lower(): model_id for model_id in model_ids}
+            configured_models = [
+                verified_by_lower[model_id.lower()]
+                for model_id in configured_models
+                if model_id.lower() in verified_by_lower
+            ]
         model_ids = list(dict.fromkeys([*configured_models, *model_ids]))
         total = len(model_ids)
         if hermes_id in _UNCAPPED_PICKER_PROVIDERS:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2199,8 +2199,18 @@ def list_authenticated_providers(
             if not isinstance(env_vars, list):
                 continue
 
-        # Check if any env var is set
+        # Check the canonical effective credential path for OpenRouter so a
+        # profile configured through model.api_key is not hidden before its
+        # authenticated policy catalog can be queried. Other providers retain
+        # their existing environment/auth-store availability checks.
         has_creds = any(os.environ.get(ev) for ev in env_vars)
+        if hermes_id == "openrouter":
+            try:
+                from hermes_cli.models import has_openrouter_catalog_credential
+
+                has_creds = has_openrouter_catalog_credential()
+            except Exception:
+                pass
         if not has_creds:
             try:
                 from hermes_cli.auth import _load_auth_store

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -7,6 +7,7 @@ Add, remove, or reorder entries here — both `hermes setup` and
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -101,7 +102,13 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
 ]
 
 _openrouter_catalog_cache: list[tuple[str, str]] | None = None
-
+_openrouter_catalog_cache_at: float = 0.0
+_openrouter_catalog_cache_key_fp: str | None = None
+_openrouter_policy_catalog_cache: dict[str, dict[str, Any]] | None = None
+_openrouter_policy_catalog_cache_at: float = 0.0
+_openrouter_policy_catalog_cache_key_fp: str | None = None
+_OPENROUTER_USER_MODELS_URL = "https://openrouter.ai/api/v1/models/user"
+_OPENROUTER_CATALOG_CACHE_TTL = 300.0
 
 # Fallback Vercel AI Gateway snapshot used when the live catalog is unavailable.
 # OSS / open-weight models prioritized first, then closed-source by family.
@@ -126,6 +133,26 @@ VERCEL_AI_GATEWAY_MODELS: list[tuple[str, str]] = [
 ]
 
 _ai_gateway_catalog_cache: list[tuple[str, str]] | None = None
+
+def _openrouter_api_key_fingerprint(api_key: str) -> str:
+    """Return a non-reversible cache partition key without retaining credentials."""
+    return hashlib.sha256(api_key.encode("utf-8")).hexdigest()
+
+
+def _resolve_openrouter_catalog_api_key() -> str:
+    """Resolve the catalog credential through the canonical runtime chain."""
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(requested="openrouter")
+    except Exception:
+        return ""
+    api_key = runtime.get("api_key") if isinstance(runtime, dict) else ""
+    if not isinstance(api_key, str):
+        return ""
+    api_key = api_key.strip()
+    return "" if api_key == "no-key-required" else api_key
+
 
 
 def _codex_curated_models() -> list[str]:
@@ -1494,21 +1521,114 @@ def _openrouter_model_supports_tools(item: Any) -> bool:
     return "tools" in params
 
 
+def _fetch_openrouter_policy_catalog(
+    timeout: float = 8.0,
+    *,
+    force_refresh: bool = False,
+) -> dict[str, dict[str, Any]] | None:
+    """Fetch OpenRouter's catalog filtered by account privacy and guardrails.
+
+    ``/models/user`` is authenticated and reflects the account's current
+    provider preferences, privacy settings, and guardrails.  ``None`` means
+    the policy-aware catalog could not be verified; an empty dict is a valid
+    response meaning the account currently has no eligible models.
+    """
+    global _openrouter_policy_catalog_cache, _openrouter_policy_catalog_cache_at
+    global _openrouter_policy_catalog_cache_key_fp
+
+    api_key = _resolve_openrouter_catalog_api_key()
+    if not api_key:
+        return None
+    key_fp = _openrouter_api_key_fingerprint(api_key)
+
+    now = time.time()
+    if (
+        _openrouter_policy_catalog_cache is not None
+        and _openrouter_policy_catalog_cache_key_fp == key_fp
+        and not force_refresh
+        and (now - _openrouter_policy_catalog_cache_at) < _OPENROUTER_CATALOG_CACHE_TTL
+    ):
+        return dict(_openrouter_policy_catalog_cache)
+
+    req = urllib.request.Request(
+        _OPENROUTER_USER_MODELS_URL,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {api_key}",
+            "User-Agent": _HERMES_USER_AGENT,
+        },
+    )
+    try:
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode())
+    except Exception:
+        return None
+
+    items = payload.get("data", []) if isinstance(payload, dict) else []
+    if not isinstance(items, list):
+        return None
+
+    catalog: dict[str, dict[str, Any]] = {}
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        model_id = str(item.get("id") or "").strip()
+        if model_id:
+            catalog[model_id] = item
+
+    _openrouter_policy_catalog_cache = catalog
+    _openrouter_policy_catalog_cache_at = now
+    _openrouter_policy_catalog_cache_key_fp = key_fp
+    return dict(catalog)
+
+
+def _openrouter_policy_model_ids(
+    *,
+    force_refresh: bool = False,
+    tool_capable: bool = False,
+) -> list[str] | None:
+    """Return model IDs eligible under the current OpenRouter policy."""
+    catalog = _fetch_openrouter_policy_catalog(force_refresh=force_refresh)
+    if catalog is None:
+        return None
+    if tool_capable:
+        return [mid for mid, item in catalog.items() if _openrouter_model_supports_tools(item)]
+    return list(catalog)
+
+
 def fetch_openrouter_models(
     timeout: float = 8.0,
     *,
     force_refresh: bool = False,
 ) -> list[tuple[str, str]]:
-    """Return the curated OpenRouter picker list, refreshed from the live catalog when possible."""
-    global _openrouter_catalog_cache
+    """Return tool-capable OpenRouter models allowed by the account policy.
 
-    if _openrouter_catalog_cache is not None and not force_refresh:
+    Curated models are listed first as a stable ordering hint, followed by
+    every additional tool-capable model returned by OpenRouter's authenticated
+    policy-aware catalog.
+
+    The picker is intentionally fail-closed: if the authenticated
+    policy-aware catalog cannot be fetched, it returns a stale filtered picker
+    cache when available, otherwise an empty list. It never falls back to the
+    unfiltered public catalog or a static snapshot that could violate the
+    account's current privacy settings.
+    """
+    global _openrouter_catalog_cache, _openrouter_catalog_cache_at
+    global _openrouter_catalog_cache_key_fp
+
+    now = time.time()
+    api_key = _resolve_openrouter_catalog_api_key()
+    key_fp = _openrouter_api_key_fingerprint(api_key) if api_key else None
+    if (
+        _openrouter_catalog_cache is not None
+        and _openrouter_catalog_cache_key_fp == key_fp
+        and not force_refresh
+        and (now - _openrouter_catalog_cache_at) < _OPENROUTER_CATALOG_CACHE_TTL
+    ):
         return list(_openrouter_catalog_cache)
 
-    # Prefer the remotely-hosted catalog manifest; fall back to the in-repo
-    # snapshot when the manifest is unreachable. Both are curated lists that
-    # drive the picker; the OpenRouter live /v1/models filter (tool support,
-    # free pricing) is applied on top either way.
+    # Prefer the remotely-hosted curated catalog manifest for stable ordering;
+    # fall back to the in-repo snapshot only as an ordering hint.
     try:
         from hermes_cli.model_catalog import get_curated_openrouter_models
         remote = get_curated_openrouter_models()
@@ -1517,56 +1637,39 @@ def fetch_openrouter_models(
     fallback = list(remote) if remote else list(OPENROUTER_MODELS)
     preferred_ids = [mid for mid, _ in fallback]
 
-    try:
-        req = urllib.request.Request(
-            "https://openrouter.ai/api/v1/models",
-            headers={"Accept": "application/json"},
-        )
-        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
-            payload = json.loads(resp.read().decode())
-    except Exception:
-        return list(_openrouter_catalog_cache or fallback)
+    live_by_id = _fetch_openrouter_policy_catalog(
+        timeout=timeout,
+        force_refresh=force_refresh,
+    )
+    if live_by_id is None:
+        if _openrouter_catalog_cache_key_fp == key_fp:
+            return list(_openrouter_catalog_cache or [])
+        return []
 
-    live_items = payload.get("data", [])
-    if not isinstance(live_items, list):
-        return list(_openrouter_catalog_cache or fallback)
+    ordered_ids = list(preferred_ids)
+    seen_ids = set(ordered_ids)
+    ordered_ids.extend(mid for mid in live_by_id if mid not in seen_ids)
 
-    live_by_id: dict[str, dict[str, Any]] = {}
-    for item in live_items:
-        if not isinstance(item, dict):
-            continue
-        mid = str(item.get("id") or "").strip()
-        if not mid:
-            continue
-        live_by_id[mid] = item
-
-    curated: list[tuple[str, str]] = []
+    models: list[tuple[str, str]] = []
     silent_default = get_preferred_silent_default_model("openrouter")
-    for preferred_id in preferred_ids:
-        live_item = live_by_id.get(preferred_id)
-        if live_item is None:
+    for model_id in ordered_ids:
+        live_item = live_by_id.get(model_id)
+        if live_item is None or not _openrouter_model_supports_tools(live_item):
             continue
-        # Hide models that don't advertise tool-calling support — hermes-agent
-        # requires it and surfacing them leads to immediate runtime failures
-        # when the user selects them. Ported from Kilo-Org/kilocode#9068.
-        if not _openrouter_model_supports_tools(live_item):
-            continue
-        if preferred_id == silent_default:
-            # Keep the silent-default badge through the live refresh so the
-            # picker shows which model Hermes lands on when none is selected.
+        if model_id == silent_default:
             desc = "default"
         else:
             desc = "free" if _openrouter_model_is_free(live_item.get("pricing")) else ""
-        curated.append((preferred_id, desc))
+        models.append((model_id, desc))
 
-    if not curated:
-        return list(_openrouter_catalog_cache or fallback)
+    if models and not models[0][1]:
+        first_id, _ = models[0]
+        models[0] = (first_id, "recommended")
 
-    first_id, first_desc = curated[0]
-    if not first_desc:
-        curated[0] = (first_id, "recommended")
-    _openrouter_catalog_cache = curated
-    return list(curated)
+    _openrouter_catalog_cache = models
+    _openrouter_catalog_cache_at = now
+    _openrouter_catalog_cache_key_fp = key_fp
+    return list(models)
 
 
 def model_ids(*, force_refresh: bool = False) -> list[str]:
@@ -3144,6 +3247,7 @@ def _credential_fingerprint(provider: str) -> str:
     import os as _os
 
     parts: list[str] = []
+    seen_env_vars: set[str] = set()
 
     # Env vars from PROVIDER_REGISTRY for this slug
     try:
@@ -3152,9 +3256,27 @@ def _credential_fingerprint(provider: str) -> str:
         if pcfg is not None:
             for ev in getattr(pcfg, "api_key_env_vars", ()) or ():
                 parts.append(f"{ev}={_os.environ.get(ev, '')}")
+                seen_env_vars.add(ev)
             bev = getattr(pcfg, "base_url_env_var", "") or ""
             if bev:
                 parts.append(f"{bev}={_os.environ.get(bev, '')}")
+                seen_env_vars.add(bev)
+    except Exception:
+        pass
+
+    # Plugin providers can be routable without an auth.PROVIDER_REGISTRY row.
+    # Include their declared credential env vars as well; otherwise every key
+    # hashes to the same empty fingerprint and the generic disk cache can leak
+    # account A's model catalog after rotating to account B.
+    try:
+        from providers import get_provider_profile  # type: ignore[attr-defined]
+
+        profile = get_provider_profile(provider)
+        if profile is not None:
+            for ev in getattr(profile, "env_vars", ()) or ():
+                if ev not in seen_env_vars:
+                    parts.append(f"{ev}={_os.environ.get(ev, '')}")
+                    seen_env_vars.add(ev)
     except Exception:
         pass
 
@@ -3168,6 +3290,13 @@ def _credential_fingerprint(provider: str) -> str:
             parts.append(f"effective_base={_openai_discovery_base_url(provider)}")
         except Exception:
             pass
+
+    # OpenRouter supports legacy/runtime aliases (notably OPENAI_API_KEY), so
+    # the declared plugin env vars alone do not fully describe the credential
+    # that the authenticated /models/user request will use.
+    if provider == "openrouter":
+        resolved_key = _resolve_openrouter_catalog_api_key()
+        parts.append(f"runtime_openrouter={resolved_key}")
 
     # OAuth / external-file mtimes that change on re-auth
     try:
@@ -3301,14 +3430,28 @@ def clear_provider_models_cache(provider: Optional[str] = None) -> None:
     entry is removed. Used by ``/model --refresh`` and
     ``hermes model --refresh``.
     """
+    global _openrouter_catalog_cache, _openrouter_catalog_cache_at
+    global _openrouter_catalog_cache_key_fp
+    global _openrouter_policy_catalog_cache, _openrouter_policy_catalog_cache_at
+    global _openrouter_policy_catalog_cache_key_fp
+
     try:
+        normalized = normalize_provider(provider) if provider is not None else None
+        if provider is None or normalized == "openrouter":
+            _openrouter_catalog_cache = None
+            _openrouter_catalog_cache_at = 0.0
+            _openrouter_catalog_cache_key_fp = None
+            _openrouter_policy_catalog_cache = None
+            _openrouter_policy_catalog_cache_at = 0.0
+            _openrouter_policy_catalog_cache_key_fp = None
+
         if provider is None:
             path = _provider_models_cache_path()
             if path.exists():
                 path.unlink()
             return
         cache = _load_provider_models_cache()
-        normalized = normalize_provider(provider) or provider or ""
+        normalized = normalized or provider or ""
         if normalized in cache:
             del cache[normalized]
             _save_provider_models_cache(cache)
@@ -5092,6 +5235,42 @@ def validate_requested_model(
                 f"model listing.  Many Anthropic-compatible proxies do not "
                 f"implement GET /v1/models.  The model name has been accepted "
                 f"without verification."
+            ),
+        }
+
+    if normalized == "openrouter":
+        eligible_models = _openrouter_policy_model_ids(tool_capable=True)
+        if eligible_models is None:
+            return {
+                "accepted": False,
+                "persist": False,
+                "recognized": False,
+                "message": (
+                    "Could not verify OpenRouter's privacy-filtered model catalog. "
+                    "The model was not selected; check the configured OpenRouter "
+                    "credential and retry."
+                ),
+            }
+        eligible_set = set(eligible_models)
+        if requested_for_lookup in eligible_set:
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "message": None,
+            }
+        suggestions = get_close_matches(requested_for_lookup, eligible_models, n=3, cutoff=0.5)
+        suggestion_text = ""
+        if suggestions:
+            suggestion_text = " Similar policy-eligible models: " + ", ".join(f"`{s}`" for s in suggestions)
+        return {
+            "accepted": False,
+            "persist": False,
+            "recognized": False,
+            "message": (
+                f"`{requested}` is not available under the current OpenRouter "
+                f"provider/privacy/guardrail policy and was not selected."
+                f"{suggestion_text}"
             ),
         }
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -109,6 +109,7 @@ _openrouter_policy_catalog_cache_at: float = 0.0
 _openrouter_policy_catalog_cache_key_fp: str | None = None
 _OPENROUTER_USER_MODELS_URL = "https://openrouter.ai/api/v1/models/user"
 _OPENROUTER_CATALOG_CACHE_TTL = 300.0
+_OPENROUTER_POLICY_CACHE_SOURCE = "authenticated-models-user-tools-v1"
 
 # Fallback Vercel AI Gateway snapshot used when the live catalog is unavailable.
 # OSS / open-weight models prioritized first, then closed-source by family.
@@ -1541,6 +1542,34 @@ def _openrouter_model_supports_tools(item: Any) -> bool:
     return any(isinstance(param, str) and param == "tools" for param in params)
 
 
+def _invalidate_openrouter_failed_verification(key_fp: str | None) -> None:
+    """Drop OpenRouter cache state after current policy verification fails."""
+    global _openrouter_catalog_cache, _openrouter_catalog_cache_at
+    global _openrouter_catalog_cache_key_fp
+    global _openrouter_policy_catalog_cache, _openrouter_policy_catalog_cache_at
+    global _openrouter_policy_catalog_cache_key_fp
+
+    if key_fp is None or _openrouter_catalog_cache_key_fp == key_fp:
+        _openrouter_catalog_cache = None
+        _openrouter_catalog_cache_at = 0.0
+        _openrouter_catalog_cache_key_fp = None
+    if key_fp is None or _openrouter_policy_catalog_cache_key_fp == key_fp:
+        _openrouter_policy_catalog_cache = None
+        _openrouter_policy_catalog_cache_at = 0.0
+        _openrouter_policy_catalog_cache_key_fp = None
+
+    # The generic provider cache has a longer TTL than the policy cache. Once
+    # a current verification attempt fails, its OpenRouter entry is no longer
+    # an authorization source and must not survive for a later picker open.
+    try:
+        cache = _load_provider_models_cache()
+        if "openrouter" in cache:
+            del cache["openrouter"]
+            _save_provider_models_cache(cache)
+    except Exception:
+        pass
+
+
 def _fetch_openrouter_policy_catalog(
     timeout: float = 8.0,
     *,
@@ -1563,6 +1592,7 @@ def _fetch_openrouter_policy_catalog(
         explicit_base_url=base_url,
     )
     if not resolved_api_key:
+        _invalidate_openrouter_failed_verification(None)
         return None
     key_fp = _openrouter_api_key_fingerprint(resolved_api_key)
 
@@ -1587,10 +1617,12 @@ def _fetch_openrouter_policy_catalog(
         with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
             payload = json.loads(resp.read().decode())
     except Exception:
+        _invalidate_openrouter_failed_verification(key_fp)
         return None
 
     items = payload.get("data", []) if isinstance(payload, dict) else []
     if not isinstance(items, list):
+        _invalidate_openrouter_failed_verification(key_fp)
         return None
 
     catalog: dict[str, dict[str, Any]] = {}
@@ -1638,11 +1670,11 @@ def fetch_openrouter_models(
     every additional tool-capable model returned by OpenRouter's authenticated
     policy-aware catalog.
 
-    The picker is intentionally fail-closed: if the authenticated
-    policy-aware catalog cannot be fetched, it returns a stale filtered picker
-    cache when available, otherwise an empty list. It never falls back to the
-    unfiltered public catalog or a static snapshot that could violate the
-    account's current privacy settings.
+    The picker is intentionally fail-closed: if a required authenticated
+    policy refresh fails, it returns an empty list and invalidates stale cache
+    state for that credential. It never falls back to the unfiltered public
+    catalog or a static snapshot that could violate the account's current
+    privacy settings.
     """
     global _openrouter_catalog_cache, _openrouter_catalog_cache_at
     global _openrouter_catalog_cache_key_fp
@@ -1673,8 +1705,6 @@ def fetch_openrouter_models(
         force_refresh=force_refresh,
     )
     if live_by_id is None:
-        if _openrouter_catalog_cache_key_fp == key_fp:
-            return list(_openrouter_catalog_cache or [])
         return []
 
     ordered_ids = list(preferred_ids)
@@ -3412,18 +3442,28 @@ def cached_provider_model_ids(
     fp = _credential_fingerprint(normalized)
     entry = cache.get(normalized)
     now = time.time()
+    effective_ttl = ttl_seconds
+    if normalized == "openrouter":
+        effective_ttl = min(effective_ttl, int(_OPENROUTER_CATALOG_CACHE_TTL))
 
     if (
         not force_refresh
         and isinstance(entry, dict)
         and entry.get("fp") == fp
+        and (
+            normalized != "openrouter"
+            or entry.get("source") == _OPENROUTER_POLICY_CACHE_SOURCE
+        )
         and isinstance(entry.get("models"), list)
         and entry["models"]
     ):
         age = now - float(entry.get("at", 0))
-        if age < ttl_seconds:
+        if age < effective_ttl:
             return list(entry["models"])
-        if age < _PROVIDER_MODELS_STALE_SERVE_MAX:
+        if (
+            normalized != "openrouter"
+            and age < _PROVIDER_MODELS_STALE_SERVE_MAX
+        ):
             # Stale-while-revalidate: serve the expired entry immediately so
             # interactive picker opens never block on serial /v1/models
             # round-trips; refresh the cache off-thread for the next open.
@@ -3433,17 +3473,29 @@ def cached_provider_model_ids(
     # Cache miss / stale / forced refresh — call the live path.
     live = provider_model_ids(normalized, force_refresh=force_refresh)
     if live:
-        cache[normalized] = {
+        cache_entry = {
             "fp": fp,
             "at": now,
             "models": list(live),
         }
+        if normalized == "openrouter":
+            cache_entry["source"] = _OPENROUTER_POLICY_CACHE_SOURCE
+        cache[normalized] = cache_entry
         _save_provider_models_cache(cache)
         return list(live)
 
-    # Live fetch returned nothing. If we have a stale entry with the
-    # SAME fingerprint, prefer it over an empty result — stale data
-    # beats no data when the network is flaky.
+    # OpenRouter's authenticated catalog is an authorization boundary. A
+    # failed current refresh must invalidate its disk entry rather than revive
+    # stale IDs. Other providers retain the ordinary availability fallback.
+    if normalized == "openrouter":
+        if normalized in cache:
+            del cache[normalized]
+            _save_provider_models_cache(cache)
+        return []
+
+    # Live fetch returned nothing. If we have a stale entry with the SAME
+    # fingerprint, prefer it over an empty result for non-authoritative
+    # providers — stale data beats no data when the network is flaky.
     if (
         isinstance(entry, dict)
         and entry.get("fp") == fp

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -139,13 +139,41 @@ def _openrouter_api_key_fingerprint(api_key: str) -> str:
     return hashlib.sha256(api_key.encode("utf-8")).hexdigest()
 
 
-def _resolve_openrouter_catalog_api_key() -> str:
-    """Resolve the catalog credential through the canonical runtime chain."""
-    try:
-        from hermes_cli.runtime_provider import resolve_runtime_provider
+def _resolve_openrouter_catalog_api_key(
+    *,
+    explicit_api_key: str | None = None,
+    explicit_base_url: str | None = None,
+) -> str:
+    """Resolve the catalog credential through the canonical runtime chain.
 
-        runtime = resolve_runtime_provider(requested="openrouter")
+    Explicit request inputs take precedence. When the picker has no request
+    context, mirror the configured main OpenRouter model inputs so legacy
+    ``model.api_key`` profiles use the same credential as inference.
+    """
+    try:
+        from hermes_cli.runtime_provider import base_url_host_matches, resolve_runtime_provider
+
+        if not explicit_api_key and not explicit_base_url:
+            from hermes_cli.config import load_config_readonly
+
+            config = load_config_readonly()
+            model_config = config.get("model", {}) if isinstance(config, dict) else {}
+            if (
+                isinstance(model_config, dict)
+                and str(model_config.get("provider") or "").strip().lower() == "openrouter"
+            ):
+                explicit_api_key = str(model_config.get("api_key") or "").strip() or None
+                explicit_base_url = str(model_config.get("base_url") or "").strip() or None
+
+        runtime = resolve_runtime_provider(
+            requested="openrouter",
+            explicit_api_key=explicit_api_key,
+            explicit_base_url=explicit_base_url,
+        )
     except Exception:
+        return ""
+    resolved_base_url = runtime.get("base_url") if isinstance(runtime, dict) else ""
+    if not isinstance(resolved_base_url, str) or not base_url_host_matches(resolved_base_url, "openrouter.ai"):
         return ""
     api_key = runtime.get("api_key") if isinstance(runtime, dict) else ""
     if not isinstance(api_key, str):
@@ -1497,34 +1525,28 @@ def _openrouter_model_is_free(pricing: Any) -> bool:
 
 
 def _openrouter_model_supports_tools(item: Any) -> bool:
-    """Return True when the model's ``supported_parameters`` advertise tool calling.
+    """Return True only when the model explicitly advertises tool calling.
 
-    hermes-agent is tool-calling-first — every provider path assumes the model
-    can invoke tools. Models that don't advertise ``tools`` in their
-    ``supported_parameters`` (e.g. image-only or completion-only models) cannot
-    be driven by the agent loop and would fail at the first tool call.
-
-    **Permissive when the field is missing.** Some OpenRouter-compatible gateways
-    (Nous Portal, private mirrors, older catalog snapshots) don't populate
-    ``supported_parameters`` at all. Treat that as "unknown capability → allow"
-    so the picker doesn't silently empty for those users. Only hide models
-    whose ``supported_parameters`` is an explicit list that omits ``tools``.
+    hermes-agent is tool-calling-first, so missing or malformed capability
+    metadata must fail closed rather than authorizing a model that may reject
+    the first tool request.
 
     Ported from Kilo-Org/kilocode#9068.
     """
     if not isinstance(item, dict):
-        return True
+        return False
     params = item.get("supported_parameters")
     if not isinstance(params, list):
-        # Field absent / malformed / None — be permissive.
-        return True
-    return "tools" in params
+        return False
+    return any(isinstance(param, str) and param == "tools" for param in params)
 
 
 def _fetch_openrouter_policy_catalog(
     timeout: float = 8.0,
     *,
     force_refresh: bool = False,
+    api_key: str | None = None,
+    base_url: str | None = None,
 ) -> dict[str, dict[str, Any]] | None:
     """Fetch OpenRouter's catalog filtered by account privacy and guardrails.
 
@@ -1536,10 +1558,13 @@ def _fetch_openrouter_policy_catalog(
     global _openrouter_policy_catalog_cache, _openrouter_policy_catalog_cache_at
     global _openrouter_policy_catalog_cache_key_fp
 
-    api_key = _resolve_openrouter_catalog_api_key()
-    if not api_key:
+    resolved_api_key = _resolve_openrouter_catalog_api_key(
+        explicit_api_key=api_key,
+        explicit_base_url=base_url,
+    )
+    if not resolved_api_key:
         return None
-    key_fp = _openrouter_api_key_fingerprint(api_key)
+    key_fp = _openrouter_api_key_fingerprint(resolved_api_key)
 
     now = time.time()
     if (
@@ -1554,7 +1579,7 @@ def _fetch_openrouter_policy_catalog(
         _OPENROUTER_USER_MODELS_URL,
         headers={
             "Accept": "application/json",
-            "Authorization": f"Bearer {api_key}",
+            "Authorization": f"Bearer {resolved_api_key}",
             "User-Agent": _HERMES_USER_AGENT,
         },
     )
@@ -1586,9 +1611,15 @@ def _openrouter_policy_model_ids(
     *,
     force_refresh: bool = False,
     tool_capable: bool = False,
+    api_key: str | None = None,
+    base_url: str | None = None,
 ) -> list[str] | None:
     """Return model IDs eligible under the current OpenRouter policy."""
-    catalog = _fetch_openrouter_policy_catalog(force_refresh=force_refresh)
+    catalog = _fetch_openrouter_policy_catalog(
+        force_refresh=force_refresh,
+        api_key=api_key,
+        base_url=base_url,
+    )
     if catalog is None:
         return None
     if tool_capable:
@@ -5239,7 +5270,11 @@ def validate_requested_model(
         }
 
     if normalized == "openrouter":
-        eligible_models = _openrouter_policy_model_ids(tool_capable=True)
+        eligible_models = _openrouter_policy_model_ids(
+            tool_capable=True,
+            api_key=api_key,
+            base_url=base_url,
+        )
         if eligible_models is None:
             return {
                 "accepted": False,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -183,6 +183,11 @@ def _resolve_openrouter_catalog_api_key(
     return "" if api_key == "no-key-required" else api_key
 
 
+def has_openrouter_catalog_credential() -> bool:
+    """Return whether the canonical OpenRouter runtime credential is usable."""
+    return bool(_resolve_openrouter_catalog_api_key())
+
+
 
 def _codex_curated_models() -> list[str]:
     """Derive the openai-codex curated list from codex_models.py.

--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -34,7 +34,9 @@ from typing import List, Dict, Any, Optional
 
 import fire
 from dotenv import load_dotenv
+from agent.openrouter_zdr import enforce_openrouter_zdr
 from agent.tool_dispatch_helpers import make_tool_result_message
+from utils import base_url_host_matches
 
 # Load environment variables
 load_dotenv()
@@ -464,6 +466,13 @@ Complete the user's task step by step."""
                     )
                     if fixed_temperature is not None:
                         api_kwargs["temperature"] = fixed_temperature
+
+                    _client_base = str(getattr(self.client, "base_url", "") or "")
+                    enforce_openrouter_zdr(
+                        api_kwargs,
+                        is_openrouter=base_url_host_matches(_client_base, "openrouter.ai"),
+                        base_url=_client_base,
+                    )
 
                     response = self.client.chat.completions.create(**api_kwargs)
                 except Exception as e:

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -9,8 +9,6 @@ from providers.base import ProviderProfile
 
 logger = logging.getLogger(__name__)
 
-_CACHE: list[str] | None = None
-
 # Anthropic model families that still accept an explicit "disable thinking"
 # request (the manual ``thinking: {type: "disabled"}`` form OpenRouter emits
 # for ``reasoning: {enabled: false}``). Everything Claude 4.6 and newer —
@@ -55,21 +53,18 @@ class OpenRouterProfile(ProviderProfile):
         base_url: str | None = None,
         timeout: float = 8.0,
     ) -> list[str] | None:
-        """Fetch from public OpenRouter catalog — no auth required.
+        """Fetch from OpenRouter's policy-filtered catalog.
 
-        Note: Tool-call capability filtering is applied by hermes_cli/models.py
-        via fetch_openrouter_models() → _openrouter_model_supports_tools(), not
-        here. The picker early-returns via the dedicated openrouter path before
-        reaching this method, so filtering here would be unreachable.
+        The authenticated ``/models/user`` endpoint reflects the account's
+        provider preferences, privacy settings, and guardrails. Tool-call
+        capability filtering remains in hermes_cli/models.py for the picker.
         """
-        global _CACHE  # noqa: PLW0603
-        if _CACHE is not None:
-            return _CACHE
         try:
-            result = super().fetch_models(api_key=None, base_url=base_url, timeout=timeout)
-            if result is not None:
-                _CACHE = result
-            return result
+            # Do not add a profile-local cache here. The canonical picker cache
+            # in hermes_cli.models is policy-aware, TTL-bounded, and partitioned
+            # by API-key fingerprint; a second unkeyed cache can leak account A's
+            # catalog after credentials rotate to account B.
+            return super().fetch_models(api_key=api_key, base_url=base_url, timeout=timeout)
         except Exception as exc:
             logger.debug("fetch_models(openrouter): %s", exc)
             return None
@@ -199,7 +194,7 @@ openrouter = OpenRouterProfile(
     description="OpenRouter — unified API for 200+ models",
     signup_url="https://openrouter.ai/keys",
     base_url="https://openrouter.ai/api/v1",
-    models_url="https://openrouter.ai/api/v1/models",
+    models_url="https://openrouter.ai/api/v1/models/user",
     fallback_models=(
         "anthropic/claude-sonnet-4.6",
         "openai/gpt-5.4",

--- a/tests/agent/test_chat_completion_helpers_provider_sort.py
+++ b/tests/agent/test_chat_completion_helpers_provider_sort.py
@@ -1,4 +1,24 @@
-from agent.chat_completion_helpers import _validated_openrouter_provider_sort
+from agent.chat_completion_helpers import (
+    _provider_preferences_for_agent,
+    _validated_openrouter_provider_sort,
+)
+
+
+def _agent(provider="openrouter"):
+    return type(
+        "Agent",
+        (),
+        {
+            "provider": provider,
+            "providers_allowed": None,
+            "providers_ignored": None,
+            "providers_order": None,
+            "provider_sort": None,
+            "provider_require_parameters": False,
+            "provider_data_collection": None,
+            "_is_openrouter_url": lambda self: False,
+        },
+    )()
 
 
 def test_validated_openrouter_provider_sort_accepts_valid_values():

--- a/tests/agent/test_openrouter_zdr.py
+++ b/tests/agent/test_openrouter_zdr.py
@@ -75,6 +75,96 @@ def test_parse_failure_state_clears_after_config_is_fixed(monkeypatch, tmp_path)
     assert fixed_kwargs["extra_body"]["provider"]["zdr"] is False
 
 
+def _write_managed_config(monkeypatch, tmp_path, *, managed_text):
+    config_mod = _write_raw_config(
+        monkeypatch, tmp_path, "openrouter:\n  zdr: false\n"
+    )
+    managed_dir = tmp_path / "managed"
+    managed_dir.mkdir()
+    (managed_dir / "config.yaml").write_text(managed_text, encoding="utf-8")
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+    from hermes_cli import managed_scope
+
+    managed_scope.invalidate_managed_cache()
+    return config_mod, managed_scope, managed_dir
+
+
+def test_invalid_managed_yaml_enforces_zdr_fail_closed(
+    monkeypatch, tmp_path, caplog
+):
+    _write_managed_config(
+        monkeypatch, tmp_path, managed_text="openrouter: ["
+    )
+    kwargs = {"extra_body": {"provider": {"zdr": False}}}
+
+    enforce_openrouter_zdr(
+        kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert kwargs["extra_body"]["provider"]["zdr"] is True
+    assert "managed config could not be parsed" in caplog.text
+
+
+def test_malformed_managed_zdr_value_enforces_zdr_fail_closed(
+    monkeypatch, tmp_path, caplog
+):
+    _write_managed_config(
+        monkeypatch,
+        tmp_path,
+        managed_text='openrouter:\n  zdr: "true"\n',
+    )
+    kwargs = {"extra_body": {"provider": {"zdr": False}}}
+
+    enforce_openrouter_zdr(
+        kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert kwargs["extra_body"]["provider"]["zdr"] is True
+    assert "effective openrouter.zdr must be a boolean" in caplog.text
+
+
+def test_managed_failure_state_clears_after_repair_or_removal(
+    monkeypatch, tmp_path
+):
+    config_mod, managed_scope, managed_dir = _write_managed_config(
+        monkeypatch, tmp_path, managed_text="openrouter: ["
+    )
+    failed_kwargs = {"extra_body": {"provider": {"zdr": False}}}
+    enforce_openrouter_zdr(
+        failed_kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert failed_kwargs["extra_body"]["provider"]["zdr"] is True
+
+    (managed_dir / "config.yaml").write_text(
+        "openrouter:\n  zdr: false\n", encoding="utf-8"
+    )
+    repaired_kwargs = {"extra_body": {"provider": {"zdr": False}}}
+    enforce_openrouter_zdr(
+        repaired_kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert repaired_kwargs["extra_body"]["provider"]["zdr"] is False
+    assert managed_scope.managed_config_load_degraded() is False
+
+    (managed_dir / "config.yaml").unlink()
+    config_mod._LOAD_CONFIG_CACHE.clear()
+    removed_kwargs = {"extra_body": {"provider": {"zdr": False}}}
+    enforce_openrouter_zdr(
+        removed_kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert removed_kwargs["extra_body"]["provider"]["zdr"] is False
+    assert managed_scope.managed_config_load_degraded() is False
+
+
 def test_quoted_zdr_value_enforces_zdr_fail_closed(monkeypatch, tmp_path, caplog):
     _write_raw_config(monkeypatch, tmp_path, 'openrouter:\n  zdr: "true"\n')
     kwargs = {"extra_body": {"provider": {"zdr": False}}}

--- a/tests/agent/test_openrouter_zdr.py
+++ b/tests/agent/test_openrouter_zdr.py
@@ -47,6 +47,25 @@ def test_shared_enforcement_overrides_false(monkeypatch):
     }
 
 
+def test_shared_enforcement_fails_closed_when_config_read_raises(monkeypatch, caplog):
+    def raise_config_error():
+        raise RuntimeError("config unavailable")
+
+    monkeypatch.setattr(
+        "hermes_cli.config.openrouter_zdr_enabled", raise_config_error
+    )
+    kwargs = {"extra_body": {"provider": {"zdr": False}}}
+
+    enforce_openrouter_zdr(
+        kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert kwargs["extra_body"]["provider"]["zdr"] is True
+    assert "enforcing ZDR fail closed" in caplog.text
+
+
 def test_shared_enforcement_skips_native_gemini(monkeypatch):
     monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: True)
     kwargs = {}
@@ -95,6 +114,52 @@ def test_summary_direct_call_enforces_zdr(monkeypatch):
     kwargs = {"extra_body": {"provider": {"zdr": False}}}
     _enforce_summary_openrouter_zdr(agent, kwargs)
     assert kwargs["extra_body"]["provider"]["zdr"] is True
+
+
+def test_summary_detection_failure_uses_strict_host_fallback(monkeypatch, caplog):
+    monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: True)
+
+    def raise_detection_error(self):
+        raise RuntimeError("detection unavailable")
+
+    agent = type(
+        "Agent",
+        (),
+        {
+            "provider": "fallback",
+            "base_url": "https://openrouter.ai/api/v1",
+            "_is_openrouter_url": raise_detection_error,
+        },
+    )()
+    kwargs = {"extra_body": {"provider": {"zdr": False}}}
+
+    _enforce_summary_openrouter_zdr(agent, kwargs)
+
+    assert kwargs["extra_body"]["provider"]["zdr"] is True
+    assert "host fallback selected is_openrouter=True" in caplog.text
+
+
+def test_summary_detection_failure_does_not_modify_other_hosts(monkeypatch, caplog):
+    monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: True)
+
+    def raise_detection_error(self):
+        raise RuntimeError("detection unavailable")
+
+    agent = type(
+        "Agent",
+        (),
+        {
+            "provider": "custom",
+            "base_url": "https://example.com/v1",
+            "_is_openrouter_url": raise_detection_error,
+        },
+    )()
+    kwargs = {}
+
+    _enforce_summary_openrouter_zdr(agent, kwargs)
+
+    assert kwargs == {}
+    assert "host fallback selected is_openrouter=False" in caplog.text
 
 
 def test_disabled_zdr_preserves_caller_policy(monkeypatch):

--- a/tests/agent/test_openrouter_zdr.py
+++ b/tests/agent/test_openrouter_zdr.py
@@ -1,0 +1,96 @@
+from agent.auxiliary_client import _build_call_kwargs
+from agent.chat_completion_helpers import _enforce_summary_openrouter_zdr
+from agent.openrouter_zdr import enforce_openrouter_zdr
+
+
+def test_config_set_enables_final_boundary_enforcement(monkeypatch, tmp_path):
+    import hermes_cli.config as config_mod
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    config_mod._LOAD_CONFIG_CACHE.clear()
+    config_mod._RAW_CONFIG_CACHE.clear()
+
+    config_mod.set_config_value("openrouter.zdr", "true")
+    kwargs = {"extra_body": {"provider": {"zdr": False}}}
+    enforce_openrouter_zdr(
+        kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert config_mod.load_config()["openrouter"]["zdr"] is True
+    assert kwargs["extra_body"]["provider"]["zdr"] is True
+
+
+def test_shared_enforcement_overrides_false(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: True)
+    kwargs = {"extra_body": {"provider": {"sort": "price", "zdr": False}}}
+    enforce_openrouter_zdr(
+        kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert kwargs["extra_body"]["provider"] == {"sort": "price", "zdr": True}
+
+
+def test_shared_enforcement_skips_native_gemini(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: True)
+    kwargs = {}
+    enforce_openrouter_zdr(
+        kwargs,
+        is_openrouter=True,
+        base_url="https://generativelanguage.googleapis.com/v1beta",
+    )
+    assert kwargs == {}
+
+
+def test_auxiliary_openrouter_enforces_zdr_after_caller_body(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: True)
+    kwargs = _build_call_kwargs(
+        "openrouter",
+        "anthropic/claude-sonnet-4.6",
+        [{"role": "user", "content": "ping"}],
+        extra_body={"provider": {"zdr": False, "sort": "price"}},
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert kwargs["extra_body"]["provider"] == {"zdr": True, "sort": "price"}
+
+
+def test_auxiliary_fallback_label_uses_openrouter_base_url(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: True)
+    kwargs = _build_call_kwargs(
+        "fallback_chain[0](openrouter)",
+        "anthropic/claude-sonnet-4.6",
+        [{"role": "user", "content": "ping"}],
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert kwargs["extra_body"]["provider"] == {"zdr": True}
+
+
+def test_summary_direct_call_enforces_zdr(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: True)
+    agent = type(
+        "Agent",
+        (),
+        {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "_is_openrouter_url": lambda self: True,
+        },
+    )()
+    kwargs = {"extra_body": {"provider": {"zdr": False}}}
+    _enforce_summary_openrouter_zdr(agent, kwargs)
+    assert kwargs["extra_body"]["provider"]["zdr"] is True
+
+
+def test_disabled_zdr_preserves_caller_policy(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: False)
+    kwargs = {"extra_body": {"provider": {"zdr": False}}}
+    enforce_openrouter_zdr(
+        kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert kwargs["extra_body"]["provider"]["zdr"] is False

--- a/tests/agent/test_openrouter_zdr.py
+++ b/tests/agent/test_openrouter_zdr.py
@@ -32,6 +32,7 @@ def _write_raw_config(monkeypatch, tmp_path, text):
     (home / "config.yaml").write_text(text, encoding="utf-8")
     monkeypatch.setenv("HERMES_HOME", str(home))
     config_mod._LOAD_CONFIG_CACHE.clear()
+    getattr(config_mod, "_LOAD_CONFIG_MANAGED_PATH_BY_USER_PATH").clear()
     config_mod._RAW_CONFIG_CACHE.clear()
     config_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
     getattr(config_mod, "_CONFIG_LOAD_FAILURE_BY_PATH").clear()
@@ -163,6 +164,58 @@ def test_managed_failure_state_clears_after_repair_or_removal(
     )
     assert removed_kwargs["extra_body"]["provider"]["zdr"] is False
     assert managed_scope.managed_config_load_degraded() is False
+
+
+def test_managed_path_change_invalidates_identical_metadata_cache(
+    monkeypatch, tmp_path
+):
+    import os
+
+    config_mod = _write_raw_config(
+        monkeypatch, tmp_path, "openrouter:\n  zdr: false\n"
+    )
+    from hermes_cli import managed_scope
+
+    managed_a = tmp_path / "managed-a"
+    managed_b = tmp_path / "managed-b"
+    managed_a.mkdir()
+    managed_b.mkdir()
+    false_text = "openrouter:\n  zdr: false\n"
+    true_text = "openrouter:\n  zdr: true\n"
+    width = max(len(false_text), len(true_text))
+    false_text = false_text.ljust(width)
+    true_text = true_text.ljust(width)
+    path_a = managed_a / "config.yaml"
+    path_b = managed_b / "config.yaml"
+    path_a.write_text(false_text, encoding="utf-8")
+    path_b.write_text(true_text, encoding="utf-8")
+    shared_mtime_ns = 1_700_000_000_000_000_000
+    os.utime(path_a, ns=(shared_mtime_ns, shared_mtime_ns))
+    os.utime(path_b, ns=(shared_mtime_ns, shared_mtime_ns))
+    assert path_a.stat().st_size == path_b.stat().st_size
+    assert path_a.stat().st_mtime_ns == path_b.stat().st_mtime_ns
+
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_a))
+    managed_scope.invalidate_managed_cache()
+    config_mod._LOAD_CONFIG_CACHE.clear()
+    getattr(config_mod, "_LOAD_CONFIG_MANAGED_PATH_BY_USER_PATH").clear()
+    first_kwargs = {"extra_body": {"provider": {"zdr": False}}}
+    enforce_openrouter_zdr(
+        first_kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert first_kwargs["extra_body"]["provider"]["zdr"] is False
+
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_b))
+    second_kwargs = {"extra_body": {"provider": {"zdr": False}}}
+    enforce_openrouter_zdr(
+        second_kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert second_kwargs["extra_body"]["provider"]["zdr"] is True
+    assert config_mod.load_config_readonly()["openrouter"]["zdr"] is True
 
 
 def test_quoted_zdr_value_enforces_zdr_fail_closed(monkeypatch, tmp_path, caplog):

--- a/tests/agent/test_openrouter_zdr.py
+++ b/tests/agent/test_openrouter_zdr.py
@@ -26,13 +26,25 @@ def test_config_set_enables_final_boundary_enforcement(monkeypatch, tmp_path):
 
 def test_shared_enforcement_overrides_false(monkeypatch):
     monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: True)
-    kwargs = {"extra_body": {"provider": {"sort": "price", "zdr": False}}}
+    kwargs = {
+        "extra_body": {
+            "provider": {
+                "sort": "price",
+                "data_collection": "allow",
+                "zdr": False,
+            }
+        }
+    }
     enforce_openrouter_zdr(
         kwargs,
         is_openrouter=True,
         base_url="https://openrouter.ai/api/v1",
     )
-    assert kwargs["extra_body"]["provider"] == {"sort": "price", "zdr": True}
+    assert kwargs["extra_body"]["provider"] == {
+        "sort": "price",
+        "data_collection": "allow",
+        "zdr": True,
+    }
 
 
 def test_shared_enforcement_skips_native_gemini(monkeypatch):

--- a/tests/agent/test_openrouter_zdr.py
+++ b/tests/agent/test_openrouter_zdr.py
@@ -32,7 +32,7 @@ def _write_raw_config(monkeypatch, tmp_path, text):
     (home / "config.yaml").write_text(text, encoding="utf-8")
     monkeypatch.setenv("HERMES_HOME", str(home))
     config_mod._LOAD_CONFIG_CACHE.clear()
-    getattr(config_mod, "_LOAD_CONFIG_MANAGED_PATH_BY_USER_PATH").clear()
+    getattr(config_mod, "_LOAD_CONFIG_MANAGED_IDENTITY_BY_USER_PATH").clear()
     config_mod._RAW_CONFIG_CACHE.clear()
     config_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
     getattr(config_mod, "_CONFIG_LOAD_FAILURE_BY_PATH").clear()
@@ -198,7 +198,7 @@ def test_managed_path_change_invalidates_identical_metadata_cache(
     monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_a))
     managed_scope.invalidate_managed_cache()
     config_mod._LOAD_CONFIG_CACHE.clear()
-    getattr(config_mod, "_LOAD_CONFIG_MANAGED_PATH_BY_USER_PATH").clear()
+    getattr(config_mod, "_LOAD_CONFIG_MANAGED_IDENTITY_BY_USER_PATH").clear()
     first_kwargs = {"extra_body": {"provider": {"zdr": False}}}
     enforce_openrouter_zdr(
         first_kwargs,
@@ -208,6 +208,60 @@ def test_managed_path_change_invalidates_identical_metadata_cache(
     assert first_kwargs["extra_body"]["provider"]["zdr"] is False
 
     monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_b))
+    second_kwargs = {"extra_body": {"provider": {"zdr": False}}}
+    enforce_openrouter_zdr(
+        second_kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert second_kwargs["extra_body"]["provider"]["zdr"] is True
+    assert config_mod.load_config_readonly()["openrouter"]["zdr"] is True
+
+
+def test_managed_symlink_retarget_invalidates_identical_metadata_cache(
+    monkeypatch, tmp_path
+):
+    import os
+
+    config_mod = _write_raw_config(
+        monkeypatch, tmp_path, "openrouter:\n  zdr: false\n"
+    )
+    from hermes_cli import managed_scope
+
+    managed_a = tmp_path / "managed-link-a"
+    managed_b = tmp_path / "managed-link-b"
+    managed_a.mkdir()
+    managed_b.mkdir()
+    false_text = "openrouter:\n  zdr: false\n"
+    true_text = "openrouter:\n  zdr: true\n"
+    width = max(len(false_text), len(true_text))
+    path_a = managed_a / "config.yaml"
+    path_b = managed_b / "config.yaml"
+    path_a.write_text(false_text.ljust(width), encoding="utf-8")
+    path_b.write_text(true_text.ljust(width), encoding="utf-8")
+    shared_mtime_ns = 1_700_000_000_000_000_000
+    os.utime(path_a, ns=(shared_mtime_ns, shared_mtime_ns))
+    os.utime(path_b, ns=(shared_mtime_ns, shared_mtime_ns))
+    assert path_a.stat().st_size == path_b.stat().st_size
+    assert path_a.stat().st_mtime_ns == path_b.stat().st_mtime_ns
+
+    managed_link = tmp_path / "managed-current"
+    managed_link.symlink_to(managed_a, target_is_directory=True)
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_link))
+    managed_scope.invalidate_managed_cache()
+    config_mod._LOAD_CONFIG_CACHE.clear()
+    getattr(config_mod, "_LOAD_CONFIG_MANAGED_IDENTITY_BY_USER_PATH").clear()
+    first_kwargs = {"extra_body": {"provider": {"zdr": False}}}
+    enforce_openrouter_zdr(
+        first_kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert first_kwargs["extra_body"]["provider"]["zdr"] is False
+
+    replacement = tmp_path / "managed-next"
+    replacement.symlink_to(managed_b, target_is_directory=True)
+    os.replace(replacement, managed_link)
     second_kwargs = {"extra_body": {"provider": {"zdr": False}}}
     enforce_openrouter_zdr(
         second_kwargs,

--- a/tests/agent/test_openrouter_zdr.py
+++ b/tests/agent/test_openrouter_zdr.py
@@ -24,6 +24,102 @@ def test_config_set_enables_final_boundary_enforcement(monkeypatch, tmp_path):
     assert kwargs["extra_body"]["provider"]["zdr"] is True
 
 
+def _write_raw_config(monkeypatch, tmp_path, text):
+    import hermes_cli.config as config_mod
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(text, encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    config_mod._LOAD_CONFIG_CACHE.clear()
+    config_mod._RAW_CONFIG_CACHE.clear()
+    config_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    getattr(config_mod, "_CONFIG_LOAD_FAILURE_BY_PATH").clear()
+    return config_mod
+
+
+def test_invalid_yaml_enforces_zdr_fail_closed(monkeypatch, tmp_path, caplog):
+    _write_raw_config(monkeypatch, tmp_path, "openrouter: [")
+    kwargs = {"extra_body": {"provider": {"zdr": False}}}
+
+    enforce_openrouter_zdr(
+        kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert kwargs["extra_body"]["provider"]["zdr"] is True
+    assert "enforcing ZDR fail closed" in caplog.text
+
+
+def test_parse_failure_state_clears_after_config_is_fixed(monkeypatch, tmp_path):
+    config_mod = _write_raw_config(monkeypatch, tmp_path, "openrouter: [")
+    failed_kwargs = {"extra_body": {"provider": {"zdr": False}}}
+    enforce_openrouter_zdr(
+        failed_kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert failed_kwargs["extra_body"]["provider"]["zdr"] is True
+
+    config_mod.get_config_path().write_text(
+        "openrouter:\n  zdr: false\n", encoding="utf-8"
+    )
+    fixed_kwargs = {"extra_body": {"provider": {"zdr": False}}}
+    enforce_openrouter_zdr(
+        fixed_kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert fixed_kwargs["extra_body"]["provider"]["zdr"] is False
+
+
+def test_quoted_zdr_value_enforces_zdr_fail_closed(monkeypatch, tmp_path, caplog):
+    _write_raw_config(monkeypatch, tmp_path, 'openrouter:\n  zdr: "true"\n')
+    kwargs = {"extra_body": {"provider": {"zdr": False}}}
+
+    enforce_openrouter_zdr(
+        kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert kwargs["extra_body"]["provider"]["zdr"] is True
+    assert "openrouter.zdr must be a boolean" in caplog.text
+
+
+def test_non_mapping_config_root_enforces_zdr_fail_closed(
+    monkeypatch, tmp_path, caplog
+):
+    _write_raw_config(monkeypatch, tmp_path, "- openrouter\n- zdr\n")
+    kwargs = {"extra_body": {"provider": {"zdr": False}}}
+
+    enforce_openrouter_zdr(
+        kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert kwargs["extra_body"]["provider"]["zdr"] is True
+    assert "could not be parsed" in caplog.text
+
+
+def test_explicit_false_from_real_config_preserves_caller_policy(
+    monkeypatch, tmp_path
+):
+    _write_raw_config(monkeypatch, tmp_path, "openrouter:\n  zdr: false\n")
+    kwargs = {"extra_body": {"provider": {"zdr": False}}}
+
+    enforce_openrouter_zdr(
+        kwargs,
+        is_openrouter=True,
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert kwargs["extra_body"]["provider"]["zdr"] is False
+
+
 def test_shared_enforcement_overrides_false(monkeypatch):
     monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: True)
     kwargs = {

--- a/tests/hermes_cli/test_managed_scope_overlay.py
+++ b/tests/hermes_cli/test_managed_scope_overlay.py
@@ -42,3 +42,29 @@ def test_overlay_preserves_user_siblings(managed):
     assert out["display"]["show_reasoning"] is True
 
 
+def test_managed_config_degradation_tracks_repair_removal_and_path_change(
+    managed, tmp_path, monkeypatch
+):
+    from hermes_cli import managed_scope
+
+    config_path = managed / "config.yaml"
+    config_path.write_text("- malformed\n- root\n", encoding="utf-8")
+    assert managed_scope.load_managed_config() == {}
+    assert managed_scope.managed_config_load_degraded() is True
+
+    config_path.write_text("openrouter:\n  zdr: false\n", encoding="utf-8")
+    assert managed_scope.load_managed_config() == {"openrouter": {"zdr": False}}
+    assert managed_scope.managed_config_load_degraded() is False
+
+    config_path.unlink()
+    assert managed_scope.load_managed_config() == {}
+    assert managed_scope.managed_config_load_degraded() is False
+
+    config_path.write_text("openrouter: [", encoding="utf-8")
+    assert managed_scope.managed_config_load_degraded() is True
+    other = tmp_path / "other-managed"
+    other.mkdir()
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(other))
+    assert managed_scope.managed_config_load_degraded() is False
+
+

--- a/tests/hermes_cli/test_model_cache_swr.py
+++ b/tests/hermes_cli/test_model_cache_swr.py
@@ -33,12 +33,12 @@ class TestProviderModelsSWR:
     def test_fresh_entry_served_without_refresh(self):
         import hermes_cli.models as mod
 
-        cache = {"openrouter": self._cache_entry(["m1"], age_seconds=10)}
+        cache = {"nous": self._cache_entry(["m1"], age_seconds=10)}
         with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
              patch.object(mod, "_credential_fingerprint", return_value="fp"), \
              patch.object(mod, "_spawn_swr_refresh") as spawn, \
              patch.object(mod, "provider_model_ids") as live:
-            out = mod.cached_provider_model_ids("openrouter")
+            out = mod.cached_provider_model_ids("nous")
         assert out == ["m1"]
         spawn.assert_not_called()
         live.assert_not_called()
@@ -47,15 +47,37 @@ class TestProviderModelsSWR:
         import hermes_cli.models as mod
 
         # 2h old — beyond the 1h TTL, within the 7d stale-serve window.
-        cache = {"openrouter": self._cache_entry(["m1", "m2"], age_seconds=7200)}
+        cache = {"nous": self._cache_entry(["m1", "m2"], age_seconds=7200)}
         with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
              patch.object(mod, "_credential_fingerprint", return_value="fp"), \
              patch.object(mod, "_spawn_swr_refresh") as spawn, \
              patch.object(mod, "provider_model_ids") as live:
-            out = mod.cached_provider_model_ids("openrouter")
+            out = mod.cached_provider_model_ids("nous")
         assert out == ["m1", "m2"]  # served stale, no blocking
-        spawn.assert_called_once_with("openrouter")
+        spawn.assert_called_once_with("nous")
         live.assert_not_called()  # the caller thread never hit the network
+
+    def test_stale_verified_openrouter_entry_fails_closed_without_swr(self):
+        import hermes_cli.models as mod
+
+        cache = {
+            "openrouter": {
+                **self._cache_entry(
+                    ["policy-stale/model"],
+                    age_seconds=mod._OPENROUTER_CATALOG_CACHE_TTL + 1,
+                ),
+                "source": mod._OPENROUTER_POLICY_CACHE_SOURCE,
+            }
+        }
+        with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
+             patch.object(mod, "_credential_fingerprint", return_value="fp"), \
+             patch.object(mod, "_save_provider_models_cache"), \
+             patch.object(mod, "_spawn_swr_refresh") as spawn, \
+             patch.object(mod, "provider_model_ids", return_value=[]) as live:
+            out = mod.cached_provider_model_ids("openrouter")
+        assert out == []
+        spawn.assert_not_called()
+        live.assert_called_once_with("openrouter", force_refresh=False)
 
     def test_too_old_entry_blocks_on_live_fetch(self):
         import hermes_cli.models as mod

--- a/tests/hermes_cli/test_model_switch_openrouter_policy.py
+++ b/tests/hermes_cli/test_model_switch_openrouter_policy.py
@@ -1,0 +1,48 @@
+"""OpenRouter policy-authority regression tests for model switching."""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import switch_model
+
+
+_REJECTED = {
+    "accepted": False,
+    "persist": False,
+    "recognized": False,
+    "message": "blocked by OpenRouter policy",
+}
+
+
+def test_saved_openrouter_model_cannot_override_policy_rejection():
+    """A local provider declaration must not bypass /models/user authority."""
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "test-key",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+            },
+        ),
+        patch("hermes_cli.models.validate_requested_model", return_value=_REJECTED),
+        patch("hermes_cli.model_switch.get_model_info", return_value=None),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        patch("hermes_cli.models.detect_provider_for_model", return_value=None),
+    ):
+        result = switch_model(
+            raw_input="blocked/model",
+            current_provider="openrouter",
+            current_model="allowed/model",
+            explicit_provider="openrouter",
+            user_providers={
+                "openrouter": {
+                    "enabled": True,
+                    "models": ["blocked/model"],
+                }
+            },
+        )
+
+    assert result.success is False
+    assert result.error_message == "blocked by OpenRouter policy"

--- a/tests/hermes_cli/test_model_switch_openrouter_policy.py
+++ b/tests/hermes_cli/test_model_switch_openrouter_policy.py
@@ -2,7 +2,8 @@
 
 from unittest.mock import patch
 
-from hermes_cli.model_switch import switch_model
+from hermes_cli.model_switch import list_authenticated_providers, switch_model
+import hermes_cli.models as models_mod
 
 
 _REJECTED = {
@@ -46,3 +47,83 @@ def test_saved_openrouter_model_cannot_override_policy_rejection():
 
     assert result.success is False
     assert result.error_message == "blocked by OpenRouter policy"
+
+
+class _CatalogResponse:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self._data
+
+
+def _list_openrouter(
+    monkeypatch,
+    tmp_path,
+    *,
+    response: bytes | Exception,
+    user_providers=None,
+):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setattr(models_mod, "_provider_models_cache_path", lambda: tmp_path / "models.json")
+    monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {"openrouter": "openrouter"})
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: {"openrouter": {"name": "OpenRouter", "env": ["OPENROUTER_API_KEY"]}},
+    )
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr(models_mod, "CANONICAL_PROVIDERS", [])
+    monkeypatch.setattr(
+        "hermes_cli.model_catalog.get_curated_openrouter_models",
+        lambda: [("curated/model", "recommended"), ("verified/model", "")],
+    )
+    models_mod.clear_provider_models_cache("openrouter")
+
+    def _open(*_args, **_kwargs):
+        if isinstance(response, Exception):
+            raise response
+        return _CatalogResponse(response)
+
+    with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=_open):
+        return list_authenticated_providers(user_providers=user_providers or {})
+
+
+def test_unavailable_openrouter_catalog_yields_no_curated_picker_models(monkeypatch, tmp_path):
+    providers = _list_openrouter(
+        monkeypatch,
+        tmp_path,
+        response=OSError("offline"),
+    )
+
+    openrouter = next(provider for provider in providers if provider["slug"] == "openrouter")
+    assert openrouter["models"] == []
+    assert openrouter["total_models"] == 0
+
+
+def test_openrouter_declarations_only_reorder_verified_catalog(monkeypatch, tmp_path):
+    providers = _list_openrouter(
+        monkeypatch,
+        tmp_path,
+        user_providers={
+            "openrouter": {
+                "enabled": True,
+                "models": ["blocked/model", "verified/model"],
+            }
+        },
+        response=(
+            b'{"data":['
+            b'{"id":"curated/model","supported_parameters":["tools"]},'
+            b'{"id":"verified/model","supported_parameters":["tools"]}'
+            b']}'
+        ),
+    )
+
+    openrouter = next(provider for provider in providers if provider["slug"] == "openrouter")
+    assert openrouter["models"] == ["verified/model", "curated/model"]
+    assert "blocked/model" not in openrouter["models"]

--- a/tests/hermes_cli/test_model_switch_openrouter_policy.py
+++ b/tests/hermes_cli/test_model_switch_openrouter_policy.py
@@ -69,8 +69,24 @@ def _list_openrouter(
     *,
     response: bytes | Exception,
     user_providers=None,
+    configured_api_key: str | None = None,
 ):
-    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: {})
+    if configured_api_key is None:
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    else:
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {
+                "model": {
+                    "provider": "openrouter",
+                    "api_key": configured_api_key,
+                    "base_url": "https://openrouter.ai/api/v1",
+                }
+            },
+        )
     monkeypatch.setattr(models_mod, "_provider_models_cache_path", lambda: tmp_path / "models.json")
     monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {"openrouter": "openrouter"})
     monkeypatch.setattr(
@@ -127,3 +143,19 @@ def test_openrouter_declarations_only_reorder_verified_catalog(monkeypatch, tmp_
     openrouter = next(provider for provider in providers if provider["slug"] == "openrouter")
     assert openrouter["models"] == ["verified/model", "curated/model"]
     assert "blocked/model" not in openrouter["models"]
+
+
+def test_configured_only_openrouter_credential_reaches_policy_picker(monkeypatch, tmp_path):
+    providers = _list_openrouter(
+        monkeypatch,
+        tmp_path,
+        configured_api_key="configured-only-key",
+        response=(
+            b'{"data":['
+            b'{"id":"verified/model","supported_parameters":["tools"]}'
+            b']}'
+        ),
+    )
+
+    openrouter = next(provider for provider in providers if provider["slug"] == "openrouter")
+    assert openrouter["models"] == ["verified/model"]

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -33,8 +33,8 @@ FAKE_API_MODELS = [
 ]
 
 
-def _validate(model, provider="openrouter", api_models=FAKE_API_MODELS, **kw):
-    """Shortcut: call validate_requested_model with mocked API."""
+def _validate(model, provider="zai", api_models=FAKE_API_MODELS, **kw):
+    """Shortcut: exercise generic provider validation with a mocked API."""
     probe_payload = {
         "models": api_models,
         "probed_url": "http://localhost:11434/v1/models",

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -46,7 +46,7 @@ class TestFetchOpenRouterModels:
                 return False
 
             def read(self):
-                return b'{"data":[{"id":"anthropic/claude-opus-4.8","pricing":{"prompt":"0.000015","completion":"0.000075"}},{"id":"qwen/qwen3.7-max","pricing":{"prompt":"0.000000325","completion":"0.00000195"}},{"id":"nvidia/nemotron-3-super-120b-a12b:free","pricing":{"prompt":"0","completion":"0"}}]}'
+                return b'{"data":[{"id":"anthropic/claude-opus-4.8","pricing":{"prompt":"0.000015","completion":"0.000075"},"supported_parameters":["tools"]},{"id":"qwen/qwen3.7-max","pricing":{"prompt":"0.000000325","completion":"0.00000195"},"supported_parameters":["tools"]},{"id":"nvidia/nemotron-3-super-120b-a12b:free","pricing":{"prompt":"0","completion":"0"},"supported_parameters":["tools"]}]}'
 
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
         monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache", None)
@@ -156,14 +156,8 @@ class TestFetchOpenRouterModels:
         # Image-only model advertised supported_parameters WITHOUT tools → must be dropped.
         assert "google/gemini-3-pro-image-preview" not in ids
 
-    def test_permissive_when_supported_parameters_missing(self, monkeypatch):
-        """Models missing the supported_parameters field keep appearing in the picker.
-
-        Some OpenRouter-compatible gateways (Nous Portal, private mirrors, older
-        catalog snapshots) don't populate supported_parameters. Treating missing
-        as 'unknown → allow' prevents the picker from silently emptying on
-        those gateways.
-        """
+    def test_fails_closed_when_supported_parameters_missing(self, monkeypatch):
+        """Unknown tool capability must not authorize a picker entry."""
         class _Resp:
             def __enter__(self):
                 return self
@@ -172,7 +166,6 @@ class TestFetchOpenRouterModels:
                 return False
 
             def read(self):
-                # No supported_parameters field at all on either entry.
                 return (
                     b'{"data":['
                     b'{"id":"anthropic/claude-opus-4.8","pricing":{"prompt":"0.000015","completion":"0.000075"}},'
@@ -186,9 +179,7 @@ class TestFetchOpenRouterModels:
         with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
             models = fetch_openrouter_models(force_refresh=True)
 
-        ids = [mid for mid, _ in models]
-        assert "anthropic/claude-opus-4.8" in ids
-        assert "qwen/qwen3.7-max" in ids
+        assert models == []
 
 
 
@@ -252,6 +243,85 @@ class TestOpenRouterPolicyCatalog:
         assert catalog is not None
         assert list(catalog) == ["alias/model"]
         assert seen["authorization"] == "Bearer openai-alias-key"
+
+    def test_fetch_uses_explicit_openrouter_runtime_inputs(self, monkeypatch):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"data":[{"id":"explicit/model","supported_parameters":["tools"]}]}'
+
+        seen = {}
+
+        def _open(req, *, timeout):
+            seen["authorization"] = req.get_header("Authorization")
+            return _Resp()
+
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache", None)
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=_open):
+            catalog = _models_mod._fetch_openrouter_policy_catalog(
+                force_refresh=True,
+                api_key="explicit-key",
+                base_url="https://openrouter.ai/api/v1",
+            )
+
+        assert catalog is not None
+        assert list(catalog) == ["explicit/model"]
+        assert seen["authorization"] == "Bearer explicit-key"
+
+    def test_fetch_uses_configured_main_openrouter_credential(self, monkeypatch):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"data":[{"id":"configured/model","supported_parameters":["tools"]}]}'
+
+        seen = {}
+
+        def _open(req, *, timeout):
+            seen["authorization"] = req.get_header("Authorization")
+            return _Resp()
+
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {
+                "model": {
+                    "provider": "openrouter",
+                    "api_key": "configured-key",
+                    "base_url": "https://openrouter.ai/api/v1",
+                }
+            },
+        )
+        monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache", None)
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=_open):
+            catalog = _models_mod._fetch_openrouter_policy_catalog(force_refresh=True)
+
+        assert catalog is not None
+        assert list(catalog) == ["configured/model"]
+        assert seen["authorization"] == "Bearer configured-key"
+
+    def test_explicit_custom_endpoint_key_is_not_sent_to_openrouter(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        resolved = _models_mod._resolve_openrouter_catalog_api_key(
+            explicit_api_key="custom-endpoint-key",
+            explicit_base_url="https://llm.example.com/v1",
+        )
+
+        assert resolved == ""
 
     def test_policy_and_picker_caches_are_partitioned_by_api_key(self, monkeypatch):
         class _Resp:
@@ -389,6 +459,23 @@ class TestOpenRouterPolicyCatalog:
         assert result["persist"] is True
         assert result["recognized"] is True
 
+    def test_direct_selection_rejects_missing_tool_capability_metadata(self):
+        from hermes_cli.models import validate_requested_model
+
+        with patch(
+            "hermes_cli.models._fetch_openrouter_policy_catalog",
+            return_value={"policy/model": {"id": "policy/model"}},
+        ):
+            result = validate_requested_model(
+                "policy/model",
+                "openrouter",
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+            )
+
+        assert result["accepted"] is False
+        assert result["persist"] is False
+
 
 class TestOpenRouterToolSupportHelper:
     """Unit tests for _openrouter_model_supports_tools (Kilo port #9068)."""
@@ -406,6 +493,13 @@ class TestOpenRouterToolSupportHelper:
         assert _openrouter_model_supports_tools(
             {"id": "x", "supported_parameters": []}
         ) is False
+
+    def test_missing_or_malformed_supported_parameters_drops_model(self):
+        from hermes_cli.models import _openrouter_model_supports_tools
+
+        assert _openrouter_model_supports_tools({"id": "x"}) is False
+        assert _openrouter_model_supports_tools({"id": "x", "supported_parameters": "tools"}) is False
+        assert _openrouter_model_supports_tools(None) is False
 
 
 class TestFindOpenrouterSlug:

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -102,6 +102,34 @@ class TestFetchOpenRouterModels:
 
         assert models == []
 
+    def test_force_refresh_failure_invalidates_same_key_memory_cache(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+        key_fp = _models_mod._openrouter_api_key_fingerprint("test-key")
+        monkeypatch.setattr(
+            _models_mod,
+            "_openrouter_catalog_cache",
+            [("stale/model", "recommended")],
+        )
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache_at", _models_mod.time.time())
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache_key_fp", key_fp)
+        monkeypatch.setattr(
+            _models_mod,
+            "_openrouter_policy_catalog_cache",
+            {"stale/model": {"supported_parameters": ["tools"]}},
+        )
+        monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache_at", _models_mod.time.time())
+        monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache_key_fp", key_fp)
+
+        with (
+            patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=None),
+            patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=OSError("offline")),
+        ):
+            models = fetch_openrouter_models(force_refresh=True)
+
+        assert models == []
+        assert _models_mod._openrouter_catalog_cache is None
+        assert _models_mod._openrouter_policy_catalog_cache is None
+
     def test_filters_out_models_without_tool_support(self, monkeypatch):
         """Models whose supported_parameters omits 'tools' must not appear in the picker.
 
@@ -422,6 +450,92 @@ class TestOpenRouterPolicyCatalog:
         assert first == ["account-a/model"]
         assert second == []
         assert fetch.call_count == 2
+
+    def test_failed_forced_openrouter_refresh_removes_stale_disk_entry(
+        self, monkeypatch, tmp_path
+    ):
+        from hermes_cli.models import cached_provider_model_ids
+
+        cache_path = tmp_path / "provider_models.json"
+        monkeypatch.setattr(_models_mod, "_provider_models_cache_path", lambda: cache_path)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+        fp = _models_mod._credential_fingerprint("openrouter")
+        _models_mod._save_provider_models_cache(
+            {
+                "openrouter": {
+                    "fp": fp,
+                    "at": _models_mod.time.time()
+                    - _models_mod._OPENROUTER_CATALOG_CACHE_TTL
+                    - 1,
+                    "models": ["stale/model"],
+                },
+                "other": {"fp": "other", "at": 0, "models": ["keep/model"]},
+            }
+        )
+
+        with (
+            patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=None),
+            patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=OSError("offline")),
+        ):
+            models = cached_provider_model_ids("openrouter", force_refresh=True)
+
+        cache = _models_mod._load_provider_models_cache()
+        assert models == []
+        assert "openrouter" not in cache
+        assert cache["other"]["models"] == ["keep/model"]
+
+    def test_unmarked_openrouter_disk_entry_is_not_treated_as_verified(
+        self, monkeypatch, tmp_path
+    ):
+        from hermes_cli.models import cached_provider_model_ids
+
+        cache_path = tmp_path / "provider_models.json"
+        monkeypatch.setattr(_models_mod, "_provider_models_cache_path", lambda: cache_path)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+        _models_mod._save_provider_models_cache(
+            {
+                "openrouter": {
+                    "fp": _models_mod._credential_fingerprint("openrouter"),
+                    "at": _models_mod.time.time(),
+                    "models": ["legacy-unverified/model"],
+                }
+            }
+        )
+
+        with patch.object(_models_mod, "provider_model_ids", return_value=[]) as refresh:
+            models = cached_provider_model_ids("openrouter")
+
+        assert models == []
+        refresh.assert_called_once_with("openrouter", force_refresh=False)
+        assert "openrouter" not in _models_mod._load_provider_models_cache()
+
+    def test_fresh_verified_openrouter_disk_entry_remains_cacheable(
+        self, monkeypatch, tmp_path
+    ):
+        from hermes_cli.models import cached_provider_model_ids
+
+        cache_path = tmp_path / "provider_models.json"
+        monkeypatch.setattr(_models_mod, "_provider_models_cache_path", lambda: cache_path)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+        _models_mod._save_provider_models_cache(
+            {
+                "openrouter": {
+                    "fp": _models_mod._credential_fingerprint("openrouter"),
+                    "at": _models_mod.time.time(),
+                    "models": ["verified/model"],
+                    "source": _models_mod._OPENROUTER_POLICY_CACHE_SOURCE,
+                }
+            }
+        )
+
+        with patch.object(
+            _models_mod,
+            "provider_model_ids",
+            side_effect=AssertionError("fresh verified cache should be reused"),
+        ):
+            models = cached_provider_model_ids("openrouter")
+
+        assert models == ["verified/model"]
 
     def test_provider_model_cache_fingerprint_tracks_openai_api_key_alias(self, monkeypatch):
         monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -37,17 +37,70 @@ class TestOpenRouterModels:
 
 
 class TestFetchOpenRouterModels:
+    def test_live_fetch_recomputes_free_tags(self, monkeypatch):
+        class _Resp:
+            def __enter__(self):
+                return self
 
+            def __exit__(self, exc_type, exc, tb):
+                return False
 
-    def test_falls_back_to_static_snapshot_on_fetch_failure(self, monkeypatch):
+            def read(self):
+                return b'{"data":[{"id":"anthropic/claude-opus-4.8","pricing":{"prompt":"0.000015","completion":"0.000075"}},{"id":"qwen/qwen3.7-max","pricing":{"prompt":"0.000000325","completion":"0.00000195"}},{"id":"nvidia/nemotron-3-super-120b-a12b:free","pricing":{"prompt":"0","completion":"0"}}]}'
+
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
-        # Pin the remote manifest out too — otherwise the fallback silently
-        # depends on whatever the deployed catalog currently contains.
+        monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache", None)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
+            models = fetch_openrouter_models(force_refresh=True)
+
+        assert models == [
+            ("anthropic/claude-opus-4.8", "recommended"),
+            ("qwen/qwen3.7-max", ""),
+            ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
+        ]
+
+    def test_includes_additional_policy_eligible_tool_models(self, monkeypatch):
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache", None)
+        monkeypatch.setattr(
+            "hermes_cli.model_catalog.get_curated_openrouter_models",
+            lambda: [("curated/model", "")],
+        )
+        policy_catalog = {
+            "curated/model": {
+                "pricing": {"prompt": "0", "completion": "0"},
+                "supported_parameters": ["tools"],
+            },
+            "additional/tool-model": {
+                "pricing": {"prompt": "0.000001", "completion": "0.000002"},
+                "supported_parameters": ["tools", "temperature"],
+            },
+            "additional/non-tool-model": {
+                "pricing": {"prompt": "0", "completion": "0"},
+                "supported_parameters": ["temperature"],
+            },
+        }
+        with patch(
+            "hermes_cli.models._fetch_openrouter_policy_catalog",
+            return_value=policy_catalog,
+        ):
+            models = fetch_openrouter_models(force_refresh=True)
+
+        assert [mid for mid, _ in models] == ["curated/model", "additional/tool-model"]
+
+
+    def test_returns_empty_on_policy_fetch_failure_without_stale_cache(self, monkeypatch):
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache", None)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        # The picker must fail closed instead of showing an unfiltered static
+        # snapshot when the policy-aware catalog cannot be verified.
         with patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=None), \
              patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=OSError("boom")):
             models = fetch_openrouter_models(force_refresh=True)
 
-        assert models == OPENROUTER_MODELS
+        assert models == []
 
     def test_filters_out_models_without_tool_support(self, monkeypatch):
         """Models whose supported_parameters omits 'tools' must not appear in the picker.
@@ -89,6 +142,8 @@ class TestFetchOpenRouterModels:
             ],
         )
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache", None)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
         with (
             patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=[]),
             patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()),
@@ -101,6 +156,238 @@ class TestFetchOpenRouterModels:
         # Image-only model advertised supported_parameters WITHOUT tools → must be dropped.
         assert "google/gemini-3-pro-image-preview" not in ids
 
+    def test_permissive_when_supported_parameters_missing(self, monkeypatch):
+        """Models missing the supported_parameters field keep appearing in the picker.
+
+        Some OpenRouter-compatible gateways (Nous Portal, private mirrors, older
+        catalog snapshots) don't populate supported_parameters. Treating missing
+        as 'unknown → allow' prevents the picker from silently emptying on
+        those gateways.
+        """
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                # No supported_parameters field at all on either entry.
+                return (
+                    b'{"data":['
+                    b'{"id":"anthropic/claude-opus-4.8","pricing":{"prompt":"0.000015","completion":"0.000075"}},'
+                    b'{"id":"qwen/qwen3.7-max","pricing":{"prompt":"0.000000325","completion":"0.00000195"}}'
+                    b']}'
+                )
+
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache", None)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
+            models = fetch_openrouter_models(force_refresh=True)
+
+        ids = [mid for mid, _ in models]
+        assert "anthropic/claude-opus-4.8" in ids
+        assert "qwen/qwen3.7-max" in ids
+
+
+
+
+class TestOpenRouterPolicyCatalog:
+    def test_fetch_uses_authenticated_user_catalog(self, monkeypatch):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"data":[{"id":"deepseek/deepseek-v4-flash"}]}'
+
+        seen = {}
+
+        def _open(req, *, timeout):
+            seen["url"] = req.full_url
+            seen["authorization"] = req.get_header("Authorization")
+            return _Resp()
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+        monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache", None)
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=_open):
+            from hermes_cli.models import _fetch_openrouter_policy_catalog
+            catalog = _fetch_openrouter_policy_catalog(force_refresh=True)
+
+        assert catalog is not None
+        assert list(catalog) == ["deepseek/deepseek-v4-flash"]
+        assert seen == {
+            "url": "https://openrouter.ai/api/v1/models/user",
+            "authorization": "Bearer test-key",
+        }
+
+    def test_fetch_uses_openai_api_key_alias_from_runtime_resolver(self, monkeypatch):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"data":[{"id":"alias/model"}]}'
+
+        seen = {}
+
+        def _open(req, *, timeout):
+            seen["authorization"] = req.get_header("Authorization")
+            return _Resp()
+
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "openai-alias-key")
+        monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache", None)
+        monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache_key_fp", None)
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=_open):
+            catalog = _models_mod._fetch_openrouter_policy_catalog(force_refresh=True)
+
+        assert catalog is not None
+        assert list(catalog) == ["alias/model"]
+        assert seen["authorization"] == "Bearer openai-alias-key"
+
+    def test_policy_and_picker_caches_are_partitioned_by_api_key(self, monkeypatch):
+        class _Resp:
+            def __init__(self, model_id):
+                self.model_id = model_id
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return (
+                    '{"data":[{"id":"%s","supported_parameters":["tools"]}]}'
+                    % self.model_id
+                ).encode()
+
+        calls = []
+
+        def _open(req, *, timeout):
+            authorization = req.get_header("Authorization")
+            calls.append(authorization)
+            model_id = "account-a/model" if authorization == "Bearer key-a" else "account-b/model"
+            return _Resp(model_id)
+
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache_key_fp", None)
+        monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache", None)
+        monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache_key_fp", None)
+        monkeypatch.setattr("hermes_cli.model_catalog.get_curated_openrouter_models", lambda: None)
+
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=_open):
+            monkeypatch.setenv("OPENROUTER_API_KEY", "key-a")
+            first = fetch_openrouter_models(force_refresh=True)
+            monkeypatch.setenv("OPENROUTER_API_KEY", "key-b")
+            second = fetch_openrouter_models()
+
+            from hermes_cli.models import validate_requested_model
+
+            old_selection = validate_requested_model("account-a/model", "openrouter")
+            new_selection = validate_requested_model("account-b/model", "openrouter")
+
+        assert [mid for mid, _ in first] == ["account-a/model"]
+        assert [mid for mid, _ in second] == ["account-b/model"]
+        assert calls == ["Bearer key-a", "Bearer key-b"]
+        assert old_selection["accepted"] is False
+        assert new_selection["accepted"] is True
+
+    def test_picker_does_not_reuse_stale_catalog_from_another_api_key(self, monkeypatch):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"data":[{"id":"account-a/model","supported_parameters":["tools"]}]}'
+
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache_key_fp", None)
+        monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache", None)
+        monkeypatch.setattr(_models_mod, "_openrouter_policy_catalog_cache_key_fp", None)
+        monkeypatch.setattr("hermes_cli.model_catalog.get_curated_openrouter_models", lambda: None)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "key-a")
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
+            first = fetch_openrouter_models(force_refresh=True)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "key-b")
+        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=OSError("offline")):
+            second = fetch_openrouter_models()
+        assert [mid for mid, _ in first] == ["account-a/model"]
+        assert second == []
+
+    def test_generic_disk_cache_is_partitioned_for_plugin_provider_keys(
+        self, monkeypatch, tmp_path
+    ):
+        from hermes_cli.models import cached_provider_model_ids
+
+        cache_path = tmp_path / "provider_models.json"
+        monkeypatch.setattr(_models_mod, "_provider_models_cache_path", lambda: cache_path)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "key-a")
+        fp_a = _models_mod._credential_fingerprint("openrouter")
+        with patch.object(
+            _models_mod,
+            "provider_model_ids",
+            side_effect=[["account-a/model"], []],
+        ) as fetch:
+            first = cached_provider_model_ids("openrouter")
+            monkeypatch.setenv("OPENROUTER_API_KEY", "key-b")
+            fp_b = _models_mod._credential_fingerprint("openrouter")
+            second = cached_provider_model_ids("openrouter")
+
+        assert fp_a != fp_b
+        assert first == ["account-a/model"]
+        assert second == []
+        assert fetch.call_count == 2
+
+    def test_provider_model_cache_fingerprint_tracks_openai_api_key_alias(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "alias-a")
+        fp_a = _models_mod._credential_fingerprint("openrouter")
+
+        monkeypatch.setenv("OPENAI_API_KEY", "alias-b")
+        fp_b = _models_mod._credential_fingerprint("openrouter")
+
+        assert fp_a != fp_b
+
+    def test_direct_selection_rejects_model_outside_policy_catalog(self):
+        from hermes_cli.models import validate_requested_model
+
+        with patch(
+            "hermes_cli.models._openrouter_policy_model_ids",
+            return_value=["deepseek/deepseek-v4-flash"],
+        ):
+            result = validate_requested_model("nvidia/nemotron-3-super-120b-a12b:free", "openrouter")
+
+        assert result["accepted"] is False
+        assert result["persist"] is False
+        assert "privacy" in (result["message"] or "")
+
+    def test_direct_selection_accepts_policy_eligible_model(self, monkeypatch):
+        from hermes_cli.models import validate_requested_model
+
+        with patch(
+            "hermes_cli.models._openrouter_policy_model_ids",
+            return_value=["deepseek/deepseek-v4-flash"],
+        ):
+            result = validate_requested_model("deepseek/deepseek-v4-flash", "openrouter")
+
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is True
 
 
 class TestOpenRouterToolSupportHelper:

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -1,5 +1,7 @@
 """Tests for the provider module registry and profiles."""
 
+from unittest.mock import patch
+
 from providers import get_provider_profile, _REGISTRY
 from providers.base import ProviderProfile, OMIT_TEMPERATURE
 
@@ -47,6 +49,20 @@ class TestKimiProfile:
 
 
 class TestOpenRouterProfile:
+    def test_fetch_models_does_not_cache_across_api_keys(self):
+        p = get_provider_profile("openrouter")
+        with patch.object(
+            ProviderProfile,
+            "fetch_models",
+            side_effect=[["account-a/model"], ["account-b/model"]],
+        ) as fetch:
+            first = p.fetch_models(api_key="key-a")
+            second = p.fetch_models(api_key="key-b")
+
+        assert first == ["account-a/model"]
+        assert second == ["account-b/model"]
+        assert [call.kwargs["api_key"] for call in fetch.call_args_list] == ["key-a", "key-b"]
+
     def test_extra_body_with_prefs(self):
         p = get_provider_profile("openrouter")
         body = p.build_extra_body(provider_preferences={"allow": ["anthropic"]})
@@ -55,6 +71,66 @@ class TestOpenRouterProfile:
 
 
 
+
+    def test_transport_enforces_configured_zdr_after_request_overrides(self, monkeypatch):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: True)
+        p = get_provider_profile("openrouter")
+        assert p is not None
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="deepseek/deepseek-chat",
+            messages=[{"role": "user", "content": "ping"}],
+            provider_profile=p,
+            extra_body_additions={"provider": {"sort": "price", "zdr": False}},
+            request_overrides={
+                "extra_body": {"provider": {"allow": ["deepinfra"], "zdr": False}}
+            },
+        )
+        assert kwargs["extra_body"]["provider"] == {
+            "allow": ["deepinfra"],
+            "zdr": True,
+        }
+
+    def test_transport_omits_zdr_when_configured_off(self, monkeypatch):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: False)
+        p = get_provider_profile("openrouter")
+        assert p is not None
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="deepseek/deepseek-chat",
+            messages=[{"role": "user", "content": "ping"}],
+            provider_profile=p,
+        )
+        assert "extra_body" not in kwargs
+
+    def test_transport_does_not_apply_zdr_to_other_profiles(self, monkeypatch):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: True)
+        p = get_provider_profile("nvidia")
+        assert p is not None
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="nvidia/nemotron",
+            messages=[{"role": "user", "content": "ping"}],
+            provider_profile=p,
+        )
+        assert "provider" not in kwargs.get("extra_body", {})
+
+    def test_transport_does_not_apply_zdr_to_native_gemini_fallback(self, monkeypatch):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: True)
+        p = get_provider_profile("openrouter")
+        assert p is not None
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="gemini-2.5-flash",
+            messages=[{"role": "user", "content": "ping"}],
+            provider_profile=p,
+            base_url="https://generativelanguage.googleapis.com/v1beta",
+        )
+        assert "provider" not in kwargs.get("extra_body", {})
 
     def test_pareto_min_coding_score_emitted_for_pareto_model(self):
         """min_coding_score → plugins block when model is openrouter/pareto-code."""

--- a/tests/test_mini_swe_runner.py
+++ b/tests/test_mini_swe_runner.py
@@ -58,3 +58,32 @@ def test_run_task_public_moonshot_kimi_k2_5_omits_temperature():
 
     assert result["completed"] is True
     assert "temperature" not in client.chat.completions.create.call_args.kwargs
+
+
+def test_run_task_openrouter_enforces_zdr(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: True)
+    with patch("openai.OpenAI") as mock_openai:
+        client = MagicMock()
+        client.base_url = "https://openrouter.ai/api/v1"
+        client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="done", tool_calls=[]))]
+        )
+        mock_openai.return_value = client
+
+        from mini_swe_runner import MiniSWERunner
+
+        runner = MiniSWERunner(
+            model="anthropic/claude-sonnet-4.6",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="test-key",
+            env_type="local",
+            max_iterations=1,
+        )
+        runner._create_env = MagicMock()
+        runner._cleanup_env = MagicMock()
+
+        result = runner.run_task("2+2")
+
+    assert result["completed"] is True
+    kwargs = client.chat.completions.create.call_args.kwargs
+    assert kwargs["extra_body"]["provider"] == {"zdr": True}

--- a/tests/test_trajectory_compressor.py
+++ b/tests/test_trajectory_compressor.py
@@ -58,6 +58,31 @@ def test_generate_summary_kimi_omits_temperature():
 
 
 
+def test_generate_summary_openrouter_enforces_zdr(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.openrouter_zdr_enabled", lambda: True)
+    config = CompressionConfig(
+        summarization_model="anthropic/claude-sonnet-4.6",
+        base_url="https://openrouter.ai/api/v1",
+        summary_target_tokens=100,
+        max_retries=1,
+    )
+    compressor = TrajectoryCompressor.__new__(TrajectoryCompressor)
+    compressor.config = config
+    compressor.logger = MagicMock()
+    compressor._use_call_llm = False
+    compressor.client = MagicMock()
+    compressor.client.chat.completions.create.return_value = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="[CONTEXT SUMMARY]: summary"))]
+    )
+
+    metrics = TrajectoryMetrics()
+    result = compressor._generate_summary("tool output", metrics)
+
+    assert result.startswith("[CONTEXT SUMMARY]:")
+    kwargs = compressor.client.chat.completions.create.call_args.kwargs
+    assert kwargs["extra_body"]["provider"] == {"zdr": True}
+
+
 # ---------------------------------------------------------------------------
 # CompressionConfig
 # ---------------------------------------------------------------------------

--- a/tests/test_trajectory_compressor.py
+++ b/tests/test_trajectory_compressor.py
@@ -126,7 +126,7 @@ metrics:
   output_file: my_metrics.json
 """
         yaml_file = tmp_path / "config.yaml"
-        yaml_file.write_text(yaml_content)
+        yaml_file.write_text(yaml_content, encoding="utf-8")
         config = CompressionConfig.from_yaml(str(yaml_file))
         assert config.tokenizer_name == "custom-tokenizer"
         assert config.trust_remote_code is False

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -769,6 +769,102 @@ class TestDelegationProviderIntegration(unittest.TestCase):
 
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_provider_override_clears_parent_openrouter_filters(
+        self, mock_creds, mock_cfg
+    ):
+        """Delegated provider should not inherit parent provider-preference filters."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "google/gemini-3-flash-preview",
+            "provider": "openrouter",
+        }
+        mock_creds.return_value = {
+            "model": "google/gemini-3-flash-preview",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        parent.providers_allowed = ["anthropic/claude-3.5-sonnet"]
+        parent.providers_ignored = ["openai/gpt-4o-mini"]
+        parent.providers_order = ["google/gemini-2.5-pro"]
+        parent.provider_sort = "price"
+        parent.provider_require_parameters = True
+        parent.provider_data_collection = "deny"
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(goal="Cross-provider test", parent_agent=parent)
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["provider"], "openrouter")
+            self.assertIsNone(kwargs["providers_allowed"])
+            self.assertIsNone(kwargs["providers_ignored"])
+            self.assertIsNone(kwargs["providers_order"])
+            self.assertIsNone(kwargs["provider_sort"])
+            self.assertIs(kwargs["provider_require_parameters"], False)
+            self.assertEqual(kwargs["provider_data_collection"], "")
+
+            # ZDR is not a per-agent routing preference. Even though the
+            # provider override clears inherited routing filters, the global
+            # request-boundary policy must still override a caller's false.
+            from agent.openrouter_zdr import enforce_openrouter_zdr
+
+            wire_kwargs = {"extra_body": {"provider": {"zdr": False}}}
+            with patch("hermes_cli.config.openrouter_zdr_enabled", return_value=True):
+                enforce_openrouter_zdr(
+                    wire_kwargs,
+                    is_openrouter=kwargs["provider"] == "openrouter",
+                    base_url=kwargs["base_url"],
+                )
+            self.assertIs(wire_kwargs["extra_body"]["provider"]["zdr"], True)
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_same_provider_inherits_all_routing_preferences(self, mock_creds, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 45}
+        mock_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        parent = _make_mock_parent(depth=0)
+        parent.provider = "nous"
+        parent.providers_allowed = ["deepseek"]
+        parent.providers_ignored = ["deepinfra"]
+        parent.providers_order = ["anthropic"]
+        parent.provider_sort = "throughput"
+        parent.provider_require_parameters = True
+        parent.provider_data_collection = "deny"
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+            delegate_task(goal="Keep routing", parent_agent=parent)
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["providers_allowed"], ["deepseek"])
+        self.assertEqual(kwargs["providers_ignored"], ["deepinfra"])
+        self.assertEqual(kwargs["providers_order"], ["anthropic"])
+        self.assertEqual(kwargs["provider_sort"], "throughput")
+        self.assertIs(kwargs["provider_require_parameters"], True)
+        self.assertEqual(kwargs["provider_data_collection"], "deny")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
     def test_direct_endpoint_credentials_reach_child_agent(self, mock_creds, mock_cfg):
         mock_cfg.return_value = {
             "max_iterations": 45,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1485,6 +1485,10 @@ def _build_child_agent(
         child_provider_sort = None
         child_provider_require_parameters = False
         child_provider_data_collection = ""
+        # OpenRouter ZDR intentionally does not participate in this
+        # inheritance/clearing block. ``openrouter.zdr`` is profile-wide and
+        # enforced at the final request boundary, so a delegated provider
+        # override cannot weaken it.
         # Note: openrouter_min_coding_score is model-gated (only emitted on
         # openrouter/pareto-code), so we keep it inherited even when the
         # provider is overridden — it's a no-op on any other model.

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -46,6 +46,7 @@ import fire
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn, TimeElapsedColumn, TimeRemainingColumn
 from rich.console import Console
 from hermes_constants import OPENROUTER_BASE_URL, get_hermes_home
+from agent.openrouter_zdr import enforce_openrouter_zdr
 from agent.retry_utils import jittered_backoff
 
 # Load .env from HERMES_HOME first, then project root as a dev fallback.
@@ -656,6 +657,11 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                     }
                     if summary_temperature is not None:
                         _create_kwargs["temperature"] = summary_temperature
+                    enforce_openrouter_zdr(
+                        _create_kwargs,
+                        is_openrouter=self._detect_provider() == "openrouter",
+                        base_url=self.config.base_url,
+                    )
                     response = self.client.chat.completions.create(**_create_kwargs)
                 
                 summary = self._coerce_summary_content(response.choices[0].message.content)
@@ -725,6 +731,11 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                     }
                     if summary_temperature is not None:
                         _create_kwargs["temperature"] = summary_temperature
+                    enforce_openrouter_zdr(
+                        _create_kwargs,
+                        is_openrouter=self._detect_provider() == "openrouter",
+                        base_url=self.config.base_url,
+                    )
                     response = await self._get_async_client().chat.completions.create(**_create_kwargs)
                 
                 summary = self._coerce_summary_content(response.choices[0].message.content)

--- a/web/src/lib/openrouter-zdr.test.ts
+++ b/web/src/lib/openrouter-zdr.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { readOpenRouterZdr, withOpenRouterZdr } from "./openrouter-zdr";
+
+describe("OpenRouter ZDR config helpers", () => {
+  it("reads only an explicit boolean true", () => {
+    expect(readOpenRouterZdr({ openrouter: { zdr: true } })).toBe(true);
+    expect(readOpenRouterZdr({ openrouter: { zdr: false } })).toBe(false);
+    expect(readOpenRouterZdr({ openrouter: { zdr: "true" } })).toBe(false);
+    expect(readOpenRouterZdr({})).toBe(false);
+  });
+
+  it("updates ZDR without dropping neighboring OpenRouter settings", () => {
+    const config = {
+      model: { provider: "openrouter" },
+      openrouter: { response_cache: true, min_coding_score: 0.65 },
+    };
+    const next = withOpenRouterZdr(config, true);
+    expect(next).toEqual({
+      model: { provider: "openrouter" },
+      openrouter: {
+        response_cache: true,
+        min_coding_score: 0.65,
+        zdr: true,
+      },
+    });
+    expect(config.openrouter).not.toHaveProperty("zdr");
+  });
+
+  it("repairs a malformed OpenRouter section", () => {
+    expect(withOpenRouterZdr({ openrouter: "bad" }, false)).toEqual({
+      openrouter: { zdr: false },
+    });
+  });
+});

--- a/web/src/lib/openrouter-zdr.ts
+++ b/web/src/lib/openrouter-zdr.ts
@@ -1,0 +1,27 @@
+export type DashboardConfig = Record<string, unknown>;
+
+export function readOpenRouterZdr(config: DashboardConfig | null | undefined): boolean {
+  const section = config?.openrouter;
+  if (!section || typeof section !== "object" || Array.isArray(section)) return false;
+  return (section as Record<string, unknown>).zdr === true;
+}
+
+export function withOpenRouterZdr(
+  config: DashboardConfig | null | undefined,
+  enabled: boolean,
+): DashboardConfig {
+  const base = config && typeof config === "object" ? config : {};
+  const current =
+    base.openrouter &&
+    typeof base.openrouter === "object" &&
+    !Array.isArray(base.openrouter)
+      ? (base.openrouter as Record<string, unknown>)
+      : {};
+  return {
+    ...base,
+    openrouter: {
+      ...current,
+      zdr: enabled,
+    },
+  };
+}

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -7,6 +7,7 @@ import {
   DollarSign,
   Eye,
   RefreshCw,
+  ShieldCheck,
   Settings2,
   Star,
   Wrench,
@@ -31,10 +32,10 @@ import {
 import { formatTokenCount } from "@/lib/format";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Switch } from "@nous-research/ui/ui/components/switch";
 import { Stats } from "@nous-research/ui/ui/components/stats";
 import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
 import { Badge } from "@nous-research/ui/ui/components/badge";
-import { Switch } from "@nous-research/ui/ui/components/switch";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { useModalBehavior } from "@/hooks/useModalBehavior";
 import { usePageHeader } from "@/contexts/usePageHeader";
@@ -42,6 +43,7 @@ import { useI18n } from "@/i18n";
 import { PluginSlot } from "@/plugins";
 import { ModelPickerDialog } from "@/components/ModelPickerDialog";
 import { ModelReloadConfirm } from "@/components/ModelReloadConfirm";
+import { readOpenRouterZdr, withOpenRouterZdr } from "@/lib/openrouter-zdr";
 
 const PERIODS = [
   { label: "7d", days: 7 },
@@ -927,6 +929,105 @@ function MoaModelsModal({
   );
 }
 
+function OpenRouterZdrToggle() {
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmDisable, setConfirmDisable] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getConfig()
+      .then((config) => {
+        if (!cancelled) setEnabled(readOpenRouterZdr(config));
+      })
+      .catch((cause) => {
+        if (!cancelled) {
+          setError(cause instanceof Error ? cause.message : String(cause));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const persist = async (next: boolean) => {
+    setSaving(true);
+    setError(null);
+    try {
+      // Re-read before writing so this focused toggle does not overwrite a
+      // model/config change made elsewhere after the page first loaded.
+      const config = await api.getConfig();
+      await api.saveConfig(withOpenRouterZdr(config, next));
+      setEnabled(next);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setSaving(false);
+      setConfirmDisable(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex min-w-0 flex-col gap-2 border border-border/50 bg-muted/20 px-3 py-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="mb-0.5 flex items-center gap-2">
+            <ShieldCheck
+              className={cn(
+                "h-3 w-3",
+                enabled ? "text-success" : "text-text-tertiary",
+              )}
+            />
+            <span className="text-display text-xs font-medium tracking-wider">
+              OpenRouter Zero Data Retention
+            </span>
+            <Badge tone={enabled ? "success" : "outline"} className="text-[10px]">
+              {enabled ? "ENFORCED" : "ACCOUNT POLICY"}
+            </Badge>
+          </div>
+          <div className="text-xs text-text-secondary">
+            {enabled
+              ? "Adds provider.zdr=true to every OpenRouter request, including auxiliary calls."
+              : "Uses OpenRouter account and guardrail privacy settings without a request-time override."}
+          </div>
+          {error && (
+            <div className="mt-1 text-xs text-destructive">Failed to save: {error}</div>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-2 self-start sm:self-center">
+          {(loading || saving) && <Spinner className="h-3.5 w-3.5" />}
+          <Switch
+            aria-label="Enforce OpenRouter Zero Data Retention"
+            checked={enabled}
+            disabled={loading || saving}
+            onCheckedChange={(next) => {
+              if (next) void persist(true);
+              else setConfirmDisable(true);
+            }}
+          />
+        </div>
+      </div>
+      <ConfirmDialog
+        open={confirmDisable}
+        title="Disable request-time ZDR?"
+        description="OpenRouter account and guardrail policies will still apply, but Hermes will stop forcing Zero Data Retention on each request. Some providers may retain prompts or use them for training."
+        confirmLabel="Disable ZDR"
+        cancelLabel="Keep enabled"
+        loading={saving}
+        onCancel={() => setConfirmDisable(false)}
+        onConfirm={() => void persist(false)}
+      />
+    </>
+  );
+}
+
+
 function ModelSettingsPanel({
   aux,
   refreshKey,
@@ -993,6 +1094,8 @@ function ModelSettingsPanel({
       </CardHeader>
 
       <CardContent className="min-w-0 space-y-3 pt-3">
+        <OpenRouterZdrToggle />
+
         {/* Main row */}
         <div className="flex min-w-0 flex-col gap-2 bg-muted/20 border border-border/50 px-3 py-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
           <div className="min-w-0 flex-1">

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1474,6 +1474,31 @@ Notes:
 - See OpenRouter's [Pareto Router docs](https://openrouter.ai/docs/guides/routing/routers/pareto-router) for the full router behavior.
 - To use the Pareto Code router for a specific **auxiliary task** (compression, vision, etc.) instead of the main agent, set `extra_body.plugins` under that task — see [Auxiliary Models → OpenRouter routing & Pareto Code for auxiliary tasks](/user-guide/configuration#openrouter-routing--pareto-code-for-auxiliary-tasks).
 
+## OpenRouter Zero Data Retention
+
+Hermes can enforce OpenRouter's Zero Data Retention policy on every inference
+request as defense in depth beyond the privacy and guardrail settings in your
+OpenRouter account:
+
+```yaml
+openrouter:
+  zdr: true
+```
+
+Toggle **OpenRouter Zero Data Retention** from the Desktop **Models** page, or
+run `hermes config set openrouter.zdr true|false`. Changes apply to the next
+request without restarting Hermes or rebuilding the current chat session.
+When enabled, Hermes adds `provider.zdr: true` to main-agent and auxiliary
+OpenRouter requests. OpenRouter account and guardrail policies still apply and
+cannot be weakened by turning this request-level setting off.
+
+This setting is intentionally separate from
+`provider_routing.data_collection`. Provider-routing values are per-agent
+preferences that can be cleared when a delegated child explicitly changes
+providers. `openrouter.zdr` is a profile-wide OpenRouter requirement enforced
+at the final request boundary, so delegation and request overrides cannot
+weaken it.
+
 ## Fallback Providers
 
 Configure a chain of backup providers Hermes tries in order when the primary model fails (rate limits, server errors, auth failures). The canonical format is a top-level `fallback_providers:` list:


### PR DESCRIPTION
## What does this PR do?

OpenRouter's model picker currently uses the public catalog and a curated snapshot, so it can both hide valid tool-capable models and surface models blocked by the API key's privacy, provider, or guardrail policy.

This PR makes OpenRouter handling policy-aware end to end. It uses the authenticated account catalog as the source of truth, validates direct selections against it, partitions caches by non-reversible credential fingerprints, and adds a profile-wide Zero Data Retention safeguard enforced at final request boundaries. It also exposes ZDR in Desktop with confirmation before disabling.

## Related Issue

Related: #60827

This overlaps with #60837 on showing all live tool-capable models. That PR still uses the public catalog and does not cover account privacy/guardrail filtering, direct-selection validation, request-time ZDR, auxiliary calls, or Desktop controls. This implementation also supersedes the narrower, now-closed #17247.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py` and `plugins/model-providers/openrouter/__init__.py`: fetch the authenticated `/api/v1/models/user` catalog, list every policy-eligible tool-capable model, preserve curated IDs only as an ordering hint, validate direct model selections, and fail closed when policy verification is unavailable.
- `hermes_cli/models.py`: partition canonical, provider-profile, and generic disk picker caches by non-reversible credential fingerprints so API-key rotation cannot reuse another account's catalog.
- `agent/openrouter_zdr.py` and core request paths: enforce `provider.zdr: true` after caller/request overrides for main transport, auxiliary/fallback calls, iteration-limit summaries, trajectory compression, and Mini-SWE.
- `tools/delegate_tool.py`: document and regression-test that delegated provider overrides cannot weaken the profile-wide ZDR requirement.
- `hermes_cli/config.py`, `cli-config.yaml.example`, and `website/docs/integrations/providers.md`: define and document `openrouter.zdr`, including its distinction from per-agent `provider_routing.data_collection`.
- `web/src/pages/ModelsPage.tsx` and `web/src/lib/openrouter-zdr.ts`: add the Desktop **OpenRouter Zero Data Retention** control with confirmation before disabling.
- `tests/`: cover policy-catalog filtering, direct-selection failure behavior, credential rotation, runtime config resolution, final-wire enforcement, native Gemini separation, delegation, auxiliary paths, summaries, compression, and Mini-SWE.
- `contributors/emails/wpinner@protonmail.com`: add the required first-contributor attribution mapping.

## Security / Privacy Behavior

- `openrouter.zdr: true` is additive defense in depth; OpenRouter account and guardrail policies still apply.
- Disabling the Hermes toggle cannot disable account- or guardrail-level ZDR.
- The picker fails closed when the authenticated policy catalog cannot be verified instead of falling back to an unfiltered public/static catalog.
- Non-tool models remain excluded because Hermes is tool-calling-first.
- Credential fingerprints are one-way cache partitions; API keys are never written to picker caches or logs.

## How to Test

1. Configure an OpenRouter API key and open Hermes' normal model picker or Desktop's **Models** page. Confirm the OpenRouter group contains the account-policy-eligible tool-capable catalog and remains searchable.
2. Select a model directly and confirm an ineligible or unverifiable OpenRouter selection fails closed rather than silently using the public/static catalog.
3. Enable **OpenRouter Zero Data Retention**, save, and make a request. Confirm the final OpenRouter payload contains `provider.zdr: true`, including when caller or delegated-agent overrides attempt to set `zdr: false`.
4. Disable the setting through Desktop's confirmation flow and confirm the change applies to the next request without restarting Hermes.
5. Run the canonical affected Python suite:

```bash
scripts/run_tests.sh \
  tests/agent/test_openrouter_zdr.py \
  tests/agent/test_chat_completion_helpers_provider_sort.py \
  tests/agent/test_auxiliary_client.py \
  tests/agent/transports/test_chat_completions.py \
  tests/hermes_cli/test_models.py \
  tests/providers/test_provider_profiles.py \
  tests/test_mini_swe_runner.py \
  tests/test_trajectory_compressor.py \
  tests/tools/test_delegate.py -q
```

6. Run the web and cross-platform checks:

```bash
npm run check -w web
npm run lint -w web
npm run build -w web
python3 scripts/check-windows-footguns.py --diff origin/main
```

## Verification Results

- canonical `scripts/run_tests.sh` affected suite — **777 passed**
- `uv run --frozen --extra dev ruff check` over all changed Python files — **passed**
- `npm run check -w web` — **100 tests passed; type-check passed**
- `npm run lint -w web` — **0 errors** (existing warnings only)
- `npm run build -w web` — **passed**
- `python3 scripts/check-windows-footguns.py --diff origin/main` — **passed; 17 files scanned**
- independent immutable review of `d0ee1b489` — **no material findings**; reviewer suite **365 passed**
- clean synthetic merge into current `main` after upstream advanced during review — affected suite **777 passed**
- temp-`HERMES_HOME` smoke — enabled ZDR overrode caller `zdr:false`; disabling the config immediately preserved caller/account policy without restarting
- headless Chromium review at 1440×1000 — control visible, readable, aligned, and unclipped
- contributor attribution precheck and `cli-config.yaml.example` YAML parse — **passed**

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository's canonical affected test suite via `scripts/run_tests.sh` — **777 passed**; the complete repository matrix is deferred to upstream CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.17.0-1018-oracle; Desktop UI additionally verified in headless Chromium

### Documentation & Housekeeping

- [x] I've updated relevant documentation (provider docs and config example)
- [x] I've updated `cli-config.yaml.example` for the new `openrouter.zdr` config key
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A; this PR does not change architecture or contributor workflows
- [x] I've considered cross-platform impact; the repository Windows-footgun checker passes on the changed Python surface
- [x] Tool description/schema changes are N/A; delegation behavior is unchanged and the PR adds an invariant comment/test

## Screenshots / Logs

The Desktop control was reviewed in headless Chromium at 1440×1000 and was visible, readable, aligned, and unclipped. Reproducible command results are listed under **Verification Results** above.
