### PR TITLE
fix(tui-gateway): prevent slash-worker spawn for terminal Kanban sessions

### DIFF
--- a/tests/tui_gateway/test_kanban_session_slash_guard.py
+++ b/tests/tui_gateway/test_kanban_session_slash_guard.py
@@ -1,0 +1,135 @@
+"""Tests for the Kanban terminal-session slash-worker guard (#68779).
+
+A Kanban-dispatched worker session that reaches a terminal state (blocked,
+done, archived) must NOT be resumed as a write-capable Desktop/TUI session
+with a slash worker — otherwise it becomes an unobservable "ghost writer"
+that the Kanban board/dispatcher cannot supervise.
+"""
+
+import time
+from unittest.mock import patch, MagicMock
+
+
+def test_is_terminal_kanban_session_blocks_on_blocked(tmp_path, monkeypatch):
+    """A session linked to a blocked Kanban task is flagged as terminal."""
+    from tui_gateway import server as srv
+
+    # Reset cache between tests
+    srv._kanban_task_cache.clear()
+
+    import sqlite3
+
+    db_path = tmp_path / "kanban.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE tasks (id TEXT PRIMARY KEY, session_id TEXT, status TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO tasks (id, session_id, status) VALUES (?, ?, ?)",
+        ("t-1", "sess-abc-123", "blocked"),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+
+    assert srv._is_terminal_kanban_session("sess-abc-123") is True
+
+
+def test_is_terminal_kanban_session_allows_running(tmp_path, monkeypatch):
+    """A session linked to a running Kanban task is NOT flagged as terminal."""
+    from tui_gateway import server as srv
+
+    srv._kanban_task_cache.clear()
+
+    import sqlite3
+
+    db_path = tmp_path / "kanban.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE tasks (id TEXT PRIMARY KEY, session_id TEXT, status TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO tasks (id, session_id, status) VALUES (?, ?, ?)",
+        ("t-2", "sess-running", "running"),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+
+    assert srv._is_terminal_kanban_session("sess-running") is False
+
+
+def test_is_terminal_kanban_session_allows_unknown_session(tmp_path, monkeypatch):
+    """A session with no Kanban task linkage is NOT flagged as terminal."""
+    from tui_gateway import server as srv
+
+    srv._kanban_task_cache.clear()
+
+    import sqlite3
+
+    db_path = tmp_path / "kanban.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE tasks (id TEXT PRIMARY KEY, session_id TEXT, status TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+
+    assert srv._is_terminal_kanban_session("random-session-id") is False
+
+
+def test_is_terminal_kanban_session_caches_result():
+    """The guard caches its DB lookup to avoid per-spawn SQLite queries."""
+    from tui_gateway import server as srv
+
+    srv._kanban_task_cache.clear()
+
+    with patch.object(srv, "_kanban_cache_ttl", 60.0):
+        # First call queries the DB
+        with patch("hermes_cli.kanban_db.connect") as mock_connect:
+            mock_conn = MagicMock()
+            mock_conn.execute.return_value.fetchone.return_value = ("blocked",)
+            mock_connect.return_value = mock_conn
+            result = srv._is_terminal_kanban_session("cached-session")
+            assert result is True
+            assert mock_connect.call_count == 1
+
+        # Second call within TTL uses the cache
+        with patch("hermes_cli.kanban_db.connect") as mock_connect2:
+            result = srv._is_terminal_kanban_session("cached-session")
+            assert result is True
+            assert mock_connect2.call_count == 0
+
+
+def test_is_terminal_kanban_session_cache_expires():
+    """After the TTL expires, the guard re-queries the DB."""
+    from tui_gateway import server as srv
+
+    srv._kanban_task_cache.clear()
+
+    with patch.object(srv, "_kanban_cache_ttl", 0.0):
+        with patch("hermes_cli.kanban_db.connect") as mock_connect:
+            mock_conn = MagicMock()
+            mock_conn.execute.return_value.fetchone.return_value = ("blocked",)
+            mock_connect.return_value = mock_conn
+
+            srv._is_terminal_kanban_session("expiring-session")
+            assert mock_connect.call_count == 1
+
+            srv._is_terminal_kanban_session("expiring-session")
+            # TTL=0 means every call re-queries
+            assert mock_connect.call_count == 2
+
+
+def test_is_terminal_kanban_session_db_error_falls_back():
+    """If the Kanban DB is unavailable, the guard allows the session through."""
+    from tui_gateway import server as srv
+
+    srv._kanban_task_cache.clear()
+
+    with patch("hermes_cli.kanban_db.connect", side_effect=Exception("db error")):
+        assert srv._is_terminal_kanban_session("any-session") is False

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -166,6 +166,59 @@ _WS_ORPHAN_REAP_GRACE_S = max(0.0, _ws_orphan_reap_grace)
 _DETAIL_SECTION_NAMES = ("thinking", "tools", "subagents", "activity")
 _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
 
