### PR TITLE
fix: expose Kanban tools to Codex workers

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -117,11 +117,31 @@ class CodexAppServerClient:
                     "-c",
                     'sandbox_mode="workspace-write"',
                     "-c",
-                    f'sandbox_workspace_write.writable_roots=["{kanban_root}"]',
+                    f"sandbox_workspace_write.writable_roots=[{json.dumps(kanban_root)}]",
                     "-c",
                     "sandbox_workspace_write.network_access=false",
                 ]
             )
+            # Codex builds configured MCP subprocesses from each server's
+            # explicit env table rather than inheriting the app-server env.
+            # Forward only worker identity/routing values; without these the
+            # hermes-tools MCP server hides kanban_complete/kanban_block.
+            for key in (
+                "HERMES_KANBAN_TASK",
+                "HERMES_KANBAN_RUN_ID",
+                "HERMES_KANBAN_BOARD",
+                "HERMES_KANBAN_DB",
+                "HERMES_KANBAN_CLAIM_LOCK",
+                "HERMES_SESSION_ID",
+            ):
+                value = spawn_env.get(key)
+                if value:
+                    app_server_args.extend(
+                        [
+                            "-c",
+                            f"mcp_servers.hermes-tools.env.{key}={json.dumps(value)}",
+                        ]
+                    )
 
         cmd = [codex_bin, "app-server"] + app_server_args
         # Codex emits tracing to stderr; default WARN keeps it quiet for users.

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -210,6 +210,7 @@ class TestSpawnEnvIsolation:
 
         class FakePopen:
             def __init__(self, cmd, *args, **kwargs):
+                captured["cmd"] = list(cmd)
                 captured["env"] = kwargs.get("env", {}).copy()
                 self.stdin = None
                 self.stdout = None
@@ -240,6 +241,10 @@ class TestSpawnEnvIsolation:
         assert captured["env"].get("CODEX_HOME") == "/tmp/profile/codex"
         # And HOME still passes through unchanged
         assert captured["env"].get("HOME") == "/users/alice"
