### PR TITLE
fix(telegram): recover exhausted request pool

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2212,14 +2212,19 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         async with self._get_general_request_drain_lock():
             try:
-                await general_req.shutdown()
+                await asyncio.wait_for(
+                    general_req.shutdown(), timeout=_DRAIN_TIMEOUT
+                )
             except Exception:
                 logger.debug(
-                    "[%s] General request shutdown failed after pool timeout (non-fatal)",
+                    "[%s] General request shutdown failed/timed out after pool "
+                    "timeout (non-fatal)",
                     self.name, exc_info=True,
                 )
             try:
-                await general_req.initialize()
+                await asyncio.wait_for(
+                    general_req.initialize(), timeout=_DRAIN_TIMEOUT
+                )
                 logger.warning(
                     "[%s] General request pool drained after Telegram pool timeout",
                     self.name,
@@ -2404,6 +2409,18 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
         except Exception:
             pass
+
+        if getattr(self, "_polling_teardown_started", False):
+            return
+        # start_polling() performs Bot API bootstrap calls through PTB's
+        # general request pool before it starts getUpdates. If that pool is
+        # exhausted by stale proxy sockets, draining only the polling request
+        # below cannot recover: every retry fails in bootstrap before polling
+        # begins. A confirmed pool timeout means the request was not sent, so
+        # it is safe to rebuild the general pool before retrying. Keep generic
+        # network-error recovery polling-only so in-flight sends are untouched.
+        if self._looks_like_pool_timeout(error):
+            await self._drain_general_connections_after_pool_timeout()
 
         if getattr(self, "_polling_teardown_started", False):
             return

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -353,6 +353,62 @@ async def test_reconnect_drains_polling_request_only():
 
 
 @pytest.mark.asyncio
+async def test_reconnect_drains_general_pool_after_pool_timeout():
+    """A confirmed bootstrap pool timeout must rebuild both request pools.
+
+    start_polling() uses the general pool for Bot API bootstrap before it can
+    reach getUpdates. Leaving that pool wedged makes every polling-only retry
+    fail with the same pool timeout.
+    """
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 1
+
+    mock_app, mock_polling_req = _make_mock_app()
+    general_req = AsyncMock()
+    general_req.shutdown = AsyncMock()
+    general_req.initialize = AsyncMock()
+    mock_app.bot._request = (mock_polling_req, general_req)
+    adapter._app = mock_app
+
+    error = Exception(
+        "Pool timeout: All connections in the connection pool are occupied. "
+        "Request was not sent to Telegram."
+    )
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_network_error(error)
+
+    general_req.shutdown.assert_awaited_once()
+    general_req.initialize.assert_awaited_once()
+    mock_polling_req.shutdown.assert_awaited_once()
+    mock_polling_req.initialize.assert_awaited_once()
+    mock_app.updater.start_polling.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_general_pool_drain_is_bounded_when_close_hangs(monkeypatch):
+    """A wedged general-pool close must not freeze the reconnect ladder."""
+    adapter = _make_adapter()
+    mock_app, mock_polling_req = _make_mock_app()
+
+    async def _hang(*args, **kwargs):
+        await asyncio.Event().wait()
+
+    general_req = AsyncMock()
+    general_req.shutdown = AsyncMock(side_effect=_hang)
+    general_req.initialize = AsyncMock(side_effect=_hang)
+    mock_app.bot._request = (mock_polling_req, general_req)
+    adapter._app = mock_app
+    monkeypatch.setattr(tg_adapter, "_DRAIN_TIMEOUT", 0.01, raising=False)
+
+    await asyncio.wait_for(
+        adapter._drain_general_connections_after_pool_timeout(), timeout=1
+    )
+
+    general_req.shutdown.assert_awaited_once()
+    general_req.initialize.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_reconnect_continues_if_drain_fails():
     """If the polling request drain raises, start_polling must still proceed."""
     adapter = _make_adapter()


### PR DESCRIPTION
## Summary

- rebuild Telegram's general Bot API request pool when polling recovery receives a confirmed pool-timeout error
- keep ordinary network-error recovery polling-only so concurrent sends are not interrupted
- bound general-pool shutdown and initialization with the existing drain timeout

## Root cause

After repeated proxy timeouts, stale sockets could accumulate in the general HTTPX pool until every slot was occupied. The heartbeat correctly entered polling recovery, but that path only rebuilt the dedicated `getUpdates` pool. Because `start_polling()` performs Bot API bootstrap calls through the general pool, every retry failed with the same pool-timeout error and the Telegram channel remained deaf until the gateway restarted.

A pool-timeout error explicitly means the request was not sent, so rebuilding the general pool at that point is safe. Generic network failures continue to leave the general pool untouched.

## Impact

Telegram polling can recover in-process after proxy disruptions exhaust the request pool, instead of repeatedly failing recovery and eventually requiring a gateway restart.

## Validation

- `79 passed` across Telegram network reconnect, CLOSE_WAIT limits, send-path health, polling progress, and polling startup timeout tests
- Ruff checks pass for the adapter and updated reconnect tests
