### PR TITLE
fix(kanban): enforce U2 admission caps

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -929,6 +929,40 @@ class GatewayKanbanWatchersMixin:
                         max_in_progress_per_profile,
                     )
 
+        max_task_starts_per_hour = None
+        raw_starts_cap = kanban_cfg.get("max_task_starts_per_hour", None)
+        if raw_starts_cap is not None:
+            try:
+                max_task_starts_per_hour = int(raw_starts_cap)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "kanban dispatcher: invalid kanban.max_task_starts_per_hour=%r; ignoring",
+                    raw_starts_cap,
+                )
+                max_task_starts_per_hour = None
+            else:
+                if max_task_starts_per_hour < 1:
+                    logger.warning(
+                        "kanban dispatcher: kanban.max_task_starts_per_hour=%r "
+                        "is below 1; ignoring",
+                        raw_starts_cap,
+                    )
+                    max_task_starts_per_hour = None
+                else:
+                    logger.info(
+                        "kanban dispatcher: max_task_starts_per_hour=%d",
+                        max_task_starts_per_hour,
+                    )
+
+        spend_config = _kb.spend_admission_config_from_kanban_config(kanban_cfg)
+        if spend_config.cap_usd is not None:
+            logger.info(
+                "kanban dispatcher: daily_spend_cap_usd=%s timezone=%s unknown_cost_policy=%s",
+                spend_config.cap_usd,
+                spend_config.timezone_name,
+                spend_config.unknown_cost_policy,
+            )
+
         # Initial delay so the gateway finishes wiring adapters before the
         # dispatcher spawns workers (those workers may hit gateway notify
         # subscriptions etc.). Matches the notifier watcher's delay.
@@ -1022,6 +1056,8 @@ class GatewayKanbanWatchersMixin:
                     stale_timeout_seconds=stale_timeout_seconds,
                     default_assignee=default_assignee,
                     max_in_progress_per_profile=max_in_progress_per_profile,
