### PR TITLE
fix(state): loud failed state.db snapshot + zeroed-file quarantine

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -283,6 +283,32 @@ def _safe_copy_db(src: Path, dst: Path) -> bool:
                     pass
 
 
+def is_zeroed_sqlite_file(path: Path, *, probe_bytes: int = 100) -> bool:
+    """True when *path* looks like the #68474 zeroed-state.db signature.
+
+    Signature: size > 0, first *probe_bytes* are all NUL (no ``SQLite format 3``
+    header). Used at SessionDB open and for snapshot diagnostics so a silent
+    all-zero file becomes a guided recovery instead of a generic failure.
+    """
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return False
+    if size <= 0:
+        return False
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(max(16, probe_bytes))
+    except OSError:
+        return False
+    if not head:
+        return False
+    if head.startswith(b"SQLite format 3"):
+        return False
+    return all(byte == 0 for byte in head)
+
+
+
 # ---------------------------------------------------------------------------
 # Backup
 # ---------------------------------------------------------------------------
@@ -858,6 +884,7 @@ def create_quick_snapshot(
     snap_dir.mkdir(parents=True, exist_ok=True)
 
     manifest: Dict[str, int] = {}  # rel_path -> file size
+    failed_dbs: list[str] = []  # present *.db that could not be snapshotted
 
     for rel in _QUICK_STATE_FILES:
         src = home / rel
@@ -887,6 +914,16 @@ def create_quick_snapshot(
                     # snapshot time) is captured consistently.
                     if sub.suffix == ".db":
                         if not _safe_copy_db(sub, dst):
+                            failed_dbs.append(sub_rel)
+                            print(
+                                f"  ⚠ Snapshot: SQLite safe copy FAILED for {sub_rel} "
+                                f"— file may be locked or corrupted"
+                            )
+                            if is_zeroed_sqlite_file(sub):
+                                print(
+                                    f"  ⚠ Snapshot: {sub_rel} looks ZEROED "
+                                    f"(no SQLite header; {sub.stat().st_size} bytes of NULs?)"
+                                )
                             continue
                     else:
                         shutil.copy2(sub, dst)
@@ -907,6 +944,16 @@ def create_quick_snapshot(
         try:
             if src.suffix == ".db":
                 if not _safe_copy_db(src, dst):
+                    failed_dbs.append(rel)
+                    print(
+                        f"  ⚠ Snapshot: SQLite safe copy FAILED for {rel} "
+                        f"— file may be locked or corrupted"
+                    )
+                    if is_zeroed_sqlite_file(src):
+                        print(
+                            f"  ⚠ Snapshot: {rel} looks ZEROED "
+                            f"(no SQLite header; {src.stat().st_size} bytes)"
+                        )
                     continue
             else:
                 shutil.copy2(src, dst)
@@ -914,8 +961,31 @@ def create_quick_snapshot(
         except (OSError, PermissionError) as exc:
             logger.warning("Could not snapshot %s: %s", rel, exc)
 
+    if failed_dbs:
+        # Critical: update path used to log-and-continue with exit 0, so a
+        # missing state.db backup looked like a successful pre-update snapshot
+        # (#68474). Surface this on stdout where operators actually look.
+        print(
+            "  ⚠ CRITICAL: could not snapshot DB file(s): "
+            + ", ".join(failed_dbs)
+        )
+        print(
+            "  ⚠ If sessions disappear after update, check "
+            f"{root} and run: hermes snapshot list"
+        )
+        logger.error(
+            "Quick snapshot failed to capture DB file(s): %s",
+            ", ".join(failed_dbs),
+        )
+
     if not manifest:
         shutil.rmtree(snap_dir, ignore_errors=True)
+        if failed_dbs:
+            # Distinguish "nothing to snapshot" from "state.db present but unreadable"
+            print(
+                "  ⚠ Snapshot aborted: no files captured "
+                f"(failed DBs: {', '.join(failed_dbs)})"
+            )
         return None
 
     # Write manifest
@@ -926,6 +996,7 @@ def create_quick_snapshot(
         "file_count": len(manifest),
         "total_size": sum(manifest.values()),
         "files": manifest,
+        "failed_dbs": failed_dbs,
     }
     with open(snap_dir / "manifest.json", "w", encoding="utf-8") as f:
         json.dump(meta, f, indent=2)

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1004,7 +1004,18 @@ def create_quick_snapshot(
     # Auto-prune. Defaults preserve historical manual /snapshot behavior; callers
     # with known high-churn safety snapshots (for example pre-update) can pass a
     # smaller keep value so large state.db copies do not accumulate indefinitely.
-    _prune_quick_snapshots(root, keep=_QUICK_DEFAULT_KEEP if keep is None else keep)
+    # #68805 review: skip pruning when a present DB failed to capture — the
+    # incomplete snapshot must not delete the older snapshot that may contain
+    # the last good database (the recovery source this hardening is meant to
+    # preserve).
+    if not failed_dbs:
+        _prune_quick_snapshots(root, keep=_QUICK_DEFAULT_KEEP if keep is None else keep)
+    else:
+        logger.warning(
+            "Skipping snapshot prune because %d DB(s) failed to capture — "
+            "preserving older snapshots as recovery source",
+            len(failed_dbs),
+        )
 
     logger.info("State snapshot created: %s (%d files)", snap_id, len(manifest))
     return snap_id

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -885,6 +885,11 @@ def create_quick_snapshot(
 
     manifest: Dict[str, int] = {}  # rel_path -> file size
     failed_dbs: list[str] = []  # present *.db that could not be snapshotted
+    # #68805: track protected DB files skipped for size — they are snapshot
+    # incompleteness just like a failed copy, so pruning must be suppressed
+    # to preserve the older complete snapshot that may contain the only
+    # recoverable database.
+    oversized_skipped: list[str] = []
 
     for rel in _QUICK_STATE_FILES:
         src = home / rel
@@ -905,6 +910,8 @@ def create_quick_snapshot(
                 if "/workspaces/" in f"/{sub_rel}/" or "/attachments/" in f"/{sub_rel}/":
                     continue
                 if _too_large(sub, sub_rel):
+                    if sub.suffix == ".db":
+                        oversized_skipped.append(sub_rel)
                     continue
                 dst = snap_dir / sub_rel
                 dst.parent.mkdir(parents=True, exist_ok=True)
@@ -936,6 +943,8 @@ def create_quick_snapshot(
             continue
 
         if _too_large(src, rel):
+            if src.suffix == ".db":
+                oversized_skipped.append(rel)
             continue
 
         dst = snap_dir / rel
@@ -997,6 +1006,7 @@ def create_quick_snapshot(
         "total_size": sum(manifest.values()),
         "files": manifest,
         "failed_dbs": failed_dbs,
+        "oversized_skipped": oversized_skipped,
     }
     with open(snap_dir / "manifest.json", "w", encoding="utf-8") as f:
         json.dump(meta, f, indent=2)
@@ -1004,17 +1014,27 @@ def create_quick_snapshot(
     # Auto-prune. Defaults preserve historical manual /snapshot behavior; callers
     # with known high-churn safety snapshots (for example pre-update) can pass a
     # smaller keep value so large state.db copies do not accumulate indefinitely.
-    # #68805 review: skip pruning when a present DB failed to capture — the
-    # incomplete snapshot must not delete the older snapshot that may contain
-    # the last good database (the recovery source this hardening is meant to
-    # preserve).
-    if not failed_dbs:
+    # #68805 review: skip pruning when a present DB failed to capture OR was
+    # skipped for size — either way the snapshot is incomplete and the older
+    # snapshot may contain the only recoverable database.
+    incomplete = failed_dbs or oversized_skipped
+    if not incomplete:
         _prune_quick_snapshots(root, keep=_QUICK_DEFAULT_KEEP if keep is None else keep)
     else:
+        if oversized_skipped:
+            print(
+                "  ⚠ Skipping snapshot prune: DB file(s) skipped for size: "
+                + ", ".join(oversized_skipped)
+            )
+            logger.warning(
+                "Quick snapshot skipped oversized DB file(s): %s",
+                ", ".join(oversized_skipped),
+            )
         logger.warning(
-            "Skipping snapshot prune because %d DB(s) failed to capture — "
-            "preserving older snapshots as recovery source",
-            len(failed_dbs),
+            "Skipping snapshot prune because %d DB(s) failed to capture "
+            "and/or %d were oversized — preserving older snapshots as "
+            "recovery source",
+            len(failed_dbs), len(oversized_skipped),
         )
 
     logger.info("State snapshot created: %s (%d files)", snap_id, len(manifest))

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -981,6 +981,64 @@ END;
 """
 
 
+
+def is_zeroed_state_db(path: Path, *, probe_bytes: int = 100) -> bool:
+    """Detect the #68474 zeroed state.db signature (size>0, NUL header).
+
+    Prefer ``hermes_cli.backup.is_zeroed_sqlite_file`` when available; this
+    local copy keeps SessionDB openable without importing the CLI package
+    in constrained embed paths.
+    """
+    try:
+        from hermes_cli.backup import is_zeroed_sqlite_file
+
+        return is_zeroed_sqlite_file(path, probe_bytes=probe_bytes)
+    except Exception:
+        pass
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return False
+    if size <= 0:
+        return False
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(max(16, probe_bytes))
+    except OSError:
+        return False
+    if not head or head.startswith(b"SQLite format 3"):
+        return False
+    return all(byte == 0 for byte in head)
+
+
+def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
+    """Move a zeroed state.db aside (preserve bytes) and return quarantine path."""
+    try:
+        ts = time.strftime("%Y%m%d-%H%M%S")
+    except Exception:
+        ts = "unknown"
+    dest = path.with_name(f"{path.name}.zeroed-{ts}.bak")
+    # Avoid clobbering a prior quarantine
+    n = 0
+    while dest.exists():
+        n += 1
+        dest = path.with_name(f"{path.name}.zeroed-{ts}-{n}.bak")
+    try:
+        path.rename(dest)
+    except OSError as exc:
+        logger.error("Failed to quarantine zeroed %s: %s", path, exc)
+        return None
+    # Also move empty WAL/SHM if present so a fresh open is clean
+    for suffix in ("-wal", "-shm"):
+        side = Path(str(path) + suffix)
+        if side.exists():
+            try:
+                side.rename(Path(str(dest) + suffix))
+            except OSError:
+                pass
+    return dest
+
+
 class SessionDB:
     """
     SQLite-backed session storage with FTS5 search.
@@ -1060,6 +1118,35 @@ class SessionDB:
                 return
 
             self.db_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # #68474: zeroed state.db (size>0, all-NUL header) used to fail as a
+            # generic "file is not a database" with no recovery path. Quarantine
+            # the bytes (do not delete) and continue so a fresh DB can open;
+            # point the operator at pre-update snapshots.
+            if (
+                not read_only
+                and self.db_path.exists()
+                and is_zeroed_state_db(self.db_path)
+            ):
+                try:
+                    zsize = self.db_path.stat().st_size
+                except OSError:
+                    zsize = -1
+                qpath = quarantine_zeroed_state_db(self.db_path)
+                snaps = self.db_path.parent / "state-snapshots"
+                msg = (
+                    f"state.db looks ZEROED ({zsize} bytes, no SQLite header). "
+                    f"Preserved at {qpath or '(quarantine failed — file left in place)'}. "
+                    f"Restore from {snaps} via `hermes snapshot list` / "
+                    f"`hermes snapshot restore <id>` if available. "
+                    "Opening a fresh empty database so the agent can start."
+                )
+                logger.error(msg)
+                _set_last_init_error(msg)
+                # If quarantine failed, do not open the zeroed file (would fail
+                # opaquely or risk further damage). Raise with the clear message.
+                if qpath is None and self.db_path.exists() and is_zeroed_state_db(self.db_path):
+                    raise sqlite3.DatabaseError(msg)
 
             def _connect_and_init():
                 self._conn = sqlite3.connect(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -15,8 +15,10 @@ Key design decisions:
 """
 
 import asyncio
+import contextlib
 import json
 import logging
+import os
 import random
 import re
 import sqlite3
@@ -1012,31 +1014,110 @@ def is_zeroed_state_db(path: Path, *, probe_bytes: int = 100) -> bool:
 
 
 def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
-    """Move a zeroed state.db aside (preserve bytes) and return quarantine path."""
+    """Move a zeroed state.db aside (preserve bytes) and return quarantine path.
+
+    Uses a cross-process lock (``#68805``) so two concurrent startups cannot
+    race: the first process moves the zeroed file and the second re-checks
+    under the lock, finding the file already gone (or a fresh DB in its place)
+    instead of clobbering the quarantine.
+    """
+    import platform
+
+    lock_path = path.with_name(path.name + ".quarantine.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = lock_path.open("a+b")
+    acquired = False
     try:
-        ts = time.strftime("%Y%m%d-%H%M%S")
-    except Exception:
-        ts = "unknown"
-    dest = path.with_name(f"{path.name}.zeroed-{ts}.bak")
-    # Avoid clobbering a prior quarantine
-    n = 0
-    while dest.exists():
-        n += 1
-        dest = path.with_name(f"{path.name}.zeroed-{ts}-{n}.bak")
-    try:
-        path.rename(dest)
-    except OSError as exc:
-        logger.error("Failed to quarantine zeroed %s: %s", path, exc)
-        return None
-    # Also move empty WAL/SHM if present so a fresh open is clean
-    for suffix in ("-wal", "-shm"):
-        side = Path(str(path) + suffix)
-        if side.exists():
-            try:
-                side.rename(Path(str(dest) + suffix))
-            except OSError:
-                pass
-    return dest
+        deadline = time.monotonic() + 5.0
+        if platform.system() == "Windows":
+            import msvcrt
+            while True:
+                try:
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                    acquired = True
+                    break
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        break
+                    time.sleep(0.020)
+        else:
+            import fcntl
+            while True:
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    acquired = True
+                    break
+                except (BlockingIOError, OSError):
+                    if time.monotonic() >= deadline:
+                        break
+                    time.sleep(0.020)
+        if not acquired:
+            logger.warning(
+                "quarantine lock for %s not acquired within 5s — proceeding "
+                "without the cross-process lock (#68805).",
+                path,
+            )
+        # Re-check under the lock: another process may have already quarantined
+        # the file, leaving a fresh DB (or no file at all) in its place.
+        if not path.exists():
+            logger.info(
+                "quarantine_zeroed_state_db: %s already moved by another process",
+                path,
+            )
+            return None
+        if not is_zeroed_state_db(path):
+            logger.info(
+                "quarantine_zeroed_state_db: %s is no longer zeroed (another "
+                "process quarantined it and a fresh DB was created)",
+                path,
+            )
+            return None
+
+        try:
+            ts = time.strftime("%Y%m%d-%H%M%S")
+        except Exception:
+            ts = "unknown"
+        # Unique destination with PID suffix to avoid collision across
+        # concurrent startups that somehow both enter the lock.
+        dest = path.with_name(
+            f"{path.name}.zeroed-{ts}-{os.getpid()}.bak"
+        )
+        # Non-clobbering: if dest somehow exists, append a counter.
+        n = 0
+        while dest.exists():
+            n += 1
+            dest = path.with_name(
+                f"{path.name}.zeroed-{ts}-{os.getpid()}-{n}.bak"
+            )
+        try:
+            path.rename(dest)
+        except OSError as exc:
+            logger.error("Failed to quarantine zeroed %s: %s", path, exc)
+            return None
+        # Also move empty WAL/SHM if present so a fresh open is clean
+        for suffix in ("-wal", "-shm"):
+            side = Path(str(path) + suffix)
+            if side.exists():
+                try:
+                    side.rename(Path(str(dest) + suffix))
+                except OSError:
+                    pass
+        return dest
+    finally:
+        try:
+            if acquired:
+                if platform.system() == "Windows":
+                    import msvcrt
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except (OSError, AttributeError):
+            pass
+        finally:
+            handle.close()
 
 
 class SessionDB:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1053,11 +1053,18 @@ def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
                         break
                     time.sleep(0.020)
         if not acquired:
-            logger.warning(
-                "quarantine lock for %s not acquired within 5s — proceeding "
-                "without the cross-process lock (#68805).",
+            # Fail closed: do NOT proceed without the lock. A slow or paused
+            # startup that still owns the lock can overlap this fallback and
+            # the two processes can act on the same live file (#68805 review).
+            logger.error(
+                "quarantine lock for %s not acquired within 5s — refusing to "
+                "quarantine without the cross-process lock. The zeroed file "
+                "is left in place. If sessions fail to load, restore from "
+                "state-snapshots via `hermes snapshot list` / "
+                "`hermes snapshot restore <id>`.",
                 path,
             )
+            return None
         # Re-check under the lock: another process may have already quarantined
         # the file, leaving a fresh DB (or no file at all) in its place.
         if not path.exists():

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1431,6 +1431,29 @@ class TestSafeCopyDb:
         assert rows == [("wal-test",)]
 
 
+
+    def test_is_zeroed_sqlite_file_detects_nul_header(self, tmp_path):
+        from hermes_cli.backup import is_zeroed_sqlite_file
+        p = tmp_path / "state.db"
+        p.write_bytes(bytes(4096))  # all NULs
+        assert is_zeroed_sqlite_file(p) is True
+
+    def test_is_zeroed_sqlite_file_rejects_valid_db(self, tmp_path):
+        from hermes_cli.backup import is_zeroed_sqlite_file
+        p = tmp_path / "ok.db"
+        conn = sqlite3.connect(str(p))
+        conn.execute("CREATE TABLE t (x INT)")
+        conn.commit()
+        conn.close()
+        assert is_zeroed_sqlite_file(p) is False
+
+    def test_is_zeroed_sqlite_file_empty_file(self, tmp_path):
+        from hermes_cli.backup import is_zeroed_sqlite_file
+        p = tmp_path / "empty.db"
+        p.write_bytes(b"")
+        assert is_zeroed_sqlite_file(p) is False
+
+
 # ---------------------------------------------------------------------------
 # Quick state snapshot tests
 # ---------------------------------------------------------------------------
@@ -1477,12 +1500,31 @@ class TestQuickSnapshot:
         snap_id = create_quick_snapshot(hermes_home=hermes_home)
         db_copy = hermes_home / "state-snapshots" / snap_id / "state.db"
         assert db_copy.exists()
-
         conn = sqlite3.connect(str(db_copy))
         rows = conn.execute("SELECT * FROM sessions").fetchall()
         conn.close()
         assert len(rows) == 1
         assert rows[0] == ("s1", "hello world")
+
+    def test_failed_state_db_copy_is_loud(self, hermes_home, monkeypatch, capsys):
+        """#68474: unreadable state.db must not look like a silent success."""
+        from hermes_cli import backup as backup_mod
+
+        def boom(src, dst):
+            return False
+
+        monkeypatch.setattr(backup_mod, "_safe_copy_db", boom)
+        snap_id = backup_mod.create_quick_snapshot(hermes_home=hermes_home)
+        err = capsys.readouterr().out
+        assert "SQLite safe copy FAILED" in err or "CRITICAL" in err
+        assert "state.db" in err
+        # Other small files may still snapshot
+        if snap_id:
+            manifest = (hermes_home / "state-snapshots" / snap_id / "manifest.json")
+            assert manifest.exists()
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            assert "state.db" not in data.get("files", {})
+            assert "state.db" in data.get("failed_dbs", [])
 
     def test_copies_nested_files(self, hermes_home):
         from hermes_cli.backup import create_quick_snapshot

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1823,6 +1823,56 @@ class TestQuickSnapshot:
         # Cleanup the seeded escape source so the test is hermetic.
         escape_src.unlink()
 
+    def test_oversized_db_suppresses_pruning(self, hermes_home, capsys):
+        """#68805: an oversized state.db skipped for size must suppress
+        pruning so the older complete snapshot (containing the only
+        recoverable database) is preserved.
+
+        Reproduces the reviewer's scenario: keep=1 + a state.db exceeding
+        the size cap → the new snapshot omits state.db, failed_dbs stays
+        empty (the file wasn't unreadable, just too large), and without
+        tracking oversized_skipped the older complete snapshot would be
+        pruned — losing the only recovery copy.
+        """
+        import json
+        import time as _t
+        from hermes_cli.backup import create_quick_snapshot, list_quick_snapshots
+
+        # First snapshot: complete (state.db is small, under any cap)
+        first_id = create_quick_snapshot(label="complete", hermes_home=hermes_home)
+        assert first_id is not None
+        first_dir = hermes_home / "state-snapshots" / first_id
+        assert (first_dir / "state.db").exists()
+
+        _t.sleep(1.05)  # ensure distinct timestamp
+
+        # Second snapshot: state.db exceeds the 1024-byte cap → skipped for
+        # size, but small config files (32-54 bytes) still land in the manifest.
+        second_id = create_quick_snapshot(
+            label="oversized", hermes_home=hermes_home, max_file_size=1024, keep=1
+        )
+        assert second_id is not None
+        second_dir = hermes_home / "state-snapshots" / second_id
+        assert not (second_dir / "state.db").exists()
+
+        # Manifest must record the oversized skip
+        with open(second_dir / "manifest.json") as f:
+            meta = json.load(f)
+        assert "state.db" in meta.get("oversized_skipped", [])
+
+        # CRITICAL: the first (complete) snapshot must survive pruning
+        # because the second snapshot is incomplete (oversized state.db).
+        all_snaps = list_quick_snapshots(limit=100, hermes_home=hermes_home)
+        snap_ids = {s["id"] for s in all_snaps}
+        assert first_id in snap_ids, (
+            f"Complete snapshot {first_id} was pruned by an incomplete "
+            f"(oversized) snapshot — the recovery copy was lost!"
+        )
+        assert second_id in snap_ids
+
+        out = capsys.readouterr().out
+        assert "skipping state.db" in out.lower() or "skipping snapshot prune" in out.lower()
+
 
 class TestQuickSnapshotProjectsKanban:
     """Regression for #52889: projects.db / kanban.db must survive an upgrade.

--- a/tests/test_zeroed_state_db.py
+++ b/tests/test_zeroed_state_db.py
@@ -1,0 +1,41 @@
+"""#68474 hardening: zeroed state.db detection + quarantine."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_is_zeroed_state_db_and_quarantine(tmp_path):
+    import hermes_state as hs
+
+    db = tmp_path / "state.db"
+    db.write_bytes(bytes(1024))
+    assert hs.is_zeroed_state_db(db) is True
+
+    q = hs.quarantine_zeroed_state_db(db)
+    assert q is not None
+    assert q.exists()
+    assert not db.exists()
+    assert q.read_bytes() == bytes(1024)
+
+
+def test_sessiondb_opens_fresh_after_zeroed_quarantine(tmp_path, monkeypatch):
+    import hermes_state as hs
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db = tmp_path / "state.db"
+    db.write_bytes(bytes(4096))
+
+    sdb = hs.SessionDB(db_path=db)
+    try:
+        # Fresh DB should open and accept schema
+        assert db.exists()
+        assert not hs.is_zeroed_state_db(db)
+        # Quarantine retained
+        backups = list(tmp_path.glob("state.db.zeroed-*.bak"))
+        assert len(backups) == 1
+        assert backups[0].stat().st_size == 4096
+    finally:
+        sdb.close()

--- a/tests/test_zeroed_state_db.py
+++ b/tests/test_zeroed_state_db.py
@@ -39,3 +39,65 @@ def test_sessiondb_opens_fresh_after_zeroed_quarantine(tmp_path, monkeypatch):
         assert backups[0].stat().st_size == 4096
     finally:
         sdb.close()
+
+
+def test_concurrent_quarantine_no_clobber(tmp_path):
+    """#68805: two concurrent startups must not race on quarantine.
+
+    Without the cross-process lock, the second process could move its
+    newly-created empty DB over the first process's quarantine backup,
+    erasing the original damaged-file evidence. With the lock, the
+    second process re-checks under the lock, finds the file no longer
+    zeroed (or gone), and returns without clobbering.
+    """
+    import hermes_state as hs
+    import threading
+    import sqlite3
+
+    db = tmp_path / "state.db"
+    db.write_bytes(bytes(4096))  # zeroed (all-NUL) 4 KB file
+
+    results: list = [None, None]
+    errors: list = [None, None]
+
+    def worker(idx):
+        try:
+            # Each worker opens its own SessionDB on the same path.
+            # The first one quarantines the zeroed file and creates a
+            # fresh DB. The second one should find a valid DB (or no
+            # file) under the lock and NOT clobber the quarantine.
+            sdb = hs.SessionDB(db_path=db)
+            try:
+                results[idx] = "ok"
+            finally:
+                sdb.close()
+        except Exception as exc:
+            errors[idx] = exc
+
+    t1 = threading.Thread(target=worker, args=(0,))
+    t2 = threading.Thread(target=worker, args=(1,))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    # Both workers should complete without error
+    assert errors[0] is None, f"Worker 0 raised: {errors[0]}"
+    assert errors[1] is None, f"Worker 1 raised: {errors[1]}"
+
+    # The quarantine backup must survive — exactly one .bak file with
+    # the original 4096 zeroed bytes.
+    backups = list(tmp_path.glob("state.db.zeroed-*.bak"))
+    assert len(backups) >= 1, "At least one quarantine backup must exist"
+    for bak in backups:
+        assert bak.stat().st_size == 4096, (
+            f"Quarantine backup {bak} was clobbered: "
+            f"expected 4096 bytes, got {bak.stat().st_size}"
+        )
+
+    # The live state.db must be a valid (non-zeroed) SQLite database
+    assert db.exists()
+    assert not hs.is_zeroed_state_db(db)
+    conn = sqlite3.connect(str(db))
+    conn.execute("SELECT 1")
+    conn.close()

--- a/tests/test_zeroed_state_db.py
+++ b/tests/test_zeroed_state_db.py
@@ -101,3 +101,70 @@ def test_concurrent_quarantine_no_clobber(tmp_path):
     conn = sqlite3.connect(str(db))
     conn.execute("SELECT 1")
     conn.close()
+
+
+def test_quarantine_fails_closed_when_lock_held(tmp_path):
+    """#68805 review: when the cross-process lock cannot be acquired within
+    the timeout, quarantine must FAIL CLOSED — return None without moving
+    the file. A fail-open fallback would let a slow/paused startup that
+    still owns the lock race with the fallback's re-check + rename.
+    """
+    import hermes_state as hs
+    import platform
+    import threading
+
+    db = tmp_path / "state.db"
+    db.write_bytes(bytes(4096))  # zeroed (all-NUL) 4 KB file
+
+    lock_path = db.with_name(db.name + ".quarantine.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Hold the cross-process lock from a background thread so the main
+    # thread's quarantine attempt cannot acquire it.
+    lock_held = threading.Event()
+    release_lock = threading.Event()
+
+    def hold_lock():
+        handle = lock_path.open("a+b")
+        try:
+            if platform.system() == "Windows":
+                import msvcrt
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            lock_held.set()
+            release_lock.wait(timeout=15)
+            if platform.system() == "Windows":
+                import msvcrt
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            lock_held.clear()
+        finally:
+            handle.close()
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    assert lock_held.wait(timeout=5), "Background thread failed to acquire lock"
+
+    # Reduce the quarantine lock timeout to keep the test fast. We patch
+    # the deadline by calling quarantine directly — it uses a 5s timeout,
+    # but we only need to verify it returns None without moving the file.
+    result = hs.quarantine_zeroed_state_db(db)
+
+    # Must fail closed: return None without moving the zeroed file
+    assert result is None, (
+        f"quarantine_zeroed_state_db returned {result} — expected None "
+        f"(fail-closed when lock is held)"
+    )
+    assert db.exists(), "Zeroed state.db was moved despite lock being held"
+    assert hs.is_zeroed_state_db(db), "File should still be zeroed (not moved)"
+
+    # Release the lock so the background thread can exit cleanly
+    release_lock.set()
+    holder.join(timeout=5)


### PR DESCRIPTION
## Summary

Hardening for [#68474](https://github.com/NousResearch/hermes-agent/issues/68474) while the storage-stack root cause remains under investigation.

A zeroed `state.db` (full original size, all NULs, empty WAL) was observed after a Windows desktop update. Pre-update snapshot already uses `_safe_copy_db`, but a **failed** copy of a present `state.db` was only a logger warning — the update could still print success with exit 0. Opening the zeroed file later produced a generic "file is not a database" with no recovery guidance.

## Changes

1. **Loud failed snapshot** (`hermes_cli/backup.py`)
   - Track `failed_dbs` when `_safe_copy_db` fails for a present `*.db`
   - Print critical stdout warnings (not log-only)
   - Detect zeroed signature during snapshot failure
   - Record `failed_dbs` in `manifest.json`
   - If nothing else was captured, abort snapshot with an explicit message

2. **Zeroed signature at SessionDB open** (`hermes_state.py`)
   - `is_zeroed_state_db()` / `quarantine_zeroed_state_db()`
   - On open: if size>0 and header is all-NUL (no `SQLite format 3`), **quarantine** the file (preserve bytes as `state.db.zeroed-<ts>.bak`), log recovery guidance pointing at `state-snapshots` / `hermes snapshot list|restore`, then open a fresh DB so the agent can start

## Out of scope

Root cause of the zeroing event itself (may be below SQLite / storage stack). This PR only makes failure **loud** and recovery **guided**.

## Test plan

- [x] `is_zeroed_sqlite_file` true on all-NUL file, false on valid DB / empty
- [x] failed `_safe_copy_db` during quick snapshot prints CRITICAL and records `failed_dbs`
- [x] SessionDB quarantines zeroed file and opens fresh schema
- [x] Existing safe-copy + snapshot tests still green

Related: #68474
