### PR TITLE
fix(desktop): downscale large images in composer preview to prevent UI freeze

### DIFF
--- a/apps/desktop/src/app/chat/composer/attachments.tsx
+++ b/apps/desktop/src/app/chat/composer/attachments.tsx
@@ -127,7 +127,7 @@ function AttachmentPill({ attachment, onRemove }: { attachment: ComposerAttachme
                   alt={attachment.label}
                   className="size-full object-cover"
                   draggable={false}
-                  src={attachment.previewUrl}
+                  src={attachment.thumbnailUrl ?? attachment.previewUrl}
                 />
               ) : (
                 <Icon className="size-3.5" />

--- a/apps/desktop/src/app/chat/composer/attachments.tsx
+++ b/apps/desktop/src/app/chat/composer/attachments.tsx
@@ -109,7 +109,7 @@ function AttachmentPill({ attachment, onRemove }: { attachment: ComposerAttachme
                   alt={attachment.label}
                   className="size-full object-cover"
                   draggable={false}
-                  src={attachment.previewUrl}
+                  src={attachment.thumbnailUrl ?? attachment.previewUrl}
                 />
               ) : (
                 <Icon className="size-3.5" />

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
@@ -1,5 +1,7 @@
+import { act, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { $composerAttachments } from '@/store/composer'
 import { $connection } from '@/store/session'
 
 import {
@@ -7,7 +9,8 @@ import {
   type DroppedFile,
   extractDroppedFiles,
   HERMES_PATHS_MIME,
-  partitionDroppedFiles
+  partitionDroppedFiles,
+  useComposerActions
 } from './use-composer-actions'
 
 // A Finder/Explorer drop carries a native File handle; an in-app drag (project
@@ -242,5 +245,88 @@ describe('attachmentPreviewDataUrl', () => {
     $connection.set({ mode: 'remote' } as never)
 
     await expect(attachmentPreviewDataUrl('/home/gateway/shot.png')).resolves.toBe(REMOTE_PREVIEW)
+  })
+})
+
+describe('attachImagePath thumbnail separation', () => {
+  // Full-resolution data URL the local bridge returns for a pasted screenshot.
+  // Content is irrelevant — the mock bitmap below reports 4000×3000 so the
+  // real downscale path runs (the data URL itself is never decoded in jsdom).
+  const FULL_RES = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+    $composerAttachments.set([])
+  })
+
+  it('keeps the full-resolution previewUrl and stores a separate downscaled thumbnailUrl', async () => {
+    const readFileDataUrl = vi.fn(async () => FULL_RES)
+
+    ;(window as unknown as { hermesDesktop: { readFileDataUrl: typeof readFileDataUrl } }).hermesDesktop = {
+      readFileDataUrl
+    }
+
+    // Exercise the real downscale path: 4000×3000 bitmap → 2048×1536 canvas.
+    const drawImage = vi.fn()
+    const close = vi.fn()
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' })
+      }))
+    )
+    vi.stubGlobal('createImageBitmap', vi.fn(async () => ({ width: 4000, height: 3000, close })))
+
+    class MockOffscreenCanvas {
+      getContext = () => ({ drawImage })
+      convertToBlob = vi.fn(async () => new Blob(['x'], { type: 'image/png' }))
+      constructor(_width: number, _height: number) {}
+    }
+
+    vi.stubGlobal('OffscreenCanvas', MockOffscreenCanvas)
+
+    const { result } = renderHook(() =>
+      useComposerActions({ activeSessionId: null, currentCwd: '', requestGateway: vi.fn() })
+    )
+
+    await act(async () => {
+      await result.current.attachImagePath('/tmp/shot.png')
+    })
+
+    const attachment = $composerAttachments.get()[0]
+
+    expect(attachment).toBeDefined()
+    // Full-resolution bytes stay on `previewUrl` — the same field main feeds
+    // to ImageLightbox and useImageDownload, so open/download keep full res.
+    expect(attachment?.previewUrl).toBe(FULL_RES)
+    // The pill thumbnail is a SEPARATE downscaled value, never the multi-MB
+    // original (which would re-introduce the main-thread decode freeze).
+    expect(attachment?.thumbnailUrl).toBeDefined()
+    expect(attachment?.thumbnailUrl).not.toBe(FULL_RES)
+    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 2048, 1536)
+    expect(close).toHaveBeenCalled()
+  })
+
+  it('leaves the thumbnail undefined when the preview is not an image', async () => {
+    const readFileDataUrl = vi.fn(async () => 'data:text/plain;base64,aGVsbG8=')
+
+    ;(window as unknown as { hermesDesktop: { readFileDataUrl: typeof readFileDataUrl } }).hermesDesktop = {
+      readFileDataUrl
+    }
+
+    const { result } = renderHook(() =>
+      useComposerActions({ activeSessionId: null, currentCwd: '', requestGateway: vi.fn() })
+    )
+
+    await act(async () => {
+      await result.current.attachImagePath('/tmp/shot.txt')
+    })
+
+    const attachment = $composerAttachments.get()[0]
+
+    expect(attachment?.previewUrl).toBe('data:text/plain;base64,aGVsbG8=')
+    expect(attachment?.thumbnailUrl).toBeUndefined()
   })
 })

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
@@ -305,7 +305,7 @@ describe('attachImagePath thumbnail separation', () => {
     // original (which would re-introduce the main-thread decode freeze).
     expect(attachment?.thumbnailUrl).toBeDefined()
     expect(attachment?.thumbnailUrl).not.toBe(FULL_RES)
-    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 2048, 1536)
+    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 512, 384)
     expect(close).toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -6,6 +6,7 @@ import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { useI18n } from '@/i18n'
 import { attachmentId, contextPath, pathLabel } from '@/lib/chat-runtime'
 import { readDesktopFileDataUrl, selectDesktopPaths } from '@/lib/desktop-fs'
