### PR TITLE
feat(telegram): add [[spoiler]] directive for photo spoiler support

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3810,6 +3810,7 @@ class BasePlatformAdapter(ABC):
         # ``content`` for it (so they can still react to it); here we just
         # keep it out of the user-visible cleaned text.
         cleaned = cleaned.replace("[[as_document]]", "")
+        cleaned = cleaned.replace("[[spoiler]]", "")
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs. The extension

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14634,6 +14634,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # through send_document (preserving bytes) instead of
             # send_multiple_images (Telegram sendPhoto recompresses to ~1280px).
             force_document_attachments = "[[as_document]]" in response
+            # Detect [[spoiler]] directive — sends photos with Telegram's
+            # blur/spoiler effect (tap to reveal).
+            has_spoiler = "[[spoiler]]" in response
 
             from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
 
@@ -14681,10 +14684,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if image_paths:
                 try:
                     images = [(f"file://{_quote(p)}", "") for p in image_paths]
+                    _image_meta = {**_thread_meta, "has_spoiler": True} if has_spoiler and _thread_meta else (
+                        {"has_spoiler": True} if has_spoiler else _thread_meta
+                    )
                     await adapter.send_multiple_images(
                         chat_id=event.source.chat_id,
                         images=images,
-                        metadata=_thread_meta,
+                        metadata=_image_meta,
                     )
                 except Exception as e:
                     logger.warning("[%s] Post-stream image batch delivery failed: %s", adapter.name, e)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6552,6 +6552,8 @@ class TelegramAdapter(BasePlatformAdapter):
         if not images:
             return
 
+        _has_spoiler = bool((metadata or {}).get("has_spoiler"))
+
         try:
             from telegram import InputMediaPhoto
         except Exception as exc:  # pragma: no cover - missing SDK
@@ -6606,9 +6608,9 @@ class TelegramAdapter(BasePlatformAdapter):
                             continue
                         fh = open(local_path, "rb")
                         opened_files.append(fh)
-                        media.append(InputMediaPhoto(media=fh, caption=caption))
+                        media.append(InputMediaPhoto(media=fh, caption=caption, has_spoiler=_has_spoiler))
                     else:
-                        media.append(InputMediaPhoto(media=image_url, caption=caption))
+                        media.append(InputMediaPhoto(media=image_url, caption=caption, has_spoiler=_has_spoiler))
 
                 if not media:
                     continue
@@ -6682,6 +6684,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 return SendResult(success=False, error=self._missing_media_path_error("Image", image_path))
 
             _thread = self._metadata_thread_id(metadata)
+            _has_spoiler = bool((metadata or {}).get("has_spoiler"))
             reply_to_id = self._reply_to_message_id_for_send(reply_to, metadata, reply_to_mode=self._reply_to_mode)
             thread_kwargs = self._thread_kwargs_for_send(
                 chat_id,
@@ -6697,6 +6700,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "chat_id": normalize_telegram_chat_id(chat_id),
                         "photo": image_file,
                         "caption": caption[:1024] if caption else None,
+                        "has_spoiler": _has_spoiler,
                         "reply_to_message_id": reply_to_id,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
@@ -6882,6 +6886,8 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] Blocked unsafe image URL (SSRF protection)", self.name)
             return await super().send_image(chat_id, image_url, caption, reply_to, metadata=metadata)
 
+        _has_spoiler = bool((metadata or {}).get("has_spoiler"))
+
         try:
             # Telegram can send photos directly from URLs (up to ~5MB)
             _photo_thread = self._metadata_thread_id(metadata)
@@ -6899,6 +6905,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     "chat_id": normalize_telegram_chat_id(chat_id),
                     "photo": image_url,
                     "caption": caption[:1024] if caption else None,
+                    "has_spoiler": _has_spoiler,
                     "reply_to_message_id": reply_to_id,
                     **photo_thread_kwargs,
                     **self._notification_kwargs(metadata),
