### PR TITLE
fix(desktop): render one compaction indicator, at the thread tail

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -63,6 +63,20 @@ export const AssistantMessage: FC<{
   // StreamStallIndicator leaf — not the footer/preview/root subtree.
   const messageStatus = useAuiState(s => s.message.status?.type)
   const isRunning = messageStatus === 'running'
+
+  // The stall/compaction indicator reflects SESSION-global state, so mounting
+  // one per running bubble renders one identical row per bubble. A reconnect or
+  // a queued prompt can leave earlier assistant bubbles marked running
+  // (#68634), so the indicator is gated on being the tail message — exactly one
+  // indicator, always at the live end of the thread. Deliberately NOT folded
+  // into `isRunning`: that also drives the enter animation and data-streaming,
+  // which stay per-message. Mirrors the latest-user lookup in user-message.tsx.
+  const isTailMessage = useAuiState(s => {
+    const messages = s.thread.messages
+
+    return messages.length === 0 || (messages[messages.length - 1] as { id?: string }).id === s.message.id
+  })
+
   const isPlaceholder = useAuiState(s => s.message.status?.type === 'running' && s.message.content.length === 0)
   const hasVisibleText = useAuiState(s => contentHasVisibleText(s.message.content))
 
@@ -103,7 +117,7 @@ export const AssistantMessage: FC<{
       >
         {/* Todos render in the composer status stack now, not inline. */}
         <MessagePrimitive.Parts components={MESSAGE_PARTS_COMPONENTS} />
-        {isRunning && <StreamStallIndicator />}
+        {isRunning && isTailMessage && <StreamStallIndicator />}
         {previewTargets.length > 0 && (
           <div className="mt-3 flex flex-wrap gap-2">
             {previewTargets.map(target => (

--- a/apps/desktop/src/components/assistant-ui/thread/compaction-indicator.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/compaction-indicator.test.tsx
@@ -1,0 +1,127 @@
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { __resetElapsedTimerRegistryForTests } from '@/components/chat/activity-timer'
+import { I18nProvider } from '@/i18n'
+import { setSessionCompacting } from '@/store/compaction'
+import { $activeSessionId, $turnStartedAt } from '@/store/session'
+
+import { Thread } from '.'
+
+// Regression cover for #68634. The compaction/stall indicator reflects
+// SESSION-global state, so mounting it per running assistant bubble rendered
+// one identical "Summarizing thread" row and timer per bubble. A reconnect or a
+// queued prompt can legitimately leave an earlier bubble marked running, so the
+// count depended on transport timing rather than on anything the user did.
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+const SESSION_ID = 'session-68634'
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => window.setTimeout(() => cb(0), 0))
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+vi.stubGlobal('CSS', { escape: (value: string) => value })
+
+Element.prototype.scrollTo = function scrollTo() {}
+
+Element.prototype.animate = function animate() {
+  return { cancel: () => {}, finished: Promise.resolve() } as unknown as Animation
+}
+
+function userMessage(id: string, text: string): ThreadMessage {
+  return {
+    id,
+    role: 'user',
+    content: [{ type: 'text', text }],
+    attachments: [],
+    createdAt,
+    metadata: { custom: {} }
+  } as ThreadMessage
+}
+
+function runningAssistant(id: string, text: string): ThreadMessage {
+  return {
+    id,
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+    status: { type: 'running' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as ThreadMessage
+}
+
+function Harness({ messages }: { messages: ThreadMessage[] }) {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages,
+    isRunning: true,
+    onNew: async () => {}
+  })
+
+  return (
+    <I18nProvider configClient={null} initialLocale="en">
+      <AssistantRuntimeProvider runtime={runtime}>
+        <Thread />
+      </AssistantRuntimeProvider>
+    </I18nProvider>
+  )
+}
+
+describe('compaction indicator (#68634)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    __resetElapsedTimerRegistryForTests()
+    $activeSessionId.set(SESSION_ID)
+    $turnStartedAt.set(Date.now())
+    setSessionCompacting(SESSION_ID, true)
+  })
+
+  afterEach(() => {
+    cleanup()
+    setSessionCompacting(SESSION_ID, false)
+    $activeSessionId.set(null)
+    $turnStartedAt.set(null)
+    __resetElapsedTimerRegistryForTests()
+    vi.useRealTimers()
+  })
+
+  it('renders one indicator when several assistant bubbles are still running', () => {
+    // The reported shape: an earlier assistant bubble never left `running`
+    // before the user's next prompt was inserted.
+    render(
+      <Harness
+        messages={[
+          userMessage('user-1', 'first question'),
+          runningAssistant('assistant-1', 'partial answer'),
+          userMessage('user-2', 'hola?'),
+          runningAssistant('assistant-2', '')
+        ]}
+      />
+    )
+
+    act(() => vi.advanceTimersByTime(17_000))
+
+    expect(screen.getAllByRole('status', { name: 'Summarizing thread' })).toHaveLength(1)
+  })
+
+  it('still renders the indicator for a single running bubble', () => {
+    render(<Harness messages={[userMessage('user-1', 'question'), runningAssistant('assistant-1', 'answer')]} />)
+
+    act(() => vi.advanceTimersByTime(17_000))
+
+    expect(screen.getAllByRole('status', { name: 'Summarizing thread' })).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Fixes #68634 — Desktop rendering the same live `Summarizing thread` indicator once per running assistant bubble.

The diagnosis in the issue is exactly right: `StreamStallIndicator` is mounted per assistant message whose status is `running` (`assistant-message.tsx`), but the state it renders — `$compactionActive` — is **session-global**. So N running bubbles draw N identical rows and timers.

Normally only the tail bubble is running, which hides it. A gateway reconnect, or a prompt queued while the previous turn is still marked running, leaves more than one — and the number of indicators then tracks transport timing rather than anything the user did.

This gates the indicator on being the **tail message**, giving exactly one indicator at the live end of the thread — the behaviour the report asks for.

## Related Issue

Fixes #68634

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx` — add an `isTailMessage` selector and gate `<StreamStallIndicator />` on it.
- `apps/desktop/src/components/assistant-ui/thread/compaction-indicator.test.tsx` — new file, 2 tests.

### Two deliberate choices

**Not folded into `isRunning`.** That value also drives `useEnterAnimation` and the `data-streaming` attribute, which are genuinely per-message and should stay that way. Only the indicator is gated, so streaming semantics elsewhere are untouched.

**Tail lookup mirrors the existing pattern** in `user-message.tsx`, which already resolves the latest user message from `s.thread.messages`, rather than introducing a different mechanism for the same question.

## How to Test

The first test is the reporter's own reproduction, more or less verbatim: user message → running assistant → user message (`hola?`) → running assistant, compaction active, timer advanced 17s.

```bash
cd apps/desktop
npx vitest run src/components/assistant-ui/thread/compaction-indicator.test.tsx   # 2 passed

git stash push src/components/assistant-ui/thread/assistant-message.tsx           # remove the fix
npx vitest run src/components/assistant-ui/thread/compaction-indicator.test.tsx   # 1 failed: expected 1, received 2
```

The second test covers the ordinary single-running-bubble case, so the gate can't silently suppress the indicator altogether.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (1 commit, 2 files)
- [x] I've added tests for my changes, and verified they fail without the fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **see note**

### Note on the test run

This change is desktop-only (TypeScript/React), so the Python suite isn't the relevant signal. What I ran, against a clean `main` for comparison:

```
apps/desktop  npx vitest run src/components/assistant-ui/thread/

main (0.19.0):  8 files, 52 passed, 0 failed
this branch:    9 files, 54 passed, 0 failed   (+1 file, +2 = the new tests)

apps/desktop  npx tsc --noEmit -p tsconfig.json   -> clean
apps/desktop  npx eslint <changed files>          -> clean
```

I did not complete a full `pytest tests/ -q`; it was still at 17% after ten minutes on this machine and already showed failures unrelated to this change. Happy to run anything more specific.

### Unrelated observation, in case it's useful

`npx tsc -b .` in `apps/desktop` emits compiled `.js` next to every source file (857 of them). They're invisible because `.gitignore:80` covers `apps/desktop/src/**/*.js`, but Vite resolves `.js` ahead of `.tsx`, so a stale artifact silently shadows an edited source — a test can then exercise the *old* code and pass or fail for reasons unrelated to the change under test. It cost me a confusing debugging cycle here.

`npx tsc --noEmit -p tsconfig.json` typechecks without emitting. Not part of this PR, but might be worth a note in the contributor docs or a `noEmit` in the project references config.
