### PR TITLE
fix(agent,transport): drop empty tool_calls array for strict API compatibility

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -196,6 +196,12 @@ class ChatCompletionsTransport(ProviderTransport):
                 break
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
+                # `"tool_calls": []` appears in histories written by older
+                # versions; strict providers (DeepSeek) reject it with
+                # HTTP 400 "Expected an array with minimum length 1".
+                if not tool_calls:
+                    needs_sanitize = True
+                    break
                 for tc in tool_calls:
                     if isinstance(tc, dict) and (
                         "call_id" in tc
@@ -252,6 +258,10 @@ class ChatCompletionsTransport(ProviderTransport):
 
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
+                if not tool_calls:
+                    out_msg = mutable_msg()
+                    out_msg.pop("tool_calls", None)
+                    continue
                 copied_tool_calls: list[Any] | None = None
                 for tc_idx, tc in enumerate(tool_calls):
                     if isinstance(tc, dict):

--- a/run_agent.py
+++ b/run_agent.py
@@ -6095,6 +6095,12 @@ class AIAgent:
         tool_calls = api_msg.get("tool_calls")
         if not isinstance(tool_calls, list):
             return api_msg
+        if not tool_calls:
+            # Strict providers (DeepSeek) reject `"tool_calls": []` with
+            # HTTP 400 "Expected an array with minimum length 1" — an empty
+            # list can appear in histories written by older versions.
+            del api_msg["tool_calls"]
+            return api_msg
         from agent.transports.chat_completions import _model_consumes_thought_signature
         _STRIP_KEYS = {"call_id", "response_item_id"}
         if not _model_consumes_thought_signature(model):


### PR DESCRIPTION
## Problem

DeepSeek and Fireworks (among other strict API providers) reject assistant messages containing `tool_calls: []` with HTTP 400:

> Expected an array with minimum length 1

Empty tool_calls arrays appear in histories written by older versions of Hermes Agent. These histories are stored on disk and replayed, causing every subsequent request in the session to fail once an empty tool_calls message enters the context.

## Fix

Two changes across the message pipeline:

1. **run_agent.py** — `_sanitize_tool_calls_for_strict_api()` now strips empty `tool_calls` arrays from the message copy before sending to the provider. This covers the summary/retry path (`handle_max_iterations`).

2. **agent/transports/chat_completions.py** — `convert_messages()` (the main-loop message sanitizer) now detects empty `tool_calls` arrays in the detection phase and removes them from the outgoing copy in the sanitization phase. This covers the primary request path used by ~16 OpenAI-compatible providers.

Both fixes operate on copies — no stored history is mutated.