### PR TITLE
fix(ollama): bound metadata probe responses

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -26,6 +26,50 @@ from hermes_constants import OPENROUTER_MODELS_URL
 logger = logging.getLogger(__name__)
 
 
+_MODEL_PROBE_RESPONSE_MAX_BYTES = 16 * 1024 * 1024
+
+
+class _ModelProbeResponseTooLarge(ValueError):
+    pass
+
+
+def _bound_model_probe_response(response: Any) -> None:
+    """Cap model-discovery responses before httpx buffers them in memory."""
+    import httpx
+
+    content_length = response.headers.get("content-length")
+    if content_length:
+        try:
+            parsed_content_length = int(content_length)
+        except ValueError:
+            parsed_content_length = None
+        if (
+            parsed_content_length is not None
+            and parsed_content_length > _MODEL_PROBE_RESPONSE_MAX_BYTES
+        ):
+            raise _ModelProbeResponseTooLarge(
+                f"model probe response exceeds {_MODEL_PROBE_RESPONSE_MAX_BYTES} bytes"
+            )
+
+    wrapped = response.stream
+
+    class _LimitedStream(httpx.SyncByteStream):
+        def __iter__(self):
+            total = 0
+            for chunk in wrapped:
+                total += len(chunk)
+                if total > _MODEL_PROBE_RESPONSE_MAX_BYTES:
+                    raise _ModelProbeResponseTooLarge(
+                        f"model probe response exceeds {_MODEL_PROBE_RESPONSE_MAX_BYTES} bytes"
+                    )
+                yield chunk
+
+        def close(self) -> None:
+            wrapped.close()
+
+    response.stream = _LimitedStream()
+
+
 def _resolve_requests_verify() -> bool | str:
     """Resolve SSL verify setting for `requests` calls from env vars.
 
@@ -755,7 +799,11 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
 
     result: Optional[str] = None
     try:
-        with httpx.Client(timeout=2.0, headers=headers) as client:
+        with httpx.Client(
+            timeout=2.0,
+            headers=headers,
+            event_hooks={"response": [_bound_model_probe_response]},
+        ) as client:
             # LM Studio exposes /api/v1/models — check first (most specific)
             try:
                 r = client.get(f"{lmstudio_url}/api/v1/models")
@@ -1525,7 +1573,11 @@ def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Option
     headers = _auth_headers(api_key)
 
     try:
-        with httpx.Client(timeout=3.0, headers=headers) as client:
+        with httpx.Client(
+            timeout=3.0,
+            headers=headers,
+            event_hooks={"response": [_bound_model_probe_response]},
+        ) as client:
             resp = client.post(f"{server_url}/api/show", json={"name": bare_model})
             if resp.status_code != 200:
                 return None
@@ -1579,7 +1631,11 @@ def query_ollama_supports_vision(model: str, base_url: str, api_key: str = "") -
     headers = _auth_headers(api_key)
 
     try:
-        with httpx.Client(timeout=3.0, headers=headers) as client:
+        with httpx.Client(
+            timeout=3.0,
+            headers=headers,
+            event_hooks={"response": [_bound_model_probe_response]},
+        ) as client:
             resp = client.post(f"{server_url}/api/show", json={"name": bare_model})
             if resp.status_code != 200:
                 return None
@@ -1656,7 +1712,11 @@ def _query_ollama_api_show_uncached(model: str, base_url: str, api_key: str = ""
     headers = _auth_headers(api_key)
 
     try:
-        with httpx.Client(timeout=5.0, headers=headers) as client:
+        with httpx.Client(
+            timeout=5.0,
+            headers=headers,
+            event_hooks={"response": [_bound_model_probe_response]},
+        ) as client:
             resp = client.post(f"{server_url}/api/show", json={"name": model})
             if resp.status_code != 200:
                 return None
@@ -1781,7 +1841,11 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
         server_type = None
 
     try:
-        with httpx.Client(timeout=3.0, headers=headers) as client:
+        with httpx.Client(
+            timeout=3.0,
+            headers=headers,
+            event_hooks={"response": [_bound_model_probe_response]},
+        ) as client:
             # Ollama: /api/show returns model details with context info
             if server_type == "ollama":
                 resp = client.post(f"{server_url}/api/show", json={"name": model})

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import time
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 from urllib.parse import urlparse
@@ -46,6 +47,76 @@ def __getattr__(name: str):
     if name == "requests":
         return _ensure_requests()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+_MODEL_PROBE_RESPONSE_MAX_BYTES = 16 * 1024 * 1024
+
+
+class _ModelProbeResponseTooLarge(ValueError):
+    pass
+
+
+def _check_model_probe_response_headers(response: Any) -> None:
+    headers = getattr(response, "headers", None)
+    if not isinstance(headers, Mapping):
+        return
+    encoding = headers.get("content-encoding", "")
+    if isinstance(encoding, str) and encoding.strip().lower() not in {"", "identity"}:
+        raise ValueError("encoded model probe responses are not accepted")
+    content_length = headers.get("content-length")
+    if isinstance(content_length, (str, int)):
+        try:
+            parsed_content_length = int(content_length)
+        except ValueError:
+            pass
+        else:
+            if parsed_content_length > _MODEL_PROBE_RESPONSE_MAX_BYTES:
+                raise _ModelProbeResponseTooLarge(
+                    f"model probe response exceeds {_MODEL_PROBE_RESPONSE_MAX_BYTES} bytes"
+                )
+
+
+def _bound_model_probe_response(response: Any) -> None:
+    """Cap model-discovery responses before httpx buffers them in memory."""
+    import httpx
+
+    _check_model_probe_response_headers(response)
+
+    wrapped = response.stream
+
+    class _LimitedStream(httpx.SyncByteStream):
+        def __iter__(self):
+            total = 0
+            for chunk in wrapped:
+                total += len(chunk)
+                if total > _MODEL_PROBE_RESPONSE_MAX_BYTES:
+                    raise _ModelProbeResponseTooLarge(
+                        f"model probe response exceeds {_MODEL_PROBE_RESPONSE_MAX_BYTES} bytes"
+                    )
+                yield chunk
+
+        def close(self) -> None:
+            wrapped.close()
+
+    response.stream = _LimitedStream()
+
+
+def _read_bounded_requests_model_probe_json(response: Any) -> Any:
+    """Decode a requests response without allowing its body to buffer unbounded."""
+    response.raise_for_status()
+    _check_model_probe_response_headers(response)
+    chunks = []
+    total = 0
+    for chunk in response.iter_content(chunk_size=64 * 1024):
+        total += len(chunk)
+        if total > _MODEL_PROBE_RESPONSE_MAX_BYTES:
+            raise _ModelProbeResponseTooLarge(
+                f"model probe response exceeds {_MODEL_PROBE_RESPONSE_MAX_BYTES} bytes"
+            )
+        chunks.append(chunk)
+    response._content = b"".join(chunks)
+    response._content_consumed = True
+    return response.json()
 
 
 def _resolve_requests_verify() -> bool | str:
@@ -643,6 +714,10 @@ def _auth_headers(api_key: str = "") -> Dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
+def _model_probe_headers(api_key: str = "") -> Dict[str, str]:
+    return {**_auth_headers(api_key), "Accept-Encoding": "identity"}
+
+
 def _is_openrouter_base_url(base_url: str) -> bool:
     return base_url_host_matches(base_url, "openrouter.ai")
 
@@ -975,7 +1050,7 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
         _endpoint_probe_path_cache[server_url] = (disk_hit, time.monotonic())
         return disk_hit
 
-    headers = _auth_headers(api_key)
+    headers = _model_probe_headers(api_key)
 
     def _probe_failed(exc: Exception) -> None:
         """Swallow a probe error — or abort the waterfall if we were blackholed.
