### PR TITLE
bluebubbles: de-duplicate re-delivered webhooks to stop double replies

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -155,6 +155,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        # Recently-processed inbound message GUIDs, for webhook de-duplication
+        # (BlueBubbles fires new-message + updated-message for one message).
+        self._seen_message_guids: OrderedDict[str, None] = OrderedDict()
 
     # ------------------------------------------------------------------
     # API helpers
@@ -923,6 +926,19 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             **_TAPBACK_REMOVED,
         }:
             return web.Response(text="ok")
+
+        # De-duplicate re-delivered webhooks. BlueBubbles fires ``new-message``
+        # and one or more ``updated-message`` events (delivery/read/edit state)
+        # for the same message; without this a single inbound message is
+        # processed as multiple turns and the agent replies more than once.
+        # Key on the stable message GUID so each message is handled exactly once.
+        msg_guid = self._value(record.get("guid"), record.get("messageGuid"))
+        if msg_guid:
+            if msg_guid in self._seen_message_guids:
+                return web.Response(text="ok")
+            self._seen_message_guids[msg_guid] = None
+            if len(self._seen_message_guids) > 2048:
+                self._seen_message_guids.popitem(last=False)
 
         text = (
             self._value(


### PR DESCRIPTION
### What

De-duplicate re-delivered BlueBubbles webhooks so the agent replies to each inbound iMessage exactly once.

Fixes #68718.

### Why

BlueBubbles delivers a `new-message` webhook **and** one or more `updated-message` webhooks (delivery / read / edit state changes) for the same message. `_handle_webhook` processes every event in `_MESSAGE_EVENTS` without deduplication, so a single inbound message is handled as multiple turns and the agent sends duplicate replies.

### How

Track recently-seen inbound message GUIDs in a bounded `OrderedDict` (cap 2048, FIFO eviction) and process each GUID only once. This keeps the `new-message` + `updated-message` subscription intact (nothing that only surfaces via `updated-message` is lost) while making the handler idempotent per message.

- The check is placed **after** the `is_from_me` and tapback filters, so those cheap skips still short-circuit first.
- It keys on the same stable `record["guid"]` the adapter already relies on elsewhere.
- No new dependencies; `OrderedDict` is already imported and used in this module.

An alternative one-line fix is to drop `updated-message` from the webhook subscription in `_register_webhook`; the dedup approach here is preferred because it doesn't remove the subscription and is robust to the same message arriving under either event.

### Testing

- `python -m py_compile gateway/platforms/bluebubbles.py` passes.
- Root cause confirmed on a live self-hosted deployment: the duplicate replies track exactly with the `updated-message` re-delivery, and suppressing that re-delivery removes them.

### Note (separate, not in this PR)

`send_typing` / `stop_typing` also gate on a cached `self._helper_connected` snapshot, which BlueBubbles can report as `false` during gateway startup even when the Private API typing endpoint already works — dropping typing indicators in that window. Happy to send that as a follow-up if useful.
