### PR TITLE
fix(gemini): handle missing thought signature on cross-provider tool replay

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -270,8 +270,13 @@ def _translate_tool_call_to_gemini(tool_call: Dict[str, Any]) -> Dict[str, Any]:
         }
     }
     thought_signature = _tool_call_extra_signature(tool_call)
-    if thought_signature:
-        part["thoughtSignature"] = thought_signature
+    # Gemini 3 requires every model-side functionCall replay to carry a
+    # thought signature. Calls made before switching to Gemini cannot have a
+    # genuine Google signature; the API documentation explicitly reserves
+    # this sentinel for manually created / cross-provider function calls.
+    part["thoughtSignature"] = (
+        thought_signature or "skip_thought_signature_validator"
+    )
     return part
 
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -52,6 +52,40 @@ def test_build_native_request_preserves_thought_signature_on_tool_replay():
     assert parts[0]["thoughtSignature"] == "sig-123"
 
 
+def test_build_native_request_adds_dummy_signature_for_cross_provider_tool_replay():
+    """Gemini 3 requires a signature on every model-side functionCall part.
+
+    Calls replayed after switching from another provider cannot carry a real
+    Gemini signature, so Google documents this sentinel for that exact case.
+    """
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_from_another_provider",
+                        "type": "function",
+                        "function": {
+                            "name": "skill_view",
+                            "arguments": '{"name": "hermes-agent"}',
+                        },
+                    }
+                ],
+            },
+        ],
+        tools=[],
+        tool_choice=None,
+    )
+
+    part = request["contents"][0]["parts"][0]
+    assert part["functionCall"]["name"] == "skill_view"
+    assert part["thoughtSignature"] == "skip_thought_signature_validator"
+
+
 def test_build_native_request_uses_original_function_name_for_tool_result():
     from agent.gemini_native_adapter import build_gemini_request
 


### PR DESCRIPTION
## Summary
Under Gemini 3, Google strictly requires a `thoughtSignature` parameter on every model-side `functionCall` part replayed in conversation history. If a tool call was originally generated by another provider (like Anthropic or OpenAI) before the user switched mid-conversation to Gemini, it lacks a Google thought signature, triggering an HTTP 400 validation error on subsequent requests.

This PR intercepts missing thought signatures during tool replay and automatically injects Google's official, documented cross-provider sentinel `'skip_thought_signature_validator'`.

## Test Plan
Added a targeted regression test `test_build_native_request_adds_dummy_signature_for_cross_provider_tool_replay` to `tests/agent/test_gemini_native_adapter.py` verifying that the sentinel is correctly appended on cross-provider functionCall replays.