### PR TITLE
fix(kanban): gate dependencies on semantic verdicts

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3401,6 +3401,37 @@ _GATE_VERDICT_RE = re.compile(
     r"RELEASE_READY|DEPLOYED|READY_FOR_CONFIRMATION)\b",
     re.IGNORECASE,
 )
+_GATE_TITLE_RE = re.compile(
+    r"^\s*\[(?:re-?review|review(?:\+qa)?|qa|release)(?:[^\]]*)\]",
+    re.IGNORECASE,
+)
+_REMEDIATION_TITLE_RE = re.compile(
+    r"^\s*(?:\[fix(?:[^\]]*)\]|fix:)",
+    re.IGNORECASE,
+)
+
+
+def _is_gate_task(assignee: object, title: object) -> bool:
+    """Return whether a task is a semantic Review/QA/Release gate.
+
+    Assignee is authoritative.  The anchored title fallback preserves older
+    boards without letting incidental text such as ``[Release notes]`` in the
+    middle of an implementation title turn that task into a gate.
+    """
+    return (
+        str(assignee or "").lower() in _GATE_ASSIGNEES
+        or bool(_GATE_TITLE_RE.match(str(title or "")))
+    )
+
+
+def _latest_completed_run(conn: sqlite3.Connection, task_id: str) -> Optional[Run]:
+    """Return the newest completed attempt for semantic-verdict readback."""
+    row = conn.execute(
+        "SELECT * FROM task_runs WHERE task_id = ? AND outcome = 'completed' "
+        "ORDER BY COALESCE(ended_at, started_at) DESC, id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    return Run.from_row(row) if row else None
 
 
 def _explicit_failed_gate_verdict(
@@ -3418,17 +3449,12 @@ def _explicit_failed_gate_verdict(
     ).fetchone()
     if task is None:
         return None
-    assignee = str(task["assignee"] or "").lower()
-    title = str(task["title"] or "").lower()
-    is_gate = (
-        assignee in _GATE_ASSIGNEES
-        or "[review" in title or "re-review" in title
-        or "[qa" in title or "[release" in title
-    )
-    if not is_gate:
+    if not _is_gate_task(task["assignee"], task["title"]):
         return None
 
-    run = latest_run(conn, task_id)
+    # A later crash/reclaim row must not erase the semantic result of the
+    # completed gate attempt.  This matches worker-context handoff readback.
+    run = _latest_completed_run(conn, task_id)
     metadata = run.metadata if run and isinstance(run.metadata, dict) else {}
     verdict = str(
         metadata.get("verdict") or metadata.get("gate_verdict") or ""
@@ -3445,6 +3471,8 @@ def _parent_dependency_satisfied(
     child_id: Optional[str] = None,
     child_title: Optional[str] = None,
     child_assignee: Optional[str] = None,
+    parent_status: Optional[str] = None,
+    failed_gate_cache: Optional[dict[str, Optional[str]]] = None,
 ) -> bool:
     """A terminal parent is satisfied unless it explicitly failed a gate.
 
@@ -3452,14 +3480,22 @@ def _parent_dependency_satisfied(
     to start *because* the parent gate failed.  Normal downstream QA/Release
     children remain held.
     """
-    row = conn.execute(
-        "SELECT status FROM tasks WHERE id = ?", (parent_id,)
-    ).fetchone()
-    if row is None or row["status"] not in ("done", "archived"):
+    if parent_status is None:
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
+        ).fetchone()
+        parent_status = str(row["status"]) if row is not None else None
+    if parent_status not in ("done", "archived"):
         return False
-    if row["status"] == "archived":
+    if parent_status == "archived":
         return True
-    if _explicit_failed_gate_verdict(conn, parent_id) is None:
+    if failed_gate_cache is None:
+        failed_verdict = _explicit_failed_gate_verdict(conn, parent_id)
+    else:
+        if parent_id not in failed_gate_cache:
+            failed_gate_cache[parent_id] = _explicit_failed_gate_verdict(conn, parent_id)
+        failed_verdict = failed_gate_cache[parent_id]
+    if failed_verdict is None:
         return True
     if child_id and (child_title is None or child_assignee is None):
         child = conn.execute(
@@ -3468,10 +3504,9 @@ def _parent_dependency_satisfied(
         if child is not None:
             child_title = str(child["title"] or "")
             child_assignee = str(child["assignee"] or "")
-    title = str(child_title or "").lower()
     assignee = str(child_assignee or "").lower()
-    return assignee == "vibe" and (
-        "[fix" in title or "remediation" in title or title.startswith("fix:")
+    return assignee == "vibe" and bool(
+        _REMEDIATION_TITLE_RE.match(str(child_title or ""))
     )
 
 
@@ -3510,8 +3545,9 @@ def recompute_ready(
         failure_limit = DEFAULT_FAILURE_LIMIT
     promoted = 0
     with write_txn(conn):
+        failed_gate_cache: dict[str, Optional[str]] = {}
         todo_rows = conn.execute(
-            "SELECT id, status, consecutive_failures, max_retries "
+            "SELECT id, title, assignee, status, consecutive_failures, max_retries "
             "FROM tasks WHERE status IN ('todo', 'blocked')"
         ).fetchall()
         for row in todo_rows:
@@ -3530,7 +3566,15 @@ def recompute_ready(
                 (task_id,),
             ).fetchall()
             if all(
-                _parent_dependency_satisfied(conn, p["id"], child_id=task_id)
+                _parent_dependency_satisfied(
+                    conn,
+                    p["id"],
+                    child_id=task_id,
+                    child_title=row["title"],
+                    child_assignee=row["assignee"],
+                    parent_status=p["status"],
+                    failed_gate_cache=failed_gate_cache,
+                )
                 for p in parents
             ):
                 if cur_status == "blocked":

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3392,11 +3392,11 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
 _GATE_ASSIGNEES = {"review", "qa", "release"}
 _FAILED_GATE_VERDICTS = {
     "REQUEST_CHANGES", "CHANGES_REQUESTED",
-    "QA_FAIL", "QA_FAILED", "FAIL",
+    "QA_FAIL", "QA_FAILED", "FAIL", "FAILED",
     "NOT_READY", "RELEASE_NOT_READY", "BLOCKED",
 }
 _GATE_VERDICT_RE = re.compile(
-    r"^\s*(REQUEST_CHANGES|CHANGES_REQUESTED|QA_FAIL(?:ED)?|FAIL|"
+    r"^\s*(REQUEST_CHANGES|CHANGES_REQUESTED|QA_FAIL(?:ED)?|FAIL(?:ED)?|"
     r"NOT_READY|RELEASE_NOT_READY|BLOCKED|APPROVE(?:D)?|QA_PASS|PASS|"
     r"RELEASE_READY|DEPLOYED|READY_FOR_CONFIRMATION)\b",
     re.IGNORECASE,
@@ -3418,17 +3418,17 @@ def _is_gate_task(assignee: object, title: object) -> bool:
     boards without letting incidental text such as ``[Release notes]`` in the
     middle of an implementation title turn that task into a gate.
     """
-    return (
-        str(assignee or "").lower() in _GATE_ASSIGNEES
-        or bool(_GATE_TITLE_RE.match(str(title or "")))
-    )
+    normalized_assignee = str(assignee or "").strip().lower()
+    if normalized_assignee:
+        return normalized_assignee in _GATE_ASSIGNEES
+    return bool(_GATE_TITLE_RE.match(str(title or "")))
 
 
 def _latest_completed_run(conn: sqlite3.Connection, task_id: str) -> Optional[Run]:
     """Return the newest completed attempt for semantic-verdict readback."""
     row = conn.execute(
         "SELECT * FROM task_runs WHERE task_id = ? AND outcome = 'completed' "
-        "ORDER BY COALESCE(ended_at, started_at) DESC, id DESC LIMIT 1",
+        "ORDER BY COALESCE(ended_at, started_at, 0) DESC, id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
     return Run.from_row(row) if row else None
@@ -3441,8 +3441,9 @@ def _explicit_failed_gate_verdict(
 
     Backward compatibility is deliberate: old terminal cards with no typed or
     anchored verdict retain the historical status-only behaviour.  New gate
-    workers are required to emit structured metadata, so an explicit failure
-    can be held without freezing legacy boards.
+    workers are required to emit structured metadata and repeat the verdict as
+    the summary's first token.  The fallback intentionally matches that first
+    token only; scanning arbitrary prose would create false-positive gates.
     """
     task = conn.execute(
         "SELECT assignee, title, result FROM tasks WHERE id = ?", (task_id,)
@@ -3461,7 +3462,7 @@ def _explicit_failed_gate_verdict(
     ).upper().strip()
     if not verdict:
         summary = str((run.summary if run else None) or task["result"] or "")
-        match = _GATE_VERDICT_RE.search(summary)
+        match = _GATE_VERDICT_RE.match(summary)
         verdict = match.group(1).upper() if match else ""
     return verdict if verdict in _FAILED_GATE_VERDICTS else None
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2596,13 +2596,15 @@ def create_task(
                         missing = _find_missing_parents(conn, parents)
                         if missing:
                             raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
-                        # If any parent is not yet done, we're todo.
-                        rows = conn.execute(
-                            "SELECT status FROM tasks WHERE id IN "
-                            "(" + ",".join("?" * len(parents)) + ")",
-                            parents,
-                        ).fetchall()
-                        if any(r["status"] != "done" for r in rows):
+                        # A done gate with an explicit failure verdict is not a
+                        # satisfied dependency (#D-012).
+                        if any(
+                            not _parent_dependency_satisfied(
+                                conn, parent_id,
+                                child_title=title, child_assignee=assignee,
+                            )
+                            for parent_id in parents
+                        ):
                             task_status = "todo"
                 # Even in triage mode we still need to validate parent ids
                 # so the eventual link rows don't dangle.
@@ -2826,11 +2828,8 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
             (parent_id, child_id),
         )
-        # If child was ready but parent is not yet done, demote child to todo.
-        parent_status = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
-        ).fetchone()["status"]
-        if parent_status != "done":
+        # Failed semantic gates demote just like unfinished parents.
+        if not _parent_dependency_satisfied(conn, parent_id, child_id=child_id):
             conn.execute(
                 "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (child_id,),
@@ -3390,6 +3389,92 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     return bool(row) and row["kind"] == "blocked"
 
 
+_GATE_ASSIGNEES = {"review", "qa", "release"}
+_FAILED_GATE_VERDICTS = {
+    "REQUEST_CHANGES", "CHANGES_REQUESTED",
+    "QA_FAIL", "QA_FAILED", "FAIL",
+    "NOT_READY", "RELEASE_NOT_READY", "BLOCKED",
+}
+_GATE_VERDICT_RE = re.compile(
+    r"^\s*(REQUEST_CHANGES|CHANGES_REQUESTED|QA_FAIL(?:ED)?|FAIL|"
+    r"NOT_READY|RELEASE_NOT_READY|BLOCKED|APPROVE(?:D)?|QA_PASS|PASS|"
+    r"RELEASE_READY|DEPLOYED|READY_FOR_CONFIRMATION)\b",
+    re.IGNORECASE,
+)
+
+
+def _explicit_failed_gate_verdict(
+    conn: sqlite3.Connection, task_id: str,
+) -> Optional[str]:
+    """Return an explicit failed gate verdict for ``task_id``, if any.
+
+    Backward compatibility is deliberate: old terminal cards with no typed or
+    anchored verdict retain the historical status-only behaviour.  New gate
+    workers are required to emit structured metadata, so an explicit failure
+    can be held without freezing legacy boards.
+    """
+    task = conn.execute(
+        "SELECT assignee, title, result FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    if task is None:
+        return None
+    assignee = str(task["assignee"] or "").lower()
+    title = str(task["title"] or "").lower()
+    is_gate = (
+        assignee in _GATE_ASSIGNEES
+        or "[review" in title or "re-review" in title
+        or "[qa" in title or "[release" in title
+    )
+    if not is_gate:
+        return None
+
+    run = latest_run(conn, task_id)
+    metadata = run.metadata if run and isinstance(run.metadata, dict) else {}
+    verdict = str(
+        metadata.get("verdict") or metadata.get("gate_verdict") or ""
+    ).upper().strip()
+    if not verdict:
+        summary = str((run.summary if run else None) or task["result"] or "")
+        match = _GATE_VERDICT_RE.search(summary)
+        verdict = match.group(1).upper() if match else ""
+    return verdict if verdict in _FAILED_GATE_VERDICTS else None
+
+
+def _parent_dependency_satisfied(
+    conn: sqlite3.Connection, parent_id: str, *,
+    child_id: Optional[str] = None,
+    child_title: Optional[str] = None,
+    child_assignee: Optional[str] = None,
+) -> bool:
+    """A terminal parent is satisfied unless it explicitly failed a gate.
+
+    A narrow remediation child is the only exception: the fix must be allowed
+    to start *because* the parent gate failed.  Normal downstream QA/Release
+    children remain held.
+    """
+    row = conn.execute(
+        "SELECT status FROM tasks WHERE id = ?", (parent_id,)
+    ).fetchone()
+    if row is None or row["status"] not in ("done", "archived"):
+        return False
+    if row["status"] == "archived":
+        return True
+    if _explicit_failed_gate_verdict(conn, parent_id) is None:
+        return True
+    if child_id and (child_title is None or child_assignee is None):
+        child = conn.execute(
+            "SELECT title, assignee FROM tasks WHERE id = ?", (child_id,)
+        ).fetchone()
+        if child is not None:
+            child_title = str(child["title"] or "")
+            child_assignee = str(child["assignee"] or "")
+    title = str(child_title or "").lower()
+    assignee = str(child_assignee or "").lower()
+    return assignee == "vibe" and (
+        "[fix" in title or "remediation" in title or title.startswith("fix:")
+    )
+
+
 def recompute_ready(
     conn: sqlite3.Connection, failure_limit: int = None,
 ) -> int:
@@ -3439,12 +3524,15 @@ def recompute_ready(
                 # this predicate back).
                 continue
             parents = conn.execute(
-                "SELECT t.status FROM tasks t "
+                "SELECT t.id, t.status FROM tasks t "
                 "JOIN task_links l ON l.parent_id = t.id "
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
-            if all(p["status"] in ("done", "archived") for p in parents):
+            if all(
+                _parent_dependency_satisfied(conn, p["id"], child_id=task_id)
+                for p in parents
+            ):
                 if cur_status == "blocked":
                     # Don't auto-recover tasks that have hit the
                     # circuit-breaker failure limit.  Without this
@@ -3505,13 +3593,18 @@ def claim_task(
         # 'todo' here — recompute_ready will re-promote when the parents
         # actually finish. See RCA at
         # kanban/boards/cookai/workspaces/t_a6acd07d/root-cause.md.
-        undone = conn.execute(
-            "SELECT 1 FROM task_links l "
+        parent_rows = conn.execute(
+            "SELECT p.id FROM task_links l "
             "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
+            "WHERE l.child_id = ?",
             (task_id,),
-        ).fetchone()
-        if undone:
+        ).fetchall()
+        unsatisfied_parent = next(
+            (p["id"] for p in parent_rows
+             if not _parent_dependency_satisfied(conn, p["id"], child_id=task_id)),
+            None,
+        )
+        if unsatisfied_parent:
             conn.execute(
                 "UPDATE tasks SET status = 'todo' "
                 "WHERE id = ? AND status = 'ready'",
@@ -3519,7 +3612,7 @@ def claim_task(
             )
             _append_event(
                 conn, task_id, "claim_rejected",
-                {"reason": "parents_not_done"},
+                {"reason": "parent_dependency_unsatisfied", "parent": unsatisfied_parent},
             )
             return None
         # Defensive: if a prior run somehow leaked (invariant violation from
@@ -5130,7 +5223,7 @@ def promote_task(
         ).fetchall()
         unsatisfied = [
             p["id"] for p in parents
-            if p["status"] not in ("done", "archived")
+            if not _parent_dependency_satisfied(conn, p["id"], child_id=task_id)
         ]
         if unsatisfied:
             return False, (
@@ -5193,13 +5286,17 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # if parents are still in progress the task must wait in 'todo'
         # until recompute_ready picks it up. RCA: Bug 2 at
         # kanban/boards/cookai/workspaces/t_a6acd07d/root-cause.md.
-        undone_parents = conn.execute(
-            "SELECT 1 FROM task_links l "
+        parent_rows = conn.execute(
+            "SELECT p.id FROM task_links l "
             "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status != 'done' LIMIT 1",
+            "WHERE l.child_id = ?",
             (task_id,),
-        ).fetchone()
-        new_status = "todo" if undone_parents else "ready"
+        ).fetchall()
+        has_unsatisfied_parent = any(
+            not _parent_dependency_satisfied(conn, p["id"], child_id=task_id)
+            for p in parent_rows
+        )
+        new_status = "todo" if has_unsatisfied_parent else "ready"
         # NOTE: deliberately does NOT touch ``block_recurrences`` or
         # ``block_kind``. Resetting the recurrence counter on unblock is exactly
         # the amnesia that let a cron unblock → worker re-block loop run

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -885,8 +885,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                         raise HTTPException(
                             status_code=409,
                             detail=(
-                                f"Cannot move to 'ready': blocked by parent(s) "
-                                f"not done — {names}"
+                                f"Cannot move to 'ready': unsatisfied parent dependency — {names}"
                             ),
                         )
                 raise HTTPException(

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -956,23 +956,26 @@ def delete_task(task_id: str, board: Optional[str] = Query(None)):
 def _parents_blocking_ready(
     conn: sqlite3.Connection, task_id: str,
 ) -> list:
-    """Return parent rows (``id``, ``title``, ``status``) that aren't ``done``
-    and therefore prevent ``task_id`` from being promoted to ``ready``.
+    """Return parent rows that semantically block promotion to ``ready``.
 
     Used to enrich the 409 response from :func:`update_task` so the
     dashboard can show an actionable toast (#26744) instead of a silent
     no-op.  Returns ``[]`` when nothing blocks the transition (e.g. no
-    parents, or all parents already done).
+    parents, or all parents passed/are archived).  A failed terminal gate is
+    still a blocker even though its task status is ``done``.
     """
     rows = conn.execute(
         "SELECT t.id, t.title, t.status FROM tasks t "
         "JOIN task_links l ON l.parent_id = t.id "
-        "WHERE l.child_id = ? AND t.status != 'done'",
+        "WHERE l.child_id = ?",
         (task_id,),
     ).fetchall()
     return [
         {"id": r["id"], "title": r["title"], "status": r["status"]}
         for r in rows
+        if not kanban_db._parent_dependency_satisfied(
+            conn, r["id"], child_id=task_id, parent_status=r["status"]
+        )
     ]
 
 
@@ -1003,13 +1006,16 @@ def _set_status_direct(
         # hasn't completed (e.g. T4 dispatched while T3 is still blocked).
         if new_status == "ready":
             parent_statuses = conn.execute(
-                "SELECT t.status FROM tasks t "
+                "SELECT t.id, t.status FROM tasks t "
                 "JOIN task_links l ON l.parent_id = t.id "
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
             if parent_statuses and not all(
-                p["status"] == "done" for p in parent_statuses
+                kanban_db._parent_dependency_satisfied(
+                    conn, p["id"], child_id=task_id, parent_status=p["status"]
+                )
+                for p in parent_statuses
             ):
                 return False
 

--- a/tests/hermes_cli/test_kanban_promote.py
+++ b/tests/hermes_cli/test_kanban_promote.py
@@ -372,6 +372,43 @@ def test_failed_gate_summary_only_fallback_holds_child(conn):
     assert kb.get_task(conn, child).status == "todo"
 
 
+def test_summary_fallback_requires_verdict_as_first_token(conn):
+    parent = kb.create_task(conn, title="[Review] gate", assignee="review")
+    assert kb.complete_task(
+        conn,
+        parent,
+        summary="Review finished.\nREQUEST_CHANGES quoted later in the handoff.",
+        metadata=None,
+    )
+    child = kb.create_task(conn, title="legacy-compatible child", parents=[parent])
+    assert kb.get_task(conn, child).status == "ready"
+
+
+def test_known_non_gate_assignee_overrides_gate_like_title(conn):
+    parent = kb.create_task(conn, title="[Review] implementation notes", assignee="vibe")
+    assert kb.complete_task(
+        conn,
+        parent,
+        summary="REQUEST_CHANGES is business prose, not a gate verdict",
+        metadata={"verdict": "REQUEST_CHANGES"},
+    )
+    child = kb.create_task(conn, title="normal downstream", parents=[parent])
+    assert kb.get_task(conn, child).status == "ready"
+
+
+def test_gate_title_fallback_is_only_for_unassigned_legacy_task(conn):
+    parent = kb.create_task(conn, title="[Review] legacy gate", assignee="review")
+    conn.execute("UPDATE tasks SET assignee = NULL WHERE id = ?", (parent,))
+    assert kb.complete_task(
+        conn,
+        parent,
+        summary="REQUEST_CHANGES legacy fallback",
+        metadata=None,
+    )
+    child = kb.create_task(conn, title="held child", parents=[parent])
+    assert kb.get_task(conn, child).status == "todo"
+
+
 def test_later_crashed_run_does_not_erase_completed_gate_verdict(conn):
     parent = _completed_gate(conn, "REQUEST_CHANGES")
     conn.execute(
@@ -423,7 +460,7 @@ def test_archived_parent_is_satisfied_across_create_link_and_unblock(conn):
 
 @pytest.mark.parametrize(
     "verdict",
-    ["CHANGES_REQUESTED", "QA_FAILED", "RELEASE_NOT_READY", "BLOCKED"],
+    ["CHANGES_REQUESTED", "QA_FAILED", "FAILED", "RELEASE_NOT_READY", "BLOCKED"],
 )
 def test_failed_gate_verdict_aliases_hold_children(conn, verdict):
     parent = _completed_gate(conn, verdict)

--- a/tests/hermes_cli/test_kanban_promote.py
+++ b/tests/hermes_cli/test_kanban_promote.py
@@ -252,3 +252,109 @@ def test_cli_promote_dedupes_duplicate_ids(kanban_home, capsys):
             (child,),
         ).fetchone()["n"]
     assert n == 1
+
+
+# ---------------------------------------------------------------------------
+# Semantic gate dependencies (D-012): terminal != passed
+# ---------------------------------------------------------------------------
+
+
+def _completed_gate(conn, verdict: str | None, *, assignee: str = "review"):
+    parent = kb.create_task(conn, title=f"[{assignee}] gate", assignee=assignee)
+    metadata = {"verdict": verdict} if verdict is not None else None
+    summary = f"{verdict} @ {'a' * 40}" if verdict is not None else "review completed"
+    assert kb.complete_task(conn, parent, summary=summary, metadata=metadata)
+    return parent
+
+
+def test_failed_review_does_not_promote_existing_child(conn):
+    parent = kb.create_task(conn, title="[Review] gate", assignee="review")
+    child = kb.create_task(conn, title="QA", assignee="qa", parents=[parent])
+    assert kb.get_task(conn, child).status == "todo"
+    assert kb.complete_task(
+        conn, parent,
+        summary=f"REQUEST_CHANGES @ {'a' * 40}",
+        metadata={"verdict": "REQUEST_CHANGES"},
+    )
+    assert kb.get_task(conn, child).status == "todo"
+    assert kb.recompute_ready(conn) == 0
+
+
+def test_child_created_after_failed_gate_stays_todo(conn):
+    parent = _completed_gate(conn, "REQUEST_CHANGES")
+    child = kb.create_task(conn, title="QA", assignee="qa", parents=[parent])
+    assert kb.get_task(conn, child).status == "todo"
+
+
+def test_explicit_fix_child_of_failed_gate_is_ready_and_claimable(conn):
+    parent = _completed_gate(conn, "REQUEST_CHANGES")
+    fix = kb.create_task(
+        conn,
+        title="[Fix][widgets] PR #17 review blocker remediation",
+        assignee="vibe",
+        parents=[parent],
+    )
+    assert kb.get_task(conn, fix).status == "ready"
+    assert kb.claim_task(conn, fix, claimer="test") is not None
+
+
+def test_non_fix_vibe_child_of_failed_gate_stays_todo(conn):
+    parent = _completed_gate(conn, "REQUEST_CHANGES")
+    child = kb.create_task(
+        conn, title="[Implement] unrelated continuation", assignee="vibe", parents=[parent]
+    )
+    assert kb.get_task(conn, child).status == "todo"
+
+
+def test_linking_failed_gate_demotes_ready_child(conn):
+    parent = _completed_gate(conn, "QA_FAIL", assignee="qa")
+    child = kb.create_task(conn, title="Release", assignee="release")
+    assert kb.get_task(conn, child).status == "ready"
+    kb.link_tasks(conn, parent, child)
+    assert kb.get_task(conn, child).status == "todo"
+
+
+def test_claim_rejects_racy_ready_child_of_failed_gate(conn):
+    parent = _completed_gate(conn, "REQUEST_CHANGES")
+    child = kb.create_task(conn, title="QA", assignee="qa", parents=[parent])
+    conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (child,))
+    assert kb.claim_task(conn, child, claimer="test") is None
+    assert kb.get_task(conn, child).status == "todo"
+    event = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id=? AND kind='claim_rejected' ORDER BY id DESC LIMIT 1",
+        (child,),
+    ).fetchone()
+    assert json.loads(event["payload"])["reason"] == "parent_dependency_unsatisfied"
+
+
+def test_manual_promote_refuses_failed_gate_without_force(conn):
+    parent = _completed_gate(conn, "NOT_READY", assignee="release")
+    child = kb.create_task(conn, title="Apply", parents=[parent])
+    ok, err = kb.promote_task(conn, child, actor="tester")
+    assert ok is False
+    assert parent in err
+
+
+def test_unblock_keeps_child_todo_when_gate_failed(conn):
+    parent = _completed_gate(conn, "REQUEST_CHANGES")
+    child = kb.create_task(conn, title="QA", assignee="qa", parents=[parent])
+    conn.execute("UPDATE tasks SET status='blocked' WHERE id=?", (child,))
+    assert kb.unblock_task(conn, child)
+    assert kb.get_task(conn, child).status == "todo"
+
+
+@pytest.mark.parametrize(
+    ("assignee", "verdict"),
+    [("review", "APPROVE"), ("qa", "QA_PASS"), ("release", "RELEASE_READY")],
+)
+def test_passing_gate_promotes_child(conn, assignee, verdict):
+    parent = kb.create_task(conn, title=f"[{assignee}] gate", assignee=assignee)
+    child = kb.create_task(conn, title="child", parents=[parent])
+    assert kb.complete_task(conn, parent, summary=verdict, metadata={"verdict": verdict})
+    assert kb.get_task(conn, child).status == "ready"
+
+
+def test_legacy_gate_without_explicit_verdict_remains_backward_compatible(conn):
+    parent = _completed_gate(conn, None)
+    child = kb.create_task(conn, title="legacy child", parents=[parent])
+    assert kb.get_task(conn, child).status == "ready"

--- a/tests/hermes_cli/test_kanban_promote.py
+++ b/tests/hermes_cli/test_kanban_promote.py
@@ -358,3 +358,74 @@ def test_legacy_gate_without_explicit_verdict_remains_backward_compatible(conn):
     parent = _completed_gate(conn, None)
     child = kb.create_task(conn, title="legacy child", parents=[parent])
     assert kb.get_task(conn, child).status == "ready"
+
+
+def test_failed_gate_summary_only_fallback_holds_child(conn):
+    parent = kb.create_task(conn, title="[Review] gate", assignee="review")
+    assert kb.complete_task(
+        conn,
+        parent,
+        summary=f"REQUEST_CHANGES @ {'b' * 40}",
+        metadata=None,
+    )
+    child = kb.create_task(conn, title="QA", assignee="qa", parents=[parent])
+    assert kb.get_task(conn, child).status == "todo"
+
+
+def test_later_crashed_run_does_not_erase_completed_gate_verdict(conn):
+    parent = _completed_gate(conn, "REQUEST_CHANGES")
+    conn.execute(
+        "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at, summary) "
+        "VALUES (?, 'crashed', 'crashed', 9999999998, 9999999999, 'provider failure')",
+        (parent,),
+    )
+    child = kb.create_task(conn, title="QA", assignee="qa", parents=[parent])
+    assert kb.get_task(conn, child).status == "todo"
+
+
+def test_non_gate_fail_summary_does_not_block_children(conn):
+    parent = kb.create_task(conn, title="Import report", assignee="vibe")
+    assert kb.complete_task(conn, parent, summary="FAIL: optional source unavailable")
+    child = kb.create_task(conn, title="Document outcome", parents=[parent])
+    assert kb.get_task(conn, child).status == "ready"
+
+
+def test_fix_child_cannot_bypass_other_unfinished_parent(conn):
+    failed_gate = _completed_gate(conn, "REQUEST_CHANGES")
+    unfinished = kb.create_task(conn, title="Prepare fixture", assignee="vibe")
+    fix = kb.create_task(
+        conn,
+        title="[Fix][widgets] narrow remediation",
+        assignee="vibe",
+        parents=[failed_gate, unfinished],
+    )
+    assert kb.get_task(conn, fix).status == "todo"
+    assert kb.complete_task(conn, unfinished, summary="fixture ready")
+    assert kb.get_task(conn, fix).status == "ready"
+
+
+def test_archived_parent_is_satisfied_across_create_link_and_unblock(conn):
+    parent = kb.create_task(conn, title="superseded gate", assignee="review")
+    assert kb.archive_task(conn, parent)
+
+    created_child = kb.create_task(conn, title="created child", parents=[parent])
+    assert kb.get_task(conn, created_child).status == "ready"
+
+    linked_child = kb.create_task(conn, title="linked child")
+    kb.link_tasks(conn, parent, linked_child)
+    assert kb.get_task(conn, linked_child).status == "ready"
+
+    blocked_child = kb.create_task(conn, title="blocked child", parents=[parent])
+    conn.execute("UPDATE tasks SET status='blocked' WHERE id=?", (blocked_child,))
+    assert kb.unblock_task(conn, blocked_child)
+    assert kb.get_task(conn, blocked_child).status == "ready"
+
+
+@pytest.mark.parametrize(
+    "verdict",
+    ["CHANGES_REQUESTED", "QA_FAILED", "RELEASE_NOT_READY", "BLOCKED"],
+)
+def test_failed_gate_verdict_aliases_hold_children(conn, verdict):
+    parent = _completed_gate(conn, verdict)
+    child = kb.create_task(conn, title="downstream", parents=[parent])
+    assert kb.get_task(conn, child).status == "todo"

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -558,6 +558,38 @@ def test_patch_drag_drop_move_todo_to_ready(client):
     assert child_after["status"] == "ready"
 
 
+def test_dashboard_cannot_promote_child_of_failed_done_gate(client):
+    """Dashboard drag/drop must honor the same semantic gate as dispatcher."""
+    parent = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "[Review] gate", "assignee": "review"},
+    ).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "[QA] downstream", "assignee": "qa", "parents": [parent["id"]]},
+    ).json()["task"]
+
+    with kb.connect() as conn:
+        assert kb.complete_task(
+            conn,
+            parent["id"],
+            summary=f"REQUEST_CHANGES @ {'c' * 40}",
+            metadata={"verdict": "REQUEST_CHANGES"},
+        )
+    assert client.get(
+        f"/api/plugins/kanban/tasks/{child['id']}"
+    ).json()["task"]["status"] == "todo"
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{child['id']}",
+        json={"status": "ready"},
+    )
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert parent["id"] in detail
+    assert "status=done" in detail
+
+
 def test_reopening_parent_demotes_ready_child(client):
     """Reopening a completed parent must invalidate ready children immediately.
 


### PR DESCRIPTION
## Summary

- separate Kanban task terminality (`done`) from semantic Review/QA/Release gate verdicts
- keep downstream tasks held for explicit `REQUEST_CHANGES`, `QA_FAIL`, `NOT_READY`, `BLOCKED`, and aliases
- allow only a narrowly identified direct `vibe` `[Fix…]` / `Fix:` remediation child to start from a failed gate
- apply the same dependency predicate to create, link, recompute, claim, manual promote, unblock, and dashboard drag/drop paths
- treat archived parents as intentionally superseded and dependency-satisfied
- read the latest completed run so later crash/reclaim rows cannot erase a completed gate verdict
- preserve legacy status-only behavior when no typed/first-token verdict exists

## Safety / compatibility

- non-gate tasks retain status-only behavior
- a known non-gate assignee is authoritative; title fallback applies only to unassigned legacy cards
- structured metadata (`verdict` / `gate_verdict`) is authoritative; summary fallback intentionally requires the verdict as the first token
- dashboard 409 messages now describe an “unsatisfied parent dependency” rather than claiming a failed `done` gate is unfinished

## Verification

- `tests/hermes_cli/test_kanban_promote.py`: **41 passed**
- `tests/plugins/test_kanban_dashboard_plugin.py`: **115 passed**
- all **35** `test_kanban*.py` files under `tests/hermes_cli`, `tests/gateway`, and `tests/plugins` pass when run in isolated pytest processes
- Ruff on changed Python files: **PASS**
- `git diff --check`: **PASS**
- independent read-only Opus review: **APPROVE**, no blocking/high findings
- production profile readback confirms the expected assignee names exist: `vibe`, `review`, `qa`, `release`

### Existing combined-process test isolation failures

Running all Kanban test files in one pytest process yields the same 17 unrelated order/isolation failures on both this branch and clean `origin/main` (worker-PID/cache, lifecycle hook, profile-roster, and plugin monkeypatch leakage). This branch adds tests but introduces no additional failures relative to the baseline.

## Out of scope

No production data/schema/env/secrets changes, no service restart, and no deployment side effects.
