### PR TITLE
feat(cron): add interactive reminder feedback

### DIFF
--- a/cron/feedback.py
+++ b/cron/feedback.py
@@ -1,0 +1,89 @@
+"""Validation and compatibility helpers for interactive cron feedback."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Optional
+
+FEEDBACK_CODE_RE = re.compile(r"^[a-z0-9_-]{1,24}$")
+FEEDBACK_JOB_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,32}$")
+MAX_FEEDBACK_CHOICES = 8
+MAX_FEEDBACK_LABEL_LENGTH = 64
+MAX_FEEDBACK_PROMPT_LENGTH = 200
+
+
+def normalize_feedback_config(value: Any) -> Optional[Dict[str, Any]]:
+    """Validate and normalize a feedback config, returning ``None`` when cleared."""
+    if value is None or value == {}:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError("feedback must be an object")
+
+    choices = value.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise ValueError("feedback.choices must contain at least one choice")
+    if len(choices) > MAX_FEEDBACK_CHOICES:
+        raise ValueError(f"feedback.choices supports at most {MAX_FEEDBACK_CHOICES} choices")
+
+    normalized_choices = []
+    seen_codes = set()
+    for choice in choices:
+        if not isinstance(choice, dict):
+            raise ValueError("each feedback choice must be an object")
+        code = str(choice.get("code") or "").strip().lower()
+        label = str(choice.get("label") or "").strip()
+        if not FEEDBACK_CODE_RE.fullmatch(code):
+            raise ValueError(
+                "feedback choice code must use 1-24 lowercase letters, digits, '_' or '-'"
+            )
+        if code in seen_codes:
+            raise ValueError(f"feedback choice code '{code}' is duplicated")
+        if not label:
+            raise ValueError("feedback choice label cannot be empty")
+        if len(label) > MAX_FEEDBACK_LABEL_LENGTH:
+            raise ValueError(
+                f"feedback choice label cannot exceed {MAX_FEEDBACK_LABEL_LENGTH} characters"
+            )
+        seen_codes.add(code)
+        normalized_choices.append({"code": code, "label": label})
+
+    prompt = str(value.get("prompt") or "").strip()
+    if len(prompt) > MAX_FEEDBACK_PROMPT_LENGTH:
+        raise ValueError(
+            f"feedback prompt cannot exceed {MAX_FEEDBACK_PROMPT_LENGTH} characters"
+        )
+    return {"prompt": prompt, "choices": normalized_choices}
+
+
+def feedback_for_job(job: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Return canonical feedback, accepting the pre-PR Telegram-specific key."""
+    raw = job.get("feedback")
+    if raw is None:
+        raw = job.get("telegram_feedback")
+    try:
+        return normalize_feedback_config(raw)
+    except ValueError:
+        return None
+
+
+def feedback_choice_label(job_id: str, action: str) -> Optional[str]:
+    """Return the configured label for an action, or ``None`` when invalid."""
+    if (
+        not FEEDBACK_JOB_ID_RE.fullmatch(job_id or "")
+        or not FEEDBACK_CODE_RE.fullmatch(action or "")
+    ):
+        return None
+    from cron.jobs import get_job
+
+    config = feedback_for_job(get_job(job_id) or {})
+    if not config:
+        return None
+    for choice in config["choices"]:
+        if choice["code"] == action:
+            return choice["label"]
+    return None
+
+
+def feedback_action_allowed(job_id: str, action: str) -> bool:
+    """Fail closed unless ``action`` is currently configured for ``job_id``."""
+    return feedback_choice_label(job_id, action) is not None

--- a/cron/feedback.py
+++ b/cron/feedback.py
@@ -11,6 +11,42 @@ MAX_FEEDBACK_CHOICES = 8
 MAX_FEEDBACK_LABEL_LENGTH = 64
 MAX_FEEDBACK_PROMPT_LENGTH = 200
 
+DEFAULT_REMINDER_FEEDBACK = {
+    "prompt": "What happened?",
+    "choices": [
+        {"code": "done", "label": "✅ Done"},
+        {"code": "not_yet", "label": "⏳ Not yet"},
+        {"code": "skip", "label": "❌ Didn't do it"},
+    ],
+}
+
+
+def default_feedback_for_reminder(
+    prompt: Optional[str], name: Optional[str]
+) -> Optional[Dict[str, Any]]:
+    """Return conservative defaults for clearly reminder-style jobs.
+
+    Detection is deliberately limited to the job name and the opening of the
+    prompt. This avoids attaching buttons merely because a longer task says
+    something like "do not create reminders" in its instructions.
+    """
+    job_name = str(name or "").strip()
+    prompt_lead = str(prompt or "").strip()[:240]
+    name_is_reminder = bool(re.search(r"\bremind(?:er)?\b", job_name, re.IGNORECASE))
+    prompt_is_reminder = bool(
+        re.match(
+            r"^(?:remind(?:er)?\b|send this exact reminder\b|one-time\b.{0,80}\breminder\b)",
+            prompt_lead,
+            re.IGNORECASE | re.DOTALL,
+        )
+    )
+    if not (name_is_reminder or prompt_is_reminder):
+        return None
+    return {
+        "prompt": DEFAULT_REMINDER_FEEDBACK["prompt"],
+        "choices": [dict(choice) for choice in DEFAULT_REMINDER_FEEDBACK["choices"]],
+    }
+
 
 def normalize_feedback_config(value: Any) -> Optional[Dict[str, Any]]:
     """Validate and normalize a feedback config, returning ``None`` when cleared."""

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1261,6 +1261,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    feedback: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1305,6 +1306,8 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        feedback: Optional interactive response prompt and choices. Platforms that
+                  support interactive controls can render these with the delivery.
 
     Returns:
         The created job dict
