### PR TITLE
fix(pairing): never rebuild the approved-users file from an unreadable read

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -171,6 +171,32 @@ def _load_json_file(path: Path) -> dict:
     return {}
 
 
+def _load_json_file_or_none(path: Path) -> Optional[dict]:
+    """Load a JSON dict, or ``None`` when the file exists but is unusable.
+
+    ``_load_json_file`` flattens every failure to ``{}``. That is safe for a
+    read-only lookup, but the merge below feeds the destination's contents
+    into the file it then WRITES: a swallowed failure there makes the merge
+    believe an intact destination is empty and overwrite it with only the
+    other directory's data, deleting every approval it held — the exact
+    "silently ignore approved users" outcome the merge exists to prevent.
+
+    ``PermissionError`` is the documented way this happens: a 0600 pairing
+    file left owned by root after ``docker exec ... hermes pairing approve``
+    is unreadable to the gateway running as ``hermes`` (#10270).
+    """
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        # OSError/PermissionError, malformed JSON, and a non-UTF-8 byte
+        # (UnicodeDecodeError) all mean the same thing here: we do not know
+        # what this file holds, so it must not be rewritten from a guess.
+        return None
+    return data if isinstance(data, dict) else None
+
+
 def _merge_pairing_dir(active_dir: Path, alternate_dir: Path) -> None:
     """Merge split legacy/new pairing data into the active PairingStore dir.
 
@@ -188,8 +214,23 @@ def _merge_pairing_dir(active_dir: Path, alternate_dir: Path) -> None:
         dest = active_dir / src.name
         merged = _load_json_file(src)
         if not merged:
+            # A failed read of the SOURCE is harmless: nothing is written and
+            # the legacy file stays intact for a later boot.
             continue
-        current = _load_json_file(dest)
+        current = _load_json_file_or_none(dest)
+        if current is None:
+            # The destination exists but we could not read it. Merging now
+            # would rewrite it from `{}` and destroy every approval it holds,
+            # so leave it alone and say why — the file is fine, our access
+            # to it is not.
+            logger.warning(
+                "Pairing merge skipped for %s: the file exists but could not be "
+                "read, and merging would overwrite it with only the legacy "
+                "contents, dropping the approvals it holds. Fix its ownership/"
+                "permissions (see #10270) and restart to complete the merge.",
+                dest,
+            )
+            continue
         before = dict(current)
         # Active data wins on key conflict; otherwise union the inactive data.
         merged.update(current)

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -68,6 +68,86 @@ class TestSplitPairingDirMigration:
         assert migrated["ou_user"]["user_name"] == "Active"
         assert migrated["ou_other"]["user_name"] == "Other"
 
+    def _split_dirs(self, tmp_path):
+        """Active dir holds two approvals; the inactive dir holds a third."""
+        home = tmp_path / "home"
+        legacy = home / "pairing"
+        new = home / "platforms" / "pairing"
+        legacy.mkdir(parents=True)
+        new.mkdir(parents=True)
+        (legacy / "feishu-approved.json").write_text(json.dumps({
+            "ou_alice": {"user_name": "Alice", "approved_at": 1.0},
+            "ou_bob": {"user_name": "Bob", "approved_at": 2.0},
+        }))
+        (new / "feishu-approved.json").write_text(json.dumps({
+            "ou_carol": {"user_name": "Carol", "approved_at": 3.0},
+        }))
+        return home, legacy, new
+
+    def test_unreadable_active_file_is_never_overwritten(self, tmp_path):
+        """The merge WRITES the destination, so a swallowed read of it would
+        rebuild the file from ``{}`` and delete every approval it holds.
+
+        ``PermissionError`` is the documented way this happens: a 0600 pairing
+        file left owned by root after ``docker exec ... hermes pairing approve``
+        is unreadable to the gateway running as ``hermes`` (#10270). The file
+        is intact — only our access to it is broken — so it must survive.
+        """
+        from gateway.pairing import _merge_pairing_dir
+
+        home, legacy, new = self._split_dirs(tmp_path)
+        dest = legacy / "feishu-approved.json"
+        real_read = Path.read_text
+
+        def _denied(self, *args, **kwargs):
+            if self == dest:
+                raise PermissionError(13, "Permission denied")
+            return real_read(self, *args, **kwargs)
+
+        with patch.object(Path, "read_text", _denied):
+            _merge_pairing_dir(legacy, new)
+
+        survived = json.loads(real_read(dest, encoding="utf-8"))
+        assert set(survived) == {"ou_alice", "ou_bob"}, (
+            "an intact pairing file was rewritten from an unreadable state, "
+            "destroying its approvals"
+        )
+
+    def test_corrupt_active_file_is_never_overwritten(self, tmp_path):
+        """Same contract for unparseable content — we do not know what the
+        file holds, so it must not be rebuilt from a guess."""
+        from gateway.pairing import _merge_pairing_dir
+
+        home, legacy, new = self._split_dirs(tmp_path)
+        dest = legacy / "feishu-approved.json"
+        dest.write_text("{ this is not json", encoding="utf-8")
+
+        _merge_pairing_dir(legacy, new)
+
+        assert dest.read_text(encoding="utf-8") == "{ this is not json"
+
+    def test_readable_active_file_still_merges(self, tmp_path):
+        """Control: the normal path must keep working."""
+        from gateway.pairing import _merge_pairing_dir
+
+        home, legacy, new = self._split_dirs(tmp_path)
+        _merge_pairing_dir(legacy, new)
+
+        merged = json.loads((legacy / "feishu-approved.json").read_text())
+        assert set(merged) == {"ou_alice", "ou_bob", "ou_carol"}
+
+    def test_absent_active_file_still_receives_legacy_data(self, tmp_path):
+        """Control: an absent destination is not an unreadable one."""
+        from gateway.pairing import _merge_pairing_dir
+
+        home, legacy, new = self._split_dirs(tmp_path)
+        (legacy / "feishu-approved.json").unlink()
+
+        _merge_pairing_dir(legacy, new)
+
+        merged = json.loads((legacy / "feishu-approved.json").read_text())
+        assert set(merged) == {"ou_carol"}
+
 
 # ---------------------------------------------------------------------------
 # _secure_write


### PR DESCRIPTION
## Summary

`_merge_pairing_dir` runs at **every gateway start** (via
`_migrate_split_pairing_dirs`) to union the legacy `{HERMES_HOME}/pairing` and
newer `{HERMES_HOME}/platforms/pairing` stores. It reads the destination,
merges, and **writes the result back**:

```python
current = _load_json_file(dest)
before = dict(current)
merged.update(current)          # active wins on conflict
if merged != before:
    _secure_write(dest, json.dumps(merged, ...))
```

`_load_json_file` flattens every failure to `{}`. That is fine where it is a
read-only lookup — but here the value it returns is what gets written back.
When the destination exists and is **intact** but cannot be read, `current` is
`{}`, `before` is `{}`, and the file is rewritten with only the *other*
directory's contents. Every approval it held is deleted from disk. The users
are not merely locked out for a boot: their grants are gone and they must
re-pair.

## Why this is reachable

The way it happens is already documented a few lines below, in the
`PermissionError` branch of `PairingStore._load_json`: a 0600 pairing file left
owned by root after `docker exec <container> hermes pairing approve ...` is
unreadable to the gateway running as `hermes` after the gosu drop (**#10270**).

That branch was hardened precisely because swallowing the error *"silently
leav[es] the user marked unauthorized"* — but it is a read-only path, so the
damage stops at one lookup. Here the same swallowed failure feeds a **write**.

## Reproduction

Against the real function, destination readable-but-denied:

```
BEFORE  active approvals: ['alice', 'bob']
BEFORE  legacy approvals: ['carol']
AFTER   active approvals: ['carol']
approvals destroyed on disk: ['alice', 'bob']
```

## Fix

Distinguish "unreadable" from "empty" for the destination read and skip the
file when we cannot see what it holds, logging what to fix. A failed read of
the **source** stays harmless — `if not merged: continue` already means nothing
is written — so only the write-feeding read changes. Absent destinations still
receive the legacy data, and a readable destination still merges exactly as
before.

## Test plan

`tests/gateway/test_pairing.py`:

- an unreadable (`PermissionError`) active file survives untouched
- an unparseable active file survives untouched
- control: a readable active file still merges (`alice`, `bob`, `carol`)
- control: an absent active file still receives the legacy data

The two data-loss tests **fail on `main`**; both controls **pass there**.
`77 passed` across the pairing suites, `403 passed` across every suite touching
`PairingStore` (2 failures in `test_pr_6656_regressions.py` are pre-existing and
fail identically on clean `main`).

## Checklist

- [x] Tested on Ubuntu 24.04
- [x] New tests fail without the fix and pass with it
- [x] No regressions (remaining failures reproduced on clean `main`)
- [x] No behavior change on the healthy merge path