### PR TITLE
fix(tui): make Kanban delivery and prompt ownership durable

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9229,9 +9229,12 @@ def claim_unseen_events_for_sub(
 
     Callers should send the claimed events, then either leave the cursor at
     ``new_cursor`` on success or call :func:`rewind_notify_cursor` if delivery
-    failed before any terminal unsubscribe removed the row.
+    failed before any terminal unsubscribe removed the row. If the connection
+    is already in a transaction, the claim joins it so the caller can commit or
+    roll back the cursor with a larger delivery acceptance boundary.
     """
-    with write_txn(conn):
+    txn = contextlib.nullcontext(conn) if conn.in_transaction else write_txn(conn)
+    with txn:
         row = conn.execute(
             "SELECT last_event_id FROM kanban_notify_subs "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3304,6 +3304,147 @@ def test_notification_poller_tui_kanban_preserves_busy_and_foreign_cursors(
         server._sessions.pop("live", None)
 
 
+def test_tui_kanban_busy_two_poller_claims_keep_full_range_retryable(
+    monkeypatch, tmp_path
+):
+    """Busy pollers cannot strand an older event behind a newer claim."""
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="range safe", assignee="worker")
+        kb.add_notify_sub(conn, task_id=task_id, platform="tui", chat_id="live-key")
+        assert kb.block_task(conn, task_id, reason="first", kind="needs_input")
+    finally:
+        conn.close()
+
+    sessions = {
+        "kanban-poller-a": _session(session_key="live-key", running=True),
+        "kanban-poller-b": _session(session_key="live-key", running=True),
+    }
+    server._sessions.update(sessions)
+    original_claim = kb.claim_unseen_events_for_sub
+    condition = threading.Condition()
+    states = {}
+    gates = {name: threading.Event() for name in sessions}
+    results = {}
+    errors = []
+
+    def _claim_then_pause(*args, **kwargs):
+        result = original_claim(*args, **kwargs)
+        name = threading.current_thread().name
+        if name in gates and result[2]:
+            with condition:
+                states[name] = (
+                    "claimed_in_txn" if args[0].in_transaction else "claimed"
+                )
+                condition.notify_all()
+            if not gates[name].wait(5):
+                raise TimeoutError(f"timed out releasing {name}")
+        return result
+
+    def _poll(name):
+        try:
+            results[name] = server._poll_tui_kanban_subscriptions(
+                name, sessions[name]
+            )
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            with condition:
+                states.setdefault(name, "unclaimed")
+                condition.notify_all()
+
+    def _wait_state(name):
+        with condition:
+            assert condition.wait_for(lambda: name in states, timeout=5)
+            return states[name]
+
+    monkeypatch.setattr(kb, "claim_unseen_events_for_sub", _claim_then_pause)
+    poller_a = threading.Thread(
+        target=_poll, args=("kanban-poller-a",), name="kanban-poller-a"
+    )
+    poller_b = threading.Thread(
+        target=_poll, args=("kanban-poller-b",), name="kanban-poller-b"
+    )
+
+    try:
+        poller_a.start()
+        state_a = _wait_state("kanban-poller-a")
+
+        if state_a == "claimed_in_txn":
+            gates["kanban-poller-a"].set()
+            poller_a.join(5)
+            assert not poller_a.is_alive()
+
+        conn = kb.connect()
+        try:
+            assert kb.unblock_task(conn, task_id)
+            assert kb.block_task(conn, task_id, reason="second", kind="capability")
+            blocked_events = conn.execute(
+                "SELECT id FROM task_events WHERE task_id = ? AND kind = 'blocked' "
+                "ORDER BY id",
+                (task_id,),
+            ).fetchall()
+        finally:
+            conn.close()
+        assert [row["id"] for row in blocked_events] == [2, 4]
+
+        poller_b.start()
+        state_b = _wait_state("kanban-poller-b")
+
+        if state_a != "claimed_in_txn":
+            gates["kanban-poller-a"].set()
+            poller_a.join(5)
+            assert not poller_a.is_alive()
+        if state_b != "unclaimed":
+            gates["kanban-poller-b"].set()
+        poller_b.join(5)
+        assert not poller_b.is_alive()
+        assert errors == []
+        assert results == {"kanban-poller-a": False, "kanban-poller-b": False}
+
+        conn = kb.connect()
+        try:
+            assert kb.list_notify_subs(conn, task_id)[0]["last_event_id"] == 0
+        finally:
+            conn.close()
+        assert state_a == state_b == "claimed_in_txn"
+
+        delivered = []
+        sessions["kanban-poller-a"]["running"] = False
+
+        def _deliver(_rid, _sid, active_session, text):
+            delivered.append(text)
+            active_session["running"] = False
+
+        monkeypatch.setattr(server, "_run_prompt_submit", _deliver)
+        assert server._poll_tui_kanban_subscriptions(
+            "kanban-poller-a", sessions["kanban-poller-a"]
+        ) is True
+        assert server._poll_tui_kanban_subscriptions(
+            "kanban-poller-a", sessions["kanban-poller-a"]
+        ) is False
+        assert delivered == [
+            f"⏸ Kanban {task_id} blocked: first\n\n"
+            f"⏸ Kanban {task_id} blocked: second"
+        ]
+        conn = kb.connect()
+        try:
+            assert kb.list_notify_subs(conn, task_id)[0]["last_event_id"] == 4
+        finally:
+            conn.close()
+    finally:
+        for gate in gates.values():
+            gate.set()
+        poller_a.join(5)
+        poller_b.join(5)
+        for name in sessions:
+            server._sessions.pop(name, None)
+
+
 def test_notification_poller_tui_kanban_rewinds_failed_injection(monkeypatch, tmp_path):
     """A failed TUI injection leaves the claimed Kanban event retryable."""
     import queue as _queue_mod

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3018,6 +3018,60 @@ def test_tui_kanban_subscription_follows_compression_lineage(monkeypatch, tmp_pa
         server._sessions.pop("live", None)
 
 
+def test_tui_kanban_subscription_prefers_live_compressed_child(monkeypatch, tmp_path):
+    """A stale parent poller cannot claim a live child's subscription first."""
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="stale parent", assignee="worker")
+        kb.add_notify_sub(conn, task_id=task_id, platform="tui", chat_id="parent-key")
+        kb.block_task(conn, task_id, reason="wake child")
+        event_id = conn.execute(
+            "SELECT id FROM task_events WHERE task_id = ? AND kind = 'blocked'",
+            (task_id,),
+        ).fetchone()["id"]
+    finally:
+        conn.close()
+
+    class _LineageDb:
+        def resolve_resume_session_id(self, key):
+            return "child-key" if key == "parent-key" else key
+
+    delivered = []
+    parent = _session(session_key="parent-key")
+    child = _session(agent=types.SimpleNamespace(session_id="child-key"), session_key="child-key")
+    server._sessions.update({"parent": parent, "child": child})
+    monkeypatch.setattr(server, "_get_db", lambda: _LineageDb())
+
+    def _deliver(_rid, sid, active_session, text):
+        delivered.append((sid, text))
+        active_session["running"] = False
+
+    monkeypatch.setattr(server, "_run_prompt_submit", _deliver)
+
+    try:
+        assert server._poll_tui_kanban_subscriptions("parent", parent) is False
+        conn = kb.connect()
+        try:
+            assert kb.list_notify_subs(conn, task_id)[0]["last_event_id"] == 0
+        finally:
+            conn.close()
+
+        assert server._poll_tui_kanban_subscriptions("child", child) is True
+        assert delivered == [("child", f"⏸ Kanban {task_id} blocked: wake child")]
+        conn = kb.connect()
+        try:
+            assert kb.list_notify_subs(conn, task_id)[0]["last_event_id"] == event_id
+        finally:
+            conn.close()
+    finally:
+        server._sessions.pop("parent", None)
+        server._sessions.pop("child", None)
+
+
 def test_tui_kanban_completed_delivery_removes_only_final_subscription(monkeypatch, tmp_path):
     """Completed subscriptions end after delivery; retryable terminal states remain."""
     from hermes_cli import kanban_db as kb
@@ -3056,6 +3110,55 @@ def test_tui_kanban_completed_delivery_removes_only_final_subscription(monkeypat
         assert completed_task not in remaining
         assert blocked_task in remaining
         assert len(delivered) == 2
+    finally:
+        server._sessions.pop("live", None)
+
+
+def test_tui_kanban_completed_cleanup_failure_preserves_accepted_turn(monkeypatch, tmp_path):
+    """A failed completed-sub cleanup cannot roll back its accepted delivery."""
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="cleanup failure", assignee="worker")
+        kb.add_notify_sub(conn, task_id=task_id, platform="tui", chat_id="live-key")
+        kb.complete_task(conn, task_id, summary="done")
+        event_id = conn.execute(
+            "SELECT id FROM task_events WHERE task_id = ? AND kind = 'completed'",
+            (task_id,),
+        ).fetchone()["id"]
+    finally:
+        conn.close()
+
+    delivered = []
+    session = _session(session_key="live-key")
+    server._sessions["live"] = session
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda _rid, _sid, _session, text: delivered.append(text),
+    )
+    monkeypatch.setattr(
+        kb,
+        "remove_notify_sub",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("remove failed")),
+    )
+
+    try:
+        assert server._poll_tui_kanban_subscriptions("live", session) is True
+        assert delivered == [f"Kanban {task_id} completed"]
+        assert session["running"] is True
+        conn = kb.connect()
+        try:
+            sub = kb.list_notify_subs(conn, task_id)[0]
+            assert sub["last_event_id"] == event_id
+        finally:
+            conn.close()
+
+        assert server._poll_tui_kanban_subscriptions("live", session) is False
+        assert delivered == [f"Kanban {task_id} completed"]
     finally:
         server._sessions.pop("live", None)
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2923,6 +2923,143 @@ class _StopAfterOneNotificationPoll:
         return self._checks > 1
 
 
