### PR TITLE
fix(desktop): stop dialog close-button tooltip appearing without hover

### DIFF
--- a/apps/desktop/src/components/ui/dialog.test.tsx
+++ b/apps/desktop/src/components/ui/dialog.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { Dialog, DialogContent, DialogTitle, preventCloseButtonAutoFocus } from './dialog'
+import { createOpenAutoFocusTipGuard, Dialog, DialogContent, DialogTitle, preventCloseButtonAutoFocus } from './dialog'
 
 afterEach(cleanup)
 
@@ -104,5 +104,64 @@ describe('DialogContent close button', () => {
       },
       { timeout: 3000 }
     )
+  })
+})
+
+describe('createOpenAutoFocusTipGuard (#68765)', () => {
+  // jsdom reproduces neither Radix's focus-scope mount timing nor the Tip's
+  // open timer reliably (see the skipped test above), so the guard is tested
+  // directly: DialogContent arms it in its onOpenAutoFocus handler and the
+  // close button routes its onFocus through `suppress`.
+
+  const focusEvent = () => {
+    const calls: number[] = []
+
+    return {
+      event: { preventDefault: () => calls.push(1) },
+      wasPrevented: () => calls.length > 0
+    }
+  }
+
+  it('prevent-defaults the focus that arrives inside the open-autofocus window', () => {
+    const guard = createOpenAutoFocusTipGuard()
+    const { event, wasPrevented } = focusEvent()
+
+    guard.arm()
+    guard.suppress(event)
+
+    expect(wasPrevented()).toBe(true)
+  })
+
+  it('is one-shot: only the first focus after arming is suppressed', () => {
+    const guard = createOpenAutoFocusTipGuard()
+    const first = focusEvent()
+    const second = focusEvent()
+
+    guard.arm()
+    guard.suppress(first.event)
+    guard.suppress(second.event)
+
+    expect(first.wasPrevented()).toBe(true)
+    expect(second.wasPrevented()).toBe(false)
+  })
+
+  it('expires on the next microtask, so user Tab focus still opens the tip', async () => {
+    const guard = createOpenAutoFocusTipGuard()
+    const { event, wasPrevented } = focusEvent()
+
+    guard.arm()
+    await Promise.resolve()
+    guard.suppress(event)
+
+    expect(wasPrevented()).toBe(false)
+  })
+
+  it('never suppresses when it was not armed (dialogs that opt out of autofocus)', () => {
+    const guard = createOpenAutoFocusTipGuard()
+    const { event, wasPrevented } = focusEvent()
+
+    guard.suppress(event)
+
+    expect(wasPrevented()).toBe(false)
   })
 })

--- a/apps/desktop/src/components/ui/dialog.tsx
+++ b/apps/desktop/src/components/ui/dialog.tsx
@@ -60,6 +60,38 @@ export function preventCloseButtonAutoFocus(event: Event) {
   event.preventDefault()
 }
 
