### PR TITLE
Fix Slack channel context and quiet defaults

### DIFF
--- a/docs/experiment-slack-dobby-channel-context.md
+++ b/docs/experiment-slack-dobby-channel-context.md
@@ -1,0 +1,83 @@
+# Slack Dobby channel context and noise control
+
+## What changed
+
+Slack now supports `channel_session_scope_channels`, a per-channel option that scopes top-level channel mentions to the shared channel session while still replying in the original Slack thread. Slack's default display profile also disables long-running heartbeat posts and busy-ack details, so workspace channels do not get permanent messages like `Working — 9 min — iteration 12/90, terminal`.
+
+## Why
+
+The `#carby-dobby` operator channel needs two behaviors at once: replies should stay threaded for Slack readability, and follow-up top-level mentions should keep context from the channel. Before this change, `reply_in_thread=true` converted every top-level mention into its own synthetic thread session, so a follow-up like "make the PRs" had no memory of the previous "come up with experiments" request.
+
+The same Slack display defaults also inherited medium-tier progress notifications. That made long-running agent work leave noisy operational breadcrumbs in the channel, including iteration counts and terminal status, even when the final useful answer or blocker was the only message the user needed.
+
+## Root cause
+
+Slack top-level messages were using the message timestamp as a synthetic `thread_ts` whenever `reply_in_thread=true`. That was correct for isolated threaded support conversations, but wrong for operator channels where Peter often sends related top-level follow-ups. There was no narrower option between "one session per Slack thread" and "flat channel replies."
+
+## What was tried
+
+The first implementation scoped configured channel messages to the shared channel session by clearing `thread_ts`, but that also cleared `reply_to_message_id`. The test caught that regression because Hermes would have lost the Slack reply anchor and answered flat in the channel. The final implementation keeps `source.thread_id=None` for session scope while setting `reply_to_message_id` to the top-level message timestamp for threaded Slack delivery.
+
+## Key files
+
+- `plugins/platforms/slack/adapter.py` handles Slack event session scoping and reply anchoring.
+- `gateway/config.py` bridges top-level `slack.channel_session_scope_channels` into the Slack platform config.
+- `gateway/display_config.py` defines Slack's default chatter level.
+- `tests/gateway/test_slack_channel_session_scope.py` proves shared session scope can coexist with threaded Slack replies.
+- `tests/gateway/test_slack_mention.py` proves the config key is bridged.
+- `tests/gateway/test_display_config.py` proves Slack's default heartbeat/busy-ack behavior stays quiet.
+
+## Gotchas for future work
+
+Do not use `reply_in_thread=false` just to preserve context in operator channels. That changes Slack delivery and makes replies flat. Use `channel_session_scope_channels` for channels like `#carby-dobby` where the channel itself is the working context but individual answers should still land as thread replies.
+
+Do not re-enable `long_running_notifications` or `busy_ack_detail` globally for Slack unless the channel explicitly wants permanent operational noise. Slack posts are durable workspace messages, not an ephemeral terminal status area.
+
+## Verification
+
+Run the focused regression suite:
+
+```bash
+scripts/run_tests.sh tests/gateway/test_display_config.py tests/gateway/test_slack_channel_session_scope.py tests/gateway/test_slack_mention.py -q
+```
+
+Expected result: all tests pass, including `test_configured_channel_can_share_session_while_replying_in_thread`, `test_config_bridges_slack_channel_session_scope_channels`, and `test_slack_workspace_chatter_defaults`.
+
+Read back the live Dobby config:
+
+```bash
+HERMES_HOME=/Users/peter/.hermes venv/bin/python - <<'PY'
+from pathlib import Path
+import yaml
+from gateway.config import Platform, load_gateway_config
+from gateway.display_config import resolve_display_setting
+
+raw = yaml.safe_load(Path('/Users/peter/.hermes/config.yaml').read_text()) or {}
+cfg = load_gateway_config()
+slack = cfg.platforms[Platform.SLACK]
+override = slack.channel_overrides.get('C0BJU6Q2890')
+print("restart_notification", slack.gateway_restart_notification)
+print("channel_scope", slack.extra.get("channel_session_scope_channels"))
+print("long_running", resolve_display_setting(raw, "slack", "long_running_notifications"))
+print("busy_ack", resolve_display_setting(raw, "slack", "busy_ack_detail"))
+print("channel_prompt_prefix", (override.system_prompt if override else "")[:80])
+PY
+```
+
+Expected result: `restart_notification False`, `channel_scope ['C0BJU6Q2890']`, `long_running False`, `busy_ack False`, and a `channel_prompt_prefix` starting with `You are Dobby in #carby-dobby`.
+
+Check the gateway after restart:
+
+```bash
+hermes gateway status
+rg 'Socket Mode connected|Gateway shutting down|Working — .*iteration|inbound message|response ready|ERROR|Traceback' ~/.hermes/logs/gateway.log | tail -n 50
+```
+
+Expected result: the gateway is supervised and connected; new channel runs do not produce `Working — ... iteration` posts or shutdown interruption posts in Slack.
+
+## Verified live surface
+
+- Slack route: BUILDFAST `#carby-dobby`, channel ID `C0BJU6Q2890`.
+- Code path: Slack Socket Mode event enters `SlackAdapter._handle_slack_message`, becomes a `MessageEvent`, then the gateway session key is derived from `SessionSource`.
+- Surface files intentionally touched: Slack adapter session/reply logic, gateway config bridging, Slack display defaults, and focused tests.
+- Stale surfaces intentionally not touched: launchd scheduling and raw cron job definitions, because the issue was gateway Slack behavior rather than job timing.

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1449,6 +1449,10 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
                 if "reply_in_thread" in platform_cfg:
                     bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
