### PR TITLE
fix(mcp): recover --env flags swallowed by argparse REMAINDER (#68944)

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -426,6 +426,31 @@ def cmd_mcp_add(args):
     auth_type = getattr(args, "auth", None)
     preset_name = getattr(args, "preset", None)
     raw_env = getattr(args, "env", None)
+
+    # ── Recover --env flags swallowed by argparse.REMAINDER ────────────
+    # ``--args`` uses ``nargs=REMAINDER`` which greedily consumes every
+    # token after it, including ``--env KEY=VALUE``.  When the user writes
+    # ``--args ... --env KEY=VALUE`` argparse folds ``--env`` and the
+    # assignment into ``args.args`` instead of ``args.env``.  Pull them
+    # back out so the env block is populated regardless of flag order.
+    if cmd_args and not raw_env:
+        recovered_env: list[str] = []
+        cleaned_args: list[str] = []
+        i = 0
+        while i < len(cmd_args):
+            if cmd_args[i] == "--env":
+                # Collect all KEY=VALUE tokens after --env until the next
+                # flag (starts with -) or end of list.
+                i += 1
+                while i < len(cmd_args) and "=" in cmd_args[i] and not cmd_args[i].startswith("-"):
+                    recovered_env.append(cmd_args[i])
+                    i += 1
+            else:
+                cleaned_args.append(cmd_args[i])
+                i += 1
+        if recovered_env:
+            cmd_args = cleaned_args
+            raw_env = recovered_env
     raw_connect_timeout = getattr(args, "connect_timeout", None)
 
     server_config: Dict[str, Any] = {}


### PR DESCRIPTION
## Problem

`hermes mcp add NAME --command CMD --args -y pkg-name --env KEY=VALUE` silently treats `--env KEY=VALUE` as positional arguments consumed by the greedy `--args` (`nargs=REMAINDER`) flag. The resulting `config.yaml` has no `env:` block — the server subprocess never receives the environment variable.

## Root Cause

`argparse.REMAINDER` on `--args` greedily consumes **all** remaining tokens, including `--env` and its `KEY=VALUE` arguments. When `--env` appears after `--args` on the command line, argparse folds it into `args.args` instead of `args.env`.

## Fix

After argparse extracts `cmd_args`, scan for `--env KEY=VALUE` patterns that were swallowed by REMAINDER. Extract them back into `raw_env` and strip them from `cmd_args`. This makes `--env` work correctly regardless of its position relative to `--args`.

## Testing

```bash
# Before fix: --env absorbed into args
hermes mcp add test --command npx --args -y @modelcontextprotocol/server-github --env TOKEN=abc
# -> config.yaml has args: [-y, @modelcontextprotocol/server-github, --env, TOKEN=abc]  (WRONG)

# After fix: --env properly extracted
hermes mcp add test --command npx --args -y @modelcontextprotocol/server-github --env TOKEN=abc
# -> config.yaml has args: [-y, @modelcontextprotocol/server-github], env: {TOKEN: abc}  (CORRECT)
```

Fixes #68944
