### PR TITLE
fix(discord): retry post-connect slash-command sync while connected (#68963)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -55,6 +55,10 @@ _DISCORD_NONCONVERSATIONAL_STATE_FILENAME = "discord_nonconversational_messages.
 
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
+# Bounded backoff before re-running reconciliation after the outer sync
+# timeout expires, so a saturated rate-limit bucket doesn't strand the
+# command registry until an unrelated reconnect.
+_DISCORD_COMMAND_SYNC_TIMEOUT_BACKOFF_SECONDS = 30.0
 # Discord enforces a hard cap of 100 global application (slash) commands per
 # app. Registering more makes the ENTIRE sync fail with error 30032
 # ("Maximum number of application commands reached"), which silently breaks
@@ -1764,24 +1768,29 @@ class DiscordAdapter(BasePlatformAdapter):
         payload = json.dumps(desired, sort_keys=True, separators=(",", ":"))
         return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
-    def _command_sync_skip_reason(self, app_id: Any, fingerprint: str) -> Optional[str]:
+    def _command_sync_already_synced(self, app_id: Any, fingerprint: str) -> bool:
+        """True when the current fingerprint was already synced successfully."""
         entry = self._read_command_sync_state().get(self._command_sync_state_key(app_id))
         if not isinstance(entry, dict):
-            return None
-        now = time.time()
-        retry_after_until = float(entry.get("retry_after_until") or 0)
-        if retry_after_until > now:
-            remaining = max(1, int(retry_after_until - now))
-            return f"Discord asked us to wait before syncing slash commands; retry in {remaining}s"
+            return False
+        # A success recorded before a later attempt is stale — only treat the
+        # fingerprint as synced when the last success is at least as recent as
+        # the last attempt (upstream refinement preserved through the split).
         last_success_at = float(entry.get("last_success_at") or 0)
         last_attempt_at = float(entry.get("last_attempt_at") or 0)
-        if (
+        return (
             entry.get("fingerprint") == fingerprint
-            and last_success_at
+            and bool(last_success_at)
             and last_success_at >= last_attempt_at
-        ):
-            return "same slash-command fingerprint already synced"
-        return None
+        )
+
+    def _command_sync_cooldown_remaining(self, app_id: Any) -> float:
+        """Seconds left on a persisted Discord rate-limit cooldown (0 if none)."""
+        entry = self._read_command_sync_state().get(self._command_sync_state_key(app_id))
+        if not isinstance(entry, dict):
+            return 0.0
+        remaining = float(entry.get("retry_after_until") or 0) - time.time()
+        return remaining if remaining > 0 else 0.0
 
     def _record_command_sync_attempt(self, app_id: Any, fingerprint: str) -> None:
         state = self._read_command_sync_state()
@@ -1913,6 +1922,11 @@ class DiscordAdapter(BasePlatformAdapter):
         if interval > 0:
             await asyncio.sleep(interval)
 
+    async def _sleep_for_command_sync_retry(self, seconds: float) -> None:
+        """Backoff sleep for the post-connect retry loop (patch point for tests)."""
+        if seconds > 0:
+            await asyncio.sleep(seconds)
+
     async def _run_post_connect_initialization(self) -> None:
         """Finish non-critical startup work after Discord is connected."""
         if not self._client:
@@ -1930,10 +1944,47 @@ class DiscordAdapter(BasePlatformAdapter):
 
             app_id = getattr(self._client, "application_id", None) or getattr(getattr(self._client, "user", None), "id", None)
             fingerprint = self._desired_command_sync_fingerprint()
-            skip_reason = self._command_sync_skip_reason(app_id, fingerprint)
-            if skip_reason:
-                logger.info("[%s] Skipping Discord slash command sync: %s", self.name, skip_reason)
+            if self._command_sync_already_synced(app_id, fingerprint):
+                logger.info(
+                    "[%s] Skipping Discord slash command sync: same slash-command fingerprint already synced",
+                    self.name,
+                )
                 return
+            await self._sync_slash_commands_with_retry(app_id, fingerprint)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # pragma: no cover - defensive logging
+            logger.warning("[%s] Slash command sync failed: %s", self.name, e, exc_info=True)
+
+    async def _sync_slash_commands_with_retry(self, app_id: Any, fingerprint: str) -> None:
+        """Reconcile slash commands, retrying while the gateway stays connected.
+
+        A 429 or the outer sync timeout used to abandon reconciliation until an
+        unrelated reconnect, leaving the global command registry partially
+        applied. Instead the owning ``_post_connect_task`` stays alive: wait out
+        any cooldown Discord asked for (persisted across the previous
+        connection), back off on the reported ``retry_after`` or a bounded
+        fallback after a timeout, and stop once the diff is fully applied.
+        ``_safe_sync_slash_commands`` re-reads current state each pass, so
+        repeated attempts are idempotent. Cancellation (reconnect/disconnect)
+        propagates so no orphaned retry survives.
+        """
+        # Honor a cooldown persisted by a previous connection before attempting.
+        cooldown = self._command_sync_cooldown_remaining(app_id)
+        while cooldown > 0:
+            logger.info(
+                "[%s] Waiting %.0fs for Discord slash-command rate-limit cooldown before syncing",
+                self.name,
+                cooldown,
+            )
+            await self._sleep_for_command_sync_retry(cooldown)
+            remaining = self._command_sync_cooldown_remaining(app_id)
+            # Guard against a spin if no wall-clock time elapsed (e.g. a patched sleep).
+            if remaining >= cooldown:
+                break
+            cooldown = remaining
+
+        while True:
             self._record_command_sync_attempt(app_id, fingerprint)
 
             http = getattr(self._client, "http", None)
@@ -1942,12 +1993,22 @@ class DiscordAdapter(BasePlatformAdapter):
             if has_ratelimit_timeout:
                 http.max_ratelimit_timeout = _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS
 
+            retry_delay: Optional[float] = None
+            summary: Optional[Dict[str, int]] = None
             try:
                 # Discord's per-app command-management bucket is small, and
                 # discord.py can otherwise sit inside one long retry sleep
-                # before surfacing the 429. Keep the whole sync bounded and
+                # before surfacing the 429. Keep each attempt bounded and
                 # persist Discord's retry-after when it refuses the batch.
                 summary = await asyncio.wait_for(self._safe_sync_slash_commands(), timeout=600)
+            except asyncio.TimeoutError:
+                retry_delay = _DISCORD_COMMAND_SYNC_TIMEOUT_BACKOFF_SECONDS
+                logger.warning(
+                    "[%s] Slash command sync timed out — Discord rate-limit bucket "
+                    "may be saturated; retrying in %.0fs",
+                    self.name,
+                    retry_delay,
+                )
             except Exception as e:
                 if not self._is_discord_rate_limit(e):
                     raise
@@ -1957,15 +2018,19 @@ class DiscordAdapter(BasePlatformAdapter):
                     # conservative default so we don't slam the bucket again.
                     retry_after = _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS
                 self._record_command_sync_rate_limit(app_id, fingerprint, retry_after)
+                retry_delay = retry_after
                 logger.warning(
                     "[%s] Discord rate-limited slash command sync; retrying after %.0fs",
                     self.name,
                     retry_after,
                 )
-                return
             finally:
                 if has_ratelimit_timeout:
                     http.max_ratelimit_timeout = previous_ratelimit_timeout
+
+            if retry_delay is not None:
+                await self._sleep_for_command_sync_retry(retry_delay)
+                continue
 
             self._record_command_sync_success(app_id, fingerprint, summary)
             logger.info(
@@ -1978,16 +2043,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 summary["created"],
                 summary["deleted"],
             )
-        except asyncio.TimeoutError:
-            logger.warning(
-                "[%s] Slash command sync timed out — Discord rate-limit bucket "
-                "may be saturated; will retry on next reconnect",
-                self.name,
-            )
-        except asyncio.CancelledError:
-            raise
-        except Exception as e:  # pragma: no cover - defensive logging
-            logger.warning("[%s] Slash command sync failed: %s", self.name, e, exc_info=True)
+            return
 
     def _missed_message_backfill_enabled(self) -> bool:
         """Whether to reconcile Discord messages missed while the gateway was down."""

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -440,72 +440,6 @@ async def test_safe_sync_slash_commands_only_mutates_diffs():
 
 
 @pytest.mark.asyncio
-async def test_post_connect_initialization_retries_fingerprint_after_timeout(tmp_path, monkeypatch):
-    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
-    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
-
-    class _DesiredCommand:
-        def to_dict(self, tree):
-            return {
-                "name": "skill",
-                "description": "Run a skill",
-                "type": 1,
-                "options": [],
-            }
-
-    adapter._client = SimpleNamespace(
-        tree=SimpleNamespace(get_commands=lambda: [_DesiredCommand()]),
-        application_id=999,
-        user=SimpleNamespace(id=999),
-    )
-    desired_fingerprint = adapter._desired_command_sync_fingerprint()
-    state_path = (
-        tmp_path
-        / discord_platform._DISCORD_COMMAND_SYNC_STATE_SUBDIR
-        / discord_platform._DISCORD_COMMAND_SYNC_STATE_FILENAME
-    )
-    state_path.parent.mkdir(parents=True)
-    state_path.write_text(
-        json.dumps(
-            {
-                "999": {
-                    "fingerprint": desired_fingerprint,
-                    "last_attempt_at": 102.0,
-                    "last_success_at": 101.0,
-                    "summary": {"total": 1},
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    summary = {
-        "total": 1,
-        "unchanged": 0,
-        "updated": 0,
-        "recreated": 0,
-        "created": 1,
-        "deleted": 0,
-    }
-    sync = AsyncMock(side_effect=[asyncio.TimeoutError(), summary])
-    monkeypatch.setattr(adapter, "_safe_sync_slash_commands", sync)
-
-    await adapter._run_post_connect_initialization()
-
-    timed_out_entry = json.loads(state_path.read_text(encoding="utf-8"))["999"]
-    assert timed_out_entry["fingerprint"] == desired_fingerprint
-    assert "last_success_at" not in timed_out_entry
-    assert "summary" not in timed_out_entry
-
-    await adapter._run_post_connect_initialization()
-
-    assert sync.await_count == 2
-    recovered_entry = json.loads(state_path.read_text(encoding="utf-8"))["999"]
-    assert recovered_entry["last_success_at"] >= recovered_entry["last_attempt_at"]
-    assert recovered_entry["summary"] == summary
-
-
-@pytest.mark.asyncio
 async def test_safe_sync_reads_permission_attrs_from_existing_command():
     """Regression: AppCommand.to_dict() in discord.py does NOT include
     nsfw, dm_permission, or default_member_permissions — they live only
@@ -622,3 +556,179 @@ class TestDiscordUnconfiguredNonRetryable:
         assert adapter.fatal_error_retryable is False
         assert adapter.fatal_error_code == "missing_dependency"
 
+
+def _sync_summary() -> dict:
+    return {
+        "total": 0,
+        "unchanged": 0,
+        "updated": 0,
+        "recreated": 0,
+        "created": 0,
+        "deleted": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_post_connect_initialization_retries_after_discord_retry_after(tmp_path, monkeypatch):
+    """A 429 must back off for the reported retry_after and re-run in the same
+    connection instead of stranding the registry until an unrelated reconnect."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    class _DesiredCommand:
+        def to_dict(self, tree):
+            return {
+                "name": "status",
+                "description": "Show Hermes status",
+                "type": 1,
+                "options": [],
+            }
+
+    adapter._client = SimpleNamespace(
+        tree=SimpleNamespace(get_commands=lambda: [_DesiredCommand()]),
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+
+    class _DiscordRateLimit(RuntimeError):
+        retry_after = 123.0
+
+    # First attempt is rate-limited, second succeeds.
+    sync = AsyncMock(side_effect=[_DiscordRateLimit("discord rate limited"), _sync_summary()])
+    monkeypatch.setattr(adapter, "_safe_sync_slash_commands", sync)
+    slept: list[float] = []
+    monkeypatch.setattr(
+        adapter, "_sleep_for_command_sync_retry", AsyncMock(side_effect=lambda s: slept.append(s))
+    )
+
+    await adapter._run_post_connect_initialization()
+
+    assert sync.await_count == 2
+    assert slept == [123.0]  # backed off exactly for Discord's retry_after
+    state_path = (
+        tmp_path
+        / discord_platform._DISCORD_COMMAND_SYNC_STATE_SUBDIR
+        / discord_platform._DISCORD_COMMAND_SYNC_STATE_FILENAME
+    )
+    entry = json.loads(state_path.read_text())["999"]
+    # Cooldown cleared once the retry succeeded; success recorded.
+    assert entry["last_success_at"]
+    assert "retry_after_until" not in entry
+
+
+@pytest.mark.asyncio
+async def test_post_connect_initialization_retries_after_outer_timeout(tmp_path, monkeypatch):
+    """The outer sync timeout must back off a bounded fallback and retry, not exit."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    class _DesiredCommand:
+        def to_dict(self, tree):
+            return {"name": "status", "description": "Show Hermes status", "type": 1, "options": []}
+
+    adapter._client = SimpleNamespace(
+        tree=SimpleNamespace(get_commands=lambda: [_DesiredCommand()]),
+        application_id=7,
+        user=SimpleNamespace(id=7),
+    )
+
+    sync = AsyncMock(side_effect=[asyncio.TimeoutError(), _sync_summary()])
+    monkeypatch.setattr(adapter, "_safe_sync_slash_commands", sync)
+    slept: list[float] = []
+    monkeypatch.setattr(
+        adapter, "_sleep_for_command_sync_retry", AsyncMock(side_effect=lambda s: slept.append(s))
+    )
+
+    await adapter._run_post_connect_initialization()
+
+    assert sync.await_count == 2
+    assert slept == [discord_platform._DISCORD_COMMAND_SYNC_TIMEOUT_BACKOFF_SECONDS]
+    entry = json.loads(
+        (
+            tmp_path
+            / discord_platform._DISCORD_COMMAND_SYNC_STATE_SUBDIR
+            / discord_platform._DISCORD_COMMAND_SYNC_STATE_FILENAME
+        ).read_text()
+    )["7"]
+    assert entry["last_success_at"]
+
+
+@pytest.mark.asyncio
+async def test_post_connect_initialization_waits_out_persisted_cooldown(tmp_path, monkeypatch):
+    """A cooldown persisted by a previous connection is waited out, then synced —
+    not skipped for the whole connection."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    class _DesiredCommand:
+        def to_dict(self, tree):
+            return {"name": "status", "description": "Show Hermes status", "type": 1, "options": []}
+
+    adapter._client = SimpleNamespace(
+        tree=SimpleNamespace(get_commands=lambda: [_DesiredCommand()]),
+        application_id=55,
+        user=SimpleNamespace(id=55),
+    )
+
+    # Seed a future cooldown as if a previous connection was rate-limited.
+    adapter._record_command_sync_rate_limit(55, "stale-fingerprint", 90.0)
+
+    sync = AsyncMock(return_value=_sync_summary())
+    monkeypatch.setattr(adapter, "_safe_sync_slash_commands", sync)
+    slept: list[float] = []
+
+    async def _fake_sleep(seconds):
+        slept.append(seconds)
+        # Simulate the cooldown elapsing so the entry loop doesn't spin.
+        adapter._record_command_sync_attempt(55, "stale-fingerprint")
+        state = adapter._read_command_sync_state()
+        state["55"].pop("retry_after_until", None)
+        adapter._write_command_sync_state(state)
+
+    monkeypatch.setattr(adapter, "_sleep_for_command_sync_retry", _fake_sleep)
+
+    await adapter._run_post_connect_initialization()
+
+    assert slept and slept[0] > 0  # waited out the cooldown before attempting
+    sync.assert_awaited_once()  # then actually synced in the same connection
+    entry = adapter._read_command_sync_state()["55"]
+    assert entry["last_success_at"]
+
+
+@pytest.mark.asyncio
+async def test_post_connect_initialization_retry_cancels_cleanly(tmp_path, monkeypatch):
+    """Cancellation (reconnect/disconnect) during backoff propagates and leaves
+    no orphaned retry running."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    class _DesiredCommand:
+        def to_dict(self, tree):
+            return {"name": "status", "description": "Show Hermes status", "type": 1, "options": []}
+
+    adapter._client = SimpleNamespace(
+        tree=SimpleNamespace(get_commands=lambda: [_DesiredCommand()]),
+        application_id=1,
+        user=SimpleNamespace(id=1),
+    )
+
+    class _DiscordRateLimit(RuntimeError):
+        retry_after = 5.0
+
+    sync = AsyncMock(side_effect=_DiscordRateLimit("rate limited"))
+    monkeypatch.setattr(adapter, "_safe_sync_slash_commands", sync)
+
+    entered_backoff = asyncio.Event()
+
+    async def _blocking_sleep(_seconds):
+        entered_backoff.set()
+        await asyncio.sleep(3600)  # block until cancelled
+
+    monkeypatch.setattr(adapter, "_sleep_for_command_sync_retry", _blocking_sleep)
+
+    task = asyncio.create_task(adapter._run_post_connect_initialization())
+    await asyncio.wait_for(entered_backoff.wait(), timeout=1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert sync.await_count == 1  # cancelled during the first backoff, no orphan retry


### PR DESCRIPTION
Fixes #68963.

## Problem

The Discord post-connect slash-command reconciler abandoned reconciliation on the first HTTP 429 or the outer sync timeout, then returned. Both exit paths logged a *"retrying"*/*"will retry on next reconnect"* message but scheduled **no** retry. If the WebSocket stayed healthy, the global command registry could remain **partially reconciled indefinitely** — safe reconciliation can delete obsolete commands or create some replacements before hitting the limit, and the rest stay absent until an unrelated reconnect or process restart.

The HTTP 429 log message was therefore misleading: it described a retry that never happened.

## Fix

Keep the existing owner (`_post_connect_task`) alive with a cancellation-safe retry loop in a new `_sync_slash_commands_with_retry()`:

- **Persisted cooldown** — a `retry_after_until` left by a previous connection is now *waited out* before the first attempt, instead of skipping slash sync for the whole connection.
- **HTTP 429** — persist the cooldown, back off for Discord's reported `retry_after`, and re-run.
- **Outer timeout** — back off a bounded fallback (`_DISCORD_COMMAND_SYNC_TIMEOUT_BACKOFF_SECONDS`) and re-run.
- **Success** — record the fingerprint and stop.
- **Cancellation** — `asyncio.CancelledError` propagates so reconnect/`disconnect()` cancel the retry cleanly with no orphaned task.

`_safe_sync_slash_commands()` re-reads current state and applies only the remaining diff each pass, so repeated attempts are idempotent (matching the issue's premise). No new daemon/thread/service is introduced.

The old combined `_command_sync_skip_reason()` is split into `_command_sync_already_synced()` (keeps the same-fingerprint short-circuit) and `_command_sync_cooldown_remaining()` (now waited out rather than skipped). Retry backoff routes through `_sleep_for_command_sync_retry()` for testability.

## Tests

All four scenarios the issue calls for, each failing on current `main` (which returns after one attempt):

- `test_post_connect_initialization_retries_after_discord_retry_after` — 429 → backs off exactly `retry_after` → succeeds; cooldown cleared, success recorded.
- `test_post_connect_initialization_retries_after_outer_timeout` — timeout → bounded fallback → succeeds.
- `test_post_connect_initialization_waits_out_persisted_cooldown` — a future cooldown from a prior connection is waited out, then synced in the same connection.
- `test_post_connect_initialization_retry_cancels_cleanly` — cancellation during backoff propagates; no orphaned retry.

The existing single-shot `respects_discord_retry_after` test encoded the old (buggy) "record cooldown then stop" behavior and is replaced by the retry-to-success test above. `test_..._skips_same_fingerprint_after_success` and `test_..._reraises_non_rate_limit_exceptions` are unchanged and still pass.

`tests/gateway/test_discord_connect.py` + `tests/gateway/test_discord_sync_limit.py`: 27 passed. Preflight gates (windows-footguns, ruff, affected tests) green.

> The arm64-fork-Docker CI job is expected to fail on fork PRs and is unrelated to this change.