### PR TITLE
fix(desktop): stop restoring draft when prompt.submit succeeds but provider fails (#68927)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1342,8 +1342,9 @@ describe('usePromptActions sleep/wake session recovery', () => {
       />
     )
 
-    // submitText swallows the error into an inline bubble and returns false.
-    expect(await handle!.submitText('message')).toBe(false)
+    // submitText swallows the error into an inline bubble and returns true
+    // (#68927: after prompt.submit was sent, the draft must not be restored).
+    expect(await handle!.submitText('message')).toBe(true)
     // No resume attempt for a non-recoverable error.
     expect(calls).not.toContain('session.resume')
   })
@@ -1373,7 +1374,10 @@ describe('usePromptActions sleep/wake session recovery', () => {
 
     // With a null stored ref, the `&& selectedStoredSessionIdRef.current` guard
     // short-circuits — no resume is attempted and the error surfaces normally.
-    expect(await handle!.submitText('message')).toBe(false)
+    // Returns true because the optimistic user message stays in the session
+    // state with an inline error bubble — the draft must not be restored
+    // after prompt.submit was acknowledged (#68927).
+    expect(await handle!.submitText('message')).toBe(true)
     expect(calls).not.toContain('session.resume')
   })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -545,14 +545,26 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         if (targetIsCurrentView() && isProviderSetupError(err)) {
           requestDesktopOnboarding(copy.providerCredentialRequired)
 
-          return false
+          // Same as the generic error case below — prompt.submit already
+          // persisted the user turn.  Never restore the draft (#68927).
+          // Clear the draft so the user can see their bubble + the provider
+          // onboarding prompt without confusing draft restoration.
+          return true
         }
 
         if (targetIsCurrentView()) {
           notifyError(err, copy.promptFailed)
         }
 
-        return false
+        // The outer catch block is reached after prompt.submit was sent and
+        // optimistically seeded — the user turn was already persisted on the
+        // backend.  Return true so that dispatchSubmit in the composer clears
+        // the draft instead of restoring the text into the input.  Restoring
+        // the draft here would make the user's Enter appear to do nothing
+        // (text stays in composer, no visible user bubble), even though the
+        // backend accepted the turn and an assistant error bubble is already
+        // part of the session state (#68927).
+        return true
       }
     },
     [


### PR DESCRIPTION
## Description

Fixes #68927 — Desktop: after long tasks Enter reaches backend but user bubble is not rendered and text remains in composer.

**Root Cause:** When prompt.submit succeeds (the user turn is persisted on the backend and the optimistic message is seeded) but the provider subsequently fails (HTTP 429/400), the outer catch block in useSubmitPrompt returns false. The composer's dispatchSubmit interprets this as "prompt rejected" and calls restore(), which loads the text back into the composer and re-stashes the draft — making it look like Enter did nothing, even though the user message was already accepted.

**Fix:** Return true from the outer catch block in useSubmitPrompt instead of false. This tells dispatchSubmit to clear the draft (clearSessionDraft) instead of restoring it. The optimistic user message (inserted via seedOptimistic before prompt.submit) stays visible in the chat, and the assistant error bubble (appended by the error handler) shows the failure reason. The composer stays empty — matching the expected UX where accepted prompts remain visible even when the assistant response fails.

Also fixes the isProviderSetupError branch for the same reason.

## Changes

### submit.ts
- isProviderSetupError branch: return false -> return true
- Generic error catch: return false -> return true

### index.test.tsx
- Updated two tests that expect submitText to return false after a prompt.submit error to expect true instead

## Verification

- The pre-submit guard (busyRef, session/create errors) still correctly returns false — the draft IS restored when the prompt was never sent
- The queue drain fromQueue + sessionBusy guard still returns false — queued entries stay queued for retry
- Early-abort paths (abortForSessionSwitch) still return false — draft restored when the session context changed before submit

## Related

Closes #68927
