### PR TITLE
fix(gateway): preserve reply targets during recovery

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -86,6 +86,7 @@ def _connect() -> sqlite3.Connection:
             platform TEXT NOT NULL,
             chat_id TEXT NOT NULL,
             thread_id TEXT,
+            reply_to TEXT,
             content TEXT NOT NULL,
             state TEXT NOT NULL,
             attempts INTEGER NOT NULL DEFAULT 0,
@@ -96,6 +97,21 @@ def _connect() -> sqlite3.Connection:
             last_error TEXT
         )"""
     )
+    columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(delivery_obligations)")
+    }
+    if "reply_to" not in columns:
+        try:
+            conn.execute("ALTER TABLE delivery_obligations ADD COLUMN reply_to TEXT")
+        except sqlite3.OperationalError:
+            # Multiple gateway profiles can open the shared DB concurrently
+            # during an upgrade. Accept a migration won by another process.
+            columns = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(delivery_obligations)")
+            }
+            if "reply_to" not in columns:
+                raise
     return conn
 
 
@@ -160,6 +176,7 @@ def record_obligation(
     chat_id: str,
     thread_id: Optional[str],
     content: str,
+    reply_to: Optional[str] = None,
 ) -> None:
     """Record a final response as owed to the platform (state='pending')."""
     now = time.time()
@@ -167,12 +184,13 @@ def record_obligation(
     with _DB_LOCK, _connect() as conn:
         conn.execute(
             """INSERT OR REPLACE INTO delivery_obligations
-               (obligation_id, session_key, platform, chat_id, thread_id,
+               (obligation_id, session_key, platform, chat_id, thread_id, reply_to,
                 content, state, attempts, created_at, updated_at,
                 owner_pid, owner_started_at)
-               VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?)""",
             (obligation_id, session_key, platform, str(chat_id),
-             str(thread_id) if thread_id else None, content, now, now,
+             str(thread_id) if thread_id else None,
+             str(reply_to) if reply_to is not None else None, content, now, now,
              pid, started),
         )
     _prune()
@@ -227,12 +245,12 @@ def sweep_recoverable(
     with _DB_LOCK, _connect() as conn:
         rows = conn.execute(
             """SELECT obligation_id, session_key, platform, chat_id, thread_id,
-                      content, state, attempts, created_at,
+                      reply_to, content, state, attempts, created_at,
                       owner_pid, owner_started_at
                FROM delivery_obligations
                WHERE state IN ('pending', 'attempting', 'failed')"""
         ).fetchall()
-        for (oid, session_key, platform, chat_id, thread_id, content, state,
+        for (oid, session_key, platform, chat_id, thread_id, reply_to, content, state,
              attempts, created_at, owner_pid, owner_started_at) in rows:
             if _owner_alive(owner_pid, owner_started_at):
                 continue  # a live gateway still owns this row
@@ -264,6 +282,7 @@ def sweep_recoverable(
                     "platform": platform,
                     "chat_id": chat_id,
                     "thread_id": thread_id,
+                    "reply_to": reply_to,
                     "content": content,
                     # pending = send never started, redeliver plainly;
                     # attempting/failed = ambiguous or rejected, carry marker.

--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -100,6 +100,7 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
             platform TEXT NOT NULL,
             chat_id TEXT NOT NULL,
             thread_id TEXT,
+            reply_to TEXT,
             content TEXT NOT NULL,
             state TEXT NOT NULL,
             attempts INTEGER NOT NULL DEFAULT 0,
@@ -110,6 +111,21 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
             last_error TEXT
         )"""
     )
+    columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(delivery_obligations)")
+    }
+    if "reply_to" not in columns:
+        try:
+            conn.execute("ALTER TABLE delivery_obligations ADD COLUMN reply_to TEXT")
+        except sqlite3.OperationalError:
+            # Multiple gateway profiles can open the shared DB concurrently
+            # during an upgrade. Accept a migration won by another process.
+            columns = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(delivery_obligations)")
+            }
+            if "reply_to" not in columns:
+                raise
 
 
 @contextmanager
@@ -193,6 +209,7 @@ def record_obligation(
     chat_id: str,
     thread_id: Optional[str],
     content: str,
+    reply_to: Optional[str] = None,
 ) -> None:
     """Record a final response as owed to the platform (state='pending')."""
     now = time.time()
@@ -200,12 +217,13 @@ def record_obligation(
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
             """INSERT OR REPLACE INTO delivery_obligations
-               (obligation_id, session_key, platform, chat_id, thread_id,
+               (obligation_id, session_key, platform, chat_id, thread_id, reply_to,
                 content, state, attempts, created_at, updated_at,
                 owner_pid, owner_started_at)
-               VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?)""",
             (obligation_id, session_key, platform, str(chat_id),
-             str(thread_id) if thread_id else None, content, now, now,
+             str(thread_id) if thread_id else None,
+             str(reply_to) if reply_to is not None else None, content, now, now,
              pid, started),
         )
     _prune()