+                    max_task_starts_per_hour=max_task_starts_per_hour,
+                    spend_config=spend_config,
                 )
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2897,6 +2897,27 @@ DEFAULT_CONFIG = {
         # otherwise saturate one profile's local model / API quota /
         # browser pool while leaving other profiles idle.
         "max_in_progress_per_profile": None,
+        # Global dispatcher concurrency caps. Unset (None) preserves
+        # historical uncapped behavior.
+        "max_in_progress": None,
+        "max_spawn": None,
+        # Rolling task-start admission cap. When set to a positive int, the
+        # dispatcher allows at most N native task_runs starts in the trailing
+        # hour. Held tasks stay ready/review and failure counters are untouched.
+        "max_task_starts_per_hour": None,
+        # Daily known-metered spend admission cap in USD. Unset disables the
+        # check. The cap reads local state.db session_model_usage ledgers across
+        # installed profiles using read-only SQLite connections. Actual dollars
+        # take precedence over estimated dollars; unknown-cost rows are visible
+        # in telemetry but do not count toward the cap unless held by policy.
+        "daily_spend_cap_usd": None,
+        # IANA timezone for the daily spend boundary. Invalid values fall back
+        # to UTC; DST boundaries are local-midnight to local-midnight.
+        "daily_spend_timezone": "UTC",
+        # Unknown-cost policy for daily spend admission: "allow" (default,
+        # report telemetry only) or "hold" (defer spawns while today's ledger
+        # has unknown-cost rows).
+        "unknown_cost_policy": "allow",
         # When true, the kanban dispatcher auto-runs the decomposer on
         # tasks that land in Triage (every dispatcher tick). When false,
         # decomposition is manual via `hermes kanban decompose <id>` or

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -74,6 +74,7 @@ import contextlib
 import hashlib
 import json
 import os
+import posixpath
 import re
 import random
 import secrets
@@ -86,8 +87,11 @@ import logging
 import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
+from datetime import datetime, time as datetime_time, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterable, Optional
+from urllib.parse import unquote, urlsplit
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
@@ -6413,6 +6417,69 @@ class DispatchResult:
     DB writes this tick — the lock holder is making progress on the same
     board. This is the steady-state signal that a single-writer guard is
     actively preventing two dispatchers from racing on ``kanban.db``."""
+    skipped_rolling_start_capped: list[tuple[str, int, int]] = field(default_factory=list)
+    """Ready/review task ids deferred by ``kanban.max_task_starts_per_hour``.
+    Entries are ``(task_id, starts_in_window, cap)``. Tasks stay ready/review
+    and failure counters are not touched."""
+    skipped_daily_spend_capped: list[tuple[str, float, float]] = field(default_factory=list)
+    """Ready/review task ids deferred by ``kanban.daily_spend_cap_usd``.
+    Entries are ``(task_id, known_metered_spend_usd, cap_usd)``."""
+    skipped_spend_ledger_unavailable: list[str] = field(default_factory=list)
+    """Ready/review task ids held fail-closed because a positive daily spend
+    cap was configured but no canonical local usage ledger could be read."""
+    skipped_unknown_cost_policy: list[tuple[str, int]] = field(default_factory=list)
+    """Ready/review task ids held by ``kanban.unknown_cost_policy: hold``
+    because today's ledger contains unmetered/unknown-cost rows."""
+    spend_telemetry: dict[str, Any] = field(default_factory=dict)
+    """Sanitized spend-admission telemetry. Contains aggregate dollars/counts
+    only; never prompt, message, or session content."""
+
+
+@dataclass(frozen=True)
+class SpendAdmissionConfig:
+    cap_usd: Optional[float] = None
+    timezone_name: str = "UTC"
+    unknown_cost_policy: str = "allow"
+
+
+@dataclass(frozen=True)
+class SpendLedgerSummary:
+    ledger_readable: bool
+    known_metered_cost_usd: float = 0.0
+    actual_cost_usd: float = 0.0
+    estimated_cost_usd: float = 0.0
+    unknown_cost_rows: int = 0
+    known_cost_rows: int = 0
+    included_cost_rows: int = 0
+    explicit_included_cost_rows: int = 0
+    transport_inferred_included_rows: int = 0
+    profiles_read: int = 0
+    ledgers_read: int = 0
+    ledgers_unavailable: int = 0
+    day_start_ts: float = 0.0
+    day_end_ts: float = 0.0
+    timezone_name: str = "UTC"
+    errors: tuple[str, ...] = ()
+
+    def telemetry(self) -> dict[str, Any]:
+        return {
+            "ledger_readable": self.ledger_readable,
+            "known_metered_cost_usd": round(self.known_metered_cost_usd, 8),
+            "actual_cost_usd": round(self.actual_cost_usd, 8),
+            "estimated_cost_usd": round(self.estimated_cost_usd, 8),
+            "unknown_cost_rows": self.unknown_cost_rows,
+            "known_cost_rows": self.known_cost_rows,
+            "included_cost_rows": self.included_cost_rows,
+            "explicit_included_cost_rows": self.explicit_included_cost_rows,
+            "transport_inferred_included_rows": self.transport_inferred_included_rows,
+            "profiles_read": self.profiles_read,
+            "ledgers_read": self.ledgers_read,
+            "ledgers_unavailable": self.ledgers_unavailable,
+            "day_start_ts": self.day_start_ts,
+            "day_end_ts": self.day_end_ts,
+            "timezone": self.timezone_name,
+            "errors": list(self.errors[:5]),
+        }
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -7770,6 +7837,270 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     return False
 
 
+def _positive_optional_int(value: Any) -> Optional[int]:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _positive_optional_float(value: Any) -> Optional[float]:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def spend_admission_config_from_kanban_config(kanban_cfg: Optional[dict]) -> SpendAdmissionConfig:
+    cfg = kanban_cfg or {}
+    tz_name = str(cfg.get("daily_spend_timezone") or "UTC").strip() or "UTC"
+    policy = str(cfg.get("unknown_cost_policy") or "allow").strip().lower()
+    if policy not in {"allow", "hold"}:
+        policy = "allow"
+    return SpendAdmissionConfig(
+        cap_usd=_positive_optional_float(cfg.get("daily_spend_cap_usd")),
+        timezone_name=tz_name,
+        unknown_cost_policy=policy,
+    )
+
+
+def _day_bounds_for_timezone(
+    tz_name: str, *, now: Optional[float] = None,
+) -> tuple[float, float, str]:
+    try:
+        tz = ZoneInfo(tz_name)
+        canonical_name = tz_name
+    except (ZoneInfoNotFoundError, ValueError):
+        tz = timezone.utc
+        canonical_name = "UTC"
+    dt = datetime.fromtimestamp(time.time() if now is None else now, tz)
+    start = datetime.combine(dt.date(), datetime_time.min, tzinfo=tz)
+    end = datetime.combine(dt.date() + timedelta(days=1), datetime_time.min, tzinfo=tz)
+    return start.timestamp(), end.timestamp(), canonical_name
+
+
+def _is_native_chatgpt_codex_subscription_transport(base_url: Any) -> bool:
+    """Return True only for Hermes' native ChatGPT Codex subscription endpoint.
+
+    This trusts endpoint shape only, not provider labels or model names. It
+    rejects userinfo, non-HTTPS schemes, and hostname suffix/substr tricks so
+    arbitrary OpenAI-compatible/custom metered endpoints stay fail-closed under
+    ``unknown_cost_policy: hold``.
+    """
+    raw = str(base_url or "").strip()
+    if not raw:
+        return False
+    try:
+        parsed = urlsplit(raw)
+    except ValueError:
+        return False
+    if parsed.scheme.lower() != "https":
+        return False
+    if parsed.username or parsed.password:
+        return False
+    hostname = (parsed.hostname or "").strip().lower().rstrip(".")
+    if hostname != "chatgpt.com":
+        return False
+    decoded_path = unquote(parsed.path or "/")
+    normalized_path = posixpath.normpath("/" + decoded_path.lstrip("/"))
+    return normalized_path == "/backend-api/codex" or normalized_path.startswith(
+        "/backend-api/codex/"
+    )
+
+
+def _installed_profile_homes_for_spend() -> list[Path]:
+    from hermes_constants import get_default_hermes_root
+
+    root = get_default_hermes_root()
+    homes = [root]
+    profiles_dir = root / "profiles"
+    try:
+        homes.extend(child for child in sorted(profiles_dir.iterdir()) if child.is_dir())
+    except OSError:
+        pass
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for home in homes:
+        try:
+            key = str(home.resolve())
+        except OSError:
+            key = str(home)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(home)
+    return unique
+
+
+def _sqlite_table_columns(conn: sqlite3.Connection, table_name: str) -> set[str]:
+    rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+    return {str(row[1]) for row in rows}
+
+
+def read_daily_spend_ledger(
+    config: SpendAdmissionConfig,
+    *,
+    now: Optional[float] = None,
+    profile_homes: Optional[list[Path]] = None,
+) -> SpendLedgerSummary:
+    """Aggregate known metered spend from installed profiles' state.db files.
+
+    Read-only by construction. Explicit subscription-included telemetry always
+    wins first and does not contribute to the spend cap. Otherwise actual
+    dollars win over estimated dollars. Zero-cost blank rows are unknown unless
+    their endpoint is the strict native ChatGPT Codex subscription transport, in
+    which case they are counted separately as transport-inferred included rows.
+    """
+    start_ts, end_ts, tz_name = _day_bounds_for_timezone(config.timezone_name, now=now)
+    homes = profile_homes if profile_homes is not None else _installed_profile_homes_for_spend()
+    known = actual = estimated = 0.0
+    unknown_rows = known_rows = included_rows = ledgers_read = unavailable = 0
+    explicit_included_rows = transport_inferred_included_rows = 0
+    errors: list[str] = []
+    for home in homes:
+        db_path = Path(home) / "state.db"
+        if not db_path.exists():
+            continue
+        conn = None
+        try:
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1.0)
+            conn.row_factory = sqlite3.Row
+            if not conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='session_model_usage'"
+            ).fetchone():
+                unavailable += 1
+                errors.append(f"{db_path}:missing session_model_usage")
+                continue
+            usage_columns = _sqlite_table_columns(conn, "session_model_usage")
+            has_sessions = bool(
+                conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='sessions'"
+                ).fetchone()
+            )
+            session_columns = _sqlite_table_columns(conn, "sessions") if has_sessions else set()
+
+            seen_terms: list[str] = []
+            if "last_seen" in usage_columns:
+                seen_terms.append("u.last_seen")
+            if has_sessions:
+                if "ended_at" in session_columns:
+                    seen_terms.append("s.ended_at")
+                if "started_at" in session_columns:
+                    seen_terms.append("s.started_at")
+            if not seen_terms:
+                unavailable += 1
+                errors.append(f"{db_path}:missing timestamp columns")
+                continue
+
+            seen_expr = (
+                seen_terms[0]
+                if len(seen_terms) == 1
+                else "COALESCE(" + ", ".join(seen_terms) + ")"
+            )
+            actual_expr = (
+                "u.actual_cost_usd" if "actual_cost_usd" in usage_columns else "NULL"
+            )
+            estimated_expr = (
+                "u.estimated_cost_usd"
+                if "estimated_cost_usd" in usage_columns
+                else "NULL"
+            )
+            billing_mode_expr = (
+                "u.billing_mode" if "billing_mode" in usage_columns else "NULL"
+            )
+            cost_status_expr = (
+                "u.cost_status" if "cost_status" in usage_columns else "NULL"
+            )
+            billing_base_url_expr = (
+                "u.billing_base_url" if "billing_base_url" in usage_columns else "NULL"
+            )
+            join_clause = "LEFT JOIN sessions s ON s.id = u.session_id" if has_sessions else ""
+            source_filter = ""
+            if has_sessions and "source" in session_columns:
+                source_filter = "AND COALESCE(s.source, '') NOT IN ('_health_probe')"
+            ledgers_read += 1
+            rows = conn.execute(
+                f"""SELECT {actual_expr} AS actual_cost_usd,
+                          {estimated_expr} AS estimated_cost_usd,
+                          {billing_mode_expr} AS billing_mode,
+                          {cost_status_expr} AS cost_status,
+                          {billing_base_url_expr} AS billing_base_url,
+                          {seen_expr} AS seen_at
+                   FROM session_model_usage u
+                   {join_clause}
+                   WHERE {seen_expr} >= ?
+                     AND {seen_expr} < ?
+                     {source_filter}""",
+                (start_ts, end_ts),
+            ).fetchall()
+            for row in rows:
+                billing_mode = str(row["billing_mode"] or "").strip().lower()
+                cost_status = str(row["cost_status"] or "").strip().lower()
+                if billing_mode == "subscription_included" or cost_status == "included":
+                    explicit_included_rows += 1
+                    included_rows += 1
+                    continue
+                try:
+                    act = float(row["actual_cost_usd"] or 0.0)
+                    est = float(row["estimated_cost_usd"] or 0.0)
+                except (TypeError, ValueError):
+                    unknown_rows += 1
+                    continue
+                if act > 0:
+                    actual += act
+                    known += act
+                    known_rows += 1
+                elif est > 0:
+                    estimated += est
+                    known += est
+                    known_rows += 1
+                elif (
+                    not billing_mode
+                    and not cost_status
+                    and _is_native_chatgpt_codex_subscription_transport(row["billing_base_url"])
+                ):
+                    transport_inferred_included_rows += 1
+                    included_rows += 1
+                else:
+                    unknown_rows += 1
+        except sqlite3.DatabaseError as exc:
+            unavailable += 1
+            errors.append(f"{db_path}:{type(exc).__name__}")
+        finally:
+            if conn is not None:
+                conn.close()
+    return SpendLedgerSummary(
+        ledger_readable=ledgers_read > 0,
+        known_metered_cost_usd=known,
+        actual_cost_usd=actual,
+        estimated_cost_usd=estimated,
+        unknown_cost_rows=unknown_rows,
+        known_cost_rows=known_rows,
+        included_cost_rows=included_rows,
+        explicit_included_cost_rows=explicit_included_rows,
+        transport_inferred_included_rows=transport_inferred_included_rows,
+        profiles_read=len(homes),
+        ledgers_read=ledgers_read,
+        ledgers_unavailable=unavailable,
+        day_start_ts=start_ts,
+        day_end_ts=end_ts,
+        timezone_name=tz_name,
+        errors=tuple(errors),
+    )
+
+
+def _task_start_count_last_hour(conn: sqlite3.Connection, *, now: Optional[int] = None) -> int:
+    cutoff = int(time.time() if now is None else now) - 3600
+    return int(
+        conn.execute(
+            "SELECT COUNT(*) FROM task_runs WHERE started_at >= ?",
+            (cutoff,),
+        ).fetchone()[0]
+    )
+
+
 def dispatch_once(
     conn: sqlite3.Connection,
     *,
@@ -7783,6 +8114,9 @@ def dispatch_once(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    max_task_starts_per_hour: Optional[int] = None,
+    spend_config: Optional[SpendAdmissionConfig] = None,
+    spend_ledger_reader=None,
 ) -> DispatchResult:
     """Run one dispatcher tick under the board's single-writer lock.
 
@@ -7817,6 +8151,9 @@ def dispatch_once(
             board=board,
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            max_task_starts_per_hour=max_task_starts_per_hour,
+            spend_config=spend_config,
+            spend_ledger_reader=spend_ledger_reader,
         )
     with _dispatch_tick_lock(db_path) as held:
         if not held:
@@ -7833,6 +8170,9 @@ def dispatch_once(
             board=board,
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            max_task_starts_per_hour=max_task_starts_per_hour,
+            spend_config=spend_config,
+            spend_ledger_reader=spend_ledger_reader,
         )
         # Still under the dispatch lock: opportunistically truncate the WAL
         # at a coarse interval so it cannot grow unbounded between restarts.
@@ -7853,6 +8193,9 @@ def _dispatch_once_locked(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    max_task_starts_per_hour: Optional[int] = None,
+    spend_config: Optional[SpendAdmissionConfig] = None,
+    spend_ledger_reader=None,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -7919,7 +8262,7 @@ def _dispatch_once_locked(
     # they sit in status='running' until the worker calls
     # kanban_complete/kanban_block (or the dispatcher TTL-reclaims them).
     running_count = 0
-    if max_spawn is not None:
+    if max_spawn is not None or max_in_progress is not None:
         running_count = int(
             conn.execute(
                 "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
@@ -7931,20 +8274,55 @@ def _dispatch_once_locked(
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
+    review_rows = conn.execute(
+        "SELECT id, assignee FROM tasks "
+        "WHERE status = 'review' AND claim_lock IS NULL "
+        "ORDER BY priority DESC, created_at ASC"
+    ).fetchall()
+    pending_admission_ids = [r["id"] for r in ready_rows] + [r["id"] for r in review_rows]
+
+    spend_cfg = spend_config or SpendAdmissionConfig()
+    if spend_cfg.cap_usd is not None and pending_admission_ids:
+        ledger_reader = spend_ledger_reader or read_daily_spend_ledger
+        spend_summary = ledger_reader(spend_cfg)
+        result.spend_telemetry = spend_summary.telemetry()
+        result.spend_telemetry["cap_usd"] = spend_cfg.cap_usd
+        result.spend_telemetry["unknown_cost_policy"] = spend_cfg.unknown_cost_policy
+        if not spend_summary.ledger_readable:
+            result.skipped_spend_ledger_unavailable.extend(pending_admission_ids)
+            return result
+        if spend_cfg.unknown_cost_policy == "hold" and spend_summary.unknown_cost_rows > 0:
+            result.skipped_unknown_cost_policy.extend(
+                (tid, spend_summary.unknown_cost_rows) for tid in pending_admission_ids
+            )
+            return result
+        if spend_summary.known_metered_cost_usd >= spend_cfg.cap_usd:
+            result.skipped_daily_spend_capped.extend(
+                (tid, spend_summary.known_metered_cost_usd, spend_cfg.cap_usd)
+                for tid in pending_admission_ids
+            )
+            return result
+
+    rolling_cap = _positive_optional_int(max_task_starts_per_hour)
+    rolling_starts = _task_start_count_last_hour(conn) if rolling_cap is not None else 0
+    if rolling_cap is not None and rolling_starts >= rolling_cap and pending_admission_ids:
+        result.skipped_rolling_start_capped.extend(
+            (tid, rolling_starts, rolling_cap) for tid in pending_admission_ids
+        )
+        return result
+
     # Honour kanban.max_in_progress: if the board already has enough running
     # tasks, skip spawning this tick so slow workers (local LLMs,
     # resource-constrained hosts) can finish what they have before more tasks
     # pile up and time out.
-    if max_in_progress is not None and ready_rows:
-        in_progress = conn.execute(
-            "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
-        ).fetchone()[0]
-        if in_progress >= max_in_progress:
+    if max_in_progress is not None and pending_admission_ids:
+        if running_count >= max_in_progress:
             return result
-        # Only spawn enough to reach the cap, respecting max_spawn too.
-        remaining = max_in_progress - in_progress
-        if max_spawn is None or max_spawn > remaining:
-            max_spawn = remaining
+        # ``max_spawn`` is also interpreted as a live cap in the loops below
+        # (``running_count + spawned >= max_spawn``), so clamp it to the
+        # global live cap rather than to the remaining slot count.
+        if max_spawn is None or max_spawn > max_in_progress:
+            max_spawn = max_in_progress
     spawned = 0
     # Per-profile concurrency cap (#21582): when set, track how many
     # workers each assignee already has in flight, and refuse to spawn
@@ -7985,6 +8363,11 @@ def _dispatch_once_locked(
     for row in ready_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break
+        if rolling_cap is not None and rolling_starts + spawned >= rolling_cap:
+            result.skipped_rolling_start_capped.append(
+                (row["id"], rolling_starts + spawned, rolling_cap)
+            )
+            continue
         row_assignee = row["assignee"]
         if not row_assignee:
             # Honour kanban.default_assignee: when the dispatcher hits an
@@ -8088,6 +8471,7 @@ def _dispatch_once_locked(
             continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
+            spawned += 1
             # Increment per-profile counter even in dry_run so the cap
             # check sees the would-be spawn on subsequent iterations.
             # Without this, dry_run reports every task as spawnable and
@@ -8168,14 +8552,14 @@ def _dispatch_once_locked(
     # Same concurrency model as ready dispatch: review spawns count
     # against max_spawn alongside ready tasks, so the total number of
     # running workers stays bounded.
-    review_rows = conn.execute(
-        "SELECT id, assignee FROM tasks "
-        "WHERE status = 'review' AND claim_lock IS NULL "
-        "ORDER BY priority DESC, created_at ASC"
-    ).fetchall()
     for row in review_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break
+        if rolling_cap is not None and rolling_starts + spawned >= rolling_cap:
+            result.skipped_rolling_start_capped.append(
+                (row["id"], rolling_starts + spawned, rolling_cap)
+            )
+            continue
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
             continue
@@ -8186,8 +8570,20 @@ def _dispatch_once_locked(
         if profile_exists is not None and not profile_exists(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
             continue
+        if _per_profile_cap is not None:
+            current = _per_profile_running.get(row["assignee"], 0)
+            if current >= _per_profile_cap:
+                result.skipped_per_profile_capped.append(
+                    (row["id"], row["assignee"], current)
+                )
+                continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
+            spawned += 1
+            if _per_profile_cap is not None and row["assignee"]:
+                _per_profile_running[row["assignee"]] = (
+                    _per_profile_running.get(row["assignee"], 0) + 1
+                )
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
@@ -8232,6 +8628,10 @@ def _dispatch_once_locked(
                 _set_worker_pid(conn, claimed.id, int(pid))
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
+            if _per_profile_cap is not None and claimed.assignee:
+                _per_profile_running[claimed.assignee] = (
+                    _per_profile_running.get(claimed.assignee, 0) + 1
+                )
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7920,9 +7920,14 @@ def _installed_profile_homes_for_spend() -> list[Path]:
         homes.extend(child for child in sorted(profiles_dir.iterdir()) if child.is_dir())
     except OSError:
         pass
+    return _unique_profile_homes_for_spend(homes)
+
+
+def _unique_profile_homes_for_spend(homes: list[Path]) -> list[Path]:
     seen: set[str] = set()
     unique: list[Path] = []
     for home in homes:
+        home = Path(home)
         try:
             key = str(home.resolve())
         except OSError:
@@ -7954,15 +7959,20 @@ def read_daily_spend_ledger(
     which case they are counted separately as transport-inferred included rows.
     """
     start_ts, end_ts, tz_name = _day_bounds_for_timezone(config.timezone_name, now=now)
-    homes = profile_homes if profile_homes is not None else _installed_profile_homes_for_spend()
+    homes = (
+        _unique_profile_homes_for_spend(profile_homes)
+        if profile_homes is not None
+        else _installed_profile_homes_for_spend()
+    )
     known = actual = estimated = 0.0
     unknown_rows = known_rows = included_rows = ledgers_read = unavailable = 0
     explicit_included_rows = transport_inferred_included_rows = 0
     errors: list[str] = []
-    for home in homes:
+    for ledger_index, home in enumerate(homes):
         db_path = Path(home) / "state.db"
         if not db_path.exists():
             continue
+        error_prefix = f"ledger_{ledger_index}"
         conn = None
         try:
             conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1.0)
