### PR TITLE
fix: distinguish kanban capacity backpressure from dispatcher stalls

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -876,6 +876,36 @@ try:
 except Exception:
     pass
 
+
+def _install_cli_asyncio_exception_filter() -> None:
+    """Install the CLI's benign-error filter on the active event loop.
+
+    This must run from prompt_toolkit's ``pre_run`` callback.  Before
+    ``Application.run()`` starts there is no running event loop, so attempting
+    to install the handler from the surrounding synchronous ``run()`` method
+    silently does nothing.
+    """
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    previous_handler = loop.get_exception_handler()
+
+    def _filter(loop, context):
+        exc = context.get("exception")
+        if isinstance(exc, RuntimeError) and "Event loop is closed" in str(exc):
+            return  # suppress benign httpx/httpcore shutdown race
+        if isinstance(exc, KeyError) and "is not registered" in str(exc):
+            return  # suppress selector registration failures (#6393)
+        if isinstance(exc, OSError) and getattr(exc, "errno", None) == errno.EIO:
+            return  # suppress I/O errors from broken stdout on interrupt (#13710)
+        if previous_handler is not None:
+            previous_handler(loop, context)
+        else:
+            loop.default_exception_handler(context)
+
+    loop.set_exception_handler(_filter)
+
+
 from rich import box as rich_box
 from rich.console import Console
 from rich.markup import escape as _escape
@@ -15405,24 +15435,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception:
             pass  # Signal handlers may fail in restricted environments
         
-        # Install a custom asyncio exception handler that suppresses the
-        # "Event loop is closed" RuntimeError from httpx transport cleanup
-        # and the "0 is not registered" KeyError from broken stdin (#6393).
-        # The RuntimeError fix is defense-in-depth — the primary fix is
-        # neuter_async_httpx_del which disables __del__ entirely.  The
-        # KeyError fix handles macOS + uv-managed Python environments where
-        # fd 0 is not reliably available to the asyncio selector.
-        def _suppress_closed_loop_errors(loop, context):
-            exc = context.get("exception")
-            if isinstance(exc, RuntimeError) and "Event loop is closed" in str(exc):
-                return  # silently suppress
-            if isinstance(exc, KeyError) and "is not registered" in str(exc):
-                return  # suppress selector registration failures (#6393)
-            if isinstance(exc, OSError) and getattr(exc, "errno", None) == errno.EIO:
-                return  # suppress I/O errors from broken stdout on interrupt (#13710)
-            # Fall back to default handler for everything else
-            loop.default_exception_handler(context)
-
         # Validate stdin before launching prompt_toolkit — on macOS with
         # uv-managed Python, fd 0 can be invalid or unregisterable with the
         # asyncio selector, causing "KeyError: '0 is not registered'" (#6393).
@@ -15465,23 +15477,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Run the application with patch_stdout for proper output handling
         try:
             with patch_stdout():
-                # Set the custom handler on prompt_toolkit's event loop
-                try:
-                    import asyncio as _aio
-                    # Use get_running_loop() to avoid DeprecationWarning on
-                    # Python 3.10+ when called outside an async context.
-                    _loop = _aio.get_running_loop()
-                    _loop.set_exception_handler(_suppress_closed_loop_errors)
-                except RuntimeError:
-                    pass  # No running loop -- nothing to patch
-                except Exception:
-                    pass
                 # The app enables focus reporting + mouse tracking; record that
                 # so _run_cleanup resets them on exit (#36823).
                 _mark_tui_input_modes_active()
                 # Drive the petdex mascot animation (no-op when no pet enabled).
                 self._pet_start_anim()
-                app.run()
+                # prompt_toolkit creates/starts the asyncio loop inside run().
+                # Install our filter from pre_run, where get_running_loop()
+                # returns that live loop instead of failing silently.
+                app.run(pre_run=_install_cli_asyncio_exception_filter)
         except (EOFError, KeyboardInterrupt, BrokenPipeError):
             pass
         except (KeyError, OSError) as _stdin_err:

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -25,6 +25,30 @@ from agent.i18n import t
 logger = logging.getLogger("gateway.run")
 
 
+def _dispatcher_health_is_stuck(results, *, ready_boards: set[str]) -> bool:
+    """Return whether a zero-spawn tick represents unexplained starvation.
+
+    Capacity caps, per-profile caps, and a contended singleton lock are
+    intentional deferrals. They must not emit the operator-facing "dispatcher
+    stuck" warning, which is reserved for spawnable work that made no progress
+    for an unexplained reason.
+    """
+    if not ready_boards:
+        return False
+    result_by_board = dict(results or [])
+    for slug in ready_boards:
+        res = result_by_board.get(slug)
+        intentionally_deferred = res is not None and (
+            bool(getattr(res, "spawned", None))
+            or getattr(res, "skipped_global_capped", False)
+            or bool(getattr(res, "skipped_per_profile_capped", None))
+            or getattr(res, "skipped_locked", False)
+        )
+        if not intentionally_deferred:
+            return True
+    return False
+
+
 def _resolve_auto_decompose_settings(
     load_config: Callable[[], Any],
 ) -> "tuple[bool, int]":