@@ -260,12 +278,12 @@ def sweep_recoverable(
     with _DB_LOCK, _transaction() as conn:
         rows = conn.execute(
             """SELECT obligation_id, session_key, platform, chat_id, thread_id,
-                      content, state, attempts, created_at,
+                      reply_to, content, state, attempts, created_at,
                       owner_pid, owner_started_at
                FROM delivery_obligations
                WHERE state IN ('pending', 'attempting', 'failed')"""
         ).fetchall()
-        for (oid, session_key, platform, chat_id, thread_id, content, state,
+        for (oid, session_key, platform, chat_id, thread_id, reply_to, content, state,
              attempts, created_at, owner_pid, owner_started_at) in rows:
             if _owner_alive(owner_pid, owner_started_at):
                 continue  # a live gateway still owns this row
@@ -297,6 +315,7 @@ def sweep_recoverable(
                     "platform": platform,
                     "chat_id": chat_id,
                     "thread_id": thread_id,
+                    "reply_to": reply_to,
                     "content": content,
                     # pending = send never started, redeliver plainly;
                     # attempting/failed = ambiguous or rejected, carry marker.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5226,6 +5226,7 @@ class BasePlatformAdapter(ABC):
                                     chat_id=event.source.chat_id,
                                     thread_id=getattr(event.source, "thread_id", None),
                                     content=text_content,
+                                    reply_to=_reply_anchor,
                                 )
                                 mark_attempting(_obligation_id)
                         except Exception:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6478,6 +6478,7 @@ class BasePlatformAdapter(ABC):
                                     chat_id=event.source.chat_id,
                                     thread_id=getattr(event.source, "thread_id", None),
                                     content=text_content,
+                                    reply_to=_reply_anchor,
                                 )
                                 await asyncio.to_thread(mark_attempting, _obligation_id)
                         except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7101,6 +7101,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 result = await adapter.send(
                     chat_id=row["chat_id"],
                     content=content,
+                    reply_to=row.get("reply_to"),
                     metadata=metadata,
                 )
             except Exception as send_err:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10788,6 +10788,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 result = await adapter.send(
                     chat_id=row["chat_id"],
                     content=content,
+                    reply_to=row.get("reply_to"),
                     metadata=metadata,
                 )
             except Exception as send_err:

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -35,6 +35,7 @@ def _record(oid="ob-1", session_key="agent:main:slack:channel:C1", **kw):
         chat_id=kw.get("chat_id", "C1"),
         thread_id=kw.get("thread_id", "171.001"),
         content=kw.get("content", "the final answer"),
+        reply_to=kw.get("reply_to"),
     )
 
 
@@ -215,7 +216,7 @@ class TestGatewayRedeliverySweep:
 
     @pytest.mark.asyncio
     async def test_pending_redelivers_plain_and_clears_resume(self):
-        _record()  # pending
+        _record(reply_to="msg-42")  # pending
         _orphan("ob-1")
         adapter = self._adapter()
         runner = self._runner(adapter)
@@ -225,6 +226,7 @@ class TestGatewayRedeliverySweep:
         assert n == 1
         sent = adapter.send.call_args.kwargs
         assert sent["content"] == "the final answer"  # no marker
+        assert sent["reply_to"] == "msg-42"
         assert sent["metadata"] == {"thread_id": "171.001"}
         assert _row("ob-1")["state"] == "delivered"
         runner._async_session_store.clear_resume_pending.assert_awaited_once_with(
@@ -244,6 +246,39 @@ class TestGatewayRedeliverySweep:
         sent = adapter.send.call_args.kwargs
         assert sent["content"].startswith(dl.RECOVERED_MARKER)
         assert sent["content"].endswith("the final answer")
+
+    def test_existing_database_adds_reply_to_column(self):
+        path = dl._db_path()
+        path.unlink(missing_ok=True)
+        import sqlite3
+
+        with sqlite3.connect(path) as conn:
+            conn.execute(
+                """CREATE TABLE delivery_obligations (
+                    obligation_id TEXT PRIMARY KEY,
+                    session_key TEXT NOT NULL,
+                    platform TEXT NOT NULL,
+                    chat_id TEXT NOT NULL,
+                    thread_id TEXT,
+                    content TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    owner_pid INTEGER,
+                    owner_started_at INTEGER,
+                    last_error TEXT
+                )"""
+            )
+
+        with dl._connect() as conn:
+            columns = {
+                row[1] for row in conn.execute(
+                    "PRAGMA table_info(delivery_obligations)"
+                )
+            }
+
+        assert "reply_to" in columns
 
     @pytest.mark.asyncio
     async def test_send_failure_marks_failed_for_next_boot(self):

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -36,6 +36,7 @@ def _record(oid="ob-1", session_key="agent:main:slack:channel:C1", **kw):
         chat_id=kw.get("chat_id", "C1"),
         thread_id=kw.get("thread_id", "171.001"),
         content=kw.get("content", "the final answer"),
+        reply_to=kw.get("reply_to"),
     )
 
 
