### PR TITLE
fix(models): accept short Kimi Code IDs (k3, kimi-for-coding*)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -319,6 +319,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "minimaxai/minimax-m3",
     ],
     "kimi-coding": [
+        # Official short IDs (docs) + catalog long forms. Keep both so pickers
+        # and routing tables that still say k3 / kimi-for-coding-* resolve.
+        "k3",
         "kimi-k3",
         "kimi-k2.7-code",
         "kimi-k2.6",
@@ -331,7 +334,10 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2-0905-preview",
     ],
     "kimi-coding-cn": [
+        "k3",
         "kimi-k3",
+        "kimi-for-coding",
+        "kimi-for-coding-highspeed",
         "kimi-k2.7-code",
         "kimi-k2.7-code-highspeed",
         "kimi-k2.6",


### PR DESCRIPTION
## Summary
- Official Kimi Code docs / routing tables often use short IDs: `k3`, `kimi-for-coding`, `kimi-for-coding-highspeed`.
- Catalog already had longer forms (`kimi-k3`, …). Add short aliases so pickers and curated lists resolve both shapes for `kimi-coding` and `kimi-coding-cn`.

## Test plan
- [ ] Open model picker for Kimi Coding / CN
- [ ] Confirm `k3` and `kimi-for-coding*` appear alongside existing long IDs
- [ ] Selecting a short ID still routes to the expected provider endpoint

No runtime auth changes — list-only.