### PR TITLE
Preserve JAIMES Telegram delivery lifecycle on Hermes v0.19

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1240,6 +1240,11 @@ def compress_context(
                         agent._flush_messages_to_session_db(messages)
                     except Exception:
                         pass  # best-effort — don't block compression on a flush error
+                    # Snapshot the gateway peer before ending the parent.  A
+                    # compression child is the same Telegram conversation, not
+                    # a new unroutable session; losing these fields strands the
+                    # final in state.db after the model completes.
+                    parent_session = agent._session_db.get_session(agent.session_id) or {}
                     # Propagate title to the new session with auto-numbering
                     old_title = agent._session_db.get_session_title(agent.session_id)
                     agent._session_db.end_session(agent.session_id, "compression")
@@ -1272,11 +1277,34 @@ def compress_context(
                     try:
                         agent._session_db.create_session(
                             session_id=agent.session_id,
-                            source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                            source=(
+                                parent_session.get("source")
+                                or agent.platform
+                                or os.environ.get("HERMES_SESSION_SOURCE", "cli")
+                            ),
                             model=agent.model,
                             model_config=agent._session_init_model_config,
+                            user_id=parent_session.get("user_id"),
+                            session_key=parent_session.get("session_key"),
+                            chat_id=parent_session.get("chat_id"),
+                            chat_type=parent_session.get("chat_type"),
+                            thread_id=parent_session.get("thread_id"),
                             parent_session_id=old_session_id,
+                            cwd=parent_session.get("cwd"),
+                            profile_name=parent_session.get("profile_name"),
                         )
+                        if parent_session.get("session_key"):
+                            agent._session_db.record_gateway_session_peer(
+                                agent.session_id,
+                                source=str(parent_session.get("source") or "gateway"),
+                                user_id=parent_session.get("user_id"),
+                                session_key=str(parent_session.get("session_key")),
+                                chat_id=parent_session.get("chat_id"),
+                                chat_type=parent_session.get("chat_type"),
+                                thread_id=parent_session.get("thread_id"),
+                                display_name=parent_session.get("display_name"),
+                                origin_json=parent_session.get("origin_json"),
+                            )
                     except Exception as _cs_err:
                         # The child row could not be created (e.g. FK constraint,
                         # contended write). Previously the outer handler simply

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5068,6 +5068,12 @@ class BasePlatformAdapter(ABC):
             if not response:
                 logger.debug("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
             if response:
+                # Stop the continuous processing heartbeat before any final
+                # user-visible delivery. Telegram has no cancel-chat-action
+                # endpoint, so a refresh racing the final send can otherwise
+                # leave a stale "typing…" bubble after the answer arrives.
+                await _stop_typing_task()
+
                 # Capture [[as_document]] before extract_media strips it, so the
                 # dispatch partition below can route image-extension files
                 # through send_document instead of send_multiple_images. Used

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -81,6 +81,7 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|auto-lowered\s+compression\s+threshold"
     r"|compacting\s+context\s+[—-]\s+summarizing\s+earlier\s+conversation"
     r"|preflight\s+compression"
+    r"|pre-api\s+compression"
     r"|session\s+compressed\s+\d+\s+times"
     r"|rate\s+limited\.\s+waiting\s+\d"
     r"|retrying\s+in\s+\d"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21962,18 +21962,55 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # what the follow-up's guard will consult.  Fail-safe in helper.
                 await self._refresh_agent_cache_message_count(session_key, session_id)
 
-                followup_result = await self._run_agent(
-                    message=next_message,
-                    context_prompt=context_prompt,
-                    history=updated_history,
-                    source=next_source,
-                    session_id=session_id,
-                    session_key=next_session_key,
-                    run_generation=run_generation,
-                    _interrupt_depth=_interrupt_depth + 1,
-                    event_message_id=next_message_id,
-                    channel_prompt=next_channel_prompt,
-                )
+                # Recursive busy-session follow-ups do not pass through the
+                # top-level _set_session_env() binder again.  Bind only the
+                # follow-up's native inbound ID around this run so transcript
+                # persistence cannot reuse the interrupted turn's ID.  Do not
+                # use next_message_id here: Telegram forum topics intentionally
+                # have no reply anchor even though the native event ID remains
+                # required for durable lifecycle correlation.
+                _followup_message_id_token = None
+                if pending_event is not None:
+                    try:
+                        from gateway.session_context import bind_session_message_id
+
+                        _followup_native_message_id = (
+                            getattr(pending_event, "message_id", None)
+                            or getattr(next_source, "message_id", None)
+                            or ""
+                        )
+                        _followup_message_id_token = bind_session_message_id(
+                            _followup_native_message_id
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Failed to bind queued follow-up native message ID",
+                            exc_info=True,
+                        )
+                try:
+                    followup_result = await self._run_agent(
+                        message=next_message,
+                        context_prompt=context_prompt,
+                        history=updated_history,
+                        source=next_source,
+                        session_id=session_id,
+                        session_key=next_session_key,
+                        run_generation=run_generation,
+                        _interrupt_depth=_interrupt_depth + 1,
+                        event_message_id=next_message_id,
+                        channel_prompt=next_channel_prompt,
+                    )
+                finally:
+                    if _followup_message_id_token is not None:
+                        try:
+                            from gateway.session_context import reset_session_message_id
+
+                            reset_session_message_id(_followup_message_id_token)
+                        except Exception:
+                            logger.debug(
+                                "Failed to restore queued follow-up native message ID",
+                                exc_info=True,
+                            )
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:
             # Stop progress sender, interrupt monitor, and notification task

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -154,6 +154,22 @@ def set_current_session_id(session_id: str) -> None:
     _SESSION_ID.set(session_id)
 
 
+def bind_session_message_id(message_id: str = ""):
+    """Temporarily bind the native inbound ID for an in-band follow-up turn.
+
+    Busy-session follow-ups recurse inside the original gateway handler rather
+    than entering through the top-level session binder again.  Returning the
+    ContextVar token lets that recursive turn expose its own native message ID
+    to persistence without disturbing the rest of the outer session context.
+    """
+    return _SESSION_MESSAGE_ID.set(str(message_id or ""))
+
+
+def reset_session_message_id(token) -> None:
+    """Restore the message-ID binding that preceded an in-band follow-up."""
+    _SESSION_MESSAGE_ID.reset(token)
+
+
 def set_session_vars(
     platform: str = "",
     source: str = "",

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1243,8 +1243,18 @@ class GatewaySlashCommandsMixin:
             "  /platform resume <name> — re-queue a paused platform"
         )
 
+    def _restart_starts_new_session(self, event: MessageEvent) -> bool:
+        """Return whether this platform opts into resetting before /restart."""
+        source = getattr(event, "source", None)
+        platform = getattr(source, "platform", None)
+        adapters = getattr(self, "adapters", None) or {}
+        adapter = adapters.get(platform)
+        config = getattr(adapter, "config", None)
+        extra = (getattr(config, "extra", {}) or {}) if config is not None else {}
+        return is_truthy_value(extra.get("restart_starts_new_session", False))
+
     async def _handle_restart_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
-        """Handle /restart command - drain active work, then restart the gateway."""
+        """Handle /restart command - optionally reset the session, then restart."""
         from gateway.run import _hermes_home
         # Defensive idempotency check: if the previous gateway process
         # recorded this same /restart (same platform + update_id) and the new
@@ -1265,6 +1275,12 @@ class GatewaySlashCommandsMixin:
                 event.platform_update_id,
             )
             return ""
+
+        # A platform may opt into a clean session boundary before restart. This
+        # prevents oversized conversation history from being auto-resumed and
+        # compressed on the restart path.
+        if self._restart_starts_new_session(event):
+            await self._handle_reset_command(event)
 
         if self._restart_requested or self._draining:
             count = self._running_agent_count()

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4131,6 +4131,38 @@ class TelegramAdapter(BasePlatformAdapter):
         """Canonicalize Topic 17 before Telegram receives the only final."""
         if str(thread_id or "") != "17" or not (metadata or {}).get("notify"):
             return content
+        prepared = re.fullmatch(r"<pre>([\s\S]*)</pre>", str(content or "").strip(), flags=re.I)
+        if prepared:
+            body = _html.unescape(prepared.group(1)).strip("\n")
+            labels = (
+                "Complete:",
+                "What was done:",
+                "Issues:",
+                "Appropriate next steps:",
+                "Approval needed:",
+            )
+            positions = [body.find(label) for label in labels]
+            header = " ".join(body[:positions[0]].split()) if positions[0] >= 0 else ""
+            valid_header = re.fullmatch(
+                r"Model:\s*\S.+?\s*\|\s*Route:\s*\S.+?\s*\|\s*Why:\s*\S.+",
+                header,
+                flags=re.I,
+            )
+            valid_sections = (
+                all(position >= 0 for position in positions)
+                and positions == sorted(positions)
+                and all(body.count(label) == 1 for label in labels)
+                and bool(re.search(r"(?m)^Complete:\s*(?:Yes|No)\b", body))
+            )
+            if not valid_header or not valid_sections:
+                raise RuntimeError("JAIMES prepared final validation failed")
+            # The runtime owner already performed the semantic normalization.
+            # This boundary only validates and converts its transport envelope.
+            return re.sub(
+                r"(?m)^([A-Za-z][A-Za-z0-9 /&()_-]{1,48}:)(?=\s|$)",
+                r"**\1**",
+                body,
+            )
         script = _Path.home() / ".openclaw" / "workspace" / "mission-control" / "scripts" / "jaimes_telegram_fast_ack.py"
         if not script.exists():
             logger.warning("[%s] JAIMES final formatter is unavailable", self.name)
@@ -4146,6 +4178,9 @@ class TelegramAdapter(BasePlatformAdapter):
             content or "",
         )
         parsed_why = header.group(3).strip() if header and header.group(3) else ""
+        runtime_evidence = card.get("terminal_runtime_evidence")
+        if not isinstance(runtime_evidence, dict):
+            runtime_evidence = {}
         payload = {
             "text": content,
             "objective": str(
@@ -4155,7 +4190,7 @@ class TelegramAdapter(BasePlatformAdapter):
             ),
             "model": str(card.get("model") or (header.group(1).strip() if header else "unverified")),
             "route": str(card.get("route") or (header.group(2).strip() if header else "unverified")),
-            "why": str(card.get("why") or parsed_why or "unverified"),
+            "why": str(card.get("why") or runtime_evidence.get("why") or parsed_why or "unverified"),
             "work_id": str(card.get("work_id") or ""),
             "run_id": str(card.get("ledger_run_id") or ""),
             "task_started_at": str(card.get("task_started_at") or card.get("started_at") or ""),

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4175,10 +4175,16 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             formatted = stdout.decode("utf-8", errors="replace").strip()
             if proc.returncode == 0 and re.fullmatch(r"<pre>[\s\S]*</pre>", formatted, flags=re.I):
-                # The adapter sends MarkdownV2, so convert the canonical HTML
-                # wrapper to one fenced code block while preserving its body.
+                # Keep the final proportional and scannable.  The canonical
+                # formatter uses <pre> as a transport envelope, but a Telegram
+                # code block makes JAIMES look materially different from the
+                # Inbox/Codex contract and is harder to read on mobile.
                 body = _html.unescape(formatted[5:-6]).strip("\n")
-                return f"```\n{body}\n```"
+                return re.sub(
+                    r"(?m)^([A-Za-z][A-Za-z0-9 /&()_-]{1,48}:)(?=\s|$)",
+                    r"**\1**",
+                    body,
+                )
             raise RuntimeError("JAIMES final formatter returned an invalid result")
         except Exception as exc:
             logger.warning("[%s] JAIMES final formatter failed: %s", self.name, exc)
@@ -4204,11 +4210,13 @@ class TelegramAdapter(BasePlatformAdapter):
         model = model_match.group(1).strip() if model_match else "JAIMES"
         objective = str(card.get("objective") or "Complete the current Telegram task")
         command = [
-            sys.executable, str(script), "update",
+            sys.executable, str(script), "done",
             "--key", str(card["key"]),
             "--title", objective,
             "--model", model,
-            "--now", "Final summary validated; sending now",
+            "--now", "Final summary validated; delivery starting",
+            "--done", "Final summary validated",
+            "--no-final-summary",
             "--chat-id", str(chat_id),
             "--thread-id", str(thread_id),
         ]
@@ -4235,12 +4243,9 @@ class TelegramAdapter(BasePlatformAdapter):
         command = self._jaimes_pre_final_card_command(chat_id, content, thread_id, metadata)
         if not command:
             return None
-        command[2] = "done"
         now_index = command.index("--now") + 1
         command[now_index] = "Final summary delivered"
         command.extend([
-            "--done", "Final summary delivered",
-            "--no-final-summary",
             "--final-message-id", str(final_message_id),
             "--final-delivery-verified-by", "hermes-adapter-success",
         ])
@@ -4337,10 +4342,9 @@ class TelegramAdapter(BasePlatformAdapter):
             # through to the legacy MarkdownV2 path on permanent/capability
             # errors or DM-topic routing skips; returns directly on success or
             # on a transient failure (which must NOT be legacy-resent).
-            # Topic 17 finals are a fixed-width canonical code block. Keep
-            # them on PTB's send_message path, whose concrete message_id is
-            # required to persist the terminal delivery receipt. A rich send
-            # may succeed without returning a persistable id.
+            # Topic 17 finals stay on PTB's send_message path, whose concrete
+            # message_id is required to persist the terminal delivery receipt.
+            # A rich send may succeed without returning a persistable id.
             if (
                 not jaimes_final
                 and jaimes_reply_markup is None

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4075,19 +4075,17 @@ class TelegramAdapter(BasePlatformAdapter):
             return None
         return InlineKeyboardMarkup(rows)
 
-    def _jaimes_pre_final_card_command(
+    def _jaimes_topic17_active_card(
         self,
         chat_id: str,
-        content: str,
         thread_id: Optional[str],
         metadata: Optional[Dict[str, Any]],
-    ) -> Optional[list[str]]:
-        """Build the completion-card edit that must precede final delivery."""
+    ) -> Optional[Dict[str, Any]]:
+        """Resolve the newest active Topic 17 card for this exact chat."""
         if str(thread_id or "") != "17" or not (metadata or {}).get("notify"):
             return None
         state_path = _Path.home() / ".openclaw" / "telegram" / "jaimes_fast_ack_state.json"
-        script = _Path.home() / ".openclaw" / "workspace" / "mission-control" / "scripts" / "jaimes_work_card.py"
-        if not state_path.exists() or not script.exists():
+        if not state_path.exists():
             return None
         try:
             state = json.loads(state_path.read_text(encoding="utf-8"))
@@ -4103,25 +4101,126 @@ class TelegramAdapter(BasePlatformAdapter):
                     candidates.append(card)
             if not candidates:
                 return None
-            card = max(candidates, key=lambda row: str(row.get("started_at") or row.get("updated_at") or ""))
+            return max(candidates, key=lambda row: str(row.get("started_at") or row.get("updated_at") or ""))
         except Exception as exc:
-            logger.warning("[%s] Could not resolve JAIMES pre-final card: %s", self.name, exc)
+            logger.warning("[%s] Could not resolve JAIMES Topic 17 card: %s", self.name, exc)
+            return None
+
+    async def _jaimes_canonical_final_before_send(
+        self,
+        chat_id: str,
+        content: str,
+        thread_id: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> str:
+        """Canonicalize Topic 17 before Telegram receives the only final."""
+        if str(thread_id or "") != "17" or not (metadata or {}).get("notify"):
+            return content
+        script = _Path.home() / ".openclaw" / "workspace" / "mission-control" / "scripts" / "jaimes_telegram_fast_ack.py"
+        if not script.exists():
+            logger.warning("[%s] JAIMES final formatter is unavailable", self.name)
+            raise RuntimeError("JAIMES final validation unavailable")
+        card = self._jaimes_topic17_active_card(chat_id, thread_id, metadata) or {}
+        header = re.search(
+            r"(?im)^Model:\s*([^|\n]+)\s*\|\s*Route:\s*([^|\n]+)",
+            content or "",
+        )
+        payload = {
+            "text": content,
+            "objective": str(card.get("objective") or "Complete the current Telegram task"),
+            "model": str(card.get("model") or (header.group(1).strip() if header else "unverified")),
+            "route": str(card.get("route") or (header.group(2).strip() if header else "unverified")),
+            "work_id": str(card.get("work_id") or ""),
+            "run_id": str(card.get("ledger_run_id") or ""),
+            "task_started_at": str(card.get("task_started_at") or card.get("started_at") or ""),
+        }
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable,
+                str(script),
+                "--format-final-json-stdin",
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(
+                proc.communicate(json.dumps(payload).encode("utf-8")),
+                timeout=8,
+            )
+            formatted = stdout.decode("utf-8", errors="replace").strip()
+            if proc.returncode == 0 and re.fullmatch(r"<pre>[\s\S]*</pre>", formatted, flags=re.I):
+                # The adapter sends MarkdownV2, so convert the canonical HTML
+                # wrapper to one fenced code block while preserving its body.
+                body = _html.unescape(formatted[5:-6]).strip("\n")
+                return f"```\n{body}\n```"
+            raise RuntimeError("JAIMES final formatter returned an invalid result")
+        except Exception as exc:
+            logger.warning("[%s] JAIMES final formatter failed: %s", self.name, exc)
+            raise RuntimeError("JAIMES final validation failed") from exc
+
+    def _jaimes_pre_final_card_command(
+        self,
+        chat_id: str,
+        content: str,
+        thread_id: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[list[str]]:
+        """Build the completion-card edit that must precede final delivery."""
+        if str(thread_id or "") != "17" or not (metadata or {}).get("notify"):
+            return None
+        script = _Path.home() / ".openclaw" / "workspace" / "mission-control" / "scripts" / "jaimes_work_card.py"
+        if not script.exists():
+            return None
+        card = self._jaimes_topic17_active_card(chat_id, thread_id, metadata)
+        if not card:
             return None
         model_match = re.search(r"(?im)^Model:\s*([^|\n]+)", content or "")
         model = model_match.group(1).strip() if model_match else "JAIMES"
         objective = str(card.get("objective") or "Complete the current Telegram task")
-        return [
-            sys.executable, str(script), "done",
+        command = [
+            sys.executable, str(script), "update",
             "--key", str(card["key"]),
             "--title", objective,
             "--model", model,
-            "--now", "summary sent",
-            "--done", "summary sent",
-            "--blocker", "None",
-            "--next", "No action needed.",
+            "--now", "Final summary validated; sending now",
             "--chat-id", str(chat_id),
             "--thread-id", str(thread_id),
         ]
+        if card.get("work_id"):
+            command.extend(["--work-id", str(card["work_id"])])
+        if card.get("ledger_run_id"):
+            command.extend(["--run-id", str(card["ledger_run_id"])])
+        task_started_at = card.get("task_started_at") or card.get("started_at")
+        if task_started_at:
+            command.extend(["--task-started-at", str(task_started_at)])
+        return command
+
+    def _jaimes_post_final_card_command(
+        self,
+        chat_id: str,
+        content: str,
+        thread_id: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+        final_message_id: Optional[str],
+    ) -> Optional[list[str]]:
+        """Bind the adapter-confirmed final receipt before closing the card."""
+        if not str(final_message_id or "").isdigit():
+            return None
+        command = self._jaimes_pre_final_card_command(chat_id, content, thread_id, metadata)
+        if not command:
+            return None
+        command[2] = "done"
+        now_index = command.index("--now") + 1
+        command[now_index] = "Final summary delivered"
+        command.extend([
+            "--done", "Final summary delivered",
+            "--blocker", "None",
+            "--next", "See the final summary for findings and next steps.",
+            "--no-final-summary",
+            "--final-message-id", str(final_message_id),
+            "--final-delivery-verified-by", "hermes-adapter-success",
+        ])
+        return command
 
     async def _jaimes_finalize_card_before_final(
         self,
@@ -4130,7 +4229,7 @@ class TelegramAdapter(BasePlatformAdapter):
         thread_id: Optional[str],
         metadata: Optional[Dict[str, Any]],
     ) -> None:
-        """Await the completion-card edit so the final can never overtake it."""
+        """Show final-ready state before delivery without claiming success."""
         command = self._jaimes_pre_final_card_command(chat_id, content, thread_id, metadata)
         if not command:
             return
@@ -4145,6 +4244,33 @@ class TelegramAdapter(BasePlatformAdapter):
                 logger.warning("[%s] JAIMES pre-final card edit exited %s", self.name, proc.returncode)
         except Exception as exc:
             logger.warning("[%s] JAIMES pre-final card edit failed: %s", self.name, exc)
+
+    async def _jaimes_complete_card_after_final(
+        self,
+        chat_id: str,
+        content: str,
+        thread_id: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+        final_message_id: Optional[str],
+    ) -> None:
+        """Close the live card only after Telegram confirms final delivery."""
+        command = self._jaimes_post_final_card_command(
+            chat_id, content, thread_id, metadata, final_message_id,
+        )
+        if not command:
+            logger.warning("[%s] JAIMES final delivery lacked a persistable message id", self.name)
+            return
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *command,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            await asyncio.wait_for(proc.wait(), timeout=12)
+            if proc.returncode:
+                logger.warning("[%s] JAIMES post-delivery card edit exited %s", self.name, proc.returncode)
+        except Exception as exc:
+            logger.warning("[%s] JAIMES post-delivery card edit failed: %s", self.name, exc)
 
     async def send(
         self,
@@ -4167,6 +4293,14 @@ class TelegramAdapter(BasePlatformAdapter):
         
         try:
             thread_id = self._metadata_thread_id(metadata)
+            jaimes_final = str(thread_id or "") == "17" and bool((metadata or {}).get("notify"))
+            if jaimes_final:
+                content = await self._jaimes_canonical_final_before_send(
+                    chat_id, content, thread_id, metadata,
+                )
+                await self._jaimes_finalize_card_before_final(
+                    chat_id, content, thread_id, metadata,
+                )
 
             # Final Telegram sends must not re-arm the one-shot typing action.
             # The gateway owns typing lifecycle and stops it before delivery.
@@ -4194,6 +4328,11 @@ class TelegramAdapter(BasePlatformAdapter):
                                 await self.send_typing(chat_id, metadata=metadata)
                             except Exception:
                                 pass  # Typing failures are non-fatal
+                        if jaimes_final:
+                            await self._jaimes_complete_card_after_final(
+                                chat_id, content, thread_id, metadata,
+                                rich_result.message_id,
+                            )
                     return rich_result
 
             # Format and split message if needed
@@ -4442,6 +4581,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     await self.send_typing(chat_id, metadata=metadata)
                 except Exception:
                     pass  # Typing failures are non-fatal
+
+            if jaimes_final:
+                await self._jaimes_complete_card_after_final(
+                    chat_id, content, thread_id, metadata,
+                    message_ids[0] if message_ids else None,
+                )
 
             return SendResult(
                 success=True,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9411,6 +9411,11 @@ class TelegramAdapter(BasePlatformAdapter):
         message_id = getattr(event, "message_id", None)
         if not (chat_id and message_id):
             return
+        # JAIMES: Control Center uses one acknowledgement-only reaction. Keep
+        # the initial eyes reaction instead of replacing it with a second
+        # thumbs-up/down reaction when processing completes.
+        if str(chat_id) == "-1003589561528" and outcome != ProcessingOutcome.CANCELLED:
+            return
         if outcome == ProcessingOutcome.CANCELLED:
             await self._clear_reactions(chat_id, message_id)
         else:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4081,7 +4081,7 @@ class TelegramAdapter(BasePlatformAdapter):
         thread_id: Optional[str],
         metadata: Optional[Dict[str, Any]],
     ) -> Optional[Dict[str, Any]]:
-        """Resolve the newest active Topic 17 card for this exact chat."""
+        """Resolve the newest visible Topic 17 card for this exact chat."""
         if str(thread_id or "") != "17" or not (metadata or {}).get("notify"):
             return None
         state_path = _Path.home() / ".openclaw" / "telegram" / "jaimes_fast_ack_state.json"
@@ -4090,14 +4090,29 @@ class TelegramAdapter(BasePlatformAdapter):
         try:
             state = json.loads(state_path.read_text(encoding="utf-8"))
             candidates = []
+            def _state_chat_id(value: object) -> str:
+                raw = str(value or "").strip()
+                if raw.startswith("telegram:"):
+                    raw = raw.split(":", 1)[1]
+                return str(normalize_telegram_chat_id(raw))
+
+            expected_chat = _state_chat_id(chat_id)
             for card in ((state.get("active_cards") or {}).values() if isinstance(state, dict) else []):
                 if not isinstance(card, dict) or card.get("status") != "active":
                     continue
-                if str(card.get("telegram_chat_id") or "") != str(chat_id):
+                try:
+                    card_chat = _state_chat_id(card.get("telegram_chat_id"))
+                except Exception:
+                    continue
+                if card_chat != expected_chat:
                     continue
                 if str(card.get("telegram_thread_id") or "") != str(thread_id):
                     continue
-                if card.get("key") and card.get("ack_message_id"):
+                if (
+                    card.get("key")
+                    and str(card.get("ack_message_id") or "").isdigit()
+                    and str(card.get("objective") or "").strip()
+                ):
                     candidates.append(card)
             if not candidates:
                 return None
@@ -4122,14 +4137,25 @@ class TelegramAdapter(BasePlatformAdapter):
             raise RuntimeError("JAIMES final validation unavailable")
         card = self._jaimes_topic17_active_card(chat_id, thread_id, metadata) or {}
         header = re.search(
-            r"(?im)^Model:\s*([^|\n]+)\s*\|\s*Route:\s*([^|\n]+)",
+            r"(?im)^\s*(?:🤖\s*)?Model:\s*([^|\n]+)\s*\|\s*"
+            r"Route:\s*([^|\n]+)(?:\s*\|\s*Why:\s*([^\n]+))?",
             content or "",
         )
+        objective_match = re.search(
+            r"(?im)^\s*(?:🎯\s*)?Objective:\s*([^\n]+)",
+            content or "",
+        )
+        parsed_why = header.group(3).strip() if header and header.group(3) else ""
         payload = {
             "text": content,
-            "objective": str(card.get("objective") or "Complete the current Telegram task"),
+            "objective": str(
+                card.get("objective")
+                or (objective_match.group(1).strip() if objective_match else "")
+                or "Complete the current Telegram task"
+            ),
             "model": str(card.get("model") or (header.group(1).strip() if header else "unverified")),
             "route": str(card.get("route") or (header.group(2).strip() if header else "unverified")),
+            "why": str(card.get("why") or parsed_why or "unverified"),
             "work_id": str(card.get("work_id") or ""),
             "run_id": str(card.get("ledger_run_id") or ""),
             "task_started_at": str(card.get("task_started_at") or card.get("started_at") or ""),
@@ -4214,8 +4240,6 @@ class TelegramAdapter(BasePlatformAdapter):
         command[now_index] = "Final summary delivered"
         command.extend([
             "--done", "Final summary delivered",
-            "--blocker", "None",
-            "--next", "See the final summary for findings and next steps.",
             "--no-final-summary",
             "--final-message-id", str(final_message_id),
             "--final-delivery-verified-by", "hermes-adapter-success",
@@ -4313,7 +4337,15 @@ class TelegramAdapter(BasePlatformAdapter):
             # through to the legacy MarkdownV2 path on permanent/capability
             # errors or DM-topic routing skips; returns directly on success or
             # on a transient failure (which must NOT be legacy-resent).
-            if jaimes_reply_markup is None and self._should_attempt_rich(content, metadata=metadata):
+            # Topic 17 finals are a fixed-width canonical code block. Keep
+            # them on PTB's send_message path, whose concrete message_id is
+            # required to persist the terminal delivery receipt. A rich send
+            # may succeed without returning a persistable id.
+            if (
+                not jaimes_final
+                and jaimes_reply_markup is None
+                and self._should_attempt_rich(content, metadata=metadata)
+            ):
                 rich_result = await self._try_send_rich(chat_id, content, reply_to, metadata)
                 if rich_result is not None:
                     if rich_result.success:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -12,6 +12,7 @@ import dataclasses
 import faulthandler
 import inspect
 import json
+import hashlib
 import logging
 import os
 import html as _html
@@ -3999,6 +4000,76 @@ class TelegramAdapter(BasePlatformAdapter):
         else:  # "first" (default)
             return chunk_index == 0
 
+    def _jaimes_topic17_reply_markup(
+        self,
+        content: str,
+        thread_id: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Any:
+        """Attach JAIMES numeric actions to the final card itself.
+
+        A separate delayed sendMessage raced the gateway's final delivery and
+        could place buttons above the final card. Reply markup in the same Bot
+        API call is guaranteed to render below ``Approval needed``.
+        """
+        if str(thread_id or "") != "17" or not (metadata or {}).get("notify"):
+            return None
+        match = re.search(
+            r"(?im)^\s*(?:🔐\s*)?(?:\*\*)?(?:Approval needed|Next steps for approval):?(?:\*\*)?\s*$",
+            content or "",
+        )
+        if not match:
+            return None
+        steps: list[str] = []
+        for raw in (content or "")[match.end():].splitlines():
+            line = raw.strip()
+            if not line:
+                continue
+            line = re.sub(r"^(?:[-*•]|\d+[.)])\s*", "", line).strip("* ")
+            if not line:
+                continue
+            normalized = " ".join(line.lower().split())
+            if normalized in {"none", "n/a", "na", "not applicable", "no action needed"}:
+                continue
+            if re.match(r"^(?:no action needed|no approval needed|nothing to approve)\b", normalized):
+                continue
+            if re.match(r"^(objective complete|tldr|challenges|complete|what was done|issues|appropriate next steps)\b", normalized):
+                break
+            steps.append(line)
+            if len(steps) >= 4:
+                break
+        if not steps:
+            return None
+
+        actions_path = _Path.home() / ".openclaw" / "telegram" / "jaimes_approval_actions.json"
+        try:
+            existing = json.loads(actions_path.read_text(encoding="utf-8")) if actions_path.exists() else {}
+            if not isinstance(existing, dict):
+                existing = {}
+        except Exception:
+            existing = {}
+        flat: list[InlineKeyboardButton] = []
+        for index, step in enumerate(steps, 1):
+            digest = hashlib.sha1(f"jaimes|{content}|{step}|{index}".encode("utf-8")).hexdigest()[:10]
+            callback = f"approve:jaimes:{digest}:{index}"
+            existing[callback] = {
+                "agent": "jaimes",
+                "objective": "Telegram final-card selection",
+                "step": step,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            }
+            flat.append(InlineKeyboardButton(str(index), callback_data=callback))
+        rows = [flat[i:i + 2] for i in range(0, len(flat), 2)]
+        try:
+            actions_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = actions_path.with_name(f"{actions_path.name}.{os.getpid()}.tmp")
+            tmp.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            os.replace(tmp, actions_path)
+        except Exception as exc:
+            logger.warning("[%s] Failed to persist JAIMES final actions: %s", self.name, exc)
+            return None
+        return InlineKeyboardMarkup(rows)
+
     async def send(
         self,
         chat_id: str,
@@ -4019,12 +4090,27 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=None)
         
         try:
+            # Final/direct sends may not have an active gateway refresh loop
+            # (cron deliveries, queued notifications, or platforms with
+            # streaming disabled).  Fire one pre-send action so Telegram still
+            # shows "typing…" while we are actually about to deliver, then do
+            # NOT re-arm it after the message lands (the message itself clears
+            # Telegram's one-shot typing state; there is no stop-typing API).
+            if (metadata or {}).get("notify"):
+                try:
+                    await self.send_typing(chat_id, metadata=metadata)
+                except Exception:
+                    pass  # Typing failures are non-fatal
+
+            thread_id = self._metadata_thread_id(metadata)
+            jaimes_reply_markup = self._jaimes_topic17_reply_markup(content, thread_id, metadata)
+
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
             # sendRichMessage so tables/task lists/etc. render natively. Falls
             # through to the legacy MarkdownV2 path on permanent/capability
             # errors or DM-topic routing skips; returns directly on success or
             # on a transient failure (which must NOT be legacy-resent).
-            if self._should_attempt_rich(content, metadata=metadata):
+            if jaimes_reply_markup is None and self._should_attempt_rich(content, metadata=metadata):
                 rich_result = await self._try_send_rich(chat_id, content, reply_to, metadata)
                 if rich_result is not None:
                     if rich_result.success:
@@ -4058,7 +4144,6 @@ class TelegramAdapter(BasePlatformAdapter):
                 ]
             
             message_ids = []
-            thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
             used_thread_fallback = False
             
@@ -4130,6 +4215,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 text=chunk,
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
+                                reply_markup=(jaimes_reply_markup if i == len(chunks) - 1 else None),
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
@@ -4144,6 +4230,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     text=plain_chunk,
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
+                                    reply_markup=(jaimes_reply_markup if i == len(chunks) - 1 else None),
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
@@ -5892,6 +5979,58 @@ class TelegramAdapter(BasePlatformAdapter):
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
 
+        # --- JAIMES final-card numeric actions ---
+        if data.startswith("approve:jaimes:"):
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to select this action.")
+                return
+            actions_path = _Path.home() / ".openclaw" / "telegram" / "jaimes_approval_actions.json"
+            try:
+                actions = json.loads(actions_path.read_text(encoding="utf-8"))
+                action = actions.get(data) if isinstance(actions, dict) else None
+            except Exception:
+                action = None
+            if not isinstance(action, dict) or not action.get("step"):
+                await query.answer(text="This option expired. Please reply with the number.")
+                return
+            step = str(action["step"])
+            await query.answer(text=f"Selected: {step[:120]}")
+            try:
+                await query.edit_message_reply_markup(reply_markup=None)
+            except Exception:
+                pass
+
+            chat_type_value = str(getattr(query_chat_type, "value", query_chat_type) or "").lower()
+            source_chat_type = "dm" if chat_type_value == "private" else ("channel" if chat_type_value == "channel" else "group")
+            chat_name = getattr(query_chat, "title", None) or getattr(query_chat, "full_name", None)
+            source = self.build_source(
+                chat_id=str(query_chat_id),
+                chat_name=chat_name,
+                chat_type=source_chat_type,
+                user_id=caller_id,
+                user_name=getattr(query.from_user, "full_name", None) or query_user_name,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                message_id=f"callback-{getattr(query, 'id', '')}",
+                is_bot=False,
+            )
+            event = MessageEvent(
+                text=f"Selected option: {step}",
+                message_type=MessageType.TEXT,
+                source=source,
+                message_id=f"callback-{getattr(query, 'id', '')}",
+                timestamp=datetime.now(timezone.utc),
+                metadata={"telegram_inline_action": True, "callback_data": data},
+            )
+            asyncio.create_task(self.handle_message(event))
+            return
+
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mpg:", "mpv:", "mm:", "mc:", "mb", "mx", "mg:")):
             chat_id = str(query.message.chat_id) if query.message else None
@@ -7320,7 +7459,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
         Unlike ``free_response_chats`` (whole-chat), each entry opens a single
         forum topic for free-response. A missing/omitted thread id on incoming
-        messages is normalized to the General topic (``1``).
+        messages is normalized to the General topic (``1``). Legacy topic-only
+        entries remain accepted for the JAIMES owned-topic contract.
         """
         raw = self.config.extra.get("free_response_topics")
         if raw is None:
@@ -7339,7 +7479,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
         thread_id = self._effective_message_thread_id(message)
         topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
-        return f"{chat_id}:{topic_id}" in topics
+        return f"{chat_id}:{topic_id}" in topics or topic_id in topics
 
     def _telegram_allowed_chats(self) -> set[str]:
         """Return the whitelist of group/supergroup chat IDs the bot will respond in.
@@ -7663,7 +7803,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._is_group_chat(message):
             return False
 
-        thread_id = getattr(message, "message_thread_id", None)
+        thread_id = self._effective_message_thread_id(message)
         allowed_topics = self._telegram_allowed_topics()
         if allowed_topics:
             topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
@@ -8109,6 +8249,25 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
+    async def _react_to_josh_control_center_message(self, message: Message) -> None:
+        """Native 👀 reaction for Josh's JAIMES Control Center messages."""
+        if not self._bot:
+            return
+        try:
+            chat_id = str(getattr(getattr(message, "chat", None), "id", ""))
+            user_id = str(getattr(getattr(message, "from_user", None), "id", ""))
+            # JAIMES: Josh expects a visible native Telegram reaction before
+            # the work-card flow starts in any Control Center topic.
+            if chat_id != "-1003589561528" or user_id != "6218150306":
+                return
+            await self._bot.set_message_reaction(
+                chat_id=int(chat_id),
+                message_id=int(message.message_id),
+                reaction="👀",
+            )
+        except Exception as exc:
+            logger.warning("[Telegram] Failed to set JAIMES ack reaction: %s", exc)
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -8134,6 +8293,7 @@ class TelegramAdapter(BasePlatformAdapter):
             if self._should_observe_unmentioned_group_message(msg):
                 self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
             return
+        await self._react_to_josh_control_center_message(msg)
         await self._ensure_forum_commands(update.message)
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
@@ -8156,6 +8316,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 getattr(getattr(msg, "chat", None), "id", None),
             )
             return
+        await self._react_to_josh_control_center_message(msg)
         await self._ensure_forum_commands(msg)
 
         event = self._build_message_event(msg, MessageType.COMMAND, update_id=update.update_id)
@@ -9103,8 +9264,14 @@ class TelegramAdapter(BasePlatformAdapter):
     # ── Message reactions (processing lifecycle) ──────────────────────────
 
     def _reactions_enabled(self) -> bool:
-        """Check if message reactions are enabled via config/env."""
-        return os.getenv("TELEGRAM_REACTIONS", "false").lower() not in {"false", "0", "no"}
+        """Check reactions from explicit env override, then live platform config."""
+        raw = os.getenv("TELEGRAM_REACTIONS")
+        if raw is not None:
+            return raw.lower() not in {"false", "0", "no", "off"}
+        configured = (getattr(self.config, "extra", {}) or {}).get("reactions")
+        if configured is None:
+            configured = True  # Telegram default: acknowledge every real inbound turn.
+        return str(configured).lower() not in {"false", "0", "no", "off"}
 
     async def _set_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
         """Set a single emoji reaction on a Telegram message."""

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4007,12 +4007,16 @@ class TelegramAdapter(BasePlatformAdapter):
         thread_id: Optional[str],
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
-        """Attach JAIMES numeric actions to the final card itself.
+        """Do not infer approval buttons from final-response prose.
 
-        A separate delayed sendMessage raced the gateway's final delivery and
-        could place buttons above the final card. Reply markup in the same Bot
-        API call is guaranteed to render below ``Approval needed``.
+        Buttons must come from an explicit approval/clarify action. Parsing
+        free-form final text caused false numeric buttons for values such as
+        ``n/a</pre>`` and made harmless summaries look actionable.
         """
+        return None
+
+        # Legacy parser retained temporarily below for a small carried-commit
+        # diff; it is intentionally unreachable and can be dropped on rebase.
         if str(thread_id or "") != "17" or not (metadata or {}).get("notify"):
             return None
         match = re.search(
@@ -4163,21 +4167,12 @@ class TelegramAdapter(BasePlatformAdapter):
         
         try:
             thread_id = self._metadata_thread_id(metadata)
-            await self._jaimes_finalize_card_before_final(chat_id, content, thread_id, metadata)
 
-            # Final/direct sends may not have an active gateway refresh loop
-            # (cron deliveries, queued notifications, or platforms with
-            # streaming disabled).  Fire one pre-send action so Telegram still
-            # shows "typing…" while we are actually about to deliver, then do
-            # NOT re-arm it after the message lands (the message itself clears
-            # Telegram's one-shot typing state; there is no stop-typing API).
-            if (metadata or {}).get("notify"):
-                try:
-                    await self.send_typing(chat_id, metadata=metadata)
-                except Exception:
-                    pass  # Typing failures are non-fatal
-
-            jaimes_reply_markup = self._jaimes_topic17_reply_markup(content, thread_id, metadata)
+            # Final Telegram sends must not re-arm the one-shot typing action.
+            # The gateway owns typing lifecycle and stops it before delivery.
+            # Approval buttons are created only by explicit approval/clarify
+            # flows, never inferred from final-response prose.
+            jaimes_reply_markup = None
 
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
             # sendRichMessage so tables/task lists/etc. render natively. Falls

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -17,6 +17,7 @@ import logging
 import os
 import html as _html
 import re
+import subprocess
 import threading
 import time
 from contextvars import ContextVar
@@ -4070,6 +4071,77 @@ class TelegramAdapter(BasePlatformAdapter):
             return None
         return InlineKeyboardMarkup(rows)
 
+    def _jaimes_pre_final_card_command(
+        self,
+        chat_id: str,
+        content: str,
+        thread_id: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[list[str]]:
+        """Build the completion-card edit that must precede final delivery."""
+        if str(thread_id or "") != "17" or not (metadata or {}).get("notify"):
+            return None
+        state_path = _Path.home() / ".openclaw" / "telegram" / "jaimes_fast_ack_state.json"
+        script = _Path.home() / ".openclaw" / "workspace" / "mission-control" / "scripts" / "jaimes_work_card.py"
+        if not state_path.exists() or not script.exists():
+            return None
+        try:
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+            candidates = []
+            for card in ((state.get("active_cards") or {}).values() if isinstance(state, dict) else []):
+                if not isinstance(card, dict) or card.get("status") != "active":
+                    continue
+                if str(card.get("telegram_chat_id") or "") != str(chat_id):
+                    continue
+                if str(card.get("telegram_thread_id") or "") != str(thread_id):
+                    continue
+                if card.get("key") and card.get("ack_message_id"):
+                    candidates.append(card)
+            if not candidates:
+                return None
+            card = max(candidates, key=lambda row: str(row.get("started_at") or row.get("updated_at") or ""))
+        except Exception as exc:
+            logger.warning("[%s] Could not resolve JAIMES pre-final card: %s", self.name, exc)
+            return None
+        model_match = re.search(r"(?im)^Model:\s*([^|\n]+)", content or "")
+        model = model_match.group(1).strip() if model_match else "JAIMES"
+        objective = str(card.get("objective") or "Complete the current Telegram task")
+        return [
+            sys.executable, str(script), "done",
+            "--key", str(card["key"]),
+            "--title", objective,
+            "--model", model,
+            "--now", "summary sent",
+            "--done", "summary sent",
+            "--blocker", "None",
+            "--next", "No action needed.",
+            "--chat-id", str(chat_id),
+            "--thread-id", str(thread_id),
+        ]
+
+    async def _jaimes_finalize_card_before_final(
+        self,
+        chat_id: str,
+        content: str,
+        thread_id: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> None:
+        """Await the completion-card edit so the final can never overtake it."""
+        command = self._jaimes_pre_final_card_command(chat_id, content, thread_id, metadata)
+        if not command:
+            return
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *command,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            await asyncio.wait_for(proc.wait(), timeout=12)
+            if proc.returncode:
+                logger.warning("[%s] JAIMES pre-final card edit exited %s", self.name, proc.returncode)
+        except Exception as exc:
+            logger.warning("[%s] JAIMES pre-final card edit failed: %s", self.name, exc)
+
     async def send(
         self,
         chat_id: str,
@@ -4090,6 +4162,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=None)
         
         try:
+            thread_id = self._metadata_thread_id(metadata)
+            await self._jaimes_finalize_card_before_final(chat_id, content, thread_id, metadata)
+
             # Final/direct sends may not have an active gateway refresh loop
             # (cron deliveries, queued notifications, or platforms with
             # streaming disabled).  Fire one pre-send action so Telegram still
@@ -4102,7 +4177,6 @@ class TelegramAdapter(BasePlatformAdapter):
                 except Exception:
                     pass  # Typing failures are non-fatal
 
-            thread_id = self._metadata_thread_id(metadata)
             jaimes_reply_markup = self._jaimes_topic17_reply_markup(content, thread_id, metadata)
 
             # Bot API 10.1 rich fast-path: send the raw agent markdown via

--- a/run_agent.py
+++ b/run_agent.py
@@ -65,6 +65,17 @@ from types import SimpleNamespace
 from hermes_constants import get_hermes_home
 
 
+def _current_gateway_message_id() -> Optional[str]:
+    """Return the native inbound ID for the task-local gateway turn."""
+    try:
+        from gateway.session_context import get_session_env
+
+        return get_session_env("HERMES_SESSION_MESSAGE_ID").strip() or None
+    except Exception:
+        # CLI/cron agents do not bind gateway context and remain unaffected.
+        return None
+
+
 def _launch_cwd_for_session(source: str) -> Optional[str]:
     """Working directory to stamp on a new session row, or None.
 
@@ -2038,6 +2049,11 @@ class AIAgent:
                     reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                    platform_message_id=(
+                        _current_gateway_message_id()
+                        if is_current_turn_user and role == "user"
+                        else None
+                    ),
                     timestamp=_row_timestamp,
                     api_content=_row_api_content,
                 )

--- a/tests/gateway/test_restart_starts_new_session.py
+++ b/tests/gateway/test_restart_starts_new_session.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+from gateway.slash_commands import GatewaySlashCommandsMixin
+
+
+class FakeRunner(GatewaySlashCommandsMixin):
+    pass
+
+
+def _event() -> MessageEvent:
+    return MessageEvent(
+        text="/restart",
+        message_type=MessageType.COMMAND,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1003589561528",
+            chat_type="group",
+            user_id="6218150306",
+            thread_id="17",
+        ),
+        message_id="123",
+        platform_update_id=456,
+    )
+
+
+def test_restart_new_session_flag_reads_platform_config():
+    runner = object.__new__(FakeRunner)
+    runner.adapters = {
+        Platform.TELEGRAM: SimpleNamespace(
+            config=PlatformConfig(
+                enabled=True,
+                token="fake",
+                extra={"restart_starts_new_session": True},
+            )
+        )
+    }
+    assert runner._restart_starts_new_session(_event()) is True
+
+
+@pytest.mark.asyncio
+async def test_restart_resets_session_before_requesting_restart(tmp_path, monkeypatch):
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+
+    runner = object.__new__(FakeRunner)
+    runner._is_stale_restart_redelivery = MagicMock(return_value=False)
+    runner._restart_requested = False
+    runner._draining = False
+    runner._restart_starts_new_session = MagicMock(return_value=True)
+    runner._handle_reset_command = AsyncMock(return_value="new session")
+    runner._running_agent_count = MagicMock(return_value=0)
+    runner.request_restart = MagicMock()
+
+    await runner._handle_restart_command(_event())
+
+    runner._handle_reset_command.assert_awaited_once()
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+    assert (
+        runner._handle_reset_command.await_args_list[0].args[0].text
+        == runner._is_stale_restart_redelivery.call_args_list[0].args[0].text
+    )

--- a/tests/gateway/test_session_split_brain_11016.py
+++ b/tests/gateway/test_session_split_brain_11016.py
@@ -77,6 +77,16 @@ def _session_key(chat_id="12345"):
     return build_session_key(source)
 
 
+async def _drain_session_task(adapter, session_key, attempts=20):
+    """Drain a spawned adapter task without assuming a fixed event-loop count."""
+    for _ in range(attempts):
+        task = adapter._session_tasks.get(session_key)
+        if task is None or task.done():
+            await asyncio.sleep(0)
+            return
+        await asyncio.sleep(0)
+
+
 # ---------------------------------------------------------------------------
 # Runner helpers
 # ---------------------------------------------------------------------------
@@ -155,8 +165,7 @@ class TestAdapterSessionCancellation:
         await adapter.handle_message(
             _make_event("/model xiaomi/mimo-v2-pro --provider nous")
         )
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        await _drain_session_task(adapter, sk)
 
         assert any("handled:model" in r for r in adapter.sent_responses), (
             f"follow-up /model stayed blocked after {command_text}"
@@ -260,9 +269,7 @@ class TestStaleSessionLockSelfHeal:
         # An ordinary message should heal the stale lock, then fall through
         # to normal dispatch.  User gets a reply instead of a busy ack.
         await adapter.handle_message(_make_event("hello"))
-        # Drain any spawned background tasks.
-        for _ in range(5):
-            await asyncio.sleep(0)
+        await _drain_session_task(adapter, sk)
 
         assert any("handled:text" in r for r in adapter.sent_responses), (
             "stale lock trapped a normal message — split-brain not healed"

--- a/tests/gateway/test_telegram_final_delivery.py
+++ b/tests/gateway/test_telegram_final_delivery.py
@@ -5,10 +5,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from plugins.platforms.telegram.adapter import TelegramAdapter
 from gateway.config import PlatformConfig
 from gateway.platforms.base import SendResult
 from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
-from plugins.platforms.telegram.adapter import TelegramAdapter
 
 
 def _adapter() -> MagicMock:

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -214,11 +214,12 @@ async def test_legacy_send_keeps_chunk_indicators_outside_fenced_code_lines(adap
 
 
 @pytest.mark.asyncio
-async def test_final_send_primes_typing_once_before_delivery(adapter):
-    """Final/direct replies should show a short pre-send typing action, but
-    must NOT re-arm Telegram's timer after the answer lands.  Cron/direct
-    deliveries may not have an active gateway refresh loop, while post-send
-    re-triggers would leave a lingering bubble (Telegram has no stop API)."""
+async def test_final_send_does_not_prime_typing_before_delivery(adapter):
+    """Final/direct replies must not re-arm Telegram's one-shot timer.
+
+    Telegram has no stop-typing endpoint, so a pre-send action can remain
+    visible after rich-message delivery and make a completed turn look active.
+    """
     adapter._bot = MagicMock()
     adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
     adapter._bot.send_chat_action = AsyncMock()
@@ -227,8 +228,7 @@ async def test_final_send_primes_typing_once_before_delivery(adapter):
     result = await adapter.send("12345", "All done.", metadata={"notify": True})
 
     assert result.success is True
-    adapter._bot.send_chat_action.assert_awaited_once()
-    assert adapter._bot.send_chat_action.await_args_list[0].kwargs["action"] == "typing"
+    adapter._bot.send_chat_action.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -214,11 +214,11 @@ async def test_legacy_send_keeps_chunk_indicators_outside_fenced_code_lines(adap
 
 
 @pytest.mark.asyncio
-async def test_final_send_does_not_retrigger_typing(adapter):
-    """The final reply (metadata['notify']) must NOT re-arm Telegram's typing
-    timer. The gateway has already torn down the refresh loop by then, so a
-    re-trigger here would leave the '...typing' bubble lingering after the
-    answer (Telegram has no stop-typing API). See #48678."""
+async def test_final_send_primes_typing_once_before_delivery(adapter):
+    """Final/direct replies should show a short pre-send typing action, but
+    must NOT re-arm Telegram's timer after the answer lands.  Cron/direct
+    deliveries may not have an active gateway refresh loop, while post-send
+    re-triggers would leave a lingering bubble (Telegram has no stop API)."""
     adapter._bot = MagicMock()
     adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
     adapter._bot.send_chat_action = AsyncMock()
@@ -227,7 +227,8 @@ async def test_final_send_does_not_retrigger_typing(adapter):
     result = await adapter.send("12345", "All done.", metadata={"notify": True})
 
     assert result.success is True
-    adapter._bot.send_chat_action.assert_not_called()
+    adapter._bot.send_chat_action.assert_awaited_once()
+    assert adapter._bot.send_chat_action.await_args_list[0].kwargs["action"] == "typing"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -33,6 +33,8 @@ def _make_adapter(
         extra["free_response_chats"] = free_response_chats
     if free_response_topics is not None:
         extra["free_response_topics"] = free_response_topics
+    else:
+        extra["free_response_topics"] = []
     if mention_patterns is not None:
         extra["mention_patterns"] = mention_patterns
     if exclusive_bot_mentions is not None:
@@ -581,6 +583,27 @@ def test_free_response_topic_messages_are_dispatched_not_observed():
     assert adapter._should_observe_unmentioned_group_message(other_topic) is True
 
 
+def test_free_response_topics_bypass_mention_requirement_only_in_owned_topics():
+    adapter = _make_adapter(require_mention=True, free_response_topics=["17", 19, "20", 56])
+
+    for topic_id in (17, 19, 20, 56):
+        assert adapter._should_process_message(
+            _group_message("untagged owner message", thread_id=topic_id)
+        ) is True
+    for topic_id in (1, 18, 21, 22):
+        assert adapter._should_process_message(
+            _group_message("untagged non-owner message", thread_id=topic_id)
+        ) is False
+
+
+def test_non_owned_topic_explicit_mention_overrides_ownership_gate():
+    adapter = _make_adapter(require_mention=True, free_response_topics=["17", "19", "20", "56"])
+    text = "@hermes_bot take this delegated task"
+    message = _group_message(text, thread_id=18, entities=[_mention_entity(text)])
+
+    assert adapter._should_process_message(message) is True
+
+
 def test_guest_mode_allows_only_direct_mentions_outside_allowed_chats():
     adapter = _make_adapter(
         require_mention=True,
@@ -803,6 +826,9 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
         "    - \"^\\\\s*chompy\\\\b\"\n"
         "  free_response_chats:\n"
         "    - \"-123\"\n"
+        "  free_response_topics:\n"
+        "    - 17\n"
+        "    - 19\n"
         "  allowed_chats:\n"
         "    - \"-100\"\n"
         "  group_allowed_chats:\n"
@@ -825,6 +851,7 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
         "TELEGRAM_GUEST_MODE",
         "TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES",
         "TELEGRAM_FREE_RESPONSE_CHATS",
+        "TELEGRAM_FREE_RESPONSE_TOPICS",
         "TELEGRAM_ALLOWED_CHATS",
         "TELEGRAM_GROUP_ALLOWED_CHATS",
         "TELEGRAM_ALLOWED_TOPICS",
@@ -855,6 +882,7 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
     # TELEGRAM_FREE_RESPONSE_CHATS is not a key that appears in developer .env
     # files, so asserting it via os.environ stays deterministic.
     assert __import__("os").environ["TELEGRAM_FREE_RESPONSE_CHATS"] == "-123"
+    assert __import__("os").environ["TELEGRAM_FREE_RESPONSE_TOPICS"] == "17,19"
 
 
 def test_config_bridges_telegram_user_allowlists(monkeypatch, tmp_path):

--- a/tests/gateway/test_telegram_jaimes_three_bubble_contract.py
+++ b/tests/gateway/test_telegram_jaimes_three_bubble_contract.py
@@ -238,7 +238,7 @@ def test_gateway_stops_typing_before_final_delivery():
     source = inspect.getsource(BasePlatformAdapter._process_message_background)
     response_branch = source.index("if response:")
     stop_at = source.index("await _stop_typing_task()", response_branch)
-    send_at = source.index("result = await self._send_with_retry", response_branch)
+    send_at = source.index("result = await delivery_adapter._send_with_retry", response_branch)
     assert stop_at < send_at
 
 

--- a/tests/gateway/test_telegram_jaimes_three_bubble_contract.py
+++ b/tests/gateway/test_telegram_jaimes_three_bubble_contract.py
@@ -131,9 +131,11 @@ def test_jaimes_final_builds_pre_delivery_edit_for_current_active_card(tmp_path)
             "-1003589561528", content, "17", {"notify": True}
         )
     assert command is not None
-    assert command[2] == "update"
+    assert command[2] == "done"
     assert command[command.index("--key") + 1] == "turn-123"
-    assert command[command.index("--now") + 1] == "Final summary validated; sending now"
+    assert command[command.index("--now") + 1] == "Final summary validated; delivery starting"
+    assert command[command.index("--done") + 1] == "Final summary validated"
+    assert "--no-final-summary" in command
     assert command[command.index("--model") + 1] == "openai-codex/gpt-5.6-sol"
     assert command[command.index("--work-id") + 1] == "work-current"
     assert command[command.index("--run-id") + 1] == "run-current"
@@ -219,7 +221,7 @@ def test_jaimes_final_formatter_receives_private_payload_over_stdin(tmp_path):
         "assert payload['work_id']=='work-current'\n"
         "assert payload['run_id']=='run-current'\n"
         "assert payload['task_started_at']=='2026-07-12T23:21:59Z'\n"
-        "print('<pre>canonical final</pre>')\n"
+        "print('<pre>Model: verified\\nComplete: Yes</pre>')\n"
     )
     adapter = _adapter()
     with patch.object(telegram_adapter._Path, "home", return_value=tmp_path):
@@ -229,7 +231,7 @@ def test_jaimes_final_formatter_receives_private_payload_over_stdin(tmp_path):
             "17",
             {"notify": True},
         ))
-    assert rendered == "```\ncanonical final\n```"
+    assert rendered == "**Model:** verified\n**Complete:** Yes"
 
 
 def test_gateway_stops_typing_before_final_delivery():
@@ -295,7 +297,7 @@ def test_unbound_final_preserves_verified_why_in_private_formatter_payload(tmp_p
         rendered = asyncio.run(_adapter()._jaimes_canonical_final_before_send(
             "-1001", content, "17", {"notify": True}
         ))
-    assert rendered == "```\ncanonical final\n```"
+    assert rendered == "canonical final"
 
 
 def test_unbound_final_only_uses_literal_objective_label(tmp_path):
@@ -332,7 +334,7 @@ def test_unbound_final_only_uses_literal_objective_label(tmp_path):
             ))
             for content in contents
         ]
-    assert rendered == ["```\ncanonical final\n```"] * 3
+    assert rendered == ["canonical final"] * 3
 
 
 def test_post_delivery_command_persists_exact_adapter_message_id(tmp_path):
@@ -400,7 +402,7 @@ def test_topic17_final_skips_rich_and_closes_with_exact_ptb_message_id():
         side_effect=AssertionError("Topic 17 final must not use rich delivery")
     )
     adapter._jaimes_canonical_final_before_send = AsyncMock(
-        return_value="```\ncanonical final\n```"
+        return_value="canonical final"
     )
     adapter._jaimes_finalize_card_before_final = AsyncMock()
     adapter._jaimes_complete_card_after_final = AsyncMock()

--- a/tests/gateway/test_telegram_jaimes_three_bubble_contract.py
+++ b/tests/gateway/test_telegram_jaimes_three_bubble_contract.py
@@ -1,7 +1,9 @@
 import asyncio
 import inspect
 import json
-from unittest.mock import patch
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -236,3 +238,189 @@ def test_gateway_stops_typing_before_final_delivery():
     stop_at = source.index("await _stop_typing_task()", response_branch)
     send_at = source.index("result = await self._send_with_retry", response_branch)
     assert stop_at < send_at
+
+
+def test_active_card_ignores_blank_zombie_and_normalizes_chat_prefix(tmp_path):
+    state_path = tmp_path / ".openclaw" / "telegram" / "jaimes_fast_ack_state.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(json.dumps({"active_cards": {
+        "zombie": {
+            "status": "active",
+            "key": "zombie",
+            "ack_message_id": "",
+            "objective": "",
+            "telegram_chat_id": "-1001",
+            "telegram_thread_id": "17",
+            "started_at": "2099-01-01T00:00:00Z",
+        },
+        "bound": {
+            "status": "active",
+            "key": "bound",
+            "ack_message_id": "44",
+            "objective": "Verify exact final delivery",
+            "telegram_chat_id": "telegram:-1001",
+            "telegram_thread_id": "17",
+            "started_at": "2026-07-18T20:00:00Z",
+        },
+    }}), encoding="utf-8")
+
+    with patch.object(telegram_adapter._Path, "home", return_value=tmp_path):
+        card = _adapter()._jaimes_topic17_active_card(
+            "-1001", "17", {"notify": True}
+        )
+    assert card and card["key"] == "bound"
+
+
+def test_unbound_final_preserves_verified_why_in_private_formatter_payload(tmp_path):
+    script = (
+        tmp_path / ".openclaw" / "workspace" / "mission-control" / "scripts"
+        / "jaimes_telegram_fast_ack.py"
+    )
+    script.parent.mkdir(parents=True)
+    script.write_text(
+        "import json,sys\n"
+        "payload=json.load(sys.stdin)\n"
+        "assert payload['model']=='openai-codex/gpt-5.6-sol'\n"
+        "assert payload['route']=='JAIMES verified execution'\n"
+        "assert payload['why']=='300/300 checks passed'\n"
+        "print('<pre>canonical final</pre>')\n",
+        encoding="utf-8",
+    )
+    content = (
+        "Model: openai-codex/gpt-5.6-sol | Route: JAIMES verified execution "
+        "| Why: 300/300 checks passed\nComplete: Yes"
+    )
+
+    with patch.object(telegram_adapter._Path, "home", return_value=tmp_path):
+        rendered = asyncio.run(_adapter()._jaimes_canonical_final_before_send(
+            "-1001", content, "17", {"notify": True}
+        ))
+    assert rendered == "```\ncanonical final\n```"
+
+
+def test_unbound_final_only_uses_literal_objective_label(tmp_path):
+    script = (
+        tmp_path / ".openclaw" / "workspace" / "mission-control" / "scripts"
+        / "jaimes_telegram_fast_ack.py"
+    )
+    script.parent.mkdir(parents=True)
+    script.write_text(
+        "import json,sys\n"
+        "payload=json.load(sys.stdin)\n"
+        "expected=('Assess the current agent workflow' "
+        "if '\\nObjective: Assess the current agent workflow' in payload['text'] "
+        "else 'Complete the current Telegram task')\n"
+        "assert payload['objective']==expected\n"
+        "assert payload['objective'] not in {'Yes','No'}\n"
+        "print('<pre>canonical final</pre>')\n",
+        encoding="utf-8",
+    )
+    adapter = _adapter()
+    contents = (
+        "Model: test | Route: test | Why: verified\nObjective Complete: Yes",
+        "Model: test | Route: test | Why: verified\nObjective Complete: No",
+        (
+            "Model: test | Route: test | Why: verified\n"
+            "Objective: Assess the current agent workflow"
+        ),
+    )
+
+    with patch.object(telegram_adapter._Path, "home", return_value=tmp_path):
+        rendered = [
+            asyncio.run(adapter._jaimes_canonical_final_before_send(
+                "-1001", content, "17", {"notify": True}
+            ))
+            for content in contents
+        ]
+    assert rendered == ["```\ncanonical final\n```"] * 3
+
+
+def test_post_delivery_command_persists_exact_adapter_message_id(tmp_path):
+    state_path = tmp_path / ".openclaw" / "telegram" / "jaimes_fast_ack_state.json"
+    script = (
+        tmp_path / ".openclaw" / "workspace" / "mission-control" / "scripts"
+        / "jaimes_work_card.py"
+    )
+    state_path.parent.mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text("# test\n", encoding="utf-8")
+    state_path.write_text(json.dumps({"active_cards": {
+        "bound": {
+            "status": "active",
+            "key": "bound",
+            "ack_message_id": "44",
+            "objective": "Verify exact final delivery",
+            "telegram_chat_id": "-1001",
+            "telegram_thread_id": "17",
+            "started_at": "2026-07-18T20:00:00Z",
+        }
+    }}), encoding="utf-8")
+    content = (
+        "Model: openai-codex/gpt-5.6-sol | Route: JAIMES verified execution "
+        "| Why: verified\nComplete: Yes"
+    )
+
+    with patch.object(telegram_adapter._Path, "home", return_value=tmp_path):
+        command = _adapter()._jaimes_post_final_card_command(
+            "-1001", content, "17", {"notify": True}, "3914"
+        )
+    assert command is not None
+    assert command[2] == "done"
+    assert command[command.index("--final-message-id") + 1] == "3914"
+    assert command[
+        command.index("--final-delivery-verified-by") + 1
+    ] == "hermes-adapter-success"
+    assert "--blocker" not in command
+    assert "--next" not in command
+
+
+def test_topic17_final_skips_rich_and_closes_with_exact_ptb_message_id():
+    adapter = _adapter()
+
+    class FakeBot:
+        async def send_message(self, **_kwargs):
+            return SimpleNamespace(message_id=777)
+
+    adapter._bot = FakeBot()
+    adapter.platform = type("Platform", (), {"value": "telegram"})()
+    adapter._send_path_degraded = False
+    adapter._reply_to_mode = "off"
+    adapter._metadata_thread_id = lambda _metadata: "17"
+    adapter._metadata_reply_to_message_id = lambda _metadata: None
+    adapter._message_thread_id_for_send = lambda thread_id: thread_id
+    adapter._is_private_dm_topic_send = lambda *_args, **_kwargs: False
+    adapter._should_thread_reply = lambda *_args, **_kwargs: False
+    adapter._thread_kwargs_for_send = lambda *_args, **_kwargs: {
+        "message_thread_id": 17
+    }
+    adapter._link_preview_kwargs = lambda: {}
+    adapter._notification_kwargs = lambda _metadata: {}
+    adapter._should_attempt_rich = lambda *_args, **_kwargs: True
+    adapter._try_send_rich = AsyncMock(
+        side_effect=AssertionError("Topic 17 final must not use rich delivery")
+    )
+    adapter._jaimes_canonical_final_before_send = AsyncMock(
+        return_value="```\ncanonical final\n```"
+    )
+    adapter._jaimes_finalize_card_before_final = AsyncMock()
+    adapter._jaimes_complete_card_after_final = AsyncMock()
+    adapter.format_message = lambda content: content
+    adapter.truncate_message = lambda content, *_args, **_kwargs: [content]
+
+    result = asyncio.run(adapter.send(
+        "-1001",
+        "Model: test | Route: test | Why: test\nComplete: Yes",
+        metadata={"notify": True, "message_thread_id": "17"},
+    ))
+
+    assert result.success is True
+    assert result.message_id == "777"
+    adapter._try_send_rich.assert_not_awaited()
+    adapter._jaimes_complete_card_after_final.assert_awaited_once()
+    assert adapter._jaimes_complete_card_after_final.await_args.args[-1] == "777"
+
+
+def test_topic17_contract_does_not_add_a_task_header():
+    source = Path(telegram_adapter.__file__).read_text(encoding="utf-8")
+    assert "--header-message-id" not in source
+    assert "JAIMES_TELEGRAM_TASK_HEADERS" not in source

--- a/tests/gateway/test_telegram_jaimes_three_bubble_contract.py
+++ b/tests/gateway/test_telegram_jaimes_three_bubble_contract.py
@@ -1,0 +1,85 @@
+from unittest.mock import patch
+
+from plugins.platforms.telegram import adapter as telegram_adapter
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+class FakeButton:
+    def __init__(self, text, callback_data=None):
+        self.text = text
+        self.callback_data = callback_data
+
+
+class FakeMarkup:
+    def __init__(self, rows):
+        self.inline_keyboard = rows
+
+
+def _adapter():
+    return object.__new__(TelegramAdapter)
+
+
+def test_jaimes_final_normal_bubble_gets_corresponding_buttons():
+    content = """🤖 gpt-5.6-sol (Codex subscription)
+
+**Objective Complete:** Yes
+
+**TLDR:**
+- Work completed
+
+**Challenges/Blockers:**
+None
+
+**Next steps for approval:**
+1. Run live canary
+2. Keep current configuration
+"""
+    with patch.object(telegram_adapter, "InlineKeyboardButton", FakeButton), patch.object(
+        telegram_adapter, "InlineKeyboardMarkup", FakeMarkup
+    ):
+        markup = _adapter()._jaimes_topic17_reply_markup(
+            content,
+            "17",
+            {"notify": True},
+        )
+    assert markup is not None
+    assert [[button.text for button in row] for row in markup.inline_keyboard] == [["1", "2"]]
+    assert not content.lstrip().startswith("```")
+
+
+def test_jaimes_final_no_action_has_no_buttons():
+    content = """🤖 gpt-5.6-sol (Codex subscription)
+
+**Objective Complete:** Yes
+
+**Next steps for approval:**
+No action needed
+"""
+    with patch.object(telegram_adapter, "InlineKeyboardButton", FakeButton), patch.object(
+        telegram_adapter, "InlineKeyboardMarkup", FakeMarkup
+    ):
+        markup = _adapter()._jaimes_topic17_reply_markup(
+            content,
+            "17",
+            {"notify": True},
+        )
+    assert markup is None
+
+
+def test_jaimes_final_no_action_with_explanation_has_no_buttons():
+    content = """🤖 gpt-5.6-sol (Codex subscription)
+
+**Objective Complete:** Yes
+
+**Next steps for approval:**
+- No action needed; future alerts use this layout
+"""
+    with patch.object(telegram_adapter, "InlineKeyboardButton", FakeButton), patch.object(
+        telegram_adapter, "InlineKeyboardMarkup", FakeMarkup
+    ):
+        markup = _adapter()._jaimes_topic17_reply_markup(
+            content,
+            "17",
+            {"notify": True},
+        )
+    assert markup is None

--- a/tests/gateway/test_telegram_jaimes_three_bubble_contract.py
+++ b/tests/gateway/test_telegram_jaimes_three_bubble_contract.py
@@ -2,6 +2,7 @@ import inspect
 import json
 from unittest.mock import patch
 
+from gateway.platforms.base import BasePlatformAdapter
 from plugins.platforms.telegram import adapter as telegram_adapter
 from plugins.platforms.telegram.adapter import TelegramAdapter
 
@@ -21,7 +22,7 @@ def _adapter():
     return object.__new__(TelegramAdapter)
 
 
-def test_jaimes_final_normal_bubble_gets_corresponding_buttons():
+def test_jaimes_final_prose_never_infers_buttons():
     content = """🤖 gpt-5.6-sol (Codex subscription)
 
 **Objective Complete:** Yes
@@ -44,9 +45,7 @@ None
             "17",
             {"notify": True},
         )
-    assert markup is not None
-    assert [[button.text for button in row] for row in markup.inline_keyboard] == [["1", "2"]]
-    assert not content.lstrip().startswith("```")
+    assert markup is None
 
 
 def test_jaimes_final_no_action_has_no_buttons():
@@ -116,8 +115,16 @@ def test_jaimes_final_builds_completion_edit_for_current_active_card(tmp_path):
     assert command[command.index("--model") + 1] == "openai-codex/gpt-5.6-sol"
 
 
-def test_jaimes_completion_edit_is_awaited_before_final_send_path():
+def test_jaimes_final_send_does_not_rearm_typing_or_autofinalize_card():
     source = inspect.getsource(TelegramAdapter.send)
-    close_at = source.index("await self._jaimes_finalize_card_before_final")
-    format_at = source.index("formatted = self.format_message")
-    assert close_at < format_at
+    assert "await self._jaimes_finalize_card_before_final" not in source
+    assert "Final/direct sends may not have an active gateway refresh loop" not in source
+    assert "jaimes_reply_markup = None" in source
+
+
+def test_gateway_stops_typing_before_final_delivery():
+    source = inspect.getsource(BasePlatformAdapter._process_message_background)
+    response_branch = source.index("if response:")
+    stop_at = source.index("await _stop_typing_task()", response_branch)
+    send_at = source.index("result = await self._send_with_retry", response_branch)
+    assert stop_at < send_at

--- a/tests/gateway/test_telegram_jaimes_three_bubble_contract.py
+++ b/tests/gateway/test_telegram_jaimes_three_bubble_contract.py
@@ -1,10 +1,13 @@
+import asyncio
 import inspect
 import json
 from unittest.mock import patch
 
-from gateway.platforms.base import BasePlatformAdapter
+import pytest
+
 from plugins.platforms.telegram import adapter as telegram_adapter
 from plugins.platforms.telegram.adapter import TelegramAdapter
+from gateway.platforms.base import BasePlatformAdapter
 
 
 class FakeButton:
@@ -86,7 +89,21 @@ def test_jaimes_final_no_action_with_explanation_has_no_buttons():
     assert markup is None
 
 
-def test_jaimes_final_builds_completion_edit_for_current_active_card(tmp_path):
+def test_jaimes_final_formatter_unavailable_fails_closed(tmp_path):
+    adapter = _adapter()
+    adapter.platform = type("Platform", (), {"value": "telegram"})()
+    with patch.object(telegram_adapter._Path, "home", return_value=tmp_path), \
+         patch.object(telegram_adapter.logger, "warning"):
+        with pytest.raises(RuntimeError, match="validation unavailable"):
+            asyncio.run(adapter._jaimes_canonical_final_before_send(
+                "-1003589561528",
+                "Complete: Yes - unverified raw result",
+                "17",
+                {"notify": True},
+            ))
+
+
+def test_jaimes_final_builds_pre_delivery_edit_for_current_active_card(tmp_path):
     state_path = tmp_path / ".openclaw" / "telegram" / "jaimes_fast_ack_state.json"
     script = tmp_path / ".openclaw" / "workspace" / "mission-control" / "scripts" / "jaimes_work_card.py"
     state_path.parent.mkdir(parents=True)
@@ -100,6 +117,9 @@ def test_jaimes_final_builds_completion_edit_for_current_active_card(tmp_path):
             "objective": "Verify the KALEIDO dip against tactical entry gates",
             "telegram_chat_id": "-1003589561528",
             "telegram_thread_id": "17",
+            "work_id": "work-current",
+            "ledger_run_id": "run-current",
+            "task_started_at": "2026-07-12T23:21:59Z",
             "started_at": "2026-07-12T23:22:00Z",
         }
     }}))
@@ -109,17 +129,105 @@ def test_jaimes_final_builds_completion_edit_for_current_active_card(tmp_path):
             "-1003589561528", content, "17", {"notify": True}
         )
     assert command is not None
-    assert command[2] == "done"
+    assert command[2] == "update"
     assert command[command.index("--key") + 1] == "turn-123"
-    assert command[command.index("--now") + 1] == "summary sent"
+    assert command[command.index("--now") + 1] == "Final summary validated; sending now"
     assert command[command.index("--model") + 1] == "openai-codex/gpt-5.6-sol"
+    assert command[command.index("--work-id") + 1] == "work-current"
+    assert command[command.index("--run-id") + 1] == "run-current"
+    assert command[command.index("--task-started-at") + 1] == "2026-07-12T23:21:59Z"
 
 
-def test_jaimes_final_send_does_not_rearm_typing_or_autofinalize_card():
+def test_jaimes_post_delivery_command_links_exact_final_message_before_close(tmp_path):
+    state_path = tmp_path / ".openclaw" / "telegram" / "jaimes_fast_ack_state.json"
+    script = tmp_path / ".openclaw" / "workspace" / "mission-control" / "scripts" / "jaimes_work_card.py"
+    state_path.parent.mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text("# test\n")
+    state_path.write_text(json.dumps({"active_cards": {
+        "current": {
+            "status": "active",
+            "key": "turn-123",
+            "ack_message_id": "44",
+            "objective": "Verify Topic 17 delivery",
+            "telegram_chat_id": "-1003589561528",
+            "telegram_thread_id": "17",
+            "work_id": "work-current",
+            "ledger_run_id": "run-current",
+            "task_started_at": "2026-07-18T19:39:36Z",
+            "started_at": "2026-07-18T19:39:40Z",
+        }
+    }}))
+    content = "Model: openai-codex/gpt-5.6-sol | Route: current run | Why: verified\nComplete: Yes"
+    with patch.object(telegram_adapter._Path, "home", return_value=tmp_path):
+        command = _adapter()._jaimes_post_final_card_command(
+            "-1003589561528", content, "17", {"notify": True}, "3914"
+        )
+        missing = _adapter()._jaimes_post_final_card_command(
+            "-1003589561528", content, "17", {"notify": True}, None
+        )
+    assert command is not None
+    assert command[2] == "done"
+    assert command[command.index("--final-message-id") + 1] == "3914"
+    assert command[command.index("--final-delivery-verified-by") + 1] == "hermes-adapter-success"
+    assert command[command.index("--work-id") + 1] == "work-current"
+    assert command[command.index("--run-id") + 1] == "run-current"
+    assert missing is None
+
+
+def test_jaimes_final_send_canonicalizes_then_closes_only_after_delivery():
     source = inspect.getsource(TelegramAdapter.send)
-    assert "await self._jaimes_finalize_card_before_final" not in source
+    canonical_at = source.index("await self._jaimes_canonical_final_before_send")
+    ready_at = source.index("await self._jaimes_finalize_card_before_final")
+    rich_complete_at = source.index("await self._jaimes_complete_card_after_final")
+    rich_return_at = source.index("return rich_result", rich_complete_at)
+    legacy_complete_at = source.rindex("await self._jaimes_complete_card_after_final")
+    legacy_return_at = source.index("return SendResult(", legacy_complete_at)
+    assert canonical_at < ready_at < rich_complete_at < rich_return_at
+    assert legacy_complete_at < legacy_return_at
     assert "Final/direct sends may not have an active gateway refresh loop" not in source
     assert "jaimes_reply_markup = None" in source
+
+
+def test_jaimes_final_formatter_receives_private_payload_over_stdin(tmp_path):
+    state_path = tmp_path / ".openclaw" / "telegram" / "jaimes_fast_ack_state.json"
+    script = tmp_path / ".openclaw" / "workspace" / "mission-control" / "scripts" / "jaimes_telegram_fast_ack.py"
+    state_path.parent.mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    state_path.write_text(json.dumps({"active_cards": {
+        "current": {
+            "status": "active",
+            "key": "turn-123",
+            "ack_message_id": "44",
+            "objective": "Assess Agent RH safely",
+            "model": "openai-codex/gpt-5.6-sol",
+            "route": "JAIMES verified execution",
+            "telegram_chat_id": "-1003589561528",
+            "telegram_thread_id": "17",
+            "work_id": "work-current",
+            "ledger_run_id": "run-current",
+            "task_started_at": "2026-07-12T23:21:59Z",
+            "started_at": "2026-07-12T23:22:00Z",
+        }
+    }}))
+    script.write_text(
+        "import json,sys\n"
+        "payload=json.load(sys.stdin)\n"
+        "assert payload['objective']=='Assess Agent RH safely'\n"
+        "assert payload['work_id']=='work-current'\n"
+        "assert payload['run_id']=='run-current'\n"
+        "assert payload['task_started_at']=='2026-07-12T23:21:59Z'\n"
+        "print('<pre>canonical final</pre>')\n"
+    )
+    adapter = _adapter()
+    with patch.object(telegram_adapter._Path, "home", return_value=tmp_path):
+        rendered = asyncio.run(adapter._jaimes_canonical_final_before_send(
+            "-1003589561528",
+            "private findings",
+            "17",
+            {"notify": True},
+        ))
+    assert rendered == "```\ncanonical final\n```"
 
 
 def test_gateway_stops_typing_before_final_delivery():

--- a/tests/gateway/test_telegram_jaimes_three_bubble_contract.py
+++ b/tests/gateway/test_telegram_jaimes_three_bubble_contract.py
@@ -1,3 +1,5 @@
+import inspect
+import json
 from unittest.mock import patch
 
 from plugins.platforms.telegram import adapter as telegram_adapter
@@ -83,3 +85,39 @@ def test_jaimes_final_no_action_with_explanation_has_no_buttons():
             {"notify": True},
         )
     assert markup is None
+
+
+def test_jaimes_final_builds_completion_edit_for_current_active_card(tmp_path):
+    state_path = tmp_path / ".openclaw" / "telegram" / "jaimes_fast_ack_state.json"
+    script = tmp_path / ".openclaw" / "workspace" / "mission-control" / "scripts" / "jaimes_work_card.py"
+    state_path.parent.mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text("# test\n")
+    state_path.write_text(json.dumps({"active_cards": {
+        "current": {
+            "status": "active",
+            "key": "turn-123",
+            "ack_message_id": "44",
+            "objective": "Verify the KALEIDO dip against tactical entry gates",
+            "telegram_chat_id": "-1003589561528",
+            "telegram_thread_id": "17",
+            "started_at": "2026-07-12T23:22:00Z",
+        }
+    }}))
+    content = "Model: openai-codex/gpt-5.6-sol | Route: live market check | Why: verified\nComplete: Yes"
+    with patch.object(telegram_adapter._Path, "home", return_value=tmp_path):
+        command = _adapter()._jaimes_pre_final_card_command(
+            "-1003589561528", content, "17", {"notify": True}
+        )
+    assert command is not None
+    assert command[2] == "done"
+    assert command[command.index("--key") + 1] == "turn-123"
+    assert command[command.index("--now") + 1] == "summary sent"
+    assert command[command.index("--model") + 1] == "openai-codex/gpt-5.6-sol"
+
+
+def test_jaimes_completion_edit_is_awaited_before_final_send_path():
+    source = inspect.getsource(TelegramAdapter.send)
+    close_at = source.index("await self._jaimes_finalize_card_before_final")
+    format_at = source.index("formatted = self.format_message")
+    assert close_at < format_at

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -30,6 +30,7 @@ CHAT_PLATFORMS = [
 
 NOISY_STATUS_MESSAGES = [
     "🗜️ Preflight compression check before sending...",
+    "📦 Pre-API compression: ~281,519 tokens near the context/output limit. Compacting before the next model call.",
     "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
     "⚠️  Session compressed 12 times — accuracy may degrade. Consider /new to start fresh.",
     "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -39,11 +39,11 @@ def _make_event(chat_id: str = "123", message_id: str = "456") -> MessageEvent:
 # ── _reactions_enabled ───────────────────────────────────────────────
 
 
-def test_reactions_disabled_by_default(monkeypatch):
-    """Telegram reactions should be disabled by default."""
+def test_reactions_enabled_by_default(monkeypatch):
+    """JAIMES keeps the single-eyes acknowledgement enabled by default."""
     monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
     adapter = _make_adapter()
-    assert adapter._reactions_enabled() is False
+    assert adapter._reactions_enabled() is True
 
 
 def test_reactions_enabled_when_set_true(monkeypatch):
@@ -144,7 +144,7 @@ async def test_on_processing_start_adds_eyes_reaction(monkeypatch):
 @pytest.mark.asyncio
 async def test_on_processing_start_skipped_when_disabled(monkeypatch):
     """Processing start should not react when reactions are disabled."""
-    monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "false")
     adapter = _make_adapter()
     event = _make_event()
 
@@ -220,7 +220,7 @@ async def test_control_center_keeps_single_eyes_reaction_on_success(monkeypatch)
 @pytest.mark.asyncio
 async def test_on_processing_complete_skipped_when_disabled(monkeypatch):
     """Processing complete should not react when reactions are disabled."""
-    monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "false")
     adapter = _make_adapter()
     event = _make_event()
 
@@ -256,7 +256,7 @@ async def test_on_processing_complete_cancelled_clears_reaction(monkeypatch):
 @pytest.mark.asyncio
 async def test_on_processing_complete_cancelled_skipped_when_disabled(monkeypatch):
     """Cancelled processing should not call the API when reactions are off."""
-    monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "false")
     adapter = _make_adapter()
     event = _make_event()
 

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -206,6 +206,18 @@ async def test_on_processing_complete_failure(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_control_center_keeps_single_eyes_reaction_on_success(monkeypatch):
+    """JAIMES Control Center should not add a second completion reaction."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter()
+    event = _make_event(chat_id="-1003589561528")
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    adapter._bot.set_message_reaction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_on_processing_complete_skipped_when_disabled(monkeypatch):
     """Processing complete should not react when reactions are disabled."""
     monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)

--- a/tests/gateway/test_telegram_voice_v0_regressions.py
+++ b/tests/gateway/test_telegram_voice_v0_regressions.py
@@ -66,6 +66,7 @@ class _PendingVoiceAdapter(BasePlatformAdapter):
 
 class _PendingVoiceAgent:
     messages = []
+    native_message_ids = []
 
     def __init__(self, **kwargs):
         self.tools = []
@@ -85,7 +86,12 @@ class _PendingVoiceAgent:
         self._interrupted.set()
 
     def run_conversation(self, message, conversation_history=None, task_id=None, **kwargs):
+        from gateway.session_context import get_session_env
+
         type(self).messages.append(message)
+        type(self).native_message_ids.append(
+            get_session_env("HERMES_SESSION_MESSAGE_ID").strip() or None
+        )
         if len(type(self).messages) == 1:
             assert self._interrupted.wait(timeout=3), "pending voice interrupt was not delivered"
             return {
@@ -189,6 +195,7 @@ async def test_monitor_to_drain_transcribes_and_echoes_pending_voice_once(
         text="",
         message_type=MessageType.VOICE,
         source=source,
+        message_id="voice-native-4288",
         media_urls=["/tmp/telegram-pending-voice.ogg"],
         media_types=["audio/ogg"],
     )
@@ -196,26 +203,42 @@ async def test_monitor_to_drain_transcribes_and_echoes_pending_voice_once(
     adapter._active_sessions[session_key] = asyncio.Event()
     adapter._active_sessions[session_key].set()
     _PendingVoiceAgent.messages = []
+    _PendingVoiceAgent.native_message_ids = []
 
-    with (
-        patch("gateway.run._hermes_home", tmp_path),
-        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "fake"}),
-        patch(
-            "tools.transcription_tools.transcribe_audio",
-            return_value={"success": True, "transcript": "hello once", "provider": "mock"},
-        ) as mock_transcribe,
-    ):
-        result = await runner._run_agent(
-            message="initial turn",
-            context_prompt="",
-            history=[],
-            source=source,
-            session_id="pending-voice-session",
-            session_key=session_key,
-        )
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    session_tokens = set_session_vars(
+        platform="telegram",
+        chat_id="12345",
+        session_key=session_key,
+        message_id="initial-native-4286",
+    )
+    try:
+        with (
+            patch("gateway.run._hermes_home", tmp_path),
+            patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "fake"}),
+            patch(
+                "tools.transcription_tools.transcribe_audio",
+                return_value={"success": True, "transcript": "hello once", "provider": "mock"},
+            ) as mock_transcribe,
+        ):
+            result = await runner._run_agent(
+                message="initial turn",
+                context_prompt="",
+                history=[],
+                source=source,
+                session_id="pending-voice-session",
+                session_key=session_key,
+            )
+    finally:
+        clear_session_vars(session_tokens)
 
     assert result["final_response"] == "follow-up complete"
     assert _PendingVoiceAgent.messages == ["initial turn", '"hello once"']
