### PR TITLE
fix(tui-gateway): fail closed on session reasoning scope

### DIFF
--- a/tests/tui_gateway/test_reasoning_session_scope.py
+++ b/tests/tui_gateway/test_reasoning_session_scope.py
@@ -47,7 +47,7 @@ class TestSessionInfoReasoningEffort:
     def test_enabled_reports_effort_and_session_scope_contract(self) -> None:
         info = _session_info(_agent({"enabled": True, "effort": "high"}))
         assert info["reasoning_effort"] == "high"
-        assert info["reasoning_session_scope"] is True
+        assert info["reasoning_effort_session_scope"] is True
 
     def test_unset_reports_empty(self) -> None:
         info = _session_info(_agent(None))
@@ -130,6 +130,22 @@ class TestConfigSetReasoningSessionScope:
             )
         assert resp["error"]["code"] == 4002
         write_key.assert_not_called()
+
+    def test_session_scope_rejects_global_display_reasoning_operations(self) -> None:
+        session = {"session_key": "k1", "agent": _agent(None)}
+        for value in ("show", "hide", "full", "clamp"):
+            with patch.dict(server._sessions, {"s1": session}, clear=True), \
+                    patch.object(server, "_save_cfg") as save_cfg:
+                resp = self._dispatch(
+                    {
+                        "key": "reasoning",
+                        "session_id": "s1",
+                        "scope": "session",
+                        "value": value,
+                    }
+                )
+            assert resp["error"]["code"] == 4002
+            save_cfg.assert_not_called()
 
     def test_no_session_persists_globally(self) -> None:
         with patch.object(server, "_write_config_key") as write_key:

--- a/tests/tui_gateway/test_reasoning_session_scope.py
+++ b/tests/tui_gateway/test_reasoning_session_scope.py
@@ -44,9 +44,10 @@ class TestSessionInfoReasoningEffort:
         info = _session_info(_agent({"enabled": False}))
         assert info["reasoning_effort"] == "none"
 
-    def test_enabled_reports_effort(self) -> None:
+    def test_enabled_reports_effort_and_session_scope_contract(self) -> None:
         info = _session_info(_agent({"enabled": True, "effort": "high"}))
         assert info["reasoning_effort"] == "high"
+        assert info["reasoning_session_scope"] is True
 
     def test_unset_reports_empty(self) -> None:
         info = _session_info(_agent(None))
@@ -68,9 +69,18 @@ class TestConfigSetReasoningSessionScope:
                 patch.object(server, "_persist_live_session_runtime"), \
                 patch.object(server, "_emit"):
             resp = self._dispatch(
-                {"key": "reasoning", "session_id": "s1", "value": "none"}
+                {
+                    "key": "reasoning",
+                    "session_id": "s1",
+                    "scope": "session",
+                    "value": "none",
+                }
             )
-        assert resp["result"]["value"] == "none"
+        assert resp["result"] == {
+            "key": "reasoning",
+            "value": "none",
+            "scope": "session",
+        }
         assert agent.reasoning_config == {"enabled": False}
         write_key.assert_not_called()
 
@@ -81,19 +91,54 @@ class TestConfigSetReasoningSessionScope:
         with patch.dict(server._sessions, {"s2": session}, clear=False), \
                 patch.object(server, "_write_config_key") as write_key:
             resp = self._dispatch(
-                {"key": "reasoning", "session_id": "s2", "value": "high"}
+                {
+                    "key": "reasoning",
+                    "session_id": "s2",
+                    "scope": "session",
+                    "value": "high",
+                }
             )
-        assert resp["result"]["value"] == "high"
+        assert resp["result"] == {
+            "key": "reasoning",
+            "value": "high",
+            "scope": "session",
+        }
         assert session["create_reasoning_override"] == {
             "enabled": True,
             "effort": "high",
         }
         write_key.assert_not_called()
 
+    def test_explicit_session_scope_rejects_missing_session(self) -> None:
+        with patch.dict(server._sessions, {}, clear=True), \
+                patch.object(server, "_write_config_key") as write_key:
+            resp = self._dispatch(
+                {
+                    "key": "reasoning",
+                    "session_id": "missing",
+                    "scope": "session",
+                    "value": "low",
+                }
+            )
+        assert resp["error"]["code"] == 4001
+        write_key.assert_not_called()
+
+    def test_unknown_scope_is_rejected_without_global_write(self) -> None:
+        with patch.object(server, "_write_config_key") as write_key:
+            resp = self._dispatch(
+                {"key": "reasoning", "scope": "sesion", "value": "low"}
+            )
+        assert resp["error"]["code"] == 4002
+        write_key.assert_not_called()
+
     def test_no_session_persists_globally(self) -> None:
         with patch.object(server, "_write_config_key") as write_key:
             resp = self._dispatch({"key": "reasoning", "value": "low"})
