### PR TITLE
fix(cli): read .worktreeinclude and .gitignore as UTF-8 in worktree setup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1362,7 +1362,15 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True) -> Optional[D
     gitignore = Path(repo_root) / ".gitignore"
     _ignore_entry = ".worktrees/"
     try:
-        existing = gitignore.read_text() if gitignore.exists() else ""
+        # utf-8-sig: git files are UTF-8 and Notepad prepends a BOM, which
+        # would glue to the first line and defeat the membership check below
+        # (duplicating the entry); the locale default also breaks non-ASCII
+        # patterns on Windows. The append below already writes UTF-8.
+        existing = (
+            gitignore.read_text(encoding="utf-8-sig", errors="replace")
+            if gitignore.exists()
+            else ""
+        )
         if _ignore_entry not in existing.splitlines():
             with open(gitignore, "a", encoding="utf-8") as f:
                 if existing and not existing.endswith("\n"):
@@ -1412,7 +1420,14 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True) -> Optional[D
         try:
             repo_root_resolved = Path(repo_root).resolve()
             wt_path_resolved = wt_path.resolve()
-            for line in include_file.read_text().splitlines():
+            # utf-8-sig, not the locale default: on a cp1251/GBK Windows
+            # machine a UTF-8 include list either decodes to mojibake paths
+            # (entries silently not copied) or raises UnicodeDecodeError,
+            # which the enclosing handler swallows at DEBUG — no include is
+            # copied at all. A Notepad BOM likewise glued to the first entry.
+            for line in include_file.read_text(
+                encoding="utf-8-sig", errors="replace"
+            ).splitlines():
                 entry = line.strip()
                 if not entry or entry.startswith("#"):
                     continue

--- a/tests/cli/test_worktree_security.py
+++ b/tests/cli/test_worktree_security.py
@@ -128,3 +128,64 @@ class TestWorktreeIncludeSecurity:
             assert (linked_dir / "lib" / "marker.txt").read_text() == "venv marker"
         finally:
             _force_remove_worktree(info)
+
+
+class TestWorktreeIncludeEncoding:
+    """The include list and .gitignore are UTF-8 files; reading them with the
+    locale default breaks Windows (cp1251/GBK mojibake or UnicodeDecodeError,
+    swallowed at DEBUG so no include is copied), and a Notepad BOM glues to
+    the first line on every platform."""
+
+    def test_bom_in_worktreeinclude_does_not_hide_first_entry(self, git_repo):
+        import cli as cli_mod
+
+        (git_repo / ".env").write_text("SECRET=***\n")
+        # Notepad-style UTF-8 with BOM; the BOM must not become part of the
+        # first entry's path.
+        (git_repo / ".worktreeinclude").write_bytes("﻿.env\n".encode("utf-8"))
+
+        info = None
+        try:
+            info = cli_mod._setup_worktree(str(git_repo))
+            assert info is not None
+            assert (Path(info["path"]) / ".env").exists()
+        finally:
+            _force_remove_worktree(info)
+
+    def test_non_ascii_worktreeinclude_entry_copied(self, git_repo):
+        import cli as cli_mod
+
+        secret = git_repo / "секреты.env"
+        secret.write_text("SECRET=***\n", encoding="utf-8")
+        (git_repo / ".worktreeinclude").write_bytes(
+            "# ключи агента\nсекреты.env\n".encode("utf-8")
+        )
+
+        info = None
+        try:
+            info = cli_mod._setup_worktree(str(git_repo))
+            assert info is not None
+            assert (Path(info["path"]) / "секреты.env").exists()
+        finally:
+            _force_remove_worktree(info)
+
+    def test_bom_in_gitignore_does_not_duplicate_worktrees_entry(self, git_repo):
+        import cli as cli_mod
+
+        (git_repo / ".gitignore").write_bytes("﻿.worktrees/\n".encode("utf-8"))
+
+        info = None
+        try:
+            info = cli_mod._setup_worktree(str(git_repo))
+            assert info is not None
+            lines = (
+                (git_repo / ".gitignore")
+                .read_text(encoding="utf-8-sig")
+                .splitlines()
+            )
+            assert lines.count(".worktrees/") == 1, (
+                "BOM glued to the first line must not defeat the membership "
+                f"check and duplicate the entry: {lines!r}"
+            )
+        finally:
+            _force_remove_worktree(info)


### PR DESCRIPTION
## Summary

`cli._setup_worktree` reads `.worktreeinclude` and `.gitignore` with the platform locale default encoding. Both are UTF-8 files (git treats path patterns as UTF-8; the same block already *appends* to `.gitignore` with `encoding="utf-8"`), so on Windows this breaks in three ways:

1. **All includes silently lost (worst case).** On a cp932/GBK-locale machine, a UTF-8 include list with any non-ASCII byte raises `UnicodeDecodeError` on `include_file.read_text()`. The enclosing `except Exception` logs at DEBUG and swallows it — **no entry is copied at all**, so the worktree starts without `.env`/keys and the agent breaks with no visible error.
2. **Non-ASCII entries never copied.** On cp1251 the same read produces mojibake paths; those entries fail `src.is_file()` and are silently skipped (reproduced live on a cp1251 machine).
3. **BOM breaks the first line on every platform.** A Notepad-saved include list glues `\ufeff` to the first entry (never copied), and a BOM'd `.gitignore` defeats the `.worktrees/` membership check, appending a duplicate entry on each worktree launch.

## Fix

Read both files with `encoding="utf-8-sig", errors="replace"`, matching the canonical `.env` readers in `hermes_cli/config.py` (utf-8-sig specifically because Notepad prepends a BOM) and the UTF-8 append this block already performs.

Same class as the merged/endorsed encoding fixes #60895 / #62123 / #62617, previously unfixed in the worktree path.

## Testing

New `TestWorktreeIncludeEncoding` in `tests/cli/test_worktree_security.py` exercises the **real** `cli._setup_worktree` (same style as the existing security tests):

- `test_bom_in_worktreeinclude_does_not_hide_first_entry` — fails without the fix on any platform
- `test_bom_in_gitignore_does_not_duplicate_worktrees_entry` — fails without the fix on any platform
- `test_non_ascii_worktreeinclude_entry_copied` — reproduces the Windows locale failure

All three fail without the fix on Windows (verified by stashing the diff); full `tests/cli/test_worktree*` suite otherwise unchanged (6 pre-existing failures in this Windows environment are present on clean main). `ruff` and `scripts/check-windows-footguns.py` clean.

Dedup: searched PRs/issues for worktreeinclude/gitignore encoding variants — existing `.worktreeinclude` PRs cover path traversal only; open Windows worktree PRs (#68252, #68391) touch quarantine/symlink semantics, not these reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)