### PR TITLE
fix: Copilot ACP weak spots + Cursor provider fallback

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -532,7 +532,9 @@ def init_agent(
         api_mode is None
         and agent.api_mode == "chat_completions"
         and agent.provider != "copilot-acp"
+        and agent.provider != "cursor"
         and not str(agent.base_url or "").lower().startswith("acp://copilot")
+        and not str(agent.base_url or "").lower().startswith("cursor://")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
         and (

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1873,6 +1873,17 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
+    if agent.provider == "cursor" or str(client_kwargs.get("base_url", "")).startswith("cursor://"):
+        from agent.cursor_agent_client import CursorAgentClient
+
+        client = CursorAgentClient(**client_kwargs)
+        _ra().logger.info(
+            "Cursor Agent client created (%s, shared=%s) %s",
+            reason,
+            shared,
+            agent._client_log_context(),
+        )
+        return client
     if agent.provider == "gemini":
         from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -201,6 +201,15 @@ def _openai_http_client_kwargs(
     return {"http_client": client}
 
 def _create_openai_client(*, api_key: str, base_url: str, **kwargs: Any) -> Any:
+    base = str(base_url or "").strip()
+    if base.startswith("acp://copilot"):
+        from agent.copilot_acp_client import CopilotACPClient
+
+        return CopilotACPClient(api_key=api_key, base_url=base, **kwargs)
+    if base.startswith("cursor://"):
+        from agent.cursor_agent_client import CursorAgentClient
+
+        return CursorAgentClient(api_key=api_key, base_url=base, **kwargs)
     kwargs = {**_openai_http_client_kwargs(base_url), **kwargs}
     # Hermes owns auxiliary retry + provider/model fallback policy (the
     # same-provider transient retry in call_llm plus the except-chain
@@ -2549,7 +2558,7 @@ def _validate_base_url(base_url: str) -> None:
     from urllib.parse import urlparse
 
     candidate = str(base_url or "").strip()
-    if not candidate or candidate.startswith("acp://"):
+    if not candidate or candidate.startswith("acp://") or candidate.startswith("cursor://"):
         return
     try:
         parsed = urlparse(candidate)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1410,16 +1410,15 @@ def run_conversation(
                 # session instead of re-failing every retry.
                 if getattr(agent, "_disable_streaming", False):
                     _use_streaming = False
-                # CopilotACPClient communicates via subprocess stdio and
-                # returns a plain SimpleNamespace — not an iterable
-                # stream.  Mirror the ACP exclusion used for Responses
-                # API upgrade (lines ~1083-1085).
-                elif (
-                    agent.provider in {"copilot-acp"}
-                    or str(agent.base_url or "").lower().startswith("acp://copilot")
-                    or str(agent.base_url or "").lower().startswith("acp+tcp://")
-                ):
+                # TCP ACP transports still return non-iterable completions.
+                # Local CopilotACPClient now yields live session/update deltas.
+                elif str(agent.base_url or "").lower().startswith("acp+tcp://"):
                     _use_streaming = False
+                elif agent.provider in {"cursor"} or str(agent.base_url or "").lower().startswith(
+                    "cursor://"
+                ):
+                    # Cursor Agent SDK shim streams when possible; keep enabled.
+                    pass
                 # MoA streams only when a display/TTS consumer is present to
                 # receive the deltas. MoAChatCompletions.create() honors
                 # stream=True (runs the references, then returns the aggregator's
@@ -3363,8 +3362,11 @@ def run_conversation(
                     # etc.) is throttling OpenRouter, so always fall back to a
                     # different model regardless of pool state.
                     _is_upstream = classified.reason == FailoverReason.upstream_rate_limit
+                    # Hard quota/billing walls won't recover by rotating keys on
+                    # the same Copilot/GitHub account — prefer fallback immediately.
                     pool_may_recover = (
-                        False if _is_upstream
+                        False
+                        if _is_upstream or classified.reason == FailoverReason.billing
                         else _ra()._pool_may_recover_from_rate_limit(
                             agent._credential_pool,
                         )
@@ -4301,18 +4303,37 @@ def run_conversation(
 
                 # For rate limits, respect the Retry-After header if present
                 _retry_after = None
+                _has_pending_fallback = agent._fallback_index < len(agent._fallback_chain)
+                # Prefer fallback over a long sleep when the pool can't help or
+                # this is a hard quota/billing wall (Copilot "quota exceeded").
+                if _has_pending_fallback and (
+                    classified.reason == FailoverReason.billing
+                    or (
+                        is_rate_limited
+                        and not _ra()._pool_may_recover_from_rate_limit(
+                            agent._credential_pool,
+                        )
+                    )
+                ):
+                    if agent._try_activate_fallback(reason=classified.reason):
+                        active_system_prompt = _sync_failover_system_message(
+                            agent, api_messages, active_system_prompt)
+                        retry_count = 0
+                        compression_attempts = 0
+                        _retry.primary_recovery_attempted = False
+                        continue
                 if is_rate_limited:
                     _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
                     if _resp_headers and hasattr(_resp_headers, "get"):
                         _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
                         if _ra_raw:
                             try:
-                                # Cap at 10 minutes. Anthropic Tier 1 input-token
-                                # buckets reset in ~171s, so a 120s cap caused us to
-                                # retry before the actual reset window and re-trip the
-                                # limit. 600s covers all realistic provider reset
-                                # windows while still rejecting pathological values. (#26293)
-                                _retry_after = min(float(_ra_raw), 600)
+                                # Cap at 10 minutes when no fallback is available.
+                                # Anthropic Tier 1 input-token buckets reset in ~171s
+                                # (#26293). When a fallback chain exists, cap much
+                                # lower so we don't park for 600s before switching.
+                                _ra_cap = 30.0 if _has_pending_fallback else 600.0
+                                _retry_after = min(float(_ra_raw), _ra_cap)
                             except (TypeError, ValueError):
                                 pass
                 wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -1,9 +1,9 @@
 """OpenAI-compatible shim that forwards Hermes requests to `copilot --acp`.
 
 This adapter lets Hermes treat the GitHub Copilot ACP server as a chat-style
-backend. Each request starts a short-lived ACP session, sends the formatted
-conversation as a single prompt, collects text chunks, and converts the result
-back into the minimal shape Hermes expects from an OpenAI client.
+backend. A long-lived ACP subprocess + session is reused across completions;
+prompts stream `session/update` chunks back as OpenAI-style deltas when
+requested.
 """
 
 from __future__ import annotations
@@ -17,6 +17,7 @@ import subprocess
 import threading
 import time
 from collections import deque
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -33,20 +34,25 @@ from tools.environments.local import hermes_subprocess_env
 ACP_MARKER_BASE_URL = "acp://copilot"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
 
-_TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
-_TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
+_TOOL_CALL_OPEN_RE = re.compile(r"<tool_call>\s*", re.IGNORECASE)
+_TOOL_CALL_CLOSE = "</tool_call>"
 
 # Stderr fingerprint of the deprecated `gh copilot` CLI extension
 # (https://github.blog/changelog/2025-09-25-upcoming-deprecation-of-gh-copilot-cli-extension).
-# We require BOTH the literal product name ("gh-copilot") AND a deprecation
-# marker, so generic stderr from the NEW `@github/copilot` CLI — whose repo
-# is github.com/github/copilot-cli and which legitimately mentions "copilot-cli"
-# in its own banners and error messages — doesn't get misclassified as the
-# deprecated extension.
 _DEPRECATION_REQUIRED = ("gh-copilot",)
 _DEPRECATION_MARKERS = (
     "has been deprecated",
     "no commands will be executed",
+)
+
+_EXEC_PERMISSION_HINTS = (
+    "exec",
+    "terminal",
+    "shell",
+    "bash",
+    "command",
+    "run_command",
+    "sudo",
 )
 
 
@@ -74,6 +80,13 @@ def _resolve_args() -> list[str]:
     return shlex.split(raw)
 
 
+def _permission_mode() -> str:
+    mode = os.getenv("HERMES_COPILOT_ACP_PERMISSION_MODE", "cwd_safe").strip().lower()
+    if mode in {"deny", "cwd_safe"}:
+        return mode
+    return "cwd_safe"
+
+
 def _resolve_home_dir() -> str:
     """Return a stable HOME for child ACP processes."""
     home = os.environ.get("HOME", "").strip()
@@ -93,9 +106,6 @@ def _resolve_home_dir() -> str:
     except Exception:
         pass
 
-    # Last resort: /tmp (writable on any POSIX system). Avoids crashing the
-    # subprocess with no HOME; callers can set HERMES_HOME explicitly if they
-    # need a different writable dir.
     return "/tmp"
 
 
@@ -106,8 +116,15 @@ def _build_subprocess_env() -> dict[str, str]:
     env = hermes_subprocess_env(inherit_credentials=True)
     home = _resolve_home_dir()
     env["HOME"] = home
-    from hermes_constants import apply_subprocess_home_env
+    from hermes_constants import apply_subprocess_home_env, get_real_home
+
     apply_subprocess_home_env(env)
+    # Copilot CLI auth lives under the real user HOME (~/.config/github-copilot).
+    # Do not remap HOME to the Hermes profile home even in containers.
+    real_home = get_real_home(env)
+    if real_home:
+        env["HERMES_REAL_HOME"] = real_home
+        env["HOME"] = real_home
     return env
 
 
@@ -134,6 +151,82 @@ def _permission_denied(message_id: Any) -> dict[str, Any]:
     }
 
 
+def _permission_allowed(message_id: Any, option_id: str = "allow_once") -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "result": {
+            "outcome": {
+                "outcome": "selected",
+                "option_id": option_id,
+            }
+        },
+    }
+
+
+def _is_sensitive_path(path: Path) -> bool:
+    try:
+        from acp_adapter.edit_approval import _is_sensitive_auto_approve_path
+
+        return _is_sensitive_auto_approve_path(str(path))
+    except Exception:
+        name = path.name.lower()
+        if name in {".env", ".env.local", ".env.production", "id_rsa", "id_ed25519"}:
+            return True
+        parts = {p.lower() for p in path.parts}
+        return ".git" in parts or ".ssh" in parts
+
+
+def _permission_looks_like_exec(params: dict[str, Any]) -> bool:
+    blob = json.dumps(params, ensure_ascii=False).lower()
+    return any(hint in blob for hint in _EXEC_PERMISSION_HINTS)
+
+
+def _extract_permission_paths(params: dict[str, Any]) -> list[str]:
+    paths: list[str] = []
+
+    def _walk(obj: Any) -> None:
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                key_l = str(key).lower()
+                if key_l in {"path", "filepath", "file_path", "uri", "target"} and isinstance(value, str):
+                    if value.startswith("file://"):
+                        value = value[len("file://"):]
+                    paths.append(value)
+                else:
+                    _walk(value)
+        elif isinstance(obj, list):
+            for item in obj:
+                _walk(item)
+
+    _walk(params)
+    return paths
+
+
+def _decide_permission(params: dict[str, Any], cwd: str) -> bool:
+    """Return True to auto-approve cwd-safe fs permissions; False to deny."""
+    if _permission_mode() == "deny":
+        return False
+    if _permission_looks_like_exec(params):
+        return False
+
+    paths = _extract_permission_paths(params)
+    if not paths:
+        # No path + not exec → deny unknown permission kinds (fail closed).
+        return False
+
+    for path_text in paths:
+        try:
+            path = _ensure_path_within_cwd(path_text, cwd)
+        except PermissionError:
+            return False
+        if _is_sensitive_path(path):
+            return False
+        if get_read_block_error(str(path)) or get_write_denied_error(str(path)):
+            return False
+    return True
+
+
 def _format_messages_as_prompt(
     messages: list[dict[str, Any]],
     model: str | None = None,
@@ -143,7 +236,7 @@ def _format_messages_as_prompt(
     sections: list[str] = [
         "You are being used as the active ACP agent backend for Hermes.",
         "Use ACP capabilities to complete tasks.",
-        "IMPORTANT: If you take an action with a tool, you MUST output tool calls using <tool_call>{...}</tool_call> blocks with JSON exactly in OpenAI function-call shape.",
+        "IMPORTANT: If you take an action with a Hermes tool, you MUST output tool calls using <tool_call>{...}</tool_call> blocks with JSON exactly in OpenAI function-call shape.",
         "If no tool is needed, answer normally.",
     ]
     if model:
@@ -169,9 +262,10 @@ def _format_messages_as_prompt(
             )
         if tool_specs:
             sections.append(
-                "Available tools (OpenAI function schema). "
-                "When using a tool, emit ONLY <tool_call>{...}</tool_call> with one JSON object "
-                "containing id/type/function{name,arguments}. arguments must be a JSON string.\n"
+                "Available Hermes tools (OpenAI function schema). "
+                "When using a Hermes tool, emit ONLY <tool_call>{...}</tool_call> with one JSON object "
+                "containing id/type/function{name,arguments}. arguments must be a JSON string. "
+                "Do not use Copilot shell/terminal for Hermes tool goals; cwd-safe ACP file reads are OK for context.\n"
                 + json.dumps(tool_specs, ensure_ascii=False)
             )
 
@@ -295,6 +389,35 @@ def _completion_to_stream_chunks(completion: SimpleNamespace) -> list[SimpleName
     return [data_chunk, usage_chunk]
 
 
+def _extract_balanced_json(text: str, start: int) -> tuple[str | None, int]:
+    """Extract one JSON object starting at ``start`` with brace balancing."""
+    if start >= len(text) or text[start] != "{":
+        return None, start
+    depth = 0
+    in_string = False
+    escape = False
+    for idx in range(start, len(text)):
+        ch = text[idx]
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : idx + 1], idx + 1
+    return None, start
+
+
 def _extract_tool_calls_from_text(text: str) -> tuple[list[ChatCompletionMessageToolCall], str]:
     if not isinstance(text, str) or not text.strip():
         return [], ""
@@ -302,19 +425,19 @@ def _extract_tool_calls_from_text(text: str) -> tuple[list[ChatCompletionMessage
     extracted: list[ChatCompletionMessageToolCall] = []
     consumed_spans: list[tuple[int, int]] = []
 
-    def _try_add_tool_call(raw_json: str) -> None:
+    def _try_add_tool_call(raw_json: str) -> bool:
         try:
             obj = json.loads(raw_json)
         except Exception:
-            return
+            return False
         if not isinstance(obj, dict):
-            return
+            return False
         fn = obj.get("function")
         if not isinstance(fn, dict):
-            return
+            return False
         fn_name = fn.get("name")
         if not isinstance(fn_name, str) or not fn_name.strip():
-            return
+            return False
         fn_args = fn.get("arguments", "{}")
         if not isinstance(fn_args, str):
             fn_args = json.dumps(fn_args, ensure_ascii=False)
@@ -329,18 +452,40 @@ def _extract_tool_calls_from_text(text: str) -> tuple[list[ChatCompletionMessage
                 arguments=fn_args,
             )
         )
+        return True
 
-    for m in _TOOL_CALL_BLOCK_RE.finditer(text):
-        raw = m.group(1)
-        _try_add_tool_call(raw)
-        consumed_spans.append((m.start(), m.end()))
+    search_from = 0
+    while True:
+        open_match = _TOOL_CALL_OPEN_RE.search(text, search_from)
+        if not open_match:
+            break
+        json_start = open_match.end()
+        while json_start < len(text) and text[json_start].isspace():
+            json_start += 1
+        raw_json, after_json = _extract_balanced_json(text, json_start)
+        if raw_json is None:
+            search_from = open_match.end()
+            continue
+        close_idx = text.lower().find(_TOOL_CALL_CLOSE, after_json)
+        end = close_idx + len(_TOOL_CALL_CLOSE) if close_idx >= 0 else after_json
+        if _try_add_tool_call(raw_json):
+            consumed_spans.append((open_match.start(), end))
+        search_from = end
 
-    # Only try bare-JSON fallback when no XML blocks were found.
+    # Bare-JSON fallback only when no XML blocks were found.
     if not extracted:
-        for m in _TOOL_CALL_JSON_RE.finditer(text):
-            raw = m.group(0)
-            _try_add_tool_call(raw)
-            consumed_spans.append((m.start(), m.end()))
+        idx = 0
+        while idx < len(text):
+            brace = text.find("{", idx)
+            if brace < 0:
+                break
+            raw_json, after = _extract_balanced_json(text, brace)
+            if raw_json is None:
+                idx = brace + 1
+                continue
+            if '"type"' in raw_json and '"function"' in raw_json and _try_add_tool_call(raw_json):
+                consumed_spans.append((brace, after))
+            idx = after
 
     if not consumed_spans:
         return extracted, text.strip()
@@ -366,7 +511,6 @@ def _extract_tool_calls_from_text(text: str) -> tuple[list[ChatCompletionMessage
     return extracted, cleaned
 
 
-
 def _ensure_path_within_cwd(path_text: str, cwd: str) -> Path:
     candidate = Path(path_text)
     if not candidate.is_absolute():
@@ -378,6 +522,36 @@ def _ensure_path_within_cwd(path_text: str, cwd: str) -> Path:
     except ValueError as exc:
         raise PermissionError(f"Path '{resolved}' is outside the session cwd '{root}'.") from exc
     return resolved
+
+
+def _estimate_usage(
+    messages: list[dict[str, Any]] | None,
+    tools: list[dict[str, Any]] | None,
+    response_text: str,
+    reasoning_text: str,
+) -> SimpleNamespace:
+    try:
+        from agent.model_metadata import (
+            estimate_request_tokens_rough,
+            estimate_tokens_rough,
+        )
+
+        prompt_tokens = int(
+            estimate_request_tokens_rough(messages or [], tools=tools) or 0
+        )
+        completion_tokens = int(
+            estimate_tokens_rough(response_text or "")
+            + estimate_tokens_rough(reasoning_text or "")
+        )
+    except Exception:
+        prompt_tokens = max(1, len(json.dumps(messages or [])) // 4)
+        completion_tokens = max(0, (len(response_text) + len(reasoning_text)) // 4)
+    return SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+    )
 
 
 class _ACPChatCompletions:
@@ -418,13 +592,23 @@ class CopilotACPClient:
         self.chat = _ACPChatNamespace(self)
         self.is_closed = False
         self._active_process: subprocess.Popen[str] | None = None
-        self._active_process_lock = threading.Lock()
+        self._active_process_lock = threading.RLock()
+        self._inbox: queue.Queue[dict[str, Any]] | None = None
+        self._stderr_tail: deque[str] = deque(maxlen=40)
+        self._next_id = 0
+        self._session_id: str | None = None
+        self._initialized = False
+        self._reader_threads: list[threading.Thread] = []
 
     def close(self) -> None:
         proc: subprocess.Popen[str] | None
         with self._active_process_lock:
             proc = self._active_process
             self._active_process = None
+            self._session_id = None
+            self._initialized = False
+            self._inbox = None
+            self._next_id = 0
         self.is_closed = True
         if proc is None:
             return
@@ -436,6 +620,18 @@ class CopilotACPClient:
                 proc.kill()
             except Exception:
                 pass
+
+    def _effective_timeout(self, timeout: Any) -> float:
+        if timeout is None:
+            return _DEFAULT_TIMEOUT_SECONDS
+        if isinstance(timeout, (int, float)):
+            return float(timeout)
+        candidates = [
+            getattr(timeout, attr, None)
+            for attr in ("read", "write", "connect", "pool", "timeout")
+        ]
+        numeric = [float(v) for v in candidates if isinstance(v, (int, float))]
+        return max(numeric) if numeric else _DEFAULT_TIMEOUT_SECONDS
 
     def _create_chat_completion(
         self,
@@ -454,35 +650,40 @@ class CopilotACPClient:
             tools=tools,
             tool_choice=tool_choice,
         )
-        # Normalise timeout: run_agent.py may pass an httpx.Timeout object
-        # (used natively by the OpenAI SDK) rather than a plain float.
-        if timeout is None:
-            _effective_timeout = _DEFAULT_TIMEOUT_SECONDS
-        elif isinstance(timeout, (int, float)):
-            _effective_timeout = float(timeout)
-        else:
-            # httpx.Timeout or similar — pick the largest component so the
-            # subprocess has enough wall-clock time for the full response.
-            _candidates = [
-                getattr(timeout, attr, None)
-                for attr in ("read", "write", "connect", "pool", "timeout")
-            ]
-            _numeric = [float(v) for v in _candidates if isinstance(v, (int, float))]
-            _effective_timeout = max(_numeric) if _numeric else _DEFAULT_TIMEOUT_SECONDS
+        _effective_timeout = self._effective_timeout(timeout)
+
+        if stream:
+            return self._stream_chat_completion(
+                prompt_text=prompt_text,
+                model=model,
+                messages=messages,
+                tools=tools,
+                timeout_seconds=_effective_timeout,
+            )
 
         response_text, reasoning_text = self._run_prompt(
             prompt_text,
             timeout_seconds=_effective_timeout,
         )
-
-        tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
-
-        usage = SimpleNamespace(
-            prompt_tokens=0,
-            completion_tokens=0,
-            total_tokens=0,
-            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        return self._build_completion(
+            model=model,
+            messages=messages,
+            tools=tools,
+            response_text=response_text,
+            reasoning_text=reasoning_text,
         )
+
+    def _build_completion(
+        self,
+        *,
+        model: str | None,
+        messages: list[dict[str, Any]] | None,
+        tools: list[dict[str, Any]] | None,
+        response_text: str,
+        reasoning_text: str,
+    ) -> SimpleNamespace:
+        tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
+        usage = _estimate_usage(messages, tools, response_text, reasoning_text)
         assistant_message = SimpleNamespace(
             content=cleaned_text,
             tool_calls=tool_calls,
@@ -492,128 +693,303 @@ class CopilotACPClient:
         )
         finish_reason = "tool_calls" if tool_calls else "stop"
         choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
-        completion = SimpleNamespace(
+        return SimpleNamespace(
             choices=[choice],
             usage=usage,
             model=model or "copilot-acp",
         )
-        if stream:
-            return _completion_to_stream_chunks(completion)
-        return completion
 
-    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
-        try:
-            proc = subprocess.Popen(
-                [self._acp_command] + self._acp_args,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                bufsize=1,
-                cwd=self._acp_cwd,
-                env=_build_subprocess_env(),
+    def _stream_chat_completion(
+        self,
+        *,
+        prompt_text: str,
+        model: str | None,
+        messages: list[dict[str, Any]] | None,
+        tools: list[dict[str, Any]] | None,
+        timeout_seconds: float,
+    ) -> Iterator[SimpleNamespace]:
+        text_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        pending_chunks: queue.Queue[SimpleNamespace | None] = queue.Queue()
+
+        def on_message_chunk(chunk: str) -> None:
+            text_parts.append(chunk)
+            pending_chunks.put(
+                SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            index=0,
+                            delta=SimpleNamespace(
+                                role="assistant",
+                                content=chunk,
+                                tool_calls=None,
+                                reasoning_content=None,
+                                reasoning=None,
+                            ),
+                            finish_reason=None,
+                        )
+                    ],
+                    model=model or "copilot-acp",
+                    usage=None,
+                )
             )
-        except FileNotFoundError as exc:
-            raise RuntimeError(
-                f"Could not start Copilot ACP command '{self._acp_command}'. "
-                "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
-            ) from exc
 
-        if proc.stdin is None or proc.stdout is None:
-            proc.kill()
-            raise RuntimeError("Copilot ACP process did not expose stdin/stdout pipes.")
+        def on_thought_chunk(chunk: str) -> None:
+            reasoning_parts.append(chunk)
+            pending_chunks.put(
+                SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            index=0,
+                            delta=SimpleNamespace(
+                                role="assistant",
+                                content=None,
+                                tool_calls=None,
+                                reasoning_content=chunk,
+                                reasoning=chunk,
+                            ),
+                            finish_reason=None,
+                        )
+                    ],
+                    model=model or "copilot-acp",
+                    usage=None,
+                )
+            )
 
-        self.is_closed = False
+        def runner() -> None:
+            try:
+                response_text, reasoning_text = self._run_prompt(
+                    prompt_text,
+                    timeout_seconds=timeout_seconds,
+                    on_message_chunk=on_message_chunk,
+                    on_thought_chunk=on_thought_chunk,
+                )
+                # Mocks / non-chunking backends may return full text without
+                # invoking live callbacks — emit one content delta then.
+                if not text_parts and response_text:
+                    on_message_chunk(response_text)
+                if not reasoning_parts and reasoning_text:
+                    on_thought_chunk(reasoning_text)
+            except Exception as exc:
+                pending_chunks.put(exc)  # type: ignore[arg-type]
+            finally:
+                pending_chunks.put(None)
+
+        thread = threading.Thread(target=runner, daemon=True)
+        thread.start()
+
+        while True:
+            item = pending_chunks.get()
+            if item is None:
+                break
+            if isinstance(item, Exception):
+                raise item
+            yield item
+
+        completion = self._build_completion(
+            model=model,
+            messages=messages,
+            tools=tools,
+            response_text="".join(text_parts),
+            reasoning_text="".join(reasoning_parts),
+        )
+        # Emit final finish + usage after live deltas (content already streamed).
+        finish_delta = SimpleNamespace(
+            role=None,
+            content=None,
+            tool_calls=None,
+            reasoning_content=None,
+            reasoning=None,
+        )
+        if completion.choices[0].message.tool_calls:
+            finish_delta.tool_calls = []
+            for index, tool_call in enumerate(completion.choices[0].message.tool_calls):
+                finish_delta.tool_calls.append(
+                    SimpleNamespace(
+                        index=index,
+                        id=getattr(tool_call, "id", None),
+                        type=getattr(tool_call, "type", "function"),
+                        function=SimpleNamespace(
+                            name=getattr(tool_call.function, "name", None),
+                            arguments=getattr(tool_call.function, "arguments", None),
+                        ),
+                    )
+                )
+            # Suppress already-streamed plain text when tool calls dominate.
+            # Live content may have included tool XML; Hermes extracts from final message path.
+        yield SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    index=0,
+                    delta=finish_delta,
+                    finish_reason=completion.choices[0].finish_reason,
+                )
+            ],
+            model=completion.model,
+            usage=None,
+        )
+        yield SimpleNamespace(
+            choices=[],
+            model=completion.model,
+            usage=completion.usage,
+        )
+
+    def _process_alive(self) -> bool:
+        proc = self._active_process
+        return proc is not None and proc.poll() is None
+
+    def _ensure_process(self) -> subprocess.Popen[str]:
         with self._active_process_lock:
-            self._active_process = proc
+            if self._process_alive() and self._inbox is not None:
+                assert self._active_process is not None
+                return self._active_process
 
-        inbox: queue.Queue[dict[str, Any]] = queue.Queue()
-        stderr_tail: deque[str] = deque(maxlen=40)
-
-        def _stdout_reader() -> None:
-            if proc.stdout is None:
-                return
-            for line in proc.stdout:
+            # Stale process/session — reset and spawn.
+            if self._active_process is not None:
                 try:
-                    inbox.put(json.loads(line))
+                    self._active_process.kill()
                 except Exception:
-                    inbox.put({"raw": line.rstrip("\n")})
+                    pass
+            self._active_process = None
+            self._session_id = None
+            self._initialized = False
+            self._next_id = 0
+            self._stderr_tail.clear()
 
-        def _stderr_reader() -> None:
-            if proc.stderr is None:
-                return
-            for line in proc.stderr:
-                stderr_tail.append(line.rstrip("\n"))
-
-        out_thread = threading.Thread(target=_stdout_reader, daemon=True)
-        err_thread = threading.Thread(target=_stderr_reader, daemon=True)
-        out_thread.start()
-        err_thread.start()
-
-        next_id = 0
-
-        def _request(method: str, params: dict[str, Any], *, text_parts: list[str] | None = None, reasoning_parts: list[str] | None = None) -> Any:
-            nonlocal next_id
-            next_id += 1
-            request_id = next_id
-            payload = {
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "method": method,
-                "params": params,
-            }
-            proc.stdin.write(json.dumps(payload) + "\n")
-            proc.stdin.flush()
-
-            deadline = time.monotonic() + timeout_seconds
-            while time.monotonic() < deadline:
-                if proc.poll() is not None:
-                    break
-                try:
-                    msg = inbox.get(timeout=0.1)
-                except queue.Empty:
-                    continue
-
-                if self._handle_server_message(
-                    msg,
-                    process=proc,
+            try:
+                proc = subprocess.Popen(
+                    [self._acp_command] + self._acp_args,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    bufsize=1,
                     cwd=self._acp_cwd,
-                    text_parts=text_parts,
-                    reasoning_parts=reasoning_parts,
-                ):
-                    continue
+                    env=_build_subprocess_env(),
+                )
+            except FileNotFoundError as exc:
+                raise RuntimeError(
+                    f"Could not start Copilot ACP command '{self._acp_command}'. "
+                    "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+                ) from exc
 
-                if msg.get("id") != request_id:
-                    continue
-                if "error" in msg:
-                    err = msg.get("error") or {}
-                    raise RuntimeError(
-                        f"Copilot ACP {method} failed: {err.get('message') or err}"
-                    )
-                return msg.get("result")
+            if proc.stdin is None or proc.stdout is None:
+                proc.kill()
+                raise RuntimeError("Copilot ACP process did not expose stdin/stdout pipes.")
 
-            stderr_text = "\n".join(stderr_tail).strip()
-            if proc.poll() is not None and stderr_text:
-                if _is_gh_copilot_deprecation_message(stderr_text):
-                    raise RuntimeError(
-                        "Hermes ACP mode requires the NEW GitHub Copilot CLI "
-                        "(github.com/github/copilot-cli), but the binary it just "
-                        "spawned is the deprecated `gh copilot` extension.\n\n"
-                        "Install the new CLI:\n"
-                        "  npm install -g @github/copilot\n"
-                        "  # then verify with: copilot --help\n\n"
-                        "If `copilot` already resolves to the new CLI but you still see this,\n"
-                        "point Hermes at it explicitly:\n"
-                        "  export HERMES_COPILOT_ACP_COMMAND=/path/to/new/copilot\n\n"
-                        "Alternative: use the `copilot` provider (no ACP, hits the Copilot API\n"
-                        "directly with a Copilot subscription token) via `hermes setup`.\n\n"
-                        f"Original error:\n{stderr_text}"
-                    )
-                raise RuntimeError(f"Copilot ACP process exited early: {stderr_text}")
-            raise TimeoutError(f"Timed out waiting for Copilot ACP response to {method}.")
+            inbox: queue.Queue[dict[str, Any]] = queue.Queue()
+            self._inbox = inbox
+            self._active_process = proc
+            self.is_closed = False
 
-        try:
-            _request(
+            def _stdout_reader() -> None:
+                if proc.stdout is None:
+                    return
+                for line in proc.stdout:
+                    try:
+                        inbox.put(json.loads(line))
+                    except Exception:
+                        inbox.put({"raw": line.rstrip("\n")})
+
+            def _stderr_reader() -> None:
+                if proc.stderr is None:
+                    return
+                for line in proc.stderr:
+                    self._stderr_tail.append(line.rstrip("\n"))
+
+            out_thread = threading.Thread(target=_stdout_reader, daemon=True)
+            err_thread = threading.Thread(target=_stderr_reader, daemon=True)
+            out_thread.start()
+            err_thread.start()
+            self._reader_threads = [out_thread, err_thread]
+            return proc
+
+    def _rpc(
+        self,
+        method: str,
+        params: dict[str, Any],
+        *,
+        timeout_seconds: float,
+        text_parts: list[str] | None = None,
+        reasoning_parts: list[str] | None = None,
+        on_message_chunk: Callable[[str], None] | None = None,
+        on_thought_chunk: Callable[[str], None] | None = None,
+    ) -> Any:
+        proc = self._ensure_process()
+        inbox = self._inbox
+        if proc.stdin is None or inbox is None:
+            raise RuntimeError("Copilot ACP process is not ready.")
+
+        with self._active_process_lock:
+            self._next_id += 1
+            request_id = self._next_id
+
+        payload = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        }
+        proc.stdin.write(json.dumps(payload) + "\n")
+        proc.stdin.flush()
+
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                break
+            try:
+                msg = inbox.get(timeout=0.1)
+            except queue.Empty:
+                continue
+
+            if self._handle_server_message(
+                msg,
+                process=proc,
+                cwd=self._acp_cwd,
+                text_parts=text_parts,
+                reasoning_parts=reasoning_parts,
+                on_message_chunk=on_message_chunk,
+                on_thought_chunk=on_thought_chunk,
+            ):
+                continue
+
+            if msg.get("id") != request_id:
+                continue
+            if "error" in msg:
+                err = msg.get("error") or {}
+                raise RuntimeError(
+                    f"Copilot ACP {method} failed: {err.get('message') or err}"
+                )
+            return msg.get("result")
+
+        stderr_text = "\n".join(self._stderr_tail).strip()
+        if proc.poll() is not None and stderr_text:
+            self.close()
+            if _is_gh_copilot_deprecation_message(stderr_text):
+                raise RuntimeError(
+                    "Hermes ACP mode requires the NEW GitHub Copilot CLI "
+                    "(github.com/github/copilot-cli), but the binary it just "
+                    "spawned is the deprecated `gh copilot` extension.\n\n"
+                    "Install the new CLI:\n"
+                    "  npm install -g @github/copilot\n"
+                    "  # then verify with: copilot --help\n\n"
+                    "If `copilot` already resolves to the new CLI but you still see this,\n"
+                    "point Hermes at it explicitly:\n"
+                    "  export HERMES_COPILOT_ACP_COMMAND=/path/to/new/copilot\n\n"
+                    "Alternative: use the `copilot` provider (no ACP, hits the Copilot API\n"
+                    "directly with a Copilot subscription token) via `hermes setup`.\n\n"
+                    f"Original error:\n{stderr_text}"
+                )
+            raise RuntimeError(f"Copilot ACP process exited early: {stderr_text}")
+        raise TimeoutError(f"Timed out waiting for Copilot ACP response to {method}.")
+
+    def _ensure_session(self, *, timeout_seconds: float) -> str:
+        with self._active_process_lock:
+            if self._process_alive() and self._session_id and self._initialized:
+                return self._session_id
+
+        if not self._initialized:
+            self._rpc(
                 "initialize",
                 {
                     "protocolVersion": 1,
@@ -629,37 +1005,59 @@ class CopilotACPClient:
                         "version": "0.0.0",
                     },
                 },
+                timeout_seconds=timeout_seconds,
             )
-            session = _request(
-                "session/new",
-                {
-                    "cwd": self._acp_cwd,
-                    "mcpServers": [],
-                },
-            ) or {}
-            session_id = str(session.get("sessionId") or "").strip()
-            if not session_id:
-                raise RuntimeError("Copilot ACP did not return a sessionId.")
+            self._initialized = True
 
+        session = self._rpc(
+            "session/new",
+            {
+                "cwd": self._acp_cwd,
+                "mcpServers": [],
+            },
+            timeout_seconds=timeout_seconds,
+        ) or {}
+        session_id = str(session.get("sessionId") or "").strip()
+        if not session_id:
+            raise RuntimeError("Copilot ACP did not return a sessionId.")
+        self._session_id = session_id
+        return session_id
+
+    def _run_prompt(
+        self,
+        prompt_text: str,
+        *,
+        timeout_seconds: float,
+        on_message_chunk: Callable[[str], None] | None = None,
+        on_thought_chunk: Callable[[str], None] | None = None,
+    ) -> tuple[str, str]:
+        with self._active_process_lock:
             text_parts: list[str] = []
             reasoning_parts: list[str] = []
-            _request(
-                "session/prompt",
-                {
-                    "sessionId": session_id,
-                    "prompt": [
-                        {
-                            "type": "text",
-                            "text": prompt_text,
-                        }
-                    ],
-                },
-                text_parts=text_parts,
-                reasoning_parts=reasoning_parts,
-            )
-            return "".join(text_parts), "".join(reasoning_parts)
-        finally:
-            self.close()
+            try:
+                session_id = self._ensure_session(timeout_seconds=timeout_seconds)
+                self._rpc(
+                    "session/prompt",
+                    {
+                        "sessionId": session_id,
+                        "prompt": [
+                            {
+                                "type": "text",
+                                "text": prompt_text,
+                            }
+                        ],
+                    },
+                    timeout_seconds=timeout_seconds,
+                    text_parts=text_parts,
+                    reasoning_parts=reasoning_parts,
+                    on_message_chunk=on_message_chunk,
+                    on_thought_chunk=on_thought_chunk,
+                )
+                return "".join(text_parts), "".join(reasoning_parts)
+            except Exception:
+                # Force respawn on next call after hard failures.
+                self.close()
+                raise
 
     def _handle_server_message(
         self,
@@ -669,6 +1067,8 @@ class CopilotACPClient:
         cwd: str,
         text_parts: list[str] | None,
         reasoning_parts: list[str] | None,
+        on_message_chunk: Callable[[str], None] | None = None,
+        on_thought_chunk: Callable[[str], None] | None = None,
     ) -> bool:
         method = msg.get("method")
         if not isinstance(method, str):
@@ -682,10 +1082,16 @@ class CopilotACPClient:
             chunk_text = ""
             if isinstance(content, dict):
                 chunk_text = str(content.get("text") or "")
-            if kind == "agent_message_chunk" and chunk_text and text_parts is not None:
-                text_parts.append(chunk_text)
-            elif kind == "agent_thought_chunk" and chunk_text and reasoning_parts is not None:
-                reasoning_parts.append(chunk_text)
+            if kind == "agent_message_chunk" and chunk_text:
+                if text_parts is not None:
+                    text_parts.append(chunk_text)
+                if on_message_chunk is not None:
+                    on_message_chunk(chunk_text)
+            elif kind == "agent_thought_chunk" and chunk_text:
+                if reasoning_parts is not None:
+                    reasoning_parts.append(chunk_text)
+                if on_thought_chunk is not None:
+                    on_thought_chunk(chunk_text)
             return True
 
         if process.stdin is None:
@@ -693,9 +1099,14 @@ class CopilotACPClient:
 
         message_id = msg.get("id")
         params = msg.get("params") or {}
+        if not isinstance(params, dict):
+            params = {}
 
         if method == "session/request_permission":
-            response = _permission_denied(message_id)
+            if _decide_permission(params, cwd):
+                response = _permission_allowed(message_id)
+            else:
+                response = _permission_denied(message_id)
         elif method == "fs/read_text_file":
             try:
                 path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)

--- a/agent/cursor_agent_client.py
+++ b/agent/cursor_agent_client.py
@@ -18,6 +18,50 @@ from typing import Any
 CURSOR_MARKER_BASE_URL = "cursor://agent"
 _DEFAULT_MODEL = "auto"
 
+# Curated picker catalog — Auto first (survives named-model usage lockouts).
+CURSOR_CURATED_MODELS = (
+    "auto",
+    "default",
+    "composer-2.5",
+    "composer-2",
+    "composer-1.5",
+)
+
+
+def list_cursor_model_ids(*, api_key: str | None = None) -> list[str]:
+    """Return Cursor model ids for ``/model`` / ``hermes model`` pickers.
+
+    Prefers a live ``Cursor.models.list()`` catalog when ``CURSOR_API_KEY``
+    works, always keeping curated Auto/default/Composer ids at the front.
+    """
+    curated = list(CURSOR_CURATED_MODELS)
+    key = (api_key or "").strip() or (os.environ.get("CURSOR_API_KEY") or "").strip()
+    if not key:
+        return curated
+    try:
+        from cursor_sdk import Cursor  # type: ignore
+
+        live_models = Cursor.models.list(api_key=key) or []
+    except Exception:
+        return curated
+
+    live_ids: list[str] = []
+    for item in live_models:
+        mid = str(getattr(item, "id", "") or "").strip()
+        if mid:
+            live_ids.append(mid)
+
+    if not live_ids:
+        return curated
+
+    merged = list(curated)
+    seen = {m.lower() for m in merged}
+    for mid in live_ids:
+        if mid.lower() not in seen:
+            merged.append(mid)
+            seen.add(mid.lower())
+    return merged
+
 
 def _estimate_usage(messages, tools, response_text, reasoning_text=""):
     from agent.copilot_acp_client import _estimate_usage as _est

--- a/agent/cursor_agent_client.py
+++ b/agent/cursor_agent_client.py
@@ -1,0 +1,230 @@
+"""OpenAI-compatible shim over the Cursor Agent SDK (`cursor-sdk`).
+
+Hermes treats Cursor as a chat-completions backend. Each request formats the
+conversation as a prompt, runs a local Cursor agent (default model ``auto``),
+and maps the assistant text (+ optional Hermes ``<tool_call>`` blocks) back
+into the OpenAI-shaped objects Hermes expects.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+CURSOR_MARKER_BASE_URL = "cursor://agent"
+_DEFAULT_MODEL = "auto"
+
+
+def _estimate_usage(messages, tools, response_text, reasoning_text=""):
+    from agent.copilot_acp_client import _estimate_usage as _est
+
+    return _est(messages, tools, response_text, reasoning_text)
+
+
+def _extract_tool_calls_from_text(text: str):
+    from agent.copilot_acp_client import _extract_tool_calls_from_text as _ext
+
+    return _ext(text)
+
+
+def _format_messages_as_prompt(
+    messages: list[dict[str, Any]],
+    model: str | None = None,
+    tools: list[dict[str, Any]] | None = None,
+) -> str:
+    from agent.copilot_acp_client import _format_messages_as_prompt as _fmt
+
+    return _fmt(messages, model=model, tools=tools)
+
+
+def _import_cursor_sdk():
+    try:
+        from cursor_sdk import Agent, LocalAgentOptions  # type: ignore
+
+        return Agent, LocalAgentOptions
+    except ImportError as exc:
+        raise RuntimeError(
+            "Cursor provider requires the `cursor-sdk` package. "
+            "Install with: pip install cursor-sdk"
+        ) from exc
+
+
+class _CursorChatCompletions:
+    def __init__(self, client: "CursorAgentClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _CursorChatNamespace:
+    def __init__(self, client: "CursorAgentClient"):
+        self.completions = _CursorChatCompletions(client)
+
+
+class CursorAgentClient:
+    """Minimal OpenAI-client-compatible facade for Cursor Agent SDK."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        cwd: str | None = None,
+        **_: Any,
+    ):
+        self.api_key = (api_key or os.getenv("CURSOR_API_KEY", "")).strip()
+        self.base_url = base_url or CURSOR_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._cwd = str(Path(cwd or os.getcwd()).resolve())
+        self.chat = _CursorChatNamespace(self)
+        self.is_closed = False
+        self._lock = threading.Lock()
+        self._agent = None
+
+    def close(self) -> None:
+        self.is_closed = True
+        agent = self._agent
+        self._agent = None
+        if agent is None:
+            return
+        close = getattr(agent, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                pass
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        stream: bool = False,
+        **_: Any,
+    ) -> Any:
+        if not self.api_key:
+            raise RuntimeError(
+                "CURSOR_API_KEY is not set. Add it to Hermes .env "
+                "(op://Infrastructure/Cursor API Key/credential)."
+            )
+
+        prompt = _format_messages_as_prompt(
+            messages or [],
+            model=model,
+            tools=tools,
+        )
+        model_id = (model or _DEFAULT_MODEL).strip() or _DEFAULT_MODEL
+
+        if stream:
+            return self._stream_completion(
+                prompt=prompt,
+                model_id=model_id,
+                messages=messages,
+                tools=tools,
+            )
+
+        response_text = self._run_prompt(prompt, model_id=model_id)
+        return self._build_completion(
+            model=model_id,
+            messages=messages,
+            tools=tools,
+            response_text=response_text,
+        )
+
+    def _build_completion(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, Any]] | None,
+        tools: list[dict[str, Any]] | None,
+        response_text: str,
+    ) -> SimpleNamespace:
+        tool_calls, cleaned = _extract_tool_calls_from_text(response_text)
+        usage = _estimate_usage(messages, tools, response_text)
+        message = SimpleNamespace(
+            content=cleaned,
+            tool_calls=tool_calls,
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+        )
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=message, finish_reason=finish_reason)],
+            usage=usage,
+            model=model,
+        )
+
+    def _run_prompt(self, prompt: str, *, model_id: str) -> str:
+        Agent, LocalAgentOptions = _import_cursor_sdk()
+        with self._lock:
+            # Prefer Agent.prompt one-shot when available; fall back to create+send.
+            if hasattr(Agent, "prompt"):
+                result = Agent.prompt(
+                    prompt,
+                    api_key=self.api_key,
+                    model=model_id,
+                    local=LocalAgentOptions(cwd=self._cwd),
+                )
+                status = getattr(result, "status", None)
+                text = (
+                    getattr(result, "result", None)
+                    or getattr(result, "text", None)
+                    or getattr(result, "output", "")
+                    or ""
+                )
+                if status == "error":
+                    raise RuntimeError(f"Cursor agent run failed: {text or status}")
+                return str(text or "")
+
+            with Agent.create(
+                api_key=self.api_key,
+                model=model_id,
+                local=LocalAgentOptions(cwd=self._cwd),
+            ) as agent:
+                run = agent.send(prompt)
+                wait = getattr(run, "wait", None)
+                if callable(wait):
+                    wait()
+                text = getattr(run, "result", None) or ""
+                if hasattr(run, "messages"):
+                    parts: list[str] = []
+                    for message in run.messages():
+                        if getattr(message, "type", None) != "assistant":
+                            continue
+                        content = getattr(getattr(message, "message", None), "content", None)
+                        if isinstance(content, list):
+                            for block in content:
+                                if getattr(block, "type", None) == "text":
+                                    parts.append(str(getattr(block, "text", "") or ""))
+                        elif isinstance(content, str):
+                            parts.append(content)
+                    if parts:
+                        text = "".join(parts)
+                return str(text or "")
+
+    def _stream_completion(
+        self,
+        *,
+        prompt: str,
+        model_id: str,
+        messages: list[dict[str, Any]] | None,
+        tools: list[dict[str, Any]] | None,
+    ) -> Iterator[SimpleNamespace]:
+        text = self._run_prompt(prompt, model_id=model_id)
+        completion = self._build_completion(
+            model=model_id,
+            messages=messages,
+            tools=tools,
+            response_text=text,
+        )
+        from agent.copilot_acp_client import _completion_to_stream_chunks
+
+        yield from _completion_to_stream_chunks(completion)

