### PR TITLE
fix(email): avoid double-decoding HTML entities

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -228,9 +228,10 @@ def _strip_html(html: str) -> str:
     text = re.sub(r"</p>", "\n", text, flags=re.IGNORECASE)
     text = re.sub(r"<[^>]+>", "", text)
     text = re.sub(r"&nbsp;", " ", text)
-    text = re.sub(r"&amp;", "&", text)
     text = re.sub(r"&lt;", "<", text)
     text = re.sub(r"&gt;", ">", text)
+    # Decode ampersands last so &amp;lt; remains literal &lt;, not markup-like text.
+    text = re.sub(r"&amp;", "&", text)
     text = re.sub(r"\n{3,}", "\n\n", text)
     return text.strip()
 

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -313,9 +313,10 @@ def _strip_html(html: str) -> str:
     text = re.sub(r"</p>", "\n", text, flags=re.IGNORECASE)
     text = re.sub(r"<[^>]+>", "", text)
     text = re.sub(r"&nbsp;", " ", text)
-    text = re.sub(r"&amp;", "&", text)
     text = re.sub(r"&lt;", "<", text)
     text = re.sub(r"&gt;", ">", text)
+    # Decode ampersands last so &amp;lt; remains literal &lt;, not markup-like text.
+    text = re.sub(r"&amp;", "&", text)
     text = re.sub(r"\n{3,}", "\n\n", text)
     return text.strip()
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -145,6 +145,12 @@ class TestHelperFunctions(unittest.TestCase):
         result = _strip_html(html)
         self.assertIn("a & b", result)
 
+    def test_strip_html_does_not_double_decode_entities(self):
+        from plugins.platforms.email.adapter import _strip_html
+        html = "The token is &amp;lt;APIKEY&amp;gt;"
+        result = _strip_html(html)
+        self.assertEqual(result, "The token is &lt;APIKEY&gt;")
+
 
 class TestExtractTextBody(unittest.TestCase):
     """Test email body extraction from different message formats."""

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -85,6 +85,14 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertNotIn("<p>", result)
         self.assertNotIn("<b>", result)
 
+    def test_strip_html_does_not_double_decode_entities(self):
+        from plugins.platforms.email.adapter import _strip_html
+
+        self.assertEqual(
+            _strip_html("The token is &amp;lt;APIKEY&amp;gt;"),
+            "The token is &lt;APIKEY&gt;",
+        )
+
 
 class TestExtractTextBody(unittest.TestCase):
     """Test email body extraction from different message formats."""


### PR DESCRIPTION
## What does this PR do?

Prevents the email HTML fallback from decoding two entity layers in one pass. Nested escaped text such as `&amp;lt;APIKEY&amp;gt;` now remains literal `&lt;APIKEY&gt;` instead of becoming `<APIKEY>`.

## Related Issue

Fixes #68704

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Decode `&lt;` and `&gt;` before `&amp;` in `plugins/platforms/email/adapter.py`.
- Add regression coverage for nested escaped entities in `tests/gateway/test_email.py`.

## How to Test

1. Run `pytest tests/gateway/test_email.py -q -k strip_html`.
2. Confirm all four HTML stripping tests pass.
3. Confirm `_strip_html("The token is &amp;lt;APIKEY&amp;gt;")` returns `The token is &lt;APIKEY&gt;`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Focused regression suite:

```text
4 passed, 85 deselected
```

Ruff passed for both touched files. A whole-file run reached one unrelated existing Windows environment failure in `TestConfigEnvOverrides.test_email_not_loaded_without_env`: clearing all environment variables makes `Path.home()` unable to resolve. The focused behavior covered by this PR passes.
