### PR TITLE
fix(desktop): navigate when resuming selected session from a non-session page

### DIFF
--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -1,46 +1,72 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { group, split } from '@/components/pane-shell/tree/model'
-import type { SessionTile } from '@/store/session-states'
-import { orderTilesByTree, selectionHomesToWorkspace } from '@/store/session-states'
+import { $selectedStoredSessionId, setSelectedStoredSessionId } from './session'
+import { $sessionTiles, focusOpenSession } from './session-states'
 
-const tile = (storedSessionId: string): SessionTile => ({ storedSessionId })
-const tilePane = (id: string) => `session-tile:${id}`
+const SESSION_A = 'session-a'
 
-describe('orderTilesByTree', () => {
-  it('no-ops (null) without a tree or below two tiles', () => {
-    expect(orderTilesByTree(null, [tile('a'), tile('b')])).toBeNull()
-    expect(orderTilesByTree(group([tilePane('a')]), [tile('a')])).toBeNull()
-  })
-
-  it('reorders tiles to layout-tree encounter order across a split', () => {
-    const tree = split('row', [group(['workspace', tilePane('b')]), group([tilePane('a')])])
-
-    expect(orderTilesByTree(tree, [tile('a'), tile('b')])).toEqual([tile('b'), tile('a')])
-  })
-
-  it('returns null when the array already matches strip order (skip persist)', () => {
-    const tree = split('row', [group([tilePane('b')]), group([tilePane('a')])])
-
-    expect(orderTilesByTree(tree, [tile('b'), tile('a')])).toBeNull()
-  })
-
-  it('sorts not-yet-adopted tiles after placed ones, stably', () => {
-    const tree = group(['workspace', tilePane('b')])
-
-    expect(orderTilesByTree(tree, [tile('a'), tile('b'), tile('c')])).toEqual([tile('b'), tile('a'), tile('c')])
-  })
+beforeEach(() => {
+  // Start clean: no selected session, no tiles, path at root.
+  setSelectedStoredSessionId(null)
+  $sessionTiles.set([])
+  window.history.pushState({}, '', '/')
 })
 
-describe('selectionHomesToWorkspace', () => {
-  const tiles = [tile('a'), tile('b')]
+afterEach(() => {
+  setSelectedStoredSessionId(null)
+  $sessionTiles.set([])
+  window.history.pushState({}, '', '/')
+})
 
-  it('homes for a null selection or a non-tile session', () => {
-    expect(selectionHomesToWorkspace(null, tiles)).toBe(true)
-    expect(selectionHomesToWorkspace('c', tiles)).toBe(true)
+describe('focusOpenSession', () => {
+  it('returns true when the session is an open tile', () => {
+    $sessionTiles.set([
+      { storedSessionId: SESSION_A }
+    ])
+
+    expect(focusOpenSession(SESSION_A)).toBe(true)
   })
 
-  it('skips homing when the selected id is already an open tile', () => {
-    expect(selectionHomesToWorkspace('a', tiles)).toBe(false)
+  it('returns true when the session is selected and current route is a session route', () => {
+    setSelectedStoredSessionId(SESSION_A)
+    window.history.pushState({}, '', `/${SESSION_A}`)
+
+    expect(focusOpenSession(SESSION_A)).toBe(true)
+  })
+
+  it('returns false when the session is selected but current route is NOT a session route', () => {
+    setSelectedStoredSessionId(SESSION_A)
+    window.history.pushState({}, '', '/messaging')
+
+    expect(focusOpenSession(SESSION_A)).toBe(false)
+  })
+
+  it('returns false when the session is selected but route is a reserved page like /skills', () => {
+    setSelectedStoredSessionId(SESSION_A)
+    window.history.pushState({}, '', '/skills')
+
+    expect(focusOpenSession(SESSION_A)).toBe(false)
+  })
+
+  it('returns false when the session does not match anything', () => {
+    setSelectedStoredSessionId(SESSION_A)
+
+    expect(focusOpenSession('other-session')).toBe(false)
+  })
+
+  it('returns false when no session is selected at all', () => {
+    window.history.pushState({}, '', '/messaging')
+
+    expect(focusOpenSession(SESSION_A)).toBe(false)
+  })
+
+  it('returns true for a tile session even when on a non-session route', () => {
+    $sessionTiles.set([
+      { storedSessionId: SESSION_A }
+    ])
+    window.history.pushState({}, '', '/messaging')
+
+    // Tiles are always navigated via revealTreePane, never via navigate.
+    expect(focusOpenSession(SESSION_A)).toBe(true)
   })
 })

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -1,9 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { group, split } from '@/components/pane-shell/tree/model'
+import type { SessionTile } from '@/store/session-states'
+import { orderTilesByTree, selectionHomesToWorkspace } from '@/store/session-states'
+
 import { setSelectedStoredSessionId } from './session'
 import { $sessionTiles, focusOpenSession } from './session-states'
 
 const SESSION_A = 'session-a'
+
+const tile = (storedSessionId: string): SessionTile => ({ storedSessionId })
+const tilePane = (id: string) => `session-tile:${id}`
 
 beforeEach(() => {
   // Start clean: no selected session, no tiles, path at root.
@@ -16,6 +23,44 @@ afterEach(() => {
   setSelectedStoredSessionId(null)
   $sessionTiles.set([])
   window.history.pushState({}, '', '/')
+})
+
+describe('orderTilesByTree', () => {
+  it('no-ops (null) without a tree or below two tiles', () => {
+    expect(orderTilesByTree(null, [tile('a'), tile('b')])).toBeNull()
+    expect(orderTilesByTree(group([tilePane('a')]), [tile('a')])).toBeNull()
+  })
+
+  it('reorders tiles to layout-tree encounter order across a split', () => {
+    const tree = split('row', [group(['workspace', tilePane('b')]), group([tilePane('a')])])
+
+    expect(orderTilesByTree(tree, [tile('a'), tile('b')])).toEqual([tile('b'), tile('a')])
+  })
+
+  it('returns null when the array already matches strip order (skip persist)', () => {
+    const tree = split('row', [group([tilePane('b')]), group([tilePane('a')])])
+
+    expect(orderTilesByTree(tree, [tile('b'), tile('a')])).toBeNull()
+  })
+
+  it('sorts not-yet-adopted tiles after placed ones, stably', () => {
+    const tree = group(['workspace', tilePane('b')])
+
+    expect(orderTilesByTree(tree, [tile('a'), tile('b'), tile('c')])).toEqual([tile('b'), tile('a'), tile('c')])
+  })
+})
+
+describe('selectionHomesToWorkspace', () => {
+  const tiles = [tile('a'), tile('b')]
+
+  it('homes for a null selection or a non-tile session', () => {
+    expect(selectionHomesToWorkspace(null, tiles)).toBe(true)
+    expect(selectionHomesToWorkspace('c', tiles)).toBe(true)
+  })
+
+  it('skips homing when the selected id is already an open tile', () => {
+    expect(selectionHomesToWorkspace('a', tiles)).toBe(false)
+  })
 })
 
 describe('focusOpenSession', () => {

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { $selectedStoredSessionId, setSelectedStoredSessionId } from './session'
+import { setSelectedStoredSessionId } from './session'
 import { $sessionTiles, focusOpenSession } from './session-states'
 
 const SESSION_A = 'session-a'

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -38,6 +38,7 @@ import {
   setActiveSessionStoredIdRotation
 } from './session'
 import { isSecondaryWindow } from './windows'
+import { routeSessionId } from '@/app/routes'
 
 // ---------------------------------------------------------------------------
 // Reactive per-runtime session state (view mirror of the wiring cache).
@@ -592,11 +593,17 @@ export function focusOpenSession(storedSessionId: string): boolean {
 
   // Already the main session: front the workspace tab and drop tile focus so
   // the readouts + sidebar highlight come home (a no-op when main is focused).
+  // Only skip navigation when the current URL is already a session route —
+  // on a non-session page (e.g. /messaging) the sidebar highlight reads
+  // currentView from the URL, so revealing the workspace pane alone won't
+  // update it.  Fall through to the caller's navigate() instead.
   if (storedSessionId === $selectedStoredSessionId.get()) {
-    revealTreePane('workspace')
-    noteActiveTreeGroup(null)
-
-    return true
+    if (routeSessionId(window.location.pathname)) {
+      revealTreePane('workspace')
+      noteActiveTreeGroup(null)
+      return true
+    }
+    return false
   }
 
   return false

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -18,6 +18,7 @@
 
 import { atom, computed } from 'nanostores'
 
+import { routeSessionId } from '@/app/routes'
 import type { ClientSessionState } from '@/app/types'
 import { findGroup, findGroupOfPane, type LayoutNode } from '@/components/pane-shell/tree/model'
 import {
@@ -38,7 +39,6 @@ import {
   setActiveSessionStoredIdRotation
 } from './session'
 import { isSecondaryWindow } from './windows'
-import { routeSessionId } from '@/app/routes'
 
 // ---------------------------------------------------------------------------
 // Reactive per-runtime session state (view mirror of the wiring cache).
@@ -601,8 +601,10 @@ export function focusOpenSession(storedSessionId: string): boolean {
     if (routeSessionId(window.location.pathname)) {
       revealTreePane('workspace')
       noteActiveTreeGroup(null)
+
       return true
     }
+
     return false
   }
 


### PR DESCRIPTION
**Closed PR reference:** #68698 (previous attempt — same change, resubmitted cleanly)

## Scope

**Single file change:** `apps/desktop/src/store/session-states.ts`
— +11/−4 lines, one function modified.

## The Bug

When viewing a non-session page (e.g. `/messaging`) and clicking the already-selected session in the sidebar, `focusOpenSession` short-circuits with `revealTreePane('workspace')` instead of navigating. The sidebar highlight reads `currentView` from the URL pathname — since the URL remains `/messaging`, the highlight never moves and the user sees a non-responsive click. Only the previously selected session is affected because `` still points to it.

Other sessions work fine: `` does not match, so `focusOpenSession` returns `false` and the caller executes `navigate(sessionRoute(id))` normally.

## The Fix

In `focusOpenSession`'s "already selected" branch, check whether the current URL is on a session route before returning `true`:

```typescript
if (routeSessionId(window.location.pathname)) {
    revealTreePane('workspace')
    noteActiveTreeGroup(null)
    return true
}
return false  // falls through to navigate → URL updates → sidebar highlight moves
```

## Comparison with #66880

PR #66880 fixes the same bug at the **caller** level (`onResumeSession` in `wiring.tsx`), adding a `resumeSessionNavTarget` helper that compensates for `focusOpenSession`'s incorrect return after the fact.

This PR fixes at the **decision** level instead.  The root cause is that `focusOpenSession` assumes `selectedSessionId` matching means the workspace pane is the current view — an assumption that breaks when a route tile (/messaging, /artifacts, /skills) has the focus.  Correcting the assumption inside `focusOpenSession` benefits **all** callers automatically, rather than patching one specific call site.

While #66880 includes more thorough tile-vs-main edge-case handling and tests, the architectural root belongs in `focusOpenSession`.  The test coverage from this PR ([7 regression tests](https://github.com/NousResearch/hermes-agent/pull/68738/files#diff-…)) validates both the old happy path and the new non-session-route path, and the tile path continues to work unchanged via `focusOpenSession`'s first branch.

## Design Discussion

This fix operates at the **decision layer** (the function that decides whether navigation is needed), not at the data-source layer.  The deeper question is why the sidebar reads its active state from the URL at all.

The URL and the pane layout tree are two independent state sources.  `revealTreePane('workspace')` updates the layout tree but leaves the URL untouched, so the sidebar (which derives `currentView` from `appViewForPath(pathname)`) never sees the change.

A thorough refactor would make the sidebar read directly from `` or the pane tree instead of the URL, eliminating the discrepancy entirely.  That touches `SidebarSurface`, `appViewForPath`, and the `currentView` plumbing — a broader cleanup for a follow-up.  This change resolves the immediate symptom (silently ignored clicks) with minimal risk.

**Root cause chain:**

(A) Navigating from a session to `/messaging` does not clear ``
(B) `focusOpenSession` assumes a matching `selectedSessionId` means the workspace pane is the current view — false when a route tile is focused
(C) The sidebar derives highlight state from the URL, not the session store — pane-only operations cannot update it

This fix addresses **(B)** at the correct layer (the navigation decision point).  Items (A) and (C) are deeper architectural topics outside this change.