### PR TITLE
fix(google-workspace): recursively extract Gmail body from nested MIME parts

### DIFF
--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -137,21 +137,31 @@ def _headers_dict(msg: dict) -> dict[str, str]:
 
 
 def _extract_message_body(msg: dict) -> str:
-    body = ""
+    # Recursively walk the MIME tree. Gmail nests bodies arbitrarily deep,
+    # e.g. multipart/mixed -> multipart/related -> multipart/alternative ->
+    # text/plain. The previous implementation only inspected the first level
+    # of ``payload["parts"]`` and returned an empty body for any message whose
+    # text/plain (or text/html) part lived deeper — common for HTML and
+    # marketing mail. Prefer text/plain anywhere in the tree, then fall back
+    # to text/html anywhere in the tree.
     payload = msg.get("payload", {})
+
+    def _walk(part: dict, want: str) -> str:
+        if part.get("mimeType") == want and part.get("body", {}).get("data"):
+            return base64.urlsafe_b64decode(part["body"]["data"]).decode("utf-8", errors="replace")
+        for sub in part.get("parts", []) or []:
+            found = _walk(sub, want)
+            if found:
+                return found
+        return ""
+
     if payload.get("body", {}).get("data"):
-        body = base64.urlsafe_b64decode(payload["body"]["data"]).decode("utf-8", errors="replace")
-    elif payload.get("parts"):
-        for part in payload["parts"]:
-            if part.get("mimeType") == "text/plain" and part.get("body", {}).get("data"):
-                body = base64.urlsafe_b64decode(part["body"]["data"]).decode("utf-8", errors="replace")
-                break
-        if not body:
-            for part in payload["parts"]:
-                if part.get("mimeType") == "text/html" and part.get("body", {}).get("data"):
-                    body = base64.urlsafe_b64decode(part["body"]["data"]).decode("utf-8", errors="replace")
-                    break
-    return body
+        return base64.urlsafe_b64decode(payload["body"]["data"]).decode("utf-8", errors="replace")
+    for want in ("text/plain", "text/html"):
+        found = _walk(payload, want)
+        if found:
+            return found
+    return ""
 
 
 def _extract_doc_text(doc: dict) -> str:

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -484,3 +484,114 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     assert isinstance(creds, FakeCredentials)
     assert saved["token"] == "ya29.refreshed"
     assert saved["type"] == "authorized_user"
+
+
+# ---------------------------------------------------------------------------
+# _extract_message_body: recursive MIME walking
+# ---------------------------------------------------------------------------
+
+def _b64(text: str) -> str:
+    import base64
+
+    return base64.urlsafe_b64encode(text.encode("utf-8")).decode("ascii")
+
+
+def test_extract_body_top_level_plain(api_module):
+    msg = {"payload": {"body": {"data": _b64("hello world")}}}
+    assert api_module._extract_message_body(msg) == "hello world"
+
+
+def test_extract_body_single_level_parts(api_module):
+    msg = {
+        "payload": {
+            "parts": [
+                {"mimeType": "text/plain", "body": {"data": _b64("plain body")}},
+                {"mimeType": "text/html", "body": {"data": _b64("<p>html</p>")}},
+            ]
+        }
+    }
+    assert api_module._extract_message_body(msg) == "plain body"
+
+
+def test_extract_body_deeply_nested_plain(api_module):
+    # Regression: multipart/mixed -> multipart/related -> multipart/alternative
+    # -> text/plain. The old one-level extractor returned "" for this shape.
+    msg = {
+        "payload": {
+            "mimeType": "multipart/mixed",
+            "parts": [
+                {
+                    "mimeType": "multipart/related",
+                    "parts": [
+                        {
+                            "mimeType": "multipart/alternative",
+                            "parts": [
+                                {
+                                    "mimeType": "text/plain",
+                                    "body": {"data": _b64("nested plain text")},
+                                },
+                                {
+                                    "mimeType": "text/html",
+                                    "body": {"data": _b64("<p>nested html</p>")},
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+    }
+    assert api_module._extract_message_body(msg) == "nested plain text"
+
+
+def test_extract_body_falls_back_to_nested_html(api_module):
+    # No text/plain anywhere -> should return the nested text/html.
+    msg = {
+        "payload": {
+            "mimeType": "multipart/mixed",
+            "parts": [
+                {
+                    "mimeType": "multipart/related",
+                    "parts": [
+                        {
+                            "mimeType": "text/html",
+                            "body": {"data": _b64("<p>only html</p>")},
+                        }
+                    ],
+                }
+            ],
+        }
+    }
+    assert api_module._extract_message_body(msg) == "<p>only html</p>"
+
+
+def test_extract_body_prefers_plain_over_html_across_tree(api_module):
+    # text/html appears at a shallower depth than text/plain; text/plain must
+    # still win (preference is by type, not by position).
+    msg = {
+        "payload": {
+            "mimeType": "multipart/mixed",
+            "parts": [
+                {"mimeType": "text/html", "body": {"data": _b64("<p>shallow html</p>")}},
+                {
+                    "mimeType": "multipart/alternative",
+                    "parts": [
+                        {"mimeType": "text/plain", "body": {"data": _b64("deep plain")}}
+                    ],
+                },
+            ],
+        }
+    }
+    assert api_module._extract_message_body(msg) == "deep plain"
+
+
+def test_extract_body_empty_when_no_text_parts(api_module):
+    msg = {
+        "payload": {
+            "mimeType": "multipart/mixed",
+            "parts": [
+                {"mimeType": "image/png", "body": {"data": _b64("notreallypng")}}
+            ],
+        }
+    }
+    assert api_module._extract_message_body(msg) == ""


### PR DESCRIPTION
## Problem

`_extract_message_body` in `skills/productivity/google-workspace/scripts/google_api.py` only inspected the **first level** of `payload["parts"]`. Gmail nests message bodies arbitrarily deep — a very common real-world shape is:

```
multipart/mixed
└─ multipart/related
   └─ multipart/alternative
      ├─ text/plain   ← the body lives here
      └─ text/html
```

For any such message the old loop found no `text/plain`/`text/html` at the top level and returned an **empty body**. This affects `gmail get` and the full-read path for HTML and marketing mail — the message is reported as having no content when it plainly does.

## Fix

Walk the MIME tree **recursively**, preferring `text/plain` anywhere in the tree, then falling back to `text/html` anywhere. Top-level `payload.body.data` is still handled first. Both call sites (`gmail get` and the full-message read) route through this single function, so the whole bug class is covered — no sibling parser to update.

## Tests

Adds 6 regression tests to `tests/skills/test_google_workspace_api.py` covering:
- top-level `body.data`
- single-level parts (plain preferred over html)
- **deeply nested `text/plain`** (the reported bug)
- fallback to nested `text/html` when no plain part exists
- preference for `text/plain` by type even when `text/html` is shallower
- empty string when there are no text parts

`pytest tests/skills/test_google_workspace_api.py` → **22 passed** (16 existing + 6 new).

## Notes

- No behavior change for messages that already worked (top-level and single-level shapes covered by tests).
- Pure helper in a skill script — no core/prompt surface touched.
