### PR TITLE
test(runner): report timed-out files separately

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -234,10 +234,11 @@ def _run_one_file(
     repo_root: Path,
     file_timeout: float,
     retries: int = 0,
-) -> Tuple[Path, int, str, dict[str, int], float]:
+) -> Tuple[Path, int, str, dict[str, int], float, bool]:
     """Run ``python -m pytest <file> <pytest_args>`` in a fresh subprocess.
 
-    Returns (file, returncode, captured_combined_output, summary_counts, subprocess_wall_seconds).
+    Returns (file, returncode, captured_combined_output, summary_counts,
+    subprocess_wall_seconds, timed_out).
 
     ``retries`` > 0 enables the one-shot flake retry: a non-zero exit is
     re-run in a fresh subprocess; if the re-run passes, the file counts as
@@ -267,27 +268,46 @@ def _run_one_file(
     orphan onto PID 1. This outer timeout exists only to
     bound a pathologically slow or hung file as a whole.
     """
-    file, rc, output, summary, subproc_wall = _run_one_file_once(
+    file, rc, output, summary, subproc_wall, timed_out = _run_one_file_once(
         file, pytest_args, repo_root, file_timeout
     )
     attempt = 0
     while rc != 0 and attempt < retries:
         attempt += 1
         first_output = output
-        file, rc, output, summary, subproc_wall2 = _run_one_file_once(
+        first_timed_out = timed_out
+        file, rc, output, summary, subproc_wall2, retry_timed_out = _run_one_file_once(
             file, pytest_args, repo_root, file_timeout
         )
         subproc_wall += subproc_wall2
         if rc == 0:
+            # Passed on retry. Preserve earlier timeout history only for the
+            # flaky note — failure bucketing is not used when rc == 0.
+            timed_out = first_timed_out or retry_timed_out
+            timeout_note = (
+                "timed out on attempt 1, passed on retry"
+                if first_timed_out
+                else "failed on attempt 1, passed on retry"
+            )
             output = (
-                f"⚠ FLAKY: failed on attempt 1, passed on retry "
+                f"⚠ FLAKY: {timeout_note} "
                 f"(attempt {attempt + 1}). Fix the flake — do not ignore this.\n"
                 f"--- first-attempt output ---\n{first_output}\n"
                 f"--- retry output ---\n{output}"
             )
             with _flaky_lock:
                 _FLAKY_RESULTS.append((file, output))
-    return file, rc, output, summary, subproc_wall
+        else:
+            # Still failed. Classification must follow the *last* attempt so an
+            # earlier timeout cannot mask a later real test failure, and a later
+            # timeout is not hidden behind a first-attempt assertion error.
+            timed_out = retry_timed_out
+            if timed_out:
+                output = (
+                    f"⚠ TIMEOUT: last attempt exceeded the per-file cap.\n"
+                    f"--- last-attempt output ---\n{output}"
+                )
+    return file, rc, output, summary, subproc_wall, timed_out
 
 
 # Files that failed once and passed on retry, with both attempts' output.
@@ -303,10 +323,10 @@ def _run_one_file_once(
     pytest_args: List[str],
     repo_root: Path,
     file_timeout: float,
-) -> Tuple[Path, int, str, dict[str, int], float]:
+) -> Tuple[Path, int, str, dict[str, int], float, bool]:
     """Single attempt of a per-file pytest subprocess (see _run_one_file)."""
     cmd = [sys.executable, "-m", "pytest", str(file), *pytest_args]
-    
+
     subproc_start = time.monotonic()
     # launch the pytest process
     proc = subprocess.Popen(
@@ -334,10 +354,12 @@ def _run_one_file_once(
         except (ProcessLookupError, PermissionError):
             pgid = None
 
+    timed_out = False
     try:
         output, _ = proc.communicate(timeout=file_timeout)
         rc = proc.returncode
     except subprocess.TimeoutExpired:
+        timed_out = True
         _kill_tree(proc, pgid=pgid)
         try:
             output, _ = proc.communicate(timeout=10)
@@ -358,7 +380,7 @@ def _run_one_file_once(
         # case it left grandchildren behind; already-dead is a no-op.
         _kill_tree(proc, pgid=pgid)
 
-        output +=  "\n"
+        output += "\n"
 
     if rc == 5:
         # No tests collected — every test in the file was filtered out.
@@ -367,7 +389,7 @@ def _run_one_file_once(
         rc = 0
     summary = _parse_pytest_summary(output)
     subproc_wall = time.monotonic() - subproc_start
-    return file, rc, output, summary, subproc_wall
+    return file, rc, output, summary, subproc_wall, timed_out
 
 
 def _parse_pytest_summary(output: str) -> dict[str, int]:
@@ -403,6 +425,31 @@ def _parse_pytest_summary(output: str) -> dict[str, int]:
         if line.startswith("FAILED") or line.startswith("SHORT TEST SUMMARY"):
             break
     return result
+
+
+def _summary_had_partial_execution(summary: dict[str, int], output: str) -> bool:
+    """Return True when pytest got far enough to report any test activity."""
+    if any(
+        summary.get(key, 0)
+        for key in ("passed", "failed", "skipped", "errors", "xfailed", "xpassed")
+    ):
+        return True
+    return "collected " in output.lower()
+
+
+def _failure_bucket(summary: dict[str, int], output: str, timed_out: bool) -> str:
+    """Classify a per-file failure for the end-of-run summary."""
+    if timed_out:
+        return (
+            "timed_out_after_partial_execution"
+            if _summary_had_partial_execution(summary, output)
+            else "timed_out_before_collection"
+        )
+    if summary.get("failed", 0) > 0:
+        return "test_failures"
+    if summary.get("passed", 0) > 0:
+        return "all_passed_but_nonzero"
+    return "no_tests_ran"
 
 
 def _format_file(file: Path, repo_root: Path) -> str:
@@ -885,7 +932,7 @@ def main() -> int:
 
     # Capture and print on completion (out-of-order is fine — keeps the
     # terminal clean rather than interleaving N parallel pytest outputs).
-    failures: List[Tuple[Path, str, Dict[str, int]]] = []
+    failures: List[Tuple[Path, str, Dict[str, int], bool]] = []
     file_times: List[Tuple[Path, float]] = []  # (file, subprocess_wall) for distribution
     started = time.monotonic()
     files_done = 0
@@ -896,17 +943,17 @@ def main() -> int:
     tests_failed = 0
     lock = threading.Lock()
 
-    def _on_done(file: Path, started_at: float, fut: "Future[Tuple[Path, int, str, dict[str, int], float]]") -> None:
+    def _on_done(file: Path, started_at: float, fut: "Future[Tuple[Path, int, str, dict[str, int], float, bool]]") -> None:
         nonlocal files_done, tests_done, pass_count, fail_count, tests_passed, tests_failed
         n_tests = test_counts.get(file, 0)
         try:
-            fpath, rc, output, summary, subproc_wall = fut.result()
+            fpath, rc, output, summary, subproc_wall, timed_out = fut.result()
         except Exception as exc:  # noqa: BLE001 — must always advance counter
             with lock:
                 files_done += 1
                 tests_done += n_tests
                 fail_count += 1
-                failures.append((file, f"runner crashed: {exc!r}", {}))
+                failures.append((file, f"runner crashed: {exc!r}", {}, False))
                 _print_progress(
                     tests_done, approx_total_tests, file, 1,
                     time.monotonic() - started_at,
@@ -926,7 +973,7 @@ def main() -> int:
                 pass_count += 1
             else:
                 fail_count += 1
-                failures.append((fpath, output, summary))
+                failures.append((fpath, output, summary, timed_out))
             _print_progress(
                 tests_done, approx_total_tests, fpath, rc,
                 time.monotonic() - started_at,
@@ -1005,17 +1052,38 @@ def main() -> int:
     if failures:
         print()
         print("=== Failure output ===")
-        for file, output, _summary in failures:
+        for file, output, _summary, _timed_out in failures:
             print()
             print(f"--- {_format_file(file, repo_root)} ---")
             print(output.rstrip())
         print()
-        # Split: files with actual test failures vs non-zero exit for other reasons
-        test_fail_files = [(f, s) for f, _o, s in failures if s.get("failed", 0) > 0]
-        all_passed_but_nonzero = [(f, s) for f, _o, s in failures
-                                  if s.get("failed", 0) == 0 and s.get("passed", 0) > 0]
-        no_tests_ran = [(f, s) for f, _o, s in failures
-                        if s.get("failed", 0) == 0 and s.get("passed", 0) == 0]
+        # Split by the actual reason a file failed so timeouts don't get
+        # lumped in with collection/import errors.
+        test_fail_files = [
+            (f, s)
+            for f, _o, s, timed_out in failures
+            if _failure_bucket(s, _o, timed_out) == "test_failures"
+        ]
+        all_passed_but_nonzero = [
+            (f, s)
+            for f, _o, s, timed_out in failures
+            if _failure_bucket(s, _o, timed_out) == "all_passed_but_nonzero"
+        ]
+        timed_out_partial = [
+            (f, s)
+            for f, _o, s, timed_out in failures
+            if _failure_bucket(s, _o, timed_out) == "timed_out_after_partial_execution"
+        ]
+        timed_out_before_collection = [
+            (f, s)
+            for f, _o, s, timed_out in failures
+            if _failure_bucket(s, _o, timed_out) == "timed_out_before_collection"
+        ]
+        no_tests_ran = [
+            (f, s)
+            for f, _o, s, timed_out in failures
+            if _failure_bucket(s, _o, timed_out) == "no_tests_ran"
+        ]
         if test_fail_files:
             total_tf = sum(s.get("failed", 0) for _, s in test_fail_files)
             print(f"=== {len(test_fail_files)} file{'s' if len(test_fail_files) != 1 else ''} with test failures ({total_tf} test{'s' if total_tf != 1 else ''} failed) ===")
@@ -1026,9 +1094,27 @@ def main() -> int:
             print(f"=== {len(all_passed_but_nonzero)} file{'s' if len(all_passed_but_nonzero) != 1 else ''} where all tests passed but pytest exited non-zero (warnings-as-errors, hook failures, etc.) ===")
             for file, s in all_passed_but_nonzero:
                 print(f"  {_format_file(file, repo_root)}  ({s.get('passed', 0)} passed)")
+        if timed_out_partial:
+            print(f"=== {len(timed_out_partial)} file{'s' if len(timed_out_partial) != 1 else ''} timed out after partial execution ===")
+            for file, s in timed_out_partial:
+                details = []
+                if s.get("passed", 0):
+                    details.append(f"{s.get('passed', 0)} passed")
+                if s.get("failed", 0):
+                    details.append(f"{s.get('failed', 0)} failed")
+                if s.get("skipped", 0):
+                    details.append(f"{s.get('skipped', 0)} skipped")
+                if s.get("errors", 0):
+                    details.append(f"{s.get('errors', 0)} errors")
+                suffix = f" ({', '.join(details)})" if details else ""
+                print(f"  {_format_file(file, repo_root)}{suffix}")
+        if timed_out_before_collection:
+            print(f"=== {len(timed_out_before_collection)} file{'s' if len(timed_out_before_collection) != 1 else ''} timed out before collection ===")
+            for file, _s in timed_out_before_collection:
+                print(f"  {_format_file(file, repo_root)}")
         if no_tests_ran:
-            print(f"=== {len(no_tests_ran)} file{'s' if len(no_tests_ran) != 1 else ''} where no tests ran (collection/import error, timeout before collection, etc.) ===")
-            for file, s in no_tests_ran:
+            print(f"=== {len(no_tests_ran)} file{'s' if len(no_tests_ran) != 1 else ''} where no tests ran (collection/import error, no collected tests, etc.) ===")
+            for file, _s in no_tests_ran:
                 print(f"  {_format_file(file, repo_root)}")
         return 1
 

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -30,6 +30,8 @@ from pathlib import Path
 
 import pytest
 
+from scripts import run_tests_parallel as runner
+
 
 # Both tests share the same handoff file: the leaker writes here, the
 # verifier reads here. We park it in $TMPDIR with a unique-per-run name
@@ -359,3 +361,103 @@ def test_file_retry_does_not_launder_deterministic_failure(tmp_path: Path) -> No
     assert proc.returncode == 1, proc.stdout
     assert "deterministic regression" in proc.stdout
     assert "FLAKY file" not in proc.stdout
+
+
+def test_timeout_failures_are_separated_from_no_tests_ran() -> None:
+    """Timeouts keep their own bucket instead of being reported as no-tests-ran."""
+    assert runner._failure_bucket({"passed": 463, "failed": 0}, "1 passed in 0.01s\n", True) == "timed_out_after_partial_execution"
+    assert runner._failure_bucket({}, "collected 463 items\n", True) == "timed_out_after_partial_execution"
+    assert runner._failure_bucket({}, "", True) == "timed_out_before_collection"
+    assert runner._failure_bucket({}, "", False) == "no_tests_ran"
+    assert runner._failure_bucket({"passed": 1}, "1 passed in 0.01s\n", False) == "all_passed_but_nonzero"
+
+
+def test_timeout_status_survives_retry_aggregation(monkeypatch, tmp_path: Path) -> None:
+    """A timeout on an earlier attempt is still visible after a successful retry."""
+    probe = tmp_path / "test_timeout_probe.py"
+    probe.write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+
+    responses = [
+        (probe, 124, "(300s exceeded; process tree SIGKILL'd)\n", {}, 0.75, True),
+        (probe, 0, "1 passed in 0.01s\n", {"passed": 1}, 0.10, False),
+    ]
+
+    def fake_run_one_file_once(*args, **kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr(runner, "_run_one_file_once", fake_run_one_file_once)
+
+    result = runner._run_one_file(probe, [], tmp_path, file_timeout=300, retries=1)
+
+    assert result[1] == 0
+    assert result[-1] is True
+    assert "timed out on attempt 1, passed on retry" in result[2]
+
+
+def test_last_attempt_failure_bucket_ignores_earlier_timeout(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """An earlier timeout must not hide later real test failures."""
+    probe = tmp_path / "test_timeout_then_fail.py"
+    probe.write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+
+    responses = [
+        (probe, 124, "(300s exceeded; process tree SIGKILL'd)\n", {}, 0.75, True),
+        (
+            probe,
+            1,
+            "2 failed, 1 passed in 0.20s\n",
+            {"failed": 2, "passed": 1},
+            0.20,
+            False,
+        ),
+    ]
+
+    def fake_run_one_file_once(*args, **kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr(runner, "_run_one_file_once", fake_run_one_file_once)
+
+    result = runner._run_one_file(probe, [], tmp_path, file_timeout=300, retries=1)
+    _file, rc, output, summary, _wall, timed_out = result
+
+    assert rc == 1
+    assert timed_out is False
+    assert "TIMEOUT" not in output
+    assert runner._failure_bucket(summary, output, timed_out) == "test_failures"
+
+
+def test_last_attempt_timeout_is_reported_after_earlier_failure(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A later timeout still classifies as timeout even if attempt 1 failed tests."""
+    probe = tmp_path / "test_fail_then_timeout.py"
+    probe.write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+
+    responses = [
+        (probe, 1, "1 failed in 0.10s\n", {"failed": 1}, 0.10, False),
+        (
+            probe,
+            124,
+            "(300s exceeded; process tree SIGKILL'd)\ncollected 10 items\n",
+            {},
+            0.75,
+            True,
+        ),
+    ]
+
+    def fake_run_one_file_once(*args, **kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr(runner, "_run_one_file_once", fake_run_one_file_once)
+
+    result = runner._run_one_file(probe, [], tmp_path, file_timeout=300, retries=1)
+    _file, rc, output, summary, _wall, timed_out = result
+
+    assert rc == 124
+    assert timed_out is True
+    assert "last attempt exceeded the per-file cap" in output
+    assert (
+        runner._failure_bucket(summary, output, timed_out)
+        == "timed_out_after_partial_execution"
+    )


### PR DESCRIPTION
## What does this PR do?

Track per-file timeout state explicitly in `scripts/run_tests_parallel.py` and report timed-out files separately from files where pytest exited before normal test results.

During a full canonical run, `tests/hermes_cli/test_web_server.py` hit the current 300s per-file timeout:

```text
(300s exceeded; process tree SIGKILL'd)
```

The same file passed when run alone:

```text
463 passed, 15 warnings in 153.34s
```

The runner previously grouped timeout-killed files into the same broad “no tests ran” style bucket used for cases such as collection/import/config errors. That is misleading: a timeout can happen after pytest has already collected tests or executed part of a file, so the operator needs to distinguish:

- **timed out after partial execution** — pytest collected or reported some test activity before the per-file wall-clock cap killed the subprocess tree,
- **timed out before collection was reported** — the subprocess exceeded the per-file cap before pytest printed collection or test-activity evidence; this usually points to import-time, plugin, `conftest.py`, or collection-hook setup hangs.
- **pytest exited before normal test results** — non-timeout failures such as collection, import, or configuration errors.

This patch carries explicit timeout state instead of inferring timeout from missing pass/fail counts, then prints dedicated timeout summary sections.

## Related Issue

No exact duplicate found.

Related overlap checked: #52332, #52334, #54143, #61729, #17836, #39038.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/run_tests_parallel.py`
  - return an explicit `timed_out` flag from per-file subprocess execution,
  - preserve timeout history in flaky notes when a later retry passes,
  - classify a still-failing file from the *last* attempt so an earlier timeout cannot mask later real test failures,
  - keep timeout failures separate from non-timeout cases where pytest exits before normal test results, such as collection/import/config errors,
  - split timeout reporting into “timed out after partial execution” and “timed out before collection” summary sections.
- `tests/test_run_tests_parallel.py`
  - add direct classification coverage for timeout buckets,
  - add retry aggregation coverage proving a first-attempt timeout remains visible if the retry passes,
  - add coverage that timeout-then-fail classifies as test failures and fail-then-timeout classifies as timeout.

## How to Test

1. Run focused runner tests directly:

   ```text
   /home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_run_tests_parallel.py -q -o 'addopts=' --tb=short
   # 11 passed
   ```

2. Run the same file through the canonical runner:

   ```text
   scripts/run_tests.sh tests/test_run_tests_parallel.py -q -- --tb=short
   # Summary: 1 files, 11 tests passed, 0 failed
   ```

3. Run Ruff on changed Python files:

   ```text
   /home/hermes/.hermes/hermes-agent/venv/bin/python -m ruff check scripts/run_tests_parallel.py tests/test_run_tests_parallel.py
   # All checks passed
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Targeted runner tests were run for this branch.
  - A canonical run with `scripts/run_tests.sh` mostly passed; it did not fully pass in my environment due to known/unrelated failures and timeouts, so this checkbox remains unchecked.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (noble), x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - N/A: no user-facing docs changed.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - N/A: no config keys changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - N/A: no architecture/workflow docs changed.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - The timeout flag/reporting path is runner-internal and platform-neutral; existing process-tree cleanup paths remain unchanged.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  - N/A: no tool schemas changed.

## Screenshots / Logs

```text
/home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_run_tests_parallel.py -q -o 'addopts=' --tb=short
...........                                                              [100%]
11 passed in 10.37s

/home/hermes/.hermes/hermes-agent/venv/bin/python -m ruff check scripts/run_tests_parallel.py tests/test_run_tests_parallel.py
All checks passed!
```

Earlier canonical-run evidence motivating this reporting change:

```text
tests/hermes_cli/test_web_server.py
(300s exceeded; process tree SIGKILL'd)

Targeted run of the same file:
463 passed, 15 warnings in 153.34s
```

A canonical run with `scripts/run_tests.sh` mostly passed, but did not fully pass in my environment due to known/unrelated failures and timeouts, so the full-suite checklist item remains unchecked:

```text
Summary: 2126 files, 43141 tests passed, 17 failed in 1997.2s
2 files timed out after partial execution:
  tests/agent/test_context_compressor.py
  tests/hermes_cli/test_web_server.py
```