### PR TITLE
fix(desktop): garbage-collect orphaned composer-queue entries so the stuck-queue error can't persist forever

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
@@ -8,8 +8,11 @@ import {
   $queuedPromptsBySession,
   enqueueQueuedPrompt,
   getQueuedPrompts,
+  MAX_AUTO_DRAIN_ATTEMPTS,
+  ORPHANED_QUEUE_MAX_AGE_MS,
   parkQueuedPrompts
 } from '@/store/composer-queue'
+import { $notifications, clearNotifications } from '@/store/notifications'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
 
 import { useBackgroundQueueDrain } from './use-background-queue-drain'
@@ -48,7 +51,70 @@ describe('useBackgroundQueueDrain', () => {
     vi.useRealTimers()
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
+    clearNotifications()
     clearAllSessionStates()
+  })
+
+  // Drive the auto-drain retry ladder to exhaustion for an always-failing submit.
+  async function exhaustDrainAttempts() {
+    for (let attempt = 0; attempt < MAX_AUTO_DRAIN_ATTEMPTS; attempt++) {
+      await act(async () => {
+        await Promise.resolve()
+        await vi.advanceTimersByTimeAsync(750)
+      })
+    }
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+  }
+
+  it('garbage-collects a stale undrainable entry after exhausting attempts, without toasting', async () => {
+    vi.useFakeTimers()
+
+    // No runtime mapping AND submit always rejects: the stored session can never
+    // be resolved or resumed — a provably orphaned queue.
+    const runtimeMap = { current: new Map<string, string>() }
+    const submitText = vi.fn(async () => false)
+
+    // Backdate the entry past the orphan cutoff so it is eligible for GC.
+    $queuedPromptsBySession.set({
+      'stored-session-a': [
+        {
+          attachments: [],
+          id: 'q-orphan',
+          queuedAt: Date.now() - ORPHANED_QUEUE_MAX_AGE_MS - 1000,
+          text: 'orphaned prompt'
+        }
+      ]
+    })
+
+    render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
+
+    await exhaustDrainAttempts()
+
+    expect(getQueuedPrompts('stored-session-a')).toHaveLength(0)
+    expect($notifications.get()).toHaveLength(0)
+  })
+
+  it('keeps a recent undrainable entry queued and toasts instead of GC-ing it', async () => {
+    vi.useFakeTimers()
+
+    const runtimeMap = { current: new Map<string, string>() }
+    const submitText = vi.fn(async () => false)
+
+    // A fresh entry may just be failing transiently (backend briefly down); it
+    // must survive and surface the "queue stuck" toast, not be discarded.
+    $queuedPromptsBySession.set({
+      'stored-session-a': [{ attachments: [], id: 'q-recent', queuedAt: Date.now(), text: 'recent prompt' }]
+    })
+
+    render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
+
+    await exhaustDrainAttempts()
+
+    expect(getQueuedPrompts('stored-session-a')).toHaveLength(1)
+    expect($notifications.get().length).toBeGreaterThan(0)
   })
 
   it('drains an idle queued prompt for a non-selected background session', async () => {

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -7,6 +7,7 @@ import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
   getQueuedPrompts,
+  isStaleQueueEntry,
   MAX_AUTO_DRAIN_ATTEMPTS,
   type QueuedPromptEntry,
   removeQueuedPrompt,
@@ -93,6 +94,19 @@ export function useBackgroundQueueDrain({
         drainFailuresRef.current.set(entry.id, failures)
 
         if (failures >= MAX_AUTO_DRAIN_ATTEMPTS) {
+          // An entry that failed every auto-drain attempt this run AND is older
+          // than ORPHANED_QUEUE_MAX_AGE_MS is provably undrainable: its stored
+          // session can no longer be resolved or resumed. Left in place it
+          // re-fires this error on every restart forever (the failure counter
+          // resets per run, so it can never accumulate enough failures to be
+          // cleaned up). Garbage-collect it instead of toasting again.
+          if (isStaleQueueEntry(entry, Date.now())) {
+            drainFailuresRef.current.delete(entry.id)
+            removeQueuedPrompt(sessionKey, entry.id)
+
+            return
+          }
+
           notify({
             id: `composer-background-queue-stuck-${sessionKey}`,
             kind: 'error',

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -9,7 +9,9 @@ import {
   enqueueQueuedPrompt,
   getQueuedPrompts,
   isQueueParked,
+  isStaleQueueEntry,
   migrateQueuedPrompts,
+  ORPHANED_QUEUE_MAX_AGE_MS,
   parkQueuedPrompts,
   promoteQueuedPrompt,
   removeQueuedPrompt,
@@ -245,5 +247,22 @@ describe('parked queue sessions', () => {
     migrateQueuedPrompts('rt-old', 'rt-new')
 
     expect(isQueueParked('rt-new')).toBe(false)
+  })
+})
+
+describe('isStaleQueueEntry', () => {
+  const entryAt = (queuedAt: number) => ({ attachments: [], id: 'q1', queuedAt, text: 'hi' })
+
+  it('treats an entry older than the orphan cutoff as stale', () => {
+    const now = Date.now()
+
+    expect(isStaleQueueEntry(entryAt(now - ORPHANED_QUEUE_MAX_AGE_MS - 1), now)).toBe(true)
+  })
+
+  it('keeps a recent entry (below the cutoff) non-stale', () => {
+    const now = Date.now()
+
+    expect(isStaleQueueEntry(entryAt(now - ORPHANED_QUEUE_MAX_AGE_MS + 1), now)).toBe(false)
+    expect(isStaleQueueEntry(entryAt(now), now)).toBe(false)
   })
 })

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -346,3 +346,25 @@ export const shouldAutoDrain = ({ isBusy, parked, queueLength }: AutoDrainInput)
 /** Auto-drain attempts for one entry before we stop retrying and toast. The
  * entry stays queued for a manual send; a remount/reconnect resets the count. */
 export const MAX_AUTO_DRAIN_ATTEMPTS = 4
+
+/**
+ * How old a queued prompt must be before the background drain garbage-collects
+ * it once it has also exhausted its auto-drain attempts.
+ *
+ * A stored session that can no longer be resolved or resumed (e.g. it was never
+ * reopened) can never drain its queue. The in-memory failure counter resets on
+ * every remount/restart, so such an entry re-fires the "queue stuck" error on
+ * every launch forever and is never cleaned up (`removeQueuedPrompt` only runs
+ * on a *successful* drain). The age gate is the safety valve: a recent entry
+ * that is merely failing transiently (backend briefly down) stays queued for a
+ * later retry, while a genuinely orphaned one eventually ages out and is dropped.
+ */
+export const ORPHANED_QUEUE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+
+/**
+ * Whether a queued entry is old enough to be discarded once it has also
+ * exhausted its auto-drain attempts. Pure so the drain policy can be unit-tested
+ * without a live clock.
+ */
+export const isStaleQueueEntry = (entry: QueuedPromptEntry, now: number): boolean =>
+  now - entry.queuedAt > ORPHANED_QUEUE_MAX_AGE_MS


### PR DESCRIPTION
## Problem

Fixes #68895.

A composer prompt queued for a stored session that is never reopened can never drain. The background drain in `use-background-queue-drain.ts` tries to resolve/resume the session and submit; for a session with no live runtime mapping and no resumable backend session, `submitText()` keeps rejecting (`accepted === false`). After `MAX_AUTO_DRAIN_ATTEMPTS` it fires the "queued message not sent" error toast.

The entry is then **never cleaned up**:
- `removeQueuedPrompt()` runs only on a *successful* drain.
- The in-memory `drainFailuresRef` counter resets on every remount/restart, so the entry can never accumulate enough failures across restarts to be treated as terminal.

Result: a stale entry in `localStorage` (`hermes.desktop.composerQueue.v1`) re-fires the error notification on **every app launch, forever**, with no recovery path except manually opening the session and clearing the queue — which the user may not know to do.

## Fix

When an entry exhausts its auto-drain attempts **and** is older than `ORPHANED_QUEUE_MAX_AGE_MS` (7 days), the background drain now garbage-collects it (`removeQueuedPrompt` + clear its failure count) instead of toasting again.

The age gate is the safety valve, chosen deliberately over "drop on first exhaustion":
- A *recent* entry that is merely failing transiently (backend briefly down, session not yet reopened) stays queued for a later retry and still surfaces the "queue stuck" toast — no behavior change, no data loss.
- Only a *genuinely stale, undrainable* entry is discarded.

I gate on repeated drain **failure** rather than on the absence of a runtime mapping on purpose: a `null` runtime id is intentionally passed so `submitText` can *resume* a stale-but-valid session by stored id (see the existing `passes a null runtime id so submitText can resume stale background sessions by stored id` test). So "no runtime mapping" ≠ "orphaned"; exhausted retries + age is the reliable signal.

## Tests

- `composer-queue.test.ts`: unit tests for the pure `isStaleQueueEntry` predicate (boundary around the 7-day cutoff).
- `use-background-queue-drain.test.tsx`:
  - a stale, always-failing entry is GC'd after exhausting attempts and **does not** toast;
  - a recent, always-failing entry is **kept** and **does** toast (regression guard against premature deletion).

`eslint` and `tsc --noEmit` clean; the affected desktop suites pass locally.