### PR TITLE
[Bob] Fix background process output redaction

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -320,6 +320,47 @@ def test_prompt_submit_fails_open_inline_when_compute_host_dispatch_breaks(monke
     assert session.get("_compute_host_active") is not True
 
 
+def test_agent_terminal_live_output_is_redacted_before_tui_emit(monkeypatch):
+    from tools.process_registry import ProcessSession, process_registry
+
+    secret = "sk-proj-synthetictuigatewaysecret123456789"
+    emitted = []
+    sid = "terminal-redaction-sid"
+    session_key = "terminal-redaction-key"
+    process = ProcessSession(
+        id="proc_terminal_redaction",
+        command=f"API_TOKEN={secret} python app.py",
+        session_key=session_key,
+    )
+    server._sessions[sid] = {"session_key": session_key}
+    monkeypatch.setattr(process_registry, "on_output", None)
+    monkeypatch.setattr(process_registry, "on_close", None)
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, owner_sid, payload=None: emitted.append((
+            event,
+            owner_sid,
+            payload,
+        )),
+    )
+
+    try:
+        server._wire_agent_terminal_output()
+        split_at = 1
+        process_registry._emit_output(process, f"READY {secret[:split_at]}")
+        process_registry._emit_output(process, f"{secret[split_at:]}\n")
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert emitted[0][0:2] == ("agent.terminal.output", sid)
+    assert emitted[0][2]["process_id"] == process.id
+    tui_output = "".join(event[2]["chunk"] for event in emitted)
+    assert "READY" in tui_output
+    assert secret not in tui_output
+    assert secret not in json.dumps(emitted)
+
+
 def test_compute_host_turn_end_updates_metadata_mirror(monkeypatch):
     session = _session(
         agent=None,

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -20,6 +20,9 @@ from tools.process_registry import (
 )
 
 
+SYNTHETIC_SECRET = "sk-proj-syntheticprocessregistrysecret123456789"
+
+
 @pytest.fixture()
 def registry():
     """Create a fresh ProcessRegistry."""
@@ -251,6 +254,106 @@ def test_reader_loop_streams_incremental_chunks_from_read1(registry, monkeypatch
     assert session.exited is True
     assert session.exit_code == 0
     assert moved == ["proc_reader_live"]
+
+
+def test_reader_redacts_before_process_output_reaches_any_surface(
+    registry, monkeypatch
+):
+    class _FakeBuffer:
+        def __init__(self):
+            split_at = 1
+            self._chunks = [
+                f"READY {SYNTHETIC_SECRET[:split_at]}".encode(),
+                f"{SYNTHETIC_SECRET[split_at:]}\n".encode(),
+                b"",
+            ]
+
+        def read1(self, _size):
+            return self._chunks.pop(0)
+
+    class _FakeStdout:
+        def __init__(self):
+            self.buffer = _FakeBuffer()
+
+    class _FakeProcess:
+        def __init__(self):
+            self.stdout = _FakeStdout()
+            self.returncode = 0
+
+        def wait(self, timeout=None):
+            return 0
+
+    session = _make_session(
+        sid="proc_redaction_surfaces",
+        command=f"API_TOKEN={SYNTHETIC_SECRET} python app.py",
+        task_id="redaction-task",
+    )
+    session.process = _FakeProcess()
+    session.notify_on_complete = True
+    session.watch_patterns = ["k-proj-"]
+    registry._running[session.id] = session
+    live_tui_chunks = []
+    registry.on_output = lambda _session, chunk: live_tui_chunks.append(chunk)
+    monkeypatch.setattr(registry, "_write_checkpoint", lambda: None)
+
+    registry._reader_loop(session)
+
+    queued_events = []
+    while not registry.completion_queue.empty():
+        queued_events.append(registry.completion_queue.get_nowait())
+
+    from tools import process_registry as process_registry_module
+
+    monkeypatch.setattr(process_registry_module, "process_registry", registry)
+    listed = json.loads(
+        process_registry_module._handle_process(
+            {"action": "list"}, task_id="redaction-task"
+        )
+    )
+    surfaced = {
+        "persisted": session.output_buffer,
+        "list": listed,
+        "live_tui": live_tui_chunks,
+        "completion_queue": queued_events,
+        "poll": registry.poll(session.id),
+        "log": registry.read_log(session.id),
+        "wait": registry.wait(session.id, timeout=1),
+    }
+
+    assert any(event["type"] == "watch_match" for event in queued_events)
+    assert any(event["type"] == "completion" for event in queued_events)
+    assert "READY" in session.output_buffer
+    assert "READY" in "".join(live_tui_chunks)
+    assert SYNTHETIC_SECRET not in json.dumps(surfaced)
+
+
+def test_reader_uses_command_aware_terminal_redaction(registry, monkeypatch):
+    opaque_secret = "syntheticopaqueprocesssecret123456789"
+
+    class _FakeStdout:
+        class _Buffer:
+            def __init__(self):
+                self._chunks = [f"PRIVATE_TOKEN={opaque_secret}\n".encode(), b""]
+
+            def read1(self, _size):
+                return self._chunks.pop(0)
+
+        def __init__(self):
+            self.buffer = self._Buffer()
+
+    process = MagicMock(stdout=_FakeStdout(), returncode=0)
+    process.wait.return_value = 0
+    session = _make_session(sid="proc_env_redaction", command="printenv")
+    session.process = process
+    registry._running[session.id] = session
+    emitted = []
+    registry.on_output = lambda _session, chunk: emitted.append(chunk)
+    monkeypatch.setattr(registry, "_write_checkpoint", lambda: None)
+
+    registry._reader_loop(session)
+
+    assert opaque_secret not in session.output_buffer
+    assert opaque_secret not in "".join(emitted)
 
 
 # =========================================================================

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -137,6 +137,7 @@ class ProcessSession:
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
+    _live_output_pending: str = field(default="", repr=False)
 
 
 class ProcessRegistry:
@@ -227,10 +228,52 @@ class ProcessRegistry:
         sink = self.on_output
         if sink is None or not chunk:
             return
+        with session._lock:
+            buffered = session._live_output_pending + chunk
+            lines = buffered.splitlines(keepends=True)
+            if lines and not lines[-1].endswith(("\n", "\r")):
+                session._live_output_pending = lines.pop()
+            else:
+                session._live_output_pending = ""
+            visible = "".join(lines)
+        if not visible:
+            return
         try:
-            sink(session, chunk)
+            sink(session, self._redact_output(session, visible))
         except Exception:
             pass
+
+    def _flush_output(self, session: ProcessSession) -> None:
+        sink = self.on_output
+        with session._lock:
+            pending = session._live_output_pending
+            session._live_output_pending = ""
+        if sink is None or not pending:
+            return
+        try:
+            sink(session, self._redact_output(session, pending))
+        except Exception:
+            pass
+
+    @staticmethod
+    def _redact_output(session: ProcessSession, output: str) -> str:
+        from agent.redact import redact_terminal_output
+
+        return redact_terminal_output(output, session.command)
+
+    @staticmethod
+    def _redact_command(command: str) -> str:
+        from agent.redact import redact_sensitive_text
+
+        return redact_sensitive_text(command, code_file=True)
+
+    def _append_output(self, session: ProcessSession, output: str) -> None:
+        with session._lock:
+            session.output_buffer = self._redact_output(
+                session, session.output_buffer + output
+            )
+            if len(session.output_buffer) > session.max_output_chars:
+                session.output_buffer = session.output_buffer[-session.max_output_chars:]
 
     def _check_watch_patterns(self, session: ProcessSession, new_text: str) -> None:
         """Scan new output for watch patterns and queue notifications.
@@ -316,7 +359,7 @@ class ProcessRegistry:
                 self.completion_queue.put({
                     "session_id": session.id,
                     "session_key": session.session_key,
-                    "command": session.command,
+                    "command": self._redact_command(session.command),
                     "type": "watch_disabled",
                     "suppressed": session._watch_suppressed,
                     "platform": session.watcher_platform,
@@ -339,6 +382,7 @@ class ProcessRegistry:
         output = "\n".join(matched_lines[:20])
         if len(output) > 2000:
             output = output[:2000] + "\n...(truncated)"
+        output = self._redact_output(session, output)
 
         # Global circuit breaker — across all sessions (secondary safety net).
         if not self._global_watch_admit(now):
@@ -347,7 +391,7 @@ class ProcessRegistry:
         self.completion_queue.put({
             "session_id": session.id,
             "session_key": session.session_key,
-            "command": session.command,
+            "command": self._redact_command(session.command),
             "type": "watch_match",
             "pattern": matched_pattern,
             "output": output,
@@ -896,13 +940,17 @@ class ProcessRegistry:
                     session.exit_code = -1
                 session.completion_reason = "failed_start"
                 session.termination_source = "failed_start"
-                session.output_buffer = result.get("output", "").strip()
+                session.output_buffer = self._redact_output(
+                    session, result.get("output", "").strip()
+                )
         except Exception as e:
             session.exited = True
             session.exit_code = -1
             session.completion_reason = "failed_start"
             session.termination_source = "failed_start"
-            session.output_buffer = f"Failed to start: {e}"
+            session.output_buffer = self._redact_output(
+                session, f"Failed to start: {e}"
+            )
 
         if not session.exited:
             # Start a poller thread that periodically reads the log file
@@ -958,10 +1006,7 @@ class ProcessRegistry:
                 if first_chunk:
                     chunk = self._clean_shell_noise(chunk)
                     first_chunk = False
-                with session._lock:
-                    session.output_buffer += chunk
-                    if len(session.output_buffer) > session.max_output_chars:
-                        session.output_buffer = session.output_buffer[-session.max_output_chars:]
+                self._append_output(session, chunk)
                 self._check_watch_patterns(session, chunk)
                 self._emit_output(session, chunk)
         except Exception as e:
@@ -997,7 +1042,9 @@ class ProcessRegistry:
                     delta = new_output[prev_output_len:] if len(new_output) > prev_output_len else ""
                     prev_output_len = len(new_output)
                     with session._lock:
-                        session.output_buffer = new_output
+                        session.output_buffer = self._redact_output(
+                            session, new_output
+                        )
                         if len(session.output_buffer) > session.max_output_chars:
                             session.output_buffer = session.output_buffer[-session.max_output_chars:]
                     if delta:
@@ -1046,10 +1093,7 @@ class ProcessRegistry:
                     if chunk:
                         # ptyprocess returns bytes
                         text = chunk if isinstance(chunk, str) else chunk.decode("utf-8", errors="replace")
-                        with session._lock:
-                            session.output_buffer += text
-                            if len(session.output_buffer) > session.max_output_chars:
-                                session.output_buffer = session.output_buffer[-session.max_output_chars:]
+                        self._append_output(session, text)
                         self._check_watch_patterns(session, text)
                         self._emit_output(session, text)
                 except EOFError:
@@ -1077,6 +1121,7 @@ class ProcessRegistry:
         with the reader thread), the second call is a no-op — no duplicate
         completion notification is enqueued.
         """
+        self._flush_output(session)
         with self._lock:
             was_running = self._running.pop(session.id, None) is not None
             self._finished[session.id] = session
@@ -1093,7 +1138,7 @@ class ProcessRegistry:
                 "type": "completion",
                 "session_id": session.id,
                 "session_key": session.session_key,
-                "command": session.command,
+                "command": self._redact_command(session.command),
                 "exit_code": session.exit_code,
                 "completion_reason": session.completion_reason,
                 "termination_source": session.termination_source,
@@ -1314,11 +1359,9 @@ class ProcessRegistry:
             except Exception as e:
                 logger.debug("Non-blocking drain failed for %s: %s", session.id, e)
 
+        if drained:
+            self._append_output(session, drained)
         with session._lock:
-            if drained:
-                session.output_buffer += drained
-                if len(session.output_buffer) > session.max_output_chars:
-                    session.output_buffer = session.output_buffer[-session.max_output_chars:]
             session.exited = True
             if session.completion_reason != "killed":
                 session.exit_code = rc
@@ -1347,7 +1390,7 @@ class ProcessRegistry:
 
         result = {
             "session_id": session.id,
-            "command": session.command,
+            "command": self._redact_command(session.command),
             "status": "exited" if session.exited else "running",
             "pid": session.pid,
             "uptime_seconds": int(time.time() - session.started_at),
@@ -1400,7 +1443,7 @@ class ProcessRegistry:
 
         result = {
             "session_id": session.id,
-            "command": session.command,
+            "command": self._redact_command(session.command),
             "status": "exited" if session.exited else "running",
             "output": "\n".join(selected),
             "total_lines": total_lines,
@@ -1460,7 +1503,7 @@ class ProcessRegistry:
                 self._completion_consumed.add(session_id)
                 result = {
                     "status": "exited",
-                    "command": session.command,
+                    "command": self._redact_command(session.command),
                     "exit_code": session.exit_code,
                     "completion_reason": session.completion_reason,
                     "termination_source": session.termination_source,
@@ -1473,7 +1516,7 @@ class ProcessRegistry:
             if _is_interrupted():
                 result = {
                     "status": "interrupted",
-                    "command": session.command,
+                    "command": self._redact_command(session.command),
                     "output": strip_ansi(session.output_buffer[-1000:]),
                     "note": "User sent a new message -- wait interrupted",
                 }
@@ -1488,7 +1531,7 @@ class ProcessRegistry:
 
         result = {
             "status": "timeout",
-            "command": session.command,
+            "command": self._redact_command(session.command),
             "output": strip_ansi(session.output_buffer[-1000:]),
         }
         if timeout_note:
@@ -1521,7 +1564,7 @@ class ProcessRegistry:
             with session._lock:
                 result = {
                     "status": "already_exited",
-                    "command": session.command,
+                    "command": self._redact_command(session.command),
                     "exit_code": session.exit_code,
                     "completion_reason": session.completion_reason,
                     "termination_source": session.termination_source,
@@ -1728,7 +1771,7 @@ class ProcessRegistry:
         for s in all_sessions:
             entry = {
                 "session_id": s.id,
-                "command": s.command[:200],
+                "command": self._redact_command(s.command)[:200],
                 "cwd": s.cwd,
                 "pid": s.pid,
                 "started_at": time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(s.started_at)),


### PR DESCRIPTION
## Summary
- redact background process output before it reaches buffers, live TUI events, list previews, or completion/watch notifications
- preserve raw watch-pattern matching while redacting any queued matched text
- redact process command fields returned by process APIs
- add regression coverage for split secret tokens across process list, poll/log/wait, completion queue, and the concrete TUI emitter

## Validation
- `python -m pytest -q tests/tools/test_process_registry.py tests/tools/test_watch_patterns.py tests/tools/test_notify_on_complete.py tests/test_tui_gateway_server.py -k "not TestOrphanedPipeReconciliation and not TestPidReuseGuard and not TestSigkillEscalation" -o "addopts="` (541 passed, 20 deselected)
- `ruff check tools/process_registry.py tests/tools/test_process_registry.py tests/test_tui_gateway_server.py`
- `python -m py_compile tools/process_registry.py tests/tools/test_process_registry.py tests/test_tui_gateway_server.py`
- `git diff --check`

The full suite was attempted but the local macOS runner exhausted file descriptors in unrelated E2E logging (`EMFILE`); targeted affected suites are green.