+    assert _PendingVoiceAgent.native_message_ids == [
+        "initial-native-4286",
+        "voice-native-4288",
+    ]
     mock_transcribe.assert_called_once_with("/tmp/telegram-pending-voice.ogg")
     assert adapter.sent == [("12345", '🎙️ "hello once"', None)]
 

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -129,6 +129,31 @@ class TestFlushAfterCompression:
             assert len(rows) == 2
             assert [row["content"] for row in rows] == ["summary", "continuing..."]
 
+    def test_current_gateway_user_row_keeps_native_platform_message_id(self):
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+            agent._persist_user_message_idx = 0
+            tokens = set_session_vars(
+                platform="telegram",
+                session_id="original-session",
+                message_id="telegram-native-9001",
+            )
+            try:
+                agent._flush_messages_to_session_db(
+                    [{"role": "user", "content": "verify topic 17"}],
+                    [],
+                )
+            finally:
+                clear_session_vars(tokens)
+
+            rows = db.get_messages("original-session")
+            assert len(rows) == 1
+            assert rows[0]["platform_message_id"] == "telegram-native-9001"
+
     def test_in_place_compression_rebaseline_prevents_duplicate_compacted_rows(self):
         """In-place compaction already persisted the compacted transcript.
 
@@ -200,7 +225,29 @@ class TestFlushAfterCompression:
             db_path = Path(tmpdir) / "test.db"
             db = SessionDB(db_path=db_path)
             parent_sid = "20260701_152840_parent"
-            db.create_session(parent_sid, "gateway", model="test/model")
+            db.create_session(
+                parent_sid,
+                "telegram",
+                model="test/model",
+                user_id="operator-1",
+                session_key="agent:main:telegram:group:-1003589561528:17",
+                chat_id="-1003589561528",
+                chat_type="group",
+                thread_id="17",
+                cwd="/tmp/topic17",
+                profile_name="default",
+            )
+            db.record_gateway_session_peer(
+                parent_sid,
+                source="telegram",
+                user_id="operator-1",
+                session_key="agent:main:telegram:group:-1003589561528:17",
+                chat_id="-1003589561528",
+                chat_type="group",
+                thread_id="17",
+                display_name="JAIMES Ops",
+                origin_json='{"message_id":"9001"}',
+            )
 
             agent = self._make_agent(db)
             agent.session_id = parent_sid
@@ -228,6 +275,16 @@ class TestFlushAfterCompression:
 
             assert agent.session_id != parent_sid
             child_sid = agent.session_id
+
+            child = db.get_session(child_sid)
+            assert child is not None
+            assert child["parent_session_id"] == parent_sid
+            assert child["session_key"] == "agent:main:telegram:group:-1003589561528:17"
+            assert child["chat_id"] == "-1003589561528"
+            assert child["thread_id"] == "17"
+            assert child["user_id"] == "operator-1"
+            assert child["display_name"] == "JAIMES Ops"
+            assert child["origin_json"] == '{"message_id":"9001"}'
 
             agent._flush_messages_to_session_db(compressed, None)
 

--- a/tests/test_telegram_jaimes_three_bubble_contract.py
+++ b/tests/test_telegram_jaimes_three_bubble_contract.py
@@ -1,0 +1,468 @@
+import asyncio
+import inspect
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from plugins.platforms.telegram import adapter as telegram_adapter
+from plugins.platforms.telegram.adapter import TelegramAdapter
+from gateway.platforms.base import BasePlatformAdapter
+
+
+class FakeButton:
+    def __init__(self, text, callback_data=None):
+        self.text = text
+        self.callback_data = callback_data
+
+
+class FakeMarkup:
+    def __init__(self, rows):
+        self.inline_keyboard = rows
+
+
+def _adapter():
+    return object.__new__(TelegramAdapter)
+
+
+def test_jaimes_final_prose_never_infers_buttons():
+    content = """🤖 gpt-5.6-sol (Codex subscription)
+
+**Objective Complete:** Yes
+
+**TLDR:**
+- Work completed
+
+**Challenges/Blockers:**
+None
+
+**Next steps for approval:**
+1. Run live canary
+2. Keep current configuration
+"""
+    with patch.object(telegram_adapter, "InlineKeyboardButton", FakeButton), patch.object(
+        telegram_adapter, "InlineKeyboardMarkup", FakeMarkup
+    ):
+        markup = _adapter()._jaimes_topic17_reply_markup(
+            content,
+            "17",
+            {"notify": True},
+        )
+    assert markup is None
+
+
+def test_jaimes_final_no_action_has_no_buttons():
+    content = """🤖 gpt-5.6-sol (Codex subscription)
+
+**Objective Complete:** Yes
+
+**Next steps for approval:**
+No action needed
+"""
+    with patch.object(telegram_adapter, "InlineKeyboardButton", FakeButton), patch.object(
+        telegram_adapter, "InlineKeyboardMarkup", FakeMarkup
+    ):
+        markup = _adapter()._jaimes_topic17_reply_markup(
+            content,
+            "17",
+            {"notify": True},
+        )
+    assert markup is None
+
+
+def test_jaimes_final_no_action_with_explanation_has_no_buttons():
+    content = """🤖 gpt-5.6-sol (Codex subscription)
+
+**Objective Complete:** Yes
+
+**Next steps for approval:**
+- No action needed; future alerts use this layout
+"""
+    with patch.object(telegram_adapter, "InlineKeyboardButton", FakeButton), patch.object(
+        telegram_adapter, "InlineKeyboardMarkup", FakeMarkup
+    ):
+        markup = _adapter()._jaimes_topic17_reply_markup(
+            content,
+            "17",
+            {"notify": True},
+        )
+    assert markup is None
+
+
+def test_jaimes_final_formatter_unavailable_fails_closed(tmp_path):
+    adapter = _adapter()
+    adapter.platform = type("Platform", (), {"value": "telegram"})()
+    with patch.object(telegram_adapter._Path, "home", return_value=tmp_path), \
+         patch.object(telegram_adapter.logger, "warning"):
+        with pytest.raises(RuntimeError, match="validation unavailable"):
+            asyncio.run(adapter._jaimes_canonical_final_before_send(
+                "-1003589561528",
+                "Complete: Yes - unverified raw result",
+                "17",
+                {"notify": True},
+            ))
+
+
+def test_jaimes_final_builds_pre_delivery_edit_for_current_active_card(tmp_path):
+    state_path = tmp_path / ".openclaw" / "telegram" / "jaimes_fast_ack_state.json"
+    script = tmp_path / ".openclaw" / "workspace" / "mission-control" / "scripts" / "jaimes_work_card.py"
+    state_path.parent.mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text("# test\n")
+    state_path.write_text(json.dumps({"active_cards": {
+        "current": {
+            "status": "active",
+            "key": "turn-123",
+            "ack_message_id": "44",
+            "objective": "Verify the KALEIDO dip against tactical entry gates",
+            "telegram_chat_id": "-1003589561528",
+            "telegram_thread_id": "17",
+            "work_id": "work-current",
+            "ledger_run_id": "run-current",
+            "task_started_at": "2026-07-12T23:21:59Z",
+            "started_at": "2026-07-12T23:22:00Z",
+        }
+    }}))
+    content = "Model: openai-codex/gpt-5.6-sol | Route: live market check | Why: verified\nComplete: Yes"
+    with patch.object(telegram_adapter._Path, "home", return_value=tmp_path):
+        command = _adapter()._jaimes_pre_final_card_command(
+            "-1003589561528", content, "17", {"notify": True}
+        )
+    assert command is not None
+    assert command[2] == "done"
+    assert command[command.index("--key") + 1] == "turn-123"
+    assert command[command.index("--now") + 1] == "Final summary validated; delivery starting"
+    assert command[command.index("--done") + 1] == "Final summary validated"
+    assert "--no-final-summary" in command
+    assert command[command.index("--model") + 1] == "openai-codex/gpt-5.6-sol"
+    assert command[command.index("--work-id") + 1] == "work-current"
+    assert command[command.index("--run-id") + 1] == "run-current"
+    assert command[command.index("--task-started-at") + 1] == "2026-07-12T23:21:59Z"
+
+
+def test_jaimes_post_delivery_command_links_exact_final_message_before_close(tmp_path):
+    state_path = tmp_path / ".openclaw" / "telegram" / "jaimes_fast_ack_state.json"
+    script = tmp_path / ".openclaw" / "workspace" / "mission-control" / "scripts" / "jaimes_work_card.py"
+    state_path.parent.mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text("# test\n")
+    state_path.write_text(json.dumps({"active_cards": {
+        "current": {
+            "status": "active",
+            "key": "turn-123",
+            "ack_message_id": "44",
+            "objective": "Verify Topic 17 delivery",
+            "telegram_chat_id": "-1003589561528",
+            "telegram_thread_id": "17",
+            "work_id": "work-current",
+            "ledger_run_id": "run-current",
+            "task_started_at": "2026-07-18T19:39:36Z",
+            "started_at": "2026-07-18T19:39:40Z",
+        }
+    }}))
+    content = "Model: openai-codex/gpt-5.6-sol | Route: current run | Why: verified\nComplete: Yes"
+    with patch.object(telegram_adapter._Path, "home", return_value=tmp_path):
+        command = _adapter()._jaimes_post_final_card_command(
+            "-1003589561528", content, "17", {"notify": True}, "3914"
+        )
+        missing = _adapter()._jaimes_post_final_card_command(
+            "-1003589561528", content, "17", {"notify": True}, None
+        )
+    assert command is not None
+    assert command[2] == "done"
+    assert command[command.index("--final-message-id") + 1] == "3914"
+    assert command[command.index("--final-delivery-verified-by") + 1] == "hermes-adapter-success"
+    assert command[command.index("--work-id") + 1] == "work-current"
+    assert command[command.index("--run-id") + 1] == "run-current"
+    assert missing is None
+
+
+def test_jaimes_final_send_canonicalizes_then_closes_only_after_delivery():
+    source = inspect.getsource(TelegramAdapter.send)
+    canonical_at = source.index("await self._jaimes_canonical_final_before_send")
+    ready_at = source.index("await self._jaimes_finalize_card_before_final")
+    rich_complete_at = source.index("await self._jaimes_complete_card_after_final")
+    rich_return_at = source.index("return rich_result", rich_complete_at)
+    legacy_complete_at = source.rindex("await self._jaimes_complete_card_after_final")
+    legacy_return_at = source.index("return SendResult(", legacy_complete_at)
+    assert canonical_at < ready_at < rich_complete_at < rich_return_at
+    assert legacy_complete_at < legacy_return_at
+    assert "Final/direct sends may not have an active gateway refresh loop" not in source
+    assert "jaimes_reply_markup = None" in source
+
+
+def test_jaimes_final_formatter_receives_private_payload_over_stdin(tmp_path):
+    state_path = tmp_path / ".openclaw" / "telegram" / "jaimes_fast_ack_state.json"
+    script = tmp_path / ".openclaw" / "workspace" / "mission-control" / "scripts" / "jaimes_telegram_fast_ack.py"
+    state_path.parent.mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    state_path.write_text(json.dumps({"active_cards": {
+        "current": {
+            "status": "active",
+            "key": "turn-123",
+            "ack_message_id": "44",
+            "objective": "Assess Agent RH safely",
+            "model": "openai-codex/gpt-5.6-sol",
+            "route": "JAIMES verified execution",
+            "telegram_chat_id": "-1003589561528",
+            "telegram_thread_id": "17",
+            "work_id": "work-current",
+            "ledger_run_id": "run-current",
+            "task_started_at": "2026-07-12T23:21:59Z",
+            "started_at": "2026-07-12T23:22:00Z",
+        }
+    }}))
+    script.write_text(
+        "import json,sys\n"
+        "payload=json.load(sys.stdin)\n"
+        "assert payload['objective']=='Assess Agent RH safely'\n"
+        "assert payload['work_id']=='work-current'\n"
+        "assert payload['run_id']=='run-current'\n"
+        "assert payload['task_started_at']=='2026-07-12T23:21:59Z'\n"
+        "print('<pre>Model: verified\\nComplete: Yes</pre>')\n"
+    )
+    adapter = _adapter()
+    with patch.object(telegram_adapter._Path, "home", return_value=tmp_path):
+        rendered = asyncio.run(adapter._jaimes_canonical_final_before_send(
+            "-1003589561528",
+            "private findings",
+            "17",
+            {"notify": True},
+        ))
+    assert rendered == "**Model:** verified\n**Complete:** Yes"
+
+
+def test_gateway_stops_typing_before_final_delivery():
+    source = inspect.getsource(BasePlatformAdapter._process_message_background)
+    response_branch = source.index("if response:")
+    stop_at = source.index("await _stop_typing_task()", response_branch)
+    send_at = source.index("result = await delivery_adapter._send_with_retry", response_branch)
+    assert stop_at < send_at
+
+
+def test_active_card_ignores_blank_zombie_and_normalizes_chat_prefix(tmp_path):
+    state_path = tmp_path / ".openclaw" / "telegram" / "jaimes_fast_ack_state.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(json.dumps({"active_cards": {
+        "zombie": {
+            "status": "active",
+            "key": "zombie",
+            "ack_message_id": "",
+            "objective": "",
+            "telegram_chat_id": "-1001",
+            "telegram_thread_id": "17",
+            "started_at": "2099-01-01T00:00:00Z",
+        },
+        "bound": {
+            "status": "active",
+            "key": "bound",
+            "ack_message_id": "44",
+            "objective": "Verify exact final delivery",
+            "telegram_chat_id": "telegram:-1001",
+            "telegram_thread_id": "17",
+            "started_at": "2026-07-18T20:00:00Z",
+        },
+    }}), encoding="utf-8")
+
+    with patch.object(telegram_adapter._Path, "home", return_value=tmp_path):
+        card = _adapter()._jaimes_topic17_active_card(
+            "-1001", "17", {"notify": True}
+        )
+    assert card and card["key"] == "bound"
+
+
+def test_unbound_final_preserves_verified_why_in_private_formatter_payload(tmp_path):
+    script = (
+        tmp_path / ".openclaw" / "workspace" / "mission-control" / "scripts"
+        / "jaimes_telegram_fast_ack.py"
+    )
+    script.parent.mkdir(parents=True)
+    script.write_text(
+        "import json,sys\n"
+        "payload=json.load(sys.stdin)\n"
+        "assert payload['model']=='openai-codex/gpt-5.6-sol'\n"
+        "assert payload['route']=='JAIMES verified execution'\n"
+        "assert payload['why']=='300/300 checks passed'\n"
+        "print('<pre>canonical final</pre>')\n",
+        encoding="utf-8",
+    )
+    content = (
+        "Model: openai-codex/gpt-5.6-sol | Route: JAIMES verified execution "
+        "| Why: 300/300 checks passed\nComplete: Yes"
+    )
+
+    with patch.object(telegram_adapter._Path, "home", return_value=tmp_path):
+        rendered = asyncio.run(_adapter()._jaimes_canonical_final_before_send(
+            "-1001", content, "17", {"notify": True}
+        ))
+    assert rendered == "canonical final"
+
+
+def test_prepared_final_bypasses_second_formatter_and_preserves_semantics():
+    content = """<pre>Model: openai-codex/gpt-5.6-sol |
+   Route: JAIMES verified execution |
+   Why: heavy workhorse reasoning
+
+Complete: Yes
+
+What was done:
+- Topic 17 ownership resolved.
+
+Issues:
+- n/a
+
+Appropriate next steps:
+- No action needed.
+
+Approval needed:
+- n/a</pre>"""
+    with patch.object(
+        telegram_adapter.asyncio,
+        "create_subprocess_exec",
+        AsyncMock(side_effect=AssertionError("prepared finals must not be formatted twice")),
+    ):
+        rendered = asyncio.run(_adapter()._jaimes_canonical_final_before_send(
+            "-1001", content, "17", {"notify": True}
+        ))
+    assert "**Complete:** Yes" in rendered
+    assert "Why: heavy workhorse reasoning" in rendered
+    assert "unverified" not in rendered
+    assert "- Why:" not in rendered
+
+
+def test_malformed_prepared_final_fails_closed():
+    malformed = "<pre>Model: verified\nComplete: Yes</pre>"
+    with pytest.raises(RuntimeError, match="prepared final validation failed"):
+        asyncio.run(_adapter()._jaimes_canonical_final_before_send(
+            "-1001", malformed, "17", {"notify": True}
+        ))
+
+
+def test_unbound_final_only_uses_literal_objective_label(tmp_path):
+    script = (
+        tmp_path / ".openclaw" / "workspace" / "mission-control" / "scripts"
+        / "jaimes_telegram_fast_ack.py"
+    )
+    script.parent.mkdir(parents=True)
+    script.write_text(
+        "import json,sys\n"
+        "payload=json.load(sys.stdin)\n"
+        "expected=('Assess the current agent workflow' "
+        "if '\\nObjective: Assess the current agent workflow' in payload['text'] "
+        "else 'Complete the current Telegram task')\n"
+        "assert payload['objective']==expected\n"
+        "assert payload['objective'] not in {'Yes','No'}\n"
+        "print('<pre>canonical final</pre>')\n",
+        encoding="utf-8",
+    )
+    adapter = _adapter()
+    contents = (
+        "Model: test | Route: test | Why: verified\nObjective Complete: Yes",
+        "Model: test | Route: test | Why: verified\nObjective Complete: No",
+        (
+            "Model: test | Route: test | Why: verified\n"
+            "Objective: Assess the current agent workflow"
+        ),
+    )
+
+    with patch.object(telegram_adapter._Path, "home", return_value=tmp_path):
+        rendered = [
+            asyncio.run(adapter._jaimes_canonical_final_before_send(
+                "-1001", content, "17", {"notify": True}
+            ))
+            for content in contents
+        ]
+    assert rendered == ["canonical final"] * 3
+
+
+def test_post_delivery_command_persists_exact_adapter_message_id(tmp_path):
+    state_path = tmp_path / ".openclaw" / "telegram" / "jaimes_fast_ack_state.json"
+    script = (
+        tmp_path / ".openclaw" / "workspace" / "mission-control" / "scripts"
+        / "jaimes_work_card.py"
+    )
+    state_path.parent.mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    script.write_text("# test\n", encoding="utf-8")
+    state_path.write_text(json.dumps({"active_cards": {
+        "bound": {
+            "status": "active",
+            "key": "bound",
+            "ack_message_id": "44",
+            "objective": "Verify exact final delivery",
+            "telegram_chat_id": "-1001",
+            "telegram_thread_id": "17",
+            "started_at": "2026-07-18T20:00:00Z",
+        }
+    }}), encoding="utf-8")
+    content = (
+        "Model: openai-codex/gpt-5.6-sol | Route: JAIMES verified execution "
+        "| Why: verified\nComplete: Yes"
+    )
+
+    with patch.object(telegram_adapter._Path, "home", return_value=tmp_path):
+        command = _adapter()._jaimes_post_final_card_command(
+            "-1001", content, "17", {"notify": True}, "3914"
+        )
+    assert command is not None
+    assert command[2] == "done"
+    assert command[command.index("--final-message-id") + 1] == "3914"
+    assert command[
+        command.index("--final-delivery-verified-by") + 1
+    ] == "hermes-adapter-success"
+    assert "--blocker" not in command
+    assert "--next" not in command
+
+
+def test_topic17_final_skips_rich_and_closes_with_exact_ptb_message_id():
+    adapter = _adapter()
+
+    class FakeBot:
+        async def send_message(self, **_kwargs):
+            return SimpleNamespace(message_id=777)
+
+    adapter._bot = FakeBot()
+    adapter.platform = type("Platform", (), {"value": "telegram"})()
+    adapter._send_path_degraded = False
+    adapter._reply_to_mode = "off"
+    adapter._metadata_thread_id = lambda _metadata: "17"
+    adapter._metadata_reply_to_message_id = lambda _metadata: None
+    adapter._message_thread_id_for_send = lambda thread_id: thread_id
+    adapter._is_private_dm_topic_send = lambda *_args, **_kwargs: False
+    adapter._should_thread_reply = lambda *_args, **_kwargs: False
+    adapter._thread_kwargs_for_send = lambda *_args, **_kwargs: {
+        "message_thread_id": 17
+    }
+    adapter._link_preview_kwargs = lambda: {}
+    adapter._notification_kwargs = lambda _metadata: {}
+    adapter._should_attempt_rich = lambda *_args, **_kwargs: True
+    adapter._try_send_rich = AsyncMock(
+        side_effect=AssertionError("Topic 17 final must not use rich delivery")
+    )
+    adapter._jaimes_canonical_final_before_send = AsyncMock(
+        return_value="canonical final"
+    )
+    adapter._jaimes_finalize_card_before_final = AsyncMock()
+    adapter._jaimes_complete_card_after_final = AsyncMock()
+    adapter.format_message = lambda content: content
+    adapter.truncate_message = lambda content, *_args, **_kwargs: [content]
+
+    result = asyncio.run(adapter.send(
+        "-1001",
+        "Model: test | Route: test | Why: test\nComplete: Yes",
+        metadata={"notify": True, "message_thread_id": "17"},
+    ))
+
+    assert result.success is True
+    assert result.message_id == "777"
+    adapter._try_send_rich.assert_not_awaited()
+    adapter._jaimes_complete_card_after_final.assert_awaited_once()
+    assert adapter._jaimes_complete_card_after_final.await_args.args[-1] == "777"
+
+
+def test_topic17_contract_does_not_add_a_task_header():
+    source = Path(telegram_adapter.__file__).read_text(encoding="utf-8")
+    assert "--header-message-id" not in source
+    assert "JAIMES_TELEGRAM_TASK_HEADERS" not in source


### PR DESCRIPTION
## What changed

- Ports the production JAIMES Telegram hardening onto Hermes v0.19.
- Keeps Topic 17 bound to its exact live-card and terminal-delivery receipts.
- Finalizes the editable card before sending the single substantive final.
- Preserves the intentional single-eyes acknowledgement, stale-typing cleanup, inferred-button suppression, restart reset option, and split-brain guards.
- Adds focused regression coverage for the three-bubble contract, exact receipt binding, restart recovery, and v0.19 delivery-adapter behavior.

## Why

JAIMES production carries Telegram lifecycle guarantees that are not yet present upstream. Upgrading directly to v0.19 without replaying these changes would regress Topic 17 into duplicate, frozen, or receipt-indeterminate responses.

## User and developer impact

Telegram retains one acknowledgement, one editable progress card, and one receipt-backed final. Restart recovery remains replay-safe, and other messaging surfaces retain their upstream behavior.

This branch is intentionally the exact production commit deployed from the v2026.7.20 stable tag. It is not rebased onto the newer upstream main because doing so would make the published source differ from the already-verified production artifact; upstream may merge or cherry-pick the ten commits after review.

## Verification

- All 50 Telegram gateway test modules passed in isolated processes.
- 364 focused tests passed from the production checkout after cutover.
- Inbox and JAIMES Ops live transport canaries passed with one final, no duplicates, and confirmed cleanup.
- JAIMES Ops passed again after a controlled Hermes restart.
- Delivery obligations were empty after restart and canary cleanup.
- Control Tower: 1,064 passed, 1 skipped; production build and regression checks passed; repeated runtime probes were green.

## Rollback

The pre-v0.19 branch, virtualenv clone, state snapshot, configuration/service archive, and verified git bundle are retained on the JAIMES host.