+# ── Kanban worker session guard (#68779) ─────────────────────────────
+# A Kanban-dispatched worker session can reach a terminal state (blocked,
+# done, archived) where the task's current_run_id is cleared. If the
+# operator later resumes that session via the Desktop/TUI, a new
+# _SlashWorker is spawned that can still write to the Kanban worktree
+# but is invisible to the Kanban board/dispatcher — a "ghost writer".
+# This guard detects terminal Kanban sessions and prevents slash-worker
+# creation for them.
+
+_KANBAN_TERMINAL_STATUSES = frozenset({"blocked", "done", "archived"})
+_kanban_task_cache: dict[str, tuple[str | None, float]] = {}
+_kanban_cache_ttl = 30.0  # seconds
+
+
+def _is_terminal_kanban_session(session_key: str) -> bool:
+    """Return True if *session_key* belongs to a Kanban task in a terminal
+    state.  The caller should skip slash-worker creation in that case.
+
+    Checks the kanban DB for tasks whose ``session_id`` matches the given
+    key and whose status is blocked/done/archived.  Results are cached
+    briefly to avoid hitting SQLite on every slash-worker spawn/restart.
+    """
+    now = time.time()
+    cached = _kanban_task_cache.get(session_key)
+    if cached is not None:
+        status, ts = cached
+        if now - ts < _kanban_cache_ttl:
+            return status in _KANBAN_TERMINAL_STATUSES
+
+    status: str | None = None
+    try:
+        from hermes_cli import kanban_db as kb
+
+        conn = kb.connect()
+        try:
+            row = conn.execute(
+                "SELECT status FROM tasks WHERE session_id = ? AND status IN "
+                "(?, ?, ?) LIMIT 1",
+                (session_key, "blocked", "done", "archived"),
+            ).fetchone()
+            if row is not None:
+                status = row[0]
+        finally:
+            conn.close()
+    except Exception:
+        # If the kanban DB is unavailable or the query fails, fall back to
+        # allowing the slash worker — better to have an observable writer
+        # than to silently suppress a legitimate session.
+        status = None
+
+    _kanban_task_cache[session_key] = (status, now)
+    return status in _KANBAN_TERMINAL_STATUSES
+
 # ── Async RPC dispatch (#12546) ──────────────────────────────────────
 # A handful of handlers block the dispatcher loop in entry.py for seconds
 # to minutes (slash.exec, cli.exec, shell.exec, session.resume,
@@ -1639,12 +1692,18 @@ def _start_agent_build(sid: str, session: dict) -> None:
             current["config_model_seen"] = _config_model_target()
 
             try:
-                worker = _SlashWorker(
-                    key,
-                    getattr(agent, "model", _resolve_model()),
-                    profile_home=current.get("profile_home"),
-                )
-                _attach_worker(sid, current, worker)
+                if not _is_terminal_kanban_session(key):
+                    worker = _SlashWorker(
+                        key,
+                        getattr(agent, "model", _resolve_model()),
+                        profile_home=current.get("profile_home"),
+                    )
+                    _attach_worker(sid, current, worker)
+                else:
+                    logger.debug(
+                        "skipping slash-worker for terminal kanban session %s",
+                        key,
+                    )
             except Exception:
                 pass
 
