### PR TITLE
fix(credential-pool): rotate on Ollama Cloud "session usage limit" 429

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1003,6 +1003,7 @@ def recover_with_credential_pool(
                 or "gousagelimit" in context_reason
                 or "usage limit reached" in context_message
                 or "usage limit has been reached" in context_message
+                or "session usage limit" in context_message
             )
         if not has_retried_429 and not usage_limit_reached:
             return False, True

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -345,6 +345,13 @@ def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     min_only_match = re.search(r"resets?\s+in\s+(\d+)\s*min\b", message, re.IGNORECASE)
     if min_only_match:
         return int(min_only_match.group(1)) * 60
+    # Ollama Cloud "session usage limit" — resets every 5 hours, but the
+    # reset window started before we hit the limit, so the actual remaining
+    # time is unknown. Use a short TTL: if the primary is still limited, the
+    # 429 fires again and we rotate back to the fallback — one wasted request.
+    # If the limit has cleared, we reclaim the primary immediately.
+    if "session usage limit" in message.lower():
+        return 30 * 60
     return None
 
 

--- a/tests/agent/test_ollama_cloud_session_usage_limit.py
+++ b/tests/agent/test_ollama_cloud_session_usage_limit.py
@@ -1,0 +1,155 @@
+"""Tests for Ollama Cloud "session usage limit" credential pool handling.
+
+Covers two fixes:
+1. ``_extract_retry_delay_seconds`` recognising "session usage limit" and
+   returning a 30-minute TTL instead of falling through to the 1-hour default.
+2. ``recover_with_credential_pool`` treating "session usage limit" as a
+   usage-limit condition so the pool rotates on the first 429 instead of
+   retrying the same credential 3 times.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from agent.credential_pool import PooledCredential
+from agent.error_classifier import FailoverReason
+
+
+# ---------------------------------------------------------------------------
+# Helpers (match conventions from test_credential_pool_interrupt.py)
+# ---------------------------------------------------------------------------
+
+def _make_entry(idx, **overrides):
+    defaults = dict(
+        provider="ollama-cloud",
+        id=f"cred-{idx}",
+        label=f"Credential {idx}",
+        auth_type="api_key",
+        priority=idx,
+        source="manual",
+        access_token=f"key-{idx}",
+    )
+    defaults.update(overrides)
+    return PooledCredential(**defaults)
+
+
+def _make_pool(entries):
+    pool = MagicMock()
+    pool.entries = entries
+    pool.current.return_value = entries[0]
+    # Must be set explicitly — MagicMock.provider returns a truthy
+    # child mock, which would trigger the provider-mismatch guard.
+    pool.provider = ""
+    return pool
+
+
+# ---------------------------------------------------------------------------
+# _extract_retry_delay_seconds
+# ---------------------------------------------------------------------------
+
+def test_session_usage_limit_returns_30_minutes():
+    from agent.credential_pool import _extract_retry_delay_seconds
+
+    msg = "you (user) have reached your session usage limit, upgrade for higher limits"
+    assert _extract_retry_delay_seconds(msg) == 30 * 60
+
+
+def test_session_usage_limit_case_insensitive():
+    from agent.credential_pool import _extract_retry_delay_seconds
+
+    msg = "Session Usage Limit reached"
+    assert _extract_retry_delay_seconds(msg) == 30 * 60
+
+
+def test_session_usage_limit_does_not_shadow_explicit_reset_time():
+    """If the message also contains an explicit 'resets in Nmin', that wins."""
+    from agent.credential_pool import _extract_retry_delay_seconds
+
+    msg = "session usage limit. Resets in 5min"
+    assert _extract_retry_delay_seconds(msg) == 5 * 60
+
+
+def test_session_usage_limit_does_not_shadow_hr_min_format():
+    """If the message also contains 'resets in Nhr Mmin', that wins."""
+    from agent.credential_pool import _extract_retry_delay_seconds
+
+    msg = "session usage limit. Resets in 2hr 15min"
+    assert _extract_retry_delay_seconds(msg) == 2 * 3600 + 15 * 60
+
+
+def test_non_session_usage_limit_returns_none():
+    from agent.credential_pool import _extract_retry_delay_seconds
+
+    assert _extract_retry_delay_seconds("rate limited, try again later") is None
+    assert _extract_retry_delay_seconds("") is None
+
+
+# ---------------------------------------------------------------------------
+# recover_with_credential_pool — usage_limit_reached detection
+# ---------------------------------------------------------------------------
+
+def test_session_usage_limit_triggers_pool_rotation_on_first_429():
+    """On the first 429 with 'session usage limit', the pool should rotate
+    immediately instead of waiting for has_retried_429=True."""
+    entries = [_make_entry(0), _make_entry(1)]
+    pool = _make_pool(entries)
+    pool.mark_exhausted_and_rotate.return_value = entries[1]
+
+    from run_agent import AIAgent
+    with patch("run_agent.get_tool_definitions", return_value=[]), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI"):
+        agent = MagicMock(spec=AIAgent)
+        agent._credential_pool = pool
+        agent._swap_credential = MagicMock()
+
+        error_context = {
+            "reason": "",
+            "message": "you (user) have reached your session usage limit, "
+                       "upgrade for higher limits",
+        }
+
+        recovered, retried = AIAgent._recover_with_credential_pool(
+            agent,
+            status_code=429,
+            has_retried_429=False,
+            classified_reason=None,
+            error_context=error_context,
+        )
+
+    assert recovered is True
+    assert retried is False
+    pool.mark_exhausted_and_rotate.assert_called_once()
+    agent._swap_credential.assert_called_once_with(entries[1])
+
+
+def test_plain_rate_limit_without_usage_limit_waits_for_retry():
+    """A normal 429 without 'session usage limit' should NOT rotate on the
+    first 429 — it should retry first (has_retried_429=False → retried=True)."""
+    entries = [_make_entry(0), _make_entry(1)]
+    pool = _make_pool(entries)
+
+    from run_agent import AIAgent
+    with patch("run_agent.get_tool_definitions", return_value=[]), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI"):
+        agent = MagicMock(spec=AIAgent)
+        agent._credential_pool = pool
+
+        error_context = {
+            "reason": "rate_limit",
+            "message": "Too many requests, try again later",
+        }
+
+        recovered, retried = AIAgent._recover_with_credential_pool(
+            agent,
+            status_code=429,
+            has_retried_429=False,
+            classified_reason=None,
+            error_context=error_context,
+        )
+
+    assert recovered is False
+    assert retried is True
+    pool.mark_exhausted_and_rotate.assert_not_called()


### PR DESCRIPTION
## Summary

When Ollama Cloud returns HTTP 429 with body text like `"you have reached your session usage limit, upgrade for higher limits"`, the credential pool's `recover_with_credential_pool()` does not recognise this as a usage-limit condition. It treats the 429 as a transient rate limit, retries the same credential 3 times, then gives up — **never rotating to the next pooled credential**.

This is a **different mechanism** from the `fallback_providers` chain (issue #65563, PR #65633): the credential pool rotates API keys within the same provider, while `fallback_providers` switches providers entirely. Both are needed — a user may have multiple Ollama Cloud API keys in a pool but no `fallback_providers` configured, or vice versa.

## Root Cause

`recover_with_credential_pool()` in `agent/agent_runtime_helpers.py` checks for these patterns to detect usage-limit exhaustion:

```python
usage_limit_reached = (
    "usage_limit_reached" in context_reason
    or "gousagelimit" in context_reason
    or "usage limit reached" in context_message
    or "usage limit has been reached" in context_message
)
```

The Ollama Cloud error string `"session usage limit"` doesn't match any of these — the word "session" separates "usage" and "limit", so `"usage limit reached"` doesn't substring-match.

Additionally, `_extract_retry_delay_seconds()` in `agent/credential_pool.py` doesn't handle `"session usage limit"`. Without a parsed delay, the exhausted credential falls back to the default 429 TTL of 1 hour (`EXHAUSTED_TTL_429_SECONDS = 3600`). Ollama Cloud's session limit resets every 5 hours, but the reset window started before the limit was hit, so the actual remaining time is unknown. A 30-minute TTL is a better default: if the primary is still limited, the 429 fires again and we rotate back — one wasted request. If the limit has cleared, we reclaim the primary immediately.

## Changes

1. **`agent/agent_runtime_helpers.py`** (+1 line): Add `"session usage limit"` to the `usage_limit_reached` pattern check in `recover_with_credential_pool()`, so the pool rotates on the first 429 instead of retrying 3×.

2. **`agent/credential_pool.py`** (+7 lines): Add a 30-minute TTL for `"session usage limit"` in `_extract_retry_delay_seconds()`. Placed after the explicit `resets in Nmin` / `resets in Nhr Mmin` parsers so those take priority when present.

3. **`tests/agent/test_ollama_cloud_session_usage_limit.py`** (new, 155 lines): 7 tests covering both fixes — retry-delay parsing (5 tests) and pool rotation on first 429 (2 tests).

## Relationship to existing PRs

| PR | Mechanism | Path | Status |
|----|----------|------|--------|
| #65633 | `fallback_providers` chain | `error_classifier.py` | Open, has blocking review (broad pattern misclassifies normal rate limits) |
| #49076 | Auxiliary task fallback | `auxiliary_client.py` | Closed, keywords partially merged |
| **This PR** | **Credential pool rotation** | `agent_runtime_helpers.py` + `credential_pool.py` | — |

These are complementary, not competing — they address different recovery mechanisms. A user with multiple Ollama Cloud API keys in a pool benefits from this PR even without `fallback_providers` configured.

## Test Plan

- [x] `pytest tests/agent/test_ollama_cloud_session_usage_limit.py` — 7 passed
- [ ] Existing credential pool tests still pass (no regressions)
- [ ] Verified with live Ollama Cloud "session usage limit" error string

Closes #68831