@@ -6936,6 +6943,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "chat_id": normalize_telegram_chat_id(chat_id),
                         "photo": image_data,
                         "caption": caption[:1024] if caption else None,
+                        "has_spoiler": _has_spoiler,
                         "reply_to_message_id": reply_to_id,
                         **upload_thread_kwargs,
                         **self._notification_kwargs(metadata),

--- a/tests/gateway/test_send_multiple_images.py
+++ b/tests/gateway/test_send_multiple_images.py
@@ -132,7 +132,7 @@ class TestTelegramMultiImage:
         import telegram
         images = [(f"https://x.com/{i}.png", f"alt{i}") for i in range(3)]
         # Make InputMediaPhoto a concrete class that records its args
-        telegram.InputMediaPhoto = MagicMock(side_effect=lambda media, caption=None: {"media": media, "caption": caption})
+        telegram.InputMediaPhoto = MagicMock(side_effect=lambda media, caption=None, has_spoiler=False: {"media": media, "caption": caption})
 
         _run(adapter.send_multiple_images("12345", images))
 
@@ -145,7 +145,7 @@ class TestTelegramMultiImage:
         """15 photos → two send_media_group calls (10 + 5)."""
         import telegram
         images = [(f"https://x.com/{i}.png", "") for i in range(15)]
-        telegram.InputMediaPhoto = MagicMock(side_effect=lambda media, caption=None: {"media": media})
+        telegram.InputMediaPhoto = MagicMock(side_effect=lambda media, caption=None, has_spoiler=False: {"media": media})
 
         _run(adapter.send_multiple_images("12345", images))
 

