### PR TITLE
fix(gateway): revert Weixin get_secret() calls that crash in multiplex mode

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -68,7 +68,6 @@ from gateway.platforms.base import (
 )
 from hermes_constants import get_hermes_home
 from utils import atomic_json_write
-from agent.secret_scope import get_secret
 
 ILINK_BASE_URL = "https://ilinkai.weixin.qq.com"
 WEIXIN_CDN_BASE_URL = "https://novac2c.cdn.weixin.qq.com/c2c"
@@ -1175,11 +1174,12 @@ class WeixinAdapter(BasePlatformAdapter):
         self._poll_task: Optional[asyncio.Task] = None
         self._dedup = MessageDeduplicator(ttl_seconds=MESSAGE_DEDUP_TTL_SECONDS)
 
-        self._account_id = str(extra.get("account_id") or get_secret("WEIXIN_ACCOUNT_ID", "")).strip()
-        self._token = str(config.token or extra.get("token") or get_secret("WEIXIN_TOKEN", "")).strip()
-        self._base_url = str(extra.get("base_url") or get_secret("WEIXIN_BASE_URL", ILINK_BASE_URL)).strip().rstrip("/")
+        # ponytail: os.getenv instead of get_secret — avoids UnscopedSecretError in multiplex mode
+        self._account_id = str(extra.get("account_id") or os.getenv("WEIXIN_ACCOUNT_ID", "")).strip()
+        self._token = str(config.token or extra.get("token") or os.getenv("WEIXIN_TOKEN", "")).strip()
+        self._base_url = str(extra.get("base_url") or os.getenv("WEIXIN_BASE_URL", ILINK_BASE_URL)).strip().rstrip("/")
         self._cdn_base_url = str(
-            extra.get("cdn_base_url") or get_secret("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)
+            extra.get("cdn_base_url") or os.getenv("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)
         ).strip().rstrip("/")
         self._send_chunk_delay_seconds = float(
             extra.get("send_chunk_delay_seconds") or os.getenv("WEIXIN_SEND_CHUNK_DELAY_SECONDS", "1.5")
@@ -2313,10 +2313,11 @@ async def send_weixin_direct(
 
     This bypasses the long-poll adapter lifecycle and uses the raw API directly.
     """
-    account_id = str(extra.get("account_id") or get_secret("WEIXIN_ACCOUNT_ID", "")).strip()
-    base_url = str(extra.get("base_url") or get_secret("WEIXIN_BASE_URL", ILINK_BASE_URL)).strip().rstrip("/")
-    cdn_base_url = str(extra.get("cdn_base_url") or get_secret("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)).strip().rstrip("/")
-    resolved_token = str(token or extra.get("token") or get_secret("WEIXIN_TOKEN", "")).strip()
+    # ponytail: os.getenv — get_secret() raises UnscopedSecretError in multiplex mode outside a profile scope
+    account_id = str(extra.get("account_id") or os.getenv("WEIXIN_ACCOUNT_ID", "")).strip()
+    base_url = str(extra.get("base_url") or os.getenv("WEIXIN_BASE_URL", ILINK_BASE_URL)).strip().rstrip("/")
+    cdn_base_url = str(extra.get("cdn_base_url") or os.getenv("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)).strip().rstrip("/")
+    resolved_token = str(token or extra.get("token") or os.getenv("WEIXIN_TOKEN", "")).strip()
     if not resolved_token:
         return {"error": "Weixin token missing. Configure WEIXIN_TOKEN or platforms.weixin.token."}
     if not account_id:


### PR DESCRIPTION
## Problem

Commit 6160a8025 replaced `os.getenv()` with `get_secret()` for Weixin credential resolution. However, `WeixinAdapter.__init__()` and `send_weixin_direct()` are called outside any `secret_scope` context. When `multiplex_profiles: true` is enabled, `get_secret()` raises `UnscopedSecretError`, preventing the platform adapter from initializing and blocking the entire gateway startup sequence.

**Reproduction:**
1. Set `multiplex_profiles: true` in `config.yaml`
2. Configure weixin platform with credentials in `.env`
3. Start gateway → crashes with `UnscopedSecretError: get_secret('WEIXIN_CDN_BASE_URL') called with no profile secret scope active`

## Fix

Revert to `os.getenv()` which is the correct fallback for credential resolution outside a scoped context. The config.yaml → env bridge in `gateway/config.py` already loads WEIXIN_* values into the PlatformConfig object (token/account_id), so `os.getenv()` serves only as the final fallback for extra config keys.

## Files Changed

- `gateway/platforms/weixin.py`: Reverted 4 `get_secret()` calls to `os.getenv()` in both `WeixinAdapter.__init__()` and `send_weixin_direct()`

## Verification

- Gateway starts successfully with `multiplex_profiles: true`
- All Weixin credentials resolved correctly via env bridge
- Weixin platform connects and processes inbound messages