### PR TITLE
fix(mcp): preserve tool filters across reconnects

### DIFF
--- a/tests/tools/test_mcp_tool_reconnect_filtering.py
+++ b/tests/tools/test_mcp_tool_reconnect_filtering.py
@@ -1,0 +1,118 @@
+"""Regression coverage for MCP include filters across reconnects."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+
+def _mcp_tool(name: str):
+    return SimpleNamespace(
+        name=name,
+        description=f"Tool {name}",
+        inputSchema={"type": "object", "properties": {}},
+    )
+
+
+def _register_raw_tool(registry, server_name: str, tool_name: str) -> str:
+    prefixed = f"mcp__{server_name}__{tool_name}"
+    registry.register(
+        name=prefixed,
+        toolset=f"mcp-{server_name}",
+        schema={
+            "name": prefixed,
+            "description": f"Tool {tool_name}",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handler=lambda *_args, **_kwargs: "{}",
+    )
+    return prefixed
+
+
+def test_59_tool_include_reconciles_initial_and_repeated_reconnects():
+    """Every tools/list result must replace stale full-surface registrations."""
+    from tools.mcp_tool import MCPServerTask, _register_server_tools
+    from tools.registry import ToolRegistry
+
+    server_name = "zernio_regression"
+    raw_tools = [_mcp_tool(f"tool_{index:03d}") for index in range(445)]
+    included_names = {tool.name for tool in raw_tools[:59]}
+    config = {
+        "url": "https://mcp.example.test/mcp",
+        "tools": {
+            "include": sorted(included_names),
+            "resources": False,
+            "prompts": False,
+        },
+    }
+    mock_registry = ToolRegistry()
+    server = MCPServerTask(server_name)
+    server._config = config
+    server.session = SimpleNamespace(
+        list_tools=AsyncMock(
+            side_effect=[
+                SimpleNamespace(tools=list(raw_tools)),
+                SimpleNamespace(tools=list(raw_tools)),
+                SimpleNamespace(tools=list(raw_tools)),
+                SimpleNamespace(tools=list(raw_tools)),
+            ]
+        )
+    )
+
+    async def scenario():
+        # Initial handshake: discovery must retain only the configured include,
+        # then the outer startup path publishes exactly those 59 tools.
+        await server._discover_tools()
+        assert {tool.name for tool in server._tools} == included_names
+        server._registered_tool_names = _register_server_tools(
+            server_name, server, config
+        )
+        assert len(server._registered_tool_names) == 59
+        assert len(mock_registry.get_tool_names_for_toolset(f"mcp-{server_name}")) == 59
+
+        # Reproduce the production failure state: an older/unfiltered path left
+        # all 445 server tools in the registry. Reconnect must remove the 386
+        # filtered-out entries, not merely overwrite ownership tracking with 59.
+        stale_full_surface = [
+            _register_raw_tool(mock_registry, server_name, tool.name)
+            for tool in raw_tools
+        ]
+        # The previous refresh bug then overwrote ownership tracking with only
+        # the included names, orphaning the other 386 live registry entries.
+        server._registered_tool_names = [
+            name
+            for name in stale_full_surface
+            if name.rsplit("__", 1)[-1] in included_names
+        ]
+        assert len(server._registered_tool_names) == 59
+        assert len(mock_registry.get_tool_names_for_toolset(f"mcp-{server_name}")) == 445
+
+        for _ in range(2):
+            # MCPServerTask.run() clears readiness before rebuilding a transport.
+            server._ready.clear()
+            await server._discover_tools()
+
+            registered = mock_registry.get_tool_names_for_toolset(
+                f"mcp-{server_name}"
+            )
+            assert {tool.name for tool in server._tools} == included_names
+            assert len(registered) == 59
+            assert len(registered) == len(set(registered))
+            assert set(server._registered_tool_names) == set(registered)
+
+        # Retry exhaustion parks the task by deregistering every tool. The
+        # subsequent self-probe still represents a reconnect even though both
+        # readiness and current ownership tracking are empty.
+        server._deregister_tools()
+        server._ready.clear()
+        assert mock_registry.get_tool_names_for_toolset(f"mcp-{server_name}") == []
+
+        await server._discover_tools()
+        revived = mock_registry.get_tool_names_for_toolset(f"mcp-{server_name}")
+        assert len(revived) == 59
+        assert len(revived) == len(set(revived))
+        assert set(server._registered_tool_names) == set(revived)
+
+    with patch("tools.registry.registry", mock_registry), patch.dict(
+        "tools.mcp_tool._mcp_tool_server_names", {}, clear=True
+    ):
+        asyncio.run(scenario())

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1709,6 +1709,50 @@ class ElicitationHandler:
 # Server task -- each MCP server lives in one long-lived asyncio Task
 # ---------------------------------------------------------------------------
 
+
+def _normalize_name_filter(value: Any, label: str) -> set[str]:
+    """Normalize include/exclude config to a set of tool names."""
+    if value is None:
+        return set()
+    if isinstance(value, str):
+        return {value}
+    if isinstance(value, (list, tuple, set)):
+        return {str(item) for item in value}
+    logger.warning(
+        "MCP config %s must be a string or list of strings; ignoring %r",
+        label,
+        value,
+    )
+    return set()
+
+
+def _filter_discovered_mcp_tools(
+    server_name: str,
+    discovered_tools: list,
+    config: dict,
+) -> list:
+    """Apply one server's include/exclude policy to a tools/list result.
+
+    This is the single filtering boundary for initial discovery, reconnects,
+    dynamic list_changed refreshes, and defensive direct registration.
+    """
+    tools_filter = config.get("tools") or {}
+    include_set = _normalize_name_filter(
+        tools_filter.get("include"),
+        f"mcp_servers.{server_name}.tools.include",
+    )
+    exclude_set = _normalize_name_filter(
+        tools_filter.get("exclude"),
+        f"mcp_servers.{server_name}.tools.exclude",
+    )
+
+    if include_set:
+        return [tool for tool in discovered_tools if tool.name in include_set]
+    if exclude_set:
+        return [tool for tool in discovered_tools if tool.name not in exclude_set]
+    return list(discovered_tools)
+
+
 class MCPServerTask:
     """Manages a single MCP server connection in a dedicated asyncio Task.
 