+                if "channel_session_scope_channels" in platform_cfg:
+                    bridged["channel_session_scope_channels"] = platform_cfg[
+                        "channel_session_scope_channels"
+                    ]
                 if "cron_continuable_surface" in platform_cfg:
                     bridged["cron_continuable_surface"] = platform_cfg["cron_continuable_surface"]
                 if "require_mention" in platform_cfg:

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -140,7 +140,12 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     # Tier 2 — edit support, often customer/workspace channels
     # Slack: tool_progress off by default — Bolt posts cannot be edited like CLI;
     # "new"/"all" spam permanent lines in channels (hermes-agent#14663).
-    "slack":           {**_TIER_MEDIUM, "tool_progress": "off"},
+    "slack":           {
+        **_TIER_MEDIUM,
+        "tool_progress": "off",
+        "long_running_notifications": False,
+        "busy_ack_detail": False,
+    },
     "mattermost":      _TIER_MEDIUM,
     "matrix":          _TIER_MEDIUM,
     "feishu":          _TIER_MEDIUM,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1801,6 +1801,25 @@ class SlackAdapter(BasePlatformAdapter):
                 return metadata["thread_ts"]
         return reply_to
 
+    def _channel_uses_shared_session_scope(self, channel_id: str) -> bool:
+        """Return true when top-level messages in this channel share one session.
+
+        ``reply_in_thread=false`` already gives Slack a channel-wide session,
+        but it also changes delivery to flat channel replies. This narrower
+        option lets operator channels keep threaded Slack replies while sharing
+        context across new top-level mentions.
+        """
+        raw = self.config.extra.get("channel_session_scope_channels")
+        if raw is True:
+            return True
+        if isinstance(raw, str):
+            candidates = [part.strip() for part in raw.split(",")]
+        elif isinstance(raw, (list, tuple, set)):
+            candidates = [str(part).strip() for part in raw]
+        else:
+            candidates = []
+        return bool(channel_id and channel_id in candidates)
+
     async def _upload_file(
         self,
         chat_id: str,
@@ -3327,6 +3346,11 @@ class SlackAdapter(BasePlatformAdapter):
             # variants (Copilot on #15464).
             if event_thread_ts_raw and event_thread_ts_raw != ts:
                 thread_ts = event_thread_ts_raw
+            elif self._channel_uses_shared_session_scope(channel_id):
+                # Keep outbound threading controlled by reply_in_thread, but
+                # scope the inbound top-level mention to the channel session so
+                # related follow-ups in operator channels retain context.
+                thread_ts = None
             elif self.config.extra.get("reply_in_thread", True):
                 # Legacy default: treat ts as a synthetic thread root so
                 # this top-level message gets its own session.
@@ -3751,6 +3775,15 @@ class SlackAdapter(BasePlatformAdapter):
             except Exception:  # pragma: no cover - defensive
                 reply_to_text = None
 
+        reply_to_message_id = thread_ts if thread_ts != ts else None
+        if (
+            reply_to_message_id is None
+            and not is_dm
+            and self._channel_uses_shared_session_scope(channel_id)
+            and self.config.extra.get("reply_in_thread", True)
+        ):
+            reply_to_message_id = ts
+
         msg_event = MessageEvent(
             text=text,
             message_type=msg_type,
@@ -3759,7 +3792,7 @@ class SlackAdapter(BasePlatformAdapter):
             message_id=ts,
             media_urls=media_urls,
             media_types=media_types,
-            reply_to_message_id=thread_ts if thread_ts != ts else None,
+            reply_to_message_id=reply_to_message_id,
             channel_prompt=_channel_prompt,
             reply_to_text=reply_to_text,
             auto_skill=_auto_skill,

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -313,6 +313,14 @@ class TestPlatformDefaults:
         assert resolve_display_setting({}, "discord", "long_running_notifications") is True
         assert resolve_display_setting({}, "discord", "busy_ack_detail") is True
 
+    def test_slack_workspace_chatter_defaults(self):
+        """Slack should not leave permanent heartbeat/debug breadcrumbs in channels."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "slack", "tool_progress") == "off"
+        assert resolve_display_setting({}, "slack", "long_running_notifications") is False
+        assert resolve_display_setting({}, "slack", "busy_ack_detail") is False
+
     def test_telegram_mobile_chatter_can_opt_in(self):
         """Per-platform config can re-enable Telegram busy-ack detail
         and re-disable the kept-on defaults."""

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -666,6 +666,27 @@ async def test_shutdown_notifications_use_cached_live_thread_source_when_origin_
 
 
 @pytest.mark.asyncio
+async def test_shutdown_notifications_are_fully_muted_when_flag_disabled():
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="active-42", chat_type="group", thread_id="topic-7")
+    session_key = build_session_key(source)
+
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    runner._running_agents[session_key] = object()
+    runner.session_store._entries[session_key] = MagicMock(origin=source)
+    adapter.send = AsyncMock()
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_restart_shutdown_notification_anchors_telegram_dm_topic():
     runner, adapter = make_restart_runner()
     runner._restart_requested = True

--- a/tests/gateway/test_slack_channel_session_scope.py
+++ b/tests/gateway/test_slack_channel_session_scope.py
@@ -193,6 +193,36 @@ class TestChannelSessionScopeShared:
         )
 
     @pytest.mark.asyncio
+    async def test_configured_channel_can_share_session_while_replying_in_thread(self, adapter):
+        """Operator channels can share context without changing Slack delivery.
+
+        ``reply_in_thread`` remains true so the eventual response is still
+        threaded, but top-level mentions in the configured channel use the
+        channel-wide session key.
+        """
+        adapter.config.extra["reply_in_thread"] = True
+        adapter.config.extra["channel_session_scope_channels"] = ["C_CHAN"]
+        event = _channel_event(
+            "<@U_BOT> follow up on the previous request",
+            ts="1700000000.000006",
+        )
+
+        captured = []
+        adapter.handle_message = AsyncMock(
+            side_effect=lambda e: captured.append(e)
+        )
+        with patch.object(
+            adapter,
+            "_resolve_user_name",
+            new=AsyncMock(return_value="testuser"),
+        ):
+            await adapter._handle_slack_message(event)
+
+        assert len(captured) == 1
+        assert captured[0].source.thread_id is None
+        assert captured[0].reply_to_message_id == "1700000000.000006"
+
+    @pytest.mark.asyncio
     async def test_thread_reply_scopes_by_thread_even_when_shared(self, adapter):
         """Bug 1's fix targets ONLY top-level channel messages.  Genuine
         thread replies (``thread_ts != ts``) must still scope per-thread

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -603,6 +603,30 @@ def test_config_bridges_slack_reply_in_thread(monkeypatch, tmp_path):
     ) == "171.000"
 
 
+def test_config_bridges_slack_channel_session_scope_channels(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  channel_session_scope_channels:\n"
+        "    - C_CHAN\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+
+    config = load_gateway_config()
+    slack_config = config.platforms[Platform.SLACK]
+    assert slack_config.extra.get("channel_session_scope_channels") == ["C_CHAN"]
+
+    adapter = SlackAdapter(slack_config)
+    assert adapter._channel_uses_shared_session_scope("C_CHAN") is True
+    assert adapter._channel_uses_shared_session_scope("C_OTHER") is False
+
+
 def test_config_bridges_slack_cron_continuable_surface_toplevel(monkeypatch, tmp_path):
     """The cron_continuable_surface key bridges from a top-level ``slack:`` block
     into slack.extra, mirroring reply_in_thread (specs D1/D6)."""


### PR DESCRIPTION
**Group chat announcement**
Slack operator channels can now keep related follow-up messages in the same agent context without forcing flat channel replies. The user experience changes from noisy progress/status posts and lost context to threaded answers that stay grounded in the channel. No human action is required beyond configuring `slack.channel_session_scope_channels` for operator channels.

**Customer message**
Not customer-facing.

**QA checklist**
- Configure a Slack channel in `slack.channel_session_scope_channels`.
- Send two related top-level mentions with `reply_in_thread=true`; the second should share the channel session while the response still replies in the Slack thread.
- Confirm Slack defaults do not emit long-running heartbeat or detailed busy-ack posts.
- Confirm unconfigured Slack channels keep the existing per-thread behavior.

**QA links**
Not applicable; this is gateway Slack behavior rather than a web route.

**BLAST RADIUS**
Slack platform gateway behavior only. The new shared-session behavior is opt-in by channel; the default Slack behavior only changes noisy heartbeat/busy-ack defaults. Other platforms are untouched.

**Why this works**
Before, `reply_in_thread=true` used each top-level Slack message timestamp as a synthetic thread session key, so top-level follow-ups lost the previous channel context. Now configured operator channels can use the channel session key while still carrying `reply_to_message_id` so Slack delivery remains threaded.

**Key concepts**
`source.thread_id` controls Hermes session scope; `reply_to_message_id` controls where Slack sends the response. Splitting those lets Hermes remember channel context without changing Slack reply layout.

**Old vs new response**
No API response shape changed.

**Prompts used**
Peter reported Slack screenshots where Dobby posted iteration/status chatter, lost context between top-level mentions, and answered with the wrong product assumptions in `#carby-dobby`.

**Restate the issue**
Slack operator channels needed shared context across top-level mentions without spammy permanent status posts or flat replies.

**UI simplification note**
No UI was touched. The Slack channel output is simpler because progress/debug chatter is suppressed by default.

**Live page proof**
Verified against BUILDFAST Slack `#carby-dobby` behavior locally: code path is Slack Socket Mode event ingestion through `SlackAdapter._handle_slack_message`, then Hermes session derivation from `SessionSource`.

**Safe to ship? what is the worst thing that could happen?**
Safe to ship. Worst case, a configured operator channel shares more context than intended; rollback is removing that channel from `slack.channel_session_scope_channels`.

Verification:
- `scripts/run_tests.sh tests/gateway/test_display_config.py tests/gateway/test_slack_channel_session_scope.py tests/gateway/test_slack_mention.py -q` — 138 passed.
- `git diff --check` passed.