### PR TITLE
test(cli): fix order-dependent test_resume_quiet_stderr flake at the source

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1024,6 +1024,7 @@ LEGACY_AUTHOR_MAP = {
     "137614867+cutepawss@users.noreply.github.com": "cutepawss",
     "96793918+memosr@users.noreply.github.com": "memosr",
     "mehmet.sr35@gmail.com": "memosr",
+    "mehmet.kar@std.yildiz.edu.tr": "mehmetkr-31",
     "milkoor@users.noreply.github.com": "milkoor",
     "xuerui911@gmail.com": "Fatty911",
     "131039422+SHL0MS@users.noreply.github.com": "SHL0MS",

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,50 @@
+"""Shared fixtures for CLI tests.
+
+prompt_toolkit / capsys isolation
+---------------------------------
+``cli._cprint`` renders through ``prompt_toolkit.print_formatted_text``,
+which — when called with no explicit ``output=`` — lazily creates an
+``Output`` from ``sys.stdout`` **and caches it on the process-global default
+``AppSession``** (``prompt_toolkit.application.current._current_app_session``,
+a ``ContextVar`` with a module-level default). The cache is keyed to nothing
+and never re-reads ``sys.stdout``.
+
+Under pytest, ``capsys`` swaps ``sys.stdout`` for a fresh buffer per test.
+So the first CLI test that emits through ``_cprint`` (e.g. one exercising
+``/queue``, which prints a "Queued: …" line) locks prompt_toolkit's cached
+output onto *its* captured stdout. Every later ``capsys`` test that asserts
+on ``_cprint`` output then reads an empty buffer, because the render went to
+the first test's now-dead capture target. That is the mechanism behind the
+order-dependent ``test_resume_quiet_stderr`` failure: it passes in isolation
+and in its own file, but fails in a full ``tests/cli`` run.
+
+Reset the cached output before every CLI test so each one re-creates a fresh
+prompt_toolkit ``Output`` bound to its own ``sys.stdout`` on first use. This
+is a no-op when prompt_toolkit isn't importable and cheap otherwise (the
+property re-creates lazily).
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_prompt_toolkit_output_cache():
+    """Clear prompt_toolkit's cached AppSession output around each CLI test.
+
+    See the module docstring for the capsys/prompt_toolkit interaction this
+    guards against.
+    """
+
+    def _clear() -> None:
+        try:
+            from prompt_toolkit.application.current import get_app_session
+
+            get_app_session()._output = None
+        except Exception:
+            # prompt_toolkit not importable / internal shape changed — the
+            # tests that rely on this simply keep their prior behavior.
+            pass
+
+    _clear()
+    yield
+    _clear()

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -45,13 +45,28 @@ def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
         "prompt_toolkit.formatted_text": MagicMock(),
         "prompt_toolkit.auto_suggest": MagicMock(),
     }
-    with patch.dict(sys.modules, prompt_toolkit_stubs), \
-         patch.dict("os.environ", clean_env, clear=False):
-        import cli as _cli_mod
-        _cli_mod = importlib.reload(_cli_mod)
-        with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), \
-             patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}):
-            return _cli_mod.HermesCLI(**kwargs)
+    try:
+        with patch.dict(sys.modules, prompt_toolkit_stubs), \
+             patch.dict("os.environ", clean_env, clear=False):
+            import cli as _cli_mod
+            _cli_mod = importlib.reload(_cli_mod)
+            with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), \
+                 patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}):
+                return _cli_mod.HermesCLI(**kwargs)
+    finally:
+        # The reload above re-executed cli.py while prompt_toolkit was stubbed
+        # with MagicMocks, permanently rebinding cli's module globals
+        # (``_pt_print``, ``_PT_ANSI``, …) to those mocks. ``patch.dict``
+        # restores ``sys.modules`` on exit, but NOT the names the reloaded
+        # module already bound — so ``sys.modules["cli"]`` is left with a
+        # mock ``_pt_print``, and ``cli._cprint`` then silently no-ops for
+        # every later test (one half of the order-dependent
+        # ``test_resume_quiet_stderr`` full-suite failure; the other half is
+        # the prompt_toolkit output cache reset in this dir's conftest).
+        # Reload once more with the real modules visible so cli's globals
+        # rebind cleanly.
+        import cli as _cli_restore
+        importlib.reload(_cli_restore)
 
 
 class TestMaxTurnsResolution:


### PR DESCRIPTION
## Summary

`tests/cli/test_resume_quiet_stderr.py::TestResumeQuietStderr::test_session_not_found_goes_to_stdout_in_full_mode` passes in isolation and in its own file but **fails in a full `tests/cli` run** — a long-standing order-dependent flake. This fixes the two independent leaks at their source rather than papering over the assertion.

## Root cause (two independent leaks, both from `test_cli_init.py::_make_cli`)

1. **`cli` left with mock prompt_toolkit globals.** `_make_cli()` reloads `cli.py` inside `patch.dict(sys.modules, prompt_toolkit_stubs)` and never reloads it back. `patch.dict` restores `sys.modules` on exit, but not the names the reloaded module already bound — so `sys.modules["cli"]` keeps a `MagicMock` `_pt_print`/`_PT_ANSI`, and `cli._cprint` silently no-ops for every later test.

2. **prompt_toolkit output cache pinned to a stale capture buffer.** `print_formatted_text` (used by `_cprint`) caches its `Output` on the process-global default `AppSession` the first time it renders with no explicit `output=`, and never re-reads `sys.stdout`. Under `capsys` (which swaps `sys.stdout` per test), the first CLI test to emit through `_cprint` — e.g. any `TestBusyInputMode` test that runs `/queue` and prints a "Queued: …" line — locks that cache onto **its** captured stdout. Every later `capsys` test asserting on `_cprint` output then reads an empty buffer. Confirmed by tracing the cached output to a `PlainTextOutput` bound to the polluter's capture fd while the victim's `sys.stdout` was a different object.

Each leak alone is enough to blank the victim's captured stdout; with leak 1 active the polluter's `_cprint` is a mock and never populates the PT cache, so fixing 1 exposes 2 — both must be addressed.

## Fix (test-only, no production change)

- `tests/cli/test_cli_init.py`: wrap `_make_cli`'s stubbed reload in `try/finally` and reload `cli` once more with the real modules visible, so `sys.modules["cli"]` rebinds clean PT globals.
- `tests/cli/conftest.py` (new): an autouse fixture that resets the default `AppSession`'s cached `_output` around each test, so every CLI test re-creates a fresh prompt_toolkit output bound to its own `sys.stdout`. This fixes the whole class of `capsys` + prompt_toolkit flakes, not just this one test.

Neither change touches production code or the flaky test's own assertion.

## Verification

```
# the exact failing pair, previously red:
pytest tests/cli/test_cli_init.py::TestBusyInputMode::test_queue_command_works_while_idle \
       tests/cli/test_resume_quiet_stderr.py::TestResumeQuietStderr::test_session_not_found_goes_to_stdout_in_full_mode
# 2 passed

pytest tests/cli   # 1101 passed (previously 1 failed in full runs)
```

## Relation to #59358

[#59358](https://github.com/NousResearch/hermes-agent/pull/59358) targets the same flaky test and identifies the same prompt_toolkit/capsys interaction, but fixes it by `patch("cli._cprint")` and asserting on the mock's call args — a test-local assertion workaround that leaves both underlying leaks in place (other `capsys` tests remain exposed, and the `_pt_print` mock leak is untouched). This PR instead removes the two leaks at the source and does **not** modify `test_resume_quiet_stderr.py`, so the two changes don't conflict; if #59358 lands first, its assertion change simply becomes redundant. Flagging for the maintainer to pick the preferred approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)