### PR TITLE
fix(tui): reclaim leaked active-session leases with an owner-tagged pid-scoped sweep

### DIFF
--- a/contributors/emails/sora.bluesky.dev@gmail.com
+++ b/contributors/emails/sora.bluesky.dev@gmail.com
@@ -1,0 +1,1 @@
+Sora-bluesky

--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -217,18 +217,29 @@ def _prune_dead(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
     ]
 
 
-def prune_stale_for_pid(pid: int, live_session_ids: set[str]) -> int:
-    """Reclaim leases owned by ``pid`` whose live session no longer exists.
+def prune_stale_for_pid(pid: int, live_session_ids: set[str], *, owner: str) -> int:
+    """Reclaim leases owned by ``pid`` AND tagged ``metadata.owner == owner``
+    whose live session no longer exists.
 
     ``active_sessions.json`` is cross-process: a PID-alive entry owned by
     ANOTHER process can't be validated from here (that process's own
     in-memory session registry isn't visible to us), so only entries whose
-    ``pid`` matches the CURRENT process are checked. A same-pid entry is
-    reclaimed when its ``metadata.live_session_id`` is set but is not a
-    member of ``live_session_ids`` (the caller's current live session-id
-    registry, e.g. a desktop/TUI backend's in-memory session map) — that
-    combination means the in-process session the lease was minted for is
-    gone, but nothing on the release path ever ran to free the slot (e.g. a
+    ``pid`` matches the CURRENT process are even considered. Within that
+    same-pid set, the ``owner`` tag is a structural (not incidental) guard:
+    a CLI lease shares the desktop backend's PID (one ``hermes serve``
+    process serves both), but the CLI's ``_active_session_lease`` is a
+    single, whole-process-lifetime lease with no ``live_session_id`` /
+    ``owner`` concept of its own — an entry missing the exact ``owner`` tag
+    (or tagged for a different owner) is left alone regardless of whether
+    its ``live_session_id`` looks stale, so this sweep can never reclaim a
+    CLI/gateway lease by accident.
+
+    A same-pid, same-owner entry is reclaimed when its
+    ``metadata.live_session_id`` is set but is not a member of
+    ``live_session_ids`` (the caller's current live session-id registry,
+    e.g. a desktop/TUI backend's in-memory session map) — that combination
+    means the in-process session the lease was minted for is gone, but
+    nothing on the release path ever ran to free the slot (e.g. a
     replacement flow that dropped the old session without an explicit
     release).
 
@@ -251,10 +262,12 @@ def prune_stale_for_pid(pid: int, live_session_ids: set[str]) -> int:
                     entry_pid = None
                 if entry_pid == pid:
                     metadata = entry.get("metadata")
-                    live_id = metadata.get("live_session_id") if isinstance(metadata, dict) else None
-                    if live_id is not None and live_id not in live_session_ids:
-                        reclaimed += 1
-                        continue
+                    metadata = metadata if isinstance(metadata, dict) else {}
+                    if metadata.get("owner") == owner:
+                        live_id = metadata.get("live_session_id")
+                        if live_id is not None and live_id not in live_session_ids:
+                            reclaimed += 1
+                            continue
                 kept.append(entry)
             if reclaimed:
                 _write_entries(state_path, kept)

--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -217,6 +217,53 @@ def _prune_dead(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
     ]
 
 
+def prune_stale_for_pid(pid: int, live_session_ids: set[str]) -> int:
+    """Reclaim leases owned by ``pid`` whose live session no longer exists.
+
+    ``active_sessions.json`` is cross-process: a PID-alive entry owned by
+    ANOTHER process can't be validated from here (that process's own
+    in-memory session registry isn't visible to us), so only entries whose
+    ``pid`` matches the CURRENT process are checked. A same-pid entry is
+    reclaimed when its ``metadata.live_session_id`` is set but is not a
+    member of ``live_session_ids`` (the caller's current live session-id
+    registry, e.g. a desktop/TUI backend's in-memory session map) — that
+    combination means the in-process session the lease was minted for is
+    gone, but nothing on the release path ever ran to free the slot (e.g. a
+    replacement flow that dropped the old session without an explicit
+    release).
+
+    Fail-open: any error is swallowed and logged, returning 0, so a
+    bookkeeping failure here never blocks the caller's actual lease
+    acquisition.
+
+    Returns the number of leases reclaimed.
+    """
+    try:
+        state_path = _state_path()
+        with _FileLock(_lock_path()):
+            entries = _prune_dead(_read_entries(state_path))
+            kept: list[dict[str, Any]] = []
+            reclaimed = 0
+            for entry in entries:
+                try:
+                    entry_pid = int(entry.get("pid"))
+                except (TypeError, ValueError):
+                    entry_pid = None
+                if entry_pid == pid:
+                    metadata = entry.get("metadata")
+                    live_id = metadata.get("live_session_id") if isinstance(metadata, dict) else None
+                    if live_id is not None and live_id not in live_session_ids:
+                        reclaimed += 1
+                        continue
+                kept.append(entry)
+            if reclaimed:
+                _write_entries(state_path, kept)
+            return reclaimed
+    except Exception:
+        logger.warning("Failed to prune stale active session leases for pid=%s", pid, exc_info=True)
+        return 0
+
+
 @dataclass
 class ActiveSessionLease:
     lease_id: str

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -371,7 +371,7 @@ def test_prune_stale_for_pid_reclaims_orphaned_same_pid_lease(tmp_path, monkeypa
         session_id="stale-key",
         surface="tui",
         config={"max_concurrent_sessions": 5},
-        metadata={"live_session_id": "sid-gone"},
+        metadata={"live_session_id": "sid-gone", "owner": "tui_gateway"},
     )
     assert message is None and stale_lease is not None
 
@@ -379,11 +379,13 @@ def test_prune_stale_for_pid_reclaims_orphaned_same_pid_lease(tmp_path, monkeypa
         session_id="live-key",
         surface="tui",
         config={"max_concurrent_sessions": 5},
-        metadata={"live_session_id": "sid-still-live"},
+        metadata={"live_session_id": "sid-still-live", "owner": "tui_gateway"},
     )
     assert message is None and live_lease is not None
 
-    reclaimed = active_sessions.prune_stale_for_pid(os.getpid(), {"sid-still-live"})
+    reclaimed = active_sessions.prune_stale_for_pid(
+        os.getpid(), {"sid-still-live"}, owner="tui_gateway"
+    )
 
     assert reclaimed == 1
     remaining = active_sessions.active_session_registry_snapshot()
@@ -410,17 +412,44 @@ def test_prune_stale_for_pid_ignores_other_pid_entries(tmp_path, monkeypatch):
                 "pid": other_pid,
                 "started_at": 1,
                 "updated_at": 1,
-                "metadata": {"live_session_id": "not-in-my-registry"},
+                "metadata": {"live_session_id": "not-in-my-registry", "owner": "tui_gateway"},
             }
         ],
     )
 