+def test_tui_kanban_no_event_claim_does_not_strand_prompt_submit(monkeypatch, tmp_path):
+    """A real prompt wins when a poll finds no terminal event."""
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="idle subscription", assignee="worker")
+        kb.add_notify_sub(conn, task_id=task_id, platform="tui", chat_id="live-key")
+    finally:
+        conn.close()
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    session = _session(session_key="live-key")
+    server._sessions["live"] = session
+    submitted = []
+    response = {}
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "queue")
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda *_args: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda *_args: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda *_args: None)
+
+    def _run_user_prompt(_rid, _sid, active_session, text):
+        submitted.append(text)
+        active_session["running"] = False
+
+    def _claim_while_user_submits(*_args, **_kwargs):
+        response["value"] = server.handle_request(
+            {
+                "id": "user",
+                "method": "prompt.submit",
+                "params": {"session_id": "live", "text": "real user prompt"},
+            }
+        )["result"]
+        return 0, 0, []
+
+    monkeypatch.setattr(server, "_run_prompt_submit", _run_user_prompt)
+    monkeypatch.setattr(kb, "claim_unseen_events_for_sub", _claim_while_user_submits)
+
+    try:
+        assert server._poll_tui_kanban_subscriptions("live", session) is False
+        assert response["value"] == {"status": "streaming"}
+        assert submitted == ["real user prompt"]
+        assert session.get("queued_prompt") is None
+    finally:
+        server._sessions.pop("live", None)
+
+
+def test_tui_kanban_subscription_follows_compression_lineage(monkeypatch, tmp_path):
+    """A parent-key TUI subscription wakes its compressed continuation."""
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="compressed subscription", assignee="worker")
+        kb.add_notify_sub(conn, task_id=task_id, platform="tui", chat_id="parent-key")
+        kb.block_task(conn, task_id, reason="needs input")
+    finally:
+        conn.close()
+
+    class _LineageDb:
+        def resolve_resume_session_id(self, key):
+            return "child-key" if key == "parent-key" else key
+
+    delivered = []
+    session = _session(
+        agent=types.SimpleNamespace(session_id="child-key"), session_key="child-key"
+    )
+    server._sessions["live"] = session
+    monkeypatch.setattr(server, "_get_db", lambda: _LineageDb())
+
+    def _deliver(_rid, _sid, active_session, text):
+        delivered.append(text)
+        active_session["running"] = False
+
+    monkeypatch.setattr(server, "_run_prompt_submit", _deliver)
+
+    try:
+        assert server._poll_tui_kanban_subscriptions("live", session) is True
+        assert delivered == [f"⏸ Kanban {task_id} blocked: needs input"]
+    finally:
+        server._sessions.pop("live", None)
+
+
+def test_tui_kanban_completed_delivery_removes_only_final_subscription(monkeypatch, tmp_path):
+    """Completed subscriptions end after delivery; retryable terminal states remain."""
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        completed_task = kb.create_task(conn, title="completed", assignee="worker")
+        blocked_task = kb.create_task(conn, title="blocked", assignee="worker")
+        kb.add_notify_sub(conn, task_id=completed_task, platform="tui", chat_id="live-key")
+        kb.add_notify_sub(conn, task_id=blocked_task, platform="tui", chat_id="live-key")
+        kb.complete_task(conn, completed_task, summary="done")
+        kb.block_task(conn, blocked_task, reason="needs input")
+    finally:
+        conn.close()
+
+    delivered = []
+    session = _session(session_key="live-key")
+    server._sessions["live"] = session
+
+    def _deliver(_rid, _sid, active_session, text):
+        delivered.append(text)
+        active_session["running"] = False
+
+    monkeypatch.setattr(server, "_run_prompt_submit", _deliver)
+
+    try:
+        assert server._poll_tui_kanban_subscriptions("live", session) is True
+        assert server._poll_tui_kanban_subscriptions("live", session) is True
+        conn = kb.connect()
+        try:
+            remaining = {sub["task_id"] for sub in kb.list_notify_subs(conn)}
+        finally:
+            conn.close()
+        assert completed_task not in remaining
+        assert blocked_task in remaining
+        assert len(delivered) == 2
+    finally:
+        server._sessions.pop("live", None)
+
+
 def test_notification_poller_delivers_tui_kanban_subscription(monkeypatch, tmp_path):
     """A TUI subscription wakes the durable session that created the task."""
     import queue as _queue_mod

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3445,6 +3445,118 @@ def test_tui_kanban_busy_two_poller_claims_keep_full_range_retryable(
             server._sessions.pop(name, None)
 
 
+def test_tui_kanban_finalization_before_acceptance_rolls_back_claim(
+    monkeypatch, tmp_path
+):
+    """Finalization winning before acceptance leaves the event retryable."""
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    real_connect = kb.connect
+    conn = real_connect()
+    try:
+        task_id = kb.create_task(conn, title="finalize race", assignee="worker")
+        kb.add_notify_sub(conn, task_id=task_id, platform="tui", chat_id="live-key")
+        assert kb.block_task(conn, task_id, reason="retry after finalize")
+    finally:
+        conn.close()
+
+    opened = []
+
+    class _TrackedConnection:
+        def __init__(self, inner):
+            self.inner = inner
+            self.closed = False
+
+        def __getattr__(self, name):
+            return getattr(self.inner, name)
+
+        def close(self):
+            self.inner.close()
+            self.closed = True
+
+    def _tracked_connect(*args, **kwargs):
+        tracked = _TrackedConnection(real_connect(*args, **kwargs))
+        opened.append(tracked)
+        return tracked
+
+    session = _session(
+        session_key="live-key",
+        attached_images=["still-attached.png"],
+    )
+    session["agent"] = None
+    server._sessions["live"] = session
+    reserved = threading.Event()
+    finalized = threading.Event()
+    result = []
+    errors = []
+    emitted = []
+    handoffs = []
+    original_submit = server._run_prompt_submit
+
+    def _pause_before_acceptance(*args):
+        reserved.set()
+        if not finalized.wait(5):
+            raise TimeoutError("timed out waiting for finalization")
+        return original_submit(*args)
+
+    def _poll():
+        try:
+            result.append(server._poll_tui_kanban_subscriptions("live", session))
+        except BaseException as exc:
+            errors.append(exc)
+
+    class _CapturedRunThread:
+        def __init__(self, *args, **kwargs):
+            handoffs.append("created")
+
+        def start(self):
+            handoffs.append("started")
+
+    poller = threading.Thread(target=_poll, name="finalize-race-poller")
+    monkeypatch.setattr(kb, "connect", _tracked_connect)
+    monkeypatch.setattr(server, "_run_prompt_submit", _pause_before_acceptance)
+    monkeypatch.setattr(server, "_emit", lambda event, *_args: emitted.append(event))
+    monkeypatch.setattr(server.threading, "Thread", _CapturedRunThread)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", lambda **_kwargs: None
+    )
+
+    try:
+        poller.start()
+        assert reserved.wait(5)
+        server._finalize_session(session)
+        assert session.get("_finalized") is True
+        finalized.set()
+        poller.join(5)
+        assert not poller.is_alive()
+
+        conn = real_connect()
+        try:
+            cursor = kb.list_notify_subs(conn, task_id)[0]["last_event_id"]
+        finally:
+            conn.close()
+
+        assert errors == []
+        assert result == [False]
+        assert cursor == 0
+        assert handoffs == []
+        assert emitted == []
+        assert session.get("_finalized") is True
+        assert session["running"] is False
+        assert "inflight_turn" not in session
+        assert "_run_thread" not in session
+        assert session["attached_images"] == ["still-attached.png"]
+        assert opened and all(connection.closed for connection in opened)
+    finally:
+        finalized.set()
+        poller.join(5)
+        server._sessions.pop("live", None)
+
+
 def test_notification_poller_tui_kanban_rewinds_failed_injection(monkeypatch, tmp_path):
     """A failed TUI injection leaves the claimed Kanban event retryable."""
     import queue as _queue_mod

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2923,6 +2923,215 @@ class _StopAfterOneNotificationPoll:
         return self._checks > 1
 
 
