### PR TITLE
fix(secrets): fall back to os.environ on scope miss when multiplexing is off (salvage #67827)

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -127,10 +127,16 @@ def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
 
     1. Genuinely-global vars (``_is_global_env``) always read ``os.environ`` —
        they are deployment settings, not profile secrets.
-    2. When a secret scope is installed (multiplexed turn), read from it; an
-       absent key returns ``default``. The scope is authoritative — we do NOT
-       fall through to ``os.environ``, because in a multiplexer ``os.environ``
-       may hold another profile's value.
+    2. When a secret scope is installed (multiplexed turn), read from it. Under
+       multiplexing the scope is authoritative — an absent key returns
+       ``default`` and we do NOT fall through to ``os.environ``, because in a
+       multiplexer ``os.environ`` may hold another profile's value. When
+       multiplexing is OFF, a scope miss falls through to ``os.environ``:
+       single-profile deployments legitimately provide credentials via the
+       process environment (systemd ``Environment=``, secret-manager wrappers
+       like ``pass-cli run`` / ``op run``, plain shell exports) rather than
+       ``<home>/.env``, and the scope — installed unconditionally around e.g.
+       every cron job — must stay a ``.env`` overlay, not a blindfold.
     3. No scope installed:
        - multiplex INACTIVE (default deployment): read ``os.environ`` —
          identical to the legacy ``os.getenv`` behavior every caller had before.
@@ -144,6 +150,17 @@ def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
     scope = _SECRET_SCOPE.get()
     if scope is not None:
         val = scope.get(name)
+        if val is not None:
+            return val
+        if _MULTIPLEX_ACTIVE:
+            return default
+        # Multiplex off: the scope is an overlay over the process environment,
+        # not an isolation boundary — there is no other profile to leak from.
+        # Without this fallthrough, credentials injected only into the process
+        # environment vanish inside any set_secret_scope(...) block (the cron
+        # scheduler installs one around every job), so cron jobs send a
+        # placeholder API key and 401 while interactive turns keep working.
+        val = os.environ.get(name)
         return val if val is not None else default
 
     if _MULTIPLEX_ACTIVE:

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -72,6 +72,53 @@ class TestMultiplexActiveFailClosed:
         assert ss.get_secret("HERMES_KANBAN_DB") == "/x/kanban.db"
 
 
+class TestScopedSingleProfile:
+    """Multiplex OFF with a scope installed: the scope is an overlay, not a
+    blindfold. The cron scheduler installs a ``<home>/.env`` scope around every
+    job unconditionally, and single-profile deployments legitimately supply
+    credentials via the process environment only (systemd ``Environment=``,
+    ``pass-cli run`` / ``op run`` wrappers) — those must keep resolving."""
+
+    def test_scope_hit_wins_over_environ(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-from-environ")
+        token = ss.set_secret_scope({"ANTHROPIC_API_KEY": "sk-from-env-file"})
+        try:
+            assert ss.get_secret("ANTHROPIC_API_KEY") == "sk-from-env-file"
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_scope_miss_falls_back_to_environ(self, monkeypatch):
+        # Regression: provider key injected into the process env but absent
+        # from <home>/.env made every cron job send a placeholder API key
+        # (401) while interactive turns kept working.
+        monkeypatch.setenv("GLM_VOOY_API_KEY", "sk-from-process-env")
+        token = ss.set_secret_scope({"UNRELATED_KEY": "x"})
+        try:
+            assert ss.get_secret("GLM_VOOY_API_KEY") == "sk-from-process-env"
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_scope_miss_absent_everywhere_returns_default(self, monkeypatch):
+        monkeypatch.delenv("NOPE_KEY", raising=False)
+        token = ss.set_secret_scope({})
+        try:
+            assert ss.get_secret("NOPE_KEY") is None
+            assert ss.get_secret("NOPE_KEY", "d") == "d"
+        finally:
+            ss.reset_secret_scope(token)
+
+    def test_multiplex_on_still_authoritative(self, monkeypatch):
+        # The fallthrough is strictly multiplex-off behavior: turning
+        # multiplexing on must restore scope-authoritative semantics.
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-other-profile")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({})
+        try:
+            assert ss.get_secret("OPENAI_API_KEY") is None
+        finally:
+            ss.reset_secret_scope(token)
+
+
 class TestScopeIsolation:
     """Two scopes never see each other's secrets."""
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -7,7 +7,11 @@ from unittest.mock import patch
 
 import pytest
 
-from agent.secret_scope import reset_secret_scope, set_secret_scope
+from agent.secret_scope import (
+    reset_secret_scope,
+    set_multiplex_active,
+    set_secret_scope,
+)
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from gateway.config import (
     ChannelOverride,
@@ -1831,6 +1835,12 @@ class TestLoadGatewayConfig:
         monkeypatch.setenv("API_SERVER_ENABLED", "true")
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "default-token")
 
+        # Model the real multiplexed gateway: run.py flips the runtime flag at
+        # startup (set_multiplex_active) BEFORE any secondary-profile config
+        # loads.  Without the flag, a scope miss legitimately falls through to
+        # os.environ (single-profile overlay semantics, #67827) and this test
+        # would no longer exercise the cross-profile isolation it's about.
+        set_multiplex_active(True)
         home_token = set_hermes_home_override(str(secondary_home))
         secret_token = set_secret_scope({"DISCORD_BOT_TOKEN": "worker-token"})
         try:
@@ -1838,6 +1848,7 @@ class TestLoadGatewayConfig:
         finally:
             reset_secret_scope(secret_token)
             reset_hermes_home_override(home_token)
+            set_multiplex_active(False)
 
         assert config.multiplex_profiles is True
         assert config.platforms[Platform.DISCORD].token == "worker-token"


### PR DESCRIPTION
## Summary

With profile multiplexing OFF, a secret-scope miss now falls through to `os.environ` — the scope acts as a `.env` overlay, not an isolation blindfold. Since the cron scheduler began installing a scope around every job unconditionally, single-profile deployments whose credentials live only in the process environment (systemd `Environment=`, `op run`/`pass` wrappers, shell exports) had cron jobs sending placeholder API keys and getting 401s while interactive turns worked.

Clean cherry-pick of PR #67827 by @Soju06. Multiplex-ON semantics unchanged: the scope stays authoritative and never falls through (the anti-leak property), with a regression test pinning that.

## Validation
| | Result |
|---|---|
| tests/agent/test_secret_scope.py | 17/17 passed |

Credit: @Soju06.

## Infographic

![scope-miss-fallback](https://v3b.fal.media/files/b/0aa33785/SVL3UVZxq0Sc6assCkeSu_g6408odn.png)
