### PR TITLE
fix(photon): make UPSTREAM_STREAM_DEGRADED non-retryable so gateway exits

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -578,7 +578,11 @@ class PhotonAdapter(BasePlatformAdapter):
             self._set_fatal_error(
                 "UPSTREAM_STREAM_DEGRADED",
                 message,
-                retryable=True,
+                # The sidecar process stops after this error (see the
+                # `received stdin EOF` log). Background reconnection can't
+                # revive a dead sidecar — the gateway must exit so launchd /
+                # systemd KeepAlive restarts the whole process (#68693).
+                retryable=False,
             )
             try:
                 await self._notify_fatal_error()

--- a/tests/plugins/platforms/photon/test_fatal_error.py
+++ b/tests/plugins/platforms/photon/test_fatal_error.py
@@ -1,0 +1,37 @@
+"""#68693: UPSTREAM_STREAM_DEGRADED must be non-retryable so the gateway
+exits and the service manager (launchd/systemd) restarts it."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+
+def test_upstream_stream_degraded_is_non_retryable():
+    """The _set_fatal_error call for UPSTREAM_STREAM_DEGRADED must pass
+    retryable=False so the gateway exits for service-manager restart."""
+    src = inspect.getsource(PhotonAdapter)
+    # Find the UPSTREAM_STREAM_DEGRADED block
+    idx = src.find("UPSTREAM_STREAM_DEGRADED")
+    assert idx >= 0, "UPSTREAM_STREAM_DEGRADED not found in PhotonAdapter"
+    # Check the nearby code for retryable=False
+    block = src[idx:idx + 400]
+    assert "retryable=False" in block, (
+        "UPSTREAM_STREAM_DEGRADED must set retryable=False so the gateway "
+        "exits for launchd/systemd restart (#68693)"
+    )
+
+
+def test_sidecar_crashed_still_retryable():
+    """SIDECAR_CRASHED should remain retryable — the sidecar can be
+    re-started by the reconnect watcher without a full gateway restart."""
+    src = inspect.getsource(PhotonAdapter)
+    idx = src.find("SIDECAR_CRASHED")
+    assert idx >= 0
+    block = src[idx:idx + 400]
+    assert "retryable=True" in block, (
+        "SIDECAR_CRASHED should remain retryable for background reconnection"
+    )


### PR DESCRIPTION
## Summary

When the Photon adapter encountered `UPSTREAM_STREAM_DEGRADED`, the sidecar process stopped but the gateway **kept running** with a dead Photon — launchd `KeepAlive` never triggered because the parent process was still alive. iMessage delivery silently failed for hours until manual restart.

## Root cause

`UPSTREAM_STREAM_DEGRADED` was set `retryable=True`, so the gateway queued it for background reconnection. But the sidecar is **dead** — background reconnection can't revive it. The gateway needs to exit so the service manager restarts the whole process.

## Fix

Change `retryable=True` → `retryable=False` for `UPSTREAM_STREAM_DEGRADED` in the Photon adapter. When the sidecar stops, the gateway exits with a non-zero code. `launchd`/`systemd` `KeepAlive`/`Restart=on-failure` restarts the entire process, which re-starts the sidecar.

`SIDECAR_CRASHED` remains `retryable=True` — the reconnect watcher can re-launch the sidecar without a full gateway restart.

## Test plan

- [x] `UPSTREAM_STREAM_DEGRADED` sets `retryable=False` (source inspection)
- [x] `SIDECAR_CRASHED` remains `retryable=True` (source inspection)

Closes #68693