+def test_notification_poller_delivers_tui_kanban_subscription(monkeypatch, tmp_path):
+    """A TUI subscription wakes the durable session that created the task."""
+    import queue as _queue_mod
+
+    from hermes_cli import kanban_db as kb
+    from tools.process_registry import process_registry
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="wake Main", assignee="worker")
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform="tui",
+            chat_id="live-tui-key",
+        )
+        kb.block_task(conn, task_id, reason="needs input")
+        event_id = conn.execute(
+            "SELECT id FROM task_events WHERE task_id = ? AND kind = 'blocked'",
+            (task_id,),
+        ).fetchone()["id"]
+    finally:
+        conn.close()
+
+    class _EmptyQueue:
+        def get(self, **_kwargs):
+            raise _queue_mod.Empty
+
+        def empty(self):
+            return True
+
+    delivered = []
+    session = _session(session_key="live-tui-key")
+    server._sessions["live-tui"] = session
+    monkeypatch.setattr(process_registry, "completion_queue", _EmptyQueue())
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda _rid, _sid, _session, text: delivered.append(text),
+    )
+
+    try:
+        server._notification_poller_loop(
+            _StopAfterOneNotificationPoll(), "live-tui", session
+        )
+        conn = kb.connect()
+        try:
+            cursor = kb.list_notify_subs(conn, task_id)[0]["last_event_id"]
+        finally:
+            conn.close()
+        assert (delivered, cursor) == (
+            [f"⏸ Kanban {task_id} blocked: needs input"],
+            event_id,
+        )
+    finally:
+        server._sessions.pop("live-tui", None)
+
+
+def test_notification_poller_tui_kanban_preserves_busy_and_foreign_cursors(
+    monkeypatch, tmp_path
+):
+    """A busy or foreign TUI session cannot consume a Kanban notification."""
+    import queue as _queue_mod
+
+    from hermes_cli import kanban_db as kb
+    from tools.process_registry import process_registry
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="mine", assignee="worker")
+        foreign_task_id = kb.create_task(conn, title="foreign", assignee="worker")
+        kb.add_notify_sub(conn, task_id=task_id, platform="tui", chat_id="live-key")
+        kb.add_notify_sub(
+            conn,
+            task_id=foreign_task_id,
+            platform="tui",
+            chat_id="foreign-key",
+        )
+        kb.block_task(conn, task_id, reason="wait")
+        kb.block_task(conn, foreign_task_id, reason="not mine")
+    finally:
+        conn.close()
+
+    class _EmptyQueue:
+        def get(self, **_kwargs):
+            raise _queue_mod.Empty
+
+        def empty(self):
+            return True
+
+    delivered = []
+    session = _session(session_key="live-key", running=True)
+    server._sessions["live"] = session
+    monkeypatch.setattr(process_registry, "completion_queue", _EmptyQueue())
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda *_args: pytest.fail("busy session must not inject a notification"),
+    )
+
+    try:
+        server._notification_poller_loop(_StopAfterOneNotificationPoll(), "live", session)
+        conn = kb.connect()
+        try:
+            cursors = {
+                sub["task_id"]: sub["last_event_id"]
+                for sub in kb.list_notify_subs(conn)
+            }
+        finally:
+            conn.close()
+        assert cursors == {task_id: 0, foreign_task_id: 0}
+
+        session["running"] = False
+
+        def _deliver(_rid, _sid, active_session, text):
+            delivered.append(text)
+            active_session["running"] = False
+
+        monkeypatch.setattr(server, "_run_prompt_submit", _deliver)
+        server._notification_poller_loop(_StopAfterOneNotificationPoll(), "live", session)
+        server._notification_poller_loop(_StopAfterOneNotificationPoll(), "live", session)
+
+        conn = kb.connect()
+        try:
+            cursors = {
+                sub["task_id"]: sub["last_event_id"]
+                for sub in kb.list_notify_subs(conn)
+            }
+        finally:
+            conn.close()
+        assert len(delivered) == 1
+        assert cursors[task_id] > 0
+        assert cursors[foreign_task_id] == 0
+    finally:
+        server._sessions.pop("live", None)
+
+
+def test_notification_poller_tui_kanban_rewinds_failed_injection(monkeypatch, tmp_path):
+    """A failed TUI injection leaves the claimed Kanban event retryable."""
+    import queue as _queue_mod
+
+    from hermes_cli import kanban_db as kb
+    from tools.process_registry import process_registry
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="retry wake", assignee="worker")
+        kb.add_notify_sub(conn, task_id=task_id, platform="tui", chat_id="live-key")
+        kb.block_task(conn, task_id, reason="retry me")
+    finally:
+        conn.close()
+
+    class _EmptyQueue:
+        def get(self, **_kwargs):
+            raise _queue_mod.Empty
+
+        def empty(self):
+            return True
+
+    session = _session(session_key="live-key")
+    server._sessions["live"] = session
+    monkeypatch.setattr(process_registry, "completion_queue", _EmptyQueue())
+
+    def _fail_injection(*_args):
+        raise RuntimeError("injection failed")
+
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        _fail_injection,
+    )
+
+    try:
+        server._notification_poller_loop(_StopAfterOneNotificationPoll(), "live", session)
+        conn = kb.connect()
+        try:
+            cursor = kb.list_notify_subs(conn, task_id)[0]["last_event_id"]
+        finally:
+            conn.close()
+        assert cursor == 0
+        assert session["running"] is False
+
+        delivered = []
+
+        def _deliver(_rid, _sid, active_session, text):
+            delivered.append(text)
+            active_session["running"] = False
+
+        monkeypatch.setattr(server, "_run_prompt_submit", _deliver)
+        server._notification_poller_loop(_StopAfterOneNotificationPoll(), "live", session)
+        server._notification_poller_loop(_StopAfterOneNotificationPoll(), "live", session)
+
+        conn = kb.connect()
+        try:
+            cursor = kb.list_notify_subs(conn, task_id)[0]["last_event_id"]
+        finally:
+            conn.close()
+        assert len(delivered) == 1
+        assert cursor > 0
+    finally:
+        server._sessions.pop("live", None)
+
+
 def test_notification_poller_live_loop_requeues_foreign_completion_for_owner(
     monkeypatch,
 ):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8152,6 +8152,61 @@ def test_queued_prompt_is_restored_when_finalization_wins_before_acceptance(
         worker.join(5)
 
 
+def test_queued_compute_host_prompt_is_restored_when_finalization_wins_before_dispatch(
+    monkeypatch,
+):
+    queued = {"text": "next prompt", "transport": None}
+    session = _session(queued_prompt=queued)
+    reserved = threading.Event()
+    finalized = threading.Event()
+    result = []
+    dispatched = []
+
+    def _pause_during_compute_host_selection(_session):
+        reserved.set()
+        if not finalized.wait(5):
+            raise TimeoutError("timed out waiting for finalization")
+        return True
+
+    def _dispatch(*args):
+        dispatched.append(args)
+        return server._ok("rid", {"status": "streaming", "turn_isolation": True})
+
+    monkeypatch.setattr(
+        server, "_session_uses_compute_host", _pause_during_compute_host_selection
+    )
+    monkeypatch.setattr(server, "_submit_prompt_to_compute_host", _dispatch)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", lambda **_kwargs: None
+    )
+
+    worker = threading.Thread(
+        target=lambda: result.append(
+            server._drain_queued_prompt("rid", "sid", session)
+        ),
+        name="queued-compute-host-finalize-race",
+    )
+    try:
+        worker.start()
+        assert reserved.wait(5)
+        server._finalize_session(session)
+        finalized.set()
+        worker.join(5)
+        assert not worker.is_alive()
+
+        assert result == [False]
+        assert dispatched == []
+        assert session["queued_prompt"] is queued
+        assert session["running"] is False
+        assert session.get("_finalized") is True
+        assert "inflight_turn" not in session
+    finally:
+        finalized.set()
+        worker.join(5)
+
+
 def test_interrupt_before_agent_ready_prevents_late_turn_start(monkeypatch):
     """Stop during lazy agent startup must not start the turn after init finishes."""
     threads = []

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8207,6 +8207,78 @@ def test_queued_compute_host_prompt_is_restored_when_finalization_wins_before_di
         worker.join(5)
 
 
+def test_queued_compute_host_rollback_merges_prompt_queued_during_reservation(
+    monkeypatch,
+):
+    q1_transport = object()
+    q1_metadata = object()
+    queued = {
+        "text": "first prompt",
+        "transport": q1_transport,
+        "metadata": q1_metadata,
+    }
+    session = _session(queued_prompt=queued)
+    reserved = threading.Event()
+    finalized = threading.Event()
+    result = []
+    dispatched = []
+
+    def _pause_during_compute_host_selection(_session):
+        reserved.set()
+        if not finalized.wait(5):
+            raise TimeoutError("timed out waiting for finalization")
+        return True
+
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "queue")
+    monkeypatch.setattr(
+        server, "_session_uses_compute_host", _pause_during_compute_host_selection
+    )
+    monkeypatch.setattr(
+        server, "_submit_prompt_to_compute_host", lambda *args: dispatched.append(args)
+    )
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", lambda **_kwargs: None
+    )
+
+    worker = threading.Thread(
+        target=lambda: result.append(
+            server._drain_queued_prompt("rid", "sid", session)
+        ),
+        name="queued-compute-host-merge-finalize-race",
+    )
+    try:
+        worker.start()
+        assert reserved.wait(5)
+
+        q2_transport = object()
+        response = server._handle_busy_submit(
+            "busy", "sid", session, "second prompt", q2_transport
+        )
+        assert response["result"]["status"] == "queued"
+
+        server._finalize_session(session)
+        finalized.set()
+        worker.join(5)
+        assert not worker.is_alive()
+
+        assert result == [False]
+        assert dispatched == []
+        assert session["queued_prompt"] is queued
+        assert queued == {
+            "text": "first prompt\n\nsecond prompt",
+            "transport": q1_transport,
+            "metadata": q1_metadata,
+        }
+        assert session["running"] is False
+        assert session.get("_finalized") is True
+        assert "inflight_turn" not in session
+    finally:
+        finalized.set()
+        worker.join(5)
+
+
 def test_interrupt_before_agent_ready_prevents_late_turn_start(monkeypatch):
     """Stop during lazy agent startup must not start the turn after init finishes."""
     threads = []

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2914,6 +2914,155 @@ def test_prompt_submit_rejects_negative_truncate_ordinal(monkeypatch):
         server._sessions.pop("trunc-sid", None)
 
 
+def test_prompt_submit_rejects_when_finalization_wins_before_acceptance(monkeypatch):
+    """A resolved session reference cannot be accepted after finalization."""
+    session = _session(agent=None, attached_images=["still-attached.png"])
+    server._sessions["finalize-race"] = session
+    resolved = threading.Event()
+    finalized = threading.Event()
+    response = []
+    errors = []
+    side_effects = []
+    real_thread = threading.Thread
+
+    def _pause_after_session_lookup():
+        resolved.set()
+        if not finalized.wait(5):
+            raise TimeoutError("timed out waiting for finalization")
+        return {
+            "turn_isolation": False,
+            "compute_host_heartbeat_secs": 15,
+            "compute_host_respawn_max": 3,
+        }
+
+    def _submit():
+        try:
+            response.append(
+                server.handle_request(
+                    {
+                        "id": "submit",
+                        "method": "prompt.submit",
+                        "params": {
+                            "session_id": "finalize-race",
+                            "text": "must not be accepted",
+                        },
+                    }
+                )
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    class _CapturedRunThread:
+        def __init__(self, *args, **kwargs):
+            side_effects.append("run-thread-created")
+
+        def start(self):
+            side_effects.append("run-thread-started")
+
+    monkeypatch.setattr(
+        server, "_load_dashboard_process_isolation_config", _pause_after_session_lookup
+    )
+    monkeypatch.setattr(
+        server,
+        "_ensure_session_db_row",
+        lambda *_args: side_effects.append("db-row"),
+    )
+    monkeypatch.setattr(
+        server,
+        "_persist_branch_seed",
+        lambda *_args: side_effects.append("branch-seed"),
+    )
+    monkeypatch.setattr(
+        server,
+        "_start_agent_build",
+        lambda *_args: side_effects.append("agent-build"),
+    )
+    monkeypatch.setattr(server, "_emit", lambda event, *_args: side_effects.append(event))
+    monkeypatch.setattr(server.threading, "Thread", _CapturedRunThread)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", lambda **_kwargs: None
+    )
+
+    submitter = real_thread(target=_submit, name="prompt-finalize-race")
+    try:
+        submitter.start()
+        assert resolved.wait(5)
+        assert server._close_session_by_id("finalize-race") is True
+        finalized.set()
+        submitter.join(5)
+        assert not submitter.is_alive()
+
+        assert errors == []
+        assert response and "error" in response[0]
+        assert response[0].get("result") != {"status": "streaming"}
+        assert side_effects == []
+        assert session.get("_finalized") is True
+        assert session["running"] is False
+        assert "inflight_turn" not in session
+        assert "_run_thread" not in session
+        assert session["attached_images"] == ["still-attached.png"]
+    finally:
+        finalized.set()
+        submitter.join(5)
+        server._sessions.pop("finalize-race", None)
+
+
+def test_busy_prompt_submit_rejects_when_finalization_wins_before_queue(monkeypatch):
+    session = _session(running=True)
+    server._sessions["busy-finalize-race"] = session
+    entered = threading.Event()
+    finalized = threading.Event()
+    response = []
+    real_handle_busy_submit = server._handle_busy_submit
+
+    def _pause_before_busy_acceptance(*args):
+        entered.set()
+        if not finalized.wait(5):
+            raise TimeoutError("timed out waiting for finalization")
+        return real_handle_busy_submit(*args)
+
+    monkeypatch.setattr(server, "_handle_busy_submit", _pause_before_busy_acceptance)
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "queue")
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", lambda **_kwargs: None
+    )
+
+    submitter = threading.Thread(
+        target=lambda: response.append(
+            server.handle_request(
+                {
+                    "id": "submit",
+                    "method": "prompt.submit",
+                    "params": {
+                        "session_id": "busy-finalize-race",
+                        "text": "must not be queued",
+                    },
+                }
+            )
+        ),
+        name="busy-prompt-finalize-race",
+    )
+    try:
+        submitter.start()
+        assert entered.wait(5)
+        server._finalize_session(session)
+        finalized.set()
+        submitter.join(5)
+        assert not submitter.is_alive()
+
+        assert response and "error" in response[0]
+        assert session.get("queued_prompt") is None
+        assert session.get("_finalized") is True
+    finally:
+        finalized.set()
+        submitter.join(5)
+        server._sessions.pop("busy-finalize-race", None)
+
+
 class _StopAfterOneNotificationPoll:
     def __init__(self):
         self._checks = 0
