### PR TITLE
fix(copilot): align GPT-5 reasoning fallbacks with catalog

### DIFF
--- a/contributors/emails/timho0110@gmail.com
+++ b/contributors/emails/timho0110@gmail.com
@@ -1,0 +1,2 @@
+timctho
+# PR #68993 Copilot reasoning effort fix

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -34,7 +34,26 @@ COPILOT_BASE_URL = "https://api.githubcopilot.com"
 COPILOT_MODELS_URL = f"{COPILOT_BASE_URL}/models"
 COPILOT_EDITOR_VERSION = "vscode/1.104.1"
 COPILOT_REASONING_EFFORTS_GPT5 = ["minimal", "low", "medium", "high"]
+COPILOT_REASONING_EFFORTS_GPT5_MINI = ["low", "medium", "high"]
+COPILOT_REASONING_EFFORTS_GPT53 = ["low", "medium", "high", "xhigh"]
+COPILOT_REASONING_EFFORTS_GPT54_55 = ["none", "low", "medium", "high", "xhigh"]
+COPILOT_REASONING_EFFORTS_GPT56 = [
+    "none",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+]
 COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
+_COPILOT_REASONING_EFFORT_ORDER = [
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+]
 
 def _urlopen_model_catalog_request(req: urllib.request.Request, *, timeout: float):
     """Open catalog requests without forwarding headers across origins."""
@@ -4033,6 +4052,18 @@ def _github_reasoning_efforts_for_model_id(model_id: str) -> list[str]:
     if raw.startswith(("openai/o1", "openai/o3", "openai/o4", "o1", "o3", "o4")):
         return list(COPILOT_REASONING_EFFORTS_O_SERIES)
     normalized = normalize_copilot_model_id(model_id).lower()
+    # Keep the no-catalog runtime path aligned with Copilot's current model
+    # capabilities. The live catalog remains authoritative when supplied to
+    # github_model_reasoning_efforts(); these fallbacks prevent normal agent
+    # requests from silently downgrading newer efforts while offline.
+    if normalized.startswith("gpt-5.6"):
+        return list(COPILOT_REASONING_EFFORTS_GPT56)
+    if normalized.startswith(("gpt-5.4", "gpt-5.5")):
+        return list(COPILOT_REASONING_EFFORTS_GPT54_55)
+    if normalized.startswith("gpt-5.3"):
+        return list(COPILOT_REASONING_EFFORTS_GPT53)
+    if normalized.startswith("gpt-5-mini"):
+        return list(COPILOT_REASONING_EFFORTS_GPT5_MINI)
     if normalized.startswith("gpt-5"):
         return list(COPILOT_REASONING_EFFORTS_GPT5)
     return []
