### PR TITLE
fix(usePet): guard pet.cells polling on enabled to prevent timeout spam

### DIFF
--- a/ui-tui/src/app/usePet.ts
+++ b/ui-tui/src/app/usePet.ts
@@ -80,6 +80,13 @@ type CacheEntry =
 
 const FRAME_MS = 160
 const POLL_MS = 2500
+// When the pet is disabled, poll at 1/4 the frequency to detect a future
+// config change (e.g. `/pet`, desktop picker, `hermes pets select`) without
+// flooding the gateway thread pool with pet.cells RPCs that will just return
+// {enabled: false}. Under thread-pool contention those requests can queue
+// past the 120s RPC timeout and produce `error: timeout: pet.cells` spam.
+// See issue #69039.
+const POLL_MS_DISABLED = 10_000
 
 // Only the standalone TUI owns a real terminal it can splat image escapes into;
 // when piped (or running under the dashboard PTY the gateway resolves to
@@ -250,9 +257,28 @@ export function usePet(): PetRender {
     [rpc, releaseKitty]
   )
 
-  // Pull frames whenever the state changes (if not already cached for the
-  // active pet), plus a steady poll that catches adopt/switch/disable.
+  // Disabled-pet poll: detect a future config change (enable / adopt / switch)
+  // without responding to petState changes (they're invisible while disabled).
+  // Slow interval avoids flooding the gateway with pet.cells RPCs that just
+  // return {enabled: false}. See issue #69039.
   useEffect(() => {
+    if (enabled) {
+      return
+    }
+
+    void sync(stateRef.current)
+    const timer = setInterval(() => void sync(stateRef.current), POLL_MS_DISABLED)
+
+    return () => clearInterval(timer)
+  }, [enabled, sync])
+
+  // Enabled-pet poll: pull frames on state change (if not cached) plus a
+  // steady poll that catches adopt/switch/scale changes.
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
     if (!cache.current.has(`${slugRef.current}:${petState}`)) {
       void sync(petState)
     }
@@ -260,7 +286,7 @@ export function usePet(): PetRender {
     const timer = setInterval(() => void sync(stateRef.current), POLL_MS)
 
     return () => clearInterval(timer)
-  }, [petState, sync])
+  }, [enabled, petState, sync])
 
   useEffect(() => releaseKitty, [releaseKitty])
 


### PR DESCRIPTION
## Problem

When `display.pet.enabled: false` is set in config, the TUI still sends `pet.cells` RPC requests every 2.5s. Under thread-pool contention (multiple TUI sessions + heavy agent work), these requests queue up and hit the 120s RPC timeout, producing repeated `error: timeout: pet.cells` messages in the system output area.

## Root Cause

In `ui-tui/src/app/usePet.ts`, the polling `useEffect` (lines 255–263) had **no `enabled` guard**, unlike the animation `useEffect` (lines 268–271) which correctly guards on `enabled`:

```typescript
// Polling effect — NO guard ❌
useEffect(() => {
  if (!cache.current.has(`${slugRef.current}:${petState}`)) {
    void sync(petState)
  }
  const timer = setInterval(() => void sync(stateRef.current), POLL_MS)
  return () => clearInterval(timer)
}, [petState, sync])

// Animation effect — HAS guard ✅
useEffect(() => {
  if (!enabled) { return }
  ...
}, [enabled])
```

The design intent was "call the RPC, let the backend return `{enabled: false}` to make the TUI clean up." This works when the backend responds quickly. But `pet.cells` is routed to a 4-worker thread pool (`_LONG_HANDLERS` in `tui_gateway/server.py`), and under contention the request queues beyond the 120s `REQUEST_TIMEOUT_MS` (`gatewayClient.ts:18`), triggering:

```typescript
// gatewayClient.ts:614
p.reject(new Error(`timeout: ${p.method}`))
```

Which surfaces as `error: timeout: pet.cells` via `useMainApp.ts:468`.

## Reproduction

1. Set `display.pet.enabled: false` in `~/.hermes/config.yaml`
2. Open multiple TUI sessions (5+)
3. Trigger a long-running agent task (e.g. `delegate_task` with 3 subagents)
4. Observe `error: timeout: pet.cells` appearing in system messages every ~120s

## Fix

Split the single polling `useEffect` into two guarded effects:

- **Disabled**: slow 10s poll (only detects future config changes like `/pet`, desktop picker, `hermes pets select`). Does not respond to `petState` changes (they are invisible while disabled).
- **Enabled**: original 2.5s poll + state-change sync (unchanged behavior).

This mirrors the existing pattern in the animation `useEffect` which already guards on `enabled`.

### Behavior changes

| Scenario | Before | After |
|---|---|---|
| Pet enabled, state change | 2.5s poll + sync | 2.5s poll + sync (no change) |
| Pet enabled, config change | 2.5s poll catches it | 2.5s poll catches it (no change) |
| Pet **disabled** | 2.5s poll, every poll sends `pet.cells` RPC | 10s poll, still sends RPC but 4× less often |
| Pet disabled → enabled | Next poll detects, `setEnabled(true)` | Same — slow poll detects, `setEnabled(true)`, enabled effect takes over |
| Pet enabled → disabled | Next poll detects, `setEnabled(false)` | Same — poll detects, `setEnabled(false)`, disabled effect takes over |

### Why not skip the RPC entirely when disabled?

The poll is still needed to detect a future `false → true` config change (e.g. the user runs `/pet` or adopts via the desktop picker). The backend `pet.cells` handler returns `{enabled: false}` immediately when disabled (server.py:6604-6605), so the RPC is cheap when the thread pool is not contended. The 10s interval is a balance between responsiveness and avoiding thread-pool pressure.

## Testing

- `vitest run src/__tests__/createGatewayEventHandler.test.ts` → 77/77 passed
- TUI build (`npm run build`) → success
- Manual verification: pet disabled + 5 TUI sessions + heavy agent work → no `timeout: pet.cells` spam

Fixes #69039
