### PR TITLE
test(mcp): fix monotonic-clock flake in circuit-breaker cooldown test

### DIFF
--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -13,6 +13,7 @@ affected MCP server failed until the gateway was manually restarted.
 import asyncio
 import json
 import threading
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -507,7 +508,14 @@ def test_session_expired_retry_waits_for_new_session(monkeypatch, tmp_path):
     server._reconnect_event = _ReconnectAdapter()
     mcp_tool._servers["hindsight"] = server
     mcp_tool._server_error_counts["hindsight"] = 7
-    mcp_tool._server_breaker_opened_at["hindsight"] = 123.0
+    # Stamp the breaker "open" far enough in the past that the cooldown has
+    # provably elapsed, so this call is a half-open probe. The breaker compares
+    # against time.monotonic() (tools/mcp_tool.py), whose origin is arbitrary and
+    # small on a freshly-booted CI container — a hardcoded literal like 123.0
+    # only looked "elapsed" on a long-uptime dev box and flaked under CI.
+    mcp_tool._server_breaker_opened_at["hindsight"] = (
+        time.monotonic() - mcp_tool._CIRCUIT_BREAKER_COOLDOWN_SEC - 1.0
+    )
 
     try:
         handler = _make_tool_handler("hindsight", "get_bank", 10.0)


### PR DESCRIPTION
## Problem

`tests/tools/test_mcp_tool_session_expired.py::test_session_expired_retry_waits_for_new_session` is a **wall-clock flake** that fails under CI but passes on dev machines.

The test simulates a circuit breaker whose cooldown has already elapsed so the next call fires as a half-open probe:

```python
mcp_tool._server_breaker_opened_at["hindsight"] = 123.0
```

But the breaker compares that stamp against `time.monotonic()`:

```python
# tools/mcp_tool.py
opened_at = _server_breaker_opened_at.get(server_name, 0.0)
age = time.monotonic() - opened_at
if age < _CIRCUIT_BREAKER_COOLDOWN_SEC:  # 60.0
    return {"error": "... Auto-retry available in ~{remaining}s ..."}
```

`time.monotonic()`'s origin is arbitrary and **small on a freshly-booted CI container** (~130s), so `age = 130 - 123 = 7s < 60s` → the breaker stays open, the half-open probe never fires, and the handler returns the *unreachable* error instead of `"bank ok"`. On a long-uptime dev box `monotonic()` is huge → `age` huge → cooldown "elapsed" → passes. The reported `Auto-retry available in ~Ns` drifts run to run (`~2s`, `~16s`) as the container's clock varies — the signature of a monotonic-origin dependency.

## Fix

Stamp `opened_at` relative to the same clock the code reads, using the module's own cooldown constant so the cooldown is provably elapsed regardless of the monotonic origin:

```python
mcp_tool._server_breaker_opened_at["hindsight"] = (
    time.monotonic() - mcp_tool._CIRCUIT_BREAKER_COOLDOWN_SEC - 1.0
)
```

`age` is now always `≈ 61s > 60s` → the half-open probe fires deterministically. No behavior change to `mcp_tool.py`; test-only.

## Verification

`scripts/run_tests.sh tests/tools/test_mcp_tool_session_expired.py` — 32 passed.