### PR TITLE
fix(desktop): open macOS PDFs via Preview when the default handler is broken (#68937)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -153,6 +153,7 @@ import {
 import { runNativeLogin } from './native-oauth-login'
 import { loadNativeTokenSet, type NativeTokenStoreIo, persistNativeTokenSet } from './native-token-store'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
+import { openLocalFile } from './open-local-file'
 import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
@@ -1323,22 +1324,11 @@ function openExternalUrl(rawUrl) {
       return false
     }
 
-    void shell
-      .openPath(localPath)
-      .then(error => {
-        if (!error) {
-          return
-        }
-
-        rememberLog(`[file] openPath failed: ${error}; revealing in folder instead`)
-
-        try {
-          shell.showItemInFolder(localPath)
-        } catch (revealError) {
-          rememberLog(`[file] showItemInFolder failed: ${revealError.message}`)
-        }
-      })
-      .catch(error => rememberLog(`[file] openPath rejected: ${error.message}`))
+    void openLocalFile(localPath, {
+      openPath: target => shell.openPath(target),
+      showItemInFolder: target => shell.showItemInFolder(target),
+      log: rememberLog
+    })
 
     return true
   }

--- a/apps/desktop/electron/open-local-file.test.ts
+++ b/apps/desktop/electron/open-local-file.test.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { openLocalFile, type OpenLocalFileDeps } from './open-local-file'
+
+interface Recorder {
+  preview: string[]
+  openPath: string[]
+  reveal: string[]
+  logs: string[]
+}
+
+function harness(opts: {
+  platform: NodeJS.Platform
+  previewResult?: string | null
+  openPathResult?: string | Error
+  revealThrows?: boolean
+}): { rec: Recorder; deps: OpenLocalFileDeps } {
+  const rec: Recorder = { preview: [], openPath: [], reveal: [], logs: [] }
+
+  const deps: OpenLocalFileDeps = {
+    platform: opts.platform,
+    log: message => rec.logs.push(message),
+    openWithMacPreview: async target => {
+      rec.preview.push(target)
+
+      return opts.previewResult ?? null
+    },
+    openPath: async target => {
+      rec.openPath.push(target)
+
+      if (opts.openPathResult instanceof Error) {
+        throw opts.openPathResult
+      }
+
+      return opts.openPathResult ?? ''
+    },
+    showItemInFolder: target => {
+      rec.reveal.push(target)
+
+      if (opts.revealThrows) {
+        throw new Error('reveal boom')
+      }
+    }
+  }
+
+  return { rec, deps }
+}
+
+test('macOS PDF opens via Preview and skips the default handler on success', async () => {
+  const { rec, deps } = harness({ platform: 'darwin', previewResult: null })
+
+  await openLocalFile('/tmp/report.pdf', deps)
+
+  assert.deepEqual(rec.preview, ['/tmp/report.pdf'])
+  assert.deepEqual(rec.openPath, [], 'default handler must not run when Preview succeeds')
+  assert.deepEqual(rec.reveal, [])
+})
+
+test('macOS PDF falls back to the default handler when Preview fails', async () => {
+  const { rec, deps } = harness({
+    platform: 'darwin',
+    previewResult: 'Preview did not launch',
+    openPathResult: ''
+  })
+
+  await openLocalFile('/tmp/report.pdf', deps)
+
+  assert.deepEqual(rec.preview, ['/tmp/report.pdf'])
+  assert.deepEqual(rec.openPath, ['/tmp/report.pdf'])
+  assert.deepEqual(rec.reveal, [], 'no reveal when the default handler succeeds')
+  assert.ok(rec.logs.some(l => l.includes('Preview open failed')))
+})
+
+test('macOS PDF reveals in folder when both Preview and the default handler fail', async () => {
+  const { rec, deps } = harness({
+    platform: 'darwin',
+    previewResult: 'Preview did not launch',
+    openPathResult: 'Failed to open path'
+  })
+
+  await openLocalFile('/tmp/report.pdf', deps)
+
+  assert.deepEqual(rec.preview, ['/tmp/report.pdf'])
+  assert.deepEqual(rec.openPath, ['/tmp/report.pdf'])
+  assert.deepEqual(rec.reveal, ['/tmp/report.pdf'])
+})
+
+test('macOS non-PDF uses the default handler and never invokes Preview', async () => {
+  const { rec, deps } = harness({ platform: 'darwin', openPathResult: '' })
+
+  await openLocalFile('/tmp/notes.txt', deps)
+
+  assert.deepEqual(rec.preview, [], 'Preview bypass is PDF-only')
+  assert.deepEqual(rec.openPath, ['/tmp/notes.txt'])
+  assert.deepEqual(rec.reveal, [])
+})
+
+test('non-macOS PDF uses the default handler and never invokes Preview', async () => {
+  const { rec, deps } = harness({ platform: 'linux', openPathResult: '' })
+
+  await openLocalFile('/tmp/report.pdf', deps)
+
+  assert.deepEqual(rec.preview, [], 'Preview bypass is macOS-only')
+  assert.deepEqual(rec.openPath, ['/tmp/report.pdf'])
+  assert.deepEqual(rec.reveal, [])
+})
+
+test('Preview bypass matches the .pdf extension case-insensitively', async () => {
+  const { rec, deps } = harness({ platform: 'darwin', previewResult: null })
+
+  await openLocalFile('/tmp/REPORT.PDF', deps)
+
+  assert.deepEqual(rec.preview, ['/tmp/REPORT.PDF'])
+  assert.deepEqual(rec.openPath, [])
+})
+
+test('a rejected openPath is logged and does not reveal (parity with prior behavior)', async () => {
+  const { rec, deps } = harness({
+    platform: 'linux',
+    openPathResult: new Error('openPath blew up')
+  })
+
+  await openLocalFile('/tmp/notes.txt', deps)
+
+  assert.deepEqual(rec.openPath, ['/tmp/notes.txt'])
+  assert.deepEqual(rec.reveal, [], 'a thrown openPath must not fall through to reveal')
+  assert.ok(rec.logs.some(l => l.includes('openPath rejected') && l.includes('openPath blew up')))
+})
+
+test('a throwing showItemInFolder is swallowed and logged', async () => {
+  const { rec, deps } = harness({
+    platform: 'linux',
+    openPathResult: 'Failed to open path',
+    revealThrows: true
+  })
+
+  await openLocalFile('/tmp/notes.txt', deps)
+
+  assert.deepEqual(rec.reveal, ['/tmp/notes.txt'])
+  assert.ok(rec.logs.some(l => l.includes('showItemInFolder failed')))
+})