--- a/agent/cursor_agent_client.py
+++ b/agent/cursor_agent_client.py
@@ -87,9 +87,9 @@ def _format_messages_as_prompt(
 
 def _import_cursor_sdk():
     try:
-        from cursor_sdk import Agent, LocalAgentOptions  # type: ignore
+        from cursor_sdk import Agent, AgentOptions, LocalAgentOptions  # type: ignore
 
-        return Agent, LocalAgentOptions
+        return Agent, AgentOptions, LocalAgentOptions
     except ImportError as exc:
         raise RuntimeError(
             "Cursor provider requires the `cursor-sdk` package. "
@@ -207,16 +207,16 @@ class CursorAgentClient:
         )
 
     def _run_prompt(self, prompt: str, *, model_id: str) -> str:
-        Agent, LocalAgentOptions = _import_cursor_sdk()
+        Agent, AgentOptions, LocalAgentOptions = _import_cursor_sdk()
+        options = AgentOptions(
+            api_key=self.api_key,
+            model=model_id,
+            local=LocalAgentOptions(cwd=self._cwd),
+        )
         with self._lock:
             # Prefer Agent.prompt one-shot when available; fall back to create+send.
             if hasattr(Agent, "prompt"):
-                result = Agent.prompt(
-                    prompt,
-                    api_key=self.api_key,
-                    model=model_id,
-                    local=LocalAgentOptions(cwd=self._cwd),
-                )
+                result = Agent.prompt(prompt, options)
                 status = getattr(result, "status", None)
                 text = (
                     getattr(result, "result", None)
@@ -228,11 +228,7 @@ class CursorAgentClient:
                     raise RuntimeError(f"Cursor agent run failed: {text or status}")
                 return str(text or "")
 
-            with Agent.create(
-                api_key=self.api_key,
-                model=model_id,
-                local=LocalAgentOptions(cwd=self._cwd),
-            ) as agent:
+            with Agent.create(options) as agent:
                 run = agent.send(prompt)
                 wait = getattr(run, "wait", None)
                 if callable(wait):

--- a/agent/cursor_agent_client.py
+++ b/agent/cursor_agent_client.py
@@ -88,13 +88,45 @@ def _format_messages_as_prompt(
 def _import_cursor_sdk():
     try:
         from cursor_sdk import Agent, AgentOptions, LocalAgentOptions  # type: ignore
-
         return Agent, AgentOptions, LocalAgentOptions
     except ImportError as exc:
         raise RuntimeError(
             "Cursor provider requires the `cursor-sdk` package. "
             "Install with: pip install cursor-sdk"
         ) from exc
+
+
+def _is_bridge_death_error(exc: Exception) -> bool:
+    """Detect a dead/stale bridge from the cursor SDK."""
+    msg = str(exc).lower()
+    return (
+        "bridge request failed" in msg
+        and "connection refused" in msg
+    ) or (
+        "connecterror" in msg
+        and "connection refused" in msg
+    )
+
+
+def _reset_cursor_bridge() -> None:
+    """Force the cursor_sdk to discard its cached dead bridge."""
+    try:
+        from cursor_sdk._client import (  # type: ignore
+            close_default_client,
+            _DEFAULT_BRIDGE,
+            _DEFAULT_CLIENT,
+        )
+        # Only clear if it looks dead (no process or process exited)
+        if _DEFAULT_BRIDGE is not None:
+            proc = getattr(_DEFAULT_BRIDGE, "process", None)
+            if proc is not None and proc.poll() is not None:
+                close_default_client()
+                return
+        # Fallback: always clear if we got here — the error already tells us
+        # the bridge is unusable, so stale-caching is worse than a relaunch.
+        close_default_client()
+    except Exception:
+        pass
 
 
 class _CursorChatCompletions:
@@ -216,7 +248,14 @@ class CursorAgentClient:
         with self._lock:
             # Prefer Agent.prompt one-shot when available; fall back to create+send.
             if hasattr(Agent, "prompt"):
-                result = Agent.prompt(prompt, options)
+                try:
+                    result = Agent.prompt(prompt, options)
+                except Exception as exc:
+                    if _is_bridge_death_error(exc):
+                        _reset_cursor_bridge()
+                        result = Agent.prompt(prompt, options)
+                    else:
+                        raise
                 status = getattr(result, "status", None)
                 text = (
                     getattr(result, "result", None)
@@ -228,7 +267,15 @@ class CursorAgentClient:
                     raise RuntimeError(f"Cursor agent run failed: {text or status}")
                 return str(text or "")
 
-            with Agent.create(options) as agent:
+            try:
+                agent_ctx = Agent.create(options)
+            except Exception as exc:
+                if _is_bridge_death_error(exc):
+                    _reset_cursor_bridge()
+                    agent_ctx = Agent.create(options)
+                else:
+                    raise
+            with agent_ctx as agent:
                 run = agent.send(prompt)
                 wait = getattr(run, "wait", None)
                 if callable(wait):

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1054,6 +1054,22 @@ def _classify_by_status(
                 should_fallback=True,
                 error_context=ctx,
             )
+        # Hard quota / usage-limit walls (e.g. Copilot "quota exceeded") arrive
+        # as HTTP 429 without a transient "try again / resets at" signal.
+        # Treat them like billing so we fail over instead of sleeping on
+        # Retry-After for up to 600s. Transient quota messages keep rate_limit.
+        has_usage_limit = any(p in error_msg for p in _USAGE_LIMIT_PATTERNS)
+        if has_usage_limit:
+            has_transient_signal = any(
+                p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS
+            )
+            if not has_transient_signal:
+                return result_fn(
+                    FailoverReason.billing,
+                    retryable=False,
+                    should_rotate_credential=True,
+                    should_fallback=True,
+                )
         return result_fn(
             FailoverReason.rate_limit,
             retryable=True,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -562,6 +562,9 @@ def has_usable_secret(value: Any, *, min_length: int = 4) -> bool:
         return False
     if cleaned.lower() in _PLACEHOLDER_SECRET_VALUES:
         return False
+    # Unresolved secret-manager references are not usable credentials.
+    if cleaned.startswith(("op://", "bw://", "${")):
+        return False
     return True
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -426,6 +426,16 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("OLLAMA_API_KEY",),
         base_url_env_var="OLLAMA_BASE_URL",
     ),
+    # Cursor Agent SDK — hardcoded so /model + resolve_runtime_provider work even
+    # when plugin discovery fails at auth import time. Overlay + plugin still
+    # supply picker metadata; runtime uses CURSOR_API_KEY + cursor://agent.
+    "cursor": ProviderConfig(
+        id="cursor",
+        name="Cursor Agent",
+        auth_type="api_key",
+        inference_base_url="cursor://agent",
+        api_key_env_vars=("CURSOR_API_KEY",),
+    ),
     "bedrock": ProviderConfig(
         id="bedrock",
         name="AWS Bedrock",
@@ -477,6 +487,13 @@ try:
                 PROVIDER_REGISTRY[_alias] = PROVIDER_REGISTRY[_pp.name]
 except Exception:
     pass
+
+# Hardcoded cursor must still expose plugin aliases even when auto-extend
+# skips the name because it is already in PROVIDER_REGISTRY.
+_cursor_cfg = PROVIDER_REGISTRY.get("cursor")
+if _cursor_cfg is not None:
+    for _cursor_alias in ("cursor-agent", "cursor-sdk"):
+        PROVIDER_REGISTRY.setdefault(_cursor_alias, _cursor_cfg)
 
 
 # =============================================================================
@@ -1789,6 +1806,7 @@ def resolve_provider(
         "ollama": "custom", "ollama_cloud": "ollama-cloud",
         "vllm": "custom", "llamacpp": "custom",
         "llama.cpp": "custom", "llama-cpp": "custom",
+        "cursor-agent": "cursor", "cursor-sdk": "cursor",
     }
     # Extend with aliases declared in plugins/model-providers/<name>/ that aren't already mapped.
     # This keeps providers/ as the single source for new aliases while the

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -8216,17 +8216,34 @@ def get_env_value_prefer_dotenv(key: str) -> Optional[str]:
     that, under an active profile scope (multiplexed gateway turn), this read
     is scope-checked rather than leaking another profile's raw ``os.environ``
     value — matching the credential-pool seeding path's behaviour.
+
+    Unresolved secret-manager references (``op://…``, ``bw://…``, ``${…}``)
+    in ``.env`` are skipped so a resolved live env / 1Password injection wins
+    instead of returning a literal reference string that APIs reject as
+    ``Invalid User API Key``.
     """
     env_vars = load_env()
     val = env_vars.get(key)
     if val:
-        return val
+        cleaned = str(val).strip()
+        if cleaned and not cleaned.startswith(("op://", "bw://", "${")):
+            return cleaned
     try:
         from agent.secret_scope import get_secret as _get_secret
 
-        return _get_secret(key)
+        scoped = _get_secret(key)
+        if scoped:
+            cleaned = str(scoped).strip()
+            if cleaned and not cleaned.startswith(("op://", "bw://", "${")):
+                return cleaned
     except Exception:
-        return os.environ.get(key)
+        pass
+    live = os.environ.get(key)
+    if live:
+        cleaned = str(live).strip()
+        if cleaned and not cleaned.startswith(("op://", "bw://", "${")):
+            return cleaned
+    return None
 
 
 # =============================================================================

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -8,7 +8,7 @@ import os
 import sys
 from pathlib import Path
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values, load_dotenv
 from utils import atomic_replace, fast_safe_load
 
 
@@ -17,6 +17,43 @@ from utils import atomic_replace, fast_safe_load
 # alter arbitrary user env vars, but credentials are known to require
 # pure ASCII (they become HTTP header values).
 _CREDENTIAL_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET", "_KEY")
+
+# Unresolved secret-manager references must never linger in ``os.environ``.
+# ``load_dotenv(override=True)`` would otherwise re-poison a previously
+# resolved vault value (``op run`` / ``secrets.onepassword``) on every
+# subsequent ``load_hermes_dotenv()`` call — OP apply is idempotent per
+# HERMES_HOME, so the second pass leaves a literal ``op://…`` that
+# ``has_usable_secret`` rejects (Cursor /model → missing_api_key).
+_UNRESOLVED_SECRET_PREFIXES = ("op://", "bw://", "${")
+
+
+def _is_unresolved_secret_ref(value: str | None) -> bool:
+    cleaned = (value or "").strip()
+    return cleaned.startswith(_UNRESOLVED_SECRET_PREFIXES)
+
+
+def _preserve_resolved_secrets_after_dotenv(path: Path, *, before: dict[str, str | None]) -> None:
+    """Undo dotenv injection of unresolved secret refs for keys in ``path``.
+
+    - If the pre-load value was already a real secret, restore it.
+    - Otherwise drop the key so ``secrets.onepassword`` / ``op run`` can
+      fill it later without ``has_usable_secret`` seeing a literal ref.
+    """
+    try:
+        parsed = dotenv_values(path) or {}
+    except Exception:
+        return
+    for key in parsed:
+        if not key:
+            continue
+        current = os.environ.get(key)
+        if not _is_unresolved_secret_ref(current):
+            continue
+        prev = before.get(key)
+        if prev is not None and not _is_unresolved_secret_ref(prev):
+            os.environ[key] = prev
+        else:
+            os.environ.pop(key, None)
 
 # Names we've already warned about during this process, so repeated
 # load_hermes_dotenv() calls (user env + project env, gateway hot-reload,
@@ -160,10 +197,20 @@ def _sanitize_loaded_credentials() -> None:
 
 
 def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
+    # Snapshot only keys present in this file so we can restore resolved
+    # secrets if dotenv would overwrite them with ``op://`` / ``bw://`` refs.
+    before: dict[str, str | None] = {}
+    try:
+        for key in (dotenv_values(path) or {}):
+            if key:
+                before[key] = os.environ.get(key)
+    except Exception:
+        before = {}
     try:
         load_dotenv(dotenv_path=path, override=override, encoding="utf-8")
     except UnicodeDecodeError:
         load_dotenv(dotenv_path=path, override=override, encoding="latin-1")
+    _preserve_resolved_secrets_after_dotenv(path, before=before)
     # Strip non-ASCII characters from credential env vars that were just
     # loaded.  API keys must be pure ASCII since they're sent as HTTP
     # header values (httpx encodes headers as ASCII).  Non-ASCII chars

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -271,6 +271,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "cursor": [
+        "auto",
+        "composer-2.5",
+        "default",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -1079,6 +1084,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
+    ProviderEntry("cursor",         "Cursor Agent",             "Cursor Agent SDK (local runtime; default model auto)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
     ProviderEntry("vertex",         "Google Vertex AI",         "Google Vertex AI (Gemini via GCP; OAuth2 service account or ADC, GCP billing/quotas)"),
@@ -1241,6 +1247,8 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "cursor-agent": "cursor",
+    "cursor-sdk": "cursor",
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -273,8 +273,10 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "cursor": [
         "auto",
-        "composer-2.5",
         "default",
+        "composer-2.5",
+        "composer-2",
+        "composer-1.5",
     ],
     "copilot": [
         "gpt-5.4",
@@ -2469,6 +2471,16 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             pass
         if normalized == "copilot-acp":
             return list(_PROVIDER_MODELS.get("copilot", []))
+    if normalized == "cursor":
+        try:
+            from agent.cursor_agent_client import list_cursor_model_ids
+
+            live = list_cursor_model_ids()
+            if live:
+                return list(live)
+        except Exception:
+            pass
+        return list(_PROVIDER_MODELS.get("cursor", []))
     if normalized == "nous":
         # Try live Nous Portal /models endpoint
         try:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -94,6 +94,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "cursor": HermesOverlay(
+        transport="openai_chat",
+        auth_type="api_key",
+        extra_env_vars=("CURSOR_API_KEY",),
+        base_url_override="cursor://agent",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -296,6 +302,10 @@ ALIASES: Dict[str, str] = {
     "github": "github-copilot",
     "github-copilot-acp": "copilot-acp",
 
+    # cursor agent sdk
+    "cursor-agent": "cursor",
+    "cursor-sdk": "cursor",
+
     # opencode (models.dev ID for OpenCode Zen)
     "opencode-zen": "opencode",
     "zen": "opencode",
@@ -382,6 +392,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "cursor": "Cursor Agent",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",
@@ -763,6 +774,27 @@ def resolve_provider_full(
     if user_providers:
         user_pdef = resolve_user_provider(raw, user_providers)
         if user_pdef is not None:
+            # Catalog-only entries (models list, no endpoint) must not shadow
+            # Hermes built-ins that carry auth/base_url (e.g. providers.cursor).
+            if not str(user_pdef.base_url or "").strip():
+                builtin = get_provider(raw) or (
+                    get_provider(canonical) if canonical != raw else None
+                )
+                if builtin is not None:
+                    if user_pdef.name and user_pdef.name != raw:
+                        return ProviderDef(
+                            id=builtin.id,
+                            name=user_pdef.name,
+                            transport=builtin.transport,
+                            api_key_env_vars=builtin.api_key_env_vars,
+                            base_url=builtin.base_url,
+                            base_url_env_var=builtin.base_url_env_var,
+                            is_aggregator=builtin.is_aggregator,
+                            auth_type=builtin.auth_type,
+                            doc=builtin.doc,
+                            source=builtin.source,
+                        )
+                    return builtin
             return user_pdef
 
     # 0.5 Exact Hermes provider IDs must win over LOSSY alias collapsing.

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1892,6 +1892,17 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    if provider == "cursor":
+        api_key = (_getenv("CURSOR_API_KEY", "") or "").strip()
+        return {
+            "provider": "cursor",
+            "api_mode": "chat_completions",
+            "base_url": "cursor://agent",
+            "api_key": api_key,
+            "source": "env:CURSOR_API_KEY" if api_key else "missing",
+            "requested_provider": requested_provider,
+        }
+
     # Anthropic (native Messages API)
     if provider == "anthropic":
         # Allow base URL override from config.yaml model.base_url, but only

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1569,6 +1569,38 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    # Cursor Agent SDK: resolve BEFORE resolve_provider(). Overlay/picker can
+    # know "cursor" while PROVIDER_REGISTRY misses it if plugin auto-extend
+    # failed at import — that produced "Could not resolve credentials …
+    # Unknown provider 'cursor'" on /model despite a working adapter.
+    if requested_provider in {"cursor", "cursor-agent", "cursor-sdk"}:
+        from hermes_cli.auth import AuthError, has_usable_secret
+
+        api_key = (_getenv("CURSOR_API_KEY", "") or "").strip()
+        if not has_usable_secret(api_key):
+            try:
+                from hermes_cli.config import get_env_value_prefer_dotenv
+
+                api_key = (get_env_value_prefer_dotenv("CURSOR_API_KEY") or "").strip()
+            except Exception:
+                api_key = ""
+        if not has_usable_secret(api_key):
+            raise AuthError(
+                "No usable CURSOR_API_KEY found. Set CURSOR_API_KEY to a Cursor "
+                "Dashboard user API key (or resolve op:// via op run / "
+                "secrets.onepassword).",
+                provider="cursor",
+                code="missing_api_key",
+            )
+        return {
+            "provider": "cursor",
+            "api_mode": "chat_completions",
+            "base_url": "cursor://agent",
+            "api_key": api_key,
+            "source": "env:CURSOR_API_KEY",
+            "requested_provider": requested_provider,
+        }
+
     # Azure Anthropic short-circuit: when explicitly targeting an Azure endpoint
     # with provider="anthropic", bypass _resolve_named_custom_runtime (which would
     # return provider="custom" with chat_completions api_mode and no valid key).
@@ -1889,35 +1921,6 @@ def resolve_runtime_provider(
             "command": creds.get("command", ""),
             "args": list(creds.get("args") or []),
             "source": creds.get("source", "process"),
-            "requested_provider": requested_provider,
-        }
-
-    if provider == "cursor":
-        # Prefer resolved live env; never pass unresolved op:// refs to the SDK.
-        from hermes_cli.auth import has_usable_secret
-
-        api_key = (_getenv("CURSOR_API_KEY", "") or "").strip()
-        if not has_usable_secret(api_key):
-            try:
-                from hermes_cli.config import get_env_value_prefer_dotenv
-
-                api_key = (get_env_value_prefer_dotenv("CURSOR_API_KEY") or "").strip()
-            except Exception:
-                api_key = ""
-        if not has_usable_secret(api_key):
-            raise AuthError(
-                "No usable CURSOR_API_KEY found. Set CURSOR_API_KEY to a Cursor "
-                "Dashboard user API key (or resolve op:// via op run / "
-                "secrets.onepassword).",
-                provider="cursor",
-                code="missing_api_key",
-            )
-        return {
-            "provider": "cursor",
-            "api_mode": "chat_completions",
-            "base_url": "cursor://agent",
-            "api_key": api_key,
-            "source": "env:CURSOR_API_KEY",
             "requested_provider": requested_provider,
         }
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1574,8 +1574,12 @@ def resolve_runtime_provider(
     # failed at import — that produced "Could not resolve credentials …
     # Unknown provider 'cursor'" on /model despite a working adapter.
     if requested_provider in {"cursor", "cursor-agent", "cursor-sdk"}:
-        from hermes_cli.auth import AuthError, has_usable_secret
-
+        # NOTE: AuthError + has_usable_secret are imported at module scope
+        # (lines 22-39). A local re-import here rebinds has_usable_secret as a
+        # function-local for the ENTIRE resolve_runtime_provider body, so the
+        # openai/api-key path at ~line 2083 hit UnboundLocalError (500:
+        # "cannot access local variable 'has_usable_secret'") whenever this
+        # cursor branch was not taken. Rely on the module-level imports.
         api_key = (_getenv("CURSOR_API_KEY", "") or "").strip()
         if not has_usable_secret(api_key):
             try:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1893,13 +1893,31 @@ def resolve_runtime_provider(
         }
 
     if provider == "cursor":
+        # Prefer resolved live env; never pass unresolved op:// refs to the SDK.
+        from hermes_cli.auth import has_usable_secret
+
         api_key = (_getenv("CURSOR_API_KEY", "") or "").strip()
+        if not has_usable_secret(api_key):
+            try:
+                from hermes_cli.config import get_env_value_prefer_dotenv
+
+                api_key = (get_env_value_prefer_dotenv("CURSOR_API_KEY") or "").strip()
+            except Exception:
+                api_key = ""
+        if not has_usable_secret(api_key):
+            raise AuthError(
+                "No usable CURSOR_API_KEY found. Set CURSOR_API_KEY to a Cursor "
+                "Dashboard user API key (or resolve op:// via op run / "
+                "secrets.onepassword).",
+                provider="cursor",
+                code="missing_api_key",
+            )
         return {
             "provider": "cursor",
             "api_mode": "chat_completions",
             "base_url": "cursor://agent",
             "api_key": api_key,
-            "source": "env:CURSOR_API_KEY" if api_key else "missing",
+            "source": "env:CURSOR_API_KEY",
             "requested_provider": requested_provider,
         }
 

--- a/plugins/model-providers/cursor/__init__.py
+++ b/plugins/model-providers/cursor/__init__.py
@@ -7,6 +7,7 @@ Default model is ``auto`` (server-selected; survives usage-limit lockouts).
 
 from __future__ import annotations
 
+from agent.cursor_agent_client import list_cursor_model_ids
 from providers import register_provider
 from providers.base import ProviderProfile
 
@@ -21,7 +22,7 @@ class CursorProfile(ProviderProfile):
         base_url: str | None = None,
         timeout: float = 8.0,
     ) -> list[str] | None:
-        return ["auto", "composer-2.5", "default"]
+        return list_cursor_model_ids(api_key=api_key)
 
 
 cursor = CursorProfile(

--- a/plugins/model-providers/cursor/__init__.py
+++ b/plugins/model-providers/cursor/__init__.py
@@ -1,0 +1,39 @@
+"""Cursor Agent SDK provider profile.
+
+Uses ``CURSOR_API_KEY`` and a custom OpenAI-compat shim
+(``agent.cursor_agent_client.CursorAgentClient``) rather than a REST chat API.
+Default model is ``auto`` (server-selected; survives usage-limit lockouts).
+"""
+
+from __future__ import annotations
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class CursorProfile(ProviderProfile):
+    """Cursor Agent — local SDK runtime with Auto model default."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        return ["auto", "composer-2.5", "default"]
+
+
+cursor = CursorProfile(
+    name="cursor",
+    aliases=("cursor-agent", "cursor-sdk"),
+    display_name="Cursor Agent",
+    description="Cursor Agent SDK (local runtime; default model auto)",
+    env_vars=("CURSOR_API_KEY",),
+    base_url="cursor://agent",
+    auth_type="api_key",
+    default_aux_model="auto",
+    api_mode="chat_completions",
+)
+
+register_provider(cursor)

--- a/plugins/model-providers/cursor/plugin.yaml
+++ b/plugins/model-providers/cursor/plugin.yaml
@@ -1,0 +1,5 @@
+name: cursor-provider
+kind: model-provider
+version: 1.0.0
+description: Cursor Agent SDK (local; model auto)
+author: Nous Research

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,7 @@ matrix = ["mautrix[encryption]==0.21.0", "aiosqlite==0.22.1", "asyncpg==0.31.0",
 # and XXE. aiohttp/httpx are already in [messaging]; defusedxml lands
 # here to keep the dependency local to wecom_callback's threat model.
 wecom = ["defusedxml==0.7.1"]
-cli = ["simple-term-menu==1.6.6"]
+cursor = ["cursor-sdk>=0.1.0"]
 tts-premium = ["elevenlabs==1.59.0"]
 voice = [
   # Local STT pulls in wheel-only transitive deps (ctranslate2, onnxruntime),

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -63,14 +63,17 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
                 messages=[{"role": "user", "content": "hello"}],
                 stream=True,
             )
-
-        chunks = list(stream)
-        self.assertEqual(len(chunks), 2)
-        self.assertEqual(chunks[0].choices[0].delta.content, "Hello from ACP")
-        self.assertIsNone(chunks[0].choices[0].delta.tool_calls)
-        self.assertEqual(chunks[0].choices[0].finish_reason, "stop")
-        self.assertEqual(chunks[1].choices, [])
-        self.assertEqual(chunks[1].usage.total_tokens, 0)
+            # Consume inside the patch — stream runs a worker thread.
+            chunks = list(stream)
+        self.assertGreaterEqual(len(chunks), 2)
+        content_chunks = [
+            c.choices[0].delta.content
+            for c in chunks
+            if c.choices and getattr(c.choices[0].delta, "content", None)
+        ]
+        self.assertEqual("".join(content_chunks), "Hello from ACP")
+        self.assertEqual(chunks[-1].choices, [])
+        self.assertGreater(chunks[-1].usage.total_tokens, 0)
 
     def test_stream_true_preserves_tool_call_deltas(self) -> None:
         tool_response = (
@@ -86,11 +89,12 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
                 messages=[{"role": "user", "content": "read README.md"}],
                 stream=True,
             )
-
-        chunks = list(stream)
-        delta = chunks[0].choices[0].delta
-        self.assertIsNone(delta.content)
-        self.assertEqual(chunks[0].choices[0].finish_reason, "tool_calls")
+            chunks = list(stream)
+        finish_chunks = [
+            c for c in chunks if c.choices and c.choices[0].finish_reason == "tool_calls"
+        ]
+        self.assertTrue(finish_chunks)
+        delta = finish_chunks[0].choices[0].delta
         self.assertEqual(len(delta.tool_calls), 1)
         tool_delta = delta.tool_calls[0]
         self.assertEqual(tool_delta.index, 0)
@@ -100,12 +104,17 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
             json.loads(tool_delta.function.arguments),
             {"path": "README.md"},
         )
-        self.assertEqual(chunks[1].choices, [])
+        self.assertEqual(chunks[-1].choices, [])
 
     def test_timeout_object_is_coerced_for_streaming_requests(self) -> None:
         captured: dict[str, float] = {}
 
-        def fake_run_prompt(prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        def fake_run_prompt(
+            prompt_text: str,
+            *,
+            timeout_seconds: float,
+            **_kwargs,
+        ) -> tuple[str, str]:
             captured["timeout"] = timeout_seconds
             return "ok", ""
 
@@ -141,7 +150,7 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertTrue(payload)
         return json.loads(payload)
 
-    def test_request_permission_is_not_auto_allowed(self) -> None:
+    def test_request_permission_without_path_is_denied(self) -> None:
         response = self._dispatch(
             {
                 "jsonrpc": "2.0",
@@ -154,6 +163,69 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
 
         outcome = (((response.get("result") or {}).get("outcome") or {}).get("outcome"))
         self.assertEqual(outcome, "cancelled")
+
+    def test_request_permission_allows_cwd_safe_fs_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "notes.txt"
+            target.write_text("ok")
+            with patch.dict(os.environ, {"HERMES_COPILOT_ACP_PERMISSION_MODE": "cwd_safe"}):
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 11,
+                        "method": "session/request_permission",
+                        "params": {"path": str(target)},
+                    },
+                    cwd=tmpdir,
+                )
+        outcome = ((response.get("result") or {}).get("outcome") or {})
+        self.assertEqual(outcome.get("outcome"), "selected")
+        self.assertEqual(outcome.get("option_id"), "allow_once")
+
+    def test_request_permission_denies_exec_even_in_cwd_safe(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"HERMES_COPILOT_ACP_PERMISSION_MODE": "cwd_safe"}):
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 12,
+                        "method": "session/request_permission",
+                        "params": {"toolCall": {"title": "run terminal", "kind": "execute"}},
+                    },
+                    cwd=tmpdir,
+                )
+        outcome = (((response.get("result") or {}).get("outcome") or {}).get("outcome"))
+        self.assertEqual(outcome, "cancelled")
+
+    def test_request_permission_deny_mode_blocks_cwd_fs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "notes.txt"
+            target.write_text("ok")
+            with patch.dict(os.environ, {"HERMES_COPILOT_ACP_PERMISSION_MODE": "deny"}):
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 13,
+                        "method": "session/request_permission",
+                        "params": {"path": str(target)},
+                    },
+                    cwd=tmpdir,
+                )
+        outcome = (((response.get("result") or {}).get("outcome") or {}).get("outcome"))
+        self.assertEqual(outcome, "cancelled")
+
+    def test_nested_tool_call_json_is_extracted(self) -> None:
+        from agent.copilot_acp_client import _extract_tool_calls_from_text
+
+        nested = (
+            '<tool_call>{"id":"c1","type":"function","function":'
+            '{"name":"write_file","arguments":"{\\"path\\":\\"a.json\\",\\"content\\":\\"{\\\\\\"k\\\\\\":1}\\"}"}}'
+            "</tool_call>"
+        )
+        calls, cleaned = _extract_tool_calls_from_text(nested)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].function.name, "write_file")
+        self.assertEqual(cleaned, "")
 
     def test_read_text_file_blocks_internal_hermes_hub_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/agent/test_cursor_agent_client.py