@@ -3952,6 +4101,193 @@ class _RecordingAgent:
     ):
         self._turns.append(prompt)
         return {"final_response": "", "messages": []}
+
+
+def test_prompt_submit_continues_when_acceptance_wins_before_finalization(
+    monkeypatch, tmp_path
+):
+    """Finalization cannot revoke an ordinary prompt already accepted under lock."""
+    _configure_immediate_prompt_run(monkeypatch, tmp_path, immediate_threads=False)
+    turns = []
+    events = []
+    accepted = threading.Event()
+    release_agent = threading.Event()
+    completed = threading.Event()
+    session = _session(agent=_RecordingAgent(turns))
+    server._sessions["accepted-finalize-race"] = session
+
+    monkeypatch.setattr(
+        server,
+        "_load_dashboard_process_isolation_config",
+        lambda: {
+            "turn_isolation": False,
+            "compute_host_heartbeat_secs": 15,
+            "compute_host_respawn_max": 3,
+        },
+    )
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda *_args: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda *_args: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", lambda **_kwargs: None
+    )
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: None)
+
+    def _wait_after_acceptance(active_session, _rid):
+        with active_session["history_lock"]:
+            assert active_session["running"] is True
+            assert isinstance(active_session.get("inflight_turn"), dict)
+        accepted.set()
+        if not release_agent.wait(5):
+            raise TimeoutError("timed out waiting for finalization")
+        return None
+
+    def _record_emit(event, *_args):
+        events.append(event)
+        if event == "message.complete":
+            completed.set()
+
+    monkeypatch.setattr(server, "_wait_agent", _wait_after_acceptance)
+    monkeypatch.setattr(server, "_emit", _record_emit)
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "submit",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "accepted-finalize-race",
+                    "text": "accepted prompt",
+                },
+            }
+        )
+
+        assert response.get("result") == {"status": "streaming"}
+        assert accepted.wait(5)
+        server._finalize_session(session)
+        release_agent.set()
+        assert completed.wait(5)
+
+        assert turns == ["accepted prompt"]
+        assert "message.start" in events
+        assert session.get("_finalized") is True
+        assert session["running"] is False
+        assert session.get("inflight_turn") is None
+    finally:
+        release_agent.set()
+        run_thread = session.get("_run_thread")
+        if isinstance(run_thread, threading.Thread):
+            run_thread.join(5)
+        server._sessions.pop("accepted-finalize-race", None)
+
+
+def test_goal_followup_does_not_restart_a_finalized_session(monkeypatch, tmp_path):
+    from hermes_cli import goals
+
+    _configure_immediate_prompt_run(monkeypatch, tmp_path)
+    turns = []
+    emitted = []
+
+    class _Agent(_RecordingAgent):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            turns.append(prompt)
+            return {
+                "final_response": "keep going",
+                "messages": [
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "keep going"},
+                ],
+            }
+
+    class _GoalManager:
+        def __init__(self, **_kwargs):
+            pass
+
+        def is_active(self):
+            return True
+
+        def evaluate_after_turn(self, *_args, **_kwargs):
+            return {
+                "message": "continue",
+                "should_continue": True,
+                "continuation_prompt": "automatic followup",
+            }
+
+    session = _session(agent=_Agent(turns), running=True)
+    monkeypatch.setattr(goals, "GoalManager", _GoalManager)
+    monkeypatch.setattr(goals, "gather_background_processes", lambda: [])
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, *_args: emitted.append((event, bool(session.get("_finalized")))),
+    )
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", lambda **_kwargs: None
+    )
+
+    def _finalize_before_followup(*_args):
+        server._finalize_session(session)
+        return False
+
+    monkeypatch.setattr(server, "_drain_queued_prompt", _finalize_before_followup)
+
+    server._run_prompt_submit("rid", "sid", session, "primary prompt")
+
+    assert turns == ["primary prompt"]
+    assert not [event for event in emitted if event == ("message.start", True)]
+    assert session.get("_finalized") is True
+    assert session["running"] is False
+
+
+def test_post_turn_drain_requeues_events_when_session_finalizes(monkeypatch, tmp_path):
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    _configure_immediate_prompt_run(monkeypatch, tmp_path)
+    event = {
+        "type": "completion",
+        "session_id": "post_turn_finalize_race",
+        "command": "echo done",
+        "exit_code": 0,
+        "output": "done",
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    emitted = []
+    session = _session(agent=_RecordingAgent([]), running=True)
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event_name, *_args: emitted.append(
+            (event_name, bool(session.get("_finalized")))
+        ),
+    )
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", lambda **_kwargs: None
+    )
+
+    def _finalize_after_drain(**_kwargs):
+        server._finalize_session(session)
+        return [(event, "formatted completion")]
+
+    monkeypatch.setattr(process_registry, "drain_notifications", _finalize_after_drain)
+
+    server._run_prompt_submit("rid", "sid", session, "primary prompt")
+
+    assert not [item for item in emitted if item == ("message.start", True)]
+    assert session.get("_finalized") is True
+    assert session["running"] is False
+    assert isolated_queue.get_nowait() == event
+    assert isolated_queue.empty()
 
 
 @pytest.mark.parametrize("exit_code", [0, 7])
@@ -7758,6 +8094,64 @@ def test_interrupt_drops_queued_prompt_for_session():
         server._sessions.pop("sid", None)
 
 
+def test_queued_prompt_stays_pending_after_session_finalization(monkeypatch):
+    queued = {"text": "next prompt", "transport": None}
+    session = _session(queued_prompt=queued, _finalized=True)
+    emitted = []
+    monkeypatch.setattr(server, "_emit", lambda event, *_args: emitted.append(event))
+
+    assert server._drain_queued_prompt("rid", "sid", session) is False
+    assert session["queued_prompt"] is queued
+    assert session["running"] is False
+    assert emitted == []
+
+
+def test_queued_prompt_is_restored_when_finalization_wins_before_acceptance(
+    monkeypatch,
+):
+    queued = {"text": "next prompt", "transport": None}
+    session = _session(queued_prompt=queued)
+    reserved = threading.Event()
+    finalized = threading.Event()
+    result = []
+    real_submit = server._run_prompt_submit
+
+    def _pause_before_acceptance(*args):
+        reserved.set()
+        if not finalized.wait(5):
+            raise TimeoutError("timed out waiting for finalization")
+        return real_submit(*args)
+
+    monkeypatch.setattr(server, "_run_prompt_submit", _pause_before_acceptance)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", lambda **_kwargs: None
+    )
+
+    worker = threading.Thread(
+        target=lambda: result.append(
+            server._drain_queued_prompt("rid", "sid", session)
+        ),
+        name="queued-prompt-finalize-race",
+    )
+    try:
+        worker.start()
+        assert reserved.wait(5)
+        server._finalize_session(session)
+        finalized.set()
+        worker.join(5)
+        assert not worker.is_alive()
+
+        assert result == [False]
+        assert session["queued_prompt"] is queued
+        assert session["running"] is False
+        assert session.get("_finalized") is True
+    finally:
+        finalized.set()
+        worker.join(5)
+
+
 def test_interrupt_before_agent_ready_prevents_late_turn_start(monkeypatch):
     """Stop during lazy agent startup must not start the turn after init finishes."""
     threads = []
@@ -10479,6 +10873,79 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
         server._sessions.pop("sid_busy", None)
         while not process_registry.completion_queue.empty():
             process_registry.completion_queue.get_nowait()
