### PR TITLE
fix(desktop): keep pane chrome out of titlebar hit testing

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -355,7 +355,10 @@ export function TreeGroup({
         </ZoneMenu>
       )}
 
-      {/* Header: the file-preview tab strip (PaneTab), one shared component. */}
+      {/* Header: the file-preview tab strip (PaneTab), one shared component.
+          This is content chrome below the window titlebar. Keep Electron app
+          regions off it so pre-hydration pane geometry cannot carve stale
+          no-drag rectangles out of the native titlebar on Windows. */}
       {headerVisible && (
         <ZoneMenu {...zoneMenu}>
           <div
@@ -364,7 +367,7 @@ export function TreeGroup({
             // PANE_TAB_STRIP_LINE; active tab cuts through it.
             // data-zone-tabstrip: a drop over here STACKS (drag-session reads it).
             className={cn(
-              'group/pane-header relative flex h-7 shrink-0 select-none bg-(--pane-tab-strip-bg) [-webkit-app-region:no-drag] [--pane-tab-active-bg:var(--ui-sidebar-surface-background)] [--pane-tab-strip-bg:var(--theme-card-seed)]',
+              'group/pane-header relative flex h-7 shrink-0 select-none bg-(--pane-tab-strip-bg) [--pane-tab-active-bg:var(--ui-sidebar-surface-background)] [--pane-tab-strip-bg:var(--theme-card-seed)]',
               PANE_TAB_STRIP_LINE
             )}
             data-zone-tabstrip={node.id}

--- a/apps/desktop/src/components/ui/pane-tab.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.tsx
@@ -9,8 +9,11 @@ export const PANE_TAB_STRIP_LINE = 'shadow-[inset_0_-1px_0_var(--ui-stroke-terti
 export const PANE_TAB_STRIP_LINE_LEFT = 'shadow-[inset_1px_0_0_var(--ui-stroke-tertiary)]'
 export const PANE_TAB_STRIP_LINE_RIGHT = 'shadow-[inset_-1px_0_0_var(--ui-stroke-tertiary)]'
 
+// Pane tabs are content chrome, never window-titlebar controls. Leaving their
+// app region unset keeps transient layout geometry out of Electron's native
+// titlebar hit-test map.
 const TAB =
-  'group/tab relative flex shrink-0 items-center border-transparent bg-(--tab-bg) text-[0.6875rem] font-medium [-webkit-app-region:no-drag]'
+  'group/tab relative flex shrink-0 items-center border-transparent bg-(--tab-bg) text-[0.6875rem] font-medium'
 
 const TAB_HORIZONTAL = 'h-full min-w-0 max-w-48 border-b not-first:border-l not-first:border-l-(--ui-stroke-quaternary)'
 


### PR DESCRIPTION
## What does this PR do?

Keeps pane-tree headers and shared pane tabs out of Electron's native app-region map.

On Windows, the layout tree can hydrate after the titlebar is first painted. The pane header and its tabs were marked `-webkit-app-region: no-drag` even though they are content chrome below the window titlebar. Electron could retain their transient pre-hydration rectangles in native hit testing, leaving a workspace-width `HTCLIENT` hole across the otherwise empty center titlebar until another native layout invalidation, such as resizing the window.

The real titlebar still owns its explicit drag strips and interactive `no-drag` controls. This change only removes app-region declarations from pane content that never belongs to the window titlebar.

Follow-up to #68331, which removed empty titlebar-slot carve-outs but did not cover pane-tree chrome.

## Related Issue

No linked issue. Follow-up to #68331.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx`: remove `no-drag` from the full pane-header strip and document why pane content must not participate in native titlebar hit testing.
- `apps/desktop/src/components/ui/pane-tab.tsx`: remove `no-drag` from the shared pane-tab shell so nested tabs cannot leave smaller stale titlebar carve-outs.

## How to Test

1. On Windows, launch Desktop into a project with the sidebar and workspace pane tabs enabled.
2. Wait for the stored session, project tree, and pane layout to finish hydrating without resizing the window.
3. Drag from the empty center titlebar before and after opening or loading terminal/log panes. The center should continue returning native caption behavior and move the window.

Focused validation performed:

- `vitest run src/components/ui/pane-tab.test.tsx src/components/pane-shell/tree/renderer/lone-header.test.ts` (10 tests passed)
- `npm run typecheck`
- ESLint on both changed files
- Prettier check on both changed files
- `npm run build`

The full suite was not run locally and is left to GitHub CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (the failure is in Electron's native Windows hit-test cache and is not reproducible in jsdom)
- [x] I've tested on my platform: Windows 11 reproduction and native `WM_NCHITTEST` inspection; focused automated checks and production build pass

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, inline comments document the app-region invariant
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pane headers remain normal interactive content on every platform
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before the fix, Windows native hit testing reported a workspace-width center segment as `HTCLIENT` while the empty titlebar segments immediately to its left and right reported `HTCAPTION`. The client segment aligned with the hydrated workspace pane header width.
