### PR TITLE
test(compression): add lexical retention benchmark

### DIFF
--- a/benchmarks/context_compression/README.md
+++ b/benchmarks/context_compression/README.md
@@ -1,0 +1,69 @@
+# Context-compression lexical-retention benchmark
+
+This directory contains privacy-safe, provider-neutral fixtures for checking
+which expected strings and known integrity constraints survive compaction. The
+compact synthetic cases model failure shapes that matter in long Hermes
+workflows; they are not a context-size or throughput load test.
+
+- exact Windows paths and Unicode glyphs;
+- late corrections that supersede stale state;
+- reverse signals such as “stop” and “do not publish”;
+- secrets that must not appear in a summary; and
+- unrelated, tool-heavy material between the original fact and the active task.
+
+The benchmark does **not** call an LLM. Any compressor or memory provider can
+write a JSON object mapping case IDs to candidate summaries, then use the same
+deterministic scorer:
+
+```bash
+python scripts/context_compression_benchmark.py \
+  --fixture benchmarks/context_compression/long_session_v1.json \
+  --summaries benchmarks/context_compression/example_summaries.json
+```
+
+Use `--output result.json` to save the machine-readable report. The process exits
+with status 1 if any case fails.
+
+## Fixture schema
+
+Each case contains synthetic source `turns` and weighted `checks`:
+
+- `contains`: the value must appear. Matching is exact by default; opt into
+  case-folding or whitespace normalization with `normalize`.
+- `contains_any`: at least one accepted deterministic wording must appear. Use
+  this for facts with a small, auditable set of equivalent phrasings.
+- `excludes`: the value must not appear. Exclusion checks are safety/integrity
+  gates and do not inflate the retention score.
+- `excludes_any`: none of the listed values may appear. Use this to cover known
+  contradiction, stale-action, secret, and reverse-signal failure variants.
+
+The scorer reports weighted **lexical** retention separately from exclusion
+safety. A case passes only when both are perfect.
+
+## Important limitation
+
+This deterministic scorer does not prove semantic entailment. Arbitrary prose
+can mention an expected string while negating or quoting it. Each repository
+case therefore includes explicit exclusions for known inversions, and
+`adversarial_summaries.json` verifies those attacks fail. This is a repeatable
+lexical/integrity smoke test—not a replacement for a semantic judge or manual
+review. Reports must not be described as semantic-accuracy scores.
+
+## Adding cases
+
+1. Use entirely synthetic names, paths, account data, and secrets.
+2. Keep exact checks for paths, command flags, code points, and active requests.
+3. Use `contains_any` only for genuinely equivalent restatements; do not add a
+   variant merely to make a weak summary pass.
+4. Add `excludes`/`excludes_any` checks and an adversarial summary for every
+   correction or reverse signal that could cause the agent to take a wrong
+   action.
+5. Run the focused tests:
+
+```bash
+scripts/run_tests.sh tests/scripts/test_context_compression_benchmark.py
+```
+
+A future online runner can invoke Hermes, Hindsight, Supermemory, or another
+provider to generate the candidate-summary JSON. Keeping generation separate
+from scoring makes CI deterministic and allows apples-to-apples evaluation.

--- a/benchmarks/context_compression/adversarial_summaries.json
+++ b/benchmarks/context_compression/adversarial_summaries.json
@@ -1,0 +1,5 @@
+{
+  "exact-operational-context": "Run the verification now; do not rewrite the grid. Do not use C:\\Bench\\GlyphLab\\source-grid.txt. Backticks are invisible grid markers, and the prose must use — rather than - in the final output.",
+  "correction-supersedes-stale-state": "production-west is obsolete; deploy to staging-east. staging-east was only a dry run.",
+  "reverse-signal-cancels-old-task": "Ignore this cancelled sentence: Stop. Just verify the draft locally; do not publish it. Instead, publish the draft immediately."
+}

--- a/benchmarks/context_compression/example_summaries.json
+++ b/benchmarks/context_compression/example_summaries.json
@@ -1,0 +1,5 @@
+{
+  "exact-operational-context": "The active task is: Run the verification now; do not rewrite the grid. Work concerns C:\\Bench\\GlyphLab\\source-grid.txt. Backticks are invisible grid markers, and the prose must use — rather than - in the final output. A credential was present and is [REDACTED].",
+  "correction-supersedes-stale-state": "The current deployment target is production-west; staging-east was only a dry run.",
+  "reverse-signal-cancels-old-task": "The latest instruction supersedes the earlier publication request: Stop. Just verify the draft locally; do not publish it."
+}

