### PR TITLE
fix(desktop): resume voice listening after assistant reply

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -360,6 +360,10 @@ export function useVoiceConversation({
           resetSpeechBuffer()
           pendingStartRef.current = true
           setStatus('idle')
+          // Status may already be 'idle' (speak() reset it in its finally),
+          // so setStatus is a no-op and won't re-fire this effect. Kick the
+          // listen loop directly instead of waiting for a re-render.
+          void startListening()
 
           return
         }
@@ -370,6 +374,7 @@ export function useVoiceConversation({
         resetSpeechBuffer()
         pendingStartRef.current = true
         setStatus('idle')
+        void startListening()
 
         return
       }


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the **desktop voice conversation stops listening after every assistant reply** — the mic goes deaf until the user manually toggles it off and back on. This makes hands-free voice conversation effectively unusable, since every single turn requires a manual mic toggle to continue.

The fix restores the intended behavior: after the assistant finishes speaking (or after an empty-transcript turn), the loop automatically returns to listening.

## Related Issue

<!-- No pre-existing issue; happy to open one for tracking if maintainers prefer. -->

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts` — in the driver `useEffect`, call `startListening()` directly in both terminal branches (the completion branch `!response.pending && !busy`, and the thinking-fallback branch `!busy && status === 'thinking'`) instead of relying on `setStatus('idle')` to re-fire the effect.

### Root cause

The loop re-arms via `pendingStartRef.current = true; setStatus('idle')`, expecting the resulting re-render to re-run the driver effect and hit the tail `if (pendingStartRef.current) void startListening()`. But by the time these branches run, `speak()`'s `finally` block has **already** set status to `'idle'`. So `setStatus('idle')` is a no-op — React skips the re-render, the effect never re-fires, and `startListening()` is never reached. The loop is left armed but unpumped.

This is also why a manual mic toggle "fixes" it every time: `toggleMute` → `setMuted(...)` is a genuine state change that *does* re-fire the effect, which then sees `pendingStartRef.current === true` and resumes.

It presented as intermittent because a reply with no speakable text enters the branch while status is still `'thinking'`, making that `setStatus('idle')` a real state change that self-recovers.

### Why this approach

`startListening()` already self-guards on `statusRef.current !== 'idle'` and resets `pendingStartRef`, so calling it directly is safe and idempotent. It is already in the effect's dependency array, so there is no stale-closure risk. The redundant `setStatus('idle')` is left in place (harmless, keeps status semantics explicit).

## How to Test

1. Enable STT and start a voice conversation in the desktop app.
2. Speak a prompt; let the assistant reply (with `auto_tts` on so it speaks aloud).
3. **Before this fix:** the mic stops listening after the reply; you must toggle the mic off/on to continue.
4. **After this fix:** the mic returns to listening automatically once the assistant finishes speaking.

Verified manually across three consecutive exchanges on macOS, covering both code paths:
- spoken-response turns (completion branch), and
- an empty-transcript turn where only silence was captured (the loop still auto-resumed).

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(desktop): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single-file, 5-line change)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: this is a TypeScript renderer change with no Python surface
- [ ] I've added tests for my changes — there is currently no test harness for `use-voice-conversation.ts` (VAD/media-recorder side effects); verified manually instead. Happy to add a Vitest test mocking the recorder/transcribe handles if maintainers want one.
- [x] I've tested on my platform: macOS 26.5.2 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavioral bug fix, no doc/config surface)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — this is renderer logic identical across platforms; the no-op-setState React behavior is platform-independent
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Diff (the entire change):

```diff
@@ export function useVoiceConversation({
           resetSpeechBuffer()
           pendingStartRef.current = true
           setStatus('idle')
+          // Status may already be 'idle' (speak() reset it in its finally),
+          // so setStatus is a no-op and won't re-fire this effect. Kick the
+          // listen loop directly instead of waiting for a re-render.
+          void startListening()

           return
         }
@@
         resetSpeechBuffer()
         pendingStartRef.current = true
         setStatus('idle')
+        void startListening()

         return
       }
```
