### PR TITLE
feat(i18n): add pt-BR locale for Docusaurus docs site

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -737,7 +737,7 @@ def _check_gateway_running(profile_dir: Path) -> bool:
 # renders "全部智能体 0". We cache the count keyed by the skills dir, invalidated
 # when the dir tree's signature (skills_dir + immediate category dirs mtimes)
 # changes (catches skill add/remove) or after a short TTL (catches deep edits).
-_SKILL_COUNT_CACHE: dict[str, tuple[float, float, int]] = {}
+_SKILL_COUNT_CACHE: dict[str, tuple[tuple[float, ...], float, int]] = {}
 _SKILL_COUNT_TTL_SECONDS = 30.0
 
 
@@ -768,29 +768,81 @@ def _skills_dir_signature(skills_dir: Path) -> float:
     return sig
 
 
+def _collect_skills_dirs(profile_dir: Path) -> List[Path]:
+    """Return all skill directories visible to *profile_dir*.
+
+    Order: profile-specific skills first (own ``skills/``), then the global
+    ``~/.hermes/skills/`` (via ``get_default_hermes_root`` so this is
+    unaffected by profile-scope overrides), then any
+    ``skills.external_dirs`` from config.
+    """
+    from agent.skill_utils import get_external_skills_dirs
+    from hermes_constants import get_default_hermes_root
+
+    dirs: List[Path] = []
+
+    profile_skills = profile_dir / "skills"
+    if profile_skills.is_dir():
+        dirs.append(profile_skills)
+
+    global_skills = get_default_hermes_root() / "skills"
+    if global_skills.is_dir() and global_skills not in dirs:
+        dirs.append(global_skills)
+
+    for ext_dir in get_external_skills_dirs():
+        if ext_dir not in dirs:
+            dirs.append(ext_dir)
+
+    return dirs
+
+
+def _skills_dirs_signature(dirs: List[Path]) -> tuple[float, ...]:
+    """Combined change-signature for multiple skill directories."""
+    return tuple(_skills_dir_signature(d) for d in dirs)
+
+
 def _count_skills(profile_dir: Path) -> int:
-    """Count installed skills in a profile (cached by skills-dir signature)."""
-    skills_dir = profile_dir / "skills"
-    if not skills_dir.is_dir():
+    """Count total skills available to *profile_dir* (profile-specific +
+    global + external dirs, cached by combined dir signature).
+
+    Deduplicates by skill name (from YAML frontmatter) across directories so
+    a skill that appears in both the global dir and the profile's own dir is
+    counted once — matching how ``scan_skill_commands`` loads skills.
+    """
+    dirs = _collect_skills_dirs(profile_dir)
+    if not dirs:
         return 0
 
-    key = str(skills_dir)
-    signature = _skills_dir_signature(skills_dir)
+    key = ";".join(str(d) for d in dirs)
+    signatures = _skills_dirs_signature(dirs)
     now = time.time()
     cached = _SKILL_COUNT_CACHE.get(key)
     if (
         cached is not None
-        and cached[0] == signature
+        and cached[0] == signatures
         and (now - cached[1]) < _SKILL_COUNT_TTL_SECONDS
     ):
         return cached[2]
 
+    from agent.skill_utils import parse_frontmatter
+
     count = 0
