### PR TITLE
fix(kanban): preserve links in concise completion notices

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from agent.i18n import t
+from hermes_cli.kanban_notification import format_completion_notification
 
 # Match the logger run.py uses (logging.getLogger(__name__) where __name__ ==
 # "gateway.run") so extracted log records keep their original logger name.
@@ -334,7 +335,7 @@ class GatewayKanbanWatchersMixin:
                             board_slug,
                         )
                         continue
-                    title = (task.title if task else sub["task_id"])[:120]
+                    title = task.title if task else sub["task_id"]
                     board_tag = f"[{board_slug}] " if board_slug else ""
                     for ev in d["events"]:
                         kind = ev.kind
@@ -349,21 +350,23 @@ class GatewayKanbanWatchersMixin:
                             # in the event payload), then fall back to
                             # task.result for legacy rows written before
                             # runs shipped.
-                            handoff = ""
                             payload_summary = None
                             if ev.payload and ev.payload.get("summary"):
                                 payload_summary = str(ev.payload["summary"])
-                            if payload_summary:
-                                lines = payload_summary.strip().splitlines()
-                                h = lines[0][:200] if lines else payload_summary[:200]
-                                handoff = f"\n{h}"
-                            elif task and task.result:
-                                lines = task.result.strip().splitlines()
-                                r = lines[0][:160] if lines else task.result[:160]
-                                handoff = f"\n{r}"
-                            msg = (
-                                f"✔ {board_tag}{tag}Kanban {sub['task_id']} done"
-                                f" — {title}{handoff}"
+                            handoff = payload_summary or (
+                                str(task.result) if task and task.result else ""
+                            )
+                            summary_urls = []
+                            if ev.payload and isinstance(ev.payload.get("summary_urls"), list):
+                                summary_urls = [
+                                    str(url) for url in ev.payload["summary_urls"]
+                                    if isinstance(url, str) and url
+                                ]
+                            msg = format_completion_notification(
+                                prefix=f"✔ {board_tag}{tag}Kanban {sub['task_id']} done",
+                                title=title,
+                                summary=handoff,
+                                explicit_urls=summary_urls,
                             )
                         elif kind == "blocked":
                             reason = ""

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -90,6 +90,7 @@ from pathlib import Path
 from typing import Any, Iterable, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
+from hermes_cli.kanban_notification import extract_complete_urls
 from toolsets import get_toolset_names
 
 _log = logging.getLogger(__name__)
@@ -4566,12 +4567,18 @@ def complete_task(
         # notifiers and dashboard WS consumers can render it without a
         # second SQL round-trip. First line only, 400 char cap — the
         # full summary stays on the run row.
-        ev_summary = (summary if summary is not None else result) or ""
+        event_handoff = (summary if summary is not None else result) or ""
+        ev_summary = event_handoff
         ev_summary = ev_summary.strip().splitlines()[0][:400] if ev_summary else ""
         completed_payload: dict = {
             "result_len": len(result) if result else 0,
             "summary": ev_summary or None,
         }
+        # Keep enough complete links for notification prioritization without
+        # letting a URL-heavy summary bloat every event row.
+        summary_urls = extract_complete_urls(event_handoff)[:8]
+        if summary_urls:
+            completed_payload["summary_urls"] = summary_urls
         if verified_cards:
             completed_payload["verified_cards"] = verified_cards
         # Carry artifact paths in the event payload so the gateway
@@ -5192,6 +5199,7 @@ def edit_completed_task_result(
             handoff_summary.strip().splitlines()[0][:400]
             if handoff_summary else ""
         )
+        edited_summary_urls = extract_complete_urls(handoff_summary)[:8]
         _append_event(
             conn, task_id, "edited",
             {
@@ -5201,6 +5209,7 @@ def edit_completed_task_result(
                 ),
                 "result_len": len(result) if result else 0,
                 "summary": ev_summary or None,
+                **({"summary_urls": edited_summary_urls} if edited_summary_urls else {}),
             },
             run_id=run_id,
         )

--- a/hermes_cli/kanban_notification.py
+++ b/hermes_cli/kanban_notification.py
@@ -1,0 +1,137 @@
+"""Concise, link-safe Kanban completion notification formatting."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+COMPLETION_NOTIFICATION_MAX_CHARS = 500
+COMPLETION_NOTIFICATION_MAX_LINES = 4
+_COMPLETION_HEADER_MAX_CHARS = 180
+_DETAILS_NOTICE = "… Full details: Kanban card."
+_MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^\s)]+)\)")
+_BARE_URL_RE = re.compile(r"https?://[^\s<>]+")
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?。！？])\s+")
+
+
+def extract_complete_urls(text: str | None) -> list[str]:
+    """Return complete, deduplicated HTTP(S) URLs without trailing prose punctuation."""
+    value = str(text or "")
+    urls: list[str] = []
+    seen: set[str] = set()
+
+    def _add(raw: str) -> None:
+        url = raw.rstrip(".,;:!?)]}")
+        if url and url not in seen:
+            seen.add(url)
+            urls.append(url)
+
+    for match in _MARKDOWN_LINK_RE.finditer(value):
+        _add(match.group(2))
+    for match in _BARE_URL_RE.finditer(value):
+        _add(match.group(0))
+    return urls
+
+
+def _link_priority(url: str) -> int:
+    lowered = url.lower()
+    if "github.com/" in lowered and "/pull/" in lowered:
+        return 0
+    if "/merge_requests/" in lowered or "/artifacts/" in lowered:
+        return 1
+    return 2
+
+
+def _plain_summary(text: str, urls: Iterable[str]) -> str:
+    value = _MARKDOWN_LINK_RE.sub(lambda match: match.group(1), text)
+    for url in urls:
+        value = value.replace(url, "")
+    value = _BARE_URL_RE.sub("", value)
+    value = value.replace("`", "")
+    value = re.sub(r"[*_~]+", "", value)
+    return " ".join(value.split()).strip(" -–—:;,.")
+
+
+def _shorten_at_boundary(text: str, budget: int) -> tuple[str, bool]:
+    value = " ".join(text.split())
+    if len(value) <= budget:
+        return value, False
+    if budget <= 1:
+        return "…"[:budget], True
+    prefix = value[: budget - 1].rstrip()
+    boundary = max(prefix.rfind(" "), prefix.rfind("/"), prefix.rfind("-"))
+    if boundary >= max(1, (budget - 1) // 2):
+        prefix = prefix[:boundary].rstrip()
+    return prefix.rstrip(".,;:–—-") + "…", True
+
+
+def _summary_lines(text: str, slots: int, per_line_budget: int) -> tuple[list[str], bool]:
+    if not text:
+        return ["Completed."], False
+    chunks = [chunk.strip() for chunk in _SENTENCE_SPLIT_RE.split(text) if chunk.strip()]
+    if not chunks:
+        chunks = [text]
+    lines: list[str] = []
+    shortened = len(chunks) > slots
+    for chunk in chunks[:slots]:
+        line, clipped = _shorten_at_boundary(chunk, per_line_budget)
+        if line:
+            lines.append(line)
+        shortened = shortened or clipped
+    return lines or ["Completed."], shortened
+
+
+def format_completion_notification(
+    *,
+    prefix: str,
+    title: str,
+    summary: str | None,
+    explicit_urls: Iterable[str] = (),
+) -> str:
+    """Build a 2–4 line completion notice without slicing URLs or Markdown tokens."""
+    title_budget = max(24, _COMPLETION_HEADER_MAX_CHARS - len(prefix) - 3)
+    short_title, title_shortened = _shorten_at_boundary(title, title_budget)
+    header = f"{prefix} — {short_title}" if short_title else prefix
+
+    source = str(summary or "").strip()
+    discovered = list(explicit_urls) + extract_complete_urls(source)
+    unique_urls = list(dict.fromkeys(url for url in discovered if url))
+    unique_urls.sort(key=_link_priority)
+
+    # Reserve at least one summary line. Two complete links still fit the
+    # 2–4-line contract; additional links remain on the Kanban card.
+    link_lines: list[str] = []
+    for url in unique_urls:
+        if len(link_lines) >= 2:
+            break
+        prospective = [header, "Completed.", *link_lines, url]
+        if len("\n".join(prospective)) <= COMPLETION_NOTIFICATION_MAX_CHARS:
+            link_lines.append(url)
+
+    summary_slots = max(1, COMPLETION_NOTIFICATION_MAX_LINES - 1 - len(link_lines))
+    fixed_chars = len(header) + sum(len(url) for url in link_lines)
+    fixed_newlines = len(link_lines) + summary_slots
+    available = max(48, COMPLETION_NOTIFICATION_MAX_CHARS - fixed_chars - fixed_newlines)
+    per_line_budget = max(48, available // summary_slots)
+    plain = _plain_summary(source, unique_urls)
+    body_lines, summary_shortened = _summary_lines(plain, summary_slots, per_line_budget)
+
+    omitted_links = len(link_lines) < len(unique_urls)
+    shortened = title_shortened or summary_shortened or omitted_links
+    if shortened:
+        last = body_lines[-1]
+        notice_budget = per_line_budget - len(_DETAILS_NOTICE) - 1
+        last, _ = _shorten_at_boundary(last, max(16, notice_budget))
+        body_lines[-1] = f"{last} {_DETAILS_NOTICE}".strip()
+
+    lines = [header, *body_lines, *link_lines]
+    message = "\n".join(lines[:COMPLETION_NOTIFICATION_MAX_LINES])
+    if len(message) > COMPLETION_NOTIFICATION_MAX_CHARS:
+        # URLs are indivisible. Only shrink prose/header if the final accounting
+        # is tight due to punctuation or a long task title.
+        overflow = len(message) - COMPLETION_NOTIFICATION_MAX_CHARS
+        target = max(24, len(body_lines[-1]) - overflow)
+        body_lines[-1], _ = _shorten_at_boundary(body_lines[-1], target)
+        lines = [header, *body_lines, *link_lines]
+        message = "\n".join(lines[:COMPLETION_NOTIFICATION_MAX_LINES])
+    return message

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -35,10 +35,10 @@ async def _run_one_notifier_tick(monkeypatch, runner):
     await runner._kanban_notifier_watcher(interval=1)
 
 
-def _make_runner(adapter):
+def _make_runner(adapter, platform=Platform.TELEGRAM):
     runner = GatewayRunner.__new__(GatewayRunner)
     runner._running = True
-    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.adapters = {platform: adapter}
     runner._kanban_sub_fail_counts = {}
     return runner
 
@@ -52,6 +52,85 @@ def _create_completed_subscription(summary="done once"):
         return tid
     finally:
         conn.close()
+
+
+def _deliver_completion_notice(monkeypatch, summary, *, legacy=False):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="Slack notifier regression", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="slack", chat_id="chat-1")
+        if legacy:
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET status = 'done', result = ? WHERE id = ?",
+                    (summary, tid),
+                )
+                kb._append_event(conn, tid, kind="completed", payload={"summary": None})
+        else:
+            kb.complete_task(conn, tid, summary=summary)
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter, Platform.SLACK)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    assert len(adapter.sent) == 1
+    return adapter.sent[0]["text"]
+
+
+def test_completion_notice_preserves_incident_pr_url(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "incident.db"))
+    kb.init_db()
+    pr_url = "https://github.com/NousResearch/hermes-agent/pull/68897"
+    summary = (
+        "Slack rich-text `!cmd` 중복을 current upstream main 기준으로 수정하고, "
+        "실제 `!model` 입력이 gateway dispatch를 거쳐 session override 메모리·영구 "
+        "저장까지 바꾸는 E2E를 추가했습니다. 13개 Slack 테스트 파일 448개가 전부 "
+        f"통과했고 upstream PR {pr_url}"
+    )
+
+    message = _deliver_completion_notice(monkeypatch, summary)
+
+    assert pr_url in message
+    assert "https://github\n" not in message
+    assert 2 <= len(message.splitlines()) <= 4
+    assert len(message) <= 500
+
+
+def test_completion_notice_shortens_oversized_summary_without_breaking_links(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "oversized.db"))
+    kb.init_db()
+    pr_url = "https://github.com/NousResearch/hermes-agent/pull/70001"
+    summary = (
+        "Shipped the notifier fix. Verification passed 448 gateway tests. "
+        + "implementation detail and internal jargon " * 180
+        + f"[upstream PR]({pr_url})"
+    )
+
+    message = _deliver_completion_notice(monkeypatch, summary)
+
+    assert pr_url in message
+    assert len(message) <= 500
+    assert 2 <= len(message.splitlines()) <= 4
+    assert "Full details" in message
+    assert "implementation detail and internal jargon " * 10 not in message
+    assert "[upstream PR](https://github.com/NousResearch/hermes-agent/pull/70001" not in message
+
+
+def test_completion_notice_legacy_result_uses_same_safe_budget(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "legacy.db"))
+    kb.init_db()
+    pr_url = "https://github.com/NousResearch/hermes-agent/pull/69999"
+    result = "Legacy worker completed the fix. " + ("details " * 200) + pr_url
+
+    message = _deliver_completion_notice(monkeypatch, result, legacy=True)
+
+    assert pr_url in message
+    assert len(message) <= 500
+    assert 2 <= len(message.splitlines()) <= 4
+    assert "Full details" in message
 
 
 def _unseen_terminal_events(tid):

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -804,7 +804,7 @@ This is the whole point of the separation:
 
 ### Auto-subscribe on `/kanban create` (gateway only)
 
-When you create a task from the gateway with `/kanban create "…"`, the originating chat (platform + chat id + thread id) is automatically subscribed to that task's terminal events (`completed`, `blocked`, `gave_up`, `crashed`, `timed_out`). You'll get one message back per terminal event — including the first line of the worker's result summary on `completed` — without having to poll or remember the task id.
+When you create a task from the gateway with `/kanban create "…"`, the originating chat (platform + chat id + thread id) is automatically subscribed to that task's terminal events (`completed`, `blocked`, `gave_up`, `crashed`, `timed_out`). You'll get one message back per terminal event. Completion notices use a concise 2–4-line summary and preserve complete PR or artifact links on their own lines; the full handoff remains on the Kanban card.
 
 ```
 you> /kanban create "transcribe today's podcast" --assignee transcriber
@@ -860,7 +860,7 @@ Workers receive `$HERMES_TENANT` and namespace their memory writes by prefix. Th
 
 ## Gateway notifications
 
-When you run `/kanban create …` from the gateway (Telegram, Discord, Slack, etc.), the originating chat is automatically subscribed to the new task. The gateway's background notifier polls `task_events` every few seconds and delivers one message per terminal event (`completed`, `blocked`, `gave_up`, `crashed`, `timed_out`) to that chat. Completed tasks also send the first line of the worker's `--result` so you see the outcome without having to `/kanban show`.
+When you run `/kanban create …` from the gateway (Telegram, Discord, Slack, etc.), the originating chat is automatically subscribed to the new task. The gateway's background notifier polls `task_events` every few seconds and delivers one message per terminal event (`completed`, `blocked`, `gave_up`, `crashed`, `timed_out`) to that chat. Completed tasks send a short outcome-and-proof summary plus complete PR or artifact links when present; longer details stay available through `/kanban show`.
 
 You can manage subscriptions explicitly from the CLI — useful when a script / cron job wants to notify a chat it didn't originate from:
 
@@ -914,7 +914,7 @@ hermes kanban runs t_abcd
 #        → implemented token bucket, keys on user_id with IP fallback
 ```
 
-Runs are exposed on the dashboard (Run History section in the drawer, one coloured row per attempt) and on the REST API (`GET /api/plugins/kanban/tasks/:id` returns a `runs[]` array). `PATCH /api/plugins/kanban/tasks/:id` with `{status: "done", summary, metadata}` forwards both to the kernel, so the dashboard's "mark done" button is CLI-equivalent. `task_events` rows carry the `run_id` they belong to so the UI can group them by attempt, and the `completed` event embeds the first-line summary in its payload (capped at 400 chars) so gateway notifiers can render structured handoffs without a second SQL round-trip.
+Runs are exposed on the dashboard (Run History section in the drawer, one coloured row per attempt) and on the REST API (`GET /api/plugins/kanban/tasks/:id` returns a `runs[]` array). `PATCH /api/plugins/kanban/tasks/:id` with `{status: "done", summary, metadata}` forwards both to the kernel, so the dashboard's "mark done" button is CLI-equivalent. `task_events` rows carry the `run_id` they belong to so the UI can group them by attempt. A `completed` event embeds the first-line summary (capped at 400 chars) plus separately extracted complete URLs, allowing gateway notifiers to stay concise without cutting links or fetching the run row again.
 
 **Bulk close caveat.** `hermes kanban complete a b c --summary X` is refused — structured handoff is per-run, so copy-pasting the same summary to N tasks is almost always wrong. Bulk close *without* `--summary` / `--metadata` still works for the common "I finished a pile of admin tasks" case.
 


### PR DESCRIPTION
[Bob]

## Summary

- replace raw `[:200]` / `[:160]` completion-summary slicing with one shared 500-character, 2–4-line formatter
- preserve complete PR and artifact URLs on separate lines, including URLs located after the event summary excerpt
- keep legacy `task.result` notifications on the same boundary-safe contract
- retain native artifact delivery and document the concise notification behavior

## Root cause

The Kanban watcher sliced the first summary line before calling the platform adapter. In the reported Slack incident, the stored summary ended with:

`https://github.com/NousResearch/hermes-agent/pull/68897`

but the adapter received text ending in `https://github`, so Slack correctly stored only `<https://github>`. The platform did not truncate the message.

The producer also caps the event summary excerpt at 400 characters. This patch therefore extracts complete URLs from the full handoff when the completion event is written and carries up to eight separately in `summary_urls`; the gateway can keep the prose concise without losing a late URL.

## Existing related PRs

#59861 and #67315 correctly identify the same raw-slice path, but expand notifications to a 3,500-character near-full handoff. This patch implements a deliberately different user-facing contract: short completion notices with the detailed handoff left on the Kanban card, while preserving complete actionable links.

## RED → GREEN

Before the fix:

```text
Discovered 1 test files (~10 tests)
3 failed, 7 passed
```

The failures reproduced the exact Slack URL cut, an oversized Markdown-link summary, and the legacy `task.result` fallback.

After the fix:

```text
Discovered 1 test files (~10 tests)
10 tests passed, 0 failed
```

## Verification

```text
scripts/run_tests.sh \
  tests/gateway/test_kanban_notifier.py \
  tests/gateway/test_kanban_watchers_mixin.py \
  tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py \
  tests/gateway/test_kanban_auto_decompose_live.py \
  tests/hermes_cli/test_kanban_notify.py \
  tests/hermes_cli/test_kanban_core_functionality.py -q

Discovered 6 test files (~206 tests)
208 tests passed, 0 failed
```

```text
ruff check gateway/kanban_watchers.py hermes_cli/kanban_db.py \
  hermes_cli/kanban_notification.py tests/gateway/test_kanban_notifier.py
All checks passed!

git diff --check
passed
```

A full `tests/gateway/` sweep was also attempted. The changed Kanban files passed, while unrelated existing macOS/environment failures remained in systemd abstract sockets, `/tmp` path canonicalization, WeCom optional XML imports, restart-loop state, timing, and subprocess/resource-limit tests.
