### PR TITLE
fix(desktop): flush stream deltas without rAF

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -242,13 +242,16 @@ export function useMessageStream({
       flushQueuedDeltas()
     }
 
-    if (sinceLast >= STREAM_DELTA_FLUSH_MS && typeof window.requestAnimationFrame === 'function') {
-      flushHandleRef.current = window.requestAnimationFrame(runFlush)
-
-      return
-    }
-
-    flushHandleRef.current = window.setTimeout(runFlush, Math.max(0, STREAM_DELTA_FLUSH_MS - sinceLast))
+    // Do not depend on requestAnimationFrame for stream delivery. Electron
+    // throttles (and can indefinitely defer) rAF while a window is occluded,
+    // unfocused, or under renderer pressure. That stranded message deltas in
+    // this queue until the next input/focus event happened to wake a frame.
+    // A timer still coalesces markdown work to the same cadence, but guarantees
+    // the buffered task log reaches the transcript without user interaction.
+    flushHandleRef.current = window.setTimeout(
+      runFlush,
+      Math.max(0, STREAM_DELTA_FLUSH_MS - sinceLast)
+    )
   }, [flushQueuedDeltas])
 
   const queueDelta = useCallback(
@@ -268,11 +271,7 @@ export function useMessageStream({
   useEffect(
     () => () => {
       if (flushHandleRef.current !== null && typeof window !== 'undefined') {
-        if (typeof window.cancelAnimationFrame === 'function') {
-          window.cancelAnimationFrame(flushHandleRef.current)
-        } else {
-          window.clearTimeout(flushHandleRef.current)
-        }
+        window.clearTimeout(flushHandleRef.current)
       }
 
       flushHandleRef.current = null

--- a/apps/desktop/src/app/session/hooks/use-message-stream/stream-flush.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/stream-flush.test.tsx
@@ -1,0 +1,81 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import type { RpcEvent } from '@/types/hermes'
+
+import { STREAM_DELTA_FLUSH_MS } from './utils'
+
+import { useMessageStream } from './index'
+
+const SID = 'stream-session'
+
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let states: Map<string, ClientSessionState>
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+    states = sessionStateByRuntimeIdRef.current
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+describe('useMessageStream delta delivery', () => {
+  beforeEach(() => {
+    handleEvent = null
+    states = new Map()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('flushes queued deltas when animation frames are paused', async () => {
+    // Simulate an occluded Electron renderer: rAF accepts work but never runs
+    // it. The previous implementation left the delta queued until focus/input.
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1)
+    vi.useFakeTimers()
+
+    render(<Harness />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(handleEvent).not.toBeNull()
+
+    act(() => handleEvent!({ payload: { text: 'still streaming' }, session_id: SID, type: 'message.delta' }))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(STREAM_DELTA_FLUSH_MS)
+    })
+
+    const message = states.get(SID)?.messages.at(-1)
+    expect(message?.parts).toEqual([{ type: 'text', text: 'still streaming' }])
+  })
+})


### PR DESCRIPTION
## What changed

- Replaced the stream-delta delivery dependency on `requestAnimationFrame` with a timer-based flush that keeps the existing coalescing interval.
- Added a regression test for an occluded Electron renderer whose animation-frame callback never runs.

## Why

Electron can throttle or indefinitely defer animation frames while a window is unfocused or occluded. That left an already-completed response buffered until later input or focus activity triggered a frame.

## User impact

Final reports and streamed assistant text are delivered without requiring a follow-up `/queue`, `/steer`, or other input to wake the renderer.

## Validation

- `npx vitest run src/app/session/hooks/use-message-stream` (8 files, 34 tests)
- `npm run typecheck`
- `npx eslint src/app/session/hooks/use-message-stream/index.ts src/app/session/hooks/use-message-stream/stream-flush.test.tsx`