+
+
+def test_notification_poller_restores_event_when_finalization_wins_after_format(
+    monkeypatch,
+):
+    """A formatted completion remains retryable when its session finalizes."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    event = {
+        "type": "completion",
+        "session_id": "proc_finalize_race",
+        "command": "echo done",
+        "exit_code": 0,
+        "output": "done",
+    }
+    isolated_queue.put(event)
+    process_registry._completion_consumed.discard(event["session_id"])
+
+    formatted = threading.Event()
+    finalized = threading.Event()
+    emitted = []
+    stop = threading.Event()
+    session = _session(agent=None, _notif_stop=stop)
+    session["agent"] = None
+    server._sessions["poll-finalize-race"] = session
+
+    def _pause_after_pop(_event):
+        formatted.set()
+        if not finalized.wait(5):
+            raise TimeoutError("timed out waiting for finalization")
+        return "formatted completion"
+
+    monkeypatch.setattr(
+        "tools.process_registry.format_process_notification", _pause_after_pop
+    )
+    monkeypatch.setattr(server, "_poll_tui_kanban_subscriptions", lambda *_args: False)
+    monkeypatch.setattr(server, "_emit", lambda event_name, *_args: emitted.append(event_name))
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", lambda **_kwargs: None
+    )
+
+    poller = threading.Thread(
+        target=server._notification_poller_loop,
+        args=(stop, "poll-finalize-race", session),
+        name="completion-finalize-race",
+    )
+    try:
+        poller.start()
+        assert formatted.wait(5)
+        assert server._close_session_by_id("poll-finalize-race") is True
+        finalized.set()
+        poller.join(5)
+        assert not poller.is_alive()
+
+        assert emitted == []
+        assert session.get("_finalized") is True
+        assert session["running"] is False
+        assert isolated_queue.get_nowait() == event
+        assert isolated_queue.empty()
+    finally:
+        finalized.set()
+        stop.set()
+        poller.join(5)
+        server._sessions.pop("poll-finalize-race", None)
+        process_registry._completion_consumed.discard(event["session_id"])
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
 
 
 def test_session_save_writes_under_hermes_home_with_system_prompt(monkeypatch, tmp_path):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3239,6 +3239,111 @@ def test_run_prompt_submit_cancelled_handoff_restores_accepted_state(monkeypatch
     assert session.get("inflight_turn") is None
 
 
+def test_tui_kanban_commit_failure_waits_for_cancel_cleanup(monkeypatch, tmp_path):
+    import sqlite3
+
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="failed commit cleanup", assignee="worker")
+        kb.add_notify_sub(conn, task_id=task_id, platform="tui", chat_id="live-key")
+        kb.block_task(conn, task_id, reason="force commit failure")
+    finally:
+        conn.close()
+
+    class _ControlledHandoff:
+        def __init__(self):
+            self.get_entered = threading.Event()
+            self.release_get = threading.Event()
+            self.value = None
+
+        def get(self):
+            self.get_entered.set()
+            assert self.release_get.wait(5)
+            return self.value
+
+        def put(self, value):
+            self.value = value
+
+    handoff = _ControlledHandoff()
+    provider_entered = threading.Event()
+
+    class _Agent:
+        session_id = "live-key"
+
+        def clear_interrupt(self):
+            pass
+
+        def run_conversation(self, _prompt, **_kwargs):
+            provider_entered.set()
+            return {"final_response": "", "messages": []}
+
+    session = _session(
+        agent=_Agent(), session_key="live-key", attached_images=["pending.png"]
+    )
+    server._sessions["live"] = session
+    monkeypatch.setattr(server.queue, "SimpleQueue", lambda: handoff)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+
+    real_boundary = kb._execute_boundary_with_retry
+
+    def _fail_commit(active_conn, sql):
+        if sql == "COMMIT":
+            assert handoff.get_entered.wait(5)
+            raise sqlite3.OperationalError("forced COMMIT failure")
+        return real_boundary(active_conn, sql)
+
+    monkeypatch.setattr(kb, "_execute_boundary_with_retry", _fail_commit)
+    result = []
+    errors = []
+    poll_done = threading.Event()
+
+    def _poll():
+        try:
+            result.append(server._poll_tui_kanban_subscriptions("live", session))
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            poll_done.set()
+
+    poller = threading.Thread(target=_poll, name="kanban-commit-cleanup-race")
+    try:
+        poller.start()
+        assert handoff.get_entered.wait(5)
+        assert not poll_done.wait(0.2)
+        with session["history_lock"]:
+            assert session["running"] is True
+            assert isinstance(session.get("inflight_turn"), dict)
+            assert session["attached_images"] == []
+
+        handoff.release_get.set()
+        poller.join(5)
+        assert not poller.is_alive()
+        assert errors == []
+        assert result == [False]
+        assert not provider_entered.is_set()
+        assert session["running"] is False
+        assert session.get("inflight_turn") is None
+        assert session["attached_images"] == ["pending.png"]
+
+        conn = kb.connect()
+        try:
+            assert kb.list_notify_subs(conn, task_id)[0]["last_event_id"] == 0
+        finally:
+            conn.close()
+    finally:
+        handoff.release_get.set()
+        poller.join(5)
+        run_thread = session.get("_run_thread")
+        if run_thread is not None:
+            run_thread.join(5)
+        server._sessions.pop("live", None)
+
+
 def test_run_prompt_submit_start_failure_restores_accepted_state(monkeypatch):
     class _BrokenThread:
         def __init__(self, **_kwargs):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3129,6 +3129,137 @@ def test_tui_kanban_no_event_claim_does_not_strand_prompt_submit(monkeypatch, tm
         server._sessions.pop("live", None)
 
 
+def test_tui_kanban_provider_starts_after_claim_commit(monkeypatch, tmp_path):
+    """The provider must not enter while the claimed-event transaction is open."""
+    from contextlib import contextmanager
+
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="post-commit provider", assignee="worker")
+        kb.add_notify_sub(conn, task_id=task_id, platform="tui", chat_id="live-key")
+        kb.block_task(conn, task_id, reason="provider must wait")
+    finally:
+        conn.close()
+
+    transaction_open = threading.Event()
+    transaction_active = threading.Event()
+    release_commit = threading.Event()
+    provider_entered = threading.Event()
+    observed_transactions = []
+    real_write_txn = kb.write_txn
+
+    @contextmanager
+    def _child_first_write_txn(active_conn):
+        try:
+            with real_write_txn(active_conn):
+                transaction_active.set()
+                yield active_conn
+                transaction_open.set()
+                assert release_commit.wait(5)
+        finally:
+            transaction_active.clear()
+
+    class _Agent:
+        session_id = "live-key"
+
+        def run_conversation(self, _prompt, **_kwargs):
+            observed_transactions.append(transaction_active.is_set())
+            provider_entered.set()
+            return {"final_response": "", "messages": []}
+
+    session = _session(agent=_Agent(), session_key="live-key")
+    server._sessions["live"] = session
+    monkeypatch.setattr(kb, "write_txn", _child_first_write_txn)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda *_args: None)
+    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda *_args: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_args: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
+    monkeypatch.setattr(server, "render_message", lambda _raw, _cols: None)
+    monkeypatch.setattr(server, "_load_interim_assistant_messages", lambda: False)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_drain_queued_prompt", lambda *_args: False)
+
+    result = []
+    errors = []
+
+    def _poll():
+        try:
+            result.append(server._poll_tui_kanban_subscriptions("live", session))
+        except BaseException as exc:
+            errors.append(exc)
+
+    poller = threading.Thread(target=_poll, name="kanban-provider-commit-race")
+
+    try:
+        poller.start()
+        assert transaction_open.wait(5)
+        entered_before_commit = provider_entered.wait(1)
+        release_commit.set()
+        poller.join(5)
+        assert not poller.is_alive()
+        assert errors == []
+        assert result == [True]
+        assert provider_entered.wait(5)
+        session["_run_thread"].join(5)
+        assert not session["_run_thread"].is_alive()
+        assert entered_before_commit is False
+        assert observed_transactions == [False]
+    finally:
+        release_commit.set()
+        poller.join(5)
+        server._sessions.pop("live", None)
+
+
+def test_run_prompt_submit_cancelled_handoff_restores_accepted_state(monkeypatch):
+    import queue
+
+    called = []
+    agent = types.SimpleNamespace(
+        run_conversation=lambda *_args, **_kwargs: called.append(True)
+    )
+    session = _session(agent=agent, running=True, attached_images=["pending.png"])
+    handoff = queue.SimpleQueue()
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+
+    server._run_prompt_submit(
+        "rid", "sid", session, "notification", start_handoff=handoff
+    )
+    handoff.put(False)
+    session["_run_thread"].join(5)
+
+    assert called == []
+    assert session["attached_images"] == ["pending.png"]
+    assert session["running"] is False
+    assert session.get("inflight_turn") is None
+
+
+def test_run_prompt_submit_start_failure_restores_accepted_state(monkeypatch):
+    class _BrokenThread:
+        def __init__(self, **_kwargs):
+            pass
+
+        def start(self):
+            raise RuntimeError("thread start failed")
+
+    session = _session(running=True, attached_images=["pending.png"])
+    monkeypatch.setattr(server.threading, "Thread", _BrokenThread)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(RuntimeError, match="thread start failed"):
+        server._run_prompt_submit("rid", "sid", session, "notification")
+
+    assert session.get("_run_thread") is None
+    assert session["attached_images"] == ["pending.png"]
+    assert session["running"] is False
+    assert session.get("inflight_turn") is None
+
+
 def test_tui_kanban_subscription_follows_compression_lineage(monkeypatch, tmp_path):
     """A parent-key TUI subscription wakes its compressed continuation."""
     from hermes_cli import kanban_db as kb
@@ -3154,7 +3285,7 @@ def test_tui_kanban_subscription_follows_compression_lineage(monkeypatch, tmp_pa
     server._sessions["live"] = session
     monkeypatch.setattr(server, "_get_db", lambda: _LineageDb())
 
-    def _deliver(_rid, _sid, active_session, text):
+    def _deliver(_rid, _sid, active_session, text, **_kwargs):
         delivered.append(text)
         active_session["running"] = False
 
@@ -3195,7 +3326,7 @@ def test_tui_kanban_subscription_prefers_live_compressed_child(monkeypatch, tmp_
     server._sessions.update({"parent": parent, "child": child})
     monkeypatch.setattr(server, "_get_db", lambda: _LineageDb())
 
-    def _deliver(_rid, sid, active_session, text):
+    def _deliver(_rid, sid, active_session, text, **_kwargs):
         delivered.append((sid, text))
         active_session["running"] = False
 
@@ -3242,7 +3373,7 @@ def test_tui_kanban_completed_delivery_removes_only_final_subscription(monkeypat
     session = _session(session_key="live-key")
     server._sessions["live"] = session
 
-    def _deliver(_rid, _sid, active_session, text):
+    def _deliver(_rid, _sid, active_session, text, **_kwargs):
         delivered.append(text)
         active_session["running"] = False
 
@@ -3287,7 +3418,7 @@ def test_tui_kanban_completed_cleanup_failure_preserves_accepted_turn(monkeypatc
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda _rid, _sid, _session, text: delivered.append(text),
+        lambda _rid, _sid, _session, text, **_kwargs: delivered.append(text),
     )
     monkeypatch.setattr(
         kb,
@@ -3352,7 +3483,7 @@ def test_notification_poller_delivers_tui_kanban_subscription(monkeypatch, tmp_p
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda _rid, _sid, _session, text: delivered.append(text),
+        lambda _rid, _sid, _session, text, **_kwargs: delivered.append(text),
     )
 
     try:
@@ -3413,7 +3544,7 @@ def test_notification_poller_tui_kanban_preserves_busy_and_foreign_cursors(
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda *_args: pytest.fail("busy session must not inject a notification"),
+        lambda *_args, **_kwargs: pytest.fail("busy session must not inject a notification"),
     )
 
     try:
@@ -3430,7 +3561,7 @@ def test_notification_poller_tui_kanban_preserves_busy_and_foreign_cursors(
 
         session["running"] = False
 
-        def _deliver(_rid, _sid, active_session, text):
+        def _deliver(_rid, _sid, active_session, text, **_kwargs):
             delivered.append(text)
             active_session["running"] = False
 
@@ -3565,7 +3696,7 @@ def test_tui_kanban_busy_two_poller_claims_keep_full_range_retryable(
         delivered = []
         sessions["kanban-poller-a"]["running"] = False
 
-        def _deliver(_rid, _sid, active_session, text):
+        def _deliver(_rid, _sid, active_session, text, **_kwargs):
             delivered.append(text)
             active_session["running"] = False
 
@@ -3644,11 +3775,11 @@ def test_tui_kanban_finalization_before_acceptance_rolls_back_claim(
     handoffs = []
     original_submit = server._run_prompt_submit
 
-    def _pause_before_acceptance(*args):
+    def _pause_before_acceptance(*args, **kwargs):
         reserved.set()
         if not finalized.wait(5):
             raise TimeoutError("timed out waiting for finalization")
-        return original_submit(*args)
+        return original_submit(*args, **kwargs)
 
     def _poll():
         try:
@@ -3734,7 +3865,7 @@ def test_notification_poller_tui_kanban_rewinds_failed_injection(monkeypatch, tm
     server._sessions["live"] = session
     monkeypatch.setattr(process_registry, "completion_queue", _EmptyQueue())
 
-    def _fail_injection(*_args):
+    def _fail_injection(*_args, **_kwargs):
         raise RuntimeError("injection failed")
 
     monkeypatch.setattr(
@@ -3755,7 +3886,7 @@ def test_notification_poller_tui_kanban_rewinds_failed_injection(monkeypatch, tm
 
         delivered = []
 
-        def _deliver(_rid, _sid, active_session, text):
+        def _deliver(_rid, _sid, active_session, text, **_kwargs):
             delivered.append(text)
             active_session["running"] = False
 
@@ -3909,7 +4040,7 @@ def test_notification_poller_live_loop_drops_addressed_orphan(
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda _rid, _sid, _session, text: delivered.append(text),
+        lambda _rid, _sid, _session, text, **_kwargs: delivered.append(text),
     )
     server._sessions["sid-live-orphan"] = session
     process_registry._completion_consumed.discard(event["session_id"])
@@ -3950,7 +4081,7 @@ def test_notification_poller_drops_orphaned_events(monkeypatch, routing):
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda _rid, _sid, _session, text: delivered.append(text),
+        lambda _rid, _sid, _session, text, **_kwargs: delivered.append(text),
     )
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
@@ -4016,7 +4147,7 @@ def test_notification_poller_delivers_owned_events(
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda _rid, _sid, _session, text: delivered.append(text),
+        lambda _rid, _sid, _session, text, **_kwargs: delivered.append(text),
     )
     monkeypatch.setattr(server, "_get_db", lambda: _CompressionDB())
 
@@ -8116,11 +8247,11 @@ def test_queued_prompt_is_restored_when_finalization_wins_before_acceptance(
     result = []
     real_submit = server._run_prompt_submit
 
-    def _pause_before_acceptance(*args):
+    def _pause_before_acceptance(*args, **kwargs):
         reserved.set()
         if not finalized.wait(5):
             raise TimeoutError("timed out waiting for finalization")
-        return real_submit(*args)
+        return real_submit(*args, **kwargs)
 
     monkeypatch.setattr(server, "_run_prompt_submit", _pause_before_acceptance)
     monkeypatch.setattr(server, "_get_db", lambda: None)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5747,7 +5747,14 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
         with session["history_lock"]:
             session["running"] = False
             if session.get("_finalized"):
-                if session.get("queued_prompt") is None:
+                pending = session.get("queued_prompt")
+                session["queued_prompt"] = queued
+                if pending is not None:
+                    # Merge normally, then keep Q1's pinned transport and metadata.
+                    _enqueue_prompt(
+                        session, pending.get("text"), pending.get("transport")
+                    )
+                    queued["text"] = session["queued_prompt"]["text"]
                     session["queued_prompt"] = queued
                 return False
     return True

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -599,21 +599,21 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
     force-quit (double Ctrl‑C, terminal‑close, SIGHUP) while the agent
     is mid‑turn.
     """