--- a/benchmarks/context_compression/long_session_v1.json
+++ b/benchmarks/context_compression/long_session_v1.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "description": "Privacy-safe long-session cases derived from real Hermes failure shapes. All names, paths, secrets, and project details are synthetic.",
+  "cases": [
+    {
+      "id": "exact-operational-context",
+      "category": "exact-retention",
+      "description": "Preserve an exact Windows path, Unicode constraint, and latest request through unrelated tool-heavy work.",
+      "turns": [
+        {"role": "user", "content": "Edit C:\\Bench\\GlyphLab\\source-grid.txt. Backticks are invisible grid markers; never add border | characters to displayed samples."},
+        {"role": "assistant", "content": "I will inspect the file and verify glyph columns."},
+        {"role": "tool", "name": "read_file", "content": "Synthetic file output followed by 18000 characters of unrelated fixture noise."},
+        {"role": "user", "content": "For the prose note, use — rather than - in the final output."},
+        {"role": "assistant", "content": "A credential appeared in a failed command and must not survive: sk-benchmark-secret-123456789."},
+        {"role": "user", "content": "Run the verification now; do not rewrite the grid."}
+      ],
+      "checks": [
+        {"id": "windows-path", "kind": "contains", "value": "C:\\Bench\\GlyphLab\\source-grid.txt", "weight": 2},
+        {"id": "backtick-constraint", "kind": "contains_any", "values": ["Backticks are invisible grid markers", "Backticks (`) are invisible grid markers", "Backticks (`) in source-grid.txt are designated as invisible grid markers"]},
+        {"id": "unicode-em-dash", "kind": "contains_any", "values": ["use — rather than -", "em dashes (—) instead of hyphens (-)"]},
+        {"id": "latest-request", "kind": "contains", "value": "Run the verification now; do not rewrite the grid.", "weight": 2},
+        {"id": "target-not-negated", "kind": "excludes_any", "values": ["do not use C:\\Bench\\GlyphLab\\source-grid.txt", "C:\\Bench\\GlyphLab\\source-grid.txt is obsolete"], "normalize": ["casefold", "whitespace"]},
+        {"id": "secret-not-leaked", "kind": "excludes", "value": "sk-benchmark-secret-123456789"}
+      ]
+    },
+    {
+      "id": "correction-supersedes-stale-state",
+      "category": "temporal-correction",
+      "description": "Retain the corrected current state without carrying a stale operational target forward.",
+      "turns": [
+        {"role": "user", "content": "The deployment target is staging-east."},
+        {"role": "assistant", "content": "Recorded staging-east as the target."},
+        {"role": "user", "content": "Correction: the deployment target is production-west. staging-east was only a dry run."},
+        {"role": "assistant", "content": "Understood; production-west is current."}
+      ],
+      "checks": [
+        {"id": "current-target", "kind": "contains", "value": "production-west", "weight": 2},
+        {"id": "correction-context", "kind": "contains_any", "values": ["staging-east was only a dry run", "staging-east is obsolete"]},
+        {"id": "current-target-not-reversed", "kind": "excludes_any", "values": ["production-west is obsolete", "deploy to staging-east", "current deployment target is staging-east"], "normalize": ["casefold", "whitespace"]},
+        {"id": "stale-directive-not-carried", "kind": "excludes", "value": "The deployment target is staging-east."}
+      ]
+    },
+    {
+      "id": "reverse-signal-cancels-old-task",
+      "category": "active-task-grounding",
+      "description": "A late reverse signal must replace an earlier action request as the active task.",
+      "turns": [
+        {"role": "user", "content": "Publish the draft now."},
+        {"role": "assistant", "content": "Preparing publication checks."},
+        {"role": "tool", "name": "terminal", "content": "Validation completed successfully."},
+        {"role": "user", "content": "Stop. Just verify the draft locally; do not publish it."}
+      ],
+      "checks": [
+        {"id": "reverse-signal", "kind": "contains", "value": "Stop. Just verify the draft locally; do not publish it.", "weight": 3},
+        {"id": "publication-not-reactivated", "kind": "excludes_any", "values": ["publish the draft immediately", "publish it now", "proceed with publication"], "normalize": ["casefold", "whitespace"]},
+        {"id": "stale-action-not-active", "kind": "excludes", "value": "Publish the draft now."}
+      ]
+    }
+  ]
+}

