### PR TITLE
fix(bluebubbles): use webhook chat GUID for read receipts

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -1042,7 +1042,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         task.add_done_callback(self._background_tasks.discard)
 
         # Fire-and-forget read receipt
-        if self.send_read_receipts and session_chat_id:
-            asyncio.create_task(self.mark_read(session_chat_id))
+        read_receipt_chat_id = chat_guid or session_chat_id
+        if self.send_read_receipts and read_receipt_chat_id:
+            asyncio.create_task(self.mark_read(read_receipt_chat_id))
 
         return web.Response(text="ok")

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -262,6 +262,37 @@ class TestBlueBubblesMentionGating:
         assert response.status == 200
         assert [event.text for event in handled] == ["hello from a dm"]
 
+    @pytest.mark.asyncio
+    async def test_dm_read_receipt_uses_webhook_chat_guid(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=True)
+        read_targets = []
+
+        async def fake_handle_message(event):
+            return None
+
+        async def fake_mark_read(chat_id):
+            read_targets.append(chat_id)
+            return True
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "mark_read", fake_mark_read)
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "MESSAGE-GUID",
+                "text": "hello",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "chats": [
+                    {"guid": "any;-;+15551234567", "chatIdentifier": "+15551234567"}
+                ],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert read_targets == ["any;-;+15551234567"]
+
 
 class TestBlueBubblesWebhookParsing:
     def test_webhook_prefers_chat_guid_over_message_guid(self, monkeypatch):


### PR DESCRIPTION
## Summary

- keep canonical BlueBubbles DM identifiers for Hermes session deduplication and profile routing
- use the raw chat GUID already present in the inbound webhook when sending read receipts
- add a regression test for BlueBubbles v1.9-style payloads where the GUID is under `data.chats[0].guid`

## Root cause

The webhook handler canonicalizes one-to-one chat IDs to a stable contact identifier. It then passed that canonical identifier to `mark_read()`, which had to resolve it back to a BlueBubbles chat GUID through `/api/v1/chat/query`.

That reverse lookup is not reliable for every existing chat. When it failed, `mark_read()` silently returned `False`, so the sender saw `Delivered` but never `Read`, even though read receipts were enabled and the BlueBubbles Private API/helper were healthy.

The webhook already provides the exact raw chat GUID. This change uses it directly and retains `session_chat_id` only as a fallback when no webhook GUID is available.

## Impact

Read receipts work without changing the canonical session key, profile routing, credentials, or outbound delivery behavior.

## Validation

- `pytest tests/gateway/test_bluebubbles.py -q` (`61 passed`)
- multiplex lifecycle/routing/auth/credential/adapter suites (`93 passed`)
- `git diff --check origin/main...HEAD`

Fixes #68750
