### PR TITLE
test: regression coverage for first-turn user multimodal interim dedup crash

### DIFF
--- a/tests/run_agent/test_interim_visible_text_multimodal.py
+++ b/tests/run_agent/test_interim_visible_text_multimodal.py
@@ -1,0 +1,58 @@
+"""Regression: _interim_assistant_visible_text must not crash on list content.
+
+On the first turn of a conversation the "previous message" used for interim
+dedup can be a *user* message whose content is a list of multimodal parts
+(text + image_url).  Passing that list into the think-block regex raised
+``TypeError: expected string or bytes-like object, got 'list'`` inside the
+outer conversation loop, which then retried the same API call indefinitely,
+streaming duplicated progress lines until the user cancelled.
+"""
+from __future__ import annotations
+
+import run_agent
+
+
+class _Host:
+    """Minimal host exposing only what _interim_assistant_visible_text needs."""
+
+    show_commentary = True
+
+    def _extract_codex_interim_visible_text(self, assistant_msg):
+        return run_agent.AIAgent._extract_codex_interim_visible_text(
+            self, assistant_msg
+        )
+
+    def _extract_codex_interim_visible_parts(self, assistant_msg):
+        return run_agent.AIAgent._extract_codex_interim_visible_parts(
+            self, assistant_msg
+        )
+
+    def _strip_think_blocks(self, content):
+        return run_agent.AIAgent._strip_think_blocks(self, content)
+
+    def _interim_assistant_visible_text(self, assistant_msg):
+        return run_agent.AIAgent._interim_assistant_visible_text(
+            self, assistant_msg
+        )
+
+
+def test_multimodal_list_content_does_not_raise():
+    msg = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "change the openrouter app url"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,xxx"}},
+        ],
+    }
+    assert _Host()._interim_assistant_visible_text(msg) == (
+        "change the openrouter app url"
+    )
+
+
+def test_plain_string_content_unchanged():
+    msg = {"role": "assistant", "content": "<think>hidden</think>visible"}
+    assert _Host()._interim_assistant_visible_text(msg) == "visible"
+
+
+def test_none_content_returns_empty():
+    assert _Host()._interim_assistant_visible_text({"content": None}) == ""


### PR DESCRIPTION
## Summary
Session `6c2c703ea1b8` showed repeated/duplicated streamed progress lines. Root cause: `_interim_assistant_visible_text` fed list-shaped (multimodal) message content directly into the think-block `re.sub`, raising `TypeError` and making the outer loop retry the same API call indefinitely.

Upstream main already flattens content via `flatten_message_text` (the #66267 fix), but the existing tests (`test_66267_multimodal_interim.py`) only cover **tool-role** messages. This PR adds regression tests for the **first-turn user message** case, where the previous message used for interim dedup is a user message whose content is a list of parts (text + `image_url`).

## Testing
- `pytest tests/run_agent/test_interim_visible_text_multimodal.py` — 3 passed
- Full `tests/agent` suite: 1893 passed, 1 pre-existing unrelated failure (`test_copilot_acp_client.py::test_run_prompt_preserves_real_home_when_profile_home_available`, fails on clean main too)