### PR TITLE
fix(clarify): treat timeout<=0 as unlimited wait

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11429,7 +11429,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         """
         import time as _time
 
-        timeout = CLI_CONFIG.get("clarify", {}).get("timeout", 120)
+        # 0 / negative = unlimited (never auto-skip mid-think). Prefer top-level
+        # clarify.timeout; fall back to agent.clarify_timeout for one-knob setups.
+        _raw_timeout = CLI_CONFIG.get("clarify", {}).get("timeout", None)
+        if _raw_timeout is None:
+            _raw_timeout = (CLI_CONFIG.get("agent") or {}).get("clarify_timeout", 120)
+        try:
+            timeout = int(_raw_timeout)
+        except (TypeError, ValueError):
+            timeout = 120
         response_queue = queue.Queue()
         is_open_ended = not choices
 
@@ -11439,7 +11447,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             "selected": 0,
             "response_queue": response_queue,
         }
-        self._clarify_deadline = _time.monotonic() + timeout
+        # None deadline ⇒ unlimited wait (no auto-proceed).
+        self._clarify_deadline = None if timeout <= 0 else (_time.monotonic() + timeout)
         # Open-ended questions skip straight to freetext input
         self._clarify_freetext = is_open_ended
 
@@ -11456,13 +11465,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         while True:
             try:
                 result = response_queue.get(timeout=1)
-                self._clarify_deadline = 0
+                self._clarify_deadline = None
                 self._persist_prompt_summary("?", "Clarify", question, str(result))
                 return result
             except queue.Empty:
-                remaining = self._clarify_deadline - _time.monotonic()
-                if remaining <= 0:
-                    break
+                if self._clarify_deadline is not None:
+                    remaining = self._clarify_deadline - _time.monotonic()
+                    if remaining <= 0:
+                        break
                 now = _time.monotonic()
                 if now - _last_countdown_refresh >= 1.0:
                     _last_countdown_refresh = now
@@ -11471,7 +11481,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Timed out — tear down the UI and let the agent decide
         self._clarify_state = None
         self._clarify_freetext = False
-        self._clarify_deadline = 0
+        self._clarify_deadline = None
         self._paint_now()
         _cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")
         return (
@@ -14411,8 +14421,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 ]
 
             if cli_ref._clarify_state:
-                remaining = max(0, int(cli_ref._clarify_deadline - time.monotonic()))
-                countdown = f'  ({remaining}s)' if cli_ref._clarify_deadline else ''
+                # None deadline = unlimited (no auto-skip); hide countdown.
+                if cli_ref._clarify_deadline is None:
+                    countdown = ''
+                else:
+                    remaining = max(0, int(cli_ref._clarify_deadline - time.monotonic()))
+                    countdown = f'  ({remaining}s)' if cli_ref._clarify_deadline else ''
                 if cli_ref._clarify_freetext:
                     return [
                         ('class:hint', '  type your answer and press Enter'),

--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -23,7 +23,14 @@ def clarify_callback(cli, question, choices):
     """
     from cli import CLI_CONFIG
 
-    timeout = CLI_CONFIG.get("clarify", {}).get("timeout", 120)
+    # 0 / negative = unlimited (never auto-skip mid-think).
+    _raw_timeout = CLI_CONFIG.get("clarify", {}).get("timeout", None)
+    if _raw_timeout is None:
+        _raw_timeout = (CLI_CONFIG.get("agent") or {}).get("clarify_timeout", 120)
+    try:
+        timeout = int(_raw_timeout)
+    except (TypeError, ValueError):
+        timeout = 120
     response_queue = queue.Queue()
     is_open_ended = not choices
 
@@ -33,7 +40,7 @@ def clarify_callback(cli, question, choices):
         "selected": 0,
         "response_queue": response_queue,
     }
-    cli._clarify_deadline = _time.monotonic() + timeout
+    cli._clarify_deadline = None if timeout <= 0 else (_time.monotonic() + timeout)
     cli._clarify_freetext = is_open_ended
 
     if hasattr(cli, "_app") and cli._app:
@@ -42,18 +49,19 @@ def clarify_callback(cli, question, choices):
     while True:
         try:
             result = response_queue.get(timeout=1)
-            cli._clarify_deadline = 0
+            cli._clarify_deadline = None
             return result
         except queue.Empty:
-            remaining = cli._clarify_deadline - _time.monotonic()
-            if remaining <= 0:
-                break
+            if cli._clarify_deadline is not None:
+                remaining = cli._clarify_deadline - _time.monotonic()
+                if remaining <= 0:
+                    break
             if hasattr(cli, "_app") and cli._app:
                 cli._app.invalidate()
 
     cli._clarify_state = None
     cli._clarify_freetext = False
-    cli._clarify_deadline = 0
+    cli._clarify_deadline = None
     if hasattr(cli, "_app") and cli._app:
         cli._app.invalidate()
     cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -108,6 +108,9 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
     for 10 minutes with zero activity touches and the gateway's inactivity
     watchdog kills the agent while the user is still typing.
 
+    ``timeout <= 0`` means unlimited wait (no auto-skip). The heartbeat
+    still runs so gateway inactivity watchdogs do not kill a live prompt.
+
     Returns the resolved response string, or ``None`` on timeout.
     """
     with _lock:
@@ -120,13 +123,19 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
     except Exception:  # pragma: no cover - optional
         touch_activity_if_due = None
 
-    deadline = time.monotonic() + max(timeout, 0.0)
+    # 0 / negative → unlimited (user preference: never auto-skip mid-think).
+    unlimited = timeout is None or float(timeout) <= 0.0
+    deadline = None if unlimited else (time.monotonic() + float(timeout))
     activity_state = {"last_touch": time.monotonic(), "start": time.monotonic()}
     while True:
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            break
-        if entry.event.wait(timeout=min(1.0, remaining)):
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            slice_s = min(1.0, remaining)
+        else:
+            slice_s = 1.0
+        if entry.event.wait(timeout=slice_s):
             break
         if touch_activity_if_due is not None:
             touch_activity_if_due(activity_state, "waiting for user clarify response")
@@ -312,6 +321,8 @@ def get_clarify_timeout() -> int:
     (#32762).
 
     Reads ``agent.clarify_timeout`` from config.yaml.
+    Set to ``0`` (or negative) for unlimited wait — never auto-skip while
+    the user is still deciding (Desktop / gateway path).
     """
     try:
         from hermes_cli.config import load_config


### PR DESCRIPTION
## Summary
- `agent.clarify_timeout: 0` (and `clarify.timeout: 0`) previously became `deadline=now` via `max(timeout, 0)` and auto-skipped immediately.
- Treat `timeout <= 0` as **unlimited wait** while still heartbeating the inactivity watchdog.
- Applies to gateway `wait_for_response`, TUI `callbacks.clarify_callback`, and classic CLI clarify path (countdown hidden when unlimited).

## Test plan
- [ ] Set `agent.clarify_timeout: 0` in config
- [ ] Trigger a `clarify` prompt in Desktop/gateway and CLI
- [ ] Confirm the prompt does **not** auto-dismiss at t≈0
- [ ] Confirm a positive timeout (e.g. 30) still expires

Relates to user configs that intentionally use `0` for never auto-skip mid-think.