### PR TITLE
fix: distinguish vLLM 'at least' lower-bound from exact input token counts

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1380,11 +1380,14 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     #    input tokens, for a total of at least 131073 tokens. Please reduce
     #    the length of the input prompt or the number of requested output
     #    tokens."
-    # Available output = window - input. When the input alone is at or over
-    # the window this stays None, so the caller correctly falls through to
-    # compression instead of futilely shrinking the output cap.
+    # IMPORTANT: ``at least N`` is vLLM's tokenizer cutoff, not an exact
+    # prompt size. It stops counting once N + requested_output exceeds the
+    # window. On a retry, lowering max_tokens merely makes N rise by the same
+    # amount, so treating the lower bound as exact loops forever at
+    # context_window + 1. Only exact input counts can yield an output budget;
+    # lower-bound counts must fall through to input compression.
     _m_vllm_input = re.search(
-        r'prompt contains (?:at least )?(\d+)\s*input tokens', error_lower
+        r'prompt contains (?!at least )(\d+)\s*input tokens', error_lower
     )
     if _m_ctx_tok and _m_vllm_input:
         _available = int(_m_ctx_tok.group(1)) - int(_m_vllm_input.group(1))

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -555,7 +555,7 @@ class ChatCompletionsTransport(ProviderTransport):
             api_kwargs["timeout"] = timeout
 
         # Tools — apply Moonshot/Kimi schema sanitization regardless of path
-        if tools:
+        if tools and profile.supports_tools:
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
             api_kwargs["tools"] = tools

--- a/providers/base.py
+++ b/providers/base.py
@@ -88,6 +88,11 @@ class ProviderProfile:
     # Temperature: None = use caller's default, OMIT_TEMPERATURE = don't send
     fixed_temperature: Any = None
     default_max_tokens: int | None = None
+
+    # Tool support — set False for providers that don't support function calling
+    # (e.g. local vLLM without --tool-call-parser to avoid qwen3_xml deadlock).
+    # When False, the transport will not send tools or tool_choice.
+    supports_tools: bool = True
     default_aux_model: str = (
         ""  # cheap model for auxiliary tasks (compression, vision, etc.)
     )

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -141,9 +141,12 @@ class TestParseVllmTokenBasedOutputCap:
         "output tokens."
     )
 
-    def test_vllm_token_based_format(self):
-        # available output = 131072 - 65537 = 65535
-        assert parse_available_output_tokens_from_error(self._VLLM_MSG) == 65535
+    def test_vllm_token_based_lower_bound_routes_to_compression(self):
+        # ``at least`` is an early tokenizer cutoff, not the real prompt size.
+        # Lowering max_tokens makes the lower bound rise by the same amount and
+        # still totals context+1, so it cannot provide a safe output budget.
+        assert parse_available_output_tokens_from_error(self._VLLM_MSG) is None
+        assert is_output_cap_error(self._VLLM_MSG) is False
 
     def test_vllm_without_at_least_qualifier(self):
         # Some versions omit the "at least" hedge.
@@ -152,9 +155,12 @@ class TestParseVllmTokenBasedOutputCap:
                "100000 input tokens, for a total of 104096 tokens.")
         assert parse_available_output_tokens_from_error(msg) == 31072
 
-    def test_vllm_retry_fits_inside_window(self):
-        # The retried cap plus the reported input must fit in the window.
-        available = parse_available_output_tokens_from_error(self._VLLM_MSG)
+    def test_vllm_exact_count_retry_fits_inside_window(self):
+        # Exact-count variants still provide a usable retry budget.
+        msg = ("This model's maximum context length is 131072 tokens. However, "
+               "you requested 65536 output tokens and your prompt contains "
+               "65537 input tokens, for a total of 131073 tokens.")
+        available = parse_available_output_tokens_from_error(msg)
         assert available is not None
         assert available + 65537 <= 131072
 


### PR DESCRIPTION
## Problem

vLLM reports context window errors in two forms:

1. **Lower bound:** `your prompt contains at least 81921 input tokens` — this is an early tokenizer cutoff, NOT the actual prompt size. vLLM stops counting once it determines N + requested\_output exceeds the window.
2. **Exact count:** `your prompt contains 81921 input tokens` — this is the actual token count.

The existing regex captured both indistinguishably:

```python
r'prompt contains (?:at least )?(\d+)\s*input tokens'
```

This caused `parse_available_output_tokens_from_error()` to treat the lower bound as exact and compute a retry budget. On a retry, lowering max\_tokens made the lower bound rise by the same amount, creating an infinite loop that always totals context\_window + 1.

## Fix

Use a negative lookahead to skip 'at least' qualified matches:

```python
r'prompt contains (?!at least )(\d+)\s*input tokens'
```

- **Lower-bound errors** (`at least N`) now return `None` from `parse_available_output_tokens_from_error()` and `False` from `is_output_cap_error()`, routing correctly to input compression.
- **Exact-count errors** still provide a usable retry budget for output-cap reduction.

## Additional changes

- Add `supports_tools` field to `ProviderProfile` for providers without function calling support (avoids sending tools to models that deadlock on unparseable schemas).
- Update test expectations to match new behavior.

## Testing

Existing tests updated. `test\_vllm\_token\_based\_lower\_bound\_routes\_to\_compression` verifies that 'at least' messages route to compression, and `test\_vllm\_exact\_count\_retry\_fits\_inside\_window` confirms exact-count messages still provide a retry budget.