### PR TITLE
feat(dashboard): show role-specific skill count in profile cards

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -630,6 +630,12 @@ class ProfileInfo:
     provider: Optional[str] = None
     has_env: bool = False
     skill_count: int = 0
+    # Count of skills that are NOT byte-identical copies of the default
+    # profile's same-named skill -- i.e. actually role-specific rather than
+    # inherited from the bundled skill set every new profile is seeded with.
+    # Equal to skill_count when this IS the default profile, or when no
+    # comparison baseline is available (see _count_role_specific_skills).
+    role_specific_skill_count: int = 0
     alias_path: Optional[Path] = None
     # Custom alias name (the wrapper file name) when it differs from ``name``;
     # falls back to ``name`` when a profile-named wrapper exists. None if no
@@ -795,6 +801,85 @@ def _count_skills(profile_dir: Path) -> int:
     return count
 
 
+# In-process cache for role-specific skill counts. Keyed by a tuple of
+# (profile skills_dir, default skills_dir) since the result depends on
+# comparing against the default profile's tree, not just this profile's own.
+# Invalidated when EITHER tree's signature changes, or after the same TTL
+# used for _SKILL_COUNT_CACHE -- this comparison additionally reads every
+# SKILL.md's bytes (not just counting files), so an uncached scan across
+# ~270 default-profile skills is significantly more expensive than
+# _count_skills' plain rglob count.
+_ROLE_SPECIFIC_SKILL_COUNT_CACHE: dict[tuple[str, str], tuple[float, float, float, int]] = {}
+
+
+def _count_role_specific_skills(profile_dir: Path) -> int:
+    """Count skills in a profile that are NOT byte-identical copies of a
+    same-named skill in the default/global profile's skills/ directory.
+
+    ``hermes profile create`` seeds every new profile with the full bundled
+    skill set (documented behavior, see ``--no-skills``), so ``_count_skills``
+    alone reports the same total for every profile and gives no signal about
+    which skills are actually role-specific vs inherited (issue #49495).
+    This compares each profile skill's SKILL.md content against the default
+    profile's copy of the same skill name; a skill present only in this
+    profile, or whose content differs from the default profile's version,
+    counts as role-specific.
+
+    Cached by (profile skills-dir signature, default skills-dir signature) —
+    see ``_count_skills``'s cache for the rationale on why this must be
+    cached at all (uncached scans across the full default skill set are slow
+    enough to time out dashboard requests).
+    """
+    skills_dir = profile_dir / "skills"
+    if not skills_dir.is_dir():
+        return 0
+    try:
+        default_home = _get_default_hermes_home()
+    except Exception:
+        default_home = None
+    default_skills_dir = (default_home / "skills") if default_home else None
+
+    profile_sig = _skills_dir_signature(skills_dir)
+    default_sig = (
+        _skills_dir_signature(default_skills_dir)
+        if default_skills_dir and default_skills_dir.is_dir()
+        else 0.0
+    )
+    cache_key = (str(skills_dir), str(default_skills_dir) if default_skills_dir else "")
+    now = time.time()
+    cached = _ROLE_SPECIFIC_SKILL_COUNT_CACHE.get(cache_key)
+    if (
+        cached is not None
+        and cached[0] == profile_sig
+        and cached[1] == default_sig
+        and (now - cached[2]) < _SKILL_COUNT_TTL_SECONDS
+    ):
+        return cached[3]
+
+    count = 0
+    for md in skills_dir.rglob("SKILL.md"):
+        if is_excluded_skill_path(md):
+            continue
+        try:
+            rel = md.relative_to(skills_dir)
+        except ValueError:
+            count += 1
+            continue
+        if default_skills_dir is None or profile_dir.resolve() == default_home.resolve():
+            # This IS the default profile, or we can't resolve one to
+            # compare against — every skill here is "its own".
+            count += 1
+            continue
+        default_md = default_skills_dir / rel
+        try:
+            if not default_md.is_file() or default_md.read_bytes() != md.read_bytes():
+                count += 1
+        except OSError:
+            count += 1
+    _ROLE_SPECIFIC_SKILL_COUNT_CACHE[cache_key] = (profile_sig, default_sig, now, count)
+    return count
+
+
 # ---------------------------------------------------------------------------
 # profile.yaml — per-profile metadata (description, role, etc.)
 # ---------------------------------------------------------------------------
