### PR TITLE
fix(desktop): isolate credentials for profile backends

### DIFF
--- a/apps/desktop/electron/backend-env.test.ts
+++ b/apps/desktop/electron/backend-env.test.ts
@@ -9,6 +9,8 @@ import {
   appendUniquePathEntries,
   buildDesktopBackendEnv,
   buildDesktopBackendPath,
+  buildPoolBackendSpawnEnv,
+  buildPrimaryBackendSpawnEnv,
   buildProfileBackendParentEnv,
   buildProfileScopedParentEnv,
   dotenvKeyNames,
@@ -168,8 +170,10 @@ test('named profile backend removes inherited variables owned by Hermes dotenv s
 
   try {
     fs.writeFileSync(path.join(hermesHome, '.env'), 'TLON_SHIP_CODE=root-secret\nOPENAI_API_KEY=root-key\n')
+    fs.writeFileSync(path.join(hermesHome, '.op.env'), 'OP_SERVICE_ACCOUNT_TOKEN=root-op-token\n')
     fs.mkdirSync(path.join(hermesHome, 'profiles', 'work'), { recursive: true })
     fs.writeFileSync(path.join(hermesHome, 'profiles', 'work', '.env'), 'ANTHROPIC_API_KEY=work-key\n')
+    fs.writeFileSync(path.join(hermesHome, 'profiles', 'work', '.op.env'), 'WORK_BOOTSTRAP_TOKEN=work-op-token\n')
 
     const env = buildProfileBackendParentEnv({
       hermesHome,
@@ -178,12 +182,74 @@ test('named profile backend removes inherited variables owned by Hermes dotenv s
         HOME: '/Users/test',
         TLON_SHIP_CODE: 'root-secret',
         OPENAI_API_KEY: 'root-key',
-        ANTHROPIC_API_KEY: 'stale-work-key'
+        ANTHROPIC_API_KEY: 'stale-work-key',
+        OP_SERVICE_ACCOUNT_TOKEN: 'root-op-token',
+        WORK_BOOTSTRAP_TOKEN: 'stale-work-op-token'
       },
       platform: 'linux'
     })
 
     assert.deepEqual(env, { HOME: '/Users/test' })
+  } finally {
+    fs.rmSync(hermesHome, { recursive: true, force: true })
+  }
+})
+
+test('pooled profile spawn receives an isolated environment with backend overrides', () => {
+  const hermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-pool-spawn-env-'))
+
+  try {
+    fs.writeFileSync(path.join(hermesHome, '.env'), 'TLON_SHIP_CODE=root-secret\n')
+    fs.writeFileSync(path.join(hermesHome, '.op.env'), 'OP_SERVICE_ACCOUNT_TOKEN=root-op-token\n')
+
+    const env = buildPoolBackendSpawnEnv({
+      hermesHome,
+      profile: 'work',
+      currentEnv: {
+        HOME: '/Users/test',
+        TLON_SHIP_CODE: 'root-secret',
+        OP_SERVICE_ACCOUNT_TOKEN: 'root-op-token'
+      },
+      backendEnv: { PYTHONPATH: '/repo/hermes-agent' },
+      childEnv: { TERMINAL_CWD: '/Users/test/work' },
+      platform: 'linux'
+    })
+
+    assert.deepEqual(env, {
+      HOME: '/Users/test',
+      HERMES_HOME: hermesHome,
+      PYTHONPATH: '/repo/hermes-agent',
+      TERMINAL_CWD: '/Users/test/work'
+    })
+  } finally {
+    fs.rmSync(hermesHome, { recursive: true, force: true })
+  }
+})
+
+test('primary profile spawn receives an isolated environment when profile selection is sticky', () => {
+  const hermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-primary-spawn-env-'))
+
+  try {
+    fs.writeFileSync(path.join(hermesHome, '.op.env'), 'OP_SERVICE_ACCOUNT_TOKEN=root-op-token\n')
+
+    const env = buildPrimaryBackendSpawnEnv({
+      hermesHome,
+      profile: null,
+      currentEnv: {
+        HOME: '/Users/test',
+        OP_SERVICE_ACCOUNT_TOKEN: 'root-op-token'
+      },
+      backendEnv: { PATH: '/managed/bin' },
+      childEnv: { HERMES_DESKTOP: '1' },
+      platform: 'linux'
+    })
+
+    assert.deepEqual(env, {
+      HOME: '/Users/test',
+      HERMES_HOME: hermesHome,
+      PATH: '/managed/bin',
+      HERMES_DESKTOP: '1'
+    })
   } finally {
     fs.rmSync(hermesHome, { recursive: true, force: true })
   }

--- a/apps/desktop/electron/backend-env.test.ts
+++ b/apps/desktop/electron/backend-env.test.ts
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 
 import { test } from 'vitest'
@@ -7,6 +9,9 @@ import {
   appendUniquePathEntries,
   buildDesktopBackendEnv,
   buildDesktopBackendPath,
+  buildProfileBackendParentEnv,
+  buildProfileScopedParentEnv,
+  dotenvKeyNames,
   normalizeHermesHomeRoot,
   pathEnvKey,
   POSIX_SANE_PATH_ENTRIES
@@ -123,4 +128,72 @@ test('Windows PATH casing and delimiter are preserved without POSIX sane entries
 
 test('appendUniquePathEntries drops empty entries and keeps first occurrence', () => {
   assert.equal(appendUniquePathEntries([':/a::/b', ['/a', '/c']], { delimiter: ':' }), '/a:/b:/c')
+})
+
+test('profile-scoped parent env removes credentials declared by any profile dotenv', () => {
+  const env = buildProfileScopedParentEnv({
+    currentEnv: {
+      HOME: '/Users/test',
+      PATH: '/usr/bin:/bin',
+      TLON_SHIP_URL: 'https://example.invalid',
+      TLON_SHIP_NAME: '~example',
+      TLON_SHIP_CODE: 'secret'
+    },
+    profileEnvContents: [
+      'TLON_SHIP_URL=https://example.invalid\nTLON_SHIP_NAME=~example',
+      '# another profile\nexport TLON_SHIP_CODE = secret\nINVALID LINE'
+    ],
+    platform: 'linux'
+  })
+
+  assert.deepEqual(env, {
+    HOME: '/Users/test',
+    PATH: '/usr/bin:/bin'
+  })
+  assert.deepEqual(dotenvKeyNames('  export API_KEY = value\n# TOKEN=x\nNAME='), ['API_KEY', 'NAME'])
+})
+
+test('profile-scoped parent env matches credential names case-insensitively on Windows', () => {
+  const env = buildProfileScopedParentEnv({
+    currentEnv: { Path: 'C:\\Windows', Telegram_Bot_Token: 'secret', TEMP: 'C:\\Temp' },
+    profileEnvContents: ['TELEGRAM_BOT_TOKEN=secret'],
+    platform: 'win32'
+  })
+
+  assert.deepEqual(env, { Path: 'C:\\Windows', TEMP: 'C:\\Temp' })
+})
+
+test('named profile backend removes inherited variables owned by Hermes dotenv scopes', () => {
+  const hermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-profile-env-'))
+
+  try {
+    fs.writeFileSync(path.join(hermesHome, '.env'), 'TLON_SHIP_CODE=root-secret\nOPENAI_API_KEY=root-key\n')
+    fs.mkdirSync(path.join(hermesHome, 'profiles', 'work'), { recursive: true })
+    fs.writeFileSync(path.join(hermesHome, 'profiles', 'work', '.env'), 'ANTHROPIC_API_KEY=work-key\n')
+
+    const env = buildProfileBackendParentEnv({
+      hermesHome,
+      profile: 'work',
+      currentEnv: {
+        HOME: '/Users/test',
+        TLON_SHIP_CODE: 'root-secret',
+        OPENAI_API_KEY: 'root-key',
+        ANTHROPIC_API_KEY: 'stale-work-key'
+      },
+      platform: 'linux'
+    })
+
+    assert.deepEqual(env, { HOME: '/Users/test' })
+  } finally {
+    fs.rmSync(hermesHome, { recursive: true, force: true })
+  }
+})
+
+test('unscoped backend environment preserves inherited variables', () => {
+  const currentEnv = { HOME: '/Users/test', OPENAI_API_KEY: 'shell-key' }
+
+  assert.deepEqual(
+    buildProfileBackendParentEnv({ hermesHome: '/Users/test/.hermes', profile: null, currentEnv }),
+    currentEnv
+  )
 })

--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -92,13 +92,14 @@ function buildProfileScopedParentEnv({
 }
 
 function readProfileEnvContents(hermesHome, { fsModule = fs, pathModule = path }: any = {}) {
-  const envPaths = [pathModule.join(hermesHome, '.env')]
+  const envNames = ['.env', '.op.env']
+  const envPaths = envNames.map(name => pathModule.join(hermesHome, name))
   const profilesRoot = pathModule.join(hermesHome, 'profiles')
 
   try {
     for (const entry of fsModule.readdirSync(profilesRoot, { withFileTypes: true })) {
       if (entry.isDirectory()) {
-        envPaths.push(pathModule.join(profilesRoot, entry.name, '.env'))
+        envPaths.push(...envNames.map(name => pathModule.join(profilesRoot, entry.name, name)))
       }
     }
   } catch {
@@ -112,6 +113,32 @@ function readProfileEnvContents(hermesHome, { fsModule = fs, pathModule = path }
       return []
     }
   })
+}
+
+function buildProfileBackendSpawnEnv({
+  hermesHome,
+  profile,
+  backendEnv = {},
+  childEnv = {},
+  currentEnv = process.env,
+  platform = process.platform,
+  fsModule = fs,
+  pathModule = path
+}: any = {}) {
+  return {
+    ...buildProfileBackendParentEnv({ hermesHome, profile, currentEnv, platform, fsModule, pathModule }),
+    HERMES_HOME: hermesHome,
+    ...(backendEnv || {}),
+    ...(childEnv || {})
+  }
+}
+
+function buildPoolBackendSpawnEnv(options: any = {}) {
+  return buildProfileBackendSpawnEnv(options)
+}
+
+function buildPrimaryBackendSpawnEnv({ profile, ...options }: any = {}) {
+  return buildProfileBackendSpawnEnv({ ...options, profile: profile || 'default' })
 }
 
 function buildProfileBackendParentEnv({
@@ -198,6 +225,8 @@ export {
   appendUniquePathEntries,
   buildDesktopBackendEnv,
   buildDesktopBackendPath,
+  buildPoolBackendSpawnEnv,
+  buildPrimaryBackendSpawnEnv,
   buildProfileBackendParentEnv,
   buildProfileScopedParentEnv,
   delimiterForPlatform,

--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import path from 'node:path'
 
 // Match the POSIX fallback surface used by the Python terminal environment.
@@ -58,6 +59,78 @@ function appendUniquePathEntries(entries, { delimiter = path.delimiter } = {}) {
   }
 
   return ordered.join(delimiter)
+}
+
+function dotenvKeyNames(contents = '') {
+  const names = []
+
+  for (const line of String(contents).split(/\r?\n/)) {
+    const match = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/)
+
+    if (match) {
+      names.push(match[1])
+    }
+  }
+
+  return names
+}
+
+function buildProfileScopedParentEnv({
+  currentEnv = process.env,
+  profileEnvContents = [],
+  platform = process.platform
+}: any = {}) {
+  const normalizeKey = platform === 'win32' ? key => key.toUpperCase() : key => key
+
+  const profileOwnedKeys = new Set(
+    profileEnvContents.flatMap(contents => dotenvKeyNames(contents)).map(key => normalizeKey(key))
+  )
+
+  return Object.fromEntries(
+    Object.entries(currentEnv || {}).filter(([key]) => !profileOwnedKeys.has(normalizeKey(key)))
+  )
+}
+
+function readProfileEnvContents(hermesHome, { fsModule = fs, pathModule = path }: any = {}) {
+  const envPaths = [pathModule.join(hermesHome, '.env')]
+  const profilesRoot = pathModule.join(hermesHome, 'profiles')
+
+  try {
+    for (const entry of fsModule.readdirSync(profilesRoot, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        envPaths.push(pathModule.join(profilesRoot, entry.name, '.env'))
+      }
+    }
+  } catch {
+    // A missing profiles directory is the normal single-profile case.
+  }
+
+  return envPaths.flatMap(envPath => {
+    try {
+      return [fsModule.readFileSync(envPath, 'utf8')]
+    } catch {
+      return []
+    }
+  })
+}
+
+function buildProfileBackendParentEnv({
+  hermesHome,
+  profile,
+  currentEnv = process.env,
+  platform = process.platform,
+  fsModule = fs,
+  pathModule = path
+}: any = {}) {
+  if (!profile || !hermesHome) {
+    return { ...(currentEnv || {}) }
+  }
+
+  return buildProfileScopedParentEnv({
+    currentEnv,
+    profileEnvContents: readProfileEnvContents(hermesHome, { fsModule, pathModule }),
+    platform
+  })
 }
 
 function buildDesktopBackendPath({
@@ -125,8 +198,12 @@ export {
   appendUniquePathEntries,
   buildDesktopBackendEnv,
   buildDesktopBackendPath,
+  buildProfileBackendParentEnv,
+  buildProfileScopedParentEnv,
   delimiterForPlatform,
+  dotenvKeyNames,
   normalizeHermesHomeRoot,
   pathEnvKey,
-  POSIX_SANE_PATH_ENTRIES
+  POSIX_SANE_PATH_ENTRIES,
+  readProfileEnvContents
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -35,7 +35,12 @@ import { classifyActiveRuntime } from './active-runtime-state'
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
-import { buildDesktopBackendEnv, buildProfileBackendParentEnv, normalizeHermesHomeRoot } from './backend-env'
+import {
+  buildDesktopBackendEnv,
+  buildPoolBackendSpawnEnv,
+  buildPrimaryBackendSpawnEnv,
+  normalizeHermesHomeRoot
+} from './backend-env'
 import { isReauthRequiredError, waitForHermesReady } from './backend-health'
 import {
   canImportHermesCli,
@@ -8111,21 +8116,23 @@ async function spawnPoolBackend(profile, entry) {
     backend.args,
     hiddenWindowsChildOptions({
       cwd: hermesCwd,
-      env: {
-        ...buildProfileBackendParentEnv({ hermesHome: HERMES_HOME, profile }),
-        HERMES_HOME,
-        ...backend.env,
-        // Pin the gateway's tool/terminal cwd to the same directory we chose for
-        // the child process. Inherited TERMINAL_CWD (or a stale config bridge)
-        // can still point at the install dir even when spawn cwd is home.
-        TERMINAL_CWD: hermesCwd,
-        HERMES_DASHBOARD_SESSION_TOKEN: token,
-        // Marks this dashboard backend as desktop-spawned so it runs the cron
-        // scheduler tick loop (the gateway isn't running under the app).
-        HERMES_DESKTOP: '1',
-        HERMES_WEB_DIST: webDist,
-        ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
-      },
+      env: buildPoolBackendSpawnEnv({
+        hermesHome: HERMES_HOME,
+        profile,
+        backendEnv: backend.env,
+        childEnv: {
+          // Pin the gateway's tool/terminal cwd to the same directory we chose for
+          // the child process. Inherited TERMINAL_CWD (or a stale config bridge)
+          // can still point at the install dir even when spawn cwd is home.
+          TERMINAL_CWD: hermesCwd,
+          HERMES_DASHBOARD_SESSION_TOKEN: token,
+          // Marks this dashboard backend as desktop-spawned so it runs the cron
+          // scheduler tick loop (the gateway isn't running under the app).
+          HERMES_DESKTOP: '1',
+          HERMES_WEB_DIST: webDist,
+          ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
+        }
+      }),
       shell: backend.shell,
       stdio: ['ignore', 'pipe', 'pipe']
     })
@@ -8399,26 +8406,28 @@ async function startHermes() {
       backend.args,
       hiddenWindowsChildOptions({
         cwd: hermesCwd,
-        env: {
-          ...buildProfileBackendParentEnv({ hermesHome: HERMES_HOME, profile: activeProfile || 'default' }),
-          // Explicitly pin HERMES_HOME for the child so Python's get_hermes_home()
-          // resolves to the SAME location our resolveHermesHome() picked. Without
-          // this pin, Python falls back to ~/.hermes on every platform — fine on
-          // mac/linux (where our default matches), but on Windows our default is
-          // %LOCALAPPDATA%\hermes, which differs from C:\Users\<u>\.hermes.
-          // Mismatch would split config / sessions / .env / logs across two
-          // directories. install.ps1 sets HERMES_HOME via setx; the desktop
-          // can't reliably do that, so we set it inline for every spawn.
-          HERMES_HOME,
-          ...backend.env,
-          TERMINAL_CWD: hermesCwd,
-          HERMES_DASHBOARD_SESSION_TOKEN: token,
-          // Marks this dashboard backend as desktop-spawned so it runs the cron
-          // scheduler tick loop (the gateway isn't running under the app).
-          HERMES_DESKTOP: '1',
-          HERMES_WEB_DIST: webDist,
-          ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
-        },
+        // Explicitly pin HERMES_HOME for the child so Python's get_hermes_home()
+        // resolves to the SAME location our resolveHermesHome() picked. Without
+        // this pin, Python falls back to ~/.hermes on every platform — fine on
+        // mac/linux (where our default matches), but on Windows our default is
+        // %LOCALAPPDATA%\hermes, which differs from C:\Users\<u>\.hermes.
+        // Mismatch would split config / sessions / .env / logs across two
+        // directories. install.ps1 sets HERMES_HOME via setx; the desktop
+        // can't reliably do that, so we set it inline for every spawn.
+        env: buildPrimaryBackendSpawnEnv({
+          hermesHome: HERMES_HOME,
+          profile: activeProfile,
+          backendEnv: backend.env,
+          childEnv: {
+            TERMINAL_CWD: hermesCwd,
+            HERMES_DASHBOARD_SESSION_TOKEN: token,
+            // Marks this dashboard backend as desktop-spawned so it runs the cron
+            // scheduler tick loop (the gateway isn't running under the app).
+            HERMES_DESKTOP: '1',
+            HERMES_WEB_DIST: webDist,
+            ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
+          }
+        }),
         shell: backend.shell,
         stdio: ['ignore', 'pipe', 'pipe']
       })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -35,7 +35,7 @@ import { classifyActiveRuntime } from './active-runtime-state'
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
-import { buildDesktopBackendEnv, normalizeHermesHomeRoot } from './backend-env'
+import { buildDesktopBackendEnv, buildProfileBackendParentEnv, normalizeHermesHomeRoot } from './backend-env'
 import { isReauthRequiredError, waitForHermesReady } from './backend-health'
 import {
   canImportHermesCli,
@@ -8112,7 +8112,7 @@ async function spawnPoolBackend(profile, entry) {
     hiddenWindowsChildOptions({
       cwd: hermesCwd,
       env: {
-        ...process.env,
+        ...buildProfileBackendParentEnv({ hermesHome: HERMES_HOME, profile }),
         HERMES_HOME,
         ...backend.env,
         // Pin the gateway's tool/terminal cwd to the same directory we chose for
@@ -8400,7 +8400,7 @@ async function startHermes() {
       hiddenWindowsChildOptions({
         cwd: hermesCwd,
         env: {
-          ...process.env,
+          ...buildProfileBackendParentEnv({ hermesHome: HERMES_HOME, profile: activeProfile || 'default' }),
           // Explicitly pin HERMES_HOME for the child so Python's get_hermes_home()
           // resolves to the SAME location our resolveHermesHome() picked. Without
           // this pin, Python falls back to ~/.hermes on every platform — fine on


### PR DESCRIPTION
## Summary

- remove Hermes dotenv-owned variables from environments inherited by Desktop-spawned profile backends
- include root and named-profile `.env` and `.op.env` secret scopes
- apply isolation to primary, sticky-profile, and pooled-profile backend launches
- preserve unrelated OS/runtime variables and Windows environment-key casing

## Root Cause

Hermes Desktop spread its full `process.env` into every backend child. When the Desktop process contained credentials loaded for another profile, those credentials remained present before the selected profile scope was applied.

Platform adapters and external secret sources could then use inherited credentials, causing multiple profiles to connect with the same identity or expose another profile's secret scope.

## Fix

The Desktop backend environment resolver now collects variable names declared by root and named-profile `.env` and `.op.env` files, then removes those variables from the inherited parent environment before starting a profile backend.

`buildPoolBackendSpawnEnv()` and `buildPrimaryBackendSpawnEnv()` are used by `spawnPoolBackend()` and `startHermes()`, respectively. The selected profile's existing dotenv loader then reloads only its own secret scope.

Secret values are never logged or included in diagnostics.

## Tests

- added filesystem-backed root/profile `.env` and `.op.env` isolation coverage
- added behavior-level assertions for pooled and primary backend spawn environments
- added Windows case-insensitive environment-key coverage
- verified unrelated environment variables remain available
- focused Electron tests: **13/13 passed**
- Electron TypeScript check: **passed**
- ESLint on touched files: **passed**
- Electron main-process production bundle: **passed**
- branch rebased onto current `main`

Fixes #68367