### PR TITLE
fix(teams): don't claim approval when the resolve matched nothing

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -1066,7 +1066,14 @@ class TeamsAdapter(BasePlatformAdapter):
                 ),
             )
 
-        resolve_gateway_approval(session_key, choice)
+        # The resolve count is authoritative, not the has_blocking_approval
+        # pre-check above: the approval wait can time out (failing closed and
+        # denying the command) between that check and this call, and another
+        # surface — /approve, a second platform, the TUI — can resolve it in
+        # the same window. Rendering "Allowed" off the button the user pressed
+        # would then tell the operator a dangerous command ran with their
+        # approval when it had in fact already been denied.
+        resolved = resolve_gateway_approval(session_key, choice)
 
         label_map = {
             "once": "✅ Allowed (once)",
@@ -1082,7 +1089,26 @@ class TeamsAdapter(BasePlatformAdapter):
             body.append(TextBlock(text=f"```\n{cmd}\n```", wrap=True))
         if desc:
             body.append(TextBlock(text=f"Reason: {desc}", wrap=True, isSubtle=True))
-        body.append(TextBlock(text=label_map[choice], wrap=True, weight="Bolder"))
+        if resolved:
+            body.append(TextBlock(text=label_map[choice], wrap=True, weight="Bolder"))
+        else:
+            body.append(
+                TextBlock(
+                    text="⌛ Approval expired — command was not run",
+                    wrap=True,
+                    weight="Bolder",
+                )
+            )
+            body.append(
+                TextBlock(
+                    text=(
+                        "Nothing was waiting on this prompt: it already timed "
+                        "out (and was denied) or was resolved elsewhere."
+                    ),
+                    wrap=True,
+                    isSubtle=True,
+                )
+            )
 
         return InvokeResponse(
             status=200,

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -1125,3 +1125,102 @@ class TestTeamsMediaAttachments:
         result = await adapter.send_document("19:abc@thread.v2", "/no/such/file.pdf")
         assert not result.success
         adapter._app.send.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Tests: approval card actions — stale-tap honesty
+# ---------------------------------------------------------------------------
+
+
+class TestTeamsApprovalCardAction:
+    """A tap must never claim approval the resolver did not actually grant.
+
+    ``has_blocking_approval`` runs BEFORE the resolve, so the approval wait can
+    time out — failing closed and denying the command — in the window between
+    the two, and another surface (/approve, a second platform, the TUI) can
+    resolve it there too.  The resolve count is the only authoritative answer.
+    Same contract the Telegram/Discord/Slack and WhatsApp Cloud/Feishu button
+    paths follow.
+    """
+
+    def _adapter(self):
+        return TeamsAdapter(
+            _make_config(client_id="id", client_secret="secret", tenant_id="tenant")
+        )
+
+    def _ctx(self, action="approve_once", user="u1"):
+        ctx = MagicMock()
+        ctx.activity.value.action.data = {
+            "hermes_action": action,
+            "session_key": "agent:main:teams:dm:u1",
+            "cmd": "rm -rf /important",
+            "desc": "recursive delete",
+        }
+        ctx.activity.from_ = MagicMock(aad_object_id=user, id=user)
+        return ctx
+
+    async def _render(self, resolve_count):
+        """Drive _on_card_action and return the rendered TextBlock texts."""
+        import os
+        from unittest.mock import patch
+
+        seen = []
+
+        def _record(*args, **kwargs):
+            if "text" in kwargs:
+                seen.append(str(kwargs["text"]))
+            elif args:
+                seen.append(str(args[0]))
+            return MagicMock()
+
+        adapter = self._adapter()
+        with patch.dict(os.environ, {"TEAMS_ALLOWED_USERS": "*"}, clear=False), \
+             patch.object(_teams_mod, "TextBlock", _record), \
+             patch("tools.approval.has_blocking_approval", return_value=True), \
+             patch("tools.approval.resolve_gateway_approval", return_value=resolve_count):
+            await adapter._on_card_action(self._ctx())
+        return seen
+
+    @pytest.mark.asyncio
+    async def test_stale_tap_shows_expired_not_approved(self):
+        """Resolver matched nothing → the command was already denied."""
+        texts = await self._render(resolve_count=0)
+
+        joined = " ".join(texts)
+        assert "Allowed" not in joined, (
+            "a tap that resolved nothing claimed the command was approved"
+        )
+        assert "expired" in joined.lower()
+        assert "was not run" in joined.lower()
+
+    @pytest.mark.asyncio
+    async def test_successful_tap_still_renders_the_choice(self):
+        """Control: a real approval must keep its normal confirmation."""
+        texts = await self._render(resolve_count=1)
+
+        joined = " ".join(texts)
+        assert "✅ Allowed (once)" in joined
+        assert "expired" not in joined.lower()
+
+    @pytest.mark.asyncio
+    async def test_stale_deny_tap_does_not_claim_a_denial_it_did_not_make(self):
+        """The same honesty applies to the deny button."""
+        seen = []
+        import os
+        from unittest.mock import patch
+
+        def _record(*args, **kwargs):
+            if "text" in kwargs:
+                seen.append(str(kwargs["text"]))
+            return MagicMock()
+
+        adapter = self._adapter()
+        with patch.dict(os.environ, {"TEAMS_ALLOWED_USERS": "*"}, clear=False), \
+             patch.object(_teams_mod, "TextBlock", _record), \
+             patch("tools.approval.has_blocking_approval", return_value=True), \
+             patch("tools.approval.resolve_gateway_approval", return_value=0):
+            await adapter._on_card_action(self._ctx(action="deny"))
+
+        joined = " ".join(seen)
+        assert "❌ Denied" not in joined
+        assert "expired" in joined.lower()


### PR DESCRIPTION
## Summary

**#68597** made every messaging approval button honest about a stale tap:
Telegram/Discord/Slack were resolving *after* rendering "✅ Approved by
\<user\>", and WhatsApp Cloud/Feishu were ignoring a zero resolve count. All of
them now resolve first and render *"Approval expired — command was not run"*
when nothing was waiting.

**Teams is in the second group and was not part of that pass.**
`_on_card_action` throws the resolve result away:

```python
resolve_gateway_approval(session_key, choice)
...
body.append(TextBlock(text=label_map[choice], ...))
```

so the confirmation card is rendered off the button the user pressed, never off
what actually happened.

The `has_blocking_approval` guard above it is a pre-check, not a substitute: the
approval wait can time out — failing closed and **denying** the command — in the
window between that check and the resolve, and another surface (`/approve`, a
second platform, the TUI) can resolve it there too. That window is exactly what
#68597 widened attention to: gateway waits were silently 60s, so taps arriving
from a push notification *after* the wait already failed closed are the common
case, not the rare one.

I audited every `resolve_gateway_approval` caller — Matrix (`if count:`), QQBot
(logs only, makes no claim) and `api_server` (`409` on `<= 0`) all honor the
result. Teams is the only outlier.

## Reproduction

Driving the real `_on_card_action` with the resolver returning 0:

```
resolver call: ('agent:main:teams:dm:u1', 'once') -> 0   (nothing was waiting)
rendered: "⚠️ Command Approval Required" | "rm -rf /important"
          | "Reason: recursive delete"   | "✅ Allowed (once)"
```

The operator is told a recursive delete ran with their approval; it had already
been denied.

## Fix

Honor the count: render the choice label only when the resolve matched
something, otherwise render the expired notice. The happy path is unchanged. The
deny button gets the same treatment — a stale tap must not report a denial it
did not make either, since that equally misrepresents what the agent did.

## Test plan

`tests/gateway/test_teams.py` — new `TestTeamsApprovalCardAction`:

- a zero-count **approve** tap renders expired and never "Allowed"
- a zero-count **deny** tap does not claim a denial it did not make
- control: a real approval keeps its normal confirmation

The two stale-tap tests **fail on `main`**; the control **passes there**.
`494 passed` across the Teams, approval, command-guard, and Telegram/Feishu
approval-button suites (2 failures in `test_approval.py` are pre-existing and
fail identically on clean `main` — a Windows symlink/pathlib artifact).

## Checklist

- [x] Tested on Ubuntu 24.04
- [x] New tests fail without the fix and pass with it
- [x] No regressions (all remaining failures reproduced on clean `main`)
- [x] Follows the contract #68597 established for the other five platforms