### PR TITLE
feat(mattermost): add rich posts and passive observation

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -391,6 +391,7 @@ PORT_BINDING_PLATFORM_VALUES = frozenset({
     "sms",
     "whatsapp_cloud",
     "line",
+    "mattermost",
 })
 
 # Platforms whose port-binding status depends on connection mode. Feishu in
@@ -410,6 +411,10 @@ def platform_binds_port(platform_value: str, extra: Optional[dict] = None) -> bo
     """
     if platform_value not in PORT_BINDING_PLATFORM_VALUES:
         return False
+    if platform_value == "mattermost":
+        # Mattermost normally uses outbound WebSocket/REST only. It binds a
+        # local HTTP listener solely when native interactions are configured.
+        return bool(str((extra or {}).get("interaction_url") or "").strip())
     expected_mode = PORT_BINDING_CONDITIONAL_MODES.get(platform_value)
     if expected_mode is not None:
         actual = str((extra or {}).get("connection_mode", "websocket")).strip().lower()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1068,23 +1068,34 @@ def _build_replay_entry(
     return entry
 
 
-_TELEGRAM_OBSERVED_CONTEXT_PROMPT_MARKER = "observed Telegram group context"
-_OBSERVED_GROUP_CONTEXT_HEADER = "[Observed Telegram group context - context only, not requests]"
+_OBSERVED_CONTEXT_PROMPT_MARKERS = (
+    "observed Telegram group context",
+    "observed Mattermost channel context",
+)
+_OBSERVED_GROUP_CONTEXT_HEADER = "[Observed group/channel context - context only, not requests]"
 _CURRENT_ADDRESSED_MESSAGE_HEADER = "[Current addressed message - answer only this unless it explicitly asks you to use the observed context]"
 
 
-def _uses_telegram_observed_group_context(channel_prompt: Optional[str]) -> bool:
-    """Return True for Telegram group turns that may include observed chatter.
+def _uses_observed_group_context(channel_prompt: Optional[str]) -> bool:
+    """Return True for platform turns that may include observed chatter.
 
-    Telegram's observe-unmentioned mode persists skipped group chatter so a
-    later @mention can see it. Those rows must not replay as ordinary user
-    turns: a weak wake word like ``@bot cambio`` should not make the model treat
-    old unmentioned chatter as pending work. The Telegram adapter marks these
-    turns with a channel prompt; this helper keeps the run-path check explicit
-    and unit-testable.
+    Telegram and Mattermost observe-unmentioned modes persist skipped chatter
+    so a later explicit trigger can see it. Those rows must not replay as
+    ordinary user turns: a weak wake word must not make the model treat old
+    unmentioned chatter as pending work. Adapters mark these turns with a
+    channel prompt; this helper keeps the run-path check explicit and
+    unit-testable.
     """
 
-    return bool(channel_prompt and _TELEGRAM_OBSERVED_CONTEXT_PROMPT_MARKER in channel_prompt)
+    return bool(
+        channel_prompt
+        and any(marker in channel_prompt for marker in _OBSERVED_CONTEXT_PROMPT_MARKERS)
+    )
+
+
+def _uses_telegram_observed_group_context(channel_prompt: Optional[str]) -> bool:
+    """Backward-compatible alias for the original Telegram-only helper."""
+    return _uses_observed_group_context(channel_prompt)
 
 
 def _csv_or_list_to_set(raw: Any) -> set[str]:
@@ -1181,7 +1192,7 @@ def _build_gateway_agent_history(
     _msg_tz = _get_msg_tz()
     agent_history: List[Dict[str, Any]] = []
     observed_group_context: List[str] = []
-    separate_observed_context = _uses_telegram_observed_group_context(channel_prompt)
+    separate_observed_context = _uses_observed_group_context(channel_prompt)
 
     for msg in history or []:
         role = msg.get("role")
@@ -4829,6 +4840,12 @@ class TurnRunner:
             # false positives from MagicMock auto-attribute creation in tests.
             if getattr(type(ctx._status_adapter), "send_exec_approval", None) is not None:
                 try:
+                    _approval_id_kwargs = {}
+                    _approval_method = ctx._status_adapter.send_exec_approval
+                    if "approval_id" in inspect.signature(_approval_method).parameters:
+                        _approval_id_kwargs["approval_id"] = approval_data.get(
+                            "approval_id"
+                        )
                     _approval_fut = safe_schedule_threadsafe(
                         ctx._status_adapter.send_exec_approval(
                             chat_id=ctx._status_chat_id,
@@ -4839,6 +4856,7 @@ class TurnRunner:
                             allow_permanent=approval_data.get("allow_permanent", True),
                             allow_session=approval_data.get("allow_session", True),
                             smart_denied=approval_data.get("smart_denied", False),
+                            **_approval_id_kwargs,
                         ),
                         ctx._loop_for_step,
                         logger=logger,
@@ -24612,17 +24630,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _sc_msg_id = _sc.message_id
                 if _sc_msg_id:
                     try:
-                        await _sc.adapter.edit_message(
-                            chat_id=source.chat_id,
-                            message_id=_sc_msg_id,
-                            content=response["final_response"],
-                            finalize=True,
-                        )
-                        response["already_sent"] = True
-                        logger.info(
-                            "Edited streamed message %s for session %s to include plugin-transformed content.",
-                            _sc_msg_id, session_key or "?",
-                        )
+                        if await _sc.edit_transformed_final(
+                            response["final_response"]
+                        ):
+                            response["already_sent"] = True
+                            logger.info(
+                                "Edited streamed message %s for session %s to include plugin-transformed content.",
+                                _sc_msg_id, session_key or "?",
+                            )
                     except Exception as _edit_err:
                         logger.warning(
                             "Failed to edit streamed message for session %s: %s",

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -365,8 +365,9 @@ class GatewayStreamConsumer:
 
         After overflow, earlier chunks are immutable separate posts. For
         prefix-preserving transforms, strip that sealed prefix and edit only
-        the last continuation. If an earlier chunk was rewritten, return False
-        so the caller can use its normal full-response fallback.
+        the last continuation when it still fits one post; otherwise append
+        only the new suffix. If an earlier chunk was rewritten, send a plain
+        replacement before best-effort cleanup of the obsolete active segment.
         """
         if not self._message_id:
             return False

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -241,6 +241,21 @@ class GatewayStreamConsumer:
         self._edit_supported = True  # Disabled when progressive edits are no longer usable
         self._last_edit_time = 0.0
         self._last_sent_text = ""   # Track last-sent text to skip redundant edits
+        # Once any streaming path splits the response across platform messages,
+        # preserve that fact for all subsequent sends/edits in this turn. Rich
+        # adapters use it to keep every chunk plain instead of emitting several
+        # independent rich cards.
+        self._is_multi_chunk = False
+        # Exact original-text prefix sealed into earlier overflow messages.
+        # Post-stream transforms can then edit only the active continuation
+        # instead of duplicating this prefix into the last message.
+        self._finalized_overflow_prefix = ""
+        # Full filtered text for the active stream segment, independent of
+        # delivery chunking. When an exact chunk prefix cannot be recovered
+        # (fallback sends or code-fence-aware truncation), prefix-preserving
+        # transforms can still be delivered as an appendix without rewriting
+        # the final continuation with the entire response.
+        self._streamed_source_text = ""
         # True when the most recent _send_or_edit split-and-delivered across
         # continuation messages (the adapter adopted a new message id).
         self._last_edit_overflowed = False
@@ -324,6 +339,8 @@ class GatewayStreamConsumer:
             meta["reply_to_message_id"] = self._initial_reply_to_id
         if expect_edits:
             meta["expect_edits"] = True
+        if self._is_multi_chunk:
+            meta["multi_chunk"] = True
         if final:
             meta["notify"] = True
         return meta or None
@@ -342,6 +359,121 @@ class GatewayStreamConsumer:
     def message_id(self) -> str | None:
         """The Discord/chat message ID of the last-sent or edited message."""
         return self._message_id
+
+    async def edit_transformed_final(self, content: str) -> bool:
+        """Apply a post-stream transform to the active visible message.
+
+        After overflow, earlier chunks are immutable separate posts. For
+        prefix-preserving transforms, strip that sealed prefix and edit only
+        the last continuation. If an earlier chunk was rewritten, return False
+        so the caller can use its normal full-response fallback.
+        """
+        if not self._message_id:
+            return False
+        transformed = self._clean_for_display(content)
+        if self._is_multi_chunk:
+            if self._finalized_overflow_prefix:
+                if not transformed.startswith(self._finalized_overflow_prefix):
+                    return await self._send_transformed_replacement(transformed)
+                transformed = transformed[len(self._finalized_overflow_prefix):]
+                if not self._fits_single_message(transformed):
+                    streamed = self._clean_for_display(self._streamed_source_text)
+                    full_transformed = self._clean_for_display(content)
+                    if streamed and full_transformed.startswith(streamed):
+                        appendix = full_transformed[len(streamed):]
+                        if not appendix.strip():
+                            return True
+                        return await self._send_transformed_appendix(appendix)
+                    return await self._send_transformed_replacement(full_transformed)
+            else:
+                streamed = self._clean_for_display(self._streamed_source_text)
+                if not streamed or not transformed.startswith(streamed):
+                    # Earlier messages cannot be rewritten safely. Never put
+                    # the full transformed response into only the final chunk.
+                    return await self._send_transformed_replacement(transformed)
+                appendix = transformed[len(streamed):]
+                if not appendix.strip():
+                    return True
+                return await self._send_transformed_appendix(appendix)
+        result = await self._edit_message(
+            message_id=self._message_id,
+            content=transformed,
+            finalize=True,
+        )
+        return bool(getattr(result, "success", False))
+
+    def _fits_single_message(self, content: str) -> bool:
+        """Return whether *content* is safe for one platform edit."""
+        limit = getattr(self.adapter, "MAX_MESSAGE_LENGTH", 4096)
+        len_fn = getattr(self.adapter, "message_len_fn", None)
+        try:
+            measured = len_fn(content) if callable(len_fn) else len(content)
+            return int(measured) <= int(limit)
+        except (TypeError, ValueError):
+            return len(content) <= 4096
+
+    async def _send_transformed_appendix(self, appendix: str) -> bool:
+        """Send an append-only transform as a fresh plain continuation."""
+        result = await self.adapter.send(
+            chat_id=self.chat_id,
+            content=appendix,
+            metadata=self._metadata_for_send(final=True),
+        )
+        if not getattr(result, "success", False):
+            return False
+        self._message_id = getattr(result, "message_id", None)
+        self._last_sent_text = appendix
+        self._track_preview_id(self._message_id)
+        self._already_sent = True
+        self._final_response_sent = True
+        self._final_content_delivered = True
+        self._notify_new_message()
+        return True
+
+    async def _send_transformed_replacement(self, transformed: str) -> bool:
+        """Send a plain replacement, then retire obsolete streamed chunks.
+
+        A non-prefix-preserving transform cannot be represented by editing only
+        the final continuation. Send the corrected response first (so cleanup
+        can never cause data loss), force multi-message/plain metadata, and
+        best-effort delete the obsolete preview chunks on capable platforms.
+        """
+        obsolete_ids = set(self._segment_preview_message_ids)
+        if self._message_id and self._message_id != "__no_edit__":
+            obsolete_ids.add(str(self._message_id))
+        result = await self.adapter.send(
+            chat_id=self.chat_id,
+            content=transformed,
+            metadata=self._metadata_for_send(final=True),
+        )
+        if not getattr(result, "success", False):
+            return False
+
+        replacement_id = getattr(result, "message_id", None)
+        delete_fn = getattr(self.adapter, "delete_message", None)
+        if callable(delete_fn):
+            for message_id in obsolete_ids:
+                if replacement_id and str(message_id) == str(replacement_id):
+                    continue
+                try:
+                    await delete_fn(self.chat_id, message_id)
+                except Exception:
+                    logger.debug(
+                        "Transformed-response cleanup failed for %s",
+                        message_id,
+                        exc_info=True,
+                    )
+
+        self._preview_message_ids.difference_update(obsolete_ids)
+        self._segment_preview_message_ids.difference_update(obsolete_ids)
+        self._message_id = replacement_id
+        self._last_sent_text = transformed
+        self._track_preview_id(replacement_id)
+        self._already_sent = True
+        self._final_response_sent = True
+        self._final_content_delivered = True
+        self._notify_new_message()
+        return True
 
     @property
     def final_content_delivered(self) -> bool:
@@ -380,14 +512,17 @@ class GatewayStreamConsumer:
         # must accept finalize= even when it is False (guarded by tests).
         kwargs["finalize"] = finalize
 
-        if self.metadata:
+        edit_metadata = dict(self.metadata) if self.metadata else {}
+        if self._is_multi_chunk:
+            edit_metadata["multi_chunk"] = True
+        if edit_metadata:
             try:
                 params = inspect.signature(self.adapter.edit_message).parameters
                 if "metadata" in params or any(
                     param.kind is inspect.Parameter.VAR_KEYWORD
                     for param in params.values()
                 ):
-                    kwargs["metadata"] = self.metadata
+                    kwargs["metadata"] = edit_metadata
             except (TypeError, ValueError):
                 pass
         return await self.adapter.edit_message(**kwargs)
@@ -481,6 +616,8 @@ class GatewayStreamConsumer:
         self._fallback_final_send = False
         self._fallback_prefix = ""
         self._fallback_preserve_partial_messages = False
+        self._finalized_overflow_prefix = ""
+        self._streamed_source_text = ""
         self._segment_preview_message_ids = set()
         # #29346: a tool/segment boundary means what we delivered was an interim
         # preamble, not the final answer — clear the flags so a premature setter
@@ -738,7 +875,12 @@ class GatewayStreamConsumer:
                             got_segment_break = True
                             flush_event = item[1]
                             break
+                        before = self._accumulated
                         self._filter_and_accumulate(item)
+                        if self._accumulated.startswith(before):
+                            self._streamed_source_text += self._accumulated[
+                                len(before):
+                            ]
                     except queue.Empty:
                         break
 
@@ -746,7 +888,10 @@ class GatewayStreamConsumer:
                 # so trailing text that was waiting for a potential open
                 # tag is not lost.
                 if got_done:
+                    before = self._accumulated
                     self._flush_think_buffer()
+                    if self._accumulated.startswith(before):
+                        self._streamed_source_text += self._accumulated[len(before):]
 
                     # Intentional-silence suppression.  When the agent chose
                     # not to reply it emits a bare control marker (NO_REPLY /
@@ -803,6 +948,8 @@ class GatewayStreamConsumer:
                 ):
                     should_edit = False
                 if should_edit and self._accumulated:
+                    if _len_fn(self._accumulated) > _safe_limit:
+                        self._is_multi_chunk = True
                     # Split overflow: if accumulated text exceeds the platform
                     # limit, split into properly sized chunks.
                     if (
@@ -810,14 +957,14 @@ class GatewayStreamConsumer:
                         and self._message_id is None
                     ):
                         # No existing message to edit (first message or after a
-                        # segment break).  Seal only the overflowing head chunks
-                        # as fixed messages, then keep the trailing chunk in
-                        # _accumulated so the normal send/edit path below makes
-                        # it the active preview.  That lets chunk 2, 3, ... keep
-                        # updating in-place as later streamed deltas arrive
-                        # instead of posting every split as an immutable message.
+                        # segment break). Seal only the overflowing head chunks
+                        # as fixed messages, then keep the trailing chunk active
+                        # so later deltas continue editing it in place. Preserve
+                        # the original source boundary for safe post-stream
+                        # transformations independently of adapter formatting.
+                        overflow_source = self._accumulated
                         chunks = self._truncate_for_stream(
-                            self._accumulated, _safe_limit, _len_fn,
+                            overflow_source, _safe_limit, _len_fn,
                         )
                         if len(chunks) <= 1:
                             # A malformed/legacy adapter result must not leave
@@ -845,6 +992,18 @@ class GatewayStreamConsumer:
                             reply_to = new_id
 
                         if all_heads_delivered:
+                            # Recover the exact original prefix represented by
+                            # the sealed posts. Adapter splitters may append a
+                            # trailing ``(N/N)`` indicator to the visible tail;
+                            # strip it only for source-boundary lookup.
+                            last_visible = re.sub(
+                                r" \(\d+/\d+\)$", "", chunks[-1]
+                            )
+                            last_start = overflow_source.rfind(last_visible)
+                            if last_start >= 0:
+                                self._finalized_overflow_prefix = overflow_source[
+                                    :last_start
+                                ]
                             self._accumulated = chunks[-1]
                             # The head chunks are sealed.  Clear the edit target
                             # so the remaining tail is sent as a fresh active
@@ -923,7 +1082,15 @@ class GatewayStreamConsumer:
                             # fallback final-send path can deliver the remaining
                             # continuation without dropping content.
                             break
-                        self._accumulated = self._accumulated[split_at:].lstrip("\n")
+                        remainder = self._accumulated[split_at:]
+                        stripped_remainder = remainder.lstrip("\n")
+                        stripped_separator = remainder[:
+                            len(remainder) - len(stripped_remainder)
+                        ]
+                        self._finalized_overflow_prefix += (
+                            self._accumulated[:split_at] + stripped_separator
+                        )
+                        self._accumulated = stripped_remainder
                         self._message_id = None
                         self._last_sent_text = ""
 
@@ -1339,8 +1506,12 @@ class GatewayStreamConsumer:
                 logger.debug("per-chat limit resolution failed: %s", e)
         safe_limit = max(500, raw_limit - 100)
         chunks = self._split_text_chunks(continuation, safe_limit, len_fn=_len_fn)
-
         stale_message_id = self._message_id  # partial message to clean up
+        # Even one continuation chunk is part of a multi-post response when a
+        # visible partial remains as its prefix.
+        if len(chunks) > 1 or (chunks and stale_message_id):
+            self._is_multi_chunk = True
+
         last_message_id: Optional[str] = None
         last_successful_chunk = ""
         sent_any_chunk = False
@@ -1388,6 +1559,7 @@ class GatewayStreamConsumer:
             sent_any_chunk = True
             last_successful_chunk = chunk
             last_message_id = result.message_id or last_message_id
+            self._track_preview_id(result.message_id)
             # Each fallback chunk is a fresh platform message — notify
             # so any stale tool-progress bubble gets closed off.
             self._notify_new_message()
@@ -1634,11 +1806,14 @@ class GatewayStreamConsumer:
         tail = self._clean_for_display(tail)
         if not tail.strip():
             return
+        # This tail follows an already visible partial message, so it and every
+        # later segment in the turn belong to a multi-post response.
+        self._is_multi_chunk = True
         try:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=tail,
-                metadata=self.metadata,
+                metadata=self._metadata_for_send(),
             )
             if result.success:
                 self._already_sent = True
@@ -1671,11 +1846,14 @@ class GatewayStreamConsumer:
         text = self._clean_for_display(text)
         if not text.strip():
             return False
+        # Commentary plus the eventual answer is a multi-message response.
+        # Mark it before either send so rich adapters keep every post plain.
+        self._is_multi_chunk = True
         try:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
-                metadata=self.metadata,
+                metadata=self._metadata_for_send(expect_edits=True),
             )
             # Note: do NOT set _already_sent = True here.
             # Commentary messages are interim status updates (e.g. "Using browser

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -19,6 +19,7 @@ import asyncio
 import inspect
 import logging
 import queue
+import re
 import threading
 import time
 from dataclasses import dataclass
@@ -413,22 +414,58 @@ class GatewayStreamConsumer:
         except (TypeError, ValueError):
             return len(content) <= 4096
 
+    def _split_transformed_content(self, content: str) -> list[str]:
+        """Split transformed delivery through the platform-safe chunking rail."""
+        raw_limit = getattr(self.adapter, "MAX_MESSAGE_LENGTH", 4096)
+        len_fn: "Callable[[str], int]" = len
+        if isinstance(self.adapter, _BasePlatformAdapter):
+            try:
+                raw_limit = self.adapter.max_message_length_for_chat(self.chat_id)
+                len_fn = self.adapter.message_len_fn_for_chat(self.chat_id)
+            except Exception as exc:
+                logger.debug("per-chat transformed limit resolution failed: %s", exc)
+        try:
+            safe_limit = max(1, int(raw_limit) - 100)
+        except (TypeError, ValueError):
+            safe_limit = 3996
+        chunks = self._truncate_for_stream(content, safe_limit, len_fn)
+        if not chunks or any(len_fn(chunk) > safe_limit for chunk in chunks):
+            chunks = self._split_text_chunks(content, safe_limit, len_fn)
+        return chunks
+
+    async def _send_transformed_chunks(self, content: str) -> Optional[list[str]]:
+        """Deliver every transformed chunk, returning IDs only on full success."""
+        chunks = self._split_transformed_content(content)
+        if not chunks:
+            return []
+        if len(chunks) > 1:
+            self._is_multi_chunk = True
+        message_ids: list[str] = []
+        for chunk in chunks:
+            result = await self.adapter.send(
+                chat_id=self.chat_id,
+                content=chunk,
+                metadata=self._metadata_for_send(final=True),
+            )
+            if not getattr(result, "success", False):
+                return None
+            message_id = getattr(result, "message_id", None)
+            if message_id:
+                message_ids.append(str(message_id))
+                self._track_preview_id(message_id)
+            self._message_id = message_id or self._message_id
+            self._last_sent_text = chunk
+            self._already_sent = True
+            self._notify_new_message()
+        return message_ids
+
     async def _send_transformed_appendix(self, appendix: str) -> bool:
         """Send an append-only transform as a fresh plain continuation."""
-        result = await self.adapter.send(
-            chat_id=self.chat_id,
-            content=appendix,
-            metadata=self._metadata_for_send(final=True),
-        )
-        if not getattr(result, "success", False):
+        message_ids = await self._send_transformed_chunks(appendix)
+        if message_ids is None:
             return False
-        self._message_id = getattr(result, "message_id", None)
-        self._last_sent_text = appendix
-        self._track_preview_id(self._message_id)
-        self._already_sent = True
         self._final_response_sent = True
         self._final_content_delivered = True
-        self._notify_new_message()
         return True
 
     async def _send_transformed_replacement(self, transformed: str) -> bool:
@@ -442,19 +479,15 @@ class GatewayStreamConsumer:
         obsolete_ids = set(self._segment_preview_message_ids)
         if self._message_id and self._message_id != "__no_edit__":
             obsolete_ids.add(str(self._message_id))
-        result = await self.adapter.send(
-            chat_id=self.chat_id,
-            content=transformed,
-            metadata=self._metadata_for_send(final=True),
-        )
-        if not getattr(result, "success", False):
+        replacement_ids = await self._send_transformed_chunks(transformed)
+        if replacement_ids is None:
             return False
 
-        replacement_id = getattr(result, "message_id", None)
+        replacement_id_set = set(replacement_ids)
         delete_fn = getattr(self.adapter, "delete_message", None)
         if callable(delete_fn):
             for message_id in obsolete_ids:
-                if replacement_id and str(message_id) == str(replacement_id):
+                if str(message_id) in replacement_id_set:
                     continue
                 try:
                     await delete_fn(self.chat_id, message_id)
@@ -467,13 +500,8 @@ class GatewayStreamConsumer:
 
         self._preview_message_ids.difference_update(obsolete_ids)
         self._segment_preview_message_ids.difference_update(obsolete_ids)
-        self._message_id = replacement_id
-        self._last_sent_text = transformed
-        self._track_preview_id(replacement_id)
-        self._already_sent = True
         self._final_response_sent = True
         self._final_content_delivered = True
-        self._notify_new_message()
         return True
 
     @property

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -9,17 +9,27 @@ Environment variables:
     MATTERMOST_TOKEN            Bot token or personal-access token
     MATTERMOST_ALLOWED_USERS    Comma-separated user IDs
     MATTERMOST_HOME_CHANNEL     Channel ID for cron/notification delivery
+    MATTERMOST_OBSERVE_UNMENTIONED_CHANNEL_MESSAGES
+                                Observe authorized unmentioned posts in allowlisted channels
 """
 
 from __future__ import annotations
 
 import asyncio
+import dataclasses
+import hashlib
+import hmac
+import ipaddress
 import json
 import logging
 import os
 import re
+import secrets
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.helpers import MessageDeduplicator
@@ -102,6 +112,10 @@ class MattermostAdapter(BasePlatformAdapter):
 
         self._bot_user_id: str = ""
         self._bot_username: str = ""
+        # Passive observation is restricted to human senders. Cache successful
+        # Mattermost user lookups so ordinary channel chatter does not require
+        # one API request per post. Lookup failures are deliberately not cached.
+        self._sender_is_bot_cache: Dict[str, bool] = {}
 
         # aiohttp session + websocket handle
         self._session: Any = None  # aiohttp.ClientSession
@@ -118,9 +132,76 @@ class MattermostAdapter(BasePlatformAdapter):
 
         self._last_post_status: Optional[int] = None
         self._last_post_error: str = ""
+        self._interaction_url = str(config.extra.get("interaction_url") or "").strip()
+        parsed_interaction_url = urlparse(self._interaction_url)
+        interaction_hostname = parsed_interaction_url.hostname or ""
+        try:
+            interaction_is_loopback = ipaddress.ip_address(
+                interaction_hostname
+            ).is_loopback
+        except ValueError:
+            interaction_is_loopback = interaction_hostname == "localhost" or (
+                interaction_hostname.endswith(".localhost")
+            )
+        interaction_transport_safe = parsed_interaction_url.scheme == "https" or (
+            parsed_interaction_url.scheme == "http" and interaction_is_loopback
+        )
+        self._interaction_url_valid = bool(
+            interaction_transport_safe
+            and interaction_hostname
+            and not parsed_interaction_url.username
+            and not parsed_interaction_url.password
+        )
+        self._interaction_host = str(
+            config.extra.get("interaction_host") or "127.0.0.1"
+        ).strip()
+        try:
+            self._interaction_port = int(config.extra.get("interaction_port", 8789))
+        except (TypeError, ValueError):
+            self._interaction_port = 8789
+        self._interaction_path = parsed_interaction_url.path or "/mattermost/actions"
+        trusted_raw = config.extra.get("interaction_allowed_cidrs", ())
+        if isinstance(trusted_raw, str):
+            trusted_values = trusted_raw.split(",")
+        elif isinstance(trusted_raw, (list, tuple, set)):
+            trusted_values = trusted_raw
+        else:
+            trusted_values = ()
+        self._interaction_allowed_networks = []
+        for value in trusted_values:
+            try:
+                self._interaction_allowed_networks.append(
+                    ipaddress.ip_network(str(value).strip(), strict=False)
+                )
+            except ValueError:
+                logger.warning(
+                    "Mattermost: ignoring invalid interaction_allowed_cidrs entry: %r",
+                    value,
+                )
+        try:
+            self._interaction_timeout_seconds = max(
+                30,
+                min(3600, int(config.extra.get("interaction_timeout_seconds", 300))),
+            )
+        except (TypeError, ValueError):
+            self._interaction_timeout_seconds = 300
+        self._interaction_runner: Any = None
+        self._interaction_start_failed = False
+        self._pending_interactions: Dict[str, Dict[str, Any]] = {}
+        self._rich_posts = str(config.extra.get("rich_posts", "false")).lower() in {
+            "true", "1", "yes", "on",
+        }
+        self._feedback_buttons = str(
+            config.extra.get("feedback_buttons", "false")
+        ).lower() in {"true", "1", "yes", "on"}
 
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
+
+    @property
+    def REQUIRES_EDIT_FINALIZE(self) -> bool:  # noqa: N802
+        """Rich posts need a final edit even when streamed text is unchanged."""
+        return self._rich_posts
 
     # ------------------------------------------------------------------
     # HTTP helpers
@@ -254,6 +335,34 @@ class MattermostAdapter(BasePlatformAdapter):
             logger.error("MM API PUT %s network error: %s", path, exc)
             return {}
 
+    async def _api_delete(self, path: str) -> bool:
+        """DELETE /api/v4/{path}."""
+        import aiohttp
+
+        if ".." in path:
+            logger.error("MM API path traversal blocked: %s", path)
+            return False
+        url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
+        try:
+            async with self._session.delete(
+                url,
+                headers=self._headers(),
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    logger.error(
+                        "MM API DELETE %s → %s: %s",
+                        path,
+                        resp.status,
+                        body[:200],
+                    )
+                    return False
+                return True
+        except aiohttp.ClientError as exc:
+            logger.error("MM API DELETE %s network error: %s", path, exc)
+            return False
+
     async def _upload_file(
         self, channel_id: str, file_data: bytes, filename: str, content_type: str = "application/octet-stream"
     ) -> Optional[str]:
@@ -312,6 +421,13 @@ class MattermostAdapter(BasePlatformAdapter):
             self._base_url,
         )
 
+        if self._interactions_available():
+            try:
+                await self._start_interaction_server()
+            except Exception as exc:
+                self._interaction_start_failed = True
+                logger.error("Mattermost: failed to start interaction endpoint: %s", exc)
+
         # Start WebSocket in background.
         self._ws_task = asyncio.create_task(self._ws_loop())
         self._mark_connected()
@@ -334,6 +450,8 @@ class MattermostAdapter(BasePlatformAdapter):
         if self._ws:
             await self._ws.close()
             self._ws = None
+
+        await self._stop_interaction_server()
 
         if self._session and not self._session.closed:
             await self._session.close()
@@ -364,30 +482,568 @@ class MattermostAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send a message (or multiple chunks) to a channel."""
+        """Send messages with optional Mattermost-native rich attachments."""
         if not content:
             return SendResult(success=True)
 
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, MAX_POST_LENGTH)
-
         last_id = None
         for chunk in chunks:
-            payload: Dict[str, Any] = _with_mentions_disabled({
-                "channel_id": chat_id,
-                "message": chunk,
-            })
+            payload: Dict[str, Any] = {"channel_id": chat_id, "message": chunk}
+            nonce = ""
+            force_plain = bool(
+                metadata
+                and (metadata.get("expect_edits") or metadata.get("multi_chunk"))
+            )
+            if self._rich_posts and len(chunks) == 1 and not force_plain:
+                actions = None
+                if self._feedback_buttons and self._interactions_available():
+                    nonce, actions = self._build_feedback_actions(chat_id)
+                try:
+                    from plugins.platforms.mattermost.rich_posts import (
+                        render_rich_post,
+                    )
+
+                    rendered = render_rich_post(chunk, actions=actions)
+                except Exception:
+                    logger.warning(
+                        "Mattermost: rich-post rendering failed; using Markdown",
+                        exc_info=True,
+                    )
+                    rendered = None
+                if rendered:
+                    payload.update(rendered)
+                    if nonce:
+                        attachment = payload["props"]["attachments"][0]
+                        remembered = self._remember_interaction(
+                            nonce,
+                            {
+                                "kind": "feedback",
+                                "channel_id": chat_id,
+                                "post_id": "",
+                                "expires_at": attachment["actions"][0]["integration"]["context"][
+                                    "expires_at"
+                                ],
+                                "choices": ["helpful", "not_helpful"],
+                                "attachment": attachment,
+                            },
+                        )
+                        if not remembered:
+                            attachment.pop("actions", None)
+                            nonce = ""
+
+            payload = _with_mentions_disabled(payload)
             # Thread support: reply_to or metadata["thread_id"] is the root post ID.
             resolved_root = await self._thread_root_for_send(reply_to, metadata)
             if resolved_root:
                 payload["root_id"] = resolved_root
 
             data = await self._post_preserving_thread(chat_id, payload, metadata)
+            if not data and (payload.get("props") or {}).get("attachments"):
+                if nonce:
+                    self._pending_interactions.pop(nonce, None)
+                plain_payload = dict(payload)
+                plain_payload.pop("props", None)
+                plain_payload["message"] = chunk
+                plain_payload = _with_mentions_disabled(plain_payload)
+                logger.warning(
+                    "Mattermost: rich post failed; retrying with plain Markdown"
+                )
+                data = await self._post_preserving_thread(
+                    chat_id, plain_payload, metadata
+                )
             if not data or "id" not in data:
+                if nonce:
+                    self._pending_interactions.pop(nonce, None)
                 return SendResult(success=False, error="Failed to create post")
             last_id = data["id"]
+            if nonce and nonce in self._pending_interactions:
+                self._pending_interactions[nonce]["post_id"] = last_id
 
         return SendResult(success=True, message_id=last_id)
+
+    # ------------------------------------------------------------------
+    # Native interactive approval support
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _secret_value(name: str) -> str:
+        """Read a secret through the authoritative profile-aware resolver."""
+        try:
+            from agent.secret_scope import get_secret
+        except ImportError:
+            # Defensive compatibility for loading this plugin outside the full
+            # Hermes package. In normal gateway operation the resolver exists.
+            return (os.getenv(name) or "").strip()
+
+        try:
+            value = get_secret(name)
+        except Exception:
+            # In multiplex mode an unscoped read is a security boundary, not a
+            # reason to fall back to another profile's process environment.
+            logger.warning("Mattermost: scoped secret lookup failed for %s", name)
+            return ""
+        return str(value).strip() if value is not None else ""
+
+    def _interaction_secret(self) -> str:
+        return self._secret_value("MATTERMOST_INTERACTION_SECRET")
+
+    def _interactions_available(self) -> bool:
+        """Return whether signed Mattermost callbacks are configured."""
+        return bool(
+            self._interaction_url_valid
+            and self._interaction_secret()
+            and self._interaction_allowed_networks
+            and not self._interaction_start_failed
+        )
+
+    def _interaction_source_is_trusted(self, remote: Any) -> bool:
+        """Accept callbacks only from explicitly configured network peers."""
+        try:
+            address = ipaddress.ip_address(str(remote or ""))
+        except ValueError:
+            return False
+        if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped:
+            address = address.ipv4_mapped
+        return any(address in network for network in self._interaction_allowed_networks)
+
+    async def _handle_interaction_request(self, request: Any) -> Any:
+        """Handle Mattermost's bounded JSON action callback."""
+        from aiohttp import web
+
+        if not self._interaction_source_is_trusted(getattr(request, "remote", None)):
+            return web.json_response(
+                {"ephemeral_text": "Untrusted interaction source."}, status=403
+            )
+        if request.content_length is not None and request.content_length > 65_536:
+            return web.json_response(
+                {"ephemeral_text": "Interaction payload is too large."}, status=413
+            )
+        try:
+            payload = await request.json()
+        except web.HTTPRequestEntityTooLarge:
+            return web.json_response(
+                {"ephemeral_text": "Interaction payload is too large."}, status=413
+            )
+        except Exception:
+            return web.json_response(
+                {"ephemeral_text": "Invalid interaction payload."}, status=400
+            )
+        if not isinstance(payload, dict):
+            return web.json_response(
+                {"ephemeral_text": "Invalid interaction payload."}, status=400
+            )
+        body, status = await self._dispatch_interaction(payload)
+        return web.json_response(body, status=status)
+
+    async def _handle_interaction_health(self, _request: Any) -> Any:
+        from aiohttp import web
+
+        return web.json_response({"status": "ok", "platform": "mattermost"})
+
+    async def _start_interaction_server(self) -> None:
+        """Start the private callback listener used by Mattermost actions."""
+        if self._interaction_runner is not None or not self._interactions_available():
+            return
+        from aiohttp import web
+
+        app = web.Application(client_max_size=65_536)
+        app.router.add_post(self._interaction_path, self._handle_interaction_request)
+        app.router.add_get(
+            f"{self._interaction_path.rstrip('/')}/health",
+            self._handle_interaction_health,
+        )
+        runner = web.AppRunner(app)
+        await runner.setup()
+        try:
+            site = web.TCPSite(
+                runner, self._interaction_host, self._interaction_port
+            )
+            await site.start()
+        except Exception:
+            await runner.cleanup()
+            raise
+        self._interaction_runner = runner
+        logger.info(
+            "Mattermost: interaction endpoint listening on http://%s:%d%s",
+            self._interaction_host,
+            self._interaction_port,
+            self._interaction_path,
+        )
+
+    async def _stop_interaction_server(self) -> None:
+        """Stop the Mattermost callback listener, if it was started."""
+        runner = self._interaction_runner
+        self._interaction_runner = None
+        if runner is not None:
+            await runner.cleanup()
+
+    def _interaction_signature(
+        self,
+        *,
+        nonce: str,
+        kind: str,
+        choice: str,
+        channel_id: str,
+        expires_at: int,
+    ) -> str:
+        message = "\x00".join(
+            (nonce, kind, choice, channel_id, str(expires_at))
+        ).encode()
+        return hmac.new(
+            self._interaction_secret().encode(), message, hashlib.sha256
+        ).hexdigest()
+
+    def _build_interaction_action(
+        self,
+        *,
+        nonce: str,
+        kind: str,
+        choice: str,
+        channel_id: str,
+        name: str,
+        style: str = "default",
+        expires_at: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        if expires_at is None:
+            expires_at = int(time.time()) + self._interaction_timeout_seconds
+        context = {
+            "nonce": nonce,
+            "kind": kind,
+            "choice": choice,
+            "expires_at": expires_at,
+            "signature": self._interaction_signature(
+                nonce=nonce,
+                kind=kind,
+                choice=choice,
+                channel_id=channel_id,
+                expires_at=expires_at,
+            ),
+        }
+        return {
+            "id": f"hermes_{kind}_{choice}",
+            "type": "button",
+            "name": name,
+            "style": style,
+            "integration": {"url": self._interaction_url, "context": context},
+        }
+
+    def _build_feedback_actions(
+        self, channel_id: str
+    ) -> Tuple[str, List[Dict[str, Any]]]:
+        nonce = secrets.token_urlsafe(18)
+        expires_at = int(time.time()) + self._interaction_timeout_seconds
+        actions = [
+            self._build_interaction_action(
+                nonce=nonce,
+                kind="feedback",
+                choice="helpful",
+                channel_id=channel_id,
+                name="Helpful",
+                style="success",
+                expires_at=expires_at,
+            ),
+            self._build_interaction_action(
+                nonce=nonce,
+                kind="feedback",
+                choice="not_helpful",
+                channel_id=channel_id,
+                name="Not helpful",
+                style="default",
+                expires_at=expires_at,
+            ),
+        ]
+        return nonce, actions
+
+    def _remember_interaction(self, nonce: str, state: Dict[str, Any]) -> bool:
+        """Remember bounded, single-use callback state without evicting approvals for feedback."""
+        now = int(time.time())
+        for pending_nonce, pending_state in list(self._pending_interactions.items()):
+            if int(pending_state.get("expires_at") or 0) <= now:
+                self._pending_interactions.pop(pending_nonce, None)
+
+        if len(self._pending_interactions) >= 256:
+            feedback_nonce = next(
+                (
+                    pending_nonce
+                    for pending_nonce, pending_state in self._pending_interactions.items()
+                    if pending_state.get("kind") == "feedback"
+                ),
+                None,
+            )
+            if feedback_nonce is not None:
+                self._pending_interactions.pop(feedback_nonce, None)
+            elif state.get("kind") == "feedback":
+                return False
+            else:
+                self._pending_interactions.pop(next(iter(self._pending_interactions)))
+
+        self._pending_interactions[nonce] = state
+        return True
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+        allow_permanent: bool = True,
+        allow_session: bool = True,
+        smart_denied: bool = False,
+        approval_id: Optional[str] = None,
+    ) -> SendResult:
+        """Send a signed Mattermost attachment with approval buttons."""
+        if not self._interactions_available():
+            return SendResult(
+                success=False,
+                error=(
+                    "Mattermost interactions require a valid interaction_url, "
+                    "MATTERMOST_INTERACTION_SECRET, trusted interaction_allowed_cidrs, "
+                    "and a healthy callback listener"
+                ),
+            )
+        if not approval_id:
+            return SendResult(
+                success=False,
+                error="Mattermost interactive approvals require an exact approval ID",
+            )
+
+        nonce = secrets.token_urlsafe(18)
+        expires_at = int(time.time()) + self._interaction_timeout_seconds
+        actions = [
+            self._build_interaction_action(
+                nonce=nonce,
+                kind="approval",
+                choice="once",
+                channel_id=chat_id,
+                name="Allow Once",
+                style="primary",
+                expires_at=expires_at,
+            )
+        ]
+        if not smart_denied and allow_session:
+            actions.append(
+                self._build_interaction_action(
+                    nonce=nonce,
+                    kind="approval",
+                    choice="session",
+                    channel_id=chat_id,
+                    name="Allow Session",
+                    expires_at=expires_at,
+                )
+            )
+        if not smart_denied and allow_permanent:
+            actions.append(
+                self._build_interaction_action(
+                    nonce=nonce,
+                    kind="approval",
+                    choice="always",
+                    channel_id=chat_id,
+                    name="Always Allow",
+                    expires_at=expires_at,
+                )
+            )
+        actions.append(
+            self._build_interaction_action(
+                nonce=nonce,
+                kind="approval",
+                choice="deny",
+                channel_id=chat_id,
+                name="Deny",
+                style="danger",
+                expires_at=expires_at,
+            )
+        )
+
+        header = "**⚠️ Command Approval Required**"
+        if smart_denied:
+            header += "\n\n**Smart DENY:** owner override applies to this operation only."
+        command_preview = command[:6000] + ("…" if len(command) > 6000 else "")
+        text = (
+            f"{header}\n\n```\n{command_preview}\n```\n\n"
+            f"Reason: {description[:1000]}"
+        )
+        fallback = f"Command approval required: {command[:160]}"
+        attachment = {
+            "fallback": fallback,
+            "color": "warning",
+            "text": text,
+            "actions": actions,
+        }
+        payload: Dict[str, Any] = {
+            "channel_id": chat_id,
+            "message": fallback,
+            "props": {"attachments": [attachment]},
+        }
+        root_id = await self._thread_root_for_send(None, metadata)
+        if root_id:
+            payload["root_id"] = root_id
+
+        self._remember_interaction(
+            nonce,
+            {
+                "kind": "approval",
+                "channel_id": chat_id,
+                "post_id": "",
+                "session_key": session_key,
+                "approval_id": approval_id,
+                "expires_at": expires_at,
+                "choices": [
+                    action["integration"]["context"]["choice"] for action in actions
+                ],
+                "attachment": attachment,
+            },
+        )
+        data = await self._post_preserving_thread(chat_id, payload, metadata)
+        post_id = str(data.get("id") or "") if data else ""
+        if not post_id:
+            self._pending_interactions.pop(nonce, None)
+            return SendResult(success=False, error="Failed to post Mattermost approval")
+        self._pending_interactions[nonce]["post_id"] = post_id
+        return SendResult(success=True, message_id=post_id, raw_response=data)
+
+    def _is_interactive_user_authorized(
+        self,
+        user_id: str,
+        *,
+        channel_id: str = "",
+        user_name: Optional[str] = None,
+        team_id: str = "",
+    ) -> bool:
+        """Apply the profile-bound gateway policy to action callbacks."""
+        normalized_user_id = str(user_id or "").strip()
+        if not normalized_user_id:
+            return False
+        # GatewayRunner installs this callback with its bound profile name, so
+        # it consults the correct profile's allowlist and pairing store. Never
+        # reconstruct a profile-less SessionSource or fall back to global env
+        # authorization for a command-approval callback.
+        return (
+            self._is_sender_authorized(
+                normalized_user_id,
+                "group",
+                str(channel_id or normalized_user_id),
+            )
+            is True
+        )
+
+    async def _dispatch_interaction(
+        self, payload: Dict[str, Any]
+    ) -> Tuple[Dict[str, Any], int]:
+        """Validate and execute one Mattermost interaction callback."""
+        context = payload.get("context")
+        if not isinstance(context, dict):
+            return {"ephemeral_text": "Invalid or expired Hermes action."}, 401
+        nonce = str(context.get("nonce") or "")
+        kind = str(context.get("kind") or "")
+        choice = str(context.get("choice") or "")
+        supplied_signature = str(context.get("signature") or "")
+        raw_expires_at = context.get("expires_at")
+        if not isinstance(raw_expires_at, (int, str)):
+            return {"ephemeral_text": "Invalid Hermes action."}, 401
+        try:
+            expires_at = int(raw_expires_at)
+        except (TypeError, ValueError):
+            return {"ephemeral_text": "Invalid Hermes action."}, 401
+        state = self._pending_interactions.get(nonce)
+        if not state:
+            return {"ephemeral_text": "This Hermes action has expired."}, 200
+
+        channel_id = str(payload.get("channel_id") or "")
+        post_id = str(payload.get("post_id") or "")
+        expected_signature = self._interaction_signature(
+            nonce=nonce,
+            kind=kind,
+            choice=choice,
+            channel_id=channel_id,
+            expires_at=expires_at,
+        )
+        if not supplied_signature or not hmac.compare_digest(
+            supplied_signature, expected_signature
+        ):
+            return {"ephemeral_text": "Invalid Hermes action."}, 401
+        if (
+            kind != state.get("kind")
+            or choice not in state.get("choices", ())
+            or expires_at != state.get("expires_at")
+            or channel_id != state.get("channel_id")
+            or post_id != state.get("post_id")
+        ):
+            return {"ephemeral_text": "Invalid Hermes action target."}, 401
+        if time.time() > expires_at:
+            self._pending_interactions.pop(nonce, None)
+            return {"ephemeral_text": "This Hermes action has expired."}, 200
+
+        user_id = str(payload.get("user_id") or "")
+        user_name = str(payload.get("user_name") or user_id or "unknown")
+        if not self._is_interactive_user_authorized(
+            user_id,
+            channel_id=channel_id,
+            user_name=user_name,
+            team_id=str(payload.get("team_id") or ""),
+        ):
+            return {"ephemeral_text": "You are not authorized for this action."}, 403
+
+        if kind == "feedback" and choice in {"helpful", "not_helpful"}:
+            state = self._pending_interactions.pop(nonce, None)
+            if not state:
+                return {"ephemeral_text": "This Hermes action has expired."}, 200
+            logger.info(
+                "Mattermost feedback clicked: value=%s user=%s channel=%s post=%s",
+                choice,
+                user_id,
+                channel_id,
+                post_id,
+            )
+            resolved_attachment = dict(state["attachment"])
+            resolved_attachment.pop("actions", None)
+            return {
+                "ephemeral_text": "Thanks for the feedback.",
+                "update": {
+                    "message": str(resolved_attachment.get("fallback") or ""),
+                    "props": {"attachments": [resolved_attachment]},
+                },
+            }, 200
+
+        if kind != "approval" or choice not in {"once", "session", "always", "deny"}:
+            return {"ephemeral_text": "Invalid Hermes action."}, 400
+
+        state = self._pending_interactions.pop(nonce, None)
+        if not state:
+            return {"ephemeral_text": "This Hermes action has expired."}, 200
+        try:
+            from tools.approval import resolve_gateway_approval
+
+            count = resolve_gateway_approval(
+                str(state["session_key"]),
+                choice,
+                approval_id=str(state["approval_id"]),
+            )
+        except Exception:
+            logger.exception("Mattermost: failed to resolve approval callback")
+            count = 0
+
+        label_map = {
+            "once": f"✅ Approved once by {user_name}",
+            "session": f"✅ Approved for session by {user_name}",
+            "always": f"✅ Approved permanently by {user_name}",
+            "deny": f"❌ Denied by {user_name}",
+        }
+        decision = label_map[choice]
+        if not count:
+            decision = "⌛ Approval expired — command was not run."
+        else:
+            self.resume_typing_for_chat(channel_id)
+        resolved_attachment = dict(state["attachment"])
+        resolved_attachment.pop("actions", None)
+        return {
+            "update": {
+                "message": decision,
+                "props": {"attachments": [resolved_attachment]},
+            }
+        }, 200
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return channel name and type."""
@@ -413,17 +1069,79 @@ class MattermostAdapter(BasePlatformAdapter):
         )
 
     async def edit_message(
-        self, chat_id: str, message_id: str, content: str, *, finalize: bool = False
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Edit an existing post."""
+        """Edit a post; render rich structure only for a single final chunk."""
         formatted = self.format_message(content)
-        data = await self._api_put(
-            f"posts/{message_id}/patch",
-            _with_mentions_disabled({"message": formatted}),
-        )
+        payload: Dict[str, Any] = {"message": formatted}
+        nonce = ""
+        multi_chunk = bool((metadata or {}).get("multi_chunk"))
+        if finalize and self._rich_posts and not multi_chunk:
+            actions = None
+            if self._feedback_buttons and self._interactions_available():
+                nonce, actions = self._build_feedback_actions(chat_id)
+            try:
+                from plugins.platforms.mattermost.rich_posts import (
+                    render_rich_post,
+                )
+
+                rendered = render_rich_post(formatted, actions=actions)
+            except Exception:
+                logger.warning(
+                    "Mattermost: final rich-post edit failed to render",
+                    exc_info=True,
+                )
+                rendered = None
+            if rendered:
+                payload.update(rendered)
+                if nonce:
+                    attachment = payload["props"]["attachments"][0]
+                    remembered = self._remember_interaction(
+                        nonce,
+                        {
+                            "kind": "feedback",
+                            "channel_id": chat_id,
+                            "post_id": message_id,
+                            "expires_at": attachment["actions"][0]["integration"][
+                                "context"
+                            ]["expires_at"],
+                            "choices": ["helpful", "not_helpful"],
+                            "attachment": attachment,
+                        },
+                    )
+                    if not remembered:
+                        attachment.pop("actions", None)
+                        nonce = ""
+
+        payload = _with_mentions_disabled(payload)
+        data = await self._api_put(f"posts/{message_id}/patch", payload)
+        if not data and (payload.get("props") or {}).get("attachments"):
+            if nonce:
+                self._pending_interactions.pop(nonce, None)
+            data = await self._api_put(
+                f"posts/{message_id}/patch",
+                _with_mentions_disabled({"message": formatted, "props": {}}),
+            )
         if not data or "id" not in data:
+            if nonce:
+                self._pending_interactions.pop(nonce, None)
             return SendResult(success=False, error="Failed to edit post")
         return SendResult(success=True, message_id=data["id"])
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a Mattermost post used as an obsolete streaming chunk."""
+        del chat_id  # Mattermost deletes posts by globally unique post ID.
+        post_id = str(message_id or "")
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", post_id):
+            logger.warning("Mattermost: refusing malformed post ID for deletion")
+            return False
+        return await self._api_delete(f"posts/{post_id}")
 
     async def send_image(
         self,
@@ -784,6 +1502,190 @@ class MattermostAdapter(BasePlatformAdapter):
                 logger.info("Mattermost: WebSocket closed (%s)", raw_msg.type)
                 break
 
+    @staticmethod
+    def _mattermost_bool(value: Any, *, default: bool = False) -> bool:
+        if value is None:
+            return default
+        if isinstance(value, str):
+            return value.strip().lower() in {"true", "1", "yes", "on"}
+        return bool(value)
+
+    def _mattermost_config_value(self, key: str, env_name: str) -> Any:
+        env_value = os.getenv(env_name)
+        if env_value not in {None, ""}:
+            return env_value
+        return (self.config.extra or {}).get(key)
+
+    def _mattermost_channel_set(self, key: str, env_name: str) -> set[str]:
+        raw = self._mattermost_config_value(key, env_name)
+        if isinstance(raw, (list, tuple, set)):
+            return {str(value).strip() for value in raw if str(value).strip()}
+        return {value.strip() for value in str(raw or "").split(",") if value.strip()}
+
+    def _mattermost_require_mention(self) -> bool:
+        return self._mattermost_bool(
+            self._mattermost_config_value("require_mention", "MATTERMOST_REQUIRE_MENTION"),
+            default=True,
+        )
+
+    def _mattermost_observe_unmentioned_channel_messages(self) -> bool:
+        """Whether eligible unmentioned channel posts are persisted as context."""
+        configured = self._mattermost_config_value(
+            "observe_unmentioned_channel_messages",
+            "MATTERMOST_OBSERVE_UNMENTIONED_CHANNEL_MESSAGES",
+        )
+        return self._mattermost_bool(configured)
+
+    def _mattermost_observation_enabled(
+        self, channel_id: str, allowed_channels: set[str]
+    ) -> bool:
+        """Fail closed unless passive observation has an explicit channel scope."""
+        return bool(
+            self._mattermost_observe_unmentioned_channel_messages()
+            and allowed_channels
+            and channel_id in allowed_channels
+        )
+
+    @staticmethod
+    def _mattermost_post_has_automation_marker(post: Dict[str, Any]) -> bool:
+        """Return True for incoming-webhook or explicitly bot-marked posts."""
+        props = post.get("props") or {}
+        if isinstance(props, str):
+            try:
+                props = json.loads(props)
+            except (TypeError, ValueError):
+                # Malformed automation metadata is not trustworthy enough for
+                # passive persistence. Fail closed.
+                return True
+        if not isinstance(props, dict):
+            return True
+        return any(
+            MattermostAdapter._mattermost_bool(props.get(key))
+            for key in ("from_webhook", "from_bot")
+        )
+
+    async def _mattermost_observation_sender_is_human(
+        self, post: Dict[str, Any]
+    ) -> bool:
+        """Verify that a passive-observation candidate came from a human.
+
+        Authorization and human-vs-automation are separate gates: an allowlisted
+        bot or webhook must still never enter shared passive context.
+        """
+        if self._mattermost_post_has_automation_marker(post):
+            return False
+        sender_id = str(post.get("user_id") or "").strip()
+        if not sender_id:
+            return False
+        cached = self._sender_is_bot_cache.get(sender_id)
+        if cached is not None:
+            return not cached
+        try:
+            user = await self._api_get(f"users/{sender_id}")
+        except Exception:
+            logger.warning(
+                "Mattermost: sender lookup failed; skipping passive observation "
+                "(user=%s)",
+                sender_id,
+                exc_info=True,
+            )
+            return False
+        if (
+            not isinstance(user, dict)
+            or type(user.get("is_bot")) is not bool
+        ):
+            logger.warning(
+                "Mattermost: sender lookup lacked a boolean is_bot; skipping passive "
+                "observation (user=%s)",
+                sender_id,
+            )
+            return False
+        is_bot = user["is_bot"]
+        if len(self._sender_is_bot_cache) >= 4096:
+            self._sender_is_bot_cache.pop(next(iter(self._sender_is_bot_cache)))
+        self._sender_is_bot_cache[sender_id] = is_bot
+        return not is_bot
+
+    def _mattermost_thread_id(self, post: Dict[str, Any], chat_type: str) -> Optional[str]:
+        thread_id = post.get("root_id") or None
+        if not thread_id and self._reply_mode == "thread" and chat_type != "dm":
+            thread_id = post.get("id") or None
+        return thread_id
+
+    @staticmethod
+    def _mattermost_observed_attributed_text(
+        sender_name: str, sender_id: str, message_text: str
+    ) -> str:
+        sender = sender_name or sender_id or "unknown"
+        user_id = sender_id or "unknown"
+        return f"[{sender}|{user_id}]\n{message_text}"
+
+    def _mattermost_observed_channel_prompt(self) -> str:
+        return (
+            "You are handling a Mattermost channel message.\n"
+            f"- Your identity: user_id={self._bot_user_id}, @-mention name "
+            f"in this workspace=@{self._bot_username}.\n"
+            "- observed Mattermost channel context may be provided in a separate "
+            "context-only block before the current message; it is not necessarily "
+            "addressed to you.\n"
+            "- Treat only the current addressed message as a request, and use "
+            "observed context only when that message asks for it."
+        )
+
+    def _observe_unmentioned_channel_message(
+        self,
+        *,
+        post: Dict[str, Any],
+        channel_id: str,
+        chat_type: str,
+        sender_id: str,
+        sender_name: str,
+        message_text: str,
+    ) -> None:
+        """Persist authorized Mattermost chatter without dispatching the agent."""
+        store = getattr(self, "_session_store", None)
+        if not store:
+            return
+        try:
+            file_ids = post.get("file_ids") or []
+            observed_text = message_text
+            if file_ids:
+                suffix = (
+                    f"[Observed Mattermost post includes {len(file_ids)} attachment(s); "
+                    "passive observation does not download attachments.]"
+                )
+                observed_text = f"{observed_text}\n{suffix}" if observed_text else suffix
+            if not observed_text:
+                return
+            source = self.build_source(
+                chat_id=channel_id,
+                chat_type=chat_type,
+                user_id=None,
+                user_name=None,
+                thread_id=self._mattermost_thread_id(post, chat_type),
+                message_id=post.get("id", ""),
+                role_authorized=True,
+            )
+            session_entry = store.get_or_create_session(source)
+            entry: Dict[str, Any] = {
+                "role": "user",
+                "content": self._mattermost_observed_attributed_text(
+                    sender_name, sender_id, observed_text
+                ),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "observed": True,
+            }
+            if post.get("id"):
+                entry["message_id"] = str(post["id"])
+            store.append_to_transcript(session_entry.session_id, entry)
+            logger.info(
+                "Mattermost: channel message observed (no bot trigger): channel=%s from=%s",
+                channel_id,
+                sender_id or "unknown",
+            )
+        except Exception as exc:
+            logger.warning("Mattermost: failed to observe channel message: %s", exc)
+
     async def _handle_ws_event(self, event: Dict[str, Any]) -> None:
         """Process a single WebSocket event."""
         event_type = event.get("event")
@@ -819,10 +1721,16 @@ class MattermostAdapter(BasePlatformAdapter):
         channel_type_raw = data.get("channel_type", "O")
         chat_type = _CHANNEL_TYPE_MAP.get(channel_type_raw, "channel")
 
+        # Resolve sender before mention gating. Passive observation must make a
+        # full authorization decision before anything reaches the transcript.
+        sender_id = post.get("user_id", "")
+        sender_name = data.get("sender_name", "").lstrip("@") or sender_id
+
         # For DMs, user_id is sufficient.  For channels, check for @mention.
         message_text = post.get("message", "")
 
         # Mention-gating for non-DM channels.
+        observation_active = False
         # Config (config.yaml `mattermost.*` with env-var fallback):
         #   require_mention / MATTERMOST_REQUIRE_MENTION: Require @mention in channels (default: true)
         #   free_response_channels / MATTERMOST_FREE_RESPONSE_CHANNELS: Channel IDs where bot responds without mention
@@ -831,15 +1739,9 @@ class MattermostAdapter(BasePlatformAdapter):
             # allowed_channels check (whitelist — must pass before other gating).
             # When set, messages from channels NOT in this list are silently
             # ignored, even if @mentioned.  DMs are already excluded above.
-            allowed_raw = self.config.extra.get("allowed_channels") if self.config.extra else None
-            if allowed_raw is None:
-                allowed_raw = os.getenv("MATTERMOST_ALLOWED_CHANNELS", "")
-            if isinstance(allowed_raw, list):
-                allowed_channels = {str(c).strip() for c in allowed_raw if str(c).strip()}
-            else:
-                allowed_channels = {
-                    c.strip() for c in str(allowed_raw).split(",") if c.strip()
-                }
+            allowed_channels = self._mattermost_channel_set(
+                "allowed_channels", "MATTERMOST_ALLOWED_CHANNELS"
+            )
             if allowed_channels and channel_id not in allowed_channels:
                 logger.debug(
                     "Mattermost: ignoring message in non-allowed channel: %s",
@@ -847,13 +1749,16 @@ class MattermostAdapter(BasePlatformAdapter):
                 )
                 return
 
-            require_mention = os.getenv(
-                "MATTERMOST_REQUIRE_MENTION", "true"
-            ).lower() not in {"false", "0", "no"}
-
-            free_channels_raw = os.getenv("MATTERMOST_FREE_RESPONSE_CHANNELS", "")
-            free_channels = {ch.strip() for ch in free_channels_raw.split(",") if ch.strip()}
+            require_mention = self._mattermost_require_mention()
+            free_channels = self._mattermost_channel_set(
+                "free_response_channels", "MATTERMOST_FREE_RESPONSE_CHANNELS"
+            )
             is_free_channel = channel_id in free_channels
+            observation_active = (
+                require_mention
+                and not is_free_channel
+                and self._mattermost_observation_enabled(channel_id, allowed_channels)
+            )
 
             mention_patterns = [
                 f"@{self._bot_username}",
@@ -865,11 +1770,45 @@ class MattermostAdapter(BasePlatformAdapter):
             )
 
             if require_mention and not is_free_channel and not has_mention:
+                if (
+                    observation_active
+                    and not message_text.lstrip().startswith("/")
+                    and self._is_sender_authorized(sender_id, chat_type, channel_id)
+                    is True
+                    and await self._mattermost_observation_sender_is_human(post)
+                ):
+                    self._observe_unmentioned_channel_message(
+                        post=post,
+                        channel_id=channel_id,
+                        chat_type=chat_type,
+                        sender_id=sender_id,
+                        sender_name=sender_name,
+                        message_text=message_text,
+                    )
                 logger.debug(
                     "Mattermost: skipping non-DM message without @mention (channel=%s)",
                     channel_id,
                 )
                 return
+
+            # Addressed turns in observed channels share the same channel/thread
+            # session as passive rows. Authenticate before removing per-sender
+            # routing identity from the event source.
+            if observation_active:
+                if self._is_sender_authorized(
+                    sender_id, chat_type, channel_id
+                ) is not True:
+                    logger.debug(
+                        "Mattermost: ignoring unauthorized sender in observed channel: %s",
+                        sender_id,
+                    )
+                    return
+                if not await self._mattermost_observation_sender_is_human(post):
+                    logger.debug(
+                        "Mattermost: ignoring automated sender in observed channel: %s",
+                        sender_id,
+                    )
+                    return
 
             # Strip @mention from the message text so the agent sees clean input.
             if has_mention:
@@ -878,20 +1817,9 @@ class MattermostAdapter(BasePlatformAdapter):
                         re.escape(pattern), "", message_text, flags=re.IGNORECASE
                     ).strip()
 
-        # Resolve sender info.
-        sender_id = post.get("user_id", "")
-        sender_name = data.get("sender_name", "").lstrip("@") or sender_id
-
-        # Thread support: if the post is in a thread, use root_id. In
-        # thread mode, top-level channel posts are valid roots for progress.
-        thread_id = post.get("root_id") or None
-        if (
-            not thread_id
-            and self._reply_mode == "thread"
-            and channel_type_raw != "D"
-            and post_id
-        ):
-            thread_id = post_id
+        # Thread support: replies use root_id; in thread reply mode, a top-level
+        # channel post becomes the root for the session and response.
+        thread_id = self._mattermost_thread_id(post, chat_type)
 
         # Determine message type.
         file_ids = post.get("file_ids") or []
@@ -964,6 +1892,27 @@ class MattermostAdapter(BasePlatformAdapter):
             self.config.extra, channel_id, None,
         )
 
+        if observation_active:
+            source = dataclasses.replace(
+                source,
+                user_id=None,
+                user_name=None,
+                user_id_alt=None,
+                # The adapter completed the gateway's full authorization
+                # callback before converting this into a shared routing source.
+                role_authorized=True,
+            )
+            if msg_type != MessageType.COMMAND:
+                message_text = self._mattermost_observed_attributed_text(
+                    sender_name, sender_id, message_text
+                )
+            observe_prompt = self._mattermost_observed_channel_prompt()
+            _channel_prompt = (
+                f"{_channel_prompt}\n\n{observe_prompt}"
+                if _channel_prompt
+                else observe_prompt
+            )
+
         msg_event = MessageEvent(
             text=message_text,
             message_type=msg_type,
@@ -993,6 +1942,7 @@ async def _standalone_send(
     thread_id: Optional[str] = None,
     media_files: Optional[list] = None,
     force_document: bool = False,
+    multi_chunk: bool = False,
 ) -> Dict[str, Any]:
     """Send via the Mattermost v4 REST API without a live gateway adapter.
 
@@ -1090,6 +2040,24 @@ async def _standalone_send(
                 "channel_id": chat_id,
                 "message": message,
             }
+            rich_posts = str(
+                (getattr(pconfig, "extra", {}) or {}).get("rich_posts", "false")
+            ).lower() in {"true", "1", "yes", "on"}
+            if (
+                rich_posts
+                and not multi_chunk
+                and len(message) <= MAX_POST_LENGTH
+            ):
+                try:
+                    from plugins.platforms.mattermost.rich_posts import (
+                        render_rich_post,
+                    )
+
+                    rendered = render_rich_post(message)
+                except Exception:
+                    rendered = None
+                if rendered:
+                    payload.update(rendered)
             if thread_id:
                 payload["root_id"] = thread_id
             if file_ids:
@@ -1100,7 +2068,28 @@ async def _standalone_send(
                 json=payload,
                 **_req_kw,
             ) as resp:
-                if resp.status not in {200, 201}:
+                if resp.status in {200, 201}:
+                    data = await resp.json()
+                elif "props" in payload:
+                    plain_payload = dict(payload)
+                    plain_payload.pop("props", None)
+                    plain_payload["message"] = message
+                    async with session.post(
+                        f"{base_url}/api/v4/posts",
+                        headers=headers,
+                        json=plain_payload,
+                        **_req_kw,
+                    ) as plain_resp:
+                        if plain_resp.status not in {200, 201}:
+                            body = await plain_resp.text()
+                            return {
+                                "error": (
+                                    f"Mattermost API error ({plain_resp.status}): "
+                                    f"{body[:400]}"
+                                )
+                            }
+                        data = await plain_resp.json()
+                else:
                     body = await resp.text()
                     return {
                         "error": (
@@ -1108,7 +2097,6 @@ async def _standalone_send(
                             f"{body[:400]}"
                         )
                     }
-                data = await resp.json()
             return {
                 "success": True,
                 "platform": "mattermost",
@@ -1212,8 +2200,8 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
 
     Env vars take precedence over YAML — every assignment is guarded
     by ``not os.getenv(...)`` so an explicit env var survives a config.yaml
-    update.  Returns ``None`` because no extras are seeded into
-    ``PlatformConfig.extra`` directly (everything flows through env).
+    update. Rich-post settings are returned as ``PlatformConfig.extra``
+    values because they are adapter-native rather than legacy env settings.
     """
     if "require_mention" in mattermost_cfg and not os.getenv("MATTERMOST_REQUIRE_MENTION"):
         os.environ["MATTERMOST_REQUIRE_MENTION"] = str(mattermost_cfg["require_mention"]).lower()
@@ -1228,7 +2216,21 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
         os.environ["MATTERMOST_ALLOWED_CHANNELS"] = str(ac)
-    return None  # all settings flow through env; nothing to merge into extras
+    nested_extra = mattermost_cfg.get("extra")
+    extras = dict(nested_extra) if isinstance(nested_extra, dict) else {}
+    for key in (
+        "rich_posts",
+        "feedback_buttons",
+        "interaction_url",
+        "interaction_host",
+        "interaction_port",
+        "interaction_timeout_seconds",
+        "interaction_allowed_cidrs",
+        "observe_unmentioned_channel_messages",
+    ):
+        if key in mattermost_cfg:
+            extras[key] = mattermost_cfg[key]
+    return extras or None
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -9,8 +9,6 @@ Environment variables:
     MATTERMOST_TOKEN            Bot token or personal-access token
     MATTERMOST_ALLOWED_USERS    Comma-separated user IDs
     MATTERMOST_HOME_CHANNEL     Channel ID for cron/notification delivery
-    MATTERMOST_OBSERVE_UNMENTIONED_CHANNEL_MESSAGES
-                                Observe authorized unmentioned posts in allowlisted channels
 """
 
 from __future__ import annotations
@@ -1530,10 +1528,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
     def _mattermost_observe_unmentioned_channel_messages(self) -> bool:
         """Whether eligible unmentioned channel posts are persisted as context."""
-        configured = self._mattermost_config_value(
-            "observe_unmentioned_channel_messages",
-            "MATTERMOST_OBSERVE_UNMENTIONED_CHANNEL_MESSAGES",
-        )
+        configured = self.config.extra.get("observe_unmentioned_channel_messages")
         return self._mattermost_bool(configured)
 
     def _mattermost_observation_enabled(
@@ -1607,10 +1602,10 @@ class MattermostAdapter(BasePlatformAdapter):
         return not is_bot
 
     def _mattermost_thread_id(self, post: Dict[str, Any], chat_type: str) -> Optional[str]:
-        thread_id = post.get("root_id") or None
-        if not thread_id and self._reply_mode == "thread" and chat_type != "dm":
-            thread_id = post.get("id") or None
-        return thread_id
+        # Session scope follows an existing Mattermost thread only. A top-level
+        # post remains channel-scoped even when replies are rendered in a new
+        # thread, so passive chatter is available to a later top-level mention.
+        return post.get("root_id") or None
 
     @staticmethod
     def _mattermost_observed_attributed_text(
@@ -1817,8 +1812,8 @@ class MattermostAdapter(BasePlatformAdapter):
                         re.escape(pattern), "", message_text, flags=re.IGNORECASE
                     ).strip()
 
-        # Thread support: replies use root_id; in thread reply mode, a top-level
-        # channel post becomes the root for the session and response.
+        # Session scope follows root_id only for actual replies. Top-level posts
+        # stay channel-scoped; reply_mode may still thread the rendered response.
         thread_id = self._mattermost_thread_id(post, chat_type)
 
         # Determine message type.

--- a/plugins/platforms/mattermost/plugin.yaml
+++ b/plugins/platforms/mattermost/plugin.yaml
@@ -7,7 +7,9 @@ description: >
   Connects to a self-hosted or cloud Mattermost instance via the v4 REST
   API + WebSocket event stream and relays messages between Mattermost
   channels/DMs and the Hermes agent. Supports thread-mode replies, native
-  file uploads, channel-scoped allowlists, and home-channel cron delivery.
+  file uploads, channel-scoped allowlists, home-channel cron delivery,
+  native rich posts, passive allowlisted channel observation, and signed
+  approval/feedback actions.
 author: NousResearch
 requires_env:
   - name: MATTERMOST_URL
@@ -19,6 +21,10 @@ requires_env:
     prompt: "Mattermost bot token"
     password: true
 optional_env:
+  - name: MATTERMOST_INTERACTION_SECRET
+    description: "Secret used to sign Mattermost approval and feedback callbacks"
+    prompt: "Interaction callback signing secret"
+    password: true
   - name: MATTERMOST_ALLOWED_USERS
     description: "Comma-separated Mattermost user IDs allowed to talk to the bot"
     prompt: "Allowed users (comma-separated)"
@@ -46,4 +52,8 @@ optional_env:
   - name: MATTERMOST_ALLOWED_CHANNELS
     description: "If set, the bot only responds in these channels (whitelist)."
     prompt: "Allowed channel IDs (comma-separated)"
+    password: false
+  - name: MATTERMOST_OBSERVE_UNMENTIONED_CHANNEL_MESSAGES
+    description: "Store authorized unmentioned posts as context in explicitly allowed channels without triggering the agent."
+    prompt: "Observe unmentioned posts in allowed channels? (true/false)"
     password: false

--- a/plugins/platforms/mattermost/plugin.yaml
+++ b/plugins/platforms/mattermost/plugin.yaml
@@ -53,7 +53,3 @@ optional_env:
     description: "If set, the bot only responds in these channels (whitelist)."
     prompt: "Allowed channel IDs (comma-separated)"
     password: false
-  - name: MATTERMOST_OBSERVE_UNMENTIONED_CHANNEL_MESSAGES
-    description: "Store authorized unmentioned posts as context in explicitly allowed channels without triggering the agent."
-    prompt: "Observe unmentioned posts in allowed channels? (true/false)"
-    password: false

--- a/plugins/platforms/mattermost/rich_posts.py
+++ b/plugins/platforms/mattermost/rich_posts.py
@@ -1,0 +1,111 @@
+"""Pure builders for Mattermost native rich-post attachments."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+_ATX_HEADING_RE = re.compile(r"^ {0,3}#{1,6}[ \t]+(.+?)[ \t]*#*[ \t]*(?:\r?\n)?$")
+_FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
+_SAFE_ACTION_STYLES = frozenset({
+    "default",
+    "primary",
+    "success",
+    "good",
+    "warning",
+    "danger",
+})
+
+
+def build_attachment_action(
+    action_id: Any,
+    name: Any,
+    url: Any,
+    *,
+    style: Any = "default",
+    context: Any = None,
+) -> Optional[dict[str, Any]]:
+    """Build one Mattermost attachment button action, or omit invalid input."""
+    required = (action_id, name, url)
+    if any(not isinstance(value, str) or not value.strip() for value in required):
+        return None
+    action_id, name, url = (value.strip() for value in required)
+    normalized_style = style.strip().lower() if isinstance(style, str) else "default"
+    if normalized_style not in _SAFE_ACTION_STYLES:
+        normalized_style = "default"
+    integration: dict[str, Any] = {"url": url}
+    if isinstance(context, dict):
+        integration["context"] = dict(context)
+    return {
+        "id": action_id,
+        "name": name,
+        "type": "button",
+        "style": normalized_style,
+        "integration": integration,
+    }
+
+
+def _sanitize_actions(actions: Any) -> list[dict[str, Any]]:
+    if not isinstance(actions, (list, tuple)):
+        return []
+    valid: list[dict[str, Any]] = []
+    for action in actions:
+        if not isinstance(action, dict) or action.get("type") != "button":
+            continue
+        integration = action.get("integration")
+        if not isinstance(integration, dict):
+            continue
+        built = build_attachment_action(
+            action.get("id"),
+            action.get("name"),
+            integration.get("url"),
+            style=action.get("style", "default"),
+            context=integration.get("context"),
+        )
+        if built is not None:
+            valid.append(built)
+    return valid
+
+
+def _promote_first_heading(markdown: str) -> tuple[Optional[str], str]:
+    lines = markdown.splitlines(keepends=True)
+    fence: Optional[str] = None
+    for index, line in enumerate(lines):
+        fence_match = _FENCE_RE.match(line)
+        if fence_match:
+            marker = fence_match.group(1)
+            if fence is None:
+                fence = marker
+            elif marker[0] == fence[0] and len(marker) >= len(fence):
+                fence = None
+            continue
+        if fence is not None:
+            continue
+        match = _ATX_HEADING_RE.match(line)
+        if match:
+            return match.group(1), "".join(lines[:index] + lines[index + 1 :])
+    return None, markdown
+
+
+def render_rich_post(
+    markdown: Any,
+    *,
+    color: Any = None,
+    actions: Any = None,
+) -> Optional[dict[str, Any]]:
+    """Build Mattermost ``props.attachments`` from Markdown, or return ``None``."""
+    if not isinstance(markdown, str) or not markdown or len(markdown) > 16_383:
+        return None
+    title, body = _promote_first_heading(markdown)
+    attachment: dict[str, Any] = {
+        "fallback": markdown,
+        "text": body,
+    }
+    if title:
+        attachment["title"] = title
+    if color:
+        attachment["color"] = color
+    valid_actions = _sanitize_actions(actions)
+    if valid_actions:
+        attachment["actions"] = valid_actions
+    return {"props": {"attachments": [attachment]}}

--- a/tests/gateway/test_approval_prompt_redaction.py
+++ b/tests/gateway/test_approval_prompt_redaction.py
@@ -120,6 +120,72 @@ class TestApprovalCommandWiring:
 
         self._assert_redacts_then_uses(api_server, "_approval_notify", "put_nowait")
 
+    def test_chat_platform_threads_approval_capabilities_to_adapter(self):
+        """The gateway must not drop the backend's one-operation UI contract."""
+        import ast
+        import inspect
+        import gateway.run as run
+
+        tree = ast.parse(inspect.getsource(run))
+        notify = next(
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "_approval_notify_sync"
+        )
+        call = next(
+            node for node in ast.walk(notify)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "send_exec_approval"
+        )
+        keywords = {kw.arg: kw.value for kw in call.keywords}
+        for name, default in (("allow_permanent", True), ("smart_denied", False)):
+            value = keywords[name]
+            assert isinstance(value, ast.Call)
+            assert isinstance(value.func, ast.Attribute) and value.func.attr == "get"
+            assert isinstance(value.args[0], ast.Constant) and value.args[0].value == name
+            assert isinstance(value.args[1], ast.Constant) and value.args[1].value is default
+
+    def test_chat_platform_threads_exact_approval_id_when_supported(self):
+        """Button adapters that opt into exact IDs must receive the queued ID."""
+        import ast
+        import inspect
+
+        import gateway.run as run
+
+        tree = ast.parse(inspect.getsource(run))
+        notify = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "_approval_notify_sync"
+        )
+        assignment = next(
+            node
+            for node in ast.walk(notify)
+            if isinstance(node, ast.Assign)
+            and isinstance(node.targets[0], ast.Subscript)
+            and isinstance(node.targets[0].value, ast.Name)
+            and node.targets[0].value.id == "_approval_id_kwargs"
+        )
+        value = assignment.value
+        assert isinstance(value, ast.Call)
+        assert isinstance(value.func, ast.Attribute) and value.func.attr == "get"
+        assert isinstance(value.args[0], ast.Constant)
+        assert value.args[0].value == "approval_id"
+
+        call = next(
+            node
+            for node in ast.walk(notify)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "send_exec_approval"
+        )
+        assert any(
+            keyword.arg is None
+            and isinstance(keyword.value, ast.Name)
+            and keyword.value.id == "_approval_id_kwargs"
+            for keyword in call.keywords
+        )
+
 
 class TestApprovalTextFallbackContract:
     def test_smart_deny_only_advertises_one_operation(self):

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -394,6 +394,277 @@ class TestMattermostMentionBehavior:
             assert self.adapter.handle_message.called
 
 
+class _ObservedSessionEntry:
+    session_id = "mattermost-observed-session"
+
+
+class _ObservedSessionStore:
+    def __init__(self):
+        self.sources = []
+        self.messages = []
+
+    def get_or_create_session(self, source):
+        self.sources.append(source)
+        return _ObservedSessionEntry()
+
+    def append_to_transcript(self, session_id, message, skip_db=False):
+        self.messages.append((session_id, message, skip_db))
+
+
+class TestMattermostObserveUnmentionedChannelMessages:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._bot_user_id = "bot_user_id"
+        self.adapter._bot_username = "hermes-bot"
+        self.adapter._api_get = AsyncMock(return_value={"is_bot": False})
+        self.adapter.handle_message = AsyncMock()
+        self.store = _ObservedSessionStore()
+        self.adapter.set_session_store(self.store)
+
+    @staticmethod
+    def _event(
+        message="side chatter",
+        *,
+        channel_id="chan_allowed",
+        channel_type="O",
+        user_id="user_123",
+        root_id=None,
+        post_id="post_observed",
+        props=None,
+    ):
+        post = {
+            "id": post_id,
+            "user_id": user_id,
+            "channel_id": channel_id,
+            "message": message,
+        }
+        if root_id is not None:
+            post["root_id"] = root_id
+        if props is not None:
+            post["props"] = props
+        return {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post),
+                "channel_type": channel_type,
+                "sender_name": "@alice",
+            },
+        }
+
+    def _enable_observation(self):
+        self.adapter.config.extra.update(
+            {
+                "require_mention": True,
+                "allowed_channels": ["chan_allowed"],
+                "observe_unmentioned_channel_messages": True,
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_unmentioned_message_is_not_observed(self):
+        self.adapter.set_authorization_check(lambda *_: True)
+
+        await self.adapter._handle_ws_event(self._event())
+
+        self.adapter.handle_message.assert_not_awaited()
+        assert self.store.messages == []
+
+    @pytest.mark.asyncio
+    async def test_observation_requires_explicit_allowed_channel(self):
+        self.adapter.config.extra.update(
+            {
+                "require_mention": True,
+                "observe_unmentioned_channel_messages": True,
+            }
+        )
+        self.adapter.set_authorization_check(lambda *_: True)
+
+        await self.adapter._handle_ws_event(self._event())
+
+        self.adapter.handle_message.assert_not_awaited()
+        assert self.store.messages == []
+
+    @pytest.mark.asyncio
+    async def test_authorized_unmentioned_message_is_observed_without_dispatch(self):
+        self._enable_observation()
+        self.adapter.set_authorization_check(lambda *_: True)
+
+        await self.adapter._handle_ws_event(self._event(root_id="root_123"))
+
+        self.adapter.handle_message.assert_not_awaited()
+        assert len(self.store.messages) == 1
+        session_id, entry, skip_db = self.store.messages[0]
+        assert session_id == "mattermost-observed-session"
+        assert entry["content"] == "[alice|user_123]\nside chatter"
+        assert entry["observed"] is True
+        assert entry["message_id"] == "post_observed"
+        assert skip_db is False
+        source = self.store.sources[0]
+        assert source.chat_id == "chan_allowed"
+        assert source.thread_id == "root_123"
+        assert source.user_id is None
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_sender_is_not_observed(self):
+        self._enable_observation()
+        self.adapter.set_authorization_check(lambda *_: False)
+
+        await self.adapter._handle_ws_event(self._event())
+
+        self.adapter.handle_message.assert_not_awaited()
+        assert self.store.messages == []
+
+    @pytest.mark.asyncio
+    async def test_unmentioned_command_is_not_persisted_as_passive_context(self):
+        self._enable_observation()
+        self.adapter.set_authorization_check(lambda *_: True)
+
+        await self.adapter._handle_ws_event(self._event(" /new"))
+
+        self.adapter.handle_message.assert_not_awaited()
+        assert self.store.messages == []
+
+    @pytest.mark.asyncio
+    async def test_incoming_webhook_post_is_not_observed(self):
+        self._enable_observation()
+        self.adapter.set_authorization_check(lambda *_: True)
+
+        await self.adapter._handle_ws_event(
+            self._event(props={"from_webhook": "true"})
+        )
+
+        self.adapter.handle_message.assert_not_awaited()
+        self.adapter._api_get.assert_not_awaited()
+        assert self.store.messages == []
+
+    @pytest.mark.asyncio
+    async def test_other_bot_account_post_is_not_observed(self):
+        self._enable_observation()
+        self.adapter.set_authorization_check(lambda *_: True)
+        self.adapter._api_get.return_value = {"id": "user_123", "is_bot": True}
+
+        await self.adapter._handle_ws_event(self._event())
+
+        self.adapter.handle_message.assert_not_awaited()
+        self.adapter._api_get.assert_awaited_once_with("users/user_123")
+        assert self.store.messages == []
+
+    @pytest.mark.asyncio
+    async def test_addressed_other_bot_is_not_dispatched_into_observed_session(self):
+        self._enable_observation()
+        self.adapter.set_authorization_check(lambda *_: True)
+        self.adapter._api_get.return_value = {"id": "user_123", "is_bot": True}
+
+        await self.adapter._handle_ws_event(
+            self._event("@hermes-bot inject this", post_id="bot-addressed")
+        )
+
+        self.adapter.handle_message.assert_not_awaited()
+        assert self.store.messages == []
+
+    @pytest.mark.asyncio
+    async def test_addressed_webhook_is_not_dispatched_into_observed_session(self):
+        self._enable_observation()
+        self.adapter.set_authorization_check(lambda *_: True)
+
+        await self.adapter._handle_ws_event(
+            self._event(
+                "@hermes-bot inject this",
+                post_id="webhook-addressed",
+                props={"from_webhook": "true"},
+            )
+        )
+
+        self.adapter.handle_message.assert_not_awaited()
+        self.adapter._api_get.assert_not_awaited()
+        assert self.store.messages == []
+
+    @pytest.mark.asyncio
+    async def test_sender_lookup_failure_fails_closed_for_observation(self):
+        self._enable_observation()
+        self.adapter.set_authorization_check(lambda *_: True)
+        self.adapter._api_get.side_effect = RuntimeError("lookup unavailable")
+
+        await self.adapter._handle_ws_event(self._event())
+
+        self.adapter.handle_message.assert_not_awaited()
+        assert self.store.messages == []
+
+    @pytest.mark.asyncio
+    async def test_malformed_is_bot_lookup_fails_closed_for_observation(self):
+        self._enable_observation()
+        self.adapter.set_authorization_check(lambda *_: True)
+        self.adapter._api_get.return_value = {"id": "user_123", "is_bot": "false"}
+
+        await self.adapter._handle_ws_event(self._event())
+
+        self.adapter.handle_message.assert_not_awaited()
+        assert self.store.messages == []
+
+    @pytest.mark.asyncio
+    async def test_free_response_channel_dispatches_instead_of_observing(self):
+        self._enable_observation()
+        self.adapter.config.extra["free_response_channels"] = ["chan_allowed"]
+        self.adapter.set_authorization_check(lambda *_: True)
+
+        await self.adapter._handle_ws_event(self._event())
+
+        self.adapter.handle_message.assert_awaited_once()
+        assert self.store.messages == []
+
+    @pytest.mark.asyncio
+    async def test_dm_dispatches_and_is_never_passively_observed(self):
+        self._enable_observation()
+        self.adapter.set_authorization_check(lambda *_: True)
+
+        await self.adapter._handle_ws_event(
+            self._event(channel_id="dm_channel", channel_type="D")
+        )
+
+        self.adapter.handle_message.assert_awaited_once()
+        assert self.store.messages == []
+
+    @pytest.mark.asyncio
+    async def test_addressed_message_uses_shared_observed_session_context(self):
+        self._enable_observation()
+        self.adapter.set_authorization_check(lambda *_: True)
+
+        await self.adapter._handle_ws_event(
+            self._event("@hermes-bot investigate this", post_id="post_trigger")
+        )
+
+        self.adapter.handle_message.assert_awaited_once()
+        event = self.adapter.handle_message.call_args.args[0]
+        assert event.text == "[alice|user_123]\ninvestigate this"
+        assert event.source.user_id is None
+        assert event.source.user_name is None
+        assert event.source.role_authorized is True
+        assert "observed Mattermost channel context" in event.channel_prompt
+
+
+def test_mattermost_observed_context_is_context_only_for_addressed_turn():
+    from gateway.run import _build_gateway_agent_history
+
+    history = [
+        {
+            "role": "user",
+            "content": "[alice|user_123]\nside chatter",
+            "observed": True,
+        },
+        {"role": "assistant", "content": "previous explicit reply"},
+    ]
+
+    agent_history, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt=(
+            "You are handling Mattermost; observed Mattermost channel context is present."
+        ),
+    )
+
+    assert agent_history == [{"role": "assistant", "content": "previous explicit reply"}]
+    assert observed_context == "[alice|user_123]\nside chatter"
+
+
 # ---------------------------------------------------------------------------
 # File upload (send_image)
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -2,6 +2,7 @@
 import json
 import os
 import time
+from typing import cast
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
@@ -469,6 +470,14 @@ class TestMattermostObserveUnmentionedChannelMessages:
         self.adapter.handle_message.assert_not_awaited()
         assert self.store.messages == []
 
+    def test_legacy_observation_env_setting_is_ignored(self):
+        legacy_key = "MATTERMOST_" + "OBSERVE_UNMENTIONED_CHANNEL_MESSAGES"
+        with patch.dict(os.environ, {legacy_key: "true"}):
+            assert (
+                self.adapter._mattermost_observe_unmentioned_channel_messages()
+                is False
+            )
+
     @pytest.mark.asyncio
     async def test_observation_requires_explicit_allowed_channel(self):
         self.adapter.config.extra.update(
@@ -503,6 +512,30 @@ class TestMattermostObserveUnmentionedChannelMessages:
         assert source.chat_id == "chan_allowed"
         assert source.thread_id == "root_123"
         assert source.user_id is None
+
+    @pytest.mark.asyncio
+    async def test_thread_reply_mode_keeps_top_level_observation_channel_scoped(self):
+        self._enable_observation()
+        self.adapter._reply_mode = "thread"
+        self.adapter.set_authorization_check(lambda *_: True)
+
+        await self.adapter._handle_ws_event(
+            self._event(post_id="observed-top-level")
+        )
+        observed_source = self.store.sources[-1]
+
+        await self.adapter._handle_ws_event(
+            self._event(
+                "@hermes-bot what did Alice say?",
+                post_id="addressed-top-level",
+            )
+        )
+        addressed_event = cast(AsyncMock, self.adapter.handle_message).call_args.args[0]
+
+        assert observed_source.chat_id == "chan_allowed"
+        assert observed_source.thread_id is None
+        assert addressed_event.source.chat_id == "chan_allowed"
+        assert addressed_event.source.thread_id is None
 
     @pytest.mark.asyncio
     async def test_unauthorized_sender_is_not_observed(self):
@@ -835,7 +868,7 @@ class TestMattermostMediaTypes:
 
 
 @pytest.mark.asyncio
-async def test_mattermost_top_level_channel_post_is_thread_root():
+async def test_mattermost_top_level_channel_post_keeps_channel_session_scope():
     adapter = _make_adapter()
     adapter._reply_mode = "thread"
     adapter._bot_user_id = "bot_user_id"
@@ -860,7 +893,7 @@ async def test_mattermost_top_level_channel_post_is_thread_root():
     await adapter._handle_ws_event(event)
 
     msg_event = adapter.handle_message.call_args[0][0]
-    assert msg_event.source.thread_id == "top_post_123"
+    assert msg_event.source.thread_id is None
     assert msg_event.source.message_id == "top_post_123"
     assert msg_event.message_id == "top_post_123"
 

--- a/tests/gateway/test_mattermost_interactions.py
+++ b/tests/gateway/test_mattermost_interactions.py
@@ -1,0 +1,455 @@
+"""Mattermost-native approval and feedback interaction tests."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+
+def _adapter(monkeypatch, *, extra=None):
+    monkeypatch.setenv("MATTERMOST_INTERACTION_SECRET", "test-secret-not-sent")
+    config = PlatformConfig(
+        enabled=True,
+        token="bot-token",
+        extra={
+            "url": "https://mm.example.com",
+            "interaction_url": "https://hermes.example.com/mattermost/actions",
+            "interaction_allowed_cidrs": ["127.0.0.1/32"],
+            **(extra or {}),
+        },
+    )
+    adapter = MattermostAdapter(config)
+    adapter._post_preserving_thread = AsyncMock(return_value={"id": "post-1"})
+    adapter._thread_root_for_send = AsyncMock(
+        side_effect=lambda _reply, metadata: (metadata or {}).get("thread_id")
+    )
+    return adapter
+
+
+def _callback_from_action(action, *, user_id="user-1", post_id="post-1"):
+    return {
+        "user_id": user_id,
+        "user_name": "Nawaf",
+        "channel_id": "channel-1",
+        "team_id": "team-1",
+        "post_id": post_id,
+        "context": action["integration"]["context"],
+    }
+
+
+def _authorize(adapter, allowed=True):
+    class Runner:
+        def __init__(self):
+            self._is_user_authorized = MagicMock(return_value=allowed)
+
+        def handler(self, _message):
+            return None
+
+    runner = Runner()
+    adapter._message_handler = runner.handler
+    adapter.set_authorization_check(runner._is_user_authorized)
+    return runner
+
+
+def test_interactive_authorization_uses_profile_bound_adapter_callback(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    runner = _authorize(adapter, allowed=True)
+    profile_bound_check = MagicMock(return_value=False)
+    adapter.set_authorization_check(profile_bound_check)
+
+    assert (
+        adapter._is_interactive_user_authorized(
+            "user-1", channel_id="channel-1", team_id="team-1"
+        )
+        is False
+    )
+    profile_bound_check.assert_called_once_with("user-1", "group", "channel-1")
+    runner._is_user_authorized.assert_not_called()
+
+
+def test_interaction_secret_does_not_fall_back_outside_profile_scope(monkeypatch):
+    monkeypatch.setenv("MATTERMOST_INTERACTION_SECRET", "wrong-profile-secret")
+    with patch("agent.secret_scope.get_secret", return_value=None):
+        assert MattermostAdapter._secret_value("MATTERMOST_INTERACTION_SECRET") == ""
+
+
+def test_interactions_require_valid_url_secret_and_trusted_source(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    assert adapter._interactions_available() is True
+
+    monkeypatch.delenv("MATTERMOST_INTERACTION_SECRET")
+    assert adapter._interactions_available() is False
+    assert (
+        _adapter(monkeypatch, extra={"interaction_url": ""})._interactions_available()
+        is False
+    )
+    assert (
+        _adapter(
+            monkeypatch, extra={"interaction_url": "https://"}
+        )._interactions_available()
+        is False
+    )
+    assert (
+        _adapter(
+            monkeypatch, extra={"interaction_url": "http://hermes.internal/actions"}
+        )._interactions_available()
+        is False
+    )
+    assert (
+        _adapter(
+            monkeypatch, extra={"interaction_url": "http://127.0.0.1:8789/actions"}
+        )._interactions_available()
+        is True
+    )
+    assert (
+        _adapter(
+            monkeypatch, extra={"interaction_allowed_cidrs": []}
+        )._interactions_available()
+        is False
+    )
+
+
+def test_feedback_state_never_evicts_live_approvals(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    monkeypatch.setattr("plugins.platforms.mattermost.adapter.time.time", lambda: 1000)
+    for index in range(256):
+        assert adapter._remember_interaction(
+            f"approval-{index}",
+            {"kind": "approval", "expires_at": 2000},
+        )
+
+    remembered = adapter._remember_interaction(
+        "feedback-new",
+        {"kind": "feedback", "expires_at": 2000},
+    )
+
+    assert remembered is False
+    assert "feedback-new" not in adapter._pending_interactions
+    assert len(adapter._pending_interactions) == 256
+    assert all(
+        state["kind"] == "approval" for state in adapter._pending_interactions.values()
+    )
+
+
+def test_remember_interaction_purges_expired_state(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    monkeypatch.setattr("plugins.platforms.mattermost.adapter.time.time", lambda: 1000)
+    adapter._pending_interactions["expired"] = {
+        "kind": "approval",
+        "expires_at": 999,
+    }
+
+    assert adapter._remember_interaction(
+        "fresh", {"kind": "feedback", "expires_at": 2000}
+    )
+    assert set(adapter._pending_interactions) == {"fresh"}
+
+
+@pytest.mark.asyncio
+async def test_send_exec_approval_uses_signed_native_actions(monkeypatch):
+    adapter = _adapter(monkeypatch)
+
+    result = await adapter.send_exec_approval(
+        chat_id="channel-1",
+        command="deploy production",
+        session_key="session-1",
+        approval_id="approval-1",
+        description="Production deployment",
+        metadata={"thread_id": "root-1"},
+        allow_permanent=True,
+        allow_session=True,
+    )
+
+    assert result.success is True
+    assert result.message_id == "post-1"
+    payload = adapter._post_preserving_thread.await_args.args[1]
+    assert payload["channel_id"] == "channel-1"
+    assert payload["root_id"] == "root-1"
+    attachment = payload["props"]["attachments"][0]
+    assert attachment["fallback"].startswith("Command approval required")
+    assert "deploy production" in attachment["text"]
+    actions = attachment["actions"]
+    assert [action["name"] for action in actions] == [
+        "Allow Once",
+        "Allow Session",
+        "Always Allow",
+        "Deny",
+    ]
+    assert all(action["type"] == "button" for action in actions)
+    assert all(
+        action["integration"]["url"].startswith("https://") for action in actions
+    )
+    serialized = repr(payload)
+    assert "test-secret-not-sent" not in serialized
+    assert "session-1" not in serialized
+    assert "approval-1" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_smart_denied_approval_only_offers_once_and_deny(monkeypatch):
+    adapter = _adapter(monkeypatch)
+
+    result = await adapter.send_exec_approval(
+        "channel-1",
+        "rm -rf build",
+        "session-1",
+        approval_id="approval-1",
+        smart_denied=True,
+    )
+
+    assert result.success is True
+    payload = adapter._post_preserving_thread.await_args.args[1]
+    actions = payload["props"]["attachments"][0]["actions"]
+    assert [action["name"] for action in actions] == ["Allow Once", "Deny"]
+    assert "Smart DENY" in payload["props"]["attachments"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_permanent_approval_is_independent_of_session_option(monkeypatch):
+    adapter = _adapter(monkeypatch)
+
+    await adapter.send_exec_approval(
+        "channel-1",
+        "deploy production",
+        "session-1",
+        approval_id="approval-1",
+        allow_session=False,
+        allow_permanent=True,
+    )
+
+    payload = adapter._post_preserving_thread.await_args.args[1]
+    actions = payload["props"]["attachments"][0]["actions"]
+    assert [action["name"] for action in actions] == [
+        "Allow Once",
+        "Always Allow",
+        "Deny",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_exec_approval_falls_back_when_callbacks_unavailable(monkeypatch):
+    adapter = _adapter(monkeypatch, extra={"interaction_url": ""})
+
+    result = await adapter.send_exec_approval("channel-1", "date", "session-1")
+
+    assert result.success is False
+    assert "interaction" in (result.error or "").lower()
+    adapter._post_preserving_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_valid_approval_callback_authorizes_resolves_and_removes_buttons(
+    monkeypatch,
+):
+    adapter = _adapter(monkeypatch)
+    runner = _authorize(adapter, allowed=True)
+    adapter.resume_typing_for_chat = MagicMock()
+    await adapter.send_exec_approval(
+        "channel-1",
+        "deploy production",
+        "session-1",
+        approval_id="approval-1",
+    )
+    payload = adapter._post_preserving_thread.await_args.args[1]
+    action = payload["props"]["attachments"][0]["actions"][0]
+
+    with patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve:
+        body, status = await adapter._dispatch_interaction(
+            _callback_from_action(action)
+        )
+
+    assert status == 200
+    resolve.assert_called_once_with("session-1", "once", approval_id="approval-1")
+    adapter.resume_typing_for_chat.assert_called_once_with("channel-1")
+    runner._is_user_authorized.assert_called_once()
+    assert "Approved once by Nawaf" in body["update"]["message"]
+    assert "actions" not in body["update"]["props"]["attachments"][0]
+
+
+@pytest.mark.asyncio
+async def test_approval_callback_rejects_unauthorized_user(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    _authorize(adapter, allowed=False)
+    await adapter.send_exec_approval(
+        "channel-1", "deploy production", "session-1", approval_id="approval-1"
+    )
+    payload = adapter._post_preserving_thread.await_args.args[1]
+    action = payload["props"]["attachments"][0]["actions"][0]
+
+    with patch("tools.approval.resolve_gateway_approval") as resolve:
+        body, status = await adapter._dispatch_interaction(
+            _callback_from_action(action, user_id="intruder")
+        )
+
+    assert status == 403
+    resolve.assert_not_called()
+    assert "authorized" in body["ephemeral_text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_tampered_and_replayed_callbacks_do_not_resolve(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    _authorize(adapter, allowed=True)
+    await adapter.send_exec_approval(
+        "channel-1", "deploy production", "session-1", approval_id="approval-1"
+    )
+    payload = adapter._post_preserving_thread.await_args.args[1]
+    action = payload["props"]["attachments"][0]["actions"][0]
+    tampered = _callback_from_action(action)
+    tampered["context"] = dict(tampered["context"], choice="always")
+
+    with patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve:
+        body, status = await adapter._dispatch_interaction(tampered)
+        assert status == 401
+        resolve.assert_not_called()
+
+        valid = _callback_from_action(action)
+        _, first_status = await adapter._dispatch_interaction(valid)
+        replay_body, replay_status = await adapter._dispatch_interaction(valid)
+
+    assert first_status == 200
+    assert replay_status == 200
+    assert "expired" in replay_body["ephemeral_text"].lower()
+    resolve.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_expired_callback_is_rejected_and_consumed(monkeypatch):
+    adapter = _adapter(monkeypatch, extra={"interaction_timeout_seconds": 60})
+    _authorize(adapter, allowed=True)
+    await adapter.send_exec_approval(
+        "channel-1", "deploy production", "session-1", approval_id="approval-1"
+    )
+    payload = adapter._post_preserving_thread.await_args.args[1]
+    action = payload["props"]["attachments"][0]["actions"][0]
+    callback = _callback_from_action(action)
+    expires_at = action["integration"]["context"]["expires_at"]
+
+    with (
+        patch(
+            "plugins.platforms.mattermost.adapter.time.time",
+            return_value=expires_at + 1,
+        ),
+        patch("tools.approval.resolve_gateway_approval") as resolve,
+    ):
+        body, status = await adapter._dispatch_interaction(callback)
+        replay_body, replay_status = await adapter._dispatch_interaction(callback)
+
+    assert status == 200 and replay_status == 200
+    assert "expired" in body["ephemeral_text"].lower()
+    assert "expired" in replay_body["ephemeral_text"].lower()
+    resolve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_callback_must_match_original_channel_and_post(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    _authorize(adapter, allowed=True)
+    await adapter.send_exec_approval(
+        "channel-1", "deploy production", "session-1", approval_id="approval-1"
+    )
+    payload = adapter._post_preserving_thread.await_args.args[1]
+    action = payload["props"]["attachments"][0]["actions"][0]
+    callback = _callback_from_action(action, post_id="different-post")
+
+    with patch("tools.approval.resolve_gateway_approval") as resolve:
+        body, status = await adapter._dispatch_interaction(callback)
+
+    assert status == 401
+    resolve.assert_not_called()
+    assert "invalid" in body["ephemeral_text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_http_callback_handler_returns_dispatch_result(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    adapter._dispatch_interaction = AsyncMock(
+        return_value=({"ephemeral_text": "Thanks"}, 200)
+    )
+    request = SimpleNamespace(
+        remote="127.0.0.1",
+        content_length=123,
+        json=AsyncMock(return_value={"x": 1}),
+    )
+
+    response = await adapter._handle_interaction_request(request)
+
+    assert response.status == 200
+    assert json.loads(response.text) == {"ephemeral_text": "Thanks"}
+    adapter._dispatch_interaction.assert_awaited_once_with({"x": 1})
+
+
+@pytest.mark.asyncio
+async def test_http_callback_handler_rejects_oversized_or_invalid_json(monkeypatch):
+    adapter = _adapter(monkeypatch)
+    oversized = SimpleNamespace(
+        remote="127.0.0.1", content_length=65_537, json=AsyncMock()
+    )
+    invalid = SimpleNamespace(
+        remote="127.0.0.1",
+        content_length=10,
+        json=AsyncMock(side_effect=UnicodeDecodeError("utf-8", b"x", 0, 1, "bad")),
+    )
+
+    oversized_response = await adapter._handle_interaction_request(oversized)
+    invalid_response = await adapter._handle_interaction_request(invalid)
+
+    assert oversized_response.status == 413
+    assert invalid_response.status == 400
+
+
+@pytest.mark.asyncio
+async def test_http_callback_handler_rejects_forged_user_from_untrusted_source(
+    monkeypatch,
+):
+    adapter = _adapter(monkeypatch)
+    _authorize(adapter, allowed=True)
+    await adapter.send_exec_approval(
+        "channel-1", "deploy production", "session-1", approval_id="approval-1"
+    )
+    payload = adapter._post_preserving_thread.await_args.args[1]
+    action = payload["props"]["attachments"][0]["actions"][0]
+    request = SimpleNamespace(
+        remote="203.0.113.9",
+        content_length=100,
+        json=AsyncMock(
+            return_value=_callback_from_action(action, user_id="allowed-user")
+        ),
+    )
+
+    with patch("tools.approval.resolve_gateway_approval") as resolve:
+        response = await adapter._handle_interaction_request(request)
+
+    assert response.status == 403
+    request.json.assert_not_awaited()
+    resolve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_interaction_server_starts_and_stops_with_config(monkeypatch):
+    adapter = _adapter(
+        monkeypatch,
+        extra={"interaction_host": "127.0.0.1", "interaction_port": 9876},
+    )
+    fake_runner = SimpleNamespace(setup=AsyncMock(), cleanup=AsyncMock())
+    fake_site = SimpleNamespace(start=AsyncMock())
+
+    with (
+        patch("aiohttp.web.AppRunner", return_value=fake_runner) as runner_cls,
+        patch("aiohttp.web.TCPSite", return_value=fake_site) as site_cls,
+    ):
+        await adapter._start_interaction_server()
+        await adapter._stop_interaction_server()
+
+    fake_runner.setup.assert_awaited_once()
+    fake_site.start.assert_awaited_once()
+    site_cls.assert_called_once_with(fake_runner, "127.0.0.1", 9876)
+    fake_runner.cleanup.assert_awaited_once()
+    app = runner_cls.call_args.args[0]
+    routes = {(route.method, route.resource.canonical) for route in app.router.routes()}
+    assert ("POST", "/mattermost/actions") in routes
+    assert ("GET", "/mattermost/actions/health") in routes

--- a/tests/gateway/test_mattermost_rich_posts.py
+++ b/tests/gateway/test_mattermost_rich_posts.py
@@ -1,0 +1,137 @@
+"""Tests for the pure Mattermost rich-post renderer."""
+
+from plugins.platforms.mattermost.rich_posts import (
+    build_attachment_action,
+    render_rich_post,
+)
+
+
+def test_empty_markdown_has_no_rich_post():
+    assert render_rich_post("") is None
+
+
+def test_oversized_or_non_string_markdown_has_no_rich_post():
+    assert render_rich_post("x" * 16_384) is None
+    assert render_rich_post({"text": "not Markdown"}) is None
+
+
+def test_markdown_is_preserved_in_fallback_and_card_text():
+    markdown = "- first\n- second\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\n---\n\n```py\nprint('ok')\n```"
+
+    assert render_rich_post(markdown) == {
+        "props": {
+            "attachments": [
+                {
+                    "fallback": markdown,
+                    "text": markdown,
+                }
+            ]
+        }
+    }
+
+
+def test_first_atx_heading_is_promoted_without_changing_remaining_body():
+    markdown = "# Release Notes\n\nIntro\n\n## Details\n- one\n- two"
+
+    payload = render_rich_post(markdown)
+    assert payload is not None
+    attachment = payload["props"]["attachments"][0]
+
+    assert attachment["fallback"] == markdown
+    assert attachment["title"] == "Release Notes"
+    assert attachment["text"] == "\nIntro\n\n## Details\n- one\n- two"
+
+
+def test_heading_inside_code_fence_is_not_promoted():
+    markdown = "```md\n# Example only\n```\n\n## Actual Title\nBody"
+
+    payload = render_rich_post(markdown)
+    assert payload is not None
+    attachment = payload["props"]["attachments"][0]
+
+    assert attachment["fallback"] == markdown
+    assert attachment["title"] == "Actual Title"
+    assert attachment["text"] == "```md\n# Example only\n```\n\nBody"
+
+
+def test_build_attachment_action_uses_mattermost_button_shape():
+    assert build_attachment_action(
+        "approve",
+        "Approve",
+        "https://bot.example/actions/approve",
+        style="success",
+    ) == {
+        "id": "approve",
+        "name": "Approve",
+        "type": "button",
+        "style": "success",
+        "integration": {"url": "https://bot.example/actions/approve"},
+    }
+
+
+def test_attachment_action_sanitizes_unsafe_style_to_default():
+    action = build_attachment_action("go", "Go", "https://example.com/go", style="neon")
+
+    assert action is not None
+    assert action["style"] == "default"
+
+
+def test_attachment_action_omits_missing_required_fields():
+    malformed = (
+        ("", "Go", "https://example.com/go"),
+        ("go", " ", "https://example.com/go"),
+        ("go", "Go", None),
+        ({"not": "an id"}, "Go", "https://example.com/go"),
+    )
+
+    assert [build_attachment_action(*values) for values in malformed] == [None] * 4
+
+
+def test_rich_post_includes_optional_color_and_actions():
+    action = build_attachment_action("open", "Open", "https://example.com/open")
+    assert action is not None
+
+    payload = render_rich_post("Status: ready", color="#22aa66", actions=[action])
+
+    assert payload == {
+        "props": {
+            "attachments": [
+                {
+                    "fallback": "Status: ready",
+                    "text": "Status: ready",
+                    "color": "#22aa66",
+                    "actions": [action],
+                }
+            ]
+        }
+    }
+
+
+def test_rich_post_omits_invalid_actions_and_keeps_supported_ones():
+    valid = build_attachment_action("open", "Open", "https://example.com/open")
+    assert valid is not None
+
+    payload = render_rich_post(
+        "Ready",
+        actions=[None, "button", {}, {"id": "missing-fields"}, valid],
+    )
+
+    assert payload is not None
+    assert payload["props"]["attachments"][0]["actions"] == [valid]
+
+
+def test_attachment_action_preserves_json_object_context():
+    context = {"nonce": "abc", "choice": "helpful"}
+    action = build_attachment_action(
+        "feedback",
+        "Helpful",
+        "https://example.com/actions",
+        context=context,
+    )
+
+    assert action is not None
+    assert action["integration"]["context"] == context
+    payload = render_rich_post("Done", actions=[action])
+    assert payload is not None
+    rendered = payload["props"]["attachments"][0]["actions"][0]
+    assert rendered["integration"]["context"] == context

--- a/tests/gateway/test_mattermost_rich_posts_adapter.py
+++ b/tests/gateway/test_mattermost_rich_posts_adapter.py
@@ -1,0 +1,316 @@
+"""MattermostAdapter wiring for opt-in native rich posts."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.mattermost.adapter import (
+    MattermostAdapter,
+    _apply_yaml_config,
+    _standalone_send,
+)
+
+
+def _adapter(*, rich_posts=False, feedback_buttons=False):
+    config = PlatformConfig(
+        enabled=True,
+        token="bot-token",
+        extra={
+            "url": "https://mm.example.com",
+            "rich_posts": rich_posts,
+            "feedback_buttons": feedback_buttons,
+            "interaction_url": "https://hermes.example.com/mattermost/actions",
+            "interaction_allowed_cidrs": ["127.0.0.1/32"],
+        },
+    )
+    adapter = MattermostAdapter(config)
+    adapter._thread_root_for_send = AsyncMock(return_value=None)
+    adapter._post_preserving_thread = AsyncMock(return_value={"id": "post-1"})
+    adapter._api_put = AsyncMock(return_value={"id": "post-1"})
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_delete_message_removes_obsolete_stream_chunk():
+    adapter = _adapter()
+    adapter._api_delete = AsyncMock(return_value=True)
+
+    assert await adapter.delete_message("channel-1", "post123") is True
+    adapter._api_delete.assert_awaited_once_with("posts/post123")
+
+
+@pytest.mark.asyncio
+async def test_delete_message_rejects_malformed_post_id():
+    adapter = _adapter()
+    adapter._api_delete = AsyncMock(return_value=True)
+
+    assert await adapter.delete_message("channel-1", "../post") is False
+    adapter._api_delete.assert_not_awaited()
+
+
+def test_yaml_bridge_seeds_rich_post_extras():
+    extras = _apply_yaml_config(
+        {},
+        {
+            "rich_posts": True,
+            "feedback_buttons": True,
+            "interaction_url": "https://hermes.example.com/mattermost/actions",
+            "interaction_host": "0.0.0.0",
+            "interaction_port": 9876,
+            "interaction_timeout_seconds": 600,
+            "interaction_allowed_cidrs": ["10.0.0.12/32"],
+            "observe_unmentioned_channel_messages": True,
+        },
+    )
+
+    assert extras == {
+        "rich_posts": True,
+        "feedback_buttons": True,
+        "interaction_url": "https://hermes.example.com/mattermost/actions",
+        "interaction_host": "0.0.0.0",
+        "interaction_port": 9876,
+        "interaction_timeout_seconds": 600,
+        "interaction_allowed_cidrs": ["10.0.0.12/32"],
+        "observe_unmentioned_channel_messages": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_standalone_sender_uses_rich_posts_and_plain_retry(monkeypatch):
+    posted = []
+    responses = [(400, {"message": "attachments disabled"}), (201, {"id": "p-1"})]
+
+    class Response:
+        def __init__(self, status, body):
+            self.status = status
+            self._body = body
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def json(self):
+            return self._body
+
+        async def text(self):
+            return str(self._body)
+
+    class Session:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        def post(self, _url, **kwargs):
+            posted.append(kwargs["json"])
+            status, body = responses.pop(0)
+            return Response(status, body)
+
+    monkeypatch.setattr("aiohttp.ClientSession", Session)
+    config = PlatformConfig(
+        enabled=True,
+        token="token",
+        extra={"url": "https://mm.example.com", "rich_posts": True},
+    )
+
+    result = await _standalone_send(config, "channel-1", "# Status\n\nReady")
+
+    assert result["success"] is True
+    assert result["message_id"] == "p-1"
+    assert posted[0]["message"] == "# Status\n\nReady"
+    assert posted[0]["props"]["attachments"][0]["fallback"] == "# Status\n\nReady"
+    assert posted[1] == {"channel_id": "channel-1", "message": "# Status\n\nReady"}
+
+    responses.extend([(201, {"id": "p-2"}), (201, {"id": "p-3"})])
+    multi_result = await _standalone_send(
+        config,
+        "channel-1",
+        "part 1",
+        multi_chunk=True,
+    )
+    long_message = "x" * 5000
+    long_result = await _standalone_send(config, "channel-1", long_message)
+
+    assert multi_result["success"] is True
+    assert long_result["success"] is True
+    assert posted[2] == {"channel_id": "channel-1", "message": "part 1"}
+    assert posted[3] == {"channel_id": "channel-1", "message": long_message}
+
+
+@pytest.mark.asyncio
+async def test_rich_posts_are_off_by_default():
+    adapter = _adapter()
+    assert adapter.REQUIRES_EDIT_FINALIZE is False
+
+    result = await adapter.send("channel-1", "# Status\n\nReady")
+
+    assert result.success is True
+    payload = adapter._post_preserving_thread.await_args.args[1]
+    assert payload == {
+        "channel_id": "channel-1",
+        "message": "# Status\n\nReady",
+        "props": {"disable_mentions": True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_single_chunk_rich_post_uses_attachment_and_fallback():
+    adapter = _adapter(rich_posts=True)
+    assert adapter.REQUIRES_EDIT_FINALIZE is True
+
+    result = await adapter.send("channel-1", "# Status\n\nReady")
+
+    assert result.success is True
+    payload = adapter._post_preserving_thread.await_args.args[1]
+    assert payload["message"] == "# Status\n\nReady"
+    attachment = payload["props"]["attachments"][0]
+    assert attachment["fallback"] == "# Status\n\nReady"
+    assert attachment["title"] == "Status"
+    assert attachment["text"] == "\nReady"
+
+
+@pytest.mark.asyncio
+async def test_multi_chunk_response_stays_plain_markdown():
+    adapter = _adapter(rich_posts=True)
+
+    result = await adapter.send("channel-1", "# Status\n\n" + ("x" * 5000))
+
+    assert result.success is True
+    assert adapter._post_preserving_thread.await_count > 1
+    for call in adapter._post_preserving_thread.await_args_list:
+        payload = call.args[1]
+        assert payload["message"]
+        assert payload["props"] == {"disable_mentions": True}
+
+
+@pytest.mark.asyncio
+async def test_rich_post_failure_retries_plain_markdown():
+    adapter = _adapter(rich_posts=True)
+    adapter._post_preserving_thread = AsyncMock(side_effect=[{}, {"id": "plain-post"}])
+
+    result = await adapter.send("channel-1", "# Status\n\nReady")
+
+    assert result.success is True
+    assert result.message_id == "plain-post"
+    first = adapter._post_preserving_thread.await_args_list[0].args[1]
+    second = adapter._post_preserving_thread.await_args_list[1].args[1]
+    assert "props" in first
+    assert second == {
+        "channel_id": "channel-1",
+        "message": "# Status\n\nReady",
+        "props": {"disable_mentions": True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_streaming_edit_only_renders_rich_post_on_finalize():
+    adapter = _adapter(rich_posts=True)
+
+    interim = await adapter.edit_message(
+        "channel-1", "post-1", "# Status\n\nWor", finalize=False
+    )
+    final = await adapter.edit_message(
+        "channel-1", "post-1", "# Status\n\nWorking", finalize=True
+    )
+
+    assert interim.success is True and final.success is True
+    interim_payload = adapter._api_put.await_args_list[0].args[1]
+    final_payload = adapter._api_put.await_args_list[1].args[1]
+    assert interim_payload == {
+        "message": "# Status\n\nWor",
+        "props": {"disable_mentions": True},
+    }
+    assert final_payload["message"] == "# Status\n\nWorking"
+    assert final_payload["props"]["attachments"][0]["title"] == "Status"
+
+
+@pytest.mark.asyncio
+async def test_finalized_stream_overflow_edit_stays_plain():
+    adapter = _adapter(rich_posts=True)
+
+    result = await adapter.edit_message(
+        "channel-1",
+        "post-1",
+        "# Status\n\nFirst overflow chunk",
+        finalize=True,
+        metadata={"multi_chunk": True},
+    )
+
+    assert result.success is True
+    payload = adapter._api_put.await_args.args[1]
+    assert payload == {
+        "message": "# Status\n\nFirst overflow chunk",
+        "props": {"disable_mentions": True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_streaming_preview_send_stays_plain_until_final_edit():
+    adapter = _adapter(rich_posts=True)
+
+    await adapter.send(
+        "channel-1",
+        "# Status\n\nStarting",
+        metadata={"expect_edits": True},
+    )
+
+    payload = adapter._post_preserving_thread.await_args.args[1]
+    assert payload == {
+        "channel_id": "channel-1",
+        "message": "# Status\n\nStarting",
+        "props": {"disable_mentions": True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_prechunked_send_message_piece_stays_plain():
+    adapter = _adapter(rich_posts=True)
+
+    await adapter.send(
+        "channel-1",
+        "part 1",
+        metadata={"multi_chunk": True},
+    )
+
+    payload = adapter._post_preserving_thread.await_args.args[1]
+    assert payload == {
+        "channel_id": "channel-1",
+        "message": "part 1",
+        "props": {"disable_mentions": True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_single_chunk_rich_post_adds_signed_feedback_buttons(monkeypatch):
+    monkeypatch.setenv("MATTERMOST_INTERACTION_SECRET", "feedback-secret")
+    adapter = _adapter(rich_posts=True, feedback_buttons=True)
+
+    result = await adapter.send("channel-1", "# Result\n\nComplete")
+
+    assert result.success is True
+    payload = adapter._post_preserving_thread.await_args.args[1]
+    actions = payload["props"]["attachments"][0]["actions"]
+    assert [action["name"] for action in actions] == ["Helpful", "Not helpful"]
+    assert "feedback-secret" not in repr(payload)
+
+    callback = {
+        "user_id": "user-1",
+        "user_name": "Nawaf",
+        "channel_id": "channel-1",
+        "post_id": "post-1",
+        "context": actions[0]["integration"]["context"],
+    }
+    adapter._is_interactive_user_authorized = lambda *args, **kwargs: True
+    body, status = await adapter._dispatch_interaction(callback)
+
+    assert status == 200
+    assert "Thanks" in body["ephemeral_text"]
+    assert body["update"]["message"] == "# Result\n\nComplete"
+    assert "actions" not in body["update"]["props"]["attachments"][0]

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -8,7 +8,12 @@ from unittest.mock import AsyncMock
 import pytest
 
 import gateway.run as gateway_run
-from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.config import (
+    GatewayConfig,
+    Platform,
+    PlatformConfig,
+    platform_binds_port,
+)
 from gateway.run import GatewayRunner
 
 
@@ -501,14 +506,14 @@ class TestFeishuPortBindingConditional:
         connected = await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
         assert connected == 0  # no error, just nothing connected
 
-
+    def test_mattermost_binds_only_with_interaction_listener(self):
         # Feishu: webhook = port binding
-        assert _platform_binds_port("feishu", {"connection_mode": "webhook"}) is True
+        assert platform_binds_port("feishu", {"connection_mode": "webhook"}) is True
 
         # Mattermost only binds its optional interaction callback listener.
-        assert _platform_binds_port("mattermost", {}) is False
-        assert _platform_binds_port("mattermost", {"interaction_url": ""}) is False
-        assert _platform_binds_port(
+        assert platform_binds_port("mattermost", {}) is False
+        assert platform_binds_port("mattermost", {"interaction_url": ""}) is False
+        assert platform_binds_port(
             "mattermost",
             {"interaction_url": "https://hermes.example.com/mattermost/actions"},
         ) is True

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -260,6 +260,12 @@ class TestSecondaryProfileConfigHandling:
                 enabled=True, extra={"connection_mode": "webhook"}
             ),
             Platform.WEBHOOK: PlatformConfig(enabled=True, extra={"port": 8644}),
+            Platform.MATTERMOST: PlatformConfig(
+                enabled=True,
+                extra={
+                    "interaction_url": "https://hermes.example.com/mattermost/actions"
+                },
+            ),
             Platform.TELEGRAM: PlatformConfig(enabled=True, token="t"),
         }
         monkeypatch.setattr(
@@ -271,6 +277,7 @@ class TestSecondaryProfileConfigHandling:
         message = str(ei.value)
         assert "feishu" in message
         assert "webhook" in message
+        assert "mattermost" in message
         assert "telegram" not in message
         assert "reviewer" not in runner._profile_adapters
 
@@ -495,3 +502,13 @@ class TestFeishuPortBindingConditional:
         assert connected == 0  # no error, just nothing connected
 
 
+        # Feishu: webhook = port binding
+        assert _platform_binds_port("feishu", {"connection_mode": "webhook"}) is True
+
+        # Mattermost only binds its optional interaction callback listener.
+        assert _platform_binds_port("mattermost", {}) is False
+        assert _platform_binds_port("mattermost", {"interaction_url": ""}) is False
+        assert _platform_binds_port(
+            "mattermost",
+            {"interaction_url": "https://hermes.example.com/mattermost/actions"},
+        ) is True

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -168,6 +168,26 @@ class RetryableOverflowEditProgressAdapter(SmallLimitProgressAdapter):
         return await super().edit_message(chat_id, message_id, content)
 
 
+class SmallLimitMetadataProgressAdapter(SmallLimitProgressAdapter):
+    MAX_MESSAGE_LENGTH = 600
+
+    async def edit_message(
+        self, chat_id, message_id, content, *, finalize: bool = False, metadata=None
+    ) -> SendResult:
+        if len(content) > self.MAX_MESSAGE_LENGTH:
+            self.oversized_edits.append(content)
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "finalize": finalize,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=message_id)
+
+
 class NonEditingProgressCaptureAdapter(ProgressCaptureAdapter):
     SUPPORTS_MESSAGE_EDITING = False
 
@@ -799,6 +819,27 @@ class TransformedStreamAgent:
         }
 
 
+class OverflowTransformedStreamAgent:
+    original = "A" * 350 + "\n" + "B" * 350
+
+    def __init__(self, **kwargs):
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.stream_delta_callback:
+            self.stream_delta_callback(self.original[:300])
+            time.sleep(0.12)
+            self.stream_delta_callback(self.original[300:])
+        return {
+            "final_response": self.original + "\n\n[plugin appended this]",
+            "response_previewed": True,
+            "response_transformed": True,
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 @pytest.mark.asyncio
 async def test_transformed_response_edits_streamed_message_in_place(monkeypatch, tmp_path):
     """When a transform_llm_output hook modifies the response after streaming,
@@ -830,6 +871,161 @@ async def test_transformed_response_edits_streamed_message_in_place(monkeypatch,
     assert any("[plugin appended this]" in text for text in edited_texts), (
         f"expected transformed text in adapter.edits, got: {edited_texts!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_transformed_overflow_edits_only_plain_last_continuation(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        OverflowTransformedStreamAgent,
+        session_id="sess-transformed-overflow",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        platform=Platform.MATRIX,
+        chat_id="!room:matrix.example.org",
+        chat_type="group",
+        thread_id="$thread",
+        adapter_cls=SmallLimitMetadataProgressAdapter,
+    )
+
+    assert result.get("already_sent") is True
+    transformed_edits = [
+        edit for edit in adapter.edits if "[plugin appended this]" in edit["content"]
+    ]
+    assert transformed_edits
+    transformed = transformed_edits[-1]
+    assert transformed["metadata"]["multi_chunk"] is True
+    assert not transformed["content"].startswith("A" * 100)
+    assert adapter.oversized_edits == []
+
+
+@pytest.mark.asyncio
+async def test_run_agent_queued_message_does_not_treat_commentary_as_final(monkeypatch, tmp_path):
+    QueuedCommentaryAgent.calls = 0
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        QueuedCommentaryAgent,
+        session_id="sess-queued-commentary",
+        pending_text="queued follow-up",
+        config_data={"display": {"interim_assistant_messages": True}},
+    )
+
+    sent_texts = [call["content"] for call in adapter.sent]
+    assert result["final_response"] == "final response 2"
+    assert "I'll inspect the repo first." in sent_texts
+    assert "final response 1" in sent_texts
+
+
+@pytest.mark.asyncio
+async def test_run_agent_suppresses_silent_first_turn_and_processes_queued_followup(
+    monkeypatch, tmp_path,
+):
+    """Regression: queued direct-send must not leak NO_REPLY to the channel."""
+    QueuedSilenceAgent.calls = 0
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        QueuedSilenceAgent,
+        session_id="sess-queued-silence",
+        pending_text="queued follow-up",
+        platform=Platform.SLACK,
+        chat_id="C123",
+        thread_id="1712345678.000100",
+    )
+
+    sent_texts = [call["content"] for call in adapter.sent]
+    assert QueuedSilenceAgent.calls == 2
+    assert result["final_response"] == "follow-up processed"
+    assert "NO_REPLY" not in sent_texts
+
+
+@pytest.mark.asyncio
+async def test_run_agent_sends_normalized_failure_before_queued_followup(
+    monkeypatch, tmp_path,
+):
+    """Queued delivery uses finalized output, not the raw empty agent result."""
+    QueuedFailedEmptyAgent.calls = 0
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        QueuedFailedEmptyAgent,
+        session_id="sess-queued-failed-empty",
+        pending_text="queued follow-up",
+        platform=Platform.SLACK,
+        chat_id="C123",
+        thread_id="1712345678.000100",
+    )
+
+    sent_texts = [call["content"] for call in adapter.sent]
+    assert QueuedFailedEmptyAgent.calls == 2
+    assert result["final_response"] == "follow-up processed"
+    assert any("The request failed: provider exploded" in text for text in sent_texts)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_defers_background_review_notification_until_release(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        BackgroundReviewAgent,
+        session_id="sess-bg-review-order",
+        config_data={"display": {"interim_assistant_messages": True}},
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_base_processing_releases_post_delivery_callback_after_main_send():
+    """Post-delivery callbacks on the adapter fire after the main response."""
+    adapter = ProgressCaptureAdapter()
+
+    async def _handler(event):
+        return "done"
+
+    adapter.set_message_handler(_handler)
+
+    released = []
+
+    def _post_delivery_cb():
+        released.append(True)
+        adapter.sent.append(
+            {
+                "chat_id": "bg-review",
+                "content": "💾 Skill 'prospect-scanner' created.",
+                "reply_to": None,
+                "metadata": None,
+            }
+        )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+    event = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="msg-1",
+    )
+    session_key = "agent:main:telegram:group:-1001:17585"
+    adapter._active_sessions[session_key] = asyncio.Event()
+    adapter._post_delivery_callbacks[session_key] = _post_delivery_cb
+
+    await adapter._process_message_background(event, session_key)
+
+    sent_texts = [call["content"] for call in adapter.sent]
+    assert sent_texts == ["done", "💾 Skill 'prospect-scanner' created."]
+    assert released == [True]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1131,6 +1131,120 @@ class TestInterimCommentaryMessages:
         assert adapter.sends[0]["metadata"]["multi_chunk"] is True
 
     @pytest.mark.asyncio
+    async def test_over_limit_appendix_is_chunked_to_platform_safe_limit(self):
+        class Adapter:
+            MAX_MESSAGE_LENGTH = 600
+
+            def __init__(self):
+                self.sends = []
+
+            async def send(self, **kwargs):
+                self.sends.append(kwargs)
+                return SimpleNamespace(
+                    success=True,
+                    message_id=f"appendix-{len(self.sends)}",
+                )
+
+        head = "h" * 400
+        tail = "t" * 300
+        appendix = "a" * 1200
+        adapter = Adapter()
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "continuation-2"
+        consumer._is_multi_chunk = True
+        consumer._finalized_overflow_prefix = head
+        consumer._streamed_source_text = head + tail
+
+        assert await consumer.edit_transformed_final(head + tail + appendix)
+        assert len(adapter.sends) == 3
+        assert all(len(call["content"]) <= 500 for call in adapter.sends)
+        assert "".join(call["content"] for call in adapter.sends) == appendix
+        assert all(call["metadata"]["multi_chunk"] is True for call in adapter.sends)
+
+    @pytest.mark.asyncio
+    async def test_over_limit_non_prefix_transform_chunks_before_cleanup(self):
+        class Adapter:
+            MAX_MESSAGE_LENGTH = 600
+
+            def __init__(self):
+                self.sends = []
+                self.deleted = []
+                self.events = []
+
+            async def send(self, **kwargs):
+                self.sends.append(kwargs)
+                message_id = f"replacement-{len(self.sends)}"
+                self.events.append(("send", message_id))
+                return SimpleNamespace(success=True, message_id=message_id)
+
+            async def delete_message(self, chat_id, message_id):
+                self.deleted.append((chat_id, message_id))
+                self.events.append(("delete", message_id))
+                return True
+
+        adapter = Adapter()
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "continuation-2"
+        consumer._preview_message_ids = {"head-1", "continuation-2"}
+        consumer._segment_preview_message_ids = {"head-1", "continuation-2"}
+        consumer._is_multi_chunk = True
+        consumer._streamed_source_text = "old response"
+        transformed = "rewritten " + ("x" * 1300)
+
+        assert await consumer.edit_transformed_final(transformed)
+        assert len(adapter.sends) == 3
+        assert all(len(call["content"]) <= 500 for call in adapter.sends)
+        assert "".join(call["content"] for call in adapter.sends) == transformed
+        assert all(call["metadata"]["multi_chunk"] is True for call in adapter.sends)
+        first_delete = next(
+            index for index, event in enumerate(adapter.events) if event[0] == "delete"
+        )
+        assert first_delete == len(adapter.sends)
+        assert set(adapter.deleted) == {
+            ("chat_123", "head-1"),
+            ("chat_123", "continuation-2"),
+        }
+
+    @pytest.mark.asyncio
+    async def test_failed_replacement_chunk_preserves_obsolete_stream_messages(self):
+        class Adapter:
+            MAX_MESSAGE_LENGTH = 600
+
+            def __init__(self):
+                self.sends = []
+                self.deleted = []
+
+            async def send(self, **kwargs):
+                self.sends.append(kwargs)
+                if len(self.sends) == 2:
+                    return SimpleNamespace(success=False, message_id=None)
+                return SimpleNamespace(success=True, message_id="replacement-1")
+
+            async def delete_message(self, chat_id, message_id):
+                self.deleted.append((chat_id, message_id))
+                return True
+
+        adapter = Adapter()
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "continuation-2"
+        consumer._preview_message_ids = {"head-1", "continuation-2"}
+        consumer._segment_preview_message_ids = {"head-1", "continuation-2"}
+        consumer._is_multi_chunk = True
+        consumer._streamed_source_text = "old response"
+
+        delivered = await consumer.edit_transformed_final(
+            "rewritten " + ("x" * 1300)
+        )
+
+        assert delivered is False
+        assert len(adapter.sends) == 2
+        assert adapter.deleted == []
+        assert {"head-1", "continuation-2"}.issubset(
+            consumer._segment_preview_message_ids
+        )
+        assert consumer.final_response_sent is False
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "streamed",
         [

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -383,6 +383,10 @@ class TestSegmentBreakOnToolBoundary:
         # The undelivered "world" tail must reach the user, and the next
         # segment must not duplicate "Hello" that was already visible.
         assert sent_texts == ["Hello ▉", "world", "Next segment"]
+        assert all(
+            call.kwargs.get("metadata", {}).get("multi_chunk") is True
+            for call in adapter.send.await_args_list[1:]
+        )
 
     @pytest.mark.asyncio
     async def test_segment_break_after_mid_stream_edit_failure_preserves_tail(self):
@@ -435,6 +439,138 @@ class TestSegmentBreakOnToolBoundary:
         # Post-boundary text must also reach the user.
         assert "Here is the tool result." in all_text
 
+    @pytest.mark.asyncio
+    async def test_no_message_id_enters_fallback_mode(self):
+        """Platform returns success but no message_id (Signal) — must not
+        re-send on every delta.  Should enter fallback mode and send only
+        the continuation at finish."""
+        adapter = MagicMock()
+        # First send succeeds but returns no message_id (Signal behavior)
+        send_result_no_id = SimpleNamespace(success=True, message_id=None)
+        # Fallback final send succeeds
+        send_result_final = SimpleNamespace(success=True, message_id="msg_final")
+        adapter.send = AsyncMock(side_effect=[send_result_no_id, send_result_final])
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer.on_delta("Hello")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.08)
+        consumer.on_delta(" world, this is a longer response.")
+        await asyncio.sleep(0.08)
+        consumer.finish()
+        await task
+
+        # Should send exactly 2 messages: initial chunk + fallback continuation
+        # NOT one message per delta
+        assert adapter.send.call_count == 2
+        assert consumer.already_sent
+        # edit_message should NOT have been called (no valid message_id to edit)
+        adapter.edit_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_message_id_single_delta_marks_already_sent(self):
+        """When the entire response fits in one delta and platform returns no
+        message_id, already_sent must still be True to prevent the gateway
+        from re-sending the full response."""
+        adapter = MagicMock()
+        send_result = SimpleNamespace(success=True, message_id=None)
+        adapter.send = AsyncMock(return_value=send_result)
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer.on_delta("Short response.")
+        consumer.finish()
+
+        await consumer.run()
+
+        assert consumer.already_sent
+        # Only one send call (the initial message)
+        assert adapter.send.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_message_id_segment_breaks_do_not_resend(self):
+        """On a platform that never returns a message_id (e.g. webhook with
+        github_comment delivery), tool-call segment breaks must NOT trigger
+        a new adapter.send() per boundary.  The fix: _message_id == '__no_edit__'
+        suppresses the reset so all text accumulates and is sent once."""
+        adapter = MagicMock()
+        # No message_id on first send, then one more for the fallback final
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id=None),
+            SimpleNamespace(success=True, message_id=None),
+        ])
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        # Simulate: text → tool boundary → text → tool boundary → text (3 segments)
+        consumer.on_delta("Phase 1 text")
+        consumer.on_delta(None)   # tool call boundary
+        consumer.on_delta("Phase 2 text")
+        consumer.on_delta(None)   # another tool call boundary
+        consumer.on_delta("Phase 3 text")
+        consumer.finish()
+
+        await consumer.run()
+
+        # Before the fix this would post 3 comments (one per segment).
+        # After the fix: only the initial partial + one fallback-final continuation.
+        assert adapter.send.call_count == 2, (
+            f"Expected 2 sends (initial + fallback), got {adapter.send.call_count}"
+        )
+        assert consumer.already_sent
+        # The continuation must contain the text from segments 2 and 3
+        final_text = adapter.send.call_args_list[1][1]["content"]
+        assert "Phase 2" in final_text
+        assert "Phase 3" in final_text
+
+    @pytest.mark.asyncio
+    async def test_fallback_final_splits_long_continuation_without_dropping_text(self):
+        """Long continuation tails should be chunked when fallback final-send runs."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id="msg_1"),
+            SimpleNamespace(success=True, message_id="msg_2"),
+            SimpleNamespace(success=True, message_id="msg_3"),
+            SimpleNamespace(success=True, message_id="msg_4"),
+        ])
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=False, error="flood_control:6"))
+        adapter.MAX_MESSAGE_LENGTH = 610
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=" ▉")
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        prefix = "Hello world"
+        tail = "x" * 620
+        consumer.on_delta(prefix)
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.08)
+        consumer.on_delta(tail)
+        await asyncio.sleep(0.08)
+        consumer.finish()
+        await task
+
+        sent_texts = [call[1]["content"] for call in adapter.send.call_args_list]
+        assert len(sent_texts) == 3
+        assert sent_texts[0].startswith(prefix)
+        assert sum(len(t) for t in sent_texts[1:]) == len(tail)
+
+        assert consumer._finalized_overflow_prefix == ""
+        assert consumer._streamed_source_text == prefix + tail
+        assert await consumer.edit_transformed_final(
+            prefix + tail + "\n\n[plugin appendix]"
+        )
+        appendix_call = adapter.send.call_args_list[-1]
+        assert appendix_call.kwargs["content"] == "\n\n[plugin appendix]"
+        assert appendix_call.kwargs["metadata"]["multi_chunk"] is True
 
     @pytest.mark.asyncio
     async def test_fallback_final_sends_full_text_at_tool_boundary(self):
@@ -546,6 +682,10 @@ class TestSegmentBreakOnToolBoundary:
             c.kwargs.get("content", "") for c in adapter.send.call_args_list
         ]
         assert any("Done!" in s and "Working on i" not in s for s in sent_contents)
+        assert all(
+            call.kwargs.get("metadata", {}).get("multi_chunk") is True
+            for call in adapter.send.await_args_list
+        )
         # ...and the head-bearing partial was NOT deleted.
         adapter.delete_message.assert_not_awaited()
         assert consumer._final_response_sent is True
@@ -591,6 +731,58 @@ class TestFinalResponseDeliveryGuard:
         assert consumer._final_response_sent is False, (
             "_already_sent leaked into _final_response_sent — gateway will "
             "wrongly suppress its fallback delivery (#10748)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stream_overflow_marks_sealed_edit_as_multi_chunk(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_1")
+        )
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_1")
+        )
+        adapter.MAX_MESSAGE_LENGTH = 600
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+        consumer.on_delta("a" * 300)
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.on_delta("b" * 400)
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        finalized_edits = [
+            call
+            for call in adapter.edit_message.await_args_list
+            if call.kwargs.get("finalize") is True
+        ]
+        assert finalized_edits
+        assert all(
+            call.kwargs.get("metadata", {}).get("multi_chunk") is True
+            for call in finalized_edits
+        )
+
+    @pytest.mark.asyncio
+    async def test_fallback_overflow_marks_every_send_as_multi_chunk(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_fallback")
+        )
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_1")
+        )
+        adapter.MAX_MESSAGE_LENGTH = 600
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+
+        await consumer._send_fallback_final("x" * 1200)
+
+        assert adapter.send.await_count > 1
+        assert all(
+            call.kwargs.get("metadata", {}).get("multi_chunk") is True
+            for call in adapter.send.await_args_list
         )
 
 
@@ -829,6 +1021,245 @@ class TestInterimCommentaryMessages:
 
         sent_texts = [call[1]["content"] for call in adapter.send.call_args_list]
         assert sent_texts == ["I'll inspect the repository first.", "Done."]
+        commentary_meta = adapter.send.call_args_list[0].kwargs["metadata"]
+        final_meta = adapter.send.call_args_list[1].kwargs["metadata"]
+        assert commentary_meta["expect_edits"] is True
+        assert commentary_meta["multi_chunk"] is True
+        assert final_meta["multi_chunk"] is True
+        assert consumer.final_response_sent is True
+
+    @pytest.mark.asyncio
+    async def test_transformed_overflow_edits_only_last_plain_continuation(self):
+        class MetadataAdapter:
+            async def edit_message(
+                self, chat_id, message_id, content, *, finalize=False, metadata=None
+            ):
+                self.edit = {
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "content": content,
+                    "finalize": finalize,
+                    "metadata": metadata,
+                }
+                return SimpleNamespace(success=True, message_id=message_id)
+
+        adapter = MetadataAdapter()
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "continuation-2"
+        consumer._is_multi_chunk = True
+        consumer._finalized_overflow_prefix = "first chunk\n"
+
+        delivered = await consumer.edit_transformed_final(
+            "first chunk\nlast chunk\n\n[plugin appended]"
+        )
+
+        assert delivered is True
+        assert adapter.edit["content"] == "last chunk\n\n[plugin appended]"
+        assert adapter.edit["finalize"] is True
+        assert adapter.edit["metadata"]["multi_chunk"] is True
+
+    @pytest.mark.asyncio
+    async def test_transformed_known_prefix_rewrite_uses_plain_replacement(self):
+        class Adapter:
+            MAX_MESSAGE_LENGTH = 600
+
+            def __init__(self):
+                self.edits = []
+                self.sends = []
+                self.deleted = []
+
+            async def edit_message(self, **kwargs):
+                self.edits.append(kwargs)
+                raise AssertionError("must not edit only the last continuation")
+
+            async def send(self, **kwargs):
+                self.sends.append(kwargs)
+                return SimpleNamespace(success=True, message_id="replacement-3")
+
+            async def delete_message(self, chat_id, message_id):
+                self.deleted.append((chat_id, message_id))
+                return True
+
+        adapter = Adapter()
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "continuation-2"
+        consumer._preview_message_ids = {"head-1", "continuation-2"}
+        consumer._segment_preview_message_ids = {"head-1", "continuation-2"}
+        consumer._is_multi_chunk = True
+        consumer._finalized_overflow_prefix = "old head\n"
+        consumer._streamed_source_text = "old head\nold tail"
+
+        assert await consumer.edit_transformed_final("rewritten response")
+        assert adapter.edits == []
+        assert adapter.sends[0]["content"] == "rewritten response"
+        assert adapter.sends[0]["metadata"]["multi_chunk"] is True
+        assert set(adapter.deleted) == {
+            ("chat_123", "head-1"),
+            ("chat_123", "continuation-2"),
+        }
+
+    @pytest.mark.asyncio
+    async def test_transformed_known_prefix_over_limit_sends_plain_appendix(self):
+        class Adapter:
+            MAX_MESSAGE_LENGTH = 600
+
+            def __init__(self):
+                self.edits = []
+                self.sends = []
+
+            async def edit_message(self, **kwargs):
+                self.edits.append(kwargs)
+                raise AssertionError("must not issue an over-limit edit")
+
+            async def send(self, **kwargs):
+                self.sends.append(kwargs)
+                return SimpleNamespace(success=True, message_id="appendix-3")
+
+        head = "h" * 400
+        tail = "t" * 300
+        appendix = "a" * 400
+        adapter = Adapter()
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "continuation-2"
+        consumer._is_multi_chunk = True
+        consumer._finalized_overflow_prefix = head
+        consumer._streamed_source_text = head + tail
+
+        assert await consumer.edit_transformed_final(head + tail + appendix)
+        assert adapter.edits == []
+        assert adapter.sends[0]["content"] == appendix
+        assert adapter.sends[0]["metadata"]["multi_chunk"] is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "streamed",
+        [
+            "fallback head\nfallback tail",
+            "```python\nprint('code-fence overflow')\n```",
+        ],
+    )
+    async def test_transformed_unknown_prefix_sends_only_plain_appendix(
+        self, streamed
+    ):
+        """Unknown chunk boundaries must never receive the full response edit."""
+
+        class Adapter:
+            def __init__(self):
+                self.edits = []
+                self.sends = []
+
+            async def edit_message(self, **kwargs):
+                self.edits.append(kwargs)
+                raise AssertionError("must not overwrite the final continuation")
+
+            async def send(self, **kwargs):
+                self.sends.append(kwargs)
+                return SimpleNamespace(success=True, message_id="appendix-3")
+
+        adapter = Adapter()
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "continuation-2"
+        consumer._is_multi_chunk = True
+        consumer._finalized_overflow_prefix = ""
+        consumer._streamed_source_text = streamed
+
+        assert await consumer.edit_transformed_final(
+            streamed + "\n\n[plugin appendix]"
+        )
+        assert adapter.edits == []
+        assert len(adapter.sends) == 1
+        assert adapter.sends[0]["content"] == "\n\n[plugin appendix]"
+        assert adapter.sends[0]["metadata"]["multi_chunk"] is True
+
+    @pytest.mark.asyncio
+    async def test_transformed_rewrite_replaces_old_chunks_without_tail_overwrite(self):
+        class Adapter:
+            def __init__(self):
+                self.edits = []
+                self.sends = []
+                self.deleted = []
+
+            async def edit_message(self, **kwargs):
+                self.edits.append(kwargs)
+                raise AssertionError("must not overwrite the final continuation")
+
+            async def send(self, **kwargs):
+                self.sends.append(kwargs)
+                return SimpleNamespace(success=True, message_id="replacement-3")
+
+            async def delete_message(self, chat_id, message_id):
+                self.deleted.append((chat_id, message_id))
+                return True
+
+        adapter = Adapter()
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "continuation-2"
+        consumer._preview_message_ids = {
+            "commentary-0",
+            "head-1",
+            "continuation-2",
+        }
+        consumer._segment_preview_message_ids = {"head-1", "continuation-2"}
+        consumer._is_multi_chunk = True
+        consumer._streamed_source_text = "old response"
+
+        assert await consumer.edit_transformed_final("rewritten response")
+        assert adapter.edits == []
+        assert adapter.sends[0]["content"] == "rewritten response"
+        assert adapter.sends[0]["metadata"]["multi_chunk"] is True
+        assert set(adapter.deleted) == {
+            ("chat_123", "head-1"),
+            ("chat_123", "continuation-2"),
+        }
+
+    @pytest.mark.asyncio
+    async def test_failed_final_send_does_not_mark_final_response_sent(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=False, message_id=None))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5),
+        )
+
+        consumer.on_delta("Done.")
+        consumer.finish()
+
+        await consumer.run()
+
+        assert consumer.final_response_sent is False
+        assert consumer.already_sent is False
+
+    @pytest.mark.asyncio
+    async def test_success_without_message_id_marks_visible_and_sends_only_tail(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id=None),
+            SimpleNamespace(success=True, message_id=None),
+        ])
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=" ▉"),
+        )
+
+        consumer.on_delta("Hello")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.08)
+        consumer.on_delta(" world")
+        await asyncio.sleep(0.08)
+        consumer.finish()
+        await task
+
+        sent_texts = [call[1]["content"] for call in adapter.send.call_args_list]
+        assert sent_texts == ["Hello ▉", "world"]
+        assert consumer.already_sent is True
         assert consumer.final_response_sent is True
 
 

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -222,6 +222,94 @@ def test_observed_group_context_uses_shared_source_and_prompt_for_later_mentions
     asyncio.run(_run())
 
 
