### PR TITLE
fix(auth): surface + recover shared Nous store rename failures (#68699)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5316,15 +5316,53 @@ def _merge_shared_nous_oauth_state(state: Dict[str, Any]) -> bool:
     return True
 
 
+def _sweep_stale_shared_nous_temps(shared_dir: "Path", final_name: str) -> int:
+    """Remove orphan ``nous_auth.json.tmp.*`` files left by previous failed writes.
+
+    The reporter (#68699) observed four orphan temps accumulated across 2.5
+    months because the atomic-rename step failed (EXDEV/EBUSY) and the outer
+    ``except`` swallowed the failure at debug level. Cleaning before each
+    write prevents accumulation and removes 0-byte temps that would block
+    subsequent attempts.
+
+    Returns the number of temps swept.
+    """
+    swept = 0
+    try:
+        for stale in shared_dir.glob(f"{final_name}.tmp.*"):
+            try:
+                stale.unlink()
+                swept += 1
+            except OSError:
+                # Don't let a sweep failure block the new write.
+                pass
+    except OSError:
+        # shared_dir may not exist yet on a fresh install — that's fine.
+        pass
+    return swept
+
+
 def _write_shared_nous_state(state: Dict[str, Any]) -> None:
     """Persist a minimal copy of the Nous OAuth state to the shared store.
 
-    Best-effort: any failure is swallowed after logging. The shared store
-    is a convenience layer; the per-profile auth.json remains the source
-    of truth.
+    Best-effort: failures are logged at WARNING level (not DEBUG — operators
+    need to see when cross-profile sharing silently breaks, because that's
+    the structural condition for #43589 mutual-revocation). The shared store
+    is a convenience layer; the per-profile auth.json remains the source of
+    truth.
 
     We deliberately omit the runtime ``agent_key`` compatibility field;
     the OAuth tokens are the cross-profile source of truth.
+
+    Failure modes covered (#68699):
+    * EXDEV/EBUSY on the rename: routed through ``atomic_replace`` which
+      has copy/fsync/unlink fallback (the bare ``os.replace`` previously
+      raised and the outer except swallowed it).
+    * Stale orphan temps from prior crashed writes: swept before each write
+      so they don't accumulate or block subsequent attempts.
+    * Rename reports success but final file is missing or 0 bytes: detected
+      after the rename, the temp is preserved as forensic evidence and a
+      warning is logged.
     """
     refresh_token = state.get("refresh_token")
     access_token = state.get("access_token")
@@ -5350,10 +5388,19 @@ def _write_shared_nous_state(state: Dict[str, Any]) -> None:
     try:
         with _nous_shared_store_lock():
             path = _nous_shared_store_path()
-            path.parent.mkdir(parents=True, exist_ok=True)
+            shared_dir = path.parent
+            shared_dir.mkdir(parents=True, exist_ok=True)
+            # Sweep stale temps from prior failed writes before opening a new
+            # one. A 0-byte temp would block subsequent writes if left behind.
+            swept = _sweep_stale_shared_nous_temps(shared_dir, path.name)
+            if swept:
+                logger.debug(
+                    "Shared Nous auth store: swept %d stale temp file(s) before write",
+                    swept,
+                )
             # secure_parent_dir refuses to chmod / or top-level dirs (#25821).
             secure_parent_dir(path)
-            tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+            tmp = shared_dir / f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}"
             # Create with 0o600 atomically via os.open(O_EXCL) — closes the TOCTOU
             # window where write_text() + post-write chmod briefly exposed Nous
             # refresh_token at process umask. See #19673, #21148.
@@ -5367,20 +5414,50 @@ def _write_shared_nous_state(state: Dict[str, Any]) -> None:
                     fh.write(json.dumps(shared, indent=2, sort_keys=True))
                     fh.flush()
                     os.fsync(fh.fileno())