@@ -895,6 +980,7 @@ def list_profiles() -> List[ProfileInfo]:
             provider=provider,
             has_env=(default_home / ".env").exists(),
             skill_count=_count_skills(default_home),
+            role_specific_skill_count=_count_role_specific_skills(default_home),
             distribution_name=dist_name,
             distribution_version=dist_version,
             distribution_source=dist_source,
@@ -935,6 +1021,7 @@ def list_profiles() -> List[ProfileInfo]:
                 provider=provider,
                 has_env=(entry / ".env").exists(),
                 skill_count=_count_skills(entry),
+                role_specific_skill_count=_count_role_specific_skills(entry),
                 alias_path=alias_path if (alias_path and alias_path.exists()) else None,
                 alias_name=alias_name,
                 distribution_name=dist_name,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13060,6 +13060,9 @@ def _profile_to_dict(info) -> Dict[str, Any]:
         "provider": _profile_attr(info, "provider"),
         "has_env": bool(_profile_attr(info, "has_env", False)),
         "skill_count": int(_profile_attr(info, "skill_count", 0) or 0),
+        "role_specific_skill_count": int(
+            _profile_attr(info, "role_specific_skill_count", 0) or 0
+        ),
         "gateway_running": bool(_profile_attr(info, "gateway_running", False)),
         "description": _profile_attr(info, "description", "") or "",
         "description_auto": bool(_profile_attr(info, "description_auto", False)),
@@ -13089,6 +13092,9 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
             "provider": provider,
             "has_env": (default_home / ".env").exists(),
             "skill_count": _safe(lambda: profiles_mod._count_skills(default_home), 0),
+            "role_specific_skill_count": _safe(
+                lambda: profiles_mod._count_role_specific_skills(default_home), 0
+            ),
             "gateway_running": _safe(lambda: profiles_mod._check_gateway_running(default_home), False),
             "description": _safe(lambda: profiles_mod.read_profile_meta(default_home).get("description", ""), ""),
             "description_auto": _safe(lambda: profiles_mod.read_profile_meta(default_home).get("description_auto", False), False),
@@ -13112,6 +13118,9 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
                 "provider": provider,
                 "has_env": (entry / ".env").exists(),
                 "skill_count": _safe(lambda entry=entry: profiles_mod._count_skills(entry), 0),
+                "role_specific_skill_count": _safe(
+                    lambda entry=entry: profiles_mod._count_role_specific_skills(entry), 0
+                ),
                 "gateway_running": _safe(lambda entry=entry: profiles_mod._check_gateway_running(entry), False),
                 "description": _safe(lambda entry=entry: profiles_mod.read_profile_meta(entry).get("description", ""), ""),
                 "description_auto": _safe(lambda entry=entry: profiles_mod.read_profile_meta(entry).get("description_auto", False), False),

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -817,3 +817,160 @@ class TestProfilesToServe:
 
 
 
