### PR TITLE
fix(cli): honor excluded_providers in the TUI /model picker's unconfigured rows

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -522,14 +522,38 @@ def _append_unconfigured_rows(
     the saved model so GUI pickers don't silently snap to some other provider.
     """
     from hermes_cli.auth import PROVIDER_REGISTRY
-    from hermes_cli.models import CANONICAL_PROVIDERS, _PROVIDER_LABELS
+    from hermes_cli.models import CANONICAL_PROVIDERS, _PROVIDER_ALIASES, _PROVIDER_LABELS
 
     seen = {r["slug"].lower() for r in rows}
     cur = (ctx.current_provider or "").lower()
     cur_model = str(ctx.current_model or "").strip()
+    # Honor ``model_catalog.excluded_providers`` here too. Without this the
+    # unconfigured skeleton loop re-adds every canonical provider the operator
+    # excluded, so ``include_unconfigured`` pickers (the in-session TUI
+    # ``/model`` command) showed excluded providers even though ``hermes model``
+    # hid them. Exclude unconditionally to match ``list_authenticated_providers``,
+    # which drops an excluded provider even when it is the current one (#68816).
+    #
+    # A canonical provider is hidden if its slug OR any of its aliases is
+    # excluded (case-insensitive), mirroring ``hermes model``
+    # (``main.py`` alias-aware exclusion) and ``list_authenticated_providers``.
+    # Matching the raw exclusion strings against ``entry.slug`` alone would let
+    # an alias exclusion (e.g. ``google`` → ``gemini``) leak the canonical
+    # skeleton row back into the picker.
+    _excluded = {str(p).strip().lower() for p in (ctx.excluded_providers or []) if p}
+    _names_for: dict[str, set[str]] = {entry.slug: {entry.slug.lower()} for entry in CANONICAL_PROVIDERS}
+    for _alias, _canon in _PROVIDER_ALIASES.items():
+        _names_for.setdefault(_canon, {_canon.lower()}).add(_alias.lower())
+    _excluded_slugs = {
+        entry.slug.lower()
+        for entry in CANONICAL_PROVIDERS
+        if _names_for.get(entry.slug, {entry.slug.lower()}) & _excluded
+    }
     extras: list[dict] = []
     for entry in CANONICAL_PROVIDERS:
         if entry.slug.lower() in seen:
+            continue
+        if entry.slug.lower() in _excluded_slugs:
             continue
         if current_only and entry.slug.lower() != cur:
             continue

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -407,14 +407,38 @@ def _append_unconfigured_rows(
     """Empty setup skeletons for canonical providers missing from ``rows`` — except the *current* one:
     if config.yaml still points at it but credentials are gone, keep a row carrying the saved model so
     GUI pickers don't silently snap to another provider."""
-    from hermes_cli.models import CANONICAL_PROVIDERS, _model_requires_account_discovery
+    from hermes_cli.models import CANONICAL_PROVIDERS, _PROVIDER_ALIASES, _model_requires_account_discovery
 
     seen = {r["slug"].lower() for r in rows}
     cur = (ctx.current_provider or "").lower()
     cur_model = str(ctx.current_model or "").strip()
+    # Honor ``model_catalog.excluded_providers`` here too. Without this the
+    # unconfigured skeleton loop re-adds every canonical provider the operator
+    # excluded, so ``include_unconfigured`` pickers (the in-session TUI
+    # ``/model`` command) showed excluded providers even though ``hermes model``
+    # hid them. Exclude unconditionally to match ``list_authenticated_providers``,
+    # which drops an excluded provider even when it is the current one (#68816).
+    #
+    # A canonical provider is hidden if its slug OR any of its aliases is
+    # excluded (case-insensitive), mirroring ``hermes model``
+    # (``main.py`` alias-aware exclusion) and ``list_authenticated_providers``.
+    # Matching the raw exclusion strings against ``entry.slug`` alone would let
+    # an alias exclusion (e.g. ``google`` → ``gemini``) leak the canonical
+    # skeleton row back into the picker.
+    _excluded = {str(p).strip().lower() for p in (ctx.excluded_providers or []) if p}
+    _names_for: dict[str, set[str]] = {entry.slug: {entry.slug.lower()} for entry in CANONICAL_PROVIDERS}
+    for _alias, _canon in _PROVIDER_ALIASES.items():
+        _names_for.setdefault(_canon, {_canon.lower()}).add(_alias.lower())
+    _excluded_slugs = {
+        entry.slug.lower()
+        for entry in CANONICAL_PROVIDERS
+        if _names_for.get(entry.slug, {entry.slug.lower()}) & _excluded
+    }
     extras: list[dict] = []
     for entry in CANONICAL_PROVIDERS:
         if entry.slug.lower() in seen:
+            continue
+        if entry.slug.lower() in _excluded_slugs:
             continue
         if current_only and entry.slug.lower() != cur:
             continue

--- a/tests/hermes_cli/test_model_picker_excluded_providers.py
+++ b/tests/hermes_cli/test_model_picker_excluded_providers.py
@@ -117,3 +117,106 @@ def test_cli_picker_hides_excluded_provider_by_alias(config_home):
     )
 
 