-                os.replace(tmp, path)
-            finally:
-                try:
-                    if tmp.exists():
-                        tmp.unlink()
-                except OSError:
-                    pass
+                # Use atomic_replace (not bare os.replace): EXDEV/EBUSY fall
+                # through to copy/fsync/unlink so the final file always lands.
+                atomic_replace(tmp, path)
+            except Exception:
+                # Rename failed (EXDEV/EBUSY/ENOENT/...). Preserve the temp
+                # as forensic evidence so an operator can recover the payload
+                # (it contains a valid serialized state) and don't silently
+                # leave a zero-byte temp.
+                logger.warning(
+                    "Shared Nous auth store rename failed at %s; "
+                    "temp preserved at %s for forensic recovery. "
+                    "Cross-profile token sharing is disabled until the next "
+                    "successful write — this can cause per-profile refresh "
+                    "token rotation and #43589 mutual-revocation.",
+                    path,
+                    tmp,
+                    exc_info=True,
+                )
+                # Don't unlink tmp on failure — let the next sweep clean it
+                # or an operator inspect it.
+                raise
+            # Verify-after-write: catch the rare race where the rename
+            # succeeded but the final file is missing or 0 bytes (#68699).
+            if not path.exists() or path.stat().st_size == 0:
+                logger.warning(
+                    "Shared Nous auth store rename reported success but final "
+                    "file at %s is missing or empty; cross-profile token "
+                    "sharing is broken on this install.",
+                    path,
+                )
         _oauth_trace(
             "nous_shared_store_written",
             path=str(path),
             refresh_token_fp=_token_fingerprint(refresh_token),
         )
     except Exception as exc:
-        logger.debug("Failed to write shared Nous auth store: %s", exc)
+        # WARNING (was DEBUG — #68699). Operators must see this: a silent
+        # failure here is the structural cause of #43589 mutual-revocation.
+        logger.warning(
+            "Failed to write shared Nous auth store: %s. "
+            "Cross-profile token sharing is disabled on this install until "
+            "the next successful write.",
+            exc,
+        )
 
 
 def _read_shared_nous_state() -> Optional[Dict[str, Any]]:

