### PR TITLE
fix(model_metadata): scope the endpoint /models cache by credential

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -113,6 +113,27 @@ _MODEL_CACHE_TTL = 3600
 _endpoint_model_metadata_cache: Dict[str, Dict[str, Dict[str, Any]]] = {}
 _endpoint_model_metadata_cache_time: Dict[str, float] = {}
 _ENDPOINT_MODEL_CACHE_TTL = 300
+
+
+def _endpoint_metadata_cache_key(normalized: str, api_key: str) -> str:
+    """Cache key for the endpoint ``/models`` metadata cache.
+
+    The probe is authenticated, and an OpenAI-compatible ``/models`` returns
+    what THAT credential is entitled to — model availability and context
+    windows vary by account (the same reason the Codex catalogue cache is
+    scoped by token fingerprint). Keying on the base URL alone lets one
+    credential's catalogue answer another credential's probe, which in a
+    multiplexed gateway means one profile's context window and pricing
+    metadata are served to a different profile.
+
+    The raw key is never retained in the cache key — only a short digest.
+    """
+    if not api_key:
+        return normalized
+    digest = hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16]
+    return f"{normalized}#{digest}"
+
+
 # Bounded-lifetime cache: after the first successful probe we remember the
 # server type so subsequent refreshes skip the full waterfall (no more 404
 # spam every 5 minutes on non-matching endpoints like /api/v1/models on vllm).
