### PR TITLE
fix(gateway): make adapter fatal-error handoff cancellation-proof; exit if a platform is stranded

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3328,6 +3328,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Key: Platform enum, Value: {"config": platform_config, "attempts": int, "next_retry": float}
         self._failed_platforms: Dict[Platform, Dict[str, Any]] = {}
 
+        # Strong refs to detached fatal-error handler tasks (see
+        # _handle_adapter_fatal_error) so the event loop can't GC them mid-run.
+        self._fatal_handler_tasks: set = set()
+
         # Track pending /update prompt responses per session.
         # Key: session_key, Value: True when a prompt is waiting for user input.
         self._update_prompt_pending: Dict[str, bool] = {}
@@ -4378,7 +4382,65 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         If the error is retryable (e.g. network blip, DNS failure), queue the
         platform for background reconnection instead of giving up permanently.
+
+        The notification arrives on the failing adapter's own polling task,
+        and the disconnect inside the handler can cancel that task mid-flight:
+        disconnect()'s current-task guard misses it because
+        _safe_adapter_disconnect runs the close in a wrapper task. A cancelled
+        handler dies between the fatal log and the reconnect queue, silently
+        stranding the platform (observed 2026-07-21: telegram popped from
+        adapters but never queued after a travel network outage). Run the real
+        work in a detached task that adapter teardown cannot cancel.
         """
+        tasks = getattr(self, "_fatal_handler_tasks", None)
+        if tasks is None:
+            tasks = self._fatal_handler_tasks = set()
+        task = asyncio.create_task(self._handle_adapter_fatal_error_detached(adapter))
+        tasks.add(task)
+        task.add_done_callback(tasks.discard)
+        # Await so callers that expect completion still get it — but through
+        # shield(): Task.cancel() on the caller also cancels the future it is
+        # awaiting (_fut_waiter), so a plain `await task` would tunnel the
+        # cancellation straight into the "detached" task. shield() absorbs
+        # it: the caller sees CancelledError, the handler runs to completion.
+        await asyncio.shield(task)
+
+    async def _handle_adapter_fatal_error_detached(
+        self, adapter: BasePlatformAdapter
+    ) -> None:
+        """Run the fatal handler; if the platform still ends up stranded
+        (not reconnected, not queued, not intentionally disabled), exit the
+        gateway with failure so the service manager restarts it instead of
+        leaving a silent partial outage."""
+        try:
+            await self._handle_adapter_fatal_error_impl(adapter)
+        except Exception:
+            logger.exception(
+                "Fatal-error handling for %s raised unexpectedly",
+                adapter.platform.value,
+            )
+        finally:
+            platform = adapter.platform
+            shutdown_event = getattr(self, "_shutdown_event", None)
+            stranded = (
+                adapter.fatal_error_retryable
+                and platform not in self.adapters
+                and platform not in getattr(self, "_failed_platforms", {})
+                and not (shutdown_event is not None and shutdown_event.is_set())
+            )
+            if stranded:
+                logger.error(
+                    "%s adapter was lost without entering the reconnection "
+                    "queue; exiting gateway so the service manager restarts it.",
+                    platform.value,
+                )
+                self._exit_reason = (
+                    f"{platform.value} adapter lost without reconnection queue"
+                )
+                self._exit_with_failure = True
+                await self.stop()
+
+    async def _handle_adapter_fatal_error_impl(self, adapter: BasePlatformAdapter) -> None:
         # Snapshot the current owner of this platform slot before doing
         # anything else. If it's neither this adapter nor empty, a different
         # adapter has already taken over (e.g. this is a delayed notification

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -949,3 +949,71 @@ class TestSpawnSupervised:
         # _MAX_SUPERVISED_RESTARTS + 1; the reset lets it run to completion.
         assert calls["n"] == target
         assert calls["n"] > runner._MAX_SUPERVISED_RESTARTS + 1
+
+
+class TestFatalHandoffCancellationProof:
+    """The fatal-error handoff must survive cancellation of the notifying
+    task, and a retryable platform must never be silently stranded."""
+
+    @pytest.mark.asyncio
+    async def test_caller_cancellation_does_not_strand_platform(self):
+        """The fatal notification arrives on the failing adapter's own
+        polling task, and adapter.disconnect() inside the handler can cancel
+        that task mid-teardown. The platform must still reach the reconnect
+        queue (previously the CancelledError killed the handler between the
+        fatal log and the queue, stranding the platform until a manual
+        restart)."""
+        runner = _make_runner()
+        runner.stop = AsyncMock()
+
+        adapter = StubAdapter(succeed=True)
+        adapter._set_fatal_error("network_error", "DNS failure", retryable=True)
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        release = asyncio.Event()
+
+        async def slow_disconnect():
+            await release.wait()
+
+        adapter.disconnect = slow_disconnect  # hold the handler mid-teardown
+
+        caller = asyncio.create_task(runner._handle_adapter_fatal_error(adapter))
+        for _ in range(5):
+            await asyncio.sleep(0)  # let the handler reach the disconnect await
+        caller.cancel()  # what disconnect() does to the notifying task
+        with pytest.raises(asyncio.CancelledError):
+            await caller
+        release.set()  # teardown completes after the caller has died
+
+        for _ in range(200):
+            if Platform.TELEGRAM in runner._failed_platforms:
+                break
+            await asyncio.sleep(0.01)
+        assert Platform.TELEGRAM in runner._failed_platforms
+
+    @pytest.mark.asyncio
+    async def test_stranded_retryable_platform_exits_for_supervisor_restart(self):
+        """If a retryable platform ends up neither reconnected nor queued
+        (e.g. its config entry is gone so queueing is skipped), the gateway
+        must exit with failure so launchd/systemd KeepAlive restarts it,
+        instead of running indefinitely with a dead platform while healthy
+        peers mask the loss (#68693)."""
+        runner = _make_runner()
+
+        async def _stop():
+            runner._shutdown_event.set()
+
+        runner.stop = AsyncMock(side_effect=_stop)
+        runner.config = GatewayConfig(platforms={})  # queueing impossible
+
+        adapter = StubAdapter(succeed=True)
+        adapter._set_fatal_error("network_error", "DNS failure", retryable=True)
+        runner.adapters[Platform.TELEGRAM] = adapter
+        # A healthy peer keeps self.adapters non-empty, so the existing
+        # "no platforms remain" shutdown branches do not fire.
+        runner.adapters[Platform.FEISHU] = StubAdapter(platform=Platform.FEISHU)
+
+        await runner._handle_adapter_fatal_error(adapter)
+
+        assert runner._exit_with_failure is True
+        assert runner.stop.await_count == 1


### PR DESCRIPTION
## What does this PR do?

Fixes the class of bug where an adapter's fatal-error handoff dies mid-flight and the gateway keeps running with a permanently dead platform.

The fatal-error notification (`_notify_fatal_error`) runs on the failing adapter's own polling task. Inside the handler, `_safe_adapter_disconnect` runs `adapter.disconnect()` in a wrapper task, so a disconnect implementation that cancels the adapter's tracked polling tasks misses its own `current_task` guard and cancels the very task that is running the handler. The `CancelledError` (a `BaseException`, so `_safe_adapter_disconnect`'s `except Exception` doesn't catch it) kills the handler between the "Fatal … adapter error" log line and the reconnect queue: the platform is popped from `self.adapters`, never queued into `_failed_platforms`, and the gateway runs on indefinitely with the platform dead until a manual restart.

#68447 fixed the telegram instance of this race at the adapter layer (releasing `_polling_error_task` ownership before notifying). This PR hardens the shared gateway dispatch so every platform gets the same protection — the same genus is reported for qqbot (#25505, #29005) and photon (#68693), and adapter authors shouldn't each have to rediscover the task-ownership dance.

Observed in production on macOS/launchd (polling mode): a travel/offline morning exhausted Telegram's network retries; the fatal log line appeared and then nothing — no "queued for background reconnection", no reconnect, no exit — for 4+ hours with the process alive, while WhatsApp kept working. A manual restart fixed it instantly.

Two layers:

1. `_handle_adapter_fatal_error` now runs the real handler in a detached task, awaited through `asyncio.shield()`. Callers keep completion semantics, but cancelling the calling task no longer kills recovery. (Plain `await task` is not enough: `Task.cancel()` also cancels the future the task is waiting on, tunneling the cancellation into the "detached" task — the new cancellation test catches exactly this.)
2. If a retryable platform still ends up neither reconnected nor queued (e.g. its config entry vanished so queueing was skipped, or a future regression of this race), the gateway exits with failure so launchd/systemd KeepAlive restarts it, instead of running indefinitely with a dead platform while healthy peers mask the loss. This is the behavior #68693 asks for, scoped narrowly: the existing "stay alive, the watcher will retry" design for *queued* platforms is unchanged.

## Related Issue

Fixes #68693
Refs #68406, #68447 (telegram-side fix for the same race)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — `_handle_adapter_fatal_error` split into a shielded-detached dispatch (`_handle_adapter_fatal_error_detached`) plus the original body (`_handle_adapter_fatal_error_impl`); new stranded-platform fallback exits with failure for supervisor restart.
- `tests/gateway/test_platform_reconnect.py` — two regression tests: caller cancellation must not strand the platform; a stranded retryable platform must trigger exit-with-failure even when other platforms are healthy.

## How to Test

1. `pytest tests/gateway/test_platform_reconnect.py tests/gateway/test_runner_fatal_adapter.py -q` — 45 passed (includes the 2 new tests).
2. The first new test reproduces the bug deterministically: it cancels the task awaiting the handler while `disconnect()` is in flight; on `main` without this patch the platform never reaches `_failed_platforms`.
3. Field reproduction (how this was found): run a telegram+whatsapp gateway in polling mode under launchd, make `api.telegram.org` unreachable until polling retries exhaust (10), restore network — without this patch telegram stays dead until a manual restart, matching the #68406 field report.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for existing PRs — #68447 fixes the telegram instance adapter-side; no PR covers the shared gateway dispatch or #68693
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/gateway -q`: 9,816 passed, 18 failed in my environment — the identical 18 tests fail on clean `main` in the same environment (verified by diffing sorted full-suite failure lists on patched vs. unpatched trees): zero regressions from this change
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), launchd KeepAlive deployment — the patch is running in production on my gateway since 2026-07-21
- [ ] Full-tree `pytest tests/ -q` not run — my venv is pinned to an older dependency snapshot; `tests/gateway` run in full as above

### Documentation & Housekeeping

- [x] Docstrings on the changed methods document the race and the recovery contract — no user-facing docs affected
- [x] No config keys added or changed — N/A
- [x] No architecture or workflow changes — N/A
- [x] Cross-platform: pure asyncio, no platform-specific APIs; the exit-for-restart fallback applies identically under systemd and launchd

🤖 Generated with [Claude Code](https://claude.com/claude-code)
