### PR TITLE
fix(desktop): prefer rich resume transcript over thin runtime projection

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -80,6 +80,7 @@ import {
   chatMessageArraysEquivalent,
   isSessionGoneError,
   patchSessionWorkspace,
+  preferDisplayTranscript,
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
   resolveStoredSession,
@@ -137,7 +138,12 @@ function reconcileAuthoritativeMessages(
   liveProjection?: Pick<SessionResumeResponse, 'inflight' | 'queued' | 'session_id'>
 ): ChatMessage[] {
   const authoritative = toChatMessages(authoritativeMessages)
-  const withLiveProjection = liveProjection ? appendLiveSessionProjection(authoritative, liveProjection) : authoritative
+  // Runtime activate/resume can return a compressed model-context projection
+  // (or empty messages + inflight tails). Prefer a richer cached/persisted
+  // body for paint so switching back to a long session does not flash full
+  // history then collapse to only submitted prompts.
+  const displayBase = preferDisplayTranscript(authoritative, previousMessages)
+  const withLiveProjection = liveProjection ? appendLiveSessionProjection(displayBase, liveProjection) : displayBase
   const reconciled = reconcileResumeMessages(withLiveProjection, previousMessages)
   const withPendingTurn = preserveLocalPendingTurnMessages(reconciled, previousMessages)
 
@@ -891,6 +897,11 @@ export function useSessionActions({
         // skip converting/reconciling the resume payload entirely — on a
         // 1000+-message session that second conversion plus the deep
         // equivalence compare costs over a second of main-thread time.
+        //
+        // Exception: when resume carries inflight/queued tails, still merge so
+        // live turns are not lost — but merge onto the richer persisted body
+        // (see preferDisplayTranscript), never replace it with a thinner
+        // runtime projection.
         const resumedStoredSessionId = resumed.session_key || resumed.resumed
 
         const prefetchMatchesResumedSession =
@@ -903,8 +914,13 @@ export function useSessionActions({
             ? localSnapshot
             : (() => {
                 const previousMessages = resumedSameSelectedSession
-                  ? preserveLocalPendingTurnMessages(currentMessages, resumeStartMessages)
-                  : currentMessages
+                  ? preserveLocalPendingTurnMessages(
+                      prefetchApplied && localSnapshot.length > 0 ? localSnapshot : currentMessages,
+                      resumeStartMessages
+                    )
+                  : prefetchApplied && localSnapshot.length > 0
+                    ? localSnapshot
+                    : currentMessages
 
                 const resumedMessages = reconcileAuthoritativeMessages(resumed.messages, previousMessages, resumed)
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
+import { chatMessageText } from '@/lib/chat-messages'
 import { $approvalModes, approvalModeForProfile } from '@/store/approval-mode'
 import { $desktopOnboarding } from '@/store/onboarding'
 import { $activeGatewayProfile } from '@/store/profile'
@@ -13,11 +14,14 @@ import {
   chatMessagesEquivalent,
   chatPartsEquivalent,
   isSessionGoneError,
+  mergeResumeDisplayMessages,
+  preferDisplayTranscript,
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
   sessionMatchesStoredId,
   sessionShouldHaveTranscript,
-  toBranchMessages
+  toBranchMessages,
+  transcriptDisplayScore
 } from './utils'
 
 const msg = (id: string, role: ChatMessage['role'], text: string, extra: Partial<ChatMessage> = {}): ChatMessage =>
@@ -497,5 +501,50 @@ describe('appendLiveSessionProjection', () => {
     const stored = [msg('stored-user', 'user', 'earlier')]
 
     expect(appendLiveSessionProjection(stored, { session_id: 'runtime-1' })).toBe(stored)
+  })
+})
+
+describe('preferDisplayTranscript / mergeResumeDisplayMessages', () => {
+  it('keeps a rich cached transcript over an empty runtime + inflight projection', () => {
+    const cached = [
+      msg('u1', 'user', 'first question'),
+      msg('a1', 'assistant', 'detailed answer with tools and context from earlier turns'),
+      msg('u2', 'user', 'follow up'),
+      msg('a2', 'assistant', 'second detailed answer')
+    ]
+    const runtimeOnlyPrompt = [msg('u-live', 'user', 'only the latest prompt')]
+
+    expect(transcriptDisplayScore(cached)).toBeGreaterThan(transcriptDisplayScore(runtimeOnlyPrompt))
+    expect(preferDisplayTranscript(runtimeOnlyPrompt, cached)).toEqual(cached)
+
+    const merged = mergeResumeDisplayMessages([], cached, {
+      session_id: 'rt-1',
+      inflight: { user: 'only the latest prompt', assistant: '', streaming: true }
+    })
+
+    expect(merged.map(m => chatMessageText(m))).toEqual([
+      'first question',
+      'detailed answer with tools and context from earlier turns',
+      'follow up',
+      'second detailed answer',
+      'only the latest prompt',
+      ''
+    ])
+    expect(merged.some(m => m.role === 'assistant' && chatMessageText(m).includes('detailed answer'))).toBe(true)
+  })
+
+  it('prefers a richer persisted body over a compressed equal-ish runtime projection', () => {
+    const persisted = [
+      msg('u1', 'user', 'q1'),
+      msg('a1', 'assistant', 'long answer one '.repeat(20)),
+      msg('u2', 'user', 'q2'),
+      msg('a2', 'assistant', 'long answer two '.repeat(20))
+    ]
+    const compressedRuntime = [
+      msg('u-sum', 'user', '[PRIOR CONTEXT] summary of earlier work'),
+      msg('u2', 'user', 'q2')
+    ]
+
+    expect(preferDisplayTranscript(compressedRuntime, persisted)).toEqual(persisted)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -391,6 +391,75 @@ export function appendLiveSessionProjection(
   return projected.length ? [...messages, ...projected] : messages
 }
 
+/**
+ * Score a transcript for display richness. Runtime activate/resume payloads can
+ * be a compressed model-context projection (or empty + inflight tails) that is
+ * much thinner than the persisted SessionDB transcript. When switching back to
+ * a long session we must not let that thinner projection replace a richer
+ * paint — users see full history flash, then only submitted prompts remain.
+ */
+export function transcriptDisplayScore(messages: ChatMessage[]): number {
+  let score = 0
+
+  for (const message of messages) {
+    if (message.hidden) {
+      continue
+    }
+
+    const text = chatMessageText(message).trim()
+    const hasNonText = message.parts.some(part => part.type !== 'text' && part.type !== 'reasoning')
+
+    if (!text && !hasNonText) {
+      continue
+    }
+
+    // Prefer assistant substance over bare user prompts when deciding which
+    // projection is the display authority.
+    score += message.role === 'assistant' ? 4 : message.role === 'user' ? 1 : 2
+
+    if (text) {
+      score += Math.min(8, Math.ceil(text.length / 240))
+    }
+
+    if (hasNonText) {
+      score += 2
+    }
+  }
+
+  return score
+}
+
+/** Prefer the richer transcript for UI paint; ties keep `preferred`. */
+export function preferDisplayTranscript(preferred: ChatMessage[], alternate: ChatMessage[]): ChatMessage[] {
+  if (!alternate.length) {
+    return preferred
+  }
+
+  if (!preferred.length) {
+    return alternate
+  }
+
+  return transcriptDisplayScore(alternate) > transcriptDisplayScore(preferred) ? alternate : preferred
+}
+
+/**
+ * Build the chat view for a resume/activate payload.
+ *
+ * - Idle: a richer cached/persisted body wins over a compressed runtime body.
+ * - Live tails (inflight/queued) always append onto that body.
+ * - Never start from an empty runtime body just because inflight is set — that
+ *   wipes the full history down to "only the submitted prompt".
+ */
+export function mergeResumeDisplayMessages(
+  runtimeMessages: ChatMessage[],
+  previousMessages: ChatMessage[],
+  liveProjection?: Pick<SessionResumeResponse, 'inflight' | 'queued' | 'session_id'>
+): ChatMessage[] {
+  const base = preferDisplayTranscript(runtimeMessages, previousMessages)
+
+  return liveProjection ? appendLiveSessionProjection(base, liveProjection) : base
+}
+
 export interface BranchMessage {
   content: string
   role: ChatMessage['role']

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -326,7 +326,8 @@ describe('Hermes REST helpers', () => {
 
     expect(api).toHaveBeenCalledWith({
       path: '/api/sessions/session-1/messages?profile=xiaoxuxu',
-      profile: 'xiaoxuxu'
+      profile: 'xiaoxuxu',
+      timeoutMs: 60_000
     })
   })
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -574,7 +574,11 @@ export function getSessionMessages(id: string, profile?: string | null): Promise
 
   return window.hermesDesktop.api<SessionMessagesResponse>({
     ...(profile ? { profile } : {}),
-    path: `/api/sessions/${encodeURIComponent(id)}/messages${suffix}`
+    path: `/api/sessions/${encodeURIComponent(id)}/messages${suffix}`,
+    // Long/tool-heavy transcripts (MB-scale JSON) can exceed the default 15s
+    // fetch budget under load; a timeout here falls through to a thinner
+    // runtime projection and looks like "history vanished on switch-back".
+    timeoutMs: SESSION_LIST_REQUEST_TIMEOUT_MS
   })
 }
 


### PR DESCRIPTION
## Summary

Session switch-back could flash full chat history and then collapse to only the latest prompt when activate/resume returned a compressed or empty runtime body plus inflight tails.

- Score cached/persisted vs runtime transcripts and keep the richer one for paint
- Always append inflight/queued live tails onto that richer body
- Never replace a full persisted transcript with an empty runtime body just because inflight is set
- Raise `getSessionMessages` timeout so large/tool-heavy transcripts do not time out into the thin path

General Desktop session UX (not Hephaestus-specific). Extracted from a local follow-up that also had obsolete PR-stack install scripts; those scripts are intentionally omitted.

## Test plan

- [x] `npx vitest run --project ui src/app/session/hooks/use-session-actions/utils.test.ts src/app/session/hooks/use-session-actions.test.tsx src/hermes.test.ts` — 77 passed
- [ ] Manual: open a long session, switch away and back while a turn is live / just submitted; history should remain, with live tails appended