@@ -982,9 +1003,13 @@ def fetch_endpoint_model_metadata(
     if not normalized or _is_openrouter_base_url(normalized):
         return {}
 
+    # Scoped by credential: the probe below is authenticated, so the catalogue
+    # it returns belongs to THIS key, not to the base URL.
+    cache_key = _endpoint_metadata_cache_key(normalized, api_key)
+
     if not force_refresh:
-        cached = _endpoint_model_metadata_cache.get(normalized)
-        cached_at = _endpoint_model_metadata_cache_time.get(normalized, 0)
+        cached = _endpoint_model_metadata_cache.get(cache_key)
+        cached_at = _endpoint_model_metadata_cache_time.get(cache_key, 0)
         if cached is not None and (time.time() - cached_at) < _ENDPOINT_MODEL_CACHE_TTL:
             return cached
 
@@ -1045,8 +1070,8 @@ def fetch_endpoint_model_metadata(
                     if isinstance(alt_id, str) and alt_id and alt_id != model_id:
                         _add_model_aliases(cache, alt_id, entry)
 
-                _endpoint_model_metadata_cache[normalized] = cache
-                _endpoint_model_metadata_cache_time[normalized] = time.time()
+                _endpoint_model_metadata_cache[cache_key] = cache
+                _endpoint_model_metadata_cache_time[cache_key] = time.time()
                 return cache
         except Exception as exc:
             last_error = exc
@@ -1099,16 +1124,16 @@ def fetch_endpoint_model_metadata(
                 except Exception:
                     pass
 
-            _endpoint_model_metadata_cache[normalized] = cache
-            _endpoint_model_metadata_cache_time[normalized] = time.time()
+            _endpoint_model_metadata_cache[cache_key] = cache
+            _endpoint_model_metadata_cache_time[cache_key] = time.time()
             return cache
         except Exception as exc:
             last_error = exc
 
     if last_error:
         logger.debug("Failed to fetch model metadata from %s/models: %s", normalized, last_error)
-    _endpoint_model_metadata_cache[normalized] = {}
-    _endpoint_model_metadata_cache_time[normalized] = time.time()
+    _endpoint_model_metadata_cache[cache_key] = {}
+    _endpoint_model_metadata_cache_time[cache_key] = time.time()
     return {}
 
 

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -638,6 +638,88 @@ class TestFetchEndpointModelMetadataLmStudio:
         assert result["publisher/model-a"]["context_length"] == 65536
 
 
+class TestEndpointMetadataCacheIsCredentialScoped:
+    """The /models probe is authenticated, so its catalogue belongs to the key.
+
+    An OpenAI-compatible ``/models`` returns what THAT credential is entitled
+    to — availability and context windows vary by account. Keying the cache on
+    the base URL alone lets one credential's catalogue answer another's probe;
+    in a multiplexed gateway that serves one profile's context window (and the
+    pricing metadata built from it) to a different profile.
+    """
+
+    URL = "https://shared-llm.example.test/v1"
+    TIERS = {
+        "Bearer key-enterprise": [{"id": "shared-model", "context_length": 1_000_000}],
+        "Bearer key-free": [{"id": "shared-model", "context_length": 128_000}],
+    }
+
+    def _clear(self):
+        import agent.model_metadata as mm
+
+        mm._endpoint_model_metadata_cache.clear()
+        mm._endpoint_model_metadata_cache_time.clear()
+
+    def _tiered_get(self, seen):
+        def _get(url, headers=None, timeout=None, verify=None, **kwargs):
+            auth = (headers or {}).get("Authorization", "")
+            seen.append(auth)
+            resp = MagicMock()
+            resp.raise_for_status.return_value = None
+            resp.ok = True
+            resp.json.return_value = {"data": self.TIERS.get(auth, [])}
+            return resp
+
+        return _get
+
+    def _ctx(self, result):
+        return result.get("shared-model", {}).get("context_length")
+
+    def test_second_credential_does_not_inherit_the_first_catalogue(self):
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        self._clear()
+        seen: list = []
+        with patch("agent.model_metadata.requests.get", self._tiered_get(seen)):
+            enterprise = fetch_endpoint_model_metadata(
+                self.URL, api_key="key-enterprise"
+            )
+            free = fetch_endpoint_model_metadata(self.URL, api_key="key-free")
+
+        assert self._ctx(enterprise) == 1_000_000
+        assert self._ctx(free) == 128_000, (
+            "the free-tier profile inherited the enterprise profile's context "
+            "window from a base-URL-keyed cache"
+        )
+
+    def test_same_credential_still_hits_the_cache(self):
+        """Scoping must not cost a refetch for the common single-key case."""
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        self._clear()
+        seen: list = []
+        with patch("agent.model_metadata.requests.get", self._tiered_get(seen)):
+            first = fetch_endpoint_model_metadata(self.URL, api_key="key-enterprise")
+            second = fetch_endpoint_model_metadata(self.URL, api_key="key-enterprise")
+
+        assert first == second
+        assert seen.count("Bearer key-enterprise") == 1, "cache stopped working"
+
+    def test_cache_key_never_embeds_the_raw_credential(self):
+        import agent.model_metadata as mm
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        self._clear()
+        with patch("agent.model_metadata.requests.get", self._tiered_get([])):
+            fetch_endpoint_model_metadata(self.URL, api_key="key-enterprise")
+
+        keys = list(mm._endpoint_model_metadata_cache)
+        assert keys, "nothing cached"
+        assert all("key-enterprise" not in k for k in keys), (
+            "raw credential leaked into an in-memory cache key"
+        )
+
+
 class TestQueryLocalContextLengthNetworkError:
     """_query_local_context_length handles network failures gracefully."""
 


### PR DESCRIPTION
## Summary

`fetch_endpoint_model_metadata(base_url, api_key)` sends the probe
**authenticated** — `headers = {"Authorization": f"Bearer {api_key}"}` — but
caches the answer under the base URL alone:

```python
cached = _endpoint_model_metadata_cache.get(normalized)
```

An OpenAI-compatible `/models` returns what *that credential* is entitled to.
Two credentials pointed at one endpoint therefore share a single cache slot,
and whoever probes first owns it for the whole 300s TTL.

This is the same defect **#68540 (`60afc290a`) just fixed one screen down in
this file** for the Codex catalogue, with the same stated reason — *"model
availability and context windows can vary by account entitlement"* — and the
same defect **#64242** addresses for the auxiliary client cache. The endpoint
metadata cache is the sibling that still keys on the URL.

## Why it matters

The multiplexed gateway runs many profiles in **one process**, with
per-profile credentials, against what may be one shared endpoint (a corporate
LLM gateway, a team OpenRouter-compatible proxy). The cached rows carry
`context_length` and `pricing`, and they feed two live consumers —
`_resolve_endpoint_context_length` and `usage_pricing.py`'s route pricing.

So a free-tier profile can be handed an enterprise profile's context window and
pack a request its own key will reject, and cost estimates can be computed from
another account's rates.

## Reproduction

Against the real function, with a tiered endpoint (per-key entitlement):

```
profile A (enterprise) sees ctx: 1000000
profile B (free tier)  sees ctx: 1000000   <-- B inherited A's window
cache keys: ['https://shared-llm.example.test/v1']
```

## Fix

Key the cache on the base URL **plus a short digest of the credential**,
mirroring `_codex_oauth_token_fingerprint`: the raw key is never retained, only
a sha256 prefix.

- A missing/empty `api_key` keeps the bare-URL key, so unauthenticated local
  endpoints are unaffected.
- A repeat probe with the same credential still hits the cache — the scoping
  costs no extra requests in the common single-key case.

## Test plan

`tests/agent/test_model_metadata_local_ctx.py` — new
`TestEndpointMetadataCacheIsCredentialScoped`:

- a second credential does not inherit the first catalogue (**fails on `main`**
  with `assert 1000000 == 128000`)
- the same credential still hits the cache (control: exactly one fetch)
- the cache key never embeds the raw credential (control)

`37 passed` in the file; `196 passed` across
`test_model_metadata_local_ctx.py`, `test_model_metadata.py`,
`test_usage_pricing.py`. A broader sweep of every suite referencing
`model_metadata` shows `3348 passed` with 15 failures that are **pre-existing —
all 15 fail identically on clean `main`** (Windows/test-isolation artifacts in
`test_config`, `test_status_command`, `test_image_routing`, `test_computer_use`,
`test_web_server`).

## Checklist

- [x] Tested on Ubuntu 24.04
- [x] New tests fail without the fix and pass with it
- [x] No regressions (all failures reproduced identically on clean `main`)
- [x] No credential material added to logs, caches, or cache keys