### PR TITLE
feat(kanban): persist canonical notification session routing

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -18,8 +18,6 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-from agent.i18n import t
-
 # Match the logger run.py uses (logging.getLogger(__name__) where __name__ ==
 # "gateway.run") so extracted log records keep their original logger name.
 logger = logging.getLogger("gateway.run")
@@ -112,6 +110,41 @@ def _release_singleton_lock(handle) -> None:
 class GatewayKanbanWatchersMixin:
     """Kanban watcher / notifier / dispatcher loops for GatewayRunner."""
 
+    def _kanban_notification_adapter_routes(
+        self, active_profile: str,
+    ) -> dict[str, Any]:
+        """Snapshot live adapters by their canonical profile/platform key."""
+        from gateway.session_context import canonical_notification_adapter_identity
+
+        routes: dict[str, Any] = {}
+        normalized_active = str(active_profile or "default").strip() or "default"
+        primary_adapters = getattr(self, "adapters", None) or {}
+        for platform in primary_adapters.keys():
+            adapter = primary_adapters.get(platform)
+            if adapter is None:
+                continue
+            platform_value = getattr(platform, "value", str(platform))
+            identity = canonical_notification_adapter_identity(
+                normalized_active, platform_value
+            )
+            if identity:
+                routes[identity] = adapter
+        for profile, adapters in (
+            getattr(self, "_profile_adapters", None) or {}
+        ).items():
+            profile_adapters = adapters or {}
+            for platform in profile_adapters.keys():
+                adapter = profile_adapters.get(platform)
+                if adapter is None:
+                    continue
+                platform_value = getattr(platform, "value", str(platform))
+                identity = canonical_notification_adapter_identity(
+                    profile, platform_value
+                )
+                if identity:
+                    routes[identity] = adapter
+        return routes
+
     async def _kanban_notifier_watcher(self, interval: float = 5.0) -> None:
         """Poll ``kanban_notify_subs`` and deliver terminal events to users.
 
@@ -198,11 +231,10 @@ class GatewayKanbanWatchersMixin:
             try:
                 def _collect():
                     deliveries: list[dict] = []
-                    active_platforms = {
-                        getattr(platform, "value", str(platform)).lower()
-                        for platform in self.adapters.keys()
-                    }
-                    if not active_platforms:
+                    live_routes = self._kanban_notification_adapter_routes(
+                        notifier_profile
+                    )
+                    if not live_routes:
                         logger.debug("kanban notifier: no connected adapters; skipping tick")
                         return deliveries
 
@@ -252,20 +284,23 @@ class GatewayKanbanWatchersMixin:
                             if not subs:
                                 logger.debug("kanban notifier: board %s has no subscriptions", slug)
                             for sub in subs:
-                                owner_profile = sub.get("notifier_profile") or None
-                                if owner_profile and owner_profile != notifier_profile:
-                                    _owner_adapters = getattr(self, "_profile_adapters", {}).get(owner_profile)
-                                    if not _owner_adapters:
-                                        logger.debug(
-                                            "kanban notifier: subscription for %s owned by profile %s; current profile %s has no adapter for it, skipping",
-                                            sub.get("task_id"), owner_profile, notifier_profile,
-                                        )
-                                        continue
                                 platform = (sub.get("platform") or "").lower()
-                                if platform not in active_platforms:
+                                owner_profile = (
+                                    str(sub.get("notifier_profile") or "").strip()
+                                    or notifier_profile
+                                )
+                                from gateway.session_context import (
+                                    canonical_notification_adapter_identity,
+                                )
+                                delivery_identity = (
+                                    canonical_notification_adapter_identity(
+                                        owner_profile, platform
+                                    )
+                                )
+                                if delivery_identity not in live_routes:
                                     logger.debug(
-                                        "kanban notifier: subscription for %s on %s skipped; adapter not connected",
-                                        sub.get("task_id"), platform or "<missing>",
+                                        "kanban notifier: subscription for %s on %s profile %s skipped; adapter not connected",
+                                        sub.get("task_id"), platform or "<missing>", owner_profile,
                                     )
                                     continue
                                 old_cursor, cursor, events = _kb.claim_unseen_events_for_sub(
@@ -302,7 +337,7 @@ class GatewayKanbanWatchersMixin:
                     board_slug = d.get("board")
                     platform_str = (sub["platform"] or "").lower()
                     try:
-                        plat = _Platform(platform_str)
+                        _Platform(platform_str)
                     except ValueError:
                         # Unknown platform string; skip and advance cursor so
                         # we don't replay forever.
@@ -311,16 +346,16 @@ class GatewayKanbanWatchersMixin:
                         )
                         continue
                     sub_profile = sub.get("notifier_profile") or ""
-                    # Route via the SAME chokepoint the authorization path uses
-                    # (gateway/authz_mixin.py::_authorization_adapter): a stamped
-                    # profile with its own adapter-registry entry must be served
-                    # by THAT profile's same-platform adapter and must NOT silently
-                    # fall back to the default profile's adapter — otherwise a
-                    # secondary profile's task notification is delivered by the
-                    # wrong bot (the cross-profile mis-delivery this whole change
-                    # exists to fix). The helper returns None only when the profile
-                    # (or default) genuinely has no adapter for the platform.
-                    adapter = self._authorization_adapter(plat, sub_profile or None)
+                    route_profile = str(sub_profile).strip() or notifier_profile
+                    from gateway.session_context import (
+                        canonical_notification_adapter_identity,
+                    )
+                    live_adapter_identity = canonical_notification_adapter_identity(
+                        route_profile, platform_str
+                    )
+                    adapter = self._kanban_notification_adapter_routes(
+                        notifier_profile
+                    ).get(live_adapter_identity)
                     if adapter is None:
                         logger.debug(
                             "kanban notifier: adapter %s disconnected before delivery for %s; rewinding claim",
@@ -402,8 +437,7 @@ class GatewayKanbanWatchersMixin:
                             # wedge a later completed/blocked event behind an
                             # unclaimed row) but are intentionally SILENT: an
                             # archive needs no user ping, and unblocked is an
-                            # internal transition. They are also excluded from
-                            # _WAKE_KINDS below, so they never wake the creator.
+                            # internal transition, so neither needs a user ping.
                             continue
                         metadata: dict[str, Any] = {}
                         if sub.get("thread_id"):
@@ -489,78 +523,6 @@ class GatewayKanbanWatchersMixin:
                         # same state. See the longer comment on TERMINAL_KINDS
                         # above for the failure mode this prevents.
                         task_terminal = task and task.status in {"done", "archived"}
-                        _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
-                        _wake_kinds = {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
-                        if _wake_kinds:
-                            try:
-                                _session_key = getattr(task, "session_id", None) or ""
-                                if _session_key:
-                                    _title = (task.title if task else sub["task_id"])[:120]
-                                    _assignee = task.assignee if task else ""
-                                    _parts = []
-                                    if "completed" in _wake_kinds: _parts.append(t("gateway.kanban.wake.completed"))
-                                    if "gave_up" in _wake_kinds: _parts.append(t("gateway.kanban.wake.gave_up"))
-                                    if "crashed" in _wake_kinds: _parts.append(t("gateway.kanban.wake.crashed"))
-                                    if "timed_out" in _wake_kinds: _parts.append(t("gateway.kanban.wake.timed_out"))
-                                    if "blocked" in _wake_kinds: _parts.append(t("gateway.kanban.wake.blocked"))
-                                    _status = t("gateway.kanban.wake.status_joiner").join(_parts) or t("gateway.kanban.wake.status_default")
-                                    _synth = t(
-                                        "gateway.kanban.wake.message",
-                                        task_id=sub["task_id"],
-                                        status=_status,
-                                        title=_title,
-                                        assignee=_assignee,
-                                        board=board_slug,
-                                    )
-                                    from gateway.session import SessionSource
-                                    from gateway.platforms.base import MessageEvent, MessageType
-                                    # KNOWN LIMITATION (tracked follow-up): the
-                                    # subscription row does not persist the
-                                    # creator's chat_type, and it is not carried
-                                    # on the session-context bridge, so we cannot
-                                    # faithfully reconstruct the creator's real
-                                    # session key here. build_session_key() keys
-                                    # DMs (":dm:<chat_id>") on a wholly different
-                                    # shape from group/thread, so any hardcoded
-                                    # value mis-routes some creators. "group" is
-                                    # the least-surprising default for the
-                                    # dashboard/group flows this wake primarily
-                                    # serves; DM-originated creators are handled
-                                    # by the follow-up that stamps + persists
-                                    # chat_type end-to-end. handle_message()
-                                    # get_or_create_session's the target, so a
-                                    # mismatch degrades to "wake lands in a fresh
-                                    # group session" — never an exception.
-                                    _source = SessionSource(
-                                        platform=plat,
-                                        chat_id=sub["chat_id"],
-                                        chat_type="group",
-                                        thread_id=sub.get("thread_id") or None,
-                                        user_id=sub.get("user_id"),
-                                        profile=sub_profile or None,
-                                    )
-                                    _synth_event = MessageEvent(
-                                        text=_synth,
-                                        message_type=MessageType.TEXT,
-                                        source=_source,
-                                        internal=True,
-                                    )
-                                    await adapter.handle_message(_synth_event)
-                                    logger.info(
-                                        "kanban notifier: woke agent for %s on %s/%s profile=%s events=%s",
-                                        sub["task_id"], platform_str, sub["chat_id"], sub_profile or "default", _wake_kinds,
-                                    )
-                            except Exception as _wk_err:
-                                # Best-effort: the notification itself already
-                                # delivered and the cursor has advanced, so a
-                                # broken wake path must not wedge the tick — but
-                                # log at WARNING with a traceback rather than
-                                # DEBUG so a persistently-failing wake is visible
-                                # in normal logs instead of silently no-op'ing.
-                                logger.warning(
-                                    "kanban notifier: wakeup injection failed for %s: %s",
-                                    sub["task_id"], _wk_err, exc_info=True,
-                                )
                         if task_terminal:
                             await asyncio.to_thread(
                                 self._kanban_unsub, sub, board_slug,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16421,7 +16421,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Returns a list of reset tokens; pass them to ``_clear_session_env``
         in a ``finally`` block.
         """