+        assert not any(
+            part.startswith("mcp_servers.hermes-tools.env.")
+            for part in captured["cmd"]
+        )
 
     def test_kanban_worker_adds_only_kanban_writable_root(self, monkeypatch):
         """Codex-runtime Kanban workers need to write board state outside
@@ -295,6 +300,103 @@ class TestSpawnEnvIsolation:
         )
         assert "sandbox_workspace_write.network_access=false" in cmd
         assert all("danger" not in part for part in cmd)
+
+    def test_kanban_worker_escapes_windows_writable_root_as_toml(self, monkeypatch):
+        """Windows backslashes must be escaped inside the TOML config override."""
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["cmd"] = list(cmd)
+                self.stdin = None
+                self.stdout = None
+                self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_smoke")
+        monkeypatch.setenv(
+            "HERMES_KANBAN_DB",
+            r"C:\Users\alice\.hermes\kanban\boards\smoke\kanban.db",
+        )
+
+        client = cas.CodexAppServerClient(codex_bin="codex")
+        client._closed = True
+
+        assert (
+            'sandbox_workspace_write.writable_roots=["C:\\\\Users\\\\alice\\\\.hermes\\\\kanban\\\\boards\\\\smoke"]'
+            in captured["cmd"]
+        )
+
+    def test_kanban_worker_forwards_lifecycle_env_to_hermes_mcp(self, monkeypatch):
+        """Codex does not inherit parent env into configured MCP servers.
+
+        Worker identity must therefore be forwarded as explicit MCP config
+        overrides or kanban_complete/kanban_block disappear from that server.
+        """
+        import json
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["cmd"] = list(cmd)
+                self.stdin = None
+                self.stdout = None
+                self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        values = {
+            "HERMES_KANBAN_TASK": "t_smoke",
+            "HERMES_KANBAN_RUN_ID": "7",
+            "HERMES_KANBAN_BOARD": "smoke",
+            "HERMES_KANBAN_DB": r"C:\Users\alice\.hermes\kanban\boards\smoke\kanban.db",
+            "HERMES_KANBAN_CLAIM_LOCK": "host:123",
+            "HERMES_SESSION_ID": "session-smoke",
+        }
+        for key, value in values.items():
+            monkeypatch.setenv(key, value)
+
+        client = cas.CodexAppServerClient(codex_bin="codex")
+        client._closed = True
+
+        cmd = captured["cmd"]
+        for key, value in values.items():
+            assert (
+                f"mcp_servers.hermes-tools.env.{key}={json.dumps(value)}" in cmd
+            )
 
 
 class TestSpawnEnvSecretStripping:


### PR DESCRIPTION
## What does this PR do?

Fixes two Windows failures in Kanban workers using the native Codex app-server runtime:

1. Windows backslashes were interpolated directly into a TOML `-c` override for `sandbox_workspace_write.writable_roots`, causing app-server initialization to reject paths such as `C:\Users\...`.
2. Codex does not broadly inherit the app-server environment into configured MCP subprocesses. The `hermes-tools` MCP subprocess therefore lacked Kanban task identity and hid `kanban_complete` / `kanban_block`, leaving otherwise-successful workers unable to complete their authoritative lifecycle.

The fix JSON/TOML-escapes the writable root and forwards only six Kanban identity/routing values into `mcp_servers.hermes-tools.env`. It does not restore broad child-process environment inheritance or forward credentials.

## Related Issue

N/A — reproduced locally while exercising the Kanban Codex app-server runtime on Windows 10.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/transports/codex_app_server.py`
  - encode Windows writable roots with `json.dumps`, producing valid TOML basic strings;
  - forward only `HERMES_KANBAN_TASK`, `HERMES_KANBAN_RUN_ID`, `HERMES_KANBAN_BOARD`, `HERMES_KANBAN_DB`, `HERMES_KANBAN_CLAIM_LOCK`, and `HERMES_SESSION_ID` to the configured `hermes-tools` MCP subprocess;
  - keep forwarding gated to Kanban workers.
- `tests/agent/transports/test_codex_app_server_runtime.py`
  - add Windows path regression coverage;
  - verify all six lifecycle values become scoped MCP overrides;
  - verify non-Kanban app-server launches receive no such overrides;
  - retain safe fake-process lifecycle behavior.

## How to Test

1. Run:
   ```bash
   scripts/run_tests.sh tests/agent/transports/test_codex_app_server_runtime.py tests/agent/transports/test_hermes_tools_mcp_server.py tests/tools/test_kanban_tools.py
   ```
   Expected: 161 passed, 0 failed.
2. Start a Kanban-context `CodexAppServerClient`, initialize it, then request `mcpServerStatus/list`.
3. Confirm `hermes-tools` exposes `kanban_complete`, `kanban_block`, `kanban_comment`, `kanban_heartbeat`, and `kanban_show`.

## Checklist

### Code

- [x] I've read the Contributing Guide and repository `AGENTS.md`
- [x] My commit message follows Conventional Commits
- [x] I searched open issues/PRs for duplicate Kanban/Codex writable-root or lifecycle-tool fixes
- [x] My PR contains only changes related to this fix
- [ ] I've run the entire test suite locally — targeted canonical suites pass; GitHub CI will run the repository matrix
- [x] I've added tests for both defects
- [x] I've tested on Windows 10

### Documentation & Housekeeping

- [x] Documentation update: N/A; behavior restored without changing user-facing configuration
- [x] `cli-config.yaml.example`: N/A; no config keys added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow change
- [x] Cross-platform impact considered: POSIX writable-root assertion remains unchanged and passing
- [x] Tool descriptions/schemas: N/A; no tool schema changed

## Screenshots / Logs

Canonical targeted verification on the final commit:

```text
3 files, 161 tests passed, 0 failed
ruff check: passed
```

Live Codex app-server MCP status included:

```text
kanban_block
kanban_comment
kanban_complete
kanban_heartbeat
kanban_show
```

Independent read-only Fable review: approve; no blocking findings.