@@ -1337,6 +1340,8 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    from cron.feedback import normalize_feedback_config
+    normalized_feedback = normalize_feedback_config(feedback)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1426,6 +1431,7 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "feedback": normalized_feedback,
     }
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
@@ -1529,6 +1535,10 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+
+            if "feedback" in updates:
+                from cron.feedback import normalize_feedback_config
+                updates["feedback"] = normalize_feedback_config(updates["feedback"])
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1308,6 +1308,8 @@ def create_job(
                 watchdogs and periodic alerts that don't need LLM reasoning.
         feedback: Optional interactive response prompt and choices. Platforms that
                   support interactive controls can render these with the delivery.
+                  Clearly reminder-style jobs receive conservative defaults when
+                  this is omitted; pass ``{}`` to suppress automatic feedback.
 
     Returns:
         The created job dict
@@ -1340,7 +1342,10 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
-    from cron.feedback import normalize_feedback_config
+    prompt_text = _coerce_job_text(prompt)
+    from cron.feedback import default_feedback_for_reminder, normalize_feedback_config
+    if feedback is None:
+        feedback = default_feedback_for_reminder(prompt_text, name)
     normalized_feedback = normalize_feedback_config(feedback)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
@@ -1359,8 +1364,6 @@ def create_job(
         context_from = [str(j).strip() for j in context_from if str(j).strip()] or None
     else:
         context_from = None
-
-    prompt_text = _coerce_job_text(prompt)
 
     # Reject cron jobs that schedule gateway-lifecycle commands. Prevents
     # agent-driven SIGTERM-respawn loops under launchd/systemd KeepAlive

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1719,6 +1719,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 thread_id = new_thread_id
                 opened_thread_id = new_thread_id
 
+        from cron.feedback import feedback_for_job
+        reminder_feedback = feedback_for_job(job)
+        route_metadata = {"job_id": job["id"]}
+        if thread_id is not None:
+            route_metadata["thread_id"] = str(thread_id)
+        if reminder_feedback:
+            route_metadata["reminder_feedback"] = reminder_feedback
+
         if live_adapter_ready:
             # Telegram topic routing (#22773, regression fixed #52060): a
             # ``telegram:<positive_chat_id>:<numeric_thread_id>`` cron target is
@@ -1771,6 +1779,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
                 media_metadata = {"thread_id": thread_id} if thread_id else None
+
+            # Telegram consumes this optional metadata and attaches a persistent
+            # inline keyboard. Other platform adapters safely ignore it.
+            if reminder_feedback:
+                route_metadata["reminder_feedback"] = reminder_feedback
 
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content.
@@ -2020,7 +2033,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 delivery_errors.extend(target_errors)
                 continue
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            coro = _send_to_platform(
+                platform, pconfig, chat_id, cleaned_delivery_content,
+                thread_id=thread_id, media_files=media_files,
+                metadata=route_metadata,
+            )
             try:
                 result = asyncio.run(coro)
             except RuntimeError as run_err:
@@ -2049,8 +2066,23 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 try:
                     pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                     try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
-                        result = future.result(timeout=30)
+                        fallback_coro = _send_to_platform(
+                            platform, pconfig, chat_id, cleaned_delivery_content,
+                            thread_id=thread_id, media_files=media_files,
+                            metadata=route_metadata,
+                        )
+                        try:
+                            future = pool.submit(asyncio.run, fallback_coro)
+                        except Exception:
+                            fallback_coro.close()
+                            raise
+                        try:
+                            result = future.result(timeout=30)
+                        except concurrent.futures.TimeoutError:
+                            raise
+                        except Exception:
+                            fallback_coro.close()
+                            raise
                     finally:
                         pool.shutdown(wait=False)
                 except Exception as e:
@@ -2068,6 +2100,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     delivery_errors.extend(target_errors)
                     continue
             except Exception as e:
+                coro.close()
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
                 logger.error("Job '%s': %s", job["id"], msg, exc_info=True)
                 target_errors.extend([msg])

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -25,6 +25,111 @@ from typing import Dict, List, Optional, Set, Any
 logger = logging.getLogger(__name__)
 
 
+_REMINDER_FEEDBACK_LOCK = threading.Lock()
+
+
+def _validated_reminder_feedback(metadata: Optional[Dict[str, Any]]) -> Optional[dict]:
+    """Return a safe cron-reminder feedback payload or ``None``."""
+    from cron.feedback import FEEDBACK_JOB_ID_RE, normalize_feedback_config
+
+    raw = (metadata or {}).get("reminder_feedback")
+    job_id = str((metadata or {}).get("job_id") or "").strip()
+    if not FEEDBACK_JOB_ID_RE.fullmatch(job_id):
+        return None
+    try:
+        feedback = normalize_feedback_config(raw)
+    except ValueError:
+        return None
+    if feedback is None:
+        return None
+    return {
+        "job_id": job_id,
+        **feedback,
+    }
+
+
+def _build_reminder_feedback_markup(
+    metadata: Optional[Dict[str, Any]],
+) -> tuple[Any, str]:
+    """Build a compact two-column keyboard and return it with its prompt."""
+    feedback = _validated_reminder_feedback(metadata)
+    if not feedback:
+        return None, ""
+    rows = []
+    choices = feedback["choices"]
+    for start in range(0, len(choices), 2):
+        rows.append([
+            InlineKeyboardButton(
+                choice["label"],
+                callback_data=f"rf:{feedback['job_id']}:{choice['code']}",
+            )
+            for choice in choices[start:start + 2]
+        ])
+    return InlineKeyboardMarkup(rows), feedback["prompt"]
+
+
+def _append_reminder_feedback_event(event: dict) -> bool:
+    """Append one profile-local event, returning False for a duplicate tap."""
+    from hermes_constants import get_hermes_home
+
+    ledger = get_hermes_home() / "reminder-feedback" / "events.jsonl"
+    ledger.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    dedupe_key = (
+        event.get("job_id"),
+        event.get("telegram_chat_id"),
+        event.get("telegram_message_id"),
+        event.get("telegram_user_id"),
+    )
+    line = json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n"
+    flags = os.O_RDWR | os.O_CREAT | os.O_APPEND
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    with _REMINDER_FEEDBACK_LOCK:
+        fd = os.open(ledger, flags, 0o600)
+        try:
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "r+", encoding="utf-8") as handle:
+                fd = -1  # owned by ``handle`` from here
+                try:
+                    import fcntl
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+                except ImportError:  # pragma: no cover - Windows
+                    pass
+                handle.seek(0)
+                for existing_line in handle:
+                    try:
+                        existing = json.loads(existing_line)
+                    except (TypeError, ValueError):
+                        continue
+                    existing_key = (
+                        existing.get("job_id"),
+                        existing.get("telegram_chat_id"),
+                        existing.get("telegram_message_id"),
+                        existing.get("telegram_user_id"),
+                    )
+                    if existing_key == dedupe_key:
+                        return False
+                handle.write(line)
+                handle.flush()
+                os.fsync(handle.fileno())
+        finally:
+            if fd >= 0:
+                os.close(fd)
+    return True
+
+
+def _feedback_resolved_text(original: str, label: str) -> str:
+    """Append a status while respecting Telegram's UTF-16 4096-unit limit."""
+    from gateway.platforms.base import utf16_len
+
+    suffix = f"\n\nFeedback: {label}"
+    remaining = max(0, 4096 - utf16_len(suffix))
+    encoded = original.rstrip().encode("utf-16-le")[: remaining * 2]
+    safe_original = encoded.decode("utf-16-le", errors="ignore").rstrip()
+    return f"{safe_original}{suffix}" if safe_original else suffix.lstrip()
+
+
 def _redact_telegram_error_text(error: object) -> str:
     """Redact secrets from Telegram transport errors before logging or returning them."""
     text = "" if error is None else str(error)
@@ -1631,6 +1736,7 @@ class TelegramAdapter(BasePlatformAdapter):
     ) -> bool:
         return bool(
             not (metadata or {}).get("expect_edits")
+            and not _validated_reminder_feedback(metadata)
             and self._rich_eligible(content)
         )
 