+def test_observed_group_context_replays_as_current_message_context_not_user_turns():
+    from gateway.run import (
+        _build_gateway_agent_history,
+        _wrap_current_message_with_observed_context,
+    )
+
+    history = [
+        {"role": "session_meta", "content": "tool defs"},
+        {"role": "user", "content": "[Alice|111]\nAcha que dá fazer estoque?", "observed": True},
+        {"role": "user", "content": "[Alice|111]\nTem lote e vencimento", "observed": True},
+        {"role": "assistant", "content": "previous explicit reply"},
+    ]
+
+    agent_history, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt="You are handling Telegram; observed Telegram group context is present.",
+    )
+    api_message = _wrap_current_message_with_observed_context(
+        "[Bob|222]\ncambio",
+        observed_context,
+    )
+
+    assert agent_history == [{"role": "assistant", "content": "previous explicit reply"}]
+    assert "[Observed group/channel context - context only, not requests]" in api_message
+    assert "[Current addressed message - answer only this" in api_message
+    assert "Acha que dá fazer estoque?" in api_message
+    assert "Tem lote e vencimento" in api_message
+    assert api_message.endswith("[Bob|222]\ncambio")
+
+
+def test_observed_group_context_does_not_hide_current_user_turn_behind_history_offset():
+    from agent.agent_runtime_helpers import repair_message_sequence
+    from gateway.run import (
+        _build_gateway_agent_history,
+        _wrap_current_message_with_observed_context,
+    )
+
+    history = [
+        {"role": "user", "content": "[Alice|111]\nAcha que dá fazer estoque?", "observed": True},
+    ]
+    agent_history, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt="observed Telegram group context",
+    )
+    api_message = _wrap_current_message_with_observed_context("[Bob|222]\ncambio", observed_context)
+    messages = list(agent_history) + [{"role": "user", "content": api_message}]
+
+    repair_message_sequence(object(), messages)
+
+    history_offset = len(agent_history)
+    new_messages = messages[history_offset:]
+    assert len(agent_history) == 0
+    assert new_messages[0]["role"] == "user"
+    assert new_messages[0]["content"].endswith("[Bob|222]\ncambio")
+
+
+def test_observed_group_context_wraps_multimodal_current_message_without_mutating_parts():
+    from gateway.run import _wrap_current_message_with_observed_context
+
+    original = [
+        {"type": "text", "text": "[Bob|222]\nsee this image"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+    ]
+
+    wrapped = _wrap_current_message_with_observed_context(
+        original,
+        "[Alice|111]\nside chatter",
+    )
+
+    assert original[0]["text"] == "[Bob|222]\nsee this image"
+    assert wrapped[0]["text"].startswith("[Observed group/channel context - context only")
+    assert wrapped[0]["text"].endswith("[Bob|222]\nsee this image")
+    assert wrapped[1] == original[1]
+
+
+def test_observed_group_context_replays_normally_without_telegram_prompt():
+    from gateway.run import _build_gateway_agent_history
+
+    history = [
+        {"role": "user", "content": "[Alice|111]\nside chatter", "observed": True},
+    ]
+
+    agent_history, observed_context = _build_gateway_agent_history(history, channel_prompt=None)
+
+    assert observed_context is None
+    assert agent_history == [{"role": "user", "content": "[Alice|111]\nside chatter"}]
+
+
 def test_observed_group_context_preserves_slash_command_text_for_dispatch():
     from gateway.platforms.base import MessageEvent, MessageType, Platform, SessionSource
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1165,10 +1165,6 @@ class TestApprovalTimeoutIsNotConsent:
             lambda: {"mode": "manual", "timeout": seconds},
         )
 
