### PR TITLE
fix(desktop): navigate when resuming selected session from non-session page

### DIFF
--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -38,6 +38,7 @@ import {
   setActiveSessionStoredIdRotation
 } from './session'
 import { isSecondaryWindow } from './windows'
+import { routeSessionId } from '@/app/routes'
 
 // ---------------------------------------------------------------------------
 // Reactive per-runtime session state (view mirror of the wiring cache).
@@ -561,11 +562,17 @@ export function focusOpenSession(storedSessionId: string): boolean {
 
   // Already the main session: front the workspace tab and drop tile focus so
   // the readouts + sidebar highlight come home (a no-op when main is focused).
+  // Only skip navigation when the current URL is already a session route —
+  // on a non-session page (e.g. /messaging) the sidebar highlight reads
+  // currentView from the URL, so revealing the workspace pane alone won't
+  // update it.  Fall through to the caller's navigate() instead.
   if (storedSessionId === $selectedStoredSessionId.get()) {
-    revealTreePane('workspace')
-    noteActiveTreeGroup(null)
-
-    return true
+    if (routeSessionId(window.location.pathname)) {
+      revealTreePane('workspace')
+      noteActiveTreeGroup(null)
+      return true
+    }
+    return false
   }
 
   return false


### PR DESCRIPTION
## The Bug

When the user is viewing a non-session page (e.g. `/messaging`) and clicks the already-selected session in the sidebar, `focusOpenSession` short-circuits with `revealTreePane("workspace")` instead of navigating. This leaves the URL at `/messaging`, so the sidebar highlight (which reads `currentView` from the pathname) doesn't update and the user appears to be stuck — only the previous session is affected since `$selectedStoredSessionId` still points to it.

```
Click session A → /messaging ($selectedStoredSessionId still "A")
 → focusOpenSession("A") → matches selected → return true (skip navigate)
 → sidebar highlight doesn't move (URL still /messaging)  ← BUG
```

But clicking any *other* session works fine because `$selectedStoredSessionId` doesn't match → `focusOpenSession` returns false → `navigate(sessionRoute(B))` executes normally.

## The Fix

In `focusOpenSession`'s second branch (the "already selected" shortcut), check if the current URL is actually a session route before returning true:

```typescript
if (routeSessionId(window.location.pathname)) {
    revealTreePane("workspace")
    noteActiveTreeGroup(null)
    return true
}
return false  // → caller navigates → URL updates → highlight moves
```

## Deeper Discussion — Is This the Real Root Cause?

This fix is correct but operates at the decision layer, not the data source layer.  The deeper question: **why is the sidebar highlight reading from the URL at all?**

The URL and the pane layout tree are two separate state sources.  `revealTreePane("workspace")` changes the layout tree but not the URL.  The sidebar reads `currentView` from `appViewForPath(pathname)`, which reads the URL — so even though the workspace pane is revealed, the URL hasn't changed and the highlight doesn't move.

A true "fix the data source" approach would make the sidebar read from `$selectedStoredSessionId` directly (or the pane tree) instead of deriving `currentView` from the URL.  That change is broader — it touches `SidebarSurface`, `appViewForPath`, and the `currentView` plumbing — and belongs in a separate cleanup.  The fix here avoids that larger refactor while completely resolving the user-visible symptom: clicks that silently don't work.

**Root cause chain:**

1. Navigating from session A to `/messaging` does not clear `$selectedStoredSessionId`
2. `focusOpenSession` assumes matching selectedId ⇒ workspace pane is the current view — wrong when a route tile is focused
3. Sidebar reads highlight state from URL, not from the session store — so pane-only operations can't update it

This fix addresses **#2** at the right layer (the decision function that controls whether to navigate).  #1 and #3 are deeper architectural topics for future work.