### PR TITLE
feat(vertex): add validated Gemini model catalog for /model picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -568,6 +568,19 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek/deepseek-r1-0528",
         "qwen/qwen3-235b-a22b-fp8",
     ],
+    # Google Vertex AI — OpenAI-compatible endpoint
+    # (aiplatform.googleapis.com/v1beta1/projects/<proj>/locations/global/endpoints/openapi)
+    # IDs must use the "google/" prefix exactly as returned by the API.
+    # All entries below have been validated live against the antse-tooling GCP
+    # project (global region) and returned HTTP 200 as of 2026-07-21.
+    "vertex": [
+        "google/gemini-3.5-flash",           # frontier Flash; strong agentic + coding
+        "google/gemini-3.6-flash",           # incremental over 3.5-flash (newer)
+        "google/gemini-3.5-flash-lite",      # lighter/cheaper 3.5 Flash variant
+        "google/gemini-3.1-pro-preview",     # 3.1 Pro preview
+        "google/gemini-3-flash-preview",     # 3.0 Flash preview
+        "google/gemini-3.1-flash-lite",      # most cost-efficient Gemini 3.x
+    ],
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a `"vertex"` key to `_PROVIDER_MODELS` in `hermes_cli/models.py` with 6 Gemini 3.x models validated live on the Vertex AI OpenAI-compatible endpoint (`aiplatform.googleapis.com`, global region).
- All entries were tested on 2026-07-21 against `antse-tooling` GCP project and returned HTTP 200.
- 8 other candidates (e.g. `gemini-3.1-flash`, `gemini-3-pro-preview`) returned 404 and were **not** included.
- No context-length changes needed — the existing `"gemini": 1_048_576` prefix entry in `agent/model_metadata.py` `DEFAULT_CONTEXT_LENGTHS` already covers all Gemini models.

**Validated (HTTP 200):**
| Model ID | Role |
|---|---|
| `google/gemini-3.5-flash` | Frontier Flash, agentic + coding |
| `google/gemini-3.6-flash` | Newer incremental over 3.5 |
| `google/gemini-3.5-flash-lite` | Lighter/cheaper 3.5 variant |
| `google/gemini-3.1-pro-preview` | 3.1 Pro preview |
| `google/gemini-3-flash-preview` | 3.0 Flash preview |
| `google/gemini-3.1-flash-lite` | Most cost-efficient Gemini 3.x |

**Rejected (HTTP 404):**
`gemini-3.1-flash`, `gemini-3.1-pro`, `gemini-3-pro-preview`, `gemini-3.5-pro`, `gemini-3.1-flash-lite-preview`, `gemini-3.1-flash-preview`, `gemini-3-flash`, `gemini-3-pro`

## Test plan

- [x] Python import check: `from hermes_cli.models import _PROVIDER_MODELS; _PROVIDER_MODELS["vertex"]` returns the 6-model list
- [x] Live API validation: all 6 models returned HTTP 200 on `antse-tooling` project (2026-07-21)
- [ ] `/model vertex` in hermes shows the picker with the 6 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)