### PR TITLE
fix(acp): keep background delegate_task dispatch in_progress until children finish

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -248,6 +248,33 @@ def _tool_result_failed(result: Optional[str], tool_name: str | None = None) -> 
     return False
 
 
+def _is_async_background_dispatch(result: Optional[str], tool_name: str | None = None) -> bool:
+    """Return True when ``delegate_task`` merely *dispatched* a background batch.
+
+    ``delegate_task(background=True)`` returns
+    ``{"status": "dispatched", "mode": "background", ...}`` the instant the async
+    unit is accepted — the child agents keep running and their consolidated
+    result re-enters the conversation later as its own out-of-turn frame (see
+    ``server._notify_background_completion``). Reporting the dispatch tool_call as
+    ``completed`` here made ACP clients show every subagent as Done ~1s after
+    dispatch. Keep the frame ``in_progress`` so completion is driven by the
+    re-entry frames, not the dispatch ack.
+
+    The pool-at-capacity and synchronous paths in ``delegate_tool`` return the
+    real aggregated results (not ``status="dispatched"``), so they stay
+    ``completed`` — this predicate matches only the accepted-async case.
+    """
+    if tool_name != "delegate_task":
+        return False
+    data = _json_loads_maybe(result)
+    if not isinstance(data, dict):
+        return False
+    return (
+        str(data.get("status") or "").strip().lower() == "dispatched"
+        and str(data.get("mode") or "").strip().lower() == "background"
+    )
+
+
 def _truncate_text(text: str, limit: int = 5000) -> str:
     if len(text) <= limit:
         return text
@@ -1321,10 +1348,16 @@ def build_tool_complete(
             function_args=function_args,
             snapshot=snapshot,
         )
+    if _is_async_background_dispatch(result, tool_name):
+        status = "in_progress"
+    elif _tool_result_failed(result, tool_name):
+        status = "failed"
+    else:
+        status = "completed"
     return acp.update_tool_call(
         tool_call_id,
         kind=kind,
-        status="failed" if _tool_result_failed(result, tool_name) else "completed",
+        status=status,
         content=content,
         raw_output=None if tool_name in _POLISHED_TOOLS or _is_structured_json_result(result) else result,
     )

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -450,6 +450,53 @@ class TestBuildToolComplete:
         result = build_tool_complete("tc-ok", "some_tool", '{"error": "timeout while reading optional source"}')
         assert result.status == "completed"
 
+    def test_build_tool_complete_keeps_background_dispatch_in_progress(self):
+        """delegate_task(background=True) only *dispatched* the batch; the child
+        agents keep running and re-enter later as their own frames. The dispatch
+        tool_call must stay in_progress so clients do not show every subagent as
+        Done ~1s after dispatch.
+        """
+        result = build_tool_complete(
+            "tc-bg",
+            "delegate_task",
+            '{"status": "dispatched", "mode": "background", "count": 2, '
+            '"delegation_id": "abc123", "goals": ["a", "b"]}',
+        )
+        assert result.status == "in_progress"
+
+    def test_build_tool_complete_marks_synchronous_delegate_completed(self):
+        """The sync / pool-at-capacity paths return aggregated child results
+        (not status=dispatched), so they must complete normally.
+        """
+        result = build_tool_complete(
+            "tc-sync",
+            "delegate_task",
+            '{"results": [{"goal": "a", "output": "done"}]}',
+        )
+        assert result.status == "completed"
+
+    def test_build_tool_complete_ignores_dispatched_without_background_mode(self):
+        """Only the accepted-async case (mode=background) stays in_progress; a
+        foreground dispatch ack must still complete.
+        """
+        result = build_tool_complete(
+            "tc-fg",
+            "delegate_task",
+            '{"status": "dispatched", "mode": "foreground"}',
+        )
+        assert result.status == "completed"
+
+    def test_build_tool_complete_background_marker_scoped_to_delegate_task(self):
+        """The in_progress carve-out is delegate_task-only; a same-shaped result
+        from another tool must not be held open.
+        """
+        result = build_tool_complete(
+            "tc-other",
+            "terminal",
+            '{"status": "dispatched", "mode": "background"}',
+        )
+        assert result.status == "completed"
+
     def test_build_tool_complete_for_skill_manage_summarizes_without_raw_json(self):
         result = build_tool_complete(
             "tc-skill-manage",


### PR DESCRIPTION
## Problem

`delegate_task(background=True)` returns its dispatch ack the instant the async
batch is accepted:

```json
{"status": "dispatched", "mode": "background", "count": N, "delegation_id": "...", "goals": [...]}
```

The child agents keep running; their consolidated results re-enter the
conversation later (via the `async_delegation` completion queue that runtimes
drain while idle — see `tools/async_delegation.py`).

`acp_adapter.tools.build_tool_complete` translated that dispatch ack into ACP
`status="completed"`, because the payload isn't a structured *failure*. As a
result, ACP clients render the `delegate_task` tool call — and every subagent it
represents — as **Done ~1 second after dispatch**, while the children are in fact
still running in the background.

## Fix

Add a narrow predicate, `_is_async_background_dispatch`, and render the dispatch
tool call as `in_progress` **only** for the accepted-async case
(`delegate_task` + `status="dispatched"` + `mode="background"`). Completion is
driven by the results that re-enter the conversation, not by the dispatch ack.

The predicate is deliberately conservative and matches the same shape
`_tool_result_failed` reads:

- The pool-at-capacity fallback and the synchronous path return the aggregated
  child results (not `status="dispatched"`), so they still `complete` normally.
- A foreground dispatch (`mode != "background"`) still completes.
- The carve-out is scoped to `delegate_task`; a same-shaped result from any other
  tool is unaffected.

### Design note

The dispatch tool call intentionally stays `in_progress` rather than flipping to
`completed`, because a background dispatch has no dispatch-scoped completion
signal — the result arrives out-of-band as a re-entry message. Leaving it
`in_progress` is more honest than reporting a premature `completed`; happy to
adjust if maintainers prefer a different terminal representation.

## Tests

`tests/acp/test_tools.py::TestBuildToolComplete` gains four regression tests
covering the async, synchronous, foreground, and non-`delegate_task` cases. Full
`TestBuildToolComplete` suite passes.