@@ -4279,6 +4310,55 @@ def github_model_reasoning_efforts(
             return []
 
     return _github_reasoning_efforts_for_model_id(str(model_id or normalized))
+
+
+def coerce_copilot_reasoning_effort(
+    requested_effort: str,
+    supported_efforts: list[str],
+) -> Optional[str]:
+    """Return the nearest Copilot-supported wire effort for a configured tier."""
+    supported = list(
+        dict.fromkeys(
+            str(effort).strip().lower()
+            for effort in supported_efforts
+            if str(effort).strip()
+        )
+    )
+    if not supported:
+        return None
+
+    requested = str(requested_effort or "medium").strip().lower() or "medium"
+    if requested == "none":
+        return "none" if "none" in supported else None
+
+    usable = [effort for effort in supported if effort != "none"]
+    if not usable:
+        return None
+
+    # Ultra is Hermes' product tier; OpenAI's strongest GPT-5.6 wire value is
+    # max. On models capped below max, the ordered fallback below chooses the
+    # nearest weaker tier instead of unexpectedly resetting to medium.
+    if requested == "ultra":
+        requested = "max"
+    if requested in usable:
+        return requested
+
+    try:
+        requested_index = _COPILOT_REASONING_EFFORT_ORDER.index(requested)
+    except ValueError:
+        return "medium" if "medium" in usable else usable[0]
+
+    ranked_supported = [
+        (index, effort)
+        for index, effort in enumerate(_COPILOT_REASONING_EFFORT_ORDER)
+        if effort in usable
+    ]
+    weaker = [item for item in ranked_supported if item[0] < requested_index]
+    if weaker:
+        return weaker[-1][1]
+    if ranked_supported:
+        return ranked_supported[0][1]
+    return "medium" if "medium" in usable else usable[0]
 
 
 def probe_api_models(

--- a/plugins/model-providers/copilot/__init__.py
+++ b/plugins/model-providers/copilot/__init__.py
@@ -30,31 +30,18 @@ class CopilotProfile(ProviderProfile):
         extra_body: dict[str, Any] = {}
         if supports_reasoning and model:
             try:
-                from hermes_cli.models import github_model_reasoning_efforts
+                from hermes_cli.models import (
+                    coerce_copilot_reasoning_effort,
+                    github_model_reasoning_efforts,
+                )
 
                 supported_efforts = github_model_reasoning_efforts(model)
                 if supported_efforts and reasoning_config:
-                    effort = reasoning_config.get("effort", "medium")
-                    # Honor the requested level when the live Copilot catalog
-                    # lists it as supported: gpt-5.5/gpt-5.4 DO support
-                    # ``xhigh``. Only downgrade levels the catalog does NOT
-                    # list (e.g. ``xhigh``/``max`` on models capped lower, or
-                    # ``minimal`` where unsupported), choosing the nearest
-                    # weaker supported level rather than forwarding verbatim.
-                    #
-                    # (Previously this unconditionally mapped xhigh->high, a
-                    #  stale guard that silently capped models which do support
-                    #  the higher level.)
-                    if effort not in supported_efforts:
-                        if effort == "xhigh" and "high" in supported_efforts:
-                            effort = "high"
-                        elif effort == "minimal" and "low" in supported_efforts:
-                            effort = "low"
-                        elif "medium" in supported_efforts:
-                            effort = "medium"
-                        else:
-                            effort = supported_efforts[0]
-                    if effort in supported_efforts:
+                    effort = coerce_copilot_reasoning_effort(
+                        reasoning_config.get("effort", "medium"),
+                        supported_efforts,
+                    )
+                    if effort:
                         extra_body["reasoning"] = {"effort": effort}
                 elif supported_efforts:
                     extra_body["reasoning"] = {"effort": "medium"}

--- a/run_agent.py
+++ b/run_agent.py
@@ -7118,7 +7118,10 @@ class AIAgent:
     def _github_models_reasoning_extra_body(self) -> dict | None:
         """Format reasoning payload for GitHub Models/OpenAI-compatible routes."""
         try:
-            from hermes_cli.models import github_model_reasoning_efforts
+            from hermes_cli.models import (
+                coerce_copilot_reasoning_effort,
+                github_model_reasoning_efforts,
+            )
         except Exception:
             return None
 
@@ -7135,17 +7138,11 @@ class AIAgent:
         else:
             requested_effort = "medium"
 
-        if requested_effort == "xhigh" and "xhigh" not in supported_efforts and "high" in supported_efforts:
-            requested_effort = "high"
-        elif requested_effort not in supported_efforts:
-            if requested_effort == "minimal" and "low" in supported_efforts:
-                requested_effort = "low"
-            elif "medium" in supported_efforts:
-                requested_effort = "medium"
-            else:
-                requested_effort = supported_efforts[0]
-
-        return {"effort": requested_effort}
+        wire_effort = coerce_copilot_reasoning_effort(
+            requested_effort,
+            supported_efforts,
+        )
+        return {"effort": wire_effort} if wire_effort else None
 
     def _build_assistant_message(self, assistant_message, finish_reason: str) -> dict:
         """Forwarder — see ``agent.chat_completion_helpers.build_assistant_message``."""

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from hermes_cli.models import (
     azure_foundry_model_api_mode,
+    coerce_copilot_reasoning_effort,
     copilot_model_api_mode,
     fetch_github_model_catalog,
     curated_models_for_provider,
@@ -221,6 +222,33 @@ class TestFetchApiModels:
 
 
 class TestGithubReasoningEfforts:
+    def test_coercion_uses_latest_wire_alias_and_nearest_supported_tier(self):
+        gpt56 = github_model_reasoning_efforts("gpt-5.6-sol")
+        gpt55 = github_model_reasoning_efforts("gpt-5.5")
+        gpt5_mini = github_model_reasoning_efforts("gpt-5-mini")
+
+        assert coerce_copilot_reasoning_effort("ultra", gpt56) == "max"
+        assert coerce_copilot_reasoning_effort("max", gpt55) == "xhigh"
+        assert coerce_copilot_reasoning_effort("xhigh", gpt5_mini) == "high"
+        assert coerce_copilot_reasoning_effort("minimal", gpt5_mini) == "low"
+
+    def test_versioned_gpt5_fallback_preserves_extended_efforts(self):
+        """Fallbacks expose each generation's strongest advertised tier."""
+        gpt53 = set(github_model_reasoning_efforts("gpt-5.3-codex"))
+        gpt55 = set(github_model_reasoning_efforts("gpt-5.5"))
+        gpt56 = set(github_model_reasoning_efforts("gpt-5.6-sol"))
+
+        assert "xhigh" in gpt53
+        assert "max" not in gpt53
+        assert "xhigh" in gpt55
+        assert "max" not in gpt55
+        assert {"xhigh", "max"}.issubset(gpt56)
+
+    def test_versioned_gpt5_fallback_does_not_overstate_older_models(self):
+        """New GPT-5.6 levels must not leak onto models that reject them."""
+        assert "max" not in github_model_reasoning_efforts("gpt-5.5")
+        assert "xhigh" not in github_model_reasoning_efforts("gpt-5-mini")
+
     def test_gpt5_supports_minimal_to_high(self):
         catalog = [{
             "id": "gpt-5.4",

--- a/tests/plugins/model_providers/test_copilot_profile.py
+++ b/tests/plugins/model_providers/test_copilot_profile.py
@@ -71,6 +71,28 @@ class TestCopilotReasoningEffortClamp:
         )
         assert extra_body["reasoning"] == {"effort": "low"}
 
+    def test_max_downgrades_to_xhigh_when_unsupported(self, copilot_profile, monkeypatch):
+        """A stronger configured tier uses the nearest weaker catalog tier."""
+        _patch_efforts(monkeypatch, ["none", "low", "medium", "high", "xhigh"])
+        extra_body, _ = copilot_profile.build_api_kwargs_extras(
+            model="gpt-5.5",
+            reasoning_config={"effort": "max"},
+            supports_reasoning=True,
+        )
+        assert extra_body["reasoning"] == {"effort": "xhigh"}
+
+    def test_ultra_uses_gpt56_max_wire_value(self, copilot_profile, monkeypatch):
+        _patch_efforts(
+            monkeypatch,
+            ["none", "low", "medium", "high", "xhigh", "max"],
+        )
+        extra_body, _ = copilot_profile.build_api_kwargs_extras(
+            model="gpt-5.6-sol",
+            reasoning_config={"effort": "ultra"},
+            supports_reasoning=True,
+        )
+        assert extra_body["reasoning"] == {"effort": "max"}
+
     def test_unsupported_effort_falls_back_to_medium(self, copilot_profile, monkeypatch):
         """An effort not in the set, with no specific rule, falls to medium."""
         _patch_efforts(monkeypatch, ["low", "medium", "high"])

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1367,6 +1367,32 @@ class TestBuildApiKwargs:
 
         assert agent._github_models_reasoning_extra_body() == {"effort": "xhigh"}
 
+    def test_core_responses_preserves_gpt56_extended_efforts(self, agent):
+        """Current GPT-5.6 Copilot levels must reach the wire without downgrading."""
+        agent.model = "gpt-5.6-sol"
+
+        for configured, wire in (
+            ("xhigh", "xhigh"),
+            ("max", "max"),
+            ("ultra", "max"),
+        ):
+            agent.reasoning_config = {"enabled": True, "effort": configured}
+            assert agent._github_models_reasoning_extra_body() == {"effort": wire}
+
+    def test_copilot_gpt56_final_request_kwargs_preserve_max(self, agent):
+        """Regression: the final Copilot Responses request must carry max."""
+        agent.provider = "copilot"
+        agent.base_url = "https://api.githubcopilot.com"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.api_mode = "codex_responses"
+        agent.model = "gpt-5.6-sol"
+        agent.reasoning_config = {"enabled": True, "effort": "max"}
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+        assert kwargs["model"] == "gpt-5.6-sol"
+        assert kwargs["reasoning"] == {"effort": "max"}
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the normal Copilot runtime path silently downgrading reasoning levels because its no-catalog GPT-5 fallback still used the original `minimal`–`high` ladder. The authenticated Copilot catalog now advertises model-specific ladders: GPT-5.3 through `xhigh`, GPT-5.4/5.5 through `xhigh`, and GPT-5.6 through `max`.

This change keeps the live catalog authoritative when supplied, aligns the no-catalog runtime fallback with current advertised capabilities, and centralizes nearest-supported effort projection across the Copilot Responses and provider-profile paths. Hermes `ultra` maps to OpenAI's GPT-5.6 wire value `max`; unsupported stronger tiers select the nearest weaker supported tier rather than resetting to `medium`.

This is a current-main, Copilot-runtime-only salvage of overlapping slices in conflict-dirty drafts #61834 and #65979. It does not replace #61834's non-Copilot provider work or #65979's desktop UI work.

## Related Issue

Related: #31702, #61834, #65979.

No issue is closed by this PR.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py`: add version-aware Copilot GPT-5 fallback ladders and shared nearest-supported effort projection.
- `run_agent.py`: use the shared projection for Copilot Responses payloads.
- `plugins/model-providers/copilot/__init__.py`: use the same projection for the registered profile path.
- `tests/`: cover current GPT-5 ladders, nearest-down projection, `ultra` to `max`, and final request kwargs.
- `contributors/emails/timho0110@gmail.com`: add the required contributor attribution mapping.

## How to Test

1. Configure Copilot with `gpt-5.6-sol` and `agent.reasoning_effort: max` (or `xhigh`).
2. Build a Copilot Responses request and verify `reasoning.effort` remains `max` (or `xhigh`) instead of becoming `medium`/`high`.
3. Run `scripts/run_tests.sh` and `python scripts/check-windows-footguns.py --diff origin/main`.

Live catalog validation compared all eight advertised GPT-5 entries against the fallback resolver: 8 checked, 0 mismatches.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and documented the overlapping conflict-dirty drafts above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — full canonical suite was attempted but hits unrelated verification-evidence failures reproduced on a clean `origin/main`; the complete affected canonical slice passes: **262 passed, 0 failed**
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2, Ubuntu 20.04, Python 3.11.11

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing setting changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); the diff is platform-neutral and the footgun scan passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. This is request-shaping logic; regression tests assert the final Copilot request fields.