@@ -1077,10 +1101,10 @@ class GatewayKanbanWatchersMixin:
                 out.append((slug, _tick_once_for_board(slug)))
             return out
 
-        def _ready_nonempty() -> bool:
-            """Cheap probe: is there at least one ready+assigned+unclaimed
-            task on ANY board whose assignee maps to a real Hermes profile
-            (i.e. one the dispatcher would actually spawn for)?
+        def _ready_board_slugs() -> set[str]:
+            """Return boards with ready+assigned+unclaimed work whose assignee
+            maps to a real Hermes profile (i.e. one the dispatcher would
+            actually spawn for).
 
             Tasks assigned to control-plane lanes (e.g. ``orion-cc``,
             ``orion-research``) are pulled by terminals via
@@ -1093,15 +1117,16 @@ class GatewayKanbanWatchersMixin:
                 boards = _kb.list_boards(include_archived=False)
             except Exception:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+            ready_boards: set[str] = set()
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
                 conn = None
                 try:
                     conn = _kb.connect(board=slug)
                     if _kb.has_spawnable_ready(conn):
-                        return True
-                    if _kb.has_spawnable_review(conn):
-                        return True
+                        ready_boards.add(slug)
+                    elif _kb.has_spawnable_review(conn):
+                        ready_boards.add(slug)
                 except Exception:
                     continue
                 finally:
@@ -1110,7 +1135,7 @@ class GatewayKanbanWatchersMixin:
                             conn.close()
                         except Exception:
                             pass
-            return False
+            return ready_boards
 
         # Auto-decompose: turn fresh triage tasks into ready workgraphs
         # before the dispatcher fans out workers. Gated by
@@ -1233,10 +1258,8 @@ class GatewayKanbanWatchersMixin:
                 if _ad_enabled:
                     await asyncio.to_thread(_auto_decompose_tick, _ad_per_tick)
                 results = await asyncio.to_thread(_tick_once)
-                any_spawned = False
                 for slug, res in (results or []):
                     if res is not None and getattr(res, "spawned", None):
-                        any_spawned = True
                         # Quiet by default — only log when something actually
                         # happened, so an idle gateway stays silent.
                         logger.info(
@@ -1250,9 +1273,11 @@ class GatewayKanbanWatchersMixin:
                             res.promoted,
                             len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
                         )
-                # Health telemetry (aggregate across boards)
-                ready_pending = await asyncio.to_thread(_ready_nonempty)
-                if ready_pending and not any_spawned:
+                # Health telemetry (correlate readiness and deferral per board)
+                ready_boards = await asyncio.to_thread(_ready_board_slugs)
+                if _dispatcher_health_is_stuck(
+                    results, ready_boards=ready_boards
+                ):
                     bad_ticks += 1
                 else:
                     bad_ticks = 0

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2347,6 +2347,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             ],
             "skipped_unassigned": res.skipped_unassigned,
             "skipped_nonspawnable": res.skipped_nonspawnable,
+            "skipped_global_capped": res.skipped_global_capped,
             "skipped_per_profile_capped": [
                 {"task_id": tid, "assignee": who, "current": current}
                 for (tid, who, current) in res.skipped_per_profile_capped
@@ -2379,6 +2380,8 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         )
     if res.skipped_unassigned:
         print(f"Skipped (unassigned): {', '.join(res.skipped_unassigned)}")
