### PR TITLE
feat(desktop): add completion sound volume slider

### DIFF
--- a/apps/desktop/src/app/settings/notifications-settings.tsx
+++ b/apps/desktop/src/app/settings/notifications-settings.tsx
@@ -6,9 +6,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { useI18n } from '@/i18n'
 import { COMPLETION_SOUND_VARIANTS, previewCompletionSound } from '@/lib/completion-sound'
 import { triggerHaptic } from '@/lib/haptics'
-import { Bell, Play } from '@/lib/icons'
+import { Bell, Play, Volume2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
-import { $completionSoundVariantId, setCompletionSoundVariantId } from '@/store/completion-sound'
+import { $completionSoundVariantId, $completionSoundVolume, setCompletionSoundVariantId, setCompletionSoundVolume } from '@/store/completion-sound'
 import {
   $nativeNotifyPrefs,
   NATIVE_NOTIFICATION_KINDS,
@@ -31,6 +31,7 @@ export function NotificationsSettings() {
   const { t } = useI18n()
   const prefs = useStore($nativeNotifyPrefs)
   const completionSoundVariantId = useStore($completionSoundVariantId)
+  const volume = useStore($completionSoundVolume)
   const copy = t.settings.notifications
 
   const runTest = async () => {
@@ -101,6 +102,28 @@ export function NotificationsSettings() {
               <Play className="size-3.5" />
               {copy.completionSoundPreview}
             </Button>
+          </div>
+        }
+        below={
+          <div className="mt-2 flex items-center gap-3">
+            <Volume2 className="size-4 shrink-0 text-(--ui-text-tertiary)" />
+            <input
+              aria-label={copy.completionSoundVolumeTitle}
+              className="h-1 w-40 cursor-pointer appearance-none rounded-full bg-(--ui-stroke-tertiary)"
+              max={3}
+              min={0}
+              onChange={event => {
+                triggerHaptic('selection')
+                setCompletionSoundVolume(Number(event.target.value))
+              }}
+              step={0.1}
+              style={{ accentColor: 'var(--dt-primary)' }}
+              type="range"
+              value={volume}
+            />
+            <span className="w-11 text-right text-[length:var(--conversation-caption-font-size)] tabular-nums text-(--ui-text-tertiary)">
+              {volume.toFixed(1)}×
+            </span>
           </div>
         }
         description={copy.completionSoundDesc}

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -350,7 +350,8 @@ export const ar = defineLocale({
       testUnsupported: 'هذا النظام لا يدعم الإشعارات الأصلية.',
       completionSoundTitle: 'صوت الاكتمال',
       completionSoundDesc: 'يُشغّل عند انتهاء دور الوكيل. اختر إعدادا مسبقا وعاينه هنا.',
-      completionSoundPreview: 'معاينة'
+      completionSoundPreview: 'معاينة',
+      completionSoundVolumeTitle: 'مستوى الصوت'
     },
     sections: {
       model: 'النموذج',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -393,7 +393,8 @@ export const en: Translations = {
       testUnsupported: 'This system does not support native notifications.',
       completionSoundTitle: 'Completion Sound',
       completionSoundDesc: 'Plays when an agent turn finishes. Pick a preset and preview it here.',
-      completionSoundPreview: 'Preview'
+      completionSoundPreview: 'Preview',
+      completionSoundVolumeTitle: 'Volume'
     },
     sections: {
       model: 'Model',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -278,7 +278,8 @@ export const ja = defineLocale({
       testUnsupported: 'このシステムはネイティブ通知に対応していません。',
       completionSoundTitle: '完了サウンド',
       completionSoundDesc: 'エージェントのターン終了時に再生されます。プリセットを選んでここで試聴できます。',
-      completionSoundPreview: '試聴'
+      completionSoundPreview: '試聴',
+      completionSoundVolumeTitle: '音量'
     },
     sections: {
       model: 'モデル',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -328,6 +328,7 @@ export interface Translations {
       completionSoundTitle: string
       completionSoundDesc: string
       completionSoundPreview: string
+      completionSoundVolumeTitle: string
     }
     sections: Record<string, string>
     searchPlaceholder: Record<'about' | 'config' | 'gateway' | 'keys' | 'mcp' | 'sessions', string>

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -271,7 +271,8 @@ export const zhHant = defineLocale({
       testUnsupported: '此系統不支援原生通知。',
       completionSoundTitle: '完成提示音',
       completionSoundDesc: '代理回合結束時播放。可在此選擇預設並預覽。',
-      completionSoundPreview: '預覽'
+      completionSoundPreview: '預覽',
+      completionSoundVolumeTitle: '音量'
     },
     sections: {
       model: '模型',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -383,7 +383,8 @@ export const zh: Translations = {
       testUnsupported: '此系统不支持原生通知。',
       completionSoundTitle: '完成提示音',
       completionSoundDesc: '智能体回合结束时播放。可在此选择预设并预览。',
-      completionSoundPreview: '预览'
+      completionSoundPreview: '预览',
+      completionSoundVolumeTitle: '音量'
     },
     sections: {
       model: '模型',

--- a/apps/desktop/src/lib/completion-sound.ts
+++ b/apps/desktop/src/lib/completion-sound.ts
@@ -2,7 +2,7 @@
 // Fourteen curated presets for A/B in Settings → Appearance. Default is variant 1.
 
 import { ownsAmbientCue } from '@/store/ambient'
-import { $completionSoundVariantId, resolveCompletionSoundVariantId } from '@/store/completion-sound'
+import { $completionSoundVariantId, $completionSoundVolume, resolveCompletionSoundVariantId } from '@/store/completion-sound'
 import { $hapticsMuted } from '@/store/haptics'
 
 type OscType = OscillatorType
@@ -429,7 +429,7 @@ function playVariant(variantId: number) {
   tone.type = 'lowpass'
   tone.frequency.setValueAtTime(3800, ac.currentTime)
   tone.Q.setValueAtTime(0.32, ac.currentTime)
-  master.gain.setValueAtTime(0.48, ac.currentTime)
+  master.gain.setValueAtTime($completionSoundVolume.get(), ac.currentTime)
   master.connect(tone)
 
   const dry = ac.createGain()

--- a/apps/desktop/src/store/completion-sound.test.ts
+++ b/apps/desktop/src/store/completion-sound.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_COMPLETION_SOUND_VOLUME, resolveCompletionSoundVolume } from './completion-sound'
+
+describe('resolveCompletionSoundVolume', () => {
+  it('returns the default when the raw value is below the minimum', () => {
+    expect(resolveCompletionSoundVolume(-1)).toBe(DEFAULT_COMPLETION_SOUND_VOLUME)
+    expect(resolveCompletionSoundVolume(-0.01)).toBe(DEFAULT_COMPLETION_SOUND_VOLUME)
+  })
+
+  it('returns the default when the raw value is above the maximum', () => {
+    expect(resolveCompletionSoundVolume(3.01)).toBe(DEFAULT_COMPLETION_SOUND_VOLUME)
+    expect(resolveCompletionSoundVolume(100)).toBe(DEFAULT_COMPLETION_SOUND_VOLUME)
+  })
+
+  it('returns the default for non-finite values', () => {
+    expect(resolveCompletionSoundVolume(NaN)).toBe(DEFAULT_COMPLETION_SOUND_VOLUME)
+    expect(resolveCompletionSoundVolume(Infinity)).toBe(DEFAULT_COMPLETION_SOUND_VOLUME)
+    expect(resolveCompletionSoundVolume(-Infinity)).toBe(DEFAULT_COMPLETION_SOUND_VOLUME)
+  })
+
+  it('passes through values within the valid range', () => {
+    expect(resolveCompletionSoundVolume(0)).toBe(0)
+    expect(resolveCompletionSoundVolume(0.48)).toBe(0.48)
+    expect(resolveCompletionSoundVolume(1)).toBe(1)
+    expect(resolveCompletionSoundVolume(2.5)).toBe(2.5)
+    expect(resolveCompletionSoundVolume(3)).toBe(3)
+  })
+})

--- a/apps/desktop/src/store/completion-sound.test.ts
+++ b/apps/desktop/src/store/completion-sound.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { DEFAULT_COMPLETION_SOUND_VOLUME, resolveCompletionSoundVolume } from './completion-sound'
 
@@ -25,5 +25,14 @@ describe('resolveCompletionSoundVolume', () => {
     expect(resolveCompletionSoundVolume(1)).toBe(1)
     expect(resolveCompletionSoundVolume(2.5)).toBe(2.5)
     expect(resolveCompletionSoundVolume(3)).toBe(3)
+  })
+
+  it('falls back to the default when nothing is persisted', async () => {
+    window.localStorage.clear()
+    vi.resetModules()
+
+    const { $completionSoundVolume } = await import('./completion-sound')
+
+    expect($completionSoundVolume.get()).toBe(DEFAULT_COMPLETION_SOUND_VOLUME)
   })
 })

--- a/apps/desktop/src/store/completion-sound.ts
+++ b/apps/desktop/src/store/completion-sound.ts
@@ -38,7 +38,7 @@ const VOLUME_STORAGE_KEY = 'hermes.desktop.completionSoundVolume'
 /** Default matches the current hardcoded master gain of 0.48 for back-compat. */
 export const DEFAULT_COMPLETION_SOUND_VOLUME = 0.48
 
-/** Clamp to [0, 3] so invalid persisted values never produce silence or clipping. */
+/** Clamp to [0, 3] so invalid persisted values can't produce extreme gain. */
 const VOLUME_MIN = 0
 const VOLUME_MAX = 3
 

--- a/apps/desktop/src/store/completion-sound.ts
+++ b/apps/desktop/src/store/completion-sound.ts
@@ -30,3 +30,38 @@ $completionSoundVariantId.subscribe(id => persistString(STORAGE_KEY, String(id))
 export function setCompletionSoundVariantId(variantId: number) {
   $completionSoundVariantId.set(resolveCompletionSoundVariantId(variantId))
 }
+
+// ── Volume ───────────────────────────────────────────────────────────────────
+
+const VOLUME_STORAGE_KEY = 'hermes.desktop.completionSoundVolume'
+
+/** Default matches the current hardcoded master gain of 0.48 for back-compat. */
+export const DEFAULT_COMPLETION_SOUND_VOLUME = 0.48
+
+/** Clamp to [0, 3] so invalid persisted values never produce silence or clipping. */
+const VOLUME_MIN = 0
+const VOLUME_MAX = 3
+
+export function resolveCompletionSoundVolume(raw: number): number {
+  return raw >= VOLUME_MIN && raw <= VOLUME_MAX ? raw : DEFAULT_COMPLETION_SOUND_VOLUME
+}
+
+function loadVolume(): number {
+  const stored = storedString(VOLUME_STORAGE_KEY)
+
+  if (stored === null) {
+    return DEFAULT_COMPLETION_SOUND_VOLUME
+  }
+
+  const parsed = Number.parseFloat(stored)
+
+  return Number.isFinite(parsed) ? resolveCompletionSoundVolume(parsed) : DEFAULT_COMPLETION_SOUND_VOLUME
+}
+
+export const $completionSoundVolume = atom(loadVolume())
+
+$completionSoundVolume.subscribe(v => persistString(VOLUME_STORAGE_KEY, String(v)))
+
+export function setCompletionSoundVolume(volume: number) {
+  $completionSoundVolume.set(resolveCompletionSoundVolume(volume))
+}

--- a/apps/desktop/src/store/completion-sound.ts
+++ b/apps/desktop/src/store/completion-sound.ts
@@ -38,7 +38,7 @@ const VOLUME_STORAGE_KEY = 'hermes.desktop.completionSoundVolume'
 /** Default matches the current hardcoded master gain of 0.48 for back-compat. */
 export const DEFAULT_COMPLETION_SOUND_VOLUME = 0.48
 
-/** Clamp to [0, 3] so invalid persisted values can't produce extreme gain. */
+/** Validate against [0, 3]; out-of-range or non-finite values fall back to the default. */
 const VOLUME_MIN = 0
 const VOLUME_MAX = 3
 


### PR DESCRIPTION
## What does this PR do?
The desktop completion sound master gain was hardcoded at `0.48` in `apps/desktop/src/lib/completion-sound.ts`, with no way for users to adjust it. This adds a volume slider (0.0–3.0×) to **Settings → Notifications → Completion Sound**, persisted globally via localStorage (consistent with the existing `variantId` store pattern).
The default is **0.48×** (the previous hardcoded value), so existing users hear no change on update.
## Related Issue
Closes #50180, Closes #63229, Closes #68368, Closes #85012 · Related: #87473, #89656, #102013, #55179
### Issue consolidation
#50180 is the canonical report (the other `Closes` issues are exact duplicates of the same ask: a completion-sound volume control). The `Related` issues share the root cause but ask for more than this diff delivers — they should stay open after merge:
- #87473, #89656, #55179 — broader notification-sound / taskbar-marker asks; the completion-sound volume control is one part of each.
- #102013 — additionally reports a **separate Windows electron repack bug** (`win-unpacked` can be incomplete); that half is **not** addressed here and needs its own fix.
Note: the slider's minimum (0.0×) also serves as a mute, per the follow-up request in #50180.
## Type of Change
<!-- Check the one that applies. -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)
## Changes Made
| File | Change |
|---|---|
| `apps/desktop/src/store/completion-sound.ts` | Add `$completionSoundVolume` atom with persistence, range validation (0–3), and fallback to the default for invalid values |
| `apps/desktop/src/lib/completion-sound.ts` | Wire `$completionSoundVolume.get()` into `master.gain.setValueAtTime()` |
| `apps/desktop/src/app/settings/notifications-settings.tsx` | Add range slider + `×` label in the `below` slot of the existing completion sound `ListRow` |
| `apps/desktop/src/i18n/{en,ja,zh,zh-hant,ar,ru}.ts` + `types.ts` | Add `completionSoundVolumeTitle` to all six locales and the type |
The slider follows the same styling pattern as the existing translucency slider in `appearance-settings.tsx`.
## How to Test
1. Open the desktop app → Settings → Notifications → Completion Sound: the new Volume slider appears under the preset picker.
2. Adjust it and trigger a turn completion — the cue volume follows the slider. Users who never touch it hear no change (default 0.48).
3. Optional (persistence edge cases): set `localStorage['hermes.desktop.completionSoundVolume']` to an out-of-range or non-finite value and reload — the store falls back to the default 0.48. Covered by `src/store/completion-sound.test.ts`.
4. Run the checks: from `apps/desktop`, `npx vitest run src/store/completion-sound.test.ts && npx tsc -p . --noEmit`.
## Checklist
<!-- Complete these before requesting review. -->
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] Tests pass: desktop TS suite run for this change (`vitest` + `tsc --noEmit` + `eslint` clean); `pytest tests/ -q` not applicable to this TS-only change
- [x] I've added tests for my changes (`src/store/completion-sound.test.ts`: below-min, above-max, non-finite, absent-persistence, in-range)
- [x] I've tested on my platform: CachyOS (Arch Linux)
### Documentation & Housekeeping
<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->
- [x] I've updated relevant documentation — N/A (user-facing string added to all six locales, see Changes Made)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (Electron renderer, platform-agnostic WebAudio/localStorage)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A