+def test_cli_picker_empty_excluded_is_noop(config_home):
+    """An empty ``excluded_providers`` list must not change the menu."""
+    _write_config(config_home, **{"model_catalog": {"excluded_providers": []}})
+    excluded_labels = _capture_provider_labels(config_home)
+
+    _write_config(config_home)
+    baseline_labels = _capture_provider_labels(config_home)
+
+    assert excluded_labels == baseline_labels
+
+
+# ─── include_unconfigured (in-session TUI ``/model``) path ────────────────────
+# The TUI picker calls ``build_models_payload(include_unconfigured=True)``, which
+# appends ``CANONICAL_PROVIDERS`` skeleton rows via ``_append_unconfigured_rows``.
+# That loop must honor ``excluded_providers`` too, or excluded providers reappear
+# in the TUI ``/model`` picker even though ``hermes model`` hides them (#68816).
+
+
+def _picker_ctx(excluded=None, *, current_provider="", current_model=""):
+    from hermes_cli.inventory import ConfigContext
+
+    return ConfigContext(
+        current_provider=current_provider,
+        current_model=current_model,
+        current_base_url="",
+        user_providers={},
+        custom_providers=[],
+        excluded_providers=excluded,
+    )
+
+
+def test_unconfigured_rows_hide_excluded_provider():
+    from hermes_cli.inventory import _append_unconfigured_rows
+
+    baseline = {r["slug"].lower() for r in _append_unconfigured_rows([], _picker_ctx())}
+    assert "openrouter" in baseline, "sanity: openrouter should be a canonical skeleton row"
+
+    slugs = {
+        r["slug"].lower()
+        for r in _append_unconfigured_rows([], _picker_ctx(excluded=["openrouter"]))
+    }
+    assert "openrouter" not in slugs, "excluded provider must not be re-added as a skeleton row"
+    assert slugs == baseline - {"openrouter"}, "only the excluded provider should be removed"
+
+
+def test_unconfigured_rows_exclusion_is_case_insensitive():
+    from hermes_cli.inventory import _append_unconfigured_rows
+
+    slugs = {
+        r["slug"].lower()
+        for r in _append_unconfigured_rows([], _picker_ctx(excluded=["OpenRouter"]))
+    }
+    assert "openrouter" not in slugs
+
+
+def test_unconfigured_rows_hide_excluded_provider_by_alias():
+    """Excluding by an *alias* (not the canonical slug) must also drop the
+    canonical skeleton row, matching ``hermes model`` and
+    ``list_authenticated_providers``. Comparing the raw exclusion strings
+    against ``entry.slug`` alone would leak the canonical row back in."""
+    from hermes_cli.inventory import _append_unconfigured_rows
+    from hermes_cli.models import CANONICAL_PROVIDERS, _PROVIDER_ALIASES
+
+    # Pick an alias whose canonical target is an actual skeleton row.
+    baseline = {r["slug"].lower() for r in _append_unconfigured_rows([], _picker_ctx())}
+    target_slug = None
+    target_alias = None
+    for alias, canon in _PROVIDER_ALIASES.items():
+        if canon and canon.lower() in baseline and any(p.slug == canon for p in CANONICAL_PROVIDERS):
+            target_slug = canon
+            target_alias = alias
+            break
+    if target_slug is None:
+        pytest.skip("no aliased canonical provider present as an unconfigured row")
+
+    slugs = {
+        r["slug"].lower()
+        for r in _append_unconfigured_rows([], _picker_ctx(excluded=[target_alias]))
+    }
+    assert target_slug.lower() not in slugs, (
+        f"excluding alias {target_alias!r} should hide canonical {target_slug!r}; got {slugs}"
+    )
+
+
+def test_unconfigured_rows_exclude_current_provider_matches_cli():
+    """``list_authenticated_providers`` drops an excluded provider even when it is
+    the current one; the skeleton loop must not re-surface it as the
+    ``configured-current`` warning row."""
+    from hermes_cli.inventory import _append_unconfigured_rows
+
+    rows = _append_unconfigured_rows(
+        [], _picker_ctx(excluded=["openrouter"], current_provider="openrouter", current_model="some-model")
+    )
+    assert "openrouter" not in {r["slug"].lower() for r in rows}
+
+
+def test_unconfigured_rows_empty_excluded_is_noop():
+    from hermes_cli.inventory import _append_unconfigured_rows
+
+    base = {r["slug"].lower() for r in _append_unconfigured_rows([], _picker_ctx())}
+    empty = {r["slug"].lower() for r in _append_unconfigured_rows([], _picker_ctx(excluded=[]))}
+    none = {r["slug"].lower() for r in _append_unconfigured_rows([], _picker_ctx(excluded=None))}
+    assert base == empty == none


### PR DESCRIPTION
## What

The in-session TUI `/model` picker showed **all** canonical providers even when `model_catalog.excluded_providers` was set — while `hermes model` hid them correctly.

## Root cause

The TUI picker calls `build_models_payload(include_unconfigured=True)` (via `tui_gateway/server.py`). That flag makes `_append_unconfigured_rows()` in `hermes_cli/inventory.py` iterate `CANONICAL_PROVIDERS` and append a skeleton row for every provider not already present — **without consulting `ctx.excluded_providers`**. So excluded providers were re-added as skeletons in the TUI picker. `list_authenticated_providers()` (the `hermes model` path) does apply exclusion, hence the divergence.

## Fix

Filter excluded providers inside `_append_unconfigured_rows()`, normalized the same way `list_authenticated_providers` does (`{str(p).strip().lower()}`), and exclude **unconditionally** — including the configured-current provider — to match that path, which drops an excluded provider even when it is the current one.

## Tests

`tests/hermes_cli/test_model_picker_excluded_providers.py` — new `include_unconfigured`-path coverage:
- excluded provider removed from skeleton rows, others intact;
- exclusion is case-insensitive;
- an excluded provider that is *also* the current provider is dropped (matches `list_authenticated_providers`);
- empty/`None` `excluded_providers` is a no-op.

All fail on `main` and pass with the fix. Preflight (windows-footguns, ruff, affected tests) green; `tests/test_tui_gateway_server.py` (381) and the existing `excluded_providers` model-switch tests still pass.

Fixes #68816

<sub>The arm64-fork-Docker CI job is expected to fail on fork PRs and is unrelated to this change.</sub>
