### PR TITLE
fix(memory): exclude synthetic delegation completions from retention

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -24,6 +24,7 @@ from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
 
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
+from agent.turn_provenance import TurnProvenance, should_retain_turn_memory
 
 logger = logging.getLogger(__name__)
 
@@ -620,6 +621,7 @@ def run_codex_app_server_turn(
     messages: List[Dict[str, Any]],
     effective_task_id: str,
     should_review_memory: bool = False,
+    turn_provenance: TurnProvenance | None = None,
 ) -> Dict[str, Any]:
     """Codex app-server runtime path. Hands the entire turn to a `codex
     app-server` subprocess and projects its events back into Hermes'
@@ -792,6 +794,7 @@ def run_codex_app_server_turn(
                 final_response=turn.final_text,
                 interrupted=False,
                 messages=messages,
+                turn_provenance=turn_provenance,
             )
         except Exception:
             logger.debug("external memory sync raised", exc_info=True)
@@ -802,12 +805,17 @@ def run_codex_app_server_turn(
     if (
         turn.final_text
         and not turn.interrupted
-        and (should_review_memory or should_review_skills)
+        and (
+            (should_retain_turn_memory(turn_provenance) and should_review_memory)
+            or should_review_skills
+        )
     ):
         try:
             agent._spawn_background_review(
                 messages_snapshot=list(messages),
-                review_memory=should_review_memory,
+                review_memory=(
+                    should_retain_turn_memory(turn_provenance) and should_review_memory
+                ),
                 review_skills=should_review_skills,
             )
         except Exception:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -37,6 +37,7 @@ from agent.turn_context import (
     compose_user_api_content,
     reanchor_current_turn_user_idx,
 )
+from agent.turn_provenance import TurnProvenance
 from agent.turn_retry_state import TurnRetryState
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
@@ -595,6 +596,7 @@ def run_conversation(
     persist_user_message: Optional[Any] = None,
     persist_user_timestamp: Optional[float] = None,
     moa_config: Optional[dict[str, Any]] = None,
+    turn_provenance: Optional[TurnProvenance] = None,
 ) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
@@ -612,7 +614,8 @@ def run_conversation(
             synthetic prefixes.
         persist_user_timestamp: Optional platform event timestamp to store
             as metadata on that persisted user message.
-                or queuing follow-up prefetch work.
+        turn_provenance: Optional semantic turn origin used to control
+            automatic memory retention for synthetic turns.
 
     Returns:
         Dict: Complete conversation result with final response and message history
@@ -647,6 +650,7 @@ def run_conversation(
         stream_callback,
         persist_user_message,
         persist_user_timestamp,
+        turn_provenance,
         restore_or_build_system_prompt=_restore_or_build_system_prompt,
         install_safe_stdio=_install_safe_stdio,
         sanitize_surrogates=_sanitize_surrogates,
@@ -666,6 +670,7 @@ def run_conversation(
     effective_task_id = _ctx.effective_task_id
     turn_id = _ctx.turn_id
     current_turn_user_idx = _ctx.current_turn_user_idx
+    turn_provenance = _ctx.turn_provenance
     _should_review_memory = _ctx.should_review_memory
     _plugin_user_context = _ctx.plugin_user_context
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
@@ -716,6 +721,7 @@ def run_conversation(
             messages=messages,
             effective_task_id=effective_task_id,
             should_review_memory=_should_review_memory,
+            turn_provenance=turn_provenance,
         )
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
@@ -5794,6 +5800,7 @@ def run_conversation(
         user_message=user_message,
         original_user_message=original_user_message,
         _should_review_memory=_should_review_memory,
+        turn_provenance=turn_provenance,
         _turn_exit_reason=_turn_exit_reason,
         _pending_verification_response=_pending_verification_response,
         _pending_verification_response_previewed=_pending_verification_response_previewed,

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -1007,9 +1007,10 @@ class MemoryManager:
         summary prompt. Empty string if no provider contributes.
         """
         parts = []
+        safe_messages = memory_safe_session_messages(messages)
         for provider in self._providers:
             try:
-                result = provider.on_pre_compress(messages)
+                result = provider.on_pre_compress(safe_messages)
                 if result and result.strip():
                     parts.append(result)
             except Exception as e:

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -35,6 +35,11 @@ from typing import Any, Callable, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
 from agent.skill_commands import extract_user_instruction_from_skill_message
+from agent.turn_provenance import (
+    TURN_MEMORY_DISPOSITION_KEY,
+    TurnMemoryDisposition,
+    get_message_turn_memory_disposition,
+)
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
@@ -351,6 +356,35 @@ def build_memory_context_block(raw_context: str) -> str:
     )
 
 
+def memory_safe_session_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return a memory-safe transcript view without non-retained turns."""
+
+    filtered: list[Dict[str, Any]] = []
+    skipping_turn = False
+    for msg in list(messages or []):
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role == "user":
+            skipping_turn = (
+                get_message_turn_memory_disposition(msg)
+                == TurnMemoryDisposition.DO_NOT_RETAIN
+            )
+            if skipping_turn:
+                continue
+        elif skipping_turn and role in {"assistant", "tool"}:
+            continue
+        elif skipping_turn:
+            # A malformed/legacy sequence may contain a system or other
+            # non-turn message before the next user turn. Preserve it rather
+            # than extending the excluded turn across unrelated history.
+            skipping_turn = False
+        safe_msg = dict(msg)
+        safe_msg.pop(TURN_MEMORY_DISPOSITION_KEY, None)
+        filtered.append(safe_msg)
+    return filtered
+
+
 class MemoryManager:
     """Orchestrates the built-in provider plus at most one external provider.
 
@@ -654,6 +688,10 @@ class MemoryManager:
         if not providers:
             return
 
+        safe_messages = (
+            memory_safe_session_messages(messages) if messages is not None else None
+        )
+
         clean_user_content = self._strip_skill_scaffolding(user_content)
         if not clean_user_content:
             return
@@ -662,12 +700,12 @@ class MemoryManager:
         def _run() -> None:
             for provider in providers:
                 try:
