### PR TITLE
Restart dashboard systemd unit after `hermes update` if one is installed

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6549,6 +6549,153 @@ def _kill_stale_dashboard_processes(
 _warn_stale_dashboard_processes = _kill_stale_dashboard_processes
 
 
+def _restart_dashboard_via_service_manager() -> bool:
+    """Restart a dashboard systemd unit after a code update, if one is installed.
+
+    The upstream ``hermes dashboard`` subcommand installs no service manager, so
+    the running process is killed by PID at the end of ``hermes update`` and the
+    user must relaunch it manually.  Users (and some packaging paths) can install
+    their own ``hermes-dashboard.service`` (e.g. via the dashboard docs or a setup
+    script).  When such a unit exists and is active, restart it the same way
+    gateways are restarted so the dashboard comes back automatically after an
+    update instead of silently dying.
+
+    Returns True if a service-managed dashboard was found (restart attempted);
+    False if no systemd unit owns the dashboard, so the caller should fall back
+    to the legacy PID-kill.
+    """
+    try:
+        from hermes_cli.gateway import (
+            supports_systemd_services,
+            _ensure_user_systemd_env,
+        )
+    except ImportError:
+        return False
+    if not supports_systemd_services():
+        return False
+    try:
+        _ensure_user_systemd_env()
+    except Exception:
+        pass
+
+    def _resolve_manage_cmd(scope, scope_cmd, svc_name):
+        cmd = scope_cmd + ["--no-ask-password"]
+        if (
+            scope == "system"
+            and hasattr(os, "geteuid")
+            and os.geteuid() != 0
+        ):
+            sudo_cmd = ["sudo", "-n"] + scope_cmd + ["--no-ask-password"]
+            sudo_ok = False
+            try:
+                _probe = subprocess.run(
+                    ["sudo", "-n", "true"], capture_output=True, timeout=5,
+                )
+                sudo_ok = _probe.returncode == 0
+                if not sudo_ok:
+                    _probe = subprocess.run(
+                        sudo_cmd + ["reset-failed", svc_name],
+                        capture_output=True, timeout=5,
+                    )
+                    sudo_ok = _probe.returncode == 0
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                sudo_ok = False
+            cmd = sudo_cmd if sudo_ok else None
+        return cmd
+
+    def _wait_active(scope_cmd, svc_name, timeout=10.0):
+        deadline = _time.monotonic() + max(timeout, 0.5)
+        while True:
+            try:
+                _verify = subprocess.run(
+                    scope_cmd + ["is-active", svc_name],
+                    capture_output=True, text=True, timeout=5,
+                )
+                if _verify.stdout.strip() == "active":
+                    return True
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                pass
+            if _time.monotonic() >= deadline:
+                return False
+            _time.sleep(0.5)
+
+    found = False
+    for scope, scope_cmd in [
+        ("user", ["systemctl", "--user"]),
+        ("system", ["systemctl"]),
+    ]:
+        try:
+            result = subprocess.run(
+                scope_cmd
+                + ["list-units", "hermes-dashboard*", "--plain",
+                   "--no-legend", "--no-pager"],
+                capture_output=True, text=True, timeout=10,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            continue
+        for line in result.stdout.strip().splitlines():
+            parts = line.split()
+            if not parts:
+                continue
+            unit = parts[0]
+            if not unit.endswith(".service"):
+                continue
+            svc_name = unit.removesuffix(".service")
+            check = subprocess.run(
+                scope_cmd + ["is-active", svc_name],
+                capture_output=True, text=True, timeout=5,
+            )
+            if check.stdout.strip() != "active":
+                continue
+            found = True
+            _manage_cmd = _resolve_manage_cmd(scope, scope_cmd, svc_name)
+            print()
+            print(f"⟲ Restarting dashboard service {svc_name}...")
+            if _manage_cmd is None:
+                _sudo_hint = "sudo " if scope == "system" else ""
+                _scope_flag = "--user " if scope == "user" else ""
+                print(
+                    f"  ⚠ {svc_name} needs root to restart.\n"
+                    f"    Restart it manually:\n"
+                    f"      {_sudo_hint}systemctl {_scope_flag}restart {svc_name}"
+                )
+                continue
+            subprocess.run(
+                _manage_cmd + ["reset-failed", svc_name],
+                capture_output=True, text=True, timeout=10,
+            )
+            restart = subprocess.run(
+                _manage_cmd + ["restart", svc_name],
+                capture_output=True, text=True, timeout=15,
+            )
+            if restart.returncode == 0 and _wait_active(
+                scope_cmd, svc_name, timeout=10.0
+            ):
+                print(f"  ✓ Restarted {svc_name}")
+            else:
+                subprocess.run(
+                    _manage_cmd + ["reset-failed", svc_name],
+                    capture_output=True, text=True, timeout=10,
+                )
+                restart = subprocess.run(
+                    _manage_cmd + ["restart", svc_name],
+                    capture_output=True, text=True, timeout=15,
+                )
+                if restart.returncode == 0 and _wait_active(
+                    scope_cmd, svc_name, timeout=10.0
+                ):
+                    print(f"  ✓ Restarted {svc_name} (retry)")
+                else:
+                    err = (restart.stderr or "").strip()
+                    print(
+                        f"  ⚠ Failed to restart {svc_name}"
+                        + (f": {err}" if err else "")
+                        + f"\n    Recover manually: systemctl "
+                        f"{'--user ' if scope == 'user' else ''}restart {svc_name}"
+                    )
+    return found
+
+
 def _atomic_replace_dir(src: str, dst: str) -> None:
     """Replace directory *dst* with *src* without leaving *dst* half-deleted.
 
@@ -11672,7 +11819,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print("  ℹ Leaving running dashboard process(es) untouched because the")
             print("    Node.js dependency refresh did not complete.")
         else:
-            _kill_stale_dashboard_processes()
+            # Prefer restarting a dashboard systemd unit if the user installed
+            # one; otherwise fall back to the legacy PID-kill (the upstream
+            # dashboard has no service manager).
+            if not _restart_dashboard_via_service_manager():
+                _kill_stale_dashboard_processes()
 
         print()
         print("Tip: You can now select a provider and model:")

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import importlib
 import os
 import sys
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -23,6 +24,7 @@ import pytest
 from hermes_cli.main import (
     _find_stale_dashboard_pids,
     _kill_stale_dashboard_processes,
+    _restart_dashboard_via_service_manager,
     _warn_stale_dashboard_processes,  # back-compat alias
 )
 
@@ -434,3 +436,182 @@ class TestWindowsWmicEncoding:
             )
             # Must not raise.
             assert _find_stale_dashboard_pids() == []
+
+
+class TestRestartDashboardViaServiceManager:
+    """Regression tests for the post-``hermes update`` dashboard restart.
+
+    Repro of the original bug: ``hermes update`` only auto-restarted
+    ``hermes-gateway*`` systemd units and SIGTERM-killed the dashboard by PID,
+    leaving a systemd-managed ``hermes-dashboard.service`` dead after every
+    update.  ``_restart_dashboard_via_service_manager()`` must detect an
+    active ``hermes-dashboard*`` unit and restart it, and return ``False`` (so
+    the caller falls back to the PID-kill) only when no unit owns the
+    dashboard.
+    """
+
+    @staticmethod
+    def _fake_systemctl(unit_line: str, *, is_active: bool = True, sudo_ok: bool = True, scope: str = "user"):
+        """Build a subprocess.run side_effect for one dashboard unit.
+
+        Routes the systemctl / sudo calls the function makes:
+          - list-units hermes-dashboard*  -> emit ``unit_line`` only for the
+            scope under test (user vs system), empty otherwise
+          - is-active <svc>               -> "active" / "inactive"
+          - reset-failed <svc>            -> rc 0
+          - restart <svc>                 -> rc 0
+          - sudo -n true                  -> rc 0 (sudo available) / rc 1
+        """
+        def _side_effect(cmd, *a, **kw):
+            if isinstance(cmd, (list, tuple)) and cmd:
+                if cmd[0] == "sudo":
+                    # Both sudo probes (``sudo -n true`` and the targeted
+                    # ``sudo -n systemctl ... reset-failed``) must reflect the
+                    # same privilege outcome, otherwise the fake lies about
+                    # sudo availability and the restart path proceeds.
+                    return SimpleNamespace(returncode=0 if sudo_ok else 1,
+                                           stdout="", stderr="")
+                if "list-units" in cmd:
+                    # Only advertise the unit in the scope under test so the
+                    # function restarts exactly one unit (mirrors reality: a
+                    # unit is active in at most one scope).
+                    in_user_scope = "--user" in cmd
+                    emit = unit_line if (
+                        (scope == "user" and in_user_scope)
+                        or (scope == "system" and not in_user_scope)
+                        or scope == "both"
+                    ) else ""
+                    return SimpleNamespace(returncode=0, stdout=emit, stderr="")
+                if "is-active" in cmd:
+                    return SimpleNamespace(
+                        returncode=0,
+                        stdout="active\n" if is_active else "inactive\n",
+                        stderr="",
+                    )
+                if "reset-failed" in cmd:
+                    return SimpleNamespace(returncode=0, stdout="", stderr="")
+                if "restart" in cmd:
+                    return SimpleNamespace(returncode=0, stdout="", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return _side_effect
+
+    def _patch_systemd(self, monkeypatch, *, supported: bool = True):
+        monkeypatch.setattr(
+            "hermes_cli.gateway.supports_systemd_services",
+            lambda: supported,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.gateway._ensure_user_systemd_env",
+            lambda: None,
+        )
+
+    def test_no_systemd_support_returns_false(self, monkeypatch):
+        """When the platform has no systemd (e.g. termux), the function must
+        short-circuit and report 'no service manager' (False)."""
+        self._patch_systemd(monkeypatch, supported=False)
+        assert _restart_dashboard_via_service_manager() is False
+
+    def test_no_dashboard_unit_returns_false(self, monkeypatch):
+        """No hermes-dashboard* unit present -> caller should fall back to the
+        legacy PID-kill (returns False)."""
+        self._patch_systemd(monkeypatch, supported=True)
+        with patch("hermes_cli.main.subprocess.run",
+                   side_effect=self._fake_systemctl("", is_active=False)):
+            assert _restart_dashboard_via_service_manager() is False
+
+    def test_user_unit_active_is_restarted(self, monkeypatch, capsys):
+        """An active user-scope hermes-dashboard.service must be restarted via
+        reset-failed + restart, and the function returns True."""
+        self._patch_systemd(monkeypatch, supported=True)
+        with (
+            patch("hermes_cli.main.subprocess.run",
+                  side_effect=self._fake_systemctl(
+                      "hermes-dashboard.service  loaded active running")) as mock_run,
+            patch("hermes_cli.main._time.monotonic", side_effect=[0.0, 0.1]),
+            patch("hermes_cli.main._time.sleep"),
+        ):
+            result = _restart_dashboard_via_service_manager()
+
+        assert result is True
+        invoked = [c.args[0] for c in mock_run.call_args_list]
+        assert ["systemctl", "--user", "--no-ask-password", "reset-failed", "hermes-dashboard"] in invoked
+        assert ["systemctl", "--user", "--no-ask-password", "restart", "hermes-dashboard"] in invoked
+        out = capsys.readouterr().out
+        assert "Restarting dashboard service hermes-dashboard" in out
+        assert "Restarted hermes-dashboard" in out
+
+    def test_system_unit_active_without_sudo_skips_and_hints(self, monkeypatch, capsys):
+        """A system-scope unit with no non-interactive sudo path must not hang
+        on a polkit prompt: it prints a manual-restart hint and returns True
+        (the unit is 'owned' by systemd, so the PID-kill fallback is skipped)."""
+        self._patch_systemd(monkeypatch, supported=True)
+        monkeypatch.setattr("hermes_cli.main.os.geteuid", lambda: 1000)
+        with (
+            patch("hermes_cli.main.subprocess.run",
+                  side_effect=self._fake_systemctl(
+                      "hermes-dashboard.service  loaded active running",
+                      sudo_ok=False, scope="system")) as mock_run,
+            patch("hermes_cli.main._time.monotonic", side_effect=[0.0, 0.1]),
+            patch("hermes_cli.main._time.sleep"),
+        ):
+            result = _restart_dashboard_via_service_manager()
+
+        assert result is True
+        # No restart/reset-failed issued: user scope has no unit and the
+        # system-scope unit has no non-interactive privilege path.
+        invoked = [c.args[0] for c in mock_run.call_args_list]
+        assert not any("restart" in c for c in invoked)
+        out = capsys.readouterr().out
+        assert "needs root to restart" in out
+        assert "systemctl restart hermes-dashboard" in out
+
+    def test_restart_fails_then_succeeds_on_retry(self, monkeypatch, capsys):
+        """If the first restart exits non-zero (transient), the function must
+        retry once and succeed."""
+        self._patch_systemd(monkeypatch, supported=True)
+        state = {"attempt": 0}
+
+        def _flaky_restart(cmd, *a, **kw):
+            if isinstance(cmd, (list, tuple)) and "list-units" in cmd:
+                # Only the user-scope unit exists (system scope finds nothing).
+                emit = "hermes-dashboard.service  loaded active running" if "--user" in cmd else ""
+                return SimpleNamespace(returncode=0, stdout=emit, stderr="")
+            if isinstance(cmd, (list, tuple)) and "is-active" in cmd:
+                return SimpleNamespace(returncode=0, stdout="active\n", stderr="")
+            if isinstance(cmd, (list, tuple)) and "reset-failed" in cmd:
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            if isinstance(cmd, (list, tuple)) and "restart" in cmd:
+                state["attempt"] += 1
+                if state["attempt"] == 1:
+                    return SimpleNamespace(returncode=1, stdout="", stderr="Job failed")
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with (
+            patch("hermes_cli.main.subprocess.run", side_effect=_flaky_restart) as mock_run,
+            patch("hermes_cli.main._time.monotonic", side_effect=[0.0, 0.1, 0.2, 0.3]),
+            patch("hermes_cli.main._time.sleep"),
+        ):
+            result = _restart_dashboard_via_service_manager()
+
+        assert result is True
+        restart_calls = [
+            c.args[0] for c in mock_run.call_args_list
+            if c.args and isinstance(c.args[0], list) and "restart" in c.args[0]
+        ]
+        assert len(restart_calls) == 2
+        out = capsys.readouterr().out
+        assert "Restarted hermes-dashboard (retry)" in out
+
+    def test_inactive_unit_is_ignored(self, monkeypatch):
+        """A hermes-dashboard* unit that exists but is not active must not be
+        restarted and must not count as 'found'."""
+        self._patch_systemd(monkeypatch, supported=True)
+        with patch("hermes_cli.main.subprocess.run",
+                   side_effect=self._fake_systemctl(
+                       "hermes-dashboard.service  loaded inactive dead",
+                       is_active=False)) as mock_run:
+            result = _restart_dashboard_via_service_manager()
+        assert result is False
+        invoked = [c.args[0] for c in mock_run.call_args_list if c.args]
+        assert not any("restart" in c for c in invoked)


### PR DESCRIPTION
## Problem

`hermes update` only auto-restarts `hermes-gateway*` systemd units. The web dashboard is killed by PID at the end of the update and never relaunched, so users who run the dashboard as a systemd service (`hermes-dashboard.service`, per the dashboard docs / packaging) end up with a silently dead dashboard after every update.

Root cause confirmed in `hermes_cli/main.py`:
- the gateway restart block lists only `hermes-gateway*` units (line ~11184),
- `_kill_stale_dashboard_processes()` (line ~6428) SIGTERMs the dashboard PID and prints a manual relaunch hint, with an explicit comment that the dashboard "has no service manager".

## Fix

Add `_restart_dashboard_via_service_manager()`. At the end of the update, instead of unconditionally PID-killing the dashboard, it:
1. Probes for an active `hermes-dashboard*` systemd unit in both `--user` and system scope (`systemctl list-units hermes-dashboard*`).
2. If found, restarts it via the same `reset-failed` -> `restart` (+ one retry) -> `is-active` poll path already used for gateways, including the non-interactive `sudo -n` privilege probe so it cannot hang on a polkit prompt.
3. Falls back to the existing PID-kill (`_kill_stale_dashboard_processes`) only when no systemd unit owns the dashboard — i.e. the upstream default (no service manager) behavior is fully preserved.

Scope note: systemd-only. There is no standardized upstream launchd label for the dashboard (only the gateway has `get_launchd_label()`), so adding launchd guesswork would be speculative. Linux systemd units are the real, reproducible case.

## Verification
- Patch generated against HEAD `75be8fb46` (live install) and against the fresh fork clone (`32a9f2a`); `git apply --check` passes in both.
- Edited module `ast.parse`-valid.
- Local unit workaround (`Restart=always`) confirmed working independently on the reporter's machine.

## Test plan
- [ ] On a machine with `hermes-dashboard.service` active: `hermes update` restarts it (visible in `systemctl --user status hermes-dashboard`).
- [ ] On a machine without a dashboard unit: behavior unchanged (legacy PID-kill + manual relaunch hint).