### PR TITLE
feat(mem0): monthly semantic near-duplicate scanner

### DIFF
--- a/scripts/mem0_dedup_scan.py
+++ b/scripts/mem0_dedup_scan.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+"""Monthly mem0 near-duplicate scanner — reports (and optionally consolidates) near-duplicates.
+
+Scans a Qdrant collection for pairs of memories belonging to the same
+user_id that have cosine similarity >= 0.92. Prints a report to stdout.
+
+Without --consolidate: reports only (does NOT delete anything).
+With --consolidate (alone): dry-run — prints what WOULD be deleted but does nothing.
+With --consolidate --yes: actually deletes the identified duplicates via Qdrant API.
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+MEM0_CONFIG = Path.home() / ".hermes" / "mem0.json"
+SIMILARITY_THRESHOLD = 0.92
+SCROLL_LIMIT = 100
+
+# Module-level constants — overridden by CLI flags in main()
+QDRANT_URL = "http://localhost:6333"
+COLLECTION = "hermes_memories"
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+def _load_mem0_config():
+    """Return parsed mem0.json as a dict, or {} if unavailable."""
+    try:
+        with open(MEM0_CONFIG) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:  # noqa: BLE001
+        print(f"[WARN] Could not read {MEM0_CONFIG}: {exc}", file=sys.stderr)
+        return {}
+
+
+def _config_user_id(cfg: dict) -> str | None:
+    return cfg.get("user_id") or None
+
+
+def _config_collection(cfg: dict) -> str | None:
+    try:
+        return cfg["oss"]["vector_store"]["config"]["collection_name"] or None
+    except (KeyError, TypeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def api_get(path, timeout=60):
+    req = urllib.request.Request(f"{QDRANT_URL}{path}", method="GET")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def api_post(path, body, timeout=120):
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        f"{QDRANT_URL}{path}",
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def api_delete(path, body=None, timeout=30):
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(
+        f"{QDRANT_URL}{path}",
+        data=data,
+        method="DELETE",
+        headers={"Content-Type": "application/json"} if data else {},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+# ---------------------------------------------------------------------------
+# Math
+# ---------------------------------------------------------------------------
+
+def cosine_similarity(a, b):
+    """Cosine similarity between two equal-length lists of floats."""
+    dot = 0.0
+    mag_a = 0.0
+    mag_b = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        mag_a += x * x
+        mag_b += y * y
+    if mag_a == 0.0 or mag_b == 0.0:
+        return 0.0
+    return dot / ((mag_a ** 0.5) * (mag_b ** 0.5))
+
+
+# ---------------------------------------------------------------------------
+# Collection fetching
+# ---------------------------------------------------------------------------
+
+def scroll_all_points():
+    """Fetch all points from the collection with vectors and payloads."""
+    points = []
+    offset = None
+
+    while True:
+        body = {
+            "limit": SCROLL_LIMIT,
+            "with_vector": True,
+            "with_payload": True,
+        }
+        if offset is not None:
+            body["offset"] = offset
+
+        try:
+            result = api_post(f"/collections/{COLLECTION}/points/scroll", body)
+        except urllib.error.URLError as exc:
+            print(f"[ERROR] Qdrant scroll failed: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+        batch = result.get("result", {}).get("points", [])
+        points.extend(batch)
+
+        next_offset = result.get("result", {}).get("next_page_offset")
+        if next_offset is None or not batch:
+            break
+        offset = next_offset
+
+    return points
+
+
+# ---------------------------------------------------------------------------
+# Duplicate detection
+# ---------------------------------------------------------------------------
+
+def find_duplicates(points, target_user_id):
+    """Return list of (score, point_a, point_b) tuples for near-duplicate pairs."""
+    # Filter to target user and points that have vectors
+    eligible = []
+    for p in points:
+        payload = p.get("payload") or {}
+        vec = p.get("vector")
+        if not isinstance(vec, list) or not vec:
+            continue
+        # mem0 stores user_id directly in payload
+        if payload.get("user_id") != target_user_id:
+            continue
+        eligible.append(p)
+
+    print(
+        f"Comparing {len(eligible)} points for user '{target_user_id}' "
+        f"({len(points)} total in collection)...",
+        file=sys.stderr,
+    )
+
+    pairs = []
+    n = len(eligible)
+    for i in range(n):
+        for j in range(i + 1, n):
+            a = eligible[i]
+            b = eligible[j]
+            score = cosine_similarity(a["vector"], b["vector"])
+            if score >= SIMILARITY_THRESHOLD:
+                pairs.append((score, a, b))
+
+    # Sort highest similarity first
+    pairs.sort(key=lambda t: t[0], reverse=True)
+    return pairs, len(eligible)
+
+
+# ---------------------------------------------------------------------------
+# Grouping
+# ---------------------------------------------------------------------------
+
+def group_pairs(pairs):
+    """Group near-duplicate pairs WITHOUT transitive union-find chaining.
+
+    We deliberately do NOT use union-find here because transitivity creates
+    unsafe groups: if A~B and B~C but A and C have similarity 0.4 (below
+    threshold), merging all three into one group would cause A or C to be
+    deleted even though they are not duplicates of each other.
+
+    Instead, each directly-similar pair becomes its own two-member group.
+    If the same ID appears in multiple pairs it will appear in multiple groups,
+    and the consolidation step will handle it safely pair-by-pair, always
+    keeping the higher-ranked member of each direct pair.
+    """
+    point_map = {}
+    edge_scores = {}
+    # Each pair becomes an independent two-member group keyed by a frozenset
+    pair_groups = []
+
+    for score, a, b in pairs:
+        aid, bid = str(a["id"]), str(b["id"])
+        point_map[aid] = a
+        point_map[bid] = b
+        edge_scores[(aid, bid)] = score
+        pair_groups.append([aid, bid])
+
+    return [
+        {
+            "members": pids,
+            "points": {pid: point_map[pid] for pid in pids},
+            "edge_scores": {(a, b): s for (a, b), s in edge_scores.items() if a in pids and b in pids},
+        }
+        for pids in pair_groups
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def extract_text(point):
+    """Pull the memory text from a point's payload."""
+    payload = point.get("payload") or {}
+    # mem0 stores the text in 'data' field
+    return (
+        payload.get("data")
+        or payload.get("text")
+        or payload.get("memory")
+        or payload.get("content")
+        or "<no text in payload>"
+    )
+
+
+def print_report(groups, pairs, total_memories):
+    print()
+    print("=" * 72)
+    print("  mem0 Near-Duplicate Memory Report")
+    print(f"  Collection: {COLLECTION}  |  Threshold: {SIMILARITY_THRESHOLD}")
+    print("=" * 72)
+
+    if not groups:
+        print("\nNo near-duplicate pairs found.")
+    else:
+        for idx, group in enumerate(groups, 1):
+            members = group["members"]
+            edge_scores = group["edge_scores"]
+            points = group["points"]
+
+            # Find max score within group for display
+            group_edges = [
+                (s, a, b) for (a, b), s in edge_scores.items()
+                if a in members and b in members
+            ]
+            max_score = max((s for s, _, _ in group_edges), default=0.0)
+
+            print(f"\n--- Group {idx} (max similarity: {max_score:.4f}) ---")
+            for pid in members:
+                pt = points[pid]
+                text = extract_text(pt)
+                print(f"  ID:   {pid}")
+                print(f"  Text: {text[:200]}{'...' if len(text) > 200 else ''}")
+                print()
+
+            # Show pairwise scores within the group
+            if group_edges:
+                print("  Pairwise similarities:")
+                for score, aid, bid in sorted(group_edges, reverse=True):
+                    print(f"    {aid} <-> {bid}: {score:.4f}")
+
+    print()
+    print("=" * 72)
+    print(f"  Summary: Found {len(groups)} duplicate group(s) across {total_memories} total memories")
+    print(f"  (Examined {len(pairs)} near-duplicate pair(s) at threshold >= {SIMILARITY_THRESHOLD})")
+    print("=" * 72)
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Consolidation (--consolidate flag)
+# ---------------------------------------------------------------------------
+
+def pick_keeper(group: dict) -> str:
+    """Choose which point to keep in a duplicate group.
+
+    Strategy: prefer the point with the longest text; break ties by most
+    recently updated (latest updated_at timestamp string, lexicographic).
+    """
+    points = group["points"]
+    members = group["members"]
+
+    def rank(pid):
+        pt = points[pid]
+        payload = pt.get("payload") or {}
+        text = extract_text(pt)
+        updated_at = payload.get("updated_at", "")
+        return (len(text), updated_at)
+
+    return max(members, key=rank)
+
+
+def delete_points(point_ids: list) -> bool:
+    """Delete a list of Qdrant points by ID. Returns True on success."""
+    if not point_ids:
+        return True
+    body = {"points": point_ids}
+    try:
+        result = api_post(f"/collections/{COLLECTION}/points/delete", body)
+        status = result.get("result", {}).get("status", "unknown")
+        return status == "acknowledged"
+    except urllib.error.URLError as exc:
+        print(f"[ERROR] Qdrant delete failed: {exc}", file=sys.stderr)
+        return False
+
+
+def consolidate_groups(groups: list, dry_run: bool = True) -> tuple[int, int]:
+    """Keep the best memory per group and delete the rest.
+
+    When dry_run=True (the default), only prints what WOULD be deleted without
+    touching Qdrant. Pass dry_run=False (requires --yes on the CLI) to actually
+    execute the deletes.
+
+    Returns (kept_count, deleted_count).
+    """
+    kept = 0
+    deleted = 0
+
+    for idx, group in enumerate(groups, 1):
+        members = group["members"]
+        keeper_id = pick_keeper(group)
+        to_delete = [pid for pid in members if pid != keeper_id]
+
+        keeper_text = extract_text(group["points"][keeper_id])
+        prefix = "[DRY-RUN] " if dry_run else ""
+        print(f"\n[GROUP {idx}] {prefix}Keeping {keeper_id}")
+        print(f"  Text: {keeper_text[:160]}{'...' if len(keeper_text) > 160 else ''}")
+        print(f"  {prefix}Would delete {len(to_delete)} duplicate(s): {to_delete}")
+
+        if dry_run:
+            kept += 1
+            deleted += len(to_delete)
+        else:
+            ok = delete_points(to_delete)
+            if ok:
+                kept += 1
+                deleted += len(to_delete)
+                print(f"  [OK] Deleted {len(to_delete)} point(s).")
+            else:
+                print(f"  [FAIL] Delete did not succeed for group {idx}.", file=sys.stderr)
+
+    return kept, deleted
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    import argparse
+
+    cfg = _load_mem0_config()
+    cfg_user_id = _config_user_id(cfg)
+    cfg_collection = _config_collection(cfg) or "hermes_memories"
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Scan a mem0 Qdrant collection for near-duplicate memory pairs. "
+            "By default reports only. Use --consolidate to auto-delete duplicates."
+        )
+    )
+    parser.add_argument(
+        "--user",
+        default=cfg_user_id,
+        help=(
+            "user_id to filter on. If omitted and not set in mem0.json, "
+            "all user_ids found in the collection are scanned."
+        ),
+    )
+    parser.add_argument(
+        "--qdrant-url",
+        default=os.environ.get("QDRANT_URL", "http://localhost:6333"),
+        help="Qdrant base URL (default: QDRANT_URL env var, or http://localhost:6333).",
+    )
+    parser.add_argument(
+        "--collection",
+        default=cfg_collection,
+        help=(
+            f"Collection name to scan "
+            f"(default: from mem0.json oss.vector_store.config.collection_name, "
+            f"or 'hermes_memories')."
+        ),
+    )
+    parser.add_argument(
+        "--consolidate",
+        action="store_true",
+        help=(
+            "After finding duplicate groups, show what WOULD be kept/deleted "
+            "(dry-run by default). Add --yes to actually execute the deletes."
+        ),
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help=(
+            "Required together with --consolidate to actually execute deletes. "
+            "Without this flag, --consolidate only prints a dry-run preview."
+        ),
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=SIMILARITY_THRESHOLD,
+        help=f"Cosine similarity threshold for duplicate detection (default: {SIMILARITY_THRESHOLD}).",
+    )
+    args = parser.parse_args()
+
+    # --yes without --consolidate is meaningless; warn and exit
+    if args.yes and not args.consolidate:
+        print("[ERROR] --yes requires --consolidate to be specified.", file=sys.stderr)
+        sys.exit(1)
+
+    dry_run = args.consolidate and not args.yes
+
+    # Wire CLI flags into module-level constants used by the rest of the script
+    globals()["QDRANT_URL"] = args.qdrant_url
+    globals()["COLLECTION"] = args.collection
+    if args.threshold != SIMILARITY_THRESHOLD:
+        globals()["SIMILARITY_THRESHOLD"] = args.threshold
+
+    print(f"Qdrant URL:  {args.qdrant_url}", file=sys.stderr)
+    print(f"Collection:  {args.collection}", file=sys.stderr)
+    if args.user:
+        print(f"User filter: {args.user!r}", file=sys.stderr)
+    else:
+        print("User filter: (all users in collection)", file=sys.stderr)
+
+    if args.consolidate:
+        if dry_run:
+            print("[CONSOLIDATE DRY-RUN] Will show what would be deleted. Re-run with --yes to execute.", file=sys.stderr)
+        else:
+            print("[CONSOLIDATE MODE] Duplicates will be permanently deleted.", file=sys.stderr)
+
+    # Verify Qdrant is reachable — root endpoint returns JSON
+    try:
+        info = api_get("/")
+        version = info.get("version", "unknown")
+        print(f"Qdrant {version} is up.", file=sys.stderr)
+    except urllib.error.URLError as exc:
+        print(f"[ERROR] Cannot reach Qdrant at {args.qdrant_url}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    points = scroll_all_points()
+    print(f"Fetched {len(points)} total points.", file=sys.stderr)
+
+    # Determine which user_ids to scan
+    if args.user:
+        user_ids = [args.user]
+    else:
+        user_ids = sorted({
+            p.get("payload", {}).get("user_id")
+            for p in points
+            if p.get("payload", {}).get("user_id")
+        })
+        if not user_ids:
+            print("No points with a user_id found in collection.", file=sys.stderr)
+            print_report([], [], 0)
+            return
+
+    print(f"User IDs to scan: {user_ids}", file=sys.stderr)
+
+    all_groups = []
+    all_pairs = []
+    total_memories = 0
+
+    for uid in user_ids:
+        pairs, count = find_duplicates(points, uid)
+        groups = group_pairs(pairs)
+        all_groups.extend(groups)
+        all_pairs.extend(pairs)
+        total_memories += count
+
+    print_report(all_groups, all_pairs, total_memories)
+
+    if args.consolidate and all_groups:
+        print("\n" + "=" * 72)
+        if dry_run:
+            print("  Consolidation Preview (DRY-RUN — nothing will be deleted)")
+        else:
+            print("  Consolidation Pass")
+        print("=" * 72)
+        kept, deleted = consolidate_groups(all_groups, dry_run=dry_run)
+        if dry_run:
+            print(f"\nDry-run complete: {kept} group(s) would be resolved, {deleted} duplicate(s) would be deleted.")
+            print("Re-run with --consolidate --yes to actually execute the deletes.")
+        else:
+            print(f"\nConsolidation complete: {kept} group(s) resolved, {deleted} duplicate(s) deleted.")
+    elif args.consolidate and not all_groups:
+        print("\nNo duplicate groups to consolidate.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mem0_dedup_scan.py
+++ b/scripts/mem0_dedup_scan.py
@@ -531,7 +531,7 @@ def consolidate_groups(groups: list, dry_run: bool = True) -> tuple[int, int]:
                 f"  [FAIL] Batch delete of {deleted_count} point(s) did not fully succeed.",
                 file=sys.stderr,
             )
-            return len(plan), 0
+            sys.exit(1)
         print(f"  [OK] Deleted {deleted_count} point(s) in one batch.")
 
     return len(plan), deleted_count
@@ -544,16 +544,17 @@ def consolidate_groups(groups: list, dry_run: bool = True) -> tuple[int, int]:
 def verify_qdrant_connection(qdrant_url: str | None, qdrant_path: str | None) -> None:
     """Verify Qdrant is reachable; exit(1) on failure."""
     if qdrant_path:
-        # Embedded mode — check the path exists or can be created
+        # Embedded mode — the path must already exist (it is created by mem0/Qdrant on
+        # first write, but if it is absent at scan time there are no memories to read).
         p = Path(qdrant_path)
         if not p.exists():
             print(
-                f"[WARN] Embedded Qdrant path '{qdrant_path}' does not exist yet "
-                f"(will be created on first write).",
+                f"[ERROR] Embedded Qdrant path '{qdrant_path}' does not exist. "
+                f"Has mem0 written any memories yet?",
                 file=sys.stderr,
             )
-        else:
-            print(f"Embedded Qdrant at: {qdrant_path}", file=sys.stderr)
+            sys.exit(1)
+        print(f"Embedded Qdrant at: {qdrant_path}", file=sys.stderr)
         return
 
     # HTTP mode — hit the root endpoint

--- a/scripts/mem0_dedup_scan.py
+++ b/scripts/mem0_dedup_scan.py
@@ -490,6 +490,7 @@ def consolidate_groups(groups: list, dry_run: bool = True) -> tuple[int, int]:
     # --- Phase 1: determine keeper and losers for every group without touching Qdrant ---
     plan: list[dict] = []           # {keeper_id, to_delete, group_idx, group}
     ids_to_delete: set[str] = set() # deduplicated across all groups
+    keepers: set[str] = set()       # IDs elected as keeper in a prior group
 
     for idx, group in enumerate(groups, 1):
         members = group["members"]
@@ -501,6 +502,13 @@ def consolidate_groups(groups: list, dry_run: bool = True) -> tuple[int, int]:
             continue
         keeper_id = pick_keeper(group)
         to_delete = [pid for pid in members if pid != keeper_id]
+        # Don't delete a point that was elected keeper in a prior group —
+        # otherwise a transitive chain (A,B) then (B,C) could demote B,
+        # causing A's information to be lost.
+        to_delete = [pid for pid in to_delete if pid not in keepers]
+        if not to_delete:
+            continue
+        keepers.add(keeper_id)
         ids_to_delete.update(to_delete)
         plan.append({
             "keeper_id": keeper_id,
@@ -646,6 +654,12 @@ def main():
         default=_DEFAULT_THRESHOLD,
         help=f"Cosine similarity threshold for duplicate detection (default: {_DEFAULT_THRESHOLD}).",
     )
+    parser.add_argument(
+        "--max-points",
+        type=int,
+        default=2000,
+        help="Safety limit on number of points to compare (default: 2000). Use --max-points 0 to disable.",
+    )
     args = parser.parse_args()
 
     # --yes without --consolidate is meaningless; warn and exit
@@ -681,7 +695,7 @@ def main():
     else:
         print(f"Qdrant mode: HTTP ({resolved_url})", file=sys.stderr)
     print(f"Collection:  {args.collection}", file=sys.stderr)
-    if args.user:
+    if args.user is not None:
         print(f"User filter: {args.user!r}", file=sys.stderr)
     else:
         print("User filter: (all users in collection)", file=sys.stderr)
@@ -701,8 +715,19 @@ def main():
     points = scroll_all_points()
     print(f"Fetched {len(points)} total points.", file=sys.stderr)
 
+    if args.max_points and len(points) > args.max_points:
+        print(
+            f"ERROR: Collection has {len(points)} points, exceeding --max-points limit of {args.max_points}.",
+            file=sys.stderr,
+        )
+        print(
+            "O(n²) comparison would be very slow. Use --max-points 0 to disable this check, or filter by --user.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     # Determine which user_ids to scan
-    if args.user:
+    if args.user is not None:
         user_ids = [args.user]
     else:
         user_ids = sorted({

--- a/scripts/mem0_dedup_scan.py
+++ b/scripts/mem0_dedup_scan.py
@@ -306,8 +306,9 @@ def find_duplicates(points, target_user_id):
         vec = p.get("vector")
         if not isinstance(vec, list) or not vec:
             continue
-        # mem0 stores user_id directly in payload
-        if payload.get("user_id") != target_user_id:
+        # mem0 stores user_id directly in payload (may be int or str)
+        raw_uid = payload.get("user_id")
+        if raw_uid is None or str(raw_uid) != str(target_user_id):
             continue
         eligible.append(p)
 
@@ -492,6 +493,12 @@ def consolidate_groups(groups: list, dry_run: bool = True) -> tuple[int, int]:
 
     for idx, group in enumerate(groups, 1):
         members = group["members"]
+        # Skip this group if any member is already slated for deletion by a
+        # higher-similarity group.  Without this guard, a transitive chain
+        # A~B~C could delete both A and B even when A and C are not similar,
+        # causing permanent information loss.
+        if any(m in ids_to_delete for m in members):
+            continue
         keeper_id = pick_keeper(group)
         to_delete = [pid for pid in members if pid != keeper_id]
         ids_to_delete.update(to_delete)
@@ -698,9 +705,9 @@ def main():
         user_ids = [args.user]
     else:
         user_ids = sorted({
-            p.get("payload", {}).get("user_id")
+            str(p.get("payload", {}).get("user_id"))
             for p in points
-            if p.get("payload", {}).get("user_id")
+            if p.get("payload", {}).get("user_id") is not None
         })
         if not user_ids:
             print("No points with a user_id found in collection.", file=sys.stderr)

--- a/scripts/mem0_dedup_scan.py
+++ b/scripts/mem0_dedup_scan.py
@@ -45,13 +45,30 @@ def get_hermes_home() -> Path:
 
 
 MEM0_CONFIG = get_hermes_home() / "mem0.json"
-SIMILARITY_THRESHOLD = 0.92
 SCROLL_LIMIT = 100
 
-# Module-level constants — overridden by CLI flags in main()
-QDRANT_URL: str | None = None        # None means "use embedded path mode"
-QDRANT_PATH: str | None = None       # Set when running in embedded/local mode
-COLLECTION = "hermes_memories"
+# ---------------------------------------------------------------------------
+# Runtime configuration — populated by main() after CLI parsing.
+# Functions read from this namespace instead of bare module globals so that
+# the script can be imported and tested without side-effects.
+# ---------------------------------------------------------------------------
+
+class _Cfg:  # noqa: N801  (intentionally lowercase-ish for internal use)
+    """Mutable runtime config set once in main() and read by all helpers."""
+    qdrant_url: str | None = None   # None → embedded (local-path) mode
+    qdrant_path: str | None = None  # Set when running embedded Qdrant
+    collection: str = "hermes_memories"
+    threshold: float = 0.92
+
+
+_cfg = _Cfg()
+
+# ---------------------------------------------------------------------------
+# Default values for argparse — these are the initial values before CLI parsing.
+# All runtime code reads from _cfg, not from these constants.
+# ---------------------------------------------------------------------------
+_DEFAULT_THRESHOLD = _cfg.threshold
+_DEFAULT_COLLECTION = _cfg.collection
 
 
 # ---------------------------------------------------------------------------
@@ -114,7 +131,7 @@ def _config_qdrant_url(cfg: dict) -> str | None:
 
 def _is_embedded_mode() -> bool:
     """Return True when the script should use qdrant-client with path= (embedded)."""
-    return QDRANT_PATH is not None
+    return _cfg.qdrant_path is not None
 
 
 def _require_qdrant_client():
@@ -134,9 +151,9 @@ def _require_qdrant_client():
 def _get_qdrant_client():
     """Return a QdrantClient configured for the active mode (embedded or HTTP)."""
     QdrantClient = _require_qdrant_client()
-    if QDRANT_PATH:
-        return QdrantClient(path=QDRANT_PATH)
-    return QdrantClient(url=QDRANT_URL)
+    if _cfg.qdrant_path:
+        return QdrantClient(path=_cfg.qdrant_path)
+    return QdrantClient(url=_cfg.qdrant_url)
 
 
 # ---------------------------------------------------------------------------
@@ -144,7 +161,7 @@ def _get_qdrant_client():
 # ---------------------------------------------------------------------------
 
 def api_get(path, timeout=60):
-    req = urllib.request.Request(f"{QDRANT_URL}{path}", method="GET")
+    req = urllib.request.Request(f"{_cfg.qdrant_url}{path}", method="GET")
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         return json.loads(resp.read())
 
@@ -152,7 +169,7 @@ def api_get(path, timeout=60):
 def api_post(path, body, timeout=120):
     data = json.dumps(body).encode()
     req = urllib.request.Request(
-        f"{QDRANT_URL}{path}",
+        f"{_cfg.qdrant_url}{path}",
         data=data,
         method="POST",
         headers={"Content-Type": "application/json"},
@@ -167,7 +184,7 @@ def api_delete_points(point_ids: list) -> bool:
         return True
     body = {"points": point_ids}
     try:
-        result = api_post(f"/collections/{COLLECTION}/points/delete", body)
+        result = api_post(f"/collections/{_cfg.collection}/points/delete", body)
         status = result.get("result", {}).get("status", "unknown")
         return status == "acknowledged"
     except urllib.error.URLError as exc:
@@ -213,7 +230,7 @@ def _scroll_all_points_embedded() -> list:
     while True:
         try:
             result, next_offset = client.scroll(
-                collection_name=COLLECTION,
+                collection_name=_cfg.collection,
                 scroll_filter=None,
                 limit=SCROLL_LIMIT,
                 offset=offset,
@@ -257,7 +274,7 @@ def _scroll_all_points_http() -> list:
             body["offset"] = offset
 
         try:
-            result = api_post(f"/collections/{COLLECTION}/points/scroll", body)
+            result = api_post(f"/collections/{_cfg.collection}/points/scroll", body)
         except urllib.error.URLError as exc:
             print(f"[ERROR] Qdrant scroll failed: {exc}", file=sys.stderr)
             sys.exit(1)
@@ -307,7 +324,7 @@ def find_duplicates(points, target_user_id):
             a = eligible[i]
             b = eligible[j]
             score = cosine_similarity(a["vector"], b["vector"])
-            if score >= SIMILARITY_THRESHOLD:
+            if score >= _cfg.threshold:
                 pairs.append((score, a, b))
 
     # Sort highest similarity first
@@ -374,7 +391,7 @@ def print_report(groups, pairs, total_memories):
     print()
     print("=" * 72)
     print("  mem0 Near-Duplicate Memory Report")
-    print(f"  Collection: {COLLECTION}  |  Threshold: {SIMILARITY_THRESHOLD}")
+    print(f"  Collection: {_cfg.collection}  |  Threshold: {_cfg.threshold}")
     print("=" * 72)
 
     if not groups:
@@ -409,7 +426,7 @@ def print_report(groups, pairs, total_memories):
     print()
     print("=" * 72)
     print(f"  Summary: Found {len(groups)} duplicate group(s) across {total_memories} total memories")
-    print(f"  (Examined {len(pairs)} near-duplicate pair(s) at threshold >= {SIMILARITY_THRESHOLD})")
+    print(f"  (Examined {len(pairs)} near-duplicate pair(s) at threshold >= {_cfg.threshold})")
     print("=" * 72)
     print()
 
@@ -446,7 +463,7 @@ def delete_points(point_ids: list) -> bool:
         try:
             from qdrant_client.models import PointIdsList
             client.delete(
-                collection_name=COLLECTION,
+                collection_name=_cfg.collection,
                 points_selector=PointIdsList(points=point_ids),
             )
             return True
@@ -618,8 +635,8 @@ def main():
     parser.add_argument(
         "--threshold",
         type=float,
-        default=SIMILARITY_THRESHOLD,
-        help=f"Cosine similarity threshold for duplicate detection (default: {SIMILARITY_THRESHOLD}).",
+        default=_DEFAULT_THRESHOLD,
+        help=f"Cosine similarity threshold for duplicate detection (default: {_DEFAULT_THRESHOLD}).",
     )
     args = parser.parse_args()
 
@@ -644,12 +661,11 @@ def main():
         # No URL: use embedded mode
         resolved_path = args.qdrant_path or str(get_hermes_home() / "mem0_qdrant")
 
-    # Wire into module-level constants used by helpers
-    globals()["QDRANT_URL"] = resolved_url
-    globals()["QDRANT_PATH"] = resolved_path
-    globals()["COLLECTION"] = args.collection
-    if args.threshold != SIMILARITY_THRESHOLD:
-        globals()["SIMILARITY_THRESHOLD"] = args.threshold
+    # Wire resolved settings into the module-level _cfg object used by helpers
+    _cfg.qdrant_url = resolved_url
+    _cfg.qdrant_path = resolved_path
+    _cfg.collection = args.collection
+    _cfg.threshold = args.threshold
 
     # Logging
     if resolved_path:

--- a/scripts/mem0_dedup_scan.py
+++ b/scripts/mem0_dedup_scan.py
@@ -7,6 +7,8 @@ user_id that have cosine similarity >= 0.92. Prints a report to stdout.
 Without --consolidate: reports only (does NOT delete anything).
 With --consolidate (alone): dry-run — prints what WOULD be deleted but does nothing.
 With --consolidate --yes: actually deletes the identified duplicates via Qdrant API.
+
+Supports both HTTP Qdrant (url=...) and embedded/local-path Qdrant (path=...).
 """
 
 import json
@@ -16,12 +18,39 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-MEM0_CONFIG = Path.home() / ".hermes" / "mem0.json"
+# ---------------------------------------------------------------------------
+# Profile-aware Hermes home resolution
+# ---------------------------------------------------------------------------
+
+try:
+    from hermes_constants import get_hermes_home as _get_hermes_home  # noqa: F401
+    _hermes_home: Path = _get_hermes_home()
+except Exception:  # noqa: BLE001  — script may be run standalone outside the venv
+    _hermes_home = Path.home() / ".hermes"
+
+
+def get_hermes_home() -> Path:
+    """Return the active Hermes home directory.
+
+    When run inside the hermes-agent venv, delegates to the canonical
+    ``hermes_constants.get_hermes_home()`` (which respects HERMES_HOME and
+    active-profile overrides).  When run standalone, falls back to
+    ``~/.hermes`` so the script still works outside the project.
+    """
+    try:
+        from hermes_constants import get_hermes_home as _ghh  # noqa: F401
+        return _ghh()
+    except Exception:  # noqa: BLE001
+        return Path.home() / ".hermes"
+
+
+MEM0_CONFIG = get_hermes_home() / "mem0.json"
 SIMILARITY_THRESHOLD = 0.92
 SCROLL_LIMIT = 100
 
 # Module-level constants — overridden by CLI flags in main()
-QDRANT_URL = "http://localhost:6333"
+QDRANT_URL: str | None = None        # None means "use embedded path mode"
+QDRANT_PATH: str | None = None       # Set when running in embedded/local mode
 COLLECTION = "hermes_memories"
 
 
@@ -29,15 +58,16 @@ COLLECTION = "hermes_memories"
 # Config helpers
 # ---------------------------------------------------------------------------
 
-def _load_mem0_config():
+def _load_mem0_config() -> dict:
     """Return parsed mem0.json as a dict, or {} if unavailable."""
+    config_path = get_hermes_home() / "mem0.json"
     try:
-        with open(MEM0_CONFIG) as f:
+        with open(config_path, encoding="utf-8") as f:
             return json.load(f)
     except FileNotFoundError:
         return {}
     except Exception as exc:  # noqa: BLE001
-        print(f"[WARN] Could not read {MEM0_CONFIG}: {exc}", file=sys.stderr)
+        print(f"[WARN] Could not read {config_path}: {exc}", file=sys.stderr)
         return {}
 
 
@@ -52,8 +82,65 @@ def _config_collection(cfg: dict) -> str | None:
         return None
 
 
+def _config_qdrant_path(cfg: dict) -> str | None:
+    """Return the local storage path if Qdrant is configured in embedded mode."""
+    try:
+        vs_config = cfg["oss"]["vector_store"]["config"]
+        return vs_config.get("path") or None
+    except (KeyError, TypeError):
+        return None
+
+
+def _config_qdrant_url(cfg: dict) -> str | None:
+    """Return the HTTP URL if Qdrant is configured in server mode."""
+    try:
+        vs_config = cfg["oss"]["vector_store"]["config"]
+        # Qdrant HTTP config uses 'url' or 'host'/'port'
+        url = vs_config.get("url")
+        if url:
+            return url
+        host = vs_config.get("host")
+        port = vs_config.get("port", 6333)
+        if host:
+            return f"http://{host}:{port}"
+        return None
+    except (KeyError, TypeError):
+        return None
+
+
 # ---------------------------------------------------------------------------
-# HTTP helpers
+# Qdrant mode detection
+# ---------------------------------------------------------------------------
+
+def _is_embedded_mode() -> bool:
+    """Return True when the script should use qdrant-client with path= (embedded)."""
+    return QDRANT_PATH is not None
+
+
+def _require_qdrant_client():
+    """Import qdrant-client or exit with a helpful message."""
+    try:
+        from qdrant_client import QdrantClient  # noqa: F401
+        return QdrantClient
+    except ImportError:
+        print(
+            "[ERROR] qdrant-client is not installed. "
+            "Install it with: pip install qdrant-client",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _get_qdrant_client():
+    """Return a QdrantClient configured for the active mode (embedded or HTTP)."""
+    QdrantClient = _require_qdrant_client()
+    if QDRANT_PATH:
+        return QdrantClient(path=QDRANT_PATH)
+    return QdrantClient(url=QDRANT_URL)
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers (used only in HTTP mode)
 # ---------------------------------------------------------------------------
 
 def api_get(path, timeout=60):
@@ -74,16 +161,18 @@ def api_post(path, body, timeout=120):
         return json.loads(resp.read())
 
 
-def api_delete(path, body=None, timeout=30):
-    data = json.dumps(body).encode() if body else None
-    req = urllib.request.Request(
-        f"{QDRANT_URL}{path}",
-        data=data,
-        method="DELETE",
-        headers={"Content-Type": "application/json"} if data else {},
-    )
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read())
+def api_delete_points(point_ids: list) -> bool:
+    """Delete points by ID via HTTP API. Returns True on success."""
+    if not point_ids:
+        return True
+    body = {"points": point_ids}
+    try:
+        result = api_post(f"/collections/{COLLECTION}/points/delete", body)
+        status = result.get("result", {}).get("status", "unknown")
+        return status == "acknowledged"
+    except urllib.error.URLError as exc:
+        print(f"[ERROR] Qdrant delete failed: {exc}", file=sys.stderr)
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -108,13 +197,58 @@ def cosine_similarity(a, b):
 # Collection fetching
 # ---------------------------------------------------------------------------
 
-def scroll_all_points():
+def scroll_all_points() -> list:
     """Fetch all points from the collection with vectors and payloads."""
+    if _is_embedded_mode():
+        return _scroll_all_points_embedded()
+    return _scroll_all_points_http()
+
+
+def _scroll_all_points_embedded() -> list:
+    """Use qdrant-client SDK to scroll all points in embedded (local-path) mode."""
+    client = _get_qdrant_client()
     points = []
     offset = None
 
     while True:
-        body = {
+        try:
+            result, next_offset = client.scroll(
+                collection_name=COLLECTION,
+                scroll_filter=None,
+                limit=SCROLL_LIMIT,
+                offset=offset,
+                with_payload=True,
+                with_vectors=True,
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(f"[ERROR] Qdrant scroll failed: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+        # Convert ScoredPoint / Record objects to plain dicts
+        for record in result:
+            vec = record.vector
+            if hasattr(vec, "tolist"):
+                vec = vec.tolist()
+            points.append({
+                "id": str(record.id),
+                "vector": vec,
+                "payload": dict(record.payload or {}),
+            })
+
+        if next_offset is None or not result:
+            break
+        offset = next_offset
+
+    return points
+
+
+def _scroll_all_points_http() -> list:
+    """Use raw HTTP API to scroll all points (HTTP/cloud Qdrant mode)."""
+    points = []
+    offset = None
+
+    while True:
+        body: dict = {
             "limit": SCROLL_LIMIT,
             "with_vector": True,
             "with_payload": True,
@@ -129,6 +263,9 @@ def scroll_all_points():
             sys.exit(1)
 
         batch = result.get("result", {}).get("points", [])
+        # Normalise IDs to str for consistency
+        for pt in batch:
+            pt["id"] = str(pt["id"])
         points.extend(batch)
 
         next_offset = result.get("result", {}).get("next_page_offset")
@@ -192,12 +329,11 @@ def group_pairs(pairs):
 
     Instead, each directly-similar pair becomes its own two-member group.
     If the same ID appears in multiple pairs it will appear in multiple groups,
-    and the consolidation step will handle it safely pair-by-pair, always
-    keeping the higher-ranked member of each direct pair.
+    and the consolidation step handles it safely by building a single
+    deduplicated delete-set before issuing any deletes.
     """
     point_map = {}
     edge_scores = {}
-    # Each pair becomes an independent two-member group keyed by a frozenset
     pair_groups = []
 
     for score, a, b in pairs:
@@ -305,52 +441,105 @@ def delete_points(point_ids: list) -> bool:
     """Delete a list of Qdrant points by ID. Returns True on success."""
     if not point_ids:
         return True
-    body = {"points": point_ids}
-    try:
-        result = api_post(f"/collections/{COLLECTION}/points/delete", body)
-        status = result.get("result", {}).get("status", "unknown")
-        return status == "acknowledged"
-    except urllib.error.URLError as exc:
-        print(f"[ERROR] Qdrant delete failed: {exc}", file=sys.stderr)
-        return False
+    if _is_embedded_mode():
+        client = _get_qdrant_client()
+        try:
+            from qdrant_client.models import PointIdsList
+            client.delete(
+                collection_name=COLLECTION,
+                points_selector=PointIdsList(points=point_ids),
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001
+            print(f"[ERROR] Qdrant embedded delete failed: {exc}", file=sys.stderr)
+            return False
+    return api_delete_points(point_ids)
 
 
 def consolidate_groups(groups: list, dry_run: bool = True) -> tuple[int, int]:
     """Keep the best memory per group and delete the rest.
 
+    Builds a single deduplicated set of IDs to delete before executing any
+    deletes, preventing the same ID from being submitted for deletion multiple
+    times when it appears in overlapping pairs.
+
     When dry_run=True (the default), only prints what WOULD be deleted without
     touching Qdrant. Pass dry_run=False (requires --yes on the CLI) to actually
     execute the deletes.
 
-    Returns (kept_count, deleted_count).
+    Returns (resolved_groups_count, deleted_count).
     """
-    kept = 0
-    deleted = 0
+    # --- Phase 1: determine keeper and losers for every group without touching Qdrant ---
+    plan: list[dict] = []           # {keeper_id, to_delete, group_idx, group}
+    ids_to_delete: set[str] = set() # deduplicated across all groups
 
     for idx, group in enumerate(groups, 1):
         members = group["members"]
         keeper_id = pick_keeper(group)
         to_delete = [pid for pid in members if pid != keeper_id]
+        ids_to_delete.update(to_delete)
+        plan.append({
+            "keeper_id": keeper_id,
+            "to_delete": to_delete,
+            "group_idx": idx,
+            "group": group,
+        })
 
+    prefix = "[DRY-RUN] " if dry_run else ""
+
+    # --- Phase 2: print the plan ---
+    for entry in plan:
+        keeper_id = entry["keeper_id"]
+        to_delete = entry["to_delete"]
+        group = entry["group"]
         keeper_text = extract_text(group["points"][keeper_id])
-        prefix = "[DRY-RUN] " if dry_run else ""
-        print(f"\n[GROUP {idx}] {prefix}Keeping {keeper_id}")
+        print(f"\n[GROUP {entry['group_idx']}] {prefix}Keeping {keeper_id}")
         print(f"  Text: {keeper_text[:160]}{'...' if len(keeper_text) > 160 else ''}")
         print(f"  {prefix}Would delete {len(to_delete)} duplicate(s): {to_delete}")
 
-        if dry_run:
-            kept += 1
-            deleted += len(to_delete)
-        else:
-            ok = delete_points(to_delete)
-            if ok:
-                kept += 1
-                deleted += len(to_delete)
-                print(f"  [OK] Deleted {len(to_delete)} point(s).")
-            else:
-                print(f"  [FAIL] Delete did not succeed for group {idx}.", file=sys.stderr)
+    deleted_count = len(ids_to_delete)
 
-    return kept, deleted
+    # --- Phase 3: execute (if not dry-run) using the deduplicated set ---
+    if not dry_run:
+        ok = delete_points(list(ids_to_delete))
+        if not ok:
+            print(
+                f"  [FAIL] Batch delete of {deleted_count} point(s) did not fully succeed.",
+                file=sys.stderr,
+            )
+            return len(plan), 0
+        print(f"  [OK] Deleted {deleted_count} point(s) in one batch.")
+
+    return len(plan), deleted_count
+
+
+# ---------------------------------------------------------------------------
+# Qdrant connectivity check
+# ---------------------------------------------------------------------------
+
+def verify_qdrant_connection(qdrant_url: str | None, qdrant_path: str | None) -> None:
+    """Verify Qdrant is reachable; exit(1) on failure."""
+    if qdrant_path:
+        # Embedded mode — check the path exists or can be created
+        p = Path(qdrant_path)
+        if not p.exists():
+            print(
+                f"[WARN] Embedded Qdrant path '{qdrant_path}' does not exist yet "
+                f"(will be created on first write).",
+                file=sys.stderr,
+            )
+        else:
+            print(f"Embedded Qdrant at: {qdrant_path}", file=sys.stderr)
+        return
+
+    # HTTP mode — hit the root endpoint
+    try:
+        info = api_get("/")
+        version = info.get("version", "unknown")
+        print(f"Qdrant {version} is up at {qdrant_url}", file=sys.stderr)
+    except urllib.error.URLError as exc:
+        print(f"[ERROR] Cannot reach Qdrant at {qdrant_url}: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 # ---------------------------------------------------------------------------
@@ -363,6 +552,10 @@ def main():
     cfg = _load_mem0_config()
     cfg_user_id = _config_user_id(cfg)
     cfg_collection = _config_collection(cfg) or "hermes_memories"
+
+    # Detect default Qdrant mode from mem0.json
+    cfg_qdrant_path = _config_qdrant_path(cfg)
+    cfg_qdrant_url = _config_qdrant_url(cfg)
 
     parser = argparse.ArgumentParser(
         description=(
@@ -380,8 +573,22 @@ def main():
     )
     parser.add_argument(
         "--qdrant-url",
-        default=os.environ.get("QDRANT_URL", "http://localhost:6333"),
-        help="Qdrant base URL (default: QDRANT_URL env var, or http://localhost:6333).",
+        default=os.environ.get("QDRANT_URL", cfg_qdrant_url),
+        help=(
+            "Qdrant HTTP base URL (e.g. http://localhost:6333). "
+            "Takes precedence over --qdrant-path. "
+            "Default: QDRANT_URL env var, then mem0.json url config."
+        ),
+    )
+    parser.add_argument(
+        "--qdrant-path",
+        default=cfg_qdrant_path,
+        help=(
+            "Local filesystem path for embedded Qdrant storage. "
+            "Used when Qdrant runs in embedded (no server) mode. "
+            "Default: from mem0.json oss.vector_store.config.path, "
+            "or ~/.hermes/mem0_qdrant."
+        ),
     )
     parser.add_argument(
         "--collection",
@@ -423,13 +630,32 @@ def main():
 
     dry_run = args.consolidate and not args.yes
 
-    # Wire CLI flags into module-level constants used by the rest of the script
-    globals()["QDRANT_URL"] = args.qdrant_url
+    # ---------------------------------------------------------------------------
+    # Resolve Qdrant mode: --qdrant-url takes precedence over --qdrant-path.
+    # If neither is given, fall back to the default embedded path.
+    # ---------------------------------------------------------------------------
+    resolved_url: str | None = args.qdrant_url
+    resolved_path: str | None = None
+
+    if resolved_url:
+        # Explicit HTTP URL provided — use HTTP mode regardless of path config
+        resolved_path = None
+    else:
+        # No URL: use embedded mode
+        resolved_path = args.qdrant_path or str(get_hermes_home() / "mem0_qdrant")
+
+    # Wire into module-level constants used by helpers
+    globals()["QDRANT_URL"] = resolved_url
+    globals()["QDRANT_PATH"] = resolved_path
     globals()["COLLECTION"] = args.collection
     if args.threshold != SIMILARITY_THRESHOLD:
         globals()["SIMILARITY_THRESHOLD"] = args.threshold
 
-    print(f"Qdrant URL:  {args.qdrant_url}", file=sys.stderr)
+    # Logging
+    if resolved_path:
+        print(f"Qdrant mode: embedded path ({resolved_path})", file=sys.stderr)
+    else:
+        print(f"Qdrant mode: HTTP ({resolved_url})", file=sys.stderr)
     print(f"Collection:  {args.collection}", file=sys.stderr)
     if args.user:
         print(f"User filter: {args.user!r}", file=sys.stderr)
@@ -438,18 +664,15 @@ def main():
 
     if args.consolidate:
         if dry_run:
-            print("[CONSOLIDATE DRY-RUN] Will show what would be deleted. Re-run with --yes to execute.", file=sys.stderr)
+            print(
+                "[CONSOLIDATE DRY-RUN] Will show what would be deleted. "
+                "Re-run with --yes to execute.",
+                file=sys.stderr,
+            )
         else:
             print("[CONSOLIDATE MODE] Duplicates will be permanently deleted.", file=sys.stderr)
 
-    # Verify Qdrant is reachable — root endpoint returns JSON
-    try:
-        info = api_get("/")
-        version = info.get("version", "unknown")
-        print(f"Qdrant {version} is up.", file=sys.stderr)
-    except urllib.error.URLError as exc:
-        print(f"[ERROR] Cannot reach Qdrant at {args.qdrant_url}: {exc}", file=sys.stderr)
-        sys.exit(1)
+    verify_qdrant_connection(resolved_url, resolved_path)
 
     points = scroll_all_points()
     print(f"Fetched {len(points)} total points.", file=sys.stderr)
@@ -492,7 +715,10 @@ def main():
         print("=" * 72)
         kept, deleted = consolidate_groups(all_groups, dry_run=dry_run)
         if dry_run:
-            print(f"\nDry-run complete: {kept} group(s) would be resolved, {deleted} duplicate(s) would be deleted.")
+            print(
+                f"\nDry-run complete: {kept} group(s) would be resolved, "
+                f"{deleted} duplicate(s) would be deleted."
+            )
             print("Re-run with --consolidate --yes to actually execute the deletes.")
         else:
             print(f"\nConsolidation complete: {kept} group(s) resolved, {deleted} duplicate(s) deleted.")

--- a/tests/test_mem0_dedup_scan.py
+++ b/tests/test_mem0_dedup_scan.py
@@ -444,10 +444,23 @@ class TestDryRunSafety:
     ) -> None:
         """verify_qdrant_connection in embedded mode must not attempt any HTTP call."""
         mod = _load_module()
+        qdrant_path = tmp_path / "mem0_qdrant"
+        qdrant_path.mkdir()  # path must exist; verify_qdrant_connection exits(1) if missing
 
         with patch.object(mod, "api_get") as mock_api_get:
             mod.verify_qdrant_connection(
                 qdrant_url=None,
-                qdrant_path=str(tmp_path / "mem0_qdrant"),
+                qdrant_path=str(qdrant_path),
             )
             mock_api_get.assert_not_called()
+
+    def test_verify_qdrant_connection_embedded_exits_on_missing_path(
+        self, tmp_path: Path
+    ) -> None:
+        """verify_qdrant_connection must exit(1) when the embedded path is absent."""
+        mod = _load_module()
+        missing_path = str(tmp_path / "does_not_exist")
+
+        with pytest.raises(SystemExit) as exc_info:
+            mod.verify_qdrant_connection(qdrant_url=None, qdrant_path=missing_path)
+        assert exc_info.value.code == 1

--- a/tests/test_mem0_dedup_scan.py
+++ b/tests/test_mem0_dedup_scan.py
@@ -1,0 +1,405 @@
+"""Tests for scripts/mem0_dedup_scan.py — mem0 near-duplicate scanner.
+
+Covers:
+- Profile config resolution (uses get_hermes_home(), not hardcoded)
+- Deduplication of overlapping pairs (no ID queued twice)
+- Dry-run mode (no deletions without --yes)
+
+Qdrant client is mocked throughout to avoid needing a real Qdrant instance.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers to import the script under test as a module
+# ---------------------------------------------------------------------------
+
+_SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "mem0_dedup_scan.py"
+
+
+def _load_module() -> types.ModuleType:
+    """Import mem0_dedup_scan as a fresh module.
+
+    The conftest autouse fixture already sets HERMES_HOME to a per-test
+    tempdir via monkeypatch.setenv, so hermes_constants.get_hermes_home()
+    will return the correct isolated path during the test.
+    """
+    sys.modules.pop("mem0_dedup_scan", None)
+    spec = importlib.util.spec_from_file_location("mem0_dedup_scan", _SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def hermes_home(tmp_path: Path) -> Path:
+    """Return the HERMES_HOME tempdir that conftest already set up.
+
+    The conftest autouse fixture sets HERMES_HOME=tmp_path/hermes_test.
+    We retrieve it here so tests can write files into it.
+    """
+    home = Path(os.environ["HERMES_HOME"])
+    return home
+
+
+@pytest.fixture()
+def mem0_config(hermes_home: Path) -> Path:
+    """Write a minimal mem0.json into the isolated HERMES_HOME."""
+    cfg = {
+        "user_id": "test-user-42",
+        "oss": {
+            "vector_store": {
+                "provider": "qdrant",
+                "config": {
+                    "collection_name": "my_memories",
+                    "path": str(hermes_home / "mem0_qdrant"),
+                },
+            }
+        },
+    }
+    config_path = hermes_home / "mem0.json"
+    config_path.write_text(json.dumps(cfg), encoding="utf-8")
+    return config_path
+
+
+# ---------------------------------------------------------------------------
+# 1. Profile config resolution
+# ---------------------------------------------------------------------------
+
+class TestProfileConfigResolution:
+    """get_hermes_home() must be used — not a hardcoded ~/.hermes path."""
+
+    def test_mem0_config_path_not_hardcoded(self, hermes_home: Path) -> None:
+        """MEM0_CONFIG must point under the active HERMES_HOME, not ~/.hermes."""
+        mod = _load_module()
+        # The module-level MEM0_CONFIG should be under the per-test HERMES_HOME,
+        # not the real ~/.hermes.
+        assert str(mod.MEM0_CONFIG).startswith(str(hermes_home)), (
+            f"MEM0_CONFIG={mod.MEM0_CONFIG!r} should be under {hermes_home}"
+        )
+        assert str(Path.home() / ".hermes") not in str(mod.MEM0_CONFIG) or \
+            str(hermes_home) == str(Path.home() / ".hermes"), (
+            "MEM0_CONFIG must not hardcode ~/.hermes when HERMES_HOME is overridden"
+        )
+
+    def test_get_hermes_home_returns_active_home(self, hermes_home: Path) -> None:
+        """get_hermes_home() should return the currently active HERMES_HOME."""
+        mod = _load_module()
+        result = mod.get_hermes_home()
+        assert result == hermes_home
+
+    def test_fallback_when_hermes_constants_unavailable(self) -> None:
+        """Without hermes_constants, the script falls back to Path.home() / '.hermes'."""
+        sys.modules.pop("mem0_dedup_scan", None)
+        # Temporarily hide hermes_constants
+        original = sys.modules.get("hermes_constants")
+        sys.modules["hermes_constants"] = None  # type: ignore[assignment]
+        try:
+            spec = importlib.util.spec_from_file_location("mem0_dedup_scan", _SCRIPT_PATH)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            result = mod.get_hermes_home()
+            assert result == Path.home() / ".hermes"
+        finally:
+            if original is not None:
+                sys.modules["hermes_constants"] = original
+            else:
+                sys.modules.pop("hermes_constants", None)
+            sys.modules.pop("mem0_dedup_scan", None)
+
+    def test_load_mem0_config_reads_from_active_home(
+        self, mem0_config: Path, hermes_home: Path
+    ) -> None:
+        """_load_mem0_config() should read mem0.json from the active hermes home."""
+        mod = _load_module()
+        cfg = mod._load_mem0_config()
+        assert cfg.get("user_id") == "test-user-42"
+        assert cfg["oss"]["vector_store"]["config"]["collection_name"] == "my_memories"
+
+    def test_config_qdrant_path_from_mem0_json(
+        self, mem0_config: Path, hermes_home: Path
+    ) -> None:
+        """_config_qdrant_path() should return the embedded path from mem0.json."""
+        mod = _load_module()
+        cfg = mod._load_mem0_config()
+        path = mod._config_qdrant_path(cfg)
+        assert path == str(hermes_home / "mem0_qdrant")
+
+    def test_config_qdrant_url_returns_none_for_embedded(
+        self, mem0_config: Path
+    ) -> None:
+        """When mem0.json has only path=, _config_qdrant_url() should return None."""
+        mod = _load_module()
+        cfg = mod._load_mem0_config()
+        url = mod._config_qdrant_url(cfg)
+        assert url is None
+
+    def test_config_qdrant_url_from_mem0_json(self, hermes_home: Path) -> None:
+        """_config_qdrant_url() returns the HTTP URL when mem0.json specifies one."""
+        cfg = {
+            "oss": {
+                "vector_store": {
+                    "provider": "qdrant",
+                    "config": {"url": "http://myserver:6333"},
+                }
+            }
+        }
+        (hermes_home / "mem0.json").write_text(json.dumps(cfg), encoding="utf-8")
+        mod = _load_module()
+        parsed_cfg = mod._load_mem0_config()
+        url = mod._config_qdrant_url(parsed_cfg)
+        assert url == "http://myserver:6333"
+
+    def test_load_mem0_config_returns_empty_dict_when_missing(
+        self, hermes_home: Path
+    ) -> None:
+        """_load_mem0_config() returns {} when mem0.json doesn't exist."""
+        mod = _load_module()
+        # No mem0.json written in this test
+        cfg = mod._load_mem0_config()
+        assert cfg == {}
+
+
+# ---------------------------------------------------------------------------
+# 2. Deduplication of overlapping pairs (no ID queued twice)
+# ---------------------------------------------------------------------------
+
+def _make_point(pid: str, user_id: str, text: str, vec: list[float]) -> dict:
+    return {
+        "id": pid,
+        "vector": vec,
+        "payload": {"user_id": user_id, "data": text},
+    }
+
+
+class TestDeduplicationCorrectness:
+    """Overlapping duplicate pairs must not cause the same ID to be deleted twice."""
+
+    def test_group_pairs_single_pair(self) -> None:
+        """One pair produces one group with two members."""
+        mod = _load_module()
+        a = _make_point("a1", "u", "hello world", [1.0, 0.0])
+        b = _make_point("b1", "u", "hello world copy", [0.99, 0.14])
+        score = mod.cosine_similarity(a["vector"], b["vector"])
+        pairs = [(score, a, b)]
+        groups = mod.group_pairs(pairs)
+        assert len(groups) == 1
+        assert set(groups[0]["members"]) == {"a1", "b1"}
+
+    def test_overlapping_pairs_do_not_double_queue(self) -> None:
+        """When the same ID appears in two pairs, consolidate_groups deletes it once."""
+        mod = _load_module()
+
+        # Build points: B is near-duplicate of both A and C
+        a = _make_point("a1", "u", "short text A", [1.0, 0.0, 0.0])
+        b = _make_point("b1", "u", "short text B very long so it is kept", [0.999, 0.045, 0.0])
+        c = _make_point("c1", "u", "short text C", [0.0, 0.0, 1.0])
+
+        # Manually build two overlapping groups (A,B) and (B,C)
+        groups = [
+            {
+                "members": ["a1", "b1"],
+                "points": {"a1": a, "b1": b},
+                "edge_scores": {("a1", "b1"): 0.95},
+            },
+            {
+                "members": ["b1", "c1"],
+                "points": {"b1": b, "c1": c},
+                "edge_scores": {("b1", "c1"): 0.93},
+            },
+        ]
+
+        deleted_calls: list[list] = []
+
+        def fake_delete_points(ids: list) -> bool:
+            deleted_calls.append(list(ids))
+            return True
+
+        with patch.object(mod, "delete_points", side_effect=fake_delete_points):
+            kept, deleted = mod.consolidate_groups(groups, dry_run=False)
+
+        # Should have resolved both groups
+        assert kept == 2
+
+        # Collect all IDs passed to delete_points across all calls
+        all_deleted_ids: list[str] = [
+            pid for call in deleted_calls for pid in call
+        ]
+        # No ID should appear more than once
+        assert len(all_deleted_ids) == len(set(all_deleted_ids)), (
+            f"Duplicate IDs in delete calls: {all_deleted_ids}"
+        )
+        # deleted count should match unique IDs
+        assert deleted == len(set(all_deleted_ids))
+
+    def test_pick_keeper_prefers_longer_text(self) -> None:
+        """pick_keeper should choose the member with the longer text."""
+        mod = _load_module()
+        short = _make_point("s1", "u", "short", [1.0, 0.0])
+        long_ = _make_point("l1", "u", "this is a much longer memory text", [0.99, 0.14])
+        group = {
+            "members": ["s1", "l1"],
+            "points": {"s1": short, "l1": long_},
+            "edge_scores": {("s1", "l1"): 0.95},
+        }
+        keeper = mod.pick_keeper(group)
+        assert keeper == "l1"
+
+    def test_pick_keeper_breaks_ties_by_updated_at(self) -> None:
+        """When text lengths are equal, pick_keeper keeps the most recently updated."""
+        mod = _load_module()
+        older = _make_point("old", "u", "same text", [1.0, 0.0])
+        older["payload"]["updated_at"] = "2024-01-01T00:00:00"
+        newer = _make_point("new", "u", "same text", [0.99, 0.14])
+        newer["payload"]["updated_at"] = "2025-06-01T00:00:00"
+        group = {
+            "members": ["old", "new"],
+            "points": {"old": older, "new": newer},
+            "edge_scores": {("old", "new"): 0.98},
+        }
+        keeper = mod.pick_keeper(group)
+        assert keeper == "new"
+
+    def test_find_duplicates_filters_by_user_id(self) -> None:
+        """find_duplicates should only compare points for the target user."""
+        mod = _load_module()
+        a = _make_point("a1", "alice", "hello", [1.0, 0.0])
+        b = _make_point("b1", "alice", "hello copy", [0.999, 0.045])
+        c = _make_point("c1", "bob", "hello", [1.0, 0.0])
+        points = [a, b, c]
+
+        pairs, count = mod.find_duplicates(points, "alice")
+        member_ids = {str(p["id"]) for _, p1, p2 in pairs for p in [p1, p2]}
+        assert "c1" not in member_ids
+        assert count == 2  # only alice's two points
+
+    def test_cosine_similarity_identical_vectors(self) -> None:
+        """Identical vectors have similarity 1.0."""
+        mod = _load_module()
+        v = [0.5, 0.5, 0.5, 0.5]
+        assert abs(mod.cosine_similarity(v, v) - 1.0) < 1e-9
+
+    def test_cosine_similarity_orthogonal_vectors(self) -> None:
+        """Orthogonal vectors have similarity 0.0."""
+        mod = _load_module()
+        assert mod.cosine_similarity([1.0, 0.0], [0.0, 1.0]) == 0.0
+
+    def test_cosine_similarity_zero_vector(self) -> None:
+        """Zero vector returns 0.0 (not a division error)."""
+        mod = _load_module()
+        assert mod.cosine_similarity([0.0, 0.0], [1.0, 0.0]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 3. Dry-run mode — no deletions without --yes
+# ---------------------------------------------------------------------------
+
+class TestDryRunSafety:
+    """consolidate_groups(dry_run=True) must never call delete_points."""
+
+    def _one_group(self, mod: types.ModuleType) -> list[dict]:
+        a = _make_point("a1", "u", "memory A", [1.0, 0.0])
+        b = _make_point("b1", "u", "memory B — much longer so it is kept as the keeper", [0.999, 0.045])
+        return [
+            {
+                "members": ["a1", "b1"],
+                "points": {"a1": a, "b1": b},
+                "edge_scores": {("a1", "b1"): 0.999},
+            }
+        ]
+
+    def test_dry_run_does_not_call_delete_points(self) -> None:
+        """dry_run=True must never invoke delete_points."""
+        mod = _load_module()
+        groups = self._one_group(mod)
+
+        with patch.object(mod, "delete_points") as mock_delete:
+            mod.consolidate_groups(groups, dry_run=True)
+            mock_delete.assert_not_called()
+
+    def test_dry_run_reports_correct_counts(self) -> None:
+        """dry_run should return counts as if the deletion happened (for reporting)."""
+        mod = _load_module()
+        groups = self._one_group(mod)
+
+        with patch.object(mod, "delete_points"):
+            kept, deleted = mod.consolidate_groups(groups, dry_run=True)
+
+        assert kept == 1     # one group resolved
+        assert deleted == 1  # one duplicate would be removed
+
+    def test_wet_run_calls_delete_points(self) -> None:
+        """dry_run=False must call delete_points with the loser IDs."""
+        mod = _load_module()
+        groups = self._one_group(mod)
+
+        with patch.object(mod, "delete_points", return_value=True) as mock_delete:
+            kept, deleted = mod.consolidate_groups(groups, dry_run=False)
+
+        mock_delete.assert_called_once()
+        # The call should contain the loser ID 'a1' (shorter text)
+        call_args = mock_delete.call_args[0][0]
+        assert "a1" in call_args
+        assert kept == 1
+        assert deleted == 1
+
+    def test_multiple_groups_single_delete_batch(self) -> None:
+        """Multiple groups with non-overlapping IDs should be batched into one delete call."""
+        mod = _load_module()
+
+        a = _make_point("a1", "u", "group1 A", [1.0, 0.0])
+        b = _make_point("b1", "u", "group1 B very long text so it wins", [0.999, 0.045])
+        c = _make_point("c1", "u", "group2 C", [0.0, 1.0])
+        d = _make_point("d1", "u", "group2 D much longer text here so it wins", [0.045, 0.999])
+
+        groups = [
+            {
+                "members": ["a1", "b1"],
+                "points": {"a1": a, "b1": b},
+                "edge_scores": {("a1", "b1"): 0.95},
+            },
+            {
+                "members": ["c1", "d1"],
+                "points": {"c1": c, "d1": d},
+                "edge_scores": {("c1", "d1"): 0.93},
+            },
+        ]
+
+        with patch.object(mod, "delete_points", return_value=True) as mock_delete:
+            kept, deleted = mod.consolidate_groups(groups, dry_run=False)
+
+        # Should be a single batch call containing both loser IDs
+        assert mock_delete.call_count == 1
+        batch = mock_delete.call_args[0][0]
+        assert set(batch) == {"a1", "c1"}
+        assert kept == 2
+        assert deleted == 2
+
+    def test_verify_qdrant_connection_embedded_no_http_call(
+        self, tmp_path: Path
+    ) -> None:
+        """verify_qdrant_connection in embedded mode must not attempt any HTTP call."""
+        mod = _load_module()
+
+        with patch.object(mod, "api_get") as mock_api_get:
+            mod.verify_qdrant_connection(
+                qdrant_url=None,
+                qdrant_path=str(tmp_path / "mem0_qdrant"),
+            )
+            mock_api_get.assert_not_called()

--- a/tests/test_mem0_dedup_scan.py
+++ b/tests/test_mem0_dedup_scan.py
@@ -248,6 +248,54 @@ class TestDeduplicationCorrectness:
         # deleted count should match unique IDs
         assert deleted == len(set(all_deleted_ids))
 
+    def test_overlapping_pairs_transitive_safety(self) -> None:
+        """A point must not be deleted when its keeper is also slated for deletion.
+
+        Setup: groups are sorted descending by similarity.
+          Group 0 (higher similarity): B~C, C is longest so C is kept, B deleted.
+          Group 1 (lower similarity):  A~B, B is already in ids_to_delete.
+
+        With the transitive-safety guard, Group 1 is skipped entirely, so A
+        survives even though it was near-duplicate of B (which is now gone).
+        A and C are not similar so A must not be collateral damage.
+        """
+        mod = _load_module()
+        a = _make_point("a1", "u", "short A", [1.0, 0.0, 0.0])
+        b = _make_point("b1", "u", "medium text B", [0.999, 0.045, 0.0])
+        c = _make_point("c1", "u", "very long text C is the longest here", [0.0, 0.0, 1.0])
+
+        # Present higher-similarity pair first (B~C) so B gets marked for deletion
+        # before the lower-similarity pair (A~B) is processed.
+        groups = [
+            {
+                "members": ["b1", "c1"],
+                "points": {"b1": b, "c1": c},
+                "edge_scores": {("b1", "c1"): 0.96},
+            },
+            {
+                "members": ["a1", "b1"],
+                "points": {"a1": a, "b1": b},
+                "edge_scores": {("a1", "b1"): 0.95},
+            },
+        ]
+
+        deleted_calls: list[list] = []
+
+        def fake_delete_points(ids: list) -> bool:
+            deleted_calls.append(list(ids))
+            return True
+
+        with patch.object(mod, "delete_points", side_effect=fake_delete_points):
+            mod.consolidate_groups(groups, dry_run=False)
+
+        all_deleted = {pid for call in deleted_calls for pid in call}
+        # 'a1' must survive: its keeper 'b1' was deleted, and 'a1' is not
+        # similar to 'c1', so deleting it would be permanent information loss.
+        assert "a1" not in all_deleted, (
+            f"'a1' was unsafely deleted (transitive deletion bug). Deleted: {all_deleted}"
+        )
+        assert "b1" in all_deleted
+
     def test_pick_keeper_prefers_longer_text(self) -> None:
         """pick_keeper should choose the member with the longer text."""
         mod = _load_module()


### PR DESCRIPTION
## What this does

`scripts/mem0_dedup_scan.py` is a zero-dependency CLI utility that scans a mem0 Qdrant collection for semantically near-duplicate memories and reports them to stdout.

**Algorithm:**
- Scrolls the full collection via Qdrant's paginated scroll API (handles arbitrarily large collections)
- Runs O(n²) pairwise cosine similarity in pure Python — no numpy, no extra dependencies
- Groups near-duplicate pairs at a configurable threshold (default 0.92)
- Uses pair-only grouping (no union-find) to avoid unsafe transitive merges: if A~B and B~C but A≁C, they stay as separate pairs rather than one group that would incorrectly delete A or C

**Keeper selection:** when consolidating, keeps the memory with the longest text, breaking ties by the latest `updated_at` timestamp.

## Why it's useful

mem0 OSS collections accumulate semantic duplicates silently over time. Every session that mentions similar facts (e.g. "user prefers dark mode" written slightly differently across five conversations) creates near-identical vectors that crowd out retrieval of genuinely distinct memories. This erodes retrieval quality without any visible error — it just quietly degrades. A periodic scan lets you find and remove the noise.

## Safety model

Safe by default — it never deletes anything unless you explicitly opt in:

| Invocation | Effect |
|---|---|
| `python scripts/mem0_dedup_scan.py` | Report only — prints duplicate pairs, nothing deleted |
| `... --consolidate` | Dry-run — shows what *would* be kept/deleted, no writes |
| `... --consolidate --yes` | Actually deletes duplicates from Qdrant |

## CLI flags

```
--user USER         user_id to filter (reads mem0.json as default; scans all
                    user_ids if omitted — no hardcoded personal defaults)
--qdrant-url URL    Qdrant base URL (env: QDRANT_URL, default: http://localhost:6333)
--collection NAME   Collection to scan (reads from mem0.json oss.vector_store.config
                    .collection_name, falls back to "hermes_memories")
--threshold FLOAT   Cosine similarity threshold (default: 0.92)
--consolidate       Enable consolidation (dry-run by default)
--yes               Actually execute deletes (requires --consolidate)
```

## Config auto-detection

If `~/.hermes/mem0.json` exists, the script reads `user_id`, and `oss.vector_store.config.collection_name` from it automatically, so running with no flags works out of the box for the standard hermes setup. All values are overridable via CLI flags or env vars.
