### PR TITLE
fix(checkpoints): recover stale locks in diff

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -19,9 +19,16 @@ from tools.checkpoint_manager import (
     _dir_file_count,
     _project_hash,
     _store_path,
+    _index_path,
     _ref_name,
     _project_meta_path,
     _touch_project,
+    _INDEX_LOCK_STALE_SECONDS,
+    _index_lock_path,
+    _is_index_lock_error,
+    _index_lock_has_open_process,
+    _remove_stale_index_lock,
+    _git_add_recover_stale_index_lock,
     format_checkpoint_list,
     prune_checkpoints,
     maybe_auto_prune_checkpoints,
@@ -1049,3 +1056,118 @@ class TestClearFunctions:
         result = clear_all()
         assert result["deleted"] is False
         assert result["bytes_freed"] == 0
+
+
+# =========================================================================
+# Stale index-lock recovery — shared helper for _take() and diff()
+# =========================================================================
+
+class TestCheckpointIndexLocks:
+    def _stale_lock(self, index_file: Path) -> Path:
+        lock_path = _index_lock_path(index_file)
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text("stale\n", encoding="utf-8")
+        old = time.time() - _INDEX_LOCK_STALE_SECONDS - 1
+        os.utime(lock_path, (old, old))
+        return lock_path
+
+    def test_diff_uses_shared_git_add_recovery_helper(
+        self, work_dir, checkpoint_base, monkeypatch,
+    ):
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        m = CheckpointManager(enabled=True, max_snapshots=50)
+        assert m.ensure_checkpoint(str(work_dir), "initial") is True
+        (work_dir / "main.py").write_text("modified\n")
+
+        called = []
+        original = _git_add_recover_stale_index_lock
+
+        def spy_helper(*args, **kwargs):
+            called.append(args[2])
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "tools.checkpoint_manager._git_add_recover_stale_index_lock",
+            spy_helper,
+        )
+
+        checkpoint = m.list_checkpoints(str(work_dir))[0]
+        result = m.diff(str(work_dir), checkpoint["hash"])
+
+        assert result["success"] is True
+        assert called == [_index_path(_store_path(checkpoint_base), _project_hash(str(work_dir)))]
+
+    def test_recovers_only_matching_stale_index_lock_error(self, tmp_path, monkeypatch):
+        work_dir = tmp_path / "project"
+        work_dir.mkdir()
+        store = tmp_path / "store"
+        index_file = store / "indexes" / ("a" * 16)
+        lock_path = self._stale_lock(index_file)
+        calls = []
+
+        def fake_run_git(args, *unused_args, **unused_kwargs):
+            calls.append(args)
+            if len(calls) == 1:
+                return False, "", f"fatal: Unable to create '{lock_path}': File exists."
+            return True, "", ""
+
+        monkeypatch.setattr("tools.checkpoint_manager._run_git", fake_run_git)
+        monkeypatch.setattr("tools.checkpoint_manager._index_lock_has_open_process", lambda _: False)
+
+        assert _git_add_recover_stale_index_lock(store, str(work_dir), index_file) == (True, "", "")
+        assert calls == [["add", "-A"], ["add", "-A"]]
+
+        calls.clear()
+        def unrelated_run_git(*args, **kwargs):
+            calls.append(args)
+            return False, "", "fatal: unrelated git failure"
+
+        monkeypatch.setattr("tools.checkpoint_manager._run_git", unrelated_run_git)
+        assert _git_add_recover_stale_index_lock(store, str(work_dir), index_file) == (
+            False,
+            "",
+            "fatal: unrelated git failure",
+        )
+        assert len(calls) == 1
+
+    def test_remove_stale_lock_quarantines_before_unlinking(self, tmp_path, monkeypatch):
+        index_file = tmp_path / "store" / "indexes" / ("b" * 16)
+        lock_path = self._stale_lock(index_file)
+        monkeypatch.setattr("tools.checkpoint_manager._index_lock_has_open_process", lambda _: False)
+        original_unlink = Path.unlink
+
+        def create_new_original_before_unlink(self, *args, **kwargs):
+            if ".quarantine." in self.name:
+                lock_path.write_text("fresh\n", encoding="utf-8")
+            return original_unlink(self, *args, **kwargs)
+
+        with patch.object(Path, "unlink", create_new_original_before_unlink):
+            assert _remove_stale_index_lock(index_file) is True
+
+        assert lock_path.exists()
+        assert lock_path.read_text(encoding="utf-8") == "fresh\n"
+
+    def test_keeps_recent_open_unknown_or_unexpected_index_locks(self, tmp_path, monkeypatch):
+        index_file = tmp_path / "store" / "indexes" / ("c" * 16)
+        lock_path = self._stale_lock(index_file)
+
+        monkeypatch.setattr("tools.checkpoint_manager._index_lock_has_open_process", lambda _: None)
+        assert _remove_stale_index_lock(index_file) is False
+        assert lock_path.exists()
+
+        monkeypatch.setattr("tools.checkpoint_manager._index_lock_has_open_process", lambda _: True)
+        assert _remove_stale_index_lock(index_file) is False
+        assert lock_path.exists()
+
+        fresh_index = tmp_path / "store" / "indexes" / ("d" * 16)
+        fresh_lock = _index_lock_path(fresh_index)
+        fresh_lock.parent.mkdir(parents=True, exist_ok=True)
+        fresh_lock.write_text("fresh\n", encoding="utf-8")
+        monkeypatch.setattr("tools.checkpoint_manager._index_lock_has_open_process", lambda _: False)
+        assert _remove_stale_index_lock(fresh_index) is False
+        assert fresh_lock.exists()
+
+        unexpected = tmp_path / "store" / "not-indexes" / ("e" * 16)
+        unexpected_lock = self._stale_lock(unexpected)
+        assert _remove_stale_index_lock(unexpected) is False
+        assert unexpected_lock.exists()

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -364,6 +364,153 @@ def _run_git(
 
 
 # ---------------------------------------------------------------------------
+# Stale index-lock recovery (shared by _take and diff)
+# ---------------------------------------------------------------------------
+
+_INDEX_LOCK_STALE_SECONDS: int = 5 * 60  # 5 minutes
+
+
+def _index_lock_path(index_file: Path) -> Path:
+    """Return the lock path Git uses while updating ``index_file``."""
+    return index_file.with_name(index_file.name + ".lock")
+
+
+def _is_index_lock_error(stderr: str, index_file: Path) -> bool:
+    """Return whether Git failed because this project's index lock exists."""
+    if not stderr:
+        return False
+    lock_path = _index_lock_path(index_file)
+    return (
+        str(lock_path) in stderr
+        and "Unable to create" in stderr
+        and "File exists" in stderr
+    )
+
+
+def _index_lock_has_open_process(lock_path: Path) -> Optional[bool]:
+    """Return whether ``lock_path`` is open, or None when that is unknown.
+
+    Git lockfiles do not record an owner PID.  ``lsof`` lets us distinguish a
+    dead, abandoned lock from one an active Git process is still writing.  If
+    it is unavailable or errors, callers must retain the lock rather than
+    guessing that it is stale.
+    """
+    if shutil.which("lsof") is None:
+        return None
+    try:
+        result = subprocess.run(
+            ["lsof", "-t", "--", str(lock_path)],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    return None
+
+
+def _remove_stale_index_lock(index_file: Path) -> bool:
+    """Atomically quarantine and remove a stale ``index_file.lock``.
+
+    Acceptance criteria (all must hold or the call returns False):
+
+    * *index_file* lives under ``indexes/<16hex>`` (rejects anything else).
+    * The lock file is at least ``_INDEX_LOCK_STALE_SECONDS`` old.
+    * ``_index_lock_has_open_process`` returns ``False`` (no holder).
+
+    TOCTOU mitigation: the lock is **renamed** to a unique quarantine
+    sibling first.  Any new lock created after the rename lands at the
+    original path and is never touched.  The quarantine copy is then
+    unlinked.  If unlinking the quarantine fails, we attempt to restore it
+    back to the original path — but only if the original is absent — and
+    return False.
+    """
+    lock_path = _index_lock_path(index_file)
+
+    # Validate: must be indexes/<16hex> (name is 16 hex chars).
+    dir_hash = index_file.name
+    if (
+        index_file.parent.name != _INDEXES_DIRNAME
+        or not re.fullmatch(r'[0-9a-f]{16}', dir_hash)
+    ):
+        return False
+
+    if not lock_path.exists():
+        return True
+
+    # Age guard.
+    try:
+        age = time.time() - lock_path.stat().st_mtime
+    except OSError:
+        return False
+    if age < _INDEX_LOCK_STALE_SECONDS:
+        return False
+
+    # Process-hold guard.
+    held = _index_lock_has_open_process(lock_path)
+    if held is not False:  # True or None (indeterminate) → refuse
+        return False
+
+    # Atomic quarantine: rename away before unlink.
+    quarantine_path = lock_path.with_name(
+        f"{dir_hash}.quarantine.{int(time.time_ns())}"
+    )
+    try:
+        lock_path.rename(quarantine_path)
+    except OSError:
+        return False
+
+    # Unlink the quarantine copy.
+    try:
+        quarantine_path.unlink()
+    except OSError:
+        # Unlink failed — try to restore quarantine back to lock_path,
+        # but only if the original path is currently absent (e.g. a new
+        # process created a lock after our rename; do NOT overwrite it).
+        if not lock_path.exists():
+            try:
+                quarantine_path.rename(lock_path)
+            except OSError:
+                pass
+        return False
+
+    return True
+
+
+def _git_add_recover_stale_index_lock(
+    store: Path,
+    working_dir: str,
+    index_file: Path,
+    timeout: int = _GIT_TIMEOUT,
+) -> Tuple[bool, str, str]:
+    """``git add`` with automatic recovery from stale index locks.
+
+    Shared by ``_take()`` and ``diff()``.  Runs ``git add`` with
+    ``allowed_returncodes={128}`` so the error path is reached without
+    noisy logging, then attempts recovery only when the stderr matches a
+    known index-lock pattern and ``_remove_stale_index_lock`` succeeds.
+    """
+    ok, stdout, stderr = _run_git(
+        ["add", "-A"], store, working_dir,
+        timeout=timeout, index_file=index_file,
+        allowed_returncodes={128},
+    )
+    if not ok and _is_index_lock_error(stderr, index_file):
+        if _remove_stale_index_lock(index_file):
+            ok, stdout, stderr = _run_git(
+                ["add", "-A"], store, working_dir,
+                timeout=timeout, index_file=index_file,
+            )
+    return ok, stdout, stderr
+
+
+# ---------------------------------------------------------------------------
 # Store initialisation + legacy migration
 # ---------------------------------------------------------------------------
 
@@ -763,8 +910,8 @@ class CheckpointManager:
         index_file = _index_path(store, dir_hash)
 
         # Stage current state into the per-project index to compare.
-        _run_git(["add", "-A"], store, abs_dir,
-                 timeout=_GIT_TIMEOUT * 2, index_file=index_file)
+        _git_add_recover_stale_index_lock(store, abs_dir, index_file,
+                                          timeout=_GIT_TIMEOUT * 2)
 
         ok_stat, stat_out, _ = _run_git(
             ["diff", "--stat", commit_hash, "--cached"],
@@ -920,9 +1067,9 @@ class CheckpointManager:
         # via ``core.bigFileThreshold`` is not what we want — instead, we
         # rely on the exclude file for broad patterns and post-stage prune
         # any path whose size exceeds max_file_size_mb.
-        ok, _, err = _run_git(
-            ["add", "-A"], store, working_dir,
-            timeout=_GIT_TIMEOUT * 2, index_file=index_file,
+        ok, _, err = _git_add_recover_stale_index_lock(
+            store, working_dir, index_file,
+            timeout=_GIT_TIMEOUT * 2,
         )
         if not ok:
             logger.debug("Checkpoint git-add failed: %s", err)


### PR DESCRIPTION
## Summary
- route checkpoint diff() git-add staging through the same stale index-lock recovery helper as checkpoint capture
- recover only matching store/indexes/<hash>.lock failures after 5 minutes and a positive no-open-holder lsof check
- quarantine stale locks with an atomic rename before unlink so a newly-created live lock at the original path is preserved

## Test Plan
- python -m pytest tests/tools/test_checkpoint_manager.py::TestCheckpointIndexLocks -q -o 'addopts='
- python -m pytest tests/tools/test_checkpoint_manager.py -q -o 'addopts='
- git diff --check
- python -m py_compile tools/checkpoint_manager.py tests/tools/test_checkpoint_manager.py