-                    if messages is not None and self._provider_sync_accepts_messages(provider):
+                    if safe_messages is not None and self._provider_sync_accepts_messages(provider):
                         provider.sync_turn(
                             user_content,
                             assistant_content,
                             session_id=session_id,
-                            messages=messages,
+                            messages=safe_messages,
                         )
                     else:
                         provider.sync_turn(
@@ -854,9 +892,10 @@ class MemoryManager:
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Notify all providers of session end."""
+        safe_messages = memory_safe_session_messages(messages)
         for provider in self._providers:
             try:
-                provider.on_session_end(messages)
+                provider.on_session_end(safe_messages)
             except Exception as e:
                 logger.warning(
                     "Memory provider '%s' on_session_end failed: %s",

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -37,6 +37,12 @@ from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
 )
+from agent.turn_provenance import (
+    TurnProvenance,
+    normalize_turn_provenance,
+    should_retain_turn_memory,
+    stamp_turn_provenance,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -257,6 +263,8 @@ class TurnContext:
     turn_id: str
     # Index of the current user turn within ``messages``.
     current_turn_user_idx: int
+    # Semantic provenance of the current turn at the memory boundary.
+    turn_provenance: TurnProvenance
     # Whether the post-turn memory review should fire.
     should_review_memory: bool = False
     # Context contributed by ``pre_llm_call`` plugins (appended to user message).
@@ -274,6 +282,7 @@ def build_turn_context(
     stream_callback,
     persist_user_message: Optional[Any],
     persist_user_timestamp: Optional[float] = None,
+    turn_provenance: Optional[TurnProvenance] = None,
     *,
     restore_or_build_system_prompt,
     install_safe_stdio,
@@ -292,6 +301,7 @@ def build_turn_context(
     """
     # Guard stdio against OSError from broken pipes (systemd/headless/daemon).
     install_safe_stdio()
+    turn_provenance = normalize_turn_provenance(turn_provenance)
 
     # NOTE: the DB session row is created later, AFTER the system prompt is
     # restored/built (see _ensure_db_session() below the system-prompt block).
@@ -450,6 +460,7 @@ def build_turn_context(
         user_msg = {"role": "user", "content": user_message}
         if isinstance(pending_cli_message, dict):
             agent._pending_cli_user_message = None
+    stamp_turn_provenance(user_msg, turn_provenance)
 
     # Hydrate todo store from conversation history.
     if conversation_history and not agent._todo_store.has_items():
@@ -492,9 +503,12 @@ def build_turn_context(
 
     # Track memory nudge trigger (turn-based, checked here).
     should_review_memory = False
-    if (agent._memory_nudge_interval > 0
-            and "memory" in agent.valid_tool_names
-            and agent._memory_store):
+    if (
+        should_retain_turn_memory(turn_provenance)
+        and agent._memory_nudge_interval > 0
+        and "memory" in agent.valid_tool_names
+        and agent._memory_store
+    ):
         agent._turns_since_memory += 1
         if agent._turns_since_memory >= agent._memory_nudge_interval:
             should_review_memory = True
@@ -792,7 +806,9 @@ def build_turn_context(
         except Exception:
             pass
 
-    # External memory provider: prefetch once before the tool loop.
+    # Recall is independent of retention: synthetic completion turns should
+    # see the same current context as ordinary turns. Only the post-turn
+    # persistence/prefetch path is gated by provenance in the finalizer.
     ext_prefetch_cache = ""
     if agent._memory_manager:
         try:
@@ -896,6 +912,7 @@ def build_turn_context(
         effective_task_id=effective_task_id,
         turn_id=turn_id,
         current_turn_user_idx=current_turn_user_idx,
+        turn_provenance=turn_provenance,
         should_review_memory=should_review_memory,
         plugin_user_context=plugin_user_context,
         ext_prefetch_cache=ext_prefetch_cache,

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -26,6 +26,7 @@ import os
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.message_content import flatten_message_text
+from agent.turn_provenance import TurnProvenance, should_retain_turn_memory
 
 
 def _is_pure_tool_call_tail(msg: dict) -> bool:
@@ -81,6 +82,7 @@ def finalize_turn(
     original_user_message,
     _should_review_memory,
     _turn_exit_reason,
+    turn_provenance: TurnProvenance | None = None,
     _pending_verification_response=None,
     _pending_verification_response_previewed=False,
 ):
@@ -586,15 +588,25 @@ def finalize_turn(
         final_response=final_response,
         interrupted=interrupted,
         messages=messages,
+        turn_provenance=turn_provenance,
     )
 
     # Background memory/skill review — runs AFTER the response is delivered
     # so it never competes with the user's task for model attention.
-    if final_response and not interrupted and (_should_review_memory or _should_review_skills):
+    if (
+        final_response
+        and not interrupted
+        and (
+            (should_retain_turn_memory(turn_provenance) and _should_review_memory)
+            or _should_review_skills
+        )
+    ):
         try:
             agent._spawn_background_review(
                 messages_snapshot=list(messages),
-                review_memory=_should_review_memory,
+                review_memory=(
+                    should_retain_turn_memory(turn_provenance) and _should_review_memory
+                ),
                 review_skills=_should_review_skills,
             )
         except Exception:

--- a/agent/turn_provenance.py
+++ b/agent/turn_provenance.py
@@ -1,0 +1,67 @@
+"""Per-turn provenance and automatic-memory retention policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+TURN_MEMORY_DISPOSITION_KEY = "_turn_memory_disposition"
+
+
+class TurnMemoryDisposition(str, Enum):
+    """Automatic-memory retention policy for one user turn."""
+
+    RETAIN = "retain"
+    DO_NOT_RETAIN = "do_not_retain"
+
+
+@dataclass(frozen=True)
+class TurnProvenance:
+    """Semantic origin of a user turn at the shared memory boundary."""
+
+    kind: str
+    memory_disposition: TurnMemoryDisposition = TurnMemoryDisposition.RETAIN
+
+
+NORMAL_USER_TURN = TurnProvenance(kind="user")
+ASYNC_DELEGATION_COMPLETION_TURN = TurnProvenance(
+    kind="async_delegation_completion",
+    memory_disposition=TurnMemoryDisposition.DO_NOT_RETAIN,
+)
+
+
+def normalize_turn_provenance(value: TurnProvenance | None) -> TurnProvenance:
+    """Return the effective provenance for a turn."""
+
+    return value if isinstance(value, TurnProvenance) else NORMAL_USER_TURN
+
+
+def should_retain_turn_memory(value: TurnProvenance | None) -> bool:
+    """Return whether automatic memory retention is enabled for the turn."""
+
+    return (
+        normalize_turn_provenance(value).memory_disposition
+        == TurnMemoryDisposition.RETAIN
+    )
+
+
+def stamp_turn_provenance(message: dict[str, Any], value: TurnProvenance | None) -> dict[str, Any]:
+    """Stamp the internal per-turn memory marker onto a message dict."""
+
+    disposition = normalize_turn_provenance(value).memory_disposition
+    if disposition == TurnMemoryDisposition.RETAIN:
+        message.pop(TURN_MEMORY_DISPOSITION_KEY, None)
+        return message
+    message[TURN_MEMORY_DISPOSITION_KEY] = disposition.value
+    return message
+
+
+def get_message_turn_memory_disposition(message: dict[str, Any] | None) -> TurnMemoryDisposition:
+    """Return a message's retention policy, defaulting legacy rows to retain."""
+
+    raw = (message or {}).get(TURN_MEMORY_DISPOSITION_KEY)
+    if raw == TurnMemoryDisposition.DO_NOT_RETAIN.value:
+        return TurnMemoryDisposition.DO_NOT_RETAIN
+    return TurnMemoryDisposition.RETAIN

--- a/cli.py
+++ b/cli.py
@@ -9464,7 +9464,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             claim = claim_event_delivery(event, consumer)
             if claim is None:
                 continue
-            self._pending_input.put(synthetic_message)
+            if event.get("type") == "async_delegation":
+                from agent.turn_provenance import ASYNC_DELEGATION_COMPLETION_TURN
+
+                self._pending_input.put(
+                    {
+                        "text": synthetic_message,
+                        "turn_provenance": ASYNC_DELEGATION_COMPLETION_TURN,
+                    }
+                )
+            else:
+                self._pending_input.put(synthetic_message)
             complete_event_delivery(event, claim)
 
     def _drain_interrupt_queue_to_pending_input(self) -> None:
@@ -11790,7 +11800,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             except Exception:
                 pass
 
-    def chat(self, message, images: list = None) -> Optional[str]:
+    def chat(self, message, images: list = None, turn_provenance=None) -> Optional[str]:
         """
         Send a message to the agent and get a response.
         
@@ -11945,6 +11955,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             agent._persist_user_message_override = None
             agent._persist_user_message_timestamp = None
             staged_user_message = {"role": "user", "content": message}
+            from agent.turn_provenance import stamp_turn_provenance
+
+            stamp_turn_provenance(staged_user_message, turn_provenance)
             agent._pending_cli_user_message = staged_user_message
             self.conversation_history.append(staged_user_message)
 
@@ -12108,6 +12121,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         task_id=self.session_id,
                         persist_user_message=_persist_clean_user_message,
                         moa_config=_moa_cfg,
+                        turn_provenance=turn_provenance,
                     )
                     if getattr(self, "_pending_moa_disable_after_turn", False):
                         _restore = getattr(self, "_pending_moa_restore_model", None) or {}
@@ -15021,6 +15035,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
                     # Unpack image payload: (text, [Path, ...]) or plain str
                     submit_images = []
+                    turn_provenance = None
+                    if isinstance(user_input, dict) and "text" in user_input:
+                        turn_provenance = user_input.get("turn_provenance")
+                        submit_images = list(user_input.get("images") or [])
+                        user_input = user_input.get("text")
                     if isinstance(user_input, tuple):
                         user_input, submit_images = user_input
 
@@ -15105,7 +15124,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     app.invalidate()  # Refresh status line
 
                     try:
-                        self.chat(user_input, images=submit_images or None)
+                        self.chat(
+                            user_input,
+                            images=submit_images or None,
+                            turn_provenance=turn_provenance,
+                        )
                     finally:
                         self._agent_running = False
                         self._spinner_text = ""

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -492,7 +492,10 @@ import dataclasses
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union
+
+if TYPE_CHECKING:
+    from agent.turn_provenance import TurnProvenance
 from enum import Enum
 
 from pathlib import Path as _Path
@@ -1811,6 +1814,11 @@ class MessageEvent:
     # Internal flag — set for synthetic events (e.g. background process
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
+
+    # Semantic turn origin at the shared memory boundary. Distinct from
+    # ``internal``: internal controls routing/authorization bypass, while this
+    # governs how the resulting turn should behave for memory retention.
+    turn_provenance: Optional["TurnProvenance"] = None
 
     # Free-form per-event metadata.  Adapters may set platform-specific
     # signals here (e.g. WhatsApp sets ``whatsapp_from_owner=True`` when

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12953,6 +12953,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                turn_provenance=event.turn_provenance,
             )
 
             # Stop persistent typing indicator now that the agent is done.
@@ -16907,15 +16908,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return None
         try:
             metadata = {}
+            turn_provenance = None
             parent_session_id = str(evt.get("parent_session_id") or "").strip()
             if parent_session_id:
                 metadata["gateway_session_id"] = parent_session_id
+            if evt.get("type") == "async_delegation":
+                from agent.turn_provenance import ASYNC_DELEGATION_COMPLETION_TURN
+
+                turn_provenance = ASYNC_DELEGATION_COMPLETION_TURN
             synth_event = MessageEvent(
                 text=synth_text,
                 message_type=MessageType.TEXT,
                 source=source,
                 internal=True,
                 message_id=str(evt.get("message_id") or "").strip() or None,
+                turn_provenance=turn_provenance,
                 metadata=metadata,
             )
             logger.info(
@@ -18783,6 +18790,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        turn_provenance: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -18801,6 +18809,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                turn_provenance=turn_provenance,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -18812,6 +18821,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                turn_provenance=turn_provenance,
             )
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
@@ -18933,6 +18943,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        turn_provenance: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -20948,6 +20959,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _conversation_kwargs["moa_config"] = moa_config
                 if _persist_user_timestamp_override is not None:
                     _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
+                if turn_provenance is not None:
+                    _conversation_kwargs["turn_provenance"] = turn_provenance
                 result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
             finally:
                 unregister_gateway_notify(_approval_session_key)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -56,6 +56,7 @@ from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
+from agent.turn_provenance import stamp_turn_provenance
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
@@ -13380,6 +13381,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 }
                 if event.message_id:
                     _user_entry["message_id"] = str(event.message_id)
+                stamp_turn_provenance(_user_entry, event.turn_provenance)
                 # Dedupe: skip if this platform message_id is already in the
                 # transcript (prevents duplicate user turns on Telegram retries
                 # after transient failures). #47237
@@ -13422,6 +13424,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     }
                     if event.message_id:
                         _user_entry["message_id"] = str(event.message_id)
+                    stamp_turn_provenance(_user_entry, event.turn_provenance)
                     await self.async_session_store.append_to_transcript(
                         session_entry.session_id,
                         _user_entry,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -20,6 +20,8 @@ from datetime import datetime, timedelta
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Any
 
+from agent.turn_provenance import TURN_MEMORY_DISPOSITION_KEY
+
 logger = logging.getLogger(__name__)
 
 
@@ -2593,6 +2595,7 @@ class SessionStore:
             platform_message_id=(message.get("platform_message_id") or message.get("message_id")),
             observed=bool(message.get("observed")),
             timestamp=message.get("timestamp"),
+            turn_memory_disposition=message.get(TURN_MEMORY_DISPOSITION_KEY),
             # api_content sidecar: the exact bytes sent to the API for
             # this message (prompt-cache-stable replay). Must survive
             # any gateway-side persistence path or the next turn's

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -91,6 +91,7 @@ from gateway.status import (
     parse_active_agents,
     read_runtime_status,
 )
+from agent.turn_provenance import TURN_MEMORY_DISPOSITION_KEY
 from utils import env_var_enabled
 
 try:
@@ -10983,6 +10984,14 @@ async def get_session_messages(
     if result is None:
         raise HTTPException(status_code=404, detail="Session not found")
     sid, _limit, messages = result
+    messages = [
+        {
+            key: value
+            for key, value in message.items()
+            if key != TURN_MEMORY_DISPOSITION_KEY
+        }
+        for message in messages
+    ]
     return {
         "session_id": sid,
         "messages": messages,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 from agent.memory_manager import sanitize_context
 from agent.message_sanitization import _sanitize_surrogates
+from agent.turn_provenance import TURN_MEMORY_DISPOSITION_KEY
 from hermes_constants import get_hermes_home
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
@@ -152,7 +153,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 22
+SCHEMA_VERSION = 23
 
 # Cap on user-controlled FTS5 query input before regex/sanitizer processing.
 # Search queries do not need to be arbitrarily large, and bounding them keeps
@@ -818,6 +819,7 @@ CREATE TABLE IF NOT EXISTS messages (
     tool_calls TEXT,
     tool_name TEXT,
     effect_disposition TEXT,
+    turn_memory_disposition TEXT,
     timestamp REAL NOT NULL,
     token_count INTEGER,
     finish_reason TEXT,
@@ -4167,6 +4169,7 @@ class SessionDB:
         platform_message_id: str = None,
         observed: bool = False,
         effect_disposition: Optional[str] = None,
+        turn_memory_disposition: Optional[str] = None,
         timestamp: Any = None,
         api_content: Optional[str] = None,
     ) -> int:
@@ -4226,10 +4229,10 @@ class SessionDB:
         def _do(conn):
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
-                   tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
+                   tool_calls, tool_name, effect_disposition, turn_memory_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
                    codex_message_items, platform_message_id, observed, active, api_content)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -4238,6 +4241,7 @@ class SessionDB:
                     tool_calls_json,
                     _scrub_surrogates(tool_name),
                     effect_disposition,
+                    turn_memory_disposition,
                     message_timestamp,
                     token_count,
                     finish_reason,
@@ -4322,10 +4326,10 @@ class SessionDB:
 
             conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
-                   tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
+                   tool_calls, tool_name, effect_disposition, turn_memory_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
                    codex_message_items, platform_message_id, observed, active, api_content)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -4334,6 +4338,7 @@ class SessionDB:
                     tool_calls_json,
                     _scrub_surrogates(msg.get("tool_name")),
                     msg.get("effect_disposition"),
+                    msg.get(TURN_MEMORY_DISPOSITION_KEY),
                     message_timestamp,
                     msg.get("token_count"),
                     msg.get("finish_reason"),
@@ -4502,6 +4507,16 @@ class SessionDB:
 
         return self._execute_write(_do)
 
+    @staticmethod
+    def _restore_internal_message_metadata(msg: Dict[str, Any]) -> Dict[str, Any]:
+        """Map durable internal columns back onto the in-memory message shape."""
+
+        disposition = msg.pop("turn_memory_disposition", None)
+        if disposition:
+            msg[TURN_MEMORY_DISPOSITION_KEY] = disposition
+        return msg
+
+
     def get_messages(
         self,
         session_id: str,
@@ -4541,6 +4556,7 @@ class SessionDB:
         result = []
         for row in rows:
             msg = dict(row)
+            self._restore_internal_message_metadata(msg)
             if "content" in msg:
                 msg["content"] = self._decode_content(msg["content"])
             if msg.get("tool_calls"):
@@ -4608,6 +4624,7 @@ class SessionDB:
         result = []
         for row in rows:
             msg = dict(row)
+            self._restore_internal_message_metadata(msg)
             if "content" in msg:
                 msg["content"] = self._decode_content(msg["content"])
             if msg.get("tool_calls"):
@@ -4872,7 +4889,7 @@ class SessionDB:
         with self._lock:
             placeholders = ",".join("?" for _ in session_ids)
             rows = self._conn.execute(
-                "SELECT role, content, tool_call_id, tool_calls, tool_name, effect_disposition, "
+                "SELECT role, content, tool_call_id, tool_calls, tool_name, effect_disposition, turn_memory_disposition, "
                 "finish_reason, reasoning, reasoning_content, reasoning_details, "
                 "codex_reasoning_items, codex_message_items, platform_message_id, observed, timestamp, "
                 "api_content "
@@ -4900,7 +4917,7 @@ class SessionDB:
     # get_messages_as_conversation and get_resume_conversations so a single
     # SELECT can feed both the model-fed and display views.
     _CONVERSATION_ROW_COLUMNS = (
-        "role, content, tool_call_id, tool_calls, tool_name, effect_disposition, "
+        "role, content, tool_call_id, tool_calls, tool_name, effect_disposition, turn_memory_disposition, "
         "finish_reason, reasoning, reasoning_content, reasoning_details, "
         "codex_reasoning_items, codex_message_items, platform_message_id, observed, timestamp, "
         "api_content"
@@ -4943,6 +4960,8 @@ class SessionDB:
                 msg["tool_name"] = row["tool_name"]
             if row["effect_disposition"]:
                 msg["effect_disposition"] = row["effect_disposition"]
+            if row["turn_memory_disposition"]:
+                msg[TURN_MEMORY_DISPOSITION_KEY] = row["turn_memory_disposition"]
             if row["tool_calls"]:
                 try:
                     msg["tool_calls"] = json.loads(row["tool_calls"])

--- a/run_agent.py
+++ b/run_agent.py
@@ -62,6 +62,7 @@ from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 
+from agent.turn_provenance import TurnProvenance, TURN_MEMORY_DISPOSITION_KEY, should_retain_turn_memory
 from hermes_constants import get_hermes_home
 
 
@@ -2038,6 +2039,7 @@ class AIAgent:
                     reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                    turn_memory_disposition=msg.get(TURN_MEMORY_DISPOSITION_KEY),
                     timestamp=_row_timestamp,
                     api_content=_row_api_content,
                 )
@@ -3508,6 +3510,7 @@ class AIAgent:
         final_response: Any,
         interrupted: bool,
         messages: list | None = None,
+        turn_provenance: TurnProvenance | None = None,
     ) -> None:
         """Mirror a completed turn into external memory providers.
 
@@ -3536,6 +3539,10 @@ class AIAgent:
         backend must not block the user from seeing their response.
         """
         if interrupted:
+            return
+        # The current turn still receives recall in turn_context. This gate is
+        # only for automatic persistence and warming the following turn.
+        if not should_retain_turn_memory(turn_provenance):
             return
         if not (self._memory_manager and final_response and original_user_message):
             return
@@ -6357,6 +6364,7 @@ class AIAgent:
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
         moa_config: Optional[dict[str, Any]] = None,
+        turn_provenance: Optional[TurnProvenance] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.aux_accounting import (
@@ -6399,6 +6407,7 @@ class AIAgent:
                     persist_user_message,
                     persist_user_timestamp=persist_user_timestamp,
                     moa_config=moa_config,
+                    turn_provenance=turn_provenance,
                 )
             finally:
                 reset_accounting_context(acct_token)
@@ -6426,10 +6435,19 @@ class AIAgent:
         messages: List[Dict[str, Any]],
         effective_task_id: str,
         should_review_memory: bool = False,
+        turn_provenance: TurnProvenance | None = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
-        return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+        return run_codex_app_server_turn(
+            self,
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            effective_task_id=effective_task_id,
+            should_review_memory=should_review_memory,
+            turn_provenance=turn_provenance,
+        )
 
 def main(
     query: str = None,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1647,7 +1647,7 @@ class AIAgent:
         review_memory: bool = False,
         review_skills: bool = False,
     ) -> None:
-        """Spawn the background memory/skill review thread.
+        """Spawn a durable review from a retention-safe transcript copy.
 
         Thin wrapper — the heavy lifting lives in
         ``agent.background_review.spawn_background_review_thread`` which
@@ -1656,10 +1656,15 @@ class AIAgent:
         keep working.
         """
         from agent.background_review import spawn_background_review_thread
+        from agent.memory_manager import memory_safe_session_messages
         from tools.thread_context import propagate_context_to_thread
+
+        # Both memory and skill reviews can write durable state. Filter at this
+        # shared seam so no runtime can replay a do-not-retain turn into either.
+        safe_messages_snapshot = memory_safe_session_messages(messages_snapshot)
         target, _prompt = spawn_background_review_thread(
             self,
-            messages_snapshot,
+            safe_messages_snapshot,
             review_memory=review_memory,
             review_skills=review_skills,
         )

--- a/tests/agent/test_memory_boundary_commit.py
+++ b/tests/agent/test_memory_boundary_commit.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List
 
 from agent.memory_manager import MemoryManager
 from agent.memory_provider import MemoryProvider
+from agent.turn_provenance import TURN_MEMORY_DISPOSITION_KEY
 
 
 class _RecordingProvider(MemoryProvider):
@@ -115,6 +116,63 @@ def test_boundary_commit_switch_still_fires_when_end_raises():
     assert mm.flush_pending(timeout=5)
 
     assert ("switch", "new-sid", True) in provider.calls
+
+
+def test_boundary_commit_filters_non_retain_turns_before_end_hook():
+    provider = _RecordingProvider()
+    mm = _make_manager(provider)
+
+    mm.commit_session_boundary_async(
+        [
+            {"role": "user", "content": "keep"},
+            {
+                "role": "user",
+                "content": "synthetic",
+                TURN_MEMORY_DISPOSITION_KEY: "do_not_retain",
+            },
+            {"role": "assistant", "content": "skip me"},
+            {"role": "user", "content": "resume"},
+        ],
+        new_session_id="new-sid",
+    )
+    assert mm.flush_pending(timeout=5)
+
+    assert provider.calls[0] == (
+        "end",
+        [
+            {"role": "user", "content": "keep"},
+            {"role": "user", "content": "resume"},
+        ],
+    )
+
+
+def test_boundary_filter_preserves_non_turn_history_and_input():
+    provider = _RecordingProvider()
+    mm = _make_manager(provider)
+    messages = [
+        {"role": "system", "content": "context"},
+        {
+            "role": "user",
+            "content": "synthetic",
+            TURN_MEMORY_DISPOSITION_KEY: "do_not_retain",
+        },
+        {"role": "assistant", "content": "skip"},
+        {"role": "system", "content": "boundary metadata"},
+        {"role": "assistant", "content": "keep"},
+    ]
+
+    mm.commit_session_boundary_async(messages, new_session_id="new-sid")
+    assert mm.flush_pending(timeout=5)
+
+    assert provider.calls[0] == (
+        "end",
+        [
+            {"role": "system", "content": "context"},
+            {"role": "system", "content": "boundary metadata"},
+            {"role": "assistant", "content": "keep"},
+        ],
+    )
+    assert messages[1][TURN_MEMORY_DISPOSITION_KEY] == "do_not_retain"
 
 
 def test_boundary_commit_noop_without_providers():

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -8,7 +8,12 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from agent.memory_provider import MemoryProvider
-from agent.memory_manager import MemoryManager, inject_memory_provider_tools
+from agent.memory_manager import (
+    MemoryManager,
+    inject_memory_provider_tools,
+    memory_safe_session_messages,
+)
+from agent.turn_provenance import TURN_MEMORY_DISPOSITION_KEY
 
 # ---------------------------------------------------------------------------
 # Concrete test provider
@@ -275,6 +280,30 @@ class TestMemoryManager:
         mgr.sync_all("user msg", "assistant msg", session_id="sess-1", messages=messages)
         mgr.flush_pending(timeout=5)
         assert p.synced_turns == [("user msg", "assistant msg", "sess-1", messages)]
+
+    def test_sync_all_filters_excluded_turns_and_internal_metadata(self):
+        mgr = MemoryManager()
+        p = MessagesMemoryProvider("external")
+        mgr.add_provider(p)
+        messages = [
+            {"role": "user", "content": "keep"},
+            {
+                "role": "user",
+                "content": "synthetic",
+                TURN_MEMORY_DISPOSITION_KEY: "do_not_retain",
+            },
+            {"role": "assistant", "content": "synthetic reply"},
+            {"role": "user", "content": "current", TURN_MEMORY_DISPOSITION_KEY: "retain"},
+        ]
+
+        mgr.sync_all("current", "reply", messages=messages)
+        mgr.flush_pending(timeout=5)
+
+        assert p.synced_turns[0][3] == [
+            {"role": "user", "content": "keep"},
+            {"role": "user", "content": "current"},
+        ]
+        assert messages[-1][TURN_MEMORY_DISPOSITION_KEY] == "retain"
 
     def test_sync_all_omits_messages_for_legacy_provider(self):
         mgr = MemoryManager()
@@ -1153,6 +1182,63 @@ class TestCommitMemorySessionRouting:
         mgr.add_provider(bad)
 
         mgr.on_session_end([])  # must not raise
+
+    def test_memory_safe_session_messages_excludes_non_retain_turn_without_mutating_source(self):
+        messages = [
+            {"role": "user", "content": "keep-1"},
+            {"role": "assistant", "content": "reply-1"},
+            {
+                "role": "user",
+                "content": "synthetic",
+                TURN_MEMORY_DISPOSITION_KEY: "do_not_retain",
+            },
+            {"role": "assistant", "content": "reply-2"},
+            {"role": "tool", "content": "tool-2", "tool_name": "search"},
+            {"role": "user", "content": "keep-3"},
+            {"role": "assistant", "content": "reply-3"},
+        ]
+
+        filtered = memory_safe_session_messages(messages)
+
+        assert [m["content"] for m in filtered] == [
+            "keep-1",
+            "reply-1",
+            "keep-3",
+            "reply-3",
+        ]
+        assert [m["content"] for m in messages] == [
+            "keep-1",
+            "reply-1",
+            "synthetic",
+            "reply-2",
+            "tool-2",
+            "keep-3",
+            "reply-3",
+        ]
+        assert all(TURN_MEMORY_DISPOSITION_KEY not in m for m in filtered)
+
+    def test_on_session_end_filters_non_retain_turns_before_provider_extraction(self):
+        mgr = MemoryManager()
+        provider = _CommitRecorder("builtin")
+        mgr.add_provider(provider)
+
+        msgs = [
+            {"role": "user", "content": "keep"},
+            {
+                "role": "user",
+                "content": "synthetic",
+                TURN_MEMORY_DISPOSITION_KEY: "do_not_retain",
+            },
+            {"role": "assistant", "content": "reply"},
+            {"role": "user", "content": "resume"},
+        ]
+
+        mgr.on_session_end(msgs)
+
+        assert provider.end_calls == [[
+            {"role": "user", "content": "keep"},
+            {"role": "user", "content": "resume"},
+        ]]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1,5 +1,6 @@
 """Tests for the memory provider interface, manager, and builtin provider."""
 
+import copy
 import json
 import threading
 import time
@@ -404,6 +405,52 @@ class TestMemoryManager:
         mgr.add_provider(p)
         mgr.on_pre_compress([{"role": "user", "content": "old"}])
         assert p.pre_compress_called
+
+    def test_on_pre_compress_passes_sanitized_messages_to_provider(self):
+        class _TrackingProvider(FakeMemoryProvider):
+            def __init__(self):
+                super().__init__("tracking")
+                self.received = None
+
+            def on_pre_compress(self, messages):
+                self.pre_compress_called = True
+                self.received = messages
+
+        mgr = MemoryManager()
+        provider = _TrackingProvider()
+        mgr.add_provider(provider)
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "retain", "meta": {"scope": "kept"}},
+            {"role": "assistant", "content": "reply-1"},
+            {
+                "role": "user",
+                "content": "synthetic",
+                TURN_MEMORY_DISPOSITION_KEY: "do_not_retain",
+            },
+            {"role": "assistant", "content": "temp-reply"},
+            {"role": "tool", "content": "temp-tool", "tool_name": "search"},
+            {"role": "user", "content": "next"},
+            {"role": "assistant", "content": "reply-2"},
+        ]
+        baseline = copy.deepcopy(messages)
+
+        mgr.on_pre_compress(messages)
+
+        assert provider.pre_compress_called
+        assert [m["content"] for m in provider.received] == [
+            "sys",
+            "retain",
+            "reply-1",
+            "next",
+            "reply-2",
+        ]
+        assert all(
+            TURN_MEMORY_DISPOSITION_KEY not in message for message in provider.received
+        )
+        assert messages == baseline
+        assert provider.received[0] is not messages[0]
+
 
     def test_shutdown_all_reverse_order(self):
         mgr = MemoryManager()

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -16,6 +16,10 @@ import pytest
 
 from agent.context_compressor import ContextCompressor
 from agent.turn_context import TurnContext, build_turn_context
+from agent.turn_provenance import (
+    ASYNC_DELEGATION_COMPLETION_TURN,
+    TURN_MEMORY_DISPOSITION_KEY,
+)
 from hermes_state import SessionDB
 
 
@@ -174,9 +178,11 @@ def test_returns_turn_context_with_user_message_appended():
     assert isinstance(ctx, TurnContext)
     assert ctx.user_message == "hello"
     # The user turn was appended and indexed.
-    assert ctx.messages[-1] == {"role": "user", "content": "hello"}
+    assert ctx.messages[-1]["role"] == "user"
+    assert ctx.messages[-1]["content"] == "hello"
     assert ctx.current_turn_user_idx == len(ctx.messages) - 1
     assert ctx.active_system_prompt == "SYSTEM"
+    assert TURN_MEMORY_DISPOSITION_KEY not in ctx.messages[-1]
 
 
 def test_applies_agent_side_effects():
@@ -307,6 +313,26 @@ def test_no_review_when_memory_disabled():
     agent = _FakeAgent()
     ctx = _build(agent)
     assert ctx.should_review_memory is False
+
+
+def test_non_retain_turn_keeps_recall_but_skips_memory_review():
+    agent = _FakeAgent()
+    agent._memory_manager = MagicMock()
+    agent._memory_manager.prefetch_all.return_value = ""
+    agent._memory_nudge_interval = 1
+    agent.valid_tool_names = {"memory"}
+    agent._memory_store = object()
+
+    ctx = _build(
+        agent,
+        turn_provenance=ASYNC_DELEGATION_COMPLETION_TURN,
+    )
+
+    assert ctx.should_review_memory is False
+    assert ctx.ext_prefetch_cache == ""
+    assert ctx.messages[-1][TURN_MEMORY_DISPOSITION_KEY] == "do_not_retain"
+    agent._memory_manager.prefetch_all.assert_called_once_with("hello")
+    assert agent._turns_since_memory == 0
 
 
 def test_ensure_db_session_runs_after_system_prompt_restore():
@@ -450,4 +476,3 @@ def test_expired_cooldown_allows_preflight(tmp_path):
     assert isinstance(ctx, TurnContext)
     agent._emit_status.assert_called_once()
     agent._compress_context.assert_called()
-

--- a/tests/agent/test_turn_provenance_memory_boundary.py
+++ b/tests/agent/test_turn_provenance_memory_boundary.py
@@ -1,0 +1,225 @@
+"""Focused tests for per-turn memory disposition behavior."""
+
+from run_agent import AIAgent
+from agent.memory_manager import MemoryManager
+from agent.turn_provenance import TURN_MEMORY_DISPOSITION_KEY
+from hermes_state import SessionDB
+
+from agent.turn_finalizer import finalize_turn
+from agent.turn_provenance import (
+    ASYNC_DELEGATION_COMPLETION_TURN,
+    NORMAL_USER_TURN,
+)
+
+
+class _Budget:
+    used = 0
+    max_total = 10
+    remaining = 10
+
+
+class _Agent:
+    def __init__(self):
+        self.max_iterations = 10
+        self.iteration_budget = _Budget()
+        self.context_compressor = None
+        self.model = "stub/model"
+        self.provider = "stub"
+        self.base_url = "http://stub"
+        self.session_id = "sess-1"
+        self.quiet_mode = True
+        self.platform = "cli"
+        self._interrupt_requested = False
+        self._interrupt_message = None
+        self._tool_guardrail_halt_decision = None
+        self._response_was_previewed = False
+        self._skill_nudge_interval = 0
+        self._iters_since_skill = 0
+        self.synced = []
+        self.review_calls = []
+        self.persisted_messages = None
+        self.session_cost_status = "ok"
+        self.session_cost_source = "stub"
+        for attr in (
+            "session_input_tokens",
+            "session_output_tokens",
+            "session_cache_read_tokens",
+            "session_cache_write_tokens",
+            "session_reasoning_tokens",
+            "session_prompt_tokens",
+            "session_completion_tokens",
+            "session_total_tokens",
+            "session_estimated_cost_usd",
+        ):
+            setattr(self, attr, 0)
+
+    def _save_trajectory(self, *args, **kwargs):
+        pass
+
+    def _cleanup_task_resources(self, *args, **kwargs):
+        pass
+
+    def _drop_trailing_empty_response_scaffolding(self, *args, **kwargs):
+        pass
+
+    def _persist_session(self, messages, conversation_history):
+        self.persisted_messages = list(messages)
+
+    def _emit_status(self, *args, **kwargs):
+        pass
+
+    def _safe_print(self, *args, **kwargs):
+        pass
+
+    def _file_mutation_verifier_enabled(self):
+        return False
+
+    def _turn_completion_explainer_enabled(self):
+        return False
+
+    def _drain_pending_steer(self):
+        return None
+
+    def clear_interrupt(self):
+        pass
+
+    def _sync_external_memory_for_turn(self, **kwargs):
+        self.synced.append(kwargs)
+
+    def _spawn_background_review(self, **kwargs):
+        self.review_calls.append(kwargs)
+
+
+class _SyncOnlyAgent:
+    def __init__(self):
+        self._memory_manager = _MemoryManagerStub()
+        self.session_id = "sess-1"
+
+
+class _MemoryManagerStub:
+    def __init__(self):
+        self.sync_calls = []
+        self.prefetch_calls = []
+
+    def sync_all(self, *args, **kwargs):
+        self.sync_calls.append((args, kwargs))
+
+    def queue_prefetch_all(self, *args, **kwargs):
+        self.prefetch_calls.append((args, kwargs))
+
+
+def _run_finalizer(turn_provenance, should_review_memory):
+    agent = _Agent()
+    messages = [{"role": "user", "content": "synthetic"}]
+    result = finalize_turn(
+        agent,
+        final_response="reply",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=None,
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        user_message="synthetic",
+        original_user_message="synthetic",
+        _should_review_memory=should_review_memory,
+        turn_provenance=turn_provenance,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+    return agent, result
+
+
+def test_normal_turn_syncs_memory_and_runs_review_when_requested():
+    agent, result = _run_finalizer(NORMAL_USER_TURN, should_review_memory=True)
+
+    assert result["final_response"] == "reply"
+    assert agent.synced and agent.synced[0]["turn_provenance"] == NORMAL_USER_TURN
+    assert agent.review_calls == [
+        {
+            "messages_snapshot": [
+                {"role": "user", "content": "synthetic"},
+                {"role": "assistant", "content": "reply"},
+            ],
+            "review_memory": True,
+            "review_skills": False,
+        }
+    ]
+
+
+def test_sync_external_memory_for_turn_skips_non_retain_turns():
+    agent = _SyncOnlyAgent()
+
+    AIAgent._sync_external_memory_for_turn(
+        agent,
+        original_user_message="synthetic",
+        final_response="reply",
+        interrupted=False,
+        messages=[{"role": "user", "content": "synthetic"}],
+        turn_provenance=ASYNC_DELEGATION_COMPLETION_TURN,
+    )
+
+    assert agent._memory_manager.sync_calls == []
+    assert agent._memory_manager.prefetch_calls == []
+
+
+def test_sync_external_memory_for_turn_keeps_default_retain_behavior():
+    agent = _SyncOnlyAgent()
+
+    AIAgent._sync_external_memory_for_turn(
+        agent,
+        original_user_message="hello",
+        final_response="reply",
+        interrupted=False,
+        messages=[{"role": "user", "content": "hello"}],
+        turn_provenance=NORMAL_USER_TURN,
+    )
+
+    assert len(agent._memory_manager.sync_calls) == 1
+    assert len(agent._memory_manager.prefetch_calls) == 1
+
+
+def test_non_retain_turn_still_persists_response_but_skips_memory_review():
+    agent, result = _run_finalizer(
+        ASYNC_DELEGATION_COMPLETION_TURN,
+        should_review_memory=True,
+    )
+
+    assert result["final_response"] == "reply"
+    assert agent.synced and agent.synced[0]["turn_provenance"] == ASYNC_DELEGATION_COMPLETION_TURN
+    assert agent.review_calls == []
+    assert agent.persisted_messages[-1] == {"role": "assistant", "content": "reply"}
+
+
+def test_persist_reload_then_session_end_filters_entire_synthetic_turn(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("sess-1", source="cli")
+    db.replace_messages(
+        "sess-1",
+        [
+            {"role": "user", "content": "ordinary question"},
+            {
+                "role": "user",
+                "content": "delegated completion",
+                TURN_MEMORY_DISPOSITION_KEY: "do_not_retain",
+            },
+            {"role": "assistant", "content": "synthetic answer"},
+            {"role": "user", "content": "ordinary follow-up"},
+            {"role": "assistant", "content": "ordinary reply"},
+        ],
+    )
+    db.close()
+
+    reloaded = SessionDB(db_path=tmp_path / "state.db")
+    provider = type("Provider", (), {})()
+    provider.name = "test"
+    provider.get_tool_schemas = lambda: []
+    provider.on_session_end = lambda messages: setattr(provider, "received", messages)
+    manager = MemoryManager()
+    manager.add_provider(provider)
+    manager.on_session_end(reloaded.get_messages_as_conversation("sess-1"))
+
+    contents = [message["content"] for message in provider.received]
+    assert contents == ["ordinary question", "ordinary follow-up", "ordinary reply"]
+    assert all(TURN_MEMORY_DISPOSITION_KEY not in message for message in provider.received)
+    reloaded.close()

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -60,6 +60,18 @@ class TestChatCompletionsBasic:
         assert "effect_disposition" not in result[0]
         assert msgs[0]["effect_disposition"] == "unknown"
 
+    def test_convert_messages_strips_internal_turn_memory_disposition(self, transport):
+        msgs = [{
+            "role": "user",
+            "content": "synthetic",
+            "_turn_memory_disposition": "do_not_retain",
+        }]
+
+        result = transport.convert_messages(msgs)
+
+        assert "_turn_memory_disposition" not in result[0]
+        assert msgs[0]["_turn_memory_disposition"] == "do_not_retain"
+
     def test_convert_messages_strips_codex_fields(self, transport):
         msgs = [
             {"role": "assistant", "content": "ok", "codex_reasoning_items": [{"id": "rs_1"}],

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -2,6 +2,7 @@
 
 import queue
 
+from agent.turn_provenance import ASYNC_DELEGATION_COMPLETION_TURN
 from cli import HermesCLI
 
 
@@ -42,7 +43,11 @@ def test_cli_completion_drain_uses_visible_session_identity(monkeypatch):
     cli._drain_process_notifications("cli-idle")
 
     assert calls == [("visible-session", True)]
-    assert cli._pending_input.get_nowait() == "completion payload"
+    queued = cli._pending_input.get_nowait()
+    assert queued == {
+        "text": "completion payload",
+        "turn_provenance": ASYNC_DELEGATION_COMPLETION_TURN,
+    }
     assert claimed == [(event, "cli-idle")]
     assert completed == [(event, "claim-token")]
 

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -21,6 +21,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from agent.turn_provenance import (
+    ASYNC_DELEGATION_COMPLETION_TURN,
+    TURN_MEMORY_DISPOSITION_KEY,
+    TurnMemoryDisposition,
+)
 import gateway.run as gateway_run
 from gateway.config import GatewayConfig, Platform
 from gateway.platforms.base import MessageEvent
@@ -81,7 +86,7 @@ def _bootstrap(monkeypatch, tmp_path):
     return runner
 
 
-def _event():
+def _event(turn_provenance=None):
     return MessageEvent(
         text="hello world",
         source=SessionSource(
@@ -91,6 +96,7 @@ def _event():
             user_id="12345",
         ),
         message_id="msg-42",
+        turn_provenance=turn_provenance,
     )
 
 
@@ -103,24 +109,42 @@ def _source():
     )
 
 
+def _user_entries(calls):
+    return [
+        call.args[1]
+        for call in calls
+        if len(call.args) >= 2
+        and isinstance(call.args[1], dict)
+        and call.args[1].get("role") == "user"
+    ]
+
+
 def _assert_user_call_has_skip_db(calls, expected_skip_db: bool):
     """Find append_to_transcript calls with role='user' and check skip_db."""
-    user_calls = []
-    for call in calls:
-        args = call.args
-        if len(args) >= 2 and isinstance(args[1], dict):
-            if args[1].get("role") == "user":
-                user_calls.append(call)
-    assert len(user_calls) >= 1, (
+    user_entries = _user_entries(calls)
+    assert len(user_entries) >= 1, (
         f"Expected at least one user-role append_to_transcript call, "
         f"got calls: {[c.args for c in calls if len(c.args)>=2]}"
     )
-    for call in user_calls:
+    for call in calls:
+        if len(call.args) < 2 or not isinstance(call.args[1], dict):
+            continue
+        if call.args[1].get("role") != "user":
+            continue
         actual = call.kwargs.get("skip_db", False)
         assert actual == expected_skip_db, (
             f"Expected skip_db={expected_skip_db} for user-role call, "
             f"got skip_db={actual}. kwargs={call.kwargs}"
         )
+
+
+def _assert_user_entries_have_disposition(calls, expected):
+    entries = _user_entries(calls)
+    assert entries, "Expected a user-role append_to_transcript call"
+    if expected is None:
+        assert all(TURN_MEMORY_DISPOSITION_KEY not in entry for entry in entries)
+    else:
+        assert all(entry.get(TURN_MEMORY_DISPOSITION_KEY) == expected for entry in entries)
 
 
 # ── Test 1: agent_failed_early path uses skip_db=True ─────────────────
@@ -181,6 +205,43 @@ async def test_agent_failed_early_no_skip_db_when_no_session_db(
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, False
     )
+    _assert_user_entries_have_disposition(
+        runner.session_store.append_to_transcript.call_args_list, None
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_failed_early_reconstructed_user_preserves_provenance(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner._session_db = None  # Gateway owns persistence for this turn.
+
+    runner._run_agent = AsyncMock(
+        return_value={
+            "failed": True,
+            "final_response": None,
+            "error": "ReadTimeout: timed out",
+            "messages": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(ASYNC_DELEGATION_COMPLETION_TURN),
+        _source(),
+        "agent:main:telegram:group:-1001:12345",
+        1,
+    )
+
+    _assert_user_entries_have_disposition(
+        runner.session_store.append_to_transcript.call_args_list,
+        TurnMemoryDisposition.DO_NOT_RETAIN.value,
+    )
+    _assert_user_call_has_skip_db(
+        runner.session_store.append_to_transcript.call_args_list, False
+    )
 
 
 # ── Test 3: not-new-messages path uses skip_db=True ───────────────────
@@ -209,6 +270,42 @@ async def test_not_new_messages_skip_db_when_agent_has_session_db(
 
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, True
+    )
+    _assert_user_entries_have_disposition(
+        runner.session_store.append_to_transcript.call_args_list, None
+    )
+
+
+@pytest.mark.asyncio
+async def test_not_new_messages_reconstructed_user_preserves_provenance(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner._session_db = None  # Gateway owns persistence for this turn.
+
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "Hello!",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [],
+            "history_offset": 1,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(ASYNC_DELEGATION_COMPLETION_TURN),
+        _source(),
+        "agent:main:telegram:group:-1001:12345",
+        1,
+    )
+
+    _assert_user_entries_have_disposition(
+        runner.session_store.append_to_transcript.call_args_list,
+        TurnMemoryDisposition.DO_NOT_RETAIN.value,
+    )
+    _assert_user_call_has_skip_db(
+        runner.session_store.append_to_transcript.call_args_list, False
     )
 
 

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from agent.turn_provenance import ASYNC_DELEGATION_COMPLETION_TURN
 from gateway.config import Platform
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
@@ -110,6 +111,9 @@ def test_duplicate_async_queue_replay_injects_once(monkeypatch, isolated_registr
     asyncio.run(runner._async_delegation_watcher(interval=0))
 
     adapter.handle_message.assert_awaited_once()
+    injected_event = adapter.handle_message.await_args.args[0]
+    assert injected_event.internal is True
+    assert injected_event.turn_provenance == ASYNC_DELEGATION_COMPLETION_TURN
 
 
 def test_unroutable_async_event_is_not_requeued_forever(

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from agent.turn_provenance import ASYNC_DELEGATION_COMPLETION_TURN
 from gateway.platforms.base import (
     BasePlatformAdapter,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
@@ -173,6 +174,20 @@ class TestMessageEventGetCommandArgs:
     def test_not_a_command_returns_full_text(self):
         event = MessageEvent(text="hello world")
         assert event.get_command_args() == "hello world"
+
+
+class TestMessageEventTurnProvenance:
+    def test_defaults_to_none(self):
+        event = MessageEvent(text="hello world")
+        assert event.turn_provenance is None
+
+    def test_accepts_first_class_turn_provenance(self):
+        event = MessageEvent(
+            text="synthetic completion",
+            internal=True,
+            turn_provenance=ASYNC_DELEGATION_COMPLETION_TURN,
+        )
+        assert event.turn_provenance == ASYNC_DELEGATION_COMPLETION_TURN
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -3,6 +3,7 @@ import json
 import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
+from agent.turn_provenance import TURN_MEMORY_DISPOSITION_KEY
 from gateway.config import Platform, HomeChannel, GatewayConfig, PlatformConfig
 from gateway.platforms.base import MessageEvent
 from gateway.session import (
@@ -716,6 +717,28 @@ class TestSessionStoreRewriteTranscript:
 
         reloaded = store.load_transcript(session_id)
         assert reloaded == []
+
+    def test_append_round_trips_turn_memory_disposition(self, store):
+        session_id = "test_session_disposition"
+        store._db.create_session(session_id=session_id, source="test")
+        marked_message = {
+            "role": "user",
+            "content": "delegate this",
+            TURN_MEMORY_DISPOSITION_KEY: "do_not_retain",
+        }
+        original_message = marked_message.copy()
+
+        store.append_to_transcript(session_id, marked_message)
+        store.append_to_transcript(
+            session_id,
+            {"role": "assistant", "content": "delegated"},
+        )
+
+        reloaded = store.load_transcript(session_id)
+
+        assert marked_message == original_message
+        assert reloaded[0][TURN_MEMORY_DISPOSITION_KEY] == "do_not_retain"
+        assert TURN_MEMORY_DISPOSITION_KEY not in reloaded[1]
 
 
 class TestLoadTranscriptDBOnly:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2159,6 +2159,44 @@ class TestWebServerEndpoints:
         assert payload["session_id"] == "desktop-tip"
         assert [m["content"] for m in payload["messages"]] == ["after compression"]
 
+    def test_get_session_messages_preserves_fields_without_private_provenance(self):
+        from agent.turn_provenance import TURN_MEMORY_DISPOSITION_KEY
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="field-preservation", source="cli")
+            db.append_message(
+                session_id="field-preservation",
+                role="assistant",
+                content="hello",
+                tool_name="lookup",
+                tool_call_id="call-1",
+                token_count=12,
+                finish_reason="stop",
+                reasoning="private reasoning",
+                reasoning_content="reasoning content",
+                platform_message_id="platform-1",
+                observed=True,
+                turn_memory_disposition="do_not_retain",
+            )
+            before = db.get_messages("field-preservation")
+        finally:
+            db.close()
+
+        response = self.client.get("/api/sessions/field-preservation/messages")
+
+        assert response.status_code == 200
+        returned = response.json()["messages"]
+        assert returned == [
+            {
+                key: value
+                for key, value in before[0].items()
+                if key != TURN_MEMORY_DISPOSITION_KEY
+            }
+        ]
+        assert before[0][TURN_MEMORY_DISPOSITION_KEY] == "do_not_retain"
+
     def test_get_sessions_archived_is_boolean(self):
         from hermes_state import SessionDB
 

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -13,7 +13,10 @@ runtime via a thread-local whitelist on the existing
 that caused the prefix-cache miss.
 """
 
+from copy import deepcopy
 from unittest.mock import patch
+
+import pytest
 
 
 def _make_agent_stub(agent_cls):
@@ -52,6 +55,71 @@ class _SyncThread:
     def start(self):
         if self._target:
             self._target()
+
+
+@pytest.mark.parametrize(
+    ("review_memory", "review_skills"),
+    [(True, False), (False, True), (True, True)],
+)
+def test_background_review_uses_memory_safe_transcript(
+    review_memory, review_skills
+):
+    """Every durable review mode receives only retained, public messages."""
+    import run_agent
+    from agent.turn_provenance import TURN_MEMORY_DISPOSITION_KEY
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    messages_snapshot = [
+        {"role": "user", "content": "keep-1"},
+        {
+            "role": "assistant",
+            "content": "reply-1",
+            TURN_MEMORY_DISPOSITION_KEY: "do_not_retain",
+        },
+        {
+            "role": "user",
+            "content": "synthetic",
+            TURN_MEMORY_DISPOSITION_KEY: "do_not_retain",
+        },
+        {"role": "assistant", "content": "synthetic reply"},
+        {"role": "tool", "content": "synthetic tool", "tool_name": "search"},
+        {"role": "user", "content": "keep-2"},
+        {"role": "assistant", "content": "reply-2"},
+    ]
+    original_messages = deepcopy(messages_snapshot)
+    captured = {}
+
+    def _capture_review(_agent, safe_messages, **kwargs):
+        captured["messages"] = safe_messages
+        captured["kwargs"] = kwargs
+        return (lambda: None), "review prompt"
+
+    with patch(
+        "agent.background_review.spawn_background_review_thread",
+        side_effect=_capture_review,
+    ), patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=messages_snapshot,
+            review_memory=review_memory,
+            review_skills=review_skills,
+        )
+
+    assert captured["messages"] == [
+        {"role": "user", "content": "keep-1"},
+        {"role": "assistant", "content": "reply-1"},
+        {"role": "user", "content": "keep-2"},
+        {"role": "assistant", "content": "reply-2"},
+    ]
+    assert captured["kwargs"] == {
+        "review_memory": review_memory,
+        "review_skills": review_skills,
+    }
+    assert messages_snapshot == original_messages
+    assert all(
+        safe_message is not original_message
+        for safe_message in captured["messages"]
+        for original_message in messages_snapshot
+    )
 
 
 def test_background_review_matches_parent_toolset_config():

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -6,6 +6,7 @@ import json
 import pytest
 
 import hermes_state
+from agent.turn_provenance import TURN_MEMORY_DISPOSITION_KEY
 from hermes_state import SCHEMA_SQL, SCHEMA_VERSION, SessionDB
 
 
@@ -1158,6 +1159,75 @@ class TestMessageStorage:
         )
 
         assert db.get_messages_as_conversation("s1")[0]["effect_disposition"] == "unknown"
+
+    def test_turn_memory_disposition_round_trips_through_session_db(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.replace_messages(
+            "s1",
+            [
+                {
+                    "role": "user",
+                    "content": "synthetic",
+                    TURN_MEMORY_DISPOSITION_KEY: "do_not_retain",
+                },
+                {"role": "assistant", "content": "reply"},
+            ],
+        )
+
+        stored = db.get_messages("s1")
+        conv = db.get_messages_as_conversation("s1")
+
+        assert stored[0][TURN_MEMORY_DISPOSITION_KEY] == "do_not_retain"
+        assert conv[0][TURN_MEMORY_DISPOSITION_KEY] == "do_not_retain"
+
+    def test_migration_keeps_legacy_disposition_null_as_retain(self, tmp_path):
+        db_path = tmp_path / "legacy.db"
+        conn = sqlite3.connect(db_path)
+        legacy_schema = SCHEMA_SQL.replace("    turn_memory_disposition TEXT,\n", "")
+        conn.executescript(legacy_schema)
+        conn.execute("DELETE FROM schema_version")
+        conn.execute("INSERT INTO schema_version(version) VALUES (22)")
+        conn.execute(
+            "INSERT INTO sessions(id, source, started_at, message_count, tool_call_count) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("s1", "cli", 1.0, 2, 0),
+        )
+        conn.execute(
+            "INSERT INTO messages(session_id, role, content, timestamp, active, compacted) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("s1", "user", "legacy prompt", 1.0, 1, 0),
+        )
+        conn.execute(
+            "INSERT INTO messages(session_id, role, content, timestamp, active, compacted) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("s1", "assistant", "legacy reply", 2.0, 1, 0),
+        )
+        conn.commit()
+        conn.close()
+
+        migrated = SessionDB(db_path=db_path)
+        try:
+            conv = migrated.get_messages_as_conversation("s1")
+            rows = migrated.get_messages("s1")
+            assert conv[0].get(TURN_MEMORY_DISPOSITION_KEY) is None
+            assert rows[0].get(TURN_MEMORY_DISPOSITION_KEY) is None
+            assert rows[1].get(TURN_MEMORY_DISPOSITION_KEY) is None
+            with migrated._lock:
+                raw = migrated._conn.execute(
+                    "SELECT turn_memory_disposition FROM messages WHERE id = 1"
+                ).fetchone()
+            assert raw[0] is None
+            # Idempotent reopen must preserve the migrated value.
+            migrated._conn.close()
+            reopened = SessionDB(db_path=db_path)
+            try:
+                reopened_rows = reopened.get_messages("s1")
+                assert reopened_rows[0].get(TURN_MEMORY_DISPOSITION_KEY) is None
+            finally:
+                reopened._conn.close()
+        finally:
+            if getattr(migrated, "_conn", None) is not None:
+                migrated._conn.close()
 
     def test_replace_messages_handles_multimodal_content(self, db):
         """`replace_messages` (used by /retry, /undo, /compress) must also

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
+from agent.turn_provenance import ASYNC_DELEGATION_COMPLETION_TURN
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from hermes_cli.active_sessions import active_session_registry_snapshot
 from hermes_cli.browser_connect import ChromeDebugLaunch
@@ -2738,6 +2739,14 @@ def test_async_delegation_event_prefers_origin_ui_session(monkeypatch):
     assert server._notification_event_belongs_elsewhere("origin-sid", mine, evt) is False
 
 
+def test_notification_event_turn_provenance_is_async_only():
+    assert (
+        server._notification_event_turn_provenance({"type": "async_delegation"})
+        == ASYNC_DELEGATION_COMPLETION_TURN
+    )
+    assert server._notification_event_turn_provenance({"type": "completion"}) is None
+
+
 def test_notification_event_follows_compression_continuation(monkeypatch):
     """Events keyed to a compressed parent route to the live continuation."""
     old_parent = _session(session_key="old-parent")
@@ -2761,6 +2770,103 @@ def test_notification_event_follows_compression_continuation(monkeypatch):
         {"old-sid": old_parent, "tip-sid": live_tip, "third-sid": third},
     )
     assert server._notification_event_belongs_elsewhere("third-sid", third, evt) is True
+
+
+def test_notification_poller_shutdown_drain_dispatches_async_delegation_turn_provenance(
+    monkeypatch,
+):
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    submitted = []
+
+    def _recording_submit(rid, sid, session, text, turn_provenance=None):
+        submitted.append(turn_provenance)
+        with session["history_lock"]:
+            session["running"] = False
+
+    sess = _session(session_key="session-a")
+    server._sessions["sid_a"] = sess
+    monkeypatch.setattr(server, "_run_prompt_submit", _recording_submit)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(
+        {
+            "type": "async_delegation",
+            "session_id": "proc_async",
+            "session_key": "session-a",
+            "delegation_id": "deleg-1",
+            "goal": "collect artifacts",
+            "status": "completed",
+            "summary": "subagent done",
+        }
+    )
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    process_registry._completion_consumed.discard("proc_async")
+
+    stop = threading.Event()
+    stop.set()
+
+    try:
+        server._notification_poller_loop(stop, "sid_a", sess)
+        assert submitted == [ASYNC_DELEGATION_COMPLETION_TURN]
+    finally:
+        server._sessions.pop("sid_a", None)
+        process_registry._completion_consumed.discard("proc_async")
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
+def test_notification_poller_live_loop_dispatches_async_delegation_with_turn_provenance(
+    monkeypatch,
+):
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    submitted = []
+    stop = threading.Event()
+
+    def _recording_submit(rid, sid, session, text, turn_provenance=None):
+        submitted.append(turn_provenance)
+        with session["history_lock"]:
+            session["running"] = False
+        stop.set()
+
+    sess = _session(session_key="session-a", running=False)
+    server._sessions["sid_live_poll"] = sess
+    monkeypatch.setattr(server, "_run_prompt_submit", _recording_submit)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(
+        {
+            "type": "async_delegation",
+            "session_id": "proc_async_live",
+            "session_key": "session-a",
+            "delegation_id": "deleg-live",
+            "goal": "collect artifacts",
+            "status": "completed",
+            "summary": "subagent done",
+        }
+    )
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    process_registry._completion_consumed.discard("proc_async_live")
+
+    try:
+        server._notification_poller_loop(stop, "sid_live_poll", sess)
+        assert submitted == [ASYNC_DELEGATION_COMPLETION_TURN]
+        assert sess["running"] is False
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop("sid_live_poll", None)
+        process_registry._completion_consumed.discard("proc_async_live")
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
 
 
 def test_finalized_origin_ui_session_falls_back_to_live_continuation(monkeypatch):
@@ -3178,6 +3284,54 @@ class _RecordingAgent:
     ):
         self._turns.append(prompt)
         return {"final_response": "", "messages": []}
+
+
+def test_run_prompt_submit_preserves_explicit_provenance_when_signature_probe_fails(
+    monkeypatch, tmp_path
+):
+    class _RunProbeAgent:
+        model = "test-model"
+        provider = "test-provider"
+
+        def __init__(self):
+            self.called = None
+
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(
+            self,
+            prompt,
+            conversation_history=None,
+            stream_callback=None,
+            task_id=None,
+            turn_provenance=None,
+        ):
+            self.called = turn_provenance
+            return {"final_response": "", "messages": []}
+
+    _configure_immediate_prompt_run(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        server.inspect,
+        "signature",
+        lambda _callable: (_ for _ in ()).throw(ValueError("uninspectable")),
+    )
+    agent = _RunProbeAgent()
+    session = _session(agent=agent)
+    server._sessions["sid"] = session
+
+    try:
+        server._run_prompt_submit(
+            "1",
+            "sid",
+            session,
+            "hello",
+            turn_provenance=ASYNC_DELEGATION_COMPLETION_TURN,
+        )
+
+        assert agent.called == ASYNC_DELEGATION_COMPLETION_TURN
+    finally:
+        server._sessions.pop("sid", None)
 
 
 @pytest.mark.parametrize("exit_code", [0, 7])

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10118,9 +10118,9 @@ def _run_prompt_submit(
                 if "task_id" in run_sig.parameters:
                     run_kwargs["task_id"] = session["session_key"]
             except (TypeError, ValueError):
-                # turn_provenance is forwarded below fail-closed because it is
-                # a retention boundary, unlike optional metadata such as task_id.
                 pass
+            # turn_provenance is a retention boundary, unlike optional task_id;
+            # forward it unconditionally so a failed signature probe cannot drop it.
             if turn_provenance is not None:
                 run_kwargs["turn_provenance"] = turn_provenance
             result = agent.run_conversation(run_message, **run_kwargs)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10118,6 +10118,8 @@ def _run_prompt_submit(
                 if "task_id" in run_sig.parameters:
                     run_kwargs["task_id"] = session["session_key"]
             except (TypeError, ValueError):
+                # turn_provenance is forwarded below fail-closed because it is
+                # a retention boundary, unlike optional metadata such as task_id.
                 pass
             if turn_provenance is not None:
                 run_kwargs["turn_provenance"] = turn_provenance

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, NamedTuple, Optional
 
+from agent.turn_provenance import ASYNC_DELEGATION_COMPLETION_TURN, TurnProvenance
 from hermes_constants import (
     get_hermes_home,
     get_hermes_home_override,
@@ -9637,6 +9638,14 @@ def _notification_event_requires_owner(evt: dict) -> bool:
     )
 
 
+def _notification_event_turn_provenance(evt: dict) -> TurnProvenance | None:
+    """Map a background notification event to an explicit turn provenance."""
+
+    if evt.get("type") == "async_delegation":
+        return ASYNC_DELEGATION_COMPLETION_TURN
+    return None
+
+
 def _notification_event_dedup_key(evt: dict) -> tuple:
     """Return the UI-emission identity for a process notification event.
 
@@ -9768,7 +9777,17 @@ def _notification_poller_loop(
             continue
         try:
             _emit("message.start", sid)
-            _run_prompt_submit(rid, sid, session, text)
+            _event_turn_provenance = _notification_event_turn_provenance(evt)
+            if _event_turn_provenance is None:
+                _run_prompt_submit(rid, sid, session, text)
+            else:
+                _run_prompt_submit(
+                    rid,
+                    sid,
+                    session,
+                    text,
+                    turn_provenance=_event_turn_provenance,
+                )
             complete_event_delivery(evt, _claim)
         except Exception as exc:
             release_event_delivery(evt, _claim)
@@ -9836,7 +9855,17 @@ def _notification_poller_loop(
             continue
         try:
             _emit("message.start", sid)
-            _run_prompt_submit(rid, sid, session, text)
+            _event_turn_provenance = _notification_event_turn_provenance(evt)
+            if _event_turn_provenance is None:
+                _run_prompt_submit(rid, sid, session, text)
+            else:
+                _run_prompt_submit(
+                    rid,
+                    sid,
+                    session,
+                    text,
+                    turn_provenance=_event_turn_provenance,
+                )
             complete_event_delivery(evt, _claim)
         except Exception as exc:
             release_event_delivery(evt, _claim)
@@ -9911,7 +9940,9 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     return stop
 
 
-def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
+def _run_prompt_submit(
+    rid, sid: str, session: dict, text: Any, turn_provenance: TurnProvenance | None = None
+) -> None:
     with session["history_lock"]:
         history = list(session["history"])
         history_version = int(session.get("history_version", 0))
@@ -10083,10 +10114,13 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 "stream_callback": _stream,
             }
             try:
-                if "task_id" in inspect.signature(agent.run_conversation).parameters:
+                run_sig = inspect.signature(agent.run_conversation)
+                if "task_id" in run_sig.parameters:
                     run_kwargs["task_id"] = session["session_key"]
             except (TypeError, ValueError):
                 pass
+            if turn_provenance is not None:
+                run_kwargs["turn_provenance"] = turn_provenance
             result = agent.run_conversation(run_message, **run_kwargs)
             if "moa_one_shot_restore" in session:
                 _restore = session.pop("moa_one_shot_restore", None)
@@ -10460,7 +10494,17 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     continue
                 try:
                     _emit("message.start", sid)
-                    _run_prompt_submit(rid, sid, session, synth)
+                    _evt_turn_provenance = _notification_event_turn_provenance(_evt)
+                    if _evt_turn_provenance is None:
+                        _run_prompt_submit(rid, sid, session, synth)
+                    else:
+                        _run_prompt_submit(
+                            rid,
+                            sid,
+                            session,
+                            synth,
+                            turn_provenance=_evt_turn_provenance,
+                        )
                     complete_event_delivery(_evt, _claim)
                 except Exception as _n_exc:
                     release_event_delivery(_evt, _claim)


### PR DESCRIPTION
## What does this PR do?

Prevents synthetic async-delegation completion turns from entering automatic durable-memory and skill-learning paths.

Async delegation results enter the conversation as synthetic user turns so the agent can process and present them. Previously, automatic memory systems could treat these turns as real user messages and retain them during provider synchronization, compression, session shutdown, or background reviews.

In the real-world incident that exposed this bug, Honcho stored an async-delegation completion under the human peer. Honcho then derived false Peer Card facts that identified the user as the AI agent and attributed the delegated model and database operations to them. Honcho's observation settings were correct; Hermes had already lost the turn's provenance before memory synchronization.

This PR adds typed turn provenance and an explicit memory disposition. Synthetic completion turns remain visible in the active conversation but are excluded from automatic retention. Ordinary user turns keep their existing behavior.

## Related Issue

No directly related issue or PR was found.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- Added typed `TurnProvenance` and `TurnMemoryDisposition` values.
- Marked async-delegation completion turns as `DO_NOT_RETAIN`.
- Propagated the disposition through:
  - standard and Codex runtimes
  - CLI delivery
  - gateway delivery and fallback paths
  - TUI and Desktop notification delivery
  - SQLite persistence and session reload
- Added a filtered transcript view for automatic retention paths.
- Applied the filter before:
  - memory-provider synchronization
  - pre-compression provider hooks
  - session-end memory extraction
  - background memory and skill reviews
- Prevented non-retained turns from triggering automatic memory reviews and prefetch warming.
- Removed private provenance metadata from model requests and WebUI/API transcript output.
- Preserved the disposition when the gateway reconstructs or separately persists a user turn.
- Added regression coverage for propagation, persistence, reload, filtering, fallback handling, and fail-closed TUI behavior.

## How to Test

Run the focused retention tests:

```bash
python -m pytest -o 'addopts=' -q \
  tests/gateway/test_42039_duplicate_user_message.py \
  tests/gateway/test_session.py::TestSessionStoreRewriteTranscript::test_append_round_trips_turn_memory_disposition \
  tests/agent/test_turn_provenance_memory_boundary.py \
  tests/run_agent/test_background_review_toolset_restriction.py
```

Expected result: `20 passed`.

Run the TUI provenance tests:

```bash
python -m pytest -o 'addopts=' -q tests/test_tui_gateway_server.py \
  -k 'notification_event_turn_provenance or notification_poller or preserves_explicit_provenance'
```

Expected result: `16 passed`.

Run static validation:

```bash
python -m ruff check $(git diff --name-only origin/main...HEAD -- '*.py')
python -m compileall -q -- $(git diff --name-only origin/main...HEAD -- '*.py')
git diff --check origin/main...HEAD
```

The complete set of candidate-affected test files was also run through the repository test runner. It produced `1,812 passed` and one unrelated `verification.status` failure. The same failure reproduced on the exact current upstream base.

## Behavior and Compatibility

- Ordinary user turns retain their existing memory behavior.
- Synthetic completion turns remain available in the active conversation.
- Existing session databases are migrated without rewriting legacy message rows.
- No configuration or user migration is required.
- This PR does not change ordinary terminal or process-completion retention.
- This PR does not redesign conversation compaction or malformed-history handling.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing issues and PRs
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for the changed behavior
- [x] I've tested on Linux with Python 3.13

The full suite has pre-existing environment or upstream failures. The candidate-affected suites and focused regression tests pass.

### Documentation & Housekeeping

- [x] No user-facing documentation change is required
- [x] No configuration keys changed
- [x] No tool schemas changed
- [x] Cross-platform impact was considered; the implementation adds no platform-specific behavior

## Screenshots / Logs

Not applicable. This PR changes internal turn provenance and automatic retention behavior without changing the UI.