-    def test_timeout_blocks_with_no_consent_and_timeout_hook(self, monkeypatch):
-        """The reported #24912 scenario — user never responds, agent must see
-        BLOCKED, and the post hook must distinguish timeout from deny so audit
-        plugins can alert on 'agent asked, user never replied'."""
     def test_resolve_by_approval_id_targets_exact_pending_entry(self):
         from tools import approval as mod
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1169,6 +1169,26 @@ class TestApprovalTimeoutIsNotConsent:
         """The reported #24912 scenario — user never responds, agent must see
         BLOCKED, and the post hook must distinguish timeout from deny so audit
         plugins can alert on 'agent asked, user never replied'."""
+    def test_resolve_by_approval_id_targets_exact_pending_entry(self):
+        from tools import approval as mod
+
+        first = mod._ApprovalEntry({"approval_id": "approval-a"})
+        second = mod._ApprovalEntry({"approval_id": "approval-b"})
+        mod._gateway_queues[self.SESSION_KEY] = [first, second]
+
+        count = mod.resolve_gateway_approval(
+            self.SESSION_KEY, "once", approval_id="approval-b"
+        )
+
+        assert count == 1
+        assert second.result == "once"
+        assert second.event.is_set()
+        assert first.result is None
+        assert not first.event.is_set()
+        assert mod._gateway_queues[self.SESSION_KEY] == [first]
+
+    def test_timeout_returns_approved_false_with_no_consent(self, monkeypatch):
+        """The reported #24912 scenario — user never responds, agent must see BLOCKED."""
         from tools import approval as mod
 
         self._force_short_timeout(monkeypatch)
