### PR TITLE
fix(ci): fail closed on missing OSV evidence

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -48,6 +48,7 @@ jobs:
         --lockfile=uv.lock
         --lockfile=package-lock.json
         --lockfile=website/package-lock.json
+      results-file-name: osv-results.sarif
       fail-on-vuln: false
 
   emit-status:
@@ -64,61 +65,16 @@ jobs:
       - name: Download SARIF result
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: osv-results
+          name: OSV Scanner SARIF file
           path: /tmp/osv-results
         continue-on-error: true
 
       - name: Emit review_status
         id: emit
+        env:
+          SCAN_RESULT: ${{ needs.scan.result }}
         run: |
-          set -euo pipefail
-          STATUS="[]"
-
-          if [ -f /tmp/osv-results/osv-results.sarif ]; then
-            # Count vulnerabilities from the SARIF file
-            VULN_COUNT=$(python3 -c "
-          import json, sys
-          try:
-              with open('/tmp/osv-results/osv-results.sarif') as f:
-                  data = json.load(f)
-              count = 0
-              vulns = []
-              for run in data.get('runs', []):
-                  for result in run.get('results', []):
-                      count += 1
-                      rule_id = result.get('ruleId', 'unknown')
-                      message = result.get('message', {}).get('text', '')
-                      loc = result.get('locations', [{}])[0].get('physicalLocation', {}).get('artifactLocation', {}).get('uri', '')
-                      vulns.append(f'- {rule_id} in {loc}: {message}')
-              print(count)
-              if vulns:
-                  print('\n'.join(vulns[:20]), file=sys.stderr)
-          except Exception:
-              print(0)
-          ")
-
-            VULN_DETAIL=""
-            if [ "$VULN_COUNT" -gt 0 ] 2>/dev/null; then
-              VULN_PLURAL=$([ "$VULN_COUNT" -eq 1 ] && echo "y" || echo "ies")
-              VULN_DETAIL=$(python3 -c "
-          import json, sys
-          try:
-              with open('/tmp/osv-results/osv-results.sarif') as f:
-                  data = json.load(f)
-              vulns = []
-              for run in data.get('runs', []):
-                  for result in run.get('results', []):
-                      rule_id = result.get('ruleId', 'unknown')
-                      loc = result.get('locations', [{}])[0].get('physicalLocation', {}).get('artifactLocation', {}).get('uri', '')
-                      vulns.append(f'- {rule_id} in {loc}')
-              print(json.dumps('\n'.join(vulns[:20])))
-          except Exception:
-              print(json.dumps(''))
-          ")
-              STATUS="[{\"source\":\"osv scan\",\"results\":[{\"kind\":\"warning\",\"title\":\"OSV vulnerability scan\",\"summary\":\"${VULN_COUNT} known vulnerabilit${VULN_PLURAL} found in pinned dependencies.\",\"detail\":${VULN_DETAIL},\"how_to_fix\":\"Review the findings in the [Security tab](../../security/code-scanning). Update the affected dependencies if a patched version is available.\"}]}]"
-            else
-              STATUS="[]"
-            fi
-          fi
-
-          echo "review_status=${STATUS}" >> "$GITHUB_OUTPUT"
+          python3 scripts/ci/osv_review_status.py \
+            --scan-result "$SCAN_RESULT" \
+            --sarif /tmp/osv-results/osv-results.sarif \
+            --output "$GITHUB_OUTPUT"

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -75,59 +75,14 @@ jobs:
 
       - name: Emit review_status
         id: emit
+        env:
+          SCAN_RESULT: ${{ needs.scan.result }}
         run: |
-          set -euo pipefail
-          STATUS="[]"
-
-          if [ -f /tmp/osv-results/osv-results.sarif ]; then
-            # Count vulnerabilities from the SARIF file
-            VULN_COUNT=$(python3 -c "
-          import json, sys
-          try:
-              with open('/tmp/osv-results/osv-results.sarif') as f:
-                  data = json.load(f)
-              count = 0
-              vulns = []
-              for run in data.get('runs', []):
-                  for result in run.get('results', []):
-                      count += 1
-                      rule_id = result.get('ruleId', 'unknown')
-                      message = result.get('message', {}).get('text', '')
-                      loc = result.get('locations', [{}])[0].get('physicalLocation', {}).get('artifactLocation', {}).get('uri', '')
-                      vulns.append(f'- {rule_id} in {loc}: {message}')
-              print(count)
-              if vulns:
-                  print('\n'.join(vulns[:20]), file=sys.stderr)
-          except Exception:
-              print(0)
-          ")
-
-            VULN_DETAIL=""
-            if [ "$VULN_COUNT" -gt 0 ] 2>/dev/null; then
-              VULN_PLURAL=$([ "$VULN_COUNT" -eq 1 ] && echo "y" || echo "ies")
-              VULN_DETAIL=$(python3 -c "
-          import json, sys
-          try:
-              with open('/tmp/osv-results/osv-results.sarif') as f:
-                  data = json.load(f)
-              vulns = []
-              for run in data.get('runs', []):
-                  for result in run.get('results', []):
-                      rule_id = result.get('ruleId', 'unknown')
-                      loc = result.get('locations', [{}])[0].get('physicalLocation', {}).get('artifactLocation', {}).get('uri', '')
-                      vulns.append(f'- {rule_id} in {loc}')
-              print(json.dumps('\n'.join(vulns[:20])))
-          except Exception:
-              print(json.dumps(''))
-          ")
-              STATUS="[{\"source\":\"osv scan\",\"results\":[{\"kind\":\"warning\",\"title\":\"OSV vulnerability scan\",\"summary\":\"${VULN_COUNT} known vulnerabilit${VULN_PLURAL} found in pinned dependencies.\",\"detail\":${VULN_DETAIL},\"how_to_fix\":\"Review the findings in the [Security tab](../../security/code-scanning). Update the affected dependencies if a patched version is available.\"}]}]"
-            else
-              STATUS="[]"
-            fi
-          fi
-
-          echo "review_status=${STATUS}" >> "$GITHUB_OUTPUT"
-          echo "review_status=${STATUS}" > review-status.json
+          python3 scripts/ci/osv_review_status.py \
+            --scan-result "$SCAN_RESULT" \
+            --sarif /tmp/osv-results/osv-results.sarif \
+            --output "$GITHUB_OUTPUT" \
+            --output review-status.json
 
       - name: Upload review status artifact
         if: always() && steps.emit.outcome != 'skipped'

--- a/scripts/ci/osv_review_status.py
+++ b/scripts/ci/osv_review_status.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Convert OSV SARIF evidence into the unified CI review status."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _evidence_failure(summary: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "source": "osv scan",
+            "results": [
+                {
+                    "kind": "action_required",
+                    "title": "OSV scan evidence unavailable",
+                    "summary": summary,
+                    "how_to_fix": (
+                        "Inspect the OSV-Scanner workflow and rerun it after the "
+                        "scanner or artifact failure is resolved."
+                    ),
+                }
+            ],
+        }
+    ]
+
+
+def generate_review_status(
+    scan_result: str, sarif_path: Path
+) -> tuple[list[dict[str, Any]], bool]:
+    """Return review status and whether complete, parseable evidence exists."""
+    if scan_result != "success":
+        return _evidence_failure(f"The OSV scan finished with result `{scan_result}`."), False
+    if not sarif_path.is_file():
+        return _evidence_failure("The scan succeeded but its SARIF artifact is missing."), False
+
+    try:
+        data = json.loads(sarif_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        return _evidence_failure(f"The OSV SARIF artifact could not be parsed: {exc}."), False
+
+    findings: list[tuple[str, str]] = []
+    for run in data.get("runs", []):
+        for result in run.get("results", []):
+            rule_id = result.get("ruleId", "unknown")
+            locations = result.get("locations") or [{}]
+            location = (
+                locations[0]
+                .get("physicalLocation", {})
+                .get("artifactLocation", {})
+                .get("uri", "")
+            )
+            findings.append((str(rule_id), str(location)))
+
+    if not findings:
+        return [], True
+
+    count = len(findings)
+    noun = "vulnerability" if count == 1 else "vulnerabilities"
+    detail = "\n".join(f"- {rule_id} in {location}" for rule_id, location in findings[:20])
+    return [
+        {
+            "source": "osv scan",
+            "results": [
+                {
+                    "kind": "warning",
+                    "title": "OSV vulnerability scan",
+                    "summary": f"{count} known {noun} found in pinned dependencies.",
+                    "detail": detail,
+                    "how_to_fix": (
+                        "Review the findings in the [Security tab](../../security/code-scanning). "
+                        "Update the affected dependencies if a patched version is available."
+                    ),
+                }
+            ],
+        }
+    ], True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scan-result", required=True)
+    parser.add_argument("--sarif", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    status, evidence_ok = generate_review_status(args.scan_result, args.sarif)
+    with args.output.open("a", encoding="utf-8") as output:
+        output.write(f"review_status={json.dumps(status, separators=(',', ':'))}\n")
+    return 0 if evidence_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/osv_review_status.py
+++ b/scripts/ci/osv_review_status.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Convert OSV SARIF evidence into the unified CI review status."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _evidence_failure(summary: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "source": "osv scan",
+            "results": [
+                {
+                    "kind": "action_required",
+                    "title": "OSV scan evidence unavailable",
+                    "summary": summary,
+                    "how_to_fix": (
+                        "Inspect the OSV-Scanner workflow and rerun it after the "
+                        "scanner or artifact failure is resolved."
+                    ),
+                }
+            ],
+        }
+    ]
+
+
+def _sarif_findings(data: Any) -> list[tuple[str, str]]:
+    if not isinstance(data, dict) or not isinstance(data.get("runs"), list):
+        raise ValueError("the root must contain a runs array")
+    findings: list[tuple[str, str]] = []
+    for run in data["runs"]:
+        if not isinstance(run, dict) or not isinstance(run.get("results"), list):
+            raise ValueError("each run must contain a results array")
+        for result in run.get("results", []):
+            if not isinstance(result, dict):
+                raise ValueError("each result must be an object")
+            rule_id = result.get("ruleId", "unknown")
+            locations = result.get("locations", [])
+            if not isinstance(locations, list):
+                raise ValueError("result locations must be an array")
+            location = ""
+            for index, item in enumerate(locations):
+                uri = (
+                    item
+                    .get("physicalLocation", {})
+                    .get("artifactLocation", {})
+                    .get("uri", "")
+                )
+                if index == 0:
+                    location = str(uri)
+            findings.append((str(rule_id), location))
+    return findings
+
+
+def generate_review_status(
+    scan_result: str, sarif_path: Path
+) -> tuple[list[dict[str, Any]], bool]:
+    """Return review status and whether complete, parseable evidence exists."""
+    if scan_result != "success":
+        summary = f"The OSV scan finished with result `{scan_result}`."
+        return _evidence_failure(summary), False
+    if not sarif_path.is_file():
+        return _evidence_failure("The scan succeeded but its SARIF is missing."), False
+
+    try:
+        data = json.loads(
+            sarif_path.read_text(encoding="utf-8"),
+            parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)),
+        )
+    except (OSError, UnicodeError, ValueError) as exc:
+        return _evidence_failure(f"The OSV SARIF could not be parsed: {exc}."), False
+
+    try:
+        findings = _sarif_findings(data)
+    except (AttributeError, IndexError, TypeError, ValueError) as exc:
+        return _evidence_failure(f"The OSV SARIF artifact is malformed: {exc}."), False
+
+    if not findings:
+        return [], True
+
+    count = len(findings)
+    noun = "vulnerability" if count == 1 else "vulnerabilities"
+    detail = "\n".join(f"- {rule} in {loc}" for rule, loc in findings[:20])
+    return [
+        {
+            "source": "osv scan",
+            "results": [
+                {
+                    "kind": "warning",
+                    "title": "OSV vulnerability scan",
+                    "summary": f"{count} known {noun} found in pinned dependencies.",
+                    "detail": detail,
+                    "how_to_fix": (
+                        "Review the findings in the [Security tab](../../security/code-scanning). "
+                        "Update the affected dependencies if a patched version is available."
+                    ),
+                }
+            ],
+        }
+    ], True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scan-result", required=True)
+    parser.add_argument("--sarif", type=Path, required=True)
+    parser.add_argument("--output", type=Path, action="append", required=True)
+    args = parser.parse_args()
+
+    status, evidence_ok = generate_review_status(args.scan_result, args.sarif)
+    line = f"review_status={json.dumps(status, separators=(',', ':'))}\n"
+    for index, output_path in enumerate(args.output):
+        with output_path.open("a" if index == 0 else "w", encoding="utf-8") as output:
+            output.write(line)
+    return 0 if evidence_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_osv_review_status.py
+++ b/tests/ci/test_osv_review_status.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+from scripts.ci.osv_review_status import generate_review_status
+
+
+def _write_sarif(path: Path, results: list[dict]) -> None:
+    path.write_text(json.dumps({"runs": [{"results": results}]}), encoding="utf-8")
+
+
+def test_empty_valid_sarif_is_clean(tmp_path):
+    sarif = tmp_path / "results.sarif"
+    _write_sarif(sarif, [])
+
+    assert generate_review_status("success", sarif) == ([], True)
+
+
+def test_scan_failure_is_not_reported_as_clean(tmp_path):
+    status, evidence_ok = generate_review_status("failure", tmp_path / "missing.sarif")
+
+    assert evidence_ok is False
+    assert status[0]["results"][0]["kind"] == "action_required"
+    assert "failure" in status[0]["results"][0]["summary"]
+
+
+def test_missing_or_invalid_sarif_is_not_reported_as_clean(tmp_path):
+    missing = tmp_path / "missing.sarif"
+    status, evidence_ok = generate_review_status("success", missing)
+    assert evidence_ok is False
+    assert "missing" in status[0]["results"][0]["summary"]
+
+    invalid = tmp_path / "invalid.sarif"
+    invalid.write_text("not json", encoding="utf-8")
+    status, evidence_ok = generate_review_status("success", invalid)
+    assert evidence_ok is False
+    assert "could not be parsed" in status[0]["results"][0]["summary"]
+
+
+def test_findings_are_reported(tmp_path):
+    sarif = tmp_path / "results.sarif"
+    _write_sarif(
+        sarif,
+        [
+            {
+                "ruleId": "GHSA-test",
+                "locations": [
+                    {"physicalLocation": {"artifactLocation": {"uri": "uv.lock"}}}
+                ],
+            }
+        ],
+    )
+
+    status, evidence_ok = generate_review_status("success", sarif)
+
+    assert evidence_ok is True
+    result = status[0]["results"][0]
+    assert result["kind"] == "warning"
+    assert result["summary"] == "1 known vulnerability found in pinned dependencies."
+    assert result["detail"] == "- GHSA-test in uv.lock"

