### PR TITLE
fix: port /curator slash command to gateway platforms

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10574,6 +10574,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _cmd_def_inner and _cmd_def_inner.name == "kanban":
                 return await self._handle_kanban_command(event)
 
+            if _cmd_def_inner and _cmd_def_inner.name == "curator":
+                return await self._handle_curator_command(event)
+
             # /goal is safe mid-run for status/pause/clear/wait (inspection
             # and control-plane only — doesn't interrupt the running turn).
             # Setting a new goal text mid-run is rejected with the same
@@ -10995,6 +10998,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "kanban":
             return await self._handle_kanban_command(event)
+
+        if canonical == "curator":
+            return await self._handle_curator_command(event)
 
         if canonical == "suggestions":
             return await self._handle_suggestions_command(event)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -509,6 +509,41 @@ class GatewaySlashCommandsMixin:
             output = output[:3800] + "\n" + t("gateway.kanban.truncated_suffix")
         return output or t("gateway.kanban.no_output")
 
+    async def _handle_curator_command(self, event: MessageEvent) -> str:
+        """Handle /curator — delegate to the shared curator CLI."""
+        import asyncio
+        import io
+        import shlex
+
+        from hermes_cli.curator import cli_main
+
+        text = (event.text or "").strip()
+        if text.startswith("/"):
+            text = text.lstrip("/")
+        if text.startswith("curator"):
+            text = text[len("curator"):].lstrip()
+
+        tokens = shlex.split(text) if text else ["status"]
+
+        try:
+            buf = io.StringIO()
+            import sys
+            old_stdout = sys.stdout
+            sys.stdout = buf
+            try:
+                cli_main(tokens)
+            except SystemExit:
+                pass
+            finally:
+                sys.stdout = old_stdout
+            output = buf.getvalue().strip()
+        except Exception as exc:
+            return f"(._.) curator: {exc}"
+
+        if len(output) > 3800:
+            output = output[:3800] + "\n... (truncated)"
+        return output or "(._.) curator: no output"
+
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""
         from gateway.run import _AGENT_PENDING_SENTINEL, _load_gateway_config, _resolve_gateway_model


### PR DESCRIPTION
Closes #68880

## What
Port the `/curator` slash command handler to gateway platforms (Telegram, Discord, Slack). Previously only worked in the local CLI.

## Changes
- Add `_handle_curator_command` to `gateway/slash_commands.py` following the established kanban pattern (delegates to `hermes_cli.curator.cli_main`)
- Wire into `gateway/run.py` dispatch tables at both mid-run and post-message locations

## Testing
- Local CLI `/curator` continues to work via existing path
- Gateway `/curator status` now dispatches to the curator CLI instead of falling through to the agent as plain text
- Follows the same pattern as `/kanban` which was already ported to gateway

AI-assisted contribution.