-    if not session or session.get("_finalized"):
+    if not session:
         return
-    session["_finalized"] = True
+    lock = session.get("history_lock")
+    guard = lock if lock is not None else contextlib.nullcontext()
+    with guard:
+        if session.get("_finalized"):
+            return
+        session["_finalized"] = True
+        history = list(session.get("history", []))
     _release_active_session_slot(session)
     stop_event = session.get("_notif_stop")
     if stop_event is not None:
         stop_event.set()
 
     agent = session.get("agent")
-    lock = session.get("history_lock")
-    if lock is not None:
-        with lock:
-            history = list(session.get("history", []))
-    else:
-        history = list(session.get("history", []))
 
     # ── Persist unflushed messages to SQLite ──────────────────────────
     # Flush ``agent._session_messages`` via ``_persist_session``'s marker-based
@@ -9765,7 +9765,6 @@ def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
                                 lines.append(
                                     f"Kanban {event.task_id} {event.kind.replace('_', ' ')}"
                                 )
-                        _emit("message.start", sid)
                         _run_prompt_submit(
                             f"__kanban__{int(time.time() * 1000)}",
                             sid,
@@ -10044,6 +10043,8 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
 
 def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
     with session["history_lock"]:
+        if session.get("_finalized"):
+            raise RuntimeError("TUI session finalized before prompt acceptance")
         history = list(session["history"])
         history_version = int(session.get("history_version", 0))
         images = list(session.get("attached_images", []))

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9759,6 +9759,7 @@ def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
                 reservation_lost = False
                 events = []
                 prompt_start = None
+                prompt_thread = None
                 try:
                     # ponytail: board-wide writer lock spans only prompt acceptance;
                     # use durable in-flight ranges if dispatch latency becomes material.
@@ -9791,7 +9792,7 @@ def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
                                     f"Kanban {event.task_id} {event.kind.replace('_', ' ')}"
                                 )
                         prompt_start = queue.SimpleQueue()
