### PR TITLE
fix(codex): preserve Kanban app-server runtime continuity

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -761,17 +761,56 @@ def run_codex_app_server_turn(
         except (TypeError, ValueError):
             pass
 
-    try:
-        turn = agent._codex_session.run_turn(
-            user_input=user_message, **timeout_kwargs
-        )
-    except Exception as exc:
-        logger.exception("codex app-server turn failed")
-        # Crash → unconditionally drop the session so the next turn
-        # respawns from scratch instead of reusing a dead client.
-        _retire_codex_app_server_session(agent)
+    api_calls = 0
+    total_tool_iterations = 0
+    usage_results = []
+    kanban_stop_attempts = getattr(agent, "_kanban_stop_nudges", 0)
+
+    while True:
+        try:
+            turn = agent._codex_session.run_turn(
+                user_input=user_message, **timeout_kwargs
+            )
+        except Exception as exc:
+            logger.exception("codex app-server turn failed")
+            # Crash → unconditionally drop the session so the next turn
+            # respawns from scratch instead of reusing a dead client.
+            _retire_codex_app_server_session(agent)
+            _user_interrupted = bool(
+                getattr(agent, "_interrupt_requested", False)
+            )
+            _interrupt_message = (
+                getattr(agent, "_interrupt_message", None)
+                if _user_interrupted
+                else None
+            )
+            if _user_interrupted:
+                agent.clear_interrupt()
+            return {
+                "final_response": (
+                    f"Codex app-server turn failed: {exc}. "
+                    f"Fall back to default runtime with `/codex-runtime auto`."
+                ),
+                "messages": messages,
+                "api_calls": api_calls,
+                "completed": False,
+                "partial": True,
+                "interrupted": _user_interrupted,
+                **(
+                    {"interrupt_message": _interrupt_message}
+                    if _interrupt_message
+                    else {}
+                ),
+                "error": str(exc),
+            }
+
+        api_calls += 1
+
+        # This runtime bypasses the normal conversation-loop finalizer. Mirror
+        # its interrupt handoff/cleanup so a hard stop cannot poison the next
+        # turn and a message-bearing compatibility interrupt can still replay.
         _user_interrupted = bool(
-            getattr(agent, "_interrupt_requested", False)
+            turn.interrupted and getattr(agent, "_interrupt_requested", False)
         )
         _interrupt_message = (
             getattr(agent, "_interrupt_message", None)
@@ -780,53 +819,69 @@ def run_codex_app_server_turn(
         )
         if _user_interrupted:
             agent.clear_interrupt()
-        return {
-            "final_response": (
-                f"Codex app-server turn failed: {exc}. "
-                f"Fall back to default runtime with `/codex-runtime auto`."
-            ),
-            "messages": messages,
-            "api_calls": 0,
-            "completed": False,
-            "partial": True,
-            "interrupted": _user_interrupted,
-            **(
-                {"interrupt_message": _interrupt_message}
-                if _interrupt_message
-                else {}
-            ),
-            "error": str(exc),
-        }
 
-    # This runtime bypasses the normal conversation-loop finalizer. Mirror its
-    # interrupt handoff/cleanup so a hard stop cannot poison the next turn and a
-    # message-bearing compatibility interrupt can still be replayed by callers.
-    _user_interrupted = bool(
-        turn.interrupted and getattr(agent, "_interrupt_requested", False)
-    )
-    _interrupt_message = (
-        getattr(agent, "_interrupt_message", None) if _user_interrupted else None
-    )
-    if _user_interrupted:
-        agent.clear_interrupt()
+        # If the turn signalled the underlying client is wedged (deadline
+        # blown, post-tool watchdog tripped, OAuth refresh died, subprocess
+        # exited), retire the session so the next turn respawns codex
+        # rather than riding the broken process. Mirrors openclaw beta.8's
+        # "retire timed-out app-server clients" fix.
+        if getattr(turn, "should_retire", False):
+            logger.warning(
+                "codex app-server session retired (turn error: %s)",
+                turn.error,
+            )
+            _retire_codex_app_server_session(agent)
 
-    # If the turn signalled the underlying client is wedged (deadline
-    # blown, post-tool watchdog tripped, OAuth refresh died, subprocess
-    # exited), retire the session so the next turn respawns codex
-    # rather than riding the broken process. Mirrors openclaw beta.8's
-    # "retire timed-out app-server clients" fix.
-    if getattr(turn, "should_retire", False):
-        logger.warning(
-            "codex app-server session retired (turn error: %s)",
-            turn.error,
-        )
-        _retire_codex_app_server_session(agent)
+        projected_messages = list(turn.projected_messages or [])
+        messages.extend(projected_messages)
+        total_tool_iterations += turn.tool_iterations
+        _record_codex_app_server_compaction(agent, turn)
+        turn_usage = _record_codex_app_server_usage(agent, turn)
+        if turn_usage:
+            usage_results.append(turn_usage)
 
-    # Splice projected messages into the conversation. The projector emits
-    # standard {role, content, tool_calls, tool_call_id} entries, which
-    # is exactly what curator.py / sessions DB expect.
-    if turn.projected_messages:
-        messages.extend(turn.projected_messages)
+        kanban_nudge = None
+        if (
+            not turn.interrupted
+            and turn.error is None
+            and not getattr(turn, "should_retire", False)
+        ):
+            try:
+                from agent.kanban_stop import build_kanban_stop_nudge
+
+                kanban_nudge = build_kanban_stop_nudge(
+                    messages=messages,
+                    attempts=kanban_stop_attempts,
+                )
+            except Exception:
+                logger.debug("kanban app-server stop-loop check failed", exc_info=True)
+
+        if kanban_nudge:
+            kanban_stop_attempts += 1
+            agent._kanban_stop_nudges = kanban_stop_attempts
+            if projected_messages and projected_messages[-1].get("role") == "assistant":
+                projected_messages[-1]["_kanban_stop_synthetic"] = True
+            else:
+                messages.append({
+                    "role": "assistant",
+                    "content": turn.final_text or "",
+                    "_kanban_stop_synthetic": True,
+                })
+            messages.append({
+                "role": "user",
+                "content": kanban_nudge,
+                "_kanban_stop_synthetic": True,
+            })
+            agent._session_messages = messages
+            logger.info(
+                "kanban app-server stop-loop nudge issued (attempt %d) task=%s",
+                kanban_stop_attempts,
+                os.environ.get("HERMES_KANBAN_TASK", ""),
+            )
+            agent._emit_status(
+                "⚠️ Kanban worker tried to exit without "
+                "kanban_complete/kanban_block — nudging to finish"
+            )
 
         # Persist the newly-projected assistant/tool messages ourselves.
         # This path is an early return that bypasses conversation_loop, whose
@@ -839,7 +894,8 @@ def run_codex_app_server_turn(
         # agent_persisted=True below, so the gateway skips its own DB write and
         # we avoid the #860/#42039 duplicate user-message write (append_message
         # is a raw INSERT with no dedup, so a gateway re-write would duplicate
-        # the already-flushed user turn). See gateway/run.py agent_persisted.
+        # the already-flushed user turn). Synthetic stop-loop scaffolding is
+        # skipped by the shared persister. See gateway/run.py agent_persisted.
         if getattr(agent, "_session_db", None) is not None:
             try:
                 agent._flush_messages_to_session_db(messages)
@@ -849,6 +905,36 @@ def run_codex_app_server_turn(
                     exc_info=True,
                 )
 
+        if not kanban_nudge:
+            break
+        user_message = kanban_nudge
+
+    usage_result = {}
+    if usage_results:
+        for key in (
+            "prompt_tokens",
+            "completion_tokens",
+            "total_tokens",
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_write_tokens",
+            "reasoning_tokens",
+        ):
+            usage_result[key] = sum(result.get(key, 0) for result in usage_results)
+        known_costs = [
+            result["estimated_cost_usd"]
+            for result in usage_results
+            if result.get("estimated_cost_usd") is not None
+        ]
+        usage_result.update(
+            {
+                "last_prompt_tokens": usage_results[-1]["last_prompt_tokens"],
+                "estimated_cost_usd": sum(known_costs) if known_costs else None,
+                "cost_status": usage_results[-1]["cost_status"],
+                "cost_source": usage_results[-1]["cost_source"],
+            }
+        )
 
     # Counter ticks for the agent-improvement loop.
     # _turns_since_memory and _user_turn_count are ALREADY incremented
@@ -858,11 +944,8 @@ def run_codex_app_server_turn(
     # chat_completions loop bumps it per tool iteration (line ~12110)
     # and that loop is bypassed on this path.
     agent._iters_since_skill = (
-        getattr(agent, "_iters_since_skill", 0) + turn.tool_iterations
+        getattr(agent, "_iters_since_skill", 0) + total_tool_iterations
     )
-    _record_codex_app_server_compaction(agent, turn)
-    usage_result = _record_codex_app_server_usage(agent, turn)
-    api_calls = 1
 
     # Now check the skill nudge AFTER iters were incremented — same
     # pattern the chat_completions path uses (line ~15432).

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -678,8 +678,11 @@ def run_codex_app_server_turn(
         # users see no live tool-progress or interim commentary while
         # codex_app_server is running — only the final answer (#33200).
         # Supersedes the narrower item/started-only bridge from #38835.
+        reasoning_config = getattr(agent, "reasoning_config", None) or {}
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
+            model=getattr(agent, "model", None),
+            reasoning_effort=reasoning_config.get("effort"),
             approval_callback=approval_callback,
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import time
 from types import SimpleNamespace
@@ -691,8 +692,22 @@ def run_codex_app_server_turn(
     # standard run_conversation() flow (line ~11823) before the early
     # return reaches us. Do NOT append again — that would duplicate.
 
+    timeout_kwargs = {}
+    if os.environ.get("HERMES_KANBAN_TASK"):
+        try:
+            terminal_timeout = float(os.environ.get("TERMINAL_TIMEOUT", ""))
+            if terminal_timeout > 0 and math.isfinite(terminal_timeout):
+                timeout_kwargs = {
+                    "turn_timeout": terminal_timeout,
+                    "post_tool_quiet_timeout": terminal_timeout,
+                }
+        except (TypeError, ValueError):
+            pass
+
     try:
-        turn = agent._codex_session.run_turn(user_input=user_message)
+        turn = agent._codex_session.run_turn(
+            user_input=user_message, **timeout_kwargs
+        )
     except Exception as exc:
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -634,10 +634,32 @@ def run_codex_app_server_turn(
         _ServerRequestRouting,
     )
 
-    # Lazy session: one CodexAppServerSession per AIAgent instance.
-    # Spawned on first turn, reused across turns, closed at AIAgent
-    # shutdown (see _cleanup hook).
-    if not hasattr(agent, "_codex_session") or agent._codex_session is None:
+    reasoning_config = getattr(agent, "reasoning_config", None) or {}
+    model = str(getattr(agent, "model", None) or "").strip() or None
+    reasoning_effort = (
+        "none"
+        if reasoning_config.get("enabled") is False
+        else str(reasoning_config.get("effort") or "").strip() or None
+    )
+    runtime_key = (model, reasoning_effort)
+
+    # Lazy session: one CodexAppServerSession per unchanged process runtime.
+    # Model and reasoning are process config, so a live selection change must
+    # retire the old thread before the next turn instead of billing stale config.
+    codex_session = getattr(agent, "_codex_session", None)
+    if (
+        codex_session is not None
+        and vars(agent).get("_codex_session_runtime_key", runtime_key)
+        != runtime_key
+    ):
+        try:
+            codex_session.close()
+        except Exception:
+            pass
+        agent._codex_session = None
+        codex_session = None
+
+    if codex_session is None:
         from agent.runtime_cwd import resolve_agent_cwd
 
         cwd = getattr(agent, "session_cwd", None) or str(resolve_agent_cwd())
@@ -678,11 +700,10 @@ def run_codex_app_server_turn(
         # users see no live tool-progress or interim commentary while
         # codex_app_server is running — only the final answer (#33200).
         # Supersedes the narrower item/started-only bridge from #38835.
-        reasoning_config = getattr(agent, "reasoning_config", None) or {}
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
-            model=getattr(agent, "model", None),
-            reasoning_effort=reasoning_config.get("effort"),
+            model=model,
+            reasoning_effort=reasoning_effort,
             approval_callback=approval_callback,
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,
@@ -690,6 +711,7 @@ def run_codex_app_server_turn(
             ),
             on_event=make_codex_app_server_event_bridge(agent),
         )
+        agent._codex_session_runtime_key = runtime_key
 
     # NOTE: the user message is ALREADY appended to messages by the
     # standard run_conversation() flow (line ~11823) before the early

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -21,6 +21,7 @@ import logging
 import math
 import os
 import time
+from collections.abc import Mapping
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
 
@@ -613,6 +614,44 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
     return on_event
 
 
+def _codex_app_server_runtime_key(agent) -> tuple[str | None, str | None]:
+    reasoning_config = vars(agent).get("reasoning_config")
+    if not reasoning_config:
+        reasoning_config = {}
+    elif not isinstance(reasoning_config, Mapping):
+        raise TypeError("reasoning_config must be a mapping or None")
+    model = str(getattr(agent, "model", None) or "").strip() or None
+    reasoning_effort = (
+        "none"
+        if reasoning_config.get("enabled") is False
+        else str(reasoning_config.get("effort") or "").strip() or None
+    )
+    return model, reasoning_effort
+
+
+def _retire_codex_app_server_session(agent) -> None:
+    codex_session = getattr(agent, "_codex_session", None)
+    agent._codex_session = None
+    vars(agent).pop("_codex_session_runtime_key", None)
+    if codex_session is None:
+        return
+    try:
+        codex_session.close()
+    except Exception:
+        pass
+
+
+def _codex_app_server_session_for_runtime(agent, runtime_key):
+    codex_session = getattr(agent, "_codex_session", None)
+    if (
+        codex_session is not None
+        and vars(agent).get("_codex_session_runtime_key", runtime_key) != runtime_key
+    ):
+        _retire_codex_app_server_session(agent)
+        return None
+    return codex_session
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -634,30 +673,23 @@ def run_codex_app_server_turn(
         _ServerRequestRouting,
     )
 
-    reasoning_config = getattr(agent, "reasoning_config", None) or {}
-    model = str(getattr(agent, "model", None) or "").strip() or None
-    reasoning_effort = (
-        "none"
-        if reasoning_config.get("enabled") is False
-        else str(reasoning_config.get("effort") or "").strip() or None
-    )
-    runtime_key = (model, reasoning_effort)
+    try:
+        runtime_key = _codex_app_server_runtime_key(agent)
+    except TypeError as exc:
+        return {
+            "final_response": f"Codex app-server configuration invalid: {exc}.",
+            "messages": messages,
+            "api_calls": 0,
+            "completed": False,
+            "partial": True,
+            "error": str(exc),
+        }
+    model, reasoning_effort = runtime_key
 
     # Lazy session: one CodexAppServerSession per unchanged process runtime.
     # Model and reasoning are process config, so a live selection change must
     # retire the old thread before the next turn instead of billing stale config.
-    codex_session = getattr(agent, "_codex_session", None)
-    if (
-        codex_session is not None
-        and vars(agent).get("_codex_session_runtime_key", runtime_key)
-        != runtime_key
-    ):
-        try:
-            codex_session.close()
-        except Exception:
-            pass
-        agent._codex_session = None
-        codex_session = None
+    codex_session = _codex_app_server_session_for_runtime(agent, runtime_key)
 
     if codex_session is None:
         from agent.runtime_cwd import resolve_agent_cwd
@@ -737,11 +769,7 @@ def run_codex_app_server_turn(
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn
         # respawns from scratch instead of reusing a dead client.
-        try:
-            agent._codex_session.close()
-        except Exception:
-            pass
-        agent._codex_session = None
+        _retire_codex_app_server_session(agent)
         _user_interrupted = bool(
             getattr(agent, "_interrupt_requested", False)
         )
@@ -792,11 +820,7 @@ def run_codex_app_server_turn(
             "codex app-server session retired (turn error: %s)",
             turn.error,
         )
-        try:
-            agent._codex_session.close()
-        except Exception:
-            pass
-        agent._codex_session = None
+        _retire_codex_app_server_session(agent)
 
     # Splice projected messages into the conversation. The projector emits
     # standard {role, content, tool_calls, tool_call_id} entries, which

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1926,7 +1926,21 @@ def _compress_context_via_codex_app_server(
             existing_prompt = agent._build_system_prompt(system_message)
         return messages, existing_prompt
 
-    codex_session = getattr(agent, "_codex_session", None)
+    from agent.codex_runtime import (
+        _codex_app_server_runtime_key,
+        _codex_app_server_session_for_runtime,
+        _retire_codex_app_server_session,
+    )
+
+    try:
+        runtime_key = _codex_app_server_runtime_key(agent)
+    except TypeError as exc:
+        logger.warning("codex app-server compaction skipped: %s", exc)
+        existing_prompt = getattr(agent, "_cached_system_prompt", None)
+        if not existing_prompt:
+            existing_prompt = agent._build_system_prompt(system_message)
+        return messages, existing_prompt
+    codex_session = _codex_app_server_session_for_runtime(agent, runtime_key)
     if codex_session is None:
         logger.info(
             "codex app-server compaction skipped: no active codex thread "
@@ -1976,11 +1990,7 @@ def _compress_context_via_codex_app_server(
         _activity_heartbeat.stop("context compression completed")
 
     if getattr(result, "should_retire", False):
-        try:
-            codex_session.close()
-        except Exception:
-            pass
-        agent._codex_session = None
+        _retire_codex_app_server_session(agent)
 
     if getattr(result, "interrupted", False) or getattr(result, "error", None):
         try:

--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -6,9 +6,9 @@ Kanban workers must end with ``kanban_complete`` or ``kanban_block``. Models
 tool calls. Hermes treats that as a clean exit → ``rc=0`` → dispatcher
 ``protocol_violation``.
 
-This module is policy-only: when a kanban worker tries to finish without a
-terminal board tool, return a bounded synthetic nudge so the conversation
-loop continues instead of exiting.
+This module is policy-only: when a kanban worker tries to finish while its
+authoritative board task is still running, return a bounded synthetic nudge so
+the conversation loop continues instead of exiting.
 """
 
 from __future__ import annotations
@@ -66,6 +66,21 @@ def session_called_kanban_terminal(messages: Iterable[dict] | None) -> bool:
     return False
 
 
+def _current_kanban_task_status(task_id: Optional[str] = None) -> Optional[str]:
+    """Return the dispatcher task's authoritative board status."""
+    tid = (task_id or os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    if not tid:
+        return None
+    try:
+        from hermes_cli import kanban_db as kb
+
+        with kb.connect_closing() as conn:
+            task = kb.get_task(conn, tid)
+        return task.status if task is not None else None
+    except Exception:
+        return None
+
+
 def build_kanban_stop_nudge(
     *,
     messages: Iterable[dict] | None = None,
@@ -73,16 +88,16 @@ def build_kanban_stop_nudge(
     max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
     task_id: Optional[str] = None,
 ) -> Optional[str]:
-    """Return a synthetic follow-up when a kanban worker exits without a terminal tool.
+    """Return a synthetic follow-up while a kanban worker task is still running.
 
     Returns ``None`` when the guard should not fire (not a kanban worker,
-    already completed/blocked, or nudge budget exhausted).
+    board task no longer running, or nudge budget exhausted).
     """
     if not kanban_stop_nudge_enabled():
         return None
     if attempts >= max_attempts:
         return None
-    if session_called_kanban_terminal(messages):
+    if _current_kanban_task_status(task_id) != "running":
         return None
 
     tid = (task_id or os.environ.get("HERMES_KANBAN_TASK") or "").strip() or "this task"

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -115,6 +115,24 @@ class CodexAppServerClient:
             )
             writable_roots = [kanban_root]
             workspace = os.path.abspath(workspace_cwd or os.getcwd())
+            authorized_git_roots = [os.path.realpath(os.path.abspath(kanban_root))]
+            assigned_workspace = spawn_env.get("HERMES_KANBAN_WORKSPACE")
+            assigned_workspace_matches = bool(assigned_workspace) and (
+                os.path.abspath(assigned_workspace) == workspace
+            )
+            source_workspace_authorized = assigned_workspace_matches and (
+                os.path.realpath(os.path.join(os.path.dirname(__file__), "..", ".."))
+                == workspace
+            )
+            worktrees_dir = os.path.dirname(workspace)
+            if (
+                assigned_workspace_matches
+                and os.path.basename(workspace) == spawn_env["HERMES_KANBAN_TASK"]
+                and os.path.basename(worktrees_dir) == ".worktrees"
+            ):
+                authorized_git_roots.append(
+                    os.path.join(os.path.dirname(worktrees_dir), ".git")
+                )
             git_marker = os.path.join(workspace, ".git")
             try:
                 if (
@@ -168,6 +186,14 @@ class CodexAppServerClient:
                                         == os.path.join(common, "worktrees")
                                         and os.path.realpath(backlink)
                                         == os.path.realpath(git_marker)
+                                        and (
+                                            source_workspace_authorized
+                                            or any(
+                                                os.path.commonpath((common, root))
+                                                == root
+                                                for root in authorized_git_roots
+                                            )
+                                        )
                                     ):
                                         writable_roots.append(common)
             except (OSError, UnicodeError, ValueError):

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -74,6 +74,7 @@ class CodexAppServerClient:
         codex_home: Optional[str] = None,
         extra_args: Optional[list[str]] = None,
         env: Optional[dict[str, str]] = None,
+        workspace_cwd: Optional[str] = None,
     ) -> None:
         self._codex_bin = codex_bin
         # codex app-server is a model-driving CLI executor: it runs a
@@ -112,12 +113,33 @@ class CodexAppServerClient:
                     ),
                 )
             )
+            writable_roots = [kanban_root]
+            workspace = os.path.abspath(workspace_cwd or os.getcwd())
+            git_marker = os.path.join(workspace, ".git")
+            if os.path.isfile(git_marker):
+                try:
+                    marker = open(git_marker, encoding="utf-8").readline().strip()
+                    if marker.startswith("gitdir:"):
+                        git_dir = marker.removeprefix("gitdir:").strip()
+                        if not os.path.isabs(git_dir):
+                            git_dir = os.path.join(workspace, git_dir)
+                        git_dir = os.path.realpath(git_dir)
+                        commondir_file = os.path.join(git_dir, "commondir")
+                        if os.path.isfile(commondir_file):
+                            common = open(
+                                commondir_file, encoding="utf-8"
+                            ).read().strip()
+                            git_dir = os.path.realpath(os.path.join(git_dir, common))
+                        writable_roots.append(git_dir)
+                except OSError:
+                    pass
             app_server_args.extend(
                 [
                     "-c",
                     'sandbox_mode="workspace-write"',
                     "-c",
-                    f'sandbox_workspace_write.writable_roots=["{kanban_root}"]',
+                    "sandbox_workspace_write.writable_roots="
+                    f"{json.dumps(writable_roots)}",
                     "-c",
                     "sandbox_workspace_write.network_access=false",
                 ]

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -116,23 +116,62 @@ class CodexAppServerClient:
             writable_roots = [kanban_root]
             workspace = os.path.abspath(workspace_cwd or os.getcwd())
             git_marker = os.path.join(workspace, ".git")
-            if os.path.isfile(git_marker):
-                try:
-                    marker = open(git_marker, encoding="utf-8").readline().strip()
+            try:
+                if (
+                    os.path.isfile(git_marker)
+                    and not os.path.islink(git_marker)
+                    and os.path.realpath(git_marker) == git_marker
+                ):
+                    with open(git_marker, encoding="utf-8") as marker_file:
+                        marker = marker_file.read().strip()
                     if marker.startswith("gitdir:"):
                         git_dir = marker.removeprefix("gitdir:").strip()
-                        if not os.path.isabs(git_dir):
-                            git_dir = os.path.join(workspace, git_dir)
-                        git_dir = os.path.realpath(git_dir)
-                        commondir_file = os.path.join(git_dir, "commondir")
-                        if os.path.isfile(commondir_file):
-                            common = open(
-                                commondir_file, encoding="utf-8"
-                            ).read().strip()
-                            git_dir = os.path.realpath(os.path.join(git_dir, common))
-                        writable_roots.append(git_dir)
-                except OSError:
-                    pass
+                        if git_dir:
+                            git_dir = os.path.abspath(
+                                git_dir
+                                if os.path.isabs(git_dir)
+                                else os.path.join(workspace, git_dir)
+                            )
+                            commondir_file = os.path.join(git_dir, "commondir")
+                            backlink_file = os.path.join(git_dir, "gitdir")
+                            if (
+                                os.path.isdir(git_dir)
+                                and not os.path.islink(git_dir)
+                                and os.path.realpath(git_dir) == git_dir
+                                and os.path.isfile(commondir_file)
+                                and not os.path.islink(commondir_file)
+                                and os.path.realpath(commondir_file) == commondir_file
+                                and os.path.isfile(backlink_file)
+                                and not os.path.islink(backlink_file)
+                                and os.path.realpath(backlink_file) == backlink_file
+                            ):
+                                with open(commondir_file, encoding="utf-8") as common_file:
+                                    common = common_file.read().strip()
+                                with open(backlink_file, encoding="utf-8") as backlink_file:
+                                    backlink = backlink_file.read().strip()
+                                if common and backlink:
+                                    common = os.path.abspath(
+                                        common
+                                        if os.path.isabs(common)
+                                        else os.path.join(git_dir, common)
+                                    )
+                                    backlink = os.path.abspath(
+                                        backlink
+                                        if os.path.isabs(backlink)
+                                        else os.path.join(git_dir, backlink)
+                                    )
+                                    if (
+                                        os.path.isdir(common)
+                                        and not os.path.islink(common)
+                                        and os.path.realpath(common) == common
+                                        and os.path.dirname(git_dir)
+                                        == os.path.join(common, "worktrees")
+                                        and os.path.realpath(backlink)
+                                        == os.path.realpath(git_marker)
+                                    ):
+                                        writable_roots.append(common)
+            except (OSError, UnicodeError, ValueError):
+                pass
             app_server_args.extend(
                 [
                     "-c",

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -24,6 +24,7 @@ call is synchronous and behaves like AIAgent's existing chat_completions loop.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import threading
@@ -277,6 +278,8 @@ class CodexAppServerSession:
         cwd: Optional[str] = None,
         codex_bin: str = "codex",
         codex_home: Optional[str] = None,
+        model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
         permission_profile: Optional[str] = None,
         approval_callback: Optional[Callable[..., str]] = None,
         on_event: Optional[Callable[[dict], None]] = None,
@@ -286,6 +289,10 @@ class CodexAppServerSession:
         self._cwd = cwd or os.getcwd()
         self._codex_bin = codex_bin
         self._codex_home = codex_home
+        self._model = str(model).strip() if model else None
+        self._reasoning_effort = (
+            str(reasoning_effort).strip() if reasoning_effort else None
+        )
         self._permission_profile = (
             permission_profile or _HERMES_TO_CODEX_PERMISSION_PROFILE.get(
                 os.environ.get("HERMES_TERMINAL_SECURITY_MODE", "auto"),
@@ -319,8 +326,22 @@ class CodexAppServerSession:
         if self._thread_id is not None:
             return self._thread_id
         if self._client is None:
+            extra_args: list[str] = []
+            if self._model:
+                extra_args.extend(["-c", f"model={json.dumps(self._model)}"])
+            if self._reasoning_effort:
+                extra_args.extend(
+                    [
+                        "-c",
+                        "model_reasoning_effort="
+                        f"{json.dumps(self._reasoning_effort)}",
+                    ]
+                )
             self._client = self._client_factory(
-                codex_bin=self._codex_bin, codex_home=self._codex_home
+                codex_bin=self._codex_bin,
+                codex_home=self._codex_home,
+                extra_args=extra_args,
+                workspace_cwd=self._cwd,
             )
         self._client.initialize(
             client_name="hermes",

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -24,6 +24,7 @@ call is synchronous and behaves like AIAgent's existing chat_completions loop.
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import os
@@ -337,12 +338,28 @@ class CodexAppServerSession:
                         f"{json.dumps(self._reasoning_effort)}",
                     ]
                 )
-            self._client = self._client_factory(
-                codex_bin=self._codex_bin,
-                codex_home=self._codex_home,
-                extra_args=extra_args,
-                workspace_cwd=self._cwd,
-            )
+            factory_kwargs = {
+                "codex_bin": self._codex_bin,
+                "codex_home": self._codex_home,
+                "extra_args": extra_args,
+                "workspace_cwd": self._cwd,
+            }
+            try:
+                parameters = inspect.signature(self._client_factory).parameters
+            except (TypeError, ValueError):
+                accepted = {"codex_bin", "codex_home"}
+            else:
+                accepted = None if any(
+                    parameter.kind is inspect.Parameter.VAR_KEYWORD
+                    for parameter in parameters.values()
+                ) else parameters
+            if accepted is not None:
+                factory_kwargs = {
+                    name: value
+                    for name, value in factory_kwargs.items()
+                    if name in accepted
+                }
+            self._client = self._client_factory(**factory_kwargs)
         self._client.initialize(
             client_name="hermes",
             client_title="Hermes Agent",

--- a/cli.py
+++ b/cli.py
@@ -1249,6 +1249,12 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
                 _active_agent_ref.shutdown_memory_provider()
     except Exception as e:
         logger.warning("CLI cleanup memory shutdown failed: %s", e, exc_info=True)
+    # close() clears _session_messages, so it must follow memory shutdown above.
+    try:
+        if _active_agent_ref and hasattr(_active_agent_ref, "close"):
+            _active_agent_ref.close()
+    except Exception as e:
+        logger.warning("CLI cleanup agent close failed: %s", e, exc_info=True)
 
 
 def _should_emit_cleanup_session_finalize(session_id: str | None) -> bool:

--- a/cli.py
+++ b/cli.py
@@ -1205,8 +1205,10 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
     # Shut down memory provider (on_session_end + shutdown_all) at actual
     # session boundary — NOT per-turn inside run_conversation().
     if notify_session_finalize:
-        cleanup_session_id = _active_agent_ref.session_id if _active_agent_ref else None
-        if _should_emit_cleanup_session_finalize(cleanup_session_id):
+        cleanup_session_id = getattr(_active_agent_ref, "session_id", None)
+        if cleanup_session_id and _should_emit_cleanup_session_finalize(
+            cleanup_session_id
+        ):
             _notify_session_finalize(
                 session_id=cleanup_session_id,
                 platform="cli",

--- a/run_agent.py
+++ b/run_agent.py
@@ -725,6 +725,10 @@ class AIAgent:
         instead of a bare reset. Default callers pass nothing and keep the
         existing reset-only behavior.
         """
+        from agent.codex_runtime import _retire_codex_app_server_session
+
+        _retire_codex_app_server_session(self)
+
         # Token usage counters
         self.session_total_tokens = 0
         self.session_input_tokens = 0
@@ -3734,12 +3738,17 @@ class AIAgent:
         We DO close:
           - OpenAI/httpx client pool (big chunk of held memory + sockets;
             the rebuilt agent gets a fresh client anyway)
+          - Codex app-server subprocess owned by this agent
           - Active child subagents (per-turn artefacts; safe to drop)
 
         Safe to call multiple times.  Distinct from close() — which is the
         hard teardown for actual session boundaries (/new, /reset, session
         expiry).
         """
+        from agent.codex_runtime import _retire_codex_app_server_session
+
+        _retire_codex_app_server_session(self)
+
         # Close active child agents (per-turn; no cross-turn persistence).
         try:
             with self._active_children_lock:
@@ -3770,6 +3779,7 @@ class AIAgent:
         """Release all resources held by this agent instance.
 
         Cleans up subprocess resources that would otherwise become orphans:
+        - Codex app-server subprocess owned by this agent
         - Background processes tracked in ProcessRegistry
         - Terminal sandbox environments
         - Browser daemon sessions
@@ -3779,6 +3789,9 @@ class AIAgent:
         Safe to call multiple times (idempotent).  Each cleanup step is
         independently guarded so a failure in one does not prevent the rest.
         """
+        from agent.codex_runtime import _retire_codex_app_server_session
+
+        _retire_codex_app_server_session(self)
         task_id = getattr(self, "session_id", None) or ""
 
         # 1. Kill background processes for this task

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -587,6 +587,8 @@ class TestBridgeWiredInRuntime:
         # Minimal stub agent — the runtime only touches a handful of
         # attributes and we mock the heavy ones to keep the test fast.
         agent = SimpleNamespace(
+            model="gpt-5.6-terra",
+            reasoning_config={"enabled": True, "effort": "high"},
             session_cwd=None,
             _codex_session=None,
             tool_progress_callback=MagicMock(),
@@ -625,6 +627,8 @@ class TestBridgeWiredInRuntime:
         assert callable(captured["on_event"]), (
             "on_event must be the bridge callable, not None or a sentinel"
         )
+        assert captured["model"] == "gpt-5.6-terra"
+        assert captured["reasoning_effort"] == "high"
 
         # And the bridge must actually drive the agent's callbacks when
         # fed a representative notification.

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -13,9 +13,25 @@ from agent.kanban_stop import (
 
 @pytest.fixture
 def clear_kanban_env(monkeypatch):
-    for var in ("HERMES_KANBAN_TASK", "HERMES_KANBAN_STOP_NUDGE"):
+    for var in (
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_STOP_NUDGE",
+    ):
         monkeypatch.delenv(var, raising=False)
     return monkeypatch
+
+
+@pytest.fixture
+def running_kanban_task(clear_kanban_env, tmp_path):
+    from hermes_cli import kanban_db as kb
+
+    clear_kanban_env.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="stop guard", assignee="test-worker")
+        assert kb.claim_task(conn, task_id, claimer="test-dispatcher") is not None
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", task_id)
+    return kb, task_id
 
 
 def test_disabled_without_kanban_task(clear_kanban_env):
@@ -35,8 +51,8 @@ def test_env_can_disable(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=[]) is None
 
 
-def test_nudge_when_no_terminal_tool(clear_kanban_env):
-    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_46be8aa5")
+def test_nudge_when_no_terminal_tool(running_kanban_task):
+    _kb, task_id = running_kanban_task
     messages = [
         {"role": "user", "content": "work kanban task"},
         {
@@ -56,12 +72,12 @@ def test_nudge_when_no_terminal_tool(clear_kanban_env):
     assert nudge is not None
     assert "kanban_complete" in nudge
     assert "kanban_block" in nudge
-    assert "t_46be8aa5" in nudge
+    assert task_id in nudge
     assert "protocol violation" in nudge.lower() or "protocol" in nudge.lower()
 
 
-def test_no_nudge_after_kanban_complete(clear_kanban_env):
-    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+def test_no_nudge_after_kanban_complete(running_kanban_task):
+    kb, task_id = running_kanban_task
     messages = [
         {
             "role": "assistant",
@@ -76,20 +92,23 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
         },
         {"role": "tool", "name": "kanban_complete", "tool_call_id": "1", "content": "done"},
     ]
+    with kb.connect_closing() as conn:
+        assert kb.complete_task(conn, task_id, summary="done") is True
     assert session_called_kanban_terminal(messages) is True
     assert build_kanban_stop_nudge(messages=messages) is None
 
 
-def test_no_nudge_after_kanban_block(clear_kanban_env):
-    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+def test_no_nudge_after_kanban_block(running_kanban_task):
+    kb, task_id = running_kanban_task
     messages = [
         {"role": "tool", "name": "kanban_block", "tool_call_id": "1", "content": "blocked"},
     ]
+    with kb.connect_closing() as conn:
+        assert kb.block_task(conn, task_id, reason="blocked") is True
     assert build_kanban_stop_nudge(messages=messages) is None
 
 
-def test_nudge_budget_exhausted(clear_kanban_env):
-    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+def test_nudge_budget_exhausted(running_kanban_task):
     assert build_kanban_stop_nudge(messages=[], attempts=2) is None
     assert build_kanban_stop_nudge(messages=[], attempts=1, max_attempts=1) is None
     assert build_kanban_stop_nudge(messages=[], attempts=0, max_attempts=1) is not None
@@ -103,9 +122,8 @@ def test_nudge_budget_exhausted(clear_kanban_env):
 # for the dispatcher-side streak tests.
 
 
-def test_nudge_text_warns_about_blocking(clear_kanban_env):
+def test_nudge_text_warns_about_blocking(running_kanban_task):
     """The nudge should warn that repeated violations will block the task."""
-    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
     nudge = build_kanban_stop_nudge(messages=[], attempts=0)
     assert nudge is not None
     assert "block" in nudge.lower(), (
@@ -113,7 +131,7 @@ def test_nudge_text_warns_about_blocking(clear_kanban_env):
     )
 
 
-def test_nudge_and_dispatcher_budgets_are_independent(clear_kanban_env):
+def test_nudge_and_dispatcher_budgets_are_independent(running_kanban_task):
     """Agent-side nudge budget (2) and dispatcher-side streak (3) are
     separate budgets — the nudge counter does not affect the dispatcher's
     violation streak, and vice versa.
@@ -123,7 +141,6 @@ def test_nudge_and_dispatcher_budgets_are_independent(clear_kanban_env):
     per session, while the dispatcher streak lives in the task_runs DB
     table and persists across worker respawns.
     """
-    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
     # Agent-side: 2 nudge attempts per session
     assert build_kanban_stop_nudge(messages=[], attempts=0) is not None
     assert build_kanban_stop_nudge(messages=[], attempts=1) is not None

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -7,6 +7,8 @@ covered by a separate live test gated on `codex --version`.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from hermes_cli.runtime_provider import (
@@ -241,6 +243,50 @@ class TestSpawnEnvIsolation:
         # And HOME still passes through unchanged
         assert captured["env"].get("HOME") == "/users/alice"
 
+    @staticmethod
+    def _spawn_kanban_client(monkeypatch, workspace):
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["cmd"] = list(cmd)
+                self.stdin = None
+                self.stdout = None
+                self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_smoke")
+        monkeypatch.setenv(
+            "HERMES_KANBAN_DB",
+            "/users/alice/.hermes/kanban/boards/smoke/kanban.db",
+        )
+        client = cas.CodexAppServerClient(codex_bin="codex", workspace_cwd=str(workspace))
+        client._closed = True
+        return json.loads(
+            next(
+                part.split("=", 1)[1]
+                for part in captured["cmd"]
+                if part.startswith("sandbox_workspace_write.writable_roots=")
+            )
+        )
+
     def test_kanban_linked_worktree_adds_board_and_git_writable_roots(
         self, monkeypatch, tmp_path
     ):
@@ -258,6 +304,7 @@ class TestSpawnEnvIsolation:
         git_dir.mkdir(parents=True)
         (workspace / ".git").write_text(f"gitdir: {git_dir}\n")
         (git_dir / "commondir").write_text("../..\n")
+        (git_dir / "gitdir").write_text(f"{workspace / '.git'}\n")
 
         class FakePopen:
             def __init__(self, cmd, *args, **kwargs):
@@ -305,6 +352,59 @@ class TestSpawnEnvIsolation:
         )
         assert "sandbox_workspace_write.network_access=false" in cmd
         assert all("danger" not in part for part in cmd)
+
+    @pytest.mark.parametrize(
+        "case",
+        (
+            "root_gitdir",
+            "symlink_marker",
+            "symlink_commondir",
+            "symlink_backlink",
+            "malformed_metadata",
+            "unreadable_metadata",
+            "foreign_backlink",
+        ),
+    )
+    def test_kanban_linked_worktree_rejects_untrusted_git_metadata(
+        self, monkeypatch, tmp_path, case
+    ):
+        """Untrusted worktree metadata cannot widen Codex's writable roots."""
+        repo = tmp_path / "repo"
+        workspace = repo / ".worktrees" / "t_smoke"
+        git_dir = repo / ".git" / "worktrees" / "t_smoke"
+        marker = workspace / ".git"
+        workspace.mkdir(parents=True)
+        git_dir.mkdir(parents=True)
+        marker.write_text(f"gitdir: {git_dir}\n")
+        (git_dir / "commondir").write_text("../..\n")
+        (git_dir / "gitdir").write_text(f"{marker}\n")
+
+        if case == "root_gitdir":
+            marker.write_text("gitdir: /\n")
+        elif case == "symlink_marker":
+            marker.unlink()
+            symlink_target = tmp_path / "marker-target"
+            symlink_target.write_text(f"gitdir: {git_dir}\n")
+            marker.symlink_to(symlink_target)
+        elif case == "symlink_commondir":
+            (git_dir / "commondir").unlink()
+            (git_dir / "commondir").symlink_to(repo / ".git")
+        elif case == "symlink_backlink":
+            (git_dir / "gitdir").unlink()
+            (git_dir / "gitdir").symlink_to(marker)
+        elif case == "malformed_metadata":
+            (git_dir / "commondir").write_text("\n")
+        elif case == "unreadable_metadata":
+            (git_dir / "commondir").chmod(0)
+        elif case == "foreign_backlink":
+            foreign_marker = tmp_path / "foreign" / ".git"
+            foreign_marker.parent.mkdir()
+            foreign_marker.write_text("gitdir: ignored\n")
+            (git_dir / "gitdir").write_text(f"{foreign_marker}\n")
+
+        assert self._spawn_kanban_client(monkeypatch, workspace) == [
+            "/users/alice/.hermes/kanban/boards/smoke"
+        ]
 
 
 class TestSpawnEnvSecretStripping:

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -273,6 +273,7 @@ class TestSpawnEnvIsolation:
 
         monkeypatch.setattr(subprocess, "Popen", FakePopen)
         monkeypatch.setenv("HERMES_KANBAN_TASK", "t_smoke")
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
         monkeypatch.setenv(
             "HERMES_KANBAN_DB",
             "/users/alice/.hermes/kanban/boards/smoke/kanban.db",
@@ -332,6 +333,7 @@ class TestSpawnEnvIsolation:
         monkeypatch.setenv("HOME", "/users/alice")
         monkeypatch.setenv("HERMES_HOME", "/users/alice/.hermes/profiles/backend-worker")
         monkeypatch.setenv("HERMES_KANBAN_TASK", "t_smoke")
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
         monkeypatch.setenv(
             "HERMES_KANBAN_DB",
             "/users/alice/.hermes/kanban/boards/smoke/kanban.db",
@@ -352,6 +354,24 @@ class TestSpawnEnvIsolation:
         )
         assert "sandbox_workspace_write.network_access=false" in cmd
         assert all("danger" not in part for part in cmd)
+
+    def test_kanban_worker_rejects_self_consistent_foreign_git_admin(
+        self, monkeypatch, tmp_path
+    ):
+        """Workspace-controlled Git metadata cannot authorize a foreign root."""
+        workspace = tmp_path / "workspace"
+        git_common = tmp_path / "foreign-admin.git"
+        git_dir = git_common / "worktrees" / "slot"
+        marker = workspace / ".git"
+        workspace.mkdir()
+        git_dir.mkdir(parents=True)
+        marker.write_text(f"gitdir: {git_dir}\n")
+        (git_dir / "commondir").write_text("../..\n")
+        (git_dir / "gitdir").write_text(f"{marker}\n")
+
+        assert self._spawn_kanban_client(monkeypatch, workspace) == [
+            "/users/alice/.hermes/kanban/boards/smoke"
+        ]
 
     @pytest.mark.parametrize(
         "case",

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -241,16 +241,23 @@ class TestSpawnEnvIsolation:
         # And HOME still passes through unchanged
         assert captured["env"].get("HOME") == "/users/alice"
 
-    def test_kanban_worker_adds_only_kanban_writable_root(self, monkeypatch):
-        """Codex-runtime Kanban workers need to write board state outside
-        their scratch/worktree workspace, but should not fall back to
-        danger-full-access. Hermes passes a narrow app-server config override
-        for the Kanban root only.
+    def test_kanban_linked_worktree_adds_board_and_git_writable_roots(
+        self, monkeypatch, tmp_path
+    ):
+        """Linked-worktree workers need the board and shared Git metadata,
+        without falling back to danger-full-access.
         """
         import subprocess
         from agent.transports import codex_app_server as cas
 
         captured = {}
+        repo = tmp_path / "repo"
+        workspace = repo / ".worktrees" / "t_smoke"
+        git_dir = repo / ".git" / "worktrees" / "t_smoke"
+        workspace.mkdir(parents=True)
+        git_dir.mkdir(parents=True)
+        (workspace / ".git").write_text(f"gitdir: {git_dir}\n")
+        (git_dir / "commondir").write_text("../..\n")
 
         class FakePopen:
             def __init__(self, cmd, *args, **kwargs):
@@ -283,14 +290,17 @@ class TestSpawnEnvIsolation:
             "/users/alice/.hermes/kanban/boards/smoke/kanban.db",
         )
 
-        client = cas.CodexAppServerClient(codex_bin="codex")
+        client = cas.CodexAppServerClient(
+            codex_bin="codex", workspace_cwd=str(workspace)
+        )
         client._closed = True
 
         cmd = captured["cmd"]
         assert cmd[:2] == ["codex", "app-server"]
         assert 'sandbox_mode="workspace-write"' in cmd
         assert (
-            'sandbox_workspace_write.writable_roots=["/users/alice/.hermes/kanban/boards/smoke"]'
+            "sandbox_workspace_write.writable_roots="
+            f'["/users/alice/.hermes/kanban/boards/smoke", "{repo / ".git"}"]'
             in cmd
         )
         assert "sandbox_workspace_write.network_access=false" in cmd

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -197,6 +197,28 @@ class TestLifecycle:
             'model_reasoning_effort="high"',
         ]
 
+    def test_legacy_client_factory_without_new_kwargs_is_supported(self):
+        client = FakeClient()
+        captured: dict = {}
+
+        def factory(codex_bin, codex_home) -> Any:
+            captured.update(codex_bin=codex_bin, codex_home=codex_home)
+            return client
+
+        session = CodexAppServerSession(
+            cwd="/tmp",
+            codex_bin="codex-test",
+            codex_home="/tmp/codex-home",
+            model="gpt-5.6-terra",
+            client_factory=factory,
+        )
+        session.ensure_started()
+
+        assert captured == {
+            "codex_bin": "codex-test",
+            "codex_home": "/tmp/codex-home",
+        }
+
     def test_close_idempotent(self):
         client = FakeClient()
         s = make_session(client)

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -174,6 +174,29 @@ class TestLifecycle:
         assert params["cwd"] == "/tmp"
         assert "permissions" not in params  # see session.ensure_started() comment
 
+    def test_model_and_effort_are_forwarded_as_process_config(self):
+        client = FakeClient()
+        captured: dict = {}
+
+        def factory(**kwargs):
+            captured.update(kwargs)
+            return client
+
+        session = CodexAppServerSession(
+            cwd="/tmp",
+            model="gpt-5.6-terra",
+            reasoning_effort="high",
+            client_factory=factory,
+        )
+        session.ensure_started()
+
+        assert captured["extra_args"] == [
+            "-c",
+            'model="gpt-5.6-terra"',
+            "-c",
+            'model_reasoning_effort="high"',
+        ]
+
     def test_close_idempotent(self):
         client = FakeClient()
         s = make_session(client)

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -21,11 +21,10 @@ def _isolate_cleanup(monkeypatch):
     monkeypatch.setattr("agent.auxiliary_client.shutdown_cached_clients", lambda: None)
 
 
-def test_cleanup_closes_active_agent_once_after_memory_shutdown(monkeypatch):
+def test_cleanup_partial_active_agent_runs_remaining_phases_once(monkeypatch):
     calls = []
 
     class FakeAgent:
-        session_id = "agent-session"
         _memory_manager = None
         _session_messages = []
 
@@ -34,12 +33,18 @@ def test_cleanup_closes_active_agent_once_after_memory_shutdown(monkeypatch):
 
         def close(self):
             calls.append(("close", None))
+            raise RuntimeError("close failed")
 
     _isolate_cleanup(monkeypatch)
+    monkeypatch.setattr(
+        cli,
+        "_notify_session_finalize",
+        lambda **kwargs: calls.append(("finalize", kwargs)),
+    )
     monkeypatch.setattr(cli, "_active_agent_ref", FakeAgent())
 
-    cli._run_cleanup(notify_session_finalize=False)
-    cli._run_cleanup(notify_session_finalize=False)
+    cli._run_cleanup()
+    cli._run_cleanup()
 
     assert calls == [("memory", []), ("close", None)]
 

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -11,6 +11,107 @@ def reset_single_query_finalize_state(monkeypatch):
     monkeypatch.setattr(cli, "_cleanup_done", False)
 
 
+def _isolate_cleanup(monkeypatch):
+    monkeypatch.setattr(cli, "_arm_exit_watchdog", lambda: None)
+    monkeypatch.setattr(cli, "_reset_terminal_input_modes_on_exit", lambda: None)
+    monkeypatch.setattr(cli, "_cleanup_all_terminals", lambda: None)
+    monkeypatch.setattr(cli, "_cleanup_all_browsers", lambda: None)
+    monkeypatch.setattr("tools.async_delegation.interrupt_all", lambda **_kwargs: None)
+    monkeypatch.setattr("tools.mcp_tool.shutdown_mcp_servers", lambda: None)
+    monkeypatch.setattr("agent.auxiliary_client.shutdown_cached_clients", lambda: None)
+
+
+def test_cleanup_closes_active_agent_once_after_memory_shutdown(monkeypatch):
+    calls = []
+
+    class FakeAgent:
+        session_id = "agent-session"
+        _memory_manager = None
+        _session_messages = []
+
+        def shutdown_memory_provider(self, messages):
+            calls.append(("memory", messages))
+
+        def close(self):
+            calls.append(("close", None))
+
+    _isolate_cleanup(monkeypatch)
+    monkeypatch.setattr(cli, "_active_agent_ref", FakeAgent())
+
+    cli._run_cleanup(notify_session_finalize=False)
+    cli._run_cleanup(notify_session_finalize=False)
+
+    assert calls == [("memory", []), ("close", None)]
+
+
+@pytest.mark.live_system_guard_bypass
+def test_finalize_single_query_stops_codex_child_and_reader_threads(monkeypatch):
+    import subprocess
+    import sys
+
+    from agent.transports import codex_app_server
+    from agent.transports.codex_app_server_session import CodexAppServerSession
+    from run_agent import AIAgent
+
+    real_popen = subprocess.Popen
+
+    def spawn_probe(_cmd, **kwargs):
+        return real_popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            **kwargs,
+        )
+
+    _isolate_cleanup(monkeypatch)
+    monkeypatch.setattr(codex_app_server.subprocess, "Popen", spawn_probe)
+    monkeypatch.setattr("run_agent.cleanup_vm", lambda _task_id: None)
+    monkeypatch.setattr("run_agent.cleanup_browser", lambda _task_id: None)
+    monkeypatch.setattr(
+        "tools.process_registry.process_registry.kill_all", lambda **_kwargs: None
+    )
+
+    client = codex_app_server.CodexAppServerClient(codex_bin="probe")
+    session = CodexAppServerSession.__new__(CodexAppServerSession)
+    session._closed = False
+    session._client = client
+    session._thread_id = "cleanup-probe"
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "cleanup-probe"
+    agent._memory_manager = None
+    agent.context_compressor = None
+    agent._session_messages = []
+    agent._codex_session = session
+    agent._codex_session_runtime_key = ("gpt-5.6-sol", "max")
+
+    releases = []
+    fake_cli = SimpleNamespace(
+        agent=agent,
+        session_id=agent.session_id,
+        _release_active_session=lambda: releases.append("release"),
+    )
+    monkeypatch.setattr(cli, "_active_agent_ref", agent)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: None)
+
+    try:
+        assert client._proc.poll() is None
+        assert client._reader.is_alive()
+        assert client._stderr_reader.is_alive()
+
+        cli._finalize_single_query(fake_cli)
+        client._reader.join(timeout=2)
+        client._stderr_reader.join(timeout=2)
+
+        assert releases == ["release"]
+        assert client._proc.poll() is not None
+        assert not client._reader.is_alive()
+        assert not client._stderr_reader.is_alive()
+        assert agent._codex_session is None
+    finally:
+        client.close(timeout=0.1)
+        client._reader.join(timeout=2)
+        client._stderr_reader.join(timeout=2)
+
+
 def test_finalize_single_query_runs_cleanup_without_reemitting_finalize_before_release(monkeypatch):
     calls = []
     fake_cli = SimpleNamespace(_release_active_session=lambda: calls.append(("release", {})))

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -75,8 +75,7 @@ def test_finalize_single_query_stops_codex_child_and_reader_threads(monkeypatch)
     )
 
     client = codex_app_server.CodexAppServerClient(codex_bin="probe")
-    session = CodexAppServerSession.__new__(CodexAppServerSession)
-    session._closed = False
+    session = CodexAppServerSession()
     session._client = client
     session._thread_id = "cleanup-probe"
 

--- a/tests/run_agent/test_codex_app_server_compaction.py
+++ b/tests/run_agent/test_codex_app_server_compaction.py
@@ -187,6 +187,58 @@ def test_codex_app_server_manual_compression_routes_to_codex_thread():
     ]
 
 
+def test_codex_app_server_compaction_retires_stale_runtime_without_rpc():
+    agent = DummyAgent(
+        TurnResult(thread_id="thread-1", turn_id="compact-turn-1")
+    )
+    stale_session = agent._codex_session
+    agent.model = "gpt-5.6-sol"
+    agent.reasoning_config = {"enabled": True, "effort": "max"}
+    agent._codex_session_runtime_key = ("gpt-5.6-terra", "high")
+    messages = [{"role": "user", "content": "hi"}]
+
+    returned, prompt = compress_context(
+        agent,
+        messages,
+        "system",
+        approx_tokens=100000,
+        task_id="test",
+        force=True,
+    )
+
+    assert returned is messages
+    assert prompt == "cached prompt"
+    assert stale_session.calls == 0
+    assert stale_session.closed is True
+    assert agent._codex_session is None
+    assert agent.context_compressor.compression_count == 0
+
+
+def test_codex_app_server_compaction_rejects_malformed_reasoning_without_mutation():
+    agent = DummyAgent(
+        TurnResult(thread_id="thread-1", turn_id="compact-turn-1")
+    )
+    session = agent._codex_session
+    agent.reasoning_config = "high"
+    messages = [{"role": "user", "content": "hi"}]
+
+    returned, prompt = compress_context(
+        agent,
+        messages,
+        "system",
+        approx_tokens=100000,
+        task_id="test",
+        force=True,
+    )
+
+    assert returned is messages
+    assert prompt == "cached prompt"
+    assert agent._codex_session is session
+    assert session.calls == 0
+    assert session.closed is False
+    assert agent.context_compressor.compression_count == 0
+
+
 def test_codex_app_server_hermes_mode_auto_compression_routes_to_codex_thread():
     agent = DummyAgent(
         TurnResult(thread_id="thread-1", turn_id="compact-turn-1"),
@@ -232,6 +284,23 @@ def test_codex_app_server_compression_failure_preserves_bookkeeping():
         ("warn", "⚠ Codex app-server compaction failed: compact failed"),
         ("compacted", COMPACTION_DONE_STATUS),
     ]
+
+
+def test_codex_app_server_compaction_should_retire_closes_session():
+    agent = DummyAgent(TurnResult(error="compact failed", should_retire=True))
+    session = agent._codex_session
+
+    compress_context(
+        agent,
+        [{"role": "user", "content": "hi"}],
+        "system",
+        approx_tokens=100000,
+        force=True,
+    )
+
+    assert session.calls == 1
+    assert session.closed is True
+    assert agent._codex_session is None
 
 
 def test_codex_app_server_native_compaction_notice_emits_status_and_event():

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -21,6 +21,29 @@ import run_agent
 from agent.transports.codex_app_server_session import CodexAppServerSession, TurnResult
 
 
+@pytest.fixture(autouse=True)
+def refresh_cached_hermes_home(monkeypatch):
+    from hermes_constants import get_hermes_home
+
+    monkeypatch.setattr(run_agent, "_hermes_home", get_hermes_home())
+
+
+def _create_running_kanban_task(monkeypatch, tmp_path):
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="normal app-server worker",
+            assignee="codex",
+            goal_mode=False,
+        )
+        assert kb.claim_task(conn, task_id, claimer="test-dispatcher") is not None
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    return kb, task_id
+
+
 @pytest.fixture
 def fake_session(monkeypatch):
     """Replace CodexAppServerSession with a stub that returns a fixed
@@ -134,6 +157,259 @@ class TestRunConversationCodexPath:
             agent.run_conversation("hello")
 
         assert fake_session == [{}]
+
+    def test_running_kanban_task_continues_in_same_codex_session(
+        self, monkeypatch, tmp_path
+    ):
+        kb, task_id = _create_running_kanban_task(monkeypatch, tmp_path)
+        monkeypatch.setenv("TERMINAL_TIMEOUT", "2370")
+        session_ids = []
+        inputs = []
+        timeout_calls = []
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            session_ids.append(id(self))
+            inputs.append(user_input)
+            timeout_calls.append(kwargs)
+            if len(inputs) == 1:
+                return TurnResult(
+                    final_text="I will finish the task next.",
+                    projected_messages=[{
+                        "role": "assistant",
+                        "content": "I will finish the task next.",
+                    }],
+                    turn_id="turn-progress",
+                    thread_id="thread-worker",
+                    token_usage_last={
+                        "totalTokens": 10,
+                        "inputTokens": 6,
+                        "cachedInputTokens": 2,
+                        "outputTokens": 2,
+                        "reasoningOutputTokens": 0,
+                    },
+                )
+            with kb.connect_closing() as conn:
+                assert kb.complete_task(conn, task_id, summary="done") is True
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "done"}],
+                turn_id="turn-done",
+                thread_id="thread-worker",
+                token_usage_last={
+                    "totalTokens": 20,
+                    "inputTokens": 12,
+                    "cachedInputTokens": 4,
+                    "outputTokens": 4,
+                    "reasoningOutputTokens": 0,
+                },
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-worker"
+        )
+        from hermes_state import SessionDB
+
+        session_db = SessionDB(tmp_path / "state.db")
+        session_id = "session-kanban-continuity"
+        session_db.create_session(
+            session_id=session_id,
+            source="test",
+            model="codex",
+        )
+        agent = _make_codex_agent(session_db=session_db, session_id=session_id)
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("work the task")
+
+        assert result["final_response"] == "done"
+        assert result["api_calls"] == 2
+        assert result["prompt_tokens"] == 24
+        assert result["completion_tokens"] == 6
+        assert result["total_tokens"] == 30
+        assert result["last_prompt_tokens"] == 16
+        assert len(set(session_ids)) == 1
+        assert inputs[0] == "work the task"
+        assert "kanban_complete" in inputs[1]
+        assert timeout_calls == [
+            {"turn_timeout": 2370, "post_tool_quiet_timeout": 2370},
+            {"turn_timeout": 2370, "post_tool_quiet_timeout": 2370},
+        ]
+        assert [message["role"] for message in result["messages"][-4:]] == [
+            "user",
+            "assistant",
+            "user",
+            "assistant",
+        ]
+        persisted = session_db.get_messages(session_id, include_inactive=True)
+        persisted_contents = [message["content"] for message in persisted]
+        assert persisted_contents.count("work the task") == 1
+        assert persisted_contents.count("I will finish the task next.") == 0
+        assert all(
+            "protocol violation" not in str(value or "")
+            for value in persisted_contents
+        )
+        assert persisted_contents.count("done") == 1
+        with kb.connect_closing() as conn:
+            task = kb.get_task(conn, task_id)
+            assert task is not None
+            assert task.goal_mode is False
+            assert task.status == "done"
+
+    @pytest.mark.parametrize("terminal_status", ["done", "blocked"])
+    def test_terminal_board_state_does_not_nudge_app_server(
+        self, monkeypatch, tmp_path, terminal_status
+    ):
+        kb, task_id = _create_running_kanban_task(monkeypatch, tmp_path)
+        calls = []
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            calls.append(user_input)
+            with kb.connect_closing() as conn:
+                if terminal_status == "done":
+                    assert kb.complete_task(conn, task_id, summary="done") is True
+                else:
+                    assert kb.block_task(
+                        conn,
+                        task_id,
+                        reason="needs input",
+                        kind="needs_input",
+                    ) is True
+            tool_name = f"kanban_{'complete' if terminal_status == 'done' else 'block'}"
+            return TurnResult(
+                final_text=terminal_status,
+                projected_messages=[
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [{
+                            "id": "terminal_1",
+                            "type": "function",
+                            "function": {"name": tool_name, "arguments": "{}"},
+                        }],
+                    },
+                    {
+                        "role": "tool",
+                        "name": tool_name,
+                        "tool_call_id": "terminal_1",
+                        "content": terminal_status,
+                    },
+                    {"role": "assistant", "content": terminal_status},
+                ],
+                turn_id=f"turn-{terminal_status}",
+                thread_id="thread-terminal",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-terminal"
+        )
+        agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("finish the task")
+
+        assert result["final_response"] == terminal_status
+        assert result["api_calls"] == 1
+        assert calls == ["finish the task"]
+        with kb.connect_closing() as conn:
+            assert kb.get_task(conn, task_id).status == terminal_status
+
+    def test_rejected_terminal_tool_nudges_while_board_is_running(
+        self, monkeypatch, tmp_path
+    ):
+        kb, task_id = _create_running_kanban_task(monkeypatch, tmp_path)
+        inputs = []
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            inputs.append(user_input)
+            if len(inputs) == 1:
+                return TurnResult(
+                    final_text="completion was rejected",
+                    projected_messages=[
+                        {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [{
+                                "id": "complete_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "kanban_complete",
+                                    "arguments": "{}",
+                                },
+                            }],
+                        },
+                        {
+                            "role": "tool",
+                            "name": "kanban_complete",
+                            "tool_call_id": "complete_1",
+                            "content": '{"error":"completion rejected"}',
+                        },
+                    ],
+                    turn_id="turn-rejected",
+                    thread_id="thread-rejected",
+                )
+            with kb.connect_closing() as conn:
+                assert kb.complete_task(conn, task_id, summary="done") is True
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "done"}],
+                turn_id="turn-recovered",
+                thread_id="thread-rejected",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-rejected"
+        )
+        agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("finish the task")
+
+        assert result["final_response"] == "done"
+        assert result["api_calls"] == 2
+        assert "kanban_complete" in inputs[1]
+        assert [message["role"] for message in result["messages"][-3:]] == [
+            "assistant",
+            "user",
+            "assistant",
+        ]
+        with kb.connect_closing() as conn:
+            assert kb.get_task(conn, task_id).status == "done"
+
+    def test_running_board_nudge_is_bounded(self, monkeypatch, tmp_path):
+        kb, task_id = _create_running_kanban_task(monkeypatch, tmp_path)
+        inputs = []
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            inputs.append(user_input)
+            return TurnResult(
+                final_text="still working",
+                projected_messages=[{
+                    "role": "assistant",
+                    "content": "still working",
+                }],
+                turn_id=f"turn-{len(inputs)}",
+                thread_id="thread-bounded",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-bounded"
+        )
+        agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("work the task")
+
+        assert result["final_response"] == "still working"
+        assert result["api_calls"] == 3
+        assert len(inputs) == 3
+        assert all("kanban_complete" in value for value in inputs[1:])
+        assert agent._kanban_stop_nudges == 2
+        with kb.connect_closing() as conn:
+            assert kb.get_task(conn, task_id).status == "running"
 
     def test_codex_app_server_token_usage_updates_session_accounting(self, monkeypatch):
         def fake_run_turn(self, user_input: str, **kwargs):

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -743,6 +743,116 @@ class TestSessionRetirementOnRunAgent:
         assert "codex segfaulted" in result["error"]
 
 
+class TestSessionRuntimeSelection:
+    def test_live_runtime_switch_replaces_session_before_next_turn(
+        self, monkeypatch
+    ):
+        events = []
+        sessions = []
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                self.runtime = (
+                    str(kwargs.get("model") or "").strip() or None,
+                    str(kwargs.get("reasoning_effort") or "").strip() or None,
+                )
+                self.thread_id = f"thread-{len(sessions) + 1}"
+                self.close_calls = 0
+                sessions.append(self)
+                events.append(("constructed", self.runtime))
+
+            def run_turn(self, user_input, **kwargs):
+                events.append(("turn", self.runtime, user_input))
+                return TurnResult(
+                    final_text="ok",
+                    projected_messages=[],
+                    turn_id=f"turn-{user_input}",
+                    thread_id=self.thread_id,
+                )
+
+            def close(self):
+                self.close_calls += 1
+                events.append(("closed", self.runtime))
+
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server_session.CodexAppServerSession",
+            FakeSession,
+        )
+        agent = _make_codex_agent()
+        agent.model = " gpt-5.6-terra "
+        agent.reasoning_config = {"enabled": True, "effort": " high "}
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            first = agent.run_conversation("first")
+            agent.model = "gpt-5.6-terra"
+            agent.reasoning_config = {"enabled": True, "effort": "high"}
+            second = agent.run_conversation("second")
+            agent.model = "gpt-5.6-sol"
+            agent.reasoning_config = {"enabled": True, "effort": "max"}
+            third = agent.run_conversation("third")
+
+        assert len(sessions) == 2
+        assert sessions[0].close_calls == 1
+        assert sessions[1].close_calls == 0
+        assert first["codex_thread_id"] == second["codex_thread_id"] == "thread-1"
+        assert third["codex_thread_id"] == "thread-2"
+        assert events == [
+            ("constructed", ("gpt-5.6-terra", "high")),
+            ("turn", ("gpt-5.6-terra", "high"), "first"),
+            ("turn", ("gpt-5.6-terra", "high"), "second"),
+            ("closed", ("gpt-5.6-terra", "high")),
+            ("constructed", ("gpt-5.6-sol", "max")),
+            ("turn", ("gpt-5.6-sol", "max"), "third"),
+        ]
+
+    def test_reasoning_disable_reaches_codex_process_config(
+        self, monkeypatch
+    ):
+        captured = {}
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def initialize(self, **kwargs):
+                pass
+
+            def request(self, method, params=None, timeout=30.0):
+                assert method == "thread/start"
+                return {"thread": {"id": "thread-disabled"}}
+
+            def close(self):
+                pass
+
+        def fake_run_turn(session, user_input, **kwargs):
+            thread_id = session.ensure_started()
+            return TurnResult(
+                final_text="ok",
+                projected_messages=[],
+                turn_id="turn-disabled",
+                thread_id=thread_id,
+            )
+
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server_session.CodexAppServerClient",
+            FakeClient,
+        )
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        agent = _make_codex_agent()
+        agent.model = "gpt-5.6-sol"
+        agent.reasoning_config = {"enabled": False}
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("no reasoning")
+
+        assert captured["extra_args"] == [
+            "-c",
+            'model="gpt-5.6-sol"',
+            "-c",
+            'model_reasoning_effort="none"',
+        ]
+
+
 class TestCodexToolProgressBridge:
     """#38835 / #33200: Codex app-server item notifications must surface as
     Hermes tool-progress so gateways show verbose breadcrumbs on this route.

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -26,7 +26,10 @@ def fake_session(monkeypatch):
     """Replace CodexAppServerSession with a stub that returns a fixed
     TurnResult, so we can drive AIAgent without spawning real codex."""
 
+    calls = []
+
     def fake_run_turn(self, user_input: str, **kwargs):
+        calls.append(kwargs)
         return TurnResult(
             final_text=f"echo: {user_input}",
             projected_messages=[
@@ -48,6 +51,7 @@ def fake_session(monkeypatch):
     monkeypatch.setattr(
         CodexAppServerSession, "ensure_started", lambda self: "thread-stub-1"
     )
+    return calls
 
 
 def _make_codex_agent(**kwargs):
@@ -85,6 +89,51 @@ class TestRunConversationCodexPath:
         assert result["api_calls"] == 1
         assert result["codex_thread_id"] == "thread-stub-1"
         assert result["codex_turn_id"] == "turn-stub-1"
+
+    def test_kanban_turn_uses_worker_runtime_for_both_timeouts(
+        self, fake_session, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_timeout")
+        monkeypatch.setenv("TERMINAL_TIMEOUT", "2370")
+        agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+
+        assert fake_session == [{
+            "turn_timeout": 2370,
+            "post_tool_quiet_timeout": 2370,
+        }]
+
+    def test_non_kanban_turn_keeps_app_server_defaults(
+        self, fake_session, monkeypatch
+    ):
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.setenv("TERMINAL_TIMEOUT", "2370")
+        agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+
+        assert fake_session == [{}]
+
+    @pytest.mark.parametrize(
+        "terminal_timeout", [None, "", "invalid", "0", "-1", "nan", "inf"]
+    )
+    def test_invalid_kanban_timeout_keeps_app_server_defaults(
+        self, fake_session, monkeypatch, terminal_timeout
+    ):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_timeout")
+        if terminal_timeout is None:
+            monkeypatch.delenv("TERMINAL_TIMEOUT", raising=False)
+        else:
+            monkeypatch.setenv("TERMINAL_TIMEOUT", terminal_timeout)
+        agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+
+        assert fake_session == [{}]
 
     def test_codex_app_server_token_usage_updates_session_accounting(self, monkeypatch):
         def fake_run_turn(self, user_input: str, **kwargs):
@@ -786,4 +835,3 @@ class TestCodexToolProgressBridge:
 
         assert "on_event" in captured_init and captured_init["on_event"] is not None
         assert ("tool.started", "exec_command", "pytest") in events
-

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -744,9 +744,71 @@ class TestSessionRetirementOnRunAgent:
 
 
 class TestSessionRuntimeSelection:
-    def test_live_runtime_switch_replaces_session_before_next_turn(
-        self, monkeypatch
+    @pytest.mark.parametrize("reasoning_config", ["high", ["high"], True])
+    def test_malformed_reasoning_config_fails_without_mutating_session(
+        self, reasoning_config
     ):
+        agent = _make_codex_agent()
+        agent.model = "gpt-5.6-sol"
+        agent.reasoning_config = reasoning_config
+        session = MagicMock()
+        agent._codex_session = session
+        agent._codex_session_runtime_key = ("gpt-5.6-sol", "max")
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert "reasoning_config must be a mapping" in result["error"]
+        assert agent._codex_session is session
+        session.run_turn.assert_not_called()
+        session.close.assert_not_called()
+
+    def test_session_reset_starts_fresh_thread_at_same_runtime(self, monkeypatch):
+        sessions = []
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                self.thread_id = f"thread-{len(sessions) + 1}"
+                self.inputs = []
+                self.close_calls = 0
+                sessions.append(self)
+
+            def run_turn(self, user_input, **kwargs):
+                self.inputs.append(user_input)
+                return TurnResult(
+                    final_text="ok",
+                    projected_messages=[],
+                    turn_id=f"turn-{user_input}",
+                    thread_id=self.thread_id,
+                )
+
+            def close(self):
+                self.close_calls += 1
+
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server_session.CodexAppServerSession",
+            FakeSession,
+        )
+        agent = _make_codex_agent()
+        agent.model = "gpt-5.6-sol"
+        agent.reasoning_config = {"enabled": True, "effort": "max"}
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            first = agent.run_conversation("old-session-secret")
+            agent.session_id = "fresh-session"
+            agent.reset_session_state()
+            second = agent.run_conversation("fresh-session-question")
+
+        assert len(sessions) == 2
+        assert sessions[0].close_calls == 1
+        assert sessions[0].inputs == ["old-session-secret"]
+        assert sessions[1].inputs == ["fresh-session-question"]
+        assert first["codex_thread_id"] == "thread-1"
+        assert second["codex_thread_id"] == "thread-2"
+
+    def test_live_runtime_switch_replaces_session_before_next_turn(self, monkeypatch):
         events = []
         sessions = []
 
@@ -786,7 +848,8 @@ class TestSessionRuntimeSelection:
             first = agent.run_conversation("first")
             agent.model = "gpt-5.6-terra"
             agent.reasoning_config = {"enabled": True, "effort": "high"}
-            second = agent.run_conversation("second")
+            second = agent.run_conversation("[Persistent goal continuation]")
+            event = agent.run_conversation("[Kanban task completed]")
             agent.model = "gpt-5.6-sol"
             agent.reasoning_config = {"enabled": True, "effort": "max"}
             third = agent.run_conversation("third")
@@ -794,12 +857,22 @@ class TestSessionRuntimeSelection:
         assert len(sessions) == 2
         assert sessions[0].close_calls == 1
         assert sessions[1].close_calls == 0
-        assert first["codex_thread_id"] == second["codex_thread_id"] == "thread-1"
+        assert (
+            first["codex_thread_id"]
+            == second["codex_thread_id"]
+            == event["codex_thread_id"]
+            == "thread-1"
+        )
         assert third["codex_thread_id"] == "thread-2"
         assert events == [
             ("constructed", ("gpt-5.6-terra", "high")),
             ("turn", ("gpt-5.6-terra", "high"), "first"),
-            ("turn", ("gpt-5.6-terra", "high"), "second"),
+            (
+                "turn",
+                ("gpt-5.6-terra", "high"),
+                "[Persistent goal continuation]",
+            ),
+            ("turn", ("gpt-5.6-terra", "high"), "[Kanban task completed]"),
             ("closed", ("gpt-5.6-terra", "high")),
             ("constructed", ("gpt-5.6-sol", "max")),
             ("turn", ("gpt-5.6-sol", "max"), "third"),

--- a/tests/run_agent/test_session_reset_fix.py
+++ b/tests/run_agent/test_session_reset_fix.py
@@ -9,6 +9,7 @@ therefore never cleared:
 import sys
 import types
 from pathlib import Path
+from unittest.mock import MagicMock
 
 
 # Ensure repo root is importable
@@ -118,3 +119,31 @@ class TestResetSessionState:
         agent.reset_session_state()
 
         assert agent._user_turn_count == 0
+
+
+class TestCodexSessionOwnership:
+    def test_release_clients_closes_and_detaches_codex_session_once(self):
+        agent = _make_minimal_agent()
+        session = MagicMock()
+        agent._codex_session = session
+        agent._codex_session_runtime_key = ("gpt-5.6-sol", "max")
+
+        agent.release_clients()
+        agent.release_clients()
+
+        session.close.assert_called_once_with()
+        assert agent._codex_session is None
+        assert "_codex_session_runtime_key" not in vars(agent)
+
+    def test_close_closes_and_detaches_codex_session_once(self):
+        agent = _make_minimal_agent()
+        session = MagicMock()
+        agent._codex_session = session
+        agent._codex_session_runtime_key = ("gpt-5.6-sol", "max")
+
+        agent.close()
+        agent.close()
+
+        session.close.assert_called_once_with()
+        assert agent._codex_session is None
+        assert "_codex_session_runtime_key" not in vars(agent)


### PR DESCRIPTION
## Summary
- inherit the Kanban card runtime budget in the nested Codex app-server turn instead of falling back to its 600s default
- forward and refresh app-server runtime configuration, retire stale sessions, and close active ownership during cleanup
- when a Codex turn returns while the authoritative Kanban card is still `running`, reuse the existing bounded stop nudge in the same app-server session
- preserve strict legacy two-argument `client_factory(codex_bin, codex_home)` callables by passing optional kwargs only when their signature accepts them
- validate linked-worktree Git metadata before adding writable roots; reject symlink/backlink/foreign-root escapes

`rc=0` is **not** treated as task completion. Only a card already moved to `done` or `blocked` terminates normally; a still-`running` card gets at most the existing two stop nudges.

## Verification
- exact PR head: `15974049aefc29742c537bdd4008e6c4e3b8f98a`
- exact tree: `ed21ffb8a7eb8197a982f8ddf98a4f27630bd1ac`
- synthetic merge with upstream `main@8fc278207b0f5b25e567966f9615e1b1737f62af`: clean, no conflicts
- focused stop/app-server suite: **58 passed, 0 failed**
- adjacent runtime/session/cleanup suite: **182 passed, 0 failed**
- hostile legacy/flexible/opaque factory compatibility probes: passed; no TypeError retry or double invocation
- Ruff, `py_compile`, `git diff --check`, remote SHA/tree verification, and diff secret/conflict-marker scan: passed
- independent exact-SHA Sol review: **APPROVED**, P0/P1/P2 = **0/0/0**

### Full-suite baseline comparison
- the repo-wide Python suite on the synthetic PR merge reported **34 failures in 14 files**
- rerunning those same 14 files on pristine upstream `main@8fc278207b0f5b25e567966f9615e1b1737f62af` reproduced the **same 34 failures in the same files**
- every failure is outside this PR's 15 changed files, so none is attributed to this candidate
- repo-wide Ruff exits 0 with one pre-existing invalid-`noqa` warning at `run_agent.py:107`

## Hosted checks
GitHub's Checks tab reports `Workflow runs completed with no jobs` for this fork head, so there is no hosted CI result to claim. The local current-main merge and baseline comparison above are the available gates.

## Relationship to #63375
#63375 overlaps the linked-worktree sandbox/ownership area and is the canonical fix for its reported issue. This PR also carries stronger Git metadata validation, but its timeout, runtime continuity, stale-session, cleanup, and bounded Kanban nudge fixes are separate. No commit in this 10-commit range is patch-equivalent to current `main` (`git cherry` reports all ten as pending).
