### PR TITLE
fix(web/xai): retry web_search on 429/503 with backoff

### DIFF
--- a/plugins/web/xai/provider.py
+++ b/plugins/web/xai/provider.py
@@ -34,7 +34,9 @@ from __future__ import annotations
 
 import json
 import logging
+import random
 import re
+import time
 from typing import Any, Dict, List, Optional
 
 from agent.web_search_provider import WebSearchProvider
@@ -48,6 +50,35 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL = "grok-build-0.1"
 DEFAULT_TIMEOUT = 90
+
+# Rate-limit (429) / overload (503) backoff. xAI enforces a low
+# requests-per-second ceiling (spend-tiered, e.g. 2 RPS); a burst of parallel
+# web_search calls trips it even when sequential use is far under budget. We
+# retry transparently with exponential backoff so the limit never surfaces to
+# the agent as a hard failure.
+RATE_LIMIT_MAX_RETRIES = 3
+RATE_LIMIT_BASE_DELAY = 1.0   # seconds
+RATE_LIMIT_MAX_DELAY = 8.0    # per-retry cap
+
+
+def _rate_limit_delay(response: Any, attempt: int) -> float:
+    """Seconds to wait before a rate-limited (429/503) xAI retry.
+
+    Honors a usable ``Retry-After`` header when present; otherwise falls back
+    to exponential backoff with jitter, capped so a retried search never
+    stalls the surrounding tool batch.
+    """
+    try:
+        if response is not None:
+            raw = response.headers.get("retry-after")
+            if raw:
+                retry_after = float(raw)
+                if retry_after >= 0:
+                    return min(retry_after, RATE_LIMIT_MAX_DELAY)
+    except (TypeError, ValueError, AttributeError):
+        pass
+    base = min(RATE_LIMIT_BASE_DELAY * (2 ** (attempt - 1)), RATE_LIMIT_MAX_DELAY)
+    return base + random.uniform(0, RATE_LIMIT_BASE_DELAY / 2)
 _MAX_DOMAIN_FILTERS = 5  # xAI hard cap on allowed_domains / excluded_domains
 
 # Match the JSON object Grok is asked to emit. Tolerates leading/trailing
@@ -252,7 +283,9 @@ class XAIWebSearchProvider(WebSearchProvider):
         # can't refresh those and an immediate retry would just burn quota.
         is_oauth_path = (creds.get("provider") == "xai-oauth")
         resp = None