+import { downscaleDataUrlForPreview } from '@/lib/image-resize'
 import { normalize } from '@/lib/text'
 import {
   addComposerAttachment,
@@ -50,17 +51,29 @@ export function isImagePath(filePath: string): boolean {
  * In local mode the facade IS the local bridge, so this stays a single read.
  */
 export async function attachmentPreviewDataUrl(filePath: string): Promise<string> {
+  let dataUrl: string
+
   try {
     const local = await window.hermesDesktop?.readFileDataUrl?.(filePath)
 
     if (local) {
-      return local
+      dataUrl = local
+    } else {
+      dataUrl = await readDesktopFileDataUrl(filePath)
     }
   } catch {
     // Not on this machine (or unreadable locally) — try the gateway.
+    dataUrl = await readDesktopFileDataUrl(filePath)
   }
 
-  return readDesktopFileDataUrl(filePath)
+  // Downscale large images for preview to prevent main-thread decode freezes.
+  // macOS ImageIO/vImage blocks the Chromium renderer on Retina screenshots
+  // (6000×4000+, >5 MB). The full-resolution bytes are still on disk for the model.
+  if (dataUrl.startsWith('data:image/')) {
+    return downscaleDataUrlForPreview(dataUrl)
+  }
+
+  return dataUrl
 }
 
 export interface DroppedFile {

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -68,13 +68,6 @@ export async function attachmentPreviewDataUrl(filePath: string): Promise<string
     dataUrl = await readDesktopFileDataUrl(filePath)
   }
 
-  // Downscale large images for preview to prevent main-thread decode freezes.
-  // macOS ImageIO/vImage blocks the Chromium renderer on Retina screenshots
-  // (6000×4000+, >5 MB). The full-resolution bytes are still on disk for the model.
-  if (dataUrl.startsWith('data:image/')) {
-    return downscaleDataUrlForPreview(dataUrl)
-  }
-
   return dataUrl
 }
 
@@ -483,7 +476,17 @@ export function useComposerActions({
         const previewUrl = await attachmentPreviewDataUrl(filePath)
 
         if (previewUrl) {
-          scope.add({ ...baseAttachment, previewUrl })
+          // Downscale only the pill thumbnail. `previewUrl` must keep the
+          // full-resolution bytes: current main feeds it to ImageLightbox and
+          // useImageDownload (attachments.tsx), and the attached-image
+          // pipeline uploads the on-disk original to the model. The helper
+          // never rejects — on failure it returns a 1×1 placeholder so the
+          // pill never renders the multi-MB original.
+          const thumbnailUrl = previewUrl.startsWith('data:image/')
+            ? await downscaleDataUrlForPreview(previewUrl)
+            : undefined
+
+          scope.add({ ...baseAttachment, previewUrl, thumbnailUrl })
         }
 
         return true

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -7,6 +7,7 @@ import { useI18n } from '@/i18n'
 import { attachmentId, contextPath, pathLabel } from '@/lib/chat-runtime'
 import { readDesktopFileDataUrl, selectDesktopPaths } from '@/lib/desktop-fs'
 import { desktopGit } from '@/lib/desktop-git'
+import { downscaleDataUrlForPreview } from '@/lib/image-resize'
 import { normalize } from '@/lib/text'
 import {
   addComposerAttachment,
@@ -52,17 +53,29 @@ export function isImagePath(filePath: string): boolean {
  * In local mode the facade IS the local bridge, so this stays a single read.
  */
 export async function attachmentPreviewDataUrl(filePath: string): Promise<string> {
+  let dataUrl: string
+
   try {
     const local = await window.hermesDesktop?.readFileDataUrl?.(filePath)
 
     if (local) {
-      return local
+      dataUrl = local
+    } else {
+      dataUrl = await readDesktopFileDataUrl(filePath)
     }
   } catch {
     // Not on this machine (or unreadable locally) — try the gateway.
+    dataUrl = await readDesktopFileDataUrl(filePath)
   }
 
-  return readDesktopFileDataUrl(filePath)
+  // Downscale large images for preview to prevent main-thread decode freezes.
+  // macOS ImageIO/vImage blocks the Chromium renderer on Retina screenshots
+  // (6000×4000+, >5 MB). The full-resolution bytes are still on disk for the model.
+  if (dataUrl.startsWith('data:image/')) {
+    return downscaleDataUrlForPreview(dataUrl)
+  }
+
+  return dataUrl
 }
 
 export interface DroppedFile {

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -66,13 +66,6 @@ export async function attachmentPreviewDataUrl(filePath: string): Promise<string
     dataUrl = await readDesktopFileDataUrl(filePath)
   }
 
-  // Downscale large images for preview to prevent main-thread decode freezes.
-  // macOS ImageIO/vImage blocks the Chromium renderer on Retina screenshots
-  // (6000×4000+, >5 MB). The full-resolution bytes are still on disk for the model.
-  if (dataUrl.startsWith('data:image/')) {
-    return downscaleDataUrlForPreview(dataUrl)
-  }
-
   return dataUrl
 }
 
@@ -434,7 +427,17 @@ export function useComposerActions({
         const previewUrl = await attachmentPreviewDataUrl(filePath)
 
         if (previewUrl) {
-          scope.add({ ...baseAttachment, previewUrl })
+          // Downscale only the pill thumbnail. `previewUrl` must keep the
+          // full-resolution bytes: current main feeds it to ImageLightbox and
+          // useImageDownload (attachments.tsx), and the attached-image
+          // pipeline uploads the on-disk original to the model. The helper
+          // never rejects — on failure it returns a 1×1 placeholder so the
+          // pill never renders the multi-MB original.
+          const thumbnailUrl = previewUrl.startsWith('data:image/')
+            ? await downscaleDataUrlForPreview(previewUrl)
+            : undefined
+
+          scope.add({ ...baseAttachment, previewUrl, thumbnailUrl })
         }
 
         return true

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -5,7 +5,7 @@ import { droppedFileInlineRef } from '@/app/chat/composer/inline-refs'
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { useI18n } from '@/i18n'
 import { attachmentId, contextPath, pathLabel } from '@/lib/chat-runtime'
-import { readDesktopFileDataUrl, selectDesktopPaths } from '@/lib/desktop-fs'
+import { readDesktopFileDataUrlLocalFirst, selectDesktopPaths } from '@/lib/desktop-fs'
 import { desktopGit } from '@/lib/desktop-git'
 import { downscaleDataUrlForPreview } from '@/lib/image-resize'
 import { normalize } from '@/lib/text'
@@ -53,22 +53,7 @@ export function isImagePath(filePath: string): boolean {
  * In local mode the facade IS the local bridge, so this stays a single read.
  */
 export async function attachmentPreviewDataUrl(filePath: string): Promise<string> {
-  let dataUrl: string
-
-  try {
-    const local = await window.hermesDesktop?.readFileDataUrl?.(filePath)
-
-    if (local) {
-      dataUrl = local
-    } else {
-      dataUrl = await readDesktopFileDataUrl(filePath)
-    }
-  } catch {
-    // Not on this machine (or unreadable locally) — try the gateway.
-    dataUrl = await readDesktopFileDataUrl(filePath)
-  }
-
-  return dataUrl
+  return readDesktopFileDataUrlLocalFirst(filePath)
 }
 
 export interface DroppedFile {

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -13,6 +13,7 @@ import {
 } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
+const THUMB_URL = 'data:image/png;base64,dGh1bWI='
 
 function attachment(overrides: Partial<ComposerAttachment> & Pick<ComposerAttachment, 'kind'>): ComposerAttachment {
   return { id: 'a', label: 'file.png', ...overrides }
@@ -25,6 +26,16 @@ describe('optimisticAttachmentRef', () => {
     // The raw data URL flows through extractEmbeddedImages → inline thumbnail,
     // dodging the remote /api/media 403 an @image:<localpath> ref would hit.
     expect(ref).toBe(DATA_URL)
+  })
+
+  it('prefers the downscaled thumbnail for the display ref when present', () => {
+    const ref = optimisticAttachmentRef(
+      attachment({ kind: 'image', detail: '/tmp/shot.png', previewUrl: DATA_URL, thumbnailUrl: THUMB_URL })
+    )
+
+    // The bubble is a display-only thumbnail; full-res previewUrl stays for
+    // lightbox/download and the model gets bytes via the upload pipeline.
+    expect(ref).toBe(THUMB_URL)
   })
 
   it('falls back to an @image: path ref when no preview is available', () => {

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -259,7 +259,10 @@ export function optimisticAttachmentRef(attachment: ComposerAttachment): string 
   }
 
   if (attachment.kind === 'image' && attachment.previewUrl?.startsWith('data:')) {
-    return attachment.previewUrl
+    // The pill and the in-flight bubble render the downscaled thumbnail; the
+    // full-resolution `previewUrl` stays for lightbox/download, and the model
+    // receives bytes via the attached-image upload pipeline, not this ref.
+    return attachment.thumbnailUrl ?? attachment.previewUrl
   }
 
   return attachmentDisplayText(attachment)

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -232,7 +232,10 @@ export function optimisticAttachmentRef(attachment: ComposerAttachment): string 
   }
 
   if (attachment.kind === 'image' && attachment.previewUrl?.startsWith('data:')) {
-    return attachment.previewUrl
+    // The pill and the in-flight bubble render the downscaled thumbnail; the
+    // full-resolution `previewUrl` stays for lightbox/download, and the model
+    // receives bytes via the attached-image upload pipeline, not this ref.
+    return attachment.thumbnailUrl ?? attachment.previewUrl
   }
 
   return attachmentDisplayText(attachment)

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -9,6 +9,7 @@ import {
   desktopGitRoot,
   readDesktopDir,
   readDesktopFileDataUrl,
+  readDesktopFileDataUrlLocalFirst,
   readDesktopFileText,
   selectDesktopPaths,
   setDesktopFsRemotePicker
@@ -213,5 +214,29 @@ describe('desktop filesystem facade', () => {
 
     expect(remoteSelect).toHaveBeenCalledWith({ directories: true, multiple: false })
     expect(selectPaths).not.toHaveBeenCalled()
+  })
+
+  describe('readDesktopFileDataUrlLocalFirst', () => {
+    it('does not retry the same unreadable path through the local facade', async () => {
+      const error = new Error('not readable')
+
+      $connection.set({ mode: 'local' } as never)
+      readFileDataUrl.mockRejectedValueOnce(error)
+
+      await expect(readDesktopFileDataUrlLocalFirst('/missing.png')).rejects.toBe(error)
+      expect(readFileDataUrl).toHaveBeenCalledOnce()
+      expect(api).not.toHaveBeenCalled()
+    })
+
+    it('falls back from local disk to the active gateway in remote mode', async () => {
+      $connection.set({ mode: 'remote' } as never)
+      readFileDataUrl.mockRejectedValueOnce(new Error('not on host'))
+
+      await expect(readDesktopFileDataUrlLocalFirst('/remote/image.png')).resolves.toBe(
+        'data:text/plain;base64,cmVtb3Rl'
+      )
+      expect(readFileDataUrl).toHaveBeenCalledOnce()
+      expect(api).toHaveBeenCalledWith({ path: '/api/fs/read-data-url?path=%2Fremote%2Fimage.png' })
+    })
   })
 })

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -109,6 +109,29 @@ export async function readDesktopFileDataUrl(path: string): Promise<string> {
   return typeof result === 'string' ? result : result.dataUrl || ''
 }
 
+/**
+ * Read a composer image local-shell first, even when the active agent is
+ * remote. Picker, clipboard, and OS-drop paths belong to this machine; in-app
+ * project-tree paths may belong only to the gateway and fall back there.
+ */
+export async function readDesktopFileDataUrlLocalFirst(path: string): Promise<string> {
+  try {
+    const local = await window.hermesDesktop?.readFileDataUrl?.(path)
+
+    if (local) {
+      return local
+    }
+  } catch (error) {
+    if (!isDesktopFsRemoteMode()) {
+      throw error
+    }
+
+    // Not on this machine (or unreadable locally) — try the active gateway.
+  }
+
+  return readDesktopFileDataUrl(path)
+}
+
 export async function desktopGitRoot(path: string): Promise<string | null> {
   const desktop = bridge()
 

--- a/apps/desktop/src/lib/image-resize.test.ts
+++ b/apps/desktop/src/lib/image-resize.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { downscaleDataUrlForPreview } from './image-resize'
+
+// A minimal valid 1x1 red PNG (67 bytes) for testing
+const TINY_PNG_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
+const TINY_PNG_DATA_URL = `data:image/png;base64,${TINY_PNG_B64}`
+
+// A 1×1 transparent PNG used as the fallback placeholder
+const FALLBACK_PLACEHOLDER =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
+
+describe('downscaleDataUrlForPreview', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  describe('without createImageBitmap (jsdom default)', () => {
+    it('returns the original when createImageBitmap is unavailable', async () => {
+      await expect(downscaleDataUrlForPreview(TINY_PNG_DATA_URL)).resolves.toBe(
+        TINY_PNG_DATA_URL
+      )
+    })
+
+    it('returns the original for a non-data-URL string', async () => {
+      await expect(downscaleDataUrlForPreview('not-a-data-url')).resolves.toBe(
+        'not-a-data-url'
+      )
+    })
+
+    it('returns the original for a data URL without a comma', async () => {
+      await expect(downscaleDataUrlForPreview('data:text/plain')).resolves.toBe(
+        'data:text/plain'
+      )
+    })
+  })
+
+  describe('with mocked createImageBitmap + OffscreenCanvas', () => {
+    /**
+     * Set up the full mock chain: fetch → createImageBitmap → OffscreenCanvas → FileReader.
+     * Mocks a bitmap of the given dimensions so the downscaling logic is exercised.
+     */
+    function setupMocks(bitmapWidth: number, bitmapHeight: number) {
+      const close = vi.fn()
+      const drawImage = vi.fn()
+      const convertToBlob = vi.fn(async () => new Blob(['x'], { type: 'image/png' }))
+
+      const bitmap = { width: bitmapWidth, height: bitmapHeight, close }
+      const ctx = { drawImage }
+
+      class MockOffscreenCanvas {
+        getContext = vi.fn(() => ctx)
+        convertToBlob = convertToBlob
+        constructor(_w: number, _h: number) {}
+      }
+
+      // Mock fetch to return a Blob from the data URL
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' })
+        }))
+      )
+      vi.stubGlobal('createImageBitmap', vi.fn(async () => bitmap))
+      vi.stubGlobal('OffscreenCanvas', MockOffscreenCanvas)
+
+      return { bitmap, close, drawImage, convertToBlob, ctx }
+    }
+
+    it('returns the original when image is smaller than maxLongEdge', async () => {
+      setupMocks(500, 300)
+
+      const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL, 2048)
+      expect(result).toBe(TINY_PNG_DATA_URL)
+    })
+
+    it('downscales when image exceeds maxLongEdge', async () => {
+      const { drawImage, close } = setupMocks(4000, 3000)
+
+      // In jsdom, FileReader.readAsDataURL won't actually produce a data URL,
+      // so the function falls through to the fallback placeholder. But the
+      // important thing is that drawImage was called with scaled dimensions
+      // and the bitmap was closed.
+      const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL, 2048)
+
+      // scale = 2048 / 4000 = 0.512 → width=2048, height=1536
+      expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 2048, 1536)
+      expect(close).toHaveBeenCalled()
+
+      // Result should be the downscaled data URL (from our mocked blob),
+      // NOT the original tiny PNG — the function attempted downscaling.
+      expect(result).not.toBe(TINY_PNG_DATA_URL)
+      // The drawImage was called with correct dimensions and bitmap was cleaned up
+      expect(drawImage).toHaveBeenCalled()
+      expect(close).toHaveBeenCalled()
+    })
+
+    it('returns placeholder when createImageBitmap throws', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' })
+        }))
+      )
+      vi.stubGlobal(
+        'createImageBitmap',
+        vi.fn(async () => {
+          throw new Error('decode failed')
+        })
+      )
+      vi.stubGlobal('OffscreenCanvas', vi.fn(() => ({})))
+
+      const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL, 2048)
+      expect(result).toBe(FALLBACK_PLACEHOLDER)
+    })
+
+    it('closes bitmap even when canvas getContext returns null', async () => {
+      const close = vi.fn()
+      const bitmap = { width: 4000, height: 3000, close }
+
+      class NullCanvas {
+        getContext = () => null
+        constructor(_w: number, _h: number) {}
+      }
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' })
+        }))
+      )
+      vi.stubGlobal('createImageBitmap', vi.fn(async () => bitmap))
+      vi.stubGlobal('OffscreenCanvas', NullCanvas)
+
+      const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL, 2048)
+      expect(result).toBe(FALLBACK_PLACEHOLDER)
+      expect(close).toHaveBeenCalled()
+    })
+
+    it('uses placeholder instead of original on convertToBlob failure', async () => {
+      const close = vi.fn()
+      const bitmap = { width: 4000, height: 3000, close }
+
+      class BrokenCanvas {
+        getContext = () => ({ drawImage: vi.fn() })
+        convertToBlob = vi.fn(async () => {
+          throw new Error('blob failed')
+        })
+        constructor(_w: number, _h: number) {}
+      }
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          blob: async () => new Blob([new Uint8Array([0])], { type: 'image/png' })
+        }))
+      )
+      vi.stubGlobal('createImageBitmap', vi.fn(async () => bitmap))
+      vi.stubGlobal('OffscreenCanvas', BrokenCanvas)
+
+      const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL, 2048)
+      expect(result).toBe(FALLBACK_PLACEHOLDER)
+      expect(close).toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/desktop/src/lib/image-resize.test.ts
+++ b/apps/desktop/src/lib/image-resize.test.ts
@@ -83,10 +83,10 @@ describe('downscaleDataUrlForPreview', () => {
       // so the function falls through to the fallback placeholder. But the
       // important thing is that drawImage was called with scaled dimensions
       // and the bitmap was closed.
-      const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL, 2048)
+      const result = await downscaleDataUrlForPreview(TINY_PNG_DATA_URL)
 
-      // scale = 2048 / 4000 = 0.512 → width=2048, height=1536
-      expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 2048, 1536)
+      // scale = 512 / 4000 = 0.128 → width=512, height=384
+      expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 512, 384)
       expect(close).toHaveBeenCalled()
 
       // Result should be the downscaled data URL (from our mocked blob),