@@ -4336,6 +4442,10 @@ class TelegramAdapter(BasePlatformAdapter):
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
+
+        feedback_markup, feedback_prompt = _build_reminder_feedback_markup(metadata)
+        if feedback_prompt:
+            content = f"{content.rstrip()}\n\n{feedback_prompt}"
         
         try:
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
@@ -4442,12 +4552,16 @@ class TelegramAdapter(BasePlatformAdapter):
                 msg = None
                 for _send_attempt in range(3):
                     try:
-                        # Try Markdown first, fall back to plain text if it fails
+                        # Try Markdown first, fall back to plain text if it fails.
+                        # Feedback belongs only on the final chunk so one reminder
+                        # never renders multiple competing keyboards.
+                        reply_markup = feedback_markup if i == len(chunks) - 1 else None
                         try:
                             msg = await self._bot.send_message(
                                 chat_id=normalize_telegram_chat_id(chat_id),
                                 text=chunk,
                                 parse_mode=ParseMode.MARKDOWN_V2,
+                                reply_markup=reply_markup,
                                 reply_to_message_id=reply_to_id,
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
@@ -4462,6 +4576,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     chat_id=normalize_telegram_chat_id(chat_id),
                                     text=plain_chunk,
                                     parse_mode=None,
+                                    reply_markup=reply_markup,
                                     reply_to_message_id=reply_to_id,
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
@@ -6234,6 +6349,99 @@ class TelegramAdapter(BasePlatformAdapter):
                 query_chat_type=query_chat_type,
                 query_thread_id=query_thread_id,
                 query_user_name=query_user_name,
+            )
+            return
+
+        # --- Durable cron-reminder feedback (rf:<job_id>:<action>) ---
+        # The callback is self-contained, so buttons survive gateway restarts.
+        if data.startswith("rf:"):
+            from cron.feedback import (
+                FEEDBACK_CODE_RE,
+                FEEDBACK_JOB_ID_RE,
+                feedback_choice_label,
+            )
+
+            parts = data.split(":", 2)
+            if len(parts) != 3:
+                await query.answer(text="Invalid reminder response.")
+                return
+            job_id, action = parts[1].strip(), parts[2].strip().lower()
+            if (
+                not FEEDBACK_JOB_ID_RE.fullmatch(job_id)
+                or not FEEDBACK_CODE_RE.fullmatch(action)
+            ):
+                await query.answer(text="Invalid reminder response.")
+                return
+
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to answer this reminder.")
+                return
+
+            label = feedback_choice_label(job_id, action)
+            if label is None:
+                await query.answer(text="Invalid reminder response.")
+                return
+
+            clicked_at = datetime.now(timezone.utc)
+            sent_at = getattr(query_message, "date", None)
+            response_seconds = None
+            if isinstance(sent_at, datetime):
+                if sent_at.tzinfo is None:
+                    sent_at = sent_at.replace(tzinfo=timezone.utc)
+                response_seconds = max(0, int((clicked_at - sent_at).total_seconds()))
+            event = {
+                "schema_version": 1,
+                "job_id": job_id,
+                "action": action,
+                "action_label": label,
+                "clicked_at": clicked_at.isoformat(),
+                "sent_at": sent_at.isoformat() if isinstance(sent_at, datetime) else None,
+                "response_seconds": response_seconds,
+                "telegram_chat_id": str(query_chat_id) if query_chat_id is not None else None,
+                "telegram_message_id": getattr(query_message, "message_id", None),
+                "thread_id": str(query_thread_id) if query_thread_id is not None else None,
+                "telegram_user_id": caller_id,
+                "telegram_user_name": query_user_name,
+            }
+            try:
+                recorded = await asyncio.to_thread(_append_reminder_feedback_event, event)
+            except Exception:
+                logger.exception("Failed to persist reminder feedback for job %s", job_id)
+                await query.answer(
+                    text="Could not save that response. Please try again.",
+                    show_alert=True,
+                )
+                return
+
+            if not recorded:
+                await query.answer(text="Already recorded.")
+                return
+
+            await query.answer(text=f"Recorded: {label}")
+            try:
+                await query.edit_message_reply_markup(reply_markup=None)
+            except Exception:
+                pass
+            try:
+                original = str(getattr(query_message, "text", "") or "").rstrip()
+                resolved = _feedback_resolved_text(original, label)
+                await query.edit_message_text(
+                    text=resolved,
+                    parse_mode=None,
+                    reply_markup=None,
+                )
+            except Exception:
+                pass
+            logger.info(
+                "Telegram reminder feedback recorded job=%s action=%s user=%s",
+                job_id, action, caller_id,
             )
             return
 

