### PR TITLE
fix(gateway): preserve custom_providers extra_body on reused-agent turns

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -436,11 +436,20 @@ def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, An
         return
 
     overrides = dict(getattr(agent, "request_overrides", {}) or {})
-    merged_extra_body = dict(extra_body)
+    # Avoid durable defaults overriding typed kwargs after OpenAI flattens extra_body.
+    top_level_keys = overrides.keys() - {"extra_body"}
+    merged_extra_body = {
+        key: value
+        for key, value in extra_body.items()
+        if key not in top_level_keys
+    }
     existing_extra_body = overrides.get("extra_body")
     if isinstance(existing_extra_body, dict):
         merged_extra_body.update(existing_extra_body)
-    overrides["extra_body"] = merged_extra_body
+    if merged_extra_body:
+        overrides["extra_body"] = merged_extra_body
+    else:
+        overrides.pop("extra_body", None)
     agent.request_overrides = overrides
 
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -379,6 +379,10 @@ def build_turn_context(
 
     # Restore the primary runtime if the previous turn activated fallback.
     agent._restore_primary_runtime()
+    custom_providers = getattr(agent, "_custom_providers", None)
+    if custom_providers:
+        from agent.agent_init import _merge_custom_provider_extra_body
+        _merge_custom_provider_extra_body(agent, custom_providers)
 
     # Tell auxiliary_client what the live main provider/model are for this turn
     # after primary restoration has settled the runtime.

--- a/tests/agent/test_custom_provider_extra_body.py
+++ b/tests/agent/test_custom_provider_extra_body.py
@@ -11,6 +11,7 @@ def test_custom_provider_extra_body_preserves_caller_override():
         model="google/gemma-4-31b-it",
         base_url="https://example.test/v1",
         request_overrides={
+            "service_tier": "priority",
             "extra_body": {
                 "reasoning_effort": "low",
                 "caller_only": True,
@@ -28,15 +29,19 @@ def test_custom_provider_extra_body_preserves_caller_override():
                 "extra_body": {
                     "enable_thinking": True,
                     "reasoning_effort": "high",
+                    "service_tier": "flex",
                 },
             }
         ],
     )
 
