### PR TITLE
fix(approval): detect recursive rm when flags follow operands (port of openai/codex#33464)

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -119,6 +119,41 @@ class TestDetectDangerousRm:
         assert key is not None
         assert "delete" in desc.lower()
 
+    def test_rm_flags_after_operands_detected(self):
+        # GNU rm permutes options: `rm build/ -rf` == `rm -rf build/`.
+        # Port of openai/codex#33464.
+        for cmd in (
+            "rm build/ -rf",
+            "rm build/ -r -f",
+            "rm build/ -fR",
+            "rm build/ --recursive --force",
+            "rm build/ --force --recursive",
+            "rm ~/projects -rf",
+            "sudo rm build/ -rf",
+            "rm -f build/ -r",
+            "rm one two three -rf",
+        ):
+            is_dangerous, key, desc = detect_dangerous_command(cmd)
+            assert is_dangerous is True, f"{cmd!r} should require approval"
+            assert "delete" in desc.lower()
+
+    def test_rm_flags_after_operands_no_false_positives(self):
+        for cmd in (
+            # after a bare `--`, -rf-looking tokens are literal filenames
+            "rm -- -weird-r-file",
+            "rm -f -- -r-file",
+            # a later pipeline/command segment's flags don't belong to rm
+            "rm foo | grep -r bar",
+            "rm foo; ls -lart",
+            # long options whose `r` is not whitespace-anchored
+            "npm rm somepkg --registry=https://registry.npmjs.org",
+            "rm old.log --verbose",
+            # plain multi-operand deletes stay safe
+            "rm build/file.txt other.txt",
+        ):
+            is_dangerous, key, desc = detect_dangerous_command(cmd)
+            assert is_dangerous is False, f"{cmd!r} should be safe, got: {desc}"
+
     def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self):
         with mock_patch("tempfile.gettempdir", return_value="/tmp"):
             for prefix in ("hermes-verify-", "hermes-ad-hoc-"):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -607,6 +607,24 @@ DANGEROUS_PATTERNS = [
     (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
     (r'\brm\s+-[^\s]*r', "recursive delete"),
     (r'\brm\s+--recursive\b', "recursive delete (long flag)"),
+    # GNU rm permutes options, so a recursive flag group may legally FOLLOW
+    # the operands: `rm build/ -rf`, `rm build/ -r -f`, and `rm build/
+    # --recursive --force` are all equivalent to the flags-first spellings the
+    # two patterns above catch — without this rule they run with no approval
+    # prompt at all. The operand run is tempered: it cannot cross a command
+    # separator (`;`, `|`, `&`, newline — so a later pipeline segment's flags,
+    # e.g. `rm foo | grep -r bar`, are not attributed to `rm`), cannot cross a
+    # quote (so `git commit -m "rm x" --amend` style data can't bridge an `rm`
+    # word to an unrelated dash token), and cannot cross a bare ` -- `
+    # end-of-options separator (after `--`, POSIX rm treats `-rf` as a literal
+    # filename, not flags; guarded both leading and mid-run). The flag token
+    # itself must start right after whitespace so the `r` inside long options
+    # like `--registry` (preceded by `-`, not whitespace) does not count.
+    # Port of openai/codex#33464 ("recognize force options when they follow
+    # operands").
+    (r'\brm\s+(?!--(?:\s|$))(?:(?!\s--(?:\s|$))[^\n"\';|&])*\s'
+     r'(?:-[a-z]*r[a-z]*\b|--recursive\b)',
+     "recursive delete (flags after operands)"),
     # Windows shell front-ends have destructive built-ins that do not look like
     # Unix `rm`. Gate only when they are executed through cmd/powershell so
     # ordinary prose or filenames containing "del"/"rd" do not trip the guard.


### PR DESCRIPTION
## Summary

`rm build/ -rf` now requires approval. GNU rm permutes options, so a recursive flag group after the operands (`rm build/ -rf`, `rm build/ -r -f`, `rm build/ --recursive --force`) is equivalent to the flags-first spelling — but every existing rm pattern in `DANGEROUS_PATTERNS` required the flag group *before* the path, so these spellings executed with **no approval prompt at all** (proven live on current main before fixing).

Port of [openai/codex#33464](https://github.com/openai/codex/pull/33464) ("Strengthen forced `rm` command detection" — the "recognize force options … when they follow operands" half).

## Scope notes

- **The hardline floor was NOT bypassed.** `rm $HOME -rf`, `rm / -rf`, `rm /etc -rf` already hardline-block: the hardline path matcher fires on the protected path regardless of flag position. The gap was the approval-prompt layer for arbitrary paths.
- **Deliberately not ported:** codex#33464's second half (forbid dangerous commands even when approvals are disabled). Hermes intentionally keeps recoverable-but-costly operations in `DANGEROUS_PATTERNS` where yolo can pass them through — that's what yolo is for (per the design comment in `tools/approval.py`).
- No overlap with the open hardline-hardening cluster (#58643, #58667, #57475, #58742, #65393) — those cover wrapper/interpreter-carrier bypasses, none touch flag ordering.

## Changes

- `tools/approval.py`: one new `DANGEROUS_PATTERNS` entry, `"recursive delete (flags after operands)"`. The operand run is tempered: cannot cross command separators (`;` `|` `&` newline), quotes, or a bare ` -- ` end-of-options separator (after `--`, POSIX rm treats `-rf` as a literal filename — guarded both leading and mid-run). The flag token must be whitespace-anchored so the `r` inside long options like `--registry` doesn't count.
- `tests/tools/test_approval.py`: 9 positive shapes + 7 negative shapes in `TestDetectDangerousRm`.

## Validation

| Command | Before | After |
|---|---|---|
| `rm build/ -rf` | silent execute | approval prompt |
| `rm ~/projects -rf` | silent execute | approval prompt |
| `rm build/ --recursive --force` | silent execute | approval prompt |
| `rm -- -weird-r-file` | safe | safe (end-of-options honored) |
| `rm foo \| grep -r bar` | safe | safe (separator-tempered) |
| `npm rm pkg --registry=…` | safe | safe (whitespace-anchored flag) |
| `rm $HOME -rf` | hardline block | hardline block (unchanged) |

Approval cluster: 868 tests green (`test_approval.py`, `test_command_guards.py`, `test_hardline_blocklist.py`, `test_yolo_mode.py`, `test_execution_flag_detection.py`, `test_smart_approval_injection.py`, `test_approval_deny_rules.py`, `test_gnu_long_option_abbreviation_bypass.py`, `test_shell_bypass_denylist.py`, + interrupt/cron/clean-slate/execute_code files). Ruff clean.

## Infographic

![rm-flags-after-operands](https://v3b.fal.media/files/b/0aa33450/J2DliLGxfqf3Wpm2jO15l_WcOyGXgA.png)
