### PR TITLE
fix(desktop): truncate cron text on Unicode boundaries

### DIFF
--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -66,7 +66,7 @@ import {
 import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
 
 import { cronEditorUpdates, jobIsScriptOnly, validateCronEditor } from './cron-job-model'
-import { jobState, jobTitle, STATE_DOT } from './job-state'
+import { jobState, jobTitle, STATE_DOT, truncateText } from './job-state'
 
 const DEFAULT_DELIVER = 'local'
 
@@ -96,7 +96,7 @@ const STATE_TONE: Record<string, PanelPillTone> = {
   completed: 'muted'
 }
 
-const truncate = (value: string, max = 80): string => (value.length > max ? `${value.slice(0, max)}…` : value)
+const truncate = (value: string, max = 80): string => truncateText(value, max)
 
 function jobName(job: CronJob): string {
   return asText(job.name).trim()

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -81,7 +81,7 @@ import {
   toggleCronDeliveryTarget,
   validateCronEditor
 } from './cron-job-model'
-import { jobState, jobTitle, STATE_DOT } from './job-state'
+import { jobState, jobTitle, STATE_DOT, truncateText } from './job-state'
 
 const DEFAULT_DELIVER = 'local'
 
@@ -113,7 +113,7 @@ const STATE_TONE: Record<string, PanelPillTone> = {
   completed: 'muted'
 }
 
-const truncate = (value: string, max = 80): string => (value.length > max ? `${value.slice(0, max)}…` : value)
+const truncate = (value: string, max = 80): string => truncateText(value, max)
 
 function jobName(job: CronJob): string {
   return asText(job.name).trim()

--- a/apps/desktop/src/app/cron/job-state.test.ts
+++ b/apps/desktop/src/app/cron/job-state.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { truncateText } from './job-state'
+
+describe('truncateText', () => {
+  it('truncates on Unicode code-point boundaries', () => {
+    const result = truncateText('😀😀😀😀', 3)
+
+    expect(result).toBe('😀😀😀…')
+    expect(Array.from(result)).toEqual(['😀', '😀', '😀', '…'])
+  })
+
+  it('does not add an ellipsis at the limit', () => {
+    expect(truncateText('😀😀😀', 3)).toBe('😀😀😀')
+  })
+})

--- a/apps/desktop/src/app/cron/job-state.ts
+++ b/apps/desktop/src/app/cron/job-state.ts
@@ -19,11 +19,16 @@ export function jobState(job: CronJob): string {
   return state || (job.enabled === false ? 'disabled' : 'scheduled')
 }
 
+export function truncateText(value: string, max: number): string {
+  const codePoints = Array.from(value)
+
+  return codePoints.length > max ? `${codePoints.slice(0, max).join('')}…` : value
+}
+
 // Human label for a job: name → first 60 of prompt → first 60 of script → id.
 // One source for the sidebar row and the Cron page so the two never drift.
 export function jobTitle(job: CronJob): string {
   const pick = (v: unknown) => (typeof v === 'string' ? v.trim() : '')
-  const clip = (v: string) => (v.length > 60 ? `${v.slice(0, 60)}…` : v)
 
-  return pick(job.name) || clip(pick(job.prompt)) || clip(pick(job.script)) || job.id || 'Cron job'
+  return pick(job.name) || truncateText(pick(job.prompt), 60) || truncateText(pick(job.script), 60) || job.id || 'Cron job'
 }


### PR DESCRIPTION
## What does this PR do?

Makes desktop cron label truncation Unicode-safe. Both the page preview and `jobTitle()` now truncate by complete code points instead of UTF-16 code units, so an emoji or another surrogate-pair character cannot be split at the boundary.

## Related Issue

Fixes #68709

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Add a shared `truncateText()` helper in `apps/desktop/src/app/cron/job-state.ts`.
- Reuse the helper for the cron page preview and prompt/script title fallbacks.
- Add focused regression tests for emoji truncation and the exact-limit case.

## How to Test

1. Run `pnpm --dir apps/desktop exec vitest run src/app/cron/job-state.test.ts`.
2. Confirm both tests pass.
3. Create a cron prompt containing emoji across the 60- or 80-character boundary and confirm the label contains only complete characters followed by an ellipsis.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (desktop TypeScript-only change)
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

```text
Test Files  1 passed (1)
Tests       2 passed (2)
```

ESLint passed for all three touched files. A full desktop typecheck was also attempted; the shared local dependency tree produced duplicate React type declarations across many untouched files, so it was not usable as a signal for this focused change.