+    if res.skipped_global_capped:
+        print("Deferred (global dispatcher capacity reached)")
     if res.skipped_per_profile_capped:
         for tid, who, current in res.skipped_per_profile_capped:
             print(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6413,6 +6413,11 @@ class DispatchResult:
     DB writes this tick — the lock holder is making progress on the same
     board. This is the steady-state signal that a single-writer guard is
     actively preventing two dispatchers from racing on ``kanban.db``."""
+    skipped_global_capped: bool = False
+    """True when ready work was deliberately deferred because the board was
+    already at ``kanban.max_spawn`` or ``kanban.max_in_progress``. Appended to
+    preserve the positional constructor order of older ``DispatchResult``
+    fields. This is expected backpressure, not a dispatcher-health failure."""
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -7919,7 +7924,7 @@ def _dispatch_once_locked(
     # they sit in status='running' until the worker calls
     # kanban_complete/kanban_block (or the dispatcher TTL-reclaims them).
     running_count = 0
-    if max_spawn is not None:
+    if max_spawn is not None or max_in_progress is not None:
         running_count = int(
             conn.execute(
                 "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
@@ -7935,16 +7940,16 @@ def _dispatch_once_locked(
     # tasks, skip spawning this tick so slow workers (local LLMs,
     # resource-constrained hosts) can finish what they have before more tasks
     # pile up and time out.
-    if max_in_progress is not None and ready_rows:
-        in_progress = conn.execute(
-            "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
-        ).fetchone()[0]
+    pending_spawnable = bool(ready_rows) or has_spawnable_review(conn)
+    if max_in_progress is not None and pending_spawnable:
+        in_progress = running_count
         if in_progress >= max_in_progress:
+            result.skipped_global_capped = True
             return result
-        # Only spawn enough to reach the cap, respecting max_spawn too.
-        remaining = max_in_progress - in_progress
-        if max_spawn is None or max_spawn > remaining:
-            max_spawn = remaining
+        # Both settings are total-concurrency caps. Keep the tighter total;
+        # the loops below already compare it against running_count + spawned.
+        if max_spawn is None or max_spawn > max_in_progress:
+            max_spawn = max_in_progress
     spawned = 0
     # Per-profile concurrency cap (#21582): when set, track how many
     # workers each assignee already has in flight, and refuse to spawn
@@ -7984,6 +7989,7 @@ def _dispatch_once_locked(
             _default_assignee_resolved = True
     for row in ready_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
+            result.skipped_global_capped = True
             break
         row_assignee = row["assignee"]
         if not row_assignee:
@@ -8175,6 +8181,7 @@ def _dispatch_once_locked(
     ).fetchall()
     for row in review_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
+            result.skipped_global_capped = True
             break
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])

--- a/tests/cli/test_cli_asyncio_exception_handler.py
+++ b/tests/cli/test_cli_asyncio_exception_handler.py
@@ -1,0 +1,41 @@
+import asyncio
+import inspect
+
+from cli import HermesCLI, _install_cli_asyncio_exception_filter
+
+
+def test_cli_exception_filter_installs_on_running_loop_and_suppresses_closed_loop():
+    delegated = []
+
+    def previous_handler(loop, context):
+        delegated.append(context)
+
+    async def scenario():
+        loop = asyncio.get_running_loop()
+        original_handler = loop.get_exception_handler()
+        try:
+            loop.set_exception_handler(previous_handler)
+            _install_cli_asyncio_exception_filter()
+
+            installed_handler = loop.get_exception_handler()
+            assert installed_handler is not None
+            assert installed_handler is not previous_handler
+
+            loop.call_exception_handler(
+                {"exception": RuntimeError("Event loop is closed")}
+            )
+            assert delegated == []
+
+            other_context = {"exception": ValueError("real failure")}
+            loop.call_exception_handler(other_context)
+            assert delegated == [other_context]
+        finally:
+            loop.set_exception_handler(original_handler)
+
+    asyncio.run(scenario())
+
+
+def test_cli_installs_exception_filter_after_prompt_toolkit_loop_starts():
+    source = inspect.getsource(HermesCLI.run)
+
+    assert "app.run(pre_run=_install_cli_asyncio_exception_filter)" in source

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 
 import inspect
 
-from gateway.kanban_watchers import GatewayKanbanWatchersMixin
+from gateway.kanban_watchers import (
+    GatewayKanbanWatchersMixin,
+    _dispatcher_health_is_stuck,
+)
+from hermes_cli.kanban_db import DispatchResult
 
 KANBAN_METHODS = [
     "_kanban_notifier_watcher",
@@ -67,3 +71,39 @@ def test_singleton_dispatcher_lock_is_exclusive(tmp_path):
     h3, st3 = _acquire_singleton_lock(lock)
     assert st3 == "held" and h3 is not None
     _release_singleton_lock(h3)
+
+
+def test_dispatcher_health_does_not_call_capacity_backpressure_stuck():
+    capped = DispatchResult(skipped_global_capped=True)
+
+    assert _dispatcher_health_is_stuck(
+        [("default", capped)], ready_boards={"default"}
+    ) is False
+
+
+def test_dispatcher_health_still_flags_unexplained_zero_spawn():
+    unexplained = DispatchResult()
+
+    assert _dispatcher_health_is_stuck(
+        [("default", unexplained)], ready_boards={"default"}
+    ) is True
+
+
+def test_dispatcher_health_does_not_hide_unexplained_board_behind_capped_board():
+    capped = DispatchResult(skipped_global_capped=True)
+    unexplained = DispatchResult()
+
+    assert _dispatcher_health_is_stuck(
+        [("capped", capped), ("broken", unexplained)],
+        ready_boards={"capped", "broken"},
+    ) is True
+
+
+def test_dispatcher_health_does_not_hide_unexplained_board_behind_active_board():
+    active = DispatchResult(spawned=[("t1", "default", "/tmp/work")])
+    unexplained = DispatchResult()
+
+    assert _dispatcher_health_is_stuck(
+        [("active", active), ("broken", unexplained)],
+        ready_boards={"active", "broken"},
+    ) is True

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -8,6 +8,7 @@ operator footgun that only manifests in long-running setups.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 import tempfile
@@ -92,6 +93,26 @@ def test_cli_max_flag_overrides_config_max_spawn(isolated_kanban_home, monkeypat
     assert captured.get("max_spawn") == 2, (
         f"CLI --max=2 must override config kanban.max_spawn=10; got {captured.get('max_spawn')!r}"
     )
+
+
+def test_cli_dispatch_json_exposes_global_capacity_deferral(
+    isolated_kanban_home, monkeypatch, capsys
+):
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"kanban": {}})
+    monkeypatch.setattr(
+        kanban_db,
+        "dispatch_once",
+        lambda conn, **kw: kanban_db.DispatchResult(skipped_global_capped=True),
+    )
+
+    args = argparse.Namespace(dry_run=True, max=None, failure_limit=2, json=True)
+    assert kb_cli._cmd_dispatch(args) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["skipped_global_capped"] is True
 
 
 def test_cli_invalid_max_in_progress_silently_disables(isolated_kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1766,8 +1766,66 @@ def test_dispatch_max_spawn_counts_existing_running_tasks(
         res = kb.dispatch_once(conn, spawn_fn=fake_spawn, max_spawn=2)
 
         assert res.spawned == []
+        assert res.skipped_global_capped is True
         assert spawns == []
         assert kb.get_task(conn, ready).status == "ready"
+
+
+def test_dispatch_result_appends_capacity_flag_without_shifting_existing_fields():
+    import dataclasses
+
+    names = [field.name for field in dataclasses.fields(kb.DispatchResult)]
+
+    assert names[-1] == "skipped_global_capped"
+
+
+def test_dispatch_max_in_progress_reports_capacity_deferral(
+    kanban_home, all_assignees_spawnable
+):
+    """A full configured worker pool is intentional backpressure, not a
+    dispatcher-health failure, so the result must expose that reason."""
+    with kb.connect() as conn:
+        running = kb.create_task(conn, title="running", assignee="alice")
+        ready = kb.create_task(conn, title="ready", assignee="bob")
+        kb.claim_task(conn, running)
+
+        res = kb.dispatch_once(conn, dry_run=True, max_in_progress=1)
+
+        assert res.spawned == []
+        assert res.skipped_global_capped is True
+        assert kb.get_task(conn, ready).status == "ready"
+
+
+def test_dispatch_max_spawn_reports_review_capacity_deferral(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        running = kb.create_task(conn, title="running", assignee="alice")
+        review = kb.create_task(conn, title="review", assignee="bob")
+        kb.claim_task(conn, running)
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (review,))
+
+        res = kb.dispatch_once(conn, dry_run=True, max_spawn=1)
+
+        assert res.spawned == []
+        assert res.skipped_global_capped is True
+        assert kb.get_task(conn, review).status == "review"
+
+
+def test_dispatch_max_in_progress_reports_review_capacity_deferral(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        running = kb.create_task(conn, title="running", assignee="alice")
+        review = kb.create_task(conn, title="review", assignee="bob")
+        kb.claim_task(conn, running)
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (review,))
+
+        res = kb.dispatch_once(conn, dry_run=True, max_in_progress=1)
+
+        assert res.spawned == []
+        assert res.skipped_global_capped is True
+        assert kb.get_task(conn, review).status == "review"
 
 
 def test_dispatch_max_spawn_fills_remaining_capacity(


### PR DESCRIPTION
## Summary
- report total-concurrency backpressure in `DispatchResult` and CLI output
- suppress false dispatcher-stuck warnings per board when work is intentionally deferred
- apply `max_in_progress` consistently to ready and review queues
- preserve detection when another board is genuinely stalled

## Verification
- `256 passed` across focused Kanban DB, per-profile cap, CLI dispatch, and gateway watcher suites
- independent final review: PASS, no blocking findings
- `git diff --check` passed

## Compatibility
- new `DispatchResult.skipped_global_capped` field is appended, preserving existing positional field order
- CLI JSON change is additive