--- a/tests/cron/test_cron_feedback.py
+++ b/tests/cron/test_cron_feedback.py
@@ -1,0 +1,76 @@
+"""First-class cron feedback configuration."""
+
+import json
+
+import pytest
+
+from cron.jobs import create_job, get_job, update_job
+from tools.cronjob_tools import CRONJOB_SCHEMA, cronjob
+
+
+def _feedback():
+    return {
+        "prompt": "What happened?",
+        "choices": [
+            {"code": "done", "label": "Done"},
+            {"code": "skip", "label": "Skipped"},
+        ],
+    }
+
+
+def test_create_job_stores_normalized_feedback():
+    job = create_job("Do the thing", "every 1h", feedback=_feedback())
+    assert job["feedback"] == _feedback()
+    assert get_job(job["id"])["feedback"] == _feedback()
+
+
+def test_update_job_can_replace_and_clear_feedback():
+    job = create_job("Do the thing", "every 1h", feedback=_feedback())
+    replacement = {
+        "prompt": "Status?",
+        "choices": [{"code": "later", "label": "Later"}],
+    }
+    update_job(job["id"], {"feedback": replacement})
+    assert get_job(job["id"])["feedback"] == replacement
+    update_job(job["id"], {"feedback": {}})
+    assert get_job(job["id"])["feedback"] is None
+
+
+@pytest.mark.parametrize(
+    "feedback",
+    [
+        {"prompt": "Missing choices"},
+        {"choices": []},
+        {"choices": [{"code": "BAD CODE", "label": "Bad"}]},
+        {"choices": [{"code": "done", "label": ""}]},
+        {"choices": [{"code": "x" * 25, "label": "Too long"}]},
+        {"choices": [{"code": str(i), "label": str(i)} for i in range(9)]},
+    ],
+)
+def test_create_job_rejects_invalid_feedback(feedback):
+    with pytest.raises(ValueError, match="feedback"):
+        create_job("Do the thing", "every 1h", feedback=feedback)
+
+
+def test_cronjob_tool_schema_and_create_round_trip(monkeypatch):
+    monkeypatch.setattr("tools.cronjob_tools._notify_provider_jobs_changed_safe", lambda: None)
+    assert "feedback" in CRONJOB_SCHEMA["parameters"]["properties"]
+    result = json.loads(
+        cronjob(
+            action="create",
+            prompt="Do the thing",
+            schedule="every 1h",
+            feedback=_feedback(),
+        )
+    )
+    assert result["success"] is True
+    assert result["job"]["feedback"] == _feedback()
+
+
+def test_legacy_telegram_feedback_is_read_but_new_jobs_use_generic_key():
+    from cron.feedback import feedback_for_job
+
+    legacy = {"telegram_feedback": _feedback()}
+    assert feedback_for_job(legacy) == _feedback()
+    job = create_job("Do the thing", "every 1h", feedback=_feedback())
+    assert "telegram_feedback" not in job

--- a/tests/cron/test_cron_feedback.py
+++ b/tests/cron/test_cron_feedback.py
@@ -74,3 +74,35 @@ def test_legacy_telegram_feedback_is_read_but_new_jobs_use_generic_key():
     assert feedback_for_job(legacy) == _feedback()
     job = create_job("Do the thing", "every 1h", feedback=_feedback())
     assert "telegram_feedback" not in job
+
+
+def test_reminder_jobs_get_default_feedback_when_omitted():
+    job = create_job(
+        "Reminder: follow up with Wendell Butler about the sponsorship.",
+        "30m",
+        name="Follow up with Wendell Butler",
+        deliver="origin",
+    )
+    assert job["feedback"] == {
+        "prompt": "What happened?",
+        "choices": [
+            {"code": "done", "label": "✅ Done"},
+            {"code": "not_yet", "label": "⏳ Not yet"},
+            {"code": "skip", "label": "❌ Didn't do it"},
+        ],
+    }
+
+
+def test_non_reminder_jobs_do_not_get_default_feedback():
+    job = create_job("Check server status", "every 1h", deliver="origin")
+    assert job["feedback"] is None
+
+
+def test_explicit_empty_feedback_suppresses_reminder_default():
+    job = create_job(
+        "Remind me to check the build",
+        "30m",
+        deliver="origin",
+        feedback={},
+    )
+    assert job["feedback"] is None