+    def test_on_no_named_profiles_returns_just_default(self, profile_env):
+        serve = profiles_to_serve(multiplex=True)
+        assert [n for n, _ in serve] == ["default"]
+
+
+class TestCountRoleSpecificSkills:
+    """Regression tests for issue #49495: hermes profile create seeds every
+    new profile with the full bundled skill set, so a plain skill_count gives
+    no signal about which skills are actually role-specific. These test
+    _count_role_specific_skills() directly (identical/missing/modified) and
+    the /api/profiles response shape (the actual gap flagged in review --
+    the field must reach _profile_to_dict, not just an internal fallback)."""
+
+    def _write_skill(self, base: Path, name: str, body: str) -> None:
+        skill_dir = base / "skills" / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(body)
+
+    def test_identical_skill_not_counted_as_role_specific(self, profile_env):
+        from hermes_cli.profiles import _count_role_specific_skills
+
+        default_home = profile_env / ".hermes"
+        self._write_skill(default_home, "pdf", "# PDF skill\nShared content.\n")
+        create_profile("librarian", no_alias=True)
+        profile_dir = get_profile_dir("librarian")
+        self._write_skill(profile_dir, "pdf", "# PDF skill\nShared content.\n")
+
+        assert _count_role_specific_skills(profile_dir) == 0
+
+    def test_modified_skill_counted_as_role_specific(self, profile_env):
+        from hermes_cli.profiles import _count_role_specific_skills
+
+        default_home = profile_env / ".hermes"
+        self._write_skill(default_home, "pdf", "# PDF skill\nShared content.\n")
+        create_profile("librarian", no_alias=True)
+        profile_dir = get_profile_dir("librarian")
+        self._write_skill(profile_dir, "pdf", "# PDF skill\nCUSTOMIZED for librarian.\n")
+
+        assert _count_role_specific_skills(profile_dir) == 1
+
+    def test_skill_missing_from_default_counted_as_role_specific(self, profile_env):
+        from hermes_cli.profiles import _count_role_specific_skills
+
+        default_home = profile_env / ".hermes"
+        default_home.mkdir(exist_ok=True)
+        create_profile("librarian", no_alias=True)
+        profile_dir = get_profile_dir("librarian")
+        self._write_skill(profile_dir, "library-catalog", "# Library-only skill\n")
+
+        assert _count_role_specific_skills(profile_dir) == 1
+
+    def test_mixed_skills_only_changed_ones_counted(self, profile_env):
+        from hermes_cli.profiles import _count_role_specific_skills
+
+        default_home = profile_env / ".hermes"
+        self._write_skill(default_home, "pdf", "shared\n")
+        self._write_skill(default_home, "web", "shared\n")
+        create_profile("librarian", no_alias=True)
+        profile_dir = get_profile_dir("librarian")
+        self._write_skill(profile_dir, "pdf", "shared\n")  # identical
+        self._write_skill(profile_dir, "web", "CHANGED\n")  # modified
+        self._write_skill(profile_dir, "library-only", "new\n")  # profile-only
+
+        assert _count_role_specific_skills(profile_dir) == 2
+
+    def test_default_profile_counts_every_skill_as_its_own(self, profile_env):
+        """The default profile has no baseline to compare against -- every
+        skill it has counts as role_specific == skill_count."""
+        from hermes_cli.profiles import _count_role_specific_skills, _count_skills
+
+        default_home = profile_env / ".hermes"
+        self._write_skill(default_home, "pdf", "shared\n")
+        self._write_skill(default_home, "web", "shared\n")
+
+        assert _count_role_specific_skills(default_home) == _count_skills(default_home) == 2
+
+    def test_no_skills_dir_returns_zero(self, profile_env):
+        from hermes_cli.profiles import _count_role_specific_skills
+
+        create_profile("empty-profile", no_alias=True)
+        profile_dir = get_profile_dir("empty-profile")
+        shutil.rmtree(profile_dir / "skills", ignore_errors=True)
+
+        assert _count_role_specific_skills(profile_dir) == 0
+
+    def test_cache_invalidates_when_profile_skill_changes(self, profile_env):
+        """Editing a skill's content after the first (cached) call must be
+        reflected once the skills-dir mtime signature changes."""
+        import time
+        from hermes_cli.profiles import _count_role_specific_skills
+
+        default_home = profile_env / ".hermes"
+        self._write_skill(default_home, "pdf", "shared\n")
+        create_profile("librarian", no_alias=True)
+        profile_dir = get_profile_dir("librarian")
+        self._write_skill(profile_dir, "pdf", "shared\n")
+
+        assert _count_role_specific_skills(profile_dir) == 0
+
+        # Modify the skill and bump the category dir's mtime so the cache
+        # signature changes (matches _skills_dir_signature's mtime check).
+        skill_dir = profile_dir / "skills" / "pdf"
+        self._write_skill(profile_dir, "pdf", "now different\n")
+        future = time.time() + 5
+        os.utime(skill_dir, (future, future))
+        os.utime(profile_dir / "skills", (future, future))
+
+        assert _count_role_specific_skills(profile_dir) == 1
+
+
+class TestProfileToDictRoleSpecificSkillCount:
+    """Regression (review of #49506): role_specific_skill_count must reach
+    the actual /api/profiles response shape -- both _profile_to_dict()
+    (the normal list_profiles() path) and _fallback_profile_dicts()
+    (the degraded-mode path) -- not just an internal dataclass field no
+    HTTP response ever reads."""
+
+    def _write_skill(self, base: Path, name: str, body: str) -> None:
+        skill_dir = base / "skills" / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(body)
+
+    def test_profile_to_dict_includes_role_specific_skill_count(self, profile_env):
+        """The actual gap flagged in review: the normal list_profiles() ->
+        _profile_to_dict() path must carry the field, not just the
+        fallback dict builder."""
+        from hermes_cli.web_server import _profile_to_dict
+
+        default_home = profile_env / ".hermes"
+        self._write_skill(default_home, "pdf", "shared\n")
+        create_profile("librarian", no_alias=True)
+        profile_dir = get_profile_dir("librarian")
+        self._write_skill(profile_dir, "pdf", "CUSTOM\n")
+
+        infos = list_profiles()
+        librarian_info = next(p for p in infos if p.name == "librarian")
+        d = _profile_to_dict(librarian_info)
+
+        assert "role_specific_skill_count" in d
+        assert d["role_specific_skill_count"] == 1
+        assert d["skill_count"] == 1
+
+    def test_fallback_profile_dicts_includes_role_specific_skill_count(self, profile_env):
+        from hermes_cli import profiles as profiles_mod
+        from hermes_cli.web_server import _fallback_profile_dicts
+
+        default_home = profile_env / ".hermes"
+        self._write_skill(default_home, "pdf", "shared\n")
+        create_profile("librarian", no_alias=True)
+        profile_dir = get_profile_dir("librarian")
+        self._write_skill(profile_dir, "pdf", "CUSTOM\n")
+
+        dicts = _fallback_profile_dicts(profiles_mod)
+        librarian_dict = next(d for d in dicts if d["name"] == "librarian")
+
+        assert "role_specific_skill_count" in librarian_dict
+        assert librarian_dict["role_specific_skill_count"] == 1

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2135,6 +2135,7 @@ export interface ProfileInfo {
   provider: string | null;
   has_env: boolean;
   skill_count: number;
+  role_specific_skill_count: number;
   gateway_running: boolean;
   description: string;
   description_auto: boolean;

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -1212,8 +1212,19 @@ export default function ProfilesPage() {
                           </span>
                         )}
 
