### PR TITLE
fix(backup): surface quick-snapshot capture failures instead of dropping them silently

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -13,6 +13,7 @@ import logging
 import os
 import shutil
 import sqlite3
+import stat
 import sys
 import tempfile
 import threading
@@ -21,7 +22,7 @@ import zipfile
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_constants import get_default_hermes_root, get_hermes_home, display_hermes_home
 
@@ -335,27 +336,28 @@ def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> 
 # SQLite safe copy
 # ---------------------------------------------------------------------------
 
-def _safe_copy_db(src: Path, dst: Path) -> bool:
+def _safe_copy_db(src: Path, dst: Path) -> Tuple[bool, Optional[str]]:
     """Copy a SQLite database safely using the backup() API.
 
     Handles WAL mode — produces a consistent snapshot even while
     the DB is being written to. Fail closed if a consistent snapshot cannot
     be created: copying only the live main file can omit committed WAL data.
+
+    Returns ``(ok, error)``: ``(True, None)`` on success, ``(False, reason)``
+    on failure. The reason string lets callers persist WHY a present file
+    could not be captured (e.g. ``file is not a database`` for a zeroed
+    state.db, issue #68474) instead of dropping it silently.
     """
     conn = None
     backup_conn = None
+    error: Optional[str] = None
     try:
         conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
         backup_conn = sqlite3.connect(str(dst))
         conn.backup(backup_conn)
-        return True
     except Exception as exc:
         logger.warning("SQLite safe copy failed for %s: %s", src, exc)
-        try:
-            dst.unlink(missing_ok=True)
-        except OSError:
-            pass
-        return False
+        error = str(exc)
     finally:
         for connection in (backup_conn, conn):
             if connection is not None:
@@ -363,6 +365,18 @@ def _safe_copy_db(src: Path, dst: Path) -> bool:
                     connection.close()
                 except Exception:
                     pass
