### PR TITLE
fix(desktop): stop long-session transcript from drifting to old turns

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildGroups, firstVisibleGroupIndex, type MessageGroup } from './list'
+import { buildGroups, firstVisibleGroupIndex, isVirtualizedGroup, LIVE_TAIL_GROUPS, type MessageGroup } from './list'
 
 // Signature rows are `${index}:${id}:${role}:${weight}` (see the useAuiState
 // selector in list.tsx).
@@ -78,5 +78,35 @@ describe('firstVisibleGroupIndex', () => {
 
   it('returns groups.length for an empty list', () => {
     expect(firstVisibleGroupIndex([], 60)).toBe(0)
+  })
+})
+
+describe('isVirtualizedGroup', () => {
+  it('never virtualizes the newest turns (the live tail)', () => {
+    const count = 20
+
+    for (let i = count - LIVE_TAIL_GROUPS; i < count; i++) {
+      expect(isVirtualizedGroup(i, count)).toBe(false)
+    }
+  })
+
+  it('virtualizes older turns that sit before the live tail', () => {
+    const count = 20
+
+    expect(isVirtualizedGroup(0, count)).toBe(true)
+    expect(isVirtualizedGroup(count - LIVE_TAIL_GROUPS - 1, count)).toBe(true)
+  })
+
+  it('keeps every turn rendered when the whole transcript fits in the tail', () => {
+    const count = LIVE_TAIL_GROUPS
+
+    for (let i = 0; i < count; i++) {
+      expect(isVirtualizedGroup(i, count)).toBe(false)
+    }
+  })
+
+  it('honors a custom tail size', () => {
+    expect(isVirtualizedGroup(5, 10, 3)).toBe(true)
+    expect(isVirtualizedGroup(7, 10, 3)).toBe(false)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -113,6 +113,27 @@ export function firstVisibleGroupIndex(groups: readonly MessageGroup[], budget: 
   return firstVisible
 }
 
+// content-visibility:auto skips off-screen turns for perf, but with
+// contain-intrinsic-size:auto the browser only remembers a turn's size AFTER
+// it has rendered. A turn that finishes streaming near the bottom may have had
+// its (smaller) mid-stream size remembered; when it scrolls just off the top
+// edge and gets skipped, it snaps back to that stale height, shifting content
+// down. With overflow-anchor:none (the viewport can't self-correct) the
+// stick-to-bottom lock drifts and the view creeps up over older turns — the
+// "long session eventually shows old responses" glitch.
+//
+// Keep the newest N turns always-rendered so a turn is only ever virtualized
+// once its layout has settled at its final size (remembered == real → skipping
+// it changes no height). Off-screen OLDER turns still skip, so the dialog/popover
+// recalc win on long transcripts is preserved (that scales with the hundreds of
+// old turns, not this small live tail).
+export const LIVE_TAIL_GROUPS = 6
+
+/** True when a visible group is old enough to virtualize (outside the live tail). */
+export function isVirtualizedGroup(indexInVisible: number, visibleCount: number, liveTail = LIVE_TAIL_GROUPS): boolean {
+  return indexInVisible < visibleCount - liveTail
+}
+
 const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   clampToComposer,
   components,
@@ -359,7 +380,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
                 {t.assistant.thread.showEarlier}
               </button>
             )}
-            {visibleGroups.map(group => (
+            {visibleGroups.map((group, indexInVisible) => (
               // content-visibility:auto — off-screen turns skip style recalc,
               // layout, and paint. On a long transcript this is what keeps
               // UNRELATED UI fast: any dialog/popover mount (Radix Presence
@@ -370,8 +391,17 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
               // real size once rendered), so scrollbar/anchoring stay stable.
               // Sticky human bubbles are unaffected — their turn is rendered
               // whenever any part of it intersects the viewport.
+              //
+              // The live tail (newest turns) is exempt: virtualizing a turn
+              // whose final size hasn't been remembered yet snaps it to a stale
+              // height when it scrolls off, drifting stick-to-bottom up over old
+              // turns. See isVirtualizedGroup.
               <div
-                className="flex min-w-0 flex-col gap-(--conversation-turn-gap) pb-(--conversation-turn-gap) [contain-intrinsic-size:auto_37.5rem] [content-visibility:auto]"
+                className={cn(
+                  'flex min-w-0 flex-col gap-(--conversation-turn-gap) pb-(--conversation-turn-gap)',
+                  isVirtualizedGroup(indexInVisible, visibleGroups.length) &&
+                    '[contain-intrinsic-size:auto_37.5rem] [content-visibility:auto]'
+                )}
                 key={group.id}
               >
                 <MessageRenderBoundary resetKey={messageSignature}>


### PR DESCRIPTION
## Symptom

In a long-running desktop session, the transcript would **eventually drift up and show old responses** while idle/waiting — purely visual, no functional impact (the session worked end-to-end).

## Root cause

Regression from `9b8b054c2` ("off-screen turns skip rendering"), which added `content-visibility: auto` + `contain-intrinsic-size: auto 37.5rem` to every turn group in `list.tsx`.

`contain-intrinsic-size: auto` only *remembers* a turn's height **after it renders**. A turn that finished streaming near the bottom had its smaller mid-stream size remembered; when it later scrolled just off the top edge and `content-visibility` skipped it, it snapped back to that **stale smaller height**, shifting content down. Because the viewport uses `overflow-anchor: none` (so `use-stick-to-bottom` owns scrollTop), the browser can't self-correct — the bottom lock drifts and the view creeps up over older turns. The error is small per turn but accumulates over a long session, so it only shows up "eventually."

## This is a well-known `content-visibility` failure mode

Not Hermes-specific — it's the documented CLS/scroll-jump behavior of `content-visibility` + `contain-intrinsic-size` when the placeholder estimate differs from real height and the shift lands above the scroll position:

- MDN and the [browser-rendering guide](https://www.browser-rendering.com/layout-and-paint-optimization/content-visibility-and-rendering-subtrees/contain-intrinsic-size-and-scroll-anchoring/) describe it directly.
- Tencent's `Hy3-preview` chat [removed `content-visibility` entirely](https://huggingface.co/spaces/tencent/Hy3-preview/commit/594ccbb427b7dafa57f55f73f8e35716990c082e) for the identical reason ("scroll-anchoring does not reliably compensate for size changes triggered by content-visibility transitions"), and recommended, if re-adding: apply it **only to older rows**, with per-row *measured* intrinsic sizes rather than a fixed guess. This PR is the "only older rows" half of that.

## Fix

Exempt the newest turns (a small **live tail**) from virtualization, so a turn is only ever skipped **after its layout has settled at its final size** (remembered == real → skipping it changes no height). Off-screen *older* turns still skip, so the dialog/popover whole-document recalc win on long transcripts is fully preserved (it scales with the hundreds of old turns, not the small tail).

Extracted a pure, tested helper (`isVirtualizedGroup` + `LIVE_TAIL_GROUPS = 6`) rather than inlining the boundary.

## History worth knowing (a latent mismatch this sidesteps)

`overflow-anchor: none` on the viewport is a **leftover from the virtualizer era**. The transcript used to be a TanStack-Virtual component (`thread-virtualizer.tsx`, now deleted); `overflow-anchor: none` was added specifically for it in `e67ab2e04` / #37866 ("stop chat scroll jumping by disabling native scroll anchoring") so *only the virtualizer compensates*. Then `76b93869d` ("rebuild thread autoscroll on use-stick-to-bottom") replaced the virtualizer with the current `content-visibility` + `use-stick-to-bottom` list — **but left `overflow-anchor: none` behind.**

So the transcript now pairs `content-visibility` (which *relies on* scroll anchoring to smooth placeholder↔real deltas) with `overflow-anchor: none` (which *disables* it) — which is why we're more exposed to this than a typical app.

## Deeper alternatives (not done here; this PR is the minimal safe fix)

1. **Native scroll anchoring**: drop `overflow-anchor: none`, set `overflow-anchor: auto` on the viewport + `none` on children + a 1px bottom sentinel, and let the browser compensate for above-viewport size deltas. Precedent: [svelte-virtual-chat #55](https://github.com/humanspeak/svelte-virtual-chat/pull/55), [aura-os](https://github.com/cypher-asi/aura-os/commit/8879923f19844c12b1ab86b89c4dbca8a11f4ead).
2. **Back to an end-anchored virtualizer**: TanStack Virtual now has first-class chat support ([#1173](https://github.com/TanStack/virtual/pull/1173): `anchorTo: 'end'`, `followOnAppend`, `scrollToEnd`) — and the sidebar already uses `@tanstack/react-virtual`.

## Verification

- New unit tests for `isVirtualizedGroup` (live tail always rendered, older turns virtualized, short-transcript, custom tail) — `list.test.ts` 12/12.
- Full `thread/` suite: 56/56.
- `tsc` typecheck clean; eslint clean; prettier clean.

Note: jsdom has no real layout / `content-visibility`, so the scroll-drift itself can't be reproduced in a unit test — the helper boundary is tested; the visual fix needs a real long-session spin to confirm.