### PR TITLE
fix(gateway): per-profile session isolation for shared-WhatsApp multiplex

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12744,9 +12744,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         for platform, platform_config in profile_cfg.platforms.items():
             if not platform_config.enabled:
                 continue
-            # Relay is shared process-level ingress in multiplex mode. The
-            # active profile owns the one connection; connector-stamped
-            # source.profile routes inbound turns to secondary profiles.
+            # Relay and WhatsApp are shared process-level ingress in multiplex
+            # mode: one connection, owned by the active profile, with
+            # route-stamped source.profile fanning inbound turns out to
+            # secondary profiles. WhatsApp joins Relay here because the bridge
+            # is a single authenticated session tied to one phone number — a
+            # secondary profile has no credentials of its own to bring, so
+            # letting it construct an adapter only produces a connect/retry
+            # loop that stalls startup for every other profile behind it.
             if (
                 getattr(self.config, "multiplex_profiles", False)
                 and platform in (Platform.RELAY, Platform.WHATSAPP)
@@ -15734,17 +15739,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
 
-        # [LOCAL PATCH] Create the session INSIDE the routed profile's scope so
-        # SessionStore._db resolves to that profile's state.db (not default).
-        # Without this the session is physically created in the default profile's
-        # state.db — leaking default history/memory (e.g. IBKR agenda) into
-        # routed cgpt/yltc replies even though the agent run itself is scoped.
-        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
-            _pscope_home = self._resolve_profile_home_for_source(source)
-            with _profile_runtime_scope(_pscope_home):
-                session_entry = await self.async_session_store.get_or_create_session(source)
-        else:
-            session_entry = await self.async_session_store.get_or_create_session(source)
+        session_entry = await self.async_session_store.get_or_create_session(source)
         session_key = session_entry.session_key
         pinned_session_id = str(
             (getattr(event, "metadata", None) or {}).get("gateway_session_id") or ""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12749,7 +12749,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # source.profile routes inbound turns to secondary profiles.
             if (
                 getattr(self.config, "multiplex_profiles", False)
-                and platform is Platform.RELAY
+                and platform in (Platform.RELAY, Platform.WHATSAPP)
             ):
                 continue
             try:
@@ -15734,7 +15734,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
 
-        session_entry = await self.async_session_store.get_or_create_session(source)
+        # [LOCAL PATCH] Create the session INSIDE the routed profile's scope so
+        # SessionStore._db resolves to that profile's state.db (not default).
+        # Without this the session is physically created in the default profile's
+        # state.db — leaking default history/memory (e.g. IBKR agenda) into
+        # routed cgpt/yltc replies even though the agent run itself is scoped.
+        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            _pscope_home = self._resolve_profile_home_for_source(source)
+            with _profile_runtime_scope(_pscope_home):
+                session_entry = await self.async_session_store.get_or_create_session(source)
+        else:
+            session_entry = await self.async_session_store.get_or_create_session(source)
         session_key = session_entry.session_key
         pinned_session_id = str(
             (getattr(event, "metadata", None) or {}).get("gateway_session_id") or ""

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1236,13 +1236,64 @@ class SessionStore:
             getattr(config, "write_sessions_json", True)
         )
         
-        # Initialize SQLite session database
-        self._db = None
+        # Initialize SQLite session database.
+        # [LOCAL PATCH] Under multiplex, self._db must resolve to the CURRENT
+        # profile's state.db (per the ContextVar-scoped get_hermes_home), not a
+        # single default one — otherwise routed WhatsApp sessions physically
+        # land in the default profile's state.db and leak its history/memory
+        # into cgpt/yltc replies. We keep self._db as a PROPERTY (below) backed
+        # by a per-home cache, so none of the ~44 self._db.* call sites change.
+        self._db_default = None
+        self._db_by_home: Dict[str, Any] = {}
+        self._db_cache_lock = threading.Lock()
         try:
             from hermes_state import SessionDB
-            self._db = SessionDB()
+            self._db_default = SessionDB()
         except Exception as e:
             print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
+
+    @property
+    def _db(self):
+        """The SessionDB for the CURRENT context's profile home.
+
+        Multiplex OFF (default): always the process-default SessionDB — behavior
+        byte-identical to before this patch. Multiplex ON: resolve/cache a
+        SessionDB opened at the ContextVar-scoped ``get_hermes_home()/state.db``,
+        so each routed profile reads+writes its OWN state.db. Falls back to the
+        default DB on any resolution error (never returns None if the default
+        opened successfully)."""
+        if not getattr(self.config, "multiplex_profiles", False):
+            return self._db_default
+        try:
+            from hermes_constants import get_hermes_home
+            home = str(get_hermes_home())
+        except Exception:
+            return self._db_default
+        # Fast path: the default home resolves to the default DB instance.
+        try:
+            from pathlib import Path
+            default_home = str(Path(self._db_default.db_path).parent) if (
+                self._db_default is not None and getattr(self._db_default, "db_path", None)
+            ) else None
+        except Exception:
+            default_home = None
+        if default_home is not None and home == default_home:
+            return self._db_default
+        cached = self._db_by_home.get(home)
+        if cached is not None:
+            return cached
+        with self._db_cache_lock:
+            cached = self._db_by_home.get(home)
+            if cached is not None:
+                return cached
+            try:
+                from pathlib import Path
+                from hermes_state import SessionDB
+                db = SessionDB(db_path=Path(home) / "state.db")
+                self._db_by_home[home] = db
+                return db
+            except Exception:
+                return self._db_default
 
     def _has_active_processes_safe(self, session_key: str, *, context: str) -> bool:
         """Return whether a session has active work, failing closed on registry errors."""
@@ -1553,6 +1604,34 @@ class SessionStore:
             return None
         if source is not None and source.profile:
             return source.profile
+        # [LOCAL PATCH] Consult gateway.profile_routes when source.profile is
+        # unset. Without this, a WhatsApp group routed via profile_routes still
+        # got the ACTIVE (default) namespace here — so its session/history/memory
+        # landed in the default profile's state.db even though its home/skills
+        # were scoped correctly, leaking default-profile data (e.g. IBKR
+        # positions) into routed replies. Stamps source.profile so home and
+        # session-key namespace agree. See run.py _profile_name_for_source.
+        if source is not None:
+            try:
+                routes = getattr(self.config, "profile_routes", None)
+                if routes:
+                    from gateway.profile_routing import match_profile_route
+                    matched = match_profile_route(
+                        routes,
+                        platform=source.platform.value,
+                        guild_id=getattr(source, "guild_id", None),
+                        chat_id=source.chat_id,
+                        thread_id=getattr(source, "thread_id", None),
+                        parent_chat_id=getattr(source, "parent_chat_id", None),
+                    )
+                    if matched:
+                        try:
+                            source.profile = matched.profile
+                        except Exception:
+                            pass
+                        return matched.profile
+            except Exception:
+                pass
         try:
             from hermes_cli.profiles import get_active_profile_name
             return get_active_profile_name() or "default"

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1236,64 +1236,13 @@ class SessionStore:
             getattr(config, "write_sessions_json", True)
         )
         
-        # Initialize SQLite session database.
-        # [LOCAL PATCH] Under multiplex, self._db must resolve to the CURRENT
-        # profile's state.db (per the ContextVar-scoped get_hermes_home), not a
-        # single default one — otherwise routed WhatsApp sessions physically
-        # land in the default profile's state.db and leak its history/memory
-        # into cgpt/yltc replies. We keep self._db as a PROPERTY (below) backed
-        # by a per-home cache, so none of the ~44 self._db.* call sites change.
-        self._db_default = None
-        self._db_by_home: Dict[str, Any] = {}
-        self._db_cache_lock = threading.Lock()
+        # Initialize SQLite session database
+        self._db = None
         try:
             from hermes_state import SessionDB
-            self._db_default = SessionDB()
+            self._db = SessionDB()
         except Exception as e:
             print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
-
-    @property
-    def _db(self):
-        """The SessionDB for the CURRENT context's profile home.
-
-        Multiplex OFF (default): always the process-default SessionDB — behavior
-        byte-identical to before this patch. Multiplex ON: resolve/cache a
-        SessionDB opened at the ContextVar-scoped ``get_hermes_home()/state.db``,
-        so each routed profile reads+writes its OWN state.db. Falls back to the
-        default DB on any resolution error (never returns None if the default
-        opened successfully)."""
-        if not getattr(self.config, "multiplex_profiles", False):
-            return self._db_default
-        try:
-            from hermes_constants import get_hermes_home
-            home = str(get_hermes_home())
-        except Exception:
-            return self._db_default
-        # Fast path: the default home resolves to the default DB instance.
-        try:
-            from pathlib import Path
-            default_home = str(Path(self._db_default.db_path).parent) if (
-                self._db_default is not None and getattr(self._db_default, "db_path", None)
-            ) else None
-        except Exception:
-            default_home = None
-        if default_home is not None and home == default_home:
-            return self._db_default
-        cached = self._db_by_home.get(home)
-        if cached is not None:
-            return cached
-        with self._db_cache_lock:
-            cached = self._db_by_home.get(home)
-            if cached is not None:
-                return cached
-            try:
-                from pathlib import Path
-                from hermes_state import SessionDB
-                db = SessionDB(db_path=Path(home) / "state.db")
-                self._db_by_home[home] = db
-                return db
-            except Exception:
-                return self._db_default
 
     def _has_active_processes_safe(self, session_key: str, *, context: str) -> bool:
         """Return whether a session has active work, failing closed on registry errors."""
@@ -1604,34 +1553,6 @@ class SessionStore:
             return None
         if source is not None and source.profile:
             return source.profile
-        # [LOCAL PATCH] Consult gateway.profile_routes when source.profile is
-        # unset. Without this, a WhatsApp group routed via profile_routes still
-        # got the ACTIVE (default) namespace here — so its session/history/memory
-        # landed in the default profile's state.db even though its home/skills
-        # were scoped correctly, leaking default-profile data (e.g. IBKR
-        # positions) into routed replies. Stamps source.profile so home and
-        # session-key namespace agree. See run.py _profile_name_for_source.
-        if source is not None:
-            try:
-                routes = getattr(self.config, "profile_routes", None)
-                if routes:
-                    from gateway.profile_routing import match_profile_route
-                    matched = match_profile_route(
-                        routes,
-                        platform=source.platform.value,
-                        guild_id=getattr(source, "guild_id", None),
-                        chat_id=source.chat_id,
-                        thread_id=getattr(source, "thread_id", None),
-                        parent_chat_id=getattr(source, "parent_chat_id", None),
-                    )
-                    if matched:
-                        try:
-                            source.profile = matched.profile
-                        except Exception:
-                            pass
-                        return matched.profile
-            except Exception:
-                pass
         try:
             from hermes_cli.profiles import get_active_profile_name
             return get_active_profile_name() or "default"

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -467,6 +467,131 @@ class TestSecondaryProfileConfigHandling:
         assert second == 1
         assert runner._profile_adapters["later"][photon] is later
 
+    @pytest.mark.asyncio
+    async def test_secondary_profile_adapter_start_skips_whatsapp(self, monkeypatch):
+        """WhatsApp is shared process-level ingress, like Relay.
+
+        The bridge is one authenticated session tied to a single phone number,
+        so a secondary profile has no credentials of its own to connect with.
+        Building an adapter for it only yields a connect/retry loop that stalls
+        startup for the profiles queued behind it.
+        """
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        class _DirectAdapter:
+            platform = Platform.TELEGRAM
+
+            def __getattr__(self, name):
+                if name.startswith("set_"):
+                    return lambda *args, **kwargs: None
+                raise AttributeError(name)
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+        runner.session_store = object()
+        runner._handle_adapter_fatal_error = object()
+        runner._handle_active_session_busy_message = object()
+        runner._recover_telegram_topic_thread_id = object()
+        runner._busy_text_mode = "queue"
+        runner._make_adapter_auth_check = lambda platform, profile_name=None: object()
+
+        secondary_cfg = GatewayConfig(multiplex_profiles=True)
+        secondary_cfg.platforms = {
+            Platform.WHATSAPP: PlatformConfig(enabled=True),
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="secondary-token"),
+        }
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config", lambda: secondary_cfg
+        )
+
+        direct = _DirectAdapter()
+        factory_calls = []
+
+        def _create_adapter(platform, config):
+            factory_calls.append(platform)
+            if platform is Platform.WHATSAPP:
+                raise AssertionError("secondary WhatsApp factory must not be invoked")
+            return direct
+
+        connect_calls = []
+
+        async def _connect(adapter, platform):
+            connect_calls.append((adapter, platform))
+            return True
+
+        monkeypatch.setattr(runner, "_create_adapter", _create_adapter)
+        monkeypatch.setattr(runner, "_connect_adapter_with_timeout", _connect)
+
+        connected = await runner._start_one_profile_adapters(
+            "clientbot", "/tmp/x", {}
+        )
+
+        # The other platform on the same profile still starts normally — the
+        # skip is scoped to WhatsApp, it does not abort the profile.
+        assert connected == 1
+        assert factory_calls == [Platform.TELEGRAM]
+        assert connect_calls == [(direct, Platform.TELEGRAM)]
+        assert runner._profile_adapters["clientbot"] == {
+            Platform.TELEGRAM: direct,
+        }
+
+    @pytest.mark.asyncio
+    async def test_non_multiplex_profile_adapter_start_keeps_whatsapp(self, monkeypatch):
+        """The WhatsApp skip is gated to multiplex mode.
+
+        Single-profile installs — the overwhelming majority — must keep
+        building their WhatsApp adapter exactly as before.
+        """
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        class _WhatsAppAdapter:
+            platform = Platform.WHATSAPP
+
+            def __getattr__(self, name):
+                if name.startswith("set_"):
+                    return lambda *args, **kwargs: None
+                raise AttributeError(name)
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=False)
+        runner._profile_adapters = {}
+        runner.session_store = object()
+        runner._handle_adapter_fatal_error = object()
+        runner._handle_active_session_busy_message = object()
+        runner._recover_telegram_topic_thread_id = object()
+        runner._busy_text_mode = "queue"
+        runner._make_adapter_auth_check = lambda platform, profile_name=None: object()
+
+        profile_cfg = GatewayConfig(multiplex_profiles=False)
+        profile_cfg.platforms = {
+            Platform.WHATSAPP: PlatformConfig(enabled=True),
+        }
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_cfg)
+
+        wa = _WhatsAppAdapter()
+        factory_calls = []
+        connect_calls = []
+
+        def _create_adapter(platform, config):
+            factory_calls.append(platform)
+            return wa
+
+        async def _connect(adapter, platform):
+            connect_calls.append((adapter, platform))
+            return True
+
+        monkeypatch.setattr(runner, "_create_adapter", _create_adapter)
+        monkeypatch.setattr(runner, "_connect_adapter_with_timeout", _connect)
+
+        connected = await runner._start_one_profile_adapters(
+            "clientbot", "/tmp/x", {}
+        )
+
+        assert connected == 1
+        assert factory_calls == [Platform.WHATSAPP]
+        assert connect_calls == [(wa, Platform.WHATSAPP)]
+
 
 class TestFeishuPortBindingConditional:
     """Feishu websocket mode does NOT bind a port; only webhook mode does (#52563)."""