--- a/tests/gateway/test_telegram_reminder_feedback.py
+++ b/tests/gateway/test_telegram_reminder_feedback.py
@@ -1,0 +1,330 @@
+"""Telegram cron-reminder feedback buttons and durable response logging."""
+
+import asyncio
+import json
+import stat
+import sys
+from concurrent.futures import Future
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cron.scheduler import _deliver_result
+from gateway.config import Platform, PlatformConfig
+from plugins.platforms.telegram.adapter import (
+    TelegramAdapter,
+    _append_reminder_feedback_event,
+    _feedback_resolved_text,
+    _validated_reminder_feedback,
+)
+from tools.send_message_tool import _send_telegram
+
+
+def _make_adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token", extra={}))
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+def _feedback():
+    return {
+        "prompt": "How did it go?",
+        "choices": [
+            {"code": "call", "label": "📞 Called"},
+            {"code": "email", "label": "✉️ Emailed"},
+            {"code": "skip", "label": "❌ Didn't do it"},
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_cron_feedback_metadata_renders_inline_keyboard_on_final_chunk(monkeypatch):
+    import plugins.platforms.telegram.adapter as telegram_adapter
+
+    class FakeButton:
+        def __init__(self, text, callback_data):
+            self.text = text
+            self.callback_data = callback_data
+
+    class FakeMarkup:
+        def __init__(self, rows):
+            self.inline_keyboard = rows
+
+    monkeypatch.setattr(telegram_adapter, "InlineKeyboardButton", FakeButton)
+    monkeypatch.setattr(telegram_adapter, "InlineKeyboardMarkup", FakeMarkup)
+    adapter = _make_adapter()
+    msg = MagicMock(message_id=42)
+    adapter._bot.send_message = AsyncMock(return_value=msg)
+
+    result = await adapter.send(
+        "12345",
+        "Follow up with a contact.",
+        metadata={"job_id": "abc123", "reminder_feedback": _feedback()},
+    )
+
+    assert result.success is True
+    kwargs = adapter._bot.send_message.call_args.kwargs
+    markup = kwargs["reply_markup"]
+    buttons = [button for row in markup.inline_keyboard for button in row]
+    assert [button.text for button in buttons] == ["📞 Called", "✉️ Emailed", "❌ Didn't do it"]
+    assert [button.callback_data for button in buttons] == [
+        "rf:abc123:call",
+        "rf:abc123:email",
+        "rf:abc123:skip",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feedback_keyboard_is_only_on_final_chunk(monkeypatch):
+    import plugins.platforms.telegram.adapter as telegram_adapter
+
+    class FakeButton:
+        def __init__(self, text, callback_data):
+            self.text = text
+            self.callback_data = callback_data
+
+    class FakeMarkup:
+        def __init__(self, rows):
+            self.inline_keyboard = rows
+
+    monkeypatch.setattr(telegram_adapter, "InlineKeyboardButton", FakeButton)
+    monkeypatch.setattr(telegram_adapter, "InlineKeyboardMarkup", FakeMarkup)
+    adapter = _make_adapter()
+    adapter._bot.send_message = AsyncMock(
+        side_effect=[MagicMock(message_id=1), MagicMock(message_id=2)]
+    )
+
+    result = await adapter.send(
+        "12345",
+        "x" * 5000,
+        metadata={"job_id": "abc123", "reminder_feedback": _feedback()},
+    )
+
+    assert result.success is True
+    calls = adapter._bot.send_message.await_args_list
+    assert len(calls) == 2
+    assert calls[0].kwargs["reply_markup"] is None
+    assert calls[-1].kwargs["reply_markup"] is not None
+
+
+def test_feedback_callback_payload_rejects_non_ascii_job_id():
+    assert _validated_reminder_feedback(
+        {"job_id": "🧠" * 32, "reminder_feedback": _feedback()}
+    ) is None
+
+
+def test_feedback_resolution_respects_telegram_utf16_limit():
+    from gateway.platforms.base import utf16_len
+
+    resolved = _feedback_resolved_text("😀" * 4096, "Done")
+    assert utf16_len(resolved) <= 4096
+    assert resolved.endswith("Feedback: Done")
+
+
+@pytest.mark.asyncio
+async def test_standalone_telegram_sender_renders_feedback_keyboard(monkeypatch):
+    import plugins.platforms.telegram.adapter as telegram_adapter
+
+    class FakeButton:
+        def __init__(self, text, callback_data):
+            self.text = text
+            self.callback_data = callback_data
+
+    class FakeMarkup:
+        def __init__(self, rows):
+            self.inline_keyboard = rows
+
+    monkeypatch.setattr(telegram_adapter, "InlineKeyboardButton", FakeButton)
+    monkeypatch.setattr(telegram_adapter, "InlineKeyboardMarkup", FakeMarkup)
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=42))
+    monkeypatch.setattr(sys.modules["telegram"], "Bot", lambda **_kwargs: bot)
+
+    result = await _send_telegram(
+        "token",
+        "12345",
+        "Follow up with a contact.",
+        metadata={"job_id": "abc123", "reminder_feedback": _feedback()},
+    )
+
+    assert result["success"] is True
+    kwargs = bot.send_message.await_args.kwargs
+    assert kwargs["reply_markup"].inline_keyboard
+    assert "How did it go?" in kwargs["text"]
+
+
+def test_feedback_messages_do_not_use_rich_send_path():
+    adapter = _make_adapter()
+    adapter._rich_messages_enabled = True
+    adapter._rich_send_disabled = False
+    adapter._bot.do_api_request = AsyncMock()
+    assert adapter._should_attempt_rich(
+        "**Reminder**",
+        metadata={"job_id": "abc123", "reminder_feedback": _feedback()},
+    ) is False
+
+
+def test_scheduler_passes_job_feedback_to_live_adapter():
+    adapter = AsyncMock()
+    adapter.send.return_value = MagicMock(success=True)
+
+    pconfig = MagicMock(enabled=True)
+    mock_cfg = MagicMock()
+    mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+    loop = MagicMock()
+    loop.is_running.return_value = True
+
+    def fake_run_coro(coro, _loop):
+        future = Future()
+        try:
+            future.set_result(asyncio.run(coro))
+        except BaseException as exc:  # noqa: BLE001
+            future.set_exception(exc)
+        return future
+
+    job = {
+        "id": "abc123",
+        "name": "Eric follow-up",
+        "deliver": "origin",
+        "origin": {"platform": "telegram", "chat_id": "12345"},
+        "feedback": _feedback(),
+    }
+    with patch("gateway.config.load_gateway_config", return_value=mock_cfg), patch(
+        "cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}
+    ), patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+        result = _deliver_result(
+            job,
+            "Follow up with a contact.",
+            adapters={Platform.TELEGRAM: adapter},
+            loop=loop,
+        )
+
+    assert result is None
+    adapter.send.assert_called_once()
+    metadata = adapter.send.call_args.kwargs["metadata"]
+    assert metadata["job_id"] == "abc123"
+    assert metadata["reminder_feedback"] == _feedback()
+
+
+def test_scheduler_passes_job_feedback_to_standalone_sender():
+    pconfig = MagicMock(enabled=True)
+    mock_cfg = MagicMock()
+    mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+    sender = AsyncMock(return_value={"success": True})
+    job = {
+        "id": "abc123",
+        "name": "Eric follow-up",
+        "deliver": "origin",
+        "origin": {"platform": "telegram", "chat_id": "12345"},
+        "feedback": _feedback(),
+    }
+    with patch("gateway.config.load_gateway_config", return_value=mock_cfg), patch(
+        "cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}
+    ), patch("tools.send_message_tool._send_to_platform", sender):
+        result = _deliver_result(job, "Follow up with a contact.", adapters=None, loop=None)
+
+    assert result is None
+    sender.assert_awaited_once()
+    metadata = sender.call_args.kwargs["metadata"]
+    assert metadata["job_id"] == "abc123"
+    assert metadata["reminder_feedback"] == _feedback()
+
+
+@pytest.mark.asyncio
+async def test_feedback_callback_logs_event_and_resolves_message(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "cron.jobs.get_job", lambda job_id: {"id": job_id, "feedback": _feedback()}
+    )
+    adapter = _make_adapter()
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
+
+    sent_at = datetime(2026, 7, 21, 14, 0, tzinfo=timezone.utc)
+    query = AsyncMock()
+    query.data = "rf:abc123:email"
+    query.from_user = MagicMock(id=1001, first_name="Tester")
+    query.message = MagicMock(
+        chat_id=-1001234567890,
+        message_id=777,
+        message_thread_id=1410,
+        text="Follow up with a contact.",
+        date=sent_at,
+    )
+    query.message.chat = MagicMock(type="supergroup")
+
+    update = MagicMock(callback_query=query)
+    await adapter._handle_callback_query(update, MagicMock())
+
+    ledger = tmp_path / "reminder-feedback" / "events.jsonl"
+    rows = [json.loads(line) for line in ledger.read_text().splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["job_id"] == "abc123"
+    assert rows[0]["action"] == "email"
+    assert rows[0]["telegram_message_id"] == 777
+    assert rows[0]["telegram_user_id"] == "1001"
+    assert rows[0]["thread_id"] == "1410"
+    assert rows[0]["response_seconds"] >= 0
+    query.answer.assert_awaited_once()
+    query.edit_message_reply_markup.assert_awaited_once_with(reply_markup=None)
+    query.edit_message_text.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_feedback_callback_fails_closed(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "cron.jobs.get_job", lambda job_id: {"id": job_id, "feedback": _feedback()}
+    )
+    adapter = _make_adapter()
+    adapter._is_callback_user_authorized = MagicMock(return_value=False)
+
+    query = AsyncMock()
+    query.data = "rf:abc123:call"
+    query.from_user = MagicMock(id=999, first_name="Intruder")
+    query.message = MagicMock(chat_id=-1001234567890, message_id=1, message_thread_id=1410)
+    query.message.chat = MagicMock(type="supergroup")
+
+    await adapter._handle_callback_query(MagicMock(callback_query=query), MagicMock())
+
+    assert not (tmp_path / "reminder-feedback" / "events.jsonl").exists()
+    query.answer.assert_awaited_once()
+    query.edit_message_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_feedback_action_is_rejected(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "cron.jobs.get_job", lambda job_id: {"id": job_id, "feedback": _feedback()}
+    )
+    adapter = _make_adapter()
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
+    query = AsyncMock()
+    query.data = "rf:abc123:forged"
+    query.from_user = MagicMock(id=1001)
+    query.message = MagicMock(chat_id=-1001234567890, message_id=2)
+    query.message.chat = MagicMock(type="supergroup")
+
+    await adapter._handle_callback_query(MagicMock(callback_query=query), MagicMock())
+
+    assert not (tmp_path / "reminder-feedback" / "events.jsonl").exists()
+    adapter._is_callback_user_authorized.assert_called_once()
+    query.answer.assert_awaited_once_with(text="Invalid reminder response.")
+
+
+def test_duplicate_feedback_event_is_not_appended(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    event = {
+        "job_id": "abc123",
+        "telegram_chat_id": "-1001",
+        "telegram_message_id": 77,
+        "telegram_user_id": "42",
+        "action": "email",
+    }
+    assert _append_reminder_feedback_event(event) is True
+    assert _append_reminder_feedback_event({**event, "action": "call"}) is False
+    ledger = tmp_path / "reminder-feedback" / "events.jsonl"
+    assert len(ledger.read_text().splitlines()) == 1
+    assert stat.S_IMODE(ledger.stat().st_mode) == 0o600

--- a/tests/gateway/test_telegram_reminder_feedback.py
+++ b/tests/gateway/test_telegram_reminder_feedback.py
@@ -166,9 +166,9 @@ def test_feedback_messages_do_not_use_rich_send_path():
     ) is False
 
 
-def test_scheduler_passes_job_feedback_to_live_adapter():
+def test_scheduler_routes_job_feedback_through_delivery_router_and_safe_schedule():
     adapter = AsyncMock()
-    adapter.send.return_value = MagicMock(success=True)
+    adapter.send.return_value = MagicMock(success=True, raw_response={})
 
     pconfig = MagicMock(enabled=True)
     mock_cfg = MagicMock()
@@ -176,7 +176,7 @@ def test_scheduler_passes_job_feedback_to_live_adapter():
     loop = MagicMock()
     loop.is_running.return_value = True
 
-    def fake_run_coro(coro, _loop):
+    def fake_schedule(coro, _loop):
         future = Future()
         try:
             future.set_result(asyncio.run(coro))
@@ -188,12 +188,18 @@ def test_scheduler_passes_job_feedback_to_live_adapter():
         "id": "abc123",
         "name": "Eric follow-up",
         "deliver": "origin",
-        "origin": {"platform": "telegram", "chat_id": "12345"},
+        "origin": {
+            "platform": "telegram",
+            "chat_id": "-1001234567890",
+            "thread_id": "777",
+        },
         "feedback": _feedback(),
     }
     with patch("gateway.config.load_gateway_config", return_value=mock_cfg), patch(
         "cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}
-    ), patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+    ), patch(
+        "agent.async_utils.safe_schedule_threadsafe", side_effect=fake_schedule
+    ) as schedule:
         result = _deliver_result(
             job,
             "Follow up with a contact.",
@@ -202,9 +208,11 @@ def test_scheduler_passes_job_feedback_to_live_adapter():
         )
 
     assert result is None
