### PR TITLE
fix: exclude Chrome/CDP browser profiles from checkpoint snapshots

### DIFF
--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -139,6 +139,9 @@ DEFAULT_EXCLUDES = [
     "Thumbs.db",
     # Logs
     "*.log",
+    # Chrome / CDP browser profiles (locked files break git add -A on Windows)
+    "chrome_cdp_profile/",
+    "agent-browser-chrome-*/",
 ]
 
 # Git subprocess timeout (seconds).


### PR DESCRIPTION
## Problem

When `checkpoints.enabled: true`, every `write_file` triggers a `git add -A` in the working directory before creating a snapshot. On Windows, Chrome locks its profile files (`Cookies`, `GPUPersistentCache/cache.db`, etc.) while running. The `git add -A` blocks indefinitely on these locked files, freezing `write_file` for minutes.

Relevant logs:
```
Git command failed: git add -A (rc=128)
error: open("chrome_cdp_profile/GPUPersistentCache/DawnGraphiteCache/.../cache.db"): Permission denied
error: open("agent-browser-chrome-.../Default/Network/Cookies"): Permission denied
```

## Fix

Add `chrome_cdp_profile/` and `agent-browser-chrome-*/` to `DEFAULT_EXCLUDES` in `checkpoint_manager.py`. These directories are created by the browser automation tool and should never be checkpointed.

## Testing

- Python syntax: OK
- Existing checkpoint tests: not run (no pytest on this Windows install)
- Manual verification: fix resolves the `write_file` freeze on a Windows machine with Chrome running and `checkpoints.enabled: true`