### PR TITLE
fix(auth): resolve_anthropic_token() bypasses profile secret scope

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -24,6 +24,7 @@ from urllib.parse import urlparse
 from hermes_constants import get_hermes_home
 from typing import Any, Dict, List, Optional, Tuple
 from utils import base_url_host_matches, normalize_proxy_env_vars
+from agent.secret_scope import get_secret
 
 # NOTE: `import anthropic` is deliberately NOT at module top — the SDK pulls
 # ~220 ms of imports (anthropic.types, anthropic.lib.tools._beta_runner, etc.)
@@ -1311,7 +1312,12 @@ def resolve_anthropic_token() -> Optional[str]:
     creds = read_claude_code_credentials()
 
     # 1. Hermes-managed OAuth/setup token env var
-    token = os.getenv("ANTHROPIC_TOKEN", "").strip()
+    #
+    # Routed through get_secret() (not os.getenv) so a multiplexed gateway's
+    # per-profile scope is honored instead of falling through to whatever
+    # profile's value happens to be sitting in process-global os.environ —
+    # see #51603.
+    token = (get_secret("ANTHROPIC_TOKEN", "") or "").strip()
     if token:
         preferred = _prefer_refreshable_claude_code_token(token, creds)
         if preferred:
@@ -1319,7 +1325,7 @@ def resolve_anthropic_token() -> Optional[str]:
         return token
 
     # 2. CLAUDE_CODE_OAUTH_TOKEN (used by Claude Code for setup-tokens)