+    schedule.assert_called_once()
     adapter.send.assert_called_once()
     metadata = adapter.send.call_args.kwargs["metadata"]
     assert metadata["job_id"] == "abc123"
+    assert metadata["thread_id"] == "777"
     assert metadata["reminder_feedback"] == _feedback()
 
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1044,7 +1044,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "feedback": {
                 "type": "object",
-                "description": "Optional interactive response prompt and choices for platforms that support buttons. On update, pass an empty object to clear.",
+                "description": "Optional interactive response prompt and choices for platforms that support buttons. Clearly reminder-style jobs receive Done / Not yet / Didn't do it defaults when this field is omitted. Pass an empty object on create to suppress those defaults, or on update to clear feedback.",
                 "properties": {
                     "prompt": {"type": "string", "maxLength": 200},
                     "choices": {

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -562,6 +562,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("feedback"):
+        result["feedback"] = job["feedback"]
     return result
 
 
@@ -641,6 +643,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    feedback: Optional[Dict[str, Any]] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -714,6 +717,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                feedback=feedback,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -835,6 +839,8 @@ def cronjob(
                 updates["name"] = name
             if deliver is not None:
                 updates["deliver"] = _normalize_deliver_param(deliver)
+            if feedback is not None:
+                updates["feedback"] = feedback
             if skills is not None or skill is not None:
                 canonical_skills = _canonical_skills(skill, skills)
                 updates["skills"] = canonical_skills
@@ -1036,6 +1042,28 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
             },
+            "feedback": {
+                "type": "object",
+                "description": "Optional interactive response prompt and choices for platforms that support buttons. On update, pass an empty object to clear.",
+                "properties": {
+                    "prompt": {"type": "string", "maxLength": 200},
+                    "choices": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 8,
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "code": {"type": "string", "pattern": "^[a-z0-9_-]{1,24}$"},
+                                "label": {"type": "string", "minLength": 1, "maxLength": 64}
+                            },
+                            "required": ["code", "label"],
+                            "additionalProperties": False
+                        }
+                    }
+                },
+                "additionalProperties": False
+            },
             "attach_to_session": {
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
@@ -1097,6 +1125,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        feedback=args.get("feedback"),
         task_id=kw.get("task_id"),
     ),
     check_fn=check_cronjob_requirements,

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -780,7 +780,10 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(
+    platform, pconfig, chat_id, message, thread_id=None, media_files=None,
+    force_document=False, metadata=None,
+):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -860,6 +863,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             thread_id=thread_id,
             disable_link_previews=disable_link_previews,
             force_document=force_document,
