### PR TITLE
fix(tests): anchor MCP breaker opened_at to monotonic now, not a literal

### DIFF
--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -13,6 +13,7 @@ affected MCP server failed until the gateway was manually restarted.
 import asyncio
 import json
 import threading
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -507,7 +508,15 @@ def test_session_expired_retry_waits_for_new_session(monkeypatch, tmp_path):
     server._reconnect_event = _ReconnectAdapter()
     mcp_tool._servers["hindsight"] = server
     mcp_tool._server_error_counts["hindsight"] = 7
-    mcp_tool._server_breaker_opened_at["hindsight"] = 123.0
+    # An absolute literal here (e.g. 123.0) races CI: time.monotonic() is
+    # seconds-since-boot on Linux, so on a fresh runner the breaker "opened"
+    # in the future / within the cooldown window and the handler returns the
+    # circuit-breaker error instead of retrying (flaked twice on slice 6,
+    # both ~170s after boot => "Auto-retry available in ~10s"). Anchor the
+    # opened_at relative to now, safely past the cooldown.
+    mcp_tool._server_breaker_opened_at["hindsight"] = (
+        time.monotonic() - mcp_tool._CIRCUIT_BREAKER_COOLDOWN_SEC - 10.0
+    )
 
     try:
         handler = _make_tool_handler("hindsight", "get_bank", 10.0)


### PR DESCRIPTION
## Summary
Kills a CI-only flake: `test_session_expired_retry_waits_for_new_session` anchored the MCP circuit-breaker `opened_at` to the literal `123.0`, but `time.monotonic()` is seconds-since-boot on Linux — on a freshly booted runner "now" can be inside (or before) the cooldown window, so the handler short-circuits with the breaker error instead of exercising the reconnect path.

Flaked twice today on test slice 6/8 (both runs ~3 minutes after runner boot: "Auto-retry available in ~10s"); passes on any machine with uptime > ~3 min, which is why it never reproduced locally.

## Changes
- `tests/tools/test_mcp_tool_session_expired.py`: `opened_at = time.monotonic() - _CIRCUIT_BREAKER_COOLDOWN_SEC - 10.0` (relative anchor, safely past cooldown) + explanatory comment

## Validation
| | Before | After |
|---|---|---|
| Runner uptime < ~3min | breaker error, test fails | reconnect path exercised, passes |
| Any other machine | passes (accidentally) | passes (by construction) |

32/32 locally.

## Infographic

![mcp-breaker-test-monotonic](https://v3b.fal.media/files/b/0aa32ea9/NhDjjQB450Q8jzA_3sCut_5SnfqMBk.png)