@@ -1193,6 +1213,7 @@ class TestApprovalTimeoutIsNotConsent:
         assert result.get("outcome") == "timeout"
         # The notify_cb DID fire — we did try to ask the user.
         assert len(notified) == 1
+        assert notified[0].get("approval_id")
 
         # The BLOCKED message must explicitly tell the agent not to rephrase;
         # without it the agent treats "Do NOT retry this command" as permission

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1675,6 +1675,156 @@ class TestSendViaAdapterStandaloneFallback:
         assert recorded["content"] == "done"
         assert recorded["metadata"] == {"publish_topic": "alerts-channel"}
 
+    @pytest.mark.asyncio
+    async def test_live_mattermost_adapter_receives_multi_chunk_metadata(self, monkeypatch):
+        from tools.send_message_tool import _send_via_adapter
+
+        platform = Platform("mattermost")
+        recorded = {}
+
+        class Adapter:
+            async def send(self, *, chat_id, content, metadata=None):
+                recorded["metadata"] = metadata
+                return SimpleNamespace(success=True, message_id="mattermost-id")
+
+        runner = SimpleNamespace(adapters={platform: Adapter()})
+        fake_gateway_run = ModuleType("gateway.run")
+        fake_gateway_run._gateway_runner_ref = lambda: runner
+        monkeypatch.setitem(sys.modules, "gateway.run", fake_gateway_run)
+
+        result = await _send_via_adapter(
+            platform,
+            SimpleNamespace(extra={}),
+            "channel-1",
+            "part 1",
+            multi_chunk=True,
+        )
+
+        assert result == {"success": True, "message_id": "mattermost-id"}
+        assert recorded["metadata"] == {"multi_chunk": True}
+
+    @pytest.mark.asyncio
+    async def test_standalone_mattermost_receives_multi_chunk_flag(self, monkeypatch):
+        from gateway.platform_registry import platform_registry
+        from tools.send_message_tool import _send_via_adapter
+
+        recorded = {}
+
+        async def fake_send(pconfig, chat_id, message, **kwargs):
+            recorded["kwargs"] = kwargs
+            return {"success": True, "message_id": "mattermost-id"}
+
+        entry = SimpleNamespace(standalone_sender_fn=fake_send)
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+        monkeypatch.setattr(
+            platform_registry,
+            "get",
+            lambda name: entry if name == "mattermost" else None,
+        )
+
+        result = await _send_via_adapter(
+            _FakePlatform("mattermost"),
+            SimpleNamespace(extra={}),
+            "channel-1",
+            "part 1",
+            multi_chunk=True,
+        )
+
+        assert result == {"success": True, "message_id": "mattermost-id"}
+        assert recorded["kwargs"]["multi_chunk"] is True
+
+    @pytest.mark.asyncio
+    async def test_standalone_sender_fn_called_when_no_adapter(self, monkeypatch):
+        """Registry has hook, runner ref returns None: the hook is awaited."""
+        from tools.send_message_tool import _send_via_adapter
+        from gateway.platform_registry import platform_registry
+
+        recorded = {}
+
+        async def fake_send(pconfig, chat_id, message, **kwargs):
+            recorded["pconfig"] = pconfig
+            recorded["chat_id"] = chat_id
+            recorded["message"] = message
+            recorded["kwargs"] = kwargs
+            return {"success": True, "message_id": "msg-42"}
+
+        platform_registry.register(self._make_entry(fake_send))
+        try:
+            monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+
+            pconfig = SimpleNamespace(extra={})
+            result = await _send_via_adapter(
+                _FakePlatform("fakeplatform"),
+                pconfig,
+                "room/123",
+                "hello cron",
+            )
+        finally:
+            platform_registry.unregister("fakeplatform")
+
+        assert result == {"success": True, "message_id": "msg-42"}
+        assert recorded["chat_id"] == "room/123"
+        assert recorded["message"] == "hello cron"
+        assert recorded["pconfig"] is pconfig
+
+    @pytest.mark.asyncio
+    async def test_standalone_sender_fn_kwargs_forwarded(self, monkeypatch):
+        """thread_id, media_files, and force_document all reach the hook."""
+        from tools.send_message_tool import _send_via_adapter
+        from gateway.platform_registry import platform_registry
+
+        recorded = {}
+
+        async def fake_send(pconfig, chat_id, message, *, thread_id=None,
+                            media_files=None, force_document=False):
+            recorded["thread_id"] = thread_id
+            recorded["media_files"] = media_files
+            recorded["force_document"] = force_document
+            return {"success": True, "message_id": "x"}
+
+        platform_registry.register(self._make_entry(fake_send))
+        try:
+            monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+
+            await _send_via_adapter(
+                _FakePlatform("fakeplatform"),
+                SimpleNamespace(extra={}),
+                "chat-1",
+                "hi",
+                thread_id="thread-7",
+                media_files=["/tmp/a.png"],
+                force_document=True,
+            )
+        finally:
+            platform_registry.unregister("fakeplatform")
+
+        assert recorded["thread_id"] == "thread-7"
+        assert recorded["media_files"] == ["/tmp/a.png"]
+        assert recorded["force_document"] is True
+
+    @pytest.mark.asyncio
+    async def test_standalone_sender_fn_absent_returns_helpful_error(self, monkeypatch):
+        """Registry entry has no hook: the fall-through error explains both
+        options (gateway-running and standalone hook)."""
+        from tools.send_message_tool import _send_via_adapter
+        from gateway.platform_registry import platform_registry
+
+        platform_registry.register(self._make_entry(None))
+        try:
+            monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+
+            result = await _send_via_adapter(
+                _FakePlatform("fakeplatform"),
+                SimpleNamespace(extra={}),
+                "chat-1",
+                "hi",
+            )
+        finally:
+            platform_registry.unregister("fakeplatform")
+
+        assert "error" in result
+        assert "fakeplatform" in result["error"]
+        assert "standalone_sender_fn" in result["error"]
 
     @pytest.mark.asyncio
     async def test_standalone_sender_fn_raises_is_caught_and_formatted(self, monkeypatch):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -15,6 +15,7 @@ import hashlib
 import logging
 import os
 import re