--- a/apps/desktop/src/lib/image-resize.ts
+++ b/apps/desktop/src/lib/image-resize.ts
@@ -1,0 +1,92 @@
+/**
+ * Downscale a data URL for preview rendering.
+ *
+ * Large images (Retina screenshots, 6000×4000+) cause the Chromium main thread
+ * to block during <img> decode because macOS ImageIO/vImage decodes synchronously.
+ * This utility uses createImageBitmap + OffscreenCanvas to resize *before* the
+ * data URL is assigned to an <img> element, keeping the preview fast.
+ *
+ * Full-resolution bytes are still saved to disk for the model — only the preview
+ * thumbnail is downscaled.
+ *
+ * @param dataUrl  The full-resolution data URL (data:image/...;base64,...)
+ * @param maxLongEdge  Maximum pixel dimension on the longest side (default 2048)
+ * @returns  A downscaled data URL (PNG), the original if already small enough,
+ *           or a 1×1 transparent PNG placeholder if downscaling fails.
+ */
+
+/** 1×1 transparent PNG — used when downscaling fails so the UI never receives a multi-MB data URL. */
+const FALLBACK_PLACEHOLDER =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
+
+export async function downscaleDataUrlForPreview(
+  dataUrl: string,
+  maxLongEdge = 2048
+): Promise<string> {
+  // Guard: createImageBitmap and OffscreenCanvas are not available in jsdom
+  // (test environment) or very old Chromium builds. Return the original if missing.
+  if (typeof createImageBitmap !== 'function' || typeof OffscreenCanvas !== 'function') {
+    return dataUrl
+  }
+
+  const commaIndex = dataUrl.indexOf(',')
+
+  if (commaIndex === -1) {
+    return dataUrl
+  }
+
+  try {
+    // fetch(dataUrl) decodes base64 natively in C++ — avoids the O(n) atob()
+    // + charCodeAt loop that creates main-thread jank for multi-MB images.
+    const blob = await fetch(dataUrl).then(r => r.blob())
+
+    // createImageBitmap decodes off the main thread in Chromium, but the
+    // operation may still be costly for >5 MB retina screenshots; we then
+    // resize quickly with OffscreenCanvas.
+    const bitmap = await createImageBitmap(blob)
+
+    try {
+      const { width, height } = bitmap
+      const longEdge = Math.max(width, height)
+
+      if (longEdge <= maxLongEdge) {
+        return dataUrl
+      }
+
+      const scale = maxLongEdge / longEdge
+      const newWidth = Math.round(width * scale)
+      const newHeight = Math.round(height * scale)
+
+      const canvas = new OffscreenCanvas(newWidth, newHeight)
+      const ctx = canvas.getContext('2d')
+
+      if (!ctx) {
+        return FALLBACK_PLACEHOLDER
+      }
+
+      ctx.drawImage(bitmap, 0, 0, newWidth, newHeight)
+
+      const resultBlob = await canvas.convertToBlob({ type: 'image/png' })
+      const reader = new FileReader()
+
+      return new Promise<string>(resolve => {
+        reader.onloadend = () => {
+          if (typeof reader.result === 'string') {
+            resolve(reader.result)
+          } else {
+            resolve(FALLBACK_PLACEHOLDER)
+          }
+        }
+        reader.onerror = () => resolve(FALLBACK_PLACEHOLDER)
+        reader.readAsDataURL(resultBlob)
+      })
+    } finally {
+      bitmap.close()
+    }
+  } catch {
+    // Downscaling failed (unsupported format, OOM, etc.) — return a tiny
+    // placeholder rather than the original multi-MB data URL, which would
+    // re-introduce the main-thread decode freeze this function exists to prevent.
+    return FALLBACK_PLACEHOLDER
+  }
+}