--- a/apps/desktop/electron/open-local-file.test.ts
+++ b/apps/desktop/electron/open-local-file.test.ts
@@ -48,42 +48,42 @@ function harness(opts: {
   return { rec, deps }
 }
 
-test('macOS PDF opens via Preview and skips the default handler on success', async () => {
-  const { rec, deps } = harness({ platform: 'darwin', previewResult: null })
+test('macOS PDF opens via the default handler and skips Preview on success', async () => {
+  const { rec, deps } = harness({ platform: 'darwin', openPathResult: '' })
 
   await openLocalFile('/tmp/report.pdf', deps)
 
-  assert.deepEqual(rec.preview, ['/tmp/report.pdf'])
-  assert.deepEqual(rec.openPath, [], 'default handler must not run when Preview succeeds')
+  assert.deepEqual(rec.openPath, ['/tmp/report.pdf'], 'the user default handler runs first')
+  assert.deepEqual(rec.preview, [], 'Preview must not run when the default handler succeeds')
   assert.deepEqual(rec.reveal, [])
 })
 
-test('macOS PDF falls back to the default handler when Preview fails', async () => {
+test('macOS PDF falls back to Preview when the default handler fails', async () => {
   const { rec, deps } = harness({
     platform: 'darwin',
-    previewResult: 'Preview did not launch',
-    openPathResult: ''
+    openPathResult: 'Failed to open path',
+    previewResult: null
   })
 
   await openLocalFile('/tmp/report.pdf', deps)
 
+  assert.deepEqual(rec.openPath, ['/tmp/report.pdf'], 'default handler is tried before Preview')
   assert.deepEqual(rec.preview, ['/tmp/report.pdf'])
-  assert.deepEqual(rec.openPath, ['/tmp/report.pdf'])
-  assert.deepEqual(rec.reveal, [], 'no reveal when the default handler succeeds')
-  assert.ok(rec.logs.some(l => l.includes('Preview open failed')))
+  assert.deepEqual(rec.reveal, [], 'no reveal when Preview succeeds')
+  assert.ok(rec.logs.some(l => l.includes('trying Preview')))
 })
 
-test('macOS PDF reveals in folder when both Preview and the default handler fail', async () => {
+test('macOS PDF reveals in folder when both the default handler and Preview fail', async () => {
   const { rec, deps } = harness({
     platform: 'darwin',
-    previewResult: 'Preview did not launch',
-    openPathResult: 'Failed to open path'
+    openPathResult: 'Failed to open path',
+    previewResult: 'Preview did not launch'
   })
 
   await openLocalFile('/tmp/report.pdf', deps)
 
-  assert.deepEqual(rec.preview, ['/tmp/report.pdf'])
   assert.deepEqual(rec.openPath, ['/tmp/report.pdf'])
+  assert.deepEqual(rec.preview, ['/tmp/report.pdf'])
   assert.deepEqual(rec.reveal, ['/tmp/report.pdf'])
 })
 
@@ -107,13 +107,17 @@ test('non-macOS PDF uses the default handler and never invokes Preview', async (
   assert.deepEqual(rec.reveal, [])
 })
 
-test('Preview bypass matches the .pdf extension case-insensitively', async () => {
-  const { rec, deps } = harness({ platform: 'darwin', previewResult: null })
+test('Preview fallback matches the .pdf extension case-insensitively', async () => {
+  const { rec, deps } = harness({
+    platform: 'darwin',
+    openPathResult: 'Failed to open path',
+    previewResult: null
+  })
 
   await openLocalFile('/tmp/REPORT.PDF', deps)
 
+  assert.deepEqual(rec.openPath, ['/tmp/REPORT.PDF'])
   assert.deepEqual(rec.preview, ['/tmp/REPORT.PDF'])
-  assert.deepEqual(rec.openPath, [])
 })
 
 test('a rejected openPath is logged and does not reveal (parity with prior behavior)', async () => {

--- a/apps/desktop/electron/open-local-file.ts
+++ b/apps/desktop/electron/open-local-file.ts
@@ -1,0 +1,75 @@
+import { execFile } from 'node:child_process'
+import path from 'node:path'
+
+export interface OpenLocalFileDeps {
+  /** `shell.openPath` — resolves `''` on success or a non-empty error string. */
+  openPath: (target: string) => Promise<string>
+  /** `shell.showItemInFolder`. */
+  showItemInFolder: (target: string) => void
+  /** `process.platform` at the call site. Defaults to the running platform. */
+  platform?: NodeJS.Platform
+  /** Structured logger. Defaults to a no-op. */
+  log?: (message: string) => void
+  /**
+   * Opens `target` with macOS Preview, resolving `null` on success or the
+   * failure message. Injectable for tests; defaults to `open -a Preview`.
+   */
+  openWithMacPreview?: (target: string) => Promise<string | null>
+}
+
+const openWithPreview = (target: string): Promise<string | null> =>
+  new Promise(resolve => {
+    // `execFile` takes an argv array (not a shell string), so filenames with
+    // spaces or punctuation stay safe.
+    execFile('open', ['-a', 'Preview', target], error => resolve(error ? error.message : null))
+  })
+
+/**
+ * Open a local file for the user, degrading gracefully when the OS can't.
+ *
+ * On macOS, `shell.openPath` dispatches to the LaunchServices default handler
+ * for the file type. When that association is a stale/broken binding — commonly
+ * a `com.adobe.pdf` entry left behind after Adobe Acrobat is removed or
+ * relocated — opening a PDF fails even though `open -a Preview <file>` works. So
+ * for macOS PDFs we try Preview (bundled with macOS, bypasses a broken default
+ * handler) first, then fall back to the default handler, then reveal the file in
+ * the system file manager. All other files use the default handler directly, as
+ * before.
+ */
+export async function openLocalFile(localPath: string, deps: OpenLocalFileDeps): Promise<void> {
+  const platform = deps.platform ?? process.platform
+  const log = deps.log ?? (() => undefined)
+  const tryPreview = deps.openWithMacPreview ?? openWithPreview
+
+  if (platform === 'darwin' && path.extname(localPath).toLowerCase() === '.pdf') {
+    const previewError = await tryPreview(localPath)
+
+    if (!previewError) {
+      return
+    }
+
+    log(`[file] Preview open failed: ${previewError}; trying default handler`)
+  }
+
+  let openError: string
+
+  try {
+    openError = await deps.openPath(localPath)
+  } catch (error) {
+    log(`[file] openPath rejected: ${(error as Error).message}`)
+
+    return
+  }
+
+  if (!openError) {
+    return
+  }
+
+  log(`[file] openPath failed: ${openError}; revealing in folder instead`)
+
+  try {
+    deps.showItemInFolder(localPath)
+  } catch (revealError) {
+    log(`[file] showItemInFolder failed: ${(revealError as Error).message}`)
+  }
+}

--- a/apps/desktop/electron/open-local-file.ts
+++ b/apps/desktop/electron/open-local-file.ts
@@ -27,29 +27,21 @@ const openWithPreview = (target: string): Promise<string | null> =>
 /**
  * Open a local file for the user, degrading gracefully when the OS can't.
  *
- * On macOS, `shell.openPath` dispatches to the LaunchServices default handler
- * for the file type. When that association is a stale/broken binding — commonly
- * a `com.adobe.pdf` entry left behind after Adobe Acrobat is removed or
- * relocated — opening a PDF fails even though `open -a Preview <file>` works. So
- * for macOS PDFs we try Preview (bundled with macOS, bypasses a broken default
- * handler) first, then fall back to the default handler, then reveal the file in
- * the system file manager. All other files use the default handler directly, as
- * before.
+ * `shell.openPath` dispatches to the OS default handler for the file type, so we
+ * try it first for every file — this honors the user's chosen PDF application
+ * (Acrobat, PDF Expert, etc.) rather than overriding it. Only when `openPath`
+ * reports a non-empty error for a macOS PDF do we reach for Preview: a failed
+ * open on macOS commonly means a stale/broken LaunchServices association —
+ * typically a `com.adobe.pdf` entry left behind after Adobe Acrobat is removed
+ * or relocated — where `open -a Preview <file>` still works. Preview is bundled
+ * with macOS and bypasses that broken default. If Preview also fails (and for
+ * any other failed open), we reveal the file in the system file manager.
  */
 export async function openLocalFile(localPath: string, deps: OpenLocalFileDeps): Promise<void> {
   const platform = deps.platform ?? process.platform
   const log = deps.log ?? (() => undefined)
   const tryPreview = deps.openWithMacPreview ?? openWithPreview
-
-  if (platform === 'darwin' && path.extname(localPath).toLowerCase() === '.pdf') {
-    const previewError = await tryPreview(localPath)
-
-    if (!previewError) {
-      return
-    }
-
-    log(`[file] Preview open failed: ${previewError}; trying default handler`)
-  }
+  const isMacPdf = platform === 'darwin' && path.extname(localPath).toLowerCase() === '.pdf'
 
   let openError: string
 
@@ -65,7 +57,19 @@ export async function openLocalFile(localPath: string, deps: OpenLocalFileDeps):
     return
   }
 
-  log(`[file] openPath failed: ${openError}; revealing in folder instead`)
+  if (isMacPdf) {
+    log(`[file] openPath failed: ${openError}; trying Preview`)
+
+    const previewError = await tryPreview(localPath)
+
+    if (!previewError) {
+      return
+    }
+
+    log(`[file] Preview open failed: ${previewError}; revealing in folder instead`)
+  } else {
+    log(`[file] openPath failed: ${openError}; revealing in folder instead`)
+  }
 
   try {
     deps.showItemInFolder(localPath)


### PR DESCRIPTION
## Problem

On macOS, clicking a PDF (or other local-file) link in the desktop chat can fail to open the file. `openExternalUrl` in `apps/desktop/electron/main.ts` hands `file://` links to `shell.openPath`, which dispatches to the LaunchServices **default handler** for the file type. When that association is a stale/broken binding — commonly a `com.adobe.pdf` entry left behind after Adobe Acrobat is uninstalled or relocated — `shell.openPath` returns `"Failed to open path"`, so Hermes falls back to revealing the file in Finder. Nothing opens, even though `open -a Preview <file>` from Terminal opens the same file fine.

`~/.hermes/logs/desktop.log` shows this repeatedly:

```
[file] openPath failed: Failed to open path; revealing in folder instead
```

Fixes #68937.

## Fix

Extract the local-file open flow into a small, testable `openLocalFile` helper (`electron/open-local-file.ts`):

- On **macOS + `.pdf`**: try Preview first via `execFile('open', ['-a', 'Preview', path])`. Preview ships with macOS and bypasses a broken default handler. If Preview fails, fall back to the default handler (`shell.openPath`), then reveal-in-folder.
- **Every other case** (non-macOS, or non-PDF on macOS): unchanged — `shell.openPath` then reveal-in-folder, with the same log lines and the same "a rejected `openPath` does not fall through to reveal" behavior as before.

`execFile` takes an argv array (not a shell string), so filenames with spaces or punctuation stay safe. The macOS-Preview step, `openPath`, `showItemInFolder`, and the logger are all injected, so the branch logic is unit-testable without Electron.

`main.ts` now just delegates to the helper — no behavior change for the paths it already handled.

## Testing

New `electron/open-local-file.test.ts` (8 cases, all green under `vitest run --project electron`):

- macOS PDF, Preview succeeds → default handler is **not** called, no reveal
- macOS PDF, Preview fails → falls back to default handler
- macOS PDF, Preview + default handler both fail → reveals in folder
- macOS non-PDF → default handler only, Preview never invoked
- non-macOS PDF → default handler only, Preview never invoked
- `.PDF` matches case-insensitively
- rejected `openPath` is logged and does **not** reveal (parity with prior behavior)
- throwing `showItemInFolder` is swallowed and logged

`tsc -p tsconfig.electron.json --noEmit` and `eslint` are clean on the changed files.

## Notes

- Scope is intentionally narrow: PDFs are the reported and most common case. If maintainers want the Preview bypass widened to other bundled-app types, that's an easy follow-up on the same helper.
- Docker/arm64 fork-CI failure is the known, expected fork limitation and unrelated to this change.