+++ b/tests/agent/test_cursor_agent_client.py
@@ -6,10 +6,29 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from agent.cursor_agent_client import CursorAgentClient
+from agent.cursor_agent_client import CURSOR_CURATED_MODELS, CursorAgentClient, list_cursor_model_ids
 
 
 class CursorAgentClientTests(unittest.TestCase):
+    def test_list_cursor_model_ids_falls_back_to_curated(self) -> None:
+        with patch.dict("os.environ", {"CURSOR_API_KEY": ""}, clear=False):
+            models = list_cursor_model_ids(api_key="")
+        self.assertEqual(models[:3], ["auto", "default", "composer-2.5"])
+        self.assertEqual(models, list(CURSOR_CURATED_MODELS))
+
+    def test_list_cursor_model_ids_merges_live_catalog(self) -> None:
+        live = [
+            SimpleNamespace(id="auto"),
+            SimpleNamespace(id="composer-2.5"),
+            SimpleNamespace(id="grok-4.5"),
+        ]
+        with patch("cursor_sdk.Cursor") as mock_cursor:
+            mock_cursor.models.list.return_value = live
+            models = list_cursor_model_ids(api_key="test-key")
+        self.assertEqual(models[0], "auto")
+        self.assertIn("composer-2.5", models)
+        self.assertIn("grok-4.5", models)
+
     def test_missing_api_key_raises(self) -> None:
         client = CursorAgentClient(api_key="")
         with self.assertRaises(RuntimeError) as ctx:

