### PR TITLE
fix(secrets): 1Password auth env fixes — Connect cache-key + desktop-probe bypass (salvage #60191 + #62829)

### DIFF
--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -98,6 +98,9 @@ _OP_ENV_ALLOWLIST = (
     "OP_ACCOUNT",
     "OP_CONNECT_HOST",
     "OP_CONNECT_TOKEN",
+    # Lets a user skip op's desktop-app integration probe (which can hang with
+    # no timeout on a wedged desktop container) and go straight to token auth.
+    "OP_LOAD_DESKTOP_APP_SETTINGS",
 )
 
 

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -172,16 +172,19 @@ def _validate_references(
 def _auth_fingerprint(token_env: str) -> str:
     """SHA-256 prefix over the auth material `op` would use.
 
-    Folds in the service-account token, ``OP_ACCOUNT``, and *all*
-    ``OP_SESSION_*`` vars (the names `op` actually exports for interactive
-    sessions — ``OP_SESSION_<account_shorthand>``).  Signing out and into a
-    different identity therefore changes the cache key, so a value cached under
-    a previous identity is never served under a new one.  Never logged or
+    Folds in the service-account token, ``OP_ACCOUNT``, the 1Password Connect
+    ``OP_CONNECT_HOST``/``OP_CONNECT_TOKEN``, and *all* ``OP_SESSION_*`` vars
+    (the names `op` actually exports for interactive sessions —
+    ``OP_SESSION_<account_shorthand>``).  Signing out and into a different
+    identity therefore changes the cache key, so a value cached under a
+    previous identity is never served under a new one.  Never logged or
     displayed; the raw token never leaves this hash.
     """
     parts: List[str] = [
         f"token={os.environ.get(token_env, '')}",
         f"account={os.environ.get('OP_ACCOUNT', '')}",
+        f"connect_host={os.environ.get('OP_CONNECT_HOST', '')}",
+        f"connect_token={os.environ.get('OP_CONNECT_TOKEN', '')}",
     ]
     for key in sorted(os.environ):
         if key.startswith("OP_SESSION_"):

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -216,6 +216,31 @@ def test_fetch_child_env_is_allowlisted(monkeypatch, tmp_path):
     assert env.get("NO_COLOR") == "1"
 
 
+def test_fetch_child_env_passes_load_desktop_app_settings(monkeypatch, tmp_path):
+    """OP_LOAD_DESKTOP_APP_SETTINGS must reach the op child when the user sets it.
+
+    On a headless box with a valid service-account token but a wedged 1Password
+    desktop app, `op read` hangs on the desktop-settings probe unless
+    OP_LOAD_DESKTOP_APP_SETTINGS=false is passed through. It's an allowlisted
+    var, so a user who exports it should see it in the op child env.
+    """
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "ops_tok")
+    monkeypatch.setenv("OP_LOAD_DESKTOP_APP_SETTINGS", "false")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs["env"]
+        return _ok("v")
+
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+    op.fetch_onepassword_secrets(
+        references={"K": "op://V/I/F"}, binary=fake_op, use_cache=False
+    )
+    assert captured["env"].get("OP_LOAD_DESKTOP_APP_SETTINGS") == "false"
+
+
 # ---------------------------------------------------------------------------
 # Caching
 # ---------------------------------------------------------------------------

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -41,6 +41,8 @@ def _clean_op_env(monkeypatch):
             monkeypatch.delenv(key, raising=False)
     monkeypatch.delenv("OP_SERVICE_ACCOUNT_TOKEN", raising=False)
     monkeypatch.delenv("OP_ACCOUNT", raising=False)
+    monkeypatch.delenv("OP_CONNECT_HOST", raising=False)
+    monkeypatch.delenv("OP_CONNECT_TOKEN", raising=False)
     yield
 
 
@@ -321,6 +323,35 @@ def test_session_change_invalidates_cache(monkeypatch, tmp_path):
     # Switch identity.
     monkeypatch.delenv("OP_SESSION_acctA", raising=False)
     monkeypatch.setenv("OP_SESSION_acctB", "sessB")
+    op._CACHE.clear()
+    op.fetch_onepassword_secrets(
+        references={"K": "op://V/I/F"}, cache_ttl_seconds=300,
+        binary=fake_op, home_path=tmp_path,
+    )
+    assert calls["n"] == 2  # cache key changed → refetch
+
+
+def test_connect_credential_change_invalidates_cache(monkeypatch, tmp_path):
+    """A different 1Password Connect identity must not reuse a cached value."""
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    calls = {"n": 0}
+
+    def fake_run(*a, **k):
+        calls["n"] += 1
+        return _ok("v")
+
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+    op._reset_cache_for_tests(tmp_path)
+
+    monkeypatch.setenv("OP_CONNECT_HOST", "https://connect.example.com")
+    monkeypatch.setenv("OP_CONNECT_TOKEN", "tokenA")
+    op.fetch_onepassword_secrets(
+        references={"K": "op://V/I/F"}, cache_ttl_seconds=300,
+        binary=fake_op, home_path=tmp_path,
+    )
+    # Rotate the Connect token → new identity.
+    monkeypatch.setenv("OP_CONNECT_TOKEN", "tokenB")
     op._CACHE.clear()
     op.fetch_onepassword_secrets(
         references={"K": "op://V/I/F"}, cache_ttl_seconds=300,


### PR DESCRIPTION
## Summary

Two 1Password auth-environment fixes, one commit per contributor:

1. **Cache-key completeness** (@briandevans, #60191): `_auth_fingerprint()` now folds `OP_CONNECT_HOST`/`OP_CONNECT_TOKEN` into the cache key, so rotating a 1Password Connect identity invalidates cached values instead of serving them across identities.
2. **Desktop-probe bypass** (@menhguin, #62829): `OP_LOAD_DESKTOP_APP_SETTINGS` added to the `op` child env allowlist, so headless boxes can set it to `false` and skip the desktop-app integration probe that hangs `op read` on a wedged desktop (likely the #60674 hang).

## Validation
| | Result |
|---|---|
| tests/test_onepassword_secrets.py | 25/25 passed |

## Infographic

![op-auth-env](https://v3b.fal.media/files/b/0aa33764/kH-Cfe-XDQ0VBE68ARcy1_OMEnWCgu.png)