+import secrets
 import shlex
 import sys
 import tempfile
@@ -2174,8 +2175,9 @@ def register_gateway_notify(session_key: str, cb) -> None:
     """Register a per-session callback for sending approval requests to the user.
 
     The callback signature is ``cb(approval_data: dict) -> None`` where
-    *approval_data* contains ``command``, ``description``, and
-    ``pattern_keys``.  The callback bridges sync→async (runs in the agent
+    *approval_data* contains ``command``, ``description``, ``pattern_keys``,
+    and an opaque ``approval_id`` for exact-entry resolution.  The callback
+    bridges sync→async (runs in the agent
     thread, must schedule the actual send on the event loop).
     """
     with _lock:
@@ -2197,7 +2199,8 @@ def unregister_gateway_notify(session_key: str) -> None:
 
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
-                             reason: Optional[str] = None) -> int:
+                             reason: Optional[str] = None,
+                             approval_id: Optional[str] = None) -> int:
     """Called by the gateway's /approve or /deny handler to unblock
     waiting agent thread(s).
 
@@ -2209,13 +2212,29 @@ def resolve_gateway_approval(session_key: str, choice: str,
     deny (``/deny <reason>``).  It is relayed back to the agent in the
     BLOCKED message so it can adapt instead of only hearing "denied".
 
+    When *approval_id* is provided, only that exact pending queue entry is
+    resolved. Calls that omit it retain the legacy FIFO or ``resolve_all``
+    behavior used by typed approval commands.
+
     Returns the number of approvals resolved (0 means nothing was pending).
     """
     with _lock:
         queue = _gateway_queues.get(session_key)
         if not queue:
             return 0