-    reclaimed = active_sessions.prune_stale_for_pid(os.getpid(), set())
+    reclaimed = active_sessions.prune_stale_for_pid(os.getpid(), set(), owner="tui_gateway")
 
     assert reclaimed == 0
     assert [entry["session_id"] for entry in active_sessions.active_session_registry_snapshot()] == [
         "other-proc-session"
     ]
+
+
+def test_prune_stale_for_pid_ignores_same_pid_lease_without_owner_tag(tmp_path, monkeypatch):
+    """A same-pid lease with no owner tag (or a different owner) — e.g. the
+    CLI's single whole-process lease sharing the desktop backend's PID —
+    must survive the sweep even though its live_session_id looks stale.
+    The owner tag is a structural guard, not an incidental one: reclaiming
+    based on live_session_id alone would silently release a live CLI
+    session's lease out from under it."""
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    cli_lease, message = active_sessions.try_acquire_active_session(
+        session_id="cli-key",
+        surface="cli",
+        config={"max_concurrent_sessions": 5},
+        metadata={"live_session_id": "not-in-tui-registry"},
+    )
+    assert message is None and cli_lease is not None
+
+    reclaimed = active_sessions.prune_stale_for_pid(os.getpid(), set(), owner="tui_gateway")
+
+    assert reclaimed == 0
+    assert [entry["session_id"] for entry in active_sessions.active_session_registry_snapshot()] == [
+        "cli-key"
+    ]
+    cli_lease.release()
 
 
 def test_prune_stale_for_pid_fails_open_on_error(tmp_path, monkeypatch):