--- a/tests/agent/test_cursor_agent_client.py
+++ b/tests/agent/test_cursor_agent_client.py
@@ -45,8 +45,9 @@ class CursorAgentClientTests(unittest.TestCase):
         with patch("agent.cursor_agent_client._import_cursor_sdk") as mock_import:
             Agent = MagicMock()
             Agent.prompt = MagicMock(return_value=fake_result)
+            AgentOptions = MagicMock(return_value=SimpleNamespace())
             LocalAgentOptions = MagicMock(return_value=SimpleNamespace(cwd="/tmp"))
-            mock_import.return_value = (Agent, LocalAgentOptions)
+            mock_import.return_value = (Agent, AgentOptions, LocalAgentOptions)
 
             response = client._create_chat_completion(
                 model="auto",
@@ -57,9 +58,13 @@ class CursorAgentClientTests(unittest.TestCase):
         self.assertEqual(response.choices[0].finish_reason, "stop")
         self.assertGreater(response.usage.total_tokens, 0)
         Agent.prompt.assert_called_once()
-        kwargs = Agent.prompt.call_args.kwargs
-        self.assertEqual(kwargs["api_key"], "test-key")
-        self.assertEqual(kwargs["model"], "auto")
+        args, _kwargs = Agent.prompt.call_args
+        self.assertEqual(len(args), 2)  # prompt text + AgentOptions
+        self.assertIn("hi", str(args[0]))
+        AgentOptions.assert_called_once()
+        opt_kwargs = AgentOptions.call_args.kwargs
+        self.assertEqual(opt_kwargs["api_key"], "test-key")
+        self.assertEqual(opt_kwargs["model"], "auto")
 
 
 if __name__ == "__main__":

--- a/tests/agent/test_cursor_agent_client.py
+++ b/tests/agent/test_cursor_agent_client.py
@@ -1,0 +1,47 @@
+"""Unit tests for the Cursor Agent OpenAI-compat shim."""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.cursor_agent_client import CursorAgentClient
+
+
+class CursorAgentClientTests(unittest.TestCase):
+    def test_missing_api_key_raises(self) -> None:
+        client = CursorAgentClient(api_key="")
+        with self.assertRaises(RuntimeError) as ctx:
+            client._create_chat_completion(
+                model="auto",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        self.assertIn("CURSOR_API_KEY", str(ctx.exception))
+
+    def test_prompt_maps_to_openai_completion(self) -> None:
+        client = CursorAgentClient(api_key="test-key", cwd="/tmp")
+        fake_result = SimpleNamespace(status="finished", result="Hello from Cursor")
+
+        with patch("agent.cursor_agent_client._import_cursor_sdk") as mock_import:
+            Agent = MagicMock()
+            Agent.prompt = MagicMock(return_value=fake_result)
+            LocalAgentOptions = MagicMock(return_value=SimpleNamespace(cwd="/tmp"))
+            mock_import.return_value = (Agent, LocalAgentOptions)
+
+            response = client._create_chat_completion(
+                model="auto",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        self.assertEqual(response.choices[0].message.content, "Hello from Cursor")
+        self.assertEqual(response.choices[0].finish_reason, "stop")
+        self.assertGreater(response.usage.total_tokens, 0)
+        Agent.prompt.assert_called_once()
+        kwargs = Agent.prompt.call_args.kwargs
+        self.assertEqual(kwargs["api_key"], "test-key")
+        self.assertEqual(kwargs["model"], "auto")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -466,6 +466,24 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.rate_limit
         assert result.should_rotate_credential is True
 
+    def test_429_quota_exceeded_without_transient_is_billing(self):
+        """Copilot-style HTTP 429 'quota exceeded' with no reset hint → billing."""
+        e = MockAPIError("HTTP 429: quota exceeded", status_code=429)
+        result = classify_api_error(e, provider="copilot")
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_429_quota_with_reset_hint_stays_rate_limit(self):
+        """Quota message that includes a reset/retry signal stays rate_limit."""
+        e = MockAPIError(
+            "quota exceeded, please retry after the window resets",
+            status_code=429,
+        )
+        result = classify_api_error(e, provider="copilot")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
     # ── 5xx that are actually request-validation errors ──
     # Some OpenAI-compatible gateways (e.g. codex.nekos.me) return
     # request-validation failures with a 5xx status. These are

--- a/tests/hermes_cli/test_cursor_provider_resolve.py
+++ b/tests/hermes_cli/test_cursor_provider_resolve.py
@@ -1,0 +1,74 @@
+"""Cursor provider must resolve without relying on plugin auto-extend alone."""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.auth import PROVIDER_REGISTRY, resolve_provider
+from hermes_cli.providers import get_provider, resolve_provider_full
+from hermes_cli import runtime_provider as rp
+
+
+def test_cursor_is_hardcoded_in_provider_registry():
+    assert "cursor" in PROVIDER_REGISTRY
+    cfg = PROVIDER_REGISTRY["cursor"]
+    assert cfg.id == "cursor"
+    assert cfg.inference_base_url == "cursor://agent"
+    assert "CURSOR_API_KEY" in cfg.api_key_env_vars
+    assert PROVIDER_REGISTRY["cursor-agent"].id == "cursor"
+    assert PROVIDER_REGISTRY["cursor-sdk"].id == "cursor"
+
+
+def test_resolve_provider_accepts_cursor_aliases():
+    assert resolve_provider("cursor") == "cursor"
+    assert resolve_provider("cursor-agent") == "cursor"
+    assert resolve_provider("cursor-sdk") == "cursor"
+
+
+def test_overlay_and_full_resolve_agree():
+    overlay = get_provider("cursor")
+    assert overlay is not None
+    assert overlay.id == "cursor"
+    assert overlay.base_url == "cursor://agent"
+
+    full = resolve_provider_full("cursor")
+    assert full is not None
+    assert full.id == "cursor"
+
+
+def test_resolve_runtime_provider_cursor_before_auth_registry(monkeypatch):
+    """Early short-circuit must not depend on resolve_provider succeeding."""
+    monkeypatch.setenv("CURSOR_API_KEY", "crsr_test_key_for_resolve")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "cursor", "default": "auto"},
+    )
+
+    # Even if auth registry somehow lacked cursor, early path still works.
+    def _boom(*_a, **_k):
+        raise rp.AuthError("Unknown provider 'cursor'.", code="invalid_provider")
+
+    monkeypatch.setattr(rp, "resolve_provider", _boom)
+
+    runtime = rp.resolve_runtime_provider(requested="cursor", target_model="auto")
+    assert runtime["provider"] == "cursor"
+    assert runtime["base_url"] == "cursor://agent"
+    assert runtime["api_key"] == "crsr_test_key_for_resolve"
+    assert runtime["api_mode"] == "chat_completions"
+
+
+def test_resolve_runtime_provider_cursor_rejects_unusable_secret(monkeypatch):
+    monkeypatch.setenv("CURSOR_API_KEY", "op://Infrastructure/Cursor API Key/credential")
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_value_prefer_dotenv",
+        lambda _name: "op://Infrastructure/Cursor API Key/credential",
+    )
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "cursor", "default": "auto"},
+    )
+
+    with pytest.raises(rp.AuthError, match="No usable CURSOR_API_KEY"):
+        rp.resolve_runtime_provider(requested="cursor", target_model="auto")

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1785,64 +1785,47 @@ def _make_acp_agent(provider="copilot-acp", base_url="acp://copilot"):
 
 
 class TestCopilotACPStreamingDecision:
-    """Verify that copilot-acp routes to the non-streaming path.
+    """Verify streaming decision for ACP / Cursor runtimes.
 
-    CopilotACPClient communicates via subprocess stdio and returns a plain
-    SimpleNamespace — not an iterable stream.  The streaming decision logic
-    must detect ACP runtimes and route to _interruptible_api_call instead.
+    Local CopilotACPClient and CursorAgentClient now yield live deltas, so
+    ``copilot-acp`` / ``acp://copilot`` / ``cursor://`` keep streaming enabled.
+    TCP ACP transports still force non-streaming.
     """
 
     @patch("run_agent.get_tool_definitions", return_value=[])
     @patch("run_agent.check_toolset_requirements", return_value={})
     @patch("agent.copilot_acp_client.CopilotACPClient")
-    def test_provider_name_triggers_non_streaming(
+    def test_provider_name_allows_streaming(
         self, mock_acp_cls, _mock_check, _mock_tools
     ):
-        """provider='copilot-acp' → non-streaming path."""
+        """provider='copilot-acp' → streaming allowed (client yields deltas)."""
         mock_acp_cls.return_value = MagicMock()
         agent = _make_acp_agent(provider="copilot-acp", base_url="acp://copilot")
 
-        with (
-            patch.object(agent, "_interruptible_api_call",
-                         return_value=_valid_acp_response()) as mock_non_stream,
-            patch.object(agent, "_interruptible_streaming_api_call") as mock_stream,
-        ):
-            # Verify the decision logic correctly disables streaming
-            _use_streaming = True
-            if getattr(agent, "_disable_streaming", False):
-                _use_streaming = False
-            elif (
-                agent.provider == "copilot-acp"
-                or str(agent.base_url or "").lower().startswith("acp://copilot")
-                or str(agent.base_url or "").lower().startswith("acp+tcp://")
-            ):
-                _use_streaming = False
+        _use_streaming = True
+        if getattr(agent, "_disable_streaming", False):
+            _use_streaming = False
+        elif str(agent.base_url or "").lower().startswith("acp+tcp://"):
+            _use_streaming = False
 
-            assert _use_streaming is False
-            # Call the non-streaming path as the loop would
-            response = mock_non_stream({})
-            mock_stream.assert_not_called()
+        assert _use_streaming is True
 
     @patch("run_agent.get_tool_definitions", return_value=[])
     @patch("run_agent.check_toolset_requirements", return_value={})
     @patch("agent.copilot_acp_client.CopilotACPClient")
-    def test_acp_base_url_triggers_non_streaming(
+    def test_acp_base_url_allows_streaming(
         self, mock_acp_cls, _mock_check, _mock_tools
     ):
-        """base_url='acp://copilot' → non-streaming even without provider name."""
+        """base_url='acp://copilot' → streaming allowed."""
         mock_acp_cls.return_value = MagicMock()
         agent = _make_acp_agent(provider="custom", base_url="acp://copilot")
         agent.provider = "custom"
 
         _use_streaming = True
-        if (
-            agent.provider == "copilot-acp"
-            or str(agent.base_url or "").lower().startswith("acp://copilot")
-            or str(agent.base_url or "").lower().startswith("acp+tcp://")
-        ):
+        if str(agent.base_url or "").lower().startswith("acp+tcp://"):
             _use_streaming = False
 
-        assert _use_streaming is False
+        assert _use_streaming is True
 
     @patch("run_agent.get_tool_definitions", return_value=[])
     @patch("run_agent.check_toolset_requirements", return_value={})
@@ -1856,11 +1839,7 @@ class TestCopilotACPStreamingDecision:
         agent.provider = "custom"
 
         _use_streaming = True
-        if (
-            agent.provider == "copilot-acp"
-            or str(agent.base_url or "").lower().startswith("acp://copilot")
-            or str(agent.base_url or "").lower().startswith("acp+tcp://")
-        ):
+        if str(agent.base_url or "").lower().startswith("acp+tcp://"):
             _use_streaming = False
 
         assert _use_streaming is False
@@ -1883,11 +1862,7 @@ class TestCopilotACPStreamingDecision:
         _use_streaming = True
         if getattr(agent, "_disable_streaming", False):
             _use_streaming = False
-        elif (
-            agent.provider == "copilot-acp"
-            or str(agent.base_url or "").lower().startswith("acp://copilot")
-            or str(agent.base_url or "").lower().startswith("acp+tcp://")
-        ):
+        elif str(agent.base_url or "").lower().startswith("acp+tcp://"):
             _use_streaming = False
 
         assert _use_streaming is True

--- a/tests/test_env_loader_op_bootstrap.py
+++ b/tests/test_env_loader_op_bootstrap.py
@@ -97,6 +97,48 @@ def test_missing_op_env_is_a_noop(tmp_path):
     assert os.environ.get("OP_SERVICE_ACCOUNT_TOKEN") is None
 
 
+def test_repeated_dotenv_load_preserves_resolved_op_secret(tmp_path, monkeypatch):
+    """Second load_hermes_dotenv must not re-poison a vault-resolved API key.
+
+    ``.env`` keeps ``op://`` references for ``op run`` / docs, while
+    ``secrets.onepassword`` (or a prior ``op run``) injects the real value.
+    OP apply is idempotent per HERMES_HOME, so a naive ``load_dotenv(override=True)``
+    on the second call would leave the literal ``op://`` in ``os.environ`` and
+    break providers that call ``has_usable_secret`` (e.g. Cursor).
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / ".env").write_text(
+        "CURSOR_API_KEY=op://Infrastructure/Cursor API Key/credential\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CURSOR_API_KEY", "crsr_already_resolved_from_vault_xxxxx")
+
+    env_loader.load_hermes_dotenv(hermes_home=home)
+    assert os.environ["CURSOR_API_KEY"] == "crsr_already_resolved_from_vault_xxxxx"
+
+    # Idempotent OP apply: second dotenv load must not clobber the resolved key.
+    env_loader.load_hermes_dotenv(hermes_home=home)
+    assert os.environ["CURSOR_API_KEY"] == "crsr_already_resolved_from_vault_xxxxx"
+    assert not os.environ["CURSOR_API_KEY"].startswith("op://")
+
+
+def test_dotenv_op_ref_does_not_enter_environ_when_unset(tmp_path, monkeypatch):
+    """Unresolved ``op://`` refs must not be left in ``os.environ`` as poison."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / ".env").write_text(
+        "CURSOR_API_KEY=op://Infrastructure/Cursor API Key/credential\nFOO=bar\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+
+    env_loader.load_hermes_dotenv(hermes_home=home)
+
+    assert os.environ.get("FOO") == "bar"
+    assert os.environ.get("CURSOR_API_KEY") is None
+
+
 # ---------------------------------------------------------------------------
 # Patch 2 — credential_pool prefers resolved value over raw op:// ref
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Harden Copilot ACP: long-lived process/session reuse, live `session/update` streaming, cwd-safe `session/request_permission`, usage estimates, and balanced-brace Hermes `<tool_call>` extraction.
- Classify HTTP 429 `"quota exceeded"` (without transient reset signals) as billing and activate provider fallback before long Retry-After sleeps when a fallback chain is configured (cap remaining rate-limit waits at 30s when fallback exists).
- Add first-class Hermes `cursor` provider via `cursor-sdk` (default model `auto`, `CURSOR_API_KEY`), so Copilot failures can fall through to Cursor then Ollama Cloud.

## Test plan
- [x] `pytest tests/agent/test_copilot_acp_client.py`
- [x] `pytest tests/agent/test_cursor_agent_client.py`
- [x] quota classifier cases for Copilot `"quota exceeded"`
- [x] `TestCopilotACPStreamingDecision` (ACP streaming allowed)
- [ ] Manual: Copilot 429 → `cursor`/`auto` when `CURSOR_API_KEY` set → `ollama-cloud`/`minimax-m2.7` → `kimi-k2.7-code`
- [ ] Manual: ACP permission matrix (cwd fs allow; exec/sensitive deny)


Made with [Cursor](https://cursor.com)