### PR TITLE
test(gateway): fix order-dependent telegram-mock flake cluster

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1024,6 +1024,7 @@ LEGACY_AUTHOR_MAP = {
     "137614867+cutepawss@users.noreply.github.com": "cutepawss",
     "96793918+memosr@users.noreply.github.com": "memosr",
     "mehmet.sr35@gmail.com": "memosr",
+    "mehmet.kar@std.yildiz.edu.tr": "mehmetkr-31",
     "milkoor@users.noreply.github.com": "milkoor",
     "xuerui911@gmail.com": "Fatty911",
     "131039422+SHL0MS@users.noreply.github.com": "SHL0MS",

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -48,6 +48,41 @@ def make_async_session_db(sync_mock=None):
     return AsyncSessionDB(sync_mock), sync_mock
 
 
+class _FakeEnumMember(str):
+    """A python-telegram-bot-faithful stand-in for a ``StrEnum`` member.
+
+    PTB constants (``ParseMode``, ``ChatType``) are ``StrEnum`` members:
+    ``str(x)`` and equality give the *value* (``"supergroup"``) while
+    ``repr(x)`` shows the qualified *member name*
+    (``<ChatType.SUPERGROUP>``). Test stubs that pick only one of those
+    shapes break the other consumer: plain strings fail assertions like
+    ``"MARKDOWN_V2" in repr(parse_mode)``, while auto-generated MagicMock
+    attributes fail the adapter's ``str(chat.type)`` normalization
+    (``adapter.py`` ``_build_message_event``). This class satisfies both,
+    so every telegram test sees the same semantics regardless of which
+    file's mock installed first.
+    """
+
+    _qualname: str
+
+    def __new__(cls, enum_name: str, member_name: str, value: str):
+        obj = str.__new__(cls, value)
+        obj._qualname = f"{enum_name}.{member_name}"
+        return obj
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"<{self._qualname}: {str.__repr__(self)}>"
+
+
+def _fake_str_enum(enum_name: str, **members: str):
+    """Build a ``SimpleNamespace``-like enum of :class:`_FakeEnumMember`."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        **{name: _FakeEnumMember(enum_name, name, value) for name, value in members.items()}
+    )
+
+
 def _ensure_telegram_mock() -> None:
     """Install a comprehensive telegram mock in sys.modules.
 
@@ -61,13 +96,26 @@ def _ensure_telegram_mock() -> None:
 
     mod = MagicMock()
     mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    mod.constants.ParseMode.MARKDOWN = "Markdown"
-    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    mod.constants.ParseMode.HTML = "HTML"
-    mod.constants.ChatType.PRIVATE = "private"
-    mod.constants.ChatType.GROUP = "group"
-    mod.constants.ChatType.SUPERGROUP = "supergroup"
-    mod.constants.ChatType.CHANNEL = "channel"
+    # One shared PTB-faithful enum namespace per constant, attached to BOTH
+    # access paths: ``sys.modules["telegram.constants"]`` is registered as
+    # the root mock below, so ``from telegram.constants import ParseMode``
+    # resolves ``mod.ParseMode`` — while config/docs-style access reads
+    # ``telegram.constants.ParseMode``. Binding the same object to both
+    # keeps every consumer comparing against identical members.
+    _parse_mode = _fake_str_enum(
+        "ParseMode", MARKDOWN="Markdown", MARKDOWN_V2="MarkdownV2", HTML="HTML"
+    )
+    _chat_type = _fake_str_enum(
+        "ChatType",
+        PRIVATE="private",
+        GROUP="group",
+        SUPERGROUP="supergroup",
+        CHANNEL="channel",
+    )
+    mod.ParseMode = _parse_mode
+    mod.constants.ParseMode = _parse_mode
+    mod.ChatType = _chat_type
+    mod.constants.ChatType = _chat_type
 
     # Mirror PTB's exception hierarchy: BadRequest is a semantic API error,
     # but inherits from NetworkError in python-telegram-bot 22.x.

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -20,30 +20,24 @@ import pytest
 from gateway.config import PlatformConfig
 
 
-def _ensure_telegram_mock():
-    telegram_mod = MagicMock()
-    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-
-    # Register telegram.constants as a separate module mock so that
-    # ``from telegram.constants import ChatType`` resolves to our mock
-    # with string-valued members (not auto-generated MagicMocks).
-    constants_mod = MagicMock()
-    constants_mod.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    constants_mod.ChatType.GROUP = "group"
-    constants_mod.ChatType.SUPERGROUP = "supergroup"
-    constants_mod.ChatType.CHANNEL = "channel"
-    constants_mod.ChatType.PRIVATE = "private"
-
-    sys.modules["telegram"] = telegram_mod
-    sys.modules["telegram.ext"] = telegram_mod.ext
-    sys.modules["telegram.constants"] = constants_mod
-    sys.modules["telegram.request"] = telegram_mod.request
-
-    # Force reimport so the adapter picks up the mock ChatType.
-    sys.modules.pop("plugins.platforms.telegram.adapter", None)
-
+# Use the shared, comprehensive telegram mock from conftest instead of a
+# file-local one. The previous local installer differed from every other
+# telegram test's stub in two ways — it registered a SEPARATE string-valued
+# ``telegram.constants`` module (others register the root mock, so ParseMode
+# members stay auto-generated MagicMock attributes) and its ``telegram.error``
+# was a bare MagicMock (conftest defines real exception subclasses with PTB's
+# hierarchy) — and it installed UNCONDITIONALLY (no real-library guard).
+# Because it also force-reimported the adapter, the divergent stub leaked into
+# sys.modules for the rest of the session: every later telegram test that
+# asserts ParseMode repr or isinstance against telegram.error classes failed
+# order-dependently in full runs while passing in isolation.
+from tests.gateway.conftest import _ensure_telegram_mock  # noqa: E402
 
 _ensure_telegram_mock()
+# Force reimport so the adapter binds to whatever sys.modules now holds
+# (the shared mock, or the real library when it is installed) rather than a
+# stub an earlier test file may have bound it to.
+sys.modules.pop("plugins.platforms.telegram.adapter", None)
 
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
 


### PR DESCRIPTION
## Summary

Eight telegram gateway tests pass in isolation and in their own files but **fail in a full `tests/gateway` run** — a long-standing order-dependent flake cluster:

- `test_telegram_slash_confirm.py::TestSendSlashConfirm::test_uses_markdown_v2_and_escapes_special_chars`
- `test_telegram_approval_buttons.py` (2 tests)
- `test_telegram_model_picker.py` (3 tests)
- `test_telegram_network_reconnect.py::test_network_error_classifier_matches_ptb_semantics` (2 params)

## Root cause

`tests/gateway/test_dm_topics.py` installed its telegram `sys.modules` mock **unconditionally** — no `hasattr(sys.modules["telegram"], "__file__")` real-library guard like every other telegram test — and force-reimported the adapter against it (`sys.modules.pop("plugins.platforms.telegram.adapter")`). Its stub also **diverged** from the shared one in two ways:

1. It registered a *separate* string-valued `telegram.constants` module, so `ParseMode.MARKDOWN_V2` was the plain string `"MarkdownV2"` — its `repr()` is `'MarkdownV2'`, which fails assertions like `"MARKDOWN_V2" in repr(parse_mode)` that expect PTB's `StrEnum` repr (`<ParseMode.MARKDOWN_V2>`).
2. Its `telegram.error` was a bare `MagicMock`, so `isinstance(exc, telegram.error.TimedOut)` checks in `test_telegram_network_reconnect.py` broke.

Because the stub installed unconditionally and force-reimported the adapter, whichever collection order reached `test_dm_topics` first leaked that divergent stub into `sys.modules` for the rest of the session — so later telegram tests asserting real-PTB semantics failed order-dependently while passing alone.

## Fix (test-only)

- `test_dm_topics.py` now uses the shared `tests/gateway/conftest.py::_ensure_telegram_mock` (guarded on the real library, comprehensive `telegram.error` hierarchy) instead of a divergent local stub. It was the **only** file that unconditionally overwrote the telegram mock.
- The shared mock now models `ParseMode`/`ChatType` as PTB-faithful `StrEnum` members via a small `_FakeEnumMember(str)`: `str(x)` and equality return the value (`"supergroup"`) while `repr(x)` shows the qualified name (`<ChatType.SUPERGROUP: 'supergroup'>`). That satisfies **both** the adapter's `str(chat.type)` normalization in `_build_message_event` and the tests' `repr`-based assertions, regardless of which file's mock installed first.

## Verification

```
pytest tests/gateway -k telegram   # 1231 passed, 2 skipped (previously 8 failed in full runs)
pytest tests/gateway/test_dm_topics.py   # 40 passed
```

A full `tests/gateway` run drops from 20 order-dependent failures to only the pre-existing non-telegram flakes (`test_wecom_callback`, `test_systemd_notify`, `test_channel_directory`, …) that also fail on pristine `main` and are unrelated to this change (separate root causes, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)