### PR TITLE
fix: enable multi-select when adding folders to an existing project

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/project-dialog.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.test.tsx
@@ -1,10 +1,13 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import type * as Nanostores from 'nanostores'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ProjectDialog } from './project-dialog'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
 
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
@@ -13,6 +16,8 @@ vi.mock('@/i18n', () => ({
       sidebar: {
         projects: {
           addFolder: 'Add folder',
+          addFolderFailed: (count: number) => `Could not add ${count} folder${count === 1 ? '' : 's'}`,
+          addFolderTitle: 'Add folder',
           create: 'Create',
           createDesc: 'Create a new project',
           createFailed: 'Failed to create project',
@@ -26,7 +31,8 @@ vi.mock('@/i18n', () => ({
           namePlaceholder: 'Project name',
           noFolders: 'No folders yet',
           primaryBadge: 'Primary',
-          removeFolder: 'Remove folder'
+          removeFolder: 'Remove folder',
+          renameTitle: 'Rename project'
         }
       }
     }
@@ -48,18 +54,25 @@ const { $projectDialog } = vi.hoisted(() => {
   }
 })
 
+const { mockAddProjectFolder, mockPickProjectFolders, mockNotifyError } = vi.hoisted(() => ({
+  mockAddProjectFolder: vi.fn(),
+  mockPickProjectFolders: vi.fn(),
+  mockNotifyError: vi.fn()
+}))
+
 vi.mock('@/store/projects', () => ({
   $projectDialog,
-  addProjectFolder: vi.fn(),
+  addProjectFolder: mockAddProjectFolder,
   closeProjectDialog: vi.fn(),
   createProject: vi.fn(),
   generateProjectIdea: vi.fn(),
   pickProjectFolder: vi.fn(async () => '/Users/test/my-folder'),
+  pickProjectFolders: mockPickProjectFolders,
   renameProject: vi.fn()
 }))
 
 vi.mock('@/store/notifications', () => ({
-  notifyError: vi.fn()
+  notifyError: mockNotifyError
 }))
 
 vi.mock('@/lib/project-idea-templates', () => ({
@@ -83,5 +96,71 @@ describe('ProjectDialog', () => {
 
     const button = await screen.findByRole('button', { name: 'Remove folder' })
     expect(tipTrigger(button)).toBeTruthy()
+  })
+})
+
+describe('ProjectDialog add-folder mode — multi-select loop', () => {
+  beforeEach(() => {
+    $projectDialog.set({ mode: 'add-folder', projectId: 'p_test' })
+  })
+
+  afterEach(() => {
+    $projectDialog.set({ mode: 'create' })
+  })
+
+  it('calls addProjectFolder once per picked directory', async () => {
+    mockPickProjectFolders.mockResolvedValue(['/work/a', '/work/b', '/work/c'])
+    mockAddProjectFolder.mockResolvedValue(undefined)
+
+    render(<ProjectDialog />)
+    fireEvent.click(screen.getByRole('button', { name: 'Add folder' }))
+
+    // Wait for async ops to settle
+    await vi.waitFor(() => {
+      expect(mockAddProjectFolder).toHaveBeenCalledTimes(3)
+    })
+
+    expect(mockAddProjectFolder).toHaveBeenCalledWith('p_test', '/work/a')
+    expect(mockAddProjectFolder).toHaveBeenCalledWith('p_test', '/work/b')
+    expect(mockAddProjectFolder).toHaveBeenCalledWith('p_test', '/work/c')
+    expect(mockNotifyError).not.toHaveBeenCalled()
+  })
+
+  it('continues iterating after a per-folder failure and surfaces errors for failed folders', async () => {
+    mockPickProjectFolders.mockResolvedValue(['/work/ok', '/work/fail', '/work/also-ok'])
+    mockAddProjectFolder
+      .mockResolvedValueOnce(undefined)         // /work/ok succeeds
+      .mockRejectedValueOnce(new Error('permission denied'))  // /work/fail fails
+      .mockResolvedValueOnce(undefined)         // /work/also-ok succeeds
+
+    render(<ProjectDialog />)
+    fireEvent.click(screen.getByRole('button', { name: 'Add folder' }))
+
+    // All three folders are attempted despite the middle failure
+    await vi.waitFor(() => {
+      expect(mockAddProjectFolder).toHaveBeenCalledTimes(3)
+    })
+
+    expect(mockAddProjectFolder).toHaveBeenCalledWith('p_test', '/work/ok')
+    expect(mockAddProjectFolder).toHaveBeenCalledWith('p_test', '/work/fail')
+    expect(mockAddProjectFolder).toHaveBeenCalledWith('p_test', '/work/also-ok')
+
+    // The partial failure is surfaced to the user
+    expect(mockNotifyError).toHaveBeenCalledOnce()
+  })
+
+  it('does not call addProjectFolder when the picker is dismissed (empty selection)', async () => {
+    mockPickProjectFolders.mockResolvedValue([])
+
+    render(<ProjectDialog />)
+    fireEvent.click(screen.getByRole('button', { name: 'Add folder' }))
+
+    await vi.waitFor(() => {
+      // Give async path time to settle
+      expect(mockPickProjectFolders).toHaveBeenCalled()
+    })
+
+    expect(mockAddProjectFolder).not.toHaveBeenCalled()
+    expect(mockNotifyError).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
@@ -26,6 +26,7 @@ import {
   createProject,
   generateProjectIdea,
   pickProjectFolder,
+  pickProjectFolders,
   renameProject
 } from '@/store/projects'
 
@@ -89,17 +90,28 @@ export function ProjectDialog() {
 
   const pickFolder = async () => {
     try {
-      const dir = await pickProjectFolder()
-
-      if (!dir) {
-        return
-      }
-
       const projectId = state?.projectId
 
       if (mode === 'add-folder' && projectId) {
-        await runSubmit(() => addProjectFolder(projectId, dir))
+        // Use multi-select so the user can pick several folders in one shot.
+        const dirs = await pickProjectFolders()
 
+        if (!dirs.length) {
+          return
+        }
+
+        await runSubmit(async () => {
+          for (const dir of dirs) {
+            await addProjectFolder(projectId, dir)
+          }
+        })
+
+        return
+      }
+
+      const dir = await pickProjectFolder()
+
+      if (!dir) {
         return
       }
 

--- a/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
@@ -101,8 +101,21 @@ export function ProjectDialog() {
         }
 
         await runSubmit(async () => {
+          const failures: string[] = []
+
           for (const dir of dirs) {
-            await addProjectFolder(projectId, dir)
+            try {
+              await addProjectFolder(projectId, dir)
+            } catch (e) {
+              failures.push(dir)
+            }
+          }
+
+          if (failures.length > 0) {
+            notifyError(
+              new Error(failures.join(', ')),
+              p.addFolderFailed(failures.length)
+            )
           }
         })
 

--- a/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
@@ -106,7 +106,8 @@ export function ProjectDialog() {
           for (const dir of dirs) {
             try {
               await addProjectFolder(projectId, dir)
-            } catch (e) {
+            } catch (err) {
+              console.error(`Failed to add folder ${dir}:`, err)
               failures.push(dir)
             }
           }

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1590,6 +1590,7 @@ export const ar = defineLocale({
       copyPath: 'نسخ المسار',
       removeFromSidebar: 'إخفاء من الشريط الجانبي',
       createFailed: 'تعذّر إنشاء المشروع',
+      addFolderFailed: (count: number) => `تعذّر إضافة ${count === 1 ? 'مجلد واحد' : `${count} مجلدات`}`,
       deleteConfirm: 'هذا يزيل المشروع المحفوظ من Hermes. تبقى الملفات ومستودعات git وأشجار العمل دون تغيير.',
       startWork: 'شجرة عمل جديدة',
       newWorktreeTitle: 'شجرة عمل جديدة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1891,6 +1891,7 @@ export const en: Translations = {
       copyPath: 'Copy path',
       removeFromSidebar: 'Hide from sidebar',
       createFailed: 'Could not create project',
+      addFolderFailed: (count: number) => `Could not add ${count === 1 ? '1 folder' : `${count} folders`}`,
       staleBackend:
         'Update the Hermes backend to create projects — your backend is older than this desktop app (Settings → Updates → Backend).',
       deleteConfirm: 'This removes the saved project from Hermes. Files, git repos, and worktrees stay untouched.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1727,6 +1727,7 @@ export const ja = defineLocale({
       copyPath: 'パスをコピー',
       removeFromSidebar: 'サイドバーから削除',
       createFailed: 'プロジェクトを作成できませんでした',
+      addFolderFailed: (count: number) => `${count} 個のフォルダーを追加できませんでした`,
       staleBackend:
         'プロジェクトを作成するには Hermes バックエンドを更新してください。バックエンドがこのデスクトップアプリより古いです（設定 → 更新 → バックエンド）。',
       deleteConfirm:

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1588,6 +1588,7 @@ export interface Translations {
       copyPath: string
       removeFromSidebar: string
       createFailed: string
+      addFolderFailed: (count: number) => string
       staleBackend: string
       deleteConfirm: string
       startWork: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1672,6 +1672,7 @@ export const zhHant = defineLocale({
       copyPath: '複製路徑',
       removeFromSidebar: '從側邊欄移除',
       createFailed: '無法建立專案',
+      addFolderFailed: (count: number) => `無法新增 ${count} 個資料夾`,
       staleBackend: '請更新 Hermes 後端以建立專案——目前後端比桌面應用舊（設定 → 更新 → 後端）。',
       deleteConfirm: '這會從 Hermes 中移除已儲存的專案。檔案、git 儲存庫和工作樹維持不變。',
       startWork: '新增工作樹',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2085,6 +2085,7 @@ export const zh: Translations = {
       copyPath: '复制路径',
       removeFromSidebar: '从侧边栏移除',
       createFailed: '无法创建项目',
+      addFolderFailed: (count: number) => `无法添加 ${count} 个文件夹`,
       staleBackend: '请更新 Hermes 后端以创建项目——当前后端比桌面应用旧（设置 → 更新 → 后端）。',
       deleteConfirm: '这会从 Hermes 中移除已保存的项目。文件、git 仓库和工作树保持不变。',
       startWork: '新建工作树',

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -204,14 +204,49 @@ describe('desktop filesystem facade', () => {
     expect(remoteSelect).not.toHaveBeenCalled()
   })
 
-  it('limits the remote picker to single-directory selection', async () => {
+  it('forwards caller options unchanged to the remote directory picker', async () => {
     const remoteSelect = vi.fn(async () => ['/remote/project'])
     $connection.set({ mode: 'remote' } as never)
     setDesktopFsRemotePicker({ selectPaths: remoteSelect })
 
     await expect(selectDesktopPaths({ directories: true })).resolves.toEqual(['/remote/project'])
 
-    expect(remoteSelect).toHaveBeenCalledWith({ directories: true, multiple: false })
+    // Options must be forwarded as-is — no hard-coded multiple: false override.
+    expect(remoteSelect).toHaveBeenCalledWith({ directories: true })
+    expect(selectPaths).not.toHaveBeenCalled()
+  })
+
+  it('forwards multiple: true to the remote directory picker for multi-select', async () => {
+    const remoteSelect = vi.fn(async () => ['/remote/a', '/remote/b', '/remote/c'])
+    $connection.set({ mode: 'remote' } as never)
+    setDesktopFsRemotePicker({ selectPaths: remoteSelect })
+
+    const result = await selectDesktopPaths({ directories: true, multiple: true })
+
+    expect(result).toEqual(['/remote/a', '/remote/b', '/remote/c'])
+    expect(remoteSelect).toHaveBeenCalledWith({ directories: true, multiple: true })
+    expect(selectPaths).not.toHaveBeenCalled()
+  })
+
+  it('returns an empty array when the remote picker is dismissed without a selection', async () => {
+    const remoteSelect = vi.fn(async () => [])
+    $connection.set({ mode: 'remote' } as never)
+    setDesktopFsRemotePicker({ selectPaths: remoteSelect })
+
+    const result = await selectDesktopPaths({ directories: true, multiple: true })
+
+    expect(result).toEqual([])
+    expect(remoteSelect).toHaveBeenCalledOnce()
+    expect(selectPaths).not.toHaveBeenCalled()
+  })
+
+  it('falls back to an empty array when no remote picker is registered', async () => {
+    $connection.set({ mode: 'remote' } as never)
+    // No setDesktopFsRemotePicker call — picker is null.
+
+    const result = await selectDesktopPaths({ directories: true, multiple: true })
+
+    expect(result).toEqual([])
     expect(selectPaths).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -187,5 +187,5 @@ export async function selectDesktopPaths(options?: HermesSelectPathsOptions): Pr
     return desktop.selectPaths(options)
   }
 
-  return remotePicker ? remotePicker.selectPaths({ ...options, multiple: false }) : []
+  return remotePicker ? remotePicker.selectPaths(options) : []
 }

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -180,12 +180,14 @@ export async function selectDesktopPaths(options?: HermesSelectPathsOptions): Pr
   const desktop = bridge()
 
   if (!isDesktopFsRemoteMode()) {
-    return desktop.selectPaths(options)
+    return (await desktop.selectPaths(options)) || []
   }
 
   if (!options?.directories) {
-    return desktop.selectPaths(options)
+    return (await desktop.selectPaths(options)) || []
   }
 
-  return remotePicker ? remotePicker.selectPaths(options) : []
+  const paths = remotePicker ? await remotePicker.selectPaths(options) : []
+
+  return paths || []
 }

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -22,6 +22,7 @@ import {
   exitProjectScope,
   openProjectCreate,
   pickProjectFolder,
+  pickProjectFolders,
   projectNameForCwd,
   refreshProjects,
   refreshProjectTree,
@@ -542,5 +543,57 @@ describe('tombstone pruning', () => {
     await refreshProjectTree()
 
     expect($removedSessionIds.get().has('sess-1')).toBe(false)
+  })
+})
+
+describe('pickProjectFolders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // pickProjectFolders always calls desktopDefaultCwd; reset to no-cwd default
+    // so tests that don't care about the seed path see defaultPath: undefined.
+    desktopDefaultCwd.mockResolvedValue(undefined)
+  })
+
+  it('returns all selected directories from the multi-select picker', async () => {
+    selectDesktopPaths.mockResolvedValue(['/work/a', '/work/b', '/work/c'])
+
+    const result = await pickProjectFolders()
+
+    expect(result).toEqual(['/work/a', '/work/b', '/work/c'])
+    expect(selectDesktopPaths).toHaveBeenCalledWith({
+      defaultPath: undefined,
+      directories: true,
+      multiple: true
+    })
+  })
+
+  it('seeds the picker with the backend cwd', async () => {
+    desktopDefaultCwd.mockResolvedValue({ branch: 'main', cwd: '/backend/projects' })
+    selectDesktopPaths.mockResolvedValue(['/backend/projects/repo1', '/backend/projects/repo2'])
+
+    const result = await pickProjectFolders()
+
+    expect(result).toEqual(['/backend/projects/repo1', '/backend/projects/repo2'])
+    expect(selectDesktopPaths).toHaveBeenCalledWith({
+      defaultPath: '/backend/projects',
+      directories: true,
+      multiple: true
+    })
+  })
+
+  it('returns an empty array when the picker is dismissed', async () => {
+    selectDesktopPaths.mockResolvedValue([])
+
+    const result = await pickProjectFolders()
+
+    expect(result).toEqual([])
+  })
+
+  it('filters out any falsy values from the picker result', async () => {
+    selectDesktopPaths.mockResolvedValue(['/work/a', '', '/work/b'])
+
+    const result = await pickProjectFolders()
+
+    expect(result).toEqual(['/work/a', '/work/b'])
   })
 })

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -1223,6 +1223,20 @@ export async function pickProjectFolder(): Promise<null | string> {
   return dir || null
 }
 
+// Multi-select variant of pickProjectFolder: opens the native directory picker
+// with multiSelections enabled so the user can pick several folders at once
+// (used by the add-folder flow on existing projects). Returns all chosen paths,
+// or an empty array when cancelled.
+export async function pickProjectFolders(): Promise<string[]> {
+  const dirs = await selectDesktopPaths({
+    defaultPath: (await desktopDefaultCwd())?.cwd,
+    directories: true,
+    multiple: true
+  })
+
+  return dirs.filter(Boolean)
+}
+
 // ⌘O / palette "Open folder…": open a folder AS a project, upserting. A folder
 // already covered by a project (explicit or auto) just enters it; anything else
 // becomes a new project named after the folder. Either way the sidebar scopes


### PR DESCRIPTION
## Summary

Fixes #68741 — when using **Add Folder** on an existing project, only one folder could be selected at a time. Project creation already supported picking multiple folders; the add-folder flow did not.

**Root cause — three independent bugs stacked:**

1. `pickProjectFolder()` in `store/projects.ts` passes `multiple: false` to `selectDesktopPaths`, so the native Electron dialog never enables `multiSelections` for that call path.

2. `pickFolder()` in `project-dialog.tsx` (add-folder mode) called the single-select helper and immediately submitted after the first pick — it never offered the user a chance to select more.

3. `selectDesktopPaths()` in `desktop-fs.ts` hard-coded `multiple: false` when forwarding to the remote-gateway picker for directory selections, which would have blocked any fix from working in remote mode.

## Changes

- **`apps/desktop/src/store/projects.ts`** — add `pickProjectFolders()` (plural), a multi-select variant of the existing helper that passes `multiple: true`. The existing `pickProjectFolder()` is untouched, so the creation-mode loop is unaffected.

- **`apps/desktop/src/app/chat/sidebar/project-dialog.tsx`** — in `add-folder` mode, switch to `pickProjectFolders()` and iterate the result, calling `addProjectFolder()` once per directory inside a single `runSubmit` beat so all folders land atomically from the user's perspective.

- **`apps/desktop/src/lib/desktop-fs.ts`** — stop overriding `multiple: false` when forwarding to the remote picker; pass `options` through unchanged so the caller's flag is respected.

## Test plan

- [ ] Open an existing project → right-click → Add Folder → verify the native file picker allows selecting multiple directories at once (Cmd+click / Shift+click on macOS, Ctrl+click on Windows/Linux)
- [ ] Confirm all selected folders appear on the project after dismissing the dialog
- [ ] Confirm that cancelling the picker (selecting nothing) does not close or mutate the dialog
- [ ] Confirm project **creation** flow (multi-folder picker already worked) is unchanged
- [ ] Remote gateway mode: verify the same multi-select behavior works when connected to a remote backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)