### PR TITLE
fix(secrets): fall back to stale disk cache when bws live fetch fails (salvage #41938)

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -411,14 +411,27 @@ def fetch_bitwarden_secrets(
     try:
         secrets, warnings = _run_bws_list(bws, access_token, project_id, server_url)
     except RuntimeError as exc:
-        # Live fetch failed (network down, DNS error, transient BWS outage).
-        # If we have a disk cache from any previous successful fetch — even
-        # past TTL — return it with a warning instead of leaving the gateway
-        # running without any secrets.  Without this fallback a fleet of bots
-        # sharing one BWS project all stop working on a single network blip.
-        # `ttl_seconds=inf` bypasses the freshness check in _read_disk_cache.
-        if use_cache:
-            stale = _read_disk_cache(cache_key, float("inf"), home_path)
+        # Live fetch failed. Fall back to a stale disk cache ONLY for
+        # transport-level failures (network down, DNS error, transient BWS
+        # outage / timeout) — never for AUTH_FAILED or a malformed-output
+        # INTERNAL error, where serving old secrets would mask a real
+        # config/credential problem the caller needs to see.  Without this
+        # fallback a fleet of bots sharing one BWS project all stop working
+        # on a single network blip.
+        #
+        # `cache_ttl_seconds <= 0` means the caller opted out of caching
+        # entirely (DiskCache.read/write both short-circuit on it) — honor
+        # that on the fallback path too, so a zero-TTL caller never gets a
+        # secret value that didn't come from a live fetch just now.
+        # `ttl_seconds=inf` on the read call itself bypasses freshness (we
+        # explicitly want a stale hit here); the caller's real TTL is what
+        # gates whether we even attempt the read, via the check above.
+        if (
+            use_cache
+            and cache_ttl_seconds > 0
+            and _classify_bws_error(str(exc)) in (ErrorKind.NETWORK, ErrorKind.TIMEOUT)
+        ):
+            stale = _DISK_CACHE.read(cache_key, float("inf"), home_path)
             if stale is not None:
                 age = max(0.0, time.time() - stale.fetched_at)
                 _CACHE[cache_key] = stale

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -408,7 +408,25 @@ def fetch_bitwarden_secrets(
             "`hermes secrets bitwarden setup`."
         )
 
-    secrets, warnings = _run_bws_list(bws, access_token, project_id, server_url)
+    try:
+        secrets, warnings = _run_bws_list(bws, access_token, project_id, server_url)
+    except RuntimeError as exc:
+        # Live fetch failed (network down, DNS error, transient BWS outage).
+        # If we have a disk cache from any previous successful fetch — even
+        # past TTL — return it with a warning instead of leaving the gateway
+        # running without any secrets.  Without this fallback a fleet of bots
+        # sharing one BWS project all stop working on a single network blip.
+        # `ttl_seconds=inf` bypasses the freshness check in _read_disk_cache.
+        if use_cache:
+            stale = _read_disk_cache(cache_key, float("inf"), home_path)
+            if stale is not None:
+                age = max(0.0, time.time() - stale.fetched_at)
+                _CACHE[cache_key] = stale
+                return stale.secrets, [
+                    f"bws live fetch failed ({exc}); "
+                    f"falling back to stale disk cache ({int(age)}s old)"
+                ]
+        raise
     entry = _CachedFetch(secrets=secrets, fetched_at=time.time())
     _CACHE[cache_key] = entry
     if use_cache:

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -883,3 +883,145 @@ def test_reset_cache_for_tests_deletes_disk_file(tmp_path):
     assert not cache_path.exists()
     # Idempotent
     bw._reset_cache_for_tests(home)
+
+
+# ---------------------------------------------------------------------------
+# Stale disk cache fallback when live bws fetch fails
+# ---------------------------------------------------------------------------
+
+
+def _seed_stale_disk_cache(home, *, secrets, age_seconds, project_id="proj-1",
+                           access_token="0.t", server_url=""):
+    """Populate the disk cache as if a successful fetch happened `age_seconds` ago."""
+    cache_key = (
+        bw._token_fingerprint(access_token), project_id, server_url,
+    )
+    entry = bw._CachedFetch(secrets=secrets, fetched_at=time.time() - age_seconds)
+    bw._write_disk_cache(cache_key, entry, home)
+
+
+def test_stale_disk_cache_returned_when_bws_fails(monkeypatch, tmp_path):
+    """When bws fails and the disk cache is stale, return the stale secrets
+    with a warning rather than raising."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("")
+    bw._reset_cache_for_tests(home)
+
+    # Seed a stale (older than TTL) disk cache from a previous successful fetch
+    _seed_stale_disk_cache(home, secrets={"OPENAI_API_KEY": "sk-old"},
+                           age_seconds=3600)
+
+    # Now simulate a BWS network failure
+    def fail_run(*a, **kw):
+        return mock.Mock(returncode=1, stdout="",
+                         stderr="Error: dns resolution failed")
+    monkeypatch.setattr(bw.subprocess, "run", fail_run)
+
+    secrets, warnings = bw.fetch_bitwarden_secrets(
+        access_token="0.t", project_id="proj-1", binary=fake_binary,
+        cache_ttl_seconds=300, home_path=home,
+    )
+    assert secrets == {"OPENAI_API_KEY": "sk-old"}
+    assert len(warnings) == 1
+    assert "stale disk cache" in warnings[0]
+    assert "dns resolution failed" in warnings[0]
+
+
+def test_stale_fallback_warning_includes_cache_age(monkeypatch, tmp_path):
+    """Operator-facing warning should report how old the cached secrets are."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("")
+    bw._reset_cache_for_tests(home)
+
+    _seed_stale_disk_cache(home, secrets={"K1": "v1"}, age_seconds=7200)
+
+    monkeypatch.setattr(
+        bw.subprocess, "run",
+        lambda *a, **kw: mock.Mock(returncode=1, stdout="", stderr="boom"),
+    )
+
+    _, warnings = bw.fetch_bitwarden_secrets(
+        access_token="0.t", project_id="proj-1", binary=fake_binary,
+        cache_ttl_seconds=300, home_path=home,
+    )
+    # 7200s == 2h; we don't pin exact integer seconds because time.time()
+    # drifts a bit between seed and call, but it must be within a small band.
+    assert "7200s old" in warnings[0] or "7199s old" in warnings[0]
+
+
+def test_no_stale_fallback_when_disk_cache_missing(monkeypatch, tmp_path):
+    """If bws fails and there's no disk cache at all, re-raise — no silent
+    success with empty secrets."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("")
+    bw._reset_cache_for_tests(home)
+
+    monkeypatch.setattr(
+        bw.subprocess, "run",
+        lambda *a, **kw: mock.Mock(returncode=1, stdout="",
+                                   stderr="Error: unreachable"),
+    )
+
+    with pytest.raises(RuntimeError, match="unreachable"):
+        bw.fetch_bitwarden_secrets(
+            access_token="0.t", project_id="proj-1", binary=fake_binary,
+            cache_ttl_seconds=300, home_path=home,
+        )
+
+
+def test_stale_fallback_skipped_when_use_cache_false(monkeypatch, tmp_path):
+    """`use_cache=False` is an explicit opt-out from any cached value,
+    including the stale fallback path — must still raise on bws failure."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("")
+    bw._reset_cache_for_tests(home)
+
+    # A stale cache exists — but use_cache=False should ignore it
+    _seed_stale_disk_cache(home, secrets={"K1": "v1"}, age_seconds=3600)
+
+    monkeypatch.setattr(
+        bw.subprocess, "run",
+        lambda *a, **kw: mock.Mock(returncode=1, stdout="", stderr="boom"),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        bw.fetch_bitwarden_secrets(
+            access_token="0.t", project_id="proj-1", binary=fake_binary,
+            cache_ttl_seconds=300, home_path=home, use_cache=False,
+        )
+
+
+def test_stale_fallback_does_not_overwrite_disk_cache(monkeypatch, tmp_path):
+    """Stale fallback must not bump the disk cache `fetched_at` — that would
+    falsely make future processes think the cache is fresh."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("")
+    bw._reset_cache_for_tests(home)
+
+    _seed_stale_disk_cache(home, secrets={"K1": "v1"}, age_seconds=3600)
+    cache_path = bw._disk_cache_path(home)
+    original_fetched_at = json.loads(cache_path.read_text())["fetched_at"]
+
+    monkeypatch.setattr(
+        bw.subprocess, "run",
+        lambda *a, **kw: mock.Mock(returncode=1, stdout="", stderr="boom"),
+    )
+
+    bw.fetch_bitwarden_secrets(
+        access_token="0.t", project_id="proj-1", binary=fake_binary,
+        cache_ttl_seconds=300, home_path=home,
+    )
+
+    # Disk cache should still carry the old fetched_at — the live fetch
+    # failed and produced no new secrets to persist.
+    assert json.loads(cache_path.read_text())["fetched_at"] == original_fetched_at

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -892,12 +892,21 @@ def test_reset_cache_for_tests_deletes_disk_file(tmp_path):
 
 def _seed_stale_disk_cache(home, *, secrets, age_seconds, project_id="proj-1",
                            access_token="0.t", server_url=""):
-    """Populate the disk cache as if a successful fetch happened `age_seconds` ago."""
+    """Populate the disk cache as if a successful fetch happened `age_seconds`
+    ago. Writes the JSON payload directly (same shape the shared DiskCache
+    reads/writes) rather than going through DiskCache.write, since that
+    would honor cache_ttl_seconds and refuse to persist an already-"stale"
+    entry — this needs to land on disk regardless of TTL."""
     cache_key = (
         bw._token_fingerprint(access_token), project_id, server_url,
     )
-    entry = bw._CachedFetch(secrets=secrets, fetched_at=time.time() - age_seconds)
-    bw._write_disk_cache(cache_key, entry, home)
+    cache_path = bw._disk_cache_path(home)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps({
+        "key": bw._cache_key_str(cache_key),
+        "secrets": secrets,
+        "fetched_at": time.time() - age_seconds,
+    }))
 
 
 def test_stale_disk_cache_returned_when_bws_fails(monkeypatch, tmp_path):
@@ -941,7 +950,8 @@ def test_stale_fallback_warning_includes_cache_age(monkeypatch, tmp_path):
 
     monkeypatch.setattr(
         bw.subprocess, "run",
-        lambda *a, **kw: mock.Mock(returncode=1, stdout="", stderr="boom"),
+        lambda *a, **kw: mock.Mock(returncode=1, stdout="",
+                                   stderr="Error: connection refused"),
     )
 
     _, warnings = bw.fetch_bitwarden_secrets(
@@ -965,10 +975,10 @@ def test_no_stale_fallback_when_disk_cache_missing(monkeypatch, tmp_path):
     monkeypatch.setattr(
         bw.subprocess, "run",
         lambda *a, **kw: mock.Mock(returncode=1, stdout="",
-                                   stderr="Error: unreachable"),
+                                   stderr="Error: network unreachable"),
     )
 
-    with pytest.raises(RuntimeError, match="unreachable"):
+    with pytest.raises(RuntimeError, match="network unreachable"):
         bw.fetch_bitwarden_secrets(
             access_token="0.t", project_id="proj-1", binary=fake_binary,
             cache_ttl_seconds=300, home_path=home,
@@ -989,10 +999,11 @@ def test_stale_fallback_skipped_when_use_cache_false(monkeypatch, tmp_path):
 
     monkeypatch.setattr(
         bw.subprocess, "run",
-        lambda *a, **kw: mock.Mock(returncode=1, stdout="", stderr="boom"),
+        lambda *a, **kw: mock.Mock(returncode=1, stdout="",
+                                   stderr="Error: connection refused"),
     )
 
-    with pytest.raises(RuntimeError, match="boom"):
+    with pytest.raises(RuntimeError, match="connection refused"):
         bw.fetch_bitwarden_secrets(
             access_token="0.t", project_id="proj-1", binary=fake_binary,
             cache_ttl_seconds=300, home_path=home, use_cache=False,
@@ -1014,7 +1025,8 @@ def test_stale_fallback_does_not_overwrite_disk_cache(monkeypatch, tmp_path):
 
     monkeypatch.setattr(
         bw.subprocess, "run",
-        lambda *a, **kw: mock.Mock(returncode=1, stdout="", stderr="boom"),
+        lambda *a, **kw: mock.Mock(returncode=1, stdout="",
+                                   stderr="Error: connection refused"),
     )
 
     bw.fetch_bitwarden_secrets(
@@ -1025,3 +1037,79 @@ def test_stale_fallback_does_not_overwrite_disk_cache(monkeypatch, tmp_path):
     # Disk cache should still carry the old fetched_at — the live fetch
     # failed and produced no new secrets to persist.
     assert json.loads(cache_path.read_text())["fetched_at"] == original_fetched_at
+
+
+def test_stale_fallback_skipped_on_auth_failure(monkeypatch, tmp_path):
+    """An AUTH_FAILED bws error must raise, not serve stale secrets — a bad
+    access token indicates a real credential problem the caller needs to
+    see, not a transient outage worth papering over."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("")
+    bw._reset_cache_for_tests(home)
+
+    _seed_stale_disk_cache(home, secrets={"K1": "v1"}, age_seconds=3600)
+
+    monkeypatch.setattr(
+        bw.subprocess, "run",
+        lambda *a, **kw: mock.Mock(returncode=1, stdout="",
+                                   stderr="Error: unauthorized (401)"),
+    )
+
+    with pytest.raises(RuntimeError, match="unauthorized"):
+        bw.fetch_bitwarden_secrets(
+            access_token="0.t", project_id="proj-1", binary=fake_binary,
+            cache_ttl_seconds=300, home_path=home,
+        )
+
+
+def test_stale_fallback_skipped_on_malformed_output(monkeypatch, tmp_path):
+    """An INTERNAL-classified failure (unparseable bws output) must raise —
+    the fallback is scoped to transport failures only, not "anything went
+    wrong"."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("")
+    bw._reset_cache_for_tests(home)
+
+    _seed_stale_disk_cache(home, secrets={"K1": "v1"}, age_seconds=3600)
+
+    # returncode == 0 but unparseable stdout raises a ValueError-wrapping
+    # RuntimeError from _run_bws_list's JSON parsing — classifies INTERNAL.
+    monkeypatch.setattr(
+        bw.subprocess, "run",
+        lambda *a, **kw: mock.Mock(returncode=0, stdout="not json", stderr=""),
+    )
+
+    with pytest.raises(RuntimeError):
+        bw.fetch_bitwarden_secrets(
+            access_token="0.t", project_id="proj-1", binary=fake_binary,
+            cache_ttl_seconds=300, home_path=home,
+        )
+
+
+def test_stale_fallback_skipped_when_cache_ttl_zero(monkeypatch, tmp_path):
+    """cache_ttl_seconds=0 means the caller opted out of caching entirely —
+    the stale fallback must honor that even though it explicitly asks the
+    disk cache for a stale (not-fresh) hit via ttl_seconds=inf internally."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("")
+    bw._reset_cache_for_tests(home)
+
+    _seed_stale_disk_cache(home, secrets={"K1": "v1"}, age_seconds=3600)
+
+    monkeypatch.setattr(
+        bw.subprocess, "run",
+        lambda *a, **kw: mock.Mock(returncode=1, stdout="",
+                                   stderr="Error: connection refused"),
+    )
+
+    with pytest.raises(RuntimeError, match="connection refused"):
+        bw.fetch_bitwarden_secrets(
+            access_token="0.t", project_id="proj-1", binary=fake_binary,
+            cache_ttl_seconds=0, home_path=home,
+        )


### PR DESCRIPTION
## Summary

Hermes now survives a transient Bitwarden/network outage at startup: when the live `bws` fetch fails with a transport-level error, the last-good disk cache is served (with a loud warning naming the failure and the cache age) instead of starting with no secrets.

Salvage of PR #41938 by @jackjin1997, ported onto the current `DiskCache` API and gated by the shared `ErrorKind` taxonomy: fallback fires ONLY on `NETWORK`/`TIMEOUT` — `AUTH_FAILED` and malformed-output errors still raise, so stale secrets never mask a real credential problem.

## Changes
- `agent/secret_sources/bitwarden.py`: catch `_run_bws_list` failure in `fetch_bitwarden_secrets()`, classify, serve stale disk cache for transport errors; honors `use_cache=False` and zero TTL opt-outs; never bumps the cache timestamp on a fallback read.
- `tests/test_bitwarden_secrets.py`: 7 new tests (fallback served, age in warning, no-cache raise, opt-outs honored, auth/malformed still raise, timestamp preserved).

## Validation
| | Result |
|---|---|
| tests/test_bitwarden_secrets.py | 50/50 passed |

Fixes #41925. Credit: @jackjin1997 (original commits preserved via cherry-pick).

## Infographic

![stale-cache-fallback](https://v3b.fal.media/files/b/0aa3375b/OYS9trNnt3THUpPVdVqs4_gSuupM6J.png)
