### PR TITLE
feat(memory): expose supermemory v4 search options

### DIFF
--- a/plugins/memory/supermemory/README.md
+++ b/plugins/memory/supermemory/README.md
@@ -53,7 +53,15 @@ Config file: `$HERMES_HOME/supermemory.json`
 | `max_recall_results` | `10` | Max recalled items to format into context |
 | `profile_frequency` | `50` | Include profile facts on first turn and every N turns |
 | `capture_mode` | `all` | Skip tiny or trivial turns by default |
-| `search_mode` | `hybrid` | Search mode: `hybrid` (profile + memories), `memories` (memories only), `documents` (documents only) |
+| `search_mode` | `hybrid` | Search mode: `hybrid` (memories + document chunks), `memories` (memories only), `documents` (document chunks only). Note: the hosted API's own default is `memories`; the plugin defaults to `hybrid` so document content is searched too. |
+| `include_documents` | `false` | Attach parent-document metadata (title, type, metadata) to each result. Does **not** control whether document content is searched — that is `search_mode`. Costs an extra document fetch per search. |
+| `include_summaries` | `false` | Include document summaries in search results |
+| `include_related_memories` | `false` | Include memories related to the matches |
+| `search_threshold` | `0.6` | Selection sensitivity, 0 (broad, more results) to 1 (strict, fewer results) |
+| `search_rerank` | `false` | Rerank results by relevance to the query |
+| `search_aggregate` | `false` | Synthesize new memories by aggregating across multiple results. Mutually exclusive with `search_rerank` — the API rejects both with a 400, and aggregate does *not* rerank (server-side they are separate branches: aggregate synthesizes via LLM, rerank runs a cross-encoder). If both are set, aggregate wins and rerank is dropped. |
+| `search_rewrite_query` | `false` | Rewrite the query to improve matching (adds ~400ms latency). Applied automatically as a one-shot retry when a search returns nothing. |
+| `allow_agent_search_overrides` | `true` | Let the agent pass `search_mode` / `rerank` / `aggregate` / `rewrite_query` per call. Set `false` to pin behavior to this config and hide those options from the tool schema (useful for cost control, since `aggregate` costs an extra LLM call). |
 | `entity_context` | built-in default | Extraction guidance passed to Supermemory |
 | `api_timeout` | `5.0` | Timeout for SDK and ingest requests |
 

--- a/plugins/memory/supermemory/README.md
+++ b/plugins/memory/supermemory/README.md
@@ -61,7 +61,7 @@ Config file: `$HERMES_HOME/supermemory.json`
 | `search_rerank` | `false` | Rerank results by relevance to the query |
 | `search_aggregate` | `false` | Synthesize new memories by aggregating across multiple results. Mutually exclusive with `search_rerank` — the API rejects both with a 400, and aggregate does *not* rerank (server-side they are separate branches: aggregate synthesizes via LLM, rerank runs a cross-encoder). If both are set, aggregate wins and rerank is dropped. |
 | `search_rewrite_query` | `false` | Rewrite the query to improve matching (adds ~400ms latency). Applied automatically as a one-shot retry when a search returns nothing. |
-| `allow_agent_search_overrides` | `true` | Let the agent pass `search_mode` / `rerank` / `aggregate` / `rewrite_query` per call. Set `false` to pin behavior to this config and hide those options from the tool schema (useful for cost control, since `aggregate` costs an extra LLM call). |
+| `allow_agent_search_overrides` | `true` | Let the agent pass `aggregate` per call. Set `false` to pin it to this config and hide the option from the tool schema (useful for cost control, since `aggregate` costs an extra LLM call). All other search options are config-only. |
 | `entity_context` | built-in default | Extraction guidance passed to Supermemory |
 | `api_timeout` | `5.0` | Timeout for SDK and ingest requests |
 

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -28,6 +28,8 @@ _DEFAULT_PROFILE_FREQUENCY = 50
 _DEFAULT_CAPTURE_MODE = "all"
 _DEFAULT_SEARCH_MODE = "hybrid"
 _VALID_SEARCH_MODES = ("hybrid", "memories", "documents")
+_DEFAULT_SEARCH_THRESHOLD = 0.6
+_DEFAULT_INCLUDE_DOCUMENTS = False
 _DEFAULT_API_TIMEOUT = 5.0
 _MIN_CAPTURE_LENGTH = 10
 _MAX_ENTITY_CONTEXT_LENGTH = 1500