@@ -7971,7 +7981,7 @@ def read_daily_spend_ledger(
                 "SELECT 1 FROM sqlite_master WHERE type='table' AND name='session_model_usage'"
             ).fetchone():
                 unavailable += 1
-                errors.append(f"{db_path}:missing session_model_usage")
+                errors.append(f"{error_prefix}:missing session_model_usage")
                 continue
             usage_columns = _sqlite_table_columns(conn, "session_model_usage")
             has_sessions = bool(
@@ -7991,7 +8001,7 @@ def read_daily_spend_ledger(
                     seen_terms.append("s.started_at")
             if not seen_terms:
                 unavailable += 1
-                errors.append(f"{db_path}:missing timestamp columns")
+                errors.append(f"{error_prefix}:missing timestamp columns")
                 continue
 
             seen_expr = (
@@ -8067,12 +8077,12 @@ def read_daily_spend_ledger(
                     unknown_rows += 1
         except sqlite3.DatabaseError as exc:
             unavailable += 1
-            errors.append(f"{db_path}:{type(exc).__name__}")
+            errors.append(f"{error_prefix}:{type(exc).__name__}")
         finally:
             if conn is not None:
                 conn.close()
     return SpendLedgerSummary(
-        ledger_readable=ledgers_read > 0,
+        ledger_readable=ledgers_read > 0 and unavailable == 0,
         known_metered_cost_usd=known,
         actual_cost_usd=actual,
         estimated_cost_usd=estimated,

--- a/tests/hermes_cli/test_kanban_admission_caps.py
+++ b/tests/hermes_cli/test_kanban_admission_caps.py
@@ -1,0 +1,651 @@
+"""Kanban dispatcher admission caps: rolling task starts and daily spend."""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_kanban_home(monkeypatch):
+    test_home = tempfile.mkdtemp(prefix="kanban_admission_caps_")
+    os.makedirs(os.path.join(test_home, "profiles", "alpha"), exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", test_home)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("hermes_cli") or mod == "hermes_constants":
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+
+    assert kanban_db.kanban_db_path() != Path("/home/hermes/.hermes/kanban/slbm-operations.db")
+
+    yield Path(test_home), kanban_db
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+def _make_ready_tasks(kb, conn, count=3):
+    return [kb.create_task(conn, title=f"task {i}", assignee="alpha") for i in range(count)]
+
+
+def _make_review_task(kb, conn, title="review task", assignee="alpha"):
+    task_id = kb.create_task(conn, title=title, assignee=assignee)
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (task_id,))
+    return task_id
+
+
+def test_defaults_preserve_dispatch_behavior(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        _make_ready_tasks(kb, conn, 2)
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True)
+    assert len(res.spawned) == 2
+    assert not res.skipped_rolling_start_capped
+    assert not res.skipped_daily_spend_capped
+    assert not res.skipped_spend_ledger_unavailable
+
+
+def test_rolling_start_cap_holds_at_exact_threshold_without_mutating_tasks(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 2)
+        now = 1_700_000_000
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_runs (task_id, profile, status, started_at) VALUES (?, ?, ?, ?)",
+                ("previous", "alpha", "completed", now - 10),
+            )
+        monkeypatch_time = pytest.MonkeyPatch()
+        monkeypatch_time.setattr(kb.time, "time", lambda: now)
+        try:
+            res = kb.dispatch_once(
+                conn,
+                spawn_fn=_fake_spawn,
+                dry_run=True,
+                max_task_starts_per_hour=1,
+            )
+        finally:
+            monkeypatch_time.undo()
+        assert [row[0] for row in res.skipped_rolling_start_capped] == task_ids
+        rows = conn.execute(
+            "SELECT status, consecutive_failures FROM tasks ORDER BY created_at"
+        ).fetchall()
+        assert [(r["status"], r["consecutive_failures"]) for r in rows] == [("ready", 0), ("ready", 0)]
+
+
+def test_rolling_start_cap_allows_remaining_capacity_then_holds_rest(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 3)
+        now = 1_700_000_000
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_runs (task_id, profile, status, started_at) VALUES (?, ?, ?, ?)",
+                ("previous", "alpha", "completed", now - 10),
+            )
+        monkeypatch_time = pytest.MonkeyPatch()
+        monkeypatch_time.setattr(kb.time, "time", lambda: now)
+        try:
+            res = kb.dispatch_once(
+                conn,
+                spawn_fn=_fake_spawn,
+                dry_run=True,
+                max_task_starts_per_hour=2,
+            )
+        finally:
+            monkeypatch_time.undo()
+        assert [s[0] for s in res.spawned] == [task_ids[0]]
+        assert [h[0] for h in res.skipped_rolling_start_capped] == task_ids[1:]
+
+
+def test_review_tasks_obey_global_max_in_progress_when_ready_queue_empty(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        running = _make_ready_tasks(kb, conn, 3)
+        for task_id in running:
+            kb.claim_task(conn, task_id)
+        review_id = _make_review_task(kb, conn)
+
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True, max_in_progress=3)
+
+        assert not res.spawned
+        assert kb.get_task(conn, review_id).status == "review"
+
+
+def test_review_tasks_obey_per_profile_max_in_progress(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        running = _make_ready_tasks(kb, conn, 3)
+        for task_id in running:
+            kb.claim_task(conn, task_id)
+        review_id = _make_review_task(kb, conn)
+
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=True,
+            max_in_progress_per_profile=3,
+        )
+
+        assert not res.spawned
+        assert res.skipped_per_profile_capped == [(review_id, "alpha", 3)]
+        assert kb.get_task(conn, review_id).status == "review"
+
+
+def test_ready_and_review_tasks_share_global_and_profile_capacity(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        running = _make_ready_tasks(kb, conn, 2)
+        for task_id in running:
+            kb.claim_task(conn, task_id)
+        ready_id = kb.create_task(conn, title="new ready", assignee="alpha")
+        review_id = _make_review_task(kb, conn)
+
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=True,
+            max_in_progress=3,
+            max_in_progress_per_profile=4,
+        )
+
+        assert [row[0] for row in res.spawned] == [ready_id]
+        assert res.skipped_per_profile_capped == []
+        assert kb.get_task(conn, review_id).status == "review"
+
+
+def _write_state_db(home: Path, rows, *, include_billing_columns: bool = True):
+    db = home / "state.db"
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute(
+            "CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, started_at REAL, ended_at REAL)"
+        )
+        billing_columns = "billing_mode TEXT DEFAULT ''," if include_billing_columns else ""
+        cost_status_column = "cost_status TEXT," if include_billing_columns else ""
+        conn.execute(
+            f"""CREATE TABLE session_model_usage (
+                   session_id TEXT, model TEXT, billing_provider TEXT DEFAULT '', billing_base_url TEXT DEFAULT '',
+                   {billing_columns} task TEXT DEFAULT '', api_call_count INTEGER DEFAULT 0,
+                   input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0,
+                   cache_read_tokens INTEGER DEFAULT 0, cache_write_tokens INTEGER DEFAULT 0,
+                   reasoning_tokens INTEGER DEFAULT 0, estimated_cost_usd REAL DEFAULT 0,
+                   actual_cost_usd REAL DEFAULT 0, {cost_status_column} cost_source TEXT,
+                   first_seen REAL, last_seen REAL
+               )"""
+        )
+        for idx, row in enumerate(rows):
+            sid = f"s{idx}"
+            conn.execute(
+                "INSERT INTO sessions (id, source, started_at, ended_at) VALUES (?, 'cli', ?, ?)",
+                (sid, row["seen"], row["seen"]),
+            )
+            columns = [
+                "session_id",
+                "model",
+                "estimated_cost_usd",
+                "actual_cost_usd",
+                "last_seen",
+            ]
+            values = [
+                sid,
+                row.get("model", "m"),
+                row.get("estimated", 0),
+                row.get("actual", 0),
+                row["seen"],
+            ]
+            columns.extend(["billing_provider", "billing_base_url"])
+            values.extend([row.get("billing_provider", ""), row.get("billing_base_url", "")])
+            if include_billing_columns:
+                columns.extend(["billing_mode", "cost_status"])
+                values.extend([row.get("billing_mode", ""), row.get("cost_status")])
+            placeholders = ", ".join("?" for _ in values)
+            conn.execute(
+                f"INSERT INTO session_model_usage ({', '.join(columns)}) VALUES ({placeholders})",
+                values,
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_daily_spend_actual_wins_over_estimated_and_multi_profile(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    profile_home = home / "profiles" / "alpha"
+    now = 1_700_000_000
+    _write_state_db(home, [{"seen": now, "estimated": 5, "actual": 2}])
+    _write_state_db(profile_home, [{"seen": now, "estimated": 3, "actual": 0}])
+    cfg = kb.SpendAdmissionConfig(cap_usd=10, timezone_name="UTC")
+    summary = kb.read_daily_spend_ledger(cfg, now=now)
+    assert summary.ledger_readable is True
+    assert summary.known_metered_cost_usd == pytest.approx(5.0)
+    assert summary.actual_cost_usd == pytest.approx(2.0)
+    assert summary.estimated_cost_usd == pytest.approx(3.0)
+
+
+def test_subscription_included_zero_cost_rows_do_not_trigger_unknown_hold(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [{
+            "seen": now,
+            "actual": 0,
+            "estimated": 0,
+            "billing_mode": "subscription_included",
+            "cost_status": "included",
+        }],
+    )
+    cfg = kb.SpendAdmissionConfig(
+        cap_usd=1,
+        timezone_name="UTC",
+        unknown_cost_policy="hold",
+    )
+
+    summary = kb.read_daily_spend_ledger(cfg, now=now, profile_homes=[home])
+
+    assert summary.ledger_readable is True
+    assert summary.included_cost_rows == 1
+    assert summary.unknown_cost_rows == 0
+    assert summary.known_metered_cost_usd == pytest.approx(0.0)
+
+
+def test_subscription_included_zero_cost_rows_allow_dispatch_under_hold(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [{
+            "seen": now,
+            "actual": 0,
+            "estimated": 0,
+            "billing_mode": "subscription_included",
+            "cost_status": "included",
+        }],
+    )
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 1)
+        monkeypatch_time = pytest.MonkeyPatch()
+        monkeypatch_time.setattr(kb.time, "time", lambda: now)
+        try:
+            res = kb.dispatch_once(
+                conn,
+                spawn_fn=_fake_spawn,
+                dry_run=True,
+                spend_config=kb.SpendAdmissionConfig(
+                    cap_usd=1,
+                    timezone_name="UTC",
+                    unknown_cost_policy="hold",
+                ),
+            )
+        finally:
+            monkeypatch_time.undo()
+
+    assert [row[0] for row in res.spawned] == task_ids
+    assert not res.skipped_unknown_cost_policy
+    assert res.spend_telemetry["included_cost_rows"] == 1
+
+
+def test_native_chatgpt_codex_blank_zero_rows_allow_dispatch_under_hold_across_profiles(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    profile_homes = [home, home / "profiles" / "coder", home / "profiles" / "reviewer"]
+    for idx, profile_home in enumerate(profile_homes):
+        profile_home.mkdir(parents=True, exist_ok=True)
+        _write_state_db(
+            profile_home,
+            [{
+                "seen": now,
+                "actual": 0,
+                "estimated": 0,
+                "billing_provider": "auto",
+                "billing_base_url": "https://chatgpt.com/backend-api/codex/",
+                "billing_mode": "",
+                "cost_status": "",
+                "model": ["gpt-5.5", "gpt-5.6-sol", "gpt-5.5"][idx],
+            }],
+        )
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 1)
+        monkeypatch_time = pytest.MonkeyPatch()
+        monkeypatch_time.setattr(kb.time, "time", lambda: now)
+        try:
+            res = kb.dispatch_once(
+                conn,
+                spawn_fn=_fake_spawn,
+                dry_run=True,
+                spend_config=kb.SpendAdmissionConfig(
+                    cap_usd=1,
+                    timezone_name="UTC",
+                    unknown_cost_policy="hold",
+                ),
+            )
+        finally:
+            monkeypatch_time.undo()
+
+    assert [row[0] for row in res.spawned] == task_ids
+    assert not res.skipped_unknown_cost_policy
+    assert res.spend_telemetry["included_cost_rows"] == 3
+    assert res.spend_telemetry["explicit_included_cost_rows"] == 0
+    assert res.spend_telemetry["transport_inferred_included_rows"] == 3
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://evilchatgpt.com/backend-api/codex/",
+        "https://chatgpt.com.evil/backend-api/codex/",
+        "https://user@chatgpt.com/backend-api/codex/",
+        "http://chatgpt.com/backend-api/codex/",
+        "https://api.openai.com/v1",
+        "https://chatgpt.com/backend-api/codexish/",
+        "https://chatgpt.com/backend-api/codex/../metered/",
+    ],
+)
+def test_native_chatgpt_codex_transport_inference_rejects_spoofed_and_custom_urls(
+    isolated_kanban_home,
+    base_url,
+):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [{
+            "seen": now,
+            "actual": 0,
+            "estimated": 0,
+            "billing_provider": "auto",
+            "billing_base_url": base_url,
+            "billing_mode": "",
+            "cost_status": "",
+            "model": "gpt-5.5",
+        }],
+    )
+
+    summary = kb.read_daily_spend_ledger(
+        kb.SpendAdmissionConfig(cap_usd=1, timezone_name="UTC", unknown_cost_policy="hold"),
+        now=now,
+        profile_homes=[home],
+    )
+
+    assert summary.unknown_cost_rows == 1
+    assert summary.included_cost_rows == 0
+    assert summary.transport_inferred_included_rows == 0
+
+
+def test_provider_or_model_alone_do_not_mark_blank_zero_rows_included(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [
+            {
+                "seen": now,
+                "actual": 0,
+                "estimated": 0,
+                "billing_provider": "auto",
+                "billing_base_url": "",
+                "billing_mode": "",
+                "cost_status": "",
+                "model": "gpt-5.5",
+            },
+            {
+                "seen": now,
+                "actual": 0,
+                "estimated": 0,
+                "billing_provider": "chatgpt",
+                "billing_base_url": "",
+                "billing_mode": "",
+                "cost_status": "",
+                "model": "other-model",
+            },
+        ],
+    )
+
+    summary = kb.read_daily_spend_ledger(
+        kb.SpendAdmissionConfig(cap_usd=1, timezone_name="UTC", unknown_cost_policy="hold"),
+        now=now,
+        profile_homes=[home],
+    )
+
+    assert summary.unknown_cost_rows == 2
+    assert summary.included_cost_rows == 0
+
+
+def test_native_chatgpt_codex_blank_positive_cost_still_counts_as_metered(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [{
+            "seen": now,
+            "actual": 1.25,
+            "estimated": 0,
+            "billing_provider": "auto",
+            "billing_base_url": "https://chatgpt.com/backend-api/codex/",
+            "billing_mode": "",
+            "cost_status": "",
+            "model": "gpt-5.5",
+        }],
+    )
+
+    summary = kb.read_daily_spend_ledger(
+        kb.SpendAdmissionConfig(cap_usd=10, timezone_name="UTC"),
+        now=now,
+        profile_homes=[home],
+    )
+
+    assert summary.known_cost_rows == 1
+    assert summary.known_metered_cost_usd == pytest.approx(1.25)
+    assert summary.included_cost_rows == 0
+    assert summary.transport_inferred_included_rows == 0
+
+
+def test_subscription_included_rows_do_not_increase_known_metered_spend(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [{
+            "seen": now,
+            "actual": 4,
+            "estimated": 7,
+            "billing_mode": "subscription_included",
+            "cost_status": "included",
+        }],
+    )
+    cfg = kb.SpendAdmissionConfig(cap_usd=10, timezone_name="UTC")
+
+    summary = kb.read_daily_spend_ledger(cfg, now=now, profile_homes=[home])
+
+    assert summary.included_cost_rows == 1
+    assert summary.known_cost_rows == 0
+    assert summary.known_metered_cost_usd == pytest.approx(0.0)
+    assert summary.actual_cost_usd == pytest.approx(0.0)
+    assert summary.estimated_cost_usd == pytest.approx(0.0)
+
+
+def test_known_metered_actual_and_estimated_rows_still_count(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [
+            {
+                "seen": now,
+                "actual": 1.25,
+                "estimated": 8,
+                "billing_mode": "metered",
+                "cost_status": "actual",
+            },
+            {
+                "seen": now,
+                "actual": 0,
+                "estimated": 2.5,
+                "billing_mode": "metered",
+                "cost_status": "estimated",
+            },
+        ],
+    )
+    cfg = kb.SpendAdmissionConfig(cap_usd=10, timezone_name="UTC")
+
+    summary = kb.read_daily_spend_ledger(cfg, now=now, profile_homes=[home])
+
+    assert summary.known_cost_rows == 2
+    assert summary.known_metered_cost_usd == pytest.approx(3.75)
+    assert summary.actual_cost_usd == pytest.approx(1.25)
+    assert summary.estimated_cost_usd == pytest.approx(2.5)
+
+
+def test_unknown_metered_rows_still_obey_hold_policy(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [{
+            "seen": now,
+            "actual": 0,
+            "estimated": 0,
+            "billing_mode": "metered",
+            "cost_status": None,
+        }],
+    )
+
+    summary = kb.read_daily_spend_ledger(
+        kb.SpendAdmissionConfig(
+            cap_usd=1,
+            timezone_name="UTC",
+            unknown_cost_policy="hold",
+        ),
+        now=now,
+        profile_homes=[home],
+    )
+
+    assert summary.unknown_cost_rows == 1
+    assert summary.known_metered_cost_usd == pytest.approx(0.0)
+
+
+def test_malformed_metered_cost_rows_are_unknown_not_crashes(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [{
+            "seen": now,
+            "actual": "not-a-number",
+            "estimated": 0,
+            "billing_mode": "metered",
+            "cost_status": "actual",
+        }],
+    )
+
+    summary = kb.read_daily_spend_ledger(
+        kb.SpendAdmissionConfig(cap_usd=1, timezone_name="UTC"),
+        now=now,
+        profile_homes=[home],
+    )
+
+    assert summary.ledger_readable is True
+    assert summary.unknown_cost_rows == 1
+    assert summary.known_metered_cost_usd == pytest.approx(0.0)
+
+
+def test_older_ledger_without_billing_columns_is_backward_compatible_fail_closed(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(
+        home,
+        [{"seen": now, "actual": 0, "estimated": 0}],
+        include_billing_columns=False,
+    )
+    cfg = kb.SpendAdmissionConfig(
+        cap_usd=1,
+        timezone_name="UTC",
+        unknown_cost_policy="hold",
+    )
+
+    summary = kb.read_daily_spend_ledger(cfg, now=now, profile_homes=[home])
+
+    assert summary.ledger_readable is True
+    assert summary.unknown_cost_rows == 1
+    assert summary.known_metered_cost_usd == pytest.approx(0.0)
+    assert summary.errors == ()
+
+
+def test_daily_spend_cap_holds_without_state_mutation(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 2)
+        summary = kb.SpendLedgerSummary(
+            ledger_readable=True,
+            known_metered_cost_usd=12.5,
+            day_start_ts=0,
+            day_end_ts=1,
+        )
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=True,
+            spend_config=kb.SpendAdmissionConfig(cap_usd=10),
+            spend_ledger_reader=lambda _cfg: summary,
+        )
+        assert [h[0] for h in res.skipped_daily_spend_capped] == task_ids
+        assert not res.spawned
+        assert [r["status"] for r in conn.execute("SELECT status FROM tasks ORDER BY created_at")] == ["ready", "ready"]
+
+
+def test_positive_spend_cap_fails_closed_when_no_ledger_readable(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 1)
+        summary = kb.SpendLedgerSummary(ledger_readable=False)
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=True,
+            spend_config=kb.SpendAdmissionConfig(cap_usd=1),
+            spend_ledger_reader=lambda _cfg: summary,
+        )
+        assert res.skipped_spend_ledger_unavailable == task_ids
+        assert not res.spawned
+
+
+def test_unknown_cost_policy_hold_defers_and_reports_rows(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 1)
+        summary = kb.SpendLedgerSummary(
+            ledger_readable=True,
+            known_metered_cost_usd=0.25,
+            unknown_cost_rows=2,
+            day_start_ts=0,
+            day_end_ts=1,
+        )
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=True,
+            spend_config=kb.SpendAdmissionConfig(cap_usd=1, unknown_cost_policy="hold"),
+            spend_ledger_reader=lambda _cfg: summary,
+        )
+        assert res.skipped_unknown_cost_policy == [(task_ids[0], 2)]
+        assert res.spend_telemetry["unknown_cost_rows"] == 2
+        assert not res.spawned
+
+
+def test_daily_spend_day_boundary_uses_local_timezone_dst(isolated_kanban_home):
+    _, kb = isolated_kanban_home
+    # 2026-03-08 in America/Chicago is a spring-forward 23-hour local day.
+    noon_chicago_utc = 1_772_989_200
+    start, end, tz = kb._day_bounds_for_timezone("America/Chicago", now=noon_chicago_utc)
+    assert tz == "America/Chicago"
+    assert end - start == 23 * 60 * 60

