### PR TITLE
fix(opencode-go): cap mimo-v2.5 output tokens

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -46,6 +46,7 @@ class OpenCodeGoProfile(ProviderProfile):
     # Setting an explicit cap here prevents the relay default from being
     # applied. Keys are normalized via _flat_model_name().
     _MODEL_MAX_TOKENS: dict[str, int] = {
+        "mimo-v2.5": 131072,
         "mimo-v2.5-pro": 131072,
     }
 

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -201,6 +201,18 @@ class TestOpenCodeGoModelGating:
         assert top_level == {}
 
 
+class TestOpenCodeGoMaxTokens:
+    @pytest.mark.parametrize(
+        "model",
+        ["mimo-v2.5", "xiaomi/mimo-v2.5", "mimo-v2.5-pro"],
+    )
+    def test_mimo_v25_models_use_supported_cap(self, opencode_go_profile, model):
+        assert opencode_go_profile.get_max_tokens(model) == 131072
+
+    def test_other_models_preserve_relay_default(self, opencode_go_profile):
+        assert opencode_go_profile.get_max_tokens("kimi-k2.6") is None
+
+
 class TestOpenCodeGoFullKwargsIntegration:
     """End-to-end transport kwargs include the profile-provided controls."""
 

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -129,6 +129,31 @@ class TestOpenCodeGoModelGating:
         assert top_level == {}
 
 
+class TestOpenCodeGoMaxTokens:
+    @pytest.mark.parametrize(
+        "model",
+        ["mimo-v2.5", "xiaomi/mimo-v2.5", "mimo-v2.5-pro"],
+    )
+    def test_mimo_v25_models_use_supported_cap(self, opencode_go_profile, model):
+        assert opencode_go_profile.get_max_tokens(model) == 131072
+
+    def test_other_models_preserve_relay_default(self, opencode_go_profile):
+        assert opencode_go_profile.get_max_tokens("kimi-k2.6") is None
+
+    def test_mimo_v25_cap_reaches_request_kwargs(self, opencode_go_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="mimo-v2.5",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=opencode_go_profile,
+            max_tokens_param_fn=lambda value: {"max_tokens": value},
+        )
+
+        assert kwargs["max_tokens"] == 131072
+
+
 class TestOpenCodeGoFullKwargsIntegration:
     """End-to-end transport kwargs include the profile-provided controls."""
 


### PR DESCRIPTION
## What does this PR do?

Applies the existing OpenCode Go MiMo v2.5 completion-token cap to the base `mimo-v2.5` model as well as `mimo-v2.5-pro`.

- maps both v2.5 variants to 131072 completion tokens
- preserves aggregator-prefixed model normalization
- leaves non-MiMo OpenCode Go models on their existing relay defaults

## Related Issue

Fixes #68745

## Type of Change

- Bug fix
- Tests

## How Has This Been Tested?

- `pytest tests/plugins/model_providers/test_opencode_go_profile.py tests/agent/transports/test_chat_completions.py -q` (`124 passed`)
- `ruff check plugins/model-providers/opencode-zen/__init__.py tests/plugins/model_providers/test_opencode_go_profile.py`
- `git diff --check`

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix is effective
- [x] New and existing focused tests pass locally
