### PR TITLE
fix(desktop): keep Cron editor open around selects

### DIFF
--- a/apps/desktop/src/app/cron/cron-editor-dialog.test.tsx
+++ b/apps/desktop/src/app/cron/cron-editor-dialog.test.tsx
@@ -1,0 +1,84 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+
+import { CronEditorDialog } from './index'
+
+vi.mock('@/lib/model-options', () => ({
+  requestModelOptions: vi.fn().mockResolvedValue({ providers: [] })
+}))
+
+afterEach(cleanup)
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.setPointerCapture ??= () => undefined
+  Element.prototype.releasePointerCapture ??= () => undefined
+  HTMLElement.prototype.scrollIntoView ??= () => undefined
+})
+
+function renderCronEditor(onClose = vi.fn()) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <QueryClientProvider client={queryClient}>
+        <CronEditorDialog editor={{ mode: 'create' }} onClose={onClose} onSave={async () => {}} />
+      </QueryClientProvider>
+    </I18nProvider>
+  )
+
+  return onClose
+}
+
+describe('CronEditorDialog', () => {
+  it('does not discard the editor when an outside pointer event dismisses an open nested select', async () => {
+    const onClose = renderCronEditor()
+
+    await act(async () => {
+      fireEvent.pointerDown(screen.getByRole('combobox', { name: 'Frequency' }), {
+        button: 0,
+        ctrlKey: false,
+        pointerType: 'mouse'
+      })
+      await new Promise<void>(resolve => window.setTimeout(resolve, 0))
+    })
+
+    // This confirms the real SelectContent lifecycle, including its Radix portal.
+    expect(await screen.findByRole('listbox')).toBeTruthy()
+
+    // Radix installs its document-level outside-interaction listener on the
+    // next task after the Select portal opens.
+    await act(async () => {
+      await new Promise<void>(resolve => window.setTimeout(resolve, 0))
+    })
+
+    // The first click dismisses the portal-backed Select. Once its layer has
+    // unmounted, the following click must not dismiss the parent editor.
+    await act(async () => {
+      fireEvent.pointerDown(window.document.body, { button: 0, ctrlKey: false, pointerType: 'mouse' })
+      fireEvent.pointerUp(window.document.body, { button: 0, ctrlKey: false, pointerType: 'mouse' })
+      fireEvent.click(window.document.body)
+    })
+    await waitFor(() => expect(screen.queryByRole('listbox')).toBeNull())
+
+    await act(async () => {
+      fireEvent.pointerDown(window.document.body, { button: 0, ctrlKey: false, pointerType: 'mouse' })
+      fireEvent.pointerUp(window.document.body, { button: 0, ctrlKey: false, pointerType: 'mouse' })
+      fireEvent.click(window.document.body)
+    })
+
+    expect(onClose).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog', { name: 'New cron job' })).toBeTruthy()
+  })
+
+  it('still closes through Cancel', () => {
+    const onClose = renderCronEditor()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -727,7 +727,16 @@ function CronJobRuns({
   )
 }
 
-function CronEditorDialog({
+// A portaled Radix Select temporarily blocks pointer events on this dialog. A
+// second click on its visible body reaches the overlay and would otherwise close
+// the editor instead of only dismissing the Select. Editor dismissal remains
+// explicit (Esc, Cancel, or close button), so partially entered cron jobs are
+// never discarded by that interaction.
+function preventCronEditorOutsideDismiss(event: Event): void {
+  event.preventDefault()
+}
+
+export function CronEditorDialog({
   editor,
   onClose,
   onSave
@@ -857,7 +866,7 @@ function CronEditorDialog({
 
   return (
     <Dialog onOpenChange={value => !value && !saving && onClose()} open={open}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-lg" onInteractOutside={preventCronEditorOutsideDismiss}>
         <DialogHeader>
           <DialogTitle>{isEdit ? c.editTitle : c.createTitle}</DialogTitle>
           <DialogDescription>{isEdit ? c.editDesc : c.createDesc}</DialogDescription>


### PR DESCRIPTION
## What does this PR do?

Fixes #68814.

Prevents the Cron create/edit dialog from closing when a click is interpreted as an outside interaction while a portaled Radix Select is active. A nested Select can temporarily redirect pointer events to the Dialog overlay; the dialog now preserves the in-progress Cron form and only closes through explicit controls.

## Related Issue

Fixes #68814

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/cron/index.tsx`
  - Prevents Dialog outside-interaction dismissal in the Cron editor so a nested, portaled Select cannot discard an in-progress form.
  - Leaves explicit dismissal available through Escape, Cancel, and the close button.
- `apps/desktop/src/app/cron/cron-editor-dialog.test.tsx`
  - Adds a regression test confirming that an outside pointer/click sequence does not invoke the Cron editor close handler.

## How to Test

1. Open **Cron** in Hermes Desktop and create or edit a job.
2. Open **Frequency**, **Deliver to**, or **Model**.
3. Click again in the visible dialog without selecting a value.
4. Confirm the select can dismiss while the Cron editor and its in-progress values remain open. Confirm Cancel, Escape, and the close button still dismiss it.

Commands run locally on Linux (CachyOS):

```bash
NODE_ENV=test NODE_OPTIONS='--max-old-space-size=8192 --localstorage-file=/tmp/hermes-pr-cron-regression.json' \
  npm --workspace apps/desktop exec -- \
  vitest run src/app/cron/cron-editor-dialog.test.tsx --environment jsdom
NODE_ENV=test npm --workspace apps/desktop exec -- \
  eslint src/app/cron/index.tsx src/app/cron/cron-editor-dialog.test.tsx
NODE_ENV=test npm --workspace apps/desktop run typecheck
NODE_OPTIONS='--max-old-space-size=8192' npm --workspace apps/desktop run build
git diff --check origin/main...HEAD
```

The focused regression passes (2/2), lint/typecheck pass, and the production Desktop build passes.

`npm --workspace apps/desktop run test:ui` is currently red outside this change. The following three failing assertions reproduce on a clean checkout of current `origin/main`:

- `BillingSettings rejects auto-refill amounts outside the billing bounds`
- `BillingSettings disables buy controls while polling and renders the settled outcome`
- `clampForDisplay truncates oversized payloads and reports the omitted count`

A later PR-head suite run also observed the unrelated, order-sensitive `terminal store persistence restores user tabs, active tab, and history on module load` failure. A clean-baseline rerun previously produced a different unrelated sidebar-persistence failure instead. These suite-scale persistence flakes do not occur in the focused Cron regression, which passes 2/2.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: this is a Desktop TypeScript/React-only change; focused Vitest, lint, typecheck, and production build are listed above.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (CachyOS)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: no user-facing contract or configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change is renderer-only and does not use OS APIs, paths, or process behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No visual layout changed. The focused regression, Desktop typecheck, ESLint, and production build passed; full UI-suite baseline details are documented above.