+            metadata=metadata,
         )
 
     # --- Discord: chunked delivery via the registry's standalone_sender_fn.
@@ -1173,7 +1177,10 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(
+    token, chat_id, message, media_files=None, thread_id=None,
+    disable_link_previews=False, force_document=False, metadata=None,
+):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -1184,6 +1191,14 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
     try:
         from telegram import Bot
         from telegram.constants import ParseMode
+
+        try:
+            from plugins.platforms.telegram.adapter import _build_reminder_feedback_markup
+            feedback_markup, feedback_prompt = _build_reminder_feedback_markup(metadata)
+        except Exception:
+            feedback_markup, feedback_prompt = None, ""
+        if feedback_prompt:
+            message = f"{message.rstrip()}\n\n{feedback_prompt}"
 
         # Auto-detect HTML tags — if present, skip MarkdownV2 and send as HTML.
         # Inspired by github.com/ashaney — PR #1568.
@@ -1281,7 +1296,11 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         _cap, _ = _media_caption_split(
             message, media_files, max_caption_len=_TELEGRAM_CAPTION_LIMIT
         )
-        if _cap is not None and _utf16_len(formatted) <= _TELEGRAM_CAPTION_LIMIT:
+        if (
+            feedback_markup is None
+            and _cap is not None
+            and _utf16_len(formatted) <= _TELEGRAM_CAPTION_LIMIT
+        ):
             _tg_caption = formatted
             formatted = ""  # suppress the separate text send below
 
@@ -1297,27 +1316,31 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             text_chunks = BasePlatformAdapter.truncate_message(
                 formatted, 4096, len_fn=utf16_len
             )
-            for chunk in text_chunks:
+            for chunk_index, chunk in enumerate(text_chunks):
+                chunk_kwargs = dict(text_kwargs)
+                if feedback_markup is not None and chunk_index == len(text_chunks) - 1:
+                    chunk_kwargs["reply_markup"] = feedback_markup
                 try:
                     last_msg = await _send_telegram_message_with_retry(
                         bot,
                         chat_id=int_chat_id, text=chunk,
-                        parse_mode=send_parse_mode, **text_kwargs
+                        parse_mode=send_parse_mode, **chunk_kwargs
                     )
                 except Exception as md_error:
                     # Thread not found — retry without message_thread_id so the
                     # message still delivers (matching the gateway adapter's
                     # fallback behaviour, issue #27012).