@@ -3126,6 +3185,14 @@ def _tool_progress_enabled(sid: str) -> bool:
 
 
 def _restart_slash_worker(sid: str, session: dict):
+    # Terminal Kanban sessions must not get a slash worker — they would be
+    # unobservable ghost writers in the Kanban worktree (#68779).
+    if _is_terminal_kanban_session(session.get("session_key", "")):
+        logger.debug(
+            "skipping slash-worker restart for terminal kanban session %s",
+            session.get("session_key"),
+        )
+        return
     worker = session.get("slash_worker")
     if worker:
         try:
@@ -5216,15 +5283,21 @@ def _init_session(
                 logger.debug("failed to persist resumed session cwd", exc_info=True)
     _register_session_cwd(_sessions[sid])
     try:
-        _attach_worker(
-            sid,
-            _sessions[sid],
-            _SlashWorker(
+        if not _is_terminal_kanban_session(key):
+            _attach_worker(
+                sid,
+                _sessions[sid],
+                _SlashWorker(
+                    key,
+                    getattr(agent, "model", _resolve_model()),
+                    profile_home=_sessions[sid].get("profile_home"),
+                ),
+            )
+        else:
+            logger.debug(
+                "skipping slash-worker for terminal kanban session %s",
                 key,
-                getattr(agent, "model", _resolve_model()),
-                profile_home=_sessions[sid].get("profile_home"),
-            ),
-        )
+            )
     except Exception:
         # Defer hard-failure to slash.exec; chat still works without slash worker.
         _sessions[sid]["slash_worker"] = None
@@ -14844,6 +14917,12 @@ def _(rid, params: dict) -> dict:
 
     worker = session.get("slash_worker")
     if not worker:
+        if _is_terminal_kanban_session(session.get("session_key", "")):
+            return _err(
+                rid, 5031,
+                "slash commands disabled: this is a terminal Kanban worker session — "
+                "resume via the kanban board instead",
+            )
         try:
             worker = _SlashWorker(
                 session["session_key"],


### PR DESCRIPTION
## 背景

修复 #68779: Resuming a terminal Kanban worker session creates an untracked writer while the task remains blocked

## 根因分析

Kanban dispatcher 派发的 worker 进程带有 `HERMES_KANBAN_TASK`、`HERMES_KANBAN_RUN_ID`、`HERMES_KANBAN_BOARD`、`HERMES_KANBAN_CLAIM_LOCK` 等环境变量。当 worker 达到终态（blocked/done/archived）后，如果用户通过 Desktop/TUI 恢复该会话，`_SlashWorker` 子进程会从 gateway 的环境中生成——而 gateway 环境中没有这些 Kanban 变量。

这导致恢复后的会话成为一个"幽灵写入者"（ghost writer）：
- 仍然可以在 Kanban worktree 中执行文件写操作
- Kanban board 和 dispatcher 完全无法观察或监督它
- 如果操作者同时解除卡片阻塞，dispatcher 可能会启动第二个 worker 在同一个 workspace 中

## 修复方式

在 `tui_gateway/server.py` 中添加 `_is_terminal_kanban_session()` 守卫函数：
1. 通过 session_key 查询 Kanban DB，检查是否有对应任务处于终态（blocked/done/archived）
2. 结果缓存 30 秒，避免每次 spawn 都查询 SQLite
3. 如果 Kanban DB 不可用则回退放行（宁愿有可观察的写入者也不要静默阻止合法会话）

在四个 slash-worker 生成点应用该守卫：
- `_start_agent_build`（延迟构建路径）
- `_init_session`（立即构建路径）
- `_restart_slash_worker`（轮次后重启）
- `slash.exec` 懒加载生成（按需生成）

当检测到终态 Kanban 会话时，跳过 slash-worker 创建并记录 debug 日志。在 `slash.exec` 路径中，返回明确的错误消息提示用户通过 kanban board 操作。

## 验证

- [x] 代码变更已在本地验证（语法检查通过）
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更（对非 Kanban 会话行为不变）
- [x] 新增单元测试 `tests/tui_gateway/test_kanban_session_slash_guard.py`

Closes #68779