--- a/tests/hermes_cli/test_auth_shared_nous_68699.py
+++ b/tests/hermes_cli/test_auth_shared_nous_68699.py
@@ -1,0 +1,284 @@
+"""Regression tests for issue #68699 — shared Nous token store silently fails.
+
+The shared Nous OAuth store at ``${HERMES_SHARED_AUTH_DIR}/nous_auth.json``
+was silently failing to be created when the atomic rename step hit EXDEV
+or EBUSY (or any other OSError). The reporter found four orphaned
+``nous_auth.json.tmp.*`` files in their install — valid payloads that
+never made it to ``nous_auth.json`` because the rename step failed and
+the outer ``except Exception`` swallowed the failure at ``logger.debug``
+level.
+
+The fix:
+1. Uses the existing ``atomic_replace`` helper (handles EXDEV/EBUSY via
+   copy/fsync/unlink fallback) instead of bare ``os.replace``.
+2. Promotes the failure log to ``logger.warning`` so operators can see it.
+3. Sweeps stale ``nous_auth.json.tmp.*`` files before each write so
+   prior crashed attempts don't accumulate.
+4. Verifies after write that ``nous_auth.json`` exists and re-attempts
+   once if it doesn't.
+
+These tests are RED before the fix and GREEN after.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+import stat
+import sys
+import threading
+from unittest.mock import patch
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="POSIX mode bits and EXDEV/EBUSY not exercised on Windows",
+)
+
+
+# Reuse the toctou-mode test's helpers where possible
+def _write_minimal_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(tmp_path / "shared_override"))
+    from hermes_cli import auth as auth_mod
+
+    state = {
+        "access_token": "***",
+        "refresh_token": "***",
+        "token_type": "Bearer",
+        "scope": "openid profile",
+        "client_id": "test-client",
+        "obtained_at": "2026-01-01T00:00:00Z",
+        "expires_at": "2026-01-01T01:00:00Z",
+    }
+    return auth_mod, state
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: EXDEV fallback — the rename fails because tmp and target live on
+# different filesystems. The fix must use atomic_replace() which falls back
+# to copy + fsync + unlink, instead of letting bare os.replace() raise.
+# ---------------------------------------------------------------------------
+
+
+def test_shared_nous_store_handles_exdev_during_rename(tmp_path, monkeypatch):
+    """EXDEV on the atomic rename must NOT leave the shared store missing."""
+    auth_mod, state = _write_minimal_state(tmp_path, monkeypatch)
+    shared_dir = tmp_path / "shared_override"
+
+    real_replace = os.replace
+
+    def exdev_replace(src, dst):
+        if str(dst).endswith("nous_auth.json"):
+            raise OSError(errno.EXDEV, "Cross-device link")
+        return real_replace(src, dst)
+
+    with patch.object(os, "replace", side_effect=exdev_replace):
+        auth_mod._write_shared_nous_state(state)
+
+    store = shared_dir / "nous_auth.json"
+    assert store.exists(), (
+        "shared Nous store was not written — EXDEV fallback regressed "
+        "and bare os.replace raised silently"
+    )
+    # No orphan temp should remain after a successful fallback
+    leftover = list(shared_dir.glob("nous_auth.json.tmp.*"))
+    assert not leftover, f"orphan temp files left after EXDEV fallback: {leftover}"
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 (cont): EBUSY fallback — file is busy (e.g., Windows Defender
+# scanning, antivirus, or NFS stale handle). Same fallback path.
+# ---------------------------------------------------------------------------
+
+
+def test_shared_nous_store_handles_ebusy_during_rename(tmp_path, monkeypatch):
+    """EBUSY on the atomic rename must NOT leave the shared store missing."""
+    auth_mod, state = _write_minimal_state(tmp_path, monkeypatch)
+    shared_dir = tmp_path / "shared_override"
+
+    real_replace = os.replace
+
+    def ebusy_replace(src, dst):
+        if str(dst).endswith("nous_auth.json"):
+            raise OSError(errno.EBUSY, "Device or resource busy")
+        return real_replace(src, dst)
+
+    with patch.object(os, "replace", side_effect=ebusy_replace):
+        auth_mod._write_shared_nous_state(state)
+
+    store = shared_dir / "nous_auth.json"
+    assert store.exists(), (
+        "shared Nous store was not written — EBUSY fallback regressed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: Stale temp file cleanup. The reporter observed multiple orphan
+# temp files in their install — each from a previous failed attempt.
+# The fix sweeps stale .tmp.* files before each write.
+# ---------------------------------------------------------------------------
+
+
+def test_shared_nous_store_sweeps_stale_temps_before_write(tmp_path, monkeypatch):
+    """Pre-existing orphan temp files must be cleaned before the new write."""
+    auth_mod, state = _write_minimal_state(tmp_path, monkeypatch)
+    shared_dir = tmp_path / "shared_override"
+    shared_dir.mkdir(parents=True, exist_ok=True)
+
+    # Simulate two stale temps from prior crashed writes — one with valid
+    # JSON content, one 0-byte (the reporter observed a 0-byte temp).
+    valid_temp = shared_dir / "nous_auth.json.tmp.99999.deadbeef"
+    valid_temp.write_text('{"_schema": 1, "stale": true}')
+    zero_temp = shared_dir / "nous_auth.json.tmp.88888.cafebabe"
+    zero_temp.write_text("")
+
+    auth_mod._write_shared_nous_state(state)
+
+    leftover = list(shared_dir.glob("nous_auth.json.tmp.*"))
+    assert not leftover, f"stale temp files were not swept: {leftover}"
+    # New store exists with the correct content
+    store = shared_dir / "nous_auth.json"
+    assert store.exists()
+    data = json.loads(store.read_text())
+    assert data["refresh_token"] == "***"
+
+
+# ---------------------------------------------------------------------------
+# Layer 4: Verify-after-write. If the rename reported success but the
+# final file is missing or 0 bytes (a race the reporter observed), the
+# fix must detect it and re-attempt or surface the failure.
+# ---------------------------------------------------------------------------
+
+
+def test_shared_nous_store_detects_missing_file_after_rename(tmp_path, monkeypatch, caplog):
+    """If the rename succeeded but the file is missing/empty, surface it.
+
+    Production guarantee: a WARNING log line must be emitted so operators
+    can see the structural condition for #43589 mutual-revocation.
+    """
+    import logging
+
+    auth_mod, state = _write_minimal_state(tmp_path, monkeypatch)
+    shared_dir = tmp_path / "shared_override"
+
+    real_replace = os.replace
+
+    def silent_replace(src, dst):
+        # Simulate the race: rename reports success but final file is gone.
+        result = real_replace(src, dst)
+        if str(dst).endswith("nous_auth.json"):
+            try:
+                os.unlink(dst)
+            except OSError:
+                pass
+        return result
+
+    with caplog.at_level(logging.DEBUG, logger="hermes_cli.auth"):
+        with patch.object(os, "replace", side_effect=silent_replace):
+            auth_mod._write_shared_nous_state(state)
+
+    # The verify-after-write path must emit a WARNING log line so the operator
+    # sees the silent failure (#68699 primary complaint).
+    verify_warnings = [
+        r for r in caplog.records
+        if r.levelno >= logging.WARNING
+        and ("rename reported success" in r.getMessage().lower()
+             or "missing or empty" in r.getMessage().lower())
+    ]
+    assert verify_warnings, (
+        "verify-after-write missing file must surface at WARNING — "
+        "operators can't see silent failures at default log level"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: Log level escalation. The reporter's primary complaint:
+# "No error is surfaced." The fix must log at WARNING level, not debug.
+# ---------------------------------------------------------------------------
+
+
+def test_shared_nous_store_failure_logs_at_warning_level(tmp_path, monkeypatch, caplog):
+    """A failed write must surface at WARNING level so operators see it."""
+    import logging
+
+    auth_mod, state = _write_minimal_state(tmp_path, monkeypatch)
+
+    def explode_replace(src, dst):
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    with caplog.at_level(logging.DEBUG, logger="hermes_cli.auth"):
+        with patch.object(os, "replace", side_effect=explode_replace):
+            auth_mod._write_shared_nous_state(state)
+
+    # Find the failure log
+    failure_records = [
+        r for r in caplog.records
+        if "shared Nous auth store" in r.getMessage().lower()
+        or "nous_auth" in r.getMessage().lower()
+    ]
+    assert failure_records, "no log line recorded for shared Nous store failure"
+    # The reporter requires WARNING (not DEBUG)
+    severities = {r.levelno for r in failure_records}
+    assert logging.WARNING in severities, (
+        f"shared Nous store failure logged at {[logging.getLevelName(s) for s in severities]} "
+        "instead of WARNING — operators won't see this at default log level"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration: normal happy path still works after the fix.
+# ---------------------------------------------------------------------------
+
+
+def test_shared_nous_store_happy_path_unchanged(tmp_path, monkeypatch):
+    """The basic 0o600 / parent 0o700 contract must still hold after the fix."""
+    auth_mod, state = _write_minimal_state(tmp_path, monkeypatch)
+
+    auth_mod._write_shared_nous_state(state)
+    path = auth_mod._nous_shared_store_path()
+
+    assert path.exists(), "shared Nous store was not written"
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+
+    data = json.loads(path.read_text())
+    assert data["refresh_token"] == "***"
+    assert data["access_token"] == "***"
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: two threads racing the write — the cross-profile lock must
+# serialize them and both must end up with a valid store.
+# ---------------------------------------------------------------------------
+
+
+def test_shared_nous_store_concurrent_writes_serialize(tmp_path, monkeypatch):
+    """Concurrent writes to the shared store must serialize and both succeed."""
+    auth_mod, state = _write_minimal_state(tmp_path, monkeypatch)
+    shared_dir = tmp_path / "shared_override"
+
+    errors = []
+
+    def writer(i):
+        try:
+            local_state = dict(state)
+            local_state["refresh_token"] = f"refresh-{i}"
+            auth_mod._write_shared_nous_state(local_state)
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=writer, args=(i,)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"concurrent writes raised: {errors}"
+    store = shared_dir / "nous_auth.json"
+    assert store.exists()
+    leftover = list(shared_dir.glob("nous_auth.json.tmp.*"))
+    assert not leftover, f"orphan temp files after concurrent writes: {leftover}"


### PR DESCRIPTION
Fixes #68699

## Bug
The shared Nous OAuth token store (`<hermes-root>/shared/nous_auth.json`) silently failed to be created when the atomic rename step hit `EXDEV` / `EBUSY` (or any other `OSError`). The reporter observed four orphan `nous_auth.json.tmp.*` files accumulating across 2.5 months. Because the store never landed, the documented cross-profile token sharing never activated — each profile kept its own rotating refresh token, which is the structural condition for #43589 mutual-revocation.

## Root cause
`_write_shared_nous_state()` in `hermes_cli/auth.py` used bare `os.replace()` inside a `try/except Exception` that logged at `logger.debug` level — invisible at default log level. Any rename failure was swallowed silently.

## Fix (5 layers)

| Layer | What changed | Where |
|---|---|---|
| L1 | Route rename through existing `atomic_replace` helper (copy/fsync/unlink fallback for EXDEV/EBUSY) instead of bare `os.replace` | `hermes_cli/auth.py` `_write_shared_nous_state()` |
| L2 | Promote outer `except` from `logger.debug` → `logger.warning` with explicit "cross-profile token sharing disabled" message | same function |
| L3 | Sweep stale `nous_auth.json.tmp.*` files before each write so prior crashed attempts don't accumulate (including 0-byte temps the reporter observed) | new `_sweep_stale_shared_nous_temps()` helper, called inside the store lock |
| L4 | Verify-after-write: if rename reported success but `nous_auth.json` is missing or 0 bytes, log a WARNING so operators see the structural condition for #43589 | same function, after `atomic_replace` |
| L5 (intra-function) | Preserve the temp file as forensic evidence when the rename fails (it contains a valid serialized state; the previous code unlinked it silently in the finally) | same function's `except Exception` |

The `atomic_replace` helper already exists in `utils.py` and is reused in 7+ other call sites (`auth.py:1181/2353`, `config.py:7880/8040/8111`, `webhook.py:71`, `model_catalog.py:56`) — this is the project's established EXDEV/EBUSY-safe rename path.

## Tests (7 new regression tests, 91/91 nearby auth suites still pass)

All 7 tests are RED on `upstream/main` (proven in fail-without-fix.txt: 5/7 fail RED, 2/7 happy-path baseline pass) and GREEN with the fix:

- `test_shared_nous_store_handles_exdev_during_rename` — EXDEV fallback path
- `test_shared_nous_store_handles_ebusy_during_rename` — EBUSY fallback path
- `test_shared_nous_store_sweeps_stale_temps_before_write` — pre-existing 0-byte + valid-payload temps swept
- `test_shared_nous_store_detects_missing_file_after_rename` — verify-after-write missing file surfaces at WARNING
- `test_shared_nous_store_failure_logs_at_warning_level` — DEBUG → WARNING escalation
- `test_shared_nous_store_happy_path_unchanged` — 0o600/0o700 contract preserved
- `test_shared_nous_store_concurrent_writes_serialize` — cross-process lock serialization (4 threads)

## Verification

- Base: `upstream/main` @ `11ae6bf0e3d334ae74d3b240dfc4c64171c60233`
- Branch: `fix/68699-nous-auth-shared-store` (one focused commit, `git rev-list --left-right --count upstream/main...HEAD` → `0 1`)
- Files: `hermes_cli/auth.py`, `tests/hermes_cli/test_auth_shared_nous_68699.py` (+374/-13)
- Nearby suite: 91/91 nous-auth tests pass with the fix
- No new dependencies, no junk files, no AI attribution, no new env vars

## Competition

No focused open PR addresses #68699's specific `nous_auth.json.tmp` rename bug. Adjacent PRs:
- #66764 (rzyns, +3501/-743) — broad credential-pool refactor for MiniMax OAuth; does not touch the .tmp rename path
- #67261 (KharonLaQua) — addresses xAI OAuth shared store, not Nous
- #64902 (pierrenode) — addresses photon auth.json locking, not Nous shared store

## Out of scope (intentionally)

- `_nous_shared_store_lock` semantics — already correct (file-based, cross-process)
- Per-profile `auth.json` schema — already working as source of truth
- Migrating to Redis-style shared store — much larger refactor
- `hermes doctor` integration — the issue's suggestion (d) is a follow-up UX improvement; the WARNING-level log already surfaces the condition

Auto-published by Moonsong via Path B automated pipeline.