### PR TITLE
fix(desktop): decode Unicode attachment filenames

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -143,12 +143,12 @@ function OpenMediaButton({ kind, path }: { kind: 'audio' | 'video'; path: string
   )
 }
 
-function MediaAttachment({ path }: { path: string }) {
+function MediaAttachment({ label, path }: { label?: string; path: string }) {
   const [src, setSrc] = useState('')
   const [failed, setFailed] = useState(false)
   const { open, openFailed } = useOpenMediaFile(path)
   const kind = mediaKind(path)
-  const name = mediaName(path)
+  const name = label || mediaName(path)
 
   useEffect(() => {
     let cancelled = false
@@ -254,6 +254,13 @@ function childrenToText(children: unknown): string {
   return ''
 }
 
+function generatedMediaLabel(children: unknown): string | undefined {
+  const text = childrenToText(children)
+  const match = /^(?:Audio|File|Image|Video):\s*(.+)$/i.exec(text)
+
+  return match?.[1]?.trim() || undefined
+}
+
 function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a'>) {
   const mediaPath = mediaPathFromMarkdownHref(href)
 
@@ -266,7 +273,7 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
       return <PreviewAttachment source="tool-result" target={mediaPath} />
     }
 
-    return <MediaAttachment path={mediaPath} />
+    return <MediaAttachment label={generatedMediaLabel(children)} path={mediaPath} />
   }
 
   const previewTarget = previewTargetFromMarkdownHref(href)

--- a/apps/desktop/src/components/assistant-ui/markdown-text.unicode-media.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.unicode-media.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { renderMediaTags } from '@/lib/chat-messages'
+
+import { MarkdownTextContent } from './markdown-text'
+
+describe('Unicode MEDIA filenames through the full renderer', () => {
+  afterEach(cleanup)
+
+  it('renders a Windows delivery path with a Chinese basename as readable text', async () => {
+    const path =
+      'C:/Users/user/Downloads/114教學實踐計畫審閱/期末報告/114教學實踐成果交流會_整合修正版.pptx'
+
+    const markdown = renderMediaTags(`MEDIA:${path}`)
+
+    expect(markdown).toContain('File: 114教學實踐成果交流會_整合修正版.pptx')
+    render(<MarkdownTextContent isRunning={false} text={markdown} />)
+
+    expect(await screen.findByText('Open 114教學實踐成果交流會_整合修正版.pptx')).toBeTruthy()
+  })
+
+  it('preserves the readable link label when the media href basename is encoded more than once', async () => {
+    const encodedPath =
+      'C:/Users/user/Downloads/114教學實踐計畫審閱/期末報告/114%25E6%2595%2599%25E5%25AD%25B8%25E5%25AF%25A6%25E8%25B8%2590%25E6%2588%2590%25E6%259E%259C%25E4%25BA%25A4%25E6%25B5%2581%25E6%259C%2583_%25E6%2595%25B4%25E5%2590%2588%25E4%25BF%25AE%25E6%25AD%25A3%25E7%2589%2588.pptx'
+
+    const href = `#media:${encodeURIComponent(encodedPath)}`
+
+    render(
+      <MarkdownTextContent
+        isRunning={false}
+        text={`[File: 114教學實踐成果交流會_整合修正版.pptx](${href})`}
+      />
+    )
+
+    expect(await screen.findByText('Open 114教學實踐成果交流會_整合修正版.pptx')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -11,9 +11,32 @@ import {
   isInlineMediaSrc,
   isRemoteGateway,
   mediaExternalUrl,
+  mediaName,
   resolveMediaDisplaySrc,
   resolveMediaPlaybackSrc
 } from './media'
+
+describe('mediaName', () => {
+  it('returns the decoded basename for a Windows path with non-ASCII characters', () => {
+    expect(
+      mediaName(
+        String.raw`C:\Users\user\Documents\張耀祖論文_送印前稽核報告.md`
+      )
+    ).toBe('張耀祖論文_送印前稽核報告.md')
+  })
+
+  it('decodes a percent-encoded non-ASCII basename from a file URL', () => {
+    expect(
+      mediaName(
+        'file:///C:/Users/user/Documents/%E5%BC%B5%E8%80%80%E7%A5%96%E8%AB%96%E6%96%87_%E9%80%81%E5%8D%B0%E5%89%8D%E7%A8%BD%E6%A0%B8%E5%A0%B1%E5%91%8A.md'
+      )
+    ).toBe('張耀祖論文_送印前稽核報告.md')
+  })
+
+  it('preserves a basename containing a malformed percent escape', () => {
+    expect(mediaName('file:///C:/Users/user/Documents/report%ZZ.md')).toBe('report%ZZ.md')
+  })
+})
 
 describe('isRemoteGateway', () => {
   afterEach(() => {

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -44,14 +44,26 @@ export function mediaMime(path: string): string {
   return mediaInfo(path)?.mime ?? 'application/octet-stream'
 }
 
+function decodeMediaName(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
 export function mediaName(path: string): string {
+  let name: string | undefined
+
   try {
     const url = new URL(path)
 
-    return url.pathname.split('/').filter(Boolean).pop() || path
+    name = url.pathname.split(/[\\/]/).filter(Boolean).pop()
   } catch {
-    return path.split(/[\\/]/).filter(Boolean).pop() || path
+    name = path.split(/[\\/]/).filter(Boolean).pop()
   }
+
+  return decodeMediaName(name || path)
 }
 
 export function mediaMarkdownHref(path: string): string {

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -55,14 +55,26 @@ export function mediaMime(path: string): string {
   return mediaInfo(path)?.mime ?? 'application/octet-stream'
 }
 
+function decodeMediaName(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
 export function mediaName(path: string): string {
+  let name: string | undefined
+
   try {
     const url = new URL(path)
 
-    return url.pathname.split('/').filter(Boolean).pop() || path
+    name = url.pathname.split(/[\\/]/).filter(Boolean).pop()
   } catch {
-    return path.split(/[\\/]/).filter(Boolean).pop() || path
+    name = path.split(/[\\/]/).filter(Boolean).pop()
   }
+
+  return decodeMediaName(name || path)
 }
 
 export function mediaMarkdownHref(path: string): string {


### PR DESCRIPTION
## Summary
- decode percent-encoded attachment basenames before displaying them
- extract basenames across both Windows (`\`) and POSIX (`/`) separators
- preserve malformed percent escapes instead of throwing
- refresh the fix onto the current `main` after the issue reappeared following a Desktop update

## Problem
Hermes Desktop displayed a local attachment named `張耀祖論文_送印前稽核報告.md` as `%E5%BC%B5%E8%80%80%E7%A5%96...md`. `new URL(path).pathname` percent-encodes non-ASCII characters, and `mediaName()` returned that encoded segment without decoding it. Windows paths also require splitting on backslashes after URL parsing.

## Tests
- `npm exec -- vitest run --project ui src/lib/media.remote.test.ts src/lib/chat-messages.test.ts` — 59 passed
- `npm run typecheck`
- `npm exec -- eslint src/lib/media.ts src/lib/media.remote.test.ts`
- production renderer build and Windows unpacked package build

Added coverage for:
1. Unicode basenames in Windows paths
2. Percent-encoded Unicode basenames in `file://` URLs
3. Malformed percent escapes