--- a/apps/desktop/src/lib/image-resize.ts
+++ b/apps/desktop/src/lib/image-resize.ts
@@ -10,7 +10,7 @@
  * thumbnail is downscaled.
  *
  * @param dataUrl  The full-resolution data URL (data:image/...;base64,...)
- * @param maxLongEdge  Maximum pixel dimension on the longest side (default 2048)
+ * @param maxLongEdge  Maximum pixel dimension on the longest side (default 512)
  * @returns  A downscaled data URL (PNG), the original if already small enough,
  *           or a 1×1 transparent PNG placeholder if downscaling fails.
  */
@@ -19,9 +19,16 @@
 const FALLBACK_PLACEHOLDER =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
 
+// Composer pills render at 32 CSS pixels; a 512px source stays sharp on
+// high-density displays while keeping a square RGBA decode at ~1 MiB. A 2048px
+// thumbnail decodes to 16,777,216 bytes — 64 bytes above Chromium's PaintOp
+// serialization limit (16,777,152) — which reproduces the renderer crash seen
+// with multi-image attaches (see issue #41169 follow-up).
+const DEFAULT_MAX_LONG_EDGE = 512
+
 export async function downscaleDataUrlForPreview(
   dataUrl: string,
-  maxLongEdge = 2048
+  maxLongEdge = DEFAULT_MAX_LONG_EDGE
 ): Promise<string> {
   // Guard: createImageBitmap and OffscreenCanvas are not available in jsdom
   // (test environment) or very old Chromium builds. Return the original if missing.

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -10,6 +10,9 @@ export interface ComposerAttachment {
   detail?: string
   refText?: string
   previewUrl?: string
+  /** Downscaled data URL for the attachment card's <img> pill only. Keeps the
+   * full-resolution `previewUrl` for lightbox/download/model bytes. */
+  thumbnailUrl?: string
   path?: string
   attachedSessionId?: string
   /** Set while the file/image bytes are being staged into the session

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -9,6 +9,9 @@ export interface ComposerAttachment {
   detail?: string
   refText?: string
   previewUrl?: string
+  /** Downscaled data URL for the attachment card's <img> pill only. Keeps the
+   * full-resolution `previewUrl` for lightbox/download/model bytes. */
+  thumbnailUrl?: string
   path?: string
   attachedSessionId?: string
   /** Set while the file/image bytes are being staged into the session


### PR DESCRIPTION
## What does this PR do?

Prevents the Desktop renderer from freezing when pasting large images (Retina screenshots >5MB / 6000×4000px) into the chat composer.

### Root cause

The paste pipeline reads the full-resolution image into memory, writes it to disk unchanged, then reads it back as a base64 data URL and assigns it directly to an `<img>` element for the attachment thumbnail. Chromium decodes images synchronously on the main thread — macOS ImageIO/vImage blocks for seconds on Retina screenshots, freezing the entire UI.

### Fix

Add canvas-based downscaling (`createImageBitmap` + `OffscreenCanvas`) that scales the *thumbnail* to max 2048px on the longest side before it is assigned to the attachment card's `<img>`. The full-resolution data URL stays on the attachment as `previewUrl` — the field the lightbox and download consume — so opening or downloading a large attachment keeps full resolution, and the model still receives the full-resolution bytes via the attached-image upload pipeline.

**New file:** `apps/desktop/src/lib/image-resize.ts` — `downscaleDataUrlForPreview(dataUrl, maxLongEdge?)`

**Modified:**
- `apps/desktop/src/app/chat/hooks/use-composer-actions.ts` — `attachImagePath` now stores a downscaled `thumbnailUrl` alongside the full-resolution `previewUrl`
- `apps/desktop/src/store/composer.ts` — `ComposerAttachment` gains `thumbnailUrl?: string`
- `apps/desktop/src/app/chat/composer/attachments.tsx` — the pill `<img>` renders `thumbnailUrl ?? previewUrl`; lightbox/download keep `previewUrl` untouched
- `apps/desktop/src/lib/chat-runtime.ts` — the in-flight bubble display ref prefers the thumbnail (display-only; model bytes still go via the upload pipeline)

### Why this is safe

- Graceful fallback: if `createImageBitmap` / `OffscreenCanvas` are unavailable (jsdom, old Chromium), the thumbnail returns the original data URL unchanged
- If downscaling fails, the thumbnail falls back to a 1×1 transparent PNG so the pill never renders a multi-MB data URL; the pill stays clickable and opens the full-resolution lightbox
- Only the composer pill thumbnail and the in-flight bubble display ref are downscaled — the full-resolution image is still written to disk, sent to the model, and used by the lightbox and download action
- Non-image data URLs (text, PDF) pass through untouched
- Images already under 2048px pass through untouched

## Related Issue

Fixes #41169

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving tests)

## Test plan

- [x] `npx vitest run src/lib/image-resize.test.ts` — 8/8
- [x] `npx vitest run src/app/chat/hooks/use-composer-actions.test.ts` — 15/15 (incl. attachment-level regression: full-res `previewUrl` + separate downscaled `thumbnailUrl`)
- [x] `npx vitest run src/lib/chat-runtime.test.ts` — 30/30 (incl. bubble display ref preferring the thumbnail)
- [x] `npx vitest run` (full suite) — passed
- [x] `npx tsc -p . --noEmit` — clean

### Manual verification (not automated)

- Paste a Retina screenshot (Cmd+Shift+3, full screen) into the Desktop composer
- Verify the attachment thumbnail appears without freezing
- Verify clicking the attachment opens the lightbox at full resolution and the download action saves the full-resolution image
- Verify the full-resolution image is still on disk in `~/*/composer-images/`
- Verify sending the message includes the full-resolution image to the model

## Notes

**Open question:** The same main-thread decode issue can also affect `GeneratedImage` and inline `MEDIA:` references in messages (see #42109). This PR only fixes the composer paste path. A follow-up could apply the same downscaling to those components if needed.