--- a/tests/gateway/test_telegram_spoiler.py
+++ b/tests/gateway/test_telegram_spoiler.py
@@ -1,0 +1,266 @@
+"""
+Tests for [[spoiler]] directive support — Telegram photo spoiler (tap to reveal).
+
+Covers:
+- [[spoiler]] stripped from cleaned text in extract_media
+- has_spoiler passed through metadata to send_photo / InputMediaPhoto
+- spoiler flag forwarded in send_image_file, send_image, send_multiple_images
+"""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter
+
+
+def _run(coro):
+    """Run a coroutine in a fresh event loop for sync-style tests."""
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# extract_media: [[spoiler]] directive stripping
+# ---------------------------------------------------------------------------
+
+
+class TestSpoilerDirectiveStripping:
+    """[[spoiler]] is a delivery directive — strip it from user-visible text."""
+
+    def test_spoiler_directive_stripped_from_cleaned_text(self):
+        """[[spoiler]] must be removed from cleaned output."""
+        content = "Here is the image:\n[[spoiler]]\nMEDIA:/tmp/nsfw.jpg"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/nsfw.jpg", False)]
+        assert "[[spoiler]]" not in cleaned
+        assert "Here is the image" in cleaned
+
+    def test_spoiler_does_not_affect_voice_flag(self):
+        """[[spoiler]] is independent of [[audio_as_voice]]."""
+        content = "[[spoiler]]\nMEDIA:/tmp/photo.png"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/photo.png", False)]  # voice flag stays False
+        assert "[[spoiler]]" not in cleaned
+
+    def test_spoiler_coexists_with_as_document(self):
+        """[[spoiler]] and [[as_document]] can appear in the same response."""
+        content = "[[spoiler]]\n[[as_document]]\nMEDIA:/tmp/img.png"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/img.png", False)]
+        assert "[[spoiler]]" not in cleaned
+        assert "[[as_document]]" not in cleaned
+
+    def test_spoiler_coexists_with_audio_as_voice(self):
+        """All three directives can coexist."""
+        content = "[[audio_as_voice]]\n[[spoiler]]\nMEDIA:/tmp/x.ogg"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/x.ogg", True)]
+        assert "[[spoiler]]" not in cleaned
+        assert "[[audio_as_voice]]" not in cleaned
+
+
+# ---------------------------------------------------------------------------
+# Telegram adapter: has_spoiler in send_photo / InputMediaPhoto
+# ---------------------------------------------------------------------------
+
+
+def _ensure_telegram_mock():
+    """Install mock telegram modules so TelegramAdapter can be imported."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+class TestTelegramSendImageFileSpoiler:
+    """send_image_file passes has_spoiler to bot.send_photo when metadata requests it."""
+
+    @pytest.fixture
+    def adapter(self):
+        config = PlatformConfig(enabled=True, token="fake-token")
+        a = TelegramAdapter(config)
+        a._bot = MagicMock()
+        return a
+
+    def test_has_spoiler_true_forwarded(self, adapter, tmp_path):
+        """When metadata has has_spoiler=True, send_photo gets has_spoiler=True."""
+        img = tmp_path / "photo.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+        mock_msg = MagicMock()
+        mock_msg.message_id = 1
+        adapter._bot.send_photo = AsyncMock(return_value=mock_msg)
+
+        result = _run(
+            adapter.send_image_file(
+                chat_id="12345",
+                image_path=str(img),
+                metadata={"has_spoiler": True},
+            )
+        )
+        assert result.success
+        call_kwargs = adapter._bot.send_photo.call_args.kwargs
+        assert call_kwargs["has_spoiler"] is True
+
+    def test_has_spoiler_false_when_not_in_metadata(self, adapter, tmp_path):
+        """When metadata does not contain has_spoiler, it defaults to False."""
+        img = tmp_path / "photo.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+        mock_msg = MagicMock()
+        mock_msg.message_id = 2
+        adapter._bot.send_photo = AsyncMock(return_value=mock_msg)
+
+        result = _run(
+            adapter.send_image_file(
+                chat_id="12345",
+                image_path=str(img),
+                metadata={"thread_id": "100"},
+            )
+        )
+        assert result.success
+        call_kwargs = adapter._bot.send_photo.call_args.kwargs
+        assert call_kwargs["has_spoiler"] is False
+
+    def test_has_spoiler_false_when_metadata_is_none(self, adapter, tmp_path):
+        """When metadata is None, has_spoiler defaults to False."""
+        img = tmp_path / "photo.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+        mock_msg = MagicMock()
+        mock_msg.message_id = 3
+        adapter._bot.send_photo = AsyncMock(return_value=mock_msg)
+
+        result = _run(
+            adapter.send_image_file(
+                chat_id="12345",
+                image_path=str(img),
+            )
+        )
+        assert result.success
+        call_kwargs = adapter._bot.send_photo.call_args.kwargs
+        assert call_kwargs["has_spoiler"] is False
+
+
+class TestTelegramSendImageSpoiler:
+    """send_image passes has_spoiler to bot.send_photo for URL-based images."""
+
+    @pytest.fixture
+    def adapter(self):
+        config = PlatformConfig(enabled=True, token="fake-token")
+        a = TelegramAdapter(config)
+        a._bot = MagicMock()
+        return a
+
+    def test_has_spoiler_forwarded_for_url_image(self, adapter):
+        """URL-based send_image passes has_spoiler through."""
+        mock_msg = MagicMock()
+        mock_msg.message_id = 10
+        adapter._bot.send_photo = AsyncMock(return_value=mock_msg)
+
+        result = _run(
+            adapter.send_image(
+                chat_id="12345",
+                image_url="https://example.com/photo.jpg",
+                metadata={"has_spoiler": True},
+            )
+        )
+        assert result.success
+        call_kwargs = adapter._bot.send_photo.call_args.kwargs
+        assert call_kwargs["has_spoiler"] is True
+
+
+class TestTelegramSendMultipleImagesSpoiler:
+    """send_multiple_images passes has_spoiler to InputMediaPhoto."""
+
+    @pytest.fixture
+    def adapter(self):
+        config = PlatformConfig(enabled=True, token="fake-token")
+        a = TelegramAdapter(config)
+        a._bot = MagicMock()
+        return a
+
+    def test_has_spoiler_passed_to_input_media_photo(self, adapter, tmp_path):
+        """InputMediaPhoto receives has_spoiler=True from metadata."""
+        from urllib.parse import quote
+
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+        # Capture InputMediaPhoto constructor calls
+        captured_kwargs = []
+        original_InputMediaPhoto = None
+
+        try:
+            from telegram import InputMediaPhoto as _IMP
+            original_InputMediaPhoto = _IMP
+        except (ImportError, TypeError):
+            pass
+
+        class SpyInputMediaPhoto:
+            def __init__(self, **kwargs):
+                captured_kwargs.append(kwargs)
+
+        mock_msgs = [MagicMock(message_id=1)]
+        adapter._bot.send_media_group = AsyncMock(return_value=mock_msgs)
+
+        images = [(f"file://{quote(str(img))}", "")]
+
+        with patch("telegram.InputMediaPhoto", SpyInputMediaPhoto):
+            _run(
+                adapter.send_multiple_images(
+                    chat_id="12345",
+                    images=images,
+                    metadata={"has_spoiler": True},
+                )
+            )
+
+        assert len(captured_kwargs) == 1
+        assert captured_kwargs[0]["has_spoiler"] is True
+
+    def test_has_spoiler_false_by_default(self, adapter, tmp_path):
+        """InputMediaPhoto receives has_spoiler=False when not in metadata."""
+        from urllib.parse import quote
+
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+        captured_kwargs = []
+
+        class SpyInputMediaPhoto:
+            def __init__(self, **kwargs):
+                captured_kwargs.append(kwargs)
+
+        mock_msgs = [MagicMock(message_id=1)]
+        adapter._bot.send_media_group = AsyncMock(return_value=mock_msgs)
+
+        images = [(f"file://{quote(str(img))}", "")]
+
+        with patch("telegram.InputMediaPhoto", SpyInputMediaPhoto):
+            _run(
+                adapter.send_multiple_images(
+                    chat_id="12345",
+                    images=images,
+                    metadata={"thread_id": "100"},
+                )
+            )
+
+        assert len(captured_kwargs) == 1
+        assert captured_kwargs[0]["has_spoiler"] is False


### PR DESCRIPTION
## Summary

Add support for Telegram's `has_spoiler` parameter on photos. When a response contains the `[[spoiler]]` directive, all images in that response are sent with the spoiler blur effect (users tap to reveal).

## Problem

Telegram Bot API supports `has_spoiler` on `sendPhoto` and `InputMediaPhoto` since Bot API 6.1 (python-telegram-bot >= 20.0), but Hermes has no way to send photos with this effect. Users who want sensitive/surprise images blurred until tapped have no mechanism.

## Description

Follows the established `[[as_document]]` / `[[audio_as_voice]]` directive pattern:

1. **`gateway/platforms/base.py`** — Strip `[[spoiler]]` from user-visible text in `extract_media()`
2. **`gateway/run.py`** — Detect `[[spoiler]]` in `_deliver_media_from_response()` and propagate `has_spoiler=True` via the metadata dict
3. **`plugins/platforms/telegram/adapter.py`** — Pass `has_spoiler` to `send_photo` and `InputMediaPhoto` in all three send methods (`send_image_file`, `send_image`, `send_multiple_images`)

The agent includes `[[spoiler]]` in a response containing `MEDIA:` tags to trigger the effect:
```
Here is the image you asked for:
[[spoiler]]
MEDIA:/path/to/image.png
```

## Changes

- `gateway/platforms/base.py` (+1 line) — strip directive
- `gateway/run.py` (+8 lines) — detect and propagate via metadata
- `plugins/platforms/telegram/adapter.py` (+10 lines) — pass to Bot API
- `tests/gateway/test_telegram_spoiler.py` (new) — directive stripping + adapter tests  
- `tests/gateway/test_send_multiple_images.py` (+2 lines) — fix existing mock signature

## Testing

- Unit tests cover: directive stripping, has_spoiler=True/False forwarding in all send methods, coexistence with other directives
- Non-Telegram platforms unaffected (they ignore metadata keys they do not understand)