### PR TITLE
fix(discord): preserve message_reference on voice replies (#68728)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3506,6 +3506,21 @@ class DiscordAdapter(BasePlatformAdapter):
                     file=forum_file,
                 )
 
+            # Resolve a reply reference (matches the text-send path). Only
+            # attempt when reply mode is enabled and a target is available —
+            # mirrors the gating used by `send()` so disabled modes and
+            # missing targets fall through to an unthreaded voice message.
+            voice_reference = None
+            if reply_to and self._reply_to_mode != "off":
+                try:
+                    ref_msg = await channel.fetch_message(int(reply_to))
+                    if hasattr(ref_msg, "to_reference"):
+                        voice_reference = ref_msg.to_reference(fail_if_not_exists=False)
+                    else:
+                        voice_reference = ref_msg
+                except Exception as e:
+                    logger.debug("Could not fetch voice reply-to message: %s", e)
+
             # Try sending as a native voice message via raw API (flags=8192).
             try:
                 import base64
@@ -3522,7 +3537,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 waveform_b64 = base64.b64encode(waveform_bytes).decode()
 
                 import json as _json
-                payload = _json.dumps({
+                payload_dict = {
                     "flags": 8192,
                     "attachments": [{
                         "id": "0",
@@ -3530,7 +3545,18 @@ class DiscordAdapter(BasePlatformAdapter):
                         "duration_secs": round(duration_secs, 2),
                         "waveform": waveform_b64,
                     }],
-                })
+                }
+                if voice_reference is not None:
+                    payload_dict["message_reference"] = (
+                        voice_reference.to_message_reference_dict()
+                        if hasattr(voice_reference, "to_message_reference_dict")
+                        else {
+                            "message_id": str(voice_reference.message_id),
+                            "channel_id": str(voice_reference.channel_id),
+                            "fail_if_not_exists": False,
+                        }
+                    )
+                payload = _json.dumps(payload_dict)
                 form = [
                     {"name": "payload_json", "value": payload},
                     {
@@ -3548,7 +3574,7 @@ class DiscordAdapter(BasePlatformAdapter):
             except Exception as voice_err:
                 logger.debug("Voice message flag failed, falling back to file: %s", voice_err)
                 file = discord.File(io.BytesIO(file_data), filename=filename)
-                msg = await channel.send(file=file)
+                msg = await channel.send(file=file, reference=voice_reference)
                 return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to send audio, falling back to base adapter: %s", self.name, e, exc_info=True)

--- a/tests/gateway/test_discord_voice_reply_anchor.py
+++ b/tests/gateway/test_discord_voice_reply_anchor.py
@@ -1,0 +1,226 @@
+"""Regression test for #68728 — Discord voice replies drop message reference.
+
+Voice sends previously posted without a `message_reference` (native path) or
+without `reference=` (file-fallback path) even when `reply_to` was supplied,
+breaking thread continuity vs. text sends.
+"""
+
+import io
+import json
+import sys
+import wave
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    # discord.http.Route is the real class — keep it but ignore its arguments.
+    discord_mod.http = SimpleNamespace(Route=lambda *args, **kwargs: SimpleNamespace(name=args, kwargs=kwargs))
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+def _make_ogg(tmp_path) -> str:
+    """Write a minimal valid ogg-opus-ish file (just bytes, no header check)."""
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"OggS" + b"\x00" * 64)
+    return str(audio)
+
+
+def _make_adapter(reply_to_mode: str = "first") -> DiscordAdapter:
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._reply_to_mode = reply_to_mode
+    return adapter
+
+
+def _make_ref_message(message_id: int = 99, channel_id: int = 555):
+    reference_obj = SimpleNamespace(
+        message_id=message_id,
+        channel_id=channel_id,
+        to_message_reference_dict=lambda: {
+            "message_id": str(message_id),
+            "channel_id": str(channel_id),
+            "fail_if_not_exists": False,
+        },
+    )
+    ref_msg = SimpleNamespace(id=message_id, to_reference=MagicMock(return_value=reference_obj))
+    return ref_msg, reference_obj
+
+
+@pytest.mark.asyncio
+async def test_send_voice_native_path_includes_message_reference(tmp_path):
+    """Native voice-message REST path must include `message_reference` in the payload."""
+    audio_path = _make_ogg(tmp_path)
+    adapter = _make_adapter()
+    ref_msg, reference_obj = _make_ref_message(99, 555)
+
+    http_calls = []
+
+    async def fake_request(route, *, form):
+        http_calls.append({"route": route, "form": form})
+        return {"id": 7777}
+
+    channel = SimpleNamespace(
+        id=555,
+        fetch_message=AsyncMock(return_value=ref_msg),
+        send=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+        http=SimpleNamespace(request=fake_request),
+    )
+
+    result = await adapter.send_voice(chat_id="555", audio_path=audio_path, reply_to="99")
+
+    assert result.success is True
+    assert result.message_id == "7777"
+    assert channel.fetch_message.await_count == 1
+    ref_msg.to_reference.assert_called_once_with(fail_if_not_exists=False)
+
+    # The native path is a single POST /channels/{id}/messages with a form
+    # whose first entry is the JSON payload containing message_reference.
+    assert len(http_calls) == 1
+    form = http_calls[0]["form"]
+    payload_entry = next(f for f in form if f["name"] == "payload_json")
+    payload = json.loads(payload_entry["value"])
+    assert "message_reference" in payload
+    assert payload["message_reference"]["message_id"] == "99"
+    assert payload["message_reference"]["channel_id"] == "555"
+    assert payload["flags"] == 8192
+
+
+@pytest.mark.asyncio
+async def test_send_voice_fallback_passes_reference_to_channel_send(tmp_path):
+    """When the native voice-flag path raises, the file fallback must forward `reference`."""
+    audio_path = _make_ogg(tmp_path)
+    adapter = _make_adapter()
+    ref_msg, reference_obj = _make_ref_message(99, 555)
+
+    async def fake_request(route, *, form):
+        raise RuntimeError("simulated voice flag failure")
+
+    sent_msg = SimpleNamespace(id=8888)
+    send_calls = []
+
+    async def fake_send(*, file, reference=None):
+        send_calls.append({"file": file, "reference": reference})
+        return sent_msg
+
+    channel = SimpleNamespace(
+        id=555,
+        fetch_message=AsyncMock(return_value=ref_msg),
+        send=AsyncMock(side_effect=fake_send),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+        http=SimpleNamespace(request=fake_request),
+    )
+
+    result = await adapter.send_voice(chat_id="555", audio_path=audio_path, reply_to="99")
+
+    assert result.success is True
+    assert result.message_id == "8888"
+    assert len(send_calls) == 1
+    assert send_calls[0]["reference"] is reference_obj
+
+
+@pytest.mark.asyncio
+async def test_send_voice_without_reply_to_sends_unthreaded(tmp_path):
+    """`reply_to=None` must not raise, and the payload must omit message_reference."""
+    audio_path = _make_ogg(tmp_path)
+    adapter = _make_adapter()
+
+    http_calls = []
+
+    async def fake_request(route, *, form):
+        http_calls.append({"route": route, "form": form})
+        return {"id": 5555}
+
+    channel = SimpleNamespace(
+        id=555,
+        fetch_message=AsyncMock(),
+        send=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+        http=SimpleNamespace(request=fake_request),
+    )
+
+    result = await adapter.send_voice(chat_id="555", audio_path=audio_path, reply_to=None)
+
+    assert result.success is True
+    assert result.message_id == "5555"
+    assert channel.fetch_message.await_count == 0
+    assert len(http_calls) == 1
+    payload = json.loads(http_calls[0]["form"][0]["value"])
+    assert "message_reference" not in payload
+
+
+@pytest.mark.asyncio
+async def test_send_voice_reply_mode_off_sends_unthreaded(tmp_path):
+    """`reply_to_mode='off'` must skip reference resolution even when reply_to is set."""
+    audio_path = _make_ogg(tmp_path)
+    adapter = _make_adapter(reply_to_mode="off")
+
+    http_calls = []
+
+    async def fake_request(route, *, form):
+        http_calls.append({"route": route, "form": form})
+        return {"id": 6666}
+
+    channel = SimpleNamespace(
+        id=555,
+        fetch_message=AsyncMock(),
+        send=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+        http=SimpleNamespace(request=fake_request),
+    )
+
+    result = await adapter.send_voice(chat_id="555", audio_path=audio_path, reply_to="99")
+
+    assert result.success is True
+    assert channel.fetch_message.await_count == 0
+    payload = json.loads(http_calls[0]["form"][0]["value"])
+    assert "message_reference" not in payload


### PR DESCRIPTION
Fixes #68728.

Discord voice replies lost their reply anchor because:

- The native voice-message REST path built a `payload_json` with `flags: 8192` + attachment metadata but **no `message_reference`** field, even when `reply_to` was supplied and reply mode was enabled.
- The file-fallback path called `channel.send(file=...)` **without `reference=`**, posting the voice file as an unthreaded channel message.

Both paths diverged from the text-send path in `send()`, which already resolves a `ref_msg.to_reference(fail_if_not_exists=False)` and forwards it as `reference=`.

## Change

`plugins/platforms/discord/adapter.py` — `send_voice()` now mirrors `send()`:

1. Resolves a reply reference when `reply_to` is set and `_reply_to_mode != "off"` (same gating as `send()`).
2. Native path: includes `message_reference` in the `payload_json` (using `discord.MessageReference.to_message_reference_dict()` when available).
3. File-fallback path: forwards `reference=` to `channel.send()`.

Reply mode `off` and missing/unresolvable targets fall through to an unthreaded voice message, same as the text path.

## Tests

`tests/gateway/test_discord_voice_reply_anchor.py` — 4 new tests:

- `test_send_voice_native_path_includes_message_reference` — native POST includes correct `message_reference` dict.
- `test_send_voice_fallback_passes_reference_to_channel_send` — file-fallback forwards the resolved reference.
- `test_send_voice_without_reply_to_sends_unthreaded` — `reply_to=None` skips reference resolution.
- `test_send_voice_reply_mode_off_sends_unthreaded` — `_reply_to_mode='off'` skips reference resolution.

All 4 pass locally; existing `test_discord_send.py` + `test_discord_opus.py` still pass (22/22).

— written by Hermes Agent on behalf of @Enough1122