-        from gateway.session_context import set_session_vars
+        from gateway.session_context import (
+            canonical_notification_adapter_identity,
+            set_session_vars,
+        )
         # Propagate the adapter's async-delivery capability so async tools
         # (terminal notify_on_complete / watch_patterns, delegate_task
         # background=True) know whether this channel can wake a later turn.
@@ -16429,19 +16432,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # (api_server) declare supports_async_delivery=False. Use getattr so
         # bare runners built via object.__new__ (tests) without self.adapters
         # don't blow up — they simply default to supported.
-        _adapters = getattr(self, "adapters", None) or {}
-        _adapter = _adapters.get(context.source.platform)
+        _active_profile = self._active_profile_name()
+        _source_profile = str(getattr(context.source, "profile", "") or "").strip()
+        _route_profile = _source_profile or _active_profile
+        if _source_profile and _source_profile != _active_profile:
+            _adapter = (
+                (getattr(self, "_profile_adapters", None) or {})
+                .get(_source_profile, {})
+                .get(context.source.platform)
+            )
+        else:
+            _adapter = (getattr(self, "adapters", None) or {}).get(
+                context.source.platform
+            )
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
+        _adapter_identity = ""
+        if _adapter is not None:
+            _adapter_identity = canonical_notification_adapter_identity(
+                _route_profile, context.source.platform.value
+            )
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
             chat_name=context.source.chat_name or "",