-        if resolve_all:
+        if approval_id:
+            target_index = next(
+                (
+                    index
+                    for index, entry in enumerate(queue)
+                    if entry.data.get("approval_id") == approval_id
+                ),
+                None,
+            )
+            if target_index is None:
+                return 0
+            targets = [queue.pop(target_index)]
+        elif resolve_all:
             targets = list(queue)
             queue.clear()
         else:
@@ -3267,6 +3286,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     primary_key = approval_data.get("pattern_key", "")
     all_keys = approval_data.get("pattern_keys", [primary_key])
 
+    approval_data = dict(approval_data)
+    approval_data["approval_id"] = secrets.token_urlsafe(18)
     entry = _ApprovalEntry(approval_data)
     with _lock:
         _gateway_queues.setdefault(session_key, []).append(entry)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -694,6 +694,7 @@ async def _send_via_adapter(
     thread_id=None,
     media_files=None,
     force_document=False,
+    multi_chunk=False,
 ):
     """Send a message via a live gateway adapter, with a standalone fallback
     for out-of-process callers (e.g. cron running separately from the gateway).
@@ -726,6 +727,8 @@ async def _send_via_adapter(
                     metadata["thread_id"] = thread_id
                 if platform_name == "ntfy" and chat_id:
                     metadata["publish_topic"] = chat_id
+                if platform_name == "mattermost" and multi_chunk:
+                    metadata["multi_chunk"] = True
                 if not metadata:
                     metadata = None
                 result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
@@ -746,13 +749,18 @@ async def _send_via_adapter(
 
     if entry is not None and entry.standalone_sender_fn is not None:
         try:
+            standalone_kwargs = {
+                "thread_id": thread_id,
+                "media_files": media_files,
+                "force_document": force_document,
+            }
+            if platform_name == "mattermost":
+                standalone_kwargs["multi_chunk"] = multi_chunk
             result = await entry.standalone_sender_fn(
                 pconfig,
                 chat_id,
                 chunk,
-                thread_id=thread_id,
-                media_files=media_files,
-                force_document=force_document,
+                **standalone_kwargs,
             )
         except asyncio.CancelledError:
             raise
@@ -1151,6 +1159,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document,
+                multi_chunk=len(chunks) > 1,
             )
 
         if isinstance(result, dict) and result.get("error"):

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -477,12 +477,14 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `QQ_SANDBOX` | Enable QQ sandbox mode for development testing (`true`/`false`) |
 | `MATTERMOST_URL` | Mattermost server URL (e.g. `https://mm.example.com`) |
 | `MATTERMOST_TOKEN` | Bot token or personal access token for Mattermost |
+| `MATTERMOST_INTERACTION_SECRET` | HMAC secret for Mattermost approval and feedback action contexts |
 | `MATTERMOST_ALLOWED_USERS` | Comma-separated Mattermost user IDs allowed to message the bot |
 | `MATTERMOST_ALLOW_ALL_USERS` | Allow any Mattermost user to trigger the bot (dev only). |
 | `MATTERMOST_ALLOWED_CHANNELS` | If set, the bot only responds in these channels (whitelist). |
 | `MATTERMOST_HOME_CHANNEL` | Channel ID for proactive message delivery (cron, notifications) |
 | `MATTERMOST_REQUIRE_MENTION` | Require `@mention` in channels (default: `true`). Set to `false` to respond to all messages. |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where bot responds without `@mention` |
+| `MATTERMOST_OBSERVE_UNMENTIONED_CHANNEL_MESSAGES` | Store authorized unmentioned posts as context in explicitly allowed channels without triggering the agent (default: `false`) |
 | `MATTERMOST_REPLY_MODE` | Reply style: `thread` (threaded replies) or `off` (flat messages, default) |
 | `MATRIX_HOMESERVER` | Matrix homeserver URL (e.g. `https://matrix.org`) |
 | `MATRIX_ACCESS_TOKEN` | Matrix access token for bot authentication |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -484,7 +484,6 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `MATTERMOST_HOME_CHANNEL` | Channel ID for proactive message delivery (cron, notifications) |
 | `MATTERMOST_REQUIRE_MENTION` | Require `@mention` in channels (default: `true`). Set to `false` to respond to all messages. |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where bot responds without `@mention` |
-| `MATTERMOST_OBSERVE_UNMENTIONED_CHANNEL_MESSAGES` | Store authorized unmentioned posts as context in explicitly allowed channels without triggering the agent (default: `false`) |
 | `MATTERMOST_REPLY_MODE` | Reply style: `thread` (threaded replies) or `off` (flat messages, default) |
 | `MATRIX_HOMESERVER` | Matrix homeserver URL (e.g. `https://matrix.org`) |
 | `MATRIX_ACCESS_TOKEN` | Matrix access token for bot authentication |

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -252,6 +252,99 @@ Behavior:
 
 See also: [admin/user slash command split](../../reference/slash-commands.md#permissions-and-adminuser-split).
 
+## Passive observation of unmentioned channel posts
+
+Mattermost can retain eligible channel chatter as context without treating every post as a request:
+
+```yaml
+mattermost:
+  require_mention: true
+  allowed_channels:
+    - "xyz987uvw654rst321opq098nml"
+  observe_unmentioned_channel_messages: true
+```
+
+This mirrors Telegram's `observe_unmentioned_group_messages` behavior. An authorized post without an `@mention` is stored as **context only**; Hermes stays silent. When an authorized user later addresses the bot in the same channel or thread, that turn may use the observed context, but the older posts are not replayed as pending requests.
+
+Safety and scope:
+
+- The option defaults to `false` and does not change existing installations.
+- `require_mention` must remain enabled, and the channel must be explicitly listed in `allowed_channels`. Observation fails closed when no channel allowlist is configured.
+- The sender must pass the existing Mattermost/gateway user authorization check before the post is persisted.
+- DMs and `free_response_channels` use normal dispatch behavior; webhook posts, bot accounts, Hermes-authored posts, system posts, unmentioned command-shaped posts, and channels outside the allowlist remain ignored. Mattermost user lookup failures fail closed and do not persist passive context.
+- Context is shared at channel scope, or at Mattermost thread-root scope for replies. Sender name and ID are retained as attribution in the observed text.
+- Passive observation records when a post has attachments but does not download those files. Addressed posts retain the existing attachment-download behavior.
+
+Environment-variable equivalent:
+
+```bash
+MATTERMOST_OBSERVE_UNMENTIONED_CHANNEL_MESSAGES=true
+```
+
+## Native rich posts and interactive actions
+
+Mattermost can render Hermes replies as native attachment cards while preserving the original Markdown as fallback text. This is opt-in so existing installations keep their current message layout.
+
+```yaml
+mattermost:
+  rich_posts: true
+  feedback_buttons: true
+  interaction_url: "https://hermes.internal.example/mattermost/actions"
+  interaction_host: "127.0.0.1"
+  interaction_port: 8789
+  interaction_timeout_seconds: 300
+  interaction_allowed_cidrs:
+    - "10.0.0.12/32" # Mattermost server's callback source IP
+```
+
+Set a separate callback-signing secret in `~/.hermes/.env`:
+
+```bash
+MATTERMOST_INTERACTION_SECRET=replace-with-a-long-random-secret
+```
+
+You can generate one with `openssl rand -hex 32`.
+
+### Rich-post behavior
+
+- `rich_posts: true` wraps replies in Mattermost-native `props.attachments` cards.
+- The first Markdown heading becomes the card title. Lists, tables, dividers, code blocks, and remaining headings stay as Mattermost Markdown in the card body.
+- The complete original Markdown is kept in the attachment's `fallback` field.
+- Streaming updates remain plain while text is changing. Hermes applies the rich layout only to the final edit, avoiding card flicker.
+- Responses that exceed Mattermost's readable chunk size stay plain across all chunks.
+- Proactive and out-of-process cron messages use the same layout.
+- If Mattermost rejects a structured post or edit, Hermes automatically retries with plain Markdown so the answer is not lost.
+
+### Approval and feedback buttons
+
+When `interaction_url`, `MATTERMOST_INTERACTION_SECRET`, and at least one trusted `interaction_allowed_cidrs` entry are configured:
+
+- execution approvals can show native **Allow once**, **Allow for session**, **Always allow**, and **Deny** buttons;
+- `feedback_buttons: true` adds **Helpful** and **Not helpful** controls to final rich replies;
+- every callback carries a signed, single-use context and is checked against the existing Mattermost user allowlist;
+- signed actions expire after `interaction_timeout_seconds` (clamped to 30–3600 seconds);
+- approval session keys and the signing secret are never sent to Mattermost.
+
+If callbacks are not configured or the interaction listener cannot start, Hermes falls back to the existing typed approval flow. `feedback_buttons` has no effect unless `rich_posts` is also enabled.
+
+### Callback reachability
+
+Mattermost itself—not the user's browser—sends the action callback. The Mattermost server must therefore be able to reach `interaction_url`. Hermes also rejects callbacks unless the direct TCP peer is in `interaction_allowed_cidrs`; use exact `/32` IPv4 or `/128` IPv6 entries whenever possible.
+
+Non-loopback callback URLs must use HTTPS. Plain HTTP is accepted only for loopback listeners such as `http://127.0.0.1:8789/...` behind a secured local proxy.
+
+Some Mattermost deployments block callbacks to private addresses. If you use an internal URL, your Mattermost administrator may need to allow that destination with `AllowedUntrustedInternalConnections`.
+
+Hermes listens locally on `interaction_host:interaction_port` and uses the path from `interaction_url` (for the example above, `/mattermost/actions`). Put that listener behind your existing reverse proxy, VPN, or private service network. You do **not** need to expose the Hermes dashboard publicly. Prefer a private route whenever Mattermost and Hermes share a trusted network.
+
+In profile-multiplex mode, this callback is a host-port listener: only the active/default profile may configure `interaction_url`. Hermes rejects callback listeners on secondary profiles at startup instead of allowing a port collision and silently degrading actions.
+
+If a reverse proxy terminates the callback, list only the proxy's direct IP in `interaction_allowed_cidrs` and configure that proxy route to accept requests only from the Mattermost server (for example with a source-IP allowlist or mutual TLS). Hermes deliberately does not trust client-supplied forwarding headers. A generally public proxy route does not provide callback provenance.
+
+:::warning
+Do not bind the interaction listener to `0.0.0.0` unless a firewall restricts access to the exact trusted peers. Do not use broad CIDRs that include ordinary users. Keep `MATTERMOST_INTERACTION_SECRET` out of `config.yaml`, source control, and logs.
+:::
+
 ## Troubleshooting
 
 ### Bot is not responding to messages

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -275,12 +275,6 @@ Safety and scope:
 - Context is shared at channel scope, or at Mattermost thread-root scope for replies. Sender name and ID are retained as attribution in the observed text.
 - Passive observation records when a post has attachments but does not download those files. Addressed posts retain the existing attachment-download behavior.
 
-Environment-variable equivalent:
-
-```bash
-MATTERMOST_OBSERVE_UNMENTIONED_CHANNEL_MESSAGES=true
-```
-
 ## Native rich posts and interactive actions
 
 Mattermost can render Hermes replies as native attachment cards while preserving the original Markdown as fallback text. This is opt-in so existing installations keep their current message layout.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/mattermost.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/mattermost.md
@@ -252,6 +252,97 @@ MATTERMOST_ALLOWED_CHANNELS="abc123def456ghi789jkl012mno,xyz987uvw654rst321opq09
 
 另请参阅：[管理员/用户斜杠命令分离](../../reference/slash-commands.md#permissions-and-adminuser-split)。
 
+## 被动观察未提及机器人的频道消息
+
+Mattermost 可以将符合条件的频道聊天保存为上下文，而不会把每条消息都当作请求：
+
+```yaml
+mattermost:
+  require_mention: true
+  allowed_channels:
+    - "xyz987uvw654rst321opq098nml"
+  observe_unmentioned_channel_messages: true
+```
+
+此行为与 Telegram 的 `observe_unmentioned_group_messages` 一致。授权用户发送但未 `@提及` 机器人的消息只会保存为**上下文**，Hermes 保持静默。之后，当授权用户在同一频道或线程中明确提及机器人时，该轮对话可以使用这些观察上下文，但旧消息不会被当作待处理请求重新执行。
+
+安全与作用范围：
+
+- 该选项默认为 `false`，不会改变现有安装。
+- 必须保持 `require_mention` 启用，并且频道必须明确列在 `allowed_channels` 中；没有频道白名单时，被动观察会安全地保持禁用。
+- 消息写入会话记录前，发送者必须通过现有 Mattermost/gateway 用户授权检查。
+- 私信和 `free_response_channels` 仍使用正常分发；Webhook 消息、机器人账号、Hermes 自身消息、系统消息、未提及机器人的命令形式消息及白名单外频道继续被忽略。Mattermost 用户查询失败时会安全地跳过，不会写入被动上下文。
+- 上下文按频道共享；回复消息则按 Mattermost 线程根范围共享。观察文本会保留发送者名称和 ID 作为来源标记。
+- 被动观察会记录消息包含附件，但不会下载文件；明确提及机器人的消息仍保留现有附件下载行为。
+
+等效环境变量：
+
+```bash
+MATTERMOST_OBSERVE_UNMENTIONED_CHANNEL_MESSAGES=true
+```
+
+## 原生富消息与交互操作
+
+Mattermost 可以将 Hermes 回复渲染为原生附件卡片，同时保留原始 Markdown 作为回退文本。此功能默认关闭，因此不会改变现有安装的消息样式。
+
+```yaml
+mattermost:
+  rich_posts: true
+  feedback_buttons: true
+  interaction_url: "https://hermes.internal.example/mattermost/actions"
+  interaction_host: "127.0.0.1"
+  interaction_port: 8789
+  interaction_timeout_seconds: 300
+  interaction_allowed_cidrs:
+    - "10.0.0.12/32" # Mattermost 服务器的回调源 IP
+```
+
+在 `~/.hermes/.env` 中单独设置回调签名密钥：
+
+```bash
+MATTERMOST_INTERACTION_SECRET=replace-with-a-long-random-secret
+```
+
+可使用 `openssl rand -hex 32` 生成密钥。
+
+### 富消息行为
+
+- `rich_posts: true` 使用 Mattermost 原生 `props.attachments` 卡片包装回复。
+- 第一个 Markdown 标题会成为卡片标题；列表、表格、分隔线、代码块和其余标题继续作为 Mattermost Markdown 渲染。
+- 完整原始 Markdown 保存在附件的 `fallback` 字段中。
+- 流式输出的中间更新保持纯文本，只有最终编辑会应用富消息布局，以避免卡片闪烁。
+- 超过 Mattermost 可读分块长度的回复会在所有分块中保持纯文本。
+- 主动通知和进程外 cron 消息使用相同布局。
+- 如果 Mattermost 拒绝结构化消息或编辑，Hermes 会自动重试纯 Markdown，避免丢失回复。
+
+### 审批与反馈按钮
+
+同时配置 `interaction_url`、`MATTERMOST_INTERACTION_SECRET`，并在 `interaction_allowed_cidrs` 中至少设置一个可信来源后：
+
+- 执行审批可显示原生的**仅允许一次**、**本会话允许**、**始终允许**和**拒绝**按钮；
+- `feedback_buttons: true` 会在最终富消息回复中添加**有帮助**和**没有帮助**按钮；
+- 每个回调都携带带签名的一次性上下文，并通过现有 Mattermost 用户白名单检查；
+- 操作会在 `interaction_timeout_seconds` 后过期（取值限制为 30–3600 秒）；
+- 审批会话密钥和签名密钥不会发送到 Mattermost。
+
+如果回调未配置或交互监听器无法启动，Hermes 会回退到现有的文本审批流程。只有启用 `rich_posts` 时，`feedback_buttons` 才会生效。
+
+### 回调可达性
+
+操作回调由 Mattermost 服务器发送，而不是用户浏览器。因此 Mattermost 服务器必须能够访问 `interaction_url`。Hermes 还会拒绝直接 TCP 对端不在 `interaction_allowed_cidrs` 中的回调；应尽量使用精确的 IPv4 `/32` 或 IPv6 `/128`。部分部署会阻止访问私有地址；使用内部 URL 时，管理员可能需要通过 `AllowedUntrustedInternalConnections` 允许该目标。
+
+非回环回调 URL 必须使用 HTTPS。只有通过安全本地代理转发的 `http://127.0.0.1:8789/...` 等回环监听地址可以使用普通 HTTP。
+
+Hermes 在本地 `interaction_host:interaction_port` 上监听，并使用 `interaction_url` 的路径。请通过现有反向代理、VPN 或私有服务网络转发该监听器；无需公开 Hermes 仪表板，并应优先使用私有路由。
+
+在多配置文件复用模式下，该回调属于主机端口监听器：只有活动/默认配置文件可以设置 `interaction_url`。Hermes 会在启动时拒绝辅助配置文件中的回调监听器，避免端口冲突后静默降级交互操作。
+
+如果回调经过反向代理，`interaction_allowed_cidrs` 中只能填写该代理的直接 IP，并且代理路由必须通过源 IP 白名单或双向 TLS 等方式只允许 Mattermost 服务器访问。Hermes 不信任客户端提供的转发头。面向公众开放的普通代理路由无法证明回调来源。
+
+:::warning
+除非防火墙已将访问限制到精确的可信对端，否则不要将交互监听器绑定到 `0.0.0.0`。不要使用包含普通用户的宽泛 CIDR。不要把 `MATTERMOST_INTERACTION_SECRET` 写入 `config.yaml`、源码仓库或日志。
+:::
+
 ## 故障排查
 
 ### 机器人不响应消息

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/mattermost.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/mattermost.md
@@ -275,12 +275,6 @@ mattermost:
 - 上下文按频道共享；回复消息则按 Mattermost 线程根范围共享。观察文本会保留发送者名称和 ID 作为来源标记。
 - 被动观察会记录消息包含附件，但不会下载文件；明确提及机器人的消息仍保留现有附件下载行为。
 
-等效环境变量：
-
-```bash
-MATTERMOST_OBSERVE_UNMENTIONED_CHANNEL_MESSAGES=true
-```
-
 ## 原生富消息与交互操作
 
 Mattermost 可以将 Hermes 回复渲染为原生附件卡片，同时保留原始 Markdown 作为回退文本。此功能默认关闭，因此不会改变现有安装的消息样式。


### PR DESCRIPTION
## Summary

Adds opt-in Mattermost-native rich posts, secure interactive actions, and passive
allowlisted channel observation. This provides parity with Hermes's Slack rich-output
experience and Telegram's context-only group observation without sending Slack Block
Kit payloads to Mattermost.

- render single-chunk final responses as Mattermost `props.attachments`
- preserve the complete Markdown in both the ordinary post `message` and attachment `fallback`
- keep every multi-chunk path plain—including streamed overflow, proactive, and standalone sends—while applying rich structure only to a single final response
- retry as plain Markdown if Mattermost rejects a structured post
- add optional Helpful / Not helpful actions
- add native command-approval actions with typed-command fallback
- preserve thread roots across sends, edits, standalone delivery, and approvals
- optionally retain authorized unmentioned channel posts as context without
  dispatching the agent
- require explicit channel scope and existing gateway user authorization before
  passive content is persisted

Closes #59401.

## Related work

PRs #59420 and #60464 address Markdown normalization/formatting. This change keeps ordinary Markdown lossless and additive, while implementing the broader Mattermost-native structured-post, final-edit, approval, feedback, fallback, and callback-security contract requested in #59401.

## Configuration

```yaml
mattermost:
  require_mention: true
  allowed_channels:
    - "your-approved-channel-id"
  observe_unmentioned_channel_messages: true
  rich_posts: true
  feedback_buttons: true
  interaction_url: "https://your-hermes-host/mattermost/actions"
  interaction_host: "127.0.0.1"
  interaction_port: 8789
  interaction_timeout_seconds: 600
  interaction_allowed_cidrs:
    - "10.0.0.12/32"
```

Interactive actions also require `MATTERMOST_INTERACTION_SECRET`.

`interaction_allowed_cidrs` authenticates the direct Mattermost-to-Hermes network peer. Reverse-proxy deployments must restrict or authenticate the proxy route independently; Hermes deliberately does not trust caller-supplied forwarding headers. Non-loopback callback URLs require HTTPS.

## Security

- HMAC-signed action context with constant-time verification
- exact signed expiry matched to server-side pending state
- single-use nonce consumption and replay rejection
- direct-peer CIDR verification before request-body parsing
- channel/post/action-choice binding
- existing profile-bound gateway user authorization policy
- exact opaque `approval_id` binding so a button resolves only the command it displayed
- approval session keys remain server-side and never enter Mattermost action payloads
- bounded callback payloads and pending-state storage
- feedback state cannot evict live approval state

## Behavior and compatibility

- rich posts and feedback controls are separately opt-in
- legacy Mattermost output remains unchanged by default
- ordinary Markdown remains the lossless fallback
- the top-level Mattermost `message` remains intentionally populated alongside
  attachments for search, notifications, accessibility clients, and API consumers
- multi-chunk responses stay plain, matching the current Slack rich-output contract
- intermediate stream edits stay lightweight
- callback/listener failure degrades to typed approval commands
- no public Hermes dashboard or Tailscale Funnel is required; only an explicitly approved Mattermost-to-callback route is needed

### Passive channel observation

- `observe_unmentioned_channel_messages` defaults to false
- it only applies while mention-gating is enabled and the channel appears in the
  explicit `allowed_channels` list
- eligible unmentioned posts are stored with `observed: true`; they do not invoke
  the agent or produce a response
- sender authorization and a fail-closed Mattermost human-account lookup run
  before passive persistence or shared-session dispatch; webhook, bot, system,
  command-shaped, and out-of-scope posts remain ignored
- a later addressed turn receives observed rows in a separate context-only block,
  rather than replaying them as pending requests
- context is channel-scoped or Mattermost-thread-root-scoped and retains sender
  attribution
- passive posts note attachment presence without downloading files

## Tests

```text
462 targeted Mattermost/streaming/transformed-output/multiplex/observation/config/approval-contract tests passed
154 send-message routing and standalone-delivery tests passed
2 exact approval-queue tests passed
Ruff checks passed
git diff --check passed
```

The repository-wide suite was also exercised, but this checkout reports unrelated baseline/environment failures across ACP, WSL/service-manager, Matrix, file-tool, macOS `/tmp` path normalization, system-guard, and other suites. The focused feature, routing, streaming, and exact-approval suites above pass.
