### PR TITLE
feat(gateway): compact sessions in background and bound state WAL

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -867,6 +867,11 @@ class ContextCompressor(ContextEngine):
       5. On subsequent compactions, iteratively update the previous summary
     """
 
+    # Class-level default keeps lightweight test/plugin instances created via
+    # object.__new__ compatible; normal construction also writes the instance
+    # value below.
+    force_main_runtime: bool = False
+
     @property
     def name(self) -> str:
         return "compressor"
@@ -1398,6 +1403,10 @@ class ContextCompressor(ContextEngine):
         self.awaiting_real_usage_after_compression = False
 
         self.summary_model = summary_model_override or ""
+        # Background gateway compaction can pin summary generation to the
+        # conversation's active chat runtime instead of applying an explicit
+        # auxiliary.compression provider/model override.
+        self.force_main_runtime = False
         self._session_db: Any = None
         self._session_id: str = ""
 
@@ -2377,7 +2386,23 @@ This compaction should PRIORITISE preserving all information related to the focu
                 # fall back to the model's native output ceiling.
                 # timeout resolved from auxiliary.compression.timeout config by call_llm
             }
-            if self.summary_model:
+            # Gateway background compaction is intentionally performed by the
+            # session's active chat model. Unlike foreground compression, it
+            # must not silently pick a differently configured per-task model:
+            # the background result may be committed after later turns have
+            # already continued, so using the same runtime keeps reasoning and
+            # provider semantics aligned with that conversation. Explicit
+            # provider/model kwargs override auxiliary.compression routing;
+            # ``task`` remains for timeout and usage attribution.
+            if self.force_main_runtime:
+                call_kwargs.update(
+                    provider=self.provider,
+                    model=self.model,
+                    base_url=self.base_url,
+                    api_key=self.api_key,
+                    api_mode=self.api_mode,
+                )
+            elif self.summary_model:
                 call_kwargs["model"] = self.summary_model
             # Compression is atomic: protect the in-flight summary call from a
             # mid-turn gateway interrupt. Without this, an incoming user message

--- a/cli.py
+++ b/cli.py
@@ -468,6 +468,10 @@ def load_cli_config() -> Dict[str, Any]:
         "compression": {
             "enabled": True,      # Auto-compress when approaching context limit
             "threshold": 0.50,    # Compress at 50% of model's context limit
+            "background_enabled": True,
+            "background_threshold": 0.65,
+            "background_chunk_tokens": 96000,
+            "background_use_main_model": True,
         },
         "agent": {
             "max_turns": 90,  # Default max tool-calling iterations (shared with subagents)

--- a/gateway/background_compaction.py
+++ b/gateway/background_compaction.py
@@ -1,0 +1,514 @@
+"""Non-blocking gateway transcript compaction.
+
+The foreground turn remains the sole owner of response delivery. Once its
+transcript flush is complete, this mixin may summarize an old, bounded prefix
+on the gateway executor. The expensive model call never holds a turn or
+database lease; publication uses a short prefix-CAS transaction so new turns
+may append safely while the summary is being generated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class BackgroundCompactionSettings:
+    enabled: bool = True
+    threshold: float = 0.65
+    chunk_tokens: int = 96_000
+    use_main_model: bool = True
+    protect_tail_messages: int = 20
+
+    @classmethod
+    def from_config(cls, config: Optional[dict]) -> "BackgroundCompactionSettings":
+        compression = config.get("compression", {}) if isinstance(config, dict) else {}
+        if not isinstance(compression, dict):
+            compression = {}
+        try:
+            threshold = float(compression.get("background_threshold", 0.65))
+        except (TypeError, ValueError):
+            threshold = 0.65
+        # The foreground 85% hygiene path is the final safety net. Keep the
+        # background trigger strictly below it even when config is malformed.
+        threshold = min(0.84, max(0.10, threshold))
+        try:
+            chunk_tokens = int(compression.get("background_chunk_tokens", 96_000))
+        except (TypeError, ValueError):
+            chunk_tokens = 96_000
+        chunk_tokens = min(192_000, max(16_000, chunk_tokens))
+        try:
+            protect_tail = int(compression.get("protect_last_n", 20))
+        except (TypeError, ValueError):
+            protect_tail = 20
+        return cls(
+            enabled=(
+                _as_bool(compression.get("enabled"), True)
+                and _as_bool(compression.get("background_enabled"), True)
+            ),
+            threshold=threshold,
+            chunk_tokens=chunk_tokens,
+            use_main_model=_as_bool(
+                compression.get("background_use_main_model"), True
+            ),
+            protect_tail_messages=max(4, protect_tail),
+        )
+
+
+@dataclass(frozen=True)
+class CompactionPrefix:
+    messages: List[Dict[str, Any]]
+    last_state_message_id: int
+    estimated_tokens: int
+
+
+def select_compaction_prefix(
+    messages: List[Dict[str, Any]],
+    *,
+    target_tokens: int,
+    protect_tail_messages: int,
+) -> Optional[CompactionPrefix]:
+    """Choose the largest bounded old prefix ending at a turn boundary.
+
+    The next conversational row must be a user message, which prevents
+    splitting assistant tool calls from their tool results. Non-conversational
+    rows are not sent to the summarizer; their IDs are still covered later by
+    the database prefix selected through ``last_state_message_id``.
+    """
+    from agent.model_metadata import estimate_messages_tokens_rough
+
+    conversational = [
+        message
+        for message in messages
+        if isinstance(message, dict)
+        and message.get("role") in {"user", "assistant", "tool", "function"}
+        and message.get("_state_message_id") is not None
+    ]
+    max_prefix_len = len(conversational) - max(4, int(protect_tail_messages))
+    if max_prefix_len < 4:
+        return None
+
+    running_tokens = 0
+    best: Optional[CompactionPrefix] = None
+    hard_ceiling = max(target_tokens, int(target_tokens * 1.25))
+    for index, message in enumerate(conversational[:max_prefix_len]):
+        clean = {
+            key: value
+            for key, value in message.items()
+            if key != "_state_message_id"
+        }
+        running_tokens += estimate_messages_tokens_rough([clean])
+        prefix_len = index + 1
+        if prefix_len < 4:
+            continue
+        next_message = conversational[prefix_len]
+        if next_message.get("role") != "user":
+            if running_tokens > hard_ceiling and best is not None:
+                break
+            continue
+        if running_tokens <= target_tokens:
+            best = CompactionPrefix(
+                messages=[
+                    {
+                        key: value
+                        for key, value in item.items()
+                        if key != "_state_message_id"
+                    }
+                    for item in conversational[:prefix_len]
+                ],
+                last_state_message_id=int(message["_state_message_id"]),
+                estimated_tokens=running_tokens,
+            )
+            continue
+        # A single unusually large turn may cross the target before any clean
+        # boundary. Permit a small overshoot, but never feed an unbounded
+        # transcript to the background summarizer.
+        if best is None and running_tokens <= hard_ceiling:
+            best = CompactionPrefix(
+                messages=[
+                    {
+                        key: value
+                        for key, value in item.items()
+                        if key != "_state_message_id"
+                    }
+                    for item in conversational[:prefix_len]
+                ],
+                last_state_message_id=int(message["_state_message_id"]),
+                estimated_tokens=running_tokens,
+            )
+        break
+    if best is None:
+        return None
+
+    # The database commit replaces every active row through the selected
+    # message ID.  Never let an unrecognised row (for example a legacy
+    # persisted ``system``/``developer`` message) get swept into that range
+    # without being summarized. Normal gateway transcripts contain only the
+    # four roles above; unusual/legacy transcripts safely fall back to the
+    # foreground compressor, which receives their complete message list.
+    covered_roles = {
+        message.get("role")
+        for message in messages
+        if isinstance(message, dict)
+        and message.get("_state_message_id") is not None
+        and int(message["_state_message_id"]) <= best.last_state_message_id
+    }
+    if not covered_roles.issubset({"user", "assistant", "tool", "function"}):
+        return None
+    return best
+
+
+class GatewayBackgroundCompactionMixin:
+    """GatewayRunner mixin implementing best-effort background compaction."""
+
+    if TYPE_CHECKING:
+        _session_db: Any
+        async_session_store: Any
+        _turn_leases: Any
+        _background_tasks: set[asyncio.Task[Any]]
+
+        def _resolve_session_agent_runtime(self, **kwargs: Any) -> tuple[str, dict]: ...
+
+        async def _run_in_executor_with_context(
+            self, func: Any, *args: Any
+        ) -> Any: ...
+
+        def _evict_cached_agent(self, session_key: str) -> None: ...
+
+    def _init_background_compaction(self) -> None:
+        self._background_compaction_tasks: Dict[str, asyncio.Task] = {}
+        self._background_compaction_generation = 0
+
+    def _background_compaction_settings(self) -> tuple[BackgroundCompactionSettings, dict]:
+        # Runtime import avoids a module cycle: gateway.run imports this mixin.
+        from gateway.run import _load_gateway_config
+
+        config = _load_gateway_config()
+        return BackgroundCompactionSettings.from_config(config), config
+
+    def _maybe_schedule_background_compaction(
+        self,
+        *,
+        source: Any,
+        session_key: str,
+        session_id: str,
+        observed_prompt_tokens: int,
+        context_length: int,
+    ) -> bool:
+        """Schedule one compactor for a session when the soft limit is crossed."""
+        if not session_id or getattr(self, "_session_db", None) is None:
+            return False
+        settings, config = self._background_compaction_settings()
+        if not settings.enabled:
+            return False
+        try:
+            observed = int(observed_prompt_tokens or 0)
+            context = int(context_length or 0)
+        except (TypeError, ValueError):
+            return False
+        if observed <= 0 or context <= 0:
+            return False
+        if observed < int(context * settings.threshold):
+            return False
+
+        task_map = getattr(self, "_background_compaction_tasks", None)
+        if not isinstance(task_map, dict):
+            self._init_background_compaction()
+            task_map = self._background_compaction_tasks
+        existing = task_map.get(session_id)
+        if existing is not None and not existing.done():
+            return False
+
+        self._background_compaction_generation += 1
+        generation = self._background_compaction_generation
+        task = asyncio.create_task(
+            self._run_background_compaction(
+                source=source,
+                session_key=session_key,
+                session_id=session_id,
+                observed_prompt_tokens=observed,
+                context_length=context,
+                settings=settings,
+                user_config=config,
+                generation=generation,
+            ),
+            name=f"background-compaction:{session_id}",
+        )
+        task_map[session_id] = task
+        background_tasks = getattr(self, "_background_tasks", None)
+        if not isinstance(background_tasks, set):
+            background_tasks = set()
+            self._background_tasks = background_tasks
+        background_tasks.add(task)
+
+        def _discard(done: asyncio.Task) -> None:
+            background_tasks.discard(done)
+            if task_map.get(session_id) is done:
+                task_map.pop(session_id, None)
+
+        task.add_done_callback(_discard)
+        logger.info(
+            "Background compaction scheduled: session=%s tokens=%s/%s threshold=%d%%",
+            session_id,
+            f"{observed:,}",
+            f"{context:,}",
+            int(settings.threshold * 100),
+        )
+        return True
+
+    async def _run_background_compaction(
+        self,
+        *,
+        source: Any,
+        session_key: str,
+        session_id: str,
+        observed_prompt_tokens: int,
+        context_length: int,
+        settings: BackgroundCompactionSettings,
+        user_config: dict,
+        generation: int,
+    ) -> None:
+        started = time.monotonic()
+        try:
+            snapshot = await self._session_db.get_compaction_snapshot(session_id)
+            if snapshot.get("status") != "ready":
+                logger.info(
+                    "Background compaction skipped: session=%s snapshot=%s",
+                    session_id,
+                    snapshot.get("status"),
+                )
+                return
+
+            messages = snapshot.get("messages") or []
+            active_ids = snapshot.get("active_message_ids") or []
+            chunk_target = min(
+                settings.chunk_tokens,
+                max(16_000, int(context_length * 0.35)),
+            )
+            prefix = select_compaction_prefix(
+                messages,
+                target_tokens=chunk_target,
+                protect_tail_messages=settings.protect_tail_messages,
+            )
+            if prefix is None:
+                logger.info(
+                    "Background compaction skipped: session=%s has no safe bounded prefix",
+                    session_id,
+                )
+                return
+            expected_prefix_ids = [
+                int(message_id)
+                for message_id in active_ids
+                if int(message_id) <= prefix.last_state_message_id
+            ]
+            if not expected_prefix_ids:
+                return
+
+            model, runtime = self._resolve_session_agent_runtime(
+                source=source,
+                session_key=session_key,
+                user_config=user_config,
+            )
+            if str(runtime.get("api_mode") or "").lower() == "codex_app_server":
+                # Codex owns the actual remote thread; rewriting only Hermes'
+                # local transcript cannot shrink that context.
+                logger.info(
+                    "Background compaction skipped for Codex app-server session %s",
+                    session_id,
+                )
+                return
+
+            context_config = (
+                user_config.get("context", {})
+                if isinstance(user_config, dict)
+                else {}
+            )
+            if isinstance(context_config, dict):
+                context_engine = str(
+                    context_config.get("engine") or "compressor"
+                ).strip().lower()
+            else:
+                context_engine = "compressor"
+            if context_engine != "compressor":
+                # A plugin engine owns its own durable context state. Rewriting
+                # the SQLite transcript behind it would violate that engine's
+                # lifecycle contract.
+                logger.info(
+                    "Background compaction skipped for context engine %s: session=%s",
+                    context_engine,
+                    session_id,
+                )
+                return
+
+            def _summarize_prefix():
+                from agent.context_compressor import ContextCompressor
+
+                compression_config = user_config.get("compression", {})
+                if not isinstance(compression_config, dict):
+                    compression_config = {}
+                try:
+                    threshold = float(compression_config.get("threshold", 0.50))
+                except (TypeError, ValueError):
+                    threshold = 0.50
+                try:
+                    protect_first = int(
+                        compression_config.get("protect_first_n", 3)
+                    )
+                except (TypeError, ValueError):
+                    protect_first = 3
+                try:
+                    target_ratio = float(
+                        compression_config.get("target_ratio", 0.20)
+                    )
+                except (TypeError, ValueError):
+                    target_ratio = 0.20
+                compressor = ContextCompressor(
+                    model=model,
+                    threshold_percent=threshold,
+                    protect_first_n=max(0, protect_first),
+                    protect_last_n=settings.protect_tail_messages,
+                    summary_target_ratio=target_ratio,
+                    quiet_mode=True,
+                    base_url=runtime.get("base_url") or "",
+                    api_key=runtime.get("api_key") or "",
+                    config_context_length=context_length,
+                    provider=runtime.get("provider") or "",
+                    api_mode=runtime.get("api_mode") or "",
+                    # Background publication is optional. A failed summary
+                    # must leave the original prefix untouched rather than
+                    # committing a deterministic failure marker.
+                    abort_on_summary_failure=True,
+                    max_tokens=runtime.get("max_tokens"),
+                )
+                compressor.force_main_runtime = settings.use_main_model
+                compressed = compressor.compress(
+                    prefix.messages,
+                    current_tokens=prefix.estimated_tokens,
+                )
+                aborted = bool(getattr(compressor, "_last_compress_aborted", False))
+                return compressed, aborted
+
+            compacted_prefix, aborted = (
+                await self._run_in_executor_with_context(_summarize_prefix)
+            )
+            if aborted or not compacted_prefix:
+                logger.warning(
+                    "Background compaction summary aborted: session=%s",
+                    session_id,
+                )
+                return
+
+            from agent.model_metadata import estimate_messages_tokens_rough
+
+            compacted_tokens = estimate_messages_tokens_rough(compacted_prefix)
+            if compacted_tokens >= int(prefix.estimated_tokens * 0.95):
+                logger.info(
+                    "Background compaction made insufficient progress: session=%s "
+                    "tokens=%s->%s",
+                    session_id,
+                    f"{prefix.estimated_tokens:,}",
+                    f"{compacted_tokens:,}",
+                )
+                return
+
+            lease_registry = getattr(self, "_turn_leases", None)
+            lease_token = None
+            if lease_registry is not None:
+                lease_token = await lease_registry.acquire(
+                    session_id,
+                    owner_key=f"{session_key}:background-compaction",
+                    generation=generation,
+                    timeout=30.0,
+                )
+                if lease_token is not None and getattr(lease_token, "degraded", False):
+                    logger.info(
+                        "Background compaction commit skipped after turn-lease timeout: %s",
+                        session_id,
+                    )
+                    return
+
+            lock_holder = (
+                f"background:{os.getpid()}:{generation}:{time.monotonic_ns()}"
+            )
+            lock_acquired = False
+            try:
+                lock_acquired = await self._session_db.try_acquire_compression_lock(
+                    session_id,
+                    lock_holder,
+                    ttl_seconds=60.0,
+                )
+                if not lock_acquired:
+                    logger.info(
+                        "Background compaction commit skipped: compression lock busy for %s",
+                        session_id,
+                    )
+                    return
+                result = await self._session_db.commit_compaction_snapshot(
+                    session_id,
+                    expected_prefix_ids,
+                    compacted_prefix,
+                )
+            finally:
+                if lock_acquired:
+                    await self._session_db.release_compression_lock(
+                        session_id, lock_holder
+                    )
+                if lease_registry is not None and lease_token is not None:
+                    lease_registry.release(lease_token)
+
+            if result.get("status") != "committed":
+                logger.info(
+                    "Background compaction result discarded: session=%s reason=%s",
+                    session_id,
+                    result.get("reason", result.get("status")),
+                )
+                return
+
+            await self.async_session_store.update_session(
+                session_key,
+                last_prompt_tokens=0,
+            )
+            self._evict_cached_agent(session_key)
+            logger.info(
+                "Background compaction committed: session=%s prefix=%d tail=%d "
+                "tokens=%s->%s duration=%.1fs",
+                session_id,
+                result.get("archived_prefix_count", 0),
+                result.get("preserved_tail_count", 0),
+                f"{prefix.estimated_tokens:,}",
+                f"{compacted_tokens:,}",
+                time.monotonic() - started,
+            )
+        except asyncio.CancelledError:
+            logger.info("Background compaction cancelled: session=%s", session_id)
+            raise
+        except Exception:
+            logger.warning(
+                "Background compaction failed: session=%s",
+                session_id,
+                exc_info=True,
+            )
+
+
+__all__ = [
+    "BackgroundCompactionSettings",
+    "CompactionPrefix",
+    "GatewayBackgroundCompactionMixin",
+    "select_compaction_prefix",
+]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1924,6 +1924,7 @@ from gateway.session import (
 from gateway.delivery import DeliveryRouter, looks_like_telegram_private_chat_id
 from gateway.turn_lease import SessionTurnLeaseRegistry
 from gateway.authz_mixin import GatewayAuthorizationMixin
+from gateway.background_compaction import GatewayBackgroundCompactionMixin
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
 from gateway.platforms.base import (
@@ -3056,7 +3057,12 @@ def _reconnect_backoff(attempt: int) -> int:
     return min(30 * (2 ** (attempt - 1)), _RECONNECT_BACKOFF_CAP)
 
 
-class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
+class GatewayRunner(
+    GatewayBackgroundCompactionMixin,
+    GatewayAuthorizationMixin,
+    GatewayKanbanWatchersMixin,
+    GatewaySlashCommandsMixin,
+):
     """
     Main gateway controller.
 
@@ -3455,6 +3461,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
+        self._init_background_compaction()
 
         # Event-loop liveness heartbeat (#66892): rewritten every 30s while
         # the loop is dispatching. External supervisors use the file mtime /
@@ -11465,6 +11472,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
 
+        _agent_result = None
         try:
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
             # Goal continuation: after the agent returns a final response
@@ -11519,6 +11527,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # (routing key, run generation) so this unwind can only ever free
             # the lease its own turn acquired, never a newer turn's.
             self._release_turn_lease(_quick_key, _run_generation)
+            # Response delivery and transcript persistence are complete at this
+            # point. Start soft-threshold compaction only after releasing the
+            # foreground session/turn leases; the summary model call then runs
+            # fully in the background and publication reacquires only a short
+            # commit lease with a DB prefix-CAS.
+            if (
+                isinstance(_agent_result, dict)
+                and not _agent_result.get("interrupted")
+                and not _agent_result.get("failed")
+            ):
+                try:
+                    self._maybe_schedule_background_compaction(
+                        source=source,
+                        session_key=_quick_key,
+                        session_id=str(_agent_result.get("session_id") or ""),
+                        observed_prompt_tokens=int(
+                            _agent_result.get("last_prompt_tokens") or 0
+                        ),
+                        context_length=int(
+                            _agent_result.get("context_length") or 0
+                        ),
+                    )
+                except Exception:
+                    logger.warning(
+                        "Could not schedule background compaction for %s",
+                        _quick_key,
+                        exc_info=True,
+                    )
 
     def _restore_moa_one_shot(self, event: "MessageEvent", quick_key: str) -> None:
         """Revert a ``/moa <prompt>`` one-shot model override after its turn.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1471,6 +1471,13 @@ DEFAULT_CONFIG = {
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
         "hygiene_hard_message_limit": 5000,  # gateway session-hygiene force-compress threshold by message count
+        "background_enabled": True,   # gateway: summarize an old transcript prefix
+                                      # after response delivery instead of blocking
+                                      # the next turn at the hard hygiene threshold
+        "background_threshold": 0.65, # gateway soft trigger as context-window ratio
+        "background_chunk_tokens": 96000,  # bounded prefix sent per background pass
+        "background_use_main_model": True,  # keep background summaries on the
+                                      # session's current chat provider/model
         "protect_first_n": 3,         # non-system head messages always preserved
                                       # verbatim, in ADDITION to the system prompt
                                       # (which is always implicitly protected). Set to
@@ -8434,6 +8441,20 @@ def show_config():
     print(f"  Enabled:      {'yes' if enabled else 'no'}")
     if enabled:
         print(f"  Threshold:    {compression.get('threshold', 0.50) * 100:.0f}%")
+        _bg_raw = compression.get('background_enabled', True)
+        _bg_enabled = _bg_raw if isinstance(_bg_raw, bool) else str(_bg_raw).strip().lower() in {'1', 'true', 'yes', 'on'}
+        print(f"  Background:   {'yes' if _bg_enabled else 'no'}")
+        if _bg_enabled:
+            try:
+                _bg_threshold = float(compression.get('background_threshold', 0.65))
+            except (TypeError, ValueError):
+                _bg_threshold = 0.65
+            try:
+                _bg_chunk = int(compression.get('background_chunk_tokens', 96000))
+            except (TypeError, ValueError):
+                _bg_chunk = 96000
+            print(f"  BG threshold: {_bg_threshold * 100:.0f}%")
+            print(f"  BG chunk:     {_bg_chunk:,} tokens")
         print(f"  Target ratio: {compression.get('target_ratio', 0.20) * 100:.0f}% of threshold preserved")
         print(f"  Protect last: {compression.get('protect_last_n', 20)} messages")
         print(f"  Protect first: {compression.get('protect_first_n', 3)} non-system head messages")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1083,6 +1083,14 @@ class SessionDB:
     _WRITE_RETRY_MAX_S = 0.150   # 150ms
     # Attempt a WAL checkpoint every N successful writes (PASSIVE mode).
     _CHECKPOINT_EVERY_N_WRITES = 50
+    # Keep the reusable WAL high-water mark bounded after a successful reset.
+    # PASSIVE checkpoints deliberately avoid exclusive locking and therefore
+    # do not truncate the file themselves; journal_size_limit asks SQLite to
+    # trim the WAL after a reset while retaining a modest buffer for steady
+    # write throughput.  Active readers may postpone the reset, so this is a
+    # safe eventual bound rather than a reason to force TRUNCATE on the hot
+    # write path.
+    _WAL_JOURNAL_SIZE_LIMIT_BYTES = 64 * 1024 * 1024
     # Merge fragmented FTS5 segments every N successful writes. The message
     # triggers append one segment per insert; left unmaintained these grow
     # into tens of thousands of segments, so every MATCH must scan them all
@@ -1156,6 +1164,7 @@ class SessionDB:
                 )
                 self._conn.row_factory = sqlite3.Row
                 apply_wal_with_fallback(self._conn, db_label="state.db")
+                self._configure_journal_size_limit()
                 self._conn.execute("PRAGMA foreign_keys=ON")
                 self._init_schema()
 
@@ -1487,10 +1496,12 @@ class SessionDB:
         periodic use because it does not block concurrent writers and
         cannot corrupt B-tree pages under I/O pressure.
 
-        PASSIVE does not truncate the WAL file — it stays at its
-        high-water mark.  WAL truncation happens in :meth:`close`
-        (TRUNCATE) and pre-VACUUM checkpoints, which run infrequently
-        under controlled conditions.
+        PASSIVE itself does not truncate the WAL file. Once every frame is
+        checkpointed, the next writer can reset the WAL and SQLite applies
+        ``journal_size_limit`` (configured to 64 MiB), preventing a multi-GB
+        high-water mark from persisting indefinitely. Explicit truncation is
+        reserved for :meth:`close` and pre-VACUUM checkpoints, which run
+        infrequently under controlled conditions.
 
         Previous TRUNCATE strategy caused B-tree corruption on large
         databases (65K+ pages) due to the exclusive-lock I/O pressure
@@ -1508,6 +1519,30 @@ class SessionDB:
                     )
         except Exception as exc:
             logger.warning("WAL checkpoint (PASSIVE) failed: %s", exc)
+
+    def _configure_journal_size_limit(self) -> None:
+        """Apply the bounded WAL/journal high-water mark. Never raises.
+
+        ``journal_size_limit`` is connection-persistent database state, but
+        every writable SessionDB applies it so a restored or externally
+        created database converges without a migration. SQLite enforces the
+        limit only when a journal/WAL reset can complete; long-lived readers
+        remain non-blocking and the periodic PASSIVE checkpoint retries later.
+        """
+        try:
+            row = self._conn.execute(
+                f"PRAGMA journal_size_limit={self._WAL_JOURNAL_SIZE_LIMIT_BYTES}"
+            ).fetchone()
+            applied = int(row[0]) if row else -1
+            if applied != self._WAL_JOURNAL_SIZE_LIMIT_BYTES:
+                logger.warning(
+                    "state.db journal_size_limit requested %d bytes but SQLite "
+                    "reported %d bytes",
+                    self._WAL_JOURNAL_SIZE_LIMIT_BYTES,
+                    applied,
+                )
+        except Exception as exc:
+            logger.warning("Could not configure state.db journal_size_limit: %s", exc)
 
     def _try_optimize_fts(self) -> None:
         """Best-effort FTS5 segment merge. Never raises.
@@ -4515,6 +4550,163 @@ class SessionDB:
             )
             return cursor.fetchone() is not None
 
+    def get_compaction_snapshot(self, session_id: str) -> Dict[str, Any]:
+        """Return an ID-stamped snapshot of a session's active transcript.
+
+        Background compaction performs the expensive summary call without a
+        database lock. Stable message IDs let the later commit prove that the
+        snapshotted prefix is still the live prefix while allowing new turns
+        to append behind it.
+        """
+        with self._lock:
+            session_row = self._conn.execute(
+                "SELECT ended_at FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if session_row is None:
+                return {
+                    "status": "missing",
+                    "session_id": session_id,
+                    "active_message_ids": [],
+                    "messages": [],
+                }
+            if session_row["ended_at"] is not None:
+                return {
+                    "status": "ended",
+                    "session_id": session_id,
+                    "active_message_ids": [],
+                    "messages": [],
+                }
+            rows = self._conn.execute(
+                f"SELECT id, {self._CONVERSATION_ROW_COLUMNS} "
+                "FROM messages WHERE session_id = ? AND active = 1 ORDER BY id",
+                (session_id,),
+            ).fetchall()
+
+        return {
+            "status": "ready",
+            "session_id": session_id,
+            "active_message_ids": [int(row["id"]) for row in rows],
+            "messages": self._rows_to_conversation(
+                rows,
+                session_id=session_id,
+                include_ancestors=False,
+                repair_alternation=False,
+                include_state_message_id=True,
+            ),
+        }
+
+    def commit_compaction_snapshot(
+        self,
+        session_id: str,
+        expected_prefix_ids: List[int],
+        compacted_prefix: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Atomically publish a background-compacted transcript prefix.
+
+        The commit succeeds only when ``expected_prefix_ids`` still exactly
+        matches the active transcript's prefix. Rows appended after the
+        snapshot are decoded and reinserted after ``compacted_prefix`` in the
+        same transaction, so users may continue chatting while the summary is
+        generated. Rewinds, resets, foreground compression, and session end
+        make the result stale and leave the transcript unchanged.
+
+        Superseded prefix rows are soft-archived with ``compacted=1`` so they
+        remain searchable. The unchanged live tail must be reinserted to put
+        it after the new summary in AUTOINCREMENT order; its superseded copies
+        use ``compacted=0`` so search does not return duplicate tail hits.
+        """
+        try:
+            prefix_ids = [int(value) for value in expected_prefix_ids]
+        except (TypeError, ValueError):
+            prefix_ids = []
+        cleaned_prefix = [
+            {
+                key: value
+                for key, value in message.items()
+                if key != "_state_message_id"
+            }
+            for message in compacted_prefix
+            if isinstance(message, dict)
+        ]
+        if not prefix_ids or not cleaned_prefix:
+            return {
+                "status": "stale",
+                "reason": "empty_prefix",
+                "session_id": session_id,
+            }
+
+        def _do(conn):
+            session_row = conn.execute(
+                "SELECT ended_at FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if session_row is None:
+                return {
+                    "status": "stale",
+                    "reason": "missing_session",
+                    "session_id": session_id,
+                }
+            if session_row["ended_at"] is not None:
+                return {
+                    "status": "stale",
+                    "reason": "ended_session",
+                    "session_id": session_id,
+                }
+
+            current_rows = conn.execute(
+                f"SELECT id, {self._CONVERSATION_ROW_COLUMNS} "
+                "FROM messages WHERE session_id = ? AND active = 1 ORDER BY id",
+                (session_id,),
+            ).fetchall()
+            current_ids = [int(row["id"]) for row in current_rows]
+            prefix_len = len(prefix_ids)
+            if current_ids[:prefix_len] != prefix_ids:
+                return {
+                    "status": "stale",
+                    "reason": "prefix_changed",
+                    "session_id": session_id,
+                    "active_count": len(current_ids),
+                }
+
+            tail_rows = current_rows[prefix_len:]
+            tail_messages = self._rows_to_conversation(
+                tail_rows,
+                session_id=session_id,
+                include_ancestors=False,
+                repair_alternation=False,
+            )
+
+            # The rows stay recoverable, but only the actually summarized
+            # prefix is marked compacted/searchable. Old copies of the
+            # preserved tail are hidden to avoid duplicate search results.
+            prefix_last_id = prefix_ids[-1]
+            conn.execute(
+                "UPDATE messages SET active = 0, "
+                "compacted = CASE WHEN id <= ? THEN 1 ELSE 0 END "
+                "WHERE session_id = ? AND active = 1",
+                (prefix_last_id, session_id),
+            )
+
+            live_messages = cleaned_prefix + tail_messages
+            inserted, tool_calls_total = self._insert_message_rows(
+                conn, session_id, live_messages
+            )
+            conn.execute(
+                "UPDATE sessions SET message_count = ?, tool_call_count = ? "
+                "WHERE id = ?",
+                (inserted, tool_calls_total, session_id),
+            )
+            return {
+                "status": "committed",
+                "session_id": session_id,
+                "active_count": inserted,
+                "archived_prefix_count": prefix_len,
+                "preserved_tail_count": len(tail_messages),
+            }
+
+        return self._execute_write(_do)
+
     def archive_and_compact(
         self, session_id: str, compacted_messages: List[Dict[str, Any]]
     ) -> int:
@@ -5010,6 +5202,7 @@ class SessionDB:
         session_id: str,
         include_ancestors: bool,
         repair_alternation: bool,
+        include_state_message_id: bool = False,
     ) -> List[Dict[str, Any]]:
         """Decode fetched message rows into the OpenAI conversation format.
 
@@ -5024,6 +5217,8 @@ class SessionDB:
             if row["role"] in {"user", "assistant"} and isinstance(content, str):
                 content = sanitize_context(content).strip()
             msg = {"role": row["role"], "content": content}
+            if include_state_message_id:
+                msg["_state_message_id"] = int(row["id"])
             # api_content is the byte-fidelity sidecar: the exact string sent
             # to the API when it differed from the clean content. Returned
             # VERBATIM — no sanitize_context, no strip — because the replay

--- a/tests/test_background_compaction.py
+++ b/tests/test_background_compaction.py
@@ -1,0 +1,360 @@
+"""Behavior tests for non-blocking gateway transcript compaction."""
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gateway.background_compaction import (
+    BackgroundCompactionSettings,
+    GatewayBackgroundCompactionMixin,
+    select_compaction_prefix,
+)
+from hermes_state import AsyncSessionDB, SessionDB
+from agent.context_compressor import ContextCompressor
+from gateway.turn_lease import SessionTurnLeaseRegistry
+
+
+@pytest.fixture()
+def db(tmp_path):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.create_session("session-1", source="discord", model="test-model")
+    yield session_db
+    session_db.close()
+
+
+def _append_exchange(db, label):
+    db.append_message("session-1", role="user", content=f"user {label}")
+    db.append_message("session-1", role="assistant", content=f"assistant {label}")
+
+
+def test_snapshot_commit_preserves_turns_appended_during_summary(db):
+    _append_exchange(db, "one")
+    _append_exchange(db, "two")
+    _append_exchange(db, "three")
+    snapshot = db.get_compaction_snapshot("session-1")
+    prefix_ids = snapshot["active_message_ids"][:4]
+
+    # This exchange lands while the model is supposedly generating a summary.
+    _append_exchange(db, "four")
+
+    result = db.commit_compaction_snapshot(
+        "session-1",
+        prefix_ids,
+        [{"role": "user", "content": "Summary of exchanges one and two."}],
+    )
+
+    assert result == {
+        "status": "committed",
+        "session_id": "session-1",
+        "active_count": 5,
+        "archived_prefix_count": 4,
+        "preserved_tail_count": 4,
+    }
+    active = db.get_messages_as_conversation("session-1")
+    assert [message["content"] for message in active] == [
+        "Summary of exchanges one and two.",
+        "user three",
+        "assistant three",
+        "user four",
+        "assistant four",
+    ]
+    archived = db._conn.execute(
+        "SELECT content, compacted FROM messages "
+        "WHERE session_id = ? AND active = 0 ORDER BY id",
+        ("session-1",),
+    ).fetchall()
+    assert [row["compacted"] for row in archived[:4]] == [1, 1, 1, 1]
+    # Superseded copies of the unchanged tail are recoverable but hidden from
+    # search to avoid duplicate results.
+    assert [row["compacted"] for row in archived[4:]] == [0, 0, 0, 0]
+
+
+def test_snapshot_commit_discards_result_after_history_rewrite(db):
+    _append_exchange(db, "one")
+    _append_exchange(db, "two")
+    snapshot = db.get_compaction_snapshot("session-1")
+
+    replacement = [
+        {"role": "user", "content": "replacement user"},
+        {"role": "assistant", "content": "replacement assistant"},
+    ]
+    db.replace_messages("session-1", replacement, active_only=True)
+    result = db.commit_compaction_snapshot(
+        "session-1",
+        snapshot["active_message_ids"][:2],
+        [{"role": "user", "content": "stale summary"}],
+    )
+
+    assert result["status"] == "stale"
+    assert result["reason"] == "prefix_changed"
+    active = db.get_messages_as_conversation("session-1")
+    assert [(message["role"], message["content"]) for message in active] == [
+        ("user", "replacement user"),
+        ("assistant", "replacement assistant"),
+    ]
+
+
+def test_snapshot_commit_discards_result_after_session_end(db):
+    _append_exchange(db, "one")
+    snapshot = db.get_compaction_snapshot("session-1")
+    db.end_session("session-1", "reset")
+
+    result = db.commit_compaction_snapshot(
+        "session-1",
+        snapshot["active_message_ids"],
+        [{"role": "user", "content": "stale summary"}],
+    )
+
+    assert result["status"] == "stale"
+    assert result["reason"] == "ended_session"
+    assert [m["content"] for m in db.get_messages_as_conversation("session-1")] == [
+        "user one",
+        "assistant one",
+    ]
+
+
+def test_snapshot_ids_are_internal_to_snapshot_projection(db):
+    _append_exchange(db, "one")
+    snapshot = db.get_compaction_snapshot("session-1")
+
+    assert all("_state_message_id" in message for message in snapshot["messages"])
+    assert all(
+        "_state_message_id" not in message
+        for message in db.get_messages_as_conversation("session-1")
+    )
+
+
+def test_prefix_selection_stops_at_clean_turn_boundary_and_keeps_tail():
+    messages = []
+    for index in range(8):
+        role = "user" if index % 2 == 0 else "assistant"
+        messages.append(
+            {
+                "role": role,
+                "content": f"{role}-{index} " + ("x" * 500),
+                "_state_message_id": index + 1,
+            }
+        )
+
+    prefix = select_compaction_prefix(
+        messages,
+        target_tokens=1_000,
+        protect_tail_messages=4,
+    )
+
+    assert prefix is not None
+    assert len(prefix.messages) == 4
+    assert prefix.messages[-1]["role"] == "assistant"
+    assert messages[len(prefix.messages)]["role"] == "user"
+    assert prefix.last_state_message_id == 4
+    assert all("_state_message_id" not in message for message in prefix.messages)
+
+
+def test_prefix_selection_never_drops_unrecognised_covered_roles():
+    messages = [
+        {
+            "role": "system",
+            "content": "legacy persisted system prompt",
+            "_state_message_id": 1,
+        }
+    ]
+    for index in range(8):
+        role = "user" if index % 2 == 0 else "assistant"
+        messages.append(
+            {
+                "role": role,
+                "content": f"{role}-{index} " + ("x" * 500),
+                "_state_message_id": index + 2,
+            }
+        )
+
+    assert (
+        select_compaction_prefix(
+            messages,
+            target_tokens=1_000,
+            protect_tail_messages=4,
+        )
+        is None
+    )
+
+
+def test_background_settings_are_safe_and_use_main_model_by_default():
+    settings = BackgroundCompactionSettings.from_config(
+        {
+            "compression": {
+                "background_threshold": 9,
+                "background_chunk_tokens": 10,
+            }
+        }
+    )
+
+    assert settings.threshold == 0.84
+    assert settings.chunk_tokens == 16_000
+    assert settings.use_main_model is True
+
+
+def test_background_summary_force_routes_to_active_chat_runtime():
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=200_000,
+    ):
+        compressor = ContextCompressor(
+            model="grok-chat-model",
+            provider="xai-oauth",
+            base_url="https://example.invalid/v1",
+            api_key="fake-key",
+            quiet_mode=True,
+        )
+    compressor.force_main_runtime = True
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="Summary body"))]
+    )
+
+    with patch("agent.context_compressor.call_llm", return_value=response) as call:
+        summary = compressor._generate_summary(
+            [
+                {"role": "user", "content": "question"},
+                {"role": "assistant", "content": "answer"},
+            ]
+        )
+
+    assert "Summary body" in summary
+    kwargs = call.call_args.kwargs
+    assert kwargs["task"] == "compression"
+    assert kwargs["provider"] == "xai-oauth"
+    assert kwargs["model"] == "grok-chat-model"
+    assert kwargs["base_url"] == "https://example.invalid/v1"
+    assert kwargs["api_key"] == "fake-key"
+
+
+class _SchedulerHarness(GatewayBackgroundCompactionMixin):
+    def __init__(self):
+        self._session_db = object()
+        self._background_tasks = set()
+        self._init_background_compaction()
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    def _background_compaction_settings(self):
+        return BackgroundCompactionSettings(), {}
+
+    async def _run_background_compaction(self, **kwargs):
+        self.started.set()
+        await self.release.wait()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_deduplicates_one_job_per_durable_session():
+    runner = _SchedulerHarness()
+    first = runner._maybe_schedule_background_compaction(
+        source=object(),
+        session_key="discord:chat",
+        session_id="session-1",
+        observed_prompt_tokens=70,
+        context_length=100,
+    )
+    await runner.started.wait()
+    second = runner._maybe_schedule_background_compaction(
+        source=object(),
+        session_key="discord:alias",
+        session_id="session-1",
+        observed_prompt_tokens=80,
+        context_length=100,
+    )
+
+    assert first is True
+    assert second is False
+    assert len(runner._background_compaction_tasks) == 1
+    runner.release.set()
+    await asyncio.gather(*runner._background_tasks)
+
+
+class _AsyncSessionStoreStub:
+    def __init__(self):
+        self.updates = []
+
+    async def update_session(self, session_key, last_prompt_tokens=None):
+        self.updates.append((session_key, last_prompt_tokens))
+
+
+class _BackgroundRunHarness(GatewayBackgroundCompactionMixin):
+    def __init__(self, db):
+        self._session_db = AsyncSessionDB(db)
+        self._turn_leases = SessionTurnLeaseRegistry()
+        self.async_session_store = _AsyncSessionStoreStub()
+        self.evicted = []
+
+    def _resolve_session_agent_runtime(self, **kwargs):
+        return "test-model", {
+            "provider": "custom",
+            "base_url": "https://example.invalid/v1",
+            "api_key": "fake-key",
+            "api_mode": "chat_completions",
+            "max_tokens": None,
+        }
+
+    async def _run_in_executor_with_context(self, func, *args):
+        return await asyncio.to_thread(func, *args)
+
+    def _evict_cached_agent(self, session_key):
+        self.evicted.append(session_key)
+
+
+@pytest.mark.asyncio
+async def test_background_run_allows_append_during_model_call_and_commits(db, monkeypatch):
+    for index in range(15):
+        db.append_message(
+            "session-1",
+            role="user",
+            content=f"old user {index} " + ("u" * 1_000),
+        )
+        db.append_message(
+            "session-1",
+            role="assistant",
+            content=f"old assistant {index} " + ("a" * 1_000),
+        )
+
+    summary_started = threading.Event()
+    release_summary = threading.Event()
+
+    def _blocking_summary(self, messages, **kwargs):
+        summary_started.set()
+        assert release_summary.wait(timeout=5)
+        return [{"role": "user", "content": "background summary"}]
+
+    monkeypatch.setattr(ContextCompressor, "compress", _blocking_summary)
+    runner = _BackgroundRunHarness(db)
+    task = asyncio.create_task(
+        runner._run_background_compaction(
+            source=object(),
+            session_key="discord:chat",
+            session_id="session-1",
+            observed_prompt_tokens=70_000,
+            context_length=100_000,
+            settings=BackgroundCompactionSettings(
+                chunk_tokens=16_000,
+                protect_tail_messages=4,
+            ),
+            user_config={"context": {"engine": "compressor"}},
+            generation=1,
+        )
+    )
+    assert await asyncio.to_thread(summary_started.wait, 5)
+
+    # The model call is still blocked, but the canonical DB accepts the next
+    # exchange. Prefix-CAS publication must rebase this tail, not discard it.
+    await asyncio.to_thread(_append_exchange, db, "during summary")
+    release_summary.set()
+    await task
+
+    active = db.get_messages_as_conversation("session-1")
+    assert active[0]["content"] == "background summary"
+    assert [message["content"] for message in active[-2:]] == [
+        "user during summary",
+        "assistant during summary",
+    ]
+    assert runner.async_session_store.updates == [("discord:chat", 0)]
+    assert runner.evicted == ["discord:chat"]

--- a/tests/test_wal_checkpoint_strategy.py
+++ b/tests/test_wal_checkpoint_strategy.py
@@ -6,6 +6,7 @@ while close() and pre-VACUUM paths still use TRUNCATE.
 
 import sqlite3
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -71,6 +72,44 @@ class TestTryWalCheckpointPassive:
     def test_checkpoint_returns_result_on_success(self, db):
         """Successful PASSIVE checkpoint does not raise."""
         db._try_wal_checkpoint()
+
+
+class TestWalJournalSizeLimit:
+    """Writable state DBs keep the reusable WAL high-water mark bounded."""
+
+    def test_session_db_configures_journal_size_limit(self, db):
+        configured = db._conn.execute("PRAGMA journal_size_limit").fetchone()[0]
+
+        assert configured == db._WAL_JOURNAL_SIZE_LIMIT_BYTES
+
+    def test_successful_passive_reset_applies_journal_size_limit(self, db):
+        # Use a small per-test limit so the invariant is exercised without a
+        # 64 MiB fixture. Production keeps the same behavior with a 64 MiB cap.
+        test_limit = 64 * 1024
+        db._conn.execute(f"PRAGMA journal_size_limit={test_limit}")
+        db._conn.execute("PRAGMA wal_autocheckpoint=0")
+        db._conn.execute("CREATE TABLE wal_payload (value BLOB)")
+        payload = b"x" * (256 * 1024)
+        for _ in range(8):
+            db._execute_write(
+                lambda conn: conn.execute(
+                    "INSERT INTO wal_payload (value) VALUES (?)", (payload,)
+                )
+            )
+
+        wal_path = f"{db.db_path}-wal"
+        assert os.path.getsize(wal_path) > test_limit
+        db._try_wal_checkpoint()
+        # PASSIVE copies all frames without taking the exclusive lock needed
+        # to reset the file. The next writer observes the fully checkpointed
+        # WAL, resets it, and SQLite applies journal_size_limit at that point.
+        db._execute_write(
+            lambda conn: conn.execute(
+                "INSERT INTO wal_payload (value) VALUES (?)", (b"next",)
+            )
+        )
+
+        assert os.path.getsize(wal_path) <= test_limit
 
 
 class TestCloseUsesTruncate:

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -84,6 +84,10 @@ compression:
   threshold: 0.50            # Fraction of context window (default: 0.50 = 50%)
   target_ratio: 0.20         # How much of threshold to keep as tail (default: 0.20)
   protect_last_n: 20         # Minimum protected tail messages (default: 20)
+  background_enabled: true   # Gateway post-response prefix compaction
+  background_threshold: 0.65 # Soft gateway trigger (default: 65%)
+  background_chunk_tokens: 96000  # Bounded summary input per pass
+  background_use_main_model: true # Use the session's active chat runtime
   codex_gpt55_autoraise: true  # gpt-5.5 on Codex OAuth: raise trigger to 85% (default: true)
   codex_gpt55_autoraise_notice: true  # Show the one-time autoraise notice (default: true)
   codex_app_server_auto: native  # native|hermes|off for Codex app-server thread compaction
@@ -104,9 +108,25 @@ auxiliary:
 | `target_ratio` | `0.20` | 0.10-0.80 | Controls tail protection token budget: `threshold_tokens × target_ratio` |
 | `protect_last_n` | `20` | ≥1 | Minimum number of recent messages always preserved |
 | `protect_first_n` | `3` | (hardcoded) | System prompt + first exchange always preserved |
+| `background_enabled` | `true` | bool | Run gateway prefix compaction after response delivery |
+| `background_threshold` | `0.65` | 0.10-0.84 | Gateway soft trigger, kept below the synchronous hygiene fallback |
+| `background_chunk_tokens` | `96000` | 16000-192000 | Maximum old transcript prefix summarized by one background job |
+| `background_use_main_model` | `true` | bool | Force the session's active chat provider/model for background summaries |
 | `codex_gpt55_autoraise` | `true` | bool | Raise the trigger to 85% for gpt-5.5 on the ChatGPT Codex OAuth route (see below). Set `false` to keep the global `threshold` |
 | `codex_gpt55_autoraise_notice` | `true` | bool | Show the one-time Codex gpt-5.5 autoraise notice. Set `false` to keep the 85% autoraise but suppress the banner |
 | `codex_app_server_auto` | `native` | `native`, `hermes`, `off` | Thread-compaction mode for Codex app-server sessions (see below) |
+
+### Gateway background compaction
+
+The gateway schedules at most one compactor per durable session after a
+successful response has been delivered and persisted. The model call runs on a
+bounded, turn-aligned prefix without holding the foreground turn lease or a DB
+write lock. Commit reacquires the turn lease briefly, takes the existing
+cross-process compression lock, and publishes only when the snapshotted message
+IDs still match the active prefix. New rows appended during summarization are
+rebased after the compacted prefix in the same transaction; destructive history
+changes make the result stale. The 85% pre-turn hygiene path is retained as a
+hard fallback.
 
 ### Codex gpt-5.5 threshold autoraise
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -748,6 +748,10 @@ compression:
   protect_last_n: 20                                # Min recent messages to keep uncompressed
   protect_first_n: 3                                # Non-system head messages pinned across compactions (0 = pin nothing)
   hygiene_hard_message_limit: 5000                  # Gateway safety valve — see below
+  background_enabled: true                          # Gateway: compact after delivering the response
+  background_threshold: 0.65                       # Soft trigger, below the 85% hygiene fallback
+  background_chunk_tokens: 96000                    # Maximum old prefix summarized per pass
+  background_use_main_model: true                   # Use the session's active chat model/provider
 
 # The summarization model/provider is configured under auxiliary:
 auxiliary:
@@ -762,6 +766,8 @@ Older configs with `compression.summary_model`, `compression.summary_provider`, 
 :::
 
 `hygiene_hard_message_limit` is a gateway-only **pre-compression safety valve**. It exists to break a death spiral: when API calls keep disconnecting on an oversized session, the gateway never receives token-usage data, so the token-based threshold can't fire, so the transcript keeps growing and disconnects get worse. This count-based floor fires on message count alone (always known, regardless of API failures) to force compression and recover the session. Default `5000` — far above any normal session, including large-context (1M+) models doing thousands of short turns, which compress on the token threshold long before this. Raise it further for unusual platforms, lower it to force more aggressive compression. Editing this value on a running gateway takes effect on the next message (see below).
+
+Gateway conversations also use **background compaction** by default. After a successful response is delivered and its transcript is flushed, Hermes snapshots a bounded old prefix at 65% context usage and summarizes it without holding the session turn lease. New messages can continue during that model call. Publication is a short atomic prefix comparison: appended turns are preserved, while a rewind, reset, foreground compression, or ended session makes the background result stale and it is discarded. The existing 85% synchronous hygiene path remains the emergency fallback. Background summaries use the session's active chat model/provider by default, even when `auxiliary.compression` points elsewhere; set `background_use_main_model: false` to use normal auxiliary compression routing.
 
 `protect_first_n` controls how many **non-system** head messages are pinned across every compaction. Default `3` — the opening user/assistant exchange survives every summarizer pass so the original goal stays visible. On long-running rolling-compaction sessions where the opening turn is no longer relevant, set `protect_first_n: 0` to pin nothing but the system prompt + summary + tail. The system prompt itself is always preserved regardless of this setting.
 


### PR DESCRIPTION
Summary

- Schedule bounded transcript-prefix compaction after a successful gateway response at 65% context usage, leaving foreground delivery and subsequent turns unblocked.
- Use the sessions active chat provider/model by default, with a prefix-CAS commit that preserves turns appended while the summary call is running and discards stale rewrites.
- Bound the reusable state.db WAL high-water mark to 64 MiB while retaining non-blocking PASSIVE checkpoints and controlled TRUNCATE on close.
- Add safe defaults, config display, and user/developer documentation.

Safety

- At most one background job per durable session.
- No turn or DB write lock is held during the model call.
- Commit takes the turn lease plus compression lock and runs in one BEGIN IMMEDIATE transaction.
- Existing 85% synchronous hygiene remains the emergency fallback.
- Codex app-server and non-built-in context-engine sessions are skipped.
- Legacy persisted roles are never covered by a background prefix.

Validation

- 690 focused DB, context-compressor, gateway race, and shutdown tests passed before rollout.
- 247 focused tests passed again on the updated live main integration.
- Ruff and ty checks pass.
- 7.08 GB live state DB reports PRAGMA quick_check=ok; WAL mode active; journal_size_limit=67108864.
- Graceful live rollout completed with Discord, Telegram, and Slack reconnected.