### PR TITLE
fix(desktop): remove orphaned composer queue entries after max drain attempts (#68895)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -93,6 +93,13 @@ export function useBackgroundQueueDrain({
         drainFailuresRef.current.set(entry.id, failures)
 
         if (failures >= MAX_AUTO_DRAIN_ATTEMPTS) {
+          // The entry is provably undrainable -- the session cannot be
+          // resolved to a runtime ID (never opened, or stale beyond
+          // migration).  Remove it so it doesn't trigger a permanent
+          // "Queued message not sent" notification on every restart.
+          removeQueuedPrompt(sessionKey, entry.id)
+          drainFailuresRef.current.delete(entry.id)
+
           notify({
             id: `composer-background-queue-stuck-${sessionKey}`,
             kind: 'error',


### PR DESCRIPTION
## Problem

Orphaned composer queue entries (for sessions never opened again) cause permanent "Queued message not sent" error notifications on every app restart. The entry can never drain because the stored session has no runtime ID mapping, and `removeQueuedPrompt` is only called on successful drain.

## Root Cause

In `use-background-queue-drain.ts`, the `onFail` handler shows a notification when `MAX_AUTO_DRAIN_ATTEMPTS` is reached but does NOT remove the orphaned entry. Since the entry persists in `localStorage`, the drain loop retries it on every restart, hitting the same failure path each time.

## Fix

After reaching `MAX_AUTO_DRAIN_ATTEMPTS`, remove the provably undrainable entry from the queue and clean up the failure counter. This prevents the permanent notification loop while still informing the user about the initial failure.

Fixes #68895