@@ -989,7 +1064,11 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
 
     result: Optional[str] = None
     try:
-        with httpx.Client(timeout=2.0, headers=headers) as client:
+        with httpx.Client(
+            timeout=2.0,
+            headers=headers,
+            event_hooks={"response": [_bound_model_probe_response]},
+        ) as client:
             # LM Studio exposes /api/v1/models — check first (most specific)
             try:
                 r = client.get(f"{lmstudio_url}/api/v1/models")
@@ -1239,7 +1318,7 @@ def fetch_endpoint_model_metadata(
     if alternate and alternate not in candidates:
         candidates.append(alternate)
 
-    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    headers = _model_probe_headers(api_key)
     last_error: Optional[Exception] = None
 
     if is_local_endpoint(normalized):
@@ -1251,9 +1330,12 @@ def fetch_endpoint_model_metadata(
                     headers=headers,
                     timeout=(5, 10),
                     verify=_resolve_requests_verify(),
+                    stream=True,
                 )
-                response.raise_for_status()
-                payload = response.json()
+                try:
+                    payload = _read_bounded_requests_model_probe_json(response)
+                finally:
+                    response.close()
                 cache: Dict[str, Dict[str, Any]] = {}
                 for model in payload.get("models", []):
                     if not isinstance(model, dict):
@@ -1323,8 +1405,7 @@ def fetch_endpoint_model_metadata(
                     url,
                 )
                 break
-            response.raise_for_status()
-            payload = response.json()
+            payload = _read_bounded_requests_model_probe_json(response)
             cache: Dict[str, Dict[str, Any]] = {}
             for model in payload.get("data", []):
                 if not isinstance(model, dict):
@@ -1354,16 +1435,28 @@ def fetch_endpoint_model_metadata(
                     # Try /v1/props first (current llama.cpp); fall back to /props for older builds
                     base = request_candidate.rstrip("/").replace("/v1", "")
                     _verify = _resolve_requests_verify()
-                    props_resp = requests.get(base + "/v1/props", headers=headers, timeout=5, verify=_verify)
+                    props_resp = requests.get(
+                        base + "/v1/props", headers=headers, timeout=5,
+                        verify=_verify, stream=True,
+                    )
                     if not props_resp.ok:
-                        props_resp = requests.get(base + "/props", headers=headers, timeout=5, verify=_verify)
+                        props_resp.close()
+                        props_resp = requests.get(
+                            base + "/props", headers=headers, timeout=5,
+                            verify=_verify, stream=True,
+                        )
                     if props_resp.ok:
-                        props = props_resp.json()
+                        try:
+                            props = _read_bounded_requests_model_probe_json(props_resp)
+                        finally:
+                            props_resp.close()
                         gen_settings = props.get("default_generation_settings", {})
                         n_ctx = gen_settings.get("n_ctx")
                         model_alias = props.get("model_alias", "")
                         if n_ctx and model_alias and model_alias in cache:
                             cache[model_alias]["context_length"] = n_ctx
+                    else:
+                        props_resp.close()
                 except Exception:
                     pass
 
@@ -1802,10 +1895,14 @@ def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Option
     if isinstance(disk_hit, int) and disk_hit > 0:
         return disk_hit
 
-    headers = _auth_headers(api_key)
+    headers = _model_probe_headers(api_key)
 
     try:
-        with httpx.Client(timeout=3.0, headers=headers) as client:
+        with httpx.Client(
+            timeout=3.0,
+            headers=headers,
+            event_hooks={"response": [_bound_model_probe_response]},
+        ) as client:
             resp = client.post(f"{server_url}/api/show", json={"name": bare_model})
             if resp.status_code != 200:
                 return None
@@ -1860,10 +1957,14 @@ def query_ollama_supports_vision(model: str, base_url: str, api_key: str = "") -
     if server_url.endswith("/v1"):
         server_url = server_url[:-3]
 
-    headers = _auth_headers(api_key)
+    headers = _model_probe_headers(api_key)
 
     try:
-        with httpx.Client(timeout=3.0, headers=headers) as client:
+        with httpx.Client(
+            timeout=3.0,
+            headers=headers,
+            event_hooks={"response": [_bound_model_probe_response]},
+        ) as client:
             resp = client.post(f"{server_url}/api/show", json={"name": bare_model})
             if resp.status_code != 200:
                 return None
@@ -1940,10 +2041,14 @@ def _query_ollama_api_show_uncached(model: str, base_url: str, api_key: str = ""
     if _endpoint_blackholed(server_url):
         return None
 
-    headers = _auth_headers(api_key)
+    headers = _model_probe_headers(api_key)
 
     try:
-        with httpx.Client(timeout=5.0, headers=headers) as client:
+        with httpx.Client(
+            timeout=5.0,
+            headers=headers,
+            event_hooks={"response": [_bound_model_probe_response]},
+        ) as client:
             resp = client.post(f"{server_url}/api/show", json={"name": model})
             if resp.status_code != 200:
                 return None
@@ -2064,7 +2169,7 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
     if _endpoint_blackholed(server_url):
         return None
 
-    headers = _auth_headers(api_key)
+    headers = _model_probe_headers(api_key)
 
     try:
         server_type = detect_local_server_type(base_url, api_key=api_key)
@@ -2072,7 +2177,11 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
         server_type = None
 
     try:
-        with httpx.Client(timeout=3.0, headers=headers) as client:
+        with httpx.Client(
+            timeout=3.0,
+            headers=headers,
+            event_hooks={"response": [_bound_model_probe_response]},
+        ) as client:
             # Ollama: /api/show returns model details with context info
             if server_type == "ollama":
                 resp = client.post(f"{server_url}/api/show", json={"name": model})

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -374,7 +374,8 @@ class TestDetectLocalServerTypeAuth:
 
         assert result == "lm-studio"
         assert mock_client.call_args.kwargs["headers"] == {
-            "Authorization": "Bearer lm-token"
+            "Authorization": "Bearer lm-token",
+            "Accept-Encoding": "identity",
         }
 
     def test_native_api_base_url_is_not_doubled(self):
@@ -477,7 +478,8 @@ class TestFetchEndpointModelMetadataLmStudio:
         assert mock_get.call_count == 1
         assert mock_get.call_args[0][0] == "http://localhost:1234/api/v1/models"
         assert mock_get.call_args.kwargs["headers"] == {
-            "Authorization": "Bearer lm-token"
+            "Authorization": "Bearer lm-token",
+            "Accept-Encoding": "identity",
         }
         assert result["lmstudio-community/Qwen3.5-27B-GGUF/Qwen3.5-27B-Q8_0.gguf"]["context_length"] == 131072
         assert result["Qwen3.5-27B-GGUF/Qwen3.5-27B-Q8_0.gguf"]["context_length"] == 131072

--- a/tests/agent/test_model_metadata_response_cap.py
+++ b/tests/agent/test_model_metadata_response_cap.py
@@ -1,0 +1,61 @@
+import httpx
+
+from agent import model_metadata
+
+
+class _ChunkStream(httpx.SyncByteStream):
+    def __init__(self, chunks: int, chunk_size: int = 1024 * 1024):
+        self.chunks = chunks
+        self.chunk = b"x" * chunk_size
+        self.pulled = 0
+        self.closed = False
+
+    def __iter__(self):
+        for _ in range(self.chunks):
+            self.pulled += 1
+            yield self.chunk
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _install_transport(monkeypatch, handler):
+    real_client = httpx.Client
+    transport = httpx.MockTransport(handler)
+
+    def client_factory(**kwargs):
+        return real_client(transport=transport, **kwargs)
+
+    monkeypatch.setattr(httpx, "Client", client_factory)
+
+
+def test_detect_local_server_type_stops_oversized_tags_stream(monkeypatch):
+    oversized = _ChunkStream(chunks=32)
+
+    def handler(request):
+        if request.url.path == "/api/tags":
+            return httpx.Response(200, stream=oversized)
+        return httpx.Response(404, json={})
+
+    _install_transport(monkeypatch, handler)
+    model_metadata._endpoint_probe_path_cache.clear()
+
+    assert model_metadata.detect_local_server_type("http://127.0.0.1:11434") is None
+    assert oversized.closed is True
+    assert oversized.pulled < oversized.chunks
+
+
+def test_ollama_show_stops_oversized_stream(monkeypatch):
+    oversized = _ChunkStream(chunks=32)
+    _install_transport(
+        monkeypatch,
+        lambda _request: httpx.Response(200, stream=oversized),
+    )
+
+    result = model_metadata._query_ollama_api_show_uncached(
+        "model", "http://127.0.0.1:11434"
+    )
+
+    assert result is None
+    assert oversized.closed is True
+    assert oversized.pulled < oversized.chunks

--- a/tests/agent/test_model_metadata_response_cap.py
+++ b/tests/agent/test_model_metadata_response_cap.py
@@ -1,0 +1,149 @@
+import json
+
+import httpx
+import pytest
+
+from agent import model_metadata
+
+
+class _ChunkStream(httpx.SyncByteStream):
+    def __init__(self, chunks: int, chunk_size: int = 1024 * 1024):
+        self.chunks = chunks
+        self.chunk = b"x" * chunk_size
+        self.pulled = 0
+        self.closed = False
+
+    def __iter__(self):
+        for _ in range(self.chunks):
+            self.pulled += 1
+            yield self.chunk
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _install_transport(monkeypatch, handler):
+    real_client = httpx.Client
+    transport = httpx.MockTransport(handler)
+
+    def client_factory(**kwargs):
+        return real_client(transport=transport, **kwargs)
+
+    monkeypatch.setattr(httpx, "Client", client_factory)
+
+
+def test_detect_local_server_type_stops_oversized_tags_stream(monkeypatch):
+    oversized = _ChunkStream(chunks=32)
+
+    def handler(request):
+        if request.url.path == "/api/tags":
+            return httpx.Response(200, stream=oversized)
+        return httpx.Response(404, json={})
+
+    _install_transport(monkeypatch, handler)
+    model_metadata._endpoint_probe_path_cache.clear()
+
+    assert model_metadata.detect_local_server_type("http://127.0.0.1:11434") is None
+    assert oversized.closed is True
+    assert oversized.pulled < oversized.chunks
+
+
+def test_ollama_show_stops_oversized_stream(monkeypatch):
+    oversized = _ChunkStream(chunks=32)
+    _install_transport(
+        monkeypatch,
+        lambda _request: httpx.Response(200, stream=oversized),
+    )
+
+    result = model_metadata._query_ollama_api_show_uncached(
+        "model", "http://127.0.0.1:11434"
+    )
+
+    assert result is None
+    assert oversized.closed is True
+    assert oversized.pulled < oversized.chunks
+
+
+def test_httpx_probe_rejects_encoded_response_before_body_read(monkeypatch):
+    encoded = _ChunkStream(chunks=1)
+    _install_transport(
+        monkeypatch,
+        lambda _request: httpx.Response(
+            200, headers={"content-encoding": "gzip"}, stream=encoded
+        ),
+    )
+
+    assert (
+        model_metadata._query_ollama_api_show_uncached(
+            "model", "http://127.0.0.1:11434"
+        )
+        is None
+    )
+    assert encoded.pulled == 0
+    assert encoded.closed is True
+
+
+class _RequestsStream:
+    def __init__(self, chunks, *, headers=None):
+        self._chunks = list(chunks)
+        self.headers = headers or {}
+        self.status_code = 200
+        self.ok = True
+        self.closed = False
+        self.pulled = 0
+        self._content = False
+        self._content_consumed = False
+
+    def raise_for_status(self):
+        return None
+
+    def iter_content(self, chunk_size=1, **_kwargs):
+        assert chunk_size == 64 * 1024
+        for chunk in self._chunks:
+            self.pulled += 1
+            yield chunk
+
+    def json(self):
+        return json.loads(self._content.decode())
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.mark.parametrize("path", ["generic", "lmstudio", "props"])
+def test_requests_metadata_paths_stop_oversized_stream(monkeypatch, path):
+    oversized = []
+
+    def oversized_response():
+        response = _RequestsStream(
+            [b"x" * (1024 * 1024)] * 32,
+            headers={"content-type": "application/json"},
+        )
+        oversized.append(response)
+        return response
+
+    model_metadata._endpoint_model_metadata_cache.clear()
+    model_metadata._endpoint_model_metadata_cache_time.clear()
+    monkeypatch.setattr(
+        model_metadata,
+        "detect_local_server_type",
+        lambda *_args, **_kwargs: "lm-studio" if path == "lmstudio" else None,
+    )
+
+    def fake_get(url, **kwargs):
+        assert kwargs["stream"] is True
+        assert kwargs["headers"]["Accept-Encoding"] == "identity"
+        if path == "props" and url.endswith("/models"):
+            return _RequestsStream([b'{"data":[{"id":"model","owned_by":"llamacpp"}]}'])
+        return oversized_response()
+
+    monkeypatch.setattr(model_metadata.requests, "get", fake_get)
+
+    result = model_metadata.fetch_endpoint_model_metadata(
+        "http://127.0.0.1:11434/v1", force_refresh=True
+    )
+
+    assert result == ({"model": {"name": "model"}} if path == "props" else {})
+    assert oversized
+    assert all(response.closed for response in oversized)
+    assert all(response.pulled < len(response._chunks) for response in oversized)


### PR DESCRIPTION
## What does this PR do?

Bounds JSON responses used by local model discovery and Ollama metadata probes before `httpx` buffers them in memory.

- rejects declared response bodies above 16 MiB before reading
- wraps chunked/unknown-length streams with the same byte cap
- fails soft through the existing probe error paths
- applies the guard consistently to `/api/tags`, `/api/show`, and related local metadata probes

## Related Issue

Fixes #68739

## Type of Change

- Bug fix
- Tests

## How Has This Been Tested?

- `pytest tests/agent/test_model_metadata_response_cap.py tests/test_ollama_num_ctx.py tests/agent/test_model_metadata_local_ctx.py -q` (`48 passed`)
- `ruff check agent/model_metadata.py tests/agent/test_model_metadata_response_cap.py`
- `git diff --check`

The regression tests use 32 MiB chunked streams and verify that reading stops at the cap instead of consuming the complete body.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix is effective
- [x] New and existing focused tests pass locally
