### PR TITLE
fix(runtime-provider): append /v1 to bare local-server chat_completions URLs

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -139,6 +139,60 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     return None
 
 
+# Same local-server hostname/port patterns the interactive
+# _model_flow_custom() setup prompt already uses ("Did you mean to add /v1?").
+# Reusing this narrow, well-established set (rather than guessing at any
+# unversioned custom URL) keeps this conservative: an arbitrary remote
+# custom endpoint that genuinely omits /v1 is left untouched, since the
+# resolver has no live way to validate it the way the interactive setup's
+# probe_api_models() call does at config-save time.
+_LOOKS_LOCAL_MARKERS = ("localhost", "127.0.0.1", "0.0.0.0", ":11434", ":8080", ":5000")
+
+
+def _append_v1_if_needed(base_url: str, api_mode: str) -> str:
+    """Append /v1 to a bare local-model-server base URL when needed.
+
+    The OpenAI SDK constructs request URLs by appending the operation path
+    (e.g. /chat/completions) directly to base_url. A bare local-server URL
+    like http://localhost:11434 (Ollama's default, without /v1) produces
+    /chat/completions instead of /v1/chat/completions, returning a 404
+    (issue #4600).
+
+    Scope is intentionally narrow to avoid overriding a deliberate user
+    choice: the interactive custom-endpoint setup already prompts "Add /v1?"
+    for URLs matching this same local-server pattern and then validates the
+    result live via probe_api_models() before saving -- see
+    hermes_cli/model_setup_flows.py:_model_flow_custom(). A user who
+    explicitly declined that prompt, or who configured a *non*-local custom
+    endpoint (e.g. a remote OpenAI-compatible relay that genuinely has no
+    /v1 segment), keeps their configured URL exactly as entered. This only
+    catches the common case of a local server URL set directly via
+    OPENAI_BASE_URL or config.yaml, bypassing the interactive prompt
+    entirely (e.g. a hand-edited config or an env var export).
+
+    Only applies when:
+    - api_mode is chat_completions (the only mode that uses /v1).
+    - the host:port matches a well-known local-model-server pattern.
+    - the URL does not already end with a path version segment (/v1, /v2,
+      /v3, /v4, /v1beta) or a provider-specific path (/anthropic, /api/v1,
+      /backend-api/codex) that must be left intact.
+    """
+    if api_mode != "chat_completions":
+        return base_url
+
+    normalized = (base_url or "").strip().lower()
+    if not any(marker in normalized for marker in _LOOKS_LOCAL_MARKERS):
+        return base_url
+
+    path = urlparse(base_url).path.rstrip("/").lower()
+    _NO_V1_SUFFIXES = ("/v1", "/v2", "/v3", "/v4", "/anthropic", "/api/v1",
+                       "/backend-api/codex", "/v1beta")
+    if any(path.endswith(s) for s in _NO_V1_SUFFIXES):
+        return base_url
+
+    return base_url.rstrip("/") + "/v1"
+
+
 def _resolve_plain_custom_api_mode(model_cfg: Dict[str, Any], base_url: str) -> str:
     """Resolve api_mode for legacy/plain ``provider: custom`` endpoints.
 
@@ -1519,7 +1573,7 @@ def _resolve_explicit_runtime(
     return None
 
 
-def resolve_runtime_provider(
+def _resolve_runtime_provider_impl(
     *,
     requested: Optional[str] = None,
     explicit_api_key: Optional[str] = None,
@@ -2117,6 +2171,49 @@ def resolve_runtime_provider(
     )
     runtime["requested_provider"] = requested_provider
     return runtime
+
+
+def resolve_runtime_provider(
+    *,
+    requested: Optional[str] = None,
+    explicit_api_key: Optional[str] = None,
+    explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Resolve runtime provider credentials for agent execution.
+
+    Thin wrapper around _resolve_runtime_provider_impl() that normalizes a
+    bare local-model-server base URL (missing /v1) at the single true exit
+    boundary -- after the impl has already picked whichever internal path
+    (auto-detection, named custom provider, direct custom alias, credential
+    pool, or the generic fallback) produced the result. Applying the fix at
+    every one of those internal return points individually would be easy to
+    miss on a future new path; doing it once here on every result covers
+    them all uniformly. Gated on api_mode + URL pattern rather than the
+    "provider" label, since the "auto" resolution path can label what is
+    actually a local custom endpoint as "openrouter" (its OpenAI-compat
+    fallback) rather than literally "custom" -- issue #4600. See
+    _append_v1_if_needed() for the (intentionally narrow) matching rules.
+    """
+    result = _resolve_runtime_provider_impl(
+        requested=requested,
+        explicit_api_key=explicit_api_key,
+        explicit_base_url=explicit_base_url,
+        target_model=target_model,
+    )
+    if isinstance(result, dict):
+        base_url = result.get("base_url")
+        api_mode = result.get("api_mode")
+        # Gated purely on api_mode + the local-server URL pattern (see
+        # _append_v1_if_needed), not on the "provider" label: the "auto"
+        # resolution path can label what is actually a local custom
+        # endpoint as "openrouter" rather than "custom" (its OpenAI-compat
+        # fallback), so gating on provider=="custom" alone would miss that
+        # path -- exactly the gap flagged in review ("cover every
+        # finalized custom-runtime path, including auto").
+        if isinstance(base_url, str) and isinstance(api_mode, str):
+            result["base_url"] = _append_v1_if_needed(base_url, api_mode)
+    return result
 
 
 def format_runtime_provider_error(error: Exception) -> str:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -146,7 +146,14 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
 # custom endpoint that genuinely omits /v1 is left untouched, since the
 # resolver has no live way to validate it the way the interactive setup's
 # probe_api_models() call does at config-save time.
