### PR TITLE
feat(kanban): add dispatcher admission caps

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -827,7 +827,7 @@ class GatewayKanbanWatchersMixin:
         interval = max(interval, 1.0)  # sanity floor — tighter than this is a footgun
 
         # Read max_spawn config to limit concurrent kanban tasks
-        max_spawn = kanban_cfg.get("max_spawn", None)
+        max_spawn = _kb._positive_optional_int(kanban_cfg.get("max_spawn", None))
         if max_spawn is not None:
             logger.info(f"kanban dispatcher: max_spawn={max_spawn}")
 
@@ -929,6 +929,23 @@ class GatewayKanbanWatchersMixin:
                         max_in_progress_per_profile,
                     )
 
+        max_task_starts_per_hour = _kb._positive_optional_int(
+            kanban_cfg.get("max_task_starts_per_hour")
+        )
+        if max_task_starts_per_hour is not None:
+            logger.info(
+                "kanban dispatcher: max_task_starts_per_hour=%d",
+                max_task_starts_per_hour,
+            )
+        spend_config = _kb.spend_admission_config_from_kanban_config(kanban_cfg)
+        if spend_config.cap_usd is not None:
+            logger.info(
+                "kanban dispatcher: daily_spend_cap_usd=%.4f timezone=%s unknown_cost_policy=%s",
+                spend_config.cap_usd,
+                spend_config.timezone_name,
+                spend_config.unknown_cost_policy,
+            )
+
         # Initial delay so the gateway finishes wiring adapters before the
         # dispatcher spawns workers (those workers may hit gateway notify
         # subscriptions etc.). Matches the notifier watcher's delay.
@@ -1022,6 +1039,8 @@ class GatewayKanbanWatchersMixin:
                     stale_timeout_seconds=stale_timeout_seconds,
                     default_assignee=default_assignee,
                     max_in_progress_per_profile=max_in_progress_per_profile,
+                    max_task_starts_per_hour=max_task_starts_per_hour,
+                    spend_config=spend_config,
                 )
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2894,6 +2894,27 @@ DEFAULT_CONFIG = {
         # otherwise saturate one profile's local model / API quota /
         # browser pool while leaving other profiles idle.
         "max_in_progress_per_profile": None,
+        # Global concurrency caps already consumed by the dispatcher. Unset
+        # (None) preserves historical uncapped behavior.
+        "max_in_progress": None,
+        "max_spawn": None,
+        # Rolling task-start admission cap. When set to a positive int, the
+        # dispatcher allows at most N native task_runs starts in the trailing
+        # hour. Held tasks stay ready/review and failure counters are untouched.
+        "max_task_starts_per_hour": None,
+        # Daily known-metered spend admission cap in USD. Unset disables the
+        # check. The cap reads local state.db session_model_usage ledgers across
+        # installed profiles using read-only SQLite connections. Actual dollars
+        # take precedence over estimated dollars; unknown-cost rows are visible
+        # in telemetry but do not count toward the cap.
+        "daily_spend_cap_usd": None,
+        # IANA timezone for the daily spend boundary. Invalid values fall back
+        # to UTC; DST boundaries are local-midnight to local-midnight.
+        "daily_spend_timezone": "UTC",
+        # Unknown-cost policy for daily spend admission: "allow" (default,
+        # report telemetry only) or "hold" (defer spawns while today's ledger
+        # has unknown-cost rows).
+        "unknown_cost_policy": "allow",
         # When true, the kanban dispatcher auto-runs the decomposer on
         # tasks that land in Triage (every dispatcher tick). When false,
         # decomposition is manual via `hermes kanban decompose <id>` or

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2287,6 +2287,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             _kanban_cfg.get("max_in_progress_per_profile")
         )
         max_in_progress = _coerce_positive_int(_kanban_cfg.get("max_in_progress"))
+        max_task_starts_per_hour = _coerce_positive_int(
+            _kanban_cfg.get("max_task_starts_per_hour")
+        )
+        spend_config = kb.spend_admission_config_from_kanban_config(_kanban_cfg)
         # CLI --max overrides config kanban.max_spawn when both are present;
         # CLI is the more explicit signal so it wins.
         cli_max = getattr(args, "max", None)
@@ -2297,6 +2301,8 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         default_assignee = None
         max_in_progress_per_profile = None
         max_in_progress = None
+        max_task_starts_per_hour = None
+        spend_config = None
         max_spawn = getattr(args, "max", None)
     with kb.connect_closing() as conn:
         res = kb.dispatch_once(
@@ -2307,6 +2313,8 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            max_task_starts_per_hour=max_task_starts_per_hour,
+            spend_config=spend_config,
         )
     if getattr(args, "json", False):
         print(json.dumps({
@@ -2327,6 +2335,20 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 for (tid, who, current) in res.skipped_per_profile_capped
             ],
             "auto_assigned_default": res.auto_assigned_default,
+            "skipped_rolling_start_capped": [
+                {"task_id": tid, "starts": starts, "cap": cap}
+                for (tid, starts, cap) in res.skipped_rolling_start_capped
+            ],
+            "skipped_daily_spend_capped": [
+                {"task_id": tid, "known_metered_cost_usd": cost, "cap_usd": cap}
+                for (tid, cost, cap) in res.skipped_daily_spend_capped
+            ],
+            "skipped_spend_ledger_unavailable": res.skipped_spend_ledger_unavailable,
+            "skipped_unknown_cost_policy": [
+                {"task_id": tid, "unknown_cost_rows": rows}
+                for (tid, rows) in res.skipped_unknown_cost_policy
+            ],
+            "spend_telemetry": res.spend_telemetry,
         }, indent=2))
         return 0
     print(f"Reclaimed:    {res.reclaimed}")
@@ -2364,6 +2386,14 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
         )
+    if res.skipped_rolling_start_capped:
+        print(f"Deferred (rolling start cap): {len(res.skipped_rolling_start_capped)}")
+    if res.skipped_daily_spend_capped:
+        print(f"Deferred (daily spend cap): {len(res.skipped_daily_spend_capped)}")
+    if res.skipped_spend_ledger_unavailable:
+        print(f"Deferred (spend ledger unavailable): {len(res.skipped_spend_ledger_unavailable)}")
+    if res.skipped_unknown_cost_policy:
+        print(f"Deferred (unknown-cost policy): {len(res.skipped_unknown_cost_policy)}")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -74,6 +74,7 @@ import contextlib
 import hashlib
 import json
 import os
+import posixpath
 import re
 import random
 import secrets
@@ -89,6 +90,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, time as datetime_time, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterable, Optional
+from urllib.parse import unquote, urlsplit
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
@@ -6115,6 +6117,8 @@ class SpendLedgerSummary:
     unknown_cost_rows: int = 0
     known_cost_rows: int = 0
     included_cost_rows: int = 0
+    explicit_included_cost_rows: int = 0
+    transport_inferred_included_rows: int = 0
     profiles_read: int = 0
     ledgers_read: int = 0
     ledgers_unavailable: int = 0
@@ -6132,6 +6136,8 @@ class SpendLedgerSummary:
             "unknown_cost_rows": self.unknown_cost_rows,
             "known_cost_rows": self.known_cost_rows,
             "included_cost_rows": self.included_cost_rows,
