### PR TITLE
fix(mcp): scope MCP server discovery to a resolved toolset allowlist

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3323,9 +3323,19 @@ def run_job(
         # ticks short-circuit on already-connected servers inside
         # register_mcp_servers(). Non-fatal on failure: a broken MCP server
         # shouldn't kill an otherwise-working cron job. See #4219.
+        #
+        # Resolved BEFORE the call (rather than reusing the enabled_toolsets
+        # passed to AIAgent below) so the MCP allowlist and the agent's own
+        # toolset scoping can never drift apart, and so a job scoped to a
+        # handful of native toolsets doesn't physically boot every MCP
+        # server configured on the profile — each cron tick was previously
+        # connecting the full fleet regardless of the job's own toolset
+        # allowlist (contributing to the 58-watchdog resource/context
+        # explosion across concurrently-running workers/jobs).
+        _job_enabled_toolsets = _resolve_cron_enabled_toolsets(job, _cfg)
         try:
             from tools.mcp_tool import discover_mcp_tools
-            _mcp_tools = discover_mcp_tools()
+            _mcp_tools = discover_mcp_tools(enabled_toolsets=_job_enabled_toolsets)
             if _mcp_tools:
                 logger.info(
                     "Job '%s': %d MCP tool(s) available",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -397,7 +397,7 @@ import shutil
 import stat
 import subprocess
 from pathlib import Path
-from typing import Optional
+from typing import Any, List, Optional
 
 
 from hermes_cli.subcommands._shared import add_accept_hooks_flag as _add_accept_hooks_flag
@@ -13213,6 +13213,34 @@ def _should_background_mcp_startup(args) -> bool:
     return args.command in {None, "chat", "rl"}
 
 
+def _parse_cli_toolsets_arg(raw: Any) -> Optional[List[str]]:
+    """Normalize the ``--toolsets``/``-t`` CLI arg into a list, or ``None``.
+
+    ``args.toolsets`` is a comma-separated string on the real argparse path
+    (``-t web,terminal,codegraph``) but tests and some callers pass a
+    list/tuple directly (mirrors the tolerant parsing already done for
+    ``cmd_chat``'s ``toolsets`` param in ``cli.py``). Returns ``None`` when
+    unset so ``discover_mcp_tools``/``start_background_mcp_discovery`` fall
+    back to their unrestricted default (connect every configured server) —
+    scoping MCP discovery is opt-in based on whether the invocation actually
+    pinned a toolset list, never forced onto ordinary interactive sessions.
+    """
+    if not raw:
+        return None
+    if isinstance(raw, str):
+        parsed = [t.strip() for t in raw.split(",") if t.strip()]
+        return parsed or None
+    if isinstance(raw, (list, tuple)):
+        parsed = []
+        for item in raw:
+            if isinstance(item, str):
+                parsed.extend(t.strip() for t in item.split(",") if t.strip())
+            elif item:
+                parsed.append(str(item))
+        return parsed or None
+    return None
+
+
 def _prepare_agent_startup(args) -> None:
     """Discover plugins/MCP/hooks for commands that can run an agent turn."""
     # --yolo: chokepoint guarantee that HERMES_YOLO_MODE is set before ANY
@@ -13260,6 +13288,7 @@ def _prepare_agent_startup(args) -> None:
             start_background_mcp_discovery(
                 logger=logger,
                 thread_name="cli-mcp-discovery",
+                enabled_toolsets=_parse_cli_toolsets_arg(getattr(args, "toolsets", None)),
             )
         except Exception:
             logger.debug(
@@ -13273,7 +13302,9 @@ def _prepare_agent_startup(args) -> None:
             # not own a later bounded/executor startup path.
             from tools.mcp_tool import discover_mcp_tools
 
-            discover_mcp_tools()
+            discover_mcp_tools(
+                enabled_toolsets=_parse_cli_toolsets_arg(getattr(args, "toolsets", None))
+            )
         except Exception:
             logger.debug(
                 "MCP tool discovery failed at CLI startup",

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -24,13 +24,23 @@ def _has_configured_mcp_servers() -> bool:
         return True
 
 
-def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
+def start_background_mcp_discovery(
+    *,
+    logger,
+    thread_name: str,
+    enabled_toolsets: Optional[list] = None,
+) -> None:
     """Spawn one shared background MCP discovery thread for this process.
 
     If the first background discovery run exits without connecting any MCP
     server (for example after startup cancellation / OOM restart), later calls
     are allowed to retry instead of permanently pinning the process in a
     "discovery already started" state with zero MCP tools.
+
+    ``enabled_toolsets``, when provided, restricts discovery to MCP servers
+    named in that list (see ``tools.mcp_tool.discover_mcp_tools``). Passed
+    straight through so a worker/job that already resolved a scoped toolset
+    list doesn't boot MCP servers outside its own tool surface.
     """
     global _mcp_discovery_started, _mcp_discovery_thread
 
@@ -60,7 +70,7 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
 
         def _discover() -> None:
             try:
-                _discover_mcp_tools_without_interactive_oauth()
+                _discover_mcp_tools_without_interactive_oauth(enabled_toolsets)
                 try:
                     from tools.mcp_tool import get_mcp_status
                     status = get_mcp_status() or []
@@ -107,7 +117,9 @@ def _resolve_discovery_timeout(explicit: "float | None") -> float:
         return 1.5
 
 
-def _discover_mcp_tools_without_interactive_oauth() -> None:
+def _discover_mcp_tools_without_interactive_oauth(
+    enabled_toolsets: Optional[list] = None,
+) -> None:
     """Run MCP discovery without letting OAuth read from the user's stdin."""
     try:
         from tools.mcp_oauth import suppress_interactive_oauth
@@ -117,7 +129,7 @@ def _discover_mcp_tools_without_interactive_oauth() -> None:
     with suppress_interactive_oauth():
         from tools.mcp_tool import discover_mcp_tools
 
-        discover_mcp_tools()
+        discover_mcp_tools(enabled_toolsets=enabled_toolsets)
 
 
 def wait_for_mcp_discovery(timeout: "float | None" = None) -> None:

--- a/tests/tools/test_mcp_toolset_scoping.py
+++ b/tests/tools/test_mcp_toolset_scoping.py
@@ -1,0 +1,243 @@
+"""Regression tests for scoping MCP server discovery to a resolved toolset list.
+
+Background
+==========
+Process audit (2026-07-21): 7 concurrently-running Hermes owners (kanban
+dispatcher-spawned workers + cron jobs) held 58 ``mcp_stdio_watchdog``
+children between them. Each owner independently called
+``discover_mcp_tools()`` with NO arguments, which unconditionally connects
+every server listed under ``mcp_servers`` in the resolved config — even
+though the dispatcher (``hermes_cli.kanban_db._resolve_worker_cli_toolsets``)
+and cron (``cron.scheduler._resolve_cron_enabled_toolsets``) already compute
+a scoped ``--toolsets``/``enabled_toolsets`` allowlist for that specific
+worker/job, and MCP server names are first-class members of that allowlist
+(``hermes_cli.tools_config.enabled_mcp_server_names``). Every additional
+concurrent worker therefore re-booted the full MCP fleet (CodeGraph,
+git_context, Qdrant, CUA, Bitwarden, Stitch, etc.) regardless of whether its
+own toolset scope even referenced those servers, multiplying process/RSS/
+connection fan-out and startup latency with every concurrent task.
+
+The fix threads an optional ``enabled_toolsets`` allowlist through
+``discover_mcp_tools()`` (and the two callers that already resolve one:
+``cron.scheduler.run_job`` and the CLI startup path via
+``hermes_cli.main._parse_cli_toolsets_arg`` / ``start_background_mcp_discovery``)
+so a scoped caller only spawns the MCP server subprocesses within its own
+tool surface. ``enabled_toolsets=None`` (the default — used by interactive
+CLI/gateway/dashboard sessions with no explicit scope) preserves the prior
+unrestricted behavior.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# _filter_servers_by_toolset_allowlist — pure filtering logic
+# ---------------------------------------------------------------------------
+
+class TestFilterServersByToolsetAllowlist:
+    def test_none_allowlist_returns_all_servers_unfiltered(self):
+        """Interactive sessions (no scoped toolset list) still see every server."""
+        from tools.mcp_tool import _filter_servers_by_toolset_allowlist
+
+        servers = {"codegraph": {"command": "codegraph"}, "bitwarden": {"command": "npx"}}
+        assert _filter_servers_by_toolset_allowlist(servers, None) == servers
+
+    def test_scoped_allowlist_keeps_only_named_servers(self):
+        """A worker's --toolsets list restricts which MCP servers connect."""
+        from tools.mcp_tool import _filter_servers_by_toolset_allowlist
+
+        servers = {
+            "codegraph": {"command": "codegraph"},
+            "git_context": {"command": "python3"},
+            "bitwarden": {"command": "npx"},
+            "stitch": {"command": "npx"},
+        }
+        allowlist = ["terminal", "file", "codegraph", "git_context"]
+        result = _filter_servers_by_toolset_allowlist(servers, allowlist)
+        assert set(result.keys()) == {"codegraph", "git_context"}
+
+    def test_allowlist_with_no_matching_servers_returns_empty(self):
+        """A worker scoped only to native toolsets connects zero MCP servers."""
+        from tools.mcp_tool import _filter_servers_by_toolset_allowlist
+
+        servers = {"codegraph": {"command": "codegraph"}, "bitwarden": {"command": "npx"}}
+        result = _filter_servers_by_toolset_allowlist(servers, ["terminal", "file", "web"])
+        assert result == {}
+
+    def test_all_sentinel_disables_filtering(self):
+        """The 'all' sentinel (matches get_tool_definitions convention) is unrestricted."""
+        from tools.mcp_tool import _filter_servers_by_toolset_allowlist
+
+        servers = {"codegraph": {"command": "codegraph"}, "bitwarden": {"command": "npx"}}
+        assert _filter_servers_by_toolset_allowlist(servers, ["all"]) == servers
+        assert _filter_servers_by_toolset_allowlist(servers, ["*"]) == servers
+
+    def test_empty_allowlist_falls_back_to_unrestricted(self):
+        """An empty list (no meaningful scope) must not silently drop every server."""
+        from tools.mcp_tool import _filter_servers_by_toolset_allowlist
+
+        servers = {"codegraph": {"command": "codegraph"}}
+        assert _filter_servers_by_toolset_allowlist(servers, []) == servers
+
+
+# ---------------------------------------------------------------------------
+# discover_mcp_tools(enabled_toolsets=...) — end-to-end scoping
+# ---------------------------------------------------------------------------
+
+class TestDiscoverMcpToolsScoping:
+    def test_discover_mcp_tools_default_connects_every_configured_server(self):
+        """No enabled_toolsets arg (interactive sessions) — prior behavior preserved."""
+        from tools.mcp_tool import discover_mcp_tools
+
+        fake_config = {
+            "codegraph": {"command": "codegraph", "args": ["serve", "--mcp"]},
+            "bitwarden": {"command": "npx", "args": ["-y", "@bitwarden/mcp-server"]},
+        }
+        register_calls = []
+
+        def fake_register(servers):
+            register_calls.append(set(servers.keys()))
+            return []
+
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_tool._load_mcp_config", return_value=fake_config), \
+             patch("tools.mcp_tool.register_mcp_servers", side_effect=fake_register):
+            discover_mcp_tools()
+
+        assert register_calls == [{"codegraph", "bitwarden"}]
+
+    def test_discover_mcp_tools_scoped_connects_only_allowlisted_servers(self):
+        """A resolved worker toolset list restricts which servers get connected —
+        the actual subprocess-spawn gate, not just post-hoc tool filtering."""
+        from tools.mcp_tool import discover_mcp_tools
+
+        fake_config = {
+            "codegraph": {"command": "codegraph", "args": ["serve", "--mcp"]},
+            "git_context": {"command": "python3"},
+            "bitwarden": {"command": "npx", "args": ["-y", "@bitwarden/mcp-server"]},
+            "stitch": {"command": "npx", "args": ["@_davideast/stitch-mcp", "proxy"]},
+        }
+        register_calls = []
+
+        def fake_register(servers):
+            register_calls.append(set(servers.keys()))
+            return []
+
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_tool._load_mcp_config", return_value=fake_config), \
+             patch("tools.mcp_tool.register_mcp_servers", side_effect=fake_register):
+            discover_mcp_tools(enabled_toolsets=["terminal", "file", "codegraph"])
+
+        assert register_calls == [{"codegraph"}]
+
+    def test_discover_mcp_tools_scoped_to_pure_native_toolsets_skips_registration_entirely(self):
+        """A worker scoped only to native toolsets (no MCP server names) never
+        calls register_mcp_servers at all — zero MCP subprocess spawns."""
+        from tools.mcp_tool import discover_mcp_tools
+
+        fake_config = {
+            "codegraph": {"command": "codegraph", "args": ["serve", "--mcp"]},
+        }
+
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_tool._load_mcp_config", return_value=fake_config), \
+             patch("tools.mcp_tool.register_mcp_servers") as mock_register:
+            result = discover_mcp_tools(enabled_toolsets=["terminal", "file", "web"])
+
+        mock_register.assert_not_called()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# cron.scheduler.run_job — MCP discovery scoped to the job's own toolsets
+# ---------------------------------------------------------------------------
+
+class TestCronSchedulerScopesMcpDiscovery:
+    def test_run_job_passes_resolved_toolsets_to_discover_mcp_tools(self):
+        """cron.scheduler must resolve the job's enabled_toolsets BEFORE calling
+        discover_mcp_tools and pass it through, so a cron job scoped away from
+        MCP servers doesn't boot them on every tick (mirrors the kanban worker
+        fix — see #P1 MCP fleet explosion)."""
+        from cron import scheduler
+
+        job = {
+            "id": "scoped-job",
+            "name": "scoped-job",
+            "no_agent": True,  # short-circuit before AIAgent construction
+            "script": "/nonexistent/script.sh",
+        }
+
+        captured_kwargs = {}
+
+        def fake_discover(**kwargs):
+            captured_kwargs.update(kwargs)
+            return []
+
+        # no_agent jobs skip discover_mcp_tools entirely (see
+        # test_scheduler_mcp_init.py::test_no_agent_cron_job_does_not_initialize_mcp),
+        # so exercise the resolver directly against the same job/cfg shape
+        # run_job would use, confirming it produces a real allowlist that
+        # _resolve_cron_enabled_toolsets alone would also produce.
+        from cron.scheduler import _resolve_cron_enabled_toolsets
+
+        cfg = {"platform_toolsets": {"cron": ["terminal", "web"]}}
+        resolved = _resolve_cron_enabled_toolsets(job, cfg)
+        assert resolved is not None
+        assert "terminal" in resolved and "web" in resolved
+
+    def test_resolved_cron_toolsets_used_as_mcp_allowlist_excludes_unlisted_servers(self):
+        """End-to-end: a job's resolved toolset list, fed into
+        discover_mcp_tools, excludes MCP servers the job never asked for."""
+        from tools.mcp_tool import discover_mcp_tools
+
+        fake_config = {
+            "codegraph": {"command": "codegraph"},
+            "bitwarden": {"command": "npx"},
+        }
+        register_calls = []
+
+        def fake_register(servers):
+            register_calls.append(set(servers.keys()))
+            return []
+
+        # Simulates a job whose per-job enabled_toolsets names only "codegraph".
+        job_toolsets = ["terminal", "file", "codegraph"]
+
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_tool._load_mcp_config", return_value=fake_config), \
+             patch("tools.mcp_tool.register_mcp_servers", side_effect=fake_register):
+            discover_mcp_tools(enabled_toolsets=job_toolsets)
+
+        assert register_calls == [{"codegraph"}]
+
+
+# ---------------------------------------------------------------------------
+# hermes_cli.main._parse_cli_toolsets_arg — CLI arg normalization
+# ---------------------------------------------------------------------------
+
+class TestParseCliToolsetsArg:
+    def test_none_returns_none(self):
+        from hermes_cli.main import _parse_cli_toolsets_arg
+        assert _parse_cli_toolsets_arg(None) is None
+
+    def test_empty_string_returns_none(self):
+        from hermes_cli.main import _parse_cli_toolsets_arg
+        assert _parse_cli_toolsets_arg("") is None
+
+    def test_comma_separated_string_splits(self):
+        from hermes_cli.main import _parse_cli_toolsets_arg
+        assert _parse_cli_toolsets_arg("web,terminal,codegraph") == [
+            "web", "terminal", "codegraph",
+        ]
+
+    def test_list_of_strings_flattened_and_comma_split(self):
+        from hermes_cli.main import _parse_cli_toolsets_arg
+        assert _parse_cli_toolsets_arg(["web", "terminal,file"]) == [
+            "web", "terminal", "file",
+        ]
+
+    def test_whitespace_stripped(self):
+        from hermes_cli.main import _parse_cli_toolsets_arg
+        assert _parse_cli_toolsets_arg(" web , terminal ") == ["web", "terminal"]

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -107,7 +107,7 @@ import time
 from types import SimpleNamespace
 from typing import Callable
 from datetime import datetime
-from typing import Any, Coroutine, Dict, List, Optional
+from typing import Any, Coroutine, Dict, Iterable, List, Optional
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
@@ -5726,7 +5726,42 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     return _existing_tool_names()
 
 
-def discover_mcp_tools() -> List[str]:
+def _filter_servers_by_toolset_allowlist(
+    servers: Dict[str, dict], enabled_toolsets: Optional[Iterable[str]]
+) -> Dict[str, dict]:
+    """Restrict ``servers`` to those named in ``enabled_toolsets``, when scoped.
+
+    MCP server names are first-class toolset names (see
+    ``hermes_cli.tools_config.enabled_mcp_server_names`` /
+    ``cron.scheduler._merge_mcp_into_per_job_toolsets``): a profile's
+    ``platform_toolsets.cli`` list names the exact MCP servers it wants
+    (e.g. ``codegraph``, ``git_context``, ``bitwarden``) directly alongside
+    native toolsets. Every caller that already resolved a scoped toolset
+    list (dispatcher-spawned kanban workers via ``--toolsets``, cron jobs
+    via ``_resolve_cron_enabled_toolsets``) can pass it straight through
+    here to stop physically spawning MCP server subprocesses the worker's
+    tool surface doesn't include — not just filtering which already-running
+    servers' tools reach ``get_tool_definitions()`` afterward.
+
+    ``enabled_toolsets=None`` (the default for interactive CLI/gateway/
+    dashboard sessions, which want every configured server available)
+    performs no filtering at all — this is opt-in, so ordinary user
+    sessions never lose MCP servers they haven't explicitly scoped away.
+    An allowlist containing ``"all"`` or ``"*"`` is likewise treated as
+    unrestricted, matching the sentinel convention used by
+    ``get_tool_definitions(enabled_toolsets=...)`` elsewhere.
+    """
+    if enabled_toolsets is None:
+        return servers
+    allowed = {str(t).strip() for t in enabled_toolsets if str(t).strip()}
+    if not allowed or "all" in allowed or "*" in allowed:
+        return servers
+    return {name: cfg for name, cfg in servers.items() if name in allowed}
+
+
+def discover_mcp_tools(
+    enabled_toolsets: Optional[Iterable[str]] = None,
+) -> List[str]:
     """Entry point: load config, connect to MCP servers, register tools.
 
     Called from ``model_tools`` after ``discover_builtin_tools()``. Safe to call even when
@@ -5734,6 +5769,17 @@ def discover_mcp_tools() -> List[str]:
 
     Idempotent for already-connected servers. If some servers failed on a
     previous call, only the missing ones are retried.
+
+    Args:
+        enabled_toolsets: Optional allowlist of toolset/MCP-server names to
+            restrict discovery to (see
+            :func:`_filter_servers_by_toolset_allowlist`). ``None`` (the
+            default) connects every configured server, matching prior
+            behavior for interactive sessions. Pass the caller's already-
+            resolved worker/job toolset list to avoid booting MCP servers
+            outside that scope — the fix for dispatcher workers each
+            independently connecting the full MCP fleet regardless of
+            their ``--toolsets`` pin.
 
     Returns:
         List of all registered MCP tool names.
@@ -5745,6 +5791,12 @@ def discover_mcp_tools() -> List[str]:
     servers = _load_mcp_config()
     if not servers:
         logger.debug("No MCP servers configured")
+        return []
+    servers = _filter_servers_by_toolset_allowlist(servers, enabled_toolsets)
+    if not servers:
+        logger.debug(
+            "No MCP servers within the resolved toolset allowlist -- skipping discovery"
+        )
         return []
 
     with _lock:


### PR DESCRIPTION
## Summary

Process audit (2026-07-21) found 7 concurrently-running Hermes owners (kanban dispatcher workers + cron jobs) holding **58 `mcp_stdio_watchdog` children** between them — each owner independently booting the near-full MCP fleet (CodeGraph, git_context, Qdrant, CUA, Bitwarden, Stitch, etc.) regardless of its own tool scope.

**Root cause:** `discover_mcp_tools()` unconditionally connects *every* server listed under `mcp_servers` in the resolved config, with no way to restrict it to a caller's already-resolved toolset scope.

Both the kanban dispatcher (`hermes_cli.kanban_db._resolve_worker_cli_toolsets`) and cron (`cron.scheduler._resolve_cron_enabled_toolsets`) already compute a scoped toolset allowlist per worker/job — and MCP server names are first-class members of that list (`hermes_cli.tools_config.enabled_mcp_server_names`). But nothing plumbed that allowlist into the actual MCP *subprocess-spawn* path, so every worker re-connected the full fleet on every dispatch, multiplying process/RSS/connection fan-out and startup latency with each concurrent task — worsening both resource usage and the tool-schema/context surface sent on every model call.

## Changes

- **`tools/mcp_tool.py`**: `discover_mcp_tools()` takes an optional `enabled_toolsets` allowlist. New `_filter_servers_by_toolset_allowlist()` restricts which configured servers actually get connected before any subprocess is spawned — not just filtering which already-running servers' tools reach `get_tool_definitions()` afterward. `enabled_toolsets=None` (the default) preserves the prior unrestricted behavior for interactive CLI/gateway/dashboard sessions — this is opt-in scoping, never forced.
- **`cron/scheduler.py`**: `run_job()` now resolves the job's `enabled_toolsets` *before* calling `discover_mcp_tools()` (previously this resolution only happened afterward, for the `AIAgent(...)` constructor) and passes it straight through, so the MCP allowlist and the agent's own toolset scoping can never drift apart.
- **`hermes_cli/main.py`**: CLI startup (`_prepare_agent_startup`) parses the resolved `--toolsets` arg via a new `_parse_cli_toolsets_arg()` helper and threads it into both the inline and background discovery paths — this is exactly the path dispatcher-spawned kanban workers hit via their pinned `--toolsets <profile-scoped-list>`.
- **`hermes_cli/mcp_startup.py`**: `start_background_mcp_discovery()` and `_discover_mcp_tools_without_interactive_oauth()` accept and forward the same allowlist.

No orphan-cleanup/liveness behavior changed: `mcp_stdio_watchdog.py`'s parent-death supervision and `_kill_orphaned_mcp_children()` are untouched — this fix reduces *how many* servers get spawned per worker in the first place, not teardown. Existing coverage in `tests/tools/test_mcp_stability.py` (`TestStdioPidTracking`, `TestStdioPgroupReaping`) continues to pass unchanged and already exercises orphan/child cleanup end-to-end (including the real subprocess-tree `test_grandchild_reaped_via_pgroup` test).

## Test plan

Local verification only (GitHub Actions CI is currently quota-broken on this account — local test/lint evidence substitutes per team policy). No process killing was performed during the diagnosis.

- `tests/tools/test_mcp_tool.py`, `test_mcp_stdio_watchdog.py`, `test_mcp_stability.py` — 242 pre-existing tests, all pass unchanged.
- `tests/cron/test_scheduler_mcp_init.py`, `tests/hermes_cli/test_kanban_worker_spawn_toolsets.py`, `tests/hermes_cli/test_mcp_config.py` — pass unchanged.
- New `tests/tools/test_mcp_toolset_scoping.py` (15 tests): the filter helper's allowlist/sentinel/empty-list semantics, `discover_mcp_tools()` end-to-end scoping (asserting `register_mcp_servers` is only called with the allowlisted subset, or not at all for a pure-native toolset list), cron's `_resolve_cron_enabled_toolsets` producing a usable allowlist, and `_parse_cli_toolsets_arg` normalization.
- Combined run: 320 tests, all green.
- `ruff check` clean on all 4 touched source files.

Two pre-existing failures in `tests/cron/test_scheduler.py::TestRoutingIntents` (photon/BlueBubbles env leakage on this host, unrelated to MCP) were confirmed to fail identically on a clean `git stash` of this branch — not caused by this change.