@@ -63,6 +65,14 @@ def _default_config() -> dict:
         "profile_frequency": _DEFAULT_PROFILE_FREQUENCY,
         "capture_mode": _DEFAULT_CAPTURE_MODE,
         "search_mode": _DEFAULT_SEARCH_MODE,
+        "search_threshold": _DEFAULT_SEARCH_THRESHOLD,
+        "search_rerank": False,
+        "search_aggregate": False,
+        "search_rewrite_query": False,
+        "include_documents": _DEFAULT_INCLUDE_DOCUMENTS,
+        "include_summaries": False,
+        "include_related_memories": False,
+        "allow_agent_search_overrides": True,
         "entity_context": _DEFAULT_ENTITY_CONTEXT,
         "api_timeout": _DEFAULT_API_TIMEOUT,
         "base_url": "",
@@ -137,6 +147,17 @@ def _load_supermemory_config(hermes_home: str) -> dict:
     config["capture_mode"] = "everything" if config.get("capture_mode") == "everything" else "all"
     raw_search_mode = str(config.get("search_mode", _DEFAULT_SEARCH_MODE)).strip().lower()
     config["search_mode"] = raw_search_mode if raw_search_mode in _VALID_SEARCH_MODES else _DEFAULT_SEARCH_MODE
+    try:
+        config["search_threshold"] = max(0.0, min(1.0, float(config.get("search_threshold", _DEFAULT_SEARCH_THRESHOLD))))
+    except Exception:
+        config["search_threshold"] = _DEFAULT_SEARCH_THRESHOLD
+    config["search_rerank"] = _as_bool(config.get("search_rerank"), False)
+    config["search_aggregate"] = _as_bool(config.get("search_aggregate"), False)
+    config["search_rewrite_query"] = _as_bool(config.get("search_rewrite_query"), False)
+    config["include_documents"] = _as_bool(config.get("include_documents"), _DEFAULT_INCLUDE_DOCUMENTS)
+    config["include_summaries"] = _as_bool(config.get("include_summaries"), False)
+    config["include_related_memories"] = _as_bool(config.get("include_related_memories"), False)
+    config["allow_agent_search_overrides"] = _as_bool(config.get("allow_agent_search_overrides"), True)
     config["entity_context"] = _clamp_entity_context(str(config.get("entity_context", _DEFAULT_ENTITY_CONTEXT)))
     try:
         config["api_timeout"] = max(0.5, min(15.0, float(config.get("api_timeout", _DEFAULT_API_TIMEOUT))))
@@ -335,12 +356,37 @@ class _SupermemoryClient:
 
     def search_memories(self, query: str, *, limit: int = 5,
                         container_tag: Optional[str] = None,
-                        search_mode: Optional[str] = None) -> list[dict]:
+                        search_mode: Optional[str] = None,
+                        threshold: Optional[float] = None,
+                        rerank: bool = False,
+                        aggregate: bool = False,
+                        rewrite_query: bool = False,
+                        include_documents: bool = False,
+                        include_summaries: bool = False,
+                        include_related_memories: bool = False) -> list[dict]:
         tag = container_tag or self._container_tag
         mode = search_mode or self._search_mode
         kwargs: dict[str, Any] = {"q": query, "container_tag": tag, "limit": limit}
         if mode in _VALID_SEARCH_MODES:
             kwargs["search_mode"] = mode
+        if threshold is not None:
+            kwargs["threshold"] = threshold
+        # API 400s if both are sent; aggregate wins.
+        if aggregate:
+            kwargs["aggregate"] = True
+        elif rerank:
+            kwargs["rerank"] = True
+        if rewrite_query:
+            kwargs["rewrite_query"] = True
+        include = {}
+        if include_documents:
+            include["documents"] = True
+        if include_summaries:
+            include["summaries"] = True
+        if include_related_memories:
+            include["relatedMemories"] = True
+        if include:
+            kwargs["include"] = include
         response = self._client.search.memories(**kwargs)
         results = []
         for item in (getattr(response, "results", None) or []):
