### PR TITLE
fix(kanban): gate dependencies on accepted outcomes

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3799,8 +3799,8 @@ def task_outcome_accepted(conn: sqlite3.Connection, task_id: str) -> bool:
         return False
     verifier_run = conn.execute(
         "SELECT id, profile, metadata FROM task_runs "
-        "WHERE id = ? AND task_id = ? AND outcome = 'completed' AND ended_at IS NOT NULL",
-        (verifier_run_id, task_id),
+        "WHERE id = ? AND outcome = 'completed' AND ended_at IS NOT NULL",
+        (verifier_run_id,),
     ).fetchone()
     if (
         verifier_run is None

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2930,13 +2930,8 @@ def create_task(
                         missing = _find_missing_parents(conn, parents)
                         if missing:
                             raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
-                        # If any parent is not yet done, we're todo.
-                        rows = conn.execute(
-                            "SELECT status FROM tasks WHERE id IN "
-                            "(" + ",".join("?" * len(parents)) + ")",
-                            parents,
-                        ).fetchall()
-                        if any(r["status"] != "done" for r in rows):
+                        # Execution completion is not outcome acceptance.
+                        if any(not task_outcome_accepted(conn, parent) for parent in parents):
                             task_status = "todo"
                 # Even in triage mode we still need to validate parent ids
                 # so the eventual link rows don't dangle.
@@ -3160,11 +3155,8 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
             (parent_id, child_id),
         )
-        # If child was ready but parent is not yet done, demote child to todo.
-        parent_status = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
-        ).fetchone()["status"]
-        if parent_status != "done":
+        # A linked parent releases its child only after outcome acceptance.
+        if not task_outcome_accepted(conn, parent_id):
             conn.execute(
                 "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (child_id,),
@@ -3724,10 +3716,72 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     return bool(row) and row["kind"] == "blocked"
 
 
+_REQUIRED_CLASSIFICATION_RE = re.compile(
+    r"^\s*(?:required classification|terminal acceptance|terminal classification)"
+    r"\s*:\s*([A-Z][A-Z0-9_-]*)\s*\.?\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_REQUIRED_EVIDENCE_TYPE_RE = re.compile(
+    r"^\s*required evidence type\s*:\s*([a-z][a-z0-9_-]*)\s*\.?\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def task_outcome_accepted(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Return whether a completed task has an explicit accepted outcome.
+
+    Execution completion remains ``tasks.status = 'done'``. Dependency
+    release is a separate fail-closed decision derived from the task's
+    declared classification and the closing run's verifier evidence.
+    """
+    row = conn.execute(
+        "SELECT status, body FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    if row is None:
+        return False
+    if row["status"] == "archived":
+        return True
+    if row["status"] != "done":
+        return False
+    required_match = _REQUIRED_CLASSIFICATION_RE.search(row["body"] or "")
+    if required_match is None:
+        # Backward-compatible rollout: existing cards without an acceptance
+        # contract retain legacy completion semantics. Cards that declare a
+        # classification opt into the fail-closed gate.
+        return True
+    evidence_type_match = _REQUIRED_EVIDENCE_TYPE_RE.search(row["body"] or "")
+    required_evidence_type = (
+        evidence_type_match.group(1).lower() if evidence_type_match else "implementation"
+    )
+    run = conn.execute(
+        "SELECT metadata FROM task_runs "
+        "WHERE task_id = ? AND outcome = 'completed' "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if run is None or not run["metadata"]:
+        return False
+    try:
+        metadata = json.loads(run["metadata"])
+    except (TypeError, json.JSONDecodeError):
+        return False
+    evidence_refs = metadata.get("evidence_refs")
+    return (
+        str(metadata.get("outcome_classification", "")).upper()
+        == required_match.group(1).upper()
+        and str(metadata.get("verifier_verdict", "")).upper() == "PASS"
+        and isinstance(evidence_refs, list)
+        and bool(evidence_refs)
+        and all(isinstance(ref, str) and ref.strip() for ref in evidence_refs)
+        and str(metadata.get("evidence_type", "")).lower()
+        == required_evidence_type
+    )
+
+
 def recompute_ready(
     conn: sqlite3.Connection, failure_limit: int = None,
 ) -> int:
-    """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
+    """Promote tasks only when every parent has an accepted outcome.
 
     Returns the number of tasks promoted.  Safe to call inside or outside
     an existing transaction; it opens its own IMMEDIATE txn.
@@ -3773,12 +3827,12 @@ def recompute_ready(
                 # this predicate back).
                 continue
             parents = conn.execute(
-                "SELECT t.status FROM tasks t "
+                "SELECT t.id FROM tasks t "
                 "JOIN task_links l ON l.parent_id = t.id "
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
-            if all(p["status"] in ("done", "archived") for p in parents):
+            if all(task_outcome_accepted(conn, p["id"]) for p in parents):
                 if cur_status == "blocked":
                     # Don't auto-recover tasks that have hit the
                     # circuit-breaker failure limit.  Without this
@@ -3839,13 +3893,13 @@ def claim_task(
         # 'todo' here — recompute_ready will re-promote when the parents
         # actually finish. See RCA at
         # kanban/boards/cookai/workspaces/t_a6acd07d/root-cause.md.
-        undone = conn.execute(
-            "SELECT 1 FROM task_links l "
+        parent_rows = conn.execute(
+            "SELECT p.id FROM task_links l "
             "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
+            "WHERE l.child_id = ?",
             (task_id,),
-        ).fetchone()
-        if undone:
+        ).fetchall()
+        if any(not task_outcome_accepted(conn, row["id"]) for row in parent_rows):
             conn.execute(
                 "UPDATE tasks SET status = 'todo' "
                 "WHERE id = ? AND status = 'ready'",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3727,6 +3727,38 @@ _REQUIRED_EVIDENCE_TYPE_RE = re.compile(
 )
 
 
+def _acceptance_evidence_valid(
+    conn: sqlite3.Connection,
+    task_id: str,
+    verifier_profile: str,
+    evidence_refs: object,
+) -> bool:
+    """Validate narrow, structured evidence against existing durable rows."""
+    if not isinstance(evidence_refs, list) or not evidence_refs:
+        return False
+    for ref in evidence_refs:
+        if not isinstance(ref, dict) or set(ref) != {"kind", "id"}:
+            return False
+        if not isinstance(ref["id"], int) or isinstance(ref["id"], bool):
+            return False
+        if ref["kind"] == "comment":
+            row = conn.execute(
+                "SELECT 1 FROM task_comments WHERE id = ? AND task_id = ? AND author = ?",
+                (ref["id"], task_id, verifier_profile),
+            ).fetchone()
+        elif ref["kind"] == "run":
+            row = conn.execute(
+                "SELECT 1 FROM task_runs "
+                "WHERE id = ? AND task_id = ? AND profile = ? AND ended_at IS NOT NULL",
+                (ref["id"], task_id, verifier_profile),
+            ).fetchone()
+        else:
+            return False
+        if row is None:
+            return False
+    return True
+
+
 def task_outcome_accepted(conn: sqlite3.Connection, task_id: str) -> bool:
     """Return whether a completed task has an explicit accepted outcome.
 
@@ -3739,42 +3771,64 @@ def task_outcome_accepted(conn: sqlite3.Connection, task_id: str) -> bool:
     ).fetchone()
     if row is None:
         return False
-    if row["status"] == "archived":
-        return True
     if row["status"] != "done":
         return False
     required_match = _REQUIRED_CLASSIFICATION_RE.search(row["body"] or "")
     if required_match is None:
-        # Backward-compatible rollout: existing cards without an acceptance
-        # contract retain legacy completion semantics. Cards that declare a
-        # classification opt into the fail-closed gate.
-        return True
+        return False
     evidence_type_match = _REQUIRED_EVIDENCE_TYPE_RE.search(row["body"] or "")
     required_evidence_type = (
         evidence_type_match.group(1).lower() if evidence_type_match else "implementation"
     )
-    run = conn.execute(
-        "SELECT metadata FROM task_runs "
+    closing_run = conn.execute(
+        "SELECT id, profile, metadata FROM task_runs "
         "WHERE task_id = ? AND outcome = 'completed' "
         "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    if run is None or not run["metadata"]:
+    if closing_run is None or not closing_run["metadata"]:
         return False
     try:
-        metadata = json.loads(run["metadata"])
+        closing_metadata = json.loads(closing_run["metadata"])
     except (TypeError, json.JSONDecodeError):
         return False
-    evidence_refs = metadata.get("evidence_refs")
+    if not isinstance(closing_metadata, dict):
+        return False
+    verifier_run_id = closing_metadata.get("verifier_run_id")
+    if not isinstance(verifier_run_id, int) or isinstance(verifier_run_id, bool):
+        return False
+    verifier_run = conn.execute(
+        "SELECT id, profile, metadata FROM task_runs "
+        "WHERE id = ? AND task_id = ? AND outcome = 'completed' AND ended_at IS NOT NULL",
+        (verifier_run_id, task_id),
+    ).fetchone()
+    if (
+        verifier_run is None
+        or verifier_run["id"] == closing_run["id"]
+        or not verifier_run["profile"]
+        or verifier_run["profile"] == closing_run["profile"]
+        or not verifier_run["metadata"]
+    ):
+        return False
+    try:
+        verifier_metadata = json.loads(verifier_run["metadata"])
+    except (TypeError, json.JSONDecodeError):
+        return False
+    if not isinstance(verifier_metadata, dict):
+        return False
+    verification = verifier_metadata.get("verification")
+    if not isinstance(verification, dict):
+        return False
     return (
-        str(metadata.get("outcome_classification", "")).upper()
+        verification.get("target_task_id") == task_id
+        and str(verification.get("classification", "")).upper()
         == required_match.group(1).upper()
-        and str(metadata.get("verifier_verdict", "")).upper() == "PASS"
-        and isinstance(evidence_refs, list)
-        and bool(evidence_refs)
-        and all(isinstance(ref, str) and ref.strip() for ref in evidence_refs)
-        and str(metadata.get("evidence_type", "")).lower()
+        and str(verification.get("verdict", "")).upper() == "PASS"
+        and str(verification.get("evidence_type", "")).lower()
         == required_evidence_type
+        and _acceptance_evidence_valid(
+            conn, task_id, verifier_run["profile"], verification.get("evidence_refs")
+        )
     )
 
 
@@ -4517,6 +4571,9 @@ def complete_task(
     ``suspected_hallucinated_references`` event. This pass is advisory
     and never blocks.
     """
+    # Reject malformed structured handoff data before any terminal mutation.
+    if metadata is not None and not isinstance(metadata, dict):
+        return False
     now = int(time.time())
 
     # Gate: verify created_cards BEFORE the main write txn. A rejected

--- a/tests/hermes_cli/test_kanban_acceptance_gates.py
+++ b/tests/hermes_cli/test_kanban_acceptance_gates.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _graph(conn, *, required="SHIPPED", evidence_type="implementation"):
+    parent = kb.create_task(
+        conn,
+        title="parent",
+        body=(
+            f"Required classification: {required}\n"
+            f"Required evidence type: {evidence_type}\n"
+        ),
+    )
+    child = kb.create_task(conn, title="child", parents=[parent])
+    return parent, child
+
+
+def _complete(conn, task_id, **metadata):
+    assert kb.complete_task(conn, task_id, summary="execution finished", metadata=metadata)
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {},
+        {"outcome_classification": "SHIPPED", "evidence_refs": ["pr:1"]},
+        {
+            "outcome_classification": "SHIPPED",
+            "verifier_verdict": "FAIL",
+            "evidence_refs": ["pr:1"],
+            "evidence_type": "implementation",
+        },
+    ],
+    ids=["no-classification", "no-verifier-pass", "verifier-fail"],
+)
+def test_unaccepted_done_parent_does_not_release_dependency(kanban_home, metadata):
+    with kb.connect() as conn:
+        parent, child = _graph(conn)
+        _complete(conn, parent, **metadata)
+        assert kb.get_task(conn, parent).status == "done"
+        assert kb.get_task(conn, child).status == "todo"
+
+
+def test_matching_classification_evidence_and_pass_releases_dependency(kanban_home):
+    with kb.connect() as conn:
+        parent, child = _graph(conn)
+        _complete(conn, parent, outcome_classification="SHIPPED", verifier_verdict="PASS", evidence_refs=["pr:1", "tests:focused"], evidence_type="implementation")
+        assert kb.get_task(conn, child).status == "ready"
+
+
+def test_reconnaissance_cannot_satisfy_implementation_gate(kanban_home):
+    with kb.connect() as conn:
+        parent, child = _graph(conn)
+        _complete(conn, parent, outcome_classification="SHIPPED", verifier_verdict="PASS", evidence_refs=["comment:research"], evidence_type="research")
+        assert kb.get_task(conn, child).status == "todo"
+
+
+def test_parent_programme_cannot_complete_with_unaccepted_child(kanban_home):
+    with kb.connect() as conn:
+        child = kb.create_task(
+            conn,
+            title="required child",
+            body="Required classification: CHILD_ACCEPTED\n",
+        )
+        programme = kb.create_task(conn, title="programme", parents=[child])
+        _complete(conn, child)
+        assert kb.get_task(conn, programme).status == "todo"
+        assert kb.complete_task(conn, programme, summary="premature") is False
+
+
+def test_research_classification_accepts_research_evidence(kanban_home):
+    with kb.connect() as conn:
+        parent, child = _graph(conn, required="RESEARCH_DECISION_READY", evidence_type="research")
+        _complete(conn, parent, outcome_classification="RESEARCH_DECISION_READY", verifier_verdict="PASS", evidence_refs=["decision:compose", "sources:official-docs"], evidence_type="research")
+        assert kb.get_task(conn, child).status == "ready"

--- a/tests/hermes_cli/test_kanban_acceptance_gates.py
+++ b/tests/hermes_cli/test_kanban_acceptance_gates.py
@@ -58,7 +58,11 @@ def _accepted_verifier(conn, task_id, *, classification="SHIPPED", evidence_type
             "evidence_refs": [{"kind": "comment", "id": comment_id}],
         }
     }
-    return _verifier_run(conn, task_id, profile=profile, metadata=metadata)
+    verifier_task = kb.create_task(conn, title="independent verification", assignee=profile)
+    assert kb.complete_task(conn, verifier_task, summary="verification finished", metadata=metadata)
+    run = kb.latest_run(conn, verifier_task)
+    assert run is not None
+    return run.id
 
 
 def _complete(conn, task_id, metadata=None):

--- a/tests/hermes_cli/test_kanban_acceptance_gates.py
+++ b/tests/hermes_cli/test_kanban_acceptance_gates.py
@@ -1,3 +1,5 @@
+import json
+import time
 from pathlib import Path
 
 import pytest
@@ -15,74 +17,151 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
-def _graph(conn, *, required="SHIPPED", evidence_type="implementation"):
-    parent = kb.create_task(
-        conn,
-        title="parent",
-        body=(
-            f"Required classification: {required}\n"
-            f"Required evidence type: {evidence_type}\n"
-        ),
-    )
+def _graph(conn, *, required="SHIPPED", evidence_type="implementation", declared=True):
+    body = ""
+    if declared:
+        body = f"Required classification: {required}\nRequired evidence type: {evidence_type}\n"
+    parent = kb.create_task(conn, title="parent", body=body, assignee="implementer")
     child = kb.create_task(conn, title="child", parents=[parent])
     return parent, child
 
 
-def _complete(conn, task_id, **metadata):
-    assert kb.complete_task(conn, task_id, summary="execution finished", metadata=metadata)
+def _comment(conn, task_id):
+    now = int(time.time())
+    cur = conn.execute(
+        "INSERT INTO task_comments(task_id, author, body, created_at) VALUES (?, ?, ?, ?)",
+        (task_id, "reviewer", "verified evidence", now),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
 
 
-@pytest.mark.parametrize(
-    "metadata",
-    [
-        {},
-        {"outcome_classification": "SHIPPED", "evidence_refs": ["pr:1"]},
-        {
-            "outcome_classification": "SHIPPED",
-            "verifier_verdict": "FAIL",
-            "evidence_refs": ["pr:1"],
-            "evidence_type": "implementation",
-        },
-    ],
-    ids=["no-classification", "no-verifier-pass", "verifier-fail"],
-)
-def test_unaccepted_done_parent_does_not_release_dependency(kanban_home, metadata):
+def _verifier_run(conn, task_id, *, profile="reviewer", metadata=None):
+    now = int(time.time())
+    cur = conn.execute(
+        "INSERT INTO task_runs(task_id, profile, status, started_at, ended_at, outcome, metadata) "
+        "VALUES (?, ?, 'done', ?, ?, 'completed', ?)",
+        (task_id, profile, now, now, json.dumps(metadata) if metadata is not None else None),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+def _accepted_verifier(conn, task_id, *, classification="SHIPPED", evidence_type="implementation", profile="reviewer"):
+    comment_id = _comment(conn, task_id)
+    metadata = {
+        "verification": {
+            "target_task_id": task_id,
+            "classification": classification,
+            "verdict": "PASS",
+            "evidence_type": evidence_type,
+            "evidence_refs": [{"kind": "comment", "id": comment_id}],
+        }
+    }
+    return _verifier_run(conn, task_id, profile=profile, metadata=metadata)
+
+
+def _complete(conn, task_id, metadata=None):
+    return kb.complete_task(conn, task_id, summary="execution finished", metadata=metadata)
+
+
+def test_completed_undeclared_parent_does_not_release_dependency(kanban_home):
     with kb.connect() as conn:
-        parent, child = _graph(conn)
-        _complete(conn, parent, **metadata)
-        assert kb.get_task(conn, parent).status == "done"
+        parent, child = _graph(conn, declared=False)
+        assert _complete(conn, parent)
         assert kb.get_task(conn, child).status == "todo"
 
 
-def test_matching_classification_evidence_and_pass_releases_dependency(kanban_home):
+def test_standalone_legacy_task_can_complete(kanban_home):
+    with kb.connect() as conn:
+        task = kb.create_task(conn, title="standalone")
+        assert _complete(conn, task)
+        assert kb.get_task(conn, task).status == "done"
+
+
+def test_archived_unaccepted_parent_does_not_release_dependency(kanban_home):
     with kb.connect() as conn:
         parent, child = _graph(conn)
-        _complete(conn, parent, outcome_classification="SHIPPED", verifier_verdict="PASS", evidence_refs=["pr:1", "tests:focused"], evidence_type="implementation")
+        assert kb.archive_task(conn, parent)
+        assert kb.get_task(conn, child).status == "todo"
+
+
+def test_missing_verifier_run_id_fails_closed(kanban_home):
+    with kb.connect() as conn:
+        parent, child = _graph(conn)
+        assert _complete(conn, parent, {})
+        assert kb.get_task(conn, child).status == "todo"
+
+
+def test_implementation_run_cannot_self_verify(kanban_home):
+    with kb.connect() as conn:
+        parent, child = _graph(conn)
+        claim = kb.claim_task(conn, parent, claimer="implementer")
+        assert claim is not None
+        run_id = kb.get_task(conn, parent).current_run_id
+        assert _complete(conn, parent, {"verifier_run_id": run_id})
+        assert kb.get_task(conn, child).status == "todo"
+
+
+def test_same_worker_identity_cannot_verify(kanban_home):
+    with kb.connect() as conn:
+        parent, child = _graph(conn)
+        verifier = _accepted_verifier(conn, parent, profile="implementer")
+        assert _complete(conn, parent, {"verifier_run_id": verifier})
+        assert kb.get_task(conn, child).status == "todo"
+
+
+@pytest.mark.parametrize("verifier_metadata", [None, [], {"verification": []}])
+def test_malformed_verifier_metadata_fails_closed(kanban_home, verifier_metadata):
+    with kb.connect() as conn:
+        parent, child = _graph(conn)
+        verifier = _verifier_run(conn, parent, metadata=verifier_metadata)
+        assert _complete(conn, parent, {"verifier_run_id": verifier})
+        assert kb.get_task(conn, child).status == "todo"
+
+
+@pytest.mark.parametrize("refs", [[], ["invented"], [{"kind": "comment"}], [{"kind": "comment", "id": 99999}]])
+def test_malformed_or_unknown_evidence_fails_closed(kanban_home, refs):
+    with kb.connect() as conn:
+        parent, child = _graph(conn)
+        verifier = _verifier_run(conn, parent, metadata={"verification": {
+            "target_task_id": parent, "classification": "SHIPPED", "verdict": "PASS",
+            "evidence_type": "implementation", "evidence_refs": refs,
+        }})
+        assert _complete(conn, parent, {"verifier_run_id": verifier})
+        assert kb.get_task(conn, child).status == "todo"
+
+
+def test_independent_verifier_with_durable_evidence_releases_dependency(kanban_home):
+    with kb.connect() as conn:
+        parent, child = _graph(conn)
+        verifier = _accepted_verifier(conn, parent)
+        assert _complete(conn, parent, {"verifier_run_id": verifier})
         assert kb.get_task(conn, child).status == "ready"
 
 
-def test_reconnaissance_cannot_satisfy_implementation_gate(kanban_home):
+def test_claim_time_recheck_blocks_when_accepted_parent_is_archived(kanban_home):
     with kb.connect() as conn:
         parent, child = _graph(conn)
-        _complete(conn, parent, outcome_classification="SHIPPED", verifier_verdict="PASS", evidence_refs=["comment:research"], evidence_type="research")
+        verifier = _accepted_verifier(conn, parent)
+        assert _complete(conn, parent, {"verifier_run_id": verifier})
+        assert kb.get_task(conn, child).status == "ready"
+        assert kb.archive_task(conn, parent)
+        assert kb.claim_task(conn, child, claimer="worker") is None
         assert kb.get_task(conn, child).status == "todo"
 
 
-def test_parent_programme_cannot_complete_with_unaccepted_child(kanban_home):
+def test_malformed_closing_metadata_has_no_partial_transition(kanban_home):
     with kb.connect() as conn:
-        child = kb.create_task(
-            conn,
-            title="required child",
-            body="Required classification: CHILD_ACCEPTED\n",
-        )
-        programme = kb.create_task(conn, title="programme", parents=[child])
-        _complete(conn, child)
-        assert kb.get_task(conn, programme).status == "todo"
-        assert kb.complete_task(conn, programme, summary="premature") is False
+        parent, child = _graph(conn)
+        assert _complete(conn, parent, []) is False
+        assert kb.get_task(conn, parent).status == "ready"
+        assert kb.get_task(conn, child).status == "todo"
 
 
 def test_research_classification_accepts_research_evidence(kanban_home):
     with kb.connect() as conn:
-        parent, child = _graph(conn, required="RESEARCH_DECISION_READY", evidence_type="research")
-        _complete(conn, parent, outcome_classification="RESEARCH_DECISION_READY", verifier_verdict="PASS", evidence_refs=["decision:compose", "sources:official-docs"], evidence_type="research")
+        parent, child = _graph(conn, required="RESEARCH_READY", evidence_type="research")
+        verifier = _accepted_verifier(conn, parent, classification="RESEARCH_READY", evidence_type="research")
+        assert _complete(conn, parent, {"verifier_run_id": verifier})
         assert kb.get_task(conn, child).status == "ready"

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -123,11 +123,11 @@ def test_run_slash_create_with_parent_and_cascade(kanban_home):
     out2 = kc.run_slash(f"create 'child' --assignee bob --parent {p}")
     assert "todo" in out2  # child starts as todo
 
-    # Complete parent; list should promote child to ready
+    # Completion without an acceptance contract must not release the child.
     kc.run_slash(f"complete {p}")
-    # Explicit filter: child should now be ready (was todo before complete).
     ready_list = kc.run_slash("list --status ready")
-    assert "child" in ready_list
+    assert "child" not in ready_list
+    assert "child" in kc.run_slash("list --status todo")
 
 
 def test_run_slash_show_includes_comments(kanban_home):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1415,11 +1415,10 @@ def test_worker_lifecycle_through_tools(worker_env):
         run = kb.latest_run(conn, worker_env)
         assert run.outcome == "completed"
         assert run.metadata == {"child_task": child_out["task_id"]}
-        # Child is todo (parent just finished, but recompute_ready may
-        # have promoted it — complete_task runs recompute internally).
+        # Execution completion alone cannot satisfy dependency acceptance.
         child = kb.get_task(conn, child_out["task_id"])
-        assert child.status == "ready", (
-            f"child should be ready after parent done, got {child.status}"
+        assert child.status == "todo", (
+            f"child must stay gated without accepted parent outcome, got {child.status}"
         )
         # Comment is visible
         assert len(kb.list_comments(conn, worker_env)) == 1


### PR DESCRIPTION
## Summary
- separate execution completion from accepted outcome for cards declaring a required classification
- require matching classification, verifier PASS, evidence references, and matching evidence type before dependency release
- support research-specific evidence contracts without software-delivery criteria
- retain backward compatibility for legacy cards without an acceptance contract

## Tests
- 253 passed: acceptance gates, Kanban DB, goal-mode exhaustion
- 161 passed: Kanban CLI and tools
- git diff --check passed

## Reuse decision
COMPOSE existing task bodies, closing-run metadata, verifier evidence, and dependency promotion; no new queue, workflow engine, or schema.