### PR TITLE
[Bob] fix: namespace Slack sessions by workspace

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -17,7 +17,7 @@ import threading
 import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
@@ -974,6 +974,9 @@ def build_session_key(
         participant_id = canonical_whatsapp_identifier(str(participant_id)) or participant_id
     key_parts = [ns, platform, source.chat_type]
 
+    if source.platform == Platform.SLACK and source.scope_id:
+        key_parts.append(source.scope_id)
+
     if source.chat_id:
         key_parts.append(source.chat_id)
     if source.thread_id:
@@ -1422,6 +1425,24 @@ class SessionStore:
             profile=self._resolve_profile_for_key(source),
         )
 
+    @staticmethod
+    def _recovered_row_matches_source_scope(
+        recovered: Dict[str, Any], source: SessionSource
+    ) -> bool:
+        if (
+            source.platform != Platform.SLACK
+            or source.chat_type == "dm"
+            or not source.scope_id
+        ):
+            return True
+        try:
+            origin = json.loads(recovered.get("origin_json") or "")
+        except (TypeError, ValueError):
+            return False
+        if not isinstance(origin, dict):
+            return False
+        return origin.get("scope_id", origin.get("guild_id")) == source.scope_id
+
     def _create_entry_from_recovered_row(
         self,
         *,
@@ -1476,6 +1497,8 @@ class SessionStore:
             return None
         if not recovered:
             return None
+        if not self._recovered_row_matches_source_scope(recovered, source):
+            return None
         if not self._recovered_row_allowed_for_active_profile(
             requested_session_key=session_key,
             recovered=recovered,
@@ -1499,7 +1522,9 @@ class SessionStore:
             now=now,
         )
 
-    def _query_recoverable_session(self, *, session_key, source, now):
+    def _query_recoverable_session(
+        self, *, session_key, source, now, lookup_session_key=None
+    ):
         """DB-only half of _recover_session_from_db (no lock needed).
 
         Returns a SessionEntry or None.  Caller assigns _entries[key] under lock.
@@ -1509,20 +1534,23 @@ class SessionStore:
         finder = getattr(self._db, "find_latest_gateway_session_for_peer", None)
         if not callable(finder):
             return None
+        lookup_key = lookup_session_key or session_key
         try:
             recovered = finder(
                 source=source.platform.value,
                 user_id=source.user_id,
-                session_key=session_key,
+                session_key=lookup_key,
                 chat_id=source.chat_id,
                 chat_type=source.chat_type,
                 thread_id=source.thread_id,
             )
         except Exception as exc:
             logger.debug("Gateway session DB recovery failed for %s: %s",
-                         session_key, exc)
+                         lookup_key, exc)
             return None
         if not isinstance(recovered, dict):
+            return None
+        if not self._recovered_row_matches_source_scope(recovered, source):
             return None
         if not self._recovered_row_allowed_for_active_profile(
             requested_session_key=session_key,
@@ -1907,6 +1935,38 @@ class SessionStore:
         session_key = self._generate_session_key(source)
         now = _now()
 
+        legacy_session_key = None
+        migrated_entry = None
+        if (
+            source.platform == Platform.SLACK
+            and source.chat_type != "dm"
+            and source.scope_id
+        ):
+            legacy_source = replace(source, scope_id=None, guild_id=None)
+            legacy_session_key = self._generate_session_key(legacy_source)
+            with self._lock:
+                self._ensure_loaded_locked()
+                legacy_entry = self._entries.get(legacy_session_key)
+                if (
+                    session_key not in self._entries
+                    and legacy_entry is not None
+                    and legacy_entry.origin is not None
+                    and legacy_entry.origin.scope_id == source.scope_id
+                ):
+                    self._entries.pop(legacy_session_key)
+                    legacy_entry.session_key = session_key
+                    legacy_entry.origin = source
+                    self._entries[session_key] = legacy_entry
+                    migrated_entry = legacy_entry
+            if migrated_entry is not None:
+                self._save_entries()
+                self._record_gateway_session_peer(
+                    migrated_entry.session_id,
+                    session_key,
+                    source,
+                    display_name=migrated_entry.display_name,
+                )
+
         db_end_session_id = None
         db_create_kwargs = None
         existing_session_id = None
@@ -2039,6 +2099,15 @@ class SessionStore:
             recovered = self._query_recoverable_session(
                 session_key=session_key, source=source, now=now,
             )
+            recovered_from_legacy = False
+            if recovered is None and legacy_session_key is not None:
+                recovered = self._query_recoverable_session(
+                    session_key=session_key,
+                    lookup_session_key=legacy_session_key,
+                    source=source,
+                    now=now,
+                )
+                recovered_from_legacy = recovered is not None
             if recovered is not None:
                 with self._lock:
                     published = self._entries.get(session_key)
@@ -2047,6 +2116,13 @@ class SessionStore:
                         published = recovered
                 entry = published
                 _needs_save = True
+                if recovered_from_legacy and published is recovered:
+                    self._record_gateway_session_peer(
+                        recovered.session_id,
+                        session_key,
+                        source,
+                        display_name=recovered.display_name,
+                    )
 
         if entry is None:
             # Create a candidate outside the lock, then publish only if another

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1,11 +1,14 @@
 """Tests for gateway session management."""
 import json
 import pytest
+from dataclasses import replace
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 from gateway.config import Platform, HomeChannel, GatewayConfig, PlatformConfig
 from gateway.platforms.base import MessageEvent
 from gateway.session import (
+    SessionEntry,
     SessionSource,
     SessionStore,
     build_session_context,
@@ -1166,6 +1169,262 @@ class TestWhatsAppSessionKeyConsistency:
         key = build_session_key(source)
         # DM logic: chat_id + thread_id, user_id never included
         assert key == "agent:main:telegram:dm:99:topic-1"
+
+
+class TestSlackWorkspaceSessionKeys:
+    def test_same_thread_and_user_in_distinct_workspaces_get_distinct_keys(self):
+        # Given
+        first = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="channel",
+            thread_id="1700000000.000001",
+            user_id="U123",
+            scope_id="T_ALPHA",
+        )
+        second = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="channel",
+            thread_id="1700000000.000001",
+            user_id="U123",
+            scope_id="T_BETA",
+        )
+
+        # When
+        first_key = build_session_key(first)
+        second_key = build_session_key(second)
+
+        # Then
+        assert first_key == "agent:main:slack:channel:T_ALPHA:C123:1700000000.000001"
+        assert second_key == "agent:main:slack:channel:T_BETA:C123:1700000000.000001"
+        assert first_key != second_key
+
+    def test_thread_per_user_isolation_keeps_user_suffix_after_workspace(self):
+        # Given
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="channel",
+            thread_id="1700000000.000001",
+            user_id="U123",
+            scope_id="T_ALPHA",
+        )
+
+        # When
+        key = build_session_key(source, thread_sessions_per_user=True)
+
+        # Then
+        assert key == "agent:main:slack:channel:T_ALPHA:C123:1700000000.000001:U123"
+
+    def test_dm_key_remains_byte_identical_when_workspace_is_present(self):
+        # Given
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="D123",
+            chat_type="dm",
+            user_id="U123",
+            scope_id="T_ALPHA",
+        )
+
+        # When
+        key = build_session_key(source)
+
+        # Then
+        assert key == "agent:main:slack:dm:D123"
+
+    def test_non_slack_key_ignores_scope(self):
+        # Given
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="C123",
+            chat_type="channel",
+            user_id="U123",
+            scope_id="GUILD_ALPHA",
+        )
+
+        # When
+        key = build_session_key(source)
+
+        # Then
+        assert key == "agent:main:discord:channel:C123:U123"
+
+    def test_matching_workspace_reuses_and_migrates_legacy_routing_entry(
+        self, tmp_path, monkeypatch
+    ):
+        # Given
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="channel",
+            thread_id="1700000000.000001",
+            user_id="U123",
+            scope_id="T_ALPHA",
+        )
+        legacy_key = "agent:main:slack:channel:C123:1700000000.000001"
+        legacy_entry = SessionEntry(
+            session_key=legacy_key,
+            session_id="legacy-session",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=source,
+            platform=Platform.SLACK,
+            chat_type="channel",
+        )
+        (tmp_path / "sessions.json").write_text(
+            json.dumps({legacy_key: legacy_entry.to_dict()}), encoding="utf-8"
+        )
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+
+        # When
+        reused = store.get_or_create_session(source)
+
+        # Then
+        scoped_key = "agent:main:slack:channel:T_ALPHA:C123:1700000000.000001"
+        assert reused.session_id == "legacy-session"
+        assert reused.session_key == scoped_key
+        assert scoped_key in store._entries
+        assert legacy_key not in store._entries
+
+    def test_scope_less_legacy_entry_is_not_adopted_by_a_workspace(
+        self, tmp_path, monkeypatch
+    ):
+        # Given
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        legacy_source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="channel",
+            thread_id="1700000000.000001",
+            user_id="U123",
+        )
+        incoming = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="channel",
+            thread_id="1700000000.000001",
+            user_id="U123",
+            scope_id="T_BETA",
+        )
+        legacy_key = "agent:main:slack:channel:C123:1700000000.000001"
+        legacy_entry = SessionEntry(
+            session_key=legacy_key,
+            session_id="ambiguous-legacy-session",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=legacy_source,
+            platform=Platform.SLACK,
+            chat_type="channel",
+        )
+        (tmp_path / "sessions.json").write_text(
+            json.dumps({legacy_key: legacy_entry.to_dict()}), encoding="utf-8"
+        )
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+
+        # When
+        routed = store.get_or_create_session(incoming)
+
+        # Then
+        assert routed.session_id != "ambiguous-legacy-session"
+        assert routed.session_key == "agent:main:slack:channel:T_BETA:C123:1700000000.000001"
+        assert store._entries[legacy_key].session_id == "ambiguous-legacy-session"
+
+    def test_matching_workspace_recovers_legacy_session_from_db(
+        self, tmp_path, monkeypatch
+    ):
+        # Given
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="channel",
+            thread_id="1700000000.000001",
+            user_id="U123",
+            scope_id="T_ALPHA",
+        )
+        legacy_key = "agent:main:slack:channel:C123:1700000000.000001"
+        original = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        original._db.create_session(
+            session_id="legacy-db-session",
+            source="slack",
+            user_id="U_FIRST_PARTICIPANT",
+            session_key=legacy_key,
+            chat_id="C123",
+            chat_type="channel",
+            thread_id="1700000000.000001",
+        )
+        original._db.record_gateway_session_peer(
+            "legacy-db-session",
+            source="slack",
+            user_id="U_FIRST_PARTICIPANT",
+            session_key=legacy_key,
+            chat_id="C123",
+            chat_type="channel",
+            thread_id="1700000000.000001",
+            origin_json=json.dumps(source.to_dict()),
+        )
+        original.append_to_transcript(
+            "legacy-db-session", {"role": "user", "content": "legacy context"}
+        )
+        original._db.close()
+        restarted = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+
+        # When
+        recovered = restarted.get_or_create_session(source)
+
+        # Then
+        assert recovered.session_id == "legacy-db-session"
+        assert recovered.session_key == "agent:main:slack:channel:T_ALPHA:C123:1700000000.000001"
+        assert restarted._db.get_session("legacy-db-session")["session_key"] == recovered.session_key
+
+    def test_scope_less_legacy_db_session_is_not_adopted_by_a_workspace(
+        self, tmp_path, monkeypatch
+    ):
+        # Given
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        legacy_source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="channel",
+            thread_id="1700000000.000001",
+            user_id="U123",
+        )
+        incoming = replace(legacy_source, scope_id="T_BETA")
+        legacy_key = "agent:main:slack:channel:C123:1700000000.000001"
+        original = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        original._db.create_session(
+            session_id="ambiguous-db-session",
+            source="slack",
+            user_id="U123",
+            session_key=legacy_key,
+            chat_id="C123",
+            chat_type="channel",
+            thread_id="1700000000.000001",
+        )
+        original._record_gateway_session_peer(
+            "ambiguous-db-session", legacy_key, legacy_source
+        )
+        original.append_to_transcript(
+            "ambiguous-db-session", {"role": "user", "content": "other workspace"}
+        )
+        original._db.close()
+        restarted = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+
+        # When
+        routed = restarted.get_or_create_session(incoming)
+
+        # Then
+        assert routed.session_id != "ambiguous-db-session"
+        assert routed.session_key == "agent:main:slack:channel:T_BETA:C123:1700000000.000001"
 
 
 class TestWhatsAppIdentifierPublicHelpers:


### PR DESCRIPTION
## Summary
- namespace non-DM Slack session keys by workspace scope
- safely migrate matching legacy routes and reject scope-ambiguous routes
- cover cross-workspace collision, unchanged DM/thread behavior, and routing/DB recovery

## Verification
- `uv run python -m pytest tests/gateway/test_session.py -q` (130 passed)
- `uv run python -m ruff check gateway/session.py tests/gateway/test_session.py`
- `uv run python -m compileall -q gateway/session.py`