### PR TITLE
fix(gateway): re-check env for late-resolved bot token on reconnect

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1595,6 +1595,19 @@ def _platform_has_bot_credential(platform: "Platform", platform_config: "Platfor
 
     Platforms that do not use ``PlatformConfig.token`` always return True so we
     never skip them here (Signal session paths, port-binding HTTP adapters, etc.).
+
+    Also re-checks ``os.environ`` for the platform's token env var and, if
+    found, backfills it onto ``platform_config.token`` in place. This covers
+    a startup race (#69XXX) where an external secret source (1Password,
+    Bitwarden, ...) is still resolving when the initial connect attempt is
+    made — the empty-token config gets queued for reconnect, the secret
+    finishes resolving into os.environ a few seconds later, but this queued
+    ``PlatformConfig`` snapshot never got the value and the platform was
+    otherwise permanently evicted from the retry queue on the very next
+    check without ever looking at the env var again. Re-reading env here is
+    cheap (a dict lookup) and does not touch the #64674 multiplex-safety
+    behavior: a token that is genuinely never configured anywhere still
+    correctly returns False and gets dropped.
     """
     from gateway.config import PLATFORM_TOKEN_ENV_NAMES
 
@@ -1606,6 +1619,16 @@ def _platform_has_bot_credential(platform: "Platform", platform_config: "Platfor
     # Some adapters also accept api_key as the primary credential.
     api_key = getattr(platform_config, "api_key", None) or ""
     if isinstance(api_key, str) and api_key.strip():
+        return True
+    # Fall back to a live env re-check: a secret source (1Password, etc.)
+    # may have finished resolving the token into os.environ after this
+    # PlatformConfig snapshot was built and queued.
+    env_token = os.environ.get(PLATFORM_TOKEN_ENV_NAMES[platform], "").strip()
+    if env_token:
+        try:
+            platform_config.token = env_token
+        except Exception:
+            pass
         return True
     return False
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1590,24 +1590,19 @@ def load_gateway_config_for_runner() -> "GatewayConfig":
         return cfg
 
 
-def _platform_has_bot_credential(platform: "Platform", platform_config: "PlatformConfig") -> bool:
+def _platform_has_bot_credential(
+    platform: "Platform",
+    platform_config: "PlatformConfig",
+    *,
+    allow_env_fallback: bool = False,
+) -> bool:
     """Return True when a token-authenticated platform has a usable bot credential.
 
     Platforms that do not use ``PlatformConfig.token`` always return True so we
     never skip them here (Signal session paths, port-binding HTTP adapters, etc.).
 
-    Also re-checks ``os.environ`` for the platform's token env var and, if
-    found, backfills it onto ``platform_config.token`` in place. This covers
-    a startup race (#69XXX) where an external secret source (1Password,
-    Bitwarden, ...) is still resolving when the initial connect attempt is
-    made — the empty-token config gets queued for reconnect, the secret
-    finishes resolving into os.environ a few seconds later, but this queued
-    ``PlatformConfig`` snapshot never got the value and the platform was
-    otherwise permanently evicted from the retry queue on the very next
-    check without ever looking at the env var again. Re-reading env here is
-    cheap (a dict lookup) and does not touch the #64674 multiplex-safety
-    behavior: a token that is genuinely never configured anywhere still
-    correctly returns False and gets dropped.
+    Non-multiplex reconnects may opt into a live environment fallback after a
+    later runtime ``.env`` reload. Multiplex callers must stay profile-scoped.
     """
     from gateway.config import PLATFORM_TOKEN_ENV_NAMES
 
@@ -1620,15 +1615,13 @@ def _platform_has_bot_credential(platform: "Platform", platform_config: "Platfor
     api_key = getattr(platform_config, "api_key", None) or ""
     if isinstance(api_key, str) and api_key.strip():
         return True
-    # Fall back to a live env re-check: a secret source (1Password, etc.)
-    # may have finished resolving the token into os.environ after this
-    # PlatformConfig snapshot was built and queued.
+    if not allow_env_fallback:
+        return False
+    # A long-running non-multiplex gateway may reload .env after this config
+    # snapshot was queued. Process-global env is unsafe in multiplex mode.
     env_token = os.environ.get(PLATFORM_TOKEN_ENV_NAMES[platform], "").strip()
     if env_token:
-        try:
-            platform_config.token = env_token
-        except Exception:
-            pass
+        platform_config.token = env_token
         return True
     return False
 
@@ -8651,7 +8644,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Empty-token primary configs can never reconnect; drop them so
                 # multiplex setups where a secondary profile owns the bot do
                 # not spin forever (#64674).
-                if not _platform_has_bot_credential(platform, platform_config):
+                if not _platform_has_bot_credential(
+                    platform,
+                    platform_config,
+                    allow_env_fallback=not bool(
+                        getattr(self.config, "multiplex_profiles", False)
+                    ),
+                ):
                     logger.warning(
                         "Reconnect %s: no bot credential on queued config, "
                         "removing from retry queue",

--- a/tests/gateway/test_64674_multiplex_primary_token_scope.py
+++ b/tests/gateway/test_64674_multiplex_primary_token_scope.py
@@ -97,6 +97,34 @@ class TestPlatformHasBotCredential:
             Platform.TELEGRAM, PlatformConfig(enabled=True, token="123:abc")
         ) is True
 
+    def test_backfills_from_env_when_config_empty(self, monkeypatch):
+        """Startup-race regression: a secret source (1Password, etc.) that
+        finishes resolving the token into os.environ AFTER a platform's
+        PlatformConfig snapshot was queued for reconnect must still be
+        picked up, instead of permanently evicting the platform from the
+        retry queue on the very next check."""
+        from gateway.config import PLATFORM_TOKEN_ENV_NAMES
+        from gateway.run import _platform_has_bot_credential
+
+        env_name = PLATFORM_TOKEN_ENV_NAMES[Platform.DISCORD]
+        monkeypatch.setenv(env_name, "late-resolved-token")
+        cfg = PlatformConfig(enabled=True, token="")
+
+        assert _platform_has_bot_credential(Platform.DISCORD, cfg) is True
+        # Also backfilled onto the config so the reconnect attempt actually
+        # uses the recovered token instead of dropping it again next cycle.
+        assert cfg.token == "late-resolved-token"
+
+    def test_still_false_when_env_also_empty(self, monkeypatch):
+        from gateway.config import PLATFORM_TOKEN_ENV_NAMES
+        from gateway.run import _platform_has_bot_credential
+
+        env_name = PLATFORM_TOKEN_ENV_NAMES[Platform.DISCORD]
+        monkeypatch.delenv(env_name, raising=False)
+        cfg = PlatformConfig(enabled=True, token="")
+
+        assert _platform_has_bot_credential(Platform.DISCORD, cfg) is False
+
     def test_non_token_platform_always_true(self):
         from gateway.run import _platform_has_bot_credential
 

--- a/tests/gateway/test_64674_multiplex_primary_token_scope.py
+++ b/tests/gateway/test_64674_multiplex_primary_token_scope.py
@@ -98,11 +98,7 @@ class TestPlatformHasBotCredential:
         ) is True
 
     def test_backfills_from_env_when_config_empty(self, monkeypatch):
-        """Startup-race regression: a secret source (1Password, etc.) that
-        finishes resolving the token into os.environ AFTER a platform's
-        PlatformConfig snapshot was queued for reconnect must still be
-        picked up, instead of permanently evicting the platform from the
-        retry queue on the very next check."""
+        """Non-multiplex reconnects may use a later runtime .env reload."""
         from gateway.config import PLATFORM_TOKEN_ENV_NAMES
         from gateway.run import _platform_has_bot_credential
 
@@ -110,7 +106,9 @@ class TestPlatformHasBotCredential:
         monkeypatch.setenv(env_name, "late-resolved-token")
         cfg = PlatformConfig(enabled=True, token="")
 
-        assert _platform_has_bot_credential(Platform.DISCORD, cfg) is True
+        assert _platform_has_bot_credential(
+            Platform.DISCORD, cfg, allow_env_fallback=True
+        ) is True
         # Also backfilled onto the config so the reconnect attempt actually
         # uses the recovered token instead of dropping it again next cycle.
         assert cfg.token == "late-resolved-token"
@@ -223,6 +221,17 @@ class TestPrimaryStartupSkipsEmptyTokenUnderMultiplex:
 
 
 class TestReconnectDropsEmptyToken:
+    def test_multiplex_path_does_not_borrow_process_global_token(self, monkeypatch):
+        from gateway.config import PLATFORM_TOKEN_ENV_NAMES
+        from gateway.run import _platform_has_bot_credential
+
+        env_name = PLATFORM_TOKEN_ENV_NAMES[Platform.DISCORD]
+        monkeypatch.setenv(env_name, "secondary-profile-token")
+        config = PlatformConfig(enabled=True, token="")
+
+        assert _platform_has_bot_credential(Platform.DISCORD, config) is False
+        assert config.token == ""
+
     @pytest.mark.asyncio
     async def test_empty_token_removed_from_queue(self):
         from gateway.run import GatewayRunner, _platform_has_bot_credential


### PR DESCRIPTION
## Root cause

Long-running non-multiplex gateways can reload `.env` during later runtime turns. If an operator supplies or rotates a platform token after a reconnect candidate's `PlatformConfig` snapshot was queued, the live environment can contain a usable token while the queued config remains empty. The reconnect watcher would treat that stale snapshot as permanently uncredentialed and remove it from the retry queue.

The previous explanation based on delayed external secret resolution was not a supported runtime path and has been removed.

## Fix

`_platform_has_bot_credential()` now has an explicit `allow_env_fallback` policy:

- Non-multiplex reconnects opt in, re-read the live environment after a supported runtime `.env` reload, and backfill the queued config.
- Multiplex reconnects do not use process-global environment fallback, because that token may belong to another profile.
- Configured `token` / `api_key` values and non-token platforms retain existing behavior.
- A genuinely empty config remains uncredentialed and is dropped from the retry queue.

## Tests

Coverage verifies runtime environment backfill, true-empty rejection, non-token behavior, and that multiplex paths do not borrow a process-global token from another profile.

```text
pytest -q tests/gateway/test_64674_multiplex_primary_token_scope.py tests/gateway/test_platform_reconnect.py
47 passed
```

The only warnings are third-party namespace deprecations.