-    cc_token = os.getenv("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
+    cc_token = (get_secret("CLAUDE_CODE_OAUTH_TOKEN", "") or "").strip()
     if cc_token:
         preferred = _prefer_refreshable_claude_code_token(cc_token, creds)
         if preferred:
@@ -1338,7 +1344,7 @@ def resolve_anthropic_token() -> Optional[str]:
 
     # 5. Regular API key, or a legacy OAuth token saved in ANTHROPIC_API_KEY.
     # This remains as a compatibility fallback for pre-migration Hermes configs.
-    api_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
+    api_key = (get_secret("ANTHROPIC_API_KEY", "") or "").strip()
     if api_key:
         return api_key
 

--- a/tests/agent/test_anthropic_token_scope_isolation.py
+++ b/tests/agent/test_anthropic_token_scope_isolation.py
@@ -1,0 +1,94 @@
+"""Credential-scope isolation proof for resolve_anthropic_token() (#51603).
+
+resolve_anthropic_token() is the fallback path agent_init.py uses when no
+explicit api_key is configured for the runtime provider. Every other
+credential reader in the multiplex gateway (hermes_cli.runtime_provider,
+tools.mcp_tool) resolves through agent.secret_scope.get_secret() so a
+profile's own .env wins over whatever happens to be sitting in process-global
+os.environ. resolve_anthropic_token() was never migrated and read os.getenv
+directly for ANTHROPIC_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY,
+so a multiplexed gateway serving Profile A could silently use Profile B's (or
+the process default's) Anthropic credential. See test_multiplex_credential_
+isolation.py for the equivalent proof already in place for runtime_provider.
+"""
+import pytest
+
+from agent import secret_scope as ss
+from agent import anthropic_adapter
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    ss.set_multiplex_active(False)
+    # Isolate resolve_anthropic_token() from any real Claude Code credential
+    # file / keychain / credential_pool state on the machine running the
+    # tests — sources 3 and 4 in the priority order are out of scope here.
+    monkeypatch.setattr(anthropic_adapter, "read_claude_code_credentials", lambda: None)
+    monkeypatch.setattr(anthropic_adapter, "_resolve_anthropic_pool_token", lambda: None)
+    yield
+    ss.set_multiplex_active(False)
+
+
+class TestResolveAnthropicTokenUsesScope:
+    def test_scoped_api_key_used_over_environ(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api-WRONG-OTHER-PROFILE")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"ANTHROPIC_API_KEY": "sk-ant-api-PROFILE-A"})
+        try:
+            assert anthropic_adapter.resolve_anthropic_token() == "sk-ant-api-PROFILE-A"
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_two_profiles_return_different_keys(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api-SHARED-ENVIRON-WRONG")
+        ss.set_multiplex_active(True)
+
+        tok_a = ss.set_secret_scope({"ANTHROPIC_API_KEY": "sk-ant-api-A"})
+        try:
+            assert anthropic_adapter.resolve_anthropic_token() == "sk-ant-api-A"
+        finally:
+            ss.reset_secret_scope(tok_a)
+
+        tok_b = ss.set_secret_scope({"ANTHROPIC_API_KEY": "sk-ant-api-B"})
+        try:
+            assert anthropic_adapter.resolve_anthropic_token() == "sk-ant-api-B"
+        finally:
+            ss.reset_secret_scope(tok_b)
+
+    def test_anthropic_token_env_does_not_shadow_scoped_api_key(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat-WRONG-OTHER-PROFILE")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"ANTHROPIC_API_KEY": "sk-ant-api-PROFILE-A"})
+        try:
+            assert anthropic_adapter.resolve_anthropic_token() == "sk-ant-api-PROFILE-A"
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_anthropic_token_in_scope_is_used(self, monkeypatch):
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"ANTHROPIC_TOKEN": "sk-ant-oat-PROFILE-A"})
+        try:
+            assert anthropic_adapter.resolve_anthropic_token() == "sk-ant-oat-PROFILE-A"
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_cc_oauth_env_does_not_shadow_scoped_api_key(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-cc-WRONG-OTHER-PROFILE")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"ANTHROPIC_API_KEY": "sk-ant-api-PROFILE-A"})
+        try:
+            assert anthropic_adapter.resolve_anthropic_token() == "sk-ant-api-PROFILE-A"
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_unscoped_call_in_multiplex_mode_fails_closed(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api-leak")
+        ss.set_multiplex_active(True)
+        with pytest.raises(ss.UnscopedSecretError):
+            anthropic_adapter.resolve_anthropic_token()
+
+    def test_unscoped_call_outside_multiplex_reads_environ(self, monkeypatch):
+        # multiplex inactive (single-profile / non-gateway callers, e.g. the
+        # `hermes` CLI itself) must keep behaving exactly like plain os.getenv.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api-legacy")
+        assert anthropic_adapter.resolve_anthropic_token() == "sk-ant-api-legacy"


### PR DESCRIPTION
## What does this PR do?

`resolve_anthropic_token()` (`agent/anthropic_adapter.py`) read `ANTHROPIC_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, and `ANTHROPIC_API_KEY` directly via `os.getenv(...)`. Every other credential reader in the multiplex gateway — `hermes_cli.runtime_provider._getenv`, `tools.mcp_tool`'s `${VAR}` interpolation — resolves through `agent.secret_scope.get_secret()` instead, so a profile's own `.env` wins over whatever happens to be sitting in process-global `os.environ`. This function was never migrated.

`agent_init.py` falls back to `resolve_anthropic_token()` whenever no explicit `api_key` is configured on the runtime provider, so in a multiplexed gateway (`gateway.multiplex_profiles: true`) one profile's Anthropic calls could silently use another profile's — or the process default's — key. Same shape of bug the scoped `_getenv` migration already fixed for every other provider; Anthropic's OAuth/setup-token fallback path was the one gap left.

## Related Issue

Fixes #51603

## Changes Made

- `agent/anthropic_adapter.py`: route the three `os.getenv` reads inside `resolve_anthropic_token()` through `agent.secret_scope.get_secret()`.
- `tests/agent/test_anthropic_token_scope_isolation.py` (new): isolation proof mirroring `tests/gateway/test_multiplex_credential_isolation.py` — two profiles never see each other's key, an unscoped call in multiplex mode fails closed via `UnscopedSecretError`, and non-multiplex callers keep reading `os.environ` unchanged.

`cron/scheduler.py`'s `run_job()` already installs the secret scope (see the comment there referencing #58720/#10200), so the cron-side gap originally described in #51603 turned out to already be covered by unrelated prior work — this PR only needed the adapter-side fix.

## How to Test

1. `git stash` the diff to `agent/anthropic_adapter.py` only, run `pytest tests/agent/test_anthropic_token_scope_isolation.py -q` — 6 of 7 tests fail (confirms red on `main`).
2. Restore the diff, re-run the same file — all 7 pass.
3. Regression: `pytest tests/agent/test_anthropic_adapter.py tests/agent/test_anthropic_keychain.py tests/agent/test_anthropic_oauth_pkce.py tests/agent/test_auxiliary_anthropic_pool_fallback_regression.py tests/gateway/test_multiplex_credential_isolation.py tests/agent/test_secret_scope.py -q` — 226 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` — full-suite run hits pre-existing, unrelated failures in this sandbox (missing `fastapi`/`uvicorn` extras, an `ast`/pytest version mismatch on time-dependent cron tests, three collection errors on `test_copilot_acp_*`/`test_markdown_tables.py`); confirmed identical failure set with and without this diff, so none are introduced by this change. Targeted suites listed above are fully green.
- [x] I've added tests for my changes
- [ ] I've tested on my platform — Linux only in this sandbox; no OS-specific code touched

### Documentation & Housekeeping

- [x] N/A — no config keys, README, or CONTRIBUTING/AGENTS changes needed for a two-line credential-resolution fix