### PR TITLE
[HERMES#69022] fix(codex): gate Pro models by account catalog

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1199,6 +1199,19 @@ def _classify_400(
 ) -> ClassifiedError:
     """Classify 400 Bad Request — context overflow, format error, or generic."""
 
+    # ChatGPT OAuth rejects account-ineligible Codex models with HTTP 400
+    # rather than 404. This is a model-route failure, not a malformed request:
+    # retrying the same slug cannot help, while a configured fallback can.
+    if (
+        provider == "openai-codex"
+        and "model is not supported when using codex" in error_msg
+    ):
+        return result_fn(
+            FailoverReason.model_not_found,
+            retryable=False,
+            should_fallback=True,
+        )
+
     # Multimodal tool content rejected from 400.  Must be checked BEFORE
     # image_too_large because the recovery is different (strip image parts
     # from tool messages, mark the model as no-list-tool-content for the

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -13,14 +13,12 @@ import os
 logger = logging.getLogger(__name__)
 
 DEFAULT_CODEX_MODELS: List[str] = [
-    # GPT-5.6 series (Sol/Terra/Luna + -pro high-effort modes) — GA 2026-07-09
-    # (previewed 2026-06-26).
+    # GPT-5.6 series — GA 2026-07-09 (previewed 2026-06-26). ``-pro``
+    # variants are entitlement-specific and must come from live discovery;
+    # synthesizing them for ChatGPT OAuth accounts produces deterministic 400s.
     "gpt-5.6-sol",
-    "gpt-5.6-sol-pro",
     "gpt-5.6-terra",
-    "gpt-5.6-terra-pro",
     "gpt-5.6-luna",
-    "gpt-5.6-luna-pro",
     "gpt-5.5",
     "gpt-5.4-mini",
     "gpt-5.4",
@@ -54,11 +52,8 @@ DEFAULT_CODEX_MODELS: List[str] = [
 
 _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
     ("gpt-5.6-sol", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.6-sol-pro", ("gpt-5.5", "gpt-5.4")),
     ("gpt-5.6-terra", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.6-terra-pro", ("gpt-5.5", "gpt-5.4")),
     ("gpt-5.6-luna", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.6-luna-pro", ("gpt-5.5", "gpt-5.4")),
     ("gpt-5.5", ("gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
     ("gpt-5.4-mini", ("gpt-5.3-codex",)),
     ("gpt-5.4", ("gpt-5.3-codex",)),

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -571,6 +571,24 @@ class TestClassifyApiError:
         assert result.should_fallback is True
         assert result.retryable is False
 
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "The 'gpt-5.6-sol-pro' model is not supported when using Codex "
+            "with a ChatGPT account.",
+            "ERROR: MODEL IS NOT SUPPORTED WHEN USING CODEX with a ChatGPT "
+            "account; choose another model.",
+        ],
+    )
+    def test_400_codex_chatgpt_unsupported_model_falls_back(self, message):
+        e = MockAPIError(message, status_code=400)
+
+        result = classify_api_error(e, provider="openai-codex")
+
+        assert result.reason == FailoverReason.model_not_found
+        assert result.should_fallback is True
+        assert result.retryable is False
+
     def test_404_generic(self):
         # Generic 404 with no "model not found" signal — common for local
         # llama.cpp/Ollama/vLLM endpoints with slightly wrong paths.  Treat

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -57,6 +57,16 @@ def test_get_codex_model_ids_falls_back_to_curated_defaults(tmp_path, monkeypatc
     assert "gpt-5.3-codex-spark" in models
 
 
+def test_curated_fallback_excludes_unverified_pro_variants(tmp_path, monkeypatch):
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    models = get_codex_model_ids()
+
+    assert not any(model.endswith("-pro") for model in models)
+
+
 def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.codex_models._fetch_models_from_api",
@@ -75,6 +85,29 @@ def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypat
         "gpt-5.4",
         "gpt-5.3-codex-spark",
     ]
+
+
+def test_live_catalog_only_surfaces_pro_variants_when_advertised(monkeypatch):
+    advertised = [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.5",
+        "gpt-5.4",
+    ]
+    monkeypatch.setattr(
+        "hermes_cli.codex_models._fetch_models_from_api",
+        lambda access_token: list(advertised),
+    )
+
+    models = get_codex_model_ids(access_token="codex-access-token")
+
+    assert not any(model.endswith("-pro") for model in models)
+
+    advertised.append("gpt-5.6-sol-pro")
+    models = get_codex_model_ids(access_token="codex-access-token")
+
+    assert "gpt-5.6-sol-pro" in models
 
 
 def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):


### PR DESCRIPTION
## Summary
- stop synthesizing account-ineligible `gpt-5.6-*-pro` variants in the curated and forward-compatible Codex catalogs
- preserve a Pro variant when the authenticated live catalog explicitly advertises it
- classify ChatGPT Codex HTTP 400 `model is not supported when using Codex` as `model_not_found`, non-retryable, with fallback enabled

## Root cause
The OAuth account catalog advertises Sol/Terra/Luna but no `*-pro` variants. Hermes nevertheless injected three Pro slugs into both fallback and forward-compatible discovery, allowing deterministic HTTP 400 failures in main and auxiliary tasks.

## Tests
Strict TDD was used: the new behavior tests failed before the production changes.

Final branch after merging current `origin/main`:

```text
224 passed in 7.42s
```

Command:

```bash
python -m pytest tests/hermes_cli/test_codex_models.py tests/agent/test_error_classifier.py -q -o 'addopts='
```

Coverage added:
- curated fallback excludes unverified Pro variants
- live discovery exposes Pro only when explicitly advertised
- the real Codex 400 wording and a capitalization/prefix variant both activate fallback

## Compatibility
If OpenAI later grants Pro entitlement and returns a Pro slug from the live account catalog, Hermes keeps and displays it. Only synthetic/unverified Pro entries are removed.

## Rollback
Revert `f9f835313`; no config or schema migration is involved.