@@ -493,12 +539,16 @@ STORE_SCHEMA = {
 
 SEARCH_SCHEMA = {
     "name": "supermemory_search",
-    "description": "Search long-term memory by semantic similarity.",
+    "description": "Search long-term memory by semantic similarity. Defaults suit most queries; tune the options below when a plain search is the wrong shape for the question.",
     "parameters": {
         "type": "object",
         "properties": {
             "query": {"type": "string", "description": "What to search for."},
             "limit": {"type": "integer", "description": "Maximum results to return, 1 to 20."},
+            "search_mode": {"type": "string", "enum": list(_VALID_SEARCH_MODES), "description": "Default hybrid (facts + document chunks). Use 'documents' when asking about the contents of an ingested file, transcript, podcast, or article. Use 'memories' for short personal facts and preferences only."},
+            "rerank": {"type": "boolean", "description": "Reorder results by relevance to the query. Use when the query is precise and result ordering matters. Cannot be combined with aggregate."},
+            "aggregate": {"type": "boolean", "description": "Synthesize an answer across multiple memories. Use for broad or summarizing questions ('what do we know about X'). Costs an extra LLM call, so skip it for simple lookups. Cannot be combined with rerank."},
+            "rewrite_query": {"type": "boolean", "description": "Rewrite a vague or conversational query into better search terms (+~400ms). Applied automatically on an empty result, so only set it upfront when the query is clearly loosely worded."},
         },
         "required": ["query"],
     },
@@ -547,6 +597,14 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._profile_frequency = _DEFAULT_PROFILE_FREQUENCY
         self._capture_mode = _DEFAULT_CAPTURE_MODE
         self._search_mode = _DEFAULT_SEARCH_MODE
+        self._search_threshold = _DEFAULT_SEARCH_THRESHOLD
+        self._search_rerank = False
+        self._search_aggregate = False
+        self._search_rewrite_query = False
+        self._include_documents = _DEFAULT_INCLUDE_DOCUMENTS
+        self._include_summaries = False
+        self._include_related_memories = False
+        self._allow_agent_search_overrides = True
         self._entity_context = _DEFAULT_ENTITY_CONTEXT
         self._api_timeout = _DEFAULT_API_TIMEOUT
         self._base_url = _DEFAULT_BASE_URL
@@ -662,6 +720,14 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._profile_frequency = self._config["profile_frequency"]
         self._capture_mode = self._config["capture_mode"]
         self._search_mode = self._config["search_mode"]
+        self._search_threshold = self._config["search_threshold"]
+        self._search_rerank = self._config["search_rerank"]
+        self._search_aggregate = self._config["search_aggregate"]
+        self._search_rewrite_query = self._config["search_rewrite_query"]
+        self._include_documents = self._config["include_documents"]
+        self._include_summaries = self._config["include_summaries"]
+        self._include_related_memories = self._config["include_related_memories"]
+        self._allow_agent_search_overrides = self._config["allow_agent_search_overrides"]
         self._entity_context = self._config["entity_context"]
         self._api_timeout = self._config["api_timeout"]
         # Base URL: config > SUPERMEMORY_BASE_URL env var > api.supermemory.ai.
@@ -910,8 +976,15 @@ class SupermemoryMemoryProvider(MemoryProvider):
                 expanded.append(copy)
             return expanded
 
+        search_schema = SEARCH_SCHEMA
+        if not self._allow_agent_search_overrides:
+            # Don't advertise knobs the agent isn't allowed to use.
+            search_schema = json.loads(json.dumps(SEARCH_SCHEMA))
+            for key in ("search_mode", "rerank", "aggregate", "rewrite_query"):
+                search_schema["parameters"]["properties"].pop(key, None)
+
         if not self._enable_custom_containers:
-            return with_kebab_aliases([STORE_SCHEMA, SEARCH_SCHEMA, FORGET_SCHEMA, PROFILE_SCHEMA])
+            return with_kebab_aliases([STORE_SCHEMA, search_schema, FORGET_SCHEMA, PROFILE_SCHEMA])
 
         # When multi-container is enabled, add optional container_tag to relevant tools
         container_param = {
@@ -919,7 +992,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
             "description": f"Optional container tag. Allowed: {', '.join(self._allowed_containers)}. Defaults to primary ({self._container_tag}).",
         }
         schemas = []
-        for base in [STORE_SCHEMA, SEARCH_SCHEMA, FORGET_SCHEMA, PROFILE_SCHEMA]:
+        for base in [STORE_SCHEMA, search_schema, FORGET_SCHEMA, PROFILE_SCHEMA]:
             schema = json.loads(json.dumps(base))  # deep copy
             schema["parameters"]["properties"]["container_tag"] = container_param
             schemas.append(schema)
@@ -960,8 +1033,39 @@ class SupermemoryMemoryProvider(MemoryProvider):
             limit = max(1, min(20, int(args.get("limit", 5) or 5)))
         except Exception:
             limit = 5
+        if self._allow_agent_search_overrides:
+            mode = str(args.get("search_mode") or "").strip().lower()
+            mode = mode if mode in _VALID_SEARCH_MODES else self._search_mode
+            rerank = _as_bool(args.get("rerank"), self._search_rerank)
+            aggregate = _as_bool(args.get("aggregate"), self._search_aggregate)
+            rewrite_query = _as_bool(args.get("rewrite_query"), self._search_rewrite_query)
+        else:
+            mode = self._search_mode
+            rerank = self._search_rerank
+            aggregate = self._search_aggregate
+            rewrite_query = self._search_rewrite_query
+
+        def _run(mode_: str, rewrite_: bool) -> list:
+            return self._client.search_memories(
+                query, limit=limit, container_tag=tag,
+                search_mode=mode_,
+                threshold=self._search_threshold,
+                rerank=rerank,
+                aggregate=aggregate,
+                rewrite_query=rewrite_,
+                include_documents=self._include_documents,
+                include_summaries=self._include_summaries,
+                include_related_memories=self._include_related_memories,
+            )
+
         try:
-            results = self._client.search_memories(query, limit=limit, container_tag=tag)
+            results = _run(mode, rewrite_query)
+            retried = False
+            # Empty hit is usually phrasing or memories-only scope; widen once.
+            if not results and not rewrite_query:
+                retry_mode = "hybrid" if mode == "memories" else mode
+                results = _run(retry_mode, True)
+                retried = bool(results)
             formatted = []
             for item in results:
                 entry: dict[str, Any] = {"id": item.get("id", ""), "content": item.get("memory", "")}
@@ -972,6 +1076,8 @@ class SupermemoryMemoryProvider(MemoryProvider):
                         pass
                 formatted.append(entry)
             resp: dict[str, Any] = {"results": formatted, "count": len(formatted)}
+            if retried:
+                resp["retried_with_rewrite"] = True
             if tag:
                 resp["container_tag"] = tag
             return json.dumps(resp)

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -539,16 +539,18 @@ STORE_SCHEMA = {
 
 SEARCH_SCHEMA = {
     "name": "supermemory_search",
-    "description": "Search long-term memory by semantic similarity. Defaults suit most queries; tune the options below when a plain search is the wrong shape for the question.",
+    "description": (
+        "Search long-term memory by semantic similarity. Searches both extracted facts and "
+        "the contents of ingested documents. Write a specific, keyword-rich query rather than "
+        "echoing the user's phrasing verbatim — retrieval quality depends on it. Raise limit "
+        "instead of narrowing the query when a question is broad."
+    ),
     "parameters": {
         "type": "object",
         "properties": {
-            "query": {"type": "string", "description": "What to search for."},
-            "limit": {"type": "integer", "description": "Maximum results to return, 1 to 20."},
-            "search_mode": {"type": "string", "enum": list(_VALID_SEARCH_MODES), "description": "Default hybrid (facts + document chunks). Use 'documents' when asking about the contents of an ingested file, transcript, podcast, or article. Use 'memories' for short personal facts and preferences only."},
-            "rerank": {"type": "boolean", "description": "Reorder results by relevance to the query. Use when the query is precise and result ordering matters. Cannot be combined with aggregate."},
-            "aggregate": {"type": "boolean", "description": "Synthesize an answer across multiple memories. Use for broad or summarizing questions ('what do we know about X'). Costs an extra LLM call, so skip it for simple lookups. Cannot be combined with rerank."},
-            "rewrite_query": {"type": "boolean", "description": "Rewrite a vague or conversational query into better search terms (+~400ms). Applied automatically on an empty result, so only set it upfront when the query is clearly loosely worded."},
+            "query": {"type": "string", "description": "Specific search terms. Prefer distinctive keywords and names over conversational phrasing."},
+            "limit": {"type": "integer", "description": "Maximum results to return, 1 to 20. Raise it for broad questions that need several sources."},
+            "aggregate": {"type": "boolean", "description": "Synthesize across multiple memories instead of returning them separately. Use for broad questions ('what do we know about X'). Costs an extra LLM call, so skip it for simple lookups."},
         },
         "required": ["query"],
     },
@@ -978,10 +980,9 @@ class SupermemoryMemoryProvider(MemoryProvider):
 
         search_schema = SEARCH_SCHEMA
         if not self._allow_agent_search_overrides:
-            # Don't advertise knobs the agent isn't allowed to use.
+            # Don't advertise a knob the agent isn't allowed to use.
             search_schema = json.loads(json.dumps(SEARCH_SCHEMA))
-            for key in ("search_mode", "rerank", "aggregate", "rewrite_query"):
-                search_schema["parameters"]["properties"].pop(key, None)
+            search_schema["parameters"]["properties"].pop("aggregate", None)
 
         if not self._enable_custom_containers:
             return with_kebab_aliases([STORE_SCHEMA, search_schema, FORGET_SCHEMA, PROFILE_SCHEMA])
@@ -1033,17 +1034,14 @@ class SupermemoryMemoryProvider(MemoryProvider):
             limit = max(1, min(20, int(args.get("limit", 5) or 5)))
         except Exception:
             limit = 5
-        if self._allow_agent_search_overrides:
-            mode = str(args.get("search_mode") or "").strip().lower()
-            mode = mode if mode in _VALID_SEARCH_MODES else self._search_mode
-            rerank = _as_bool(args.get("rerank"), self._search_rerank)
-            aggregate = _as_bool(args.get("aggregate"), self._search_aggregate)
-            rewrite_query = _as_bool(args.get("rewrite_query"), self._search_rewrite_query)
-        else:
-            mode = self._search_mode
-            rerank = self._search_rerank
-            aggregate = self._search_aggregate
-            rewrite_query = self._search_rewrite_query
+        mode = self._search_mode
+        rerank = self._search_rerank
+        rewrite_query = self._search_rewrite_query
+        aggregate = (
+            _as_bool(args.get("aggregate"), self._search_aggregate)
+            if self._allow_agent_search_overrides
+            else self._search_aggregate
+        )
 
         def _run(mode_: str, rewrite_: bool) -> list:
             return self._client.search_memories(

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -6,7 +6,9 @@ import threading
 import pytest
 
 from plugins.memory.supermemory import (
+    SEARCH_SCHEMA,
     SupermemoryMemoryProvider,
+    _SupermemoryClient,
     _clean_text_for_capture,
     _format_connection_summary,
     _format_prefetch_context,
@@ -30,6 +32,7 @@ class FakeClient:
         self.ingest_calls = []
         self.forgotten_ids = []
         self.forget_by_query_response = {"success": True, "message": "Forgot"}
+        self.search_calls = []
 
     def add_memory(self, content, metadata=None, *, entity_context="",
                    container_tag=None, custom_id=None):
@@ -42,7 +45,17 @@ class FakeClient:
         })
         return {"id": "mem_123"}
 
-    def search_memories(self, query, *, limit=5, container_tag=None, search_mode=None):
+    def search_memories(self, query, *, limit=5, container_tag=None, search_mode=None,
+                        threshold=None, rerank=False, aggregate=False, rewrite_query=False,
+                        include_documents=False, include_summaries=False,
+                        include_related_memories=False):
+        self.search_calls.append({
+            "query": query, "limit": limit, "container_tag": container_tag,
+            "search_mode": search_mode, "threshold": threshold, "rerank": rerank,
+            "aggregate": aggregate, "rewrite_query": rewrite_query,
+            "include_documents": include_documents, "include_summaries": include_summaries,
+            "include_related_memories": include_related_memories,
+        })
         return self.search_results
 
     def get_profile(self, query=None, *, container_tag=None):
@@ -284,6 +297,111 @@ def test_search_tool_formats_results(provider):
     result = json.loads(provider.handle_tool_call("supermemory_search", {"query": "concise docs"}))
     assert result["count"] == 1
     assert result["results"][0]["similarity"] == 92
+
+
+def test_search_tool_forwards_config_defaults(provider):
+    provider.handle_tool_call("supermemory_search", {"query": "podcast notes"})
+    call = provider._client.search_calls[-1]
+    assert call["search_mode"] == "hybrid"
+    assert call["include_documents"] is False
+    assert call["threshold"] == 0.6
+    assert call["rerank"] is False
+    assert call["aggregate"] is False
+
+
+def test_search_tool_args_override_config(provider):
+    provider.handle_tool_call("supermemory_search", {
+        "query": "podcast notes", "rerank": True, "aggregate": True,
+        "rewrite_query": True, "search_mode": "documents",
+    })
+    call = provider._client.search_calls[-1]
+    assert call["search_mode"] == "documents"
+    assert call["rerank"] is True
+    assert call["aggregate"] is True
+    assert call["rewrite_query"] is True
+
+
+def test_empty_result_retries_once_with_rewrite(provider):
+    provider._client.search_results = []
+    out = json.loads(provider.handle_tool_call("supermemory_search", {"query": "quokkas"}))
+    calls = provider._client.search_calls
+    assert len(calls) == 2
+    assert calls[0]["rewrite_query"] is False
+    assert calls[1]["rewrite_query"] is True
+    assert out["count"] == 0
+    assert "retried_with_rewrite" not in out  # retry also found nothing
+
+
+def test_retry_upgrades_memories_mode_to_hybrid(provider):
+    provider._client.search_results = []
+    provider._search_mode = "memories"
+    provider.handle_tool_call("supermemory_search", {"query": "podcast"})
+    calls = provider._client.search_calls
+    assert calls[0]["search_mode"] == "memories"
+    assert calls[1]["search_mode"] == "hybrid"
+
+
+def test_no_retry_when_first_search_hits(provider):
+    provider._client.search_results = [{"id": "m1", "memory": "found", "similarity": 0.9}]
+    provider.handle_tool_call("supermemory_search", {"query": "x"})
+    assert len(provider._client.search_calls) == 1
+
+
+def test_overrides_ignored_when_disabled(provider):
+    provider._allow_agent_search_overrides = False
+    provider.handle_tool_call("supermemory_search", {
+        "query": "x", "aggregate": True, "search_mode": "documents"})
+    call = provider._client.search_calls[0]
+    assert call["aggregate"] is False
+    assert call["search_mode"] == "hybrid"
+
+
+def test_disabled_overrides_hides_knobs_from_schema(provider):
+    provider._allow_agent_search_overrides = False
+    schema = next(s for s in provider.get_tool_schemas() if s["name"] == "supermemory_search")
+    props = schema["parameters"]["properties"]
+    assert "query" in props
+    for knob in ("search_mode", "rerank", "aggregate", "rewrite_query"):
+        assert knob not in props
+    # global schema untouched
+    assert "aggregate" in SEARCH_SCHEMA["parameters"]["properties"]
+
+
+def _bare_client(captured):
+    """Build a _SupermemoryClient without touching the real SDK."""
+    c = object.__new__(_SupermemoryClient)
+    c._container_tag = "hermes"
+    c._search_mode = "hybrid"
+
+    class _Search:
+        def memories(self, **kwargs):
+            captured.update(kwargs)
+            return type("R", (), {"results": []})()
+
+    c._client = type("C", (), {"search": _Search()})()
+    return c
+
+
+def test_aggregate_and_rerank_are_mutually_exclusive():
+    # API returns 400 "Cannot use both aggregate and rerank simultaneously".
+    captured = {}
+    _bare_client(captured).search_memories("q", rerank=True, aggregate=True)
+    assert captured.get("aggregate") is True
+    assert "rerank" not in captured
+
+
+def test_rerank_sent_when_aggregate_off():
+    captured = {}
+    _bare_client(captured).search_memories("q", rerank=True)
+    assert captured.get("rerank") is True
+    assert "aggregate" not in captured
+
+
+def test_include_flags_use_api_casing():
+    captured = {}
+    _bare_client(captured).search_memories(
+        "q", include_documents=True, include_related_memories=True)
+    assert captured["include"] == {"documents": True, "relatedMemories": True}
 
 
 def test_forget_tool_by_id(provider):

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -309,16 +309,18 @@ def test_search_tool_forwards_config_defaults(provider):
     assert call["aggregate"] is False
 
 
-def test_search_tool_args_override_config(provider):
+def test_aggregate_is_the_only_agent_override(provider):
+    provider._client.search_results = [{"id": "m1", "memory": "hit", "similarity": 0.9}]
     provider.handle_tool_call("supermemory_search", {
-        "query": "podcast notes", "rerank": True, "aggregate": True,
-        "rewrite_query": True, "search_mode": "documents",
+        "query": "podcast notes", "aggregate": True,
+        # not agent-controllable — must not leak through
+        "rerank": True, "rewrite_query": True, "search_mode": "documents",
     })
-    call = provider._client.search_calls[-1]
-    assert call["search_mode"] == "documents"
-    assert call["rerank"] is True
+    call = provider._client.search_calls[0]
     assert call["aggregate"] is True
-    assert call["rewrite_query"] is True
+    assert call["search_mode"] == "hybrid"
+    assert call["rerank"] is False
+    assert call["rewrite_query"] is False
 
 
 def test_empty_result_retries_once_with_rewrite(provider):
@@ -347,24 +349,25 @@ def test_no_retry_when_first_search_hits(provider):
     assert len(provider._client.search_calls) == 1
 
 
-def test_overrides_ignored_when_disabled(provider):
+def test_aggregate_override_ignored_when_disabled(provider):
     provider._allow_agent_search_overrides = False
-    provider.handle_tool_call("supermemory_search", {
-        "query": "x", "aggregate": True, "search_mode": "documents"})
-    call = provider._client.search_calls[0]
-    assert call["aggregate"] is False
-    assert call["search_mode"] == "hybrid"
+    provider.handle_tool_call("supermemory_search", {"query": "x", "aggregate": True})
+    assert provider._client.search_calls[0]["aggregate"] is False
 
 
-def test_disabled_overrides_hides_knobs_from_schema(provider):
+def test_disabled_overrides_hides_aggregate_from_schema(provider):
     provider._allow_agent_search_overrides = False
     schema = next(s for s in provider.get_tool_schemas() if s["name"] == "supermemory_search")
     props = schema["parameters"]["properties"]
-    assert "query" in props
-    for knob in ("search_mode", "rerank", "aggregate", "rewrite_query"):
-        assert knob not in props
+    assert "query" in props and "limit" in props
+    assert "aggregate" not in props
     # global schema untouched
     assert "aggregate" in SEARCH_SCHEMA["parameters"]["properties"]
+
+
+def test_schema_exposes_only_query_limit_aggregate(provider):
+    schema = next(s for s in provider.get_tool_schemas() if s["name"] == "supermemory_search")
+    assert set(schema["parameters"]["properties"]) == {"query", "limit", "aggregate"}
 
 
 def _bare_client(captured):

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -581,7 +581,15 @@ stays local.
 | `max_recall_results` | `10` | Max recalled items to format into context |
 | `profile_frequency` | `50` | Include profile facts on first turn and every N turns |
 | `capture_mode` | `all` | Skip tiny or trivial turns by default |
-| `search_mode` | `hybrid` | Search mode: `hybrid`, `memories`, or `documents` |
+| `search_mode` | `hybrid` | Search mode: `hybrid` (memories + document chunks), `memories`, or `documents`. Plugin defaults to `hybrid`; the hosted API's own default is `memories`. |
+| `include_documents` | `false` | Attach parent-document metadata (title, type, metadata) to each result. Does **not** control whether document content is searched — that is `search_mode`. Costs an extra document fetch per search. |
+| `include_summaries` | `false` | Include document summaries in search results |
+| `include_related_memories` | `false` | Include memories related to the matches |
+| `search_threshold` | `0.6` | Selection sensitivity, 0 (broad, more results) to 1 (strict, fewer results) |
+| `search_rerank` | `false` | Rerank results by relevance to the query |
+| `search_aggregate` | `false` | Synthesize new memories by aggregating across multiple results. Mutually exclusive with `search_rerank` — the API rejects both with a 400, and aggregate does *not* rerank (server-side they are separate branches: aggregate synthesizes via LLM, rerank runs a cross-encoder). If both are set, aggregate wins and rerank is dropped. |
+| `search_rewrite_query` | `false` | Rewrite the query to improve matching (adds ~400ms latency). Applied automatically as a one-shot retry when a search returns nothing. |
+| `allow_agent_search_overrides` | `true` | Let the agent pass `search_mode` / `rerank` / `aggregate` / `rewrite_query` per call. Set `false` to pin behavior to this config and hide those options from the tool schema (useful for cost control, since `aggregate` costs an extra LLM call). |
 | `api_timeout` | `5.0` | Timeout for SDK and ingest requests |
 
 **Environment variables:** `SUPERMEMORY_API_KEY` (required), `SUPERMEMORY_BASE_URL` (compatibility fallback when `base_url` is not configured), `SUPERMEMORY_CONTAINER_TAG` (overrides config).

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -589,7 +589,7 @@ stays local.
 | `search_rerank` | `false` | Rerank results by relevance to the query |
 | `search_aggregate` | `false` | Synthesize new memories by aggregating across multiple results. Mutually exclusive with `search_rerank` — the API rejects both with a 400, and aggregate does *not* rerank (server-side they are separate branches: aggregate synthesizes via LLM, rerank runs a cross-encoder). If both are set, aggregate wins and rerank is dropped. |
 | `search_rewrite_query` | `false` | Rewrite the query to improve matching (adds ~400ms latency). Applied automatically as a one-shot retry when a search returns nothing. |
-| `allow_agent_search_overrides` | `true` | Let the agent pass `search_mode` / `rerank` / `aggregate` / `rewrite_query` per call. Set `false` to pin behavior to this config and hide those options from the tool schema (useful for cost control, since `aggregate` costs an extra LLM call). |
+| `allow_agent_search_overrides` | `true` | Let the agent pass `aggregate` per call. Set `false` to pin it to this config and hide the option from the tool schema (useful for cost control, since `aggregate` costs an extra LLM call). All other search options are config-only. |
 | `api_timeout` | `5.0` | Timeout for SDK and ingest requests |
 
 **Environment variables:** `SUPERMEMORY_API_KEY` (required), `SUPERMEMORY_BASE_URL` (compatibility fallback when `base_url` is not configured), `SUPERMEMORY_CONTAINER_TAG` (overrides config).


### PR DESCRIPTION
## What does this PR do?

The Supermemory plugin only sends `q`, `container_tag`, `limit` and `search_mode` to `/v4/search`. The endpoint accepts considerably more, and the unused options are the ones that matter when a plain semantic lookup is the wrong shape for the question — `threshold`, `rerank`, `aggregate`, `rewriteQuery` and `include.{documents,summaries,relatedMemories}`.

This wires them through as config keys in `$HERMES_HOME/supermemory.json`, and additionally as per-call arguments on the `supermemory_search` tool so the agent can pick the right retrieval shape per query rather than depending on the user having pre-tuned a config file they may not know exists.

Three details worth calling out:

- **`aggregate` and `rerank` are mutually exclusive server-side.** Sending both returns `400 Cannot use both aggregate and rerank simultaneously`. They are separate post-processing branches (`aggregate` synthesizes new memories via an LLM; `rerank` runs a cross-encoder), so this is not a combination that degrades gracefully — `aggregate` takes precedence and `rerank` is dropped rather than letting every search hard-fail.
- **Empty results retry once.** A search that returns nothing is retried with `rewriteQuery=true`, upgrading `memories` mode to `hybrid` on the retry, since an empty hit is usually query phrasing or too narrow a scope. The response carries `retried_with_rewrite` so the caller can tell. No retry happens when the first attempt succeeds, so the common path is unaffected.
- **`allow_agent_search_overrides`** (default `true`) pins behaviour to the config file when set to `false`, and also strips those options from the advertised tool schema so a locked-down deployment doesn't spend tokens describing options the agent can't use. `aggregate` costs an extra server-side LLM call, so this is a real cost lever.

Defaults are deliberately conservative: every new option is off except `search_mode`, which already defaulted to `hybrid`. No behaviour changes unless a key is set.

## Related Issue

No existing issue. Related, but independent: #66137 fixes result text being read from the wrong SDK field. That PR and this one touch the same file but different concerns — this one deliberately does **not** change result-text extraction so the two don't conflict.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/supermemory/__init__.py`
  - `_default_config()` / `_load_supermemory_config()`: added `search_threshold`, `search_rerank`, `search_aggregate`, `search_rewrite_query`, `include_documents`, `include_summaries`, `include_related_memories`, `allow_agent_search_overrides`, validated with the existing `_as_bool` helper and the same clamping style as `api_timeout`.
  - `_SupermemoryClient.search_memories()`: forwards the new parameters, building `include` only from the flags that are set, and enforcing the aggregate/rerank exclusion.
  - `_tool_search()`: resolves per-call overrides (gated by `allow_agent_search_overrides`), runs the empty-result retry.
  - `SEARCH_SCHEMA`: documents when to reach for each option rather than just what it is.
  - `get_tool_schemas()`: deep-copies and strips the options when overrides are disabled, leaving the module-level schema untouched.
- `plugins/memory/supermemory/README.md`, `website/docs/user-guide/features/memory-providers.md`: config tables updated.
- `tests/plugins/memory/test_supermemory_provider.py`: 10 new tests.

## How to Test

1. Set `memory.provider: supermemory` with a valid `SUPERMEMORY_API_KEY`, then ingest a document (a transcript or article works well).
2. Run `supermemory_search` for content that only exists in that document. With `search_mode: "documents"` it searches document chunks; with `"memories"` it searches extracted facts only.
3. Add `{"search_aggregate": true}` to `$HERMES_HOME/supermemory.json` and repeat a broad query — results now include synthesized entries flagged `isAggregated` by the API alongside the literal matches.
4. Set `{"search_aggregate": true, "search_rerank": true}` and confirm searches still succeed (before this change that combination would return a 400 from the API).
5. Set `{"allow_agent_search_overrides": false}` and confirm the `search_mode` / `rerank` / `aggregate` / `rewrite_query` arguments disappear from the `supermemory_search` schema and are ignored if passed.

Verified end-to-end against the live Supermemory API: ingested a document, confirmed `documents`/`hybrid` mode returns its content while `memories` mode does not, confirmed `aggregate` returns synthesized entries, and confirmed the previously-400 combination now succeeds. Test data was removed afterwards.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] N/A — these keys live in `$HERMES_HOME/supermemory.json`, not `cli-config.yaml.example`
- [x] N/A — no architecture or workflow changes
- [x] N/A — no file I/O, process management, or terminal handling touched