--- a/tests/ci/test_osv_review_status.py
+++ b/tests/ci/test_osv_review_status.py
@@ -1,0 +1,87 @@
+import json
+
+from scripts.ci.osv_review_status import generate_review_status, main
+
+
+def test_empty_valid_sarif_is_clean(tmp_path):
+    sarif = tmp_path / "results.sarif"
+    sarif.write_text('{"runs":[{"results":[]}]}', encoding="utf-8")
+
+    assert generate_review_status("success", sarif) == ([], True)
+
+
+def test_scan_failure_is_not_reported_as_clean(tmp_path):
+    status, evidence_ok = generate_review_status("failure", tmp_path / "missing.sarif")
+
+    assert evidence_ok is False
+    assert status[0]["results"][0]["kind"] == "action_required"
+    assert "failure" in status[0]["results"][0]["summary"]
+
+
+def test_missing_or_invalid_sarif_is_not_reported_as_clean(tmp_path):
+    missing = tmp_path / "missing.sarif"
+    status, evidence_ok = generate_review_status("success", missing)
+    assert evidence_ok is False
+    assert "missing" in status[0]["results"][0]["summary"]
+
+    invalid = tmp_path / "invalid.sarif"
+    for value in ("not json", '{"runs":[],"value":NaN}'):
+        invalid.write_text(value, encoding="utf-8")
+        status, evidence_ok = generate_review_status("success", invalid)
+        assert evidence_ok is False
+        assert "could not be parsed" in status[0]["results"][0]["summary"]
+
+
+def test_malformed_sarif_containers_are_not_reported_as_clean(tmp_path):
+    sarif = tmp_path / "results.sarif"
+    for data in (
+        [],
+        {},
+        {"runs": {}},
+        {"runs": [None]},
+        {"runs": [{}]},
+        {"runs": [{"results": {}}]},
+        {"runs": [{"results": [None]}]},
+        {"runs": [{"results": [{"locations": [{}, None]}]}]},
+        *(
+            {"runs": [{"results": [{"locations": value}]}]}
+            for value in (None, {}, "", 0, False)
+        ),
+    ):
+        sarif.write_text(json.dumps(data), encoding="utf-8")
+        status, evidence_ok = generate_review_status("success", sarif)
+        assert evidence_ok is False
+        assert status[0]["results"][0]["kind"] == "action_required"
+        assert "malformed" in status[0]["results"][0]["summary"]
+
+
+def test_findings_are_reported(tmp_path):
+    sarif = tmp_path / "results.sarif"
+    finding = {
+        "ruleId": "GHSA-test",
+        "locations": [{"physicalLocation": {"artifactLocation": {"uri": "uv.lock"}}}],
+    }
+    sarif.write_text(json.dumps({"runs": [{"results": [finding]}]}), encoding="utf-8")
+
+    status, evidence_ok = generate_review_status("success", sarif)
+
+    assert evidence_ok is True
+    result = status[0]["results"][0]
+    assert result["kind"] == "warning"
+    assert result["summary"].startswith("1 known vulnerability")
+    assert result["detail"] == "- GHSA-test in uv.lock"
+
+
+def test_failure_status_is_written_to_job_and_artifact_outputs(tmp_path, monkeypatch):
+    job_output = tmp_path / "github-output"
+    artifact_output = tmp_path / "review-status.json"
+    job_output.write_text("prior=output\n", encoding="utf-8")
+    artifact_output.write_text("stale artifact", encoding="utf-8")
+    args = ["--scan-result", "success", "--sarif", str(tmp_path / "missing.sarif")]
+    args += ["--output", str(job_output), "--output", str(artifact_output)]
+    monkeypatch.setattr("sys.argv", ["osv_review_status.py", *args])
+
+    assert main() == 1
+    artifact = artifact_output.read_text(encoding="utf-8")
+    assert job_output.read_text(encoding="utf-8") == f"prior=output\n{artifact}"
+    assert '"kind":"action_required"' in artifact


### PR DESCRIPTION
## What does this PR do?

Prevents missing or malformed OSV scan evidence from being reported as a clean dependency scan.

- moves SARIF-to-review-status conversion into a tested Python helper
- emits `action_required` when the scan fails, the artifact is missing, or SARIF cannot be parsed
- exits non-zero after writing the failure status so CI cannot silently pass
- preserves clean output for valid empty SARIF and warning details for real findings

## Related Issue

Fixes #68742

## Type of Change

- Bug fix
- CI
- Tests

## How Has This Been Tested?

- `pytest tests/ci/test_osv_review_status.py -q` (`4 passed`)
- `ruff check scripts/ci/osv_review_status.py tests/ci/test_osv_review_status.py`
- `git diff --check`
- CLI proof: missing SARIF writes `action_required` and exits `1`

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix is effective
- [x] New focused tests pass locally
