### PR TITLE
fix(auxiliary): handle retired OpenRouter free slugs

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3057,7 +3057,8 @@ def _is_payment_error(exc: Exception) -> bool:
             "out of funds", "run out of funds",
             "balance_depleted", "no usable credits",
             "model_not_supported_on_free_tier",
-            "not available on the free tier",
+            "not available on the free tier", "unavailable for free",
+            "paid version is available",
             "requires a subscription", "upgrade for access",
             "upgrade for higher limits", "reached your session usage limit",
             # Daily / monthly / weekly quota exhaustion keywords
@@ -3114,7 +3115,8 @@ def _is_rate_limit_error(exc: Exception) -> bool:
             "out of funds", "run out of funds",
             "balance_depleted", "no usable credits",
             "model_not_supported_on_free_tier",
-            "not available on the free tier",
+            "not available on the free tier", "unavailable for free",
+            "paid version is available",
         )):
             return True
     return False
@@ -3309,7 +3311,8 @@ def _is_model_not_found_error(exc: Exception) -> bool:
     if any(kw in err_lower for kw in (
         "credits", "insufficient funds", "billing", "out of funds",
         "balance_depleted", "no usable credits", "free tier", "free-tier",
-        "not available on the free tier",
+        "not available on the free tier", "unavailable for free",
+        "paid version is available",
     )):
         return False
     if status not in {404, 400, None}:
@@ -3367,6 +3370,7 @@ def _is_model_incompatible_error(exc: Exception) -> bool:
         "credits", "insufficient funds", "billing", "out of funds",
         "balance_depleted", "no usable credits", "payment required",
         "free tier", "free-tier", "not available on the free tier",
+        "unavailable for free", "paid version is available",
         "model_not_supported_on_free_tier", "quota",
     )):
         return False

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1667,6 +1667,15 @@ class TestIsPaymentError:
         exc.status_code = 404
         assert _is_payment_error(exc) is True
 
+    def test_404_openrouter_retired_free_slug_is_payment(self):
+        """OpenRouter's exact retired ``:free`` response must trigger fallback."""
+        exc = Exception(
+            "This model is unavailable for free. The paid version is available "
+            "now - use this slug instead: meta-llama/llama-4-maverick"
+        )
+        exc.status_code = 404
+        assert _is_payment_error(exc) is True
+
     def test_403_subscription_required_is_payment(self):
         exc = Exception(
             "this model requires a subscription, upgrade for access: "


### PR DESCRIPTION
## What does this PR do?

OpenRouter returns HTTP 404 when a configured `:free` slug is retired:

> This model is unavailable for free. The paid version is available now — use this slug instead: ...

The auxiliary client did not classify that wording as a payment/capacity error, so compression and other auxiliary tasks skipped their configured/main-model fallback and failed. This PR recognizes the exact response and keeps the payment, rate-limit, model-not-found, and model-incompatible classifiers mutually consistent.

## Related Issue

Related to #49983. This complements #50006: that PR improves main-agent tool-calling diagnostics, while this PR repairs auxiliary fallback routing for retired free slugs.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: classify OpenRouter's `unavailable for free` / `paid version is available` 404 as payment/capacity and exclude it from sibling error buckets.
- `tests/agent/test_auxiliary_client.py`: add a regression test using the exact observed OpenRouter response.

## How to Test

1. Configure `auxiliary.compression` with a retired OpenRouter `:free` slug and a viable fallback/main model.
2. Trigger context summary generation.
3. Confirm Hermes marks OpenRouter temporarily unhealthy and successfully generates the summary through fallback instead of pausing compression after the 404.

Local verification:

- Exact live reproduction failed before the change and generated a real fallback summary afterward.
- `tests/agent/test_auxiliary_client.py`: 322 passed.
- Auxiliary + context-compressor focused suite: 514 passed.
- Ruff: clean.
- Independent code review: pass, no blocking findings.

## Checklist

- [x] Read the contributing guide
- [x] Conventional commit message
- [x] Searched open issues and PRs
- [x] Focused PR with regression coverage
- [x] Tested on Windows 10 / Git Bash with Python 3.11
- [x] No config keys, tool schemas, or user documentation changed
