### PR TITLE
fix(desktop): keep queued drains out of the foreground session on session switch

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1132,6 +1132,7 @@ describe('usePromptActions submit / queue drain semantics', () => {
     let handle: HarnessHandle | null = null
     render(
       <Harness
+        getRuntimeIdForStoredSession={storedId => (storedId === 'stored-session-a' ? 'rt-session-a' : null)}
         onReady={h => (handle = h)}
         onUpdateState={(sessionId, storedSessionId, state) => updates.push({ sessionId, state, storedSessionId })}
         refreshSessions={async () => undefined}
@@ -1160,6 +1161,102 @@ describe('usePromptActions submit / queue drain semantics', () => {
     ).toBe(true)
     // Offscreen queue drains must not flip the foreground composer into Thinking.
     expect($busy.get()).toBe(false)
+  })
+
+  it('a fromQueue drain carrying a stale runtime id re-homes via session.resume instead of landing in the foreground session', async () => {
+    // The session-switch window this guards: the composer's queue key has
+    // already flipped to session B (route-driven) while the foreground runtime
+    // id prop still reads session A (resume-driven, one settle behind). Without
+    // the central-binding check, prompt.submit fires with session_id=A and B's
+    // queued prompt — plus its whole answer turn — lands inside A. With no
+    // binding recorded for B yet, the stale id must be dropped and the drain
+    // re-homed through the stored-session resume path.
+    const updates: { sessionId: string; state: Record<string, unknown>; storedSessionId: null | string | undefined }[] =
+      []
+
+    const requestGateway = vi.fn(
+      async (method: string) => (method === 'session.resume' ? { session_id: 'rt-session-b' } : {}) as never
+    )
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onUpdateState={(sessionId, storedSessionId, state) => updates.push({ sessionId, state, storedSessionId })}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    const accepted = await handle!.submitText('queued for B mid-switch', {
+      fromQueue: true,
+      sessionId: 'rt-session-a',
+      storedSessionId: 'stored-session-b'
+    })
+
+    expect(accepted).toBe(true)
+    expect(requestGateway).toHaveBeenCalledWith('session.resume', {
+      session_id: 'stored-session-b',
+      source: 'desktop'
+    })
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: 'rt-session-b',
+        text: 'queued for B mid-switch'
+      },
+      1_800_000
+    )
+    // The invariant: the stale foreground runtime never receives the prompt.
+    expect(
+      requestGateway.mock.calls.every(
+        ([method, params]) =>
+          method !== 'prompt.submit' || (params as { session_id?: string }).session_id !== 'rt-session-a'
+      )
+    ).toBe(true)
+    expect(
+      updates.some(update => update.sessionId === 'rt-session-b' && update.storedSessionId === 'stored-session-b')
+    ).toBe(true)
+  })
+
+  it('a fromQueue drain rebinds to the centrally recorded runtime when its explicit id is stale', async () => {
+    // Same window, but B's runtime binding is already known centrally — the
+    // drain should adopt the authoritative binding directly (no resume
+    // round-trip) rather than trusting the leftover foreground id.
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        getRuntimeIdForStoredSession={storedId => (storedId === 'stored-session-b' ? 'rt-session-b-live' : null)}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    const accepted = await handle!.submitText('queued for B, B already re-bound', {
+      fromQueue: true,
+      sessionId: 'rt-session-a',
+      storedSessionId: 'stored-session-b'
+    })
+
+    expect(accepted).toBe(true)
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: 'rt-session-b-live',
+        text: 'queued for B, B already re-bound'
+      },
+      1_800_000
+    )
+    expect(requestGateway).not.toHaveBeenCalledWith('session.resume', expect.anything())
+    expect(
+      requestGateway.mock.calls.every(
+        ([method, params]) =>
+          method !== 'prompt.submit' || (params as { session_id?: string }).session_id !== 'rt-session-a'
+      )
+    ).toBe(true)
   })
 
   it('a fromQueue drain with null runtime id does NOT land in the foreground session (cross-session leak guard)', async () => {
@@ -2015,6 +2112,13 @@ describe('usePromptActions sleep/wake session recovery', () => {
     let handle: HarnessHandle | null = null
     render(
       <Harness
+        // The central binding is stale in lockstep with the caller here: the
+        // sleep/wake reaper only clears the GATEWAY's in-memory session, so
+        // client-side state still swears by the old runtime id. That is what
+        // routes this case to the reactive 404→resume→retry path instead of
+        // the proactive binding check (covered by the cross-session drain
+        // tests above).
+        getRuntimeIdForStoredSession={storedId => (storedId === STORED_SESSION_ID ? 'rt-background-stale' : null)}
         onReady={h => (handle = h)}
         refreshSessions={async () => undefined}
         requestGateway={requestGateway}

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -179,6 +179,30 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
       let sessionId: null | string = options?.sessionId ?? (isBackgroundQueueDrain ? null : activeSessionIdRef.current)
 
+      // An explicit queued runtime id is authoritative ONLY while it still
+      // belongs to its stored session. On a session switch the composer's
+      // queue key flips with the route while the foreground runtime id lags a
+      // resume behind, so a drain can fire with storedSessionId=B but
+      // sessionId=A-runtime — and the prompt.submit below would land B's
+      // queued prompt (and its whole answer turn) inside A. Verify the pair
+      // against the central binding and drop a stale explicit id: the
+      // targetStoredSessionId resume path below then rebinds the right
+      // runtime, exactly as a background drain with an unknown binding does.
+      // The identity pair (storedSessionId === sessionId) is the fresh-chat
+      // fallback — an unpersisted conversation's queue key IS its runtime id,
+      // so it has no central binding to check against and is left untouched.
+      if (
+        options?.sessionId &&
+        options?.storedSessionId &&
+        options.storedSessionId !== options.sessionId
+      ) {
+        const boundRuntimeId = getRuntimeIdForStoredSession(options.storedSessionId)
+
+        if (boundRuntimeId !== options.sessionId) {
+          sessionId = boundRuntimeId
+        }
+      }
+
       // Pin the foreground session context for the whole async submit pipeline.
       // Without this, a fast session switch during session.resume / file.attach
       // can redirect the user's text into a different chat (#54527). Mutable —


### PR DESCRIPTION
## Summary

During a session switch there is a one-settle window in which the composer's
queue key has already flipped to the newly selected session (route-driven)
while the foreground runtime id still belongs to the previous session
(resume-driven). A foreground auto-drain that fires inside this window pairs
the **new** session's queued text with the **stale** runtime id, so
`prompt.submit` delivers session B's prompt — and its entire answer turn —
into session A.

Queue storage itself is correctly keyed per session
(`store/composer-queue.ts`); the defect is the drain path trusting the
explicit `sessionId` option without checking it against the centrally
recorded runtime↔stored-session binding. The background drain
(`use-background-queue-drain.ts`) already resolves its runtime through that
binding and does not have this defect.

## Root cause

`use-prompt-actions/submit.ts` treated an explicit `options.sessionId` as
"authoritative and left untouched". When the drain passed the leftover
foreground runtime id together with the new session's `storedSessionId`, the
pair was never validated, so the stale id won.

## Fix

Validate the explicit `sessionId`/`storedSessionId` pair against
`getRuntimeIdForStoredSession` before trusting it:

- Pair matches the central binding → proceed unchanged (fast path).
- Binding exists but differs → adopt the authoritative bound runtime id.
- No binding recorded (or mismatch without a live binding) → drop the stale
  explicit id and re-home through the stored-session resume path — the same
  fallback the background drain uses for unknown bindings.
- Identity pairs (`storedSessionId === sessionId`, the queue key of a
  brand-new unsaved session) are explicitly allowed through.

## Tests

Two regression tests in `use-prompt-actions/index.test.tsx`
(`describe('usePromptActions submit / queue drain semantics')`):

1. **Stale id, no binding for B** — the drain must not call `prompt.submit`
   with `session_id: rt-session-a`; it re-homes via `session.resume` and
   lands in B's fresh runtime.
2. **Stale id, B already bound centrally** — the drain adopts the
   authoritative binding (`rt-session-b-live`) directly, with no resume
   round-trip and no call touching the stale id.

`npx vitest run src/app/session/hooks/use-prompt-actions/index.test.tsx` →
54/54 pass. `tsc -p . --noEmit` clean.

## Scope / risk

- One guarded branch in `submit.ts`; no storage, routing, or queue-key
  changes. Background drain untouched (already correct).
- The fix repairs the whole bug class (any caller passing an explicit
  session pair), not just the observed composer-drain symptom.
- Complements the upstream queue park/unpark work (`a85df69c0`): that change
  stops Stop/Esc from auto-sending the next prompt; this change ensures a
  drain that *does* fire can never target the wrong session.
