### PR TITLE
model picker: show full live catalog when a provider has no explicit models: list

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2176,12 +2176,16 @@ def list_authenticated_providers(
             # Prefer the endpoint's live /models list when discoverable,
             # unless the provider explicitly opts out via discover_models: false.
             # Policy mirrors Section 4's should_probe logic:
-            # - With an api_key: always probe (user opted into the endpoint).
-            # - Without an api_key but with explicit models: skip — the user
-            #   is narrowing a public endpoint to a specific subset.
-            # - Without an api_key AND no explicit models: probe anyway so
-            #   bare-endpoint providers (local llama.cpp / Ollama servers)
-            #   still show their full model catalog.
+            # - An explicit ``models:`` list is the user narrowing the endpoint
+            #   to a curated subset — keep it verbatim and do NOT probe. This is
+            #   the only case where the picker shows fewer than the endpoint's
+            #   full catalog, honoring an intentional configuration choice.
+            # - No ``models:`` list declared (whether or not a ``default_model``
+            #   is set): probe the live /v1/models endpoint and surface ALL
+            #   available models. A bare ``default_model``-only provider should
+            #   not show a one-line picker — the user asked to see everything.
+            #   This covers local llama.cpp / Ollama / vLLM servers (no api_key)
+            #   as well as keyed aggregators/gateways.
             api_key = str(ep_cfg.get("api_key", "") or "").strip()
             if not api_key:
                 key_env = str(ep_cfg.get("key_env", "") or "").strip()
@@ -2189,7 +2193,7 @@ def list_authenticated_providers(
             discover = ep_cfg.get("discover_models", True)
             if isinstance(discover, str):
                 discover = discover.lower() not in {"false", "no", "0"}
-            has_explicit_models = bool(models_list)
+            has_explicit_models = bool(ep_cfg.get("models"))
             _ep_url_norm = str(api_url).strip().rstrip("/").lower()
             _ep_slug_norm = str(ep_name).strip().lower()
             _ep_custom_slug_norm = custom_provider_slug(display_name).lower()
@@ -2202,9 +2206,14 @@ def list_authenticated_providers(
                     and _ep_url_norm == _current_base_url_norm
                 )
             )
-            should_probe = _can_probe_custom_provider(row_is_current=_ep_is_current) and bool(api_url) and discover and (
-                bool(api_key) or not has_explicit_models
-            )
+            # Probe the live /v1/models endpoint whenever the user has NOT
+            # declared an explicit ``models:`` list (and discovery is on). This
+            # is independent of the ``probe_custom_providers`` flag: when the
+            # endpoint is un-narrowed the user wants to see its FULL catalog, so
+            # we discover it for every row — not just the current one. When an
+            # explicit ``models:`` list IS declared we keep it verbatim and
+            # never probe (enforced by the ``not has_explicit_models`` gate).
+            should_probe = bool(api_url) and discover and not has_explicit_models
             if should_probe:
                 try:
                     from hermes_cli.models import fetch_api_models
@@ -2214,9 +2223,16 @@ def list_authenticated_providers(
                         headers=_extra_headers_from_config(ep_cfg) or None,
                     )
                     if live_models:
+                        # No explicit ``models:`` list declared: show the full
+                        # live catalog (the gate guarantees has_explicit_models
+                        # is False, so there is nothing to preserve/merge).
                         models_list = live_models
                 except Exception:
                     pass
+
+            # Sort auto-discovered models alphabetically (preserve config order for explicit lists)
+            if models_list and not has_explicit_models:
+                models_list = sorted(models_list, key=str.lower)
 
             results.append({
                 "slug": ep_name,
@@ -2442,33 +2458,23 @@ def list_authenticated_providers(
             _grp_url_norm = _pair_key[1]
             if _grp_url_norm and _grp_url_norm in _builtin_endpoints:
                 continue
-            # Live model discovery from custom provider endpoints (matches
-            # Section 3 behavior for user ``providers:`` entries).
-            # Also probes when no api_key is set (e.g. local llama.cpp /
-            # Ollama servers) — the /models endpoint often works without
-            # auth.  The CLI's _model_flow_named_custom always probes, so
-            # the Telegram/Discord picker should do the same for parity.
-            # Live-discovery policy:
-            # - With an api_key, the user has explicitly opted into the
-            #   endpoint and live /models is the source of truth — replace
-            #   the (possibly partial) ``models:`` subset configured for
-            #   context-length overrides with the full live catalog.
-            #   This is the Bifrost / aggregator-gateway case.
-            # - Without an api_key but with an explicit ``models:`` list,
-            #   the user is narrowing a public endpoint to a specific subset
-            #   (e.g. ollama.com /v1/models returns 35 models but the user
-            #   only wants 4). Preserve the explicit list and skip live
-            #   discovery. The singular ``model:`` field is only the current
-            #   active selection and must not suppress discovery on local
-            #   no-key endpoints.
-            # - Without an api_key AND no explicit models, fall through to
-            #   live discovery so bare-endpoint custom providers (local
-            #   llama.cpp / Ollama servers) still appear populated.
-            # - When discover_models: false is set, skip live discovery and
-            #   keep the explicit ``models:`` list regardless of whether an
-            #   api_key is present. This supports endpoints that expose a
-            #   full aggregator catalog via /models but only serve a subset
-            #   (parity with section 3's user ``providers:`` behaviour).
+            # Live model discovery from custom provider endpoints (mirrors
+            # Section 3's user ``providers:`` entries).
+            # Policy:
+            # - No explicit ``models:`` list declared (whether or not a
+            #   singular ``model:`` / default_model is set): probe the live
+            #   /v1/models endpoint and surface the FULL catalog. This covers
+            #   local llama.cpp / Ollama / vLLM servers (no api_key) as well
+            #   as keyed aggregators/gateways — the user asked to see every
+            #   available model for an un-narrowed endpoint, so discovery runs
+            #   for every row regardless of the ``probe_custom_providers`` flag.
+            # - An explicit ``models:`` list is the user narrowing the endpoint
+            #   to a curated subset: keep it verbatim and do NOT probe/replace.
+            #   This is the only case the picker shows fewer than the endpoint's
+            #   full catalog, honoring an intentional configuration choice
+            #   (e.g. a gateway exposing 35 models but the user only wants 4).
+            # - discover_models: false is a hard opt-out of live discovery that
+            #   keeps whatever list is configured (explicit or singular).
             _grp_is_current = slug.lower() == _current_provider_norm or (
                 _current_provider_norm == "custom"
                 and bool(_current_base_url_norm)
@@ -2476,9 +2482,8 @@ def list_authenticated_providers(
                 and _current_base_url_group_count == 1
             )
             should_probe = (
-                _can_probe_custom_provider(row_is_current=_grp_is_current)
-                and bool(api_url)
-                and (bool(api_key) or not grp.get("has_explicit_models"))
+                bool(api_url)
+                and not grp.get("has_explicit_models")
                 and grp.get("discover_models", True)
             )
             if should_probe:

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -46,9 +46,14 @@ def test_list_authenticated_providers_includes_custom_providers(monkeypatch):
     )
 
 
-def test_list_authenticated_providers_can_skip_custom_provider_live_probe(monkeypatch):
+def test_list_authenticated_providers_skip_probe_via_discover_models_false(monkeypatch):
+    """A custom provider can still skip live discovery via ``discover_models:
+    false`` — the real opt-out. Even with ``probe_custom_providers=False`` and no
+    explicit ``models:`` list, an un-narrowed endpoint would otherwise be probed;
+    ``discover_models: false`` must suppress it and keep the singular ``model``.
+    """
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
-    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
     fetch = lambda *a, **k: (_ for _ in ()).throw(AssertionError("unexpected probe"))
     monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
 
@@ -60,6 +65,7 @@ def test_list_authenticated_providers_can_skip_custom_provider_live_probe(monkey
                 "base_url": "http://127.0.0.1:8080/v1",
                 "api_key": "sk-local",
                 "model": "local-model",
+                "discover_models": False,
             }
         ],
         probe_custom_providers=False,
@@ -70,9 +76,14 @@ def test_list_authenticated_providers_can_skip_custom_provider_live_probe(monkey
     assert row["total_models"] == 1
 
 
-def test_list_authenticated_providers_can_probe_only_current_custom_provider(monkeypatch):
+def test_list_authenticated_providers_probes_unnarrowed_non_current_custom_provider(monkeypatch):
+    """When a custom provider has no explicit ``models:`` list, the /model menu
+    must probe its full /v1/models catalog even for NON-current providers —
+    regardless of ``probe_custom_providers=False``. This is the requested fix:
+    a provider configured without a models: tag should show every available model.
+    """
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
-    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
 
     calls = []
 
@@ -80,6 +91,8 @@ def test_list_authenticated_providers_can_probe_only_current_custom_provider(mon
         calls.append(api_url)
         if api_url == "http://active.local/v1":
             return ["active-a", "active-b"]
+        if api_url == "http://offline.local/v1":
+            return ["offline-a", "offline-b"]
         raise AssertionError(f"unexpected probe for {api_url}")
 
     monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
@@ -105,12 +118,13 @@ def test_list_authenticated_providers_can_probe_only_current_custom_provider(mon
         probe_current_custom_provider=True,
     )
 
+    # Both un-narrowed providers are probed (no explicit models: list).
+    assert set(calls) == {"http://active.local/v1", "http://offline.local/v1"}
     active = next(p for p in providers if p["slug"] == "custom:active-proxy")
     offline = next(p for p in providers if p["slug"] == "custom:offline-proxy")
-    assert calls == ["http://active.local/v1"]
     assert active["is_current"] is True
     assert active["models"] == ["active-a", "active-b"]
-    assert offline["models"] == ["configured-offline"]
+    assert offline["models"] == ["offline-a", "offline-b"]
 
 
 def test_resolve_provider_full_finds_named_custom_provider():
@@ -433,8 +447,12 @@ def test_custom_provider_group_explicit_duplicate_skips_probe(monkeypatch):
     assert row["models"] == ["llama3"]
 
 
-def test_custom_provider_current_only_probe_respects_explicit_catalog(monkeypatch):
-    """Normal GUI opens probe only the active singular-only provider."""
+def test_custom_provider_probes_unnarrowed_providers_regardless_of_current(monkeypatch):
+    """Un-narrowed custom providers (no explicit ``models:`` list) are probed
+    for their full catalog on a normal GUI open — even the non-current ones —
+    because the user wants to see every available model. An explicit ``models:``
+    list is still honored verbatim and never probed.
+    """
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
     calls = []
@@ -471,10 +489,15 @@ def test_custom_provider_current_only_probe_respects_explicit_catalog(monkeypatc
         probe_current_custom_provider=True,
     )
 
-    assert calls == [("", "http://active.local/v1", {"headers": None})]
+    # Both un-narrowed providers (Active + Offline) are probed; Static (explicit
+    # list) is not.
+    assert sorted(calls) == [
+        ("", "http://active.local/v1", {"headers": None}),
+        ("", "http://offline.local/v1", {"headers": None}),
+    ]
     rows = {row["name"]: row for row in providers if row.get("is_user_defined")}
     assert rows["Active"]["models"] == ["live-a", "live-b"]
-    assert rows["Offline"]["models"] == ["offline-seed"]
+    assert rows["Offline"]["models"] == ["live-a", "live-b"]
     assert rows["Static"]["models"] == ["only"]
 
 
@@ -933,13 +956,13 @@ def test_lmstudio_picker_skips_probe_when_not_configured(monkeypatch):
 
 
 def test_custom_providers_uses_live_models_for_multi_model_endpoint(monkeypatch):
-    """Custom providers with api_key + base_url should prefer live /models.
+    """Custom providers with api_key + base_url and NO explicit ``models:`` list
+    should prefer the live /v1/models catalog.
 
     Custom providers (section 4 of list_authenticated_providers) point at
-    gateways like Bifrost that expose hundreds of models.  Reading only the
-    static ``models:`` dict from config.yaml leaves the /model picker with
-    a stale subset.  Live discovery fills the picker with all available
-    models from the endpoint.
+    gateways like Bifrost that expose hundreds of models.  When the user has
+    not declared an explicit ``models:`` subset, live discovery fills the
+    picker with every available model from the endpoint.
     """
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
@@ -955,13 +978,9 @@ def test_custom_providers_uses_live_models_for_multi_model_endpoint(monkeypatch)
     custom_providers = [
         {
             "name": "my-gateway",
-            "api_key": "sk-gateway-key",
+            "api_key": "***",
             "base_url": "https://gateway.example.com/v1",
-            "model": "gateway-model-a",
-            "models": {
-                "gateway-model-a": {"context_length": 128000},
-                "gateway-model-b": {"context_length": 128000},
-            },
+            # No explicit ``models:`` list — discovery must run.
         }
     ]
 
@@ -983,13 +1002,13 @@ def test_custom_providers_uses_live_models_for_multi_model_endpoint(monkeypatch)
 
     assert gateway_prov is not None, "Custom provider group not found in results"
     assert calls == [
-        ("sk-gateway-key", "https://gateway.example.com/v1", {"headers": None})
+        ("***", "https://gateway.example.com/v1", {"headers": None})
     ], "fetch_api_models must be called with the custom provider's credentials"
     assert gateway_prov["models"] == [
         "gateway-model-a",
         "gateway-model-b",
         "gateway-model-c",
-    ], "Live models must replace the static subset"
+    ], "Live models must fill the picker when no explicit subset is configured"
     assert gateway_prov["total_models"] == 3
 
 
@@ -1332,8 +1351,9 @@ def test_discovered_models_auto_saved_to_cache(monkeypatch):
     """Discovered models are persisted to config so ``discover_models: false``
     has a populated cache on the next read (#65652).
 
-    When a successful probe returns live models, ``_save_discovered_models_to_config``
-    must be called with the provider's base_url and the discovered model list.
+    When a provider has NO explicit ``models:`` list, the picker probes the
+    live /v1/models endpoint and, on success, ``_save_discovered_models_to_config``
+    is called with the provider's base_url and the discovered model list.
     """
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
@@ -1355,8 +1375,8 @@ def test_discovered_models_auto_saved_to_cache(monkeypatch):
             "api_key": "***",
             "base_url": "https://gateway.example.com/v1",
             "discover_models": True,
-            "model": "only-model",
-            "models": {"only-model": {"context_length": 128000}},
+            # No explicit ``models:`` list — this is the un-narrowed case that
+            # should be probed and cached.
         }
     ]
 

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -131,12 +131,13 @@ def test_list_authenticated_providers_enumerates_dict_format_models(monkeypatch)
     ]
 
 
-def test_list_authenticated_providers_uses_live_models_for_user_provider(monkeypatch):
-    """User-defined OpenAI-compatible providers should prefer live /models.
+def test_list_authenticated_providers_keeps_explicit_models_verbatim_for_user_provider(monkeypatch):
+    """A user-defined provider with an explicit ``models:`` list must keep that
+    list verbatim and NOT probe the live endpoint — the user intentionally
+    narrowed the endpoint to a curated subset.
 
-    Regression: CRS-style providers with a stale config ``models:`` dict kept
-    showing only the configured subset in the /model picker, even though their
-    /v1/models endpoint exposed newly added models.
+    Regression for the new policy: an explicit ``models:`` tag is the only case
+    where the /model picker shows fewer than the endpoint's full catalog.
     """
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
@@ -146,7 +147,7 @@ def test_list_authenticated_providers_uses_live_models_for_user_provider(monkeyp
 
     def fake_fetch_api_models(api_key, base_url, **kwargs):
         calls.append((api_key, base_url, kwargs))
-        return ["old-configured-model", "new-live-model"]
+        return ["new-live-model"]
 
     monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
 
@@ -155,9 +156,9 @@ def test_list_authenticated_providers_uses_live_models_for_user_provider(monkeyp
             "name": "CRS Henkee",
             "base_url": "http://127.0.0.1:3000/api/v1",
             "key_env": "CRS_TEST_KEY",
-            "model": "old-configured-model",
+            "model": "configured-model",
             "models": {
-                "old-configured-model": {"context_length": 200000},
+                "configured-model": {"context_length": 200000},
             },
         }
     }
@@ -175,9 +176,10 @@ def test_list_authenticated_providers_uses_live_models_for_user_provider(monkeyp
     )
 
     assert user_prov is not None
-    assert calls == [("sk-test", "http://127.0.0.1:3000/api/v1", {"headers": None})]
-    assert user_prov["models"] == ["old-configured-model", "new-live-model"]
-    assert user_prov["total_models"] == 2
+    # Explicit list must be preserved verbatim; live probe must NOT run.
+    assert calls == [], "explicit models: list must suppress live discovery"
+    assert user_prov["models"] == ["configured-model"]
+    assert user_prov["total_models"] == 1
 
 
 def test_user_provider_live_model_probe_uses_extra_headers(monkeypatch):


### PR DESCRIPTION
## Summary

In `list_authenticated_providers()`, the `/model` picker (CLI + GUI) only probed a
user/custom provider's live `/v1/models` endpoint for the **current** provider (or
when `probe_custom_providers=True`). Any other configured provider with no explicit
`models:` list showed only its `default_model` — or nothing — in the menu.

This changes the discovery rule so the behavior matches user intent:

- **No `models:` list declared** (with or without a `default_model`): probe the
  live `/v1/models` endpoint and show **all** available models, for every row —
  not just the current provider. The `probe_custom_providers` flag no longer gates
  this, because an un-narrowed endpoint is exactly where the user wants to see the
  full catalog.
- **`models:` list declared**: show only that curated subset; do not probe/replace.
  This is the one case where the menu intentionally shows fewer than the full catalog.
- **`discover_models: false`**: hard opt-out of live discovery.

Applies symmetrically to both `providers:` (Section 3) and `custom_providers:`
(Section 4) config sections. Tests updated to encode the new policy.

## Tradeoff / note for reviewers

The previous `probe_custom_providers=False` gate existed so the GUI picker wouldn't
block on a dead/offline non-current endpoint. This PR makes un-narrowed providers
probe on open. The probe is bounded by `fetch_api_models`' timeout (the picker passes
~1.5s), so worst case is a short delay rather than a silent one-line menu. Endpoints
that are slow/offline can still opt out via `discover_models: false`.

## Test plan

- `tests/hermes_cli/test_model_switch_custom_providers.py`
- `tests/hermes_cli/test_user_providers_model_switch.py`
- `tests/hermes_cli/test_inventory.py`

All pass. (The broader `tests/hermes_cli/` suite has pre-existing network-dependent
failures unrelated to this change.)