### PR TITLE
fix(xai): rediscover retired OAuth token endpoint

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4335,6 +4335,21 @@ def _xai_oauth_discovery(timeout_seconds: float = 15.0) -> Dict[str, str]:
     }
 
 
+def _xai_resolve_token_endpoint(token_endpoint: str, timeout_seconds: float) -> str:
+    """Resolve missing or retired xAI token endpoints through OIDC discovery."""
+    endpoint = token_endpoint.strip()
+    parsed = urlparse(endpoint)
+    uses_retired_endpoint = (
+        parsed.scheme == "https"
+        and parsed.netloc.lower() in {"auth.x.ai", "auth.x.ai:443"}
+        and parsed.path.rstrip("/") == "/oauth/token"
+    )
+    if not endpoint or uses_retired_endpoint:
+        endpoint = _xai_oauth_discovery(timeout_seconds)["token_endpoint"]
+    _xai_validate_oauth_endpoint(endpoint, field="token_endpoint")
+    return endpoint
+
+
 def refresh_xai_oauth_pure(
     access_token: str,
     refresh_token: str,
@@ -4350,13 +4365,12 @@ def refresh_xai_oauth_pure(
             code="xai_auth_missing_refresh_token",
             relogin_required=True,
         )
-    endpoint = token_endpoint.strip() or _xai_oauth_discovery(timeout_seconds)["token_endpoint"]
+    endpoint = _xai_resolve_token_endpoint(token_endpoint, timeout_seconds)
     # Re-validate cached endpoints on the refresh hot path: an auth.json
     # written by an older Hermes (or hand-edited) may carry a non-xAI
     # token_endpoint that would receive every future refresh_token in
     # plaintext if we trusted it blindly. Cheap suffix check; fast-fail
     # with a clear error so the user can re-run `hermes model` to refetch.
-    _xai_validate_oauth_endpoint(endpoint, field="token_endpoint")
     timeout = httpx.Timeout(max(5.0, float(timeout_seconds)))
     with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}) as client:
         response = client.post(
@@ -4512,8 +4526,10 @@ def resolve_xai_oauth_runtime_credentials(
             if (not should_refresh) and refresh_if_expiring:
                 should_refresh = _xai_access_token_is_expiring(access_token, effective_skew)
             if should_refresh:
-                if not token_endpoint:
-                    token_endpoint = _xai_oauth_discovery(refresh_timeout_seconds)["token_endpoint"]
+                token_endpoint = _xai_resolve_token_endpoint(
+                    token_endpoint,
+                    refresh_timeout_seconds,
+                )
                 try:
                     tokens = _refresh_xai_oauth_tokens(
                         tokens,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4868,6 +4868,24 @@ def _xai_oauth_discovery(timeout_seconds: float = 15.0) -> Dict[str, str]:
     }
 
 
+def _xai_resolve_token_endpoint(token_endpoint: str, timeout_seconds: float) -> str:
+    """Resolve missing or retired xAI token endpoints through OIDC discovery."""
+    endpoint = token_endpoint.strip()
+    parsed = urlparse(endpoint)
+    uses_retired_endpoint = (
+        parsed.scheme == "https"
+        and parsed.netloc.lower() in {"auth.x.ai", "auth.x.ai:443"}
+        and parsed.path in {"/oauth/token", "/oauth/token/"}
+        and not parsed.params
+        and not parsed.query
+        and not parsed.fragment
+    )
+    if not endpoint or uses_retired_endpoint:
+        endpoint = _xai_oauth_discovery(timeout_seconds)["token_endpoint"]
+    _xai_validate_oauth_endpoint(endpoint, field="token_endpoint")
+    return endpoint
+
+
 def refresh_xai_oauth_pure(
     access_token: str,
     refresh_token: str,
@@ -4883,13 +4901,12 @@ def refresh_xai_oauth_pure(
             code="xai_auth_missing_refresh_token",
             relogin_required=True,
         )
-    endpoint = token_endpoint.strip() or _xai_oauth_discovery(timeout_seconds)["token_endpoint"]
+    endpoint = _xai_resolve_token_endpoint(token_endpoint, timeout_seconds)
     # Re-validate cached endpoints on the refresh hot path: an auth.json
     # written by an older Hermes (or hand-edited) may carry a non-xAI
     # token_endpoint that would receive every future refresh_token in
     # plaintext if we trusted it blindly. Cheap suffix check; fast-fail
     # with a clear error so the user can re-run `hermes model` to refetch.
-    _xai_validate_oauth_endpoint(endpoint, field="token_endpoint")
     timeout = httpx.Timeout(max(5.0, float(timeout_seconds)))
     with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}) as client:
         response = client.post(
@@ -5048,8 +5065,10 @@ def resolve_xai_oauth_runtime_credentials(
             if (not should_refresh) and refresh_if_expiring:
                 should_refresh = _xai_access_token_is_expiring(access_token, effective_skew)
             if should_refresh:
-                if not token_endpoint:
-                    token_endpoint = _xai_oauth_discovery(refresh_timeout_seconds)["token_endpoint"]
+                token_endpoint = _xai_resolve_token_endpoint(
+                    token_endpoint,
+                    refresh_timeout_seconds,
+                )
                 try:
                     tokens = _refresh_xai_oauth_tokens(
                         tokens,

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -366,6 +366,45 @@ def test_resolve_xai_runtime_credentials_refreshes_expiring_token(tmp_path, monk
     assert creds["api_key"] == new_access
 
 
+def test_resolve_xai_runtime_credentials_rediscovers_retired_token_endpoint(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes"
+    expiring = _jwt_with_exp(int(time.time()) - 10)
+    auth_file = _setup_hermes_auth(
+        hermes_home,
+        access_token=expiring,
+        discovery={"token_endpoint": "https://auth.x.ai/oauth/token"},
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_discovery",
+        lambda _timeout: {
+            "authorization_endpoint": "https://auth.x.ai/oauth2/auth",
+            "token_endpoint": "https://auth.x.ai/oauth2/token",
+        },
+    )
+
+    new_access = _jwt_with_exp(int(time.time()) + 2 * 60 * 60)
+    holder = _patch_httpx_client(
+        monkeypatch,
+        _StubHTTPResponse(200, {"access_token": new_access, "refresh_token": "rt-new"}),
+    )
+
+    creds = resolve_xai_oauth_runtime_credentials()
+
+    assert creds["api_key"] == new_access
+    client = holder["client"]
+    assert client is not None
+    _method, args, _kwargs = client.last_call
+    assert args[0] == "https://auth.x.ai/oauth2/token"
+    persisted = json.loads(auth_file.read_text())
+    assert (
+        persisted["providers"]["xai-oauth"]["discovery"]["token_endpoint"]
+        == "https://auth.x.ai/oauth2/token"
+    )
+
+
 def test_resolve_xai_runtime_credentials_force_refresh(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     fresh = _jwt_with_exp(int(time.time()) + 2 * 60 * 60)
@@ -787,6 +826,33 @@ def test_refresh_xai_oauth_pure_returns_updated_tokens(monkeypatch):
     assert kwargs["data"]["grant_type"] == "refresh_token"
     assert kwargs["data"]["refresh_token"] == "rt-old"
     assert kwargs["data"]["client_id"] == XAI_OAUTH_CLIENT_ID
+
+
+def test_refresh_xai_oauth_pure_rediscovers_retired_token_endpoint(monkeypatch):
+    new_access = _jwt_with_exp(int(time.time()) + 2 * 60 * 60)
+    holder = _patch_httpx_client(
+        monkeypatch,
+        _StubHTTPResponse(200, {"access_token": new_access, "refresh_token": "rt-new"}),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_discovery",
+        lambda _timeout: {
+            "authorization_endpoint": "https://auth.x.ai/oauth2/auth",
+            "token_endpoint": "https://auth.x.ai/oauth2/token",
+        },
+    )
+
+    updated = refresh_xai_oauth_pure(
+        "at",
+        "rt-old",
+        token_endpoint="https://auth.x.ai/oauth/token",
+    )
+
+    assert updated["access_token"] == new_access
+    client = holder["client"]
+    assert client is not None
+    _method, args, _kwargs = client.last_call
+    assert args[0] == "https://auth.x.ai/oauth2/token"
 
 
 def test_refresh_xai_oauth_pure_keeps_refresh_token_when_response_omits_it(monkeypatch):

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -259,6 +259,45 @@ def test_resolve_xai_runtime_credentials_refreshes_expiring_token(tmp_path, monk
     assert creds["api_key"] == new_access
 
 
+def test_resolve_xai_runtime_credentials_rediscovers_retired_token_endpoint(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes"
+    expiring = _jwt_with_exp(int(time.time()) - 10)
+    auth_file = _setup_hermes_auth(
+        hermes_home,
+        access_token=expiring,
+        discovery={"token_endpoint": "https://auth.x.ai/oauth/token"},
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_discovery",
+        lambda _timeout: {
+            "authorization_endpoint": "https://auth.x.ai/oauth2/auth",
+            "token_endpoint": "https://auth.x.ai/oauth2/token",
+        },
+    )
+
+    new_access = _jwt_with_exp(int(time.time()) + 2 * 60 * 60)
+    holder = _patch_httpx_client(
+        monkeypatch,
+        _StubHTTPResponse(200, {"access_token": new_access, "refresh_token": "rt-new"}),
+    )
+
+    creds = resolve_xai_oauth_runtime_credentials()
+
+    assert creds["api_key"] == new_access
+    client = holder["client"]
+    assert client is not None
+    _method, args, _kwargs = client.last_call
+    assert args[0] == "https://auth.x.ai/oauth2/token"
+    persisted = json.loads(auth_file.read_text())
+    assert (
+        persisted["providers"]["xai-oauth"]["discovery"]["token_endpoint"]
+        == "https://auth.x.ai/oauth2/token"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Inference base-URL host guard (xai-oauth bearer leak protection)
 #
@@ -422,6 +461,45 @@ def test_format_auth_error_tier_denied_does_not_suggest_relogin():
     assert "re-authenticate" not in rendered.lower()
     assert "hermes model" not in rendered.lower()
     assert "XAI_API_KEY" in rendered
+
+
+def test_refresh_xai_oauth_pure_rediscovers_retired_token_endpoint(monkeypatch):
+    new_access = _jwt_with_exp(int(time.time()) + 2 * 60 * 60)
+    holder = _patch_httpx_client(
+        monkeypatch,
+        _StubHTTPResponse(200, {"access_token": new_access, "refresh_token": "rt-new"}),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_discovery",
+        lambda _timeout: {
+            "authorization_endpoint": "https://auth.x.ai/oauth2/auth",
+            "token_endpoint": "https://auth.x.ai/oauth2/token",
+        },
+    )
+
+    updated = refresh_xai_oauth_pure(
+        "at",
+        "rt-old",
+        token_endpoint="https://auth.x.ai/oauth/token",
+    )
+
+    assert updated["access_token"] == new_access
+    client = holder["client"]
+    assert client is not None
+    _method, args, _kwargs = client.last_call
+    assert args[0] == "https://auth.x.ai/oauth2/token"
+
+
+def test_xai_retired_endpoint_match_preserves_url_components(monkeypatch):
+    from hermes_cli.auth import _xai_resolve_token_endpoint
+
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_discovery",
+        lambda _timeout: pytest.fail("distinct endpoint must not trigger discovery"),
+    )
+    for suffix in ("//", ";tenant", "?audience=api", "#client"):
+        endpoint = f"https://auth.x.ai/oauth/token{suffix}"
+        assert _xai_resolve_token_endpoint(endpoint, 20.0) == endpoint
 
 
 def test_xai_oauth_discovery_raises_typed_error_on_malformed_json(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Prevents xAI OAuth refresh from remaining stuck on the retired `https://auth.x.ai/oauth/token` endpoint stored by older state.

The refresh path now reruns xAI OIDC discovery when that known retired path is encountered, uses the discovered endpoint, and passes the canonical value into the existing successful-refresh persistence path. Other valid xAI endpoints retain their current behavior, and discovery failures do not fall back to the retired URL.

## Related Issue

Fixes #68694

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Add focused resolution for the known retired xAI token endpoint.
- Apply the resolution in direct refresh and runtime credential refresh paths.
- Add regression coverage for request routing and canonical endpoint persistence.

## How to Test

1. Run `uv run --extra dev pytest tests/hermes_cli/test_auth_xai_oauth_provider.py -q`.
2. Run `uv run --extra dev ruff check hermes_cli/auth.py tests/hermes_cli/test_auth_xai_oauth_provider.py`.
3. Seed isolated auth state with `https://auth.x.ai/oauth/token`, force refresh, and verify the POST and persisted discovery state both use `https://auth.x.ai/oauth2/token`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: URL parsing and auth-state behavior are platform-independent
- [x] Tool descriptions/schemas update: N/A

## Screenshots / Logs

```text
75 passed in 5.14s
All checks passed!

OIDC discovery token_endpoint: https://auth.x.ai/oauth2/token
https://auth.x.ai/oauth/token  -> 403 text/html; charset=UTF-8
https://auth.x.ai/oauth2/token -> 400 application/json
```