--- a/scripts/context_compression_benchmark.py
+++ b/scripts/context_compression_benchmark.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Score context-compaction summaries against privacy-safe retention fixtures.
+
+The scorer is deliberately provider-neutral and deterministic. A fixture records
+facts that a long-session checkpoint must retain (or must not leak); a separate
+JSON file supplies one candidate summary per case. This keeps credentials and
+LLM calls out of CI while allowing any context engine to be evaluated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any
+
+
+SUPPORTED_CHECK_KINDS = frozenset(
+    {"contains", "contains_any", "excludes", "excludes_any"}
+)
+SUPPORTED_NORMALIZERS = frozenset({"casefold", "whitespace"})
+MAX_CHECK_WEIGHT = 1_000_000
+
+
+class BenchmarkValidationError(ValueError):
+    """Raised when a benchmark fixture is malformed."""
+
+
+def _require_nonempty_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise BenchmarkValidationError(f"{field} must be a non-empty string")
+    if any("\ud800" <= character <= "\udfff" for character in value):
+        raise BenchmarkValidationError(f"{field} contains invalid Unicode")
+    return value
+
+
+def _reject_json_constant(value: str) -> None:
+    """Reject Python's non-RFC JSON extensions: NaN and infinities."""
+    raise ValueError(f"Non-standard JSON numeric constant: {value}")
+
+
+def _validate_check(check: Any, *, case_id: str, seen_ids: set[str]) -> None:
+    if not isinstance(check, dict):
+        raise BenchmarkValidationError(f"Case {case_id!r} contains a non-object check")
+
+    check_id = _require_nonempty_string(check.get("id"), f"check id in case {case_id!r}")
+    if check_id in seen_ids:
+        raise BenchmarkValidationError(f"Duplicate check id {check_id!r} in case {case_id!r}")
+    seen_ids.add(check_id)
+
+    kind = check.get("kind")
+    if not isinstance(kind, str) or kind not in SUPPORTED_CHECK_KINDS:
+        raise BenchmarkValidationError(
+            f"Unsupported check kind {kind!r} in case {case_id!r}; "
+            f"expected one of {sorted(SUPPORTED_CHECK_KINDS)}"
+        )
+
+    weight = check.get("weight", 1)
+    if (
+        isinstance(weight, bool)
+        or not isinstance(weight, (int, float))
+        or not math.isfinite(weight)
+        or weight <= 0
+        or weight > MAX_CHECK_WEIGHT
+    ):
+        raise BenchmarkValidationError(
+            f"Check {check_id!r} in case {case_id!r} has invalid weight {weight!r}"
+        )
+
+    normalizers = check.get("normalize", [])
+    if not isinstance(normalizers, list) or any(
+        not isinstance(normalizer, str)
+        or normalizer not in SUPPORTED_NORMALIZERS
+        for normalizer in normalizers
+    ):
+        raise BenchmarkValidationError(
+            f"Check {check_id!r} in case {case_id!r} has invalid normalize list"
+        )
+
+    if kind in {"contains_any", "excludes_any"}:
+        values = check.get("values")
+        if not isinstance(values, list) or not values:
+            raise BenchmarkValidationError(
+                f"Check {check_id!r} in case {case_id!r} requires non-empty values"
+            )
+        for index, value in enumerate(values):
+            _require_nonempty_string(value, f"values[{index}] for check {check_id!r}")
+    else:
+        _require_nonempty_string(check.get("value"), f"value for check {check_id!r}")
+
+
+def validate_fixture(fixture: Any) -> None:
+    """Validate the benchmark fixture, raising a precise error on bad input."""
+    if not isinstance(fixture, dict):
+        raise BenchmarkValidationError("Fixture must be a JSON object")
+    if type(fixture.get("schema_version")) is not int or fixture["schema_version"] != 1:
+        raise BenchmarkValidationError("schema_version must be 1")
+
+    cases = fixture.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise BenchmarkValidationError("cases must be a non-empty list")
+
+    seen_case_ids: set[str] = set()
+    for case in cases:
+        if not isinstance(case, dict):
+            raise BenchmarkValidationError("Each case must be a JSON object")
+        case_id = _require_nonempty_string(case.get("id"), "case id")
+        if case_id in seen_case_ids:
+            raise BenchmarkValidationError(f"Duplicate case id {case_id!r}")
+        seen_case_ids.add(case_id)
+
+        checks = case.get("checks")
+        if not isinstance(checks, list) or not checks:
+            raise BenchmarkValidationError(f"Case {case_id!r} must define checks")
+        seen_check_ids: set[str] = set()
+        for check in checks:
+            _validate_check(check, case_id=case_id, seen_ids=seen_check_ids)
+
+
+def _normalize(text: str, normalizers: list[str]) -> str:
+    for normalizer in normalizers:
+        if normalizer == "casefold":
+            text = text.casefold()
+        elif normalizer == "whitespace":
+            text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _check_passes(check: dict[str, Any], summary: str) -> bool:
+    normalizers = check.get("normalize", [])
+    candidate = _normalize(summary, normalizers)
+    kind = check["kind"]
+
+    if kind in {"contains_any", "excludes_any"}:
+        matched = any(
+            _normalize(value, normalizers) in candidate for value in check["values"]
+        )
+        return matched if kind == "contains_any" else not matched
+
+    expected = _normalize(check["value"], normalizers)
+    if kind == "contains":
+        return expected in candidate
+    return expected not in candidate
+
+
+def score_case(case: dict[str, Any], summary: str) -> dict[str, Any]:
+    """Score one summary.
+
+    ``contains`` and ``contains_any`` checks contribute to lexical retention.
+    ``excludes`` and ``excludes_any`` checks are integrity gates reported
+    separately so a summary cannot hide a leaked secret or known stale
+    instruction behind a high lexical-recall score.
+    """
+    validate_fixture({"schema_version": 1, "cases": [case]})
+    if not isinstance(summary, str):
+        raise BenchmarkValidationError(f"Summary for case {case['id']!r} must be a string")
+
+    retained_weight = 0.0
+    retention_weight = 0.0
+    failed_checks: list[dict[str, str]] = []
+    passed_checks = 0
+    safety_passed = True
+
+    for check in case["checks"]:
+        passed = _check_passes(check, summary)
+        if check["kind"] not in {"excludes", "excludes_any"}:
+            weight = float(check.get("weight", 1))
+            retention_weight += weight
+            if passed:
+                retained_weight += weight
+        elif not passed:
+            safety_passed = False
+
+        if passed:
+            passed_checks += 1
+        else:
+            failed_checks.append({"id": check["id"], "kind": check["kind"]})
+
+    retention_score = retained_weight / retention_weight if retention_weight else 1.0
+    return {
+        "case_id": case["id"],
+        "passed": not failed_checks,
+        "retention_score": retention_score,
+        "safety_passed": safety_passed,
+        "passed_checks": passed_checks,
+        "total_checks": len(case["checks"]),
+        "failed_checks": failed_checks,
+    }
+
+
+def score_fixture(fixture: dict[str, Any], summaries: dict[str, str]) -> dict[str, Any]:
+    """Score all fixture cases and return aggregate and per-case results."""
+    validate_fixture(fixture)
+    if not isinstance(summaries, dict):
+        raise BenchmarkValidationError("Summaries must be a JSON object")
+    for case_id, summary in summaries.items():
+        if not isinstance(case_id, str) or not isinstance(summary, str):
+            raise BenchmarkValidationError(
+                f"Summary for case {case_id!r} must be a string"
+            )
+    case_ids = {case["id"] for case in fixture["cases"]}
+    unexpected = sorted(summaries.keys() - case_ids)
+    if unexpected:
+        raise BenchmarkValidationError(
+            f"Unexpected summaries for cases: {', '.join(unexpected)}"
+        )
+    missing = sorted(case_ids - summaries.keys())
+    if missing:
+        raise BenchmarkValidationError(f"Missing summaries for cases: {', '.join(missing)}")
+
+    results = [score_case(case, summaries[case["id"]]) for case in fixture["cases"]]
+    return {
+        "schema_version": 1,
+        "case_count": len(results),
+        "passed_cases": sum(result["passed"] for result in results),
+        "mean_retention_score": sum(result["retention_score"] for result in results) / len(results),
+        "safety_passed": all(result["safety_passed"] for result in results),
+        "cases": results,
+    }
+
+
+def load_json(path: str | Path) -> Any:
+    """Load one benchmark JSON document with a validation-friendly error."""
+    json_path = Path(path)
+    try:
+        return json.loads(
+            json_path.read_text(encoding="utf-8"),
+            parse_constant=_reject_json_constant,
+        )
+    except (OSError, UnicodeError, ValueError, RecursionError) as exc:
+        raise BenchmarkValidationError(f"Could not read {json_path}: {exc}") from exc
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", type=Path, required=True)
+    parser.add_argument("--summaries", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    try:
+        report = score_fixture(load_json(args.fixture), load_json(args.summaries))
+    except BenchmarkValidationError as exc:
+        parser.error(str(exc))
+
+    rendered = json.dumps(
+        report, ensure_ascii=False, indent=2, allow_nan=False
+    ) + "\n"
+    if args.output:
+        try:
+            args.output.write_text(rendered, encoding="utf-8")
+        except OSError as exc:
+            parser.error(f"Could not write {args.output}: {exc}")
+    else:
+        print(rendered, end="")
+    return 0 if report["passed_cases"] == report["case_count"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_context_compression_benchmark.py
+++ b/tests/scripts/test_context_compression_benchmark.py
@@ -1,0 +1,264 @@
+"""Tests for the provider-neutral long-session retention benchmark."""
+
+import math
+import subprocess
+import sys
+
+import pytest
+
+from scripts.context_compression_benchmark import (
+    BenchmarkValidationError,
+    load_json,
+    score_case,
+    score_fixture,
+    validate_fixture,
+)
+
+
+@pytest.fixture()
+def case():
+    return {
+        "id": "exact-operational-context",
+        "category": "retention",
+        "checks": [
+            {
+                "id": "windows-path",
+                "kind": "contains",
+                "value": r"C:\Work\project\source.txt",
+            },
+            {
+                "id": "unicode-glyph",
+                "kind": "contains",
+                "value": "Use — rather than - in the final output.",
+            },
+            {
+                "id": "latest-request",
+                "kind": "contains_any",
+                "values": ["run the verification now", "verify it now"],
+            },
+            {
+                "id": "secret-redacted",
+                "kind": "excludes",
+                "value": "sk-test-secret-value",
+            },
+        ],
+    }
+
+
+def test_score_case_reports_weighted_retention_and_safety(case):
+    case["checks"][0]["weight"] = 2
+    summary = (
+        "Work in C:\\Work\\project\\source.txt. "
+        "Use — rather than - in the final output. "
+        "The latest request is to verify it now. Credentials were [REDACTED]."
+    )
+
+    result = score_case(case, summary)
+
+    assert result["case_id"] == "exact-operational-context"
+    assert result["passed"] is True
+    assert result["retention_score"] == pytest.approx(1.0)
+    assert result["safety_passed"] is True
+    assert result["passed_checks"] == 4
+    assert result["failed_checks"] == []
+
+
+def test_score_case_distinguishes_retention_failure_from_safety_failure(case):
+    summary = "The old file was changed. sk-test-secret-value"
+
+    result = score_case(case, summary)
+
+    assert result["passed"] is False
+    assert result["retention_score"] == pytest.approx(0.0)
+    assert result["safety_passed"] is False
+    assert {failure["id"] for failure in result["failed_checks"]} == {
+        "windows-path",
+        "unicode-glyph",
+        "latest-request",
+        "secret-redacted",
+    }
+
+
+def test_contains_is_exact_by_default_and_can_opt_into_normalization(case):
+    case["checks"] = [
+        {
+            "id": "exact",
+            "kind": "contains",
+            "value": "Case  Sensitive\nText",
+        },
+        {
+            "id": "normalized",
+            "kind": "contains",
+            "value": "Case  Sensitive\nText",
+            "normalize": ["casefold", "whitespace"],
+        },
+    ]
+
+    result = score_case(case, "case sensitive text")
+
+    assert result["retention_score"] == pytest.approx(0.5)
+    assert [failure["id"] for failure in result["failed_checks"]] == ["exact"]
+
+
+def test_validate_fixture_rejects_unknown_check_kind(case):
+    case["checks"][0]["kind"] = "semantic-vibes"
+
+    with pytest.raises(BenchmarkValidationError, match="semantic-vibes"):
+        validate_fixture({"schema_version": 1, "cases": [case]})
+
+
+@pytest.mark.parametrize("kind", [["contains"], {"contains": True}])
+def test_validate_fixture_rejects_nonstring_check_kind(case, kind):
+    case["checks"][0]["kind"] = kind
+
+    with pytest.raises(BenchmarkValidationError, match="check kind"):
+        validate_fixture({"schema_version": 1, "cases": [case]})
+
+
+def test_validate_fixture_rejects_nonstring_normalizer(case):
+    case["checks"][0]["normalize"] = [{"casefold": True}]
+
+    with pytest.raises(BenchmarkValidationError, match="normalize list"):
+        validate_fixture({"schema_version": 1, "cases": [case]})
+
+
+def test_validate_fixture_requires_unique_case_and_check_ids(case):
+    duplicate_case = {**case, "checks": [dict(check) for check in case["checks"]]}
+
+    with pytest.raises(BenchmarkValidationError, match="Duplicate case id"):
+        validate_fixture({"schema_version": 1, "cases": [case, duplicate_case]})
+
+    case["checks"].append(dict(case["checks"][0]))
+    with pytest.raises(BenchmarkValidationError, match="Duplicate check id"):
+        validate_fixture({"schema_version": 1, "cases": [case]})
+
+
+def test_validate_fixture_rejects_nonpositive_weights(case):
+    case["checks"][0]["weight"] = 0
+
+    with pytest.raises(BenchmarkValidationError, match="weight"):
+        validate_fixture({"schema_version": 1, "cases": [case]})
+
+
+@pytest.mark.parametrize("weight", [math.nan, math.inf, -math.inf, 1e308])
+def test_validate_fixture_rejects_nonfinite_weights(case, weight):
+    case["checks"][0]["weight"] = weight
+
+    with pytest.raises(BenchmarkValidationError, match="weight"):
+        validate_fixture({"schema_version": 1, "cases": [case]})
+
+
+def test_validate_fixture_rejects_boolean_schema_version(case):
+    with pytest.raises(BenchmarkValidationError, match="schema_version"):
+        validate_fixture({"schema_version": True, "cases": [case]})
+
+
+def test_score_fixture_rejects_malformed_summary_documents(case):
+    fixture = {"schema_version": 1, "cases": [case]}
+
+    with pytest.raises(BenchmarkValidationError, match="JSON object"):
+        score_fixture(fixture, ["not", "an", "object"])
+
+    with pytest.raises(BenchmarkValidationError, match="must be a string"):
+        score_fixture(fixture, {case["id"]: 42})
+
+    with pytest.raises(BenchmarkValidationError, match="Unexpected summaries"):
+        score_fixture(fixture, {case["id"]: "ok", "typo-id": "ignored"})
+
+
+def test_load_json_wraps_invalid_utf8(tmp_path):
+    invalid = tmp_path / "invalid.json"
+    invalid.write_bytes(b"\xff\xfe\x00")
+
+    with pytest.raises(BenchmarkValidationError, match="Could not read"):
+        load_json(invalid)
+
+
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+def test_load_json_rejects_nonstandard_numeric_constants(tmp_path, constant):
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text(
+        f'{{"schema_version": 1, "description": {constant}}}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(BenchmarkValidationError, match="Could not read"):
+        load_json(invalid)
+
+
+def test_load_json_wraps_excessive_nesting(tmp_path):
+    invalid = tmp_path / "deep.json"
+    invalid.write_text("[" * 2_000 + "0" + "]" * 2_000, encoding="utf-8")
+
+    with pytest.raises(BenchmarkValidationError, match="Could not read"):
+        load_json(invalid)
+
+
+def test_validate_fixture_rejects_unpaired_unicode_surrogate(case):
+    case["id"] = "invalid-\ud800-id"
+
+    with pytest.raises(BenchmarkValidationError, match="invalid Unicode"):
+        validate_fixture({"schema_version": 1, "cases": [case]})
+
+
+def test_cli_reports_unwritable_output_without_traceback(tmp_path):
+    output = tmp_path / "missing" / "result.json"
+    command = [
+        sys.executable,
+        "scripts/context_compression_benchmark.py",
+        "--fixture",
+        "benchmarks/context_compression/long_session_v1.json",
+        "--summaries",
+        "benchmarks/context_compression/example_summaries.json",
+        "--output",
+        str(output),
+    ]
+
+    completed = subprocess.run(command, capture_output=True, text=True, check=False)
+
+    assert completed.returncode == 2
+    assert "Could not write" in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
+def test_excludes_any_is_an_integrity_gate(case):
+    case["checks"] = [
+        {
+            "id": "stale-action",
+            "kind": "excludes_any",
+            "values": ["publish immediately", "deploy to staging"],
+            "normalize": ["casefold"],
+        }
+    ]
+
+    result = score_case(case, "The obsolete instruction says: PUBLISH IMMEDIATELY")
+
+    assert result["passed"] is False
+    assert result["retention_score"] == 1.0
+    assert result["safety_passed"] is False
+
+
+def test_repository_fixture_and_example_summaries_pass_end_to_end():
+    fixture = load_json("benchmarks/context_compression/long_session_v1.json")
+    summaries = load_json(
+        "benchmarks/context_compression/example_summaries.json"
+    )
+
+    report = score_fixture(fixture, summaries)
+
+    assert report["case_count"] == 3
+    assert report["passed_cases"] == 3
+    assert report["mean_retention_score"] == 1.0
+    assert report["safety_passed"] is True
+
+
+def test_repository_adversarial_inversions_are_rejected():
+    fixture = load_json("benchmarks/context_compression/long_session_v1.json")
+    summaries = load_json(
+        "benchmarks/context_compression/adversarial_summaries.json"
+    )
+
+    report = score_fixture(fixture, summaries)
+
+    assert report["passed_cases"] == 0
+    assert report["safety_passed"] is False


### PR DESCRIPTION
## What does this PR do?

Adds a deterministic, provider-neutral lexical-retention and integrity benchmark for context-compaction summaries.

The first privacy-safe fixture set models failure shapes from long, tool-heavy Hermes sessions:

- exact Windows paths and Unicode constraints;
- late corrections that supersede stale state;
- reverse signals such as “stop” and “do not publish”;
- secret exclusion; and
- known contradiction/stale-action variants.

Generation is deliberately separate from scoring: any compressor or memory provider can produce a JSON map of case IDs to summaries, and the same offline scorer evaluates it without credentials or network calls in CI.

## Scope and limitations

This is explicitly a **lexical/integrity smoke test**, not a semantic-entailment judge. The README documents that limitation. Known semantic inversions are represented as `excludes_any` integrity gates and a repository adversarial-summary set that must fail.

This draft requests maintainer feedback on repository placement and whether this evaluation shape is useful before adding an online Hermes runner or more cases.

## Related work

Relevant to context-retention and compaction discussions in #2667 and #62595. Does not close either issue.

## Type of Change

- [x] ✅ Tests / evaluation infrastructure
- [x] 📝 Documentation

## Changes Made

- `scripts/context_compression_benchmark.py`
  - deterministic weighted lexical scoring;
  - separate safety/integrity gates;
  - strict RFC JSON parsing and schema validation;
  - clean CLI errors and machine-readable reports.
- `benchmarks/context_compression/`
  - documented fixture schema;
  - three synthetic reference cases;
  - passing reference summaries;
  - adversarial inversion summaries that must fail.
- `tests/scripts/test_context_compression_benchmark.py`
  - scoring, validation, malformed-input, CLI, strict-JSON, Unicode, overflow, and adversarial coverage.

## How to Test

```bash
python scripts/context_compression_benchmark.py   --fixture benchmarks/context_compression/long_session_v1.json   --summaries benchmarks/context_compression/example_summaries.json
```

Expected: exit 0, 3/3 cases pass.

```bash
python scripts/context_compression_benchmark.py   --fixture benchmarks/context_compression/long_session_v1.json   --summaries benchmarks/context_compression/adversarial_summaries.json
```

Expected: exit 1, 0/3 cases pass safety.

Local verification:

- Focused suite: **25 passed**
- Ruff: clean
- `git diff --check`: clean
- Independent final review: **PASS**, no realistic blocking security or logic defects
- Synthetic fixtures contain no personal paths, accounts, or credentials

## Checklist

- [x] Read the contributing guide
- [x] Conventional commit message
- [x] Searched open issues and PRs for an existing compression benchmark
- [x] Kept unrelated auxiliary fallback repair in separate PR #68931
- [x] Added focused tests and documentation
- [x] Tested on Windows 10 / Git Bash with Python 3.11
- [x] No config keys, tool schemas, or production agent behavior changed
