### PR TITLE
Add missing Fireworks models to fallback list (minimax-m3, glm-5p1)

### DIFF
--- a/plugins/model-providers/fireworks/__init__.py
+++ b/plugins/model-providers/fireworks/__init__.py
@@ -26,10 +26,15 @@ fireworks = ProviderProfile(
     # A standard pay-as-you-go catalog ``/models/`` ID.
     default_aux_model="accounts/fireworks/models/glm-5p2",
     # Curated safety net shown in the picker when the live catalog fetch fails.
+    # The live /v1/models endpoint only returns a subset of what Fireworks
+    # actually serves on chat completions (e.g. minimax-m3 is callable but not listed),
+    # so we keep the most useful models here so they always show in the UI.
     fallback_models=(
+        "accounts/fireworks/models/minimax-m3",
         "accounts/fireworks/models/kimi-k2p6",
         "accounts/fireworks/models/glm-5p2",
         "accounts/fireworks/models/kimi-k2p7-code",
+        "accounts/fireworks/models/glm-5p1",
     ),
 )
 


### PR DESCRIPTION
## Problem
The Fireworks AI provider picker does not list the `minimax-m3` model (and also `glm-5p1`) even though they are callable via the Fireworks API. Users cannot select these models in the UI, which limits functionality.

## Fix
Updated `plugins/model-providers/fireworks/__init__.py` to extend the `fallback_models` tuple with the missing model identifiers:
- `accounts/fireworks/models/minimax-m3`
- `accounts/fireworks/models/glm-5p1`

Added explanatory comments explaining why these models are included.

## Impact
Users will now see the previously missing models in the model picker, enabling them to use these models directly from the UI.

Closes #68628