-                    if _is_telegram_thread_not_found(md_error) and text_kwargs.get("message_thread_id") is not None:
+                    if _is_telegram_thread_not_found(md_error) and chunk_kwargs.get("message_thread_id") is not None:
                         logger.warning(
                             "Thread %s not found in _send_telegram, retrying without message_thread_id",
-                            text_kwargs.get("message_thread_id"),
+                            chunk_kwargs.get("message_thread_id"),
                         )
+                        chunk_kwargs.pop("message_thread_id", None)
                         text_kwargs.pop("message_thread_id", None)
                         last_msg = await _send_telegram_message_with_retry(
                             bot,
                             chat_id=int_chat_id, text=chunk,
-                            parse_mode=send_parse_mode, **text_kwargs
+                            parse_mode=send_parse_mode, **chunk_kwargs
                         )
                     elif "parse" in str(md_error).lower() or "markdown" in str(md_error).lower() or "html" in str(md_error).lower():
                         logger.warning(
@@ -1336,7 +1359,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                         last_msg = await _send_telegram_message_with_retry(
                             bot,
                             chat_id=int_chat_id, text=plain,
-                            parse_mode=None, **text_kwargs
+                            parse_mode=None, **chunk_kwargs
                         )
                     else:
                         raise

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -100,6 +100,11 @@ Cron jobs can include structured feedback choices. Telegram renders them as inli
 buttons on the final message chunk; platforms without interactive controls ignore
 the optional metadata and deliver the message normally.
 
+Clearly reminder-style jobs get a conservative default set when `feedback` is
+omitted: **Done**, **Not yet**, and **Didn't do it**. Detection is limited to the
+job name and the opening of its prompt. Pass `feedback={}` at creation to suppress
+automatic buttons, or provide explicit choices to replace the defaults.
+
 ```python
 cronjob(
     action="create",

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -94,6 +94,36 @@ global defaults. A switch to a paid provider or model can therefore spend money
 on every scheduled run.
 :::
 
+## Interactive reminder feedback
+
+Cron jobs can include structured feedback choices. Telegram renders them as inline
+buttons on the final message chunk; platforms without interactive controls ignore
+the optional metadata and deliver the message normally.
+
+```python
+cronjob(
+    action="create",
+    prompt="Remind me to follow up with Eric.",
+    schedule="0 9 * * 1",
+    deliver="telegram",
+    feedback={
+        "prompt": "What happened?",
+        "choices": [
+            {"code": "call", "label": "📞 Called"},
+            {"code": "email", "label": "✉️ Emailed"},
+            {"code": "skip", "label": "Skipped"},
+        ],
+    },
+)
+```
+
+Choice codes must contain 1–24 lowercase letters, digits, underscores, or hyphens.
+A job supports up to eight choices. Telegram callback payloads contain the job ID
+and choice code, so buttons remain valid across gateway restarts. Accepted responses
+are appended to `~/.hermes/reminder-feedback/events.jsonl`, including the response
+time and Telegram message/user identifiers. Repeated taps on the same reminder are
+recorded once.
+
 ## Skill-backed cron jobs
 
 A cron job can load one or more skills before it runs the prompt.


### PR DESCRIPTION
## Summary

Add optional structured feedback choices to cron jobs and render them as Telegram inline buttons.

Feedback is opt-in and platform-neutral at the cron API boundary. Telegram is the first renderer; other delivery adapters continue to ignore the metadata. Taps are authorized through the existing Telegram callback policy and recorded durably without changing the job schedule.

## Changes

- add a validated `feedback` field to cron create/update, tool schema, formatter, and registry paths
- automatically attach conservative Done / Not yet / Didn't do it defaults to clearly reminder-style jobs when feedback is omitted; `feedback={}` remains an explicit opt-out
- propagate normalized feedback metadata through live and standalone delivery
- render keyboards only on the final Telegram message chunk
- use restart-safe `rf:<job_id>:<action>` callback data with strict ID/action validation
- validate tapped actions against the job's configured choices
- fail closed for unauthorized callers
- suppress duplicate responses by job/chat/message/user
- persist profile-local JSONL events with process/thread locking and owner-only permissions
- remove resolved keyboards independently and keep status edits within Telegram's UTF-16 limit
- preserve legacy `telegram_feedback` job data while standardizing new jobs on `feedback`
- document configuration and persistence behavior

## Security and behavior

- callback IDs are restricted to ASCII-safe lengths below Telegram's 64-byte limit
- invalid or unconfigured actions are rejected
- durable writes are offloaded from the Telegram event loop
- reminder text is not stored in the feedback ledger
- button taps record structured feedback only; they do **not** mutate schedules
- in shared chats, the existing Telegram authorized-caller policy determines who may respond

## Duplicate gate

Searched open and merged issues/PRs for Telegram reminder buttons, cron feedback, and interactive reminders. The closest open Telegram callback PR fixes unrelated CCC callback dispatch and does not add cron feedback.

## Verification

- `22 passed` — new cron feedback and Telegram reminder-feedback tests
- `309 passed` — scheduler plus adjacent Telegram callback/button suites after rebasing to current main
- `382 passed` — current cron jobs/tools/schema and standalone message-sender regression suites
- Ruff on all changed Python files: clean
- Python bytecode compilation on all changed Python files: clean
- `git diff --check`: clean

The official full repository runner was also started. It reached 33.6% with 14,539 passing tests before the 10-minute command limit. The observed failures were pre-existing environment/setup failures outside the changed paths, primarily the unavailable optional `acp` package; the changed cron and Telegram suites completed successfully.

## Checklist

- [x] Read the contributing guide
- [x] Conventional commit title
- [x] Searched for duplicate issues and PRs
- [x] PR contains only cron/Telegram feedback changes
- [x] Added create/update, delivery, callback, storage, and chunking tests
- [x] Ran focused and adjacent regression suites

