### PR TITLE
fix(desktop): disable haptics audio to prevent CoreAudio stutter

### DIFF
--- a/apps/desktop/src/components/haptics-provider.registration.test.tsx
+++ b/apps/desktop/src/components/haptics-provider.registration.test.tsx
@@ -1,0 +1,54 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as hapticsModule from '@/lib/haptics'
+import { registerHapticTrigger } from '@/lib/haptics'
+import { setHapticsMuted } from '@/store/haptics'
+
+import { HapticsProvider } from './haptics-provider'
+
+const { triggerMock } = vi.hoisted(() => ({ triggerMock: vi.fn() }))
+
+vi.mock('web-haptics/react', () => ({
+  useWebHaptics: () => ({ cancel: vi.fn(), isSupported: false, trigger: triggerMock })
+}))
+
+vi.mock('@/lib/haptics', async importOriginal => {
+  const actual = await importOriginal<typeof hapticsModule>()
+
+  return { ...actual, registerHapticTrigger: vi.fn() }
+})
+
+const registerMock = vi.mocked(registerHapticTrigger)
+
+// The provider's registration contract (`muted ? null : trigger`) is not
+// observable through triggerHaptic(): lib/haptics gates on $hapticsMuted
+// itself, so a provider that ignored the muted flag would be masked. Spy on
+// registerHapticTrigger directly to pin the registration behavior.
+describe('HapticsProvider registration', () => {
+  beforeEach(() => {
+    setHapticsMuted(false)
+    registerMock.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('registers the live trigger when unmuted and null when muted', async () => {
+    render(<HapticsProvider>{null}</HapticsProvider>)
+
+    expect(registerMock).toHaveBeenLastCalledWith(triggerMock)
+
+    await act(async () => {
+      setHapticsMuted(true)
+    })
+    expect(registerMock).toHaveBeenLastCalledWith(null)
+
+    await act(async () => {
+      setHapticsMuted(false)
+    })
+    expect(registerMock).toHaveBeenLastCalledWith(triggerMock)
+  })
+})

--- a/apps/desktop/src/components/haptics-provider.test.tsx
+++ b/apps/desktop/src/components/haptics-provider.test.tsx
@@ -1,0 +1,111 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { triggerHaptic } from '@/lib/haptics'
+import { setHapticsMuted } from '@/store/haptics'
+
+import { HapticsProvider } from './haptics-provider'
+
+// web-haptics computes `WebHaptics.isSupported` (typeof navigator.vibrate)
+// once at module load. Desktop Chromium exposes navigator.vibrate as a
+// no-op function, so simulate that BEFORE the library module is imported —
+// otherwise jsdom's missing Vibration API flips the library onto its
+// DOM-only fallback and the mute test below wouldn't exercise the real
+// desktop path.
+const { vibrateMock } = vi.hoisted(() => {
+  const vibrateMock = vi.fn()
+  Object.defineProperty(navigator, 'vibrate', { configurable: true, value: vibrateMock })
+
+  return { vibrateMock }
+})
+
+class MockAudioContext {
+  static constructed = 0
+
+  destination = {}
+  sampleRate = 44100
+  state = 'running'
+
+  constructor() {
+    MockAudioContext.constructed++
+  }
+
+  close() {
+    return Promise.resolve()
+  }
+
+  createBiquadFilter() {
+    return { Q: { value: 0 }, connect: () => undefined, frequency: { value: 0 }, type: '' }
+  }
+
+  createBuffer(channels: number, length: number) {
+    return { getChannelData: () => new Float32Array(length) }
+  }
+
+  createBufferSource() {
+    return {
+      buffer: null,
+      connect: () => undefined,
+      disconnect: () => undefined,
+      onended: null,
+      start: () => undefined
+    }
+  }
+
+  createGain() {
+    return { connect: () => undefined, gain: { value: 0 } }
+  }
+
+  resume() {
+    return Promise.resolve()
+  }
+}
+
+describe('HapticsProvider', () => {
+  beforeEach(() => {
+    MockAudioContext.constructed = 0
+    setHapticsMuted(false)
+    vi.stubGlobal('AudioContext', MockAudioContext)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('never constructs an AudioContext when a haptic fires', () => {
+    render(<HapticsProvider>{null}</HapticsProvider>)
+
+    triggerHaptic('submit')
+
+    expect(MockAudioContext.constructed).toBe(0)
+  })
+
+  it('registers a live trigger and keeps the persisted mute control functional', async () => {
+    render(<HapticsProvider>{null}</HapticsProvider>)
+
+    triggerHaptic('submit')
+    expect(vibrateMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      setHapticsMuted(true)
+    })
+
+    triggerHaptic('submit')
+    expect(vibrateMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not warm an AudioContext at idle on mount', () => {
+    vi.stubGlobal('requestIdleCallback', (callback: () => void) => {
+      callback()
+
+      return 0
+    })
+    vi.stubGlobal('cancelIdleCallback', () => undefined)
+
+    render(<HapticsProvider>{null}</HapticsProvider>)
+
+    expect(MockAudioContext.constructed).toBe(0)
+  })
+})

--- a/apps/desktop/src/components/haptics-provider.tsx
+++ b/apps/desktop/src/components/haptics-provider.tsx
@@ -5,39 +5,23 @@ import { useWebHaptics } from 'web-haptics/react'
 import { registerHapticTrigger } from '@/lib/haptics'
 import { $hapticsMuted } from '@/store/haptics'
 
+// web-haptics' `debug` option is its desktop audio fallback: on platforms
+// where navigator.vibrate exists (Chromium exposes it as a no-op on
+// desktop) the library plays synthesized click sounds through an
+// AudioContext whenever debug is enabled, briefly seizing the macOS audio
+// device and interrupting other playback (Spotify, Apple Music, Bluetooth
+// streams) on every prompt submit. Desktop has no vibration motor, so
+// keep the provider and the persisted mute control wired, but never
+// enable the audio fallback.
 export function HapticsProvider({ children }: { children: ReactNode }) {
   const muted = useStore($hapticsMuted)
-  const { trigger } = useWebHaptics({ debug: true, showSwitch: false })
+  const { trigger } = useWebHaptics({ showSwitch: false })
 
   useEffect(() => {
     registerHapticTrigger(muted ? null : trigger)
 
     return () => registerHapticTrigger(null)
   }, [muted, trigger])
-
-  // web-haptics builds its AudioContext lazily inside the first trigger(), and
-  // the process's first AudioContext pays the CoreAudio spin-up (~850ms stall
-  // in profiles) — which landed on the first streamStart haptic as the first
-  // token painted. Open/close a throwaway context at idle so the real one
-  // connects to an already-warm audio service in single-digit ms.
-  useEffect(() => {
-    if (typeof requestIdleCallback !== 'function' || typeof AudioContext === 'undefined') {
-      return undefined
-    }
-
-    const id = requestIdleCallback(
-      () => {
-        try {
-          void new AudioContext().close().catch(() => undefined)
-        } catch {
-          // No audio device (headless CI) — nothing to warm.
-        }
-      },
-      { timeout: 2000 }
-    )
-
-    return () => cancelIdleCallback(id)
-  }, [])
 
   return <>{children}</>
 }


### PR DESCRIPTION
## Fix: Disable the web-haptics audio fallback on desktop to prevent CoreAudio stutter

Fixes #68894

### Problem

On macOS, when music is playing and the user presses Enter to submit a prompt in Hermes Desktop, there is a consistent fraction-of-a-second interruption to audio playback (Spotify, Apple Music, Bluetooth streams, etc.).

### Root cause

The `web-haptics` library is initialized with `debug: true` in `HapticsProvider`. `debug` is the library's desktop audio fallback: on platforms where `navigator.vibrate` exists (Chromium exposes it as a no-op on desktop), it plays synthesized click sounds through an `AudioContext` on every haptic trigger — `triggerHaptic('submit')` fires on every prompt submission, and `triggerHaptic('streamStart')` on first token. This briefly seizes the audio device, interrupting other streams.

The existing warmup effect (`new AudioContext().close()` in `requestIdleCallback`) was ineffective — closing the context immediately releases CoreAudio, so the real one still had to re-acquire the device from scratch — and it constructed an `AudioContext` of its own.

### Fix

Desktop has no vibration motor, so haptic output is inert here. Narrow the change to the audio path only: omit the `debug` option (default `false`), which removes the `AudioContext`/CoreAudio interaction entirely, and drop the ineffective idle warmup. The provider and the persisted titlebar mute/unmute control keep working unchanged.

### Changes

- `apps/desktop/src/components/haptics-provider.tsx`: stop passing `debug: true` to `useWebHaptics`, remove the AudioContext warmup effect.
- `apps/desktop/src/components/haptics-provider.test.tsx` + `haptics-provider.registration.test.tsx`: provider-level regression tests — no `AudioContext` is constructed on trigger or mount, a live trigger is registered while unmuted (`null` while muted), haptics are suppressed while muted. All four tests are mutation-checked (re-adding `debug: true`, permanent null registration, the warmup effect, or a mute-ignoring provider each fails the corresponding test).

### Notes

- All `triggerHaptic()` call sites are unaffected — they call through `@/lib/haptics`, which already guards on `registeredTrigger` being non-null and on the muted flag.