+            chat_type=context.source.chat_type or "",
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
-            profile=getattr(context.source, "profile", "") or "",
+            profile=_route_profile,
+            adapter_identity=_adapter_identity,
             async_delivery=_async_delivery,
         )
 

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -74,6 +74,7 @@ _SESSION_PLATFORM: ContextVar = ContextVar("HERMES_SESSION_PLATFORM", default=_U
 _SESSION_SOURCE: ContextVar = ContextVar("HERMES_SESSION_SOURCE", default=_UNSET)
 _SESSION_CHAT_ID: ContextVar = ContextVar("HERMES_SESSION_CHAT_ID", default=_UNSET)
 _SESSION_CHAT_NAME: ContextVar = ContextVar("HERMES_SESSION_CHAT_NAME", default=_UNSET)
+_SESSION_CHAT_TYPE: ContextVar = ContextVar("HERMES_SESSION_CHAT_TYPE", default=_UNSET)
 _SESSION_THREAD_ID: ContextVar = ContextVar("HERMES_SESSION_THREAD_ID", default=_UNSET)
 _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNSET)
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
@@ -92,6 +93,9 @@ _SESSION_UI_SESSION_ID: ContextVar = ContextVar("HERMES_UI_SESSION_ID", default=
 _SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
 
 _SESSION_PROFILE: ContextVar = ContextVar("HERMES_SESSION_PROFILE", default=_UNSET)
+_SESSION_ADAPTER_IDENTITY: ContextVar = ContextVar(
+    "HERMES_SESSION_ADAPTER_IDENTITY", default=_UNSET
+)
 
 # Whether the current session's delivery channel can route an ASYNC completion
 # back to the agent AFTER the current turn ends (i.e. wake a fresh turn).
@@ -125,6 +129,7 @@ _VAR_MAP = {
     "HERMES_SESSION_SOURCE": _SESSION_SOURCE,
     "HERMES_SESSION_CHAT_ID": _SESSION_CHAT_ID,
     "HERMES_SESSION_CHAT_NAME": _SESSION_CHAT_NAME,
+    "HERMES_SESSION_CHAT_TYPE": _SESSION_CHAT_TYPE,
     "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
     "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
@@ -133,6 +138,7 @@ _VAR_MAP = {
     "HERMES_UI_SESSION_ID": _SESSION_UI_SESSION_ID,
     "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
     "HERMES_SESSION_PROFILE": _SESSION_PROFILE,
+    "HERMES_SESSION_ADAPTER_IDENTITY": _SESSION_ADAPTER_IDENTITY,
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
     "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,
@@ -169,6 +175,8 @@ def set_session_vars(
     cwd: str = "",
     async_delivery: bool = True,
     ui_session_id: str = "",
+    chat_type: str = "",
+    adapter_identity: str = "",
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -195,6 +203,7 @@ def set_session_vars(
         _SESSION_SOURCE.set(source),
         _SESSION_CHAT_ID.set(chat_id),
         _SESSION_CHAT_NAME.set(chat_name),
+        _SESSION_CHAT_TYPE.set(chat_type),
         _SESSION_THREAD_ID.set(thread_id),
         _SESSION_USER_ID.set(user_id),
         _SESSION_USER_NAME.set(user_name),
@@ -203,6 +212,7 @@ def set_session_vars(
         _SESSION_UI_SESSION_ID.set(ui_session_id),
         _SESSION_MESSAGE_ID.set(message_id),
         _SESSION_PROFILE.set(profile),
+        _SESSION_ADAPTER_IDENTITY.set(adapter_identity),
         _SESSION_ASYNC_DELIVERY.set(bool(async_delivery)),
     ]
     try:
@@ -230,6 +240,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_SOURCE,
         _SESSION_CHAT_ID,
         _SESSION_CHAT_NAME,
+        _SESSION_CHAT_TYPE,
         _SESSION_THREAD_ID,
         _SESSION_USER_ID,
         _SESSION_USER_NAME,
@@ -238,6 +249,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_UI_SESSION_ID,
         _SESSION_MESSAGE_ID,
         _SESSION_PROFILE,
+        _SESSION_ADAPTER_IDENTITY,
     ):
         var.set("")
     # Reset async-delivery capability to the "never set" sentinel rather than a
@@ -325,6 +337,20 @@ def get_session_env(name: str, default: str = "") -> str:
             return value
     # Fall back to os.environ for CLI, cron, and test compatibility
     return os.getenv(name, default)
+
+
+def canonical_notification_adapter_identity(profile: str, platform: str) -> str:
+    """Return the stable, non-secret registry route key for an adapter.
+
+    The identity intentionally contains only the normalized profile/platform
+    registry coordinates. It never includes adapter class names, credentials,
+    or credential fingerprints.
+    """
+    normalized_profile = str(profile or "").strip().lower()
+    normalized_platform = str(platform or "").strip().lower()
+    if not normalized_profile or not normalized_platform:
+        return ""
+    return f"profile:{normalized_profile}|platform:{normalized_platform}"
 
 
 def declare_stateless_channel() -> None:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -481,6 +481,60 @@ class GatewaySlashCommandsMixin:
                     thread_id = str(getattr(source, "thread_id", "") or "")
                     user_id = str(getattr(source, "user_id", "") or "") or None
                     if platform_str and chat_id:
+                        canonical_route: dict[str, str] = {}
+                        try:
+                            session_entry = (
+                                await self.async_session_store.get_or_create_session(
+                                    source
+                                )
+                            )
+                            canonical_session_key = str(
+                                getattr(session_entry, "session_key", "") or ""
+                            ).strip()
+                            active_profile = (
+                                getattr(self, "_kanban_notifier_profile", None)
+                                or self._active_profile_name()
+                            )
+                            route_profile = str(
+                                getattr(source, "profile", None)
+                                or active_profile
+                                or "default"
+                            ).strip()
+                            from gateway.session_context import (
+                                canonical_notification_adapter_identity,
+                            )
+                            adapter_identity = (
+                                canonical_notification_adapter_identity(
+                                    route_profile, platform_str
+                                )
+                            )
+                            live_routes = self._kanban_notification_adapter_routes(
+                                active_profile
+                            )
+                            chat_type = str(
+                                getattr(source, "chat_type", "") or ""
+                            ).strip()
+                            if (
+                                canonical_session_key
+                                and chat_type
+                                and adapter_identity in live_routes
+                            ):
+                                canonical_route = {
+                                    "canonical_session_key": canonical_session_key,
+                                    "chat_type": chat_type,
+                                    "notifier_profile": route_profile,
+                                    "adapter_identity": adapter_identity,
+                                }
+                        except Exception:
+                            # A slash-created task still keeps its visible
+                            # notification subscription. Without a verified
+                            # SessionEntry/live adapter route it remains
+                            # deliberately notify-only.
+                            logger.debug(
+                                "kanban create: canonical notification route unavailable",
+                                exc_info=True,
+                            )
+
                         def _sub():
                             from hermes_cli import kanban_db as _kb
                             conn = _kb.connect(board=requested_board)
@@ -490,7 +544,18 @@ class GatewaySlashCommandsMixin:
                                     platform=platform_str, chat_id=chat_id,
                                     thread_id=thread_id or None,
                                     user_id=user_id,
-                                    notifier_profile=getattr(self, "_kanban_notifier_profile", None) or self._active_profile_name(),
+                                    notifier_profile=(
+                                        canonical_route.get("notifier_profile")
+                                        or getattr(self, "_kanban_notifier_profile", None)
+                                        or self._active_profile_name()
+                                    ),
+                                    canonical_session_key=canonical_route.get(
+                                        "canonical_session_key"
+                                    ),
+                                    chat_type=canonical_route.get("chat_type"),
+                                    adapter_identity=canonical_route.get(
+                                        "adapter_identity"
+                                    ),
                                 )
                             finally:
                                 conn.close()

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1259,6 +1259,9 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     thread_id     TEXT NOT NULL DEFAULT '',
     user_id       TEXT,
     notifier_profile TEXT,
+    canonical_session_key TEXT,
+    chat_type     TEXT,
+    adapter_identity TEXT,
     created_at    INTEGER NOT NULL,
     last_event_id INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
@@ -2357,10 +2360,15 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         notify_cols = {
             row["name"] for row in conn.execute("PRAGMA table_info(kanban_notify_subs)")
         }
-        if "notifier_profile" not in notify_cols:
-            _add_column_if_missing(
-                conn, "kanban_notify_subs", "notifier_profile", "notifier_profile TEXT"
-            )
+        notify_additive_columns = {
+            "notifier_profile": "notifier_profile TEXT",
+            "canonical_session_key": "canonical_session_key TEXT",
+            "chat_type": "chat_type TEXT",
+            "adapter_identity": "adapter_identity TEXT",
+        }
+        for column, ddl in notify_additive_columns.items():
+            if column not in notify_cols:
+                _add_column_if_missing(conn, "kanban_notify_subs", column, ddl)
 
     # One-shot backfill: any task that is 'running' before runs existed
     # had its claim_lock / claim_expires / worker_pid on the task row.
@@ -2484,7 +2492,8 @@ _REBUILD_SPECS = {
         "CREATE TABLE kanban_notify_subs ("
         " task_id TEXT NOT NULL, platform TEXT NOT NULL, chat_id TEXT NOT NULL,"
         " thread_id TEXT NOT NULL DEFAULT '', user_id TEXT,"
-        " notifier_profile TEXT, created_at INTEGER NOT NULL,"
+        " notifier_profile TEXT, canonical_session_key TEXT, chat_type TEXT,"
+        " adapter_identity TEXT, created_at INTEGER NOT NULL,"
         " last_event_id INTEGER NOT NULL DEFAULT 0,"
         " PRIMARY KEY (task_id, platform, chat_id, thread_id))",
         ("CREATE INDEX idx_notify_task ON kanban_notify_subs(task_id)",),
@@ -9103,6 +9112,9 @@ def add_notify_sub(
     thread_id: Optional[str] = None,
     user_id: Optional[str] = None,
     notifier_profile: Optional[str] = None,
+    canonical_session_key: Optional[str] = None,
+    chat_type: Optional[str] = None,
+    adapter_identity: Optional[str] = None,
 ) -> None:
     """Register a gateway source that wants terminal-state notifications
     for ``task_id``. Idempotent on (task, platform, chat, thread)."""
@@ -9111,12 +9123,47 @@ def add_notify_sub(
         conn.execute(
             """
             INSERT OR IGNORE INTO kanban_notify_subs
-                (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+                (task_id, platform, chat_id, thread_id, user_id, notifier_profile,
+                 canonical_session_key, chat_type, adapter_identity,
+                 created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (task_id, platform, chat_id, thread_id or "", user_id, notifier_profile, now),
+            (
+                task_id, platform, chat_id, thread_id or "", user_id,
+                notifier_profile, canonical_session_key, chat_type,
+                adapter_identity, now,
+            ),
         )
-        if notifier_profile:
+        trusted_route = all(
+            str(value or "").strip()
+            for value in (
+                canonical_session_key,
+                platform,
+                chat_type,
+                notifier_profile,
+                adapter_identity,
+            )
+        )
+        if trusted_route:
+            # Upgrade an existing legacy row only when every canonical routing
+            # field came from the live gateway session context. Updating the
+            # fields together prevents a partial migration from being treated
+            # as a canonical route.
+            conn.execute(
+                """
+                UPDATE kanban_notify_subs
+                   SET user_id = ?, notifier_profile = ?,
+                       canonical_session_key = ?, chat_type = ?,
+                       adapter_identity = ?
+                 WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
+                """,
+                (
+                    user_id, notifier_profile, canonical_session_key, chat_type,
+                    adapter_identity, task_id, platform, chat_id,
+                    thread_id or "",
+                ),
+            )
+        elif notifier_profile:
             # Self-heal legacy rows that predate notifier ownership by
             # backfilling only when the existing value is unset.
             conn.execute(

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -1,18 +1,24 @@
 import asyncio
 from pathlib import Path
 
+import pytest
 
-from gateway.config import Platform
+from gateway.config import GatewayConfig, Platform
 from gateway.run import GatewayRunner
+from gateway.session import SessionSource, SessionStore, build_session_key
 from hermes_cli import kanban_db as kb
 
 
 class RecordingAdapter:
     def __init__(self):
         self.sent = []
+        self.handled = []
 
     async def send(self, chat_id, text, metadata=None):
         self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+    async def handle_message(self, event):
+        self.handled.append(event)
 
 
 class DisconnectedAdapters(dict):
@@ -39,8 +45,64 @@ def _make_runner(adapter):
     runner = GatewayRunner.__new__(GatewayRunner)
     runner._running = True
     runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._profile_adapters = {}
+    runner._kanban_notifier_profile = "default"
     runner._kanban_sub_fail_counts = {}
     return runner
+
+
+def _store_with_live_session(tmp_path, source):
+    store = SessionStore(
+        sessions_dir=tmp_path / "sessions",
+        config=GatewayConfig(),
+    )
+    store.get_or_create_session(source)
+    return store
+
+
+def _create_routed_completed_subscription(
+    *,
+    chat_id,
+    chat_type,
+    thread_id=None,
+    user_id=None,
+    profile="default",
+    adapter_identity=None,
+    canonical_session_key=None,
+):
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        thread_id=thread_id,
+        user_id=user_id,
+        profile=profile if profile != "default" else None,
+    )
+    session_key = canonical_session_key or build_session_key(
+        source, profile=profile if profile != "default" else None
+    )
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="canonical route", assignee="worker")
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id=chat_id,
+            thread_id=thread_id,
+            user_id=user_id,
+            notifier_profile=profile,
+            canonical_session_key=session_key,
+            chat_type=chat_type,
+            adapter_identity=(
+                adapter_identity
+                or f"profile:{profile}|platform:telegram"
+            ),
+        )
+        kb.complete_task(conn, tid, summary="done")
+        return tid, session_key
+    finally:
+        conn.close()
 
 
 def _create_completed_subscription(summary="done once"):
@@ -119,6 +181,158 @@ def test_kanban_notifier_rewinds_claim_if_adapter_disconnects(tmp_path, monkeypa
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
     assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"]
+
+
+def test_legacy_subscription_delivers_notification_but_never_wakes_agent(
+    tmp_path, monkeypatch,
+):
+    """Delivery coordinates from an old row are not a trusted session route."""
+    db_path = tmp_path / "legacy-notify-only.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="legacy route",
+            assignee="worker",
+            session_id="agent:main:telegram:dm:legacy-chat",
+        )
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="legacy-chat"
+        )
+        kb.complete_task(conn, tid, summary="done")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 1
+    assert adapter.handled == []
+
+
+@pytest.mark.parametrize(
+    ("chat_id", "chat_type", "thread_id", "user_id"),
+    [
+        ("dm-1", "dm", None, "user-1"),
+        ("group-1", "group", None, "user-1"),
+        ("channel-1", "thread", "thread-7", "user-1"),
+    ],
+    ids=["dm", "group", "thread"],
+)
+def test_canonical_subscription_delivers_but_never_wakes_dm_group_or_thread(
+    tmp_path, monkeypatch, chat_id, chat_type, thread_id, user_id,
+):
+    db_path = tmp_path / f"canonical-{chat_type}.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    _create_routed_completed_subscription(
+        chat_id=chat_id,
+        chat_type=chat_type,
+        thread_id=thread_id,
+        user_id=user_id,
+    )
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner.session_store = _store_with_live_session(
+        tmp_path,
+        SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=chat_id,
+            chat_type=chat_type,
+            thread_id=thread_id,
+            user_id=user_id,
+        ),
+    )
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["chat_id"] == chat_id
+    expected_metadata = {"thread_id": thread_id} if thread_id else {}
+    assert adapter.sent[0]["metadata"] == expected_metadata
+    assert adapter.handled == []
+
+
+def test_mismatched_canonical_metadata_remains_notification_only(
+    tmp_path, monkeypatch,
+):
+    db_path = tmp_path / "adapter-identity-mismatch.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    _create_routed_completed_subscription(
+        chat_id="chat-1",
+        chat_type="dm",
+        user_id="user-1",
+        adapter_identity="profile:other|platform:telegram",
+    )
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 1
+    assert adapter.handled == []
+
+
+def test_secondary_only_adapter_is_enumerated_and_routes_by_canonical_identity(
+    tmp_path, monkeypatch,
+):
+    db_path = tmp_path / "secondary-only.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    _create_routed_completed_subscription(
+        chat_id="beta-chat",
+        chat_type="group",
+        user_id="beta-user",
+        profile="beta",
+    )
+
+    adapter = RecordingAdapter()
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {}
+    runner._profile_adapters = {"beta": {Platform.TELEGRAM: adapter}}
+    runner._kanban_notifier_profile = "default"
+    runner._kanban_sub_fail_counts = {}
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert adapter.handled == []
+
+
+def test_default_secondary_adapter_routes_when_active_profile_is_named(
+    tmp_path, monkeypatch,
+):
+    """The active named profile must not receive default-profile deliveries."""
+    db_path = tmp_path / "active-named-default-secondary.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    _create_routed_completed_subscription(
+        chat_id="default-chat",
+        chat_type="group",
+        user_id="default-user",
+        profile="default",
+    )
+
+    active_adapter = RecordingAdapter()
+    default_adapter = RecordingAdapter()
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.TELEGRAM: active_adapter}
+    runner._profile_adapters = {
+        "default": {Platform.TELEGRAM: default_adapter},
+    }
+    runner._kanban_notifier_profile = "alpha"
+    runner._kanban_sub_fail_counts = {}
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(default_adapter.sent) == 1
+    assert default_adapter.handled == []
+    assert active_adapter.sent == []
+    assert active_adapter.handled == []
 
 
 def test_kanban_db_path_is_test_isolated_from_real_home():
@@ -238,15 +452,10 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
 def test_notifier_owning_profile_adapter_no_default_fallback(tmp_path, monkeypatch):
     """A subscription owned by a secondary profile whose profile-adapter
     registry entry EXISTS but lacks this platform must NOT fall back to the
-    default profile's same-platform adapter — the notifier must route through
-    the shared ``_authorization_adapter`` chokepoint, which forbids that
-    fallback (gateway/authz_mixin.py). Delivering via the default profile's bot
-    is the exact cross-profile mis-delivery this whole change exists to fix
-    (`[230002] Bot can NOT be out of the chat`).
+    active profile's same-platform adapter. Delivering via that adapter would
+    send through the wrong bot.
 
-    Mutation check: reverting kanban_watchers.py's adapter selection to the old
-    inline ``if adapter is None: adapter = self.adapters.get(plat)`` fallback
-    makes this test FAIL (the default adapter receives the delivery).
+    The canonical profile/platform route lookup must fail closed instead.
     """
     db_path = tmp_path / "profile-no-fallback.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -244,6 +244,38 @@ def test_set_session_env_includes_session_key():
     assert get_session_env("HERMES_SESSION_KEY") != "tg:-1001:17585"
 
 
+def test_set_session_env_stamps_canonical_notification_route_for_secondary_profile():
+    """The gateway, not a tool subprocess, owns the trusted adapter route key."""
+    runner = object.__new__(GatewayRunner)
+    adapter = object()
+    runner.adapters = {}
+    runner._profile_adapters = {"beta": {Platform.TELEGRAM: adapter}}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="group-42",
+        chat_type="thread",
+        thread_id="topic-7",
+        profile="beta",
+    )
+    context = SessionContext(
+        source=source,
+        connected_platforms=[],
+        home_channels={},
+        session_key="agent:beta:telegram:thread:group-42:topic-7",
+    )
+
+    tokens = runner._set_session_env(context)
+    try:
+        assert get_session_env("HERMES_SESSION_CHAT_TYPE") == "thread"
+        assert get_session_env("HERMES_SESSION_PROFILE") == "beta"
+        assert (
+            get_session_env("HERMES_SESSION_ADAPTER_IDENTITY")
+            == "profile:beta|platform:telegram"
+        )
+    finally:
+        runner._clear_session_env(tokens)
+
+
 def test_session_key_no_race_condition_with_contextvars(monkeypatch):
     """Prove contextvars isolates SESSION_KEY across concurrent async tasks.
 
@@ -393,4 +425,3 @@ async def test_gateway_executor_refuses_resurrection_after_shutdown():
             await runner._run_in_executor_with_context(lambda: "second")
     finally:
         runner._shutdown_executor()
-

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -115,13 +115,24 @@ def test_legacy_text_pk_tables_rebuilt_to_integer_autoincrement(tmp_path, monkey
 
         lei = {r["name"]: r for r in conn.execute("PRAGMA table_info(kanban_notify_subs)")}
         assert lei["last_event_id"]["type"].upper() == "INTEGER"
+        assert {
+            "canonical_session_key",
+            "chat_type",
+            "adapter_identity",
+        }.issubset(lei)
 
         # Data preserved across the rebuild.
         assert len(conn.execute("SELECT * FROM task_events").fetchall()) == 2
         assert conn.execute("SELECT body FROM task_comments").fetchone()["body"] == "hi"
         assert len(conn.execute("SELECT * FROM task_runs").fetchall()) == 1
         # Non-numeric legacy cursor ("e-1") casts to 0.
-        assert conn.execute("SELECT last_event_id FROM kanban_notify_subs").fetchone()["last_event_id"] == 0
+        migrated_sub = conn.execute(
+            "SELECT * FROM kanban_notify_subs"
+        ).fetchone()
+        assert migrated_sub["last_event_id"] == 0
+        assert migrated_sub["canonical_session_key"] is None
+        assert migrated_sub["chat_type"] is None
+        assert migrated_sub["adapter_identity"] is None
 
         # Indexes restored, including idx_events_run (added by the additive pass).
         indexes = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='index'")}
@@ -161,6 +172,64 @@ def test_migration_is_idempotent(tmp_path, monkeypatch):
         id_col = {r["name"]: r for r in conn.execute("PRAGMA table_info(task_events)")}["id"]
         assert id_col["type"].upper() == "INTEGER"
         assert len(conn.execute("SELECT * FROM task_events").fetchall()) == 2
+
+
+def test_partial_notify_routing_schema_is_completed_without_trusting_legacy_row(
+    tmp_path, monkeypatch,
+):
+    """A partially migrated subscription table gains every routing column.
+
+    Existing rows stay explicitly untrusted: migration cannot infer a canonical
+    session, chat type, or adapter registry identity from delivery coordinates.
+    """
+    db_path = _setup_home(tmp_path, monkeypatch)
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(kb.SCHEMA_SQL)
+    conn.executescript(
+        """
+        DROP TABLE kanban_notify_subs;
+        CREATE TABLE kanban_notify_subs (
+            task_id TEXT NOT NULL,
+            platform TEXT NOT NULL,
+            chat_id TEXT NOT NULL,
+            thread_id TEXT NOT NULL DEFAULT '',
+            user_id TEXT,
+            notifier_profile TEXT,
+            canonical_session_key TEXT,
+            created_at INTEGER NOT NULL,
+            last_event_id INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (task_id, platform, chat_id, thread_id)
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at) "
+        "VALUES ('task-1', 'T', 'ready', 1000)"
+    )
+    conn.execute(
+        "INSERT INTO kanban_notify_subs "
+        "(task_id, platform, chat_id, created_at) "
+        "VALUES ('task-1', 'telegram', 'legacy-chat', 1000)"
+    )
+    conn.commit()
+    conn.close()
+
+    with kb.connect(db_path) as migrated:
+        columns = {
+            row["name"]
+            for row in migrated.execute("PRAGMA table_info(kanban_notify_subs)")
+        }
+        assert {
+            "canonical_session_key",
+            "chat_type",
+            "adapter_identity",
+        }.issubset(columns)
+        row = migrated.execute(
+            "SELECT * FROM kanban_notify_subs WHERE task_id = 'task-1'"
+        ).fetchone()
+        assert row["canonical_session_key"] is None
+        assert row["chat_type"] is None
+        assert row["adapter_identity"] is None
 
 
 def test_unseen_events_for_sub_survives_migrated_db(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -481,12 +481,64 @@ async def test_gateway_create_autosubscribes_on_explicit_board(kanban_home):
     assert len(subs) == 1
     assert subs[0]["chat_id"] == "chat1"
     assert subs[0]["thread_id"] == "th1"
+    assert subs[0]["canonical_session_key"] is None
+    assert subs[0]["chat_type"] is None
+    assert subs[0]["adapter_identity"] is None
 
     conn = kb.connect(board="default")
     try:
         assert kb.list_notify_subs(conn) == []
     finally:
         conn.close()
+
+
+@pytest.mark.asyncio
+async def test_gateway_create_persists_trusted_canonical_session_route(kanban_home):
+    """Slash auto-subscribe stamps routing only after a real SessionEntry lookup."""
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource, build_session_key
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-trusted",
+        chat_type="thread",
+        thread_id="topic-9",
+        user_id="user-3",
+        profile="beta",
+    )
+    expected_key = build_session_key(source, profile="beta")
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._profile_adapters = {"beta": {Platform.TELEGRAM: object()}}
+    runner._kanban_notifier_profile = "default"
+    runner.session_store = SimpleNamespace(
+        get_or_create_session=lambda _source: SimpleNamespace(
+            session_key=expected_key
+        ),
+    )
+    event = SimpleNamespace(
+        text='/kanban create "trusted route" --assignee alice',
+        source=source,
+    )
+
+    out = await GatewayRunner._handle_kanban_command(runner, event)
+
+    assert "subscribed" in out.lower()
+    conn = kb.connect()
+    try:
+        task = next(t for t in kb.list_tasks(conn) if t.title == "trusted route")
+        sub = kb.list_notify_subs(conn, task.id)[0]
+    finally:
+        conn.close()
+    assert sub["canonical_session_key"] == expected_key
+    assert sub["chat_type"] == "thread"
+    assert sub["thread_id"] == "topic-9"
+    assert sub["notifier_profile"] == "beta"
+    assert (
+        sub["adapter_identity"]
+        == "profile:beta|platform:telegram"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1778,6 +1778,13 @@ def test_home_subscribe_creates_notify_sub_row(client, with_home_channels):
     assert subs[0]["chat_id"] == "1234567"
     assert subs[0]["thread_id"] == "42"
     assert subs[0]["notifier_profile"] == "default"
+    # A configured home is a delivery target, not proof of an existing
+    # canonical conversation. Dashboard subscriptions therefore stay
+    # notify-only unless a future authenticated request supplies a trusted
+    # session route end to end.
+    assert subs[0]["canonical_session_key"] is None
+    assert subs[0]["chat_type"] is None
+    assert subs[0]["adapter_identity"] is None
 
 
 def test_home_subscribe_flips_subscribed_flag_in_subsequent_get(client, with_home_channels):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -2149,6 +2149,15 @@ def test_create_subscribes_gateway_session(monkeypatch, worker_env):
     monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-42")
     monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "thread-7")
     monkeypatch.setenv("HERMES_SESSION_USER_ID", "user-9")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_TYPE", "group")
+    monkeypatch.setenv(
+        "HERMES_SESSION_KEY", "agent:main:telegram:group:chat-42:thread-7"
+    )
+    monkeypatch.setenv("HERMES_SESSION_PROFILE", "default")
+    monkeypatch.setenv(
+        "HERMES_SESSION_ADAPTER_IDENTITY",
+        "profile:default|platform:telegram",
+    )
 
     out = kt._handle_create({
         "title": "auto-sub gateway",
@@ -2166,6 +2175,16 @@ def test_create_subscribes_gateway_session(monkeypatch, worker_env):
     assert s["chat_id"] == "chat-42"
     assert s["thread_id"] == "thread-7"
     assert s["user_id"] == "user-9"
+    assert (
+        s["canonical_session_key"]
+        == "agent:main:telegram:group:chat-42:thread-7"
+    )
+    assert s["chat_type"] == "group"
+    assert s["notifier_profile"] == "default"
+    assert (
+        s["adapter_identity"]
+        == "profile:default|platform:telegram"
+    )
 
 
 def test_create_subscribes_tui_session_via_session_key(monkeypatch, worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1258,9 +1258,14 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             chat_id = session_key
         thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "") or None
         user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
+        canonical_session_key = get_session_env("HERMES_SESSION_KEY", "") or None
+        chat_type = get_session_env("HERMES_SESSION_CHAT_TYPE", "") or None
         notifier_profile = (
             get_session_env("HERMES_SESSION_PROFILE", "")
             or os.environ.get("HERMES_PROFILE")
+        )
+        adapter_identity = (
+            get_session_env("HERMES_SESSION_ADAPTER_IDENTITY", "") or None
         )
 
         # Lazy-import to keep the module-level dependency light
@@ -1270,6 +1275,9 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             platform=platform, chat_id=chat_id,
             thread_id=thread_id, user_id=user_id,
             notifier_profile=notifier_profile,
+            canonical_session_key=canonical_session_key,
+            chat_type=chat_type,
+            adapter_identity=adapter_identity,
         )
         return True
     except Exception as _exc:


### PR DESCRIPTION
## Summary

- Persist a canonical notification route: session key, platform, chat type, thread, profile, and a non-secret adapter identity.
- Route notifications through the exact active or secondary profile adapter without falling back across profiles.
- Keep legacy, partial, CLI, and tool-originated subscriptions notify-only; this PR intentionally does not wake an agent.
- Preserve old databases with additive nullable migrations and refuse to infer missing canonical fields.

## Validation

- `scripts/run_tests.sh tests/gateway/test_kanban_notifier.py tests/gateway/test_session_env.py tests/hermes_cli/test_kanban_db_init.py tests/hermes_cli/test_kanban_notify.py tests/plugins/test_kanban_dashboard_plugin.py tests/tools/test_kanban_tools.py -q` (278 passed)
- `python scripts/check-windows-footguns.py gateway/kanban_watchers.py gateway/run.py gateway/session_context.py gateway/slash_commands.py hermes_cli/kanban_db.py tools/kanban_tools.py tests/gateway/test_kanban_notifier.py tests/gateway/test_session_env.py tests/hermes_cli/test_kanban_db_init.py tests/hermes_cli/test_kanban_notify.py tests/plugins/test_kanban_dashboard_plugin.py tests/tools/test_kanban_tools.py`

The full repository suite currently has unrelated environment and platform failures on this macOS runner; this change's focused suite is green.