--- a/tests/hermes_cli/test_kanban_admission_caps.py
+++ b/tests/hermes_cli/test_kanban_admission_caps.py
@@ -218,6 +218,11 @@ def _write_state_db(home: Path, rows, *, include_billing_columns: bool = True):
         conn.close()
 
 
+def _write_corrupt_state_db(home: Path):
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "state.db").write_bytes(b"not a sqlite database")
+
+
 def test_daily_spend_actual_wins_over_estimated_and_multi_profile(isolated_kanban_home):
     home, kb = isolated_kanban_home
     profile_home = home / "profiles" / "alpha"
@@ -601,6 +606,142 @@ def test_daily_spend_cap_holds_without_state_mutation(isolated_kanban_home):
         assert [h[0] for h in res.skipped_daily_spend_capped] == task_ids
         assert not res.spawned
         assert [r["status"] for r in conn.execute("SELECT status FROM tasks ORDER BY created_at")] == ["ready", "ready"]
+
+
+def test_partial_unreadable_spend_ledger_fails_closed_without_start_mutation(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(home, [{"seen": now, "estimated": 3, "actual": 0}])
+    _write_corrupt_state_db(home / "profiles" / "alpha")
+
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 2)
+        monkeypatch_time = pytest.MonkeyPatch()
+        monkeypatch_time.setattr(kb.time, "time", lambda: now)
+        try:
+            res = kb.dispatch_once(
+                conn,
+                spawn_fn=_fake_spawn,
+                spend_config=kb.SpendAdmissionConfig(cap_usd=25, timezone_name="UTC"),
+            )
+        finally:
+            monkeypatch_time.undo()
+
+        assert res.skipped_spend_ledger_unavailable == task_ids
+        assert not res.skipped_daily_spend_capped
+        assert not res.spawned
+        assert res.spend_telemetry["ledger_readable"] is False
+        assert res.spend_telemetry["ledgers_read"] == 1
+        assert res.spend_telemetry["ledgers_unavailable"] == 1
+        assert res.spend_telemetry["known_metered_cost_usd"] == pytest.approx(3.0)
+        assert res.spend_telemetry["errors"] == ["ledger_1:DatabaseError"]
+        assert conn.execute("SELECT COUNT(*) FROM task_runs").fetchone()[0] == 0
+        statuses = conn.execute("SELECT status FROM tasks ORDER BY created_at").fetchall()
+        assert [row["status"] for row in statuses] == ["ready", "ready"]
+
+
+def test_unreadable_ledger_takes_precedence_over_over_cap_healthy_ledger(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(home, [{"seen": now, "estimated": 30, "actual": 0}])
+    _write_corrupt_state_db(home / "profiles" / "alpha")
+
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 1)
+        monkeypatch_time = pytest.MonkeyPatch()
+        monkeypatch_time.setattr(kb.time, "time", lambda: now)
+        try:
+            res = kb.dispatch_once(
+                conn,
+                spawn_fn=_fake_spawn,
+                spend_config=kb.SpendAdmissionConfig(cap_usd=25, timezone_name="UTC"),
+            )
+        finally:
+            monkeypatch_time.undo()
+
+    assert res.skipped_spend_ledger_unavailable == task_ids
+    assert not res.skipped_daily_spend_capped
+    assert not res.spawned
+    assert res.spend_telemetry["ledger_readable"] is False
+    assert res.spend_telemetry["known_metered_cost_usd"] == pytest.approx(30.0)
+
+
+def test_query_failing_ledger_schema_fails_closed_even_with_healthy_ledger(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(home, [{"seen": now, "estimated": 2, "actual": 0}])
+    profile_home = home / "profiles" / "alpha"
+    profile_home.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(profile_home / "state.db")
+    try:
+        conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
+        conn.commit()
+    finally:
+        conn.close()
+
+    with kb.connect_closing() as board_conn:
+        task_ids = _make_ready_tasks(kb, board_conn, 1)
+        monkeypatch_time = pytest.MonkeyPatch()
+        monkeypatch_time.setattr(kb.time, "time", lambda: now)
+        try:
+            res = kb.dispatch_once(
+                board_conn,
+                spawn_fn=_fake_spawn,
+                spend_config=kb.SpendAdmissionConfig(cap_usd=25, timezone_name="UTC"),
+            )
+        finally:
+            monkeypatch_time.undo()
+
+    assert res.skipped_spend_ledger_unavailable == task_ids
+    assert not res.spawned
+    assert res.spend_telemetry["ledger_readable"] is False
+    assert res.spend_telemetry["ledgers_unavailable"] == 1
+    assert res.spend_telemetry["errors"] == ["ledger_1:missing session_model_usage"]
+
+
+def test_duplicate_spend_ledger_paths_are_counted_once(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(home, [{"seen": now, "estimated": 2, "actual": 0}])
+
+    summary = kb.read_daily_spend_ledger(
+        kb.SpendAdmissionConfig(cap_usd=25, timezone_name="UTC"),
+        now=now,
+        profile_homes=[home, home.resolve(), home],
+    )
+
+    assert summary.ledger_readable is True
+    assert summary.profiles_read == 1
+    assert summary.ledgers_read == 1
+    assert summary.known_metered_cost_usd == pytest.approx(2.0)
+
+
+def test_all_healthy_multi_profile_spend_ledgers_allow_dispatch(isolated_kanban_home):
+    home, kb = isolated_kanban_home
+    now = 1_700_000_000
+    _write_state_db(home, [{"seen": now, "estimated": 2, "actual": 0}])
+    _write_state_db(home / "profiles" / "alpha", [{"seen": now, "estimated": 3, "actual": 0}])
+
+    with kb.connect_closing() as conn:
+        task_ids = _make_ready_tasks(kb, conn, 1)
+        monkeypatch_time = pytest.MonkeyPatch()
+        monkeypatch_time.setattr(kb.time, "time", lambda: now)
+        try:
+            res = kb.dispatch_once(
+                conn,
+                spawn_fn=_fake_spawn,
+                dry_run=True,
+                spend_config=kb.SpendAdmissionConfig(cap_usd=25, timezone_name="UTC"),
+            )
+        finally:
+            monkeypatch_time.undo()
+
+    assert [row[0] for row in res.spawned] == task_ids
+    assert not res.skipped_spend_ledger_unavailable
+    assert res.spend_telemetry["ledger_readable"] is True
+    assert res.spend_telemetry["ledgers_read"] == 2
+    assert res.spend_telemetry["ledgers_unavailable"] == 0
+    assert res.spend_telemetry["known_metered_cost_usd"] == pytest.approx(5.0)
 
 
 def test_positive_spend_cap_fails_closed_when_no_ledger_readable(isolated_kanban_home):

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -226,7 +226,23 @@ up on the next tick (60s by default).
 kanban:
   dispatch_in_gateway: true        # default
   dispatch_interval_seconds: 60    # default
+  max_spawn: null                  # optional live global worker cap
+  max_in_progress: null            # optional live global running-task cap
+  max_in_progress_per_profile: null # optional live cap per assignee profile
+  max_task_starts_per_hour: null   # optional rolling native task-start cap
+  daily_spend_cap_usd: null        # optional known-metered local spend cap
+  daily_spend_timezone: UTC        # IANA day boundary for spend cap
+  unknown_cost_policy: allow       # allow | hold unknown-cost rows
 ```
+
+Admission caps apply to both `ready` implementation work and `review`
+handoffs. Global and per-profile caps share one accounting path, so review
+agents cannot bypass `max_in_progress` or `max_in_progress_per_profile` when
+the ready queue is empty. Spend admission reads local `state.db` usage ledgers
+read-only across installed profiles: explicit `subscription_included` rows and
+Hermes' native ChatGPT Codex subscription transport are not metered, positive
+actual/estimated API costs are counted, and unknown-cost rows can either be
+reported (`allow`) or held fail-closed (`hold`).
 
 Override the config flag at runtime via `HERMES_KANBAN_DISPATCH_IN_GATEWAY=0`
 for debugging. Standard gateway supervision applies: run `hermes gateway


### PR DESCRIPTION
## Summary
- Port U2 kanban admission-cap support into the current dispatcher path.
- Add config/defaults and gateway wiring for `max_task_starts_per_hour`, `daily_spend_cap_usd`, `daily_spend_timezone`, and `unknown_cost_policy`.
- Enforce admission caps across both `ready` and `review` queues so review handoffs cannot bypass global/per-profile caps when the ready queue is empty.
- Document kanban admission-cap config and add regression coverage for rolling-start caps, daily spend caps, native ChatGPT Codex subscription accounting, dry-run behavior, and review queue admission.

## Freshness / prod-truth
- Fetched `origin/main` immediately before commit; branch is based on `413ed6b9d`, current `origin/main` at fetch time.
- No Supabase functions, production DDL/DML, or deployed body diffs involved.

## Verification
- `python -m py_compile hermes_cli/kanban_db.py gateway/kanban_watchers.py hermes_cli/config.py`
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_admission_caps.py -q` — 28 passed
- `scripts/run_tests.sh tests/hermes_cli/test_kanban*.py -q` — 788 passed
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_admission_caps.py tests/hermes_cli/test_kanban*.py tests/hermes_cli/test_env_loader.py tests/tools/test_skills_tool.py tests/tools/test_skills_tool_profile_scope.py tests/tools/test_skills_tool_discovery_cache.py -q` — 903 passed, 0 failed; runner reported `tests/tools/test_skills_tool_discovery_cache.py` as flaky (failed once, passed on retry) on an unrelated existing test.
- `git diff --cached --check`

## Review notes
- `max_spawn` and `max_in_progress` are both live concurrency caps in the dispatcher loop; the global cap clamp intentionally uses the live cap value instead of remaining slots so existing `running_count + spawned >= max_spawn` semantics stay coherent.
- Daily spend admission reads local profile `state.db` usage ledgers read-only and only emits aggregate telemetry; it does not log prompt/session content.
