### PR TITLE
fix(hindsight): clear the shutdown latch on session switch so long-lived processes keep retaining

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1607,6 +1607,9 @@ class HindsightMemoryProvider(MemoryProvider):
         that drains an in-memory queue. Once shutdown() has been called,
         further sync_turn() calls are dropped — this prevents post-exit
         retains from reaching aiohttp after interpreter shutdown begins.
+        The drop is not permanent on a long-lived process: the next
+        on_session_switch() clears the latch, because a fresh session is
+        proof the interpreter is not tearing down.
         """
         if not self._auto_retain:
             logger.debug("sync_turn: skipped (auto_retain disabled)")
@@ -1815,6 +1818,16 @@ class HindsightMemoryProvider(MemoryProvider):
         new_id = str(new_session_id or "").strip()
         if not new_id:
             return
+
+        # 0. Un-latch a prior shutdown(). _shutting_down is meant to stop
+        # retains racing interpreter teardown, but on a long-lived process
+        # (gateway) the same provider instance serves many sessions: after
+        # one shutdown() the sync_turn()/queue_prefetch() gates dropped every
+        # later session's writes forever, while reads kept working — silent
+        # memory loss. A session switch is affirmative proof the process is
+        # NOT tearing down (atexit never starts new sessions), so revive
+        # here; _ensure_writer() starts a fresh writer on the next retain.
+        self._shutting_down.clear()
 
         # 1. Flush any buffered turns under the OLD identifiers. Snapshot
         # everything before mutating self._* so metadata + tags + doc_id

--- a/tests/plugins/test_hindsight_retain_latch.py
+++ b/tests/plugins/test_hindsight_retain_latch.py
@@ -1,0 +1,96 @@
+"""Retain latch after shutdown() must not outlive the session it protected.
+
+``shutdown()`` sets ``_shutting_down`` so retains can't race interpreter
+teardown. But on a long-lived process (the messaging gateway) the same
+provider instance serves many sessions, and the ``sync_turn()`` /
+``queue_prefetch()`` gates returned before anything could clear the flag —
+one shutdown() silently dropped every later session's writes while reads
+kept working. ``on_session_switch()`` is the revive point: a new session is
+affirmative proof the process is not tearing down (atexit never starts new
+sessions).
+"""
+
+import importlib
+import json
+
+hindsight = importlib.import_module("plugins.memory.hindsight")
+HindsightMemoryProvider = hindsight.HindsightMemoryProvider
+
+
+def _make_provider(monkeypatch):
+    """Bare provider wired so sync_turn() reaches the writer hermetically."""
+    provider = HindsightMemoryProvider()
+    provider._session_id = "sess-a"
+    provider._document_id = "sess-a-doc-1"
+    # Keep the retain path off the network: no API probe, no client, and no
+    # initialize()-only config fields (these tests pin lifecycle, not kwargs).
+    monkeypatch.setattr(
+        provider, "_resolve_retain_target", lambda fallback: (fallback, None)
+    )
+    monkeypatch.setattr(
+        provider,
+        "_build_retain_kwargs",
+        lambda content, **kw: {"content": content, **kw},
+    )
+    retained = []
+    monkeypatch.setattr(
+        provider, "_run_hindsight_operation", lambda op: retained.append(op)
+    )
+    # No atexit registration from tests.
+    monkeypatch.setattr(provider, "_register_atexit", lambda: None)
+    return provider, retained
+
+
+def _turn(provider, text):
+    provider.sync_turn(text, "ack", session_id=provider._session_id)
+    provider._retain_queue.join()
+
+
+def test_sync_turn_retains_before_shutdown(monkeypatch):
+    provider, retained = _make_provider(monkeypatch)
+    _turn(provider, "hello")
+    assert len(retained) == 1
+    provider.shutdown()
+
+
+def test_sync_turn_dropped_after_shutdown(monkeypatch):
+    provider, retained = _make_provider(monkeypatch)
+    _turn(provider, "hello")
+    provider.shutdown()
+    provider.sync_turn("after teardown", "ack", session_id="sess-a")
+    assert len(retained) == 1  # dropped: teardown protection holds
+
+
+def test_session_switch_revives_retains_after_shutdown(monkeypatch):
+    provider, retained = _make_provider(monkeypatch)
+    _turn(provider, "hello")
+    provider.shutdown()
+
+    provider.on_session_switch("sess-b")
+    assert not provider._shutting_down.is_set()
+    provider._retain_queue.join()
+    flushed = len(retained)  # the switch may re-flush the old session's turns
+    assert flushed >= 1
+
+    provider._session_id = "sess-b"
+    _turn(provider, "next session's turn")
+    assert len(retained) == flushed + 1  # the new session's write landed
+
+    # The revived write carries the NEW session's turn, not stale state.
+    turns = provider._session_turns
+    assert len(turns) == 1
+    assert "next session's turn" in json.loads(turns[0])[0]["content"]
+
+
+def test_session_switch_flushes_buffered_turns_after_shutdown(monkeypatch):
+    # retain_every_n_turns > 1 buffers turns; a switch after shutdown() must
+    # still flush the old session's buffer (same data-loss class).
+    provider, retained = _make_provider(monkeypatch)
+    provider._retain_every_n_turns = 5
+    provider.sync_turn("buffered", "ack", session_id="sess-a")
+    provider.shutdown()
+    assert len(retained) == 0
+
+    provider.on_session_switch("sess-b")
+    provider._retain_queue.join()
+    assert len(retained) == 1  # the old session's buffered turn flushed


### PR DESCRIPTION
## Problem

`shutdown()` sets `_shutting_down` so retains can't race interpreter teardown. But `sync_turn()` and `queue_prefetch()` gate on that flag **before** anything can clear it — the only reset lives in `_ensure_writer()`, which is unreachable once the gates return early.

On a long-lived process (the messaging gateway), the same provider instance serves many sessions. After one `shutdown()`, every later session's writes are silently dropped while reads keep working: **silent memory loss with no error surface**.

Observed in production: a gateway latched on 2026-07-19; 5 sessions / 53 messages afterward produced zero retains until the process was restarted. The smoke signal was a staleness checker, not any error from the plugin itself.

## Fix

`on_session_switch()` now clears the latch. A fresh session is affirmative proof the interpreter is not tearing down — atexit never starts new sessions — so this is the safe revive point. `_ensure_writer()` then starts a fresh writer on the next retain (it already handled restart; it was just unreachable).

The teardown protection is unchanged: after a process-exit `shutdown()`, no session switch ever fires, so post-exit `sync_turn()` calls stay dropped.

## Tests

`tests/plugins/test_hindsight_retain_latch.py` (hermetic, no network):
- retain lands before shutdown
- retain dropped after shutdown (teardown protection holds)
- session switch after shutdown revives retains, and the revived write carries the new session's turn
- a switch after shutdown still flushes the old session's buffered turns (`retain_every_n_turns > 1`)

`python -m pytest tests/plugins/test_hindsight_retain_latch.py tests/plugins/test_hindsight_root_guard.py tests/plugins/test_hindsight_health_grace_timeout.py` → 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
