### PR TITLE
fix(memory): guard HRR queries against empty/zero-byte vectors

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -152,7 +152,7 @@ class FactRetriever:
                 )
 
         # Score against individual fact vectors directly
-        where = "WHERE hrr_vector IS NOT NULL"
+        where = "WHERE hrr_vector IS NOT NULL AND length(hrr_vector) > 0"
         params: list = []
         if category:
             where += " AND category = ?"
@@ -212,7 +212,7 @@ class FactRetriever:
         entity_vec = hrr.encode_atom(entity.lower(), self.hrr_dim)
 
         # Get all facts with vectors
-        where = "WHERE hrr_vector IS NOT NULL"
+        where = "WHERE hrr_vector IS NOT NULL AND length(hrr_vector) > 0"
         params: list = []
         if category:
             where += " AND category = ?"
@@ -291,7 +291,7 @@ class FactRetriever:
             entity_residuals.append(probe_key)
 
         # Get all facts with vectors
-        where = "WHERE hrr_vector IS NOT NULL"
+        where = "WHERE hrr_vector IS NOT NULL AND length(hrr_vector) > 0"
         params: list = []
         if category:
             where += " AND category = ?"
@@ -356,7 +356,7 @@ class FactRetriever:
         conn = self.store._conn
 
         # Get all facts with vectors and their linked entities
-        where = "WHERE f.hrr_vector IS NOT NULL"
+        where = "WHERE f.hrr_vector IS NOT NULL AND length(f.hrr_vector) > 0"
         params: list = []
         if category:
             where += " AND f.category = ?"
@@ -450,7 +450,7 @@ class FactRetriever:
         """Score facts by similarity to a target vector."""
         conn = self.store._conn
 
-        where = "WHERE hrr_vector IS NOT NULL"
+        where = "WHERE hrr_vector IS NOT NULL AND length(hrr_vector) > 0"
         params: list = []
         if category:
             where += " AND category = ?"

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -552,7 +552,7 @@ class MemoryStore:
 
             bank_name = f"cat:{category}"
             rows = self._conn.execute(
-                "SELECT hrr_vector FROM facts WHERE category = ? AND hrr_vector IS NOT NULL",
+                "SELECT hrr_vector FROM facts WHERE category = ? AND hrr_vector IS NOT NULL AND length(hrr_vector) > 0",
                 (category,),
             ).fetchall()
 


### PR DESCRIPTION
## Problem

A recovered holographic memory DB left 25 facts with zero-byte `hrr_vector` blobs. Since a 0-byte blob satisfies `IS NOT NULL`, the existing `WHERE hrr_vector IS NOT NULL` filter allowed them through into `_rebuild_bank`, `probe`, and `reason`.

The result: numpy 2.x `vstack`/`array` encountered `(0,)` arrays alongside `(1024,)` ones and aborted with `inhomogeneous shape` errors. This was triggered by `fact_store remove` (each removal rebuilds the category bank) but could also surface during normal retrieval.

## Fix

Added `AND length(hrr_vector) > 0` to all six HRR SQL queries across two files:

- `plugins/memory/holographic/retrieval.py` — 5 queries (probe, reason, and bank rebuild paths)
- `plugins/memory/holographic/store.py` — 1 query (category listing)

Empty vectors are now treated as missing and never reach numpy stacking.

## Verification

- Existing HRR tests pass
- Manual verification: DB with 25 zero-byte facts no longer crashes on probe/reason/remove