-        assert resp["result"]["value"] == "low"
+        assert resp["result"] == {
+            "key": "reasoning",
+            "value": "low",
+            "scope": "global",
+        }
         write_key.assert_called_once_with("agent.reasoning_effort", "low")
 
     def test_unknown_value_rejected(self) -> None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3824,6 +3824,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "model": mirror.get("model", getattr(agent, "model", "")),
         "provider": mirror.get("provider", getattr(agent, "provider", "")),
         "reasoning_effort": reasoning_effort,
+        "reasoning_session_scope": True,
         "service_tier": service_tier,
         "fast": service_tier == "priority",
         "yolo": yolo,
@@ -11620,7 +11621,11 @@ def _(rid, params: dict) -> dict:
 
             arg = str(value or "").strip().lower()
             scope = str(params.get("scope") or "").strip().lower()
+            if scope not in {"", "session", "global"}:
+                return _err(rid, 4002, f"unknown reasoning scope: {scope}")
             global_scope = scope == "global"
+            if scope == "session" and session is None:
+                return _err(rid, 4001, "session not found")
             if arg in {"show", "on"}:
                 cfg = _load_cfg()
                 display = (
@@ -11719,7 +11724,8 @@ def _(rid, params: dict) -> dict:
                     params.get("session_id", ""),
                     _session_info(session["agent"], session),
                 )
-            return _ok(rid, {"key": key, "value": arg})
+            result_scope = "global" if global_scope or session is None else "session"
+            return _ok(rid, {"key": key, "value": arg, "scope": result_scope})
         except Exception as e:
             return _err(rid, 5001, str(e))
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3824,7 +3824,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "model": mirror.get("model", getattr(agent, "model", "")),
         "provider": mirror.get("provider", getattr(agent, "provider", "")),
         "reasoning_effort": reasoning_effort,
-        "reasoning_session_scope": True,
+        "reasoning_effort_session_scope": True,
         "service_tier": service_tier,
         "fast": service_tier == "priority",
         "yolo": yolo,
@@ -11626,6 +11626,10 @@ def _(rid, params: dict) -> dict:
             global_scope = scope == "global"
             if scope == "session" and session is None:
                 return _err(rid, 4001, "session not found")
+            if scope == "session" and arg in {
+                "show", "on", "hide", "off", "full", "all", "clamp", "collapse", "short",
+            }:
+                return _err(rid, 4002, "reasoning display values require global scope")
             if arg in {"show", "on"}:
                 cfg = _load_cfg()
                 display = (


### PR DESCRIPTION
## Summary

- make `config.set key=reasoning scope=session` fail closed when the requested live session no longer exists
- include the applied `scope` in reasoning-effort mutation acknowledgements
- advertise the strict contract as `reasoning_effort_session_scope` in `session.info`
- reject unknown scopes and display-only reasoning values under explicit session scope

## Why

The handler currently falls back to writing `agent.reasoning_effort` globally whenever the supplied `session_id` cannot be found. A desktop/mobile client can therefore request a session-only change while a session is closing and silently change the profile default. The existing `{key, value}` response does not reveal which branch ran.

Display controls such as `show`, `hide`, `full`, and `clamp` are global configuration. They now fail closed when a caller explicitly requests session scope instead of persisting globally behind a session-scoped request.

This preserves legacy behavior for calls that omit `scope`: no-session calls still persist globally. Clients that explicitly request `scope=session` now get an atomic fail-closed reasoning-effort contract and can validate the returned scope.

This contract is needed by nilesjarvis/nile#10.

## Tests

- `uv run --extra dev pytest tests/tui_gateway/test_reasoning_session_scope.py tests/tui_gateway/test_fast_session_scope.py -q -o 'addopts='` — 22 passed
- `uv run --extra dev ruff check tui_gateway/server.py tests/tui_gateway/test_reasoning_session_scope.py` — passed
- `git diff --check` — passed