### PR DESCRIPTION
## Problem

Running `gateway.multiplex_profiles` with a **single shared WhatsApp (Baileys) account** routed to multiple profiles via `gateway.profile_routes`, inbound messages were served by the **default** profile's config/skills/memory/session-DB even when a `profile_route` matched — leaking default-profile data (memory, `session_search` history, filesystem) into routed replies. Three related gaps:

### 1. Secondary profiles tried to start their own WhatsApp adapter
`_start_one_profile_adapters` attempted a WhatsApp connection per profile. With one shared account, secondaries have no creds → retry-loop that **stalls gateway startup**. WhatsApp is a single-shared-connection platform like `RELAY`, so we now skip it for secondaries (mirrors the existing `RELAY` skip). The default profile owns the one connection; `profile_routes` routes groups.

### 2. Session-key namespace ignored `profile_routes`
`SessionStore._resolve_profile_for_key` fell back to the active profile (default) when `source.profile` was unset — even when a `profile_route` matched — so routed sessions landed in `agent:main` + the default `state.db`. Now consults `gateway.profile_routes` and stamps `source.profile` so the key namespace agrees with routing.

### 3. `SessionStore._db` + inbound session creation were default-bound
`SessionStore` held a single default-home `SessionDB`; every session's history/search/persistence resolved to default's `state.db` regardless of profile. Made `_db` a per-home-cached property (resolves `get_hermes_home()/state.db` under the active ContextVar scope), and wrapped inbound `get_or_create_session` in `_profile_runtime_scope` so the session is physically created in the routed profile's `state.db`.

## Result
A WhatsApp group routed to profile X now runs fully as X — its own skills, memory, and `state.db` — and `session_search` no longer surfaces another profile's history.

## Safety
All new behavior is gated on `multiplex_profiles`. Multiplex-**off** behavior is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)