### PR TITLE
docs(nous-portal): fix browser Tool Gateway config key

### DIFF
--- a/website/docs/integrations/nous-portal.md
+++ b/website/docs/integrations/nous-portal.md
@@ -222,7 +222,8 @@ tts:
   provider: nous
 
 browser:
-  backend: nous
+  cloud_provider: browser-use   # browser automation routes through Tool Gateway
+  use_gateway: true
 ```
 
 The OAuth refresh token is stored separately at `~/.hermes/auth.json` (not in `config.yaml` — credentials and configuration are kept separate by design).


### PR DESCRIPTION
## the bug

The Tool Gateway config example on `/docs/integrations/nous-portal` sets:

```yaml
browser:
  backend: nous
```

`browser.backend` is not a key Hermes reads. Copying that block leaves browser automation unrouted, with no error to indicate it.

## the fix

The browser tool is configured with `cloud_provider` + `use_gateway`, matching what `/docs/user-guide/features/tool-gateway` already documents:

```yaml
browser:
  cloud_provider: browser-use   # browser automation routes through Tool Gateway
  use_gateway: true
```

## verification

- `browser.cloud_provider` is read in `hermes_cli/nous_subscription.py` (via `normalize_browser_cloud_provider`) and dispatched through `tools.browser_tool._get_cloud_provider`; `hermes_cli/plugins.py` describes a provider plugin's `provider.name` as what `browser.cloud_provider` matches.
- `browser.use_gateway` is set by the tools-config flow (`hermes_cli/tools_config.py`) and read in `nous_subscription.py`.
- No read of `browser.backend` exists, and it is absent from the browser defaults block in `hermes_cli/config.py` on `main`.

Found while configuring browser automation on a v0.19.0 install after a community question about keeping an agent logged in across sites. The neighbouring `web.backend` in the same example *is* a real key, which is likely why this went unnoticed.