### PR TITLE
fix(desktop): bound optimistic user-row preservation to the in-flight tail (#68979)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -327,6 +327,81 @@ describe('preserveLocalPendingTurnMessages', () => {
 
     expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
   })
+
+  it('drops committed optimistic user rows after compression shifts their ordinal', () => {
+    // Context compression rewrote history: the authoritative transcript now has
+    // fewer user rows than the local view, so every committed optimistic row
+    // matches the wrong role ordinal. Only content-based matching recognizes
+    // them as committed and keeps them from re-stacking at the tail.
+    const previous = [
+      msg('user-q1', 'user', 'question one'),
+      msg('a1', 'assistant', 'answer one'),
+      msg('user-q2', 'user', 'question two'),
+      msg('a2', 'assistant', 'answer two'),
+      msg('user-q3', 'user', 'question three'),
+      msg('a3', 'assistant', 'answer three')
+    ]
+
+    // Authoritative transcript: q1 was compressed away, so the user ordinals no
+    // longer line up with the local view.
+    const next = [
+      msg('sum', 'assistant', '[summary of earlier turns]'),
+      msg('q2-stored', 'user', 'question two'),
+      msg('a2-stored', 'assistant', 'answer two'),
+      msg('q3-stored', 'user', 'question three'),
+      msg('a3-stored', 'assistant', 'answer three')
+    ]
+
+    // Every optimistic user row is committed by content, so nothing is
+    // resurrected at the tail.
+    expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
+  })
+
+  it('keeps only the in-flight tail turn while dropping compressed history', () => {
+    const previous = [
+      msg('user-q1', 'user', 'question one'),
+      msg('a1', 'assistant', 'answer one'),
+      msg('user-q2', 'user', 'question two'),
+      msg('a2', 'assistant', 'answer two'),
+      // genuine in-flight turn the server projection has not caught up to
+      msg('user-inflight', 'user', 'brand new question'),
+      msg('assistant-stream-1', 'assistant', 'partial', { pending: true })
+    ]
+
+    const next = [
+      msg('sum', 'assistant', '[summary]'),
+      msg('q2-stored', 'user', 'question two'),
+      msg('a2-stored', 'assistant', 'answer two')
+    ]
+
+    expect(preserveLocalPendingTurnMessages(next, previous).map(message => message.id)).toEqual([
+      'sum',
+      'q2-stored',
+      'a2-stored',
+      'user-inflight',
+      'assistant-stream-1'
+    ])
+  })
+
+  it('drains an already-polluted cache instead of re-preserving on every pass', () => {
+    // The warm-resume path re-runs this merge over its own output. A previously
+    // polluted view (orphan user rows tail-appended) must reconcile back to the
+    // authoritative transcript rather than re-appending the orphans forever.
+    const authoritative = [
+      msg('q1-stored', 'user', 'question one'),
+      msg('a1-stored', 'assistant', 'answer one'),
+      msg('q2-stored', 'user', 'question two'),
+      msg('a2-stored', 'assistant', 'answer two')
+    ]
+
+    const polluted = [
+      ...authoritative,
+      msg('user-q1', 'user', 'question one'),
+      msg('user-q2', 'user', 'question two')
+    ]
+
+    expect(preserveLocalPendingTurnMessages(authoritative, polluted)).toBe(authoritative)
+  })
 })
 
 describe('appendLiveSessionProjection', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -231,9 +231,19 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
  * dropping either makes an accepted turn appear to vanish during transport
  * churn.
  *
- * Authoritative rows use different ids, so match by role ordinal. A matching
- * user row is considered committed only when its visible text also matches;
- * any authoritative assistant at the same ordinal supersedes the local stream.
+ * Only the single newest optimistic user turn is eligible for preservation —
+ * the one turn a lagging server projection can genuinely be behind on. Bare
+ * role-ordinal matching resurrected a whole window of history instead: context
+ * compression (the one sanctioned operation that rewrites history) leaves the
+ * authoritative list with *fewer* user rows than the local view, so every
+ * committed optimistic row matched the wrong ordinal, failed its text check,
+ * and got re-appended at the tail — forever, because each warm-resume pass
+ * re-runs this merge over its own polluted output (the orphan rows are cached,
+ * not just painted). Bounding to the last optimistic user row, and matching it
+ * as committed by content anywhere in the authoritative transcript (not by
+ * ordinal), keeps preservation to the genuinely in-flight tail and drains an
+ * already-polluted cache on the next pass. A pending assistant is superseded by
+ * any authoritative assistant at the same ordinal.
  */
 export function preserveLocalPendingTurnMessages(
   nextMessages: ChatMessage[],
@@ -245,16 +255,28 @@ export function preserveLocalPendingTurnMessages(
 
   const nextByRoleOrdinal = new Map<string, ChatMessage>()
   const nextRoleCounts = new Map<ChatMessage['role'], number>()
+  const authoritativeUserText = new Set<string>()
 
   for (const message of nextMessages) {
     const ordinal = nextRoleCounts.get(message.role) ?? 0
     nextRoleCounts.set(message.role, ordinal + 1)
     nextByRoleOrdinal.set(`${message.role}:${ordinal}`, message)
+
+    if (message.role === 'user') {
+      authoritativeUserText.add(chatMessageText(message).trim())
+    }
   }
 
   const nextIds = new Set(nextMessages.map(message => message.id))
   const previousRoleCounts = new Map<ChatMessage['role'], number>()
   const preserved: ChatMessage[] = []
+
+  // The genuinely in-flight user turn is the newest one; any earlier optimistic
+  // user row is stale history that compression may have dropped from the
+  // authoritative list entirely, so it must never be resurrected.
+  const lastOptimisticUser = [...previousMessages]
+    .reverse()
+    .find(message => message.role === 'user' && message.id.startsWith('user-'))
 
   for (const message of previousMessages) {
     const ordinal = previousRoleCounts.get(message.role) ?? 0
@@ -269,16 +291,23 @@ export function preserveLocalPendingTurnMessages(
       continue
     }
 
+    if (isOptimisticUser) {
+      // Preserve only the newest optimistic user turn, and only until the
+      // authoritative transcript carries its text (matched by content, wherever
+      // compression shifted its ordinal to).
+      if (message !== lastOptimisticUser || authoritativeUserText.has(chatMessageText(message).trim())) {
+        continue
+      }
+
+      preserved.push(message)
+
+      continue
+    }
+
     const authoritative = nextByRoleOrdinal.get(`${message.role}:${ordinal}`)
 
     if (authoritative) {
-      if (isPendingAssistant) {
-        continue
-      }
-
-      if (chatMessageText(authoritative).trim() === chatMessageText(message).trim()) {
-        continue
-      }
+      continue
     }
 
     preserved.push(message)


### PR DESCRIPTION
Fixes #68979.

## Problem

In long desktop threads, after context compression, the user's ~10 most recent messages re-stack consecutively at the **bottom** of the thread, below the assistant's last reply — each rendered pending-style, forcing the user to scroll up to find the newest answer. `state.db` is fully correct throughout; this is renderer-side reconciliation only. Switching sessions does **not** clear it (only a full window reload does), because the polluted array lives in the per-session warm cache and is re-preserved on every switch-back — a self-renewing loop.

## Root cause

`preserveLocalPendingTurnMessages()` decides whether a local optimistic row is "already committed" by matching `${role}:${ordinal}` against the authoritative transcript. Context compression is the one sanctioned operation that rewrites history: afterwards the authoritative list holds **fewer** user rows than the local view, so every committed optimistic `user-` row matches the wrong ordinal, fails its text check, is classified "not yet committed," and lands in `preserved` — which is appended to the tail (`[...nextMessages, ...preserved]`).

All five warm-resume callsites funnel through this one function, and each pass re-runs the merge over its own cached output, so once ordinals shift the orphan window is re-appended forever.

## Fix

Preserve only the **newest** optimistic user turn — the single turn a lagging server projection can genuinely be behind on — and treat it as committed the moment its text appears **anywhere** in the authoritative transcript (content match, not bare ordinal). This:

- stops the whole recent window from resurrecting (earlier optimistic rows are stale history, never restored);
- drains an already-polluted cache on the next reconciliation pass, since the orphans' text is present in the authoritative transcript — fixing the self-renewing loop, not just the injection;
- leaves genuine transport-churn preservation intact (an in-flight turn whose text the projection hasn't caught up to is still kept), and a pending assistant is still superseded by any authoritative assistant at the same ordinal.

This follows the reporter's own traced suggestion (match by content when lengths diverge; bound preservation to the in-flight tail).

## Tests

`apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts` — three new cases (all red before the fix, green after):
- committed optimistic user rows dropped after compression shifts their ordinal;
- the in-flight tail turn survives while compressed history is dropped;
- an already-polluted cache drains instead of re-appending on the next pass.

Existing `preserveLocalPendingTurnMessages` / `chat-messages` tests unchanged and green (62 passed). `tsc --noEmit` and eslint clean.