-                        _run_prompt_submit(
+                        prompt_thread = _run_prompt_submit(
                             f"__kanban__{int(time.time() * 1000)}",
                             sid,
                             session,
@@ -9801,10 +9802,12 @@ def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
                 except Exception as exc:
                     if prompt_start is not None:
                         prompt_start.put(False)
+                    if prompt_thread is not None:
+                        prompt_thread.join()
                     if reservation_lost:
                         return False
                     logger.warning("TUI Kanban notification dispatch failed: %s", exc)
-                    if reserved:
+                    if reserved and prompt_thread is None:
                         with session["history_lock"]:
                             session["running"] = False
                     return False
@@ -10096,7 +10099,7 @@ def _run_prompt_submit(
     text: Any,
     *,
     start_handoff: queue.SimpleQueue | None = None,
-) -> None:
+) -> threading.Thread:
     with session["history_lock"]:
         accepted_turn = session.get("running") and isinstance(
             session.get("inflight_turn"), dict
@@ -10694,6 +10697,7 @@ def _run_prompt_submit(
             session["running"] = False
             _clear_inflight_turn(session)
         raise
+    return run_thread
 
 
 @method("clipboard.paste")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5725,6 +5725,10 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
             session["transport"] = queued["transport"]
     try:
         if _session_uses_compute_host(session):
+            with session["history_lock"]:
+                if session.get("_finalized"):
+                    raise RuntimeError("TUI session finalized before prompt acceptance")
+                _start_inflight_turn(session, queued["text"])
             resp = _submit_prompt_to_compute_host(rid, sid, session, queued["text"])
             if resp.get("error"):
                 message = str(((resp.get("error") or {}).get("message")) or "queued prompt failed")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9688,8 +9688,7 @@ def _notification_event_dedup_key(evt: dict) -> tuple:
 
 def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
     """Inject one claimed terminal Kanban notification for this TUI session."""
-    session_key = str(session.get("session_key") or "")
-    if not session_key:
+    if not session.get("session_key"):
         return False
 
     try:
@@ -9724,16 +9723,15 @@ def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
             for sub in subs:
                 if (
                     (sub.get("platform") or "").lower() != "tui"
-                    or str(sub.get("chat_id") or "") != session_key
+                ):
+                    continue
+                if not _session_owns_notification_event(
+                    sid, session, {"session_key": str(sub.get("chat_id") or "")}
                 ):
                     continue
 
-                with session["history_lock"]:
-                    if session.get("running") or session.get("_finalized"):
-                        return False
-                    session["running"] = True
-
                 old_cursor = cursor = 0
+                reserved = False
                 try:
                     old_cursor, cursor, events = kb.claim_unseen_events_for_sub(
                         conn,
@@ -9744,9 +9742,23 @@ def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
                         kinds=("completed", "blocked", "gave_up", "crashed", "timed_out"),
                     )
                     if not events:
-                        with session["history_lock"]:
-                            session["running"] = False
                         continue
+
+                    with session["history_lock"]:
+                        if not session.get("running") and not session.get("_finalized"):
+                            session["running"] = True
+                            reserved = True
+                    if not reserved:
+                        kb.rewind_notify_cursor(
+                            conn,
+                            task_id=sub["task_id"],
+                            platform=sub["platform"],
+                            chat_id=sub["chat_id"],
+                            thread_id=sub.get("thread_id") or "",
+                            claimed_cursor=cursor,
+                            old_cursor=old_cursor,
+                        )
+                        return False
 
                     lines = []
                     for event in events:
@@ -9765,6 +9777,14 @@ def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
                         session,
                         "\n\n".join(lines),
                     )
+                    if any(event.kind == "completed" for event in events):
+                        kb.remove_notify_sub(
+                            conn,
+                            task_id=sub["task_id"],
+                            platform=sub["platform"],
+                            chat_id=sub["chat_id"],
+                            thread_id=sub.get("thread_id") or "",
+                        )
                     return True
                 except Exception as exc:
                     if cursor != old_cursor:
@@ -9781,8 +9801,9 @@ def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
                         except Exception:
                             logger.warning("TUI Kanban poll failed to rewind cursor", exc_info=True)
                     logger.warning("TUI Kanban notification dispatch failed: %s", exc)
-                    with session["history_lock"]:
-                        session["running"] = False
+                    if reserved:
+                        with session["history_lock"]:
+                            session["running"] = False
                     return False
         except Exception as exc:
             logger.debug("TUI Kanban poll failed for board %s: %s", board, exc)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9686,6 +9686,111 @@ def _notification_event_dedup_key(evt: dict) -> tuple:
     return (evt_sid, evt_type)
 
 
+def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
+    """Inject one claimed terminal Kanban notification for this TUI session."""
+    session_key = str(session.get("session_key") or "")
+    if not session_key:
+        return False
+
+    try:
+        from hermes_cli import kanban_db as kb
+    except Exception:
+        return False
+
+    # ponytail: scans all boards at most twice per second; add a subscription index if board count grows.
+    try:
+        boards = kb.list_boards(include_archived=False)
+    except Exception:
+        boards = [kb.read_board_metadata(kb.DEFAULT_BOARD)]
+
+    seen_db_paths = set()
+    for board_meta in boards:
+        board = board_meta.get("slug") or kb.DEFAULT_BOARD
+        try:
+            db_path = str(kb.kanban_db_path(board).resolve())
+        except Exception:
+            db_path = f"board:{board}"
+        if db_path in seen_db_paths:
+            continue
+        seen_db_paths.add(db_path)
+
+        try:
+            conn = kb.connect(board=board)
+        except Exception as exc:
+            logger.debug("TUI Kanban poll cannot open board %s: %s", board, exc)
+            continue
+        try:
+            subs = kb.list_notify_subs(conn)
+            for sub in subs:
+                if (
+                    (sub.get("platform") or "").lower() != "tui"
+                    or str(sub.get("chat_id") or "") != session_key
+                ):
+                    continue
+
+                with session["history_lock"]:
+                    if session.get("running") or session.get("_finalized"):
+                        return False
+                    session["running"] = True
+
+                old_cursor = cursor = 0
+                try:
+                    old_cursor, cursor, events = kb.claim_unseen_events_for_sub(
+                        conn,
+                        task_id=sub["task_id"],
+                        platform=sub["platform"],
+                        chat_id=sub["chat_id"],
+                        thread_id=sub.get("thread_id") or "",
+                        kinds=("completed", "blocked", "gave_up", "crashed", "timed_out"),
+                    )
+                    if not events:
+                        with session["history_lock"]:
+                            session["running"] = False
+                        continue
+
+                    lines = []
+                    for event in events:
+                        if event.kind == "blocked" and event.payload and event.payload.get("reason"):
+                            lines.append(
+                                f"⏸ Kanban {event.task_id} blocked: {event.payload['reason']}"
+                            )
+                        else:
+                            lines.append(
+                                f"Kanban {event.task_id} {event.kind.replace('_', ' ')}"
+                            )
+                    _emit("message.start", sid)
+                    _run_prompt_submit(
+                        f"__kanban__{int(time.time() * 1000)}",
+                        sid,
+                        session,
+                        "\n\n".join(lines),
+                    )
+                    return True
+                except Exception as exc:
+                    if cursor != old_cursor:
+                        try:
+                            kb.rewind_notify_cursor(
+                                conn,
+                                task_id=sub["task_id"],
+                                platform=sub["platform"],
+                                chat_id=sub["chat_id"],
+                                thread_id=sub.get("thread_id") or "",
+                                claimed_cursor=cursor,
+                                old_cursor=old_cursor,
+                            )
+                        except Exception:
+                            logger.warning("TUI Kanban poll failed to rewind cursor", exc_info=True)
+                    logger.warning("TUI Kanban notification dispatch failed: %s", exc)
+                    with session["history_lock"]:
+                        session["running"] = False
+                    return False
+        except Exception as exc:
+            logger.debug("TUI Kanban poll failed for board %s: %s", board, exc)
+        finally:
+            conn.close()
+    return False
+
+
 def _notification_poller_loop(
     stop_event: threading.Event, sid: str, session: dict
 ) -> None:
@@ -9702,7 +9807,13 @@ def _notification_poller_loop(
     from tools.process_registry import process_registry, format_process_notification
 
     _emitted = set()  # dedup re-queued events so same completion isn't emitted 50 times while session is busy
+    next_kanban_poll = 0.0
     while not stop_event.is_set() and not session.get("_finalized"):
+        now = time.monotonic()
+        if now >= next_kanban_poll:
+            next_kanban_poll = now + 0.5
+            if _poll_tui_kanban_subscriptions(sid, session):
+                continue
         try:
             evt = process_registry.completion_queue.get(timeout=0.5)
         except Exception:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5677,22 +5677,25 @@ def _handle_busy_submit(
     mode = _load_busy_input_mode()
     agent = session.get("agent")
     with session["history_lock"]:
+        if session.get("_finalized"):
+            return _err(rid, 4001, "session not found")
         if not session.get("running"):
             # The turn ended between prompt.submit's first busy check and this
             # helper. Let the caller retry and claim the now-idle session.
             return None
-    if mode == "steer" and agent is not None and hasattr(agent, "steer"):
-        try:
-            if agent.steer(text):
-                with session["history_lock"]:
+        if mode == "steer" and agent is not None and hasattr(agent, "steer"):
+            try:
+                if agent.steer(text):
                     session["last_active"] = time.time()
-                return _ok(rid, {"status": "steered"})
-        except Exception:
-            pass  # fall through to queue
+                    return _ok(rid, {"status": "steered"})
+            except Exception:
+                pass  # fall through to queue
     # Queue before asking the live turn to stop. In particular, never call a
     # provider or compute-host method while holding history_lock: an interrupt
     # can wait behind the very operation it is trying to cancel.
     with session["history_lock"]:
+        if session.get("_finalized"):
+            return _err(rid, 4001, "session not found")
         if not session.get("running"):
             return None
         _enqueue_prompt(session, text, transport)
@@ -5711,6 +5714,8 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
     claim-under-lock pattern used by the goal-continuation re-fire.
     """
     with session["history_lock"]:
+        if session.get("_finalized"):
+            return False
         queued = session.get("queued_prompt")
         if not queued or session.get("running"):
             return False
@@ -5737,6 +5742,10 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
         )
         with session["history_lock"]:
             session["running"] = False
+            if session.get("_finalized"):
+                if session.get("queued_prompt") is None:
+                    session["queued_prompt"] = queued
+                return False
     return True
 
 
@@ -9420,6 +9429,8 @@ def _(rid, params: dict) -> dict:
     while True:
         busy_transport = None
         with session["history_lock"]:
+            if session.get("_finalized"):
+                return _err(rid, 4001, "session not found")
             if session.get("running"):
                 # Don't reject a mid-turn prompt — queue it (and, by default,
                 # interrupt the live turn) so it runs as the next turn. The
@@ -9436,6 +9447,8 @@ def _(rid, params: dict) -> dict:
         # queue whose drain already ran.
 
     with session["history_lock"]:
+        if session.get("_finalized"):
+            return _err(rid, 4001, "session not found")
         # A watch session's run lives in the PARENT turn, so its own running
         # flag is False — without this, typing mid-run builds a second agent
         # racing the in-flight child on the same stored session (interleaved
@@ -9866,23 +9879,22 @@ def _notification_poller_loop(
         if not text:
             continue
 
-        # Only emit the same notification identity to TUI once — re-queued
-        # completions get re-emitted every 0.5s otherwise when session is busy,
-        # while distinct watch_match events from the same process must remain
-        # visible independently.
+        # Emit only after the finalized check below has accepted this event.
         _dedup_key = _notification_event_dedup_key(evt)
-        if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
-            _emitted.add(_dedup_key)
-
         _requeued = False
         with session["history_lock"]:
+            if session.get("_finalized"):
+                process_registry.completion_queue.put(evt)
+                break
             if session.get("running"):
                 process_registry.completion_queue.put(evt)
                 _requeued = True
             else:
                 session["running"] = True
         if _requeued:
+            if _dedup_key not in _emitted:
+                _emit("status.update", sid, {"kind": "process", "text": text})
+                _emitted.add(_dedup_key)
             # Back off before re-polling: the re-queued event keeps the queue
             # non-empty, so without a sleep this loop spins at full speed
             # (100% CPU, GIL churn) for as long as the session stays busy.
@@ -9897,8 +9909,10 @@ def _notification_poller_loop(
         if _claim is None:
             continue
         try:
-            _emit("message.start", sid)
             _run_prompt_submit(rid, sid, session, text)
+            if _dedup_key not in _emitted:
+                _emit("status.update", sid, {"kind": "process", "text": text})
+                _emitted.add(_dedup_key)
             complete_event_delivery(evt, _claim)
         except Exception as exc:
             release_event_delivery(evt, _claim)
@@ -9909,6 +9923,8 @@ def _notification_poller_loop(
             )
             with session["history_lock"]:
                 session["running"] = False
+                if session.get("_finalized"):
+                    process_registry.completion_queue.put(evt)
 
     # Drain any remaining events after stop signal (process all pending
     # before exiting so nothing is lost on shutdown). Events owned by other
@@ -9920,6 +9936,10 @@ def _notification_poller_loop(
             evt = process_registry.completion_queue.get_nowait()
         except Exception:
             break
+        with session["history_lock"]:
+            if session.get("_finalized"):
+                deferred.append(evt)
+                continue
         if _notification_event_belongs_elsewhere(sid, session, evt):
             deferred.append(evt)
             continue
@@ -9947,15 +9967,21 @@ def _notification_poller_loop(
             continue
 
         _dedup_key = _notification_event_dedup_key(evt)
-        if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
-            _emitted.add(_dedup_key)
-
+        _requeued = False
         with session["history_lock"]:
+            if session.get("_finalized"):
+                deferred.append(evt)
+                continue
             if session.get("running"):
                 process_registry.completion_queue.put(evt)
-                break
-            session["running"] = True
+                _requeued = True
+            else:
+                session["running"] = True
+        if _requeued:
+            if _dedup_key not in _emitted:
+                _emit("status.update", sid, {"kind": "process", "text": text})
+                _emitted.add(_dedup_key)
+            break
 
         rid = f"__notif__{int(time.time() * 1000)}"
         from tools.async_delegation import (
@@ -9965,8 +9991,10 @@ def _notification_poller_loop(
         if _claim is None:
             continue
         try:
-            _emit("message.start", sid)
             _run_prompt_submit(rid, sid, session, text)
+            if _dedup_key not in _emitted:
+                _emit("status.update", sid, {"kind": "process", "text": text})
+                _emitted.add(_dedup_key)
             complete_event_delivery(evt, _claim)
         except Exception as exc:
             release_event_delivery(evt, _claim)
@@ -9977,6 +10005,8 @@ def _notification_poller_loop(
             )
             with session["history_lock"]:
                 session["running"] = False
+                if session.get("_finalized"):
+                    deferred.append(evt)
 
     # Hand any other sessions' events back to the shared queue.
     for evt in deferred:
@@ -10043,7 +10073,10 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
 
 def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
     with session["history_lock"]:
-        if session.get("_finalized"):
+        accepted_turn = session.get("running") and isinstance(
+            session.get("inflight_turn"), dict
+        )
+        if session.get("_finalized") and not accepted_turn:
             raise RuntimeError("TUI session finalized before prompt acceptance")
         history = list(session["history"])
         history_version = int(session.get("history_version", 0))
@@ -10539,13 +10572,12 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         # we check that guard before re-firing.
         if goal_followup:
             with session["history_lock"]:
-                if session.get("running"):
+                if session.get("_finalized") or session.get("running"):
                     # User already sent something — their turn wins,
                     # the judge will re-run on the next turn anyway.
                     return
                 session["running"] = True
             try:
-                _emit("message.start", sid)
                 _run_prompt_submit(rid, sid, session, goal_followup)
             except Exception as _cont_exc:
                 print(
@@ -10567,6 +10599,9 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         try:
             from tools.process_registry import process_registry
 
+            with session["history_lock"]:
+                if session.get("_finalized"):
+                    return
             # Positive-proof ownership (compression-chain aware) — the same
             # fail-closed gate the poller uses, so the post-turn drain can't
             # adopt another session's addressed notification while a
@@ -10579,7 +10614,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             )
             for index, (_evt, synth) in enumerate(drained):
                 with session["history_lock"]:
-                    if session.get("running"):
+                    if session.get("_finalized") or session.get("running"):
                         for pending_evt, _pending_synth in drained[index:]:
                             process_registry.completion_queue.put(pending_evt)
                         break
@@ -10591,7 +10626,6 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 if _claim is None:
                     continue
                 try:
-                    _emit("message.start", sid)
                     _run_prompt_submit(rid, sid, session, synth)
                     complete_event_delivery(_evt, _claim)
                 except Exception as _n_exc:
@@ -10603,6 +10637,8 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     )
                     with session["history_lock"]:
                         session["running"] = False
+                        if session.get("_finalized"):
+                            process_registry.completion_queue.put(_evt)
         except Exception as _drain_exc:
             print(
                 f"[tui_gateway] completion queue drain failed: "

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9731,67 +9731,50 @@ def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
                 if not _session_owns_notification_event(sid, session, sub_event):
                     continue
 
-                old_cursor = cursor = 0
                 reserved = False
+                reservation_lost = False
+                events = []
                 try:
-                    old_cursor, cursor, events = kb.claim_unseen_events_for_sub(
-                        conn,
-                        task_id=sub["task_id"],
-                        platform=sub["platform"],
-                        chat_id=sub["chat_id"],
-                        thread_id=sub.get("thread_id") or "",
-                        kinds=("completed", "blocked", "gave_up", "crashed", "timed_out"),
-                    )
-                    if not events:
-                        continue
-
-                    with session["history_lock"]:
-                        if not session.get("running") and not session.get("_finalized"):
-                            session["running"] = True
-                            reserved = True
-                    if not reserved:
-                        kb.rewind_notify_cursor(
+                    # ponytail: board-wide writer lock spans only prompt acceptance;
+                    # use durable in-flight ranges if dispatch latency becomes material.
+                    with kb.write_txn(conn):
+                        _, _, events = kb.claim_unseen_events_for_sub(
                             conn,
                             task_id=sub["task_id"],
                             platform=sub["platform"],
                             chat_id=sub["chat_id"],
                             thread_id=sub.get("thread_id") or "",
-                            claimed_cursor=cursor,
-                            old_cursor=old_cursor,
+                            kinds=("completed", "blocked", "gave_up", "crashed", "timed_out"),
                         )
-                        return False
+                        if not events:
+                            continue
+                        with session["history_lock"]:
+                            if session.get("running") or session.get("_finalized"):
+                                reservation_lost = True
+                                raise RuntimeError("TUI Kanban session reservation lost")
+                            session["running"] = True
+                            reserved = True
 
-                    lines = []
-                    for event in events:
-                        if event.kind == "blocked" and event.payload and event.payload.get("reason"):
-                            lines.append(
-                                f"⏸ Kanban {event.task_id} blocked: {event.payload['reason']}"
-                            )
-                        else:
-                            lines.append(
-                                f"Kanban {event.task_id} {event.kind.replace('_', ' ')}"
-                            )
-                    _emit("message.start", sid)
-                    _run_prompt_submit(
-                        f"__kanban__{int(time.time() * 1000)}",
-                        sid,
-                        session,
-                        "\n\n".join(lines),
-                    )
+                        lines = []
+                        for event in events:
+                            if event.kind == "blocked" and event.payload and event.payload.get("reason"):
+                                lines.append(
+                                    f"⏸ Kanban {event.task_id} blocked: {event.payload['reason']}"
+                                )
+                            else:
+                                lines.append(
+                                    f"Kanban {event.task_id} {event.kind.replace('_', ' ')}"
+                                )
+                        _emit("message.start", sid)
+                        _run_prompt_submit(
+                            f"__kanban__{int(time.time() * 1000)}",
+                            sid,
+                            session,
+                            "\n\n".join(lines),
+                        )
                 except Exception as exc:
-                    if cursor != old_cursor:
-                        try:
-                            kb.rewind_notify_cursor(
-                                conn,
-                                task_id=sub["task_id"],
-                                platform=sub["platform"],
-                                chat_id=sub["chat_id"],
-                                thread_id=sub.get("thread_id") or "",
-                                claimed_cursor=cursor,
-                                old_cursor=old_cursor,
-                            )
-                        except Exception:
-                            logger.warning("TUI Kanban poll failed to rewind cursor", exc_info=True)
+                    if reservation_lost:
+                        return False
                     logger.warning("TUI Kanban notification dispatch failed: %s", exc)
                     if reserved:
                         with session["history_lock"]:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9758,6 +9758,7 @@ def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
                 reserved = False
                 reservation_lost = False
                 events = []
+                prompt_start = None
                 try:
                     # ponytail: board-wide writer lock spans only prompt acceptance;
                     # use durable in-flight ranges if dispatch latency becomes material.
@@ -9789,13 +9790,17 @@ def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
                                 lines.append(
                                     f"Kanban {event.task_id} {event.kind.replace('_', ' ')}"
                                 )
+                        prompt_start = queue.SimpleQueue()
                         _run_prompt_submit(
                             f"__kanban__{int(time.time() * 1000)}",
                             sid,
                             session,
                             "\n\n".join(lines),
+                            start_handoff=prompt_start,
                         )
                 except Exception as exc:
+                    if prompt_start is not None:
+                        prompt_start.put(False)
                     if reservation_lost:
                         return False
                     logger.warning("TUI Kanban notification dispatch failed: %s", exc)
@@ -9803,6 +9808,8 @@ def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
                         with session["history_lock"]:
                             session["running"] = False
                     return False
+                if prompt_start is not None:
+                    prompt_start.put(True)
                 if any(event.kind == "completed" for event in events):
                     try:
                         kb.remove_notify_sub(
@@ -10082,7 +10089,14 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     return stop
 
 
-def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
+def _run_prompt_submit(
+    rid,
+    sid: str,
+    session: dict,
+    text: Any,
+    *,
+    start_handoff: queue.SimpleQueue | None = None,
+) -> None:
     with session["history_lock"]:
         accepted_turn = session.get("running") and isinstance(
             session.get("inflight_turn"), dict
@@ -10101,15 +10115,25 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             agent.clear_interrupt()
         except Exception:
             pass
-    _emit("message.start", sid)
+    if start_handoff is None:
+        _emit("message.start", sid)
 
     def run():
         approval_token = None
         session_tokens = []
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
         goal_followup = None  # set by the post-turn goal hook below
-        one_turn_restore = session.pop("one_turn_model_restore", None)
+        one_turn_restore = None
         try:
+            if start_handoff is not None:
+                if not start_handoff.get():
+                    with session["history_lock"]:
+                        session["attached_images"] = images + list(
+                            session.get("attached_images", [])
+                        )
+                    return
+                _emit("message.start", sid)
+            one_turn_restore = session.pop("one_turn_model_restore", None)
             from tools.approval import (
                 reset_current_session_key,
                 set_current_session_key,
@@ -10659,7 +10683,17 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
 
     run_thread = threading.Thread(target=run, daemon=True)
     session["_run_thread"] = run_thread
-    run_thread.start()
+    try:
+        run_thread.start()
+    except Exception:
+        session.pop("_run_thread", None)
+        with session["history_lock"]:
+            session["attached_images"] = images + list(
+                session.get("attached_images", [])
+            )
+            session["running"] = False
+            _clear_inflight_turn(session)
+        raise
 
 
 @method("clipboard.paste")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9725,9 +9725,10 @@ def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
                     (sub.get("platform") or "").lower() != "tui"
                 ):
                     continue
-                if not _session_owns_notification_event(
-                    sid, session, {"session_key": str(sub.get("chat_id") or "")}
-                ):
+                sub_event = {"session_key": str(sub.get("chat_id") or "")}
+                if _notification_event_belongs_elsewhere(sid, session, sub_event):
+                    continue
+                if not _session_owns_notification_event(sid, session, sub_event):
                     continue
 
                 old_cursor = cursor = 0
@@ -9777,15 +9778,6 @@ def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
                         session,
                         "\n\n".join(lines),
                     )
-                    if any(event.kind == "completed" for event in events):
-                        kb.remove_notify_sub(
-                            conn,
-                            task_id=sub["task_id"],
-                            platform=sub["platform"],
-                            chat_id=sub["chat_id"],
-                            thread_id=sub.get("thread_id") or "",
-                        )
-                    return True
                 except Exception as exc:
                     if cursor != old_cursor:
                         try:
@@ -9805,6 +9797,18 @@ def _poll_tui_kanban_subscriptions(sid: str, session: dict) -> bool:
                         with session["history_lock"]:
                             session["running"] = False
                     return False
+                if any(event.kind == "completed" for event in events):
+                    try:
+                        kb.remove_notify_sub(
+                            conn,
+                            task_id=sub["task_id"],
+                            platform=sub["platform"],
+                            chat_id=sub["chat_id"],
+                            thread_id=sub.get("thread_id") or "",
+                        )
+                    except Exception as exc:
+                        logger.warning("TUI Kanban completed subscription cleanup failed: %s", exc)
+                return True
         except Exception as exc:
             logger.debug("TUI Kanban poll failed for board %s: %s", board, exc)
         finally:


### PR DESCRIPTION
## Summary
- deliver subscribed Kanban terminal events to the owning TUI/Desktop session with lineage-aware ownership and transactional cursor rollback
- make claim ranges, finalization, queued prompt rollback, and compute-host dispatch race-safe
- start provider work only after the Kanban claim commit and await failed-claim cleanup before releasing ownership

## Verification
- `scripts/run_tests.sh tests/test_tui_gateway_server.py tests/hermes_cli/test_kanban_db.py`
- **639 passed, 0 failed** on current upstream `main`
- supervised activation: a 1,062-second card resumed the same Desktop lineage and removed its consumed subscription
- `git diff --check origin/main...HEAD`

The commits preserve their original authorship and were rebased onto current upstream main.