### PR TITLE
fix(telegram): skip rich entity detection for emails

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -24,6 +24,13 @@ from typing import Dict, List, Optional, Set, Any
 
 logger = logging.getLogger(__name__)
 
+_RICH_EMAIL_TOKEN_RE = re.compile(
+    r"[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Z0-9]"
+    r"(?:[A-Z0-9-]{0,61}[A-Z0-9])?"
+    r"(?:\.[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)+",
+    re.IGNORECASE,
+)
+
 
 def _redact_telegram_error_text(error: object) -> str:
     """Redact secrets from Telegram transport errors before logging or returning them."""
@@ -1647,7 +1654,7 @@ class TelegramAdapter(BasePlatformAdapter):
         in the rich-message path.  See ``_rich_normalize_linebreaks``.
         """
         payload: Dict[str, Any] = {"markdown": _rich_normalize_linebreaks(content)}
-        if skip_entity_detection:
+        if skip_entity_detection or _RICH_EMAIL_TOKEN_RE.search(content):
             payload["skip_entity_detection"] = True
         return payload
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -24,6 +24,13 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
 
+_RICH_EMAIL_TOKEN_RE = re.compile(
+    r"[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Z0-9]"
+    r"(?:[A-Z0-9-]{0,61}[A-Z0-9])?"
+    r"(?:\.[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)+",
+    re.IGNORECASE,
+)
+
 
 def _redact_telegram_error_text(error: object) -> str:
     """Redact secrets from Telegram transport errors before logging or returning them."""
@@ -1847,7 +1854,7 @@ class TelegramAdapter(BasePlatformAdapter):
         in the rich-message path.  See ``_rich_normalize_linebreaks``.
         """
         payload: Dict[str, Any] = {"markdown": _rich_normalize_linebreaks(content)}
-        if skip_entity_detection:
+        if skip_entity_detection or _RICH_EMAIL_TOKEN_RE.search(content):
             payload["skip_entity_detection"] = True
         return payload
 

--- a/tests/gateway/test_telegram_rich_newlines.py
+++ b/tests/gateway/test_telegram_rich_newlines.py
@@ -117,6 +117,21 @@ class TestRichMessageNewlineNormalization:
         payload = adapter._rich_message_payload("Line 1\nLine 2", skip_entity_detection=True)
         assert payload.get("skip_entity_detection") is True
 
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "OAuth profile: openai:test.user@example.com",
+            "Account test.user@example.com is active",
+        ],
+    )
+    def test_email_tokens_disable_rich_entity_detection(self, adapter, content):
+        payload = adapter._rich_message_payload(content)
+        assert payload["skip_entity_detection"] is True
+
+    def test_non_email_content_keeps_entity_detection(self, adapter):
+        payload = adapter._rich_message_payload("See https://example.com/status")
+        assert "skip_entity_detection" not in payload
+
 
 class TestRichMessageTableProtection:
     """Hard-break injection must not corrupt GFM tables (rendered natively)."""

--- a/tests/gateway/test_telegram_rich_newlines.py
+++ b/tests/gateway/test_telegram_rich_newlines.py
@@ -65,6 +65,21 @@ class TestRichMessageNewlineNormalization:
         # Single newlines converted to hard breaks
         assert "`/new` -- Start  \n`/model` -- Switch  \n`/reset` -- Reset" in md
 
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "OAuth profile: openai:test.user@example.com",
+            "Account test.user@example.com is active",
+        ],
+    )
+    def test_email_tokens_disable_rich_entity_detection(self, adapter, content):
+        payload = adapter._rich_message_payload(content)
+        assert payload["skip_entity_detection"] is True
+
+    def test_non_email_content_keeps_entity_detection(self, adapter):
+        payload = adapter._rich_message_payload("See https://example.com/status")
+        assert "skip_entity_detection" not in payload
+
 
 class TestRichMessageTableProtection:
     """Hard-break injection must not corrupt GFM tables (rendered natively)."""


### PR DESCRIPTION
## What does this PR do?

Keeps Telegram rich messages deliverable when status, draft, or final text contains an email address.

- detects email-like tokens in the centralized rich-message payload builder
- sets `skip_entity_detection` before Telegram can auto-link an invalid provider-prefixed email entity
- covers rich send, edit, and draft paths through the shared builder
- preserves normal entity detection for content without email tokens

## Related Issue

Fixes #68754

## Type of Change

- Bug fix
- Tests

## How Has This Been Tested?

- `pytest tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_rich_newlines.py -q` (`85 passed`)
- `ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_rich_newlines.py`
- `git diff --check`

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix is effective
- [x] New and existing focused tests pass locally