+            "explicit_included_cost_rows": self.explicit_included_cost_rows,
+            "transport_inferred_included_rows": self.transport_inferred_included_rows,
             "profiles_read": self.profiles_read,
             "ledgers_read": self.ledgers_read,
             "ledgers_unavailable": self.ledgers_unavailable,
@@ -7539,6 +7545,35 @@ def _day_bounds_for_timezone(tz_name: str, *, now: Optional[float] = None) -> tu
     return start.timestamp(), end.timestamp(), canonical_name
 
 
+def _is_native_chatgpt_codex_subscription_transport(base_url: Any) -> bool:
+    """Return True only for Hermes' native ChatGPT Codex subscription endpoint.
+
+    This intentionally trusts endpoint shape only, not provider labels or model
+    names. It also rejects userinfo, non-HTTPS schemes, and hostname suffix or
+    substring tricks so arbitrary OpenAI-compatible/custom metered endpoints stay
+    fail-closed under ``unknown_cost_policy: hold``.
+    """
+    raw = str(base_url or "").strip()
+    if not raw:
+        return False
+    try:
+        parsed = urlsplit(raw)
+    except ValueError:
+        return False
+    if parsed.scheme.lower() != "https":
+        return False
+    if parsed.username or parsed.password:
+        return False
+    hostname = (parsed.hostname or "").strip().lower().rstrip(".")
+    if hostname != "chatgpt.com":
+        return False
+    decoded_path = unquote(parsed.path or "/")
+    normalized_path = posixpath.normpath("/" + decoded_path.lstrip("/"))
+    return normalized_path == "/backend-api/codex" or normalized_path.startswith(
+        "/backend-api/codex/"
+    )
+
+
 def _installed_profile_homes_for_spend() -> list[Path]:
     from hermes_constants import get_default_hermes_root
 
@@ -7576,14 +7611,17 @@ def read_daily_spend_ledger(
 ) -> SpendLedgerSummary:
     """Aggregate known metered spend from installed profiles' state.db files.
 
-    Read-only by construction. Actual dollars win over estimated dollars for a
-    row; rows with neither stay visible as unknown-cost telemetry and do not
-    contribute to the spend cap.
+    Read-only by construction. Explicit subscription-included telemetry always
+    wins first and does not contribute to the spend cap. Otherwise actual
+    dollars win over estimated dollars. Zero-cost blank rows are unknown unless
+    their endpoint is the strict native ChatGPT Codex subscription transport, in
+    which case they are counted separately as transport-inferred included rows.
     """
     start_ts, end_ts, tz_name = _day_bounds_for_timezone(config.timezone_name, now=now)
     homes = profile_homes if profile_homes is not None else _installed_profile_homes_for_spend()
     known = actual = estimated = 0.0
     unknown_rows = known_rows = included_rows = ledgers_read = unavailable = 0
+    explicit_included_rows = transport_inferred_included_rows = 0
     errors: list[str] = []
     for home in homes:
         db_path = Path(home) / "state.db"
