### PR TITLE
fix(whatsapp): end-to-end allowlisted group intake for multi-member chats

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -345,6 +345,13 @@ class GatewayAuthorizationMixin:
             chat_allowlist_env = {
                 Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_CHATS",
                 Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
+                # WhatsApp group allowlist is chat-scoped (group JIDs), same
+                # shape as Telegram's GROUP_ALLOWED_CHATS. Without this entry,
+                # messages that already passed the adapter's group_policy still
+                # fail the gateway user allowlist for non-DM-allowlisted
+                # senders — so other members' text/voice in an allowlisted
+                # group is silently unauthorized.
+                Platform.WHATSAPP: "WHATSAPP_GROUP_ALLOWED_USERS",
             }.get(source.platform, "")
             if chat_allowlist_env:
                 raw_chat_allowlist = os.getenv(chat_allowlist_env, "").strip()
@@ -354,7 +361,23 @@ class GatewayAuthorizationMixin:
                         for cid in raw_chat_allowlist.split(",")
                         if cid.strip()
                     }
-                    if "*" in allowed_group_ids or source.chat_id in allowed_group_ids:
+                    # WhatsApp JIDs: accept bare numeric id or full @g.us form.
+                    if source.platform == Platform.WHATSAPP:
+                        bare = source.chat_id.split("@", 1)[0]
+                        expanded = set()
+                        for cid in allowed_group_ids:
+                            expanded.add(cid)
+                            expanded.add(cid.split("@", 1)[0])
+                            if "@" not in cid:
+                                expanded.add(f"{cid}@g.us")
+                        allowed_group_ids = expanded
+                        if (
+                            "*" in allowed_group_ids
+                            or source.chat_id in allowed_group_ids
+                            or bare in allowed_group_ids
+                        ):
+                            return True
+                    elif "*" in allowed_group_ids or source.chat_id in allowed_group_ids:
                         return True
 
         # Bots admitted by {PLATFORM}_ALLOW_BOTS bypass the human allowlist (#4466).
@@ -403,6 +426,10 @@ class GatewayAuthorizationMixin:
         platform_group_chat_env_map = {
             Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_CHATS",
             Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
+            # Chat-scoped WhatsApp groups (JIDs). Must match the early
+            # chat_allowlist_env map above so the later group_chat_allowlist
+            # branch also authorizes allowlisted @g.us chats.
+            Platform.WHATSAPP: "WHATSAPP_GROUP_ALLOWED_USERS",
         }
         platform_allow_all_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOW_ALL_USERS",

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -357,6 +357,30 @@ def check_whatsapp_requirements() -> bool:
         return False
 
 
