### PR TITLE
fix(holographic): guard similarity() against dimension mismatch (#68682)

### DIFF
--- a/plugins/memory/holographic/holographic.py
+++ b/plugins/memory/holographic/holographic.py
@@ -103,8 +103,15 @@ def similarity(a: "np.ndarray", b: "np.ndarray") -> float:
 
     Returns 1.0 for identical vectors, near 0.0 for random (unrelated) vectors,
     and -1.0 for perfectly anti-correlated vectors.
+
+    Returns 0.0 if the inputs have mismatched dimensions — a dimension mismatch
+    means the vectors were encoded with different ``hrr_dim`` settings and are
+    not comparable. Without this guard, ``np.cos(a - b)`` raises a broadcast
+    ValueError that crashes the entire retrieval pipeline (see #68682).
     """
     _require_numpy()
+    if a.shape != b.shape:
+        return 0.0
     return float(np.mean(np.cos(a - b)))
 
 

--- a/tests/plugins/memory/test_holographic_retrieval.py
+++ b/tests/plugins/memory/test_holographic_retrieval.py
@@ -13,6 +13,7 @@ pytest.importorskip("numpy")  # retrieval module imports numpy indirectly
 
 from plugins.memory.holographic.retrieval import FactRetriever
 from plugins.memory.holographic.store import MemoryStore
+from plugins.memory.holographic import holographic as hrr
 
 
 # ---------------------------------------------------------------------------
@@ -127,3 +128,31 @@ def test_prefetch_stopword_only_query_empty(retriever_with_facts):
     results = retriever_with_facts.search("the and of")
     # Either zero results or it errored-gracefully to [] — both are fine
     assert isinstance(results, list)
+
+
+# ---------------------------------------------------------------------------
+# similarity() dimension guard — regression for #68682
+#
+# The OLD formula `np.mean(np.cos(a - b))` raised ValueError on shape
+# mismatch, which crashed the entire retrieval pipeline when stored facts
+# had different hrr_dim settings. The guard returns 0.0 instead.
+# ---------------------------------------------------------------------------
+
+def test_similarity_matched_dims_unchanged():
+    """Same-dim pair still returns cosine similarity (no regression)."""
+    import numpy as np
+
+    rng = np.random.default_rng(0)
+    a = rng.uniform(-np.pi, np.pi, size=256)
+    assert abs(hrr.similarity(a, a) - 1.0) < 1e-9
+
+
+def test_similarity_mismatched_dims_returns_zero_not_crash():
+    """Different-dim pair returns 0.0 (no-crash sentinel) instead of ValueError."""
+    import numpy as np
+
+    a_256 = np.zeros(256)
+    b_1024 = np.zeros(1024)
+    # OLD code raised ValueError("operands could not be broadcast together")
+    result = hrr.similarity(a_256, b_1024)
+    assert result == 0.0


### PR DESCRIPTION
## Summary

`holographic.py::similarity()` raised `ValueError: operands could not be broadcast together` whenever the two input vectors had different `hrr_dim` settings. Because every retrieval code path (search/probe/reason/contradict) calls `similarity()` on vectors decoded from the DB, a single fact stored under one `hrr_dim` and a query built under another would crash the entire retrieval pipeline. The agent saw a generic "I encountered repeated errors" message; the actual numpy exception was only visible in `agent.log`.

This PR adds a one-line guard that returns `0.0` on shape mismatch — semantically "not comparable, no similarity" — instead of letting the broadcast `ValueError` escape.

## Root cause

```python
# plugins/memory/holographic/holographic.py:101-108
def similarity(a, b):
    _require_numpy()
    return float(np.mean(np.cos(a - b)))   # 💥 shapes (256,) (1024,)
```

When `a.shape == (256,)` and `b.shape == (1024,)`, `a - b` raises:

```
ValueError: operands could not be broadcast together with shapes (256,) (1024,)
```

This was independently verified against current `main` by a commenter on the issue.

## Fix

```python
def similarity(a, b):
    _require_numpy()
    if a.shape != b.shape:
        return 0.0
    return float(np.mean(np.cos(a - b)))
```

2 source lines added (5 total with the docstring update explaining the new behavior). Same-dim behaviour is byte-identical.

## Tests

Added 2 regression tests to `tests/plugins/memory/test_holographic_retrieval.py`:

- `test_similarity_matched_dims_unchanged` — same-dim self-similarity still returns `1.0` (no regression).
- `test_similarity_mismatched_dims_returns_zero_not_crash` — the (256, 1024) case that previously raised `ValueError` now returns `0.0`.

Verified via the git-stash three-step dance:

- **OLD code** (fix stashed): `test_similarity_mismatched_dims_returns_zero_not_crash` FAILS with the exact issue error.
- **NEW code** (fix applied): both tests PASS.

Full file: `12 passed in 7.55s`.

## Scope

The issue proposes three sub-fixes. This PR ships only the first (the guard). The other two are intentionally out of scope:

1. ✅ Dimension guard in `similarity()` — this PR.
2. ❌ `_safe_vec()` wrapper for the 8 unprotected `bytes_to_phases()` call sites in `retrieval.py` — a larger refactor that touches retrieval semantics and deserves its own discussion (also covers the second defect: "Retrieval has zero error isolation").
3. ❌ Persisting `hrr_dim` to the DB so the dimension can't drift across restarts — a schema change that requires a migration story for existing DBs.

Surfacing these as a follow-up is more useful than bundling them: the dimension guard is the smallest change that prevents the crash, ships independently, and unblocks the agent even when the other two are still under debate.

Closes #68682