@@ -7639,6 +7677,12 @@ def read_daily_spend_ledger(
             cost_status_expr = (
                 "u.cost_status" if "cost_status" in usage_columns else "NULL"
             )
+            billing_provider_expr = (
+                "u.billing_provider" if "billing_provider" in usage_columns else "NULL"
+            )
+            billing_base_url_expr = (
+                "u.billing_base_url" if "billing_base_url" in usage_columns else "NULL"
+            )
             join_clause = "LEFT JOIN sessions s ON s.id = u.session_id" if has_sessions else ""
             source_filter = ""
             if has_sessions and "source" in session_columns:
@@ -7649,6 +7693,8 @@ def read_daily_spend_ledger(
                           {estimated_expr} AS estimated_cost_usd,
                           {billing_mode_expr} AS billing_mode,
                           {cost_status_expr} AS cost_status,
+                          {billing_provider_expr} AS billing_provider,
+                          {billing_base_url_expr} AS billing_base_url,
                           {seen_expr} AS seen_at
                    FROM session_model_usage u
                    {join_clause}
@@ -7660,7 +7706,13 @@ def read_daily_spend_ledger(
             for row in rows:
                 billing_mode = str(row["billing_mode"] or "").strip().lower()
                 cost_status = str(row["cost_status"] or "").strip().lower()
+                # Classification precedence is load-bearing for fail-closed
+                # admission: explicit included rows are ignored even if legacy
+                # code wrote dollars; positive metered costs always count;
+                # only then can a zero-cost blank row be inferred as included
+                # from the native ChatGPT Codex subscription endpoint.
                 if billing_mode == "subscription_included" or cost_status == "included":
+                    explicit_included_rows += 1
                     included_rows += 1
                     continue
                 try:
@@ -7677,6 +7729,15 @@ def read_daily_spend_ledger(
                     estimated += est
                     known += est
                     known_rows += 1
+                elif (
+                    not billing_mode
+                    and not cost_status
+                    and _is_native_chatgpt_codex_subscription_transport(
+                        row["billing_base_url"]
+                    )
+                ):
+                    transport_inferred_included_rows += 1
+                    included_rows += 1
                 else:
                     unknown_rows += 1
         except sqlite3.DatabaseError as exc:
@@ -7693,6 +7754,8 @@ def read_daily_spend_ledger(
         unknown_cost_rows=unknown_rows,
         known_cost_rows=known_rows,
         included_cost_rows=included_rows,
+        explicit_included_cost_rows=explicit_included_rows,
+        transport_inferred_included_rows=transport_inferred_included_rows,
         profiles_read=len(homes),
         ledgers_read=ledgers_read,
         ledgers_unavailable=unavailable,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -86,8 +86,10 @@ import logging
 import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
+from datetime import datetime, time as datetime_time, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterable, Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
@@ -6079,6 +6081,63 @@ class DispatchResult:
     DB writes this tick — the lock holder is making progress on the same
     board. This is the steady-state signal that a single-writer guard is
     actively preventing two dispatchers from racing on ``kanban.db``."""
+    skipped_rolling_start_capped: list[tuple[str, int, int]] = field(default_factory=list)
+    """Ready/review task ids deferred by ``kanban.max_task_starts_per_hour``.
+    Entries are ``(task_id, starts_in_window, cap)``. Tasks stay ready/review
+    and failure counters are not touched."""
+    skipped_daily_spend_capped: list[tuple[str, float, float]] = field(default_factory=list)
+    """Ready/review task ids deferred by ``kanban.daily_spend_cap_usd``.
+    Entries are ``(task_id, known_metered_spend_usd, cap_usd)``."""
+    skipped_spend_ledger_unavailable: list[str] = field(default_factory=list)
+    """Ready/review task ids held fail-closed because a positive daily spend
+    cap was configured but no canonical local usage ledger could be read."""
+    skipped_unknown_cost_policy: list[tuple[str, int]] = field(default_factory=list)
+    """Ready/review task ids held by ``kanban.unknown_cost_policy: hold``
+    because today's ledger contains unmetered/unknown-cost rows."""
+    spend_telemetry: dict[str, Any] = field(default_factory=dict)
+    """Sanitized spend-admission telemetry. Contains aggregate dollars/counts
+    only; never prompt, message, or session content."""
+
+
+@dataclass(frozen=True)
+class SpendAdmissionConfig:
+    cap_usd: Optional[float] = None
+    timezone_name: str = "UTC"
+    unknown_cost_policy: str = "allow"
+
+
+@dataclass(frozen=True)
+class SpendLedgerSummary:
+    ledger_readable: bool
+    known_metered_cost_usd: float = 0.0
+    actual_cost_usd: float = 0.0
+    estimated_cost_usd: float = 0.0
+    unknown_cost_rows: int = 0
+    known_cost_rows: int = 0
+    profiles_read: int = 0
+    ledgers_read: int = 0
+    ledgers_unavailable: int = 0
+    day_start_ts: float = 0.0
+    day_end_ts: float = 0.0
+    timezone_name: str = "UTC"
+    errors: tuple[str, ...] = ()
+
+    def telemetry(self) -> dict[str, Any]:
+        return {
+            "ledger_readable": self.ledger_readable,
+            "known_metered_cost_usd": round(self.known_metered_cost_usd, 8),
+            "actual_cost_usd": round(self.actual_cost_usd, 8),
+            "estimated_cost_usd": round(self.estimated_cost_usd, 8),
+            "unknown_cost_rows": self.unknown_cost_rows,
+            "known_cost_rows": self.known_cost_rows,
+            "profiles_read": self.profiles_read,
+            "ledgers_read": self.ledgers_read,
+            "ledgers_unavailable": self.ledgers_unavailable,
+            "day_start_ts": self.day_start_ts,
+            "day_end_ts": self.day_end_ts,
+            "timezone": self.timezone_name,
+            "errors": list(self.errors[:5]),
+        }
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -7436,6 +7495,162 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     return False
 
 
+def _positive_optional_int(value: Any) -> Optional[int]:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _positive_optional_float(value: Any) -> Optional[float]:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def spend_admission_config_from_kanban_config(kanban_cfg: Optional[dict]) -> SpendAdmissionConfig:
+    cfg = kanban_cfg or {}
+    tz_name = str(cfg.get("daily_spend_timezone") or "UTC").strip() or "UTC"
+    policy = str(cfg.get("unknown_cost_policy") or "allow").strip().lower()
+    if policy not in {"allow", "hold"}:
+        policy = "allow"
+    return SpendAdmissionConfig(
+        cap_usd=_positive_optional_float(cfg.get("daily_spend_cap_usd")),
+        timezone_name=tz_name,
+        unknown_cost_policy=policy,
+    )
+
+
+def _day_bounds_for_timezone(tz_name: str, *, now: Optional[float] = None) -> tuple[float, float, str]:
+    try:
+        tz = ZoneInfo(tz_name)
+        canonical_name = tz_name
+    except (ZoneInfoNotFoundError, ValueError):
+        tz = timezone.utc
+        canonical_name = "UTC"
+    dt = datetime.fromtimestamp(time.time() if now is None else now, tz)
+    start = datetime.combine(dt.date(), datetime_time.min, tzinfo=tz)
+    end = datetime.combine(dt.date() + timedelta(days=1), datetime_time.min, tzinfo=tz)
+    return start.timestamp(), end.timestamp(), canonical_name
+
+
+def _installed_profile_homes_for_spend() -> list[Path]:
+    from hermes_constants import get_default_hermes_root
+
+    root = get_default_hermes_root()
+    homes = [root]
+    profiles_dir = root / "profiles"
+    try:
+        homes.extend(child for child in sorted(profiles_dir.iterdir()) if child.is_dir())
+    except OSError:
+        pass
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for home in homes:
+        try:
+            key = str(home.resolve())
+        except OSError:
+            key = str(home)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(home)
+    return unique
+
+
+def read_daily_spend_ledger(
+    config: SpendAdmissionConfig,
+    *,
+    now: Optional[float] = None,
+    profile_homes: Optional[list[Path]] = None,
+) -> SpendLedgerSummary:
+    """Aggregate known metered spend from installed profiles' state.db files.
+
+    Read-only by construction. Actual dollars win over estimated dollars for a
+    row; rows with neither stay visible as unknown-cost telemetry and do not
+    contribute to the spend cap.
+    """
+    start_ts, end_ts, tz_name = _day_bounds_for_timezone(config.timezone_name, now=now)
+    homes = profile_homes if profile_homes is not None else _installed_profile_homes_for_spend()
+    known = actual = estimated = 0.0
+    unknown_rows = known_rows = ledgers_read = unavailable = 0
+    errors: list[str] = []
+    for home in homes:
+        db_path = Path(home) / "state.db"
+        if not db_path.exists():
+            continue
+        conn = None
+        try:
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1.0)
+            conn.row_factory = sqlite3.Row
+            if not conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='session_model_usage'"
+            ).fetchone():
+                unavailable += 1
+                errors.append(f"{db_path}:missing session_model_usage")
+                continue
+            ledgers_read += 1
+            rows = conn.execute(
+                """SELECT u.actual_cost_usd, u.estimated_cost_usd,
+                          COALESCE(u.last_seen, s.ended_at, s.started_at) AS seen_at
+                   FROM session_model_usage u
+                   LEFT JOIN sessions s ON s.id = u.session_id
+                   WHERE COALESCE(u.last_seen, s.ended_at, s.started_at) >= ?
+                     AND COALESCE(u.last_seen, s.ended_at, s.started_at) < ?
+                     AND COALESCE(s.source, '') NOT IN ('_health_probe')""",
+                (start_ts, end_ts),
+            ).fetchall()
+            for row in rows:
+                try:
+                    act = float(row["actual_cost_usd"] or 0.0)
+                    est = float(row["estimated_cost_usd"] or 0.0)
+                except (TypeError, ValueError):
+                    unknown_rows += 1
+                    continue
+                if act > 0:
+                    actual += act
+                    known += act
+                    known_rows += 1
+                elif est > 0:
+                    estimated += est
+                    known += est
+                    known_rows += 1
+                else:
+                    unknown_rows += 1
+        except sqlite3.DatabaseError as exc:
+            unavailable += 1
+            errors.append(f"{db_path}:{type(exc).__name__}")
+        finally:
+            if conn is not None:
+                conn.close()
+    return SpendLedgerSummary(
+        ledger_readable=ledgers_read > 0,
+        known_metered_cost_usd=known,
+        actual_cost_usd=actual,
+        estimated_cost_usd=estimated,
+        unknown_cost_rows=unknown_rows,
+        known_cost_rows=known_rows,
+        profiles_read=len(homes),
+        ledgers_read=ledgers_read,
+        ledgers_unavailable=unavailable,
+        day_start_ts=start_ts,
+        day_end_ts=end_ts,
+        timezone_name=tz_name,
+        errors=tuple(errors),
+    )
+
+
+def _task_start_count_last_hour(conn: sqlite3.Connection, *, now: Optional[int] = None) -> int:
+    cutoff = int(time.time() if now is None else now) - 3600
+    return int(conn.execute(
+        "SELECT COUNT(*) FROM task_runs WHERE started_at >= ?",
+        (cutoff,),
+    ).fetchone()[0])
+
+
 def dispatch_once(
     conn: sqlite3.Connection,
     *,
@@ -7449,6 +7664,9 @@ def dispatch_once(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    max_task_starts_per_hour: Optional[int] = None,
+    spend_config: Optional[SpendAdmissionConfig] = None,
+    spend_ledger_reader=None,
 ) -> DispatchResult:
     """Run one dispatcher tick under the board's single-writer lock.
 
@@ -7483,6 +7701,9 @@ def dispatch_once(
             board=board,
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            max_task_starts_per_hour=max_task_starts_per_hour,
+            spend_config=spend_config,
+            spend_ledger_reader=spend_ledger_reader,
         )
     with _dispatch_tick_lock(db_path) as held:
         if not held:
@@ -7499,6 +7720,9 @@ def dispatch_once(
             board=board,
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            max_task_starts_per_hour=max_task_starts_per_hour,
+            spend_config=spend_config,
+            spend_ledger_reader=spend_ledger_reader,
         )
 
 
@@ -7515,6 +7739,9 @@ def _dispatch_once_locked(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    max_task_starts_per_hour: Optional[int] = None,
+    spend_config: Optional[SpendAdmissionConfig] = None,
+    spend_ledger_reader=None,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -7593,6 +7820,48 @@ def _dispatch_once_locked(
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
+    _review_probe_rows = conn.execute(
+        "SELECT id, assignee FROM tasks "
+        "WHERE status = 'review' AND claim_lock IS NULL "
+        "ORDER BY priority DESC, created_at ASC"
+    ).fetchall()
+    _pending_admission_ids = [r["id"] for r in ready_rows] + [r["id"] for r in _review_probe_rows]
+
+    _spend_cfg = spend_config or SpendAdmissionConfig()
+    if _spend_cfg.cap_usd is not None and _pending_admission_ids:
+        _ledger_reader = spend_ledger_reader or read_daily_spend_ledger
+        _spend_summary = _ledger_reader(_spend_cfg)
+        result.spend_telemetry = _spend_summary.telemetry()
+        result.spend_telemetry["cap_usd"] = _spend_cfg.cap_usd
+        result.spend_telemetry["unknown_cost_policy"] = _spend_cfg.unknown_cost_policy
+        if not _spend_summary.ledger_readable:
+            result.skipped_spend_ledger_unavailable.extend(_pending_admission_ids)
+            return result
+        if (
+            _spend_cfg.unknown_cost_policy == "hold"
+            and _spend_summary.unknown_cost_rows > 0
+        ):
+            result.skipped_unknown_cost_policy.extend(
+                (tid, _spend_summary.unknown_cost_rows) for tid in _pending_admission_ids
+            )
+            return result
+        if _spend_summary.known_metered_cost_usd >= _spend_cfg.cap_usd:
+            result.skipped_daily_spend_capped.extend(
+                (tid, _spend_summary.known_metered_cost_usd, _spend_cfg.cap_usd)
+                for tid in _pending_admission_ids
+            )
+            return result
+
+    _rolling_cap = _positive_optional_int(max_task_starts_per_hour)
+    _rolling_starts = (
+        _task_start_count_last_hour(conn) if _rolling_cap is not None else 0
+    )
+    if _rolling_cap is not None and _rolling_starts >= _rolling_cap and _pending_admission_ids:
+        result.skipped_rolling_start_capped.extend(
+            (tid, _rolling_starts, _rolling_cap) for tid in _pending_admission_ids
+        )
+        return result
+
     # Honour kanban.max_in_progress: if the board already has enough running
     # tasks, skip spawning this tick so slow workers (local LLMs,
     # resource-constrained hosts) can finish what they have before more tasks
@@ -7647,6 +7916,9 @@ def _dispatch_once_locked(
     for row in ready_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break
+        if _rolling_cap is not None and _rolling_starts + spawned >= _rolling_cap:
+            result.skipped_rolling_start_capped.append((row["id"], _rolling_starts + spawned, _rolling_cap))
+            continue
         row_assignee = row["assignee"]
         if not row_assignee:
             # Honour kanban.default_assignee: when the dispatcher hits an
@@ -7750,6 +8022,7 @@ def _dispatch_once_locked(
             continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
+            spawned += 1
             # Increment per-profile counter even in dry_run so the cap
             # check sees the would-be spawn on subsequent iterations.
             # Without this, dry_run reports every task as spawnable and
@@ -7830,14 +8103,13 @@ def _dispatch_once_locked(
     # Same concurrency model as ready dispatch: review spawns count
     # against max_spawn alongside ready tasks, so the total number of
     # running workers stays bounded.
-    review_rows = conn.execute(
-        "SELECT id, assignee FROM tasks "
-        "WHERE status = 'review' AND claim_lock IS NULL "
-        "ORDER BY priority DESC, created_at ASC"
-    ).fetchall()
+    review_rows = _review_probe_rows
     for row in review_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break
+        if _rolling_cap is not None and _rolling_starts + spawned >= _rolling_cap:
+            result.skipped_rolling_start_capped.append((row["id"], _rolling_starts + spawned, _rolling_cap))
+            continue
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
             continue
@@ -7850,6 +8122,7 @@ def _dispatch_once_locked(
             continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
+            spawned += 1
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6114,6 +6114,7 @@ class SpendLedgerSummary:
     estimated_cost_usd: float = 0.0
     unknown_cost_rows: int = 0
     known_cost_rows: int = 0
+    included_cost_rows: int = 0
     profiles_read: int = 0
     ledgers_read: int = 0
     ledgers_unavailable: int = 0
@@ -6130,6 +6131,7 @@ class SpendLedgerSummary:
             "estimated_cost_usd": round(self.estimated_cost_usd, 8),
             "unknown_cost_rows": self.unknown_cost_rows,
             "known_cost_rows": self.known_cost_rows,
+            "included_cost_rows": self.included_cost_rows,
             "profiles_read": self.profiles_read,
             "ledgers_read": self.ledgers_read,
             "ledgers_unavailable": self.ledgers_unavailable,
@@ -7561,6 +7563,11 @@ def _installed_profile_homes_for_spend() -> list[Path]:
     return unique
 
 
+def _sqlite_table_columns(conn: sqlite3.Connection, table_name: str) -> set[str]:
+    rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+    return {str(row[1]) for row in rows}
+
+
 def read_daily_spend_ledger(
     config: SpendAdmissionConfig,
     *,
@@ -7576,7 +7583,7 @@ def read_daily_spend_ledger(
     start_ts, end_ts, tz_name = _day_bounds_for_timezone(config.timezone_name, now=now)
     homes = profile_homes if profile_homes is not None else _installed_profile_homes_for_spend()
     known = actual = estimated = 0.0
-    unknown_rows = known_rows = ledgers_read = unavailable = 0
+    unknown_rows = known_rows = included_rows = ledgers_read = unavailable = 0
     errors: list[str] = []
     for home in homes:
         db_path = Path(home) / "state.db"
@@ -7592,18 +7599,70 @@ def read_daily_spend_ledger(
                 unavailable += 1
                 errors.append(f"{db_path}:missing session_model_usage")
                 continue
+            usage_columns = _sqlite_table_columns(conn, "session_model_usage")
+            has_sessions = bool(
+                conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='sessions'"
+                ).fetchone()
+            )
+            session_columns = _sqlite_table_columns(conn, "sessions") if has_sessions else set()
+
+            seen_terms: list[str] = []
+            if "last_seen" in usage_columns:
+                seen_terms.append("u.last_seen")
+            if has_sessions:
+                if "ended_at" in session_columns:
+                    seen_terms.append("s.ended_at")
+                if "started_at" in session_columns:
+                    seen_terms.append("s.started_at")
+            if not seen_terms:
+                unavailable += 1
+                errors.append(f"{db_path}:missing timestamp columns")
+                continue
+
+            seen_expr = (
+                seen_terms[0]
+                if len(seen_terms) == 1
+                else "COALESCE(" + ", ".join(seen_terms) + ")"
+            )
+            actual_expr = (
+                "u.actual_cost_usd" if "actual_cost_usd" in usage_columns else "NULL"
+            )
+            estimated_expr = (
+                "u.estimated_cost_usd"
+                if "estimated_cost_usd" in usage_columns
+                else "NULL"
+            )
+            billing_mode_expr = (
+                "u.billing_mode" if "billing_mode" in usage_columns else "NULL"
+            )
+            cost_status_expr = (
+                "u.cost_status" if "cost_status" in usage_columns else "NULL"
+            )
+            join_clause = "LEFT JOIN sessions s ON s.id = u.session_id" if has_sessions else ""
+            source_filter = ""
+            if has_sessions and "source" in session_columns:
+                source_filter = "AND COALESCE(s.source, '') NOT IN ('_health_probe')"
             ledgers_read += 1
             rows = conn.execute(
-                """SELECT u.actual_cost_usd, u.estimated_cost_usd,
-                          COALESCE(u.last_seen, s.ended_at, s.started_at) AS seen_at
+                f"""SELECT {actual_expr} AS actual_cost_usd,
+                          {estimated_expr} AS estimated_cost_usd,
+                          {billing_mode_expr} AS billing_mode,
+                          {cost_status_expr} AS cost_status,
+                          {seen_expr} AS seen_at
                    FROM session_model_usage u
-                   LEFT JOIN sessions s ON s.id = u.session_id
-                   WHERE COALESCE(u.last_seen, s.ended_at, s.started_at) >= ?
-                     AND COALESCE(u.last_seen, s.ended_at, s.started_at) < ?
-                     AND COALESCE(s.source, '') NOT IN ('_health_probe')""",
+                   {join_clause}
+                   WHERE {seen_expr} >= ?
+                     AND {seen_expr} < ?
+                     {source_filter}""",
                 (start_ts, end_ts),
             ).fetchall()
             for row in rows:
+                billing_mode = str(row["billing_mode"] or "").strip().lower()
+                cost_status = str(row["cost_status"] or "").strip().lower()
+                if billing_mode == "subscription_included" or cost_status == "included":
+                    included_rows += 1
+                    continue
                 try:
                     act = float(row["actual_cost_usd"] or 0.0)
                     est = float(row["estimated_cost_usd"] or 0.0)
@@ -7633,6 +7692,7 @@ def read_daily_spend_ledger(
         estimated_cost_usd=estimated,
         unknown_cost_rows=unknown_rows,
         known_cost_rows=known_rows,
+        included_cost_rows=included_rows,
         profiles_read=len(homes),
         ledgers_read=ledgers_read,
         ledgers_unavailable=unavailable,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -50,6 +50,7 @@ from pydantic import BaseModel, Field
 
 from hermes_cli import kanban_db
 from hermes_cli import kanban_diagnostics as kd
+from hermes_cli.config import load_config
 
 log = logging.getLogger(__name__)
 
@@ -1959,8 +1960,17 @@ def dispatch(
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
+        cfg = load_config()
+        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
         result = kanban_db.dispatch_once(
-            conn, dry_run=dry_run, max_spawn=max_n, board=board,
+            conn,
+            dry_run=dry_run,
+            max_spawn=max_n,
+            board=board,
+            max_task_starts_per_hour=kanban_db._positive_optional_int(
+                kanban_cfg.get("max_task_starts_per_hour")
+            ),
+            spend_config=kanban_db.spend_admission_config_from_kanban_config(kanban_cfg),
         )
         # DispatchResult is a dataclass.
         try:

--- a/tests/hermes_cli/test_kanban_admission_caps.py
+++ b/tests/hermes_cli/test_kanban_admission_caps.py
@@ -1,0 +1,213 @@
+"""Kanban dispatcher admission caps: rolling task starts and daily spend."""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_kanban_home(monkeypatch):
+    test_home = tempfile.mkdtemp(prefix="kanban_admission_caps_")
+    os.makedirs(os.path.join(test_home, "profiles", "alpha"), exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", test_home)
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("hermes_cli") or mod == "hermes_constants":
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+
+    yield Path(test_home), kanban_db
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+def _make_ready_tasks(kb, conn, count=3):
+    return [kb.create_task(conn, title=f"task {i}", assignee="alpha") for i in range(count)]
+
+
+def test_defaults_preserve_dispatch_behavior(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        _make_ready_tasks(kb, conn, 2)
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True)
+    assert len(res.spawned) == 2
+    assert not res.skipped_rolling_start_capped
+    assert not res.skipped_daily_spend_capped
+    assert not res.skipped_spend_ledger_unavailable
+
+
+def test_rolling_start_cap_holds_at_exact_threshold_without_mutating_tasks(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 2)
+        now = 1_700_000_000
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_runs (task_id, profile, status, started_at) VALUES (?, ?, ?, ?)",
+                ("previous", "alpha", "completed", now - 10),
+            )
+        monkeypatch_time = pytest.MonkeyPatch()
+        monkeypatch_time.setattr(kb.time, "time", lambda: now)
+        try:
+            res = kb.dispatch_once(
+                conn,
+                spawn_fn=_fake_spawn,
+                dry_run=True,
+                max_task_starts_per_hour=1,
+            )
+        finally:
+            monkeypatch_time.undo()
+        assert [row[0] for row in res.skipped_rolling_start_capped] == task_ids
+        rows = conn.execute(
+            "SELECT status, consecutive_failures FROM tasks ORDER BY created_at"
+        ).fetchall()
+        assert [(r["status"], r["consecutive_failures"]) for r in rows] == [("ready", 0), ("ready", 0)]
+
+
+def test_rolling_start_cap_allows_remaining_capacity_then_holds_rest(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 3)
+        now = 1_700_000_000
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_runs (task_id, profile, status, started_at) VALUES (?, ?, ?, ?)",
+                ("previous", "alpha", "completed", now - 10),
+            )
+        monkeypatch_time = pytest.MonkeyPatch()
+        monkeypatch_time.setattr(kb.time, "time", lambda: now)
+        try:
+            res = kb.dispatch_once(
+                conn,
+                spawn_fn=_fake_spawn,
+                dry_run=True,
+                max_task_starts_per_hour=2,
+            )
+        finally:
+            monkeypatch_time.undo()
+        assert [s[0] for s in res.spawned] == [task_ids[0]]
+        assert [h[0] for h in res.skipped_rolling_start_capped] == task_ids[1:]
+
+
+def _write_state_db(home: Path, rows):
+    db = home / "state.db"
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, started_at REAL, ended_at REAL)")
+        conn.execute(
+            """CREATE TABLE session_model_usage (
+                   session_id TEXT, model TEXT, billing_provider TEXT DEFAULT '', billing_base_url TEXT DEFAULT '',
+                   billing_mode TEXT DEFAULT '', task TEXT DEFAULT '', api_call_count INTEGER DEFAULT 0,
+                   input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0,
+                   cache_read_tokens INTEGER DEFAULT 0, cache_write_tokens INTEGER DEFAULT 0,
+                   reasoning_tokens INTEGER DEFAULT 0, estimated_cost_usd REAL DEFAULT 0,
+                   actual_cost_usd REAL DEFAULT 0, cost_status TEXT, cost_source TEXT,
+                   first_seen REAL, last_seen REAL
+               )"""
+        )
+        for idx, row in enumerate(rows):
+            sid = f"s{idx}"
+            conn.execute(
+                "INSERT INTO sessions (id, source, started_at, ended_at) VALUES (?, 'cli', ?, ?)",
+                (sid, row["seen"], row["seen"]),
+            )
+            conn.execute(
+                """INSERT INTO session_model_usage
+                   (session_id, model, estimated_cost_usd, actual_cost_usd, last_seen)
+                   VALUES (?, 'm', ?, ?, ?)""",
+                (sid, row.get("estimated", 0), row.get("actual", 0), row["seen"]),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_daily_spend_actual_wins_over_estimated_and_multi_profile(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    profile_home = home / "profiles" / "alpha"
+    now = 1_700_000_000
+    _write_state_db(home, [{"seen": now, "estimated": 5, "actual": 2}])
+    _write_state_db(profile_home, [{"seen": now, "estimated": 3, "actual": 0}])
+    cfg = kb.SpendAdmissionConfig(cap_usd=10, timezone_name="UTC")
+    summary = kb.read_daily_spend_ledger(cfg, now=now)
+    assert summary.ledger_readable is True
+    assert summary.known_metered_cost_usd == pytest.approx(5.0)
+    assert summary.actual_cost_usd == pytest.approx(2.0)
+    assert summary.estimated_cost_usd == pytest.approx(3.0)
+
+
+def test_daily_spend_cap_holds_without_state_mutation(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 2)
+        summary = kb.SpendLedgerSummary(
+            ledger_readable=True,
+            known_metered_cost_usd=12.5,
+            day_start_ts=0,
+            day_end_ts=1,
+        )
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=True,
+            spend_config=kb.SpendAdmissionConfig(cap_usd=10),
+            spend_ledger_reader=lambda _cfg: summary,
+        )
+        assert [h[0] for h in res.skipped_daily_spend_capped] == task_ids
+        assert not res.spawned
+        assert [r["status"] for r in conn.execute("SELECT status FROM tasks ORDER BY created_at")] == ["ready", "ready"]
+
+
+def test_positive_spend_cap_fails_closed_when_no_ledger_readable(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 1)
+        summary = kb.SpendLedgerSummary(ledger_readable=False)
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=True,
+            spend_config=kb.SpendAdmissionConfig(cap_usd=1),
+            spend_ledger_reader=lambda _cfg: summary,
+        )
+        assert res.skipped_spend_ledger_unavailable == task_ids
+        assert not res.spawned
+
+
+def test_unknown_cost_policy_hold_defers_and_reports_rows(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 1)
+        summary = kb.SpendLedgerSummary(
+            ledger_readable=True,
+            known_metered_cost_usd=0.25,
+            unknown_cost_rows=2,
+            day_start_ts=0,
+            day_end_ts=1,
+        )
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=True,
+            spend_config=kb.SpendAdmissionConfig(cap_usd=1, unknown_cost_policy="hold"),
+            spend_ledger_reader=lambda _cfg: summary,
+        )
+        assert res.skipped_unknown_cost_policy == [(task_ids[0], 2)]
+        assert res.spend_telemetry["unknown_cost_rows"] == 2
+        assert not res.spawned
+
+
+def test_daily_spend_day_boundary_uses_local_timezone_dst(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    # 2026-03-08 in America/Chicago is a spring-forward 23-hour local day.
+    noon_chicago_utc = 1_772_989_200
+    start, end, tz = kb._day_bounds_for_timezone("America/Chicago", now=noon_chicago_utc)
+    assert tz == "America/Chicago"
+    assert end - start == 23 * 60 * 60

--- a/tests/hermes_cli/test_kanban_admission_caps.py
+++ b/tests/hermes_cli/test_kanban_admission_caps.py
@@ -131,11 +131,13 @@ def _write_state_db(home: Path, rows, *, include_billing_columns: bool = True):
             ]
             values = [
                 sid,
-                "m",
+                row.get("model", "m"),
                 row.get("estimated", 0),
                 row.get("actual", 0),
                 row["seen"],
             ]
+            columns.extend(["billing_provider", "billing_base_url"])
+            values.extend([row.get("billing_provider", ""), row.get("billing_base_url", "")])
             if include_billing_columns:
                 columns.extend(["billing_mode", "cost_status"])
                 values.extend([row.get("billing_mode", ""), row.get("cost_status")])
@@ -224,6 +226,161 @@ def test_subscription_included_zero_cost_rows_allow_dispatch_under_hold(isolated
     assert [row[0] for row in res.spawned] == task_ids
     assert not res.skipped_unknown_cost_policy
     assert res.spend_telemetry["included_cost_rows"] == 1
+
+
+def test_native_chatgpt_codex_blank_zero_rows_allow_dispatch_under_hold_across_profiles(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    profile_homes = [home, home / "profiles" / "coder", home / "profiles" / "reviewer"]
+    for idx, profile_home in enumerate(profile_homes):
+        profile_home.mkdir(parents=True, exist_ok=True)
+        _write_state_db(
+            profile_home,
+            [{
+                "seen": now,
+                "actual": 0,
+                "estimated": 0,
+                "billing_provider": "auto",
+                "billing_base_url": "https://chatgpt.com/backend-api/codex/",
+                "billing_mode": "",
+                "cost_status": "",
+                "model": ["gpt-5.5", "gpt-5.6-sol", "gpt-5.5"][idx],
+            }],
+        )
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 1)
+        monkeypatch_time = pytest.MonkeyPatch()
+        monkeypatch_time.setattr(kb.time, "time", lambda: now)
+        try:
+            res = kb.dispatch_once(
+                conn,
+                spawn_fn=_fake_spawn,
+                dry_run=True,
+                spend_config=kb.SpendAdmissionConfig(
+                    cap_usd=1,
+                    timezone_name="UTC",
+                    unknown_cost_policy="hold",
+                ),
+            )
+        finally:
+            monkeypatch_time.undo()
+
+    assert [row[0] for row in res.spawned] == task_ids
+    assert not res.skipped_unknown_cost_policy
+    assert res.spend_telemetry["included_cost_rows"] == 3
+    assert res.spend_telemetry["explicit_included_cost_rows"] == 0
+    assert res.spend_telemetry["transport_inferred_included_rows"] == 3
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://evilchatgpt.com/backend-api/codex/",
+        "https://chatgpt.com.evil/backend-api/codex/",
+        "https://user@chatgpt.com/backend-api/codex/",
+        "http://chatgpt.com/backend-api/codex/",
+        "https://api.openai.com/v1",
+        "https://chatgpt.com/backend-api/codexish/",
+        "https://chatgpt.com/backend-api/codex/../metered/",
+    ],
+)
+def test_native_chatgpt_codex_transport_inference_rejects_spoofed_and_custom_urls(
+    isolated_kanban_home,
+    base_url,
+):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [{
+            "seen": now,
+            "actual": 0,
+            "estimated": 0,
+            "billing_provider": "auto",
+            "billing_base_url": base_url,
+            "billing_mode": "",
+            "cost_status": "",
+            "model": "gpt-5.5",
+        }],
+    )
+
+    summary = kb.read_daily_spend_ledger(
+        kb.SpendAdmissionConfig(cap_usd=1, timezone_name="UTC", unknown_cost_policy="hold"),
+        now=now,
+        profile_homes=[home],
+    )
+
+    assert summary.unknown_cost_rows == 1
+    assert summary.included_cost_rows == 0
+    assert summary.transport_inferred_included_rows == 0
+
+
+def test_provider_or_model_alone_do_not_mark_blank_zero_rows_included(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [
+            {
+                "seen": now,
+                "actual": 0,
+                "estimated": 0,
+                "billing_provider": "auto",
+                "billing_base_url": "",
+                "billing_mode": "",
+                "cost_status": "",
+                "model": "gpt-5.5",
+            },
+            {
+                "seen": now,
+                "actual": 0,
+                "estimated": 0,
+                "billing_provider": "chatgpt",
+                "billing_base_url": "",
+                "billing_mode": "",
+                "cost_status": "",
+                "model": "other-model",
+            },
+        ],
+    )
+
+    summary = kb.read_daily_spend_ledger(
+        kb.SpendAdmissionConfig(cap_usd=1, timezone_name="UTC", unknown_cost_policy="hold"),
+        now=now,
+        profile_homes=[home],
+    )
+
+    assert summary.unknown_cost_rows == 2
+    assert summary.included_cost_rows == 0
+
+
+def test_native_chatgpt_codex_blank_positive_cost_still_counts_as_metered(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [{
+            "seen": now,
+            "actual": 1.25,
+            "estimated": 0,
+            "billing_provider": "auto",
+            "billing_base_url": "https://chatgpt.com/backend-api/codex/",
+            "billing_mode": "",
+            "cost_status": "",
+            "model": "gpt-5.5",
+        }],
+    )
+
+    summary = kb.read_daily_spend_ledger(
+        kb.SpendAdmissionConfig(cap_usd=10, timezone_name="UTC"),
+        now=now,
+        profile_homes=[home],
+    )
+
+    assert summary.known_cost_rows == 1
+    assert summary.known_metered_cost_usd == pytest.approx(1.25)
+    assert summary.included_cost_rows == 0
+    assert summary.transport_inferred_included_rows == 0
 
 
 def test_subscription_included_rows_do_not_increase_known_metered_spend(isolated_kanban_home):

--- a/tests/hermes_cli/test_kanban_admission_caps.py
+++ b/tests/hermes_cli/test_kanban_admission_caps.py
@@ -96,19 +96,23 @@ def test_rolling_start_cap_allows_remaining_capacity_then_holds_rest(isolated_ka
         assert [h[0] for h in res.skipped_rolling_start_capped] == task_ids[1:]
 
 
-def _write_state_db(home: Path, rows):
+def _write_state_db(home: Path, rows, *, include_billing_columns: bool = True):
     db = home / "state.db"
     conn = sqlite3.connect(db)
     try:
-        conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, started_at REAL, ended_at REAL)")
         conn.execute(
-            """CREATE TABLE session_model_usage (
+            "CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, started_at REAL, ended_at REAL)"
+        )
+        billing_columns = "billing_mode TEXT DEFAULT ''," if include_billing_columns else ""
+        cost_status_column = "cost_status TEXT," if include_billing_columns else ""
+        conn.execute(
+            f"""CREATE TABLE session_model_usage (
                    session_id TEXT, model TEXT, billing_provider TEXT DEFAULT '', billing_base_url TEXT DEFAULT '',
-                   billing_mode TEXT DEFAULT '', task TEXT DEFAULT '', api_call_count INTEGER DEFAULT 0,
+                   {billing_columns} task TEXT DEFAULT '', api_call_count INTEGER DEFAULT 0,
                    input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0,
                    cache_read_tokens INTEGER DEFAULT 0, cache_write_tokens INTEGER DEFAULT 0,
                    reasoning_tokens INTEGER DEFAULT 0, estimated_cost_usd REAL DEFAULT 0,
-                   actual_cost_usd REAL DEFAULT 0, cost_status TEXT, cost_source TEXT,
+                   actual_cost_usd REAL DEFAULT 0, {cost_status_column} cost_source TEXT,
                    first_seen REAL, last_seen REAL
                )"""
         )
@@ -118,11 +122,27 @@ def _write_state_db(home: Path, rows):
                 "INSERT INTO sessions (id, source, started_at, ended_at) VALUES (?, 'cli', ?, ?)",
                 (sid, row["seen"], row["seen"]),
             )
+            columns = [
+                "session_id",
+                "model",
+                "estimated_cost_usd",
+                "actual_cost_usd",
+                "last_seen",
+            ]
+            values = [
+                sid,
+                "m",
+                row.get("estimated", 0),
+                row.get("actual", 0),
+                row["seen"],
+            ]
+            if include_billing_columns:
+                columns.extend(["billing_mode", "cost_status"])
+                values.extend([row.get("billing_mode", ""), row.get("cost_status")])
+            placeholders = ", ".join("?" for _ in values)
             conn.execute(
-                """INSERT INTO session_model_usage
-                   (session_id, model, estimated_cost_usd, actual_cost_usd, last_seen)
-                   VALUES (?, 'm', ?, ?, ?)""",
-                (sid, row.get("estimated", 0), row.get("actual", 0), row["seen"]),
+                f"INSERT INTO session_model_usage ({', '.join(columns)}) VALUES ({placeholders})",
+                values,
             )
         conn.commit()
     finally:
@@ -141,6 +161,200 @@ def test_daily_spend_actual_wins_over_estimated_and_multi_profile(isolated_kanba
     assert summary.known_metered_cost_usd == pytest.approx(5.0)
     assert summary.actual_cost_usd == pytest.approx(2.0)
     assert summary.estimated_cost_usd == pytest.approx(3.0)
+
+
+def test_subscription_included_zero_cost_rows_do_not_trigger_unknown_hold(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [{
+            "seen": now,
+            "actual": 0,
+            "estimated": 0,
+            "billing_mode": "subscription_included",
+            "cost_status": "included",
+        }],
+    )
+    cfg = kb.SpendAdmissionConfig(
+        cap_usd=1,
+        timezone_name="UTC",
+        unknown_cost_policy="hold",
+    )
+
+    summary = kb.read_daily_spend_ledger(cfg, now=now, profile_homes=[home])
+
+    assert summary.ledger_readable is True
+    assert summary.included_cost_rows == 1
+    assert summary.unknown_cost_rows == 0
+    assert summary.known_metered_cost_usd == pytest.approx(0.0)
+
+
+def test_subscription_included_zero_cost_rows_allow_dispatch_under_hold(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [{
+            "seen": now,
+            "actual": 0,
+            "estimated": 0,
+            "billing_mode": "subscription_included",
+            "cost_status": "included",
+        }],
+    )
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 1)
+        monkeypatch_time = pytest.MonkeyPatch()
+        monkeypatch_time.setattr(kb.time, "time", lambda: now)
+        try:
+            res = kb.dispatch_once(
+                conn,
+                spawn_fn=_fake_spawn,
+                dry_run=True,
+                spend_config=kb.SpendAdmissionConfig(
+                    cap_usd=1,
+                    timezone_name="UTC",
+                    unknown_cost_policy="hold",
+                ),
+            )
+        finally:
+            monkeypatch_time.undo()
+
+    assert [row[0] for row in res.spawned] == task_ids
+    assert not res.skipped_unknown_cost_policy
+    assert res.spend_telemetry["included_cost_rows"] == 1
+
+
+def test_subscription_included_rows_do_not_increase_known_metered_spend(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [{
+            "seen": now,
+            "actual": 4,
+            "estimated": 7,
+            "billing_mode": "subscription_included",
+            "cost_status": "included",
+        }],
+    )
+    cfg = kb.SpendAdmissionConfig(cap_usd=10, timezone_name="UTC")
+
+    summary = kb.read_daily_spend_ledger(cfg, now=now, profile_homes=[home])
+
+    assert summary.included_cost_rows == 1
+    assert summary.known_cost_rows == 0
+    assert summary.known_metered_cost_usd == pytest.approx(0.0)
+    assert summary.actual_cost_usd == pytest.approx(0.0)
+    assert summary.estimated_cost_usd == pytest.approx(0.0)
+
+
+def test_known_metered_actual_and_estimated_rows_still_count(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [
+            {
+                "seen": now,
+                "actual": 1.25,
+                "estimated": 8,
+                "billing_mode": "metered",
+                "cost_status": "actual",
+            },
+            {
+                "seen": now,
+                "actual": 0,
+                "estimated": 2.5,
+                "billing_mode": "metered",
+                "cost_status": "estimated",
+            },
+        ],
+    )
+    cfg = kb.SpendAdmissionConfig(cap_usd=10, timezone_name="UTC")
+
+    summary = kb.read_daily_spend_ledger(cfg, now=now, profile_homes=[home])
+
+    assert summary.known_cost_rows == 2
+    assert summary.known_metered_cost_usd == pytest.approx(3.75)
+    assert summary.actual_cost_usd == pytest.approx(1.25)
+    assert summary.estimated_cost_usd == pytest.approx(2.5)
+
+
+def test_unknown_metered_rows_still_obey_hold_policy(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [{
+            "seen": now,
+            "actual": 0,
+            "estimated": 0,
+            "billing_mode": "metered",
+            "cost_status": None,
+        }],
+    )
+
+    summary = kb.read_daily_spend_ledger(
+        kb.SpendAdmissionConfig(
+            cap_usd=1,
+            timezone_name="UTC",
+            unknown_cost_policy="hold",
+        ),
+        now=now,
+        profile_homes=[home],
+    )
+
+    assert summary.unknown_cost_rows == 1
+    assert summary.known_metered_cost_usd == pytest.approx(0.0)
+
+
+def test_malformed_metered_cost_rows_are_unknown_not_crashes(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [{
+            "seen": now,
+            "actual": "not-a-number",
+            "estimated": 0,
+            "billing_mode": "metered",
+            "cost_status": "actual",
+        }],
+    )
+
+    summary = kb.read_daily_spend_ledger(
+        kb.SpendAdmissionConfig(cap_usd=1, timezone_name="UTC"),
+        now=now,
+        profile_homes=[home],
+    )
+
+    assert summary.ledger_readable is True
+    assert summary.unknown_cost_rows == 1
+    assert summary.known_metered_cost_usd == pytest.approx(0.0)
+
+
+def test_older_ledger_without_billing_columns_is_backward_compatible_fail_closed(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [{"seen": now, "actual": 0, "estimated": 0}],
+        include_billing_columns=False,
+    )
+    cfg = kb.SpendAdmissionConfig(
+        cap_usd=1,
+        timezone_name="UTC",
+        unknown_cost_policy="hold",
+    )
+
+    summary = kb.read_daily_spend_ledger(cfg, now=now, profile_homes=[home])
+
+    assert summary.ledger_readable is True
+    assert summary.unknown_cost_rows == 1
+    assert summary.known_metered_cost_usd == pytest.approx(0.0)
+    assert summary.errors == ()
 
 
 def test_daily_spend_cap_holds_without_state_mutation(isolated_kanban_home):

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -226,7 +226,26 @@ up on the next tick (60s by default).
 kanban:
   dispatch_in_gateway: true        # default
   dispatch_interval_seconds: 60    # default
+  max_spawn: null                  # optional global running-worker cap
+  max_in_progress: null            # optional global running-task cap
+  max_in_progress_per_profile: null # optional per-profile running cap
+  max_task_starts_per_hour: null   # optional rolling task-run start cap
+  daily_spend_cap_usd: null        # optional daily known-metered spend cap
+  daily_spend_timezone: UTC        # IANA timezone for the local day boundary
+  unknown_cost_policy: allow       # allow | hold; unknown rows are telemetry
 ```
+
+Admission caps are native dispatcher brakes, not task failures. When a cap is
+hit, `ready` / `review` tasks stay in place for the next tick; the dispatcher
+does not increment failure counters, block tasks, kill active workers, or start a
+second scheduler. The rolling-start cap is checked under the board dispatch lock
+against `task_runs.started_at` rows from the trailing hour. The daily spend cap
+uses read-only connections to each installed profile's `state.db` and sums only
+known metered cost from `session_model_usage`: `actual_cost_usd` wins when
+present, otherwise `estimated_cost_usd` is used. Rows with no known cost are
+reported in sanitized telemetry and do not count toward the cap unless you set
+`unknown_cost_policy: hold`. If a positive spend cap is configured but no local
+ledger can be read at all, spawning fails closed for that tick.
 
 Override the config flag at runtime via `HERMES_KANBAN_DISPATCH_IN_GATEWAY=0`
 for debugging. Standard gateway supervision applies: run `hermes gateway


### PR DESCRIPTION
## Summary
- add native kanban dispatcher admission brakes for rolling task-start caps and daily known-metered spend caps
- aggregate spend from installed profiles' state.db files via read-only SQLite ledger reads, with sanitized telemetry and unknown-cost policy handling
- thread the config through gateway, CLI dispatch, and dashboard dispatch nudge; document the new config knobs

## Verification
- git fetch origin main before final verification
- python -m py_compile hermes_cli/kanban_db.py hermes_cli/kanban.py gateway/kanban_watchers.py plugins/kanban/dashboard/plugin_api.py tests/hermes_cli/test_kanban_admission_caps.py
- git diff --check
- scripts/run_tests.sh tests/hermes_cli/test_kanban_admission_caps.py tests/hermes_cli/test_kanban_per_profile_cap.py tests/hermes_cli/test_kanban_cli.py — 64 passed
- scripts/run_tests.sh tests/hermes_cli/test_kanban*.py — 743 passed

## Notes
Defaults preserve historical behavior: caps are disabled unless configured. Admission holds leave tasks in ready/review and do not increment failure counters.