@@ -432,4 +461,4 @@ def test_prune_stale_for_pid_fails_open_on_error(tmp_path, monkeypatch):
         lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("boom")),
     )
 
-    assert active_sessions.prune_stale_for_pid(os.getpid(), set()) == 0
+    assert active_sessions.prune_stale_for_pid(os.getpid(), set(), owner="tui_gateway") == 0

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -354,3 +354,82 @@ def test_pid_start_time_mismatch_prunes_reused_pid(tmp_path, monkeypatch):
         "new-session"
     ]
     lease.release()
+
+
+def test_prune_stale_for_pid_reclaims_orphaned_same_pid_lease(tmp_path, monkeypatch):
+    """A same-pid lease whose live_session_id is no longer live is reclaimed.
+
+    Mirrors #68920: a desktop/TUI session-replacement flow can drop the OLD
+    in-memory session without ever releasing its lease. The lease is still
+    tagged with the (now-gone) in-memory sid via metadata.live_session_id, so
+    a pid-scoped sweep can tell it apart from a genuinely-live sibling lease.
+    """
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    stale_lease, message = active_sessions.try_acquire_active_session(
+        session_id="stale-key",
+        surface="tui",
+        config={"max_concurrent_sessions": 5},
+        metadata={"live_session_id": "sid-gone"},
+    )
+    assert message is None and stale_lease is not None
+
+    live_lease, message = active_sessions.try_acquire_active_session(
+        session_id="live-key",
+        surface="tui",
+        config={"max_concurrent_sessions": 5},
+        metadata={"live_session_id": "sid-still-live"},
+    )
+    assert message is None and live_lease is not None
+
+    reclaimed = active_sessions.prune_stale_for_pid(os.getpid(), {"sid-still-live"})
+
+    assert reclaimed == 1
+    remaining = active_sessions.active_session_registry_snapshot()
+    assert [entry["session_id"] for entry in remaining] == ["live-key"]
+    live_lease.release()
+
+
+def test_prune_stale_for_pid_ignores_other_pid_entries(tmp_path, monkeypatch):
+    """A PID-alive entry owned by another process must never be touched —
+    that process's live-session registry isn't visible from here."""
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("gateway.status._pid_exists", lambda _pid: True)
+    runtime = home / "runtime"
+    runtime.mkdir(parents=True)
+    other_pid = os.getpid() + 1
+    active_sessions._write_entries(
+        runtime / "active_sessions.json",
+        [
+            {
+                "lease_id": "other-proc",
+                "session_id": "other-proc-session",
+                "surface": "tui",
+                "pid": other_pid,
+                "started_at": 1,
+                "updated_at": 1,
+                "metadata": {"live_session_id": "not-in-my-registry"},
+            }
+        ],
+    )
+
+    reclaimed = active_sessions.prune_stale_for_pid(os.getpid(), set())
+
+    assert reclaimed == 0
+    assert [entry["session_id"] for entry in active_sessions.active_session_registry_snapshot()] == [
+        "other-proc-session"
+    ]
+
+
+def test_prune_stale_for_pid_fails_open_on_error(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(
+        active_sessions,
+        "_read_entries",
+        lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    assert active_sessions.prune_stale_for_pid(os.getpid(), set()) == 0

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -81,6 +81,61 @@ def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
         reset_hermes_home_override(token)
 
 
+def test_session_create_reclaims_lease_dropped_without_release(monkeypatch, tmp_path):
+    """Regression for #68920: a session-replacement flow that drops the old
+    in-memory session dict WITHOUT calling ``_release_active_session_slot``
+    (e.g. desktop's ``/new`` superseding a prior draft) must not permanently
+    burn a slot. ``_claim_active_session_slot`` sweeps same-pid leases whose
+    ``live_session_id`` is no longer a live key in ``server._sessions``
+    before acquiring, so the orphaned lease is reclaimed and a 4th session
+    can be created even though only 2 sessions are actually live."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("max_concurrent_sessions: 3\n", encoding="utf-8")
+    token = set_hermes_home_override(home)
+
+    def _clear_server_sessions():
+        for session in list(server._sessions.values()):
+            server._teardown_session(session)
+        server._sessions.clear()
+
+    try:
+        server._cfg_cache = None
+        server._cfg_mtime = None
+        server._cfg_path = None
+        _clear_server_sessions()
+        monkeypatch.setattr(server, "_start_agent_build", lambda *args, **kwargs: None)
+        monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
+
+        first = server._methods["session.create"]("r1", {"cols": 80})
+        second = server._methods["session.create"]("r2", {"cols": 80})
+        third = server._methods["session.create"]("r3", {"cols": 80})
+        assert "result" in first and "result" in second and "result" in third
+
+        # Simulate the replacement bug directly: the "first" session's
+        # in-memory dict is dropped WITHOUT going through
+        # _release_active_session_slot / _teardown_session, exactly as a
+        # buggy supersession path would (leaving its lease dangling).
+        dropped_sid = first["result"]["session_id"]
+        server._sessions.pop(dropped_sid, None)
+        assert len(active_session_registry_snapshot()) == 3
+
+        # At the cap (3 leases, 2 live sessions) a naive create still blocks...
+        blocked = server._methods["session.create"]("r4", {"cols": 80})
+        # ...but the sweep inside _claim_active_session_slot ran on THIS
+        # attempt too, reclaiming the dangling lease before the acquire
+        # check — so the very same call that would have been rejected
+        # under the old cap now succeeds.
+        assert "result" in blocked, blocked
+        assert len(active_session_registry_snapshot()) == 3
+    finally:
+        _clear_server_sessions()
+        server._cfg_cache = None
+        server._cfg_mtime = None
+        server._cfg_path = None
+        reset_hermes_home_override(token)
+
+
 def test_session_context_uses_session_cwd(monkeypatch, tmp_path):
     """Desktop/TUI sessions must pin the agent cwd per session.
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,3 +1,4 @@
+import contextvars
 import json
 import os
 import subprocess
@@ -130,6 +131,76 @@ def test_session_create_reclaims_lease_dropped_without_release(monkeypatch, tmp_
         assert len(active_session_registry_snapshot()) == 3
     finally:
         _clear_server_sessions()
+        server._cfg_cache = None
+        server._cfg_mtime = None
+        server._cfg_path = None
+        reset_hermes_home_override(token)
+
+
+def test_concurrent_claim_does_not_reclaim_unpublished_in_flight_lease(monkeypatch, tmp_path):
+    """Regression for the #68920 review's sweep-vs-acquire race.
+
+    ``_claim_active_session_slot`` returns to its caller (the RPC handler)
+    BEFORE that caller publishes the new sid into ``server._sessions`` — the
+    dict-literal assignment is separate code, outside the claim call. If a
+    second claim's stale-lease sweep runs in exactly that gap, it would see
+    the first sid missing from ``_sessions`` and reclaim its brand-new
+    lease. Two real threads force thread A's claim to fully complete (lease
+    minted, sid deliberately left unpublished) before thread B's claim runs
+    its own sweep — an ``Event`` (no sleeps) makes the ordering
+    deterministic. The pending-claims set must protect A's lease through
+    that gap regardless of whether A ever actually publishes."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("max_concurrent_sessions: 5\n", encoding="utf-8")
+    token = set_hermes_home_override(home)
+    server._cfg_cache = None
+    server._cfg_mtime = None
+    server._cfg_path = None
+    server._pending_active_session_claims.clear()
+
+    claim_a_done = threading.Event()
+    results: dict[str, tuple] = {}
+
+    def _claim_a():
+        # Deliberately never publishes "sid-a" into server._sessions —
+        # reproduces a claimer that crashed/lost a race before publishing.
+        results["a"] = server._claim_active_session_slot(
+            "key-a", live_session_id="sid-a", surface="tui"
+        )
+        claim_a_done.set()
+
+    def _claim_b():
+        claim_a_done.wait(timeout=5)
+        results["b"] = server._claim_active_session_slot(
+            "key-b", live_session_id="sid-b", surface="tui"
+        )
+
+    # A plain threading.Thread does NOT inherit the spawning thread's
+    # contextvars (unlike asyncio tasks) — copy_context() carries the
+    # HERMES_HOME override set above into each worker thread so _load_cfg()
+    # resolves the same tmp_path config instead of falling back to the
+    # real ~/.hermes/config.yaml.
+    ctx = contextvars.copy_context()
+    thread_a = threading.Thread(target=lambda: ctx.run(_claim_a))
+    thread_b = threading.Thread(target=lambda: ctx.run(_claim_b))
+    try:
+        thread_a.start()
+        thread_a.join(timeout=5)
+        thread_b.start()
+        thread_b.join(timeout=5)
+
+        lease_a, message_a = results["a"]
+        lease_b, message_b = results["b"]
+        assert message_a is None and lease_a is not None
+        assert message_b is None and lease_b is not None
+
+        snapshot = active_session_registry_snapshot()
+        assert {entry["session_id"] for entry in snapshot} == {"key-a", "key-b"}
+        lease_a.release()
+        lease_b.release()
+    finally:
+        server._pending_active_session_claims.clear()
         server._cfg_cache = None
         server._cfg_mtime = None
         server._cfg_path = None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -468,17 +468,49 @@ def _notify_session_boundary(
         pass
 
 
+# Structural owner tag for every lease this backend mints (see
+# _claim_active_session_slot). prune_stale_for_pid only ever reclaims
+# same-pid entries carrying this exact tag, so a CLI lease sharing the same
+# "hermes serve" pid (metadata without this tag, or none at all) can never
+# be swept by mistake.
+_ACTIVE_SESSION_OWNER = "tui_gateway"
+
+# Guards the {mark pending -> snapshot live ids -> prune -> acquire}
+# sequence in _claim_active_session_slot as one transaction, and the pending
+# set closes the gap prune_stale_for_pid's own file lock can't see: a lease
+# is written to active_sessions.json (and thus visible to a concurrent
+# claimer's prune) BEFORE the caller publishes its sid into _sessions (the
+# dict literal assignment happens in the RPC handler, after
+# _claim_active_session_slot has already returned). Without this, a second
+# thread's claim could run its sweep in exactly that gap and reclaim the
+# first thread's just-minted, not-yet-published lease (#68920 review).
+_active_session_claim_lock = threading.Lock()
+_pending_active_session_claims: set[str] = set()
+
+
 def _prune_stale_active_sessions_for_this_pid() -> None:
-    """Reclaim same-pid leases whose in-memory session is already gone.
+    """Reclaim same-pid, same-owner leases whose in-memory session is gone.
 
     Desktop/TUI session replacement (e.g. a superseding ``session.create``)
     can leave the OLD session's dict out of ``_sessions`` without ever
     calling ``_release_active_session_slot`` on it. Since every lease this
-    process minted carries the in-memory sid as ``metadata.live_session_id``
-    (see ``_claim_active_session_slot`` below), any lease owned by our own
-    pid whose sid is no longer a live key in ``_sessions`` is safe to
-    reclaim — sweeping it here, right before the next acquire, keeps a
-    single desktop process from starving itself at ``max_concurrent_sessions``.
+    process mints carries the in-memory sid as ``metadata.live_session_id``
+    and is tagged ``metadata.owner=_ACTIVE_SESSION_OWNER`` (see
+    ``_claim_active_session_slot`` below), any such lease whose sid is no
+    longer a live key in ``_sessions`` is safe to reclaim — sweeping it here,
+    right before the next acquire, keeps a single desktop process from
+    starving itself at ``max_concurrent_sessions``.
+
+    A sid pending publication (in ``_pending_active_session_claims``, added
+    by a claim still mid-flight — see below) counts as live even though it
+    is not in ``_sessions`` yet, closing the race where a concurrent claim's
+    sweep could otherwise reclaim a lease the FIRST claim just minted but
+    hasn't published. Once a pending sid does show up in ``_sessions`` it is
+    dropped from the pending set here (self-cleaning) so the set never grows
+    unbounded across a long-running gateway process; a claim that instead
+    fails/aborts before publishing is still cleared explicitly in
+    ``_claim_active_session_slot``.
+
     Best-effort: never blocks or fails the caller's acquire.
     """
     try:
@@ -486,7 +518,9 @@ def _prune_stale_active_sessions_for_this_pid() -> None:
 
         with _sessions_lock:
             live_ids = set(_sessions.keys())
-        prune_stale_for_pid(os.getpid(), live_ids)
+        _pending_active_session_claims.difference_update(live_ids)
+        live_ids |= _pending_active_session_claims
+        prune_stale_for_pid(os.getpid(), live_ids, owner=_ACTIVE_SESSION_OWNER)
     except Exception:
         logger.debug("Failed to prune stale active session leases", exc_info=True)
 
@@ -497,19 +531,34 @@ def _claim_active_session_slot(
     live_session_id: str,
     surface: str = "tui",
 ) -> tuple[Any, str | None]:
-    _prune_stale_active_sessions_for_this_pid()
-    try:
-        from hermes_cli.active_sessions import try_acquire_active_session
+    with _active_session_claim_lock:
+        _pending_active_session_claims.add(live_session_id)
+        try:
+            _prune_stale_active_sessions_for_this_pid()
+            try:
+                from hermes_cli.active_sessions import try_acquire_active_session
 
-        return try_acquire_active_session(
-            session_id=session_key,
-            surface=surface,
-            config=_load_cfg(),
-            metadata={"live_session_id": live_session_id},
-        )
-    except Exception as exc:
-        logger.warning("Failed to claim active session slot: %s", exc)
-        return None, None
+                lease, message = try_acquire_active_session(
+                    session_id=session_key,
+                    surface=surface,
+                    config=_load_cfg(),
+                    metadata={
+                        "live_session_id": live_session_id,
+                        "owner": _ACTIVE_SESSION_OWNER,
+                    },
+                )
+            except Exception as exc:
+                logger.warning("Failed to claim active session slot: %s", exc)
+                lease, message = None, None
+        finally:
+            # No lease minted (or the attempt raised) — this sid was never
+            # written to the registry, so it can't leak protection forever.
+            # On success it stays pending until
+            # _prune_stale_active_sessions_for_this_pid observes it in
+            # _sessions (self-cleaning above).
+            if lease is None:
+                _pending_active_session_claims.discard(live_session_id)
+        return lease, message
 
 
 def _release_active_session_slot(session: dict | None) -> None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -468,12 +468,36 @@ def _notify_session_boundary(
         pass
 
 
+def _prune_stale_active_sessions_for_this_pid() -> None:
+    """Reclaim same-pid leases whose in-memory session is already gone.
+
+    Desktop/TUI session replacement (e.g. a superseding ``session.create``)
+    can leave the OLD session's dict out of ``_sessions`` without ever
+    calling ``_release_active_session_slot`` on it. Since every lease this
+    process minted carries the in-memory sid as ``metadata.live_session_id``
+    (see ``_claim_active_session_slot`` below), any lease owned by our own
+    pid whose sid is no longer a live key in ``_sessions`` is safe to
+    reclaim — sweeping it here, right before the next acquire, keeps a
+    single desktop process from starving itself at ``max_concurrent_sessions``.
+    Best-effort: never blocks or fails the caller's acquire.
+    """
+    try:
+        from hermes_cli.active_sessions import prune_stale_for_pid
+
+        with _sessions_lock:
+            live_ids = set(_sessions.keys())
+        prune_stale_for_pid(os.getpid(), live_ids)
+    except Exception:
+        logger.debug("Failed to prune stale active session leases", exc_info=True)
+
+
 def _claim_active_session_slot(
     session_key: str,
     *,
     live_session_id: str,
     surface: str = "tui",
 ) -> tuple[Any, str | None]:
+    _prune_stale_active_sessions_for_this_pid()
     try:
         from hermes_cli.active_sessions import try_acquire_active_session
 


### PR DESCRIPTION
Fixes #68920.

## Problem

Desktop/TUI sessions leak active-session leases in `~/.hermes/runtime/active_sessions.json` until `max_concurrent_sessions` blocks all new sessions. `release_active_session()` is reachable only through `_finalize_session()` (teardown/disconnect paths); a session superseded by a new one (the desktop `/new` flow — `session.create` mints an independent sid with no reference to its predecessor) drops out of the server's `_sessions` map with its lease intact. `_prune_dead()` can't reclaim it: it checks PID liveness only, and every desktop lease points at the same healthy `hermes serve` PID — the reporter's two-entries-one-PID evidence exactly.

## Fix

A pid-scoped, owner-tagged registry sweep, run before every acquire:

- `prune_stale_for_pid(pid, live_session_ids, *, owner)` (hermes_cli/active_sessions.py) reclaims leases that match **all three**: same pid, `metadata.owner` equals the caller's tag, and `metadata.live_session_id` absent from the caller's live-session set. Ownership is structural, not accidental: CLI/gateway leases in the same pid are protected by the missing tag, not by luck. Fail-open — a sweep failure never blocks the acquire.
- The TUI server tags every acquire with `owner="tui_gateway"` and sweeps with `os.getpid()` + its live `_sessions` keys at the top of `_claim_active_session_slot`. Layering stays clean (hermes_cli does not import tui_gateway).
- **Race-safe by construction** (from adversarial review): a lease is published to `_sessions` only after the claim returns, so a concurrent sweep could reclaim a just-minted lease. A claim lock plus a `_pending_claims` set (unioned into the live set; self-cleaning once the sid is observed published, cleared on failure) closes the window. The interleaving is regression-tested deterministically with two real threads and `threading.Event` — no sleeps.

A per-supersession release call site was considered and deliberately not added: `session.create` has no reference to the session it supersedes, so there is no single clean hook — the sweep reclaims the orphan regardless of which path dropped it.

## Relationship to #57052 / #57059

Adjacent, not duplicate (also noted on the issue): #57052 is about **idle-but-connected** tabs pinning slots while connected; its fix PR #57059 (lazy claim + idle release) has been in conflict with main since early July and targets idleness. This issue is about **superseded/dropped** sessions whose leases outlive the session dict entirely — which idle-release wouldn't necessarily reclaim. The two are complementary.

## Tests

- Reproduction pinned: three sessions at `max_concurrent_sessions=3`, one dropped without release, fourth `session.create` succeeds (fails with `4090 at the active session limit` pre-fix — verified RED).
- Sweep unit tests: reclaims owner-tagged same-pid orphan; ignores other-pid entries; ignores same-pid leases without the owner tag; fails open on error.
- Concurrency: barrier-driven two-acquirer test proving the sweep never reclaims an in-flight unpublished lease (RED verified by removing the pending-set union).
- `tests/hermes_cli/test_active_sessions.py` 13 passed, server-side suite 400 passed; baseline-diffed against clean `upstream/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