@@ -169,7 +170,7 @@ class TestGatewayRedeliverySweep:
 
     @pytest.mark.asyncio
     async def test_pending_redelivers_plain_and_clears_resume(self):
-        _record()  # pending
+        _record(reply_to="msg-42")  # pending
         _orphan("ob-1")
         adapter = self._adapter()
         runner = self._runner(adapter)
@@ -179,6 +180,7 @@ class TestGatewayRedeliverySweep:
         assert n == 1
         sent = adapter.send.call_args.kwargs
         assert sent["content"] == "the final answer"  # no marker
+        assert sent["reply_to"] == "msg-42"
         assert sent["metadata"] == {"thread_id": "171.001"}
         assert _row("ob-1")["state"] == "delivered"
         runner._async_session_store.clear_resume_pending.assert_awaited_once_with(
@@ -198,6 +200,39 @@ class TestGatewayRedeliverySweep:
         sent = adapter.send.call_args.kwargs
         assert sent["content"].startswith(dl.RECOVERED_MARKER)
         assert sent["content"].endswith("the final answer")
+
+    def test_existing_database_adds_reply_to_column(self):
+        path = dl._db_path()
+        path.unlink(missing_ok=True)
+        import sqlite3
+
+        with sqlite3.connect(path) as conn:
+            conn.execute(
+                """CREATE TABLE delivery_obligations (
+                    obligation_id TEXT PRIMARY KEY,
+                    session_key TEXT NOT NULL,
+                    platform TEXT NOT NULL,
+                    chat_id TEXT NOT NULL,
+                    thread_id TEXT,
+                    content TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    owner_pid INTEGER,
+                    owner_started_at INTEGER,
+                    last_error TEXT
+                )"""
+            )
+
+        with dl._connect() as conn:
+            columns = {
+                row[1] for row in conn.execute(
+                    "PRAGMA table_info(delivery_obligations)"
+                )
+            }
+
+        assert "reply_to" in columns
 
     @pytest.mark.parametrize(
         ("send_success", "ledger_method"),

--- a/tests/gateway/test_delivery_ledger_producer.py
+++ b/tests/gateway/test_delivery_ledger_producer.py
@@ -61,7 +61,7 @@ def _event(text="hello agent"):
 def _rows():
     with dl._connect() as conn:
         return conn.execute(
-            "SELECT obligation_id, state, content FROM delivery_obligations"
+            "SELECT obligation_id, state, content, reply_to FROM delivery_obligations"
         ).fetchall()
 
 
@@ -83,6 +83,7 @@ class TestProducerHook:
         assert len(rows) == 1
         assert rows[0][1] == "delivered"
         assert rows[0][2] == "final answer"
+        assert rows[0][3] == "msg-42"
 
     @pytest.mark.asyncio
     async def test_send_failure_leaves_failed_row(self):

--- a/tests/gateway/test_delivery_ledger_producer.py
+++ b/tests/gateway/test_delivery_ledger_producer.py
@@ -62,7 +62,7 @@ def _event(text="hello agent"):
 def _rows():
     with dl._connect() as conn:
         return conn.execute(
-            "SELECT obligation_id, state, content FROM delivery_obligations"
+            "SELECT obligation_id, state, content, reply_to FROM delivery_obligations"
         ).fetchall()
 
 
@@ -109,6 +109,7 @@ class TestProducerHook:
         assert len(rows) == 1
         assert rows[0][1] == "delivered"
         assert rows[0][2] == "final answer"
+        assert rows[0][3] == "msg-42"
 
     @pytest.mark.asyncio
     async def test_send_failure_leaves_failed_row(self):


### PR DESCRIPTION
## What does this PR do?

Preserves the original platform reply target when a final response is redelivered from the durable delivery ledger after a gateway restart.

- stores nullable `reply_to` alongside each delivery obligation
- migrates existing `state.db` tables in place, including concurrent profile startup
- returns the target from `sweep_recoverable()`
- passes it back to `adapter.send()` during recovery

## Related Issue

Fixes #68749

## Type of Change

- Bug fix
- Database migration
- Tests

## How Has This Been Tested?

- `pytest tests/gateway/test_delivery_ledger.py tests/gateway/test_delivery_ledger_producer.py -q` (`38 passed`)
- `ruff check gateway/delivery_ledger.py gateway/platforms/base.py gateway/run.py tests/gateway/test_delivery_ledger.py tests/gateway/test_delivery_ledger_producer.py`
- `git diff --check`

Coverage includes old-schema migration, producer persistence, and startup redelivery with the original reply target.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix is effective
- [x] New and existing focused tests pass locally