-        for attempt in range(2):
+        auth_retry_used = False
+        rate_limit_retries = 0
+        while True:
             try:
                 resp = httpx.post(
                     f"{base_url}/responses",
@@ -264,7 +297,21 @@ class XAIWebSearchProvider(WebSearchProvider):
                 break
             except httpx.HTTPStatusError as exc:
                 status = exc.response.status_code if exc.response is not None else 0
-                if status == 401 and attempt == 0 and is_oauth_path:
+                # Transient rate-limit (429) / overload (503): back off and
+                # retry transparently so xAI's per-second cap never surfaces
+                # to the agent as a failed search.
+                if status in (429, 503) and rate_limit_retries < RATE_LIMIT_MAX_RETRIES:
+                    rate_limit_retries += 1
+                    delay = _rate_limit_delay(exc.response, rate_limit_retries)
+                    logger.info(
+                        "xAI web search HTTP %d (rate-limited); backing off %.2fs "
+                        "then retry %d/%d.",
+                        status, delay, rate_limit_retries, RATE_LIMIT_MAX_RETRIES,
+                    )
+                    time.sleep(delay)
+                    continue
+                if status == 401 and not auth_retry_used and is_oauth_path:
+                    auth_retry_used = True
                     logger.info(
                         "xAI web search got 401 on first attempt; forcing OAuth "
                         "refresh and retrying once.",
@@ -301,7 +348,7 @@ class XAIWebSearchProvider(WebSearchProvider):
                 return {"success": False, "error": f"Could not reach xAI: {exc}"}
 
         if resp is None:
-            # Defensive — both attempts somehow exited the loop without resp.
+            # Defensive — the loop somehow exited without resp.
             return {"success": False, "error": "xAI web search produced no response"}
 
         try:

--- a/tests/tools/test_web_providers_xai.py
+++ b/tests/tools/test_web_providers_xai.py
@@ -448,13 +448,18 @@ class TestXAIProviderSearchErrors:
         posted.assert_not_called()
 
     def test_http_error_returns_failure(self):
+        """A non-retryable HTTP error (e.g. 403) surfaces as a clean failure.
+
+        429/503 are retried (see the rate-limit tests); other 4xx/5xx that
+        aren't 401 fail fast without a retry.
+        """
         import httpx
         from plugins.web.xai import provider as xai_provider
 
         bad = MagicMock()
-        bad.status_code = 429
-        bad.text = "rate limited"
-        err = httpx.HTTPStatusError("429", request=MagicMock(), response=bad)
+        bad.status_code = 403
+        bad.text = "forbidden"
+        err = httpx.HTTPStatusError("403", request=MagicMock(), response=bad)
 
         with patch.object(xai_provider, "resolve_xai_http_credentials", return_value=_creds()), \
              patch.object(xai_provider, "_load_xai_web_config", return_value={}), \
@@ -462,7 +467,7 @@ class TestXAIProviderSearchErrors:
             result = xai_provider.XAIWebSearchProvider().search("q", limit=5)
 
         assert result["success"] is False
-        assert "429" in result["error"]
+        assert "403" in result["error"]
 
     def test_request_error_returns_failure(self):
         import httpx
@@ -610,8 +615,8 @@ class TestXAIProviderSearchErrors:
         assert calls["refresh_count"] == 1
 
     def test_non_401_http_error_is_not_retried(self):
-        """Only 401 is retryable — 429 / 500 / 503 must fail fast so the
-        agent (or upstream rate-limiter) decides what to do."""
+        """401 (auth) and 429/503 (rate-limit/overload) are retried; other
+        4xx/5xx like 500 fail fast so the agent decides what to do."""
         import httpx
         from plugins.web.xai import provider as xai_provider
 
@@ -640,6 +645,127 @@ class TestXAIProviderSearchErrors:
         assert "500" in result["error"]
         assert calls["posts"] == 1
         assert calls["refreshed"] is False
+
+    def test_429_is_retried_with_backoff_then_succeeds(self):
+        """A transient 429 (xAI per-second cap) is retried transparently so
+        the rate limit never surfaces to the agent as a failed search."""
+        import httpx
+        from plugins.web.xai import provider as xai_provider
+
+        bad = MagicMock()
+        bad.status_code = 429
+        bad.text = "resource-exhausted"
+        bad.headers = {}
+        rate_limited = httpx.HTTPStatusError("429", request=MagicMock(), response=bad)
+
+        calls = {"posts": 0}
+
+        def fake_post(url, **kwargs):
+            calls["posts"] += 1
+            if calls["posts"] <= 2:
+                raise rate_limited
+            return _mock_resp(_responses_payload(json.dumps(
+                {"results": [{"title": "T", "url": "https://e.com", "description": "d"}]}
+            )))
+
+        sleeps = []
+        with patch.object(xai_provider, "resolve_xai_http_credentials", return_value=_creds()), \
+             patch.object(xai_provider, "_load_xai_web_config", return_value={}), \
+             patch.object(xai_provider.time, "sleep", side_effect=sleeps.append), \
+             patch("httpx.post", side_effect=fake_post):
+            result = xai_provider.XAIWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is True
+        assert result["data"]["web"][0]["url"] == "https://e.com"
+        # Two 429s → two backoff sleeps → third post succeeds.
+        assert calls["posts"] == 3
+        assert len(sleeps) == 2
+
+    def test_503_overload_is_retried(self):
+        """503 (model overloaded) is retried on the same backoff path as 429."""
+        import httpx
+        from plugins.web.xai import provider as xai_provider
+
+        bad = MagicMock()
+        bad.status_code = 503
+        bad.text = "overloaded"
+        bad.headers = {}
+        overloaded = httpx.HTTPStatusError("503", request=MagicMock(), response=bad)
+
+        calls = {"posts": 0}
+
+        def fake_post(url, **kwargs):
+            calls["posts"] += 1
+            if calls["posts"] == 1:
+                raise overloaded
+            return _mock_resp(_responses_payload(json.dumps({"results": []})))
+
+        with patch.object(xai_provider, "resolve_xai_http_credentials", return_value=_creds()), \
+             patch.object(xai_provider, "_load_xai_web_config", return_value={}), \
+             patch.object(xai_provider.time, "sleep", return_value=None), \
+             patch("httpx.post", side_effect=fake_post):
+            result = xai_provider.XAIWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is True
+        assert calls["posts"] == 2
+
+    def test_persistent_429_gives_up_after_max_retries(self):
+        """When 429 never clears, we stop after RATE_LIMIT_MAX_RETRIES and
+        return a clean error (bounded retries, no infinite loop)."""
+        import httpx
+        from plugins.web.xai import provider as xai_provider
+
+        bad = MagicMock()
+        bad.status_code = 429
+        bad.text = "resource-exhausted"
+        bad.headers = {}
+        rate_limited = httpx.HTTPStatusError("429", request=MagicMock(), response=bad)
+
+        calls = {"posts": 0}
+
+        def fake_post(url, **kwargs):
+            calls["posts"] += 1
+            raise rate_limited
+
+        with patch.object(xai_provider, "resolve_xai_http_credentials", return_value=_creds()), \
+             patch.object(xai_provider, "_load_xai_web_config", return_value={}), \
+             patch.object(xai_provider.time, "sleep", return_value=None), \
+             patch("httpx.post", side_effect=fake_post):
+            result = xai_provider.XAIWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "429" in result["error"]
+        # Initial attempt + RATE_LIMIT_MAX_RETRIES retries.
+        assert calls["posts"] == xai_provider.RATE_LIMIT_MAX_RETRIES + 1
+
+    def test_retry_after_header_is_honored(self):
+        """A ``Retry-After`` header sets the backoff delay (capped)."""
+        import httpx
+        from plugins.web.xai import provider as xai_provider
+
+        bad = MagicMock()
+        bad.status_code = 429
+        bad.text = "resource-exhausted"
+        bad.headers = {"retry-after": "2"}
+        rate_limited = httpx.HTTPStatusError("429", request=MagicMock(), response=bad)
+
+        calls = {"posts": 0}
+
+        def fake_post(url, **kwargs):
+            calls["posts"] += 1
+            if calls["posts"] == 1:
+                raise rate_limited
+            return _mock_resp(_responses_payload(json.dumps({"results": []})))
+
+        sleeps = []
+        with patch.object(xai_provider, "resolve_xai_http_credentials", return_value=_creds()), \
+             patch.object(xai_provider, "_load_xai_web_config", return_value={}), \
+             patch.object(xai_provider.time, "sleep", side_effect=sleeps.append), \
+             patch("httpx.post", side_effect=fake_post):
+            result = xai_provider.XAIWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is True
+        assert sleeps == [2.0]
 
     def test_http_200_with_error_envelope_surfaces_failure(self):
         """xAI sometimes returns 200 with ``{"error": {...}}`` (model


### PR DESCRIPTION
## Problem

xAI's Web Search backend enforces a low requests-per-second ceiling (spend-tiered, e.g. 2 RPS). When the agent fires a burst of parallel `web_search` calls in a single turn, the burst trips the per-second cap even though sequential use is far under budget (each xAI search takes 26-40s, so serial is ~0.03 RPS).

The provider had **no 429 handling**: `raise_for_status()` in the request loop only special-cased 401 (OAuth refresh). A 429/503 fell straight through to a hard error return, so a rate-limited search surfaced to the agent as a failed tool call and got re-fired on later turns, producing recurring user-visible "search rate limited" friction.

## Fix

Add transparent exponential backoff-and-retry for **429** (rate limit) and **503** (overload) in the Responses request loop:

- Honors a `Retry-After` header when present (capped), else exponential backoff with jitter.
- Bounded at `RATE_LIMIT_MAX_RETRIES` (3) so a persistent 429 still returns a clean error instead of looping.
- Existing 401 OAuth force-refresh path preserved unchanged; other 4xx/5xx (400/403/500) still fail fast.

## Tests

- 4 new cases: 429-then-success (asserts 2 sleeps + 3 posts), 503 retry, persistent-429 give-up (bounded), `Retry-After` honored. `time.sleep` is mocked so the suite stays fast.
- Updated 2 existing tests whose semantics changed: 429/503 are now retried rather than fail-fast.
- `44 passed in 0.48s`.