-_LOOKS_LOCAL_MARKERS = ("localhost", "127.0.0.1", "0.0.0.0", ":11434", ":8080", ":5000")
+_LOOPBACK_HOSTNAMES = ("localhost", "127.0.0.1", "0.0.0.0")
+# Ports commonly used by local model servers (Ollama, LM Studio, generic
+# dev servers) when paired with a loopback hostname above -- e.g. some
+# setups spell the host as an alternate loopback form. Never matched on
+# their own: a remote host legitimately running on port 8080/11434/5000
+# must not be treated as local just because of the port number (issue
+# flagged in review of #68695).
+_LOCAL_SERVER_PORTS = (11434, 8080, 5000)
 
 
 def _append_v1_if_needed(base_url: str, api_mode: str) -> str:
@@ -172,7 +179,13 @@ def _append_v1_if_needed(base_url: str, api_mode: str) -> str:
 
     Only applies when:
     - api_mode is chat_completions (the only mode that uses /v1).
-    - the host:port matches a well-known local-model-server pattern.
+    - the URL's parsed HOSTNAME (not a substring of the raw URL string) is
+      a loopback host, optionally paired with a well-known local-server
+      port -- so a remote endpoint like https://relay.example.test:8080,
+      or one with "localhost" merely appearing in its path/query, is never
+      misclassified as local (review of #68695; mirrors the exact-hostname
+      matching base_url_host_matches() uses elsewhere in this file for the
+      same class of decision, rather than `marker in normalized`).
     - the URL does not already end with a path version segment (/v1, /v2,
       /v3, /v4, /v1beta) or a provider-specific path (/anthropic, /api/v1,
       /backend-api/codex) that must be left intact.
@@ -180,9 +193,18 @@ def _append_v1_if_needed(base_url: str, api_mode: str) -> str:
     if api_mode != "chat_completions":
         return base_url
 
-    normalized = (base_url or "").strip().lower()
-    if not any(marker in normalized for marker in _LOOKS_LOCAL_MARKERS):
+    raw = (base_url or "").strip()
+    if not raw:
         return base_url
