### PR TITLE
feat(cron): add config-driven drift_policy (adapt|fail) for unpinned cron jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -277,7 +277,7 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run, claim_dispatch, heartbeat_run_claim
+from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run, claim_dispatch, heartbeat_run_claim, update_job
 from cron.executions import create_execution, finish_execution, mark_execution_running
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
@@ -3280,23 +3280,64 @@ def run_job(
                 )
         if _drift:
             _changes = "; ".join(_drift)
-            logger.warning(
-                "Job '%s': SKIPPED — global inference config drifted since "
-                "creation (%s) and this job is unpinned. Skipped to prevent "
-                "unintended spend. Pin explicitly to proceed: "
-                "`cronjob action=update job_id=%s provider=<p> model=<m>`.",
-                job_id,
-                _changes,
-                job_id,
-            )
-            raise RuntimeError(
-                f"Skipped to prevent unintended spend: global inference config "
-                f"drifted since this job was created ({_changes}), and this job "
-                f"is unpinned. No inference call was made. To run on the new "
-                f"config, pin it explicitly: `cronjob action=update "
-                f"job_id={job_id} provider=<provider> model=<model>` "
-                f"(or pin the original values to keep them). See #44585."
-            )
+            _drift_policy = str(
+                (_cfg.get("cron") or {}).get("drift_policy", "fail")
+            ).strip().lower()
+
+            if _drift_policy == "adapt":
+                # Auto-re-snapshot: update the job's provider/model snapshots
+                # to current values so the next tick doesn't re-detect drift.
+                # The job follows the new global config. Log the transition
+                # visibly so operators can audit config changes that affected
+                # cron jobs (#44585).
+                _snapshot_updates: dict = {}
+                if _provider_snapshot:
+                    _snapshot_updates["provider_snapshot"] = str(
+                        primary_provider_for_drift
+                        or runtime.get("provider")
+                        or ""
+                    ).strip().lower() or None
+                if _model_snapshot:
+                    _snapshot_updates["model_snapshot"] = str(
+                        primary_model_for_drift or ""
+                    ).strip().lower() or None
+                if _snapshot_updates:
+                    try:
+                        update_job(job_id, _snapshot_updates)
+                    except Exception as _snap_exc:
+                        logger.warning(
+                            "Job '%s': drift detected (%s) but failed to "
+                            "persist updated snapshots: %s — running with "
+                            "current config anyway.",
+                            job_id, _changes, _snap_exc,
+                        )
+                logger.warning(
+                    "Job '%s': global inference config drifted since "
+                    "creation (%s) — auto-adapted snapshots to current "
+                    "values (drift_policy=adapt).",
+                    job_id, _changes,
+                )
+                # Fall through — run normally with the current global config.
+            else:
+                # Fail-closed (default) — skip the job, no inference call.
+                logger.warning(
+                    "Job '%s': SKIPPED — global inference config drifted "
+                    "since creation (%s) and this job is unpinned. Skipped "
+                    "to prevent unintended spend. Pin explicitly or set "
+                    "cron.drift_policy=adapt to auto-follow config changes.",
+                    job_id,
+                    _changes,
+                )
+                raise RuntimeError(
+                    f"Skipped to prevent unintended spend: global inference "
+                    f"config drifted since this job was created ({_changes}), "
+                    f"and this job is unpinned. No inference call was made. "
+                    f"To run on the new config, pin it explicitly: "
+                    f"`cronjob action=update job_id={job_id} provider="
+                    f"<provider> model=<model>` (or pin the original values "
+                    f"to keep them). Or set cron.drift_policy=adapt to "
+                    f"auto-follow config changes. See #44585."
+                )
 
         fallback_model = get_fallback_chain(_cfg) or None
         credential_pool = None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2842,6 +2842,12 @@ DEFAULT_CONFIG = {
         # recent .md files and prunes older ones. 0 or negative disables
         # pruning (for operators who manage cleanup externally). Default 50.
         "output_retention": 50,
+        # Provider/model drift behavior for unpinned cron jobs (#44585).
+        # "fail" — skip the job when global config changed since creation
+        #           (prevents unintended spend; current behaviour).
+        # "adapt" — auto-update snapshots and continue running on the new
+        #            global config (cron jobs follow the user's default).
+        "drift_policy": "fail",
         # Timeout (seconds) for SessionDB() init inside cron jobs.
         # SessionDB opens/migrates state.db synchronously and has no timeout
         # of its own against a wedged sqlite3.connect. An unbounded hang here

--- a/tests/cron/test_cron_provider_pin.py
+++ b/tests/cron/test_cron_provider_pin.py
@@ -44,11 +44,18 @@ def _base_job(**overrides):
     return job
 
 
-def _run_with_current_provider(job, current_provider, tmp_path):
+def _run_with_current_provider(job, current_provider, tmp_path, drift_policy=None):
     """Drive run_job with resolve_runtime_provider pinned to ``current_provider``.
+
+    Args:
+        drift_policy: If set, writes config.yaml with this cron.drift_policy.
 
     Returns (success, output, final_response, error, agent_constructed).
     """
+    if drift_policy is not None:
+        (tmp_path / "config.yaml").write_text(
+            f"cron:\n  drift_policy: {drift_policy}\n"
+        )
     fake_db = MagicMock()
     with patch("cron.scheduler._hermes_home", tmp_path), \
          patch("cron.scheduler._resolve_origin", return_value=None), \
@@ -109,6 +116,18 @@ class TestProviderDriftGuard:
         assert "spend" in blob
         assert "cronjob action=update" in blob
         assert "44585" in blob
+
+    def test_b2_adapt_provider_drift_succeeds(self, tmp_path):
+        """(b2) Unpinned job with drift_policy=adapt → auto-adapts and runs."""
+        job = _base_job(provider_snapshot="openrouter")
+        success, output, final_response, error, agent_constructed = \
+            _run_with_current_provider(
+                job, "nous", tmp_path, drift_policy="adapt",
+            )
+
+        assert agent_constructed is True, "must run with adapt policy"
+        assert success is True
+        assert error is None
 
     def test_c_no_snapshot_runs_backcompat(self, tmp_path):
         """(c) Pre-existing job with NO provider_snapshot → runs (back-compat).
@@ -243,12 +262,17 @@ class TestCreateJobSnapshot:
         assert job["model_snapshot"] is None
 
 
-def _run_with_current_provider_and_model(job, current_provider, current_model, tmp_path):
+def _run_with_current_provider_and_model(job, current_provider, current_model, tmp_path, drift_policy=None):
     """Drive run_job with resolved provider pinned and config.yaml model.default
-    set to ``current_model`` (the unpinned-model fire-time source)."""
-    (tmp_path / "config.yaml").write_text(
-        f"model:\n  default: {current_model}\n"
-    )
+    set to ``current_model`` (the unpinned-model fire-time source).
+
+    Args:
+        drift_policy: If set, includes cron.drift_policy in the config.
+    """
+    config = f"model:\n  default: {current_model}\n"
+    if drift_policy is not None:
+        config += f"cron:\n  drift_policy: {drift_policy}\n"
+    (tmp_path / "config.yaml").write_text(config)
     fake_db = MagicMock()
     with patch("cron.scheduler._hermes_home", tmp_path), \
          patch("cron.scheduler._get_hermes_home", return_value=tmp_path), \
@@ -296,6 +320,21 @@ class TestModelDriftGuard:
         assert "claude-fable-5" in blob
         assert "llama-3.3-70b-instruct:free" in blob
         assert "44585" in blob
+
+    def test_model_drift_adapt_mode_succeeds(self, tmp_path):
+        """Model drift with drift_policy=adapt → auto-adapts and runs."""
+        job = _base_job(
+            provider_snapshot="openrouter",
+            model_snapshot="llama-3.3-70b-instruct:free",
+        )
+        success, output, final_response, error, agent_constructed = \
+            _run_with_current_provider_and_model(
+                job, "openrouter", "claude-fable-5",
+                tmp_path, drift_policy="adapt",
+            )
+        assert agent_constructed is True, "must run with adapt policy"
+        assert success is True
+        assert error is None
 
     def test_model_snapshot_matches_runs(self, tmp_path):
         # Default model unchanged → runs normally.


### PR DESCRIPTION
## What does this PR do?

Adds a new `cron.drift_policy` config option (values: `"fail"` | `"adapt"`, default: `"fail"`) that controls what happens when an unpinned cron job's provider/model snapshot no longer matches the current global config.

**`"fail"` (default):** Existing behaviour — the job is skipped with a `RuntimeError`, no inference call is made, and the user gets a loud actionable error telling them to pin. For operators who actively change their global provider/model and expect all unpinned cron jobs to keep working, this is disruptive: every manually-created job needs a `cronjob action=update` after every `hermes model` switch.

**`"adapt"`:** On drift detection, the scheduler logs the drift as a warning, persists updated `provider_snapshot`/`model_snapshot` via `update_job()`, and runs the job normally on the new global config. This means cron jobs naturally follow the user's default — which is what anyone who runs `hermes model [new-model]` expects their cron jobs to do.

The implementation is minimal: reads `_cfg["cron"]["drift_policy"]` in the existing drift-guard block (`scheduler.py:3281`), computes the new snapshot values from the same `primary_provider_for_drift` / `primary_model_for_drift` variables already in scope, and calls the existing `update_job()` API.

## Related Issue

Closes #44585 (second half: make the guard configurable rather than always fail-closed). The original guard was introduced to prevent the $7.73 incident where an unpinned job silently inherited a paid provider; the adapt mode preserves the audit trail (logged warning) while removing the hard block.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/config.py` — added `cron.drift_policy: "fail"` default with full docstring explaining both modes
- `cron/scheduler.py` — import `update_job`; replaced the unconditional fail-closed block with a policy branch: `adapt` re-snapshots and continues, `fail` raises the original `RuntimeError`. Error message updated to mention `cron.drift_policy=adapt` as an alternative to pinning
- `tests/cron/test_cron_provider_pin.py` — added `test_b2_adapt_provider_drift_succeeds` (provider-level adapt) and `test_model_drift_adapt_mode_succeeds` (model-level adapt); extended both test helpers with `drift_policy` parameter

## How to Test

1. Set `cron.drift_policy: adapt` in config.yaml
2. Create an unpinned cron job (`cronjob create`)
3. Switch the default model (`hermes model [new-model]`)
4. The next tick should log the drift warning and run the job with the new model instead of skipping
5. Set `cron.drift_policy: fail` (default) — drift reverts to skip+error

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/cron/test_cron_provider_pin.py -v` — 17/17 passed
- [x] I've run `pytest tests/cron/ -v` — 732 passed (full cron suite, no regressions)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 Trixie, Linux 7.0.7+deb13-amd64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [ ] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [ ] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — config-driven behaviour change, no UI component.