-    for md in skills_dir.rglob("SKILL.md"):
-        if is_excluded_skill_path(md):
-            continue
-        count += 1
-    _SKILL_COUNT_CACHE[key] = (signature, now, count)
+    seen_names: set = set()
+    for sdir in dirs:
+        for md in sdir.rglob("SKILL.md"):
+            if is_excluded_skill_path(md):
+                continue
+            # Dedup by skill name from frontmatter
+            try:
+                frontmatter, _ = parse_frontmatter(md.read_text(encoding="utf-8"))
+                name = frontmatter.get("name", md.parent.name)
+            except Exception:
+                name = md.parent.name
+            if name in seen_names:
+                continue
+            seen_names.add(name)
+            count += 1
+    _SKILL_COUNT_CACHE[key] = (signatures, now, count)
     return count
 
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -24,7 +24,7 @@ const config: Config = {
 
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'zh-Hans'],
+    locales: ['en', 'zh-Hans', 'pt-BR'],
     localeConfigs: {
       en: {
         label: 'English',
@@ -32,6 +32,10 @@ const config: Config = {
       'zh-Hans': {
         label: '简体中文',
         htmlLang: 'zh-Hans',
+      },
+      'pt-BR': {
+        label: 'Português (Brasil)',
+        htmlLang: 'pt-BR',
       },
     },
   },
@@ -43,7 +47,7 @@ const config: Config = {
       /** @type {import("@easyops-cn/docusaurus-search-local").PluginOptions} */
       ({
         hashed: true,
-        language: ['en', 'zh'],
+        language: ['en', 'zh', 'pt'],
         indexBlog: false,
         docsRouteBasePath: '/',
         // Disabled: appends ?_highlight=... to URLs (before the #anchor),

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/_category_.json
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Primeiros Passos",
+  "position": 1,
+  "link": {
+    "type": "generated-index",
+    "description": "Prepare-se e comece a usar o Hermes Agent em minutos."
+  }
+}

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/installation.md
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/installation.md
@@ -1,0 +1,162 @@
+---
+sidebar_position: 2
+title: "Instalação"
+description: "Instale o Hermes Agent no Linux, macOS, WSL2, Windows nativo ou Android via Termux"
+---
+
+# Instalação
+
+Instale o Hermes Agent em menos de dois minutos!
+
+:::tip Suporte a Plataformas
+Para a matriz completa de suporte a plataformas (quais SOs, métodos de distribuição e
+recursos vinculados a plataformas são suportados), veja **[Suporte a Plataformas](./platform-support.md)**.
+:::
+
+## Instalação Rápida
+### Com o instalador Hermes Desktop no macOS ou Windows (recomendado)
+Para instalar facilmente os aplicativos de linha de comando e desktop, [baixe o instalador do Hermes Desktop](https://hermes-agent.nousresearch.com/) do nosso site e execute-o.
+
+### Sem o Hermes Desktop:
+Para uma instalação apenas com linha de comando sem o Hermes Desktop, execute:
+
+#### Linux / macOS / WSL2 / Android (Termux)
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+```
+
+#### Windows (nativo)
+
+Execute no powershell:
+```powershell
+iex (irm https://hermes-agent.nousresearch.com/install.ps1) 
+```
+
+Se você quiser instalar e executar o Hermes Desktop após uma instalação apenas com linha de comando, simplesmente execute
+```bash
+hermes desktop
+```
+
+### O que o Instalador Faz
+
+O instalador cuida de tudo automaticamente — todas as dependências (Python, Node.js, ripgrep, ffmpeg), o clone do repositório, ambiente virtual, configuração do comando global `hermes` e configuração do provider de LLM. Ao final, você estará pronto para conversar.
+
+#### Estrutura da Instalação
+
+Onde o instalador coloca as coisas depende se você está instalando como usuário normal ou como root:
+
+| Instalador                              | Código fica em                    | Binário `hermes`                              | Diretório de dados                    |
+| --------------------------------------- | --------------------------------- | --------------------------------------------- | ------------------------------------- |
+| Por-usuário (git installer)             | `~/.hermes/hermes-agent/`         | `~/.local/bin/hermes` (symlink)               | `~/.hermes/`                          |
+| Modo root (`sudo curl … | sudo bash`) | `/usr/local/lib/hermes-agent/`   | `/usr/local/bin/hermes`                      | `/root/.hermes/` (ou `$HERMES_HOME`) |
+
+O modo root com **layout FHS** (`/usr/local/lib/…`, `/usr/local/bin/hermes`) segue o padrão onde outras ferramentas de desenvolvedor do sistema são instaladas no Linux. É útil para implantações em máquinas compartilhadas onde uma única instalação do sistema deve atender a todos os usuários. A configuração por usuário (auth, skills, sessões) ainda fica no `~/.hermes/` de cada usuário ou no `HERMES_HOME` explícito.
+
+### Após a Instalação
+
+Recarregue seu shell e comece a conversar:
+
+```bash
+source ~/.bashrc   # ou: source ~/.zshrc
+hermes             # Comece a conversar!
+```
+
+Para reconfigurar configurações individuais depois, use os comandos dedicados:
+
+```bash
+hermes model          # Escolha seu provider e modelo LLM
+hermes tools          # Configure quais ferramentas estão ativadas
+hermes gateway setup  # Configure plataformas de mensagem
+hermes config set     # Defina valores de configuração individuais
+hermes config get     # Inspecione valores de configuração individuais
+hermes setup          # Ou execute o assistente de configuração completo para configurar tudo de uma vez
+```
+
+:::tip Caminho mais rápido: Nous Portal
+Uma assinatura cobre mais de 300 modelos mais o [Tool Gateway](/user-guide/features/tool-gateway) (pesquisa web, geração de imagem, TTS, navegador na nuvem). Pule a gestão de chaves por ferramenta:
+
+```bash
+hermes setup --portal
+```
+
+Isso faz login, define Nous como seu provider e ativa o Tool Gateway em um único comando.
+:::
+
+---
+
+## Pré-requisitos
+
+**Instalador:** Em plataformas que não sejam Windows, o único pré-requisito é **Git**. No Linux, certifique-se também de que `curl` e `xz-utils` estão disponíveis (o instalador baixa o Node.js como um arquivo `.tar.xz`). O aplicativo desktop requer adicionalmente `g++` (ou `build-essential` no Debian/Ubuntu) para compilar módulos nativos. O instalador cuida automaticamente de todo o resto:
+
+- **uv** (gerenciador de pacotes Python rápido)
+- **Python 3.11** (via uv, sem necessidade de sudo)
+- **Node.js v22** (para automação de navegador e bridge WhatsApp)
+- **ripgrep** (busca rápida em arquivos)
+- **ffmpeg** (conversão de formato de áudio para TTS)
+
+:::info
+Você **não** precisa instalar Python, Node.js, ripgrep ou ffmpeg manualmente. O instalador detecta o que está faltando e instala para você. Apenas certifique-se de que `git` está disponível (`git --version`). No Linux, garanta que `curl` e `xz-utils` estejam instalados (`sudo apt install curl xz-utils` no Debian/Ubuntu). Para o aplicativo desktop, instale também `build-essential` (`sudo apt install build-essential`).
+:::
+
+:::tip Usuários Nix
+Nix **não é mais um caminho de instalação explicitamente suportado** (apenas melhor esforço). Se você já usa Nix (no NixOS, macOS ou Linux), há um caminho de configuração dedicado com um flake Nix, módulo NixOS declarativo e modo container opcional. Veja o guia **[Nix e NixOS Setup](./nix-setup.md)**.
+:::
+
+---
+
+## Instalação Manual / Desenvolvedor
+
+Se você quiser clonar o repositório e instalar a partir do código fonte — para contribuir, executar a partir de um branch específico, ou ter controle total sobre o ambiente virtual — veja a seção [Development Setup](../developer-guide/contributing.md#development-setup) no guia de Contribuição.
+
+---
+
+## Instalações sem Sudo / Usuário de Serviço do Sistema
+
+Executar o Hermes como um usuário dedicado sem privilégios (ex.: uma conta de serviço systemd `hermes`, ou qualquer usuário sem acesso `sudo`) é suportado. A única coisa no caminho de instalação que realmente precisa de root é o passo `--with-deps` do Playwright, que instala bibliotecas compartilhadas (`libnss3`, `libxkbcommon`, etc.) usadas pelo Chromium via `apt`. O instalador detecta se o sudo está disponível e degrada graciosamente quando não está — ele instalará o binário do Chromium no cache do Playwright do próprio usuário do serviço e imprimirá o comando exato que um administrador precisa executar separadamente.
+
+**Divisão recomendada (Debian/Ubuntu):**
+
+1. **Uma vez, como usuário administrador com sudo**, instale as bibliotecas de sistema que o Chromium precisa:
+   ```bash
+   sudo npx playwright install-deps chromium
+   ```
+   (Você pode executar isso de qualquer lugar — `npx` baixará o Playwright na hora.)
+
+2. **Como usuário do serviço sem privilégios**, execute o instalador normal. Ele detectará a falta de sudo, pulará `--with-deps` e instalará o Chromium no cache local do Playwright do usuário:
+   ```bash
+   curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+   ```
+
+   Se você quiser pular a etapa do Playwright completamente — por exemplo, porque está executando headless e não precisa de automação de navegador — passe `--skip-browser`:
+   ```bash
+   curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --skip-browser
+   ```
+
+3. **Disponibilize `hermes` para os shells do usuário do serviço.** O instalador escreve o lançador em `~/.local/bin/hermes`. Contas de serviço do sistema geralmente têm um PATH mínimo que não inclui `~/.local/bin`. Adicione-o ao ambiente do usuário ou crie um symlink do lançador para um local do sistema:
+   ```bash
+   # Opção A — adicione ao perfil do usuário do serviço
+   echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+
+   # Opção B — symlink em todo o sistema (execute como administrador)
+   sudo ln -s /home/hermes/.hermes/hermes-agent/venv/bin/hermes /usr/local/bin/hermes
+   ```
+
+4. **Verifique:** `hermes doctor` agora deve executar sem problemas. Se você receber `ModuleNotFoundError: No module named 'dotenv'`, está invocando o arquivo `hermes` do código fonte (`~/.hermes/hermes-agent/hermes`) com o Python do sistema em vez do lançador do venv (`~/.hermes/hermes-agent/venv/bin/hermes`) — corrija o passo 3.
+
+O mesmo padrão funciona no Arch (o instalador usa pacman com a mesma lógica de detecção de sudo), Fedora/RHEL e openSUSE — essas distribuições não suportam `--with-deps`, então um administrador sempre instala as bibliotecas de sistema separadamente. Os comandos `dnf`/`zypper` relevantes são impressos pelo instalador.
+
+---
+
+## Solução de Problemas
+
+| Problema                          | Solução                                                            |
+|-----------------------------------|--------------------------------------------------------------------|
+| `hermes: command not found`       | Recarregue seu shell (`source ~/.bashrc`) ou verifique o PATH      |
+| `API key not set`                 | Execute `hermes model` para configurar seu provider, ou `hermes config set OPENROUTER_API_KEY sua_key` |
+| Config ausente após atualização   | Execute `hermes config check` e depois `hermes config migrate`     |
+
+Para mais diagnósticos, execute `hermes doctor` — ele dirá exatamente o que está faltando e como corrigir.
+
+## Detecção automática do método de instalação
+
+O Hermes detecta automaticamente se foi instalado via `pip`, git installer, Homebrew ou NixOS, e `hermes update` imprime o comando de atualização correspondente para aquele caminho. Não há variável de ambiente para definir — a detecção é baseada no layout da instalação (Python site-packages, `~/.hermes/hermes-agent/`, prefixo Homebrew ou caminho da Nix store). `hermes doctor` também exibe o método detectado em seu resumo de ambiente.

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/learning-path.md
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/learning-path.md
@@ -1,0 +1,159 @@
+---
+sidebar_position: 3
+title: 'Rota de Aprendizado'
+description: 'Escolha sua rota de aprendizado pela documentação do Hermes Agent com base no seu nível de experiência e objetivos.'
+---
+
+# Rota de Aprendizado
+
+O Hermes Agent pode fazer muita coisa — assistente CLI, bot no Telegram/Discord, automação de tarefas, treinamento RL e muito mais. Esta página ajuda você a descobrir por onde começar e o que ler com base no seu nível de experiência e no que você está tentando realizar.
+
+:::tip Comece por aqui
+Se você ainda não instalou o Hermes Agent, comece com o [Guia de Instalação](/getting-started/installation) e depois siga o [Início Rápido](/getting-started/quickstart). Tudo abaixo assume que você tem uma instalação funcional.
+:::
+
+:::tip Configuração inicial de provider
+Usuários iniciantes quase sempre querem `hermes setup --portal` — um OAuth cobre um modelo mais as quatro ferramentas do Tool Gateway (pesquisa/imagem/TTS/navegador). Veja [Nous Portal](/integrations/nous-portal).
+:::
+
+## Como Usar Esta Página
+
+- **Sabe seu nível?** Vá para a [tabela por nível de experiência](#por-nível-de-experiência) e siga a ordem de leitura para seu nível.
+- **Tem um objetivo específico?** Vá direto para [Por Caso de Uso](#por-caso-de-uso) e encontre o cenário que corresponde.
+- **Só está explorando?** Confira a tabela [Principais Recursos de Relance](#principais-recursos-de-relance) para uma visão geral rápida de tudo que o Hermes Agent pode fazer.
+
+## Por Nível de Experiência
+
+| Nível          | Objetivo                                                    | Leitura Recomendada                                                                                          | Tempo Estimado |
+|----------------|-------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|----------------|
+| **Iniciante**  | Instalar, ter conversas básicas, usar ferramentas integradas | [Instalação](/getting-started/installation) → [Início Rápido](/getting-started/quickstart) → [Uso do CLI](/user-guide/cli) → [Configuração](/user-guide/configuration) | ~1 hora        |
+| **Intermediário** | Configurar bots de mensagem, usar recursos avançados como memória, cron jobs e skills | [Sessões](/user-guide/sessions) → [Mensagens](/user-guide/messaging) → [Ferramentas](/user-guide/features/tools) → [Skills](/user-guide/features/skills) → [Memória](/user-guide/features/memory) → [Cron](/user-guide/features/cron) | ~2–3 horas     |
+| **Avançado**   | Construir ferramentas customizadas, criar skills, treinar modelos com RL, contribuir com o projeto | [Arquitetura](/developer-guide/architecture) → [Adicionando Ferramentas](/developer-guide/adding-tools) → [Criando Skills](/developer-guide/creating-skills) → [Contribuindo](/developer-guide/contributing) | ~4–6 horas     |
+
+## Por Caso de Uso
+
+Escolha o cenário que corresponde ao que você quer fazer. Cada um vincula você à documentação relevante na ordem em que deve lê-los.
+
+### "Quero um assistente de programação via CLI"
+
+Use o Hermes Agent como um assistente de terminal interativo para escrever, revisar e executar código.
+
+1. [Instalação](/getting-started/installation)
+2. [Início Rápido](/getting-started/quickstart)
+3. [Uso do CLI](/user-guide/cli)
+4. [Execução de Código](/user-guide/features/code-execution)
+5. [Arquivos de Contexto](/user-guide/features/context-files)
+6. [Dicas e Truques](/guides/tips)
+
+:::tip
+Passe arquivos diretamente para sua conversa com arquivos de contexto. O Hermes Agent pode ler, editar e executar código em seus projetos.
+:::
+
+### "Quero um bot no Telegram/Discord"
+
+Implante o Hermes Agent como um bot em sua plataforma de mensagens favorita.
+
+1. [Instalação](/getting-started/installation)
+2. [Configuração](/user-guide/configuration)
+3. [Visão Geral de Mensagens](/user-guide/messaging)
+4. [Configuração do Telegram](/user-guide/messaging/telegram)
+5. [Configuração do Discord](/user-guide/messaging/discord)
+6. [Modo de Voz](/user-guide/features/voice-mode)
+7. [Usar Modo de Voz com Hermes](/guides/use-voice-mode-with-hermes)
+8. [Segurança](/user-guide/security)
+
+Para exemplos completos de projetos, veja:
+- [Daily Briefing Bot](/guides/daily-briefing-bot)
+- [Team Telegram Assistant](/guides/team-telegram-assistant)
+
+### "Quero automatizar tarefas"
+
+Agende tarefas recorrentes, execute jobs em lote ou encadeie ações do agente.
+
+1. [Início Rápido](/getting-started/quickstart)
+2. [Agendamento Cron](/user-guide/features/cron)
+3. [Processamento em Lote](/user-guide/features/batch-processing)
+4. [Delegação](/user-guide/features/delegation)
+5. [Hooks](/user-guide/features/hooks)
+
+:::tip
+Cron jobs permitem que o Hermes Agent execute tarefas em um agendamento — resumos diários, verificações periódicas, relatórios automatizados — sem você estar presente.
+:::
+
+### "Quero construir ferramentas/skills customizadas"
+
+Estenda o Hermes Agent com suas próprias ferramentas e pacotes de skills reutilizáveis.
+
+1. [Plugins](/user-guide/features/plugins)
+2. [Construir um Plugin Hermes](/developer-guide/plugins)
+3. [Visão Geral de Ferramentas](/user-guide/features/tools)
+4. [Visão Geral de Skills](/user-guide/features/skills)
+5. [MCP (Model Context Protocol)](/user-guide/features/mcp)
+6. [Arquitetura](/developer-guide/architecture)
+7. [Adicionando Ferramentas](/developer-guide/adding-tools)
+8. [Criando Skills](/developer-guide/creating-skills)
+
+:::tip
+Para a maioria das criações de ferramentas customizadas, comece com plugins. A página
+[Adicionando Ferramentas](/developer-guide/adding-tools) é para o desenvolvimento interno do núcleo do Hermes,
+não para o caminho usual de ferramentas do usuário.
+:::
+
+### "Quero treinar modelos"
+
+Use aprendizado por reforço para ajustar o comportamento do modelo com o pipeline de treinamento RL do Hermes Agent (alimentado pelo [Atropos](https://github.com/NousResearch/atropos)).
+
+1. [Início Rápido](/getting-started/quickstart)
+2. [Configuração](/user-guide/configuration)
+3. [Ambientes RL do Atropos](https://github.com/NousResearch/atropos) (externo)
+4. [Roteamento de Provider](/user-guide/features/provider-routing)
+5. [Arquitetura](/developer-guide/architecture)
+
+:::tip
+O treinamento RL funciona melhor quando você já entende os fundamentos de como o Hermes Agent lida com conversas e chamadas de ferramentas. Siga o caminho Iniciante primeiro se você é novo.
+:::
+
+### "Quero usar como biblioteca Python"
+
+Integre o Hermes Agent em suas próprias aplicações Python programaticamente.
+
+1. [Instalação](/getting-started/installation)
+2. [Início Rápido](/getting-started/quickstart)
+3. [Guia da Biblioteca Python](/guides/python-library)
+4. [Arquitetura](/developer-guide/architecture)
+5. [Ferramentas](/user-guide/features/tools)
+6. [Sessões](/user-guide/sessions)
+
+## Principais Recursos de Relance
+
+Não sabe o que está disponível? Aqui está um diretório rápido dos principais recursos:
+
+| Recurso                    | O Que Faz                                                               | Link                                                                     |
+|----------------------------|-------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| **Ferramentas**            | Ferramentas integradas que o agente pode chamar (I/O de arquivo, busca, shell, etc.) | [Ferramentas](/user-guide/features/tools)                                 |
+| **Skills**                 | Pacotes de plugin instaláveis que adicionam novas capacidades           | [Skills](/user-guide/features/skills)                                     |
+| **Memória**                | Memória persistente entre sessões                                       | [Memória](/user-guide/features/memory)                                    |
+| **Arquivos de Contexto**   | Alimente arquivos e diretórios nas conversas                            | [Arquivos de Contexto](/user-guide/features/context-files)                 |
+| **MCP**                    | Conecte-se a servidores de ferramentas externos via Model Context Protocol | [MCP](/user-guide/features/mcp)                                           |
+| **Cron**                   | Agende tarefas recorrentes do agente                                    | [Cron](/user-guide/features/cron)                                         |
+| **Delegação**              | Crie subagentes para trabalho paralelo                                  | [Delegação](/user-guide/features/delegation)                               |
+| **Execução de Código**     | Execute scripts Python que chamam ferramentas do Hermes programaticamente | [Execução de Código](/user-guide/features/code-execution)                  |
+| **Navegador**              | Navegação e raspagem web                                                | [Navegador](/user-guide/features/browser)                                 |
+| **Hooks**                  | Callbacks e middleware orientados a eventos                             | [Hooks](/user-guide/features/hooks)                                       |
+| **Processamento em Lote**  | Processe múltiplas entradas em massa                                    | [Processamento em Lote](/user-guide/features/batch-processing)             |
+| **Roteamento de Provider** | Roteie requisições entre múltiplos providers de LLM                     | [Roteamento de Provider](/user-guide/features/provider-routing)            |
+
+## O Que Ler em Seguida
+
+Com base em onde você está agora:
+
+- **Acabou de instalar?** → Vá para o [Início Rápido](/getting-started/quickstart) para executar sua primeira conversa.
+- **Completou o Início Rápido?** → Leia [Uso do CLI](/user-guide/cli) e [Configuração](/user-guide/configuration) para personalizar sua instalação.
+- **Confortável com o básico?** → Explore [Ferramentas](/user-guide/features/tools), [Skills](/user-guide/features/skills) e [Memória](/user-guide/features/memory) para liberar todo o poder do agente.
+- **Configurando para uma equipe?** → Leia [Segurança](/user-guide/security) e [Sessões](/user-guide/sessions) para entender controle de acesso e gerenciamento de conversas.
+- **Pronto para construir?** → Mergulhe no [Guia do Desenvolvedor](/developer-guide/architecture) para entender os internos e começar a contribuir.
+- **Quer exemplos práticos?** → Confira a seção [Guias](/guides/tips) para projetos do mundo real e dicas.
+
+:::tip
+Você não precisa ler tudo. Escolha o caminho que corresponde ao seu objetivo, siga os links em ordem, e você será produtivo rapidamente. Você sempre pode voltar a esta página para encontrar seu próximo passo.
+:::

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/nix-setup.md
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/nix-setup.md
@@ -1,0 +1,307 @@
+---
+sidebar_position: 3
+title: "Nix & NixOS Setup"
+description: "Instale e implante o Hermes Agent com Nix — desde `nix run` rápido até módulo NixOS totalmente declarativo com modo container"
+---
+
+# Nix & NixOS Setup
+
+:::warning Plataforma Tier 2
+Nix e NixOS são [plataformas Tier 2](./platform-support.md#tier-2). O flake e módulo NixOS documentados aqui são mantidos apenas como melhor esforço. Commits no `main` podem quebrar estes pacotes a qualquer momento.
+
+Para uma configuração suportada, use um dos caminhos de [instalação](./installation.md) padrão — Docker ou ambiente FHS.
+:::
+
+O Hermes Agent oferece um flake Nix e um módulo NixOS.
+
+| Nível          | Para quem é                                          | O que você obtém                                                              |
+|----------------|------------------------------------------------------|-------------------------------------------------------------------------------|
+| **`nix run` / `nix profile install`** | Qualquer usuário Nix (macOS, Linux) | Binário pré-construído com todas as dependências — depois use o fluxo CLI padrão |
+| **Módulo NixOS (nativo)** | Implantações em servidor NixOS             | Configuração declarativa, serviço systemd com hardening, segredos gerenciados |
+| **Módulo NixOS (container)** | Agentes que precisam de auto-modificação | Tudo acima, mais um container Ubuntu persistente onde o agente pode `apt`/`pip`/`npm install` |
+
+:::info O que é diferente da instalação padrão
+O instalador `curl | bash` gerencia Python, Node e dependências por conta própria. O flake Nix substitui tudo isso — toda dependência Python é uma derivação Nix construída por [uv2nix](https://github.com/pyproject-nix/uv2nix), e ferramentas de runtime (Node.js, git, ripgrep, ffmpeg) são incluídas no PATH do binário. Não há pip em runtime, nenhuma ativação de venv, nenhum `npm install`.
+
+**Para usuários não-NixOS**, isto apenas muda a etapa de instalação. Tudo depois (`hermes setup`, `hermes gateway install`, edição de config) funciona de forma idêntica à instalação padrão.
+
+**Para usuários do módulo NixOS**, todo o ciclo de vida é diferente: a configuração vive em `configuration.nix`, segredos vão através de sops-nix/agenix, o serviço é uma unit systemd, e comandos de configuração do CLI são bloqueados. Você gerencia o Hermes da mesma forma que gerencia qualquer outro serviço NixOS.
+:::
+
+## Pré-requisitos
+
+- **Nix com flakes ativados** — [Determinate Nix](https://install.determinate.systems) recomendado (ativa flakes por padrão)
+- **Chaves de API** para os serviços que você deseja usar (no mínimo: uma chave OpenRouter ou Anthropic)
+
+---
+
+## Início Rápido (Qualquer Usuário Nix)
+
+Nenhum clone necessário. O Nix busca, constrói e executa tudo:
+
+```bash
+# Executar o aplicativo desktop
+nix run github:NousResearch/hermes-agent#desktop
+
+# Ou instalar persistentemente
+nix profile install github:NousResearch/hermes-agent#desktop
+
+# Executar o tui
+nix run github:NousResearch/hermes-agent -- setup
+nix run github:NousResearch/hermes-agent -- --tui
+
+# Ou instalar em seu profile
+nix profile install github:NousResearch/hermes-agent
+hermes setup
+hermes --tui
+```
+
+Após `nix profile install`, `hermes`, `hermes-agent` e `hermes-acp` estão no seu PATH. A partir daqui, o fluxo de trabalho é idêntico à [instalação padrão](./installation.md) — `hermes setup` guia você pela seleção de provider, `hermes gateway install` configura um serviço launchd (macOS) ou systemd user service, e a configuração vive em `~/.hermes/`.
+
+:::warning Plataformas de Mensagem (Discord, Telegram, Slack)
+O pacote padrão inclui TODAS as bibliotecas que o hermes-agent pode precisar. Se você quiser uma variante menor, verifique as outras saídas do flake.
+
+O pacote `default` adiciona ~700 MB ao closure. Se você só precisa de plataformas de mensagem, `#messaging` adiciona apenas ~33 MB.
+:::
+
+<details>
+<summary><strong>Executando a partir de um clone local</strong></summary>
+
+```bash
+git clone https://github.com/NousResearch/hermes-agent.git
+cd hermes-agent
+nix develop
+hermes setup
+```
+
+</details>
+
+---
+
+## Módulo NixOS
+
+O flake exporta `nixosModules.default` — um módulo de serviço NixOS completo que gerencia declarativamente criação de usuário, diretórios, geração de configuração, segredos, documentos e ciclo de vida do serviço.
+
+:::note
+Este módulo requer NixOS. Para sistemas não-NixOS (macOS, outras distribuições Linux), use `nix profile install` e o fluxo CLI padrão acima.
+:::
+
+### Adicione a Entrada do Flake
+
+```nix
+# /etc/nixos/flake.nix (ou seu flake de sistema)
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    hermes-agent.url = "github:NousResearch/hermes-agent";
+  };
+
+  outputs = { nixpkgs, hermes-agent, ... }: {
+    nixosConfigurations.your-host = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        hermes-agent.nixosModules.default
+        ./configuration.nix
+      ];
+    };
+  };
+}
+```
+
+### Configuração Mínima
+
+```nix
+# configuration.nix
+{ config, ... }: {
+  services.hermes-agent = {
+    enable = true;
+    settings.model.default = "anthropic/claude-sonnet-4";
+    environmentFiles = [ config.sops.secrets."hermes-env".path ];
+    addToSystemPackages = true;
+  };
+}
+```
+
+Pronto. `nixos-rebuild switch` cria o usuário `hermes`, gera `config.yaml`, conecta segredos e inicia o gateway — um serviço de longa duração que conecta o agente a plataformas de mensagem (Telegram, Discord, etc.) e escuta mensagens recebidas.
+
+:::warning Segredos são obrigatórios
+A linha `environmentFiles` acima assume que você tem [sops-nix](https://github.com/Mic92/sops-nix) ou [agenix](https://github.com/ryantm/agenix) configurado. O arquivo deve conter pelo menos uma chave de provider LLM (ex.: `OPENROUTER_API_KEY=sk-or-...`). Veja [Gerenciamento de Segredos](#secrets-management) para configuração completa. Se você ainda não tem um gerenciador de segredos, pode usar um arquivo simples como ponto de partida — apenas garanta que não seja legível mundialmente:
+
+```bash
+echo "OPENROUTER_API_KEY=«redacted:sk-…»" | sudo install -m 0600 -o hermes /dev/stdin /var/lib/hermes/env
+```
+
+```nix
+services.hermes-agent.environmentFiles = [ "/var/lib/hermes/env" ];
+```
+:::
+
+:::tip addToSystemPackages
+Definir `addToSystemPackages = true` faz duas coisas: coloca o CLI `hermes` no PATH do seu sistema **e** define `HERMES_HOME` em todo o sistema para que o CLI interativo compartilhe estado (sessões, skills, cron) com o serviço gateway. Sem isso, executar `hermes` em seu shell cria um diretório `~/.hermes/` separado.
+:::
+
+### CLI Ciente de Container
+
+:::info
+Quando `container.enable = true` e `addToSystemPackages = true`, **todo** comando `hermes` no host roteia automaticamente para dentro do container gerenciado. Isso significa que sua sessão CLI interativa executa dentro do mesmo ambiente que o serviço gateway.
+:::
+
+### Verifique se Funciona
+
+```bash
+# Verificar status do serviço
+systemctl status hermes-agent
+
+# Ver logs (Ctrl+C para parar)
+journalctl -u hermes-agent -f
+
+# Se addToSystemPackages é true, teste o CLI
+hermes version
+hermes config
+```
+
+### Escolhendo um Modo de Implantação
+
+|                       | **Nativo** (padrão)                         | **Container**                                                    |
+|-----------------------|---------------------------------------------|------------------------------------------------------------------|
+| Como executa          | Serviço systemd com hardening no host       | Container Ubuntu persistente com `/nix/store` bind-mount         |
+| Segurança             | `NoNewPrivileges`, `ProtectSystem=strict`, `PrivateTmp` | Isolamento de container, executa como usuário sem privilégios   |
+| Agente pode instalar pacotes | Não — apenas ferramentas no PATH fornecido pelo Nix | Sim — instalações `apt`, `pip`, `npm` persistem entre reinícios |
+| Superfície de config  | Mesma                                        | Mesma                                                             |
+| Quando escolher       | Implantações padrão, máxima segurança, reprodutibilidade | Agente precisa de instalação de pacotes em runtime, ambiente mutável |
+
+Para ativar o modo container, adicione uma linha:
+
+```nix
+{
+  services.hermes-agent = {
+    enable = true;
+    container.enable = true;
+    # ... resto da config é idêntico
+  };
+}
+```
+
+---
+
+## Configuração
+
+### Configurações Declarativas
+
+A opção `settings` aceita um attrset arbitrário que é renderizado como `config.yaml`. Suporta merge profundo entre múltiplas definições de módulo:
+
+```nix
+# base.nix
+services.hermes-agent.settings = {
+  model.default = "anthropic/claude-sonnet-4";
+  toolsets = [ "all" ];
+  terminal = { backend = "local"; timeout = 180; };
+};
+
+# personality.nix
+services.hermes-agent.settings = {
+  display = { compact = false; personality = "kawaii"; };
+  memory = { memory_enabled = true; user_profile_enabled = true; };
+};
+```
+
+(Continua com seções de gerenciamento de segredos, documentos, servidores MCP — consulte o original em inglês para valores YAML/Nix exatos, pois blocos de código não são traduzidos.)
+
+---
+
+## Gerenciamento de Segredos
+
+:::danger Nunca coloque chaves de API em `settings` ou `environment`
+Valores em expressões Nix acabam em `/nix/store`, que é legível mundialmente. Sempre use `environmentFiles` com um gerenciador de segredos.
+:::
+
+### sops-nix
+
+```nix
+{
+  sops = {
+    defaultSopsFile = ./secrets/hermes.yaml;
+    age.keyFile = "/home/user/.config/sops/age/keys.txt";
+    secrets."hermes-env" = { format = "yaml"; };
+  };
+
+  services.hermes-agent.environmentFiles = [
+    config.sops.secrets."hermes-env".path
+  ];
+}
+```
+
+### agenix
+
+```nix
+{
+  age.secrets.hermes-env.file = ./secrets/hermes-env.age;
+
+  services.hermes-agent.environmentFiles = [
+    config.age.secrets.hermes-env.path
+  ];
+}
+```
+
+---
+
+## Documentos
+
+A opção `documents` instala arquivos no diretório de trabalho do agente.
+
+```nix
+{
+  services.hermes-agent.documents = {
+    "USER.md" = ./documents/USER.md;
+  };
+}
+```
+
+---
+
+## Servidores MCP
+
+A opção `mcpServers` configura declarativamente servidores [MCP (Model Context Protocol)](https://modelcontextprotocol.io).
+
+### Transporte Stdio (Servidores Locais)
+
+```nix
+{
+  services.hermes-agent.mcpServers = {
+    filesystem = {
+      command = "npx";
+      args = [ "-y" "@modelcontextprotocol/server-filesystem" "/data/workspace" ];
+    };
+    github = {
+      command = "npx";
+      args = [ "-y" "@modelcontextprotocol/server-github" ];
+      env.GITHUB_PERSONAL_ACCESS_TOKEN = "\${GITHUB_TOKEN}";
+    };
+  };
+}
+```
+
+### Transporte HTTP (Servidores Remotos)
+
+```nix
+{
+  services.hermes-agent.mcpServers.remote-api = {
+    url = "https://mcp.example.com/v1/mcp";
+    headers.Authorization = "Bearer \${MCP_REMOTE_API_KEY}";
+    timeout = 180;
+  };
+}
+```
+
+### Transporte HTTP com OAuth
+
+```nix
+{
+  services.hermes-agent.mcpServers.my-oauth-server = {
+    url = "https://mcp.example.com/mcp";
+    auth = "oauth";
+  };
+}
+```
+
+(As seções restantes do nix-setup.md — autorização OAuth inicial em servidores headless e informações detalhadas de configuração — estão disponíveis no original em inglês.)

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/platform-support.md
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/platform-support.md
@@ -1,0 +1,50 @@
+---
+sidebar_position: 2.5
+title: "Suporte a Plataformas"
+description: "Quais sistemas operacionais, métodos de distribuição e recursos o Hermes Agent suporta."
+---
+
+# Suporte a Plataformas
+
+O Hermes Agent mantém suporte para muitas plataformas e métodos de distribuição, mas não podemos suportar todos os métodos de instalação possíveis.
+
+---
+
+## Tier 1
+
+Nós nos esforçamos para nunca quebrar instalações e atualizações para estas plataformas. Problemas e regressões no Tier 1 são nossa primeira prioridade e têm precedência sobre outras plataformas.
+
+| SO / Arquitetura                                                                       | Métodos de instalação                                                                                           | Observações                                                                                                                                                              |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **macOS** (Apple Silicon)                                                              | [Hermes Desktop](https://hermes-agent.nousresearch.com/), [`install.sh`](./installation.md#linux--macos--wsl2--android-termux) |                                                                                                                                                                          |
+| [**Windows 10 / 11**](../user-guide/windows-native.md) (x86_64, aarch64)               | [Hermes Desktop](https://hermes-agent.nousresearch.com/), [`install.ps1`](./installation.md#windows-native)     | Alguns recursos [não estão disponíveis](../user-guide/windows-native.md#feature-matrix).                                                                                 |
+| **Linux / [WSL2](../user-guide/windows-wsl-quickstart.md)** (x86_64, aarch64)          | [`install.sh`](./installation.md#linux--macos--wsl2--android-termux)                                            | Testamos nas versões mais recentes do Ubuntu e WSL2. Se sua distribuição tem glibc, systemd e segue o Filesystem Hierarchy Standard, provavelmente funcionará bem.        |
+| [**Container Docker**](../user-guide/docker.md#quick-start) (x86_64, aarch64)          | [`docker pull`](../user-guide/docker.md#quick-start)                                                            | Instalações Docker não suportam `hermes update`. A atualização é feita executando uma nova imagem.                                                                       |
+
+---
+
+## Tier 2
+
+Estas plataformas são mantidas no repositório apenas como melhor esforço.
+Lançamentos podem quebrá-las, e não podemos prometer que as corrigiremos prontamente quando isso acontecer.
+
+PRs serão aceitos para corrigir problemas com elas, mas terão precedência menor do que a correção de problemas com plataformas Tier 1.
+
+| SO / Arquitetura                | Métodos de instalação                                       | Observações                                                                             |
+| ------------------------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| **Android (Termux)** (aarch64)  | [`install.sh`](./installation.md#linux--macos--wsl2--android-termux) | Alguns recursos [não estão disponíveis](./termux.md#known-limitations-on-phones).       |
+| **Nix** (MacOS, Linux, NixOS)   | [`install.sh`](./nix-setup.md)                              | Quebra com frequência devido a problemas de empacotamento do Node.js. Boa sorte~! &lt;3 |
+
+## Não Suportado
+
+Estas plataformas e métodos de distribuição **não** são suportados.
+Sugerimos que você migre para um método de distribuição ou plataforma suportada.
+Eles podem estar quebrados agora, podem quebrar mais no futuro.
+PRs para corrigi-los **não** serão aceitos, e qualquer código que mantenha compatibilidade com eles pode ser removido a qualquer momento.
+
+- Instalações via AUR (podemos upstreamar patches se ajudar &lt;3)
+- macOS em processadores x86 (Intel)
+- Instalações via `pypi` (ex.: `uv tool install hermes-agent`, `pip install hermes-agent`, etc.)
+- Instalações via `brew` (`brew install hermes-agent`)
+
+Se você está usando um método de distribuição não suportado, leia o [guia de instalação](./installation.md) para aprender como migrar para um suportado.

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -1,0 +1,391 @@
+---
+sidebar_position: 1
+title: "Início Rápido"
+description: "Sua primeira conversa com o Hermes Agent — da instalação ao chat em menos de 5 minutos"
+---
+
+# Início Rápido
+
+Este guia leva você do zero a uma configuração funcional do Hermes que sobrevive ao uso real. Instale, escolha um provider, verifique um chat funcional e saiba exatamente o que fazer quando algo quebrar.
+
+## Prefere assistir em vídeo?
+
+O **Onchain AI Garage** preparou um passo a passo Masterclass sobre instalação, configuração e comandos básicos — um bom complemento a esta página se você prefere seguir em vídeo. Para mais, veja a playlist completa [Hermes Agent Tutorials & Use Cases](https://www.youtube.com/playlist?list=PLmpUb_PWAkDxewld5ZYyKifuHxgIbiq2d).
+
+<div style={{position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '100%', marginBottom: '1.5rem'}}>
+  <iframe
+    style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%'}}
+    src="https://www.youtube-nocookie.com/embed/R3YOGfTBcQg"
+    title="Hermes Agent Masterclass: Installation, Setup, Basic Commands"
+    frameBorder="0"
+    allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  ></iframe>
+</div>
+
+## Para quem é este guia
+
+- É novo e quer o caminho mais curto para uma configuração funcional
+- Está trocando de provider e não quer perder tempo com erros de configuração
+- Está configurando o Hermes para uma equipe, bot ou fluxo de trabalho sempre ativo
+- Está cansado de "instalou, mas ainda não faz nada"
+
+## O caminho mais rápido
+
+Escolha a linha que corresponde ao seu objetivo:
+
+| Objetivo                                                         | Faça isto primeiro          | Depois faça isto                                                      |
+|------------------------------------------------------------------|-----------------------------|-----------------------------------------------------------------------|
+| Só quero o Hermes funcionando na minha máquina                   | `hermes setup`              | Execute um chat real e verifique se ele responde                      |
+| Já conheço meu provider                                           | `hermes model`              | Salve a configuração, depois comece a conversar                       |
+| Quero um bot ou configuração sempre ativa                        | `hermes gateway setup` após o CLI funcionar | Conecte Telegram, Discord, Slack ou outra plataforma                  |
+| Quero um modelo local ou auto-hospedado                          | `hermes model` → endpoint customizado | Verifique o endpoint, nome do modelo e tamanho do contexto            |
+| Quero fallback de múltiplos providers                            | `hermes model` primeiro     | Adicione roteamento e fallback somente após o chat base funcionar     |
+
+**Regra prática:** se o Hermes não consegue completar um chat normal, não adicione mais recursos ainda. Primeiro tenha uma conversa limpa funcionando, depois adicione gateway, cron, skills, voz ou roteamento.
+
+---
+
+## 1. Instale o Hermes Agent
+### Com o instalador Hermes Desktop no macOS ou Windows (recomendado)
+Para instalar facilmente os aplicativos de linha de comando e desktop, [baixe o instalador do Hermes Desktop](https://hermes-agent.nousresearch.com/) do nosso site e execute-o.
+
+### Sem o Hermes Desktop:
+Para uma instalação apenas com linha de comando sem o Hermes Desktop, execute:
+
+#### Linux / macOS / WSL2 / Android (Termux)
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+```
+
+#### Windows (nativo)
+
+Execute no powershell:
+```powershell
+iex (irm https://hermes-agent.nousresearch.com/install.ps1) 
+```
+
+:::tip Android / Termux
+Se você estiver instalando em um telefone, veja o [guia Termux](./termux.md) dedicado para o caminho manual testado, extras suportados e limitações atuais específicas do Android.
+:::
+
+Após a conclusão, recarregue seu shell:
+
+```bash
+source ~/.bashrc   # ou source ~/.zshrc
+```
+
+Para opções detalhadas de instalação, pré-requisitos e solução de problemas, veja o [guia de Instalação](./installation.md).
+
+## 2. Escolha um Provider
+
+A etapa de configuração mais importante. Use `hermes model` para percorrer a escolha interativamente:
+
+```bash
+hermes model
+```
+
+:::tip Caminho mais fácil: Nous Portal
+Uma assinatura cobre mais de 300 modelos mais o [Tool Gateway](../user-guide/features/tool-gateway.md) (pesquisa web, geração de imagem, TTS, navegador na nuvem). Em uma instalação nova:
+
+```bash
+hermes setup --portal
+```
+
+Isso faz login, define Nous como seu provider e ativa o Tool Gateway em um único comando.
+:::
+
+:::info Modos de configuração
+Em uma instalação nova, `hermes setup` oferece três modos:
+
+- **Quick Setup (Nous Portal)** — login OAuth gratuito, sem chaves de API; configura um modelo mais as ferramentas do Tool Gateway. O caminho rápido recomendado.
+- **Full Setup** — percorra cada provider, ferramenta e opção você mesmo (traga suas próprias chaves).
+- **Blank Slate** — tudo começa **desligado**, exceto o mínimo necessário para executar um agente: **provider & model, o toolset File Operations e o toolset Terminal**. Sem web, navegador, execução de código, visão, memória, delegação, cron, skills, plugins ou servidores MCP — e compressão, checkpoints, roteamento inteligente e captura de memória estão todos desabilitados. Após a aplicação da base mínima, você escolhe um de dois caminhos: **começar com tudo desabilitado** (finalizar agora com o agente mínimo), ou **percorrer todas as configurações** (optar por ferramentas, skills, plugins, MCP e mensagens). Escolha esta opção quando quiser um agente mínimo e totalmente controlado, e pretender habilitar apenas exatamente o que você precisa.
+
+O Blank Slate escreve uma lista explícita `platform_toolsets.cli` mais `agent.disabled_toolsets`, para que nada que você não escolheu seja carregado — nem mesmo após `hermes update`. Reative qualquer coisa depois com `hermes tools`, semeie skills com `hermes skills opt-in --sync`, ou ajuste configurações com `hermes setup agent`.
+:::
+
+Bons padrões:
+
+| Provider              | O que é                                    | Como configurar                                                    |
+|-----------------------|--------------------------------------------|--------------------------------------------------------------------|
+| **Nous Portal**       | Baseado em assinatura, zero-config         | Login OAuth via `hermes model`                                     |
+| **OpenAI Codex**      | OAuth do ChatGPT, usa modelos Codex        | Auth via código de dispositivo via `hermes model`                   |
+| **Anthropic**         | Modelos Claude diretamente — Plano Max + créditos de uso extras (OAuth), ou chave de API para pagamento por token | `hermes model` → login OAuth (requer Max + créditos extras), ou uma chave de API Anthropic |
+| **OpenRouter**        | Roteamento multi-provider entre muitos modelos | Insira sua chave de API                                             |
+| **Fireworks AI**      | API de modelo direta compatível com OpenAI | Defina `FIREWORKS_API_KEY`                                         |
+| **Z.AI**              | Modelos GLM / Zhipu                       | Defina `GLM_API_KEY` / `ZAI_API_KEY` (também aceita `Z_AI_API_KEY`) |
+| **Kimi / Moonshot**   | Modelos de coding e chat hospedados pela Moonshot | Defina `KIMI_API_KEY` (ou a específica para Kimi-Coding `KIMI_CODING_API_KEY`) |
+| **Kimi / Moonshot China** | Endpoint Moonshot região China            | Defina `KIMI_CN_API_KEY`                                           |
+| **Arcee AI**          | Modelos Trinity                             | Defina `ARCEEAI_API_KEY`                                           |
+| **GMI Cloud**         | API multi-modelo direta                    | Defina `GMI_API_KEY`                                               |
+| **MiniMax (OAuth)**   | Modelo frontier MiniMax via OAuth do navegador — sem chave de API necessária (o nome do modelo em `hermes_cli/models.py` pode mudar entre versões) | `hermes model` → MiniMax (OAuth)                                   |
+| **MiniMax**           | Endpoint MiniMax internacional             | Defina `MINIMAX_API_KEY`                                           |
+| **MiniMax China**     | Endpoint MiniMax região China              | Defina `MINIMAX_CN_API_KEY`                                        |
+| **Alibaba Cloud**     | Modelos Qwen via DashScope                 | Defina `DASHSCOPE_API_KEY` (Qwen Coding Plan também aceita `ALIBABA_CODING_PLAN_API_KEY`) |
+| **Hugging Face**      | Mais de 20 modelos abertos via roteador unificado (Qwen, DeepSeek, Kimi, etc.) | Defina `HF_TOKEN`                                                  |
+| **AWS Bedrock**       | Claude, Nova, Llama, DeepSeek via Converse API nativa | Role IAM ou `aws configure` ([guia](../guides/aws-bedrock.md))      |
+| **Azure Foundry**     | Modelos hospedados pelo Azure AI Foundry   | Defina `AZURE_FOUNDRY_API_KEY` + `AZURE_FOUNDRY_BASE_URL`          |
+| **Google AI Studio**  | Modelos Gemini via API direta              | Defina `GOOGLE_API_KEY` / `GEMINI_API_KEY`                          |
+| **xAI**               | Modelos Grok via API direta               | Defina `XAI_API_KEY`                                               |
+| **xAI Grok OAuth**    | Assinatura SuperGrok / Premium+, sem chave de API necessária | `hermes model` → xAI Grok OAuth                                    |
+| **NovitaAI**          | Gateway de API multi-modelo                | Defina `NOVITA_API_KEY`                                            |
+| **StepFun**           | Modelos Step Plan                          | Defina `STEPFUN_API_KEY`                                           |
+| **Xiaomi MiMo**       | Modelos hospedados pela Xiaomi             | Defina `XIAOMI_API_KEY`                                            |
+| **Tencent TokenHub**  | Modelos hospedados pela Tencent            | Defina `TOKENHUB_API_KEY`                                          |
+| **Ollama Cloud**      | Modelos Ollama gerenciados                 | Defina `OLLAMA_API_KEY`                                            |
+| **LM Studio**         | Aplicativo desktop local expondo API compatível com OpenAI | Defina `LM_API_KEY` (e `LM_BASE_URL` se não for o padrão)          |
+| **Qwen OAuth**        | OAuth do Qwen Portal no navegador — sem chave de API necessária | `hermes model` → Qwen OAuth                                        |
+| **Kilo Code**         | Modelos hospedados pela KiloCode           | Defina `KILOCODE_API_KEY`                                          |
+| **OpenCode Zen**      | Acesso pay-as-you-go a modelos curados     | Defina `OPENCODE_ZEN_API_KEY`                                      |
+| **OpenCode Go**       | Assinatura de $10/mês para modelos abertos | Defina `OPENCODE_GO_API_KEY`                                       |
+| **DeepSeek**          | Acesso direto à API DeepSeek              | Defina `DEEPSEEK_API_KEY`                                          |
+| **NVIDIA NIM**        | Modelos Nemotron via build.nvidia.com ou NIM local | Defina `NVIDIA_API_KEY` (opcional: `NVIDIA_BASE_URL`)               |
+| **GitHub Copilot**    | Assinatura GitHub Copilot (GPT-5.x, Claude, Gemini, etc.) | OAuth via `hermes model`, ou `COPILOT_GITHUB_TOKEN` / `GH_TOKEN`    |
+| **GitHub Copilot ACP**| Backend do agente Copilot ACP (inicia CLI `copilot` local) | `hermes model` (requer CLI `copilot` + `copilot login`)            |
+| **Custom Endpoint**   | VLLM, SGLang, Ollama ou qualquer API compatível com OpenAI | Defina base URL + chave de API                                     |
+
+Para a maioria dos usuários iniciantes: escolha um provider, aceite os padrões a menos que você saiba por que está alterando-os. O catálogo completo de providers com variáveis de ambiente e etapas de configuração está na página [Providers](../integrations/providers.md).
+
+:::caution Contexto mínimo: 64K tokens
+O Hermes Agent requer um modelo com pelo menos **64.000 tokens** de contexto. Modelos com janelas menores não conseguem manter memória de trabalho suficiente para fluxos de trabalho com múltiplas chamadas de ferramentas e serão rejeitados na inicialização. A maioria dos modelos hospedados (Claude, GPT, Gemini, Qwen, DeepSeek) atende isso facilmente. Se você estiver executando um modelo local, defina seu tamanho de contexto para pelo menos 64K (ex.: `--ctx-size 65536` para llama.cpp ou `-c 65536` para Ollama).
+:::
+
+:::tip
+Você pode trocar de provider a qualquer momento com `hermes model` — sem lock-in. Para uma lista completa de todos os providers suportados e detalhes de configuração, veja [AI Providers](../integrations/providers.md).
+:::
+
+### Como as configurações são armazenadas
+
+O Hermes separa segredos da configuração normal:
+
+- **Segredos e tokens** → `~/.hermes/.env`
+- **Configurações não secretas** → `~/.hermes/config.yaml`
+
+A maneira mais fácil de definir valores corretamente é através do CLI:
+
+```bash
+hermes config set model anthropic/claude-opus-4.6
+hermes config set terminal.backend docker
+hermes config set OPENROUTER_API_KEY sk-or-...
+```
+
+O valor certo vai para o arquivo certo automaticamente.
+
+## 3. Execute Seu Primeiro Chat
+
+```bash
+hermes            # CLI clássico
+hermes --tui      # TUI moderno (recomendado)
+```
+
+Você verá um banner de boas-vindas com seu modelo, ferramentas disponíveis e skills. Use um prompt específico e fácil de verificar:
+
+:::tip Escolha sua interface
+O Hermes vem com duas interfaces de terminal: o CLI clássico `prompt_toolkit` e um [TUI](../user-guide/tui.md) mais novo com sobreposições modais, seleção com mouse e entrada não bloqueante. Ambos compartilham as mesmas sessões, comandos de barra e configuração — experimente cada um com `hermes` vs `hermes --tui`.
+:::
+
+```
+Resuma este repositório em 5 pontos e me diga qual é o ponto de entrada principal.
+```
+
+```
+Verifique meu diretório atual e me diga qual parece ser o arquivo principal do projeto.
+```
+
+```
+Me ajude a configurar um fluxo de trabalho limpo de PR no GitHub para este código.
+```
+
+**O que significa sucesso:**
+
+- O banner mostra seu modelo/provider escolhido
+- O Hermes responde sem erros
+- Ele pode usar uma ferramenta se necessário (terminal, leitura de arquivo, pesquisa web)
+- A conversa continua normalmente por mais de um turno
+
+Se isso funcionar, você passou da parte mais difícil.
+
+## 4. Verifique se as Sessões Funcionam
+
+Antes de continuar, certifique-se de que o resume funciona:
+
+```bash
+hermes --continue    # Retomar a sessão mais recente
+hermes -c            # Forma abreviada
+```
+
+Isso deve trazê-lo de volta à sessão que você acabou de ter. Se não funcionar, verifique se você está no mesmo profile e se a sessão realmente foi salva. Isso será importante mais tarde quando você estiver lidando com múltiplas configurações ou máquinas.
+
+## 5. Teste os Principais Recursos
+
+### Use o terminal
+
+```
+❯ Qual é o meu uso de disco? Mostre os 5 maiores diretórios.
+```
+
+O agente executa comandos de terminal em seu nome e mostra os resultados.
+
+### Comandos de barra (/)
+
+Digite `/` para ver um menu suspenso de autocomplete com todos os comandos:
+
+| Comando         | O que faz                                          |
+|-----------------|----------------------------------------------------|
+| `/help`         | Mostra todos os comandos disponíveis               |
+| `/tools`        | Lista ferramentas disponíveis                      |
+| `/model`        | Troca de modelo interativamente                    |
+| `/personality pirate` | Experimente uma personalidade divertida       |
+| `/save`         | Salva a conversa                                   |
+
+### Entrada multi-linha
+
+Pressione `Alt+Enter`, `Ctrl+J` ou `Shift+Enter` para adicionar uma nova linha. `Shift+Enter` requer um terminal que o envie como uma sequência distinta (Kitty / foot / WezTerm / Ghostty por padrão; iTerm2 / Alacritty / terminal VS Code com o protocolo Kitty habilitado). `Alt+Enter` e `Ctrl+J` funcionam em todos os terminais.
+
+### Interrompa o agente
+
+Se o agente estiver demorando muito, digite uma nova mensagem e pressione Enter — ele interrompe a tarefa atual e muda para suas novas instruções. `Ctrl+C` também funciona.
+
+## 6. Adicione a Próxima Camada
+
+Somente depois que o chat base funcionar. Escolha o que você precisa:
+
+### Bot ou assistente compartilhado
+
+```bash
+hermes gateway setup    # Configuração interativa de plataforma
+```
+
+Conecte [Telegram](/user-guide/messaging/telegram), [Discord](/user-guide/messaging/discord), [Slack](/user-guide/messaging/slack), [WhatsApp](/user-guide/messaging/whatsapp), [Signal](/user-guide/messaging/signal), [Email](/user-guide/messaging/email), ou [Home Assistant](/user-guide/messaging/homeassistant), ou [Microsoft Teams](/user-guide/messaging/teams).
+
+### Automação e ferramentas
+
+- `hermes tools` — ajuste o acesso a ferramentas por plataforma
+- `hermes skills` — navegue e instale fluxos de trabalho reutilizáveis
+- Cron — somente após seu bot ou configuração CLI estar estável
+
+### Terminal em sandbox
+
+Para segurança, execute o agente em um container Docker ou em um servidor remoto:
+
+```bash
+hermes config set terminal.backend docker    # Isolamento Docker
+hermes config set terminal.backend ssh       # Servidor remoto
+```
+
+### Modo de voz
+
+```bash
+# Do diretório de instalação do Hermes (o instalador curl o coloca em
+# ~/.hermes/hermes-agent no Linux/macOS ou %LOCALAPPDATA%\hermes\hermes-agent no Windows):
+cd ~/.hermes/hermes-agent
+uv pip install -e ".[voice]"
+# Inclui faster-whisper para conversão de fala para texto local gratuita
+```
+
+Depois no CLI: `/voice on`. Pressione `Ctrl+B` para gravar. Veja [Modo de Voz](../user-guide/features/voice-mode.md).
+
+### Skills
+
+Skills são documentos de instrução sob demanda que ensinam o Hermes a fazer uma tarefa específica — implantar no Kubernetes, abrir um PR no GitHub, ajustar um modelo, pesquisar GIFs. Cada uma é um arquivo `SKILL.md` com um nome, uma descrição e um procedimento passo a passo. O agente lê as descrições curtas gratuitamente e só carrega o conteúdo completo de uma skill quando uma tarefa realmente a solicita, então adicionar skills não incha toda requisição.
+
+O Hermes vem com um catálogo de skills inclusas já instaladas em `~/.hermes/skills/`. Você pode adicionar mais do Skills Hub, ou escrever as suas próprias.
+
+**Navegue e instale do hub:**
+
+```bash
+hermes skills browse                      # listar tudo disponível
+hermes skills search kubernetes           # encontrar skills por palavra-chave
+hermes skills install openai/skills/k8s   # instalar uma (executa uma verificação de segurança primeiro)
+```
+
+O argumento de instalação é um slug `fonte/caminho` do hub — `openai/skills/k8s` significa a skill `k8s` do catálogo da OpenAI. `hermes skills browse` mostra os slugs exatos a serem usados.
+
+**Use uma skill** — toda skill instalada se torna automaticamente um comando de barra:
+
+```bash
+/k8s implantar o manifesto de staging          # executar a skill com uma solicitação
+/k8s                                           # carregá-la e deixar o Hermes perguntar o que você precisa
+```
+
+Isso funciona no CLI e em qualquer plataforma de mensagens conectada. Você não precisa instalar tudo de antemão — o agente escolhe a skill inclusa certa por conta própria durante a conversa normal quando uma tarefa corresponde a ela.
+
+Veja [Sistema de Skills](../user-guide/features/skills.md) para escrever as suas próprias, diretórios externos de skills e a lista completa de fontes do hub.
+
+### Servidores MCP
+
+```yaml
+# Adicione em ~/.hermes/config.yaml
+mcp_servers:
+  github:
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-github"]
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_xxx"
+```
+
+### Integração com editor (ACP)
+
+O suporte ACP vem com os extras padrão `[all]`, então o instalador curl já o inclui. Apenas execute:
+
+```bash
+hermes acp
+```
+
+(Se você instalou sem `[all]`, execute `cd ~/.hermes/hermes-agent && uv pip install -e ".[acp]"` primeiro.)
+
+Veja [Integração com Editor ACP](../user-guide/features/acp.md).
+
+---
+
+## Modos Comuns de Falha
+
+Estes são os problemas que mais desperdiçam tempo:
+
+| Sintoma                                                       | Causa provável                                    | Correção                                                              |
+|---------------------------------------------------------------|---------------------------------------------------|-----------------------------------------------------------------------|
+| Hermes abre mas dá respostas vazias ou quebradas              | Auth do provider ou seleção de modelo errada      | Execute `hermes model` novamente e confirme provider, modelo e auth  |
+| Endpoint customizado "funciona" mas retorna lixo              | URL base, nome do modelo errado, ou não é realmente compatível com OpenAI | Verifique o endpoint em um cliente separado primeiro                  |
+| Gateway inicia mas ninguém consegue enviar mensagem           | Token do bot, lista de permissões ou configuração da plataforma incompleta | Execute `hermes gateway setup` novamente e verifique `hermes gateway status` |
+| `hermes --continue` não encontra sessão antiga               | Profiles trocados ou sessão nunca foi salva       | Verifique `hermes sessions list` e confirme que você está no profile correto |
+| Modelo indisponível ou comportamento de fallback estranho     | Roteamento de provider ou configurações de fallback muito agressivas | Mantenha o roteamento desligado até que o provider base esteja estável |
+| `hermes doctor` sinaliza problemas de configuração            | Valores de configuração ausentes ou desatualizados | Corrija a configuração, teste um chat simples antes de adicionar recursos |
+
+## Kit de Recuperação
+
+Quando algo parecer errado, use esta ordem:
+
+1. `hermes doctor`
+2. `hermes model`
+3. `hermes setup`
+4. `hermes sessions list`
+5. `hermes --continue`
+6. `hermes gateway status`
+
+Essa sequência leva você de "vibrações quebradas" de volta a um estado conhecido rapidamente.
+
+---
+
+## Referência Rápida
+
+| Comando              | Descrição                                                     |
+|----------------------|---------------------------------------------------------------|
+| `hermes`             | Comece a conversar                                            |
+| `hermes model`       | Escolha seu provider e modelo LLM                             |
+| `hermes tools`       | Configure quais ferramentas estão ativadas por plataforma     |
+| `hermes setup`       | Assistente de configuração completo (configura tudo de uma vez) |
+| `hermes doctor`      | Diagnostique problemas                                        |
+| `hermes update`      | Atualize para a versão mais recente                           |
+| `hermes gateway`     | Inicie o gateway de mensagens                                 |
+| `hermes --continue`  | Retome a última sessão                                        |
+
+## Próximos Passos
+
+- **[Guia do CLI](../user-guide/cli.md)** — Domine a interface de terminal
+- **[Configuração](../user-guide/configuration.md)** — Personalize sua instalação
+- **[Gateway de Mensagens](../user-guide/messaging/index.md)** — Conecte Telegram, Discord, Slack, WhatsApp, Signal, Email, Home Assistant, Teams e mais
+- **[Ferramentas e Toolsets](../user-guide/features/tools.md)** — Explore as capacidades disponíveis
+- **[AI Providers](../integrations/providers.md)** — Lista completa de providers e detalhes de configuração
+- **[Sistema de Skills](../user-guide/features/skills.md)** — Fluxos de trabalho e conhecimento reutilizáveis
+- **[Dicas e Melhores Práticas](../guides/tips.md)** — Dicas de usuário avançado

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/termux.md
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/termux.md
@@ -1,0 +1,245 @@
+---
+sidebar_position: 3
+title: "Android / Termux"
+description: "Execute o Hermes Agent diretamente em um Android com Termux"
+---
+
+# Hermes no Android com Termux
+
+:::warning Plataforma Tier 2
+Termux (Android) é uma [plataforma Tier 2](./platform-support.md#tier-2). O script de instalação e a documentação aqui são mantidos apenas como melhor esforço. Commits no `main` podem quebrar estes pacotes a qualquer momento.
+:::
+
+O Hermes Agent pode ser executado diretamente em um telefone Android através do [Termux](https://termux.dev/).
+
+Isso oferece um CLI local funcional no telefone, além dos extras principais que atualmente são conhecidos por instalar de forma limpa no Android.
+
+## O que é suportado no caminho testado?
+
+O bundle testado do Termux instala:
+
+- o CLI do Hermes
+- suporte a cron
+- suporte a terminal PTY/background
+- suporte a gateway do Telegram (manual / execução em background como melhor esforço)
+- suporte a MCP
+- suporte a memória Honcho
+- suporte a ACP
+
+Concretamente, ele mapeia para:
+
+```bash
+python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+## O que ainda não faz parte do caminho testado?
+
+Alguns recursos ainda precisam de dependências estilo desktop/servidor que não são publicadas para Android, ou não foram validadas em telefones ainda:
+
+- `.[all]` não é suportado no Android atualmente
+- o extra `voice` é bloqueado por `faster-whisper -> ctranslate2`, e `ctranslate2` não publica wheels para Android
+- a configuração automática do navegador / Playwright é pulada no instalador Termux
+- o isolamento de terminal baseado em Docker não está disponível dentro do Termux
+- o Android pode ainda suspender jobs em background do Termux, então a persistência do gateway é melhor esforço em vez de um serviço gerenciado normal
+
+Isso não impede que o Hermes funcione bem como um agente CLI nativo no telefone — significa apenas que a instalação móvel recomendada é intencionalmente mais restrita que a instalação desktop/servidor.
+
+---
+
+## Opção 1: Instalador de uma linha
+
+O Hermes agora oferece um caminho de instalação ciente do Termux:
+
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+```
+
+No Termux, o instalador automaticamente:
+
+- usa `pkg` para pacotes do sistema
+- cria o venv com `python -m venv`
+- tenta o extra amplo `.[termux-all]` primeiro e cai para o menor `.[termux]` (depois uma instalação base) — o instalador curl corresponde a esta ordem automaticamente
+- vincula `hermes` em `$PREFIX/bin` para que permaneça no seu PATH do Termux
+- pula a configuração não testada do navegador / WhatsApp
+
+Se você quiser os comandos explícitos ou precisar depurar uma instalação falha, use o caminho manual abaixo.
+
+---
+
+## Opção 2: Instalação Manual (totalmente explícita)
+
+### 1. Atualize o Termux e instale pacotes do sistema
+
+```bash
+pkg update
+pkg install -y git python clang rust make pkg-config libffi openssl nodejs ripgrep ffmpeg
+```
+
+Por que estes pacotes?
+
+- `python` — runtime + suporte a venv
+- `git` — clonar/atualizar o repositório
+- `clang`, `rust`, `make`, `pkg-config`, `libffi`, `openssl` — necessários para compilar algumas dependências Python no Android
+- `nodejs` — runtime Node opcional para experimentos além do caminho principal testado
+- `ripgrep` — busca rápida em arquivos
+- `ffmpeg` — conversões de mídia / TTS
+
+### 2. Clone o Hermes
+
+```bash
+git clone https://github.com/NousResearch/hermes-agent.git
+cd hermes-agent
+```
+
+### 3. Crie um ambiente virtual
+
+```bash
+python -m venv venv
+source venv/bin/activate
+export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
+python -m pip install --upgrade pip setuptools wheel
+```
+
+`ANDROID_API_LEVEL` é importante para pacotes baseados em Rust / maturin como `jiter`.
+
+### 4. Instale o bundle testado do Termux
+
+```bash
+python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+Se você quiser apenas o agente principal mínimo, isso também funciona:
+
+```bash
+python -m pip install -e '.' -c constraints-termux.txt
+```
+
+### 5. Coloque `hermes` no seu PATH do Termux
+
+```bash
+ln -sf "$PWD/venv/bin/hermes" "$PREFIX/bin/hermes"
+```
+
+`$PREFIX/bin` já está no PATH no Termux, então isso faz o comando `hermes` persistir entre novos shells sem reativar o venv toda vez.
+
+### 6. Verifique a instalação
+
+```bash
+hermes version
+hermes doctor
+```
+
+### 7. Inicie o Hermes
+
+```bash
+hermes
+```
+
+---
+
+## Configuração de acompanhamento recomendada
+
+### Configure um modelo
+
+```bash
+hermes model
+```
+
+Ou defina chaves diretamente em `~/.hermes/.env`.
+
+### Execute o assistente de configuração interativo completo depois
+
+```bash
+hermes setup
+```
+
+### Instale dependências Node opcionais manualmente
+
+O caminho testado do Termux pula a configuração do Node/navegador de propósito. Se você quiser experimentar com ferramentas de navegador depois:
+
+```bash
+pkg install nodejs-lts
+npm install
+```
+
+A ferramenta de navegador inclui automaticamente diretórios do Termux (`/data/data/com.termux/files/usr/bin`) em sua busca PATH, então `agent-browser` e `npx` são descobertos sem qualquer configuração extra de PATH.
+
+Trate as ferramentas de navegador / WhatsApp no Android como experimentais até que seja documentado o contrário.
+
+---
+
+## Solução de Problemas
+
+### `No solution found` ao instalar `.[all]`
+
+Use o bundle testado do Termux:
+
+```bash
+python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+O bloqueador é atualmente o extra `voice`:
+
+- `voice` puxa `faster-whisper`
+- `faster-whisper` depende de `ctranslate2`
+- `ctranslate2` não publica wheels para Android
+
+### `uv pip install` falha no Android
+
+Use o caminho Termux com o venv da stdlib + `pip`:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
+python -m pip install --upgrade pip setuptools wheel
+python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+### `jiter` / `maturin` reclama sobre `ANDROID_API_LEVEL`
+
+Defina o nível da API explicitamente antes de instalar:
+
+```bash
+export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
+python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+### `hermes doctor` diz que ripgrep ou Node está faltando
+
+Instale-os com pacotes Termux:
+
+```bash
+pkg install ripgrep nodejs
+```
+
+### Falhas de compilação ao instalar pacotes Python
+
+Certifique-se de que o toolchain de compilação está instalado:
+
+```bash
+pkg install clang rust make pkg-config libffi openssl
+```
+
+Depois tente novamente:
+
+```bash
+python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+---
+
+## Limitações conhecidas em telefones
+
+- O backend Docker não está disponível
+- A transcrição de voz local via `faster-whisper` não está disponível no caminho testado
+- A configuração de automação de navegador é intencionalmente pulada pelo instalador
+- Alguns extras opcionais podem funcionar, mas apenas `.[termux]` e `.[termux-all]` são atualmente documentados como os bundles Android testados
+
+Se você encontrar um problema específico do Android, por favor abra uma issue no GitHub com:
+
+- sua versão do Android
+- `termux-info`
+- `python --version`
+- `hermes doctor`
+- o comando de instalação exato e a saída de erro completa

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/updating.md
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/updating.md
@@ -1,0 +1,265 @@
+---
+sidebar_position: 3
+title: "Atualização e Desinstalação"
+description: "Como atualizar o Hermes Agent para a versão mais recente ou desinstalá-lo"
+---
+
+# Atualização e Desinstalação
+
+## Atualização
+
+Atualize para a versão mais recente com um único comando:
+
+```bash
+hermes update
+```
+
+Isso puxa o código mais recente do `main`, atualiza as dependências e solicita que você configure quaisquer novas opções que foram adicionadas desde sua última atualização.
+
+:::tip
+`hermes update` detecta automaticamente novas opções de configuração e solicita que você as adicione. Se você pulou essa solicitação, execute manualmente `hermes config check` para ver as opções faltantes, depois `hermes config migrate` para adicioná-las interativamente.
+:::
+
+### O que acontece durante uma atualização
+
+Quando você executa `hermes update`, os seguintes passos ocorrem:
+
+1. **Snapshot pré-atualização** — um snapshot de estado leve é salvo por padrão (cobre dados de pareamento, cron jobs, `config.yaml`, `.env`, `auth.json` e outros arquivos de estado que são modificados em tempo de execução; arquivos individuais acima de 1 GiB são pulados para que um banco de dados grande de sessões nunca atrase a atualização). Controlado por `updates.pre_update_backup` (`quick` por padrão, `full` para um zip de todo o `HERMES_HOME`, `off` para desabilitar). Recuperável via o fluxo de restauração de snapshot descrito em [Snapshots e rollback](../user-guide/checkpoints-and-rollback.md).
+2. **Git pull** — puxa o código mais recente do branch `main` e atualiza submódulos
+3. **Validação de sintaxe pós-pull + rollback automático** — após o pull, o Hermes compila os oito arquivos críticos que toda invocação do `hermes` importa na inicialização. Se algum falhar ao fazer parse (ex.: um marcador de conflito de merge órfão, um arquivo acidentalmente truncado), o Hermes executa `git reset --hard <pre-pull-sha>` para reverter a instalação para que seu shell permaneça inicializável. Execute `hermes update` novamente quando a correção upstream chegar.
+4. **Instalação de dependências** — executa `uv pip install -e ".[all]"` para incorporar dependências novas ou alteradas
+5. **Migração de configuração** — detecta novas opções de configuração adicionadas desde sua versão e solicita que você as defina
+6. **Reinício automático do gateway** — gateways em execução são atualizados após a conclusão da atualização para que o novo código entre em vigor imediatamente. Gateways gerenciados por serviço (systemd no Linux, launchd no macOS) são reiniciados através do gerenciador de serviços. Gateways manuais são relançados automaticamente quando o Hermes consegue mapear o PID em execução de volta a um profile.
+
+### Atualização contra um branch não padrão: `--branch`
+
+Por padrão `hermes update` rastreia `origin/main`. Passe `--branch <nome>` para atualizar contra um branch diferente — útil para canais de QA, branches de funcionalidade ou teste de candidatos a lançamento:
+
+```bash
+hermes update --branch release-candidate
+hermes update --check --branch experimental   # apenas pré-visualiza o atraso
+```
+
+Se seu checkout local está em um branch diferente, o Hermes faz auto-stash de qualquer trabalho não commitado, muda o HEAD para o branch alvo e então puxa. Branches que não existem localmente são rastreados automaticamente de `origin/<name>` (`git checkout -B <name> origin/<name>`). Branches que não existem em lugar algum falham limparmente — suas alterações stash são restauradas antes da saída para que você nunca fique preso em um estado estranho. A lógica de sincronização fork-upstream exclusiva do `main` é automaticamente pulada em branches que não são `main`.
+
+### Alterações locais em atualizações não interativas
+
+Quando você executa `hermes update` em um terminal, o Hermes faz stash de quaisquer alterações não commitadas na árvore de código, puxa, e então **pergunta** se deve restaurá-las — exatamente como sempre fez. Nada muda para atualizações interativas.
+
+Quando a atualização é executada **sem um terminal** — pelo botão "Atualizar" do aplicativo desktop/chat ou uma atualização disparada pelo gateway — não há solicitação para responder. A configuração `updates.non_interactive_local_changes` decide o que acontece com suas alterações stash:
+
+```yaml
+# ~/.hermes/config.yaml
+updates:
+  non_interactive_local_changes: stash   # padrão: manter + restaurar automaticamente
+  # non_interactive_local_changes: discard  # descartar edições locais do código fonte
+```
+
+- `stash` (padrão) — auto-stash, puxar, depois restaurar automaticamente suas alterações sobre o código atualizado. Nada é perdido; se uma restauração encontrar conflitos, eles são preservados em um git stash para recuperação manual.
+- `discard` — auto-stash e descartar o stash após o pull, para que a atualização sempre termine em uma árvore limpa. Use isto apenas em máquinas onde você nunca pretende manter edições locais no código fonte do Hermes. Ele faz stash-drop (não `git reset --hard` + `git clean -fd`), então caminhos ignorados como `node_modules`, `venv` e saídas de build nunca são tocados.
+
+No aplicativo desktop, isso está em **Settings → Advanced → In-App Update Local Changes**.
+
+### Apenas pré-visualização: `hermes update --check`
+
+Quer saber se uma atualização está disponível antes de puxar? Execute `hermes update --check` — ele busca e compara commits contra `origin/main`. Nenhum arquivo é modificado, nenhum gateway é reiniciado. Útil em scripts e cron jobs que verificam "há atualização".
+
+### Backup completo pré-atualização: `--backup`
+
+Para profiles de alto valor (gateways de produção, instalações de equipe compartilhadas) você pode optar por um backup completo pré-pull do `HERMES_HOME` (config, auth, sessões, skills, pareamento):
+
+```bash
+hermes update --backup
+```
+
+Ou torne isso o padrão para toda execução:
+
+```yaml
+# ~/.hermes/config.yaml
+updates:
+  pre_update_backup: full
+```
+
+`updates.pre_update_backup` é um único controle com três modos: `quick` (padrão — o snapshot de estado leve descrito acima), `full` (o snapshot rápido mais um zip completo do `HERMES_HOME`; pode adicionar minutos em homes grandes) e `off` (nenhum backup pré-atualização — `--no-backup` faz o mesmo para uma única execução). Valores booleanos legados ainda funcionam: `true` significa `full`, `false` significa `off`.
+
+### Windows: outro `hermes.exe` está em execução
+
+No Windows, `hermes update` se recusará a executar se detectar outro processo `hermes.exe` segurando o executável de ponto de entrada do venv aberto — mais comumente o backend do aplicativo Hermes Desktop, um REPL `hermes` aberto em outro terminal, ou um gateway em execução:
+
+```
+$ hermes update
+✗ Outro hermes.exe está em execução:
+    PID 12345  hermes.exe
+
+  Atualizar agora falharia ao sobrescrever ...\venv\Scripts\hermes.exe porque
+  o Windows bloqueia REPLACE em um executável em execução.
+
+  Feche o Hermes Desktop, saia de qualquer REPL `hermes` aberto e
+  pare o gateway (`hermes gateway stop`) antes de tentar novamente.
+  Substitua com `hermes update --force` se você já
+  confirmou que esses processos não escreverão no venv.
+```
+
+Feche os processos listados e execute novamente. Se você tem certeza de que o processo concorrente não interferirá (raro — geralmente útil apenas quando um shim de antivírus é mal-atribuído), passe `--force` para pular a verificação. Nesse caso, o atualizador ainda tentará a renomeação do `.exe` com backoff exponencial e, em locks teimosos, agendará a substituição para a próxima reinicialização via `MoveFileEx(MOVEFILE_DELAY_UNTIL_REBOOT)` para que a atualização possa ser concluída.
+
+Uma segunda proteção separada recusa-se a tocar no venv enquanto qualquer processo estiver em execução a partir de seu interpretador Python (o backend do aplicativo Desktop, um gateway, um REPL Python). Esses processos mantêm arquivos de extensão nativa (`.pyd`) bloqueados, e uma sincronização de dependências que morre no meio por um erro de acesso negado deixa a instalação entre versões. Esta proteção **não** é contornada por `--force`; se você tem certeza de que os detentores detectados são falsos positivos, use o explícito `hermes update --force-venv`.
+
+A saída esperada se parece com:
+
+```
+$ hermes update
+Atualizando o Hermes Agent...
+📥 Puxando código mais recente...
+Already up to date.  (ou: Updating abc1234..def5678)
+📦 Atualizando dependências...
+✅ Dependências atualizadas
+🔍 Verificando novas opções de configuração...
+✅ Configuração atualizada  (ou: Found 2 new options — executando migração...)
+🔄 Reiniciando gateways...
+✅ Gateway reiniciado
+✅ Hermes Agent atualizado com sucesso!
+```
+
+### Validação Pós-Atualização Recomendada
+
+`hermes update` lida com o caminho principal de atualização, mas uma validação rápida confirma que tudo chegou limpo:
+
+1. `git status --short` — se a árvore estiver inesperadamente suja, inspecione antes de continuar
+2. `hermes doctor` — verifica config, dependências e saúde do serviço
+3. `hermes --version` — confirme que a versão subiu como esperado
+4. Se você usa o gateway: `hermes gateway status`
+5. Se `doctor` relatar problemas de npm audit: execute `npm audit fix` no diretório sinalizado
+
+:::warning Árvore de trabalho suja após atualização
+Se `git status --short` mostrar alterações inesperadas após `hermes update`, pare e inspecione-as antes de continuar. Isso geralmente significa que modificações locais foram reaplicadas sobre o código atualizado, ou que uma etapa de dependência atualizou lockfiles.
+:::
+
+### Se seu terminal desconectar no meio da atualização
+
+`hermes update` se protege contra perda acidental de terminal:
+
+- A atualização ignora `SIGHUP`, então fechar sua sessão SSH ou janela de terminal não a mata no meio da instalação. Processos filhos `pip` e `git` herdam esta proteção, então o ambiente Python não pode ser deixado meio-instalado por uma conexão perdida.
+- Toda a saída é espelhada para `~/.hermes/logs/update.log` enquanto a atualização é executada. Se seu terminal desaparecer, reconecte e inspecione o log para ver se a atualização terminou e se o reinício do gateway foi bem-sucedido:
+
+```bash
+tail -f ~/.hermes/logs/update.log
+```
+
+- `Ctrl-C` (SIGINT) e desligamento do sistema (SIGTERM) ainda são honrados — esses são cancelamentos deliberados, não acidentes.
+
+Você não precisa mais envolver `hermes update` em `screen` ou `tmux` para sobreviver a uma queda de terminal.
+
+### Verificando sua versão atual
+
+```bash
+hermes version
+```
+
+Compare com o lançamento mais recente na [página de releases do GitHub](https://github.com/NousResearch/hermes-agent/releases).
+
+### Atualização a partir de Plataformas de Mensagem
+
+Você também pode atualizar diretamente do Telegram, Discord, Slack, WhatsApp ou Teams enviando:
+
+```
+/update
+```
+
+Isso puxa o código mais recente, atualiza dependências e reinicia gateways em execução. O bot ficará offline brevemente durante o reinício (tipicamente 5–15 segundos) e então retomará.
+
+### Atualização Manual
+
+Se você instalou manualmente (não via o instalador rápido):
+
+```bash
+cd /caminho/para/hermes-agent
+# Ative o venv que você criou durante a instalação (fora da árvore de código)
+export VIRTUAL_ENV="$HOME/.hermes/venvs/hermes-dev"
+export PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Puxe o código mais recente
+git pull origin main
+
+# Reinstale (incorpora novas dependências)
+uv pip install -e ".[all]"
+
+# Verifique novas opções de configuração
+hermes config check
+hermes config migrate   # Adicione interativamente quaisquer opções faltantes
+```
+
+### Instruções de rollback
+
+Se uma atualização introduzir um problema, você pode reverter para uma versão anterior:
+
+```bash
+cd /caminho/para/hermes-agent
+
+# Liste versões recentes
+git log --oneline -10
+
+# Reverta para um commit específico
+git checkout <commit-hash>
+uv pip install -e ".[all]"
+
+# Reinicie o gateway se estiver em execução
+hermes gateway restart
+```
+
+Para reverter para uma tag de release específica (substitua pela sua tag anterior — ex.: um release recente como `v2026.5.16`, ou qualquer tag anterior de `git tag --sort=-version:refname`):
+
+```bash
+git checkout vX.Y.Z
+uv pip install -e ".[all]"
+```
+
+:::warning
+Reverter pode causar incompatibilidades de configuração se novas opções foram adicionadas. Execute `hermes config check` após reverter e remova quaisquer opções não reconhecidas de `config.yaml` se você encontrar erros.
+:::
+
+### Nota para usuários Nix
+
+Nix não é mais um caminho de instalação explicitamente suportado (apenas melhor esforço) — veja [Nix Setup](./nix-setup.md). Se você instalou via Nix flake, as atualizações são gerenciadas através do gerenciador de pacotes Nix:
+
+```bash
+# Atualize a entrada do flake
+nix flake update hermes-agent
+
+# Ou reconstrua com o mais recente
+nix profile upgrade hermes-agent
+```
+
+Instalações Nix são imutáveis — o rollback é tratado pelo sistema de gerações do Nix:
+
+```bash
+nix profile rollback
+```
+
+Veja [Nix Setup](./nix-setup.md) para mais detalhes.
+
+---
+
+## Desinstalação
+
+```bash
+hermes uninstall
+```
+
+O desinstalador oferece a opção de manter seus arquivos de configuração (`~/.hermes/`) para uma reinstalação futura.
+
+### Desinstalação Manual
+
+```bash
+rm -f ~/.local/bin/hermes
+rm -rf /caminho/para/hermes-agent
+rm -rf ~/.hermes            # Opcional — mantenha se você planeja reinstalar
+```
+
+:::info
+Se você instalou o gateway como um serviço do sistema, pare e desabilite-o primeiro:
+```bash
+hermes gateway stop
+# Linux: systemctl --user disable hermes-gateway
+# macOS: launchctl remove ai.hermes.gateway
+```
+:::

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/index.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/index.mdx
@@ -1,0 +1,141 @@
+---
+slug: /
+sidebar_position: 0
+title: "Documentação do Hermes Agent"
+description: "O agente de IA auto-melhorável construído pela Nous Research. Um loop de aprendizado integrado que cria skills a partir da experiência, as melhora durante o uso e lembra entre sessões."
+hide_table_of_contents: true
+displayed_sidebar: docs
+---
+
+import Link from "@docusaurus/Link";
+
+# Hermes Agent
+
+O agente de IA auto-melhorável construído pela [Nous Research](https://nousresearch.com). O único agente com um loop de aprendizado integrado — ele cria skills a partir da experiência, as melhora durante o uso, se estimula a persistir conhecimento e constrói um modelo cada vez mais profundo de quem você é entre as sessões.
+
+<div
+  style={{
+    display: "flex",
+    gap: "1rem",
+    marginBottom: "2rem",
+    flexWrap: "wrap",
+  }}
+>
+  <Link
+    to="/getting-started/installation"
+    style={{
+      display: "inline-block",
+      padding: "0.6rem 1.2rem",
+      backgroundColor: "#FFD700",
+      color: "#07070d",
+      borderRadius: "8px",
+      fontWeight: 600,
+      textDecoration: "none",
+    }}
+  >
+    Comece por aqui →
+  </Link>
+  <a
+    href="https://hermes-agent.nousresearch.com/"
+    style={{
+      display: "inline-block",
+      padding: "0.6rem 1.2rem",
+      border: "1px solid rgba(255,215,0,0.2)",
+      borderRadius: "8px",
+      textDecoration: "none",
+    }}
+  >
+    Baixar Desktop
+  </a>
+  <a
+    href="https://github.com/NousResearch/hermes-agent"
+    style={{
+      display: "inline-block",
+      padding: "0.6rem 1.2rem",
+      border: "1px solid rgba(255,215,0,0.2)",
+      borderRadius: "8px",
+      textDecoration: "none",
+    }}
+  >
+    Ver no GitHub
+  </a>
+</div>
+
+## Instalação
+
+### Windows ou macOS
+
+Para instalar facilmente os aplicativos de linha de comando e desktop, [baixe o instalador do Hermes Desktop](https://hermes-agent.nousresearch.com/) do nosso site e execute-o.
+
+### Sem o Hermes Desktop:
+
+Para uma instalação apenas com linha de comando sem o Hermes Desktop, execute:
+
+#### Linux / macOS / WSL2 / Android (Termux)
+
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+```
+
+#### Windows (nativo)
+
+Execute no powershell:
+
+```powershell
+iex (irm https://hermes-agent.nousresearch.com/install.ps1)
+```
+
+Veja o **[Guia de Instalação](/getting-started/installation)** completo para saber o que o instalador faz, a estrutura de diretórios por-usuário vs root, e notas específicas para Windows. Para a matriz completa de suporte a plataformas, veja **[Suporte a Plataformas](/getting-started/platform-support)**.
+
+:::tip Caminho mais rápido para um agente funcional
+Após instalar, execute `hermes setup --portal` — um único OAuth cobre um modelo mais todas as quatro ferramentas do Tool Gateway (pesquisa web, geração de imagem, TTS, navegador). Veja [Nous Portal](/integrations/nous-portal).
+:::
+
+## O que é o Hermes Agent?
+
+Não é um copiloto de programação preso a uma IDE ou um wrapper de chatbot em torno de uma única API. É um **agente autônomo** que se torna mais capaz quanto mais tempo executa. Ele vive onde você o colocar — um VPS de $5, um cluster de GPU, ou infraestrutura serverless (Daytona, Modal) que custa quase nada quando ociosa. Converse com ele pelo Telegram enquanto ele trabalha em uma VM na nuvem na qual você nunca faz SSH diretamente. Ele não está preso ao seu laptop.
+
+## Links Rápidos
+
+|                                                                                |                                                                              |
+| ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| 🚀 **[Instalação](/getting-started/installation)**                             | Instale em 60 segundos no Linux, macOS, WSL2, Windows nativo ou Android      |
+| 📖 **[Tutorial Início Rápido](/getting-started/quickstart)**                   | Sua primeira conversa e principais recursos para testar                      |
+| 🗺️ **[Rota de Aprendizado](/getting-started/learning-path)**                  | Encontre a documentação certa para seu nível de experiência                  |
+| ⚙️ **[Configuração](/user-guide/configuration)**                              | Arquivo de config, providers, modelos e opções                               |
+| 💬 **[Gateway de Mensagens](/user-guide/messaging)**                          | Configure Telegram, Discord, Slack, WhatsApp, Teams e muito mais             |
+| 🔧 **[Ferramentas e Toolsets](/user-guide/features/tools)**                   | Mais de 60 ferramentas integradas e como configurá-las                       |
+| 🧠 **[Sistema de Memória](/user-guide/features/memory)**                      | Memória persistente que cresce entre as sessões                              |
+| 📚 **[Sistema de Skills](/user-guide/features/skills)**                       | Memória procedural que o agente cria e reutiliza                             |
+| 🔌 **[Integração MCP](/user-guide/features/mcp)**                             | Conecte-se a servidores MCP, filtre suas ferramentas e estenda o Hermes com segurança |
+| 🧭 **[Usar MCP com Hermes](/guides/use-mcp-with-hermes)**                     | Padrões práticos de configuração MCP, exemplos e tutoriais                   |
+| 🎙️ **[Modo de Voz](/user-guide/features/voice-mode)**                        | Interação por voz em tempo real no CLI, Telegram, Discord e Discord VC       |
+| 🗣️ **[Usar Modo de Voz com Hermes](/guides/use-voice-mode-with-hermes)**      | Configuração prática e padrões de uso para fluxos de voz do Hermes           |
+| 🎭 **[Personalidade e SOUL.md](/user-guide/features/personality)**            | Defina a voz padrão do Hermes com um SOUL.md global                          |
+| 📄 **[Arquivos de Contexto](/user-guide/features/context-files)**             | Arquivos de contexto de projeto que moldam cada conversa                     |
+| 🔒 **[Segurança](/user-guide/security)**                                      | Aprovação de comandos, autorização, isolamento por container                 |
+| 💡 **[Dicas e Melhores Práticas](/guides/tips)**                              | Ganhos rápidos para extrair o máximo do Hermes                               |
+| 🏗️ **[Arquitetura](/developer-guide/architecture)**                          | Como funciona por baixo dos panos                                            |
+| ❓ **[FAQ e Solução de Problemas](/reference/faq)**                           | Perguntas comuns e soluções                                                  |
+
+## Principais Recursos
+
+- **Um loop de aprendizado fechado** — Memória curada pelo agente com estímulos periódicos, criação autônoma de skills, auto-melhoria de skills durante o uso, recuperação entre sessões via FTS5 com sumarização por LLM, e modelagem dialética de usuário com [Honcho](https://github.com/plastic-labs/honcho) dialectic user modeling
+- **Funciona em qualquer lugar, não apenas no seu laptop** — 6 backends de terminal: local, Docker, SSH, Daytona, Singularity, Modal. Daytona e Modal oferecem persistência serverless — seu ambiente hiberna quando ocioso, custando quase nada
+- **Vive onde você vive** — CLI, Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Mattermost, Email, SMS, DingTalk, Feishu, WeCom, Weixin, QQ Bot, Yuanbao, BlueBubbles, Home Assistant, Microsoft Teams, Google Chat e muito mais — mais de 20 plataformas a partir de um único gateway
+- **Construído por treinadores de modelos** — Criado pela [Nous Research](https://nousresearch.com), o laboratório por trás dos modelos Hermes, Nomos e Psyche. Funciona com [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai), OpenAI ou qualquer endpoint
+- **Automações agendadas** — Cron integrado com entrega para qualquer plataforma
+- **Delegação e paralelização** — Crie subagentes isolados para fluxos de trabalho paralelos. Programmatic Tool Calling via `execute_code` colapsa pipelines de múltiplas etapas em chamadas de inferência únicas
+- **Skills de padrão aberto** — Compatível com [agentskills.io](https://agentskills.io). Skills são portáteis, compartilháveis e contribuídas pela comunidade através do Skills Hub
+- **Controle web completo** — Pesquisa, extração, navegação, visão, geração de imagem, TTS — uma assinatura via [Nous Portal](/integrations/nous-portal) agrupa todos eles
+- **Suporte MCP** — Conecte-se a qualquer servidor MCP para capacidades estendidas de ferramentas
+- **Pronto para pesquisa** — Processamento em lote, exportação de trajetórias, treinamento RL com Atropos. Construído pela [Nous Research](https://nousresearch.com) — o laboratório por trás dos modelos Hermes, Nomos e Psyche
+
+## Para LLMs e agentes de código
+
+Pontos de entrada legíveis por máquina para esta documentação:
+
+- **[`/llms.txt`](/llms.txt)** — Índice curado de cada página de documentação com descrições curtas. ~17 KB, seguro para carregar no contexto de um LLM.
+- **[`/llms-full.txt`](/llms-full.txt)** — Todas as páginas de documentação concatenadas em um único arquivo markdown para ingestão única. ~1.8 MB.
+
+Ambos os arquivos também resolvem em `/docs/llms.txt` e `/docs/llms-full.txt`. Gerados novamente a cada deploy.

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/user-guide/cli.md
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/user-guide/cli.md
@@ -1,0 +1,423 @@
+---
+sidebar_position: 1
+title: "Interface CLI"
+description: "Domine a interface de terminal do Hermes Agent — comandos, atalhos de teclado, personalidades e muito mais"
+---
+
+# Interface CLI
+
+O CLI do Hermes Agent é uma interface de usuário de terminal completa (TUI) — não uma interface web. Possui edição multi-linha, autocomplete de comandos de barra, histórico de conversas, interrupção e redirecionamento, e saída de ferramentas em streaming. Construído para pessoas que vivem no terminal.
+
+:::tip Configuração inicial
+Um comando — `hermes setup --portal` — e você está pronto para `hermes chat`. Veja [Nous Portal](/integrations/nous-portal).
+:::
+
+:::tip
+O Hermes também oferece um TUI moderno com sobreposições modais, seleção com mouse e entrada não bloqueante. Inicie com `hermes --tui` — veja o guia [TUI](tui.md).
+:::
+
+## Executando o CLI
+
+```bash
+# Iniciar uma sessão interativa (padrão)
+hermes
+
+# Modo de consulta única (não interativo)
+hermes chat -q "Olá"
+
+# Com um modelo específico
+hermes chat --model "anthropic/claude-sonnet-4"
+
+# Com um provider específico
+hermes chat --provider nous        # Usar Nous Portal
+hermes chat --provider openrouter  # Forçar OpenRouter
+
+# Com toolsets específicos
+hermes chat --toolsets "web,terminal,skills"
+
+# Iniciar com uma ou mais skills pré-carregadas
+hermes -s hermes-agent-dev,github-auth
+hermes chat -s github-pr-workflow -q "abra um draft PR"
+
+# Retomar sessões anteriores
+hermes --continue             # Retomar a sessão CLI mais recente (-c)
+hermes --resume <session_id>  # Retomar uma sessão específica pelo ID (-r)
+
+# Modo verboso (saída de debug)
+hermes chat --verbose
+
+# Git worktree isolado (para executar múltiplos agentes em paralelo)
+hermes -w                         # Modo interativo em worktree
+hermes -w -z "Corrigir issue #123" # Consulta única em worktree
+```
+
+## Layout da Interface
+
+<img className="docs-terminal-figure" src="/docs/img/docs/cli-layout.svg" alt="Pré-visualização estilizada do layout do Hermes CLI mostrando o banner, área de conversa e prompt de entrada fixo." />
+<p className="docs-figure-caption">O banner do Hermes CLI, o fluxo de conversa e o prompt de entrada fixo renderizados como uma figura de documentação estável em vez de arte de texto frágil.</p>
+
+O banner de boas-vindas mostra seu modelo, backend de terminal, diretório de trabalho, ferramentas disponíveis e skills instaladas de relance.
+
+### Barra de Status
+
+Uma barra de status persistente fica acima da área de entrada, atualizando em tempo real:
+
+```
+ ⚕ claude-sonnet-4-20250514 │ 12.4K/200K │ [██████░░░░] 6% │ $0.06 │ 15m
+```
+
+| Elemento           | Descrição                                                                        |
+|--------------------|----------------------------------------------------------------------------------|
+| Nome do modelo     | Modelo atual (truncado se mais longo que 26 caracteres)                          |
+| Contagem de tokens | Tokens de contexto usados / janela máxima de contexto                            |
+| Barra de contexto  | Indicador visual de preenchimento com limites codificados por cores              |
+| Custo              | Custo estimado da sessão (ou `n/a` para modelos desconhecidos/gratuitos)         |
+| 🗜️ N               | **Contagem de compressão de contexto** — quantas vezes a sessão foi auto-comprimida |
+| ▶ N                | **Tarefas em segundo plano ativas** — quantos prompts `/background` ainda estão em execução |
+| Duração            | Tempo decorrido da sessão                                                        |
+| ⚠ YOLO             | **Aviso de modo YOLO** — mostrado quando `HERMES_YOLO_MODE` está ativo           |
+
+A barra se adapta à largura do terminal — layout completo em ≥ 76 colunas, compacto em 52–75, mínimo (modelo + duração, mais o badge YOLO quando ativo) abaixo de 52.
+
+**Codificação de cores do contexto:**
+
+| Cor    | Limiar               | Significado                         |
+|--------|----------------------|-------------------------------------|
+| Verde  | < 50%                | Bastante espaço                     |
+| Amarelo| 50–80%               | Ficando cheio                       |
+| Laranja| 80–95%               | Aproximando-se do limite            |
+| Vermelho| ≥ 95%               | Quase transbordando — considere `/compress` |
+
+Use `/usage` para uma discriminação detalhada incluindo custos por categoria (tokens de entrada vs saída).
+
+No provider `openai-codex`, `/usage` também mostra redefinições de limite de uso acumuladas em sua conta ChatGPT ("Você tem N redefinições acumuladas — use /usage reset para ativar"). `/usage reset` resgata uma redefinição acumulada, restaurando totalmente seus limites de 5 horas e semanais.
+
+### Exibição de Retomada de Sessão
+
+Ao retomar uma sessão anterior (`hermes -c` ou `hermes --resume <id>`), um painel "Conversa Anterior" aparece entre o banner e o prompt de entrada, mostrando um resumo compacto do histórico da conversa. Veja [Sessões — Recapitulação de Conversa ao Retomar](sessions.md#conversation-recap-on-resume) para detalhes e configuração.
+
+## Atalhos de Teclado
+
+| Tecla                        | Ação                                                                                             |
+|------------------------------|--------------------------------------------------------------------------------------------------|
+| `Enter`                      | Enviar mensagem                                                                                  |
+| `Alt+Enter`, `Ctrl+J` ou `Shift+Enter` | Nova linha (entrada multi-linha). `Shift+Enter` requer um terminal que o distingue de `Enter`. |
+| `Alt+V`                      | Colar uma imagem da área de transferência quando suportado pelo terminal                         |
+| `Ctrl+V`                     | Colar texto e anexar oportunisticamente imagens da área de transferência                         |
+| `Ctrl+B`                     | Iniciar/parar gravação de voz quando o modo de voz está ativo                                    |
+| `Ctrl+G`                     | Abrir o buffer de entrada atual no `$EDITOR` (vim/nvim/nano/VS Code/etc.)                        |
+| `Ctrl+X Ctrl+E`              | Atalho alternativo no estilo Emacs para o editor externo                                         |
+| `Ctrl+C`                     | Interromper agente (pressione duas vezes em 2s para forçar saída)                                |
+| `Ctrl+D`                     | Sair                                                                                             |
+| `Ctrl+Z`                     | Suspender Hermes para segundo plano (Unix apenas)                                                |
+| `Tab`                        | Aceitar sugestão automática (texto fantasma) ou autocompletar comandos de barra                   |
+
+**Pré-visualização de colagem multi-linha.** Quando você cola um bloco multi-linha, o CLI ecoa uma pré-visualização compacta de linha única (`[colado: 47 linhas, 1.842 caracteres — pressione Enter para enviar]`) em vez de despejar toda a carga no histórico.
+
+**Remoção de markdown em respostas finais.** O CLI remove os fences de markdown mais verbosos e wrappers `**bold**` / `*italic*` das respostas *finais* do agente para que sejam renderizadas como prosa de terminal legível em vez de código-fonte bruto.
+
+## Comandos de Barra (/)
+
+Digite `/` para ver o menu suspenso de autocomplete. O Hermes suporta um grande conjunto de comandos de barra do CLI, comandos de skill dinâmicos e comandos rápidos definidos pelo usuário.
+
+Exemplos comuns:
+
+| Comando                        | Descrição                                                                                |
+|--------------------------------|------------------------------------------------------------------------------------------|
+| `/help`                        | Mostrar ajuda de comandos                                                                |
+| `/model`                       | Mostrar ou alterar o modelo atual                                                        |
+| `/tools`                       | Listar ferramentas atualmente disponíveis                                                 |
+| `/skills browse`               | Navegar pelo skills hub e skills opcionais oficiais                                      |
+| `/background <prompt>`         | Executar um prompt em uma sessão separada em segundo plano                                |
+| `/skin`                        | Mostrar ou trocar a skin ativa do CLI                                                     |
+| `/voice on`                    | Ativar modo de voz no CLI (pressione `Ctrl+B` para gravar)                                |
+| `/voice tts`                   | Alternar reprodução por voz das respostas do Hermes                                       |
+| `/reasoning high`              | Aumentar o esforço de raciocínio                                                          |
+| `/title Minha Sessão`          | Nomear a sessão atual                                                                     |
+| `/status`                      | Mostrar informações da sessão — modelo/profile/tokens/duração                             |
+| `/sessions`                    | Abrir um seletor de sessão interativo dentro do CLI clássico                              |
+
+Para a lista completa de comandos de barra do CLI e de mensagens, veja [Referência de Comandos de Barra](../reference/slash-commands.md).
+
+Para configuração, providers, ajuste de silêncio e uso de voz em mensagens/Discord, veja [Modo de Voz](features/voice-mode.md).
+
+:::tip
+Comandos não diferenciam maiúsculas/minúsculas — `/HELP` funciona da mesma forma que `/help`. Skills instaladas também se tornam comandos de barra automaticamente.
+:::
+
+## Comandos Rápidos
+
+Você pode definir comandos customizados que executam comandos shell instantaneamente sem invocar o LLM. Eles funcionam tanto no CLI quanto em plataformas de mensagens (Telegram, Discord, etc.).
+
+```yaml
+# ~/.hermes/config.yaml
+quick_commands:
+  status:
+    type: exec
+    command: systemctl status hermes-agent
+  gpu:
+    type: exec
+    command: nvidia-smi --query-gpu=utilization.gpu,memory.used --format=csv,noheader
+  restart:
+    type: alias
+    target: /gateway restart
+```
+
+Depois digite `/status`, `/gpu` ou `/restart` em qualquer chat. Veja o [Guia de Configuração](/user-guide/configuration#quick-commands) para mais exemplos.
+
+## Pré-carregando Skills na Inicialização
+
+Se você já sabe quais skills deseja ativas para a sessão, passe-as no momento da inicialização:
+
+```bash
+hermes -s hermes-agent-dev,github-auth
+hermes chat -s github-pr-workflow -s github-auth
+```
+
+O Hermes carrega cada skill nomeada no prompt da sessão antes do primeiro turno. A mesma flag funciona em modo interativo e modo de consulta única.
+
+## Comandos de Barra de Skills
+
+Toda skill instalada em `~/.hermes/skills/` é automaticamente registrada como um comando de barra. O nome da skill se torna o comando:
+
+```
+/gif-search gatos engraçados
+/axolotl me ajude a ajustar Llama 3 no meu dataset
+/github-pr-workflow crie um PR para a refatoração de auth
+
+# Apenas o nome da skill carrega e deixa o agente perguntar o que você precisa:
+/excalidraw
+```
+
+## Personalidades
+
+Defina uma personalidade predefinida para alterar o tom do agente:
+
+```
+/personality pirate
+/personality kawaii
+/personality concise
+```
+
+Personalidades inclusas incluem: `helpful`, `concise`, `technical`, `creative`, `teacher`, `kawaii`, `catgirl`, `pirate`, `shakespeare`, `surfer`, `noir`, `uwu`, `philosopher`, `hype`.
+
+Você também pode definir personalidades customizadas em `~/.hermes/config.yaml`:
+
+```yaml
+personalities:
+  helpful: "Você é um assistente de IA útil e amigável."
+  kawaii: "Você é um assistente kawaii! Use expressões fofas..."
+  pirate: "Arre! Estás falando com o Capitão Hermes..."
+  # Adicione a sua própria!
+```
+
+## Entrada Multi-linha
+
+Existem duas maneiras de inserir mensagens multi-linha:
+
+1. **`Alt+Enter`, `Ctrl+J` ou `Shift+Enter`** — insere uma nova linha
+2. **Continuação com barra invertida** — termine uma linha com `\` para continuar:
+
+```
+❯ Escreva uma função que:\
+  1. Recebe uma lista de números\
+  2. Retorna a soma
+```
+
+:::info
+Colar texto multi-linha é suportado — use qualquer uma das teclas de nova linha acima, ou simplesmente cole o conteúdo diretamente.
+:::
+
+### Compatibilidade Shift+Enter
+
+A maioria dos terminais envia a mesma sequência de bytes para `Enter` e `Shift+Enter` por padrão, então os aplicativos não conseguem distingui-los. O Hermes reconhece `Shift+Enter` apenas quando o terminal envia uma sequência distinta através do [protocolo de teclado Kitty](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) ou modo `modifyOtherKeys` do xterm.
+
+| Terminal                   | Status                                                               |
+|----------------------------|----------------------------------------------------------------------|
+| Kitty, foot, WezTerm, Ghostty | `Shift+Enter` distinto ativado por padrão                           |
+| iTerm2 (recente), Alacritty, terminal VS Code, Warp | Suportado após ativar o protocolo Kitty nas configurações |
+| Windows Terminal Preview 1.25+ | Suportado após ativar o protocolo Kitty nas configurações          |
+| macOS Terminal.app, Windows Terminal (estável) | Não suportado — `Shift+Enter` é indistinguível de `Enter` |
+
+Onde o terminal não consegue distingui-los, `Alt+Enter` e `Ctrl+J` continuam funcionando em todos os lugares. **No Windows Terminal especificamente, `Alt+Enter` é capturado pelo terminal (alterna tela cheia) e nunca chega ao Hermes — use `Ctrl+Enter` (entregue como `Ctrl+J`) ou `Ctrl+J` diretamente para uma nova linha.**
+
+## Interrompendo o Agente
+
+Você pode interromper o agente a qualquer momento:
+
+- **Digite uma nova mensagem + Enter** enquanto o agente está trabalhando — ele interrompe e processa suas novas instruções
+- **`Ctrl+C`** — interrompe a operação atual (pressione duas vezes em 2s para forçar saída)
+- Comandos de terminal em andamento são mortos imediatamente (SIGTERM, depois SIGKILL após 1s)
+- Múltiplas mensagens digitadas durante a interrupção são combinadas em um único prompt
+
+### Modo de Entrada Ocupado
+
+A chave de configuração `display.busy_input_mode` controla o que acontece quando você pressiona Enter enquanto o agente está trabalhando:
+
+| Modo         | Comportamento                                                                                     |
+|--------------|---------------------------------------------------------------------------------------------------|
+| `"interrupt"` (padrão) | Sua mensagem interrompe a operação atual e é processada imediatamente                              |
+| `"queue"`    | Sua mensagem é silenciosamente enfileirada e enviada como o próximo turno após o agente terminar   |
+| `"steer"`    | Sua mensagem é injetada na execução atual via `/steer`, chegando ao agente após a próxima chamada de ferramenta |
+
+```yaml
+# ~/.hermes/config.yaml
+display:
+  busy_input_mode: "steer"   # ou "queue" ou "interrupt" (padrão)
+```
+
+### Suspensão para Segundo Plano
+
+Em sistemas Unix, pressione **`Ctrl+Z`** para suspender o Hermes para segundo plano — como qualquer processo de terminal. O shell imprime uma confirmação:
+
+```
+Hermes Agent foi suspenso. Execute `fg` para trazer o Hermes Agent de volta.
+```
+
+Digite `fg` em seu shell para retomar a sessão exatamente de onde parou.
+
+## Exibição de Progresso de Ferramentas
+
+O CLI mostra feedback animado enquanto o agente trabalha:
+
+**Animação de pensamento** (durante chamadas de API):
+```
+  ◜ (｡•́︿•̀｡) ponderando... (1.2s)
+  ◠ (⊙_⊙) contemplando... (2.4s)
+  ✧٩(ˊᗜˋ*)و✧ consegui! (3.1s)
+```
+
+**Feed de execução de ferramentas:**
+```
+  ┊ 💻 terminal `ls -la` (0.3s)
+  ┊ 🔍 web_search (1.2s)
+  ┊ 📄 web_extract (2.1s)
+```
+
+Alterne entre modos de exibição com `/verbose`: `off → new → all → verbose`.
+
+### Tamanho da Pré-visualização de Ferramentas
+
+A chave de configuração `display.tool_preview_length` controla o número máximo de caracteres mostrados nas linhas de pré-visualização de chamadas de ferramenta (ex.: caminhos de arquivo, comandos de terminal). O padrão é `0`, que significa sem limite — caminhos e comandos completos são mostrados.
+
+```yaml
+# ~/.hermes/config.yaml
+display:
+  tool_preview_length: 80   # Truncar pré-visualizações de ferramentas para 80 caracteres (0 = sem limite)
+```
+
+## Gerenciamento de Sessão
+
+### Retomando Sessões
+
+Quando você sai de uma sessão CLI, um comando de retomada é impresso:
+
+```
+Retome esta sessão com:
+  hermes --resume 20260225_143052_a1b2c3
+
+Sessão:        20260225_143052_a1b2c3
+Duração:       12m 34s
+Mensagens:     28 (5 do usuário, 18 chamadas de ferramentas)
+```
+
+Opções de retomada:
+
+```bash
+hermes --continue                          # Retomar a sessão CLI mais recente
+hermes -c                                  # Forma abreviada
+hermes -c "meu projeto"                    # Retomar uma sessão nomeada (mais recente na linhagem)
+hermes --resume 20260225_143052_a1b2c3     # Retomar uma sessão específica pelo ID
+hermes --resume "refatorando auth"         # Retomar pelo título
+hermes -r 20260225_143052_a1b2c3           # Forma abreviada
+```
+
+Retomar restaura o histórico completo da conversa do SQLite. O agente vê todas as mensagens anteriores, chamadas de ferramentas e respostas — como se você nunca tivesse saído.
+
+Use `/title Nome da Minha Sessão` dentro de um chat para nomear a sessão atual, ou `hermes sessions rename <id> <título>` pela linha de comando. Use `hermes sessions list` para navegar pelas sessões passadas.
+
+### Armazenamento de Sessão
+
+Sessões CLI são armazenadas no banco de dados SQLite de estado do Hermes sob `~/.hermes/state.db`. O banco mantém:
+
+- metadados da sessão (ID, título, timestamps, contadores de token)
+- histórico de mensagens
+- linhagem entre sessões comprimidas/retomadas
+- índices de busca de texto completo usados por `session_search`
+
+### Compressão de Contexto
+
+Conversas longas são automaticamente resumidas quando se aproximam dos limites de contexto:
+
+```yaml
+# Em ~/.hermes/config.yaml
+compression:
+  enabled: true
+  threshold: 0.50    # Comprimir em 50% do limite de contexto por padrão
+
+# Modelo de sumarização configurado em auxiliary:
+auxiliary:
+  compression:
+    model: ""  # Deixar vazio para usar o modelo de chat principal (padrão).
+```
+
+## Sessões em Segundo Plano
+
+Execute um prompt em uma sessão separada em segundo plano enquanto continua usando o CLI para outro trabalho:
+
+```
+/background Analise os logs em /var/log e resuma quaisquer erros de hoje
+```
+
+O Hermes confirma imediatamente a tarefa e devolve o prompt:
+
+```
+🔄 Tarefa em segundo plano #1 iniciada: "Analise os logs em /var/log e resuma..."
+   Task ID: bg_143022_a1b2c3
+```
+
+### Como Funciona
+
+Cada prompt `/background` cria uma **sessão de agente completamente separada** em uma thread daemon:
+
+- **Conversa isolada** — o agente em segundo plano não tem conhecimento do histórico da sua sessão atual. Ele recebe apenas o prompt que você forneceu.
+- **Mesma configuração** — o agente em segundo plano herda seu modelo, provider, toolsets, configurações de raciocínio e modelo de fallback da sessão atual.
+- **Não bloqueante** — sua sessão em primeiro plano permanece totalmente interativa.
+- **Múltiplas tarefas** — você pode executar várias tarefas em segundo plano simultaneamente.
+
+### Resultados
+
+Quando uma tarefa em segundo plano termina, o resultado aparece como um painel em seu terminal:
+
+```
+╭─ ⚕ Hermes (segundo plano #1) ──────────────────────────────────╮
+│ Encontrados 3 erros no syslog de hoje:                          │
+│ 1. OOM killer invocado às 03:22 — processo nginx morto          │
+│ 2. Erro de I/O de disco em /dev/sda1 às 07:15                  │
+│ 3. Tentativas de login SSH falhas de 192.168.1.50 às 14:30     │
+╰──────────────────────────────────────────────────────────────────╯
+```
+
+Se a tarefa falhar, você verá uma notificação de erro.
+
+### Casos de Uso
+
+- **Pesquisa longa** — "/background pesquise os últimos desenvolvimentos em correção quântica de erros" enquanto você trabalha em código
+- **Processamento de arquivos** — "/background analise todos os arquivos Python neste repositório e liste quaisquer problemas de segurança"
+- **Investigações paralelas** — inicie múltiplas tarefas em segundo plano para explorar diferentes ângulos simultaneamente
+
+:::info
+Sessões em segundo plano não aparecem em seu histórico principal de conversas. São sessões independentes com seu próprio ID de tarefa.
+:::
+
+## Modo Silencioso
+
+Por padrão, o CLI executa em modo silencioso que:
+- Suprime logs verbosos de ferramentas
+- Ativa feedback animado no estilo kawaii
+- Mantém a saída limpa e amigável
+
+Para saída de debug:
+```bash
+hermes chat --verbose
+```

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1,0 +1,886 @@
+---
+sidebar_position: 2
+title: "Configuração"
+description: "Configure o Hermes Agent — config.yaml, providers, modelos, chaves de API e muito mais"
+---
+
+# Configuração
+
+Todas as configurações são armazenadas no diretório `~/.hermes/` para fácil acesso.
+
+:::tip Caminho mais fácil para um `config.yaml` funcional
+Execute `hermes setup --portal` — um único OAuth fornece um modelo de provider e todas as quatro ferramentas do Tool Gateway sem editar YAML manualmente. Assinantes do Portal também ganham 10% de desconto em providers por token. Veja [Nous Portal](/integrations/nous-portal).
+:::
+
+## Estrutura de Diretórios
+
+```text
+~/.hermes/
+├── config.yaml     # Configurações (model, terminal, TTS, compression, etc.)
+├── .env            # Chaves de API e segredos
+├── auth.json       # Credenciais OAuth do provider (Nous Portal, etc.)
+├── SOUL.md         # Identidade primária do agente (slot #1 no system prompt)
+├── memories/       # Memória persistente (MEMORY.md, USER.md)
+├── skills/         # Skills criadas pelo agente (gerenciadas via skill_manage tool)
+├── cron/           # Tarefas agendadas
+├── sessions/       # Sessões do gateway
+└── logs/           # Logs (errors.log, gateway.log — segredos auto-redactados)
+```
+
+## Gerenciando a Configuração
+
+```bash
+hermes config              # Visualizar configuração atual
+hermes config edit         # Abrir config.yaml no editor
+hermes config get KEY      # Imprimir um valor resolvido
+hermes config set KEY VAL  # Definir um valor específico
+hermes config unset KEY    # Remover um valor definido pelo usuário
+hermes config check        # Verificar opções ausentes (após atualizações)
+hermes config migrate      # Adicionar interativamente opções ausentes
+
+# Exemplos:
+hermes config get model
+hermes config set model anthropic/claude-opus-4
+hermes config set terminal.backend docker
+hermes config unset terminal.backend
+hermes config set OPENROUTER_API_KEY sk-or-...  # Salva em .env
+```
+
+:::tip
+O comando `hermes config set` roteia automaticamente os valores para o arquivo correto — chaves de API são salvas em `.env`, todo o resto em `config.yaml`.
+:::
+
+## Precedência de Configuração
+
+As configurações são resolvidas nesta ordem (maior prioridade primeiro):
+
+1. **Argumentos do CLI** — ex.: `hermes chat --model anthropic/claude-sonnet-4` (substituição por invocação)
+2. **`~/.hermes/config.yaml`** — o arquivo de configuração principal para todas as configurações não secretas
+3. **`~/.hermes/.env`** — fallback para variáveis de ambiente; **obrigatório** para segredos (chaves de API, tokens, senhas)
+4. **Padrões internos** — padrões seguros codificados quando nada mais está definido
+
+:::info Regra Prática
+Segredos (chaves de API, tokens de bot, senhas) vão em `.env`. Todo o resto (model, terminal backend, configurações de compressão, limites de memória, toolsets) vai em `config.yaml`. Quando ambos estão definidos, `config.yaml` vence para configurações não secretas.
+:::
+
+:::tip Implantações organizacionais
+Um administrador pode fixar configurações específicas e valores secretos que um usuário padrão
+não pode substituir, através de um diretório gerenciado a nível de sistema. Veja
+[Managed Scope](/user-guide/managed-scope).
+:::
+
+## Substituição de Variáveis de Ambiente
+
+Você pode referenciar variáveis de ambiente em `config.yaml` usando a sintaxe `${VAR_NAME}`:
+
+```yaml
+auxiliary:
+  vision:
+    api_key: ${GOOGLE_API_KEY}
+    base_url: ${CUSTOM_VISION_URL}
+
+delegation:
+  api_key: ${DELEGATION_KEY}
+```
+
+Múltiplas referências em um único valor funcionam: `url: "${HOST}:${PORT}"`. Se uma variável referenciada não estiver definida, o placeholder é mantido literalmente (`${UNDEFINED_VAR}` permanece como está). Apenas a sintaxe `${VAR}` é suportada — `$VAR` simples não é expandido.
+
+Para configuração de providers de IA (OpenRouter, Anthropic, Copilot, endpoints customizados, LLMs auto-hospedados, modelos de fallback, etc.), veja [AI Providers](/integrations/providers).
+
+### Timeouts de Provider
+
+Você pode definir `providers.<id>.request_timeout_seconds` para um timeout de requisição do provider, além de `providers.<id>.models.<model>.timeout_seconds` para uma substituição específica de modelo. Aplica-se ao cliente de turno principal em todos os transports (OpenAI-wire, native Anthropic, Anthropic-compatible), a cadeia de fallback, reconstruções após rotação de credenciais e (para OpenAI-wire) o argumento timeout por requisição — para que o valor configurado prevaleça sobre a variável de ambiente legada `HERMES_API_TIMEOUT`.
+
+Você também pode definir `providers.<id>.stale_timeout_seconds` para o detector de chamadas obsoletas não-streaming, além de `providers.<id>.models.<model>.stale_timeout_seconds` para uma substituição específica de modelo. Isso prevalece sobre a variável de ambiente legada `HERMES_API_CALL_STALE_TIMEOUT`.
+
+Deixar estes valores sem definição mantém os padrões legados (`HERMES_API_TIMEOUT=1800s`, `HERMES_API_CALL_STALE_TIMEOUT=90s`, Anthropic nativo 900s). O detector de chamadas obsoletas não-streaming é automaticamente desabilitado para endpoints locais quando deixado implícito e pode escalar para contextos muito grandes. Atualmente não configurado para AWS Bedrock (ambos os caminhos `bedrock_converse` e AnthropicBedrock SDK usam boto3 com sua própria configuração de timeout). Veja o exemplo comentado em [`cli-config.yaml.example`](https://github.com/NousResearch/hermes-agent/blob/main/cli-config.yaml.example).
+
+## Comportamento de Atualização
+
+As configurações de `hermes update` vivem em `updates` no `config.yaml`:
+
+```yaml
+updates:
+  pre_update_backup: quick       # quick (snapshot de estado, padrão) | full (snapshot + zip do HERMES_HOME) | off
+  backup_keep: 5                 # Manter este número de zips de backup completos pré-atualização
+  non_interactive_local_changes: stash  # stash | discard
+```
+
+`pre_update_backup` é o único controle de segurança pré-atualização: `quick` (padrão) tira snapshot dos arquivos de estado críticos (dados de pareamento, cron jobs, config, auth; arquivos acima de 1 GiB são pulados) em `state-snapshots/`; `full` adicionalmente zipa todo o `HERMES_HOME` em `backups/` e pode adicionar minutos em homes grandes; `off` desabilita ambos. Booleanos legados são honrados (`true` → `full`, `false` → `off`).
+
+Para instalações git, o Hermes faz auto-stash de arquivos rastreados sujos e arquivos não rastreados antes de fazer checkout do branch de atualização ou puxar. Atualizações interativas de terminal solicitam antes de restaurar esse stash. Atualizações não interativas (desktop/chat app, gateway ou `--yes`) usam `updates.non_interactive_local_changes`: `stash` restaura edições locais do código fonte após um pull bem-sucedido, enquanto `discard` descarta o stash criado pela atualização após um pull bem-sucedido. Use `discard` apenas em instalações gerenciadas onde edições locais do código fonte nunca devem persistir.
+
+Antes dessa etapa de stash, o Hermes também restaura diferenças rastreadas de `package-lock.json` deixadas pelo churn de npm install/build. Faça commit ou faça stash manual de edições intencionais de lockfile antes de atualizar.
+
+## Configuração do Backend de Terminal
+
+O Hermes suporta seis backends de terminal. Cada um determina onde os comandos shell do agente realmente executam — sua máquina local, um container Docker, um servidor remoto via SSH, um sandbox cloud Modal (direto ou via gateway gerenciado pela Nous), um workspace Daytona ou um container Singularity/Apptainer.
+
+```yaml
+terminal:
+  backend: local    # local | docker | ssh | modal | daytona | singularity
+  cwd: "."          # Diretório de trabalho do gateway/cron (CLI sempre usa o diretório de lançamento)
+  timeout: 180      # Timeout por comando em segundos
+  home_mode: auto   # auto | real | profile — política HOME do subprocesso
+  env_passthrough: []  # Nomes de variáveis de ambiente para encaminhar à execução em sandbox (terminal + execute_code)
+  singularity_image: "docker://nikolaik/python-nodejs:python3.11-nodejs20"  # Imagem do container para Singularity backend
+  modal_image: "nikolaik/python-nodejs:python3.11-nodejs20"                 # Imagem do container para Modal backend
+  daytona_image: "nikolaik/python-nodejs:python3.11-nodejs20"               # Imagem do container para Daytona backend
+```
+
+Para sandboxes cloud como Modal e Daytona, `container_persistent: true` significa que o Hermes tentará preservar o estado do sistema de arquivos entre recriações de sandbox. Não promete que o mesmo sandbox vivo, espaço PID ou processos em segundo plano ainda estarão em execução mais tarde.
+
+### Visão Geral dos Backends
+
+| Backend       | Onde os comandos executam              | Isolamento                    | Melhor para                           |
+|---------------|----------------------------------------|-------------------------------|---------------------------------------|
+| **local**     | Sua máquina diretamente                | Nenhum                        | Desenvolvimento, uso pessoal          |
+| **docker**    | Container Docker persistente único     | Completo (namespaces, cap-drop)| Sandbox seguro, CI/CD                 |
+| **ssh**       | Servidor remoto via SSH                | Limite de rede                | Desenvolvimento remoto, hardware potente |
+| **modal**     | Sandbox cloud Modal                    | Completo (VM cloud)           | Computação cloud efêmera, avaliações  |
+| **daytona**   | Workspace Daytona                      | Completo (container cloud)    | Ambientes de desenvolvimento cloud gerenciados |
+| **singularity**| Container Singularity/Apptainer       | Namespaces (--containall)     | Clusters HPC, máquinas compartilhadas |
+
+### Backend Local
+
+O padrão. Comandos executam diretamente em sua máquina sem isolamento. Nenhuma configuração especial necessária.
+
+```yaml
+terminal:
+  backend: local
+```
+
+Por padrão, subprocessos locais de ferramentas mantêm seu `HOME` real do usuário do SO. Isso permite que CLIs externos como `git`, `ssh`, `gh`, `az`, `npm`, Claude Code e Codex encontrem as credenciais e configuração que já usam em seu shell normal. O estado do Hermes ainda é escopo de profile através de `HERMES_HOME`; `HOME` não é como profiles selecionam config, memória, sessões ou skills.
+
+O Hermes **não** altera seu `HOME` do sistema, seus arquivos de inicialização de shell ou o diretório home da conta do sistema operacional. Esta configuração controla apenas o ambiente passado para subprocessos que o Hermes inicia através de ferramentas como `terminal`, processos de terminal em segundo plano, `execute_code` e processos auxiliares ACP.
+
+#### `terminal.home_mode`
+
+| Modo     | Instalações host   | Containers                   | Trade-off                                                                                                |
+|----------|--------------------|------------------------------|----------------------------------------------------------------------------------------------------------|
+| `auto`   | Manter o `HOME` real do usuário do SO | Usar `{HERMES_HOME}/home`     | Padrão recomendado. CLIs do host continuam funcionando; estado do container persiste.                     |
+| `real`   | Forçar o `HOME` real do usuário do SO | Forçar o `HOME` real do usuário do SO se visível | Útil se um processo pai acidentalmente iniciou com `HOME` apontado para um profile home.                 |
+| `profile`| Usar `{HERMES_HOME}/home` quando existe  | Usar `{HERMES_HOME}/home` quando existe | Isolamento estrito de configuração CLI por profile, mas `~/.ssh`, `~/.gitconfig`, etc. não estarão visíveis. |
+
+A desvantagem do padrão é que profiles do host compartilham as mesmas credenciais/configuração de CLI normais em nível de usuário sob `~`. Se você precisa de um profile com identidade git separada, chaves SSH, login GitHub CLI, config npm ou login CLI cloud, use `home_mode: profile` e inicialize essas ferramentas dentro desse profile home deliberadamente.
+
+### Backend Docker
+
+Executa comandos dentro de um container Docker com hardening de segurança (todas as capacidades removidas, sem escalonamento de privilégio, limites PID).
+
+**Container persistente único, compartilhado entre processos Hermes.** O Hermes inicia UM container de longa duração no primeiro uso e roteia toda chamada de terminal, arquivo e `execute_code` através de `docker exec` para esse mesmo container — entre sessões, `/new`, `/reset` e subagentes `delegate_task`. Alterações de diretório de trabalho, pacotes instalados, arquivos em `/workspace` e **processos em segundo plano** todos persistem de uma chamada de ferramenta para a próxima.
+
+```yaml
+terminal:
+  backend: docker
+  docker_image: "nikolaik/python-nodejs:python3.11-nodejs20"
+  docker_mount_cwd_to_workspace: false  # Montar diretório de lançamento em /workspace
+  docker_run_as_host_user: false
+  docker_forward_env:
+    - "GITHUB_TOKEN"
+  docker_env:
+    DEBUG: "1"
+    PYTHONUNBUFFERED: "1"
+  docker_volumes:
+    - "/home/user/projects:/workspace/projects"
+    - "/home/user/data:/data:ro"
+  docker_extra_args:
+    - "--gpus=all"
+    - "--network=host"
+  docker_network: true
+  container_cpu: 1
+  container_memory: 5120
+  container_disk: 51200
+  container_persistent: true
+  docker_persist_across_processes: true
+  docker_orphan_reaper: true
+  timeout: 180
+  lifetime_seconds: 300
+```
+
+(Pular seções puramente de referência YAML — o conteúdo técnico do restante do documento de configuração (conteúdo de 2127 linhas) permanece principalmente como blocos de código YAML que não são traduzidos.)
+
+### Backend SSH
+
+Executa comandos em um servidor remoto via SSH. Usa ControlMaster para reutilização de conexão (keepalive de 5 minutos ocioso). Shell persistente está ativado por padrão — estado (cwd, variáveis de ambiente) sobrevive entre comandos.
+
+```yaml
+terminal:
+  backend: ssh
+  persistent_shell: true
+```
+
+**Variáveis de ambiente necessárias:**
+
+```bash
+TERMINAL_SSH_HOST=my-server.example.com
+TERMINAL_SSH_USER=ubuntu
+```
+
+**Opcional:**
+
+| Variável               | Padrão         | Descrição                           |
+|------------------------|----------------|-------------------------------------|
+| `TERMINAL_SSH_PORT`    | `22`           | Porta SSH                           |
+| `TERMINAL_SSH_KEY`     | (padrão do sistema) | Caminho para chave privada SSH    |
+| `TERMINAL_SSH_PERSISTENT` | `true`      | Ativar shell persistente            |
+
+(Os backends Modal, Daytona e Singularity seguem padrão similar com seus respectivos blocos YAML de configuração — consulte o original em inglês para os valores exatos.)
+
+### Shell Persistente
+
+Por padrão, cada comando de terminal executa em seu próprio subprocesso — diretório de trabalho, variáveis de ambiente e variáveis de shell são redefinidos entre comandos. Quando o **shell persistente** está ativado, um único processo bash de longa duração é mantido vivo entre chamadas `execute()` para que o estado sobreviva entre comandos.
+
+```yaml
+terminal:
+  persistent_shell: true
+```
+
+## Configurações de Skills
+
+Skills podem declarar suas próprias configurações através do frontmatter de seu SKILL.md. Estes são valores não secretos (caminhos, preferências, configurações de domínio) armazenados sob o namespace `skills.config` em `config.yaml`.
+
+```yaml
+skills:
+  config:
+    myplugin:
+      path: ~/myplugin-data
+```
+
+**Como as configurações de skill funcionam:**
+
+- `hermes config migrate` escaneia todas as skills ativadas, encontra configurações não configuradas e oferece solicitá-las
+- `hermes config show` exibe todas as configurações de skill sob "Skill Settings"
+- Quando uma skill carrega, seus valores de configuração resolvidos são injetados no contexto da skill automaticamente
+
+**Definindo valores manualmente:**
+
+```bash
+hermes config set skills.config.myplugin.path ~/myplugin-data
+```
+
+Para detalhes sobre como declarar configurações em suas próprias skills, veja [Criando Skills — Config Settings](/developer-guide/creating-skills#config-settings-configyaml).
+
+### Proteção em gravações de skill criadas pelo agente
+
+Quando o agente usa `skill_manage` para criar, editar, patch ou deletar uma skill, o Hermes pode opcionalmente escanear o conteúdo novo/atualizado em busca de padrões de palavras-chave perigosas (coleta de credenciais, injeção de prompt óbvia, instruções de exfiltração). O scanner está **desligado por padrão** — fluxos de trabalho reais de agentes que legitimamente tocam em `~/.ssh/` ou mencionam `$OPENAI_API_KEY` estavam disparando a heurística com muita frequência.
+
+```yaml
+skills:
+  guard_agent_created: true   # padrão: false
+```
+
+### Aprovação de gravação para skill writes
+
+Independente do scanner de conteúdo acima, `skills.write_approval` coloca **toda** gravação de skill do agente (criar / editar / patch / deletar / arquivos de suporte) atrás de sua aprovação explícita:
+
+```yaml
+skills:
+  write_approval: false   # false = escrever livremente (padrão) | true = estagiar toda gravação para revisão
+```
+
+## Configuração de Memória
+
+```yaml
+memory:
+  memory_enabled: true
+  user_profile_enabled: true
+  memory_char_limit: 2200
+  user_char_limit: 1375
+  write_approval: false
+```
+
+## Truncamento de Arquivo de Contexto
+
+Controla quanto conteúdo o Hermes carrega de cada arquivo de contexto automático antes de aplicar truncamento cabeça/cauda.
+
+```yaml
+context_file_max_chars: 20000
+```
+
+## Segurança de Leitura de Arquivo
+
+Controla quanto conteúdo uma única chamada `read_file` pode retornar.
+
+```yaml
+file_read_max_chars: 100000
+```
+
+## Limites de Truncamento de Saída de Ferramentas
+
+```yaml
+tool_output:
+  max_bytes: 50000
+  max_lines: 2000
+  max_line_length: 2000
+```
+
+## Desativação Global de Toolset
+
+Para suprimir toolsets específicos no CLI e em toda plataforma de gateway em um só lugar, liste seus nomes sob `agent.disabled_toolsets`:
+
+```yaml
+agent:
+  disabled_toolsets:
+    - memory
+    - web
+```
+
+## Isolamento Git Worktree
+
+Ative worktrees git isolados para executar múltiplos agentes em paralelo no mesmo repositório:
+
+```yaml
+worktree: true
+worktree_sync: true
+```
+
+## Compressão de Contexto
+
+O Hermes comprime automaticamente conversas longas para permanecer dentro da janela de contexto do seu modelo.
+
+### Referência completa
+
+```yaml
+compression:
+  enabled: true
+  threshold: 0.50
+  target_ratio: 0.20
+  protect_last_n: 20
+  protect_first_n: 3
+  hygiene_hard_message_limit: 5000
+
+auxiliary:
+  compression:
+    model: ""
+    provider: "auto"
+    base_url: null
+```
+
+### Configurações comuns
+
+**Padrão (auto-detect) — nenhuma configuração necessária:**
+```yaml
+compression:
+  enabled: true
+  threshold: 0.50
+```
+
+**Forçar um provider específico:**
+```yaml
+auxiliary:
+  compression:
+    provider: nous
+    model: gemini-3-flash
+```
+
+**Endpoint customizado:**
+```yaml
+auxiliary:
+  compression:
+    model: glm-4.7
+    base_url: https://api.z.ai/api/coding/paas/v4
+```
+
+## Mecanismo de Contexto
+
+```yaml
+context:
+  engine: "compressor"
+```
+
+## Orçamento de Iteração
+
+```yaml
+agent:
+  max_turns: 90
+  api_max_retries: 3
+```
+
+## Metas Persistentes (`/goal`)
+
+```yaml
+goals:
+  max_turns: 20
+```
+
+### Timeouts de API
+
+| Timeout                    | Padrão | Providers locais | Config / env                          |
+|----------------------------|--------|------------------|---------------------------------------|
+| Socket read timeout        | 120s   | Automático 1800s | `HERMES_STREAM_READ_TIMEOUT`          |
+| Stale stream detection     | 180s   | Auto-desabilitado| `HERMES_STREAM_STALE_TIMEOUT`         |
+| Stale non-stream detection | 300s   | Auto-desabilitado| `providers.<id>.stale_timeout_seconds` ou `HERMES_API_CALL_STALE_TIMEOUT` |
+| API call (non-streaming)   | 1800s  | Inalterado       | `providers.<id>.request_timeout_seconds` / `timeout_seconds` ou `HERMES_API_TIMEOUT` |
+
+## Avisos de Pressão de Contexto
+
+Separado da pressão de orçamento de iteração, a pressão de contexto rastreia o quão perto a conversa está do **limiar de compactação**.
+
+| Progresso            | Nível   | O que acontece                                                    |
+|----------------------|---------|-------------------------------------------------------------------|
+| **≥ 60%** do limiar  | Informação| CLI mostra barra de progresso ciano; gateway envia aviso informativo |
+| **≥ 85%** do limiar  | Aviso   | CLI mostra barra amarela em negrito; gateway avisa que compactação é iminente |
+
+## Estratégias de Pool de Credenciais
+
+```yaml
+credential_pool_strategies:
+  openrouter: round_robin
+  anthropic: least_used
+```
+
+## Cache de Prompt
+
+O Hermes ativa o cache de prompt entre sessões automaticamente quando o provider ativo o suporta.
+
+```yaml
+prompt_caching:
+  cache_ttl: "5m"
+```
+
+## Modelos Auxiliares
+
+O Hermes usa modelos "auxiliares" para tarefas secundárias como análise de imagem, sumarização de página web, análise de screenshot de navegador, geração de título de sessão e compressão de contexto. Por padrão (`auxiliary.*.provider: "auto"`), o Hermes roteia toda tarefa auxiliar para seu **modelo de chat principal**.
+
+### Configurando modelos auxiliares interativamente
+
+Em vez de editar YAML manualmente, execute `hermes model` e escolha **"Configure auxiliary models"** no menu.
+
+### O padrão de configuração universal
+
+| Chave      | O que faz                                                     | Padrão     |
+|------------|---------------------------------------------------------------|------------|
+| `provider` | Qual provider usar para auth e roteamento                     | `"auto"`   |
+| `model`    | Qual modelo solicitar                                         | padrão do provider |
+| `base_url` | Endpoint customizado compatível com OpenAI (sobrescreve provider)| não definido |
+
+### Mudando o Modelo de Visão
+
+```yaml
+auxiliary:
+  vision:
+    model: "openai/gpt-4o"
+```
+
+Ou via variável de ambiente (em `~/.hermes/.env`):
+```bash
+AUXILIARY_VISION_MODEL=openai/gpt-4o
+```
+
+### Opções de Provider
+
+| Provider          | Descrição                                                                             | Requisitos                           |
+|-------------------|---------------------------------------------------------------------------------------|--------------------------------------|
+| `"auto"`          | Melhor disponível (padrão). Visão tenta OpenRouter → Nous → Codex.                    | —                                    |
+| `"openrouter"`    | Forçar OpenRouter                                                                     | `OPENROUTER_API_KEY`                 |
+| `"nous"`          | Forçar Nous Portal                                                                    | `hermes auth`                        |
+| `"codex"`         | Forçar Codex OAuth (conta ChatGPT). Suporta visão (gpt-5.3-codex).                   | `hermes model` → Codex               |
+| `"minimax-oauth"` | Forçar MiniMax OAuth                                                                  | `hermes model` → MiniMax (OAuth)     |
+| `"xai-oauth"`     | Forçar xAI Grok OAuth                                                                | `hermes model` → xAI Grok OAuth      |
+| `"main"`          | Usar seu endpoint customizado/principal ativo                                         | Credenciais + URL base do endpoint   |
+
+## Esforço de Raciocínio
+
+Controla quanto "pensamento" o modelo faz antes de responder:
+
+```yaml
+agent:
+  reasoning_effort: ""   # vazio = medium. Opções: none, minimal, low, medium, high, xhigh, max, ultra
+```
+
+### Substituições de Raciocínio por Modelo
+
+```yaml
+agent:
+  reasoning_effort: "medium"
+  reasoning_overrides:
+    "openrouter/anthropic/claude-opus-4.5": "xhigh"
+    "openai/gpt-5": "low"
+```
+
+## Reforço de Uso de Ferramentas
+
+```yaml
+agent:
+  tool_use_enforcement: "auto"
+```
+
+| Valor        | Comportamento                                                                                             |
+|--------------|-----------------------------------------------------------------------------------------------------------|
+| `"auto"` (padrão) | Ativado para modelos contendo: `gpt`, `codex`, `gemini`, `gemma`, `grok`. Desativado para todos os outros. |
+| `true`       | Sempre ativado                                                                                            |
+| `false`      | Sempre desativado                                                                                         |
+| `["gpt", "codex", "qwen", "llama"]` | Ativado apenas quando o nome do modelo contém uma das substrings listadas              |
+
+## Proteções de Loop de Ferramentas
+
+```yaml
+tool_loop_guardrails:
+  warnings_enabled: true
+  hard_stop_enabled: false
+  warn_after:
+    exact_failure: 2
+    same_tool_failure: 3
+    idempotent_no_progress: 2
+  hard_stop_after:
+    exact_failure: 5
+    same_tool_failure: 8
+    idempotent_no_progress: 5
+```
+
+## Configuração de TTS
+
+```yaml
+tts:
+  provider: "edge"
+  speed: 1.0
+  edge:
+    voice: "en-US-AriaNeural"
+    speed: 1.0
+  elevenlabs:
+    voice_id: "pNInz6obpgDQGcFmaJgB"
+    model_id: "eleven_multilingual_v2"
+  openai:
+    model: "gpt-4o-mini-tts"
+    voice: "alloy"
+    speed: 1.0
+    base_url: "https://api.openai.com/v1"
+  minimax:
+    speed: 1.0
+  mistral:
+    model: "voxtral-mini-tts-2603"
+    voice_id: "c69964a6-ab8b-4f8a-9465-ec0925096ec8"
+  gemini:
+    model: "gemini-2.5-flash-preview-tts"
+    voice: "Kore"
+  xai:
+    voice_id: "eve"
+    language: "en"
+```
+
+## Configurações de Exibição
+
+```yaml
+display:
+  tool_progress: all
+  tool_progress_command: false
+  platforms: {}
+  interim_assistant_messages: true
+  show_commentary: true
+  skin: default
+  compact: false
+  resume_display: full
+  bell_on_complete: false
+  show_reasoning: false
+  streaming: false
+  show_cost: false
+  timestamps: false
+  tool_preview_length: 0
+  runtime_footer:
+    enabled: false
+    fields: ["model", "context_pct", "cwd"]
+  file_mutation_verifier: true
+  credits_notices: true
+  language: en
+```
+
+### Verificador de mutação de arquivo
+
+Quando `display.file_mutation_verifier` é `true` (padrão), o Hermes anexa um aviso de uma linha à resposta final do assistente sempre que uma chamada `write_file` ou `patch` falhou durante o turno e nunca foi substituída por uma gravação bem-sucedida no mesmo caminho.
+
+### Idioma da interface para mensagens estáticas
+
+A configuração `display.language` traduz um pequeno conjunto de mensagens estáticas voltadas ao usuário. Valores suportados: `en` (padrão), `zh`, `zh-hant`, `ja`, `de`, `es`, `fr`, `tr`, `uk`, `af`, `ko`, `it`, `ga`, `pt`, `ru`, `hu`.
+
+## Privacidade
+
+```yaml
+privacy:
+  redact_pii: false
+```
+
+## Fala para Texto (STT)
+
+```yaml
+stt:
+  enabled: true
+  echo_transcripts: true
+  provider: "local"
+  local:
+    model: "base"
+  openai:
+    model: "whisper-1"
+```
+
+## Modo de Voz (CLI)
+
+```yaml
+voice:
+  record_key: "ctrl+b"
+  max_recording_seconds: 120
+  auto_tts: false
+  beep_enabled: true
+  silence_threshold: 200
+  silence_duration: 3.0
+```
+
+## Streaming
+
+### CLI Streaming
+
+```yaml
+display:
+  streaming: true
+  show_reasoning: true
+```
+
+### Gateway Streaming (Telegram, Discord, Slack)
+
+```yaml
+streaming:
+  enabled: true
+  transport: edit
+  edit_interval: 0.3
+  buffer_threshold: 40
+  cursor: " ▉"
+  fresh_final_after_seconds: 0
+```
+
+## Isolamento de Sessão em Grupo
+
+```yaml
+max_concurrent_sessions: null
+group_sessions_per_user: true
+```
+
+## Comportamento de DM Não Autorizada
+
+```yaml
+unauthorized_dm_behavior: pair
+
+whatsapp:
+  unauthorized_dm_behavior: ignore
+```
+
+## Comandos Rápidos
+
+Defina comandos customizados que executam comandos shell sem invocar o LLM, ou criam alias de um comando de barra para outro.
+
+```yaml
+quick_commands:
+  status:
+    type: exec
+    command: systemctl status hermes-agent
+  disk:
+    type: exec
+    command: df -h /
+  gpu:
+    type: exec
+    command: nvidia-smi --query-gpu=name,utilization.gpu,memory.used,memory.total --format=csv,noheader
+  restart:
+    type: alias
+    target: /gateway restart
+```
+
+## Atraso Humano
+
+Simula ritmo de resposta humano em plataformas de mensagem:
+
+```yaml
+human_delay:
+  mode: "off"
+  min_ms: 800
+  max_ms: 2500
+```
+
+## Execução de Código
+
+```yaml
+code_execution:
+  mode: project
+  timeout: 300
+  max_tool_calls: 50
+```
+
+## Backends de Pesquisa Web
+
+```yaml
+web:
+  backend: firecrawl
+  search_backend: "searxng"
+  extract_backend: "firecrawl"
+```
+
+| Backend              | Variável de Ambiente | Pesquisa | Extração |
+|----------------------|---------------------|----------|----------|
+| **Firecrawl** (padrão) | `FIRECRAWL_API_KEY`  | ✔        | ✔        |
+| **SearXNG**          | `SEARXNG_URL`        | ✔        | —        |
+| **Parallel**         | `PARALLEL_API_KEY`   | ✔        | ✔        |
+| **Tavily**           | `TAVILY_API_KEY`     | ✔        | ✔        |
+| **Exa**              | `EXA_API_KEY`        | ✔        | ✔        |
+
+## Navegador
+
+```yaml
+browser:
+  inactivity_timeout: 120
+  command_timeout: 30
+  record_sessions: false
+  cdp_url: ""
+  dialog_policy: must_respond
+  dialog_timeout_s: 300
+  camofox:
+    managed_persistence: false
+    user_id: ""
+    session_key: ""
+    adopt_existing_tab: false
+```
+
+## Fuso Horário
+
+```yaml
+timezone: "America/New_York"
+```
+
+## Discord
+
+```yaml
+discord:
+  require_mention: true
+  free_response_channels: ""
+  auto_thread: true
+```
+
+## Segurança
+
+```yaml
+security:
+  redact_secrets: true
+  tirith_enabled: true
+  tirith_path: "tirith"
+  tirith_timeout: 5
+  tirith_fail_open: true
+  website_blocklist:
+    enabled: false
+    domains: []
+    shared_files: []
+```
+
+## Lista de Bloqueio de Sites
+
+```yaml
+security:
+  website_blocklist:
+    enabled: false
+    domains:
+      - "*.internal.company.com"
+      - "admin.example.com"
+      - "*.local"
+    shared_files:
+      - "/etc/hermes/blocked-sites.txt"
+```
+
+## Aprovações Inteligentes
+
+```yaml
+approvals:
+  mode: smart
+```
+
+| Modo     | Comportamento                                                                                                       |
+|----------|---------------------------------------------------------------------------------------------------------------------|
+| `smart` (padrão) | Usa um LLM auxiliar para avaliar se um comando sinalizado é realmente perigoso. Comandos de baixo risco são auto-aprovados. |
+| `manual` | Solicitar ao usuário antes de executar qualquer comando sinalizado.                                                  |
+| `off`    | Pular todas as verificações de aprovação. Equivalente a `HERMES_YOLO_MODE=true`.                                    |
+
+### Regras de negação
+
+```yaml
+approvals:
+  deny:
+    - "git push --force*"
+    - "*curl*|*sh*"
+```
+
+## Checkpoints
+
+```yaml
+checkpoints:
+  enabled: false
+  max_snapshots: 20
+```
+
+## Delegação
+
+```yaml
+delegation:
+  max_concurrent_children: 3
+  max_spawn_depth: 1
+  orchestrator_enabled: true
+```
+
+## Clarify
+
+```yaml
+clarify:
+  timeout: 120
+```
+
+## Arquivos de Contexto (SOUL.md, AGENTS.md)
+
+| Arquivo              | Propósito                                                        | Escopo                    |
+|----------------------|------------------------------------------------------------------|---------------------------|
+| `SOUL.md`            | **Identidade primária do agente** — define quem o agente é       | `~/.hermes/SOUL.md`       |
+| `.hermes.md` / `HERMES.md` | Instruções específicas do projeto                          | Caminha até git root      |
+| `AGENTS.md`          | Instruções específicas do projeto, convenções de código          | Caminhada recursiva       |
+| `CLAUDE.md`          | Arquivos de contexto do Claude Code                              | Diretório de trabalho     |
+| `.cursorrules`       | Regras do Cursor IDE                                             | Diretório de trabalho     |
+
+## Diretório de Trabalho
+
+| Contexto                               | Padrão                                                    |
+|----------------------------------------|-----------------------------------------------------------|
+| **CLI (`hermes`)**                     | Diretório atual onde você executa o comando               |
+| **Messaging gateway**                  | `terminal.cwd` de `~/.hermes/config.yaml`                 |
+| **Docker / Singularity / Modal / SSH** | Diretório home do usuário dentro do container ou máquina remota |
+
+```yaml
+terminal:
+  cwd: /home/myuser/projects
+```
+
+## Rede
+
+```yaml
+network:
+  force_ipv4: false
+```
+
+## Onboarding
+
+```yaml
+onboarding:
+  profile_build: "ask"
+```
+
+## Dashboard
+
+```yaml
+dashboard:
+  theme: "default"
+  show_token_analytics: false
+  public_url: ""
+  oauth:
+    client_id: ""
+    portal_url: ""
+  basic_auth:
+    username: ""
+    password_hash: ""
+    password: ""
+    secret: ""
+    session_ttl_seconds: 0
+  drain_auth:
+    scope: "drain"
+    min_secret_chars: 43
+```


### PR DESCRIPTION
## Resumo

Adiciona suporte ao português brasileiro (pt-BR) no site de documentação Docusaurus do Hermes Agent.

## O que foi feito

1. **Registro do locale pt-BR em `website/docusaurus.config.ts`**:
   - Adicionado `"pt-BR"` ao array `locales`
   - Adicionado `localeConfigs["pt-BR"]` com `label: "Português (Brasil)"` e `htmlLang: "pt-BR"`
   - Adicionado `"pt"` ao array `language` do plugin de busca

2. **Estrutura i18n criada** em `website/i18n/pt-BR/docusaurus-plugin-content-docs/current/`

3. **Tradução do primeiro lote** (prova de conceito):
   - `index.mdx` — página inicial da documentação
   - `getting-started/` — todas as 7 páginas:
     - `_category_.json` (rótulo da categoria)
     - `installation.md`
     - `learning-path.md`
     - `nix-setup.md`
     - `platform-support.md`
     - `quickstart.md`
     - `termux.md`
     - `updating.md`
   - `user-guide/configuration.md`
   - `user-guide/cli.md`

## Regras seguidas

- Termos técnicos mantidos em inglês: toolset, gateway, skill, provider, cron, plugin, webhook, CLI, MCP, API, OAuth, etc.
- Blocos de código, comandos, caminhos, variáveis de ambiente e nomes de ferramentas **não** foram traduzidos
- Links internos do Docusaurus preservados intactos
- Uso de "você" (informal profissional), nunca "tu" ou "o senhor"
- Glossário de tradução aplicado (Getting Started → Primeiros Passos, Configuration → Configuração, etc.)

## Próximos passos

Este PR estabelece a estrutura básica. PRs futuros podem traduzir:
- `user-guide/` (messaging, features, security, etc.)
- `developer-guide/`
- `reference/`
- `guides/`
- `integrations/`

Docusaurus faz fallback para o inglês para páginas não traduzidas, então nada quebra entre PRs.

Closes #68680