+    if error is not None:
+        # Remove the partial destination AFTER closing the connections: on
+        # Windows an open handle makes unlink fail with a (swallowed)
+        # PermissionError, silently leaving a broken copy in the snapshot.
+        try:
+            dst.unlink(missing_ok=True)
+        except OSError as cleanup_exc:
+            logger.warning(
+                "Could not remove partial copy %s: %s", dst, cleanup_exc
+            )
+        return False, error
+    return True, None
 
 
 def is_zeroed_sqlite_file(
@@ -557,7 +571,9 @@ def copy_db_and_verify(src: Path, dst: Path) -> bool:
     rather than a full ``PRAGMA integrity_check`` that would page through
     the whole file.
     """
-    if not _safe_copy_db(src, dst):
+    copied, copy_error = _safe_copy_db(src, dst)
+    if not copied:
+        logger.warning("Backup of %s failed to copy: %s", src, copy_error)
         return False
     integrity = verify_sqlite_integrity(dst, run_pragma=True)
     if not integrity.get("valid"):
@@ -713,7 +729,7 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
                         suffix=".db", delete=False, dir=str(out_path.parent)
                     ) as tmp:
                         tmp_db = Path(tmp.name)
-                    if _safe_copy_db(abs_path, tmp_db):
+                    if _safe_copy_db(abs_path, tmp_db)[0]:
                         zf.write(tmp_db, arcname=str(rel_path))
                         total_bytes += tmp_db.stat().st_size
                         tmp_db.unlink(missing_ok=True)
@@ -1121,6 +1137,16 @@ _QUICK_STATE_FILES = (
 _QUICK_SNAPSHOTS_DIR = "state-snapshots"
 _QUICK_DEFAULT_KEEP = 20
 
+# Total-work budget (scandir'd directory entries) for one protected-root
+# capture in create_quick_snapshot(). Bounds a directory-cycle traversal
+# (e.g. a Windows junction looping back to an ancestor, linearly or via
+# branching) without any per-entry identity check — see the guard's own
+# comment in create_quick_snapshot() for the full rationale (#68907
+# review, pass 5). A real Hermes state tree never comes close to this;
+# module-level (not a function-local constant) so tests can monkeypatch
+# it down to a small value instead of driving 200k synthetic iterations.
+_QUICK_SNAPSHOT_MAX_TRAVERSAL_ENTRIES = 200_000
+
 
 def _quick_snapshot_root(hermes_home: Optional[Path] = None) -> Path:
     home = hermes_home or get_hermes_home()
@@ -1171,6 +1197,17 @@ def _create_quick_snapshot_locked(
     home = hermes_home or get_hermes_home()
     root = _quick_snapshot_root(home)
 
+    # Protected files intentionally skipped for exceeding max_file_size. Unlike
+    # ``failed`` these are NOT capture errors — the cap is deliberate (e.g. a
+    # multi-GB state.db that must not stall an update) — so they are reported as
+    # a plain skip rather than a "corrupted or locked" failure. But a skipped
+    # protected file still leaves the snapshot INCOMPLETE, so it must block
+    # pruning of the last complete snapshot exactly as a failure does (#68907
+    # review): a pre-update run whose state.db crosses the cap would otherwise
+    # delete the previous good snapshot and reintroduce issue #68474's
+    # recovery-loss.
+    size_skipped: Dict[str, str] = {}
+
     def _too_large(path: Path, rel_name: str) -> bool:
         """True (and warn) when ``path`` exceeds the max_file_size cap."""
         if max_file_size is None:
@@ -1191,6 +1228,9 @@ def _create_quick_snapshot_locked(
             size,
             max_file_size,
         )
+        size_skipped[rel_name] = (
+            f"{_format_size(size)} exceeds {_format_size(max_file_size)} limit"
+        )
         return True
 
     ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
@@ -1200,6 +1240,7 @@ def _create_quick_snapshot_locked(
     while (root / snap_id).exists():
         snap_id = f"{base_snap_id}-{suffix}"
         suffix += 1
+
     snap_dir = root / snap_id
     staging_dir = root / f".{snap_id}.{os.getpid()}.partial"
     shutil.rmtree(staging_dir, ignore_errors=True)
@@ -1207,62 +1248,267 @@ def _create_quick_snapshot_locked(
     logger.info("quick snapshot phase=copy status=started id=%s", snap_id)
 
     manifest: Dict[str, int] = {}  # rel_path -> file size
-    failed_dbs: list[str] = []  # present *.db that could not be snapshotted
+    # rel_path -> reason, for files that EXISTED but could not be captured.
+    # Persisted in the manifest and reported loudly: a present-but-unreadable
+    # state.db (e.g. zeroed to null bytes, issue #68474) must not ride
+    # through an update behind an apparently-successful snapshot.
+    failed: Dict[str, str] = {}
+    # #68805's list, kept with its original meaning: present *.db files that
+    # could not be captured. It drives the DB-specific CRITICAL report, so a
+    # non-DB failure must NOT appear here even though it still counts as
+    # snapshot incompleteness (that is what ``failed`` is for).
+    failed_dbs: list[str] = []
     # #68805: track protected DB files skipped for size — they are snapshot
     # incompleteness just like a failed copy, so pruning must be suppressed
     # to preserve the older complete snapshot that may contain the only
     # recoverable database.
     oversized_skipped: list[str] = []
 
+    def _record_failure(rel_name: str, reason: str) -> None:
+        # Idempotent: a path can be reported twice (e.g. a stat() race inside
+        # the zeroed-file diagnostic), and the first reason is the useful one.
+        if rel_name in failed:
+            return
+        failed[rel_name] = reason
+        if rel_name.endswith(".db"):
+            failed_dbs.append(rel_name)
+        print(f"  ⚠ Snapshot: could not capture {rel_name}: {reason}")
+
     for rel in _QUICK_STATE_FILES:
         src = home / rel
-        if not src.exists():
+
+        # Classify src through the SAME choke point the descendants use
+        # below: raw os.stat(), not Path.exists()/is_dir()/is_file().
+        # Those pathlib methods silently swallow OSError for a specific
+        # errno set (ENOENT, ENOTDIR, EBADF, ELOOP —
+        # pathlib._IGNORED_ERRNOS) and return False. A transient
+        # EBADF/EACCES/ESTALE while stat-ing a PRESENT protected
+        # top-level file (e.g. state.db) would look identical to "doesn't
+        # exist", silently dropping it with nothing recorded and letting
+        # the keep=1 prune evict the last good snapshot (#68907 review,
+        # Finding 1). Only a genuine absence (ENOENT/ENOTDIR — most
+        # _QUICK_STATE_FILES entries are optional and won't exist on a
+        # given install) is a silent skip; anything else is recorded.
+        try:
+            top_stat = os.stat(src)
+        except FileNotFoundError:
+            continue
+        except NotADirectoryError:
+            continue
+        except OSError as exc:
+            _record_failure(rel, str(exc))
             continue
 
-        if src.is_dir():
+        if stat.S_ISDIR(top_stat.st_mode):
             # Walk the directory and record each file individually in the
             # manifest so restore can treat them uniformly.  Empty dirs are
             # skipped (nothing to snapshot).
-            for sub in src.rglob("*"):
-                if not sub.is_file():
-                    continue
-                sub_rel = sub.relative_to(home).as_posix()
-                # Skip heavy, regenerable per-board subtrees (scratch
-                # workspaces and task attachments can be large); we only need
-                # the board databases + their metadata to restore a board.
-                if "/workspaces/" in f"/{sub_rel}/" or "/attachments/" in f"/{sub_rel}/":
-                    continue
-                if _too_large(sub, sub_rel):
-                    if sub.suffix == ".db":
-                        oversized_skipped.append(sub_rel)
-                    continue
-                dst = staging_dir / sub_rel
-                dst.parent.mkdir(parents=True, exist_ok=True)
+            #
+            # Recurse via os.scandir ourselves — not Path.rglob, not
+            # os.walk(onerror=...) — so every directory-entry
+            # classification is a single choke point that funnels failures
+            # into `failed`. Both alternatives have a verified blind spot:
+            #  - Path.rglob() SILENTLY SUPPRESSES OSError raised while
+            #    scanning a subdirectory it cannot list (Python 3.13).
+            #  - os.walk()'s `onerror` only fires for scandir() open/
+            #    iteration failures. When entry.is_dir() itself raises,
+            #    os.walk catches that OSError internally and classifies
+            #    the entry as a non-directory — WITHOUT calling onerror
+            #    (CPython 3.13 Lib/os.py, walk(): the
+            #    `try: is_dir = entry.is_dir() except OSError: is_dir =
+            #    False` around line 389). The caller then sees that name in
+            #    `filenames`, and checking sub.is_file() on it either
+            #    silently returns False (errno ENOENT/ENOTDIR/EBADF/ELOOP,
+            #    ignored by pathlib) or raises unhandled (any other
+            #    errno) — either way nothing is recorded.
+            # Either blind spot lets a snapshot that silently missed part
+            # of a protected directory (pairing/, platforms/pairing/,
+            # kanban/boards/) look complete, so the keep=1 prune would
+            # then evict the last good snapshot — reintroducing #68474's
+            # recovery-loss (#68907 review).
+            def _rel_for(path: Path) -> str:
                 try:
-                    # Route SQLite DBs through the WAL-safe backup() path so a
-                    # board DB with an open WAL (the gateway may hold it at
-                    # snapshot time) is captured consistently.
-                    if sub.suffix == ".db":
-                        if not _safe_copy_db(sub, dst):
-                            failed_dbs.append(sub_rel)
-                            print(
-                                f"  ⚠ Snapshot: SQLite safe copy FAILED for {sub_rel} "
-                                f"— file may be locked or corrupted"
+                    return path.relative_to(home).as_posix()
+                except ValueError:
+                    return str(path)
+
+            # Guards against unbounded recursion — in particular a Windows
+            # directory junction (or a POSIX hardlink-to-directory)
+            # aliasing an ancestor, which would otherwise recurse forever,
+            # re-copying the same files under an ever-deeper path until
+            # resource exhaustion (#68907 review, Finding 2).
+            # os.path.islink() does NOT catch junctions/reparse points
+            # (they aren't POSIX symlinks).
+            #
+            # TWO prior versions of this guard were both wrong:
+            #  - An identity visited-set keyed on (st_dev, st_ino) from
+            #    DirEntry.stat(). Verified by direct measurement on this
+            #    Windows machine: DirEntry.stat() (the cached fast-path
+            #    stat, unlike os.stat()) reports st_dev=0, st_ino=0 for
+            #    EVERY entry — any two sibling directories collide on
+            #    (0, 0) and the second is silently dropped, with neither
+            #    `failed` nor `size_skipped` set. Worse than the bug it
+            #    targeted: broke every multi-subdirectory protected root
+            #    on Windows.
+            #  - A max recursion DEPTH (64). Depth only bounds path
+            #    LENGTH, not total WORK. Two junctions forming a BINARY
+            #    cycle (pairing/a -> pairing, pairing/b -> pairing) still
+            #    reach depth 64 on every path, but getting there costs
+            #    2**65-1 ~= 3.7e19 scandir calls — the snapshot hangs
+            #    long before any failure is recorded.
+            #
+            # The fix is a total-work BUDGET: platform-independent (no
+            # identity, cannot collide) and bounds branching as well as
+            # depth (a bounded-depth linear traversal is necessarily
+            # bounded in total entries too, so the budget subsumes a
+            # depth check — it is the ONLY guard here, not stacked with
+            # one). When exceeded, it goes through the same
+            # _record_failure() choke point as every other capture
+            # problem — recorded once, and the WHOLE traversal for this
+            # root aborts immediately (not just the offending branch, so
+            # a branching cycle can't keep burning budget on other
+            # branches) — blocking the keep=1 prune instead of silently
+            # dropping data. A junction looping back to an ancestor
+            # (linear or branching) burns through the budget and stops
+            # (recorded, safe). A junction pointing at an unrelated
+            # sibling causes at most a bounded redundant re-capture of
+            # already-protected files (harmless for a snapshot). A
+            # legitimate Hermes state tree (pairing/, kanban/boards/) is
+            # tiny, so the budget is never approached by real data.
+            entries_visited = 0
+            budget_exceeded = False
+
+            stack = [src]
+            while stack:
+                current = stack.pop()
+                try:
+                    scandir_it = os.scandir(current)
+                except OSError as exc:
+                    _record_failure(_rel_for(current), str(exc))
+                    continue
+
+                # Iterate the ScandirIterator directly — NOT
+                # list(os.scandir(current)) — so the budget is checked per
+                # yield, before the entry is processed. list() would
+                # eagerly materialize the WHOLE directory listing first: a
+                # lazy high-fan-out cycle (a junction whose listing itself
+                # yields thousands+ self-referential entries) would blow
+                # past the budget — or exhaust memory — inside that single
+                # list() call, before entries_visited is ever incremented
+                # (#68907 review, pass 6). Advancing via next() (instead of
+                # a plain `for entry in scandir_it:`) lets an OSError raised
+                # WHILE iterating — not just on open — be routed through
+                # _record_failure() too (scandir can fail mid-iteration on
+                # some filesystems); this mirrors CPython's own os.walk()
+                # implementation. `with` guarantees the OS handle is closed
+                # even when the budget cuts iteration short.
+                with scandir_it:
+                    while True:
+                        try:
+                            entry = next(scandir_it)
+                        except StopIteration:
+                            break
+                        except OSError as exc:
+                            _record_failure(_rel_for(current), str(exc))
+                            break
+
+                        entries_visited += 1
+                        if entries_visited > _QUICK_SNAPSHOT_MAX_TRAVERSAL_ENTRIES:
+                            _record_failure(
+                                _rel_for(current),
+                                f"traversal work budget exceeded "
+                                f"({_QUICK_SNAPSHOT_MAX_TRAVERSAL_ENTRIES} "
+                                f"entries) — possible directory cycle",
                             )
-                            if is_zeroed_sqlite_file(sub):
-                                print(
-                                    f"  ⚠ Snapshot: {sub_rel} looks ZEROED "
-                                    f"(no SQLite header; {sub.stat().st_size} bytes of NULs?)"
-                                )
+                            budget_exceeded = True
+                            break
+
+                        entry_path = Path(entry.path)
+
+                        try:
+                            is_dir = entry.is_dir()
+                        except OSError as exc:
+                            _record_failure(_rel_for(entry_path), str(exc))
                             continue
-                    else:
-                        shutil.copy2(sub, dst)
-                    manifest[sub_rel] = dst.stat().st_size
-                except (OSError, PermissionError) as exc:
-                    logger.warning("Could not snapshot %s: %s", sub_rel, exc)
+
+                        if is_dir:
+                            # Skip heavy, regenerable per-board subtrees
+                            # (scratch workspaces and task attachments can be
+                            # large); we only need the board databases + their
+                            # metadata to restore a board. These names are
+                            # always directory roots in this codebase (see
+                            # kanban_db.py's workspaces_root() /
+                            # attachments_root()) — never plain files — so
+                            # this check is intentionally directory-only; a
+                            # FILE literally named "workspaces"/"attachments"
+                            # is not a layout this codebase produces and is
+                            # captured normally. Pruned BEFORE descent so an
+                            # unreadable workspaces/attachments subtree can
+                            # never mark the snapshot incomplete — nothing
+                            # under it belongs in the snapshot anyway (#68907
+                            # review, Finding 2).
+                            if entry.name in ("workspaces", "attachments"):
+                                continue
+                            # Don't follow symlinked directories — matches the
+                            # followlinks=False convention every other os.walk()
+                            # call site in this file uses. os.path.islink()
+                            # never raises (swallows OSError, returns False).
+                            if os.path.islink(entry.path):
+                                continue
+                            stack.append(entry_path)
+                            continue
+
+                        try:
+                            is_file = entry.is_file()
+                        except OSError as exc:
+                            _record_failure(_rel_for(entry_path), str(exc))
+                            continue
+                        if not is_file:
+                            continue
+
+                        sub = entry_path
+                        sub_rel = _rel_for(sub)
+                        if _too_large(sub, sub_rel):
+                            if sub.suffix == ".db":
+                                oversized_skipped.append(sub_rel)
+                            continue
+                        dst = staging_dir / sub_rel
+                        try:
+                            dst.parent.mkdir(parents=True, exist_ok=True)
+                            # Route SQLite DBs through the WAL-safe backup() path so a
+                            # board DB with an open WAL (the gateway may hold it at
+                            # snapshot time) is captured consistently.
+                            if sub.suffix == ".db":
+                                ok, err = _safe_copy_db(sub, dst)
+                                if not ok:
+                                    _record_failure(sub_rel, err or "SQLite safe copy failed")
+                                    # Best-effort extra diagnosis: under the
+                                    # safe-read contract (fbd5e5772) this probe
+                                    # returns False instead of reading when a
+                                    # live connection to the file exists in
+                                    # this process — the CRITICAL failure report
+                                    # above still fires either way.
+                                    if is_zeroed_sqlite_file(sub):
+                                        print(
+                                            f"  ⚠ Snapshot: {sub_rel} looks ZEROED "
+                                            f"(no SQLite header; {sub.stat().st_size} bytes of NULs?)"
+                                        )
+                                    continue
+                            else:
+                                shutil.copy2(sub, dst)
+                            manifest[sub_rel] = dst.stat().st_size
+                        except (OSError, PermissionError) as exc:
+                            logger.warning("Could not snapshot %s: %s", sub_rel, exc)
+                            _record_failure(sub_rel, str(exc))
+
+                if budget_exceeded:
+                    break
             continue
 
-        if not src.is_file():
+        if not stat.S_ISREG(top_stat.st_mode):
+            # Not a regular file (socket, fifo, device, ...) — nothing to
+            # protect here. Reuses the single os.stat() already taken
+            # above instead of a second, possibly-racy Path.is_file() call.
             continue
 
         if _too_large(src, rel):
@@ -1271,16 +1517,14 @@ def _create_quick_snapshot_locked(
             continue
 
         dst = staging_dir / rel
-        dst.parent.mkdir(parents=True, exist_ok=True)
 
         try:
+            dst.parent.mkdir(parents=True, exist_ok=True)
             if src.suffix == ".db":
-                if not _safe_copy_db(src, dst):
-                    failed_dbs.append(rel)
-                    print(
-                        f"  ⚠ Snapshot: SQLite safe copy FAILED for {rel} "
-                        f"— file may be locked or corrupted"
-                    )
+                ok, err = _safe_copy_db(src, dst)
+                if not ok:
+                    _record_failure(rel, err or "SQLite safe copy failed")
+                    # Same safe-read caveat as the directory-walk site above.
                     if is_zeroed_sqlite_file(src):
                         print(
                             f"  ⚠ Snapshot: {rel} looks ZEROED "
@@ -1292,6 +1536,7 @@ def _create_quick_snapshot_locked(
             manifest[rel] = dst.stat().st_size
         except (OSError, PermissionError) as exc:
             logger.warning("Could not snapshot %s: %s", rel, exc)
+            _record_failure(rel, str(exc))
 
     if failed_dbs:
         # Critical: update path used to log-and-continue with exit 0, so a
@@ -1307,17 +1552,15 @@ def _create_quick_snapshot_locked(
         )
         logger.error(
             "Quick snapshot failed to capture DB file(s): %s",
-            ", ".join(failed_dbs),
+            ", ".join(f"{name}: {failed[name]}" for name in failed_dbs),
         )
 
-    if not manifest:
+    if not manifest and not failed and not size_skipped:
+        # Nothing protected existed at all. #68805's failed-DB message lived
+        # here, but it cannot fire under `not failed`: failed_dbs is only
+        # written by _record_failure, which fills `failed` first. The loud
+        # report for that case is the CRITICAL block above.
         shutil.rmtree(staging_dir, ignore_errors=True)
-        if failed_dbs:
-            # Distinguish "nothing to snapshot" from "state.db present but unreadable"
-            print(
-                "  ⚠ Snapshot aborted: no files captured "
-                f"(failed DBs: {', '.join(failed_dbs)})"
-            )
         return None
 
     # Write manifest
@@ -1331,8 +1574,38 @@ def _create_quick_snapshot_locked(
         "failed_dbs": failed_dbs,
         "oversized_skipped": oversized_skipped,
     }
-    with open(staging_dir / "manifest.json", "w", encoding="utf-8") as f:
-        json.dump(meta, f, indent=2)
+    if failed:
+        # Forensic record: which existing files this snapshot could NOT
+        # protect, and why. Keeps the "was it already broken before the
+        # update?" question answerable after the fact (issue #68474).
+        meta["failed"] = failed
+    if size_skipped:
+        # Protected files that were present but skipped for exceeding the size
+        # cap. Recorded so the manifest shows WHY the snapshot is incomplete
+        # (and why the previous snapshot was retained instead of pruned).
+        meta["size_skipped"] = size_skipped
+    try:
+        with open(staging_dir / "manifest.json", "w", encoding="utf-8") as f:
+            json.dump(meta, f, indent=2)
+    except OSError as exc:
+        # A snapshot without a manifest cannot be restored — treat as a
+        # full failure rather than leaving an unusable directory behind.
+        print(f"  ⚠ Snapshot FAILED: could not write manifest: {exc}")
+        logger.warning("Quick snapshot manifest write failed: %s", exc)
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        return None
+
+    if failed:
+        names = ", ".join(sorted(failed))
+        print(
+            f"  ⚠ Snapshot INCOMPLETE: {len(failed)} existing file(s) could not "
+            f"be captured ({names}) — they are NOT protected by this snapshot. "
+            f"If this is unexpected, investigate before relying on it "
+            f"(the file may be corrupted or locked)."
+        )
+        logger.warning(
+            "Quick snapshot %s incomplete: failed to capture %s", snap_id, names
+        )
 
     os.replace(staging_dir, snap_dir)
 
@@ -1342,7 +1615,11 @@ def _create_quick_snapshot_locked(
     # #68805 review: skip pruning when a present DB failed to capture OR was
     # skipped for size — either way the snapshot is incomplete and the older
     # snapshot may contain the only recoverable database.
-    incomplete = failed_dbs or oversized_skipped
+    # Gate on `failed` and `size_skipped`, not on #68805's DB-only lists: a
+    # non-DB protected file that failed to capture or crossed the size cap
+    # makes the snapshot just as incomplete, and pruning it away would still
+    # evict the last complete snapshot.
+    incomplete = failed or size_skipped
     if not incomplete:
         _prune_quick_snapshots(root, keep=_QUICK_DEFAULT_KEEP if keep is None else keep)
     else:
@@ -1355,11 +1632,17 @@ def _create_quick_snapshot_locked(
                 "Quick snapshot skipped oversized DB file(s): %s",
                 ", ".join(oversized_skipped),
             )
+        other_skipped = sorted(set(size_skipped) - set(oversized_skipped))
+        if other_skipped:
+            print(
+                "  ⚠ Skipping snapshot prune: protected file(s) skipped "
+                "for size: " + ", ".join(other_skipped)
+            )
         logger.warning(
-            "Skipping snapshot prune because %d DB(s) failed to capture "
-            "and/or %d were oversized — preserving older snapshots as "
-            "recovery source",
-            len(failed_dbs), len(oversized_skipped),
+            "Skipping snapshot prune because %d file(s) failed to capture "
+            "and/or %d were skipped for size — preserving older snapshots "
+            "as recovery source",
+            len(failed), len(size_skipped),
         )
 
     logger.info(
@@ -1703,7 +1986,7 @@ def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional
                         ) as tmp:
                             tmp_db = Path(tmp.name)
                         try:
-                            if not _safe_copy_db(abs_path, tmp_db):
+                            if not _safe_copy_db(abs_path, tmp_db)[0]:
                                 logger.warning(
                                     "Full-zip backup aborted: SQLite snapshot failed for %s",
                                     rel_path,

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2557,7 +2557,11 @@ def _run_pre_update_backup(args) -> Optional[str]:
 
     Returns the quick-snapshot id (used by the post-update cron-jobs
     restore safety net), or ``None`` when mode is ``off`` or the snapshot
-    failed.
+    could not be created at all. An id can also come back for a snapshot
+    that captured only some of its files — it is kept as a forensic record,
+    with the uncaptured files named in the manifest's ``failed`` map and
+    printed as ``Snapshot INCOMPLETE``. Callers must not read an id as
+    "everything was captured".
     """
     mode = _resolve_pre_update_backup_mode(args)
 
@@ -2570,6 +2574,7 @@ def _run_pre_update_backup(args) -> Optional[str]:
         return None
 
     snapshot_id = None
+    snapshot_error: Optional[Exception] = None
     try:
         from hermes_cli.backup import (
             _quick_snapshot_root,
@@ -2635,8 +2640,24 @@ def _run_pre_update_backup(args) -> Optional[str]:
         if snapshot_id:
             print(f"◆ Pre-update snapshot: {snapshot_id}")
     except Exception as exc:
-        # Never let a snapshot failure block an update.
-        logging.getLogger(__name__).debug("Pre-update snapshot failed: %s", exc)
+        snapshot_error = exc
+        logging.getLogger(__name__).warning("Pre-update snapshot failed: %s", exc)
+
+    if not snapshot_id:
+        # The recovery snapshot was NOT created -- either create_quick_snapshot
+        # raised before it could report (e.g. snap_dir.mkdir on a full or
+        # read-only filesystem, which raises ahead of any per-file reporting) or
+        # it returned None with nothing captured. The pre-update snapshot is the
+        # recovery boundary before the updater mutates state, so this wrapper
+        # reports the missing snapshot loudly regardless of HOW the helper
+        # failed -- raise, internal report, or a silent None -- instead of
+        # letting the update proceed with no recovery point and no warning
+        # (#68907 review). It still does not block the update.
+        detail = f" ({snapshot_error})" if snapshot_error else ""
+        print(
+            f"  ⚠ Pre-update snapshot FAILED{detail}; the update will proceed "
+            f"WITHOUT a recovery snapshot."
+        )
 
     if mode != "full":
         if snapshot_id:
@@ -3603,8 +3624,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
     # Pre-update backup — runs before any git/file mutation so users can
     # always roll back to the exact state they had before this update.
-    # Returns the quick-snapshot id (or None when disabled/failed); the
-    # post-update cron-jobs safety net uses it to detect job loss.
+    # Returns the quick-snapshot id (or None when disabled, or when nothing
+    # could be captured); the post-update cron-jobs safety net uses it to
+    # detect job loss. An id does not by itself mean the snapshot is complete.
     pre_update_snapshot_id = _m()._run_pre_update_backup(args)
 
     _windows_gateway_resume = _m()._pause_windows_gateways_for_update()

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1,7 +1,9 @@
 """Tests for hermes backup and import commands."""
 
+import errno
 import json
 import os
+import shutil
 import sqlite3
 import zipfile
 from argparse import Namespace
@@ -41,6 +43,42 @@ def _advance_backup_clock(seconds: float = 1.1) -> None:
     else:
         shim = _backup.datetime
     shim._offset += _dt.timedelta(seconds=seconds)
+
+class _FakeScandirIterator:
+    """A faithful stand-in for os.scandir()'s return value: an ITERATOR
+    (supports direct next(), not just `for x in it`) AND a context manager
+    (create_quick_snapshot() does ``with scandir_it:`` then advances via
+    next(), matching CPython's own os.walk() implementation — see #68907
+    review pass 6). A plain list supports neither: no __enter__/__exit__,
+    and calling next() on a list itself (rather than iter(list)) raises
+    TypeError. Tests that fake os.scandir() must wrap their entries in
+    this so they exercise the real code path instead of an unrelated
+    protocol mismatch.
+
+    Tracks `closed` so a test can assert the `with scandir_it:` block
+    actually released the (simulated) OS handle — including on an early
+    break, e.g. when the traversal budget trips mid-listing (#68907
+    review pass 7 nit)."""
+
+    def __init__(self, entries):
+        self._it = iter(entries)
+        self.closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._it)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        self.close()
+        return False
+
+    def close(self):
+        self.closed = True
 
 
 def _make_hermes_tree(root: Path) -> None:
@@ -620,13 +658,50 @@ class TestSafeCopyDb:
         conn.commit()
         conn.close()
 
-        result = _safe_copy_db(src, dst)
-        assert result is True
+        ok, err = _safe_copy_db(src, dst)
+        assert ok is True
+        assert err is None
 
         conn = sqlite3.connect(str(dst))
         rows = conn.execute("SELECT x FROM t").fetchall()
         conn.close()
         assert rows == [(42,)]
+
+    def test_copies_wal_mode_database(self, tmp_path):
+        from hermes_cli.backup import _safe_copy_db
+        src = tmp_path / "wal.db"
+        dst = tmp_path / "copy.db"
+
+        conn = sqlite3.connect(str(src))
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("CREATE TABLE t (x TEXT)")
+        conn.execute("INSERT INTO t VALUES ('wal-test')")
+        conn.commit()
+        conn.close()
+
+        ok, err = _safe_copy_db(src, dst)
+        assert ok is True
+        assert err is None
+
+        conn = sqlite3.connect(str(dst))
+        rows = conn.execute("SELECT x FROM t").fetchall()
+        conn.close()
+        assert rows == [("wal-test",)]
+
+    def test_unreadable_database_fails_closed_with_reason(self, tmp_path):
+        """A present-but-unreadable DB (e.g. zeroed by storage failure,
+        issue #68474) must fail closed AND surface the sqlite error so
+        callers can record why the file was not captured."""
+        from hermes_cli.backup import _safe_copy_db
+        src = tmp_path / "zeroed.db"
+        src.write_bytes(b"\x00" * 4096)  # valid size, no SQLite header
+        dst = tmp_path / "copy.db"
+
+        ok, err = _safe_copy_db(src, dst)
+        assert ok is False
+        assert err is not None and "not a database" in err
+        assert not dst.exists()
+
 
 
     def test_is_zeroed_sqlite_file_detects_nul_header(self, tmp_path):
@@ -682,7 +757,9 @@ class TestQuickSnapshot:
         from hermes_cli import backup as backup_mod
 
         def boom(src, dst):
-            return False
+            # _safe_copy_db returns (ok, reason) on this branch so the
+            # failure can be reported with its cause.
+            return False, "simulated unreadable database"
 
         monkeypatch.setattr(backup_mod, "_safe_copy_db", boom)
         snap_id = backup_mod.create_quick_snapshot(hermes_home=hermes_home)
@@ -706,8 +783,280 @@ class TestQuickSnapshot:
 
 
 
+    def test_non_db_failure_is_incomplete_but_not_reported_as_a_db(
+        self, hermes_home, monkeypatch, capsys
+    ):
+        """A non-DB protected file that fails to copy must not be reported as a
+        failed DATABASE.
+
+        #71223's ``failed_dbs`` means "present *.db that could not be
+        snapshotted" and drives a DB-specific CRITICAL report. Recording every
+        failure there made a failed ``.env`` print "could not snapshot DB
+        file(s): .env". The failure still has to make the snapshot incomplete,
+        which is what ``failed`` is for, so pruning must still be blocked.
+        """
+        import shutil as _shutil
+
+        from hermes_cli import backup as backup_mod
+
+        prior = hermes_home / "state-snapshots" / "20200101-000000"
+        prior.mkdir(parents=True)
+        (prior / "manifest.json").write_text('{"id": "20200101-000000", "files": {}}')
+
+        real_copy2 = _shutil.copy2
+
+        def copy2_failing_on_env(src, dst, *a, **k):
+            if str(src).endswith(".env"):
+                raise OSError("simulated unreadable .env")
+            return real_copy2(src, dst, *a, **k)
+
+        monkeypatch.setattr(backup_mod.shutil, "copy2", copy2_failing_on_env)
+
+        snap_id = backup_mod.create_quick_snapshot(hermes_home=hermes_home, keep=1)
+        assert snap_id is not None
+        out = capsys.readouterr().out
+
+        with open(hermes_home / "state-snapshots" / snap_id / "manifest.json") as f:
+            meta = json.load(f)
+        # Recorded as a failure with its reason...
+        assert ".env" in meta["failed"]
+        # ...but NOT as a failed database.
+        assert ".env" not in meta.get("failed_dbs", [])
+        assert "could not snapshot DB file(s)" not in out
+        # Still incomplete, so the prior complete snapshot survives keep=1.
+        assert prior.is_dir(), "a non-DB failure let the prune evict the last snapshot"
+
+    def test_oversized_protected_file_does_not_evict_prior_snapshot(
+        self, hermes_home, capsys
+    ):
+        """A protected file skipped for exceeding the size cap makes the
+        snapshot incomplete, so the keep=1 prune must NOT delete the previous
+        complete snapshot. Otherwise a state.db that crosses the cap on a
+        pre-update run would destroy the last good recovery source — the exact
+        loss the #68474 fix exists to prevent (#68907 review)."""
+        from hermes_cli.backup import create_quick_snapshot
+
+        # A prior COMPLETE snapshot that must survive the incomplete run.
+        prior = hermes_home / "state-snapshots" / "20200101-000000"
+        prior.mkdir(parents=True)
+        (prior / "manifest.json").write_text('{"id": "20200101-000000", "files": {}}')
+
+        # state.db in the fixture is a few KB — cap below it so it is skipped
+        # for SIZE (not corruption), under the pre-update keep=1 policy.
+        snap_id = create_quick_snapshot(
+            hermes_home=hermes_home, max_file_size=1024, keep=1
+        )
+        assert snap_id is not None
+        snap_dir = hermes_home / "state-snapshots" / snap_id
+
+        # The prior complete snapshot is retained, not evicted.
+        assert prior.is_dir(), "prior complete snapshot was pruned by an incomplete run"
+        # state.db was skipped for size; small protected files still captured.
+        assert not (snap_dir / "state.db").exists()
+        assert (snap_dir / "cron" / "jobs.json").exists()
+        # The manifest records the size skip as the reason it is incomplete.
+        with open(snap_dir / "manifest.json") as f:
+            meta = json.load(f)
+        assert "state.db" in meta["size_skipped"]
+        assert "state.db" not in meta["files"]
+        out = capsys.readouterr().out
+        # A skipped *.db is reported through #71223's DB-specific line; the
+        # generic protected-file line covers the non-DB case (see
+        # test_oversized_file_inside_protected_dir_blocks_eviction).
+        assert (
+            "Skipping snapshot prune: DB file(s) skipped for size: state.db"
+            in out
+        )
+
+    def test_oversized_file_inside_protected_dir_blocks_eviction(
+        self, hermes_home
+    ):
+        """The residual-bypass guard must cover the rglob path too: an oversized
+        file inside a protected DIRECTORY (not just a top-level protected file)
+        is recorded in size_skipped and must not let the prune evict the prior
+        complete snapshot (#68907 review)."""
+        from hermes_cli.backup import create_quick_snapshot
+
+        prior = hermes_home / "state-snapshots" / "20200101-000000"
+        prior.mkdir(parents=True)
+        (prior / "manifest.json").write_text(
+            '{"id": "20200101-000000", "files": {"state.db": 100}}'
+        )
+        # Oversized file inside the protected `kanban/boards` directory, which the
+        # snapshot walks via rglob (exercises the directory-contained call site).
+        board = hermes_home / "kanban" / "boards" / "board1"
+        board.mkdir(parents=True)
+        (board / "kanban.db").write_bytes(b"x" * 4096)
+
+        snap_id = create_quick_snapshot(
+            hermes_home=hermes_home, max_file_size=1024, keep=1
+        )
+        snap_dir = hermes_home / "state-snapshots" / snap_id
+        with open(snap_dir / "manifest.json") as f:
+            meta = json.load(f)
+        # The directory-contained oversized file is recorded via the rglob path.
+        assert "kanban/boards/board1/kanban.db" in meta["size_skipped"]
+        # The prior complete snapshot survives the incomplete run.
+        assert prior.is_dir()
+
+    def test_all_size_skipped_snapshot_persists_manifest_and_keeps_prior(
+        self, tmp_path
+    ):
+        """When EVERY present protected file is skipped for size, `manifest`
+        and `failed` both stay empty -- only `size_skipped` is populated. The
+        snapshot must still persist a manifest recording size_skipped and must
+        NOT be deleted, and a prior complete snapshot must survive.
+
+        Reproduces egilewski's report on #68907: an 8 KiB state.db as the only
+        present protected file with a 4 KiB cap left no durable size_skipped
+        record, because `if not manifest and not failed:` fired and deleted
+        snap_dir before the manifest (and its size_skipped entries) could ever
+        be written -- losing the forensic "these files existed but were
+        skipped for size" record."""
+        from hermes_cli.backup import create_quick_snapshot
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        # Only protected file present, and it is over the cap -- the
+        # all-size-skipped path (manifest={}, failed={}, size_skipped={...}).
+        (home / "state.db").write_bytes(b"x" * 8192)
+
+        prior = home / "state-snapshots" / "20200101-000000"
+        prior.mkdir(parents=True)
+        (prior / "manifest.json").write_text('{"id": "20200101-000000", "files": {}}')
+
+        snap_id = create_quick_snapshot(hermes_home=home, max_file_size=4096, keep=1)
+
+        assert snap_id is not None, (
+            "an all-size-skipped snapshot must not return None -- it has a "
+            "durable size_skipped record to persist"
+        )
+        snap_dir = home / "state-snapshots" / snap_id
+        assert snap_dir.is_dir(), "snapshot dir must not be deleted"
+        manifest_path = snap_dir / "manifest.json"
+        assert manifest_path.exists(), (
+            "manifest must persist even though manifest/failed are both empty"
+        )
+        with open(manifest_path) as f:
+            meta = json.load(f)
+        assert meta.get("files") == {}
+        assert "state.db" in meta.get("size_skipped", {})
+        # The prior complete snapshot must not be evicted by this incomplete run.
+        assert prior.is_dir(), "prior complete snapshot was pruned by an incomplete run"
+
+    def test_failed_capture_never_prunes_any_snapshot(self, hermes_home):
+        """A HARD capture failure blocks pruning entirely: an older snapshot may
+        be the only copy of the file this run failed on, so nothing is evicted
+        (the #68474 no-evict guarantee, locked in for the failed path)."""
+        from hermes_cli.backup import create_quick_snapshot
+
+        snaps = hermes_home / "state-snapshots"
+        for name in ("20200101-000000", "20200102-000000"):
+            d = snaps / name
+            d.mkdir(parents=True)
+            (d / "manifest.json").write_text(f'{{"id": "{name}", "files": {{}}}}')
+
+        # Zero out state.db so the copy fails (not a size skip).
+        (hermes_home / "state.db").write_bytes(b"\x00" * 8192)
+
+        snap_id = create_quick_snapshot(hermes_home=hermes_home, keep=1)
+        assert snap_id is not None
+        # Nothing is pruned in the hard-failure case.
+        assert (snaps / "20200101-000000").is_dir()
+        assert (snaps / "20200102-000000").is_dir()
+        assert (snaps / snap_id).is_dir()
+
+    def test_max_file_size_none_copies_everything(self, hermes_home):
+        """Default (no cap) preserves manual /snapshot behavior."""
+        from hermes_cli.backup import create_quick_snapshot
+        snap_id = create_quick_snapshot(hermes_home=hermes_home, max_file_size=None)
+        assert (hermes_home / "state-snapshots" / snap_id / "state.db").exists()
 
 
+    def test_failed_db_capture_is_loud_and_recorded(self, hermes_home, capsys):
+        """An existing state.db that cannot be captured (e.g. zeroed to null
+        bytes, issue #68474) must not ride through silently: the failure is
+        printed prominently and persisted in the manifest for forensics,
+        while the small files the snapshot exists to protect still land."""
+        from hermes_cli.backup import create_quick_snapshot
+        (hermes_home / "state.db").write_bytes(b"\x00" * 8192)
+
+        snap_id = create_quick_snapshot(hermes_home=hermes_home)
+        assert snap_id is not None
+        snap_dir = hermes_home / "state-snapshots" / snap_id
+        assert not (snap_dir / "state.db").exists()
+        assert (snap_dir / "cron" / "jobs.json").exists()
+
+        with open(snap_dir / "manifest.json") as f:
+            meta = json.load(f)
+        assert "state.db" not in meta["files"]
+        assert "not a database" in meta["failed"]["state.db"]
+
+        out = capsys.readouterr().out
+        assert "could not capture state.db" in out
+        assert "Snapshot INCOMPLETE" in out
+        assert "NOT protected" in out
+
+    def test_failed_plain_copy_is_recorded(self, hermes_home, capsys):
+        """Non-DB copy failures (OSError from shutil.copy2) are recorded in
+        the manifest too, not just logged."""
+        from hermes_cli.backup import create_quick_snapshot
+        real_copy2 = shutil.copy2
+
+        def failing_copy2(src, dst, **kw):
+            if str(src).endswith(".env"):
+                raise OSError("disk full")
+            return real_copy2(src, dst, **kw)
+
+        with patch("hermes_cli.backup.shutil.copy2", side_effect=failing_copy2):
+            snap_id = create_quick_snapshot(hermes_home=hermes_home)
+
+        assert snap_id is not None
+        with open(hermes_home / "state-snapshots" / snap_id / "manifest.json") as f:
+            meta = json.load(f)
+        assert ".env" not in meta["files"]
+        assert "disk full" in meta["failed"][".env"]
+        assert "Snapshot INCOMPLETE" in capsys.readouterr().out
+
+    def test_incomplete_snapshot_never_prunes_older_snapshots(self, hermes_home):
+        """An incomplete snapshot must not evict older (possibly complete)
+        snapshots: with the pre-update keep=1 policy, pruning would delete
+        the last snapshot still holding a good copy of the very file this
+        run failed to capture (issue #68474)."""
+        from hermes_cli.backup import create_quick_snapshot
+        good_id = create_quick_snapshot(label="good", hermes_home=hermes_home, keep=1)
+        assert good_id is not None
+
+        (hermes_home / "state.db").write_bytes(b"\x00" * 8192)
+        bad_id = create_quick_snapshot(label="bad", hermes_home=hermes_home, keep=1)
+        assert bad_id is not None
+
+        root = hermes_home / "state-snapshots"
+        assert (root / good_id).is_dir(), "complete snapshot was evicted"
+        assert (root / bad_id).is_dir()
+
+    def test_complete_snapshot_still_prunes(self, hermes_home):
+        """Prune behavior is unchanged when every capture succeeds."""
+        from hermes_cli.backup import create_quick_snapshot
+        first = create_quick_snapshot(label="a", hermes_home=hermes_home, keep=1)
+        second = create_quick_snapshot(label="b", hermes_home=hermes_home, keep=1)
+        root = hermes_home / "state-snapshots"
+        assert not (root / first).exists()
+        assert (root / second).is_dir()
+
+    def test_clean_snapshot_has_no_failed_key(self, hermes_home, capsys):
+        """The failed key and the INCOMPLETE warning appear only on failure."""
+        from hermes_cli.backup import create_quick_snapshot
+        snap_id = create_quick_snapshot(hermes_home=hermes_home)
+        with open(hermes_home / "state-snapshots" / snap_id / "manifest.json") as f:
+            meta = json.load(f)
+        assert "failed" not in meta
+        assert "Snapshot INCOMPLETE" not in capsys.readouterr().out
+
+    def test_list_snapshots(self, hermes_home):
+        from hermes_cli.backup import create_quick_snapshot, list_quick_snapshots
+        id1 = create_quick_snapshot(label="first", hermes_home=hermes_home)
+        id2 = create_quick_snapshot(label="second", hermes_home=hermes_home)
 
 
     def test_snapshot_includes_pairing_directories(self, hermes_home):
@@ -752,6 +1101,901 @@ class TestQuickSnapshot:
         assert "feishu_comment_pairing.json" in files
 
 
+
+    def test_directory_scandir_open_failure_blocks_prune_and_is_recorded(
+        self, hermes_home, capsys
+    ):
+        """A protected directory that cannot be opened at all for listing
+        (e.g. a mode-000 ``pairing/`` on POSIX — os.scandir() itself raises)
+        must be treated like a hard capture failure: recorded in the
+        manifest so it is visible why the snapshot is incomplete, and
+        blocking the keep=1 prune so the prior complete snapshot survives.
+
+        Python 3.13's ``Path.rglob()`` SILENTLY suppresses ``OSError`` raised
+        while scanning a subdirectory it cannot list, so a snapshot walk built
+        on rglob would just yield fewer manifest entries with neither
+        ``failed`` nor ``size_skipped`` set — reintroducing #68474's
+        recovery-loss via directory-backed state (#68907 review).
+
+        The failure is driven through a monkeypatched ``os.scandir`` (rather
+        than a real mode-000 directory) so the reproduction is deterministic
+        on both POSIX and Windows — real permission bits don't work the same
+        way on Windows CI.
+        """
+        from hermes_cli import backup as backup_mod
+        from hermes_cli.backup import create_quick_snapshot
+
+        # A prior COMPLETE snapshot that must survive the incomplete run.
+        prior = hermes_home / "state-snapshots" / "20200101-000000"
+        prior.mkdir(parents=True)
+        (prior / "manifest.json").write_text(
+            '{"id": "20200101-000000", "files": {}}'
+        )
+
+        pairing_dir = hermes_home / "pairing"
+        pairing_dir.mkdir()
+        (pairing_dir / "users.json").write_text(
+            '{"12345": {"user_name": "alice"}}'
+        )
+
+        real_scandir = backup_mod.os.scandir
+
+        def fake_scandir(path):
+            # os.scandir accepts an int dir-fd on POSIX, and this patch is
+            # process-global, so an unrelated fd-based scandir call (e.g.
+            # from shutil.copy2's Linux sendfile fast path) must pass
+            # through untouched; only intercept a real path to pairing/.
+            if not isinstance(path, int) and Path(path) == pairing_dir:
+                raise OSError(13, "Permission denied", str(pairing_dir))
+            return real_scandir(path)
+
+        with patch.object(backup_mod.os, "scandir", side_effect=fake_scandir):
+            snap_id = create_quick_snapshot(hermes_home=hermes_home, keep=1)
+
+        assert snap_id is not None
+        snap_dir = hermes_home / "state-snapshots" / snap_id
+
+        with open(snap_dir / "manifest.json") as f:
+            meta = json.load(f)
+
+        # The enumeration failure is recorded so the manifest shows WHY the
+        # snapshot is incomplete (same forensic contract as `failed` for a
+        # per-file capture error).
+        assert "failed" in meta, "directory enumeration failure was not recorded"
+        assert "pairing" in meta["failed"]
+        assert "Permission denied" in meta["failed"]["pairing"]
+
+        # The file inside the unreadable directory was never captured.
+        assert "pairing/users.json" not in meta["files"]
+        assert not (snap_dir / "pairing" / "users.json").exists()
+
+        # The prior complete snapshot must survive: an enumeration failure
+        # blocks the keep=1 prune exactly like a hard capture failure does.
+        assert prior.is_dir(), (
+            "prior complete snapshot was pruned despite a directory "
+            "enumeration failure"
+        )
+
+        out = capsys.readouterr().out
+        assert "Snapshot INCOMPLETE" in out
+
+    def test_dir_entry_classification_failure_blocks_prune_and_is_recorded(
+        self, hermes_home, capsys
+    ):
+        """A subdirectory whose type cannot be classified — DirEntry.is_dir()
+        itself raises OSError, distinct from scandir() failing to open the
+        parent — must also be recorded and block the keep=1 prune.
+
+        Verified against CPython 3.13's ``Lib/os.py`` ``walk()``: when
+        ``entry.is_dir()`` raises, ``os.walk`` catches the OSError
+        internally and puts the entry in ``filenames`` WITHOUT calling
+        ``onerror`` (this is why an os.walk(onerror=...)-based fix is not
+        enough — the traversal must control classification itself via
+        os.scandir, per Finding 1 of the #68907 review). A caller then sees
+        the misclassified name in ``filenames`` and either silently drops
+        it or crashes — either way nothing is recorded and #68474's
+        recovery-loss reproduces via a subtly different enumeration op.
+
+        Driven through a monkeypatched ``os.scandir`` that returns a
+        wrapper whose ``is_dir()`` raises for one specific entry, so the
+        reproduction is deterministic on both POSIX and Windows.
+        """
+        from hermes_cli import backup as backup_mod
+        from hermes_cli.backup import create_quick_snapshot
+
+        prior = hermes_home / "state-snapshots" / "20200101-000000"
+        prior.mkdir(parents=True)
+        (prior / "manifest.json").write_text(
+            '{"id": "20200101-000000", "files": {}}'
+        )
+
+        pairing_dir = hermes_home / "pairing"
+        pairing_dir.mkdir()
+        # A sibling FILE directly in pairing/ — the success path for a
+        # normal entry must be unaffected by the misclassified sibling.
+        (pairing_dir / "telegram-approved.json").write_text(
+            '{"12345": {"user_name": "alice"}}'
+        )
+        # A subdirectory whose classification will be made to raise.
+        private_dir = pairing_dir / "private"
+        private_dir.mkdir()
+        (private_dir / "users.json").write_text('{"67890": {"user_name": "bob"}}')
+
+        class _RaisingIsDirEntry:
+            """Wraps a real os.DirEntry, forcing is_dir() to raise —
+            simulating the ESTALE/EIO/transient-error class of failure
+            CPython's os.walk() swallows silently."""
+
+            def __init__(self, real_entry):
+                self._real = real_entry
+                self.name = real_entry.name
+                self.path = real_entry.path
+
+            def is_dir(self, *args, **kwargs):
+                raise OSError(5, "Simulated classification failure", self.path)
+
+            def is_file(self, *args, **kwargs):
+                return self._real.is_file(*args, **kwargs)
+
+        real_scandir = backup_mod.os.scandir
+
+        def fake_scandir(path):
+            # os.scandir accepts an int dir-fd on POSIX, and this patch is
+            # process-global, so an unrelated fd-based scandir call (e.g.
+            # from shutil.copy2's Linux sendfile fast path) must pass
+            # through untouched; only intercept a real path to pairing/.
+            if not isinstance(path, int) and Path(path) == pairing_dir:
+                wrapped = []
+                for entry in real_scandir(path):
+                    if entry.name == "private":
+                        wrapped.append(_RaisingIsDirEntry(entry))
+                    else:
+                        wrapped.append(entry)
+                return _FakeScandirIterator(wrapped)
+            return real_scandir(path)
+
+        with patch.object(backup_mod.os, "scandir", side_effect=fake_scandir):
+            snap_id = create_quick_snapshot(hermes_home=hermes_home, keep=1)
+
+        assert snap_id is not None
+        snap_dir = hermes_home / "state-snapshots" / snap_id
+
+        with open(snap_dir / "manifest.json") as f:
+            meta = json.load(f)
+
+        # The classification failure is recorded ...
+        assert "failed" in meta, "DirEntry classification failure was not recorded"
+        assert "pairing/private" in meta["failed"]
+        assert "Simulated classification failure" in meta["failed"]["pairing/private"]
+
+        # ... the file inside the misclassified subdirectory was never
+        # captured ...
+        assert "pairing/private/users.json" not in meta["files"]
+        assert not (snap_dir / "pairing" / "private" / "users.json").exists()
+
+        # ... but the readable sibling file is captured normally (success
+        # path unchanged).
+        assert "pairing/telegram-approved.json" in meta["files"]
+        assert (snap_dir / "pairing" / "telegram-approved.json").exists()
+
+        # The prior complete snapshot must survive.
+        assert prior.is_dir(), (
+            "prior complete snapshot was pruned despite a DirEntry "
+            "classification failure"
+        )
+
+        out = capsys.readouterr().out
+        assert "Snapshot INCOMPLETE" in out
+
+    def test_unreadable_excluded_subtree_does_not_block_prune(self, hermes_home):
+        """An enumeration failure INSIDE an excluded subtree (workspaces/
+        attachments under a kanban board) must NOT mark the snapshot
+        incomplete: nothing under those subtrees is ever captured, so a
+        failure there carries no recovery-loss risk and must not block
+        pruning forever (#68907 review, Finding 2).
+
+        The exclusion must be applied BEFORE descending into the
+        subdirectory — asserted here by poisoning os.scandir for the
+        excluded path: if the implementation ever descended into it, this
+        test would surface a failure entry instead of a clean prune.
+        """
+        from hermes_cli import backup as backup_mod
+        from hermes_cli.backup import create_quick_snapshot
+
+        prior = hermes_home / "state-snapshots" / "20200101-000000"
+        prior.mkdir(parents=True)
+        (prior / "manifest.json").write_text(
+            '{"id": "20200101-000000", "files": {}}'
+        )
+
+        board = hermes_home / "kanban" / "boards" / "board1"
+        board.mkdir(parents=True)
+        conn = sqlite3.connect(str(board / "kanban.db"))
+        conn.execute("CREATE TABLE tasks (id TEXT PRIMARY KEY)")
+        conn.commit()
+        conn.close()
+
+        workspaces_dir = board / "workspaces"
+        workspaces_dir.mkdir()
+        (workspaces_dir / "scratch.txt").write_text("regenerable scratch data")
+
+        real_scandir = backup_mod.os.scandir
+
+        def fake_scandir(path):
+            # os.scandir accepts an int dir-fd on POSIX, and this patch is
+            # process-global, so unrelated fd-based scandir calls must pass
+            # through untouched; only intercept a real path to workspaces/.
+            if not isinstance(path, int):
+                p = Path(path)
+                if p == workspaces_dir or workspaces_dir in p.parents:
+                    raise OSError(13, "Permission denied", str(path))
+            return real_scandir(path)
+
+        with patch.object(backup_mod.os, "scandir", side_effect=fake_scandir):
+            snap_id = create_quick_snapshot(hermes_home=hermes_home, keep=1)
+
+        assert snap_id is not None
+        snap_dir = hermes_home / "state-snapshots" / snap_id
+
+        with open(snap_dir / "manifest.json") as f:
+            meta = json.load(f)
+
+        # The board db is still captured normally.
+        assert "kanban/boards/board1/kanban.db" in meta["files"]
+        # Nothing under the excluded, unreadable workspaces/ subtree was
+        # ever touched, so the snapshot is complete.
+        assert not meta.get("failed"), (
+            f"unreadable excluded subtree wrongly marked incomplete: {meta.get('failed')}"
+        )
+
+        # A complete capture prunes normally — the excluded subtree's
+        # unreadability must not block pruning forever.
+        assert not prior.is_dir(), (
+            "prior snapshot was retained even though the only failure was "
+            "inside an excluded (never-descended) subtree"
+        )
+
+    def test_top_level_classification_failure_blocks_prune_and_is_recorded(
+        self, hermes_home, capsys
+    ):
+        """A transient classification failure on a PRESENT top-level
+        protected file (e.g. state.db) must be recorded and block the
+        keep=1 prune — not silently treated as "doesn't exist".
+
+        Path.exists()/is_dir()/is_file() swallow OSError for a specific
+        errno set (pathlib._IGNORED_ERRNOS = ENOENT, ENOTDIR, EBADF,
+        ELOOP) and return False. EBADF in particular is a real,
+        documented transient failure mode (pathlib's own source notes it
+        guards against a macOS stat() quirk) — using those methods for
+        the top-level src classification means a present file can look
+        identical to an absent one, silently dropping it from the
+        manifest with nothing recorded (#68907 review, Finding 1).
+
+        Driven through a monkeypatched os.stat (deterministic on any OS —
+        the errno is synthesized, not produced by a real syscall).
+        """
+        from hermes_cli import backup as backup_mod
+        from hermes_cli.backup import create_quick_snapshot
+
+        prior = hermes_home / "state-snapshots" / "20200101-000000"
+        prior.mkdir(parents=True)
+        (prior / "manifest.json").write_text(
+            '{"id": "20200101-000000", "files": {}}'
+        )
+
+        target = hermes_home / "state.db"
+        real_stat = backup_mod.os.stat
+
+        def fake_stat(path, *args, **kwargs):
+            # os.stat accepts an int fd on POSIX (equivalent to os.fstat),
+            # and this patch is process-global, so an unrelated fd-based
+            # stat call (e.g. from shutil.copy2's Linux sendfile fast
+            # path, which stats the source fd for its size) must pass
+            # through untouched; only intercept the real target path.
+            if not isinstance(path, int) and Path(path) == target:
+                raise OSError(errno.EBADF, "Bad file descriptor", str(target))
+            return real_stat(path, *args, **kwargs)
+
+        with patch.object(backup_mod.os, "stat", side_effect=fake_stat):
+            snap_id = create_quick_snapshot(hermes_home=hermes_home, keep=1)
+
+        assert snap_id is not None
+        snap_dir = hermes_home / "state-snapshots" / snap_id
+
+        with open(snap_dir / "manifest.json") as f:
+            meta = json.load(f)
+
+        # The classification failure is recorded ...
+        assert "failed" in meta, "top-level classification failure was not recorded"
+        assert "state.db" in meta["failed"]
+        assert "Bad file descriptor" in meta["failed"]["state.db"]
+
+        # ... state.db was never captured ...
+        assert "state.db" not in meta["files"]
+        assert not (snap_dir / "state.db").exists()
+
+        # ... but another protected file is still captured normally
+        # (success path unaffected by the unrelated failure).
+        assert "cron/jobs.json" in meta["files"]
+        assert (snap_dir / "cron" / "jobs.json").exists()
+
+        # The prior complete snapshot must survive.
+        assert prior.is_dir(), (
+            "prior complete snapshot was pruned despite a top-level "
+            "classification failure"
+        )
+
+        out = capsys.readouterr().out
+        assert "Snapshot INCOMPLETE" in out
+
+    def test_multi_subdirectory_windows_stat_collision_does_not_drop_files(
+        self, hermes_home
+    ):
+        """Two distinct sibling subdirectories under a protected root must
+        BOTH be captured, even when DirEntry.stat() reports colliding
+        identity for them.
+
+        Verified by direct measurement on a real Windows machine: CPython
+        3.13's DirEntry.stat() — the cached fast-path stat, as opposed to
+        os.stat() — returns st_dev=0, st_ino=0 for every entry. A prior
+        fix (commit dd860c07c) used a visited-set keyed on (st_dev,
+        st_ino) from entry.stat() to guard against directory cycles. On
+        Windows this silently collided ANY two sibling directories on
+        (0, 0): the second one visited was treated as "already seen" and
+        never scanned, dropping its files from the manifest with neither
+        `failed` nor `size_skipped` set — a regression worse than the
+        junction bug it targeted, breaking every multi-subdirectory
+        protected root (pairing/, kanban/boards/) on Windows. The fix
+        removes identity checking entirely in favor of a depth bound
+        (#68907 review, pass 4) — this test's fake scandir has zero
+        effect on that new code path.
+
+        The (0, 0) collision is reproduced deterministically on any host
+        OS (not just Windows) by wrapping every scanned entry so its
+        stat() zeroes out st_dev/st_ino, exactly matching the real
+        Windows behavior regardless of which OS runs this test.
+        """
+        from hermes_cli import backup as backup_mod
+        from hermes_cli.backup import create_quick_snapshot
+
+        pairing_dir = hermes_home / "pairing"
+        pairing_dir.mkdir()
+        (pairing_dir / "a").mkdir()
+        (pairing_dir / "a" / "one.json").write_text('{"one": true}')
+        (pairing_dir / "b").mkdir()
+        (pairing_dir / "b" / "two.json").write_text('{"two": true}')
+
+        class _ZeroIdentityStat:
+            """Delegates to a real stat_result but zeroes st_dev/st_ino —
+            replicating DirEntry.stat()'s measured Windows behavior."""
+
+            def __init__(self, real_result):
+                self._real = real_result
+                self.st_dev = 0
+                self.st_ino = 0
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+        class _ZeroIdentityEntry:
+            def __init__(self, real_entry):
+                self._real = real_entry
+                self.name = real_entry.name
+                self.path = real_entry.path
+
+            def is_dir(self, *args, **kwargs):
+                return self._real.is_dir(*args, **kwargs)
+
+            def is_file(self, *args, **kwargs):
+                return self._real.is_file(*args, **kwargs)
+
+            def stat(self, *args, **kwargs):
+                return _ZeroIdentityStat(self._real.stat(*args, **kwargs))
+
+        real_scandir = backup_mod.os.scandir
+
+        def fake_scandir(path):
+            return _FakeScandirIterator(
+                [_ZeroIdentityEntry(e) for e in real_scandir(path)]
+            )
+
+        with patch.object(backup_mod.os, "scandir", side_effect=fake_scandir):
+            snap_id = create_quick_snapshot(hermes_home=hermes_home)
+
+        assert snap_id is not None
+        snap_dir = hermes_home / "state-snapshots" / snap_id
+        with open(snap_dir / "manifest.json") as f:
+            meta = json.load(f)
+
+        assert "pairing/a/one.json" in meta["files"], (
+            "first sibling directory's file missing from manifest"
+        )
+        assert "pairing/b/two.json" in meta["files"], (
+            "second sibling directory dropped — (st_dev, st_ino) identity "
+            "collision silently skipped it"
+        )
+        assert not meta.get("failed"), (
+            f"a working (non-colliding) traversal should not need to "
+            f"record any failure here: {meta.get('failed')}"
+        )
+        assert (snap_dir / "pairing" / "a" / "one.json").exists()
+        assert (snap_dir / "pairing" / "b" / "two.json").exists()
+
+    def test_linear_cycle_terminates_via_traversal_budget_and_blocks_prune(
+        self, hermes_home, monkeypatch
+    ):
+        """A directory structure that recurses unboundedly in a straight
+        line (e.g. a Windows junction looping back to an ancestor) must
+        be caught by the traversal work budget: the traversal
+        terminates, the overrun is recorded as a failure (visible,
+        forensic), and the keep=1 prune is blocked — never silent data
+        loss, never an unbounded hang (#68907 review, pass 5).
+
+        A prior version of this guard used a max recursion DEPTH (64)
+        instead of a total-work budget. Depth alone only bounds path
+        LENGTH: it happens to catch a purely linear chain like this one
+        fine, but a BRANCHING cycle (see
+        test_binary_cycle_terminates_via_traversal_budget_and_blocks_prune
+        below) blows up exponentially long before any fixed depth is
+        reached. The work budget subsumes the linear case too, so this
+        test now exercises the budget instead of a separate depth check.
+
+        The budget (_QUICK_SNAPSHOT_MAX_TRAVERSAL_ENTRIES) is patched
+        down to a small value so the test runs fast without needing
+        200k synthetic iterations; production still uses 200_000.
+        Simulated by an os.scandir fake that always yields exactly one
+        (synthetic) child directory, however deep the traversal goes —
+        behaviorally identical to a self-referencing junction. The test
+        carries its own independent safety ceiling, comfortably above
+        the patched budget: if the production guard somehow failed to
+        stop it, the test's sentinel (non-OSError) exception fires
+        instead of letting the test hang.
+        """
+        from hermes_cli import backup as backup_mod
+        from hermes_cli.backup import create_quick_snapshot
+
+        # raising=False: on a pre-pass-5 commit this attribute doesn't
+        # exist yet, and the patch should be a harmless no-op there (that
+        # commit's own — different — bound mechanism is exercised as-is).
+        monkeypatch.setattr(
+            backup_mod, "_QUICK_SNAPSHOT_MAX_TRAVERSAL_ENTRIES", 50, raising=False
+        )
+
+        prior = hermes_home / "state-snapshots" / "20200101-000000"
+        prior.mkdir(parents=True)
+        (prior / "manifest.json").write_text(
+            '{"id": "20200101-000000", "files": {}}'
+        )
+
+        pairing_dir = hermes_home / "pairing"
+        pairing_dir.mkdir()
+
+        class _LoopEntry:
+            """A synthetic subdirectory whose own listing always yields
+            another copy of itself."""
+
+            name = "loop"
+
+            def __init__(self, path):
+                self.path = str(path)
+
+            def is_dir(self, *args, **kwargs):
+                return True
+
+            def is_file(self, *args, **kwargs):
+                return False
+
+        class _RunawayRecursion(Exception):
+            """Raised only if the traversal exceeds the test's own
+            ceiling — proves the traversal budget failed to terminate
+            the recursion, without ever letting the test actually
+            hang."""
+
+        call_count = {"n": 0}
+        CALL_CEILING = 500  # far above the patched budget (50)
+
+        real_scandir = backup_mod.os.scandir
+        created_iterators = []
+
+        def fake_scandir(path):
+            call_count["n"] += 1
+            if call_count["n"] > CALL_CEILING:
+                raise _RunawayRecursion(
+                    f"os.scandir called {call_count['n']} times — the "
+                    "traversal work budget did not stop recursion"
+                )
+            # os.scandir accepts an int dir-fd on POSIX, and this patch is
+            # process-global, so an unrelated fd-based scandir call (e.g.
+            # from shutil.copy2's Linux sendfile fast path) must pass
+            # through untouched; only intercept a real path to pairing/.
+            if not isinstance(path, int):
+                p = Path(path)
+                if p == pairing_dir or p.name == "loop":
+                    it = _FakeScandirIterator([_LoopEntry(p / "loop")])
+                    created_iterators.append(it)
+                    return it
+            return real_scandir(path)
+
+        with patch.object(backup_mod.os, "scandir", side_effect=fake_scandir):
+            snap_id = create_quick_snapshot(hermes_home=hermes_home, keep=1)
+
+        assert snap_id is not None
+        assert call_count["n"] <= CALL_CEILING, (
+            "traversal did not terminate within the safety ceiling"
+        )
+
+        # `with scandir_it:` must close the handle for every directory
+        # scanned, including the last one — the one whose iteration is
+        # what actually trips the budget and breaks out early (#68907
+        # review pass 7 nit: this was previously true by inspection only).
+        assert created_iterators, "fake scandir was never exercised"
+        assert all(it.closed for it in created_iterators), (
+            "not every scandir iterator was closed — `with scandir_it:` "
+            "did not release the handle on early budget break"
+        )
+
+        snap_dir = hermes_home / "state-snapshots" / snap_id
+        with open(snap_dir / "manifest.json") as f:
+            meta = json.load(f)
+
+        assert "failed" in meta, "traversal budget was exceeded but not recorded"
+        assert any("cycle" in reason for reason in meta["failed"].values()), (
+            meta["failed"]
+        )
+
+        assert prior.is_dir(), (
+            "prior complete snapshot was pruned despite an unterminated "
+            "traversal budget"
+        )
+
+    def test_binary_cycle_terminates_via_traversal_budget_and_blocks_prune(
+        self, hermes_home, monkeypatch
+    ):
+        """A BRANCHING directory cycle — e.g. two Windows junctions
+        pairing/a -> pairing and pairing/b -> pairing (junctions bypass
+        islink()) — must also be caught, and caught FAST.
+
+        This is the case a depth-only bound misses: reaching a fixed
+        depth of 64 down EVERY branch of a binary cycle requires
+        2**65-1 ~= 3.7e19 scandir calls, so the snapshot would hang or
+        exhaust resources long before any failure is recorded. A
+        total-work budget (counting entries visited, not path length)
+        catches this almost immediately, because branching makes the
+        entry count explode exponentially per level.
+
+        The budget is patched down to a small value for a fast,
+        deterministic test; production still uses 200_000. The test
+        carries its own independent safety ceiling — generously above
+        what the patched budget needs, but tiny compared to what a
+        depth-only guard would need for this shape — so a version with
+        no total-work budget (only depth) fails this test LOUDLY AND
+        FAST (RED against 959130e40) instead of hanging, and the
+        work-budgeted version passes almost immediately (GREEN).
+        """
+        from hermes_cli import backup as backup_mod
+        from hermes_cli.backup import create_quick_snapshot
+
+        # raising=False: on a pre-pass-5 commit (959130e40, depth-only)
+        # this attribute doesn't exist — the patch is then a harmless
+        # no-op and that commit's own depth-64 bound runs unmodified,
+        # which is exactly what should fail this test's ceiling.
+        monkeypatch.setattr(
+            backup_mod, "_QUICK_SNAPSHOT_MAX_TRAVERSAL_ENTRIES", 50, raising=False
+        )
+
+        prior = hermes_home / "state-snapshots" / "20200101-000000"
+        prior.mkdir(parents=True)
+        (prior / "manifest.json").write_text(
+            '{"id": "20200101-000000", "files": {}}'
+        )
+
+        pairing_dir = hermes_home / "pairing"
+        pairing_dir.mkdir()
+
+        class _BranchEntry:
+            """A synthetic subdirectory whose own listing always yields
+            TWO more copies of the same shape — an infinite binary tree,
+            modeling two junctions that each loop back into the cycle."""
+
+            def __init__(self, path, name):
+                self.path = str(path)
+                self.name = name
+
+            def is_dir(self, *args, **kwargs):
+                return True
+
+            def is_file(self, *args, **kwargs):
+                return False
+
+        class _RunawayRecursion(Exception):
+            """Raised only if the traversal exceeds the test's own
+            ceiling — proves the traversal budget failed to bound the
+            branching cycle, without ever letting the test actually
+            hang."""
+
+        call_count = {"n": 0}
+        # Generous vs. what the patched budget (50) needs (~25-30 calls,
+        # since each call yields 2 entries) but minuscule compared to
+        # what an unbounded-branching depth-64 traversal would need.
+        CALL_CEILING = 2000
+
+        real_scandir = backup_mod.os.scandir
+
+        def fake_scandir(path):
+            call_count["n"] += 1
+            if call_count["n"] > CALL_CEILING:
+                raise _RunawayRecursion(
+                    f"os.scandir called {call_count['n']} times — the "
+                    "traversal budget did not bound the branching cycle"
+                )
+            # os.scandir accepts an int dir-fd on POSIX, and this patch is
+            # process-global, so an unrelated fd-based scandir call (e.g.
+            # from shutil.copy2's Linux sendfile fast path) must pass
+            # through untouched; only intercept a real path to pairing/.
+            if not isinstance(path, int):
+                p = Path(path)
+                if p == pairing_dir or p.name in ("a", "b"):
+                    return _FakeScandirIterator([
+                        _BranchEntry(p / "a", "a"),
+                        _BranchEntry(p / "b", "b"),
+                    ])
+            return real_scandir(path)
+
+        with patch.object(backup_mod.os, "scandir", side_effect=fake_scandir):
+            snap_id = create_quick_snapshot(hermes_home=hermes_home, keep=1)
+
+        assert snap_id is not None
+        assert call_count["n"] <= CALL_CEILING, (
+            "branching traversal did not terminate within the safety ceiling"
+        )
+
+        snap_dir = hermes_home / "state-snapshots" / snap_id
+        with open(snap_dir / "manifest.json") as f:
+            meta = json.load(f)
+
+        assert "failed" in meta, "traversal budget was exceeded but not recorded"
+        # Exactly one failure: the whole protected-root traversal must
+        # abort immediately on budget overrun, not just skip the
+        # offending branch and keep burning budget on the others.
+        assert len(meta["failed"]) == 1, (
+            f"expected exactly one recorded failure (traversal aborts "
+            f"immediately), got: {meta['failed']}"
+        )
+        assert any("cycle" in reason for reason in meta["failed"].values()), (
+            meta["failed"]
+        )
+
+        assert prior.is_dir(), (
+            "prior complete snapshot was pruned despite an unbounded "
+            "branching cycle"
+        )
+
+    def test_lazy_high_fan_out_scandir_is_not_eagerly_drained(
+        self, hermes_home, monkeypatch
+    ):
+        """A SINGLE os.scandir() call whose listing itself yields many
+        entries — a junction whose target directory has high fan-out —
+        must have the traversal budget checked PER YIELD, not after the
+        whole listing has been pulled.
+
+        A prior version of this guard did
+        ``entries = list(os.scandir(current))``: that fully DRAINS the
+        directory listing before entries_visited is ever incremented.
+        Neither the binary-cycle test above nor the linear-cycle test can
+        catch this — both simulate the cycle across MANY separate
+        os.scandir() calls (one entry per call), so even an eager list()
+        of a 1-element listing is trivially cheap either way. This test
+        isolates the eager-vs-lazy question specifically: ONE scandir()
+        call, many entries (#68907 review, pass 6).
+
+        Reproduced with a Python generator (the same lazy, pull-based
+        shape a real ScandirIterator has under the hood) that yields
+        entries one at a time and raises a distinct sentinel exception if
+        ever pulled past 100 yields. The production budget is patched
+        down to 50. A correct (lazy) implementation stops pulling at
+        ~entries_visited + 1 (to detect the overrun) — the generator must
+        NEVER be asked for its 60th+ item, let alone its 100th. An eager
+        implementation (list(os.scandir(...))) drains the whole
+        generator up front to build the list, tripping the sentinel with
+        entries_visited still at 0 — the unambiguous RED signal.
+        """
+        from hermes_cli import backup as backup_mod
+        from hermes_cli.backup import create_quick_snapshot
+
+        monkeypatch.setattr(
+            backup_mod, "_QUICK_SNAPSHOT_MAX_TRAVERSAL_ENTRIES", 50, raising=False
+        )
+
+        prior = hermes_home / "state-snapshots" / "20200101-000000"
+        prior.mkdir(parents=True)
+        (prior / "manifest.json").write_text(
+            '{"id": "20200101-000000", "files": {}}'
+        )
+
+        pairing_dir = hermes_home / "pairing"
+        pairing_dir.mkdir()
+
+        class _LazyOverdrawn(Exception):
+            """Raised only if the generator below is pulled past
+            SENTINEL_AFTER — proves entries were drained without the
+            budget ever stopping the pull (eager materialization), not a
+            real resource limit or an infinite hang."""
+
+        class _ChildEntry:
+            """A synthetic subdirectory entry — never actually descended
+            into either way (a correct implementation aborts the whole
+            traversal before popping any of these off the stack; an
+            eager implementation crashes on _LazyOverdrawn before ever
+            reaching the stack at all)."""
+
+            def __init__(self, path, name):
+                self.path = str(path)
+                self.name = name
+
+            def is_dir(self, *args, **kwargs):
+                return True
+
+            def is_file(self, *args, **kwargs):
+                return False
+
+        yielded = {"n": 0}
+        SENTINEL_AFTER = 100  # far above the patched budget (50)
+
+        def lazy_children():
+            """Yields _ChildEntry objects ONE AT A TIME from a single
+            (simulated) directory listing — exactly how a real
+            ScandirIterator behaves: it does not pre-build a list
+            internally either."""
+            i = 0
+            while True:
+                yielded["n"] += 1
+                if yielded["n"] > SENTINEL_AFTER:
+                    raise _LazyOverdrawn(
+                        f"generator was pulled {yielded['n']} times — the "
+                        "traversal budget did not stop the pull; entries "
+                        "were drained eagerly instead of lazily"
+                    )
+                yield _ChildEntry(pairing_dir / f"child-{i}", f"child-{i}")
+                i += 1
+
+        real_scandir = backup_mod.os.scandir
+        created_iterator = {}
+
+        def fake_scandir(path):
+            # os.scandir accepts an int dir-fd on POSIX, and this patch is
+            # process-global, so an unrelated fd-based scandir call (e.g.
+            # from shutil.copy2's Linux sendfile fast path) must pass
+            # through untouched; only intercept a real path to pairing/.
+            if not isinstance(path, int) and Path(path) == pairing_dir:
+                it = _FakeScandirIterator(lazy_children())
+                created_iterator["it"] = it
+                return it
+            return real_scandir(path)
+
+        with patch.object(backup_mod.os, "scandir", side_effect=fake_scandir):
+            snap_id = create_quick_snapshot(hermes_home=hermes_home, keep=1)
+
+        assert snap_id is not None
+        assert yielded["n"] <= SENTINEL_AFTER, (
+            "the generator's own sentinel had to intervene — the "
+            "production code drained more entries than the budget "
+            "should ever have allowed"
+        )
+        # The real assertion: pulls stop close to the patched budget (50),
+        # nowhere near the generator's full 100-yield sentinel. A margin
+        # (not exact equality) avoids coupling the test to the "+1 to
+        # detect overrun" implementation detail.
+        assert yielded["n"] <= 60, (
+            f"generator was pulled {yielded['n']} times for a budget of "
+            f"50 — entries were not stopped promptly (looks eager, not "
+            f"lazy)"
+        )
+
+        # `with scandir_it:` must release the handle even though the
+        # budget cut iteration short partway through the listing (#68907
+        # review pass 7 nit: previously true by inspection only).
+        assert "it" in created_iterator, "fake scandir was never exercised"
+        assert created_iterator["it"].closed, (
+            "the scandir iterator was not closed — `with scandir_it:` did "
+            "not release the handle on early budget break"
+        )
+
+        snap_dir = hermes_home / "state-snapshots" / snap_id
+        with open(snap_dir / "manifest.json") as f:
+            meta = json.load(f)
+
+        assert "failed" in meta, "traversal budget was exceeded but not recorded"
+        assert any("cycle" in reason for reason in meta["failed"].values()), (
+            meta["failed"]
+        )
+
+        assert prior.is_dir(), (
+            "prior complete snapshot was pruned despite an unbounded "
+            "high-fan-out listing"
+        )
+
+    def test_mid_iteration_scandir_error_blocks_prune_and_is_recorded(
+        self, hermes_home, capsys
+    ):
+        """An OSError raised WHILE ITERATING a directory listing — not
+        just at os.scandir()'s open call — must be recorded and block
+        the keep=1 prune, exactly like an open-time failure does.
+        scandir can fail mid-iteration on some filesystems (transient
+        ESTALE/EIO partway through a listing), and the production code
+        already routes this through the same next()/except OSError path
+        CPython's own os.walk() uses (#68907 review pass 7) — this test
+        is the previously-missing regression guard for that path, not a
+        behavior change.
+
+        A generator yields one REAL DirEntry (proving a file enumerated
+        before the failure is still captured — partial success, not
+        total loss) and then raises OSError instead of returning
+        normally — a mid-listing failure the try/except around
+        os.scandir(current) itself (open time) cannot catch, since
+        scandir() already succeeded there.
+        """
+        from hermes_cli import backup as backup_mod
+        from hermes_cli.backup import create_quick_snapshot
+
+        prior = hermes_home / "state-snapshots" / "20200101-000000"
+        prior.mkdir(parents=True)
+        (prior / "manifest.json").write_text(
+            '{"id": "20200101-000000", "files": {}}'
+        )
+
+        pairing_dir = hermes_home / "pairing"
+        pairing_dir.mkdir()
+        (pairing_dir / "telegram-approved.json").write_text(
+            '{"12345": {"user_name": "alice"}}'
+        )
+
+        real_scandir = backup_mod.os.scandir
+
+        def mid_iteration_entries():
+            # os.scandir(pairing_dir) itself succeeds — the failure
+            # happens partway through consuming the results, which is
+            # exactly what a try/except wrapped only around the open
+            # call would miss.
+            yield from real_scandir(pairing_dir)
+            raise OSError(5, "Input/output error", str(pairing_dir))
+
+        def fake_scandir(path):
+            # os.scandir accepts an int dir-fd on POSIX, and this patch is
+            # process-global, so an unrelated fd-based scandir call (e.g.
+            # from shutil.copy2's Linux sendfile fast path) must pass
+            # through untouched; only intercept a real path to pairing/.
+            if not isinstance(path, int) and Path(path) == pairing_dir:
+                return _FakeScandirIterator(mid_iteration_entries())
+            return real_scandir(path)
+
+        with patch.object(backup_mod.os, "scandir", side_effect=fake_scandir):
+            snap_id = create_quick_snapshot(hermes_home=hermes_home, keep=1)
+
+        assert snap_id is not None
+        snap_dir = hermes_home / "state-snapshots" / snap_id
+        with open(snap_dir / "manifest.json") as f:
+            meta = json.load(f)
+
+        # The file enumerated BEFORE the mid-iteration error is still
+        # captured — a partial listing failure doesn't undo already
+        # completed work.
+        assert "pairing/telegram-approved.json" in meta["files"]
+        assert (snap_dir / "pairing" / "telegram-approved.json").exists()
+
+        # The mid-iteration failure itself is recorded ...
+        assert "failed" in meta, "mid-iteration scandir error was not recorded"
+        assert "pairing" in meta["failed"]
+        assert "Input/output error" in meta["failed"]["pairing"]
+
+        # ... and blocks the keep=1 prune exactly like an open-time
+        # failure or a per-entry classification failure would.
+        assert prior.is_dir(), (
+            "prior complete snapshot was pruned despite a mid-iteration "
+            "scandir error"
+        )
+
+        out = capsys.readouterr().out
+        assert "Snapshot INCOMPLETE" in out
 
 # ---------------------------------------------------------------------------
 # Pre-update backup (hermes update safety net)
@@ -1028,6 +2272,50 @@ class TestRunPreUpdateBackup:
         return [p for p in d.iterdir() if p.is_dir()] if d.exists() else []
 
 
+    def test_snapshot_creation_failure_is_surfaced_loudly(self, hermes_home, capsys):
+        """A pre-update snapshot that never gets created -- e.g. snap_dir.mkdir
+        failing on a full or read-only filesystem, which raises before any
+        per-file reporting can run -- must be surfaced loudly through the caller,
+        not swallowed at debug level, so the user knows the update is proceeding
+        without a recovery point (#68907 review)."""
+        from hermes_cli.main import _run_pre_update_backup
+        with patch(
+            "hermes_cli.backup.create_quick_snapshot",
+            side_effect=OSError("[Errno 30] Read-only file system"),
+        ):
+            snap_id = _run_pre_update_backup(Namespace(no_backup=False, backup=False))
+        # The failure does not block the update...
+        assert snap_id is None
+        # ...but it is loud, not silent.
+        out = capsys.readouterr().out
+        assert "Pre-update snapshot FAILED" in out
+        assert "WITHOUT a recovery snapshot" in out
+        assert "Read-only file system" in out
+
+    def test_snapshot_returning_none_is_surfaced_loudly(self, hermes_home, capsys):
+        """create_quick_snapshot() can also return None with nothing captured --
+        another silent no-recovery-point path the caller must surface, not only
+        the raise path. The trust-boundary wrapper reports a missing snapshot
+        regardless of HOW the helper failed (#68907 review, Sol)."""
+        from hermes_cli.main import _run_pre_update_backup
+        with patch("hermes_cli.backup.create_quick_snapshot", return_value=None):
+            snap_id = _run_pre_update_backup(Namespace(no_backup=False, backup=False))
+        assert snap_id is None
+        out = capsys.readouterr().out
+        assert "Pre-update snapshot FAILED" in out
+        assert "WITHOUT a recovery snapshot" in out
+
+    def test_backup_flag_forces_full(self, hermes_home, capsys):
+        """--backup forces the full zip (plus quick snapshot) for one run."""
+        from hermes_cli.main import _run_pre_update_backup
+        snap_id = _run_pre_update_backup(Namespace(no_backup=False, backup=True))
+        out = capsys.readouterr().out
+        assert snap_id is not None
+        assert "Pre-update snapshot" in out
+        assert "Creating pre-update backup" in out
+        assert "Saved:" in out
+        assert "hermes import" in out
+        assert len(self._zips(hermes_home)) == 1
 
 
     def test_config_off_disables_everything_silently(self, hermes_home, capsys):

--- a/tests/hermes_cli/test_backup_stability.py
+++ b/tests/hermes_cli/test_backup_stability.py
@@ -98,7 +98,12 @@ def test_failed_automatic_backup_preserves_previous_archive(tmp_path, monkeypatc
     archive = tmp_path / "automatic.zip"
     archive.write_bytes(b"previous-valid-backup")
 
-    monkeypatch.setattr("hermes_cli.backup._safe_copy_db", lambda _src, _dst: False)
+    # _safe_copy_db returns (ok, reason) so callers can persist WHY a present
+    # file could not be captured (#68907); stub the failing shape accordingly.
+    monkeypatch.setattr(
+        "hermes_cli.backup._safe_copy_db",
+        lambda _src, _dst: (False, "stubbed failure"),
+    )
 
     assert _write_full_zip_backup(archive, home) is None
     assert archive.read_bytes() == b"previous-valid-backup"

--- a/tests/hermes_cli/test_state_db_guard.py
+++ b/tests/hermes_cli/test_state_db_guard.py
@@ -61,6 +61,39 @@ def test_oversized_db_probe_catches_malformed_schema(tmp_path):
 
 
 
+def test_copy_db_and_verify_honours_the_copy_failure_itself(valid_db, tmp_path, monkeypatch):
+    """Contract test: a failed-copy result must decide on its own.
+
+    ``_safe_copy_db`` returns ``(ok, reason)`` and ``if not <2-tuple>`` is always
+    False, so a bare truthiness check on it stops rejecting failed copies. The
+    other cases here don't notice: a real failing copy usually leaves no usable
+    destination, so the integrity gate below returns False second-hand.
+
+    The stub leaves a valid destination in place so only the ``(ok, reason)``
+    contract can reject the operation. It does not reproduce the real helper's
+    usual side effect — that one best-effort removes the destination after a
+    failed copy, though the removal is allowed to fail and be swallowed.
+    """
+    import shutil
+
+    from hermes_cli import backup as bk
+
+    dst = tmp_path / "snapshot" / "state.db"
+    dst.parent.mkdir()
+    shutil.copy2(valid_db, dst)  # a stale but perfectly valid earlier backup
+    assert verify_sqlite_integrity(dst)["valid"] is True  # premise of the test
+
+    def _fails_without_touching_dst(src, dest):
+        return False, "unable to open database file"
+
+    monkeypatch.setattr(bk, "_safe_copy_db", _fails_without_touching_dst)
+
+    assert bk.copy_db_and_verify(valid_db, dst) is False
+    # Still valid, which is the evidence: we returned at the copy gate instead
+    # of falling through to the integrity branch (that one unlinks).
+    assert verify_sqlite_integrity(dst)["valid"] is True
+
+
 def test_restore_flow_end_to_end(valid_db, tmp_path):
     """Simulate the #68474 recovery path: live db zeroed, snapshot valid →
     restore snapshot over live file → verify restored copy."""


### PR DESCRIPTION
## What does this PR do?

Re-scope of the original PR onto current main. Main already includes DB failure reporting and snapshot-preservation fixes: failed DB copies are listed in the manifest (`failed_dbs`), an older snapshot is kept when a DB failed or was skipped for size, the failure is printed at error level, and the SQLite handle is closed before a partial copy is unlinked. This branch now carries only what is still missing after that.

- The reason a DB could not be copied was logged but never persisted.
- A non-DB candidate whose copy failed was omitted from the manifest after a warning-level log, without suppressing pruning.
- An oversized non-DB candidate was skipped but not recorded in the manifest.
- A failing `dst.parent.mkdir` raised out of the whole copy walk.
- A failing `manifest.json` write left the staging directory behind.
- The updater logged snapshot exceptions at debug level and added no updater-level notice for a `None` result.

Every yielded candidate that is neither captured nor skipped for size enters a `failed` map (`rel -> one-line reason`) in the manifest. Size skips of any file enter `size_skipped`. Both are new keys next to the existing ones, so readers of `files`, `failed_dbs` and `oversized_skipped` are unaffected. Non-DB failures get a per-file warning and one `Snapshot INCOMPLETE` summary. Any incompleteness suppresses pruning. `dst.parent.mkdir` and the destination `stat()` run inside the per-candidate boundary, so one failure records that candidate and the walk continues. An `OSError` during manifest writing triggers a warning and a staging-directory cleanup attempt, and the function returns `None` without publishing. In `hermes update`, one line is printed when a usable pre-update snapshot cannot be confirmed (exception during creation or verification, or a `None` result), and the update continues as before.

`_safe_copy_db` keeps returning `bool`. The optional `failure` mapping is only used by the quick-snapshot walk, so its other callers are unchanged. The traversal (`_quick_snapshot_candidates`) is unchanged.

## Related Issue

Refs #68474

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/backup.py`: `_one_line_reason`. `_safe_copy_db(..., failure=None)`. `_copy_quick_snapshot_files` returns `(manifest, failed_dbs, oversized_skipped, failed, size_skipped)` with mkdir and destination stat inside the per-candidate boundary. `_create_quick_snapshot_locked` writes the two new manifest keys, prints the `INCOMPLETE` summary and abort line, guards the manifest write, and suppresses pruning on any incompleteness.
- `hermes_cli/update_cmd_maint.py`: `_run_pre_update_backup` reports when the pre-update snapshot cannot be confirmed and continues.
- Tests: `tests/hermes_cli/test_backup.py` (`TestSafeCopyDb`, `TestQuickSnapshot`, `TestRunPreUpdateBackup`), `tests/hermes_cli/test_backup_stability.py`, `tests/hermes_cli/test_state_db_guard.py`.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_backup.py tests/hermes_cli/test_backup_stability.py tests/hermes_cli/test_state_db_guard.py`. On this branch: 93 passed, 5 failed, 9 skipped on Windows. The same 5 fail identically on unmodified main (`d4625b593d`), so no additional failures were observed in these three suites.
2. All new test cases pass here. The 14 regression cases among them fail on unmodified main (checked by running the updated test files against `d4625b593d`); the compatibility cases pass on both.
3. `python scripts/ci/check_public_surface.py --base d4625b593d --head HEAD --strict` reports no dropped public names or tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (ran the three backup suites listed above, not the full tree)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
