### PR TITLE
fix(desktop): add Kilo Gateway pricing to model picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2056,11 +2056,14 @@ def _fetch_kilocode_pricing(
             entry["prompt"] = "0"
             entry["completion"] = "0"
         else:
-            if pricing.get("prompt"):
+            # `is not None` (not truthiness): a custom proxy may report
+            # numeric 0/0.0 pricing, which must surface as "0" rather than
+            # being dropped.
+            if pricing.get("prompt") is not None:
                 entry["prompt"] = str(pricing["prompt"])
-            if pricing.get("completion"):
+            if pricing.get("completion") is not None:
                 entry["completion"] = str(pricing["completion"])
-        if pricing.get("input_cache_read"):
+        if pricing.get("input_cache_read") is not None:
             entry["input_cache_read"] = str(pricing["input_cache_read"])
 
         if entry:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1937,6 +1937,11 @@ def _resolve_openrouter_api_key() -> str:
     return os.getenv("OPENROUTER_API_KEY", "").strip()
 
 
+def _resolve_kilocode_api_key() -> str:
+    """Best-effort Kilo Code API key for pricing fetch."""
+    return os.getenv("KILOCODE_API_KEY", "").strip()
+
+
 _DEFAULT_NOUS_INFERENCE_BASE = "https://inference-api.nousresearch.com"
 
 
@@ -1985,8 +1990,86 @@ def _resolve_nous_pricing_credentials() -> tuple[str, str]:
     return (api_key, base_url)
 
 
+def _fetch_kilocode_pricing(
+    timeout: float = 8.0,
+    *,
+    force_refresh: bool = False,
+) -> dict[str, dict[str, str]]:
+    """Fetch pricing from the Kilo Gateway models endpoint.
+
+    The catalog is served from the provider's base URL at ``/models`` — the
+    same composition the doctor probe uses for Kilo connectivity checks
+    (``{KILOCODE_BASE_URL}/models``). The default base
+    (``https://api.kilo.ai/api/gateway``) serves the same OpenRouter-shaped
+    catalog as ``/api/openrouter/models``; honoring the override means a
+    custom endpoint shows its own catalog instead of the public one.
+
+    The endpoint is public, so the API key is attached best-effort (same as
+    the OpenRouter and Nous fetchers) rather than gating the fetch.
+
+    The Kilo API returns ``isFree`` as an explicit boolean per model, which
+    is more reliable than inferring from zero pricing — some free models
+    (e.g. ``kilo-auto/free``) are routers with non-zero underlying costs.
+    When ``isFree`` is True, pricing is set to ``"0"`` so the downstream
+    ``_apply_pricing()`` logic naturally marks the model as free.
+
+    Results are cached keyed on the resolved base URL so a custom
+    ``KILOCODE_BASE_URL`` never serves another endpoint's pricing.
+    """
+    api_key = _resolve_kilocode_api_key()
+
+    base_url = os.getenv("KILOCODE_BASE_URL", "").strip() or "https://api.kilo.ai/api/gateway"
+    cache_key = base_url.rstrip("/")
+    if not force_refresh and cache_key in _pricing_cache:
+        return _pricing_cache[cache_key]
+
+    url = cache_key + "/models"
+    headers: dict[str, str] = {
+        "Accept": "application/json",
+        "User-Agent": _HERMES_USER_AGENT,
+    }
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode())
+    except Exception:
+        _pricing_cache[cache_key] = {}
+        return {}
+
+    result: dict[str, dict[str, str]] = {}
+    for item in payload.get("data", []):
+        if not isinstance(item, dict):
+            continue
+        mid = item.get("id")
+        if not mid:
+            continue
+        pricing = item.get("pricing") or {}
+        is_free = bool(item.get("isFree"))
+
+        entry: dict[str, str] = {}
+        if is_free:
+            entry["prompt"] = "0"
+            entry["completion"] = "0"
+        else:
+            if pricing.get("prompt"):
+                entry["prompt"] = str(pricing["prompt"])
+            if pricing.get("completion"):
+                entry["completion"] = str(pricing["completion"])
+        if pricing.get("input_cache_read"):
+            entry["input_cache_read"] = str(pricing["input_cache_read"])
+
+        if entry:
+            result[str(mid)] = entry
+
+    _pricing_cache[cache_key] = result
+    return result
+
+
 def get_pricing_for_provider(provider: str, *, force_refresh: bool = False) -> dict[str, dict[str, str]]:
-    """Return live pricing for providers that support it (openrouter, nous, ai-gateway, novita)."""
+    """Return live pricing for providers that support it (openrouter, nous, ai-gateway, novita, kilocode)."""
     normalized = normalize_provider(provider)
     if normalized == "openrouter":
         return fetch_models_with_pricing(
@@ -2017,6 +2100,8 @@ def get_pricing_for_provider(provider: str, *, force_refresh: bool = False) -> d
                 # Sale chrome (pricing.original) is Nous Portal-only.
                 include_sale_original=True,
             )
+    if normalized == "kilocode":
+        return _fetch_kilocode_pricing(force_refresh=force_refresh)
     return {}
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2013,17 +2013,19 @@ def _fetch_kilocode_pricing(
     When ``isFree`` is True, pricing is set to ``"0"`` so the downstream
     ``_apply_pricing()`` logic naturally marks the model as free.
 
-    Results are cached keyed on the resolved base URL so a custom
-    ``KILOCODE_BASE_URL`` never serves another endpoint's pricing.
+    Results are cached keyed on a provider-namespaced resolved base URL so a
+    custom ``KILOCODE_BASE_URL`` never serves another endpoint's pricing —
+    and a base URL shared with another provider (e.g. a proxy) can't collide
+    in the shared cache.
     """
     api_key = _resolve_kilocode_api_key()
 
     base_url = os.getenv("KILOCODE_BASE_URL", "").strip() or "https://api.kilo.ai/api/gateway"
-    cache_key = base_url.rstrip("/")
+    cache_key = "kilocode:" + base_url.rstrip("/")
     if not force_refresh and cache_key in _pricing_cache:
         return _pricing_cache[cache_key]
 
-    url = cache_key + "/models"
+    url = base_url.rstrip("/") + "/models"
     headers: dict[str, str] = {
         "Accept": "application/json",
         "User-Agent": _HERMES_USER_AGENT,

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1,7 +1,9 @@
 """Tests for API-key provider support (z.ai/GLM, Kimi, MiniMax, AI Gateway)."""
 
+import email.message
 import json
 import os
+import urllib.error
 
 import pytest
 
@@ -1183,6 +1185,181 @@ class TestDeepInfraPricingFetcher:
         assert float(result["vendor/model-a"]["completion"]) == pytest.approx(0.3 / 1_000_000)
         assert "input_cache_read" in result["vendor/model-a"]
         assert "input_cache_read" not in result["vendor/model-b"]
+
+
+@pytest.fixture
+def _kilocode_cache_isolation(monkeypatch):
+    """Reset the shared _pricing_cache around each Kilo pricing test.
+
+    The Kilo fetcher keys _pricing_cache by the resolved base URL; without
+    resetting it, a simulated failure (negative cache) or a base-URL override
+    would leak into the next test in the same session.
+    """
+    import hermes_cli.models as _models_mod
+    monkeypatch.setattr(_models_mod, "_pricing_cache", {})
+    yield
+
+
+@pytest.mark.usefixtures("_kilocode_cache_isolation")
+class TestKilocodePricingFetcher:
+    """_fetch_kilocode_pricing maps Kilo's OpenRouter-shaped catalog (per-token
+    pricing + explicit isFree) into picker-shape strings, honors
+    KILOCODE_BASE_URL, and is wired into the get_pricing_for_provider
+    dispatch."""
+
+    def test_pricing_shape_and_dispatch(self, monkeypatch):
+        payload = {"data": [
+            {
+                "id": "vendor/model-paid",
+                "pricing": {
+                    "prompt": "0.000005",
+                    "completion": "0.000025",
+                    "input_cache_read": "0.000001",
+                },
+            },
+            {
+                "id": "vendor/model-free",
+                "isFree": True,
+                # Non-zero underlying cost — isFree must win over pricing
+                # (the kilo-auto/free router case).
+                "pricing": {"prompt": "0.000002", "completion": "0.000010"},
+            },
+            # Malformed records must be skipped, not crash the parser.
+            {"id": "vendor/no-pricing"},
+            {"id": ""},
+            "not-a-dict",
+        ]}
+        import hermes_cli.models as models
+        monkeypatch.setattr(
+            models,
+            "_urlopen_model_catalog_request",
+            _make_urlopen_returning(payload),
+        )
+        from hermes_cli.models import get_pricing_for_provider
+
+        # get_pricing_for_provider → _fetch_kilocode_pricing dispatch path
+        result = get_pricing_for_provider("kilocode")
+        assert set(result) == {"vendor/model-paid", "vendor/model-free"}
+        # Paid: per-token strings pass through unchanged.
+        assert result["vendor/model-paid"]["prompt"] == "0.000005"
+        assert result["vendor/model-paid"]["completion"] == "0.000025"
+        assert result["vendor/model-paid"]["input_cache_read"] == "0.000001"
+        # isFree: explicit zero mapping.
+        assert result["vendor/model-free"]["prompt"] == "0"
+        assert result["vendor/model-free"]["completion"] == "0"
+
+    def test_catalog_fetchable_without_api_key(self, monkeypatch):
+        """The Kilo catalog endpoint is public — no key, no gate."""
+        import hermes_cli.models as models
+        monkeypatch.delenv("KILOCODE_API_KEY", raising=False)
+        monkeypatch.setattr(
+            models,
+            "_urlopen_model_catalog_request",
+            _make_urlopen_returning({"data": [
+                {"id": "a/b", "pricing": {"prompt": "0.1", "completion": "0.2"}},
+            ]}),
+        )
+        from hermes_cli.models import get_pricing_for_provider
+
+        result = get_pricing_for_provider("kilocode")
+        assert set(result) == {"a/b"}
+
+    def test_default_base_uses_gateway_models_endpoint(self, monkeypatch):
+        """No KILOCODE_BASE_URL → default base + /models (doctor-probe
+        composition, same catalog as /api/openrouter/models)."""
+        import hermes_cli.models as models
+        monkeypatch.delenv("KILOCODE_BASE_URL", raising=False)
+        seen: dict[str, str] = {}
+
+        def fake_urlopen(req, timeout=None):
+            seen["url"] = req.full_url
+            return _make_urlopen_returning({"data": []})(req, timeout=timeout)
+
+        monkeypatch.setattr(models, "_urlopen_model_catalog_request", fake_urlopen)
+        from hermes_cli.models import _fetch_kilocode_pricing
+
+        _fetch_kilocode_pricing()
+        assert seen["url"] == "https://api.kilo.ai/api/gateway/models"
+
+    def test_base_url_override_controls_endpoint(self, monkeypatch):
+        """KILOCODE_BASE_URL override → catalog fetched from {base}/models."""
+        import hermes_cli.models as models
+        monkeypatch.setenv("KILOCODE_BASE_URL", "https://proxy.example.com/kilo")
+        seen: dict[str, str] = {}
+
+        def fake_urlopen(req, timeout=None):
+            seen["url"] = req.full_url
+            return _make_urlopen_returning({"data": [
+                {"id": "x/y", "pricing": {"prompt": "0.1", "completion": "0.2"}},
+            ]})(req, timeout=timeout)
+
+        monkeypatch.setattr(models, "_urlopen_model_catalog_request", fake_urlopen)
+        from hermes_cli.models import _fetch_kilocode_pricing
+
+        result = _fetch_kilocode_pricing()
+        assert seen["url"] == "https://proxy.example.com/kilo/models"
+        assert "x/y" in result
+
+    def test_network_failure_returns_empty(self, monkeypatch):
+        import hermes_cli.models as models
+        monkeypatch.setattr(
+            models,
+            "_urlopen_model_catalog_request",
+            lambda *a, **kw: (_ for _ in ()).throw(Exception("timeout")),
+        )
+        from hermes_cli.models import _fetch_kilocode_pricing
+
+        assert _fetch_kilocode_pricing() == {}
+
+    def test_custom_base_404_returns_empty_and_caches_negative(self, monkeypatch):
+        """A custom base that doesn't serve /models fails gracefully: {} with
+        no retry on the next call (negative cache), matching _fetch_novita_pricing."""
+        import hermes_cli.models as models
+        monkeypatch.setenv("KILOCODE_BASE_URL", "https://proxy.example.com/kilo")
+        call_count = {"n": 0}
+
+        def fake_urlopen(req, timeout=None):
+            call_count["n"] += 1
+            raise urllib.error.HTTPError(req.full_url, 404, "Not Found", email.message.Message(), None)
+
+        monkeypatch.setattr(models, "_urlopen_model_catalog_request", fake_urlopen)
+        from hermes_cli.models import _fetch_kilocode_pricing
+
+        assert _fetch_kilocode_pricing() == {}
+        assert _fetch_kilocode_pricing() == {}
+        assert call_count["n"] == 1  # failure cached — no immediate retry
+
+    def test_cache_hit_and_force_refresh(self, monkeypatch):
+        import hermes_cli.models as models
+        call_count = {"n": 0}
+        payload = {"data": [
+            {"id": "a/b", "pricing": {"prompt": "0.1", "completion": "0.2"}},
+        ]}
+
+        class _FakeResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                import json as _json
+                return _json.dumps(payload).encode()
+
+        def fake_urlopen(req, timeout=None):
+            call_count["n"] += 1
+            return _FakeResp()
+
+        monkeypatch.setattr(models, "_urlopen_model_catalog_request", fake_urlopen)
+        from hermes_cli.models import _fetch_kilocode_pricing
+
+        first = _fetch_kilocode_pricing()
+        second = _fetch_kilocode_pricing()
+        assert call_count["n"] == 1  # cache hit
+        third = _fetch_kilocode_pricing(force_refresh=True)
+        assert call_count["n"] == 2  # forced refetch
+        assert first == second == third
 
 
 class TestDeepInfraProviderProfile:

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1224,6 +1224,11 @@ class TestKilocodePricingFetcher:
                 # (the kilo-auto/free router case).
                 "pricing": {"prompt": "0.000002", "completion": "0.000010"},
             },
+            {
+                "id": "vendor/model-zero-numeric",
+                # Custom proxy reporting numeric zeros — must surface as "0".
+                "pricing": {"prompt": 0, "completion": 0.0},
+            },
             # Malformed records must be skipped, not crash the parser.
             {"id": "vendor/no-pricing"},
             {"id": ""},
@@ -1239,7 +1244,7 @@ class TestKilocodePricingFetcher:
 
         # get_pricing_for_provider → _fetch_kilocode_pricing dispatch path
         result = get_pricing_for_provider("kilocode")
-        assert set(result) == {"vendor/model-paid", "vendor/model-free"}
+        assert set(result) == {"vendor/model-paid", "vendor/model-free", "vendor/model-zero-numeric"}
         # Paid: per-token strings pass through unchanged.
         assert result["vendor/model-paid"]["prompt"] == "0.000005"
         assert result["vendor/model-paid"]["completion"] == "0.000025"
@@ -1247,6 +1252,10 @@ class TestKilocodePricingFetcher:
         # isFree: explicit zero mapping.
         assert result["vendor/model-free"]["prompt"] == "0"
         assert result["vendor/model-free"]["completion"] == "0"
+        # Numeric zero pricing (custom proxy) is surfaced, not dropped; the
+        # shared formatter maps both "0" and "0.0" to "free" downstream.
+        assert result["vendor/model-zero-numeric"]["prompt"] == "0"
+        assert result["vendor/model-zero-numeric"]["completion"] == "0.0"
 
     def test_catalog_fetchable_without_api_key(self, monkeypatch):
         """The Kilo catalog endpoint is public — no key, no gate."""


### PR DESCRIPTION
Adds a `_fetch_kilocode_pricing()` function and `kilocode` branch to `get_pricing_for_provider()` so the Desktop model picker shows pricing and "Free" badges for Kilo Gateway models.

The Kilo Gateway API returns `isFree` as an explicit boolean per model and full per-token pricing. This data was available but never fetched — `get_pricing_for_provider("kilocode")` fell through to `return {}`, causing `_apply_pricing()` to skip the entire provider.

## Scope

This is a bug fix in an existing integration, not a new third-party integration. The `kilocode` provider is already fully wired in the tree:

- Plugin: `plugins/model-providers/kilocode/__init__.py`
- Auth: `KILOCODE_API_KEY` in credential pool, env var resolution in `auth.py`
- Model discovery: `_PROVIDER_MODELS["kilocode"]` (models.py), `_MODELS_DEV_PREFERRED`, `_merge_with_models_dev()`
- Aggregator flag: `is_aggregator=True` in `providers.py`
- Aux model: `default_aux_model` in the plugin
- Doctor probe: hardcoded at `doctor.py`

Five other providers (openrouter, nous, novita, deepinfra, fireworks) already have pricing branches in `get_pricing_for_provider()`. This adds the missing branch for an already-integrated provider — same pattern, same conventions, same return format.

## Changes

- `hermes_cli/models.py`:
 - `_resolve_kilocode_api_key()` — env var resolver (same pattern as `_resolve_openrouter_api_key()`)
 - `_fetch_kilocode_pricing()` — fetcher that resolves `KILOCODE_BASE_URL` (default `https://api.kilo.ai/api/gateway`) and composes `{base}/models` — the same composition the doctor probe uses for Kilo connectivity checks
 - `kilocode` branch in `get_pricing_for_provider()` dispatch
 - Cache keyed by provider-namespaced resolved base URL (`"kilocode:" + base_url`) so a custom endpoint never displays another catalog's pricing
 - The catalog endpoint is public, so the API key is attached best-effort (same as the OpenRouter/Nous fetchers) rather than gating the fetch
 - Updated docstring
- `tests/hermes_cli/test_api_key_providers.py` — new `TestKilocodePricingFetcher` (dispatcher-level, mocked network, mirroring `TestDeepInfraPricingFetcher`): paid per-token values incl. cache-read, `isFree` zero-price mapping, malformed records, `KILOCODE_BASE_URL` override and default-endpoint composition, public catalog without a key, network failure + 404 negative caching, cache hit vs `force_refresh`

Zero changes to `_apply_pricing()`, `inventory.py`, or the frontend — the existing pipeline works unmodified once pricing data is supplied.

## Design decision: `isFree` vs zero-pricing inference

The Kilo API returns `isFree` as a top-level boolean, separate from pricing. This is used directly rather than inferring from zero pricing because some free models (e.g. `kilo-auto/free`) are routers with non-zero underlying costs. When `isFree` is True, pricing is set to `"0"` so the downstream `_apply_pricing()` logic (`is_free = inp == "free" and (out == "free" or out == "")`) naturally marks the model as free.

## Verification

```
$ python3 -c "from hermes_cli.models import get_pricing_for_provider; p = get_pricing_for_provider('kilocode'); print(len(p))"
349 models  (live; public endpoint, no key required)

$ env -u PYTHONPATH -u VIRTUAL_ENV venv/bin/python -m pytest tests/hermes_cli/test_api_key_providers.py -q
112 passed

$ python3 -c "from hermes_cli.models import get_pricing_for_provider; from hermes_cli.inventory import _apply_pricing; rows=[{'slug':'kilocode','models':['anthropic/claude-opus-4.6','kilo-auto/free']}]; _apply_pricing(rows); print(rows[0]['pricing'])"
{'anthropic/claude-opus-4.6': {'input': '$5.00', 'output': '$25.00', 'cache': '$0.50', 'free': False}, 'kilo-auto/free': {'input': 'free', 'output': 'free', 'cache': 'free', 'free': True}}
```

Mutation check: reverting the fetch rework to the pre-review shape (hard-coded URL + API-key gate + literal cache key) makes 5 of the 6 rework-specific tests fail; all pass on the fixed shape.

Rebased onto current main (the initial submission was created before several main catalog/provider commits).

Closes #68838