+def _resolve_allow_list_source(config_extra: dict, *config_keys: str, env_vars: tuple[str, ...] | list[str]):
+    """Resolve an allowlist source with explicit-empty-means-deny-all semantics.
+
+    If any of ``config_keys`` is present in ``config_extra`` (even if its
+    value is an empty list or empty string), that value wins and we never
+    fall back to the environment. Only when none of the config keys are
+    present at all do we fall back to the first non-empty env var in
+    ``env_vars``. This prevents an explicit ``allow_from: []`` in config
+    from silently widening to a stale environment allowlist.
+    """
+    for key in config_keys:
+        if key in config_extra:
+            return config_extra[key]
+    for env_var in env_vars:
+        value = os.getenv(env_var)
+        if value is not None and str(value).strip() != "":
+            return value
+    # Last env var wins even if empty so callers can still see "" vs None.
+    for env_var in env_vars:
+        if os.getenv(env_var) is not None:
+            return os.getenv(env_var)
+    return None
+
+
 class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     """
     WhatsApp adapter.
@@ -407,9 +431,40 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         ))
         self._reply_prefix: Optional[str] = config.extra.get("reply_prefix")
         self._dm_policy = str(config.extra.get("dm_policy") or os.getenv("WHATSAPP_DM_POLICY", "pairing")).strip().lower()
-        self._allow_from = self._coerce_allow_list(config.extra.get("allow_from") or config.extra.get("allowFrom"))
+        # Prefer PlatformConfig.extra (YAML / plugin bridge), then the documented
+        # env vars. Without the env fallback, a wizard/.env-only install ends up
+        # with dm_policy=allowlist and an EMPTY allowlist — every inbound DM and
+        # (with group_policy=allowlist) every group message is silently dropped
+        # after the bridge has already queued it. Mirrors WhatsApp Cloud
+        # (WHATSAPP_CLOUD_ALLOWED_USERS) and the documented WHATSAPP_* vars.
+        # Key-presence semantics: explicit empty config stays deny-all.
+        self._allow_from = self._coerce_allow_list(
+            _resolve_allow_list_source(
+                config.extra,
+                "allow_from",
+                "allowFrom",
+                env_vars=("WHATSAPP_ALLOWED_USERS", "WHATSAPP_ALLOW_FROM"),
+            )
+        )
+        # WHATSAPP_ALLOW_ALL_USERS=* / true is the documented open-DM opt-in.
+        # Only apply when no allowlist source was configured at all.
+        _allow_all = (os.getenv("WHATSAPP_ALLOW_ALL_USERS") or "").strip().lower()
+        if (
+            not self._allow_from
+            and "allow_from" not in config.extra
+            and "allowFrom" not in config.extra
+            and _allow_all in {"true", "1", "yes", "on", "*"}
+        ):
+            self._allow_from = {"*"}
         self._group_policy = str(config.extra.get("group_policy") or os.getenv("WHATSAPP_GROUP_POLICY", "pairing")).strip().lower()
-        self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
+        self._group_allow_from = self._coerce_allow_list(
+            _resolve_allow_list_source(
+                config.extra,
+                "group_allow_from",
+                "groupAllowFrom",
+                env_vars=("WHATSAPP_GROUP_ALLOWED_USERS", "WHATSAPP_GROUP_ALLOW_FROM"),
+            )
+        )
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -33,6 +33,8 @@ import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
+import { classifyFromMeGroupGate } from './from_me_group_gate.js';
+import { shouldEnforceDmSenderAllowlist } from './dm_allowlist_scope.js';
 import {
   buildPollPayload,
   buildLocationPayload,
@@ -546,17 +548,46 @@ async function startSocket() {
       // Handle fromMe messages based on mode
       let fromOwner = false;
       if (msg.key.fromMe) {
-        if (isGroup || chatId.includes('status')) {
+        const isStatus = chatId.includes('status');
+        const groupDecision = classifyFromMeGroupGate({
+          isGroup,
+          fromMe: true,
+          isStatus,
+          mode: WHATSAPP_MODE,
+          forwardOwnerMessages: FORWARD_OWNER_MESSAGES,
+          recentlySent: recentlySentIds.has(msg.key.id),
+        });
+        if (groupDecision.action === 'drop_status') {
           emitDebugEvent({
             stage: 'ignored',
-            reason: isGroup ? 'from_me_group' : 'from_me_status',
+            reason: 'from_me_status',
             chatId: redactWhatsAppId(chatId),
           });
           continue;
         }
-
-        if (WHATSAPP_MODE === 'bot') {
-          // Bot mode: separate bot number. fromMe inbound is either
+        if (groupDecision.action === 'drop_echo') {
+          continue;
+        }
+        if (groupDecision.action === 'drop_from_me_group') {
+          emitDebugEvent({
+            stage: 'ignored',
+            reason: 'from_me_group',
+            chatId: redactWhatsAppId(chatId),
+          });
+          try {
+            console.log(JSON.stringify({
+              event: 'ignored',
+              reason: 'from_me_group',
+              chatId,
+              senderId,
+            }));
+          } catch {}
+          continue;
+        }
+        if (groupDecision.action === 'forward_owner') {
+          fromOwner = true;
+        } else if (WHATSAPP_MODE === 'bot') {
+          // Bot mode DM: fromMe inbound is either
           //   (a) an echo of our own /send (recentlySentIds will catch it), or
           //   (b) a message the owner typed from their own phone using the
           //       linked-device session.
@@ -634,7 +665,18 @@ async function startSocket() {
           } catch {}
           continue;
         }
-        if (WHATSAPP_DM_POLICY !== 'pairing' && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
+        // DM allowlist applies to direct chats only. Group chats are gated by
+        // WHATSAPP_GROUP_POLICY / WHATSAPP_GROUP_ALLOWED_USERS in the Python
+        // adapter — applying the DM sender allowlist here blocked every
+        // non-owner participant (and made allowlisted groups look "dead").
+        if (
+          shouldEnforceDmSenderAllowlist({
+            isGroup,
+            fromMe: false,
+            dmPolicy: WHATSAPP_DM_POLICY,
+          })
+          && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)
+        ) {
           try {
             console.log(JSON.stringify({
               event: 'ignored',

--- a/scripts/whatsapp-bridge/dm_allowlist_scope.js
+++ b/scripts/whatsapp-bridge/dm_allowlist_scope.js
@@ -1,0 +1,24 @@
+/**
+ * Decide whether the DM sender allowlist should run for this inbound.
+ *
+ * Group chats are gated by WHATSAPP_GROUP_POLICY / WHATSAPP_GROUP_ALLOWED_USERS
+ * on the Python adapter. Applying WHATSAPP_ALLOWED_USERS (DM sender allowlist)
+ * to group participants blocked every non-owner member and made allowlisted
+ * support groups look "dead".
+ *
+ * @param {object} opts
+ * @param {boolean} opts.isGroup
+ * @param {boolean} opts.fromMe
+ * @param {string}  opts.dmPolicy   WHATSAPP_DM_POLICY
+ * @returns {boolean} true if the bridge should enforce the DM sender allowlist
+ */
+export function shouldEnforceDmSenderAllowlist({
+  isGroup = false,
+  fromMe = false,
+  dmPolicy = 'allowlist',
+} = {}) {
+  if (fromMe) return false;
+  if (isGroup) return false;
+  if (dmPolicy === 'pairing') return false;
+  return true;
+}

--- a/scripts/whatsapp-bridge/dm_allowlist_scope.test.mjs
+++ b/scripts/whatsapp-bridge/dm_allowlist_scope.test.mjs
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { shouldEnforceDmSenderAllowlist } from './dm_allowlist_scope.js';
+
+test('DM stranger under allowlist policy is enforced', () => {
+  assert.equal(
+    shouldEnforceDmSenderAllowlist({
+      isGroup: false,
+      fromMe: false,
+      dmPolicy: 'allowlist',
+    }),
+    true,
+  );
+});
+
+test('group messages never run the DM sender allowlist', () => {
+  assert.equal(
+    shouldEnforceDmSenderAllowlist({
+      isGroup: true,
+      fromMe: false,
+      dmPolicy: 'allowlist',
+    }),
+    false,
+  );
+});
+
+test('pairing policy skips bridge allowlist (Python pairing handles it)', () => {
+  assert.equal(
+    shouldEnforceDmSenderAllowlist({
+      isGroup: false,
+      fromMe: false,
+      dmPolicy: 'pairing',
+    }),
+    false,
+  );
+});
+
+test('fromMe never runs the stranger DM allowlist', () => {
+  assert.equal(
+    shouldEnforceDmSenderAllowlist({
+      isGroup: false,
+      fromMe: true,
+      dmPolicy: 'allowlist',
+    }),
+    false,
+  );
+});

--- a/scripts/whatsapp-bridge/from_me_group_gate.js
+++ b/scripts/whatsapp-bridge/from_me_group_gate.js
@@ -1,0 +1,55 @@
+/**
+ * Pure classifier for fromMe messages that land in a WhatsApp group.
+ *
+ * Stock Hermes dropped every fromMe group message (`from_me_group`), which
+ * blocked two legitimate paths:
+ *   1. self-chat mode operators talking to the agent in a group
+ *   2. bot-mode personal-number deployments where the linked phone is the
+ *      owner's own number and they type in an allowlisted group
+ *
+ * Group membership / group_policy is enforced on the Python side
+ * (WHATSAPP_GROUP_ALLOWED_USERS). This gate only decides whether the
+ * bridge should forward a fromMe group message at all.
+ *
+ * @param {object} opts
+ * @param {boolean} opts.isGroup
+ * @param {boolean} opts.fromMe
+ * @param {boolean} opts.isStatus
+ * @param {string}  opts.mode                 'bot' | 'self-chat'
+ * @param {boolean} opts.forwardOwnerMessages WHATSAPP_FORWARD_OWNER_MESSAGES
+ * @param {boolean} opts.recentlySent         true if this message id was our /send
+ * @returns {{ action: 'not_applicable'|'drop_status'|'drop_echo'|'drop_from_me_group'|'forward_owner' }}
+ */
+export function classifyFromMeGroupGate({
+  isGroup = false,
+  fromMe = false,
+  isStatus = false,
+  mode = 'bot',
+  forwardOwnerMessages = false,
+  recentlySent = false,
+} = {}) {
+  if (!fromMe) {
+    return { action: 'not_applicable' };
+  }
+  if (isStatus) {
+    return { action: 'drop_status' };
+  }
+  if (!isGroup) {
+    return { action: 'not_applicable' };
+  }
+  if (recentlySent) {
+    return { action: 'drop_echo' };
+  }
+  // Self-chat: the linked account is the only speaker the agent ever sees.
+  // Group fromMe must reach Python so group_policy / group_allow_from apply.
+  if (mode === 'self-chat') {
+    return { action: 'forward_owner' };
+  }
+  // Bot mode: only when the operator opts into owner-typed forwards
+  // (personal-number bot testing). Default stays drop_from_me_group so
+  // dedicated bot-number deployments are unchanged.
+  if (forwardOwnerMessages) {
+    return { action: 'forward_owner' };
+  }
+  return { action: 'drop_from_me_group' };
+}

--- a/scripts/whatsapp-bridge/from_me_group_gate.test.mjs
+++ b/scripts/whatsapp-bridge/from_me_group_gate.test.mjs
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { classifyFromMeGroupGate } from './from_me_group_gate.js';
+
+test('non-fromMe is not applicable', () => {
+  assert.equal(
+    classifyFromMeGroupGate({ isGroup: true, fromMe: false }).action,
+    'not_applicable',
+  );
+});
+
+test('status broadcasts always drop', () => {
+  assert.equal(
+    classifyFromMeGroupGate({
+      isGroup: false,
+      fromMe: true,
+      isStatus: true,
+    }).action,
+    'drop_status',
+  );
+});
+
+test('fromMe DM is not applicable (handled by owner_message_gate)', () => {
+  assert.equal(
+    classifyFromMeGroupGate({
+      isGroup: false,
+      fromMe: true,
+      mode: 'bot',
+      forwardOwnerMessages: true,
+    }).action,
+    'not_applicable',
+  );
+});
+
+test('bot mode drops group fromMe by default', () => {
+  assert.equal(
+    classifyFromMeGroupGate({
+      isGroup: true,
+      fromMe: true,
+      mode: 'bot',
+      forwardOwnerMessages: false,
+    }).action,
+    'drop_from_me_group',
+  );
+});
+
+test('bot mode forwards group fromMe when FORWARD_OWNER_MESSAGES is on', () => {
+  assert.equal(
+    classifyFromMeGroupGate({
+      isGroup: true,
+      fromMe: true,
+      mode: 'bot',
+      forwardOwnerMessages: true,
+    }).action,
+    'forward_owner',
+  );
+});
+
+test('self-chat mode always forwards group fromMe', () => {
+  assert.equal(
+    classifyFromMeGroupGate({
+      isGroup: true,
+      fromMe: true,
+      mode: 'self-chat',
+      forwardOwnerMessages: false,
+    }).action,
+    'forward_owner',
+  );
+});
+
+test('echo of our own /send is dropped even when forward is enabled', () => {
+  assert.equal(
+    classifyFromMeGroupGate({
+      isGroup: true,
+      fromMe: true,
+      mode: 'bot',
+      forwardOwnerMessages: true,
+      recentlySent: true,
+    }).action,
+    'drop_echo',
+  );
+});

--- a/tests/gateway/test_whatsapp_baileys_allowlist_env.py
+++ b/tests/gateway/test_whatsapp_baileys_allowlist_env.py
@@ -1,0 +1,121 @@
+"""Regression: Baileys WhatsApp adapter must honor documented env allowlists.
+
+Wizard / .env-only installs write WHATSAPP_ALLOWED_USERS and
+WHATSAPP_GROUP_ALLOWED_USERS but leave PlatformConfig.extra empty. Before
+this fix the adapter only read allow_from / group_allow_from from extra,
+so dm_policy=allowlist + a non-empty env allowlist still ran with an empty
+set and silently dropped every inbound after the bridge queued it.
+
+Mirrors the WhatsApp Cloud salvage (PR #58504 / #58448) and adopts
+key-presence semantics so explicit allow_from: [] stays deny-all even when
+a stale env allowlist is present (review feedback on #61924).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _build_adapter(monkeypatch, tmp_path, extra=None, env=None):
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    monkeypatch.setattr(WhatsAppAdapter, "_DEFAULT_BRIDGE_DIR", tmp_path / "bridge")
+
+    for key in (
+        "WHATSAPP_ALLOWED_USERS",
+        "WHATSAPP_ALLOW_FROM",
+        "WHATSAPP_ALLOW_ALL_USERS",
+        "WHATSAPP_GROUP_ALLOWED_USERS",
+        "WHATSAPP_GROUP_ALLOW_FROM",
+        "WHATSAPP_DM_POLICY",
+        "WHATSAPP_GROUP_POLICY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in (env or {}).items():
+        monkeypatch.setenv(key, value)
+
+    config = PlatformConfig(enabled=True, extra=extra or {})
+    return WhatsAppAdapter(config)
+
+
+def test_dm_allowlist_falls_back_to_env_var(monkeypatch, tmp_path):
+    adapter = _build_adapter(
+        monkeypatch,
+        tmp_path,
+        extra={"dm_policy": "allowlist"},
+        env={"WHATSAPP_ALLOWED_USERS": "15551234567,15557654321"},
+    )
+    assert adapter._allow_from == {"15551234567", "15557654321"}
+
+
+def test_group_allowlist_falls_back_to_env_var(monkeypatch, tmp_path):
+    adapter = _build_adapter(
+        monkeypatch,
+        tmp_path,
+        extra={"group_policy": "allowlist"},
+        env={"WHATSAPP_GROUP_ALLOWED_USERS": "120363001234567890@g.us"},
+    )
+    assert adapter._group_allow_from == {"120363001234567890@g.us"}
+
+
+def test_group_allow_from_legacy_env_alias(monkeypatch, tmp_path):
+    adapter = _build_adapter(
+        monkeypatch,
+        tmp_path,
+        env={"WHATSAPP_GROUP_ALLOW_FROM": "120363009999999999@g.us"},
+    )
+    assert "120363009999999999@g.us" in adapter._group_allow_from
+
+
+def test_explicit_empty_allow_from_does_not_fallback_to_env(monkeypatch, tmp_path):
+    adapter = _build_adapter(
+        monkeypatch,
+        tmp_path,
+        extra={"dm_policy": "allowlist", "allow_from": []},
+        env={"WHATSAPP_ALLOWED_USERS": "15551234567"},
+    )
+    # Explicit empty config must stay deny-all (no silent widen via env).
+    assert adapter._allow_from == set()
+
+
+def test_explicit_empty_group_allow_from_does_not_fallback_to_env(monkeypatch, tmp_path):
+    adapter = _build_adapter(
+        monkeypatch,
+        tmp_path,
+        extra={"group_policy": "allowlist", "group_allow_from": []},
+        env={"WHATSAPP_GROUP_ALLOWED_USERS": "120363001234567890@g.us"},
+    )
+    assert adapter._group_allow_from == set()
+
+
+def test_config_extra_wins_over_env(monkeypatch, tmp_path):
+    adapter = _build_adapter(
+        monkeypatch,
+        tmp_path,
+        extra={"allow_from": ["15550000001"]},
+        env={"WHATSAPP_ALLOWED_USERS": "15559999999"},
+    )
+    assert adapter._allow_from == {"15550000001"}
+
+
+def test_allow_all_users_opts_in_when_no_allowlist_configured(monkeypatch, tmp_path):
+    adapter = _build_adapter(
+        monkeypatch,
+        tmp_path,
+        env={"WHATSAPP_ALLOW_ALL_USERS": "true"},
+    )
+    assert adapter._allow_from == {"*"}
+
+
+def test_allow_all_users_does_not_override_explicit_empty(monkeypatch, tmp_path):
+    adapter = _build_adapter(
+        monkeypatch,
+        tmp_path,
+        extra={"allow_from": []},
+        env={"WHATSAPP_ALLOW_ALL_USERS": "true"},
+    )
+    assert adapter._allow_from == set()

--- a/tests/gateway/test_whatsapp_group_chat_authz.py
+++ b/tests/gateway/test_whatsapp_group_chat_authz.py
@@ -1,0 +1,145 @@
+"""Gateway authz must treat WHATSAPP_GROUP_ALLOWED_USERS as chat-scoped.
+
+WHATSAPP_GROUP_ALLOWED_USERS holds group JIDs (same shape as
+TELEGRAM_GROUP_ALLOWED_CHATS), not sender user IDs. Without wiring it into
+GatewayAuthorizationMixin's chat-allowlist maps, a message that already
+passed the adapter's group_policy still hits Unauthorized user for any
+sender who is not also on WHATSAPP_ALLOWED_USERS — so customer-support
+groups only work for the owner DM allowlist.
+
+This is the multi-member / support-group path: any participant in an
+allowlisted @g.us chat is authorized; DMs stay on the DM allowlist.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from gateway.authz_mixin import GatewayAuthorizationMixin
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+class _Authz(GatewayAuthorizationMixin):
+    def __init__(self):
+        self.adapters = {}
+        self.config = None
+        self.pairing_store = None
+        self.pairing_stores = {}
+
+
+def _clear_allow_env(monkeypatch):
+    for key in list(os.environ):
+        if any(
+            tok in key
+            for tok in (
+                "ALLOW",
+                "WHATSAPP",
+                "GATEWAY",
+                "TELEGRAM",
+                "DISCORD",
+                "SIGNAL",
+                "SLACK",
+            )
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+
+def _src(**kwargs) -> SessionSource:
+    return SessionSource(platform=Platform.WHATSAPP, **kwargs)
+
+
+def test_allowlisted_group_authorizes_any_member(monkeypatch):
+    _clear_allow_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "15550000001")
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "120363001234567890@g.us")
+    authz = _Authz()
+
+    assert authz._is_user_authorized(
+        _src(
+            chat_id="120363001234567890@g.us",
+            chat_type="group",
+            user_id="999888777@lid",
+            user_name="Customer",
+        )
+    )
+    assert authz._is_user_authorized(
+        _src(
+            chat_id="120363001234567890@g.us",
+            chat_type="group",
+            user_id="15550000001",
+            user_name="Owner",
+        )
+    )
+
+
+def test_non_allowlisted_group_still_denies_strangers(monkeypatch):
+    _clear_allow_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "15550000001")
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "120363001234567890@g.us")
+    authz = _Authz()
+
+    assert not authz._is_user_authorized(
+        _src(
+            chat_id="120363009999999999@g.us",
+            chat_type="group",
+            user_id="999888777@lid",
+            user_name="Customer",
+        )
+    )
+
+
+def test_dm_stranger_still_denied(monkeypatch):
+    _clear_allow_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "15550000001")
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "120363001234567890@g.us")
+    authz = _Authz()
+
+    assert not authz._is_user_authorized(
+        _src(
+            chat_id="999888777@s.whatsapp.net",
+            chat_type="dm",
+            user_id="999888777",
+            user_name="Stranger",
+        )
+    )
+    assert authz._is_user_authorized(
+        _src(
+            chat_id="15550000001@s.whatsapp.net",
+            chat_type="dm",
+            user_id="15550000001",
+            user_name="Owner",
+        )
+    )
+
+
+def test_bare_group_id_in_env_matches_full_jid(monkeypatch):
+    _clear_allow_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "120363001234567890")
+    authz = _Authz()
+
+    assert authz._is_user_authorized(
+        _src(
+            chat_id="120363001234567890@g.us",
+            chat_type="group",
+            user_id="anyone@lid",
+            user_name="Customer",
+        )
+    )
+
+
+def test_wildcard_group_allowlist(monkeypatch):
+    _clear_allow_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "*")
+    authz = _Authz()
+
+    assert authz._is_user_authorized(
+        _src(
+            chat_id="120363001234567890@g.us",
+            chat_type="group",
+            user_id="anyone@lid",
+            user_name="Customer",
+        )
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes the full path that makes **allowlisted WhatsApp groups dead for anyone who is not also on the DM allowlist** — the customer-support / multi-member group use case.

A message from a non-owner group member currently dies at up to three independent gates even when `WHATSAPP_GROUP_ALLOWED_USERS` contains that group's JID:

| Layer | Bug | Effect |
|-------|-----|--------|
| **Baileys adapter** | `_allow_from` / `_group_allow_from` only read `config.extra`, never the documented env vars | Wizard / `.env`-only installs run `*_policy=allowlist` with an **empty** set → every inbound silently dropped after the bridge queues it |
| **Bridge** | DM sender allowlist (`WHATSAPP_ALLOWED_USERS`) applied to **group** participants | Non-owner members never leave the Node process (`allowlist_mismatch`) |
| **Gateway authz** | `WHATSAPP_GROUP_ALLOWED_USERS` not wired as a **chat-scoped** allowlist (unlike `TELEGRAM_GROUP_ALLOWED_CHATS`) | Adapter-accepted group traffic still hits `Unauthorized user` for members not on the DM allowlist |

Also forwards owner-typed (`fromMe`) group messages when `WHATSAPP_FORWARD_OWNER_MESSAGES=true` (personal-number bot) or `WHATSAPP_MODE=self-chat`, so operators can talk to the agent in groups. Default remains drop (`from_me_group`) for dedicated bot-number deployments.

**Why one PR (not three):** each layer alone still leaves the group looking dead. Reviewers cannot validate the customer-support path without all three. Pure classifiers are unit-tested so each gate stays reviewable in isolation.

### Related open PRs (partial coverage — this supersedes the E2E gap)

- Env adapter fallback only: #37452, #40245, #61924, #56769 (wrong path / labeled duplicate / group-only)
- Authz / broader: #53623 (CONFLICTING), #8278 (CONFLICTING)
- Bridge group allowlist: #43929 (CONFLICTING)
- Self-chat fromMe groups: #20429

Happy to close or coordinate if a maintainer prefers salvaging one of the above instead.

## Related Issue

Related to #7269 (group members unauthorized). Complements the WhatsApp Cloud env-allowlist salvage (#58504 / #58448) for the Baileys path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/whatsapp/adapter.py` — `_resolve_allow_list_source()` with **key-presence** semantics (explicit `allow_from: []` stays deny-all; no silent widen via stale env). Falls back to `WHATSAPP_ALLOWED_USERS` / `WHATSAPP_ALLOW_FROM` and `WHATSAPP_GROUP_ALLOWED_USERS` / `WHATSAPP_GROUP_ALLOW_FROM`. Optional `WHATSAPP_ALLOW_ALL_USERS` → `*` only when no config key present.
- `gateway/authz_mixin.py` — map `Platform.WHATSAPP` → `WHATSAPP_GROUP_ALLOWED_USERS` in both chat-allowlist maps; accept bare numeric group id or full `@g.us` JID.
- `scripts/whatsapp-bridge/dm_allowlist_scope.js` — pure helper: DM sender allowlist is **not** applied to groups.
- `scripts/whatsapp-bridge/from_me_group_gate.js` — pure helper: group `fromMe` forward rules (self-chat always; bot only with `WHATSAPP_FORWARD_OWNER_MESSAGES`; always drop status / `/send` echoes).
- `scripts/whatsapp-bridge/bridge.js` — wire both helpers.
- Tests: `test_whatsapp_baileys_allowlist_env.py`, `test_whatsapp_group_chat_authz.py`, `dm_allowlist_scope.test.mjs`, `from_me_group_gate.test.mjs`.

## How to Test

1. **Env-only allowlists (adapter)**
   ```bash
   ./scripts/run_tests.sh tests/gateway/test_whatsapp_baileys_allowlist_env.py
   ```
2. **Gateway group chat authz (any member in allowlisted @g.us)**
   ```bash
   ./scripts/run_tests.sh tests/gateway/test_whatsapp_group_chat_authz.py
   ```
3. **Bridge pure gates**
   ```bash
   cd scripts/whatsapp-bridge
   node --test dm_allowlist_scope.test.mjs from_me_group_gate.test.mjs allowlist.test.mjs owner_message_gate.test.mjs
   node --check bridge.js
   ```
4. **Existing suites still green**
   ```bash
   ./scripts/run_tests.sh tests/gateway/test_whatsapp_group_gating.py tests/gateway/test_whatsapp_from_owner.py tests/gateway/test_whatsapp_cloud_allowed_users.py
   ```
5. **Manual E2E (optional)**
   - `WHATSAPP_MODE=bot`
   - `WHATSAPP_DM_POLICY=allowlist` + `WHATSAPP_ALLOWED_USERS=<owner phone only>`
   - `WHATSAPP_GROUP_POLICY=allowlist` + `WHATSAPP_GROUP_ALLOWED_USERS=<group JID>`
   - Non-owner member texts the group → agent replies
   - Stranger DM still denied
   - With `WHATSAPP_FORWARD_OWNER_MESSAGES=true`, owner-typed group message is processed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(targeted WhatsApp / authz suites above — 66 Python + 24 Node)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(behavior matches already-documented env vars; no new keys)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(Node + Python pure logic, no OS-specific paths)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Security / defaults

| Path | Before | After |
|------|--------|-------|
| Env-only DM allowlist | empty set → drop all | honors `WHATSAPP_ALLOWED_USERS` |
| Explicit `allow_from: []` + stale env | could widen via `or` chain | stays deny-all (key-presence) |
| Allowlisted group, non-owner member | bridge and/or authz drop | authorized |
| Non-allowlisted group | drop | drop |
| Stranger DM | drop / pair per policy | unchanged |
| Group `fromMe` (bot, flag off) | drop | drop (unchanged default) |
| Group `fromMe` (flag on / self-chat) | drop | forward + Python group gates |

## Screenshots / Logs

Local validation:

```
Python: 66 passed (baileys env, group authz, group gating, from_owner, cloud allowed users, lid resolution)
Node:   24 passed (dm_allowlist_scope, from_me_group_gate, allowlist, owner_message_gate)
```