@@ -1724,7 +1768,7 @@ class MCPServerTask:
         "_task", "_ready", "_shutdown_event", "_reconnect_event",
         "_tools", "_error", "_config",
         "_sampling", "_elicitation",
-        "_registered_tool_names", "_auth_type", "_refresh_lock",
+        "_registered_tool_names", "_has_published_tools", "_auth_type", "_refresh_lock",
         "_rpc_lock", "_pending_refresh_tasks",
         "_pending_call_context",
         "_lifecycle_started_at", "_last_tool_call_at",
@@ -1752,6 +1796,9 @@ class MCPServerTask:
         self._sampling: Optional[SamplingHandler] = None
         self._elicitation: Optional[ElicitationHandler] = None
         self._registered_tool_names: list[str] = []
+        # Remains true after parking deregisters every tool, allowing the next
+        # successful self-probe to distinguish revival from initial discovery.
+        self._has_published_tools: bool = False
         self._reconnect_retries: int = 0
         self._auth_type: str = ""
         self._refresh_lock = asyncio.Lock()
@@ -1966,8 +2013,6 @@ class MCPServerTask:
         After the initial ``await`` (list_tools), all mutations are synchronous
         — atomic from the event loop's perspective.
         """
-        from tools.registry import registry
-
         if not self._advertises_tools():
             # A server that doesn't implement tools/* should never send
             # tools/list_changed, but guard anyway — calling tools/list
@@ -1984,28 +2029,15 @@ class MCPServerTask:
                     self.session.list_tools, "tools", self.name
                 )
 
-            # 2. Re-register with fresh tool list. Avoid nuke-and-repave for
-            # all names: live agent turns may already have tool-call IDs
-            # pointing at existing handler functions. Replacing entries
-            # in-place is enough for unchanged names and avoids transient
-            # "tool not connected" / stale-handler races during startup
-            # notifications. Tools absent from the fresh list are no longer
-            # callable, so remove only those stale registry entries first.
-            stale_tool_names = old_tool_names - {
-                mcp_prefixed_tool_name(self.name, tool.name)
-                for tool in new_mcp_tools
-            }
-            for tool_name in stale_tool_names:
-                registry.deregister(tool_name)
-                _forget_mcp_tool_server(tool_name)
+            # 2. Apply the same include/exclude policy used by the initial
+            # handshake and every reconnect, then reconcile the live registry.
+            # Comparing stale names against the RAW list is unsafe: a tool can
+            # still exist on the server while being removed by tools.include.
+            # That previously left hundreds of filtered-out entries registered
+            # and then forgot their ownership when this list was overwritten.
+            self._replace_discovered_tools(new_mcp_tools, reconcile_registry=True)
 
-            # 3. Re-register with fresh tool list
-            self._tools = new_mcp_tools
-            self._registered_tool_names = _register_server_tools(
-                self.name, self, self._config
-            )
-
-            # 5. Log what changed (user-visible notification)
+            # 3. Log what changed (user-visible notification)
             new_tool_names = set(self._registered_tool_names)
             added = new_tool_names - old_tool_names
             removed = old_tool_names - new_tool_names
@@ -2780,30 +2812,66 @@ class MCPServerTask:
                 "skipping tools/list (prompts/resources remain available)",
                 self.name,
             )
-            self._tools = []
-            self._register_discovered_tools_if_needed()
+            self._replace_discovered_tools([])
             return
         async with self._rpc_lock:
-            self._tools = await _paginate_full_list(
+            discovered_tools = await _paginate_full_list(
                 self.session.list_tools, "tools", self.name
             )
-        self._register_discovered_tools_if_needed()
+        self._replace_discovered_tools(discovered_tools)
 
-    def _register_discovered_tools_if_needed(self) -> None:
-        """Re-register tools after a post-ready reconnect if needed.
+    def _replace_discovered_tools(
+        self,
+        discovered_tools: list,
+        *,
+        reconcile_registry: bool = False,
+    ) -> None:
+        """Filter a tools/list result and reconcile reconnect registry state.
 
         Initial registration is performed by ``_discover_and_register_server``
-        after ``start()`` completes. During a later reconnect, however,
-        ``_ready`` remains set; if outage handling previously deregistered
-        stale tools (parking calls ``_deregister_tools``), a successful
-        revival must publish the freshly discovered tools again — otherwise
-        the transport comes back alive with zero registered tools.
+        after ``start()`` completes. Every later discovery result must refresh
+        the existing registration, even when ``run()`` cleared ``_ready`` before
+        rebuilding the transport. This also scrubs stale entries left by older
+        unfiltered paths instead of losing their ownership tracking.
         """