-    assert agent.request_overrides["extra_body"] == {
-        "enable_thinking": True,
-        "reasoning_effort": "low",
-        "caller_only": True,
+    assert agent.request_overrides == {
+        "service_tier": "priority",
+        "extra_body": {
+            "enable_thinking": True,
+            "reasoning_effort": "low",
+            "caller_only": True,
+        },
     }
 
 

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -208,6 +208,31 @@ def test_returns_turn_context_with_user_message_appended():
     assert ctx.active_system_prompt == "SYSTEM"
 
 
+@pytest.mark.parametrize("restore_primary", [True, False])
+def test_custom_provider_extra_body_uses_active_runtime(restore_primary):
+    agent = _FakeAgent()
+    agent.model = "fallback/model"
+    agent.provider = "openrouter"
+    agent.base_url = "https://openrouter.ai/api/v1"
+    agent.request_overrides = {}
+    agent._custom_providers = [{
+        "base_url": "https://custom.example/v1",
+        "extra_body": {"reasoning_effort": "xhigh"},
+    }]
+
+    def restore():
+        if restore_primary:
+            agent.model = "primary/model"
+            agent.provider = "custom"
+            agent.base_url = "https://custom.example/v1"
+
+    agent._restore_primary_runtime = restore
+    _build(agent)
+
+    expected = {"extra_body": {"reasoning_effort": "xhigh"}} if restore_primary else {}
+    assert agent.request_overrides == expected
+
+
 def test_turn_start_replaces_stale_parent_history_with_compression_child():
     agent = _FakeAgent()
     stale_history = [{"role": "user", "content": "stale parent"}]
@@ -331,7 +356,6 @@ def test_between_turns_refresh_adds_late_tool_when_servers_registered():
 
     assert "mcp_x_tool" in agent.valid_tool_names
     assert any(t["function"]["name"] == "mcp_x_tool" for t in agent.tools)
-
 
 
 

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -10,6 +10,7 @@ import pytest
 import yaml
 
 import gateway.run as gateway_run
+from agent.agent_init import _merge_custom_provider_extra_body
 from gateway.config import Platform
 from gateway.platforms.base import MessageEvent
 from gateway.session import SessionSource
@@ -18,9 +19,27 @@ from gateway.session import SessionSource
 class _CapturingAgent:
     last_init = None
     last_run = None
+    init_count = 0
+    turn_request_overrides = []
 
     def __init__(self, *args, **kwargs):
         type(self).last_init = dict(kwargs)
+        type(self).init_count += 1
+        self.model = kwargs["model"]
+        self.provider = kwargs["provider"]
+        self.base_url = kwargs["base_url"]
+        self.request_overrides = dict(kwargs.get("request_overrides") or {})
+        self._custom_providers = [
+            {
+                "base_url": self.base_url,
+                "extra_body": {
+                    "reasoning_effort": "xhigh",
+                    "service_tier": "flex",
+                },
+            }
+        ]
+        _merge_custom_provider_extra_body(self, self._custom_providers)
+        self.context_compressor = None
         self.tools = []
 
     def run_conversation(
@@ -38,6 +57,8 @@ class _CapturingAgent:
             "persist_user_message": persist_user_message,
             "persist_user_timestamp": persist_user_timestamp,
         }
+        _merge_custom_provider_extra_body(self, self._custom_providers)
+        type(self).turn_request_overrides.append(dict(self.request_overrides))
         return {
             "final_response": "ok",
             "messages": [],
@@ -170,3 +191,59 @@ async def test_session_fast_override_beats_config_default(monkeypatch, tmp_path)
     assert runner._resolve_session_service_tier(session_key="other-session") == "priority"
 
 
+@pytest.mark.asyncio
+async def test_cached_custom_provider_overrides_survive_fast_then_normal_turn(monkeypatch):
+    _CapturingAgent.init_count = 0
+    _CapturingAgent.turn_request_overrides = []
+    _install_fake_agent(monkeypatch)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda *_args: set())
+
+    runner = _make_runner()
+    runner.config.multiplex_profiles = False
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "gpt-5.4",
+        {
+            "api_key": "***",
+            "base_url": "http://my-endpoint/v1",
+            "provider": "custom",
+            "api_mode": "chat_completions",
+        },
+    )
+    tiers = iter(["priority", None])
+    runner._resolve_session_service_tier = lambda **_kwargs: next(tiers)
+    runner._resolve_session_reasoning_config = lambda **_kwargs: None
+    runner._get_system_prompt_for_channel = lambda *_args, **_kwargs: ""
+    runner._refresh_fallback_model = lambda: None
+    runner._enforce_agent_cache_cap = lambda: None
+
+    source = _make_source()
+    run_kwargs = {
+        "context_prompt": "",
+        "history": [],
+        "source": source,
+        "session_id": "session-1",
+        "session_key": "agent:main:telegram:dm:12345",
+    }
+
+    await runner._run_agent(message="fast turn", **run_kwargs)
+    await runner._run_agent(message="normal turn", **run_kwargs)
+
+    assert _CapturingAgent.init_count == 1
+    assert _CapturingAgent.turn_request_overrides == [
+        {
+            "service_tier": "priority",
+            "extra_body": {"reasoning_effort": "xhigh"},
+        },
+        {
+            "extra_body": {
+                "reasoning_effort": "xhigh",
+                "service_tier": "flex",
+            }
+        },
+    ]


### PR DESCRIPTION
## Why

Gateway cached-agent turns replace `request_overrides`, dropping durable `custom_providers[].extra_body` values initialized on the agent. Custom-provider requests therefore behave differently between CLI and messaging paths, silently removing fields such as `reasoning_effort`.

## What

Reapply matching custom-provider `extra_body` defaults after active-runtime restoration at the start of each agent turn. Explicit turn-level top-level and nested values retain precedence, and defaults are applied only to the active provider runtime so cooldown-active fallbacks do not inherit primary-provider settings.

Add regression coverage for a reused gateway agent across fast and normal turns, merge precedence, restored primary runtimes, and cooldown-active fallbacks.

## Testing

- `scripts/run_tests.sh tests/agent/test_custom_provider_extra_body.py tests/agent/test_turn_context.py tests/gateway/test_fast_command.py -q`
- `python -m ruff check agent/agent_init.py agent/turn_context.py tests/agent/test_custom_provider_extra_body.py tests/agent/test_turn_context.py tests/gateway/test_fast_command.py`
- `git diff --check origin/main..HEAD`

## References

- Fixes #54922