-                        <span>
-                          {t.profiles.skills}: {p.skill_count}
+                        <span
+                          title={
+                            p.role_specific_skill_count != null &&
+                            p.role_specific_skill_count !== p.skill_count
+                              ? `${p.role_specific_skill_count} role-specific, ${p.skill_count} total (incl. inherited)`
+                              : undefined
+                          }
+                        >
+                          {t.profiles.skills}:{" "}
+                          {p.role_specific_skill_count != null &&
+                          p.role_specific_skill_count !== p.skill_count
+                            ? `${p.role_specific_skill_count} / ${p.skill_count}`
+                            : p.skill_count}
                         </span>
 
                         <span className="font-mono truncate">{p.path}</span>


### PR DESCRIPTION
## Context

Ports #49506 forward onto current main per @teknium1's review.

## Problem

hermes profile create seeds every new profile with the full bundled skill set, so the dashboard showed the same skill_count for every profile (issue #49495).

## Fix

Per review, fixes three real gaps in the original port:

1. **Threaded through the actual normal API path**: ProfileInfo dataclass, both list_profiles() construction sites, and _profile_to_dict() -- the original only added the field to _fallback_profile_dicts(), a degraded-mode path the normal response doesn't go through.
2. **Cached** _count_role_specific_skills() the same way _count_skills() already is, keyed by (profile signature, default signature). This comparison additionally reads every SKILL.md's bytes, so leaving it uncached would reproduce the multi-second dashboard timeout the existing cache was added to fix.
3. **Regression coverage**: identical/modified/profile-only skill cases, default-profile no-baseline case, cache invalidation, and tests asserting the actual API dict builders carry the field.

Frontend ported unchanged: renders "<role-specific> / <total>" with a tooltip when they differ.

## Verification

`npx tsc --noEmit` -- 0 errors. 9/9 new tests pass; 164/164 in the full `tests/hermes_cli/test_profiles.py` file.