### PR TITLE
fix(gemini): prevent user message merge into adjacent function response

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -392,17 +392,34 @@ def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[st
         if parts:
             contents.append({"role": gemini_role, "parts": parts})
 
-    # Gemini's generateContent requires strict user/model alternation;
-    # consecutive same-role contents are rejected with HTTP 400 "Please ensure
-    # that multiturn requests alternate between user and model". The loop above
-    # emits one content per source message, so parallel tool calls (N tool
-    # results become N user functionResponse contents), back-to-back user turns,
-    # or merged assistant turns would each violate that. Merge adjacent
-    # same-role contents by concatenating their parts. For parallel calls this
-    # also produces the grouped multi-functionResponse turn Gemini expects.
+    # Compatibility contract for native Gemini generateContent:
+    # 1) Same-role adjacent contents still merge in general (strict user/model
+    #    alternation for ordinary text turns and parallel tool-result grouping).
+    # 2) Exception: do NOT merge a human user text turn into a preceding user
+    #    content that only carries functionResponse parts (or vice versa).
+    #    Gemini 3 accepts that fold with HTTP 200 but then returns an empty
+    #    model response; keeping the boundary emits two consecutive user
+    #    contents, which current Gemini APIs accept for this specific case.
+    # 3) Parallel tool results (functionResponse + functionResponse) still
+    #    merge into one user content — only mixed functionResponse/text is split.
     merged_contents: List[Dict[str, Any]] = []
     for content in contents:
-        if merged_contents and merged_contents[-1]["role"] == content["role"]:
+        same_role = bool(
+            merged_contents and merged_contents[-1]["role"] == content["role"]
+        )
+        if same_role and content["role"] == "user":
+            previous_has_function_response = any(
+                isinstance(part, dict) and "functionResponse" in part
+                for part in merged_contents[-1].get("parts", [])
+            )
+            current_has_function_response = any(
+                isinstance(part, dict) and "functionResponse" in part
+                for part in content.get("parts", [])
+            )
+            if previous_has_function_response != current_has_function_response:
+                same_role = False
+
+        if same_role:
             merged_contents[-1]["parts"].extend(content["parts"])
         else:
             merged_contents.append(content)

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -28,6 +28,47 @@ class DummyResponse:
 
 
 
+def test_followup_user_turn_is_not_merged_into_function_response_turn():
+    """Human follow-up after tool results must stay its own user content.
+
+    Scope: only the functionResponse↔human-text boundary. Ordinary same-role
+    merges (parallel tool results, back-to-back plain user texts) remain
+    required for Gemini alternation and are covered by sibling tests.
+    """
+    from agent.gemini_native_adapter import _build_gemini_contents
+
+    messages = [
+        {"role": "user", "content": "Load the skill"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "skill_view",
+                        "arguments": '{"name":"hermes-agent"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "loaded"},
+        {"role": "user", "content": "Continue"},
+    ]
+
+    contents, _ = _build_gemini_contents(messages)
+
+    assert [content["role"] for content in contents] == [
+        "user",
+        "model",
+        "user",
+        "user",
+    ]
+    assert "functionResponse" in contents[-2]["parts"][0]
+    assert contents[-1]["parts"] == [{"text": "Continue"}]
+
+
 def test_parallel_tool_results_merge_into_one_user_content():
     """Gemini requires strict user/model alternation; two consecutive `user`
     contents are rejected with HTTP 400. Parallel tool calls produce two tool


### PR DESCRIPTION
## Summary
To satisfy Gemini's strict role-alternation rules, the adapter merges adjacent same-role messages. However, folding a subsequent standard human user message into a preceding user `functionResponse` (tool result) block causes the Gemini 3 engine to ignore the prompt and return an empty candidate response.

This PR adds a boundary check during content merging to ensure standard user turns and `functionResponses` are kept in separate `contents` blocks (which the Gemini 3 API accepts and processes correctly).

## Test Plan
Added a targeted regression test `test_followup_user_turn_is_not_merged_into_function_response_turn` to `tests/agent/test_gemini_native_adapter.py` verifying that follow-up human prompts are not folded into preceding tool results.