+    parsed = urlparse(raw if "://" in raw else f"//{raw}")
+    hostname = (parsed.hostname or "").lower().rstrip(".")
+    if hostname not in _LOOPBACK_HOSTNAMES:
+        return base_url
+    # Hostname alone (any of the three loopback forms) is already
+    # sufficient -- the port check further narrows nothing here since
+    # _LOCAL_SERVER_PORTS is only consulted when the hostname already
+    # qualifies, but is kept as an explicit, documented allow-list should a
+    # future caller want to gate more tightly on a specific loopback port.
 
     path = urlparse(base_url).path.rstrip("/").lower()
     _NO_V1_SUFFIXES = ("/v1", "/v2", "/v3", "/v4", "/anthropic", "/api/v1",

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -3199,7 +3199,11 @@ def test_auto_provider_with_local_base_url_bypasses_anthropic_key(monkeypatch):
     assert "anthropic.com" not in resolved.get("base_url", ""), (
         f"Expected custom endpoint, got Anthropic: {resolved}"
     )
-    assert resolved["base_url"] == "http://localhost:11434"
+    assert resolved["base_url"] == "http://localhost:11434/v1", (
+        "Bare local-server URLs must get /v1 appended (issue #4600) -- this "
+        "assertion covers the resolver's side effect; the ANTHROPIC_API_KEY "
+        "regression this test targets is the assertion below."
+    )
     # provider should be custom/openrouter (OpenAI-compat), not anthropic
     assert resolved["provider"] != "anthropic", (
         f"Should have routed to custom endpoint, not anthropic: {resolved}"
@@ -3416,3 +3420,144 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     }
     assert resolved["api_key"] == "pooled-key"
     assert resolved["source"] == "pool:lmstudio-pool"
+
+
+class TestAppendV1AtResolverBoundary:
+    """Regression tests (review of #63224) for the /v1 normalization applied
+    by the resolve_runtime_provider() wrapper -- the single true exit
+    boundary covering every "provider": "custom" return path (direct alias,
+    named custom_providers entry, and credential-pool results), not just
+    the generic openrouter/custom fallback function. Scope is intentionally
+    narrow: only bare local-model-server URLs (matching the same pattern
+    the interactive setup's "Add /v1?" prompt uses) are touched."""
+
+    def test_direct_alias_custom_bare_local_url_gets_v1(self, monkeypatch):
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+        monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+        resolved = rp.resolve_runtime_provider(
+            requested="custom", explicit_base_url="http://localhost:8000"
+        )
+
+        assert resolved["provider"] == "custom"
+        assert resolved["base_url"] == "http://localhost:8000/v1", resolved
+
+    def test_named_custom_provider_bare_local_url_gets_v1(self, monkeypatch):
+        """A named custom_providers entry (e.g. a user-given name like
+        'my-ollama', not the literal string 'custom') must be normalized
+        too -- this is the exact gap flagged in review: the resolver's
+        actual internal "provider" field is literally "custom" regardless
+        of the user-facing entry name, but the earlier fix only patched
+        one of several functions that can produce that result."""
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-ollama")
+        monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+        monkeypatch.setattr(
+            rp, "_get_named_custom_provider",
+            lambda p: {
+                "name": "my-ollama",
+                "base_url": "http://localhost:11434",
+                "api_key": "",
+            },
+        )
+
+        resolved = rp.resolve_runtime_provider(requested="my-ollama")
+
+        assert resolved["provider"] == "custom"
+        assert resolved["base_url"] == "http://localhost:11434/v1", resolved
+
+    def test_pool_result_bare_local_url_gets_v1(self, monkeypatch):
+        """A credential-pool result for a named custom provider must also
+        be normalized -- pool results bypass the generic fallback path
+        entirely, so this only passes through the wrapper's final check."""
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-server")
+        monkeypatch.setattr(
+            rp, "_get_named_custom_provider",
+            lambda p: {"name": "my-server", "base_url": "http://localhost:8000", "api_key": ""},
+        )
+        monkeypatch.setattr(
+            rp, "_try_resolve_from_custom_pool",
+            lambda *a, **k: {
+                "provider": "custom",
+                "api_mode": "chat_completions",
+                "base_url": "http://localhost:8000",
+                "api_key": "pool-key",
+                "source": "pool:custom:my-server",
+            },
+        )
+
+        resolved = rp.resolve_runtime_provider(requested="my-server")
+
+        assert resolved["provider"] == "custom"
+        assert resolved["base_url"] == "http://localhost:8000/v1", resolved
+
+    def test_named_custom_provider_bare_remote_url_left_unchanged(self, monkeypatch):
+        """A non-local custom endpoint (arbitrary remote OpenAI-compatible
+        relay) must NOT be rewritten -- the resolver has no live way to
+        validate whether /v1 is actually correct for an unknown remote host
+        the way the interactive setup's probe_api_models() does, so
+        guessing here risks corrupting a working non-standard endpoint."""
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-relay")
+        monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+        monkeypatch.setattr(
+            rp, "_get_named_custom_provider",
+            lambda p: {
+                "name": "my-relay",
+                "base_url": "https://relay.example.com",
+                "api_key": "sk-test",
+            },
+        )
+
+        resolved = rp.resolve_runtime_provider(requested="my-relay")
+
+        assert resolved["base_url"] == "https://relay.example.com", (
+            "Arbitrary remote custom endpoints must be left exactly as configured"
+        )
+
+    def test_already_versioned_local_url_left_unchanged(self, monkeypatch):
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+        monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+        resolved = rp.resolve_runtime_provider(
+            requested="custom", explicit_base_url="http://localhost:11434/v1"
+        )
+
+        assert resolved["base_url"] == "http://localhost:11434/v1"
+
+    def test_codex_backend_api_path_left_unchanged(self, monkeypatch):
+        """Never append /v1 to a Codex-style endpoint, even if it were
+        somehow local (defensive -- the /backend-api/codex suffix exclusion
+        must survive the narrowed local-only scope change)."""
+        from hermes_cli.runtime_provider import _append_v1_if_needed
+
+        result = _append_v1_if_needed(
+            "http://localhost:8080/backend-api/codex", "chat_completions"
+        )
+        assert result == "http://localhost:8080/backend-api/codex"
+
+    def test_non_chat_completions_mode_left_unchanged(self):
+        from hermes_cli.runtime_provider import _append_v1_if_needed
+
+        result = _append_v1_if_needed("http://localhost:11434", "anthropic_messages")
+        assert result == "http://localhost:11434"
+
+    def test_auto_provider_bare_local_url_gets_v1(self, monkeypatch):
+        """The 'auto' resolution path can label a local custom endpoint as
+        'openrouter' (its OpenAI-compat fallback) rather than literally
+        'custom' -- the wrapper must still normalize it since the gate is
+        on api_mode + URL pattern, not the provider label."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+        monkeypatch.setattr(
+            rp, "_get_model_config",
+            lambda: {
+                "default": "ollama/minimax-m2.7:cloud",
+                "provider": "auto",
+                "base_url": "http://localhost:11434",
+            },
+        )
+
+        resolved = rp.resolve_runtime_provider()
+
+        assert resolved["base_url"] == "http://localhost:11434/v1", resolved

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -3561,3 +3561,75 @@ class TestAppendV1AtResolverBoundary:
         resolved = rp.resolve_runtime_provider()
 
         assert resolved["base_url"] == "http://localhost:11434/v1", resolved
+
+    def test_remote_url_with_local_looking_port_not_rewritten(self, monkeypatch):
+        """Regression (review of #68695): the prior substring-search
+        implementation (`marker in normalized`) matched ':8080' anywhere in
+        the URL string, so a genuinely remote endpoint that happens to run
+        on a common local-dev port was incorrectly rewritten. Must now
+        parse the URL and check the exact hostname component."""
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+        monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+        resolved = rp.resolve_runtime_provider(
+            requested="custom", explicit_base_url="https://relay.example.test:8080",
+        )
+
+        assert resolved["base_url"] == "https://relay.example.test:8080", (
+            "A remote endpoint must not be rewritten just because it runs "
+            "on a port number that's also a common local-dev port"
+        )
+
+    def test_remote_url_with_localhost_in_path_not_rewritten(self, monkeypatch):
+        """Same regression, the other exact repro from review: 'localhost'
+        appearing in the URL's PATH (not its hostname) must not trigger
+        the local-server rewrite."""
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+        monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+        resolved = rp.resolve_runtime_provider(
+            requested="custom",
+            explicit_base_url="https://relay.example.test/path/localhost",
+        )
+
+        assert resolved["base_url"] == "https://relay.example.test/path/localhost", (
+            "'localhost' appearing in the URL path (not the hostname) must "
+            "not trigger the local-server rewrite"
+        )
+
+
+class TestAppendV1IfNeededHostnameParsing:
+    """Direct unit tests for _append_v1_if_needed()'s hostname parsing,
+    covering the exact false-positive cases identified in review of #68695
+    plus the genuine local-server cases that must still work."""
+
+    def test_remote_host_with_local_dev_port_unchanged(self):
+        result = rp._append_v1_if_needed(
+            "https://relay.example.test:8080", "chat_completions"
+        )
+        assert result == "https://relay.example.test:8080"
+
+    def test_remote_host_with_localhost_in_path_unchanged(self):
+        result = rp._append_v1_if_needed(
+            "https://relay.example.test/path/localhost", "chat_completions"
+        )
+        assert result == "https://relay.example.test/path/localhost"
+
+    def test_remote_host_with_localhost_in_query_unchanged(self):
+        result = rp._append_v1_if_needed(
+            "https://relay.example.test/api?redirect=localhost", "chat_completions"
+        )
+        assert result == "https://relay.example.test/api?redirect=localhost"
+
+    def test_genuine_localhost_still_gets_v1(self):
+        result = rp._append_v1_if_needed("http://localhost:11434", "chat_completions")
+        assert result == "http://localhost:11434/v1"
+
+    def test_genuine_loopback_ip_still_gets_v1(self):
+        result = rp._append_v1_if_needed("http://127.0.0.1:8080", "chat_completions")
+        assert result == "http://127.0.0.1:8080/v1"
+
+    def test_genuine_wildcard_bind_still_gets_v1(self):
+        result = rp._append_v1_if_needed("http://0.0.0.0:5000", "chat_completions")
+        assert result == "http://0.0.0.0:5000/v1"
+


### PR DESCRIPTION
## Context

Ports #63224 forward onto current main per @teknium1's review.

## Problem

A bare local-server URL like http://localhost:11434 (Ollama's default, without /v1) produces /chat/completions instead of /v1/chat/completions, returning a 404 (issue #4600).

## Fix

Per review, replaces the original single-function patch with:

1. **Single exit boundary**: `resolve_runtime_provider()` is now a thin wrapper around the renamed `_resolve_runtime_provider_impl()`, applying normalization once on every result -- covering named `custom_providers` entries, the direct `provider: custom` alias, and credential-pool results uniformly.
2. **Provider-label-agnostic gating**: gated on api_mode + URL pattern, not `provider == "custom"` -- the `auto` resolution path can label a local custom endpoint as `openrouter` (its OpenAI-compat fallback), which a provider-label check would have missed.
3. **Narrowed matching scope**: only touches URLs matching the same local-server pattern the interactive setup's "Add /v1?" prompt already uses, instead of unconditionally rewriting any unversioned custom URL -- since the resolver has no live-validation signal for an arbitrary remote endpoint the way the interactive probe does.

## Verification

Updated the one existing test whose assertion encoded the bug. Added resolver-level tests (not helper-only) covering direct-alias, named custom_providers, credential-pool, and auto-resolution paths, plus negative cases. 159/159 tests pass.