### PR TITLE
fix(desktop): /goal arg stays editable, kickoff queues when busy, header stops echoing long args

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { textPart } from '@/lib/chat-messages'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
+import { $queuedPromptsBySession, getQueuedPrompts } from '@/store/composer-queue'
 import { $busy, $connection, $messages, $sessions, $turnStartedAt, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -337,6 +338,113 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
 
     expect(renderedText).toContain('⊙ Goal set. Starting now.')
     expect(renderedText).not.toContain('/goal: no output')
+  })
+
+  it('queues the /goal kickoff instead of dropping it when the session is busy (#63352)', async () => {
+    // The backend sets the goal the moment slash.exec runs — dropping the
+    // returned kickoff message because busyRef was true left a goal the agent
+    // never heard about. The busy path must park the kickoff on the composer
+    // queue so the settle drain sends it.
+    $queuedPromptsBySession.set({})
+
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const states: Record<string, unknown>[] = []
+    const busyRef = { current: true }
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'slash.exec') {
+        return {
+          type: 'send',
+          notice: '⊙ Goal set (20-turn budget): ship the release notes',
+          message: 'ship the release notes'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        busyRef={busyRef}
+        onReady={h => (handle = h)}
+        onSeedState={s => states.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/goal ship the release notes')
+
+    // The kickoff must NOT submit mid-turn — and must NOT vanish either.
+    expect(calls.map(c => c.method)).toEqual(['slash.exec'])
+
+    const queued = getQueuedPrompts(RUNTIME_SESSION_ID)
+    expect(queued.map(entry => entry.text)).toEqual(['ship the release notes'])
+
+    const renderedText = states
+      .flatMap(state => {
+        const messages = Array.isArray(state.messages)
+          ? (state.messages as Array<{ parts?: Array<{ text?: string }> }>)
+          : []
+
+        return messages.flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
+      })
+      .join('\n')
+
+    // The notice still renders, and the busy line reports a queue, not a demand
+    // to /interrupt.
+    expect(renderedText).toContain('⊙ Goal set (20-turn budget): ship the release notes')
+    expect(renderedText).toContain('queued')
+
+    $queuedPromptsBySession.set({})
+  })
+
+  it('slash status header carries the command token, not the full invocation', async () => {
+    // `/goal <long prose>` used to echo the entire invocation in the mono
+    // header AND the goal text again in the backend notice right under it.
+    const states: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {
+        return {
+          type: 'send',
+          notice: '⊙ Goal set: build the whole thing',
+          message: 'build the whole thing end to end with tests'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => states.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/goal build the whole thing end to end with tests')
+
+    const systemTexts = states
+      .flatMap(state => {
+        const messages = Array.isArray(state.messages)
+          ? (state.messages as Array<{ role?: string; parts?: Array<{ text?: string }> }>)
+          : []
+
+        return messages
+          .filter(message => message.role === 'system')
+          .flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
+      })
+      .join('\n')
+
+    expect(systemTexts).toContain('slash:/goal\n')
+    expect(systemTexts).not.toContain('slash:/goal build the whole thing')
   })
 
   it('dispatches a slash command with a multiline arg instead of "empty slash command" (#41323, #55510)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -15,19 +15,23 @@ import {
 import { setSessionYolo } from '@/lib/yolo-session'
 import { openCommandPalettePage } from '@/store/command-palette'
 import { setComposerDraft } from '@/store/composer'
+import { enqueueQueuedPrompt } from '@/store/composer-queue'
 import { notify, notifyError } from '@/store/notifications'
 import { setPetScale } from '@/store/pet-gallery'
 import { $petGenInput, openPetGenerate } from '@/store/pet-generate'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import {
   $connection,
+  $selectedStoredSessionId,
   $sessions,
   $yoloActive,
+  resolveComposerSessionKey,
   setModelPickerOpen,
   setSessionPickerOpen,
   setSessions,
   setYoloActive
 } from '@/store/session'
+import { $sessionStates } from '@/store/session-states'
 
 import type { BrowserManageResponse, SessionTitleResponse, SlashExecResponse } from '../../../types'
 
@@ -89,8 +93,8 @@ export function useSlashCommand(deps: SlashCommandDeps) {
 
   return useCallback(
     async (rawCommand: string, options?: { sessionId?: string; recordInput?: boolean }) => {
-      const ensureSessionId = async (sessionHint?: string) =>
-        sessionHint || activeSessionIdRef.current || (await createBackendSessionForSend())
+      const ensureSessionId = async (sessionHint?: string, preview?: null | string) =>
+        sessionHint || activeSessionIdRef.current || (await createBackendSessionForSend(preview))
 
       // Resolve the target session plus a writer for inline slash output, or
       // notify + return null when none can be created. Folds the ensure / bail /
@@ -98,7 +102,11 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       const withSlashOutput = async (
         ctx: SlashActionCtx
       ): Promise<{ render: (text: string) => void; sessionId: string } | null> => {
-        const sessionId = await ensureSessionId(ctx.sessionHint)
+        // A slash on a fresh draft creates the backend session; seed the
+        // sidebar preview with the typed command so the row doesn't sit as
+        // "Untitled session" (auto-title only fires after a full exchange,
+        // which a bare exec command never produces).
+        const sessionId = await ensureSessionId(ctx.sessionHint, ctx.command)
 
         if (!sessionId) {
           notify({ kind: 'error', title: copy.sessionUnavailable, message: copy.createSessionFailed })
@@ -106,8 +114,11 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           return null
         }
 
+        // Header carries the command token only. The full invocation would
+        // duplicate long args — `/goal <prose>` echoed the whole goal in the
+        // mono header, then again in the backend notice right under it.
         const render = (text: string) =>
-          appendSessionTextMessage(sessionId, 'system', ctx.recordInput ? slashStatusText(ctx.command, text) : text)
+          appendSessionTextMessage(sessionId, 'system', ctx.recordInput ? slashStatusText(`/${ctx.name}`, text) : text)
 
         return { render, sessionId }
       }
@@ -179,7 +190,20 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           }
 
           if (busyRef.current) {
-            renderSlashOutput('session busy — /interrupt the current turn before sending this command')
+            // The backend already executed the command — for `/goal <text>`
+            // the goal is set and `message` is its kickoff prompt. Dropping
+            // it here loses the kickoff silently (the goal exists but the
+            // agent never hears about it, #63352). Queue it on the composer
+            // queue instead: it fires when the running turn settles, and the
+            // queue panel above the composer shows it in the meantime.
+            const storedId = $sessionStates.get()[sessionId]?.storedSessionId || $selectedStoredSessionId.get()
+            const queueKey = resolveComposerSessionKey(storedId, $sessions.get()) || storedId || sessionId
+
+            if (enqueueQueuedPrompt(queueKey, { attachments: [], text: message })) {
+              renderSlashOutput('session busy — message queued to send when the current turn finishes')
+            } else {
+              renderSlashOutput('session busy — /interrupt the current turn before sending this command')
+            }
 
             return
           }

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -73,6 +73,14 @@ describe('desktop slash command curation', () => {
     expect(resolveDesktopCommand('/browser')?.args).toBe(true)
   })
 
+  it('keeps /goal arg text editable instead of sealing it into a chip', () => {
+    // /goal takes free prose (the goal itself) plus subcommands. Without
+    // args:true, Space after the command name committed a sealed directive
+    // chip and the goal text rendered awkwardly after a pill.
+    expect(resolveDesktopCommand('/goal')?.surface).toEqual({ kind: 'exec' })
+    expect(resolveDesktopCommand('/goal')?.args).toBe(true)
+  })
+
   it('routes /journey (and aliases) to the memory graph overlay action', () => {
     expect(resolveDesktopCommand('/journey')?.surface).toEqual({ kind: 'action', action: 'journey' })
     expect(resolveDesktopCommand('/memory-graph')?.surface).toEqual({ kind: 'action', action: 'journey' })

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -150,7 +150,7 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   { name: '/background', description: 'Run a prompt in the background', aliases: ['/bg', '/btw'], surface: exec() },
   { name: '/compress', description: 'Compress this conversation context', surface: exec() },
   { name: '/debug', description: 'Create a debug report', surface: exec() },
-  { name: '/goal', description: 'Manage the standing goal for this session', surface: exec() },
+  { name: '/goal', description: 'Manage the standing goal for this session', surface: exec(), args: true },
   { name: '/personality', description: 'Switch personality for this session', surface: exec(), args: true },
   {
     name: '/pet',


### PR DESCRIPTION
## What does this PR do?

Running `/goal <text>` on desktop misbehaves four ways at once, and they compound into "the goal didn't stick":

1. **The typed text renders weirdly.** `/goal` was registered without `args: true`, so the trigger engine treated it as a no-arg command: pressing Space sealed it into a non-editable directive chip and the goal prose sat awkwardly after a pill. `/personality` and `/tools` already carry `args: true`; `/goal` now matches.

2. **The goal text was echoed three times.** The slash status header used the full invocation (`slash:/goal <entire goal prose>` in mono), directly above the backend notice that repeats the goal ("⊙ Goal set (20-turn budget): ...") and the kickoff user bubble that repeats it again. The header now carries just the command token.

3. **The kickoff was silently dropped when the session was busy — the real "goal didn't register" bug (#63352).** By the time `slash.exec` returns its `send` dispatch, the backend has **already set the goal** (`GoalManager.set` runs server-side). `handleDispatch` then hit `busyRef.current`, rendered "session busy — /interrupt ...", and returned — discarding the kickoff message. Result: the goal exists in the judge's state, but the agent never hears about it, so every subsequent turn looks goal-unaware. The busy path now queues the kickoff on the composer queue: it sends when the running turn settles, and it's visible and editable in the queue panel meanwhile. If the queue rejects the entry, the old message is preserved as fallback.

4. **A `/goal` (or any slash) on a fresh chat left the session named "Untitled session".** The slash path created the backend session with no preview seed, and auto-title needs a completed user→assistant exchange — which never happened when the kickoff was dropped. `ensureSessionId` now seeds the sidebar preview with the typed command, and fixing (3) restores the auto-title path.

Related but out of scope: #54985 (gateway `/goal` lacks `draft/show/wait/unwait` parity — backend), #48236 (goal status bar — feature), #62202 (gateway post-turn goal continuation — backend). #63376 addresses a different submit race after `/goal` (stale `activeSessionId` prop in `useSubmitPrompt`) and composes with this change rather than overlapping it.

## Related Issue

Fixes the kickoff-drop half of #63352.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/desktop-slash-commands.ts`: `args: true` on the `/goal` registry row.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts`:
  - `withSlashOutput` renders the status header with the command token (`/${ctx.name}`) instead of the full invocation.
  - `ensureSessionId` accepts a preview and `withSlashOutput` passes the typed command, so slash-created sessions seed a sidebar row name.
  - the `handleDispatch` busy guard enqueues the dispatch message on the composer queue (keyed via `resolveComposerSessionKey`, mirroring the ChatBar queue scope) instead of dropping it; the inline status line reports the queue.
- Tests:
  - `desktop-slash-commands.test.ts`: `/goal` registry contract (exec + args).
  - `use-prompt-actions/index.test.tsx`: busy-path test proving the kickoff neither submits mid-turn nor vanishes (it lands on the queue and the notice still renders), and a header-token test proving long args are no longer echoed in the header.

## How to Test

1. Start a long turn, then type `/goal finish the readme` and press Enter while the agent is busy.
2. Before: "session busy — /interrupt the current turn before sending this command", and the kickoff is gone — the goal is set backend-side but the agent never receives it. After: the notice renders, the status line says the message is queued, the queue panel shows it, and it fires when the turn settles.
3. Type `/goal ` (with a space) in the composer: the text after the command stays editable prose instead of collapsing into a chip.
4. On a brand-new chat, run `/goal <text>`: the sidebar row is named from the command immediately, and auto-title runs after the kickoff exchange completes.
5. Renderer checks: `cd apps/desktop && npx tsc -p . --noEmit && npx vitest run --project ui` (1745 passed, 209 files), eslint clean on touched files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the desktop renderer suite (`npx vitest run --project ui`) and all tests pass; `pytest` N/A, no Python changes
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no user-facing docs describe the broken behaviors)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (renderer-only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
