### PR TITLE
fix(gateway): wait for launchd bootout to settle before re-bootstrapping in deferred reload

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4129,11 +4129,29 @@ def refresh_launchd_plist_if_needed() -> bool:
         # gateway is still draining (default agent.restart_drain_timeout=180s),
         # so a fixed ~10s window is too short — bound by that budget instead.
         _reload_budget = int(max(30.0, _get_restart_drain_timeout()))
+        # Phase 1 below is load-bearing: after `bootout`, `launchctl list`
+        # keeps returning 0 for the OLD registration while the drained
+        # gateway is still tearing down (up to ExitTimeOut + SIGKILL). A
+        # bootstrap attempted in that window fails silently with EIO, and a
+        # success check against `launchctl list` "verifies" the stale
+        # registration — the helper then exits, launchd finishes the bootout,
+        # removes the service, and nothing re-bootstraps it (2026-07-21
+        # outage: gateway dark after `hermes update` + `hermes gateway start`
+        # from inside the gateway's own process tree). So: wait for the label
+        # to disappear first; only then does a `launchctl list` success prove
+        # a FRESH registration.
         reload_script = (
             f"sleep 2; "
             f"launchctl bootout {shlex.quote(target)} 2>/dev/null; "
-            f"sleep 1; "
             f"_deadline=$(($(date +%s) + {_reload_budget})); "
+            f"while launchctl list {shlex.quote(label)} >/dev/null 2>&1; do "
+            f"  if [ $(date +%s) -ge $_deadline ]; then "
+            f"    echo \"[$(date '+%Y-%m-%d %H:%M:%S %z')] old registration for {shlex.quote(target)} still present after {_reload_budget}s — bootstrapping anyway (verification may see the stale label)\" >> {shlex.quote(str(reload_log_path))}; "
+            f"    break; "
+            f"  fi; "
+            f"  sleep 2; "
+            f"done; "
+            f"_deadline=$(($(date +%s) + 60)); "
             f"while :; do "
             f"  launchctl bootstrap {shlex.quote(domain)} {shlex.quote(str(plist_path))} 2>/dev/null; "
             f"  if launchctl list {shlex.quote(label)} >/dev/null 2>&1; then break; fi; "
@@ -4142,7 +4160,7 @@ def refresh_launchd_plist_if_needed() -> bool:
             f"  sleep 2; "
             f"done; "
             f"if ! launchctl list {shlex.quote(label)} >/dev/null 2>&1; then "
-            f"  echo \"[$(date '+%Y-%m-%d %H:%M:%S %z')] FAILED launchd reload for {shlex.quote(target)} — service NOT registered after {_reload_budget}s of retries\" >> {shlex.quote(str(reload_log_path))}; "
+            f"  echo \"[$(date '+%Y-%m-%d %H:%M:%S %z')] FAILED launchd reload for {shlex.quote(target)} — service NOT registered after retries\" >> {shlex.quote(str(reload_log_path))}; "
             f"fi"
         )
         try:


### PR DESCRIPTION
## Problem

On macOS, a gateway self-update can leave the launchd service **unregistered**, so the gateway stays offline until someone manually runs `launchctl bootstrap`. `KeepAlive` can't help because launchd no longer knows about the job.

Reproduced deterministically on a production install (macOS 25.5.0, gateway serving Telegram):

1. The agent is asked (in chat) to update itself; it runs `hermes update` via its terminal tool — so the CLI is a child of the gateway process.
2. `hermes update` restarts the gateway via the SIGUSR1 self-restart path; the gateway begins draining.
3. The agent follows up with `hermes gateway start`. The update changed the generated plist, so `refresh_launchd_plist_if_needed()` fires. Since it's running inside the gateway's own process tree, it correctly defers to the detached bash helper (a direct bootout would kill the CLI mid-sequence, #43842).
4. The helper runs `launchctl bootout`, sleeps 1s, then loops `launchctl bootstrap` + verifies with `launchctl list <label>`.
5. **Bug:** the old gateway is still draining, so launchd hasn't finished the bootout — `launchctl list` still returns 0 for the *stale* registration. The `bootstrap` in that window fails silently with EIO, but the verification passes, so the helper breaks out of the loop and exits believing it succeeded. Nothing is written to `launchd-reload.log`.
6. The old gateway finishes exiting; launchd completes the bootout and removes the service. No process is left to re-bootstrap it. Gateway dark.

Incident timeline from the affected host (2026-07-21):

```
02:36:45  hermes update starts (child of gateway PID 5777)
02:37:19  gateway.log: "Stopping gateway for restart..." (SIGUSR1 drain begins)
02:37:44  agent runs `hermes gateway start` → plist rewritten → detached helper spawned
02:37:46  gateway.log: "Received SIGTERM" (launchd tearing down the job after helper's bootout)
02:37:4x  helper: bootstrap fails (EIO, job still tearing down); `launchctl list` passes
          against the stale registration → helper exits "successfully"
02:38:xx  old gateway exits; launchd removes the registration; service gone
next day  `launchctl print gui/<uid>/ai.hermes.gateway` → "Could not find service" 
```

## Fix

In the deferred-reload helper script: after `bootout`, **wait (bounded by the existing drain budget) for the label to disappear from launchd** before entering the bootstrap+verify loop. Once the old registration has been observed gone, a `launchctl list` success can only mean a *fresh* registration, making the verification sound. If the old registration never clears within the budget, the helper logs that verification may be unreliable instead of silently passing.

The bootstrap loop keeps its retry-with-verification behavior (a fresh 60s window after teardown settles), and all failure paths still append to `~/.hermes/logs/launchd-reload.log` for the watchdog to tail.

## Testing

- `pytest tests/hermes_cli/test_gateway_service.py -k "refresh or reload"` — 17 passed (existing assertions on the helper script contents still hold).
- Manually validated the failure mode and recovery on the affected host: booting out a draining gateway leaves `launchctl list` returning 0 until teardown completes, which is exactly the window the old verification raced against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