-        if not self._ready.is_set() or self._registered_tool_names:
+        from tools.registry import registry
+
+        own_toolset = f"mcp-{self.name}"
+        # Registry membership is authoritative. Older refresh code could
+        # overwrite _registered_tool_names with only the filtered subset while
+        # leaving filtered-out entries live, so tracking alone cannot identify
+        # every stale tool that must be scrubbed.
+        old_tool_names = set(
+            registry.get_tool_names_for_toolset(own_toolset)
+        )
+        old_tool_names.update(self._registered_tool_names)
+        self._tools = _filter_discovered_mcp_tools(
+            self.name, discovered_tools, self._config
+        )
+
+        # Initial discovery deliberately leaves registration to
+        # _discover_and_register_server. Reconnects are recognizable by either
+        # prior registrations or a previously-ready lifecycle (parked revival).
+        should_reconcile = (
+            reconcile_registry
+            or bool(old_tool_names)
+            or self._ready.is_set()
+            or self._has_published_tools
+        )
+        if not should_reconcile:
             return
-        self._registered_tool_names = _register_server_tools(
+
+        registered_names = _register_server_tools(
             self.name, self, self._config
         )
+        new_tool_names = set(registered_names)
+        for tool_name in old_tool_names - new_tool_names:
+            # Never remove a built-in/plugin entry that may now own a formerly
+            # MCP-shaped name. Only scrub entries still owned by this server.
+            if registry.get_toolset_for_tool(tool_name) == own_toolset:
+                registry.deregister(tool_name)
+                _forget_mcp_tool_server(tool_name)
+        self._registered_tool_names = registered_names
 
     async def run(self, config: dict):
         """Long-lived coroutine: connect, discover tools, wait, disconnect.
@@ -4861,18 +4929,6 @@ def _build_utility_schemas(server_name: str) -> List[dict]:
     ]
 
 
-def _normalize_name_filter(value: Any, label: str) -> set[str]:
-    """Normalize include/exclude config to a set of tool names."""
-    if value is None:
-        return set()
-    if isinstance(value, str):
-        return {value}
-    if isinstance(value, (list, tuple, set)):
-        return {str(item) for item in value}
-    logger.warning("MCP config %s must be a string or list of strings; ignoring %r", label, value)
-    return set()
-
-
 def _parse_boolish(value: Any, default: bool = True) -> bool:
     """Parse a bool-like config value with safe fallback."""
     if value is None:
@@ -5035,27 +5091,12 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
     registered_names: List[str] = []
     toolset_name = f"mcp-{name}"
 
-    # Selective tool loading: honour include/exclude lists from config.
-    # Rules (matching issue #690 spec):
-    #   tools.include — whitelist: only these tool names are registered
-    #   tools.exclude — blacklist: all tools EXCEPT these are registered
-    #   include takes precedence over exclude
-    #   Neither set → register all tools (backward-compatible default)
-    tools_filter = config.get("tools") or {}
-    include_set = _normalize_name_filter(tools_filter.get("include"), f"mcp_servers.{name}.tools.include")
-    exclude_set = _normalize_name_filter(tools_filter.get("exclude"), f"mcp_servers.{name}.tools.exclude")
+    # Discovery already filters before storing server._tools. Apply the shared
+    # helper again defensively for direct/fake connection paths that bypass the
+    # normal MCPServerTask handshake.
+    filtered_tools = _filter_discovered_mcp_tools(name, server._tools, config)
 
-    def _should_register(tool_name: str) -> bool:
-        if include_set:
-            return tool_name in include_set
-        if exclude_set:
-            return tool_name not in exclude_set
-        return True
-
-    for mcp_tool in server._tools:
-        if not _should_register(mcp_tool.name):
-            logger.debug("MCP server '%s': skipping tool '%s' (filtered by config)", name, mcp_tool.name)
-            continue
+    for mcp_tool in filtered_tools:
 
         # Scan tool description for prompt injection patterns
         _scan_mcp_description(name, mcp_tool.name, mcp_tool.description or "")
@@ -5125,6 +5166,10 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
     if registered_names:
         registry.register_toolset_alias(name, toolset_name)
 
+    # Publication history must survive _deregister_tools() while a server is
+    # parked. Its later self-probe runs with empty ownership tracking and a
+    # cleared readiness event but still needs to republish filtered tools.
+    server._has_published_tools = True
     return registered_names
 
 


### PR DESCRIPTION
## Summary
- apply MCP `tools.include` / `tools.exclude` immediately after every `tools/list` result
- reconcile reconnect and `list_changed` registrations against authoritative registry membership so filtered-out orphan tools are removed
- preserve publication history across parked-server deregistration so self-probe revival republishes the filtered surface
- add a 445-raw / 59-included regression covering initial discovery, repeated reconnects, stale orphan cleanup, and parked revival

## Root cause
Reconnect discovery stored the raw server surface while conditional re-registration could be skipped, and dynamic refresh compared stale names against the unfiltered list. Filtered-out entries could therefore remain live in the registry after tracking was replaced by the filtered subset.

## Verification
- `245 passed` across the focused MCP registration/reconnect/lifecycle suite
- regression test passes with exactly 59 unique registrations on initial connect, two reconnects, and parked revival
- `ruff check`, `compileall`, and `git diff --check` pass
- live isolated MCP validation: 39 currently available filtered server tools remain 39 after parked revival and repeated reconnect; representative Telegram payload resolves to 68 unique tools (<200)

Broader repository sweeps expose existing order-dependent/global-state failures outside this diff; the affected tests pass in isolation and the focused MCP set is clean.