### PR TITLE
fix(whatsapp): gate group media downloads

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -60,6 +60,8 @@ def _get_wsecret(name, default=None):
 
 logger = logging.getLogger(__name__)
 
+_MISSING_SECRET = object()
+
 
 class WhatsAppBehaviorMixin:
     """Shared behavior for all WhatsApp adapters (Baileys + Cloud API).
@@ -169,11 +171,12 @@ class WhatsAppBehaviorMixin:
         """
         source = getattr(self, "_dm_allowlist_source", None)
         if isinstance(source, str) and source != "config":
-            if source in os.environ:
-                return self._coerce_allow_list(os.environ.get(source, ""))
-            # Key removed (e.g. sole-entry pairing revoke) — do not revive the
-            # stale construction snapshot.
-            return set()
+            raw = _get_wsecret(source, _MISSING_SECRET)
+            if raw is _MISSING_SECRET:
+                # Key removed (e.g. sole-entry pairing revoke) — do not revive
+                # the stale construction snapshot.
+                return set()
+            return self._coerce_allow_list(raw)
         return set(self._allow_from or ())
 
     # ------------------------------------------------------------------ JID helpers

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -355,6 +355,34 @@ def _file_content_hash(path: Path) -> str:
         return ""
 
 
+def _serialize_bridge_allowlist(values) -> str:
+    """Return a stable bridge env representation for an effective allowlist."""
+    return ",".join(
+        sorted(str(value).strip() for value in (values or ()) if str(value).strip())
+    )
+
+
+def _bridge_access_policy_hash(
+    *,
+    mode: str,
+    dm_policy: str,
+    allowed_users,
+    group_policy: str,
+    group_allowed_users,
+) -> str:
+    """Fingerprint access settings that are snapshotted by the Node bridge."""
+    import hashlib
+
+    fields = (
+        str(mode or "self-chat"),
+        str(dm_policy or "open").strip().lower(),
+        _serialize_bridge_allowlist(allowed_users),
+        str(group_policy or "pairing").strip().lower(),
+        _serialize_bridge_allowlist(group_allowed_users),
+    )
+    return hashlib.sha256("\0".join(fields).encode("utf-8")).hexdigest()[:16]
+
+
 def check_whatsapp_requirements() -> bool:
     """
     Check if WhatsApp dependencies are available.
@@ -449,7 +477,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             allow_raw = None
         self._allow_from = self._coerce_allow_list(allow_raw)
         self._group_policy = str(config.extra.get("group_policy") or _wenv("WHATSAPP_GROUP_POLICY", "pairing")).strip().lower()
-        self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
+        if "group_allow_from" in config.extra:
+            group_allow_raw = config.extra.get("group_allow_from")
+        elif "groupAllowFrom" in config.extra:
+            group_allow_raw = config.extra.get("groupAllowFrom")
+        else:
+            group_allow_raw = (
+                _wenv("WHATSAPP_GROUP_ALLOWED_USERS")
+                or _wenv("WHATSAPP_GROUP_ALLOW_FROM")
+            )
+        self._group_allow_from = self._coerce_allow_list(group_allow_raw)
         read_receipts = config.extra.get("send_read_receipts", False)
         self._send_read_receipts = (
             read_receipts if isinstance(read_receipts, bool)
@@ -614,7 +651,37 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # Ensure session directory exists
             self._session_path.mkdir(parents=True, exist_ok=True)
             
-            # Check if bridge is already running and connected
+            # Check if bridge is already running and connected. Access-policy
+            # settings are snapshotted by Node at process start, so bridge reuse
+            # requires both the script and effective policy fingerprints to match.
+            whatsapp_mode = _wenv("WHATSAPP_MODE", "self-chat")
+            effective_dm_policy = getattr(
+                self,
+                "_dm_policy",
+                str(_wenv("WHATSAPP_DM_POLICY", "pairing")).strip().lower(),
+            )
+            effective_allowed_users = getattr(
+                self,
+                "_allow_from",
+                self._coerce_allow_list(_wenv("WHATSAPP_ALLOWED_USERS", "")),
+            )
+            effective_group_policy = getattr(
+                self,
+                "_group_policy",
+                str(_wenv("WHATSAPP_GROUP_POLICY", "pairing")).strip().lower(),
+            )
+            effective_group_allowed_users = getattr(
+                self,
+                "_group_allow_from",
+                self._coerce_allow_list(_wenv("WHATSAPP_GROUP_ALLOWED_USERS", "")),
+            )
+            expected_policy_hash = _bridge_access_policy_hash(
+                mode=whatsapp_mode,
+                dm_policy=effective_dm_policy,
+                allowed_users=effective_allowed_users,
+                group_policy=effective_group_policy,
+                group_allowed_users=effective_group_allowed_users,
+            )
             import aiohttp
             try:
                 async with aiohttp.ClientSession() as session:
@@ -627,36 +694,38 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                             bridge_status = data.get("status", "unknown")
                             if bridge_status == "connected":
                                 # Staleness handshake: only reuse a running
-                                # bridge if it is serving the same bridge.js
-                                # that is on disk right now.  A long-lived
-                                # bridge survives gateway restarts AND
-                                # `hermes update`, so without this check it
-                                # keeps serving pre-update code forever
-                                # (e.g. no inbound media download).  Old
-                                # bridges that don't report scriptHash are
-                                # treated as stale by definition.
+                                # bridge when both its bridge.js source and its
+                                # snapshotted access policy match current state.
+                                # A long-lived bridge survives gateway restarts
+                                # AND `hermes update`; either mismatch can retain
+                                # stale behavior or authorization. Old bridges
+                                # missing either hash are stale by definition.
                                 running_hash = data.get("scriptHash", "")
+                                running_policy_hash = data.get("policyHash", "")
                                 disk_hash = _file_content_hash(bridge_path)
                                 running_read_receipts = bool(data.get("sendReadReceipts", False))
+                                code_matches = bool(
+                                    running_hash and disk_hash and running_hash == disk_hash
+                                )
+                                policy_matches = bool(
+                                    running_policy_hash
+                                    and running_policy_hash == expected_policy_hash
+                                )
                                 config_matches = running_read_receipts == self._send_read_receipts
-                                if (
-                                    running_hash
-                                    and disk_hash
-                                    and running_hash == disk_hash
-                                    and config_matches
-                                ):
+                                if code_matches and policy_matches and config_matches:
                                     print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
                                     self._mark_connected()
                                     self._bridge_process = None  # Not managed by us
                                     self._http_session = aiohttp.ClientSession()
                                     self._poll_task = asyncio.create_task(self._poll_messages())
                                     return True
-                                stale_reason = (
-                                    f"running={running_hash or 'unversioned'}, disk={disk_hash}"
-                                    if running_hash != disk_hash
-                                    else "send_read_receipts config changed"
+                                print(
+                                    f"[{self.name}] Running bridge is stale "
+                                    f"(script={running_hash or 'unversioned'}/{disk_hash}, "
+                                    f"policy={running_policy_hash or 'unversioned'}/{expected_policy_hash}, "
+                                    f"send_read_receipts={running_read_receipts}/{self._send_read_receipts}), "
+                                    "restarting"
                                 )
-                                print(f"[{self.name}] Running bridge is stale ({stale_reason}), restarting")
                             else:
                                 print(f"[{self.name}] Bridge found but not connected (status: {bridge_status}), restarting")
             except Exception:
@@ -670,7 +739,6 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # Start the bridge process in its own process group.
             # Route output to a log file so QR codes, errors, and reconnection
             # messages are preserved for troubleshooting.
-            whatsapp_mode = _wenv("WHATSAPP_MODE", "self-chat")
             self._bridge_log = self._session_path.parent / "bridge.log"
             bridge_log_fh = open(self._bridge_log, "a", encoding="utf-8")
             self._bridge_log_fh = bridge_log_fh
@@ -680,6 +748,18 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # can use it without the user needing to set a separate env var.
             # with_hermes_node_path() copies os.environ when called with no arg.
             bridge_env = with_hermes_node_path()
+            # Always pass the adapter's effective access policy to Node. Values
+            # may originate in config.yaml rather than os.environ; relying on a
+            # copied process environment can therefore make Node and Python
+            # enforce different policies.
+            bridge_env["WHATSAPP_DM_POLICY"] = effective_dm_policy
+            bridge_env["WHATSAPP_ALLOWED_USERS"] = _serialize_bridge_allowlist(
+                effective_allowed_users
+            )
+            bridge_env["WHATSAPP_GROUP_POLICY"] = effective_group_policy
+            bridge_env["WHATSAPP_GROUP_ALLOWED_USERS"] = _serialize_bridge_allowlist(
+                effective_group_allowed_users
+            )
             if self._reply_prefix is not None:
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
             bridge_env["WHATSAPP_SEND_READ_RECEIPTS"] = (

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -369,6 +369,7 @@ def _bridge_access_policy_hash(
     allowed_users,
     group_policy: str,
     group_allowed_users,
+    forward_owner_messages: bool,
 ) -> str:
     """Fingerprint access settings that are snapshotted by the Node bridge."""
     import hashlib
@@ -379,6 +380,7 @@ def _bridge_access_policy_hash(
         _serialize_bridge_allowlist(allowed_users),
         str(group_policy or "pairing").strip().lower(),
         _serialize_bridge_allowlist(group_allowed_users),
+        "true" if forward_owner_messages else "false",
     )
     return hashlib.sha256("\0".join(fields).encode("utf-8")).hexdigest()[:16]
 
@@ -675,12 +677,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "_group_allow_from",
                 self._coerce_allow_list(_wenv("WHATSAPP_GROUP_ALLOWED_USERS", "")),
             )
+            effective_forward_owner_messages = _wenv(
+                "WHATSAPP_FORWARD_OWNER_MESSAGES", "false"
+            ).strip().lower() in {"1", "true", "yes", "on"}
             expected_policy_hash = _bridge_access_policy_hash(
                 mode=whatsapp_mode,
                 dm_policy=effective_dm_policy,
                 allowed_users=effective_allowed_users,
                 group_policy=effective_group_policy,
                 group_allowed_users=effective_group_allowed_users,
+                forward_owner_messages=effective_forward_owner_messages,
             )
             import aiohttp
             try:
@@ -748,18 +754,6 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # can use it without the user needing to set a separate env var.
             # with_hermes_node_path() copies os.environ when called with no arg.
             bridge_env = with_hermes_node_path()
-            # Always pass the adapter's effective access policy to Node. Values
-            # may originate in config.yaml rather than os.environ; relying on a
-            # copied process environment can therefore make Node and Python
-            # enforce different policies.
-            bridge_env["WHATSAPP_DM_POLICY"] = effective_dm_policy
-            bridge_env["WHATSAPP_ALLOWED_USERS"] = _serialize_bridge_allowlist(
-                effective_allowed_users
-            )
-            bridge_env["WHATSAPP_GROUP_POLICY"] = effective_group_policy
-            bridge_env["WHATSAPP_GROUP_ALLOWED_USERS"] = _serialize_bridge_allowlist(
-                effective_group_allowed_users
-            )
             if self._reply_prefix is not None:
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
             bridge_env["WHATSAPP_SEND_READ_RECEIPTS"] = (
@@ -789,6 +783,19 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 _v = _wenv(_key)
                 if _v:
                     bridge_env[_key] = _v
+            # Config-derived access values are authoritative over copied/profile
+            # environment values and must exactly match the policy fingerprint.
+            bridge_env["WHATSAPP_DM_POLICY"] = effective_dm_policy
+            bridge_env["WHATSAPP_ALLOWED_USERS"] = _serialize_bridge_allowlist(
+                effective_allowed_users
+            )
+            bridge_env["WHATSAPP_GROUP_POLICY"] = effective_group_policy
+            bridge_env["WHATSAPP_GROUP_ALLOWED_USERS"] = _serialize_bridge_allowlist(
+                effective_group_allowed_users
+            )
+            bridge_env["WHATSAPP_FORWARD_OWNER_MESSAGES"] = (
+                "true" if effective_forward_owner_messages else "false"
+            )
             # Pass the profile-aware cache directories so the bridge writes
             # media where the Python side reads it.  Without these the bridge
             # hardcodes ~/.hermes/{image,audio,document}_cache, which diverges

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -34,7 +34,7 @@ from hermes_constants import (
     with_hermes_node_path,
 )
 
-def _wenv(name: str, default: str = "") -> str:
+def _wenv(name: str, default: Any = "") -> Any:
     """Read a WHATSAPP_* env var through the profile secret scope.
 
     Under multiplexing, ``os.getenv`` bypasses the per-profile ``.env`` and
@@ -480,14 +480,23 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._allow_from = self._coerce_allow_list(allow_raw)
         self._group_policy = str(config.extra.get("group_policy") or _wenv("WHATSAPP_GROUP_POLICY", "pairing")).strip().lower()
         if "group_allow_from" in config.extra:
+            self._group_allowlist_source = "config"
             group_allow_raw = config.extra.get("group_allow_from")
         elif "groupAllowFrom" in config.extra:
+            self._group_allowlist_source = "config"
             group_allow_raw = config.extra.get("groupAllowFrom")
         else:
-            group_allow_raw = (
-                _wenv("WHATSAPP_GROUP_ALLOWED_USERS")
-                or _wenv("WHATSAPP_GROUP_ALLOW_FROM")
-            )
+            canonical_group_allow = _wenv("WHATSAPP_GROUP_ALLOWED_USERS", None)
+            legacy_group_allow = _wenv("WHATSAPP_GROUP_ALLOW_FROM", None)
+            if canonical_group_allow is not None:
+                self._group_allowlist_source = "WHATSAPP_GROUP_ALLOWED_USERS"
+                group_allow_raw = canonical_group_allow
+            elif legacy_group_allow is not None:
+                self._group_allowlist_source = "WHATSAPP_GROUP_ALLOW_FROM"
+                group_allow_raw = legacy_group_allow
+            else:
+                self._group_allowlist_source = None
+                group_allow_raw = None
         self._group_allow_from = self._coerce_allow_list(group_allow_raw)
         read_receipts = config.extra.get("send_read_receipts", False)
         self._send_read_receipts = (
@@ -684,11 +693,20 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "_group_policy",
                 str(_wenv("WHATSAPP_GROUP_POLICY", "pairing")).strip().lower(),
             )
-            effective_group_allowed_users = getattr(
-                self,
-                "_group_allow_from",
-                self._coerce_allow_list(_wenv("WHATSAPP_GROUP_ALLOWED_USERS", "")),
-            )
+            group_allowlist_source = getattr(self, "_group_allowlist_source", None)
+            if group_allowlist_source == "config":
+                effective_group_allowed_users = set(
+                    getattr(self, "_group_allow_from", ()) or ()
+                )
+            elif isinstance(group_allowlist_source, str):
+                live_group_allow = _wenv(group_allowlist_source, None)
+                effective_group_allowed_users = self._coerce_allow_list(
+                    live_group_allow
+                )
+            elif hasattr(self, "_group_allow_from"):
+                effective_group_allowed_users = set(self._group_allow_from or ())
+            else:
+                effective_group_allowed_users = set()
             effective_forward_owner_messages = _wenv(
                 "WHATSAPP_FORWARD_OWNER_MESSAGES", "false"
             ).strip().lower() in {"1", "true", "yes", "on"}

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -662,11 +662,23 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "_dm_policy",
                 str(_wenv("WHATSAPP_DM_POLICY", "pairing")).strip().lower(),
             )
-            effective_allowed_users = getattr(
-                self,
-                "_allow_from",
-                self._coerce_allow_list(_wenv("WHATSAPP_ALLOWED_USERS", "")),
-            )
+            # Pairing approve/revoke updates env-backed DM allowlists live. Read
+            # that source through _wenv so multiplexed profiles cannot borrow a
+            # process-global allowlist from another profile; explicit config
+            # remains authoritative over any env carrier.
+            dm_allowlist_source = getattr(self, "_dm_allowlist_source", None)
+            if dm_allowlist_source == "config":
+                effective_allowed_users = set(getattr(self, "_allow_from", ()) or ())
+            elif isinstance(dm_allowlist_source, str):
+                effective_allowed_users = self._coerce_allow_list(
+                    _wenv(dm_allowlist_source, "")
+                )
+            elif hasattr(self, "_allow_from"):
+                effective_allowed_users = set(self._allow_from or ())
+            else:
+                effective_allowed_users = self._coerce_allow_list(
+                    _wenv("WHATSAPP_ALLOWED_USERS", "")
+                )
             effective_group_policy = getattr(
                 self,
                 "_group_policy",

--- a/scripts/whatsapp-bridge/allowlist.js
+++ b/scripts/whatsapp-bridge/allowlist.js
@@ -89,8 +89,9 @@ export function classifyInboundAccessBeforeMedia({
   groupAllowedUsers,
   sessionDir,
 }) {
-  // Owner-authored group messages are rejected earlier in bridge.js. This
-  // classifies ordinary inbound groups before media extraction.
+  // Ordinary inbound group messages reach this classifier after the bridge's
+  // existing fromMe-group rejection. Keep their authorization ahead of media
+  // extraction so blocked-group attachments cannot touch disk.
   if (isGroup) {
     if (!matchesInboundWhatsAppGroup({
       chatId,
@@ -108,6 +109,18 @@ export function classifyInboundAccessBeforeMedia({
   }
 
   return { allowed: true };
+}
+
+export function prepareInboundMediaDispatch({ downloadMedia, ...accessInput }) {
+  const access = classifyInboundAccessBeforeMedia(accessInput);
+  const guardedDownloadMedia = async (...args) => {
+    if (!access?.allowed) {
+      throw new Error(access?.reason || 'media_download_rejected_before_access');
+    }
+    return downloadMedia(...args);
+  };
+
+  return { access, downloadMedia: guardedDownloadMedia };
 }
 
 export function matchesAllowedUser(senderId, allowedUsers, sessionDir) {

--- a/scripts/whatsapp-bridge/allowlist.js
+++ b/scripts/whatsapp-bridge/allowlist.js
@@ -78,6 +78,38 @@ export function matchesInboundWhatsAppGroup({
   return groupPolicy === 'open';
 }
 
+export function classifyInboundAccessBeforeMedia({
+  isGroup,
+  fromMe,
+  chatId,
+  senderId,
+  dmPolicy,
+  allowedUsers,
+  groupPolicy,
+  groupAllowedUsers,
+  sessionDir,
+}) {
+  // Owner-authored group messages are rejected earlier in bridge.js. This
+  // classifies ordinary inbound groups before media extraction.
+  if (isGroup) {
+    if (!matchesInboundWhatsAppGroup({
+      chatId,
+      groupPolicy,
+      groupAllowedUsers,
+      sessionDir,
+    })) {
+      return { allowed: false, reason: 'group_policy_rejected_before_media' };
+    }
+    return { allowed: true };
+  }
+
+  if (!fromMe && dmPolicy !== 'pairing' && !matchesAllowedUser(senderId, allowedUsers, sessionDir)) {
+    return { allowed: false, reason: 'allowlist_mismatch' };
+  }
+
+  return { allowed: true };
+}
+
 export function matchesAllowedUser(senderId, allowedUsers, sessionDir) {
   // Empty allowlist = NO ONE allowed (secure default, #8389).  Operators
   // who want an open bot must set ``WHATSAPP_ALLOWED_USERS=*`` explicitly.

--- a/scripts/whatsapp-bridge/allowlist.js
+++ b/scripts/whatsapp-bridge/allowlist.js
@@ -63,6 +63,21 @@ export function expandWhatsAppIdentifiers(identifier, sessionDir) {
   return resolved;
 }
 
+export function matchesInboundWhatsAppGroup({
+  chatId,
+  groupPolicy,
+  groupAllowedUsers,
+  sessionDir,
+}) {
+  if (groupPolicy === 'disabled' || groupPolicy === 'pairing') {
+    return false;
+  }
+  if (groupPolicy === 'allowlist') {
+    return matchesAllowedUser(chatId, groupAllowedUsers, sessionDir);
+  }
+  return groupPolicy === 'open';
+}
+
 export function matchesAllowedUser(senderId, allowedUsers, sessionDir) {
   // Empty allowlist = NO ONE allowed (secure default, #8389).  Operators
   // who want an open bot must set ``WHATSAPP_ALLOWED_USERS=*`` explicitly.

--- a/scripts/whatsapp-bridge/allowlist.test.mjs
+++ b/scripts/whatsapp-bridge/allowlist.test.mjs
@@ -11,7 +11,9 @@ import {
   matchesAllowedUser,
   normalizeWhatsAppIdentifier,
   parseAllowedUsers,
+  prepareInboundMediaDispatch,
 } from './allowlist.js';
+import { extractBridgeEvent } from './bridge_helpers.js';
 
 test('normalizeWhatsAppIdentifier strips jid syntax and plus prefix', () => {
   assert.equal(normalizeWhatsAppIdentifier('+19175395595@s.whatsapp.net'), '19175395595');
@@ -79,6 +81,98 @@ test('group intake follows group policy and group-JID allowlist independently of
   } finally {
     rmSync(sessionDir, { recursive: true, force: true });
   }
+});
+
+test('blocked ordinary group is rejected before media handling', () => {
+  const result = classifyInboundAccessBeforeMedia({
+    isGroup: true,
+    fromMe: false,
+    chatId: '120363009999999999@g.us',
+    senderId: '15551230000@s.whatsapp.net',
+    dmPolicy: 'allowlist',
+    allowedUsers: parseAllowedUsers('*'),
+    groupPolicy: 'allowlist',
+    groupAllowedUsers: parseAllowedUsers('120363001234567890@g.us'),
+    sessionDir: '',
+  });
+
+  assert.deepEqual(result, {
+    allowed: false,
+    reason: 'group_policy_rejected_before_media',
+  });
+});
+
+test('allowed ordinary group passes the pre-media access check', () => {
+  const result = classifyInboundAccessBeforeMedia({
+    isGroup: true,
+    fromMe: false,
+    chatId: '120363001234567890@g.us',
+    senderId: '15551230000@s.whatsapp.net',
+    dmPolicy: 'allowlist',
+    allowedUsers: new Set(),
+    groupPolicy: 'allowlist',
+    groupAllowedUsers: parseAllowedUsers('120363001234567890@g.us'),
+    sessionDir: '',
+  });
+
+  assert.deepEqual(result, { allowed: true });
+});
+
+test('dispatch boundary never calls media downloader for a rejected ordinary group', async () => {
+  let downloadCalls = 0;
+  let writeCalls = 0;
+  const dispatch = prepareInboundMediaDispatch({
+    isGroup: true,
+    fromMe: false,
+    chatId: '120363009999999999@g.us',
+    senderId: '15551230000@s.whatsapp.net',
+    dmPolicy: 'allowlist',
+    allowedUsers: parseAllowedUsers('*'),
+    groupPolicy: 'allowlist',
+    groupAllowedUsers: parseAllowedUsers('120363001234567890@g.us'),
+    sessionDir: '',
+    downloadMedia: async () => {
+      downloadCalls += 1;
+      return Buffer.from('blocked media');
+    },
+  });
+  assert.equal(dispatch.access.allowed, false);
+
+  const originalWarn = console.warn;
+  console.warn = () => {};
+  try {
+    await extractBridgeEvent({
+      msg: {
+        key: {
+          id: 'blocked-group-image',
+          remoteJid: '120363009999999999@g.us',
+          participant: '15551230000@s.whatsapp.net',
+          fromMe: false,
+        },
+        messageTimestamp: 123,
+        message: {
+          imageMessage: {
+            caption: 'must not reach disk',
+            mimetype: 'image/jpeg',
+          },
+        },
+      },
+      chatId: '120363009999999999@g.us',
+      senderId: '15551230000@s.whatsapp.net',
+      senderNumber: '15551230000',
+      isGroup: true,
+      downloadMedia: dispatch.downloadMedia,
+      writeMediaFile: async () => {
+        writeCalls += 1;
+        return '/tmp/blocked.jpg';
+      },
+    });
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.equal(downloadCalls, 0);
+  assert.equal(writeCalls, 0);
 });
 
 test('matchesAllowedUser rejects everyone when allowlist is empty (#8389)', () => {

--- a/scripts/whatsapp-bridge/allowlist.test.mjs
+++ b/scripts/whatsapp-bridge/allowlist.test.mjs
@@ -6,6 +6,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 
 import {
   expandWhatsAppIdentifiers,
+  matchesInboundWhatsAppGroup,
   matchesAllowedUser,
   normalizeWhatsAppIdentifier,
   parseAllowedUsers,
@@ -53,6 +54,27 @@ test('matchesAllowedUser treats * as allow-all wildcard', () => {
     const allowedUsers = parseAllowedUsers('*');
     assert.equal(matchesAllowedUser('19175395595@s.whatsapp.net', allowedUsers, sessionDir), true);
     assert.equal(matchesAllowedUser('267383306489914@lid', allowedUsers, sessionDir), true);
+  } finally {
+    rmSync(sessionDir, { recursive: true, force: true });
+  }
+});
+
+test('group intake follows group policy and group-JID allowlist independently of DM users', () => {
+  const sessionDir = mkdtempSync(path.join(os.tmpdir(), 'hermes-wa-allowlist-'));
+
+  try {
+    const groupAllowedUsers = parseAllowedUsers('120363001234567890@g.us');
+    const base = {
+      chatId: '120363001234567890@g.us',
+      groupAllowedUsers,
+      sessionDir,
+    };
+
+    assert.equal(matchesInboundWhatsAppGroup({ ...base, groupPolicy: 'allowlist' }), true);
+    assert.equal(matchesInboundWhatsAppGroup({ ...base, chatId: 'other@g.us', groupPolicy: 'allowlist' }), false);
+    assert.equal(matchesInboundWhatsAppGroup({ ...base, chatId: 'other@g.us', groupPolicy: 'open' }), true);
+    assert.equal(matchesInboundWhatsAppGroup({ ...base, groupPolicy: 'disabled' }), false);
+    assert.equal(matchesInboundWhatsAppGroup({ ...base, groupPolicy: 'pairing' }), false);
   } finally {
     rmSync(sessionDir, { recursive: true, force: true });
   }

--- a/scripts/whatsapp-bridge/allowlist.test.mjs
+++ b/scripts/whatsapp-bridge/allowlist.test.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 
 import {
+  classifyInboundAccessBeforeMedia,
   expandWhatsAppIdentifiers,
   matchesInboundWhatsAppGroup,
   matchesAllowedUser,

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -112,11 +112,26 @@ const PAIR_ONLY = args.includes('--pair-only');
 const PAIR_JSON = args.includes('--pair-json');
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
 const WHATSAPP_DM_POLICY = String(process.env.WHATSAPP_DM_POLICY || 'open').trim().toLowerCase();
+const ALLOWED_USERS_RAW = process.env.WHATSAPP_ALLOWED_USERS || '';
+const ALLOWED_USERS = parseAllowedUsers(ALLOWED_USERS_RAW);
 const WHATSAPP_GROUP_POLICY = String(process.env.WHATSAPP_GROUP_POLICY || 'pairing').trim().toLowerCase();
-const ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_ALLOWED_USERS || '');
+const GROUP_ALLOWED_USERS_RAW = process.env.WHATSAPP_GROUP_ALLOWED_USERS || '';
 // Group authorization is by group JID, not by every participant's JID.  The
 // Python adapter still applies group policy and mention rules after intake.
-const GROUP_ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_GROUP_ALLOWED_USERS || '');
+const GROUP_ALLOWED_USERS = parseAllowedUsers(GROUP_ALLOWED_USERS_RAW);
+// Fingerprint settings that affect which chats reach extraction. The Python
+// adapter compares this value before reusing a long-lived bridge, preventing a
+// policy change from leaving stale media-download authorization in memory.
+const POLICY_HASH = createHash('sha256')
+  .update([
+    WHATSAPP_MODE,
+    WHATSAPP_DM_POLICY,
+    ALLOWED_USERS_RAW,
+    WHATSAPP_GROUP_POLICY,
+    GROUP_ALLOWED_USERS_RAW,
+  ].join('\0'))
+  .digest('hex')
+  .slice(0, 16);
 const DEFAULT_REPLY_PREFIX = '⚕ *Hermes Agent*\n────────────\n';
 const REPLY_PREFIX = process.env.WHATSAPP_REPLY_PREFIX === undefined
   ? DEFAULT_REPLY_PREFIX
@@ -1123,6 +1138,7 @@ app.get('/health', (req, res) => {
     queueLength: messageQueue.length,
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
+    policyHash: POLICY_HASH,
     sendReadReceipts: SEND_READ_RECEIPTS,
   });
 });

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -30,7 +30,7 @@ import { randomBytes, createHash } from 'crypto';
 import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
-import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { matchesInboundWhatsAppGroup, matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
@@ -112,7 +112,11 @@ const PAIR_ONLY = args.includes('--pair-only');
 const PAIR_JSON = args.includes('--pair-json');
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
 const WHATSAPP_DM_POLICY = String(process.env.WHATSAPP_DM_POLICY || 'open').trim().toLowerCase();
+const WHATSAPP_GROUP_POLICY = String(process.env.WHATSAPP_GROUP_POLICY || 'pairing').trim().toLowerCase();
 const ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_ALLOWED_USERS || '');
+// Group authorization is by group JID, not by every participant's JID.  The
+// Python adapter still applies group policy and mention rules after intake.
+const GROUP_ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_GROUP_ALLOWED_USERS || '');
 const DEFAULT_REPLY_PREFIX = '⚕ *Hermes Agent*\n────────────\n';
 const REPLY_PREFIX = process.env.WHATSAPP_REPLY_PREFIX === undefined
   ? DEFAULT_REPLY_PREFIX
@@ -646,11 +650,20 @@ async function startSocket() {
           } catch {}
           continue;
         }
-        if (WHATSAPP_DM_POLICY !== 'pairing' && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
+        const intakeAllowed = isGroup
+          ? matchesInboundWhatsAppGroup({
+              chatId,
+              groupPolicy: WHATSAPP_GROUP_POLICY,
+              groupAllowedUsers: GROUP_ALLOWED_USERS,
+              sessionDir: SESSION_DIR,
+            })
+          : WHATSAPP_DM_POLICY === 'pairing'
+            || matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR);
+        if (!intakeAllowed) {
           try {
             console.log(JSON.stringify({
               event: 'ignored',
-              reason: 'allowlist_mismatch',
+              reason: isGroup ? 'group_policy_rejected' : 'allowlist_mismatch',
               chatId,
               senderId,
             }));

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -30,7 +30,7 @@ import { randomBytes, createHash } from 'crypto';
 import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
-import { classifyInboundAccessBeforeMedia, matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { matchesAllowedUser, parseAllowedUsers, prepareInboundMediaDispatch } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
@@ -667,10 +667,11 @@ async function startSocket() {
       }
 
       // Apply group policy before extractBridgeEvent() for ordinary inbound
-      // group messages. fromMe groups retain the existing early rejection.
-      // Python repeats this gate as defense in depth, but that later check is
-      // too late to prevent blocked-group media from touching the local cache.
-      const inboundAccess = classifyInboundAccessBeforeMedia({
+      // group messages. fromMe groups retain the existing early rejection at
+      // the top of this handler. Python repeats this gate as defense in depth,
+      // but that later check is too late to prevent blocked-group media from
+      // touching the local cache.
+      const mediaDispatch = prepareInboundMediaDispatch({
         isGroup,
         fromMe: !!msg.key.fromMe,
         chatId,
@@ -680,7 +681,9 @@ async function startSocket() {
         groupPolicy: WHATSAPP_GROUP_POLICY,
         groupAllowedUsers: GROUP_ALLOWED_USERS,
         sessionDir: SESSION_DIR,
+        downloadMedia: async (mediaMsg) => downloadMediaMessage(mediaMsg, 'buffer', {}, { logger, reuploadRequest: sock.updateMediaMessage }),
       });
+      const inboundAccess = mediaDispatch.access;
       if (!inboundAccess.allowed) {
         try {
           console.log(JSON.stringify({
@@ -760,7 +763,7 @@ async function startSocket() {
         senderNumber,
         botIds,
         isGroup,
-        downloadMedia: async (mediaMsg) => downloadMediaMessage(mediaMsg, 'buffer', {}, { logger, reuploadRequest: sock.updateMediaMessage }),
+        downloadMedia: mediaDispatch.downloadMedia,
         cacheDirs: {
           image: IMAGE_CACHE_DIR,
           document: DOCUMENT_CACHE_DIR,

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -30,7 +30,7 @@ import { randomBytes, createHash } from 'crypto';
 import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
-import { matchesInboundWhatsAppGroup, matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { classifyInboundAccessBeforeMedia, matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
@@ -129,6 +129,7 @@ const POLICY_HASH = createHash('sha256')
     ALLOWED_USERS_RAW,
     WHATSAPP_GROUP_POLICY,
     GROUP_ALLOWED_USERS_RAW,
+    String(FORWARD_OWNER_MESSAGES),
   ].join('\0'))
   .digest('hex')
   .slice(0, 16);
@@ -653,38 +654,43 @@ async function startSocket() {
       // themselves — stranger DMs / group pings must never reach the
       // Python gateway, otherwise a pairing-code reply fires in response
       // to arbitrary incoming messages (#8389).
-      if (!msg.key.fromMe) {
-        if (WHATSAPP_MODE === 'self-chat') {
-          try {
-            console.log(JSON.stringify({
-              event: 'ignored',
-              reason: 'self_chat_mode_rejects_non_self',
-              chatId,
-              senderId,
-            }));
-          } catch {}
-          continue;
-        }
-        const intakeAllowed = isGroup
-          ? matchesInboundWhatsAppGroup({
-              chatId,
-              groupPolicy: WHATSAPP_GROUP_POLICY,
-              groupAllowedUsers: GROUP_ALLOWED_USERS,
-              sessionDir: SESSION_DIR,
-            })
-          : WHATSAPP_DM_POLICY === 'pairing'
-            || matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR);
-        if (!intakeAllowed) {
-          try {
-            console.log(JSON.stringify({
-              event: 'ignored',
-              reason: isGroup ? 'group_policy_rejected' : 'allowlist_mismatch',
-              chatId,
-              senderId,
-            }));
-          } catch {}
-          continue;
-        }
+      if (!msg.key.fromMe && WHATSAPP_MODE === 'self-chat') {
+        try {
+          console.log(JSON.stringify({
+            event: 'ignored',
+            reason: 'self_chat_mode_rejects_non_self',
+            chatId,
+            senderId,
+          }));
+        } catch {}
+        continue;
+      }
+
+      // Apply group policy before extractBridgeEvent() for ordinary inbound
+      // group messages. fromMe groups retain the existing early rejection.
+      // Python repeats this gate as defense in depth, but that later check is
+      // too late to prevent blocked-group media from touching the local cache.
+      const inboundAccess = classifyInboundAccessBeforeMedia({
+        isGroup,
+        fromMe: !!msg.key.fromMe,
+        chatId,
+        senderId,
+        dmPolicy: WHATSAPP_DM_POLICY,
+        allowedUsers: ALLOWED_USERS,
+        groupPolicy: WHATSAPP_GROUP_POLICY,
+        groupAllowedUsers: GROUP_ALLOWED_USERS,
+        sessionDir: SESSION_DIR,
+      });
+      if (!inboundAccess.allowed) {
+        try {
+          console.log(JSON.stringify({
+            event: 'ignored',
+            reason: inboundAccess.reason,
+            chatId,
+            senderId,
+          }));
+        } catch {}
+        continue;
       }
 
       const messageContent = getMessageContent(msg);

--- a/tests/gateway/test_75349_whatsapp_multiplex_secret_scope.py
+++ b/tests/gateway/test_75349_whatsapp_multiplex_secret_scope.py
@@ -81,6 +81,23 @@ class TestWhatsAppEnvViaSecretScope:
         finally:
             ss.reset_secret_scope(tok_b)
 
+    def test_empty_canonical_group_allowlist_does_not_fall_back_to_legacy(
+        self, monkeypatch
+    ):
+        """An explicit empty canonical list must revoke stale legacy grants."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "")
+        monkeypatch.setenv("WHATSAPP_GROUP_ALLOW_FROM", "stale-group@g.us")
+
+        adapter = WhatsAppAdapter(
+            PlatformConfig(enabled=True, extra={"group_policy": "allowlist"})
+        )
+
+        assert adapter._group_allow_from == set()
+        assert adapter._group_allowlist_source == "WHATSAPP_GROUP_ALLOWED_USERS"
+
 
 class TestWhatsAppCommonUsesSecretScope:
     """The shared WhatsAppBehaviorMixin methods must also use get_secret."""
@@ -125,6 +142,23 @@ class TestWhatsAppCommonUsesSecretScope:
             mixin.name = "test"
 
             assert mixin._whatsapp_require_mention() is True
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_live_dm_allowlist_uses_profile_scope(self, tmp_path, monkeypatch):
+        """Python intake must enforce the same profile list passed to Node."""
+        from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+
+        monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "111")
+        ss.set_multiplex_active(True)
+        (tmp_path / ".env").write_text("WHATSAPP_ALLOWED_USERS=222\n")
+        tok = ss.set_secret_scope(ss.build_profile_secret_scope(tmp_path))
+        try:
+            mixin = object.__new__(WhatsAppBehaviorMixin)
+            mixin._dm_allowlist_source = "WHATSAPP_ALLOWED_USERS"
+            mixin._allow_from = {"stale-snapshot"}
+
+            assert mixin._live_dm_allow_from() == {"222"}
         finally:
             ss.reset_secret_scope(tok)
 

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -116,6 +116,7 @@ def _default_policy_hash() -> str:
         allowed_users=set(),
         group_policy="pairing",
         group_allowed_users=set(),
+        forward_owner_messages=False,
     )
 
 
@@ -154,6 +155,23 @@ class TestFileContentHash:
         # Node side: createHash('sha256').update(bytes).digest('hex').slice(0, 16)
         expected = hashlib.sha256(b"const x = 1;\n").hexdigest()[:16]
         assert _file_content_hash(f) == expected
+
+
+    def test_policy_hash_changes_with_owner_forwarding(self):
+        from plugins.platforms.whatsapp.adapter import _bridge_access_policy_hash
+
+        common = {
+            "mode": "bot",
+            "dm_policy": "pairing",
+            "allowed_users": set(),
+            "group_policy": "allowlist",
+            "group_allowed_users": {"120363001234567890@g.us"},
+        }
+        assert _bridge_access_policy_hash(
+            **common, forward_owner_messages=False
+        ) != _bridge_access_policy_hash(
+            **common, forward_owner_messages=True
+        )
 
 
 class TestStaleBridgeHandshake:
@@ -425,7 +443,8 @@ class TestDepRefreshStamp:
 
 class TestCacheDirEnvPassthrough:
     @pytest.mark.asyncio
-    async def test_bridge_spawn_env_has_cache_dirs(self, tmp_path):
+    async def test_bridge_spawn_env_has_cache_dirs(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("WHATSAPP_FORWARD_OWNER_MESSAGES", "true")
         bridge_dir = _setup_bridge_dir(tmp_path)
         _fresh_node_modules(bridge_dir)
         adapter = _make_adapter(
@@ -469,3 +488,4 @@ class TestCacheDirEnvPassthrough:
             "120363001234567890@g.us,120363009999999999@g.us"
         )
         assert env["WHATSAPP_SEND_READ_RECEIPTS"] == "true"
+        assert env["WHATSAPP_FORWARD_OWNER_MESSAGES"] == "true"

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -452,7 +452,11 @@ class TestCacheDirEnvPassthrough:
             session_path=tmp_path / "session",
         )
         adapter._dm_policy = "allowlist"
-        adapter._allow_from = {"15550000002", "15550000001"}
+        adapter._allow_from = {"stale-snapshot"}
+        adapter._dm_allowlist_source = "WHATSAPP_ALLOWED_USERS"
+        monkeypatch.setenv(
+            "WHATSAPP_ALLOWED_USERS", "15550000002,15550000001"
+        )
         adapter._group_policy = "allowlist"
         adapter._group_allow_from = {
             "120363009999999999@g.us",

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -458,10 +458,12 @@ class TestCacheDirEnvPassthrough:
             "WHATSAPP_ALLOWED_USERS", "15550000002,15550000001"
         )
         adapter._group_policy = "allowlist"
-        adapter._group_allow_from = {
-            "120363009999999999@g.us",
-            "120363001234567890@g.us",
-        }
+        adapter._group_allow_from = {"stale-group@g.us"}
+        adapter._group_allowlist_source = "WHATSAPP_GROUP_ALLOWED_USERS"
+        monkeypatch.setenv(
+            "WHATSAPP_GROUP_ALLOWED_USERS",
+            "120363009999999999@g.us,120363001234567890@g.us",
+        )
         adapter._send_read_receipts = True
         mock_proc = MagicMock()
         mock_proc.poll.return_value = 1

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -7,10 +7,10 @@ long-lived bridge process therefore survived gateway restarts AND
 ``hermes update``, serving pre-update bridge.js behavior forever (e.g.
 no inbound media download → images/voice notes arrive as placeholders).
 
-The fix: bridge.js reports a hash of its own source in ``/health``
-(``scriptHash``); the adapter compares it against the bridge.js on disk
-and restarts the bridge on mismatch.  Bridges that predate the handshake
-report no hash and are treated as stale by definition.
+The fix: bridge.js reports hashes of its source and effective access policy in
+``/health`` (``scriptHash`` and ``policyHash``); the adapter compares both
+against its current code/config and restarts the bridge on mismatch. Bridges
+that predate either handshake are treated as stale by definition.
 
 Also covers the npm dependency-refresh stamp: deps are reinstalled when
 package.json changes, not only when node_modules is missing.
@@ -53,6 +53,10 @@ def _make_adapter(bridge_script: str = "/tmp/test-bridge.js",
     adapter._bridge_log = None
     adapter._bridge_process = None
     adapter._reply_prefix = None
+    adapter._dm_policy = "pairing"
+    adapter._allow_from = set()
+    adapter._group_policy = "pairing"
+    adapter._group_allow_from = set()
     adapter._send_read_receipts = False
     adapter._running = False
     adapter._message_handler = None
@@ -103,6 +107,18 @@ def _fresh_node_modules(bridge_dir: Path) -> None:
     )
 
 
+def _default_policy_hash() -> str:
+    from plugins.platforms.whatsapp.adapter import _bridge_access_policy_hash
+
+    return _bridge_access_policy_hash(
+        mode="self-chat",
+        dm_policy="pairing",
+        allowed_users=set(),
+        group_policy="pairing",
+        group_allowed_users=set(),
+    )
+
+
 class TestFileContentHash:
     def test_hashes_file(self, tmp_path):
         from plugins.platforms.whatsapp.adapter import _file_content_hash
@@ -113,9 +129,62 @@ class TestFileContentHash:
         assert len(h) == 16
         assert h == _file_content_hash(f)  # deterministic
 
+    def test_changes_with_content(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        f = tmp_path / "x.js"
+        f.write_text("abc")
+        h1 = _file_content_hash(f)
+        f.write_text("def")
+        assert _file_content_hash(f) != h1
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        assert _file_content_hash(tmp_path / "nope.js") == ""
+
+    def test_matches_bridge_js_self_hash_algorithm(self, tmp_path):
+        """Python and Node must compute the same hash for the same bytes."""
+        import hashlib
+
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        f = tmp_path / "bridge.js"
+        f.write_bytes(b"const x = 1;\n")
+        # Node side: createHash('sha256').update(bytes).digest('hex').slice(0, 16)
+        expected = hashlib.sha256(b"const x = 1;\n").hexdigest()[:16]
+        assert _file_content_hash(f) == expected
+
 
 class TestStaleBridgeHandshake:
+    @pytest.mark.asyncio
+    async def test_reuses_bridge_when_hash_matches(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
 
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        mock_client = _mock_health({
+            "status": "connected",
+            "scriptHash": disk_hash,
+            "policyHash": _default_policy_hash(),
+        })
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.create_task") as mock_task, \
+             patch("subprocess.Popen") as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True), \
+             patch.object(adapter, "_mark_connected", create=True):
+            result = await adapter.connect()
+
+        assert result is True
+        mock_popen.assert_not_called()  # reused, never spawned
+        mock_task.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_restarts_bridge_when_read_receipt_config_changed(self, tmp_path):
@@ -129,13 +198,130 @@ class TestStaleBridgeHandshake:
         )
         adapter._send_read_receipts = True
         disk_hash = _file_content_hash(bridge_dir / "bridge.js")
-        mock_client = _mock_health(
-            {
-                "status": "connected",
-                "scriptHash": disk_hash,
-                "sendReadReceipts": False,
-            }
+        mock_client = _mock_health({
+            "status": "connected",
+            "scriptHash": disk_hash,
+            "policyHash": _default_policy_hash(),
+            "sendReadReceipts": False,
+        })
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        mock_popen.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_restarts_bridge_on_hash_mismatch(self, tmp_path):
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
         )
+        mock_client = _mock_health(
+            {"status": "connected", "scriptHash": "deadbeefdeadbeef"}
+        )
+        # Spawned bridge dies immediately → connect() returns False, but the
+        # assertion that matters is that the stale bridge was NOT reused and
+        # a new process spawn was attempted.
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process") as mock_kill_port, \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            result = await adapter.connect()
+
+        assert result is False  # mock proc died; not the point of the test
+        mock_popen.assert_called_once()  # stale bridge replaced, not reused
+        mock_kill_port.assert_called_once_with(adapter._bridge_port)
+
+    @pytest.mark.asyncio
+    async def test_restarts_bridge_on_policy_hash_mismatch(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        mock_client = _mock_health({
+            "status": "connected",
+            "scriptHash": disk_hash,
+            "policyHash": "deadbeefdeadbeef",
+        })
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process") as mock_kill_port, \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            result = await adapter.connect()
+
+        assert result is False
+        mock_popen.assert_called_once()
+        mock_kill_port.assert_called_once_with(adapter._bridge_port)
+
+    @pytest.mark.asyncio
+    async def test_restarts_bridge_without_policy_hash(self, tmp_path):
+        """Bridges without a policy fingerprint are stale even when code matches."""
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        mock_client = _mock_health({"status": "connected", "scriptHash": disk_hash})
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        mock_popen.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_restarts_unversioned_bridge(self, tmp_path):
+        """Bridges predating the handshake report no scriptHash → stale."""
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        # Old bridge /health payload: no scriptHash key at all
+        mock_client = _mock_health({"status": "connected"})
         mock_proc = MagicMock()
         mock_proc.poll.return_value = 1
         mock_proc.returncode = 1
@@ -177,6 +363,65 @@ class TestDepRefreshStamp:
 
         mock_run.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_reinstalls_when_package_json_changed(self, tmp_path):
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        # Simulate `hermes update` bumping the Baileys pin
+        (bridge_dir / "package.json").write_text('{"name": "bridge", "v": 2}\n')
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", _mock_health({"status": "disconnected"})), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_run, \
+             patch("subprocess.Popen", return_value=mock_proc), \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        mock_run.assert_called_once()
+        assert "install" in mock_run.call_args[0][0]
+        # Stamp updated to the new package.json hash
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+        stamp = (bridge_dir / "node_modules" / ".hermes-pkg-hash").read_text().strip()
+        assert stamp == _file_content_hash(bridge_dir / "package.json")
+
+    @pytest.mark.asyncio
+    async def test_installs_when_node_modules_missing(self, tmp_path):
+        bridge_dir = _setup_bridge_dir(tmp_path)  # no node_modules
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        def _npm_install(*args, **kwargs):
+            # npm creates node_modules as a side effect
+            (bridge_dir / "node_modules").mkdir(exist_ok=True)
+            return MagicMock(returncode=0)
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", _mock_health({"status": "disconnected"})), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.run", side_effect=_npm_install) as mock_run, \
+             patch("subprocess.Popen", return_value=mock_proc), \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        mock_run.assert_called_once()
+
 
 class TestCacheDirEnvPassthrough:
     @pytest.mark.asyncio
@@ -187,6 +432,13 @@ class TestCacheDirEnvPassthrough:
             bridge_script=str(bridge_dir / "bridge.js"),
             session_path=tmp_path / "session",
         )
+        adapter._dm_policy = "allowlist"
+        adapter._allow_from = {"15550000002", "15550000001"}
+        adapter._group_policy = "allowlist"
+        adapter._group_allow_from = {
+            "120363009999999999@g.us",
+            "120363001234567890@g.us",
+        }
         adapter._send_read_receipts = True
         mock_proc = MagicMock()
         mock_proc.poll.return_value = 1
@@ -210,4 +462,10 @@ class TestCacheDirEnvPassthrough:
         assert env["HERMES_IMAGE_CACHE_DIR"] == str(get_image_cache_dir())
         assert env["HERMES_AUDIO_CACHE_DIR"] == str(get_audio_cache_dir())
         assert env["HERMES_DOCUMENT_CACHE_DIR"] == str(get_document_cache_dir())
+        assert env["WHATSAPP_DM_POLICY"] == "allowlist"
+        assert env["WHATSAPP_ALLOWED_USERS"] == "15550000001,15550000002"
+        assert env["WHATSAPP_GROUP_POLICY"] == "allowlist"
+        assert env["WHATSAPP_GROUP_ALLOWED_USERS"] == (
+            "120363001234567890@g.us,120363009999999999@g.us"
+        )
         assert env["WHATSAPP_SEND_READ_RECEIPTS"] == "true"


### PR DESCRIPTION
## Summary

- consolidate the focused group-ingress classifier from #73465 while preserving its original authorship
- enforce WhatsApp group policy before inbound media extraction
- couple the access decision to the media-download callback so rejected groups cannot call `downloadMediaMessage()` or write media locally
- pass the adapter's effective DM/group policies and allowlists explicitly to the Node subprocess
- fingerprint bridge access-policy state and restart a reused bridge when its code or policy is stale
- preserve downstream Python authorization as defense in depth

## Problem

The Python adapter applies group-policy checks after the Node bridge has already extracted an incoming event. Media extraction can invoke `downloadMediaMessage()`, so media from a blocked group could touch the local Hermes cache before Python rejects the event.

A long-running bridge also survives gateway restarts. Reusing it based only on the `bridge.js` source hash can retain stale authorization after a policy or allowlist change.

## Behavior

- `group_policy: open` permits ordinary inbound group events.
- `group_policy: allowlist` permits only configured group IDs.
- `disabled`, `pairing`, empty, and unsupported policies deny group events at the bridge boundary.
- Existing early rejection of all `fromMe` group messages remains unchanged.
- DM behavior remains on the existing DM-policy path.
- Allowed-group mention/wake-phrase behavior remains downstream and unchanged.
- `/health` reports `scriptHash` and `policyHash`; missing or mismatched values force a bridge restart before reuse.
- The policy fingerprint includes mode, DM/group policies, effective allowlists, and owner-forwarding state without exposing allowlist contents through `/health`.
- Profile-scoped environment resolution and explicit config precedence are preserved when spawning the bridge.

## Consolidation

The first commit is #73465's focused ingress change, retaining Waldo's authorship. The subsequent commits add only the distinct safeguards requested in the cross-PR triage: the dispatch-boundary guard, stale-policy fingerprint/restart behavior, and behavior-level no-download regression.

## Verification

- `node --check scripts/whatsapp-bridge/{allowlist,bridge}.js`
- `node --test scripts/whatsapp-bridge/*.test.mjs` — 26 passed
- `pytest tests/gateway/test_whatsapp*.py tests/gateway/test_pairing_allowlist_bypass.py -q` — 142 passed
- `ruff check plugins/platforms/whatsapp/adapter.py tests/gateway/test_whatsapp_stale_bridge.py`
- Python/Node policy-hash parity check
- static security scan of added lines
- `git diff --check`
