### PR TITLE
fix(compression): make continuation rotation atomic

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1263,9 +1263,30 @@ def compress_context(
                         pass  # best-effort — don't block compression on a flush error
                     # Propagate title to the new session with auto-numbering
                     old_title = agent._session_db.get_session_title(agent.session_id)
-                    agent._session_db.end_session(agent.session_id, "compression")
                     old_session_id = agent.session_id
-                    agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+                    new_session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+                    try:
+                        agent._session_db.rotate_session_for_compression(
+                            parent_session_id=old_session_id,
+                            child_session_id=new_session_id,
+                            source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                            model=agent.model,
+                            model_config=agent._session_init_model_config,
+                        )
+                    except Exception as _cs_err:
+                        # Closing the parent and creating its continuation share
+                        # one transaction. A failure therefore leaves the live
+                        # parent open and indexed; never publish the unpersisted
+                        # child id to the agent/gateway contexts.
+                        logger.warning(
+                            "Compression child session create failed (%s) — "
+                            "atomic rotation rolled back to parent session %s.",
+                            _cs_err, old_session_id,
+                        )
+                        old_session_id = None  # no rotation happened
+                        agent._session_db_created = True
+                        raise
+                    agent.session_id = new_session_id
                     # Ordering contract: the agent thread updates the contextvar here;
                     # the gateway propagates to SessionEntry after run_in_executor returns.
                     try:
@@ -1289,53 +1310,6 @@ def compress_context(
                         set_session_context(agent.session_id)
                     except Exception:
                         pass
-                    agent._session_db_created = False
-                    try:
-                        agent._session_db.create_session(
-                            session_id=agent.session_id,
-                            source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
-                            model=agent.model,
-                            model_config=agent._session_init_model_config,
-                            parent_session_id=old_session_id,
-                        )
-                    except Exception as _cs_err:
-                        # The child row could not be created (e.g. FK constraint,
-                        # contended write). Previously the outer handler simply
-                        # warned and let the agent continue on the NEW id — which
-                        # has no row in state.db, producing an orphan: the parent
-                        # is ended, the child is never indexed, and every
-                        # subsequent message is attributed to a session that
-                        # doesn't exist (#33906/#33907). Roll the live id back to
-                        # the parent so the conversation stays attached to a real,
-                        # indexed session instead of a phantom.
-                        logger.warning(
-                            "Compression child session create failed (%s) — "
-                            "rolling back to parent session %s to avoid an orphan.",
-                            _cs_err, old_session_id,
-                        )
-                        agent.session_id = old_session_id
-                        try:
-                            from gateway.session_context import set_current_session_id
-                            set_current_session_id(agent.session_id)
-                        except Exception:
-                            os.environ["HERMES_SESSION_ID"] = agent.session_id
-                        try:
-                            from hermes_logging import set_session_context
-                            set_session_context(agent.session_id)
-                        except Exception:
-                            pass
-                        # Re-open the parent: it was ended above, but we're
-                        # continuing on it, so it must not stay closed.
-                        try:
-                            agent._session_db.reopen_session(old_session_id)
-                        except Exception:
-                            pass
-                        old_session_id = None  # no rotation happened
-                        # The parent row already exists in state.db, so mark the
-                        # session as created — _ensure_db_session would otherwise
-                        # retry a (harmless INSERT OR IGNORE) create next turn.
-                        agent._session_db_created = True
-                        raise
                     agent._session_db_created = True
                     # Carry a persistent /goal onto the continuation session.
                     # Compression mints a fresh child id; load_goal does a flat

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2017,6 +2017,59 @@ class SessionDB:
     # Session lifecycle
     # =========================================================================
 
+    @staticmethod
+    def _insert_session_row_in_transaction(
+        conn: sqlite3.Connection,
+        session_id: str,
+        source: str,
+        model: Optional[str] = None,
+        model_config: Optional[Dict[str, Any]] = None,
+        system_prompt: Optional[str] = None,
+        user_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+        chat_id: Optional[str] = None,
+        chat_type: Optional[str] = None,
+        thread_id: Optional[str] = None,
+        parent_session_id: Optional[str] = None,
+        cwd: Optional[str] = None,
+        profile_name: Optional[str] = None,
+    ) -> None:
+        """Insert or enrich one session row using the caller's transaction."""
+        conn.execute(
+            """INSERT INTO sessions (
+               id, source, user_id, session_key, chat_id, chat_type, thread_id,
+               model, model_config, system_prompt, parent_session_id, cwd, profile_name, started_at
+            )
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(id) DO UPDATE SET
+                   model = COALESCE(sessions.model, excluded.model),
+                   model_config = COALESCE(sessions.model_config, excluded.model_config),
+                   system_prompt = COALESCE(sessions.system_prompt, excluded.system_prompt),
+                   session_key = COALESCE(sessions.session_key, excluded.session_key),
+                   chat_id = COALESCE(sessions.chat_id, excluded.chat_id),
+                   chat_type = COALESCE(sessions.chat_type, excluded.chat_type),
+                   thread_id = COALESCE(sessions.thread_id, excluded.thread_id),
+                   parent_session_id = COALESCE(sessions.parent_session_id, excluded.parent_session_id),
+                   cwd = COALESCE(sessions.cwd, excluded.cwd),
+                   profile_name = COALESCE(sessions.profile_name, excluded.profile_name)""",
+            (
+                session_id,
+                source,
+                user_id,
+                session_key,
+                chat_id,
+                chat_type,
+                thread_id,
+                model,
+                json.dumps(model_config) if model_config else None,
+                system_prompt,
+                parent_session_id,
+                cwd,
+                profile_name,
+                time.time(),
+            ),
+        )
+
     def _insert_session_row(
         self,
         session_id: str,
@@ -2052,39 +2105,21 @@ class SessionDB:
         no chat/thread to compare).
         """
         def _do(conn):
-            conn.execute(
-                """INSERT INTO sessions (
-                   id, source, user_id, session_key, chat_id, chat_type, thread_id,
-                   model, model_config, system_prompt, parent_session_id, cwd, profile_name, started_at
-                )
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                   ON CONFLICT(id) DO UPDATE SET
-                       model = COALESCE(sessions.model, excluded.model),
-                       model_config = COALESCE(sessions.model_config, excluded.model_config),
-                       system_prompt = COALESCE(sessions.system_prompt, excluded.system_prompt),
-                       session_key = COALESCE(sessions.session_key, excluded.session_key),
-                       chat_id = COALESCE(sessions.chat_id, excluded.chat_id),
-                       chat_type = COALESCE(sessions.chat_type, excluded.chat_type),
-                       thread_id = COALESCE(sessions.thread_id, excluded.thread_id),
-                       parent_session_id = COALESCE(sessions.parent_session_id, excluded.parent_session_id),
-                       cwd = COALESCE(sessions.cwd, excluded.cwd),
-                       profile_name = COALESCE(sessions.profile_name, excluded.profile_name)""",
-                (
-                    session_id,
-                    source,
-                    user_id,
-                    session_key,
-                    chat_id,
-                    chat_type,
-                    thread_id,
-                    model,
-                    json.dumps(model_config) if model_config else None,
-                    system_prompt,
-                    parent_session_id,
-                    cwd,
-                    profile_name,
-                    time.time(),
-                ),
+            self._insert_session_row_in_transaction(
+                conn,
+                session_id=session_id,
+                source=source,
+                model=model,
+                model_config=model_config,
+                system_prompt=system_prompt,
+                user_id=user_id,
+                session_key=session_key,
+                chat_id=chat_id,
+                chat_type=chat_type,
+                thread_id=thread_id,
+                parent_session_id=parent_session_id,
+                cwd=cwd,
+                profile_name=profile_name,
             )
         self._execute_write(_do)
 
@@ -2092,6 +2127,39 @@ class SessionDB:
         """Create a new session record. Returns the session_id."""
         self._insert_session_row(session_id, source, **kwargs)
         return session_id
+
+    def rotate_session_for_compression(
+        self,
+        parent_session_id: str,
+        child_session_id: str,
+        source: str,
+        **child_kwargs,
+    ) -> str:
+        """Close a compression parent and create its child atomically.
+
+        Session pruning selects ended rows. Keeping both writes in one
+        transaction prevents a concurrent prune from deleting the parent in
+        the gap between ``end_session`` and ``create_session`` and leaving the
+        live agent attached to a child row that was never persisted.
+        """
+        child_kwargs.pop("parent_session_id", None)
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET ended_at = ?, end_reason = ? "
+                "WHERE id = ? AND ended_at IS NULL",
+                (time.time(), "compression", parent_session_id),
+            )
+            self._insert_session_row_in_transaction(
+                conn,
+                session_id=child_session_id,
+                source=source,
+                parent_session_id=parent_session_id,
+                **child_kwargs,
+            )
+
+        self._execute_write(_do)
+        return child_session_id
 
     def record_gateway_session_peer(
         self,

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -18,6 +18,7 @@ These tests drive the real ``compress_context`` path against a real SessionDB.
 from __future__ import annotations
 
 import os
+import threading
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -126,21 +127,97 @@ class TestOrphanRollbackOnCreateFailure:
         db.create_session(parent, source="cli")
         agent = _build_agent_with_db(db, parent)
 
-        # Make the CHILD create_session raise, but let the initial parent
-        # end_session/reopen work. We patch create_session to blow up.
-        real_create = db.create_session
-
         def _boom(*a, **k):
             raise RuntimeError("FOREIGN KEY constraint failed")
 
-        with patch.object(db, "create_session", side_effect=_boom):
+        with patch.object(db, "rotate_session_for_compression", side_effect=_boom):
             agent._compress_context(_msgs(), "sys", approx_tokens=120_000)
 
         # The live id must roll back to the still-indexed parent — NOT a
         # phantom child id that has no row in state.db.
         assert agent.session_id == parent
-        assert db.get_session(parent) is not None
-        _ = real_create  # silence unused
+        parent_row = db.get_session(parent)
+        assert parent_row is not None
+        assert parent_row["ended_at"] is None
+
+
+class TestAtomicCompressionRotation:
+    def test_prune_cannot_delete_parent_before_child_is_created(self, tmp_path: Path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        prune_db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_ATOMIC_ROT"
+        child = "CHILD_ATOMIC_ROT"
+        db.create_session(parent, source="telegram")
+
+        child_insert_reached = threading.Event()
+        allow_child_insert = threading.Event()
+        child_insert_timed_out = threading.Event()
+        prune_attempted = threading.Event()
+        rotation_errors = []
+        prune_result = []
+
+        def _trace(sql):
+            if sql.startswith("INSERT INTO sessions") and child in sql:
+                child_insert_reached.set()
+                if not allow_child_insert.wait(timeout=5):
+                    child_insert_timed_out.set()
+
+        assert db._conn is not None
+        db._conn.set_trace_callback(_trace)
+        real_prune_write = prune_db._execute_write
+
+        def _mark_prune_attempt(fn):
+            prune_attempted.set()
+            return real_prune_write(fn)
+
+        def _rotate():
+            try:
+                db.rotate_session_for_compression(
+                    parent_session_id=parent,
+                    child_session_id=child,
+                    source="telegram",
+                    model="test/model",
+                )
+            except BaseException as exc:
+                rotation_errors.append(exc)
+
+        def _prune():
+            prune_result.append(
+                prune_db.prune_sessions(older_than_days=None, started_after=0)
+            )
+
+        rotation_thread = threading.Thread(target=_rotate)
+        prune_thread = threading.Thread(target=_prune)
+        with patch.object(prune_db, "_execute_write", side_effect=_mark_prune_attempt):
+            rotation_thread.start()
+            assert child_insert_reached.wait(timeout=2)
+            # A WAL reader must still see the pre-rotation snapshot while the
+            # atomic writer is between its parent UPDATE and child INSERT. A
+            # split implementation exposes ended parent + missing child here.
+            visible_parent = prune_db.get_session(parent)
+            assert visible_parent is not None
+            assert visible_parent["ended_at"] is None
+            assert prune_db.get_session(child) is None
+            prune_thread.start()
+            assert prune_attempted.wait(timeout=2)
+            allow_child_insert.set()
+            rotation_thread.join(timeout=2)
+            prune_thread.join(timeout=2)
+
+        assert not rotation_thread.is_alive()
+        assert not prune_thread.is_alive()
+        assert not child_insert_timed_out.is_set()
+        assert rotation_errors == []
+        assert prune_result == [1]
+        assert db.get_session(parent) is None
+        child_row = db.get_session(child)
+        assert child_row is not None
+        assert child_row["parent_session_id"] is None
+        db.append_message(child, role="assistant", content="persisted after prune")
+        assert db.get_messages(child)[-1]["content"] == "persisted after prune"
+
+        db.close()
+        prune_db.close()
 
 
 class TestPlatformForwardedAtBoundary:


### PR DESCRIPTION
[Bob]

## Summary

- close a compression parent and create its continuation child in one `BEGIN IMMEDIATE` transaction
- publish the new in-memory session id only after the atomic DB rotation succeeds
- add a deterministic WAL race regression proving a concurrent reader/pruner can never observe an ended parent without its child

## Root cause

Legacy rotation called `end_session()` and `create_session()` as separate transactions. Auto-prune could select and delete the newly ended parent between those writes, so the child insert lost its lineage target and the live agent could continue with a session id that was never persisted.

## Verification

- `uv run pytest -q tests/agent/test_compression_rotation_state.py tests/agent/test_compression_concurrent_fork.py tests/test_hermes_state.py` — 435 passed
- race regression repeated 40/40 successfully
- mutation probe against the old split sequence exposed `parent_ended=true, child_visible=false`, confirming the test distinguishes the regression
- `uv run ruff check agent/conversation_compression.py hermes_state.py tests/agent/test_compression_rotation_state.py` — clean
- independent review — PASS, no blockers