+// One-shot guard for the open-autofocus → close-button-tip interaction
+// (#68765): armed during Radix's synchronous mount-autofocus window, it
+// prevent-defaults exactly one focus event so the close button's Tip skips
+// its focus-open (Radix composes handlers with `checkForDefaultPrevented`;
+// the focus itself is unaffected — same mechanism as
+// `suppressNonKeyboardFocusOpen` in tooltip.tsx). Exported as a pure factory
+// because jsdom reproduces neither Radix's focus-scope timing nor the Tip's
+// open timer reliably (see the skipped test in dialog.test.tsx).
+export interface OpenAutoFocusTipGuard {
+  arm(): void
+  suppress(event: { preventDefault(): void }): void
+}
+
+export function createOpenAutoFocusTipGuard(): OpenAutoFocusTipGuard {
+  let active = false
+
+  return {
+    arm() {
+      active = true
+      queueMicrotask(() => {
+        active = false
+      })
+    },
+    suppress(event) {
+      if (active) {
+        active = false
+        event.preventDefault()
+      }
+    }
+  }
+}
+
 function DialogContent({
   className,
   children,
@@ -89,6 +121,27 @@ function DialogContent({
   // an input) is what most dialogs want. Dialogs with no input should pass
   // `onOpenAutoFocus={preventCloseButtonAutoFocus}` explicitly instead.
 
+  // In a dialog with no input, Radix's open-autofocus lands on the close
+  // button, and Tip opens on focus — so the "Close" tip appeared with no
+  // pointer near it (#68765). The per-dialog `preventCloseButtonAutoFocus`
+  // opt-out exists, but any dialog that forgets it regresses. Arm a guard
+  // for the synchronous open-autofocus window so the close button suppresses
+  // its tip-open for exactly that programmatic focus; a later keyboard Tab
+  // onto the button still shows the tip (a11y unchanged).
+  const tipGuardRef = React.useRef<OpenAutoFocusTipGuard | null>(null)
+  tipGuardRef.current ??= createOpenAutoFocusTipGuard()
+
+  const handleOpenAutoFocus = (event: Event) => {
+    onOpenAutoFocus?.(event)
+
+    if (!event.defaultPrevented) {
+      // Radix focuses the first tabbable element synchronously right after
+      // this event; the guard expires on the next microtask, before any
+      // user-driven focus can reach the close button.
+      tipGuardRef.current?.arm()
+    }
+  }
+
   // `Tip` wraps `DialogPrimitive.Close asChild` (not the other way around) so
   // Radix's `Slot` can forward `Close`'s `onClick` straight through to the
   // `Button`. When `Tip` was the innermost wrapper, `onClick` was absorbed by
@@ -100,6 +153,7 @@ function DialogContent({
         <Button
           aria-label={t.common.close}
           className="absolute right-2.5 top-2.5 z-20 text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground"
+          onFocus={event => tipGuardRef.current?.suppress(event)}
           size="icon-xs"
           variant="ghost"
         >
@@ -128,7 +182,7 @@ function DialogContent({
             'gap-0'
           )}
           data-slot="dialog-content"
-          onOpenAutoFocus={onOpenAutoFocus}
+          onOpenAutoFocus={handleOpenAutoFocus}
           {...props}
         >
           {/* Scroll lives on an inner box so this shell keeps a painted bottom radius. */}
@@ -166,7 +220,7 @@ function DialogContent({
           className
         )}
         data-slot="dialog-content"
-        onOpenAutoFocus={onOpenAutoFocus}
+        onOpenAutoFocus={handleOpenAutoFocus}
         {...props}
       >
         {children}

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1024,6 +1024,7 @@ LEGACY_AUTHOR_MAP = {
     "137614867+cutepawss@users.noreply.github.com": "cutepawss",
     "96793918+memosr@users.noreply.github.com": "memosr",
     "mehmet.sr35@gmail.com": "memosr",
+    "mehmet.kar@std.yildiz.edu.tr": "mehmetkr-31",
     "milkoor@users.noreply.github.com": "milkoor",
     "xuerui911@gmail.com": "Fatty911",
     "131039422+SHL0MS@users.noreply.github.com": "SHL0MS",


### PR DESCRIPTION
## Summary

Fixes #68765: on modals with no input field, the close button's "Close" rollover/tooltip label rendered as permanently visible on open, with the pointer nowhere near the control.

## Root cause

The mechanism is already documented inside `apps/desktop/src/components/ui/dialog.tsx` (comment above `preventCloseButtonAutoFocus`): Radix autofocuses the first focusable element inside `Dialog.Content` on open. In dialogs with no input that's the close button, and `Tip` opens on focus as well as hover — so the tooltip appears immediately. The focus-visible gate added in `tooltip.tsx` (`suppressNonKeyboardFocusOpen`) doesn't reliably cover this path because Chromium can mark the programmatic focus as `:focus-visible` (e.g. keyboard-opened dialogs), and the existing per-dialog `onOpenAutoFocus={preventCloseButtonAutoFocus}` opt-out (used by `updates-overlay.tsx`) only helps dialogs that remember to pass it — any new no-input dialog regresses, which is what #68765 reports.

## Fix (whole class, shared component)

A one-shot guard in the shared `DialogContent`:

- `handleOpenAutoFocus` wraps the caller's `onOpenAutoFocus` and — when autofocus is not prevented — arms the guard for the synchronous mount-autofocus window (expires on the next microtask).
- The close button's `onFocus` routes through `guard.suppress()`, which prevent-defaults exactly one focus event inside that window. Radix Tooltip composes its handlers with `checkForDefaultPrevented`, so the tip-open is skipped while the focus itself is unaffected — the same mechanism `tooltip.tsx`'s `suppressNonKeyboardFocusOpen` already relies on.

Behavior preserved:
- Dialogs with inputs keep Radix's normal first-input autofocus (no change to the `onOpenAutoFocus` default, which an earlier iteration of this file deliberately kept — see the comment at `dialog.test.tsx`'s "does not prevent Radix autofocus" test).
- Keyboard users Tabbing onto the close button still get the tooltip (guard expires after the open window; a11y unchanged, `aria-label`/sr-only text untouched).
- Existing `preventCloseButtonAutoFocus` opt-outs keep working (guard is never armed when autofocus is prevented).
- `sheet.tsx`'s close button has no `Tip` (aria-label only), so dialogs are the only affected surface.

## Tests

The guard is exported as a pure factory (`createOpenAutoFocusTipGuard`) and tested directly — jsdom reproduces neither Radix's focus-scope mount timing nor the Tip's open timer reliably (the pre-existing skipped test in `dialog.test.tsx` documents that flake). 4 new tests: suppression inside the window, one-shot semantics, microtask expiry (Tab focus still opens the tip), and the never-armed path. All existing dialog tests pass unchanged (8 passed, 1 pre-existing skip); `tsc -b`, eslint, and prettier clean.

Closes #68765

🤖 Generated with [Claude Code](https://claude.com/claude-code)