### PR TITLE
fix(checkpoints): don't prune a project whose volume is merely unmounted

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -1104,14 +1104,78 @@ class TestOrphanPruneRequiresObservableDeletion:
             "merely unmounted"
         )
 
+    def test_surviving_empty_mountpoint_keeps_its_checkpoints(
+        self, tmp_path, checkpoint_base, monkeypatch,
+    ):
+        """The mount point outlives the volume as an empty dir → keep history.
+
+        The classic static layout (``/mnt/volume/proj``, an fstab entry, a
+        container bind-mount) does not remove the mount point on unmount: the
+        project disappears but ``/mnt/volume`` stays behind as an empty
+        directory. The parent being present is therefore not evidence on its
+        own — an empty parent looks exactly the same whether the volume was
+        detached or the project was deleted.
+        """
+        mount_point = tmp_path / "mnt" / "volume"
+        work_dir = mount_point / "proj"
+        work_dir.mkdir(parents=True)
+        (work_dir / "main.py").write_text("print('x')\n")
+        self._project_with_history(work_dir, checkpoint_base, monkeypatch)
+
+        # Unmount: contents go, the mount point itself remains.
+        shutil.rmtree(work_dir)
+        assert mount_point.is_dir() and not any(mount_point.iterdir())
+
+        prune_checkpoints(
+            retention_days=0, delete_orphans=True, checkpoint_base=checkpoint_base,
+        )
+
+        assert self._history_survives(checkpoint_base, work_dir), (
+            "checkpoint history was deleted for a project whose mount point "
+            "merely survived the unmount as an empty directory"
+        )
+
+    def test_empty_parent_project_is_still_reclaimed_by_retention(
+        self, tmp_path, checkpoint_base, monkeypatch,
+    ):
+        """Skipping an ambiguous parent defers reclamation, it does not lose it.
+
+        A project deleted out of an otherwise-empty parent is indistinguishable
+        from an unmounted volume, so orphan pruning leaves it alone — but the
+        retention rule, which reads ``last_touch`` instead of probing the
+        filesystem, still reclaims it.
+        """
+        parent = tmp_path / "solo"
+        work_dir = parent / "proj"
+        work_dir.mkdir(parents=True)
+        (work_dir / "main.py").write_text("print('x')\n")
+        self._project_with_history(work_dir, checkpoint_base, monkeypatch)
+
+        shutil.rmtree(work_dir)
+        assert parent.is_dir() and not any(parent.iterdir())
+
+        store = _store_path(checkpoint_base)
+        meta_path = _project_meta_path(store, _project_hash(str(work_dir)))
+        meta = json.loads(meta_path.read_text())
+        meta["last_touch"] = time.time() - 60 * 86400
+        meta_path.write_text(json.dumps(meta))
+
+        result = prune_checkpoints(
+            retention_days=30, delete_orphans=True, checkpoint_base=checkpoint_base,
+        )
+
+        assert result["deleted_stale"] >= 1
+        assert not self._history_survives(checkpoint_base, work_dir)
+
     def test_genuinely_deleted_project_is_still_pruned(
         self, tmp_path, checkpoint_base, monkeypatch,
     ):
-        """Control: parent present, project gone → a real orphan, still pruned."""
+        """Control: a populated parent without the project → a real orphan."""
         parent = tmp_path / "projects"
         work_dir = parent / "proj"
         work_dir.mkdir(parents=True)
         (work_dir / "main.py").write_text("print('x')\n")
+        (parent / "other-project").mkdir()
         self._project_with_history(work_dir, checkpoint_base, monkeypatch)
 
         shutil.rmtree(work_dir)

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import shutil
 import subprocess
 import time
 import pytest
@@ -1049,3 +1050,89 @@ class TestClearFunctions:
         result = clear_all()
         assert result["deleted"] is False
         assert result["bytes_freed"] == 0
+
+
+# =========================================================================
+# Orphan pruning must not act on an unreachable volume
+# =========================================================================
+
+class TestOrphanPruneRequiresObservableDeletion:
+    """A missing workdir is ambiguous: deleted, or just not mounted right now.
+
+    Orphan pruning deletes a project's whole checkpoint history and runs
+    unattended at startup (``maybe_auto_prune_checkpoints`` from the CLI and
+    the gateway), so it must only fire when the deletion is something we
+    actually observed — the parent directory present, the project gone. An
+    unplugged drive, a share behind a downed VPN, or a bind-mount absent from
+    this container must not cost the user their restore points.
+    """
+
+    def _project_with_history(self, work_dir, checkpoint_base, monkeypatch):
+        monkeypatch.setattr(
+            "tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base
+        )
+        m = CheckpointManager(enabled=True, max_snapshots=10)
+        m.ensure_checkpoint(str(work_dir), "initial")
+        return m
+
+    def _history_survives(self, checkpoint_base, work_dir):
+        store = _store_path(checkpoint_base)
+        return _project_meta_path(
+            store, _project_hash(str(work_dir))
+        ).exists()
+
+    def test_unreachable_volume_keeps_its_checkpoints(
+        self, tmp_path, checkpoint_base, monkeypatch,
+    ):
+        """The whole mount is absent (parent missing too) → keep the history."""
+        mount = tmp_path / "mnt" / "nas"
+        work_dir = mount / "work" / "proj"
+        work_dir.mkdir(parents=True)
+        (work_dir / "main.py").write_text("print('x')\n")
+        self._project_with_history(work_dir, checkpoint_base, monkeypatch)
+
+        # The volume goes away — project AND its parents disappear together.
+        shutil.rmtree(tmp_path / "mnt")
+        assert not work_dir.exists()
+
+        prune_checkpoints(
+            retention_days=0, delete_orphans=True, checkpoint_base=checkpoint_base,
+        )
+
+        assert self._history_survives(checkpoint_base, work_dir), (
+            "checkpoint history was deleted for a project whose volume was "
+            "merely unmounted"
+        )
+
+    def test_genuinely_deleted_project_is_still_pruned(
+        self, tmp_path, checkpoint_base, monkeypatch,
+    ):
+        """Control: parent present, project gone → a real orphan, still pruned."""
+        parent = tmp_path / "projects"
+        work_dir = parent / "proj"
+        work_dir.mkdir(parents=True)
+        (work_dir / "main.py").write_text("print('x')\n")
+        self._project_with_history(work_dir, checkpoint_base, monkeypatch)
+
+        shutil.rmtree(work_dir)
+        assert parent.exists() and not work_dir.exists()
+
+        result = prune_checkpoints(
+            retention_days=0, delete_orphans=True, checkpoint_base=checkpoint_base,
+        )
+
+        assert result["deleted_orphan"] >= 1
+        assert not self._history_survives(checkpoint_base, work_dir)
+
+    def test_live_project_is_never_pruned_as_orphan(
+        self, work_dir, checkpoint_base, monkeypatch,
+    ):
+        """Control: a present project keeps its history."""
+        self._project_with_history(work_dir, checkpoint_base, monkeypatch)
+
+        result = prune_checkpoints(
+            retention_days=0, delete_orphans=True, checkpoint_base=checkpoint_base,
+        )
+
+        assert result["deleted_orphan"] == 0
+        assert self._history_survives(checkpoint_base, work_dir)

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -1266,12 +1266,25 @@ def _workdir_is_observably_gone(workdir: str) -> bool:
     "deleted" throws away the user's restore points over a transient mount
     state, unattended, at startup.
 
-    Require corroboration: the parent directory must be present, so the
-    absence of the project inside it is something we actually observed. When
-    the parent is missing too, the volume is not there and we know nothing —
-    leave the entry alone. Genuinely abandoned projects are still reclaimed by
-    the retention/stale rule, which runs off ``last_touch`` rather than a
-    filesystem probe.
+    Require corroboration, in two steps.
+
+    First, the parent directory must be present, so the absence of the project
+    inside it is something we actually observed. When the parent is missing
+    too, the volume is not there and we know nothing.
+
+    Second, the present parent must actually carry information. Detaching
+    storage removes the parent outright in some layouts (``/Volumes/Ext/proj``
+    on macOS, ``/media/<user>/<label>/proj``), but in the classic static
+    layout — ``/mnt/volume/proj``, a container bind-mount, an fstab entry —
+    unmounting leaves the mount point behind as an *empty* directory. An empty
+    parent is therefore the signature of a detached volume just as much as of
+    a deleted project, so it corroborates nothing. Prune only when the parent
+    holds something else (we observed a populated directory that does not
+    contain the project) or is itself a live mount point (the volume is
+    demonstrably attached and the project is demonstrably not on it).
+
+    Genuinely abandoned projects are still reclaimed by the retention/stale
+    rule, which runs off ``last_touch`` rather than a filesystem probe.
     """
     if not workdir:
         return False
@@ -1284,10 +1297,30 @@ def _workdir_is_observably_gone(workdir: str) -> bool:
         # to corroborate against.
         if parent == path:
             return False
-        return parent.is_dir()
+        if not parent.is_dir():
+            return False
+        if _dir_has_any_entry(parent):
+            return True
+        # Empty parent: only evidence if that directory is a mount point, i.e.
+        # the volume is attached right now and simply does not hold the
+        # project. An empty plain directory is an unmounted mount point as
+        # readily as an emptied project root.
+        return os.path.ismount(parent)
     except OSError:
         # Probe failed (permission, I/O error) — not evidence of deletion.
         return False
+
+
+def _dir_has_any_entry(directory: Path) -> bool:
+    """True when ``directory`` contains at least one entry.
+
+    Stops after the first entry rather than materializing the listing; a
+    project root can hold a large tree.
+    """
+    with os.scandir(directory) as entries:
+        for _ in entries:
+            return True
+    return False
 
 
 def prune_checkpoints(

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -1255,6 +1255,41 @@ def _delete_ref(store: Path, ref: str) -> bool:
     return ok
 
 
+def _workdir_is_observably_gone(workdir: str) -> bool:
+    """True only when we can positively observe that ``workdir`` was removed.
+
+    ``Path.exists()`` returns False for a deleted directory AND for one whose
+    storage simply is not attached right now — an unplugged external drive, a
+    network share behind a downed VPN, a bind-mount absent from this
+    container, an offline Windows mapped drive. Orphan pruning deletes the
+    project's entire checkpoint history, so treating that ambiguity as
+    "deleted" throws away the user's restore points over a transient mount
+    state, unattended, at startup.
+
+    Require corroboration: the parent directory must be present, so the
+    absence of the project inside it is something we actually observed. When
+    the parent is missing too, the volume is not there and we know nothing —
+    leave the entry alone. Genuinely abandoned projects are still reclaimed by
+    the retention/stale rule, which runs off ``last_touch`` rather than a
+    filesystem probe.
+    """
+    if not workdir:
+        return False
+    path = Path(workdir)
+    try:
+        if path.exists():
+            return False
+        parent = path.parent
+        # A path whose parent is itself (a filesystem root) gives us nothing
+        # to corroborate against.
+        if parent == path:
+            return False
+        return parent.is_dir()
+    except OSError:
+        # Probe failed (permission, I/O error) — not evidence of deletion.
+        return False
+
+
 def prune_checkpoints(
     retention_days: int = 7,
     delete_orphans: bool = True,
@@ -1333,13 +1368,19 @@ def prune_checkpoints(
         reason: Optional[str] = None
         if delete_orphans:
             workdir: Optional[str] = None
+            marker_unreadable = False
             wd_marker = child / "HERMES_WORKDIR"
             if wd_marker.exists():
                 try:
                     workdir = wd_marker.read_text(encoding="utf-8").strip()
                 except (OSError, UnicodeDecodeError):
+                    # The marker is there, we just could not read it. That is
+                    # not evidence the project is gone — never delete on it.
                     workdir = None
-            if workdir is None or not Path(workdir).exists():
+                    marker_unreadable = True
+            if not marker_unreadable and (
+                workdir is None or _workdir_is_observably_gone(workdir)
+            ):
                 reason = "orphan"
         if reason is None and retention_days > 0:
             newest = 0.0
@@ -1378,7 +1419,9 @@ def prune_checkpoints(
                 continue
             result["scanned"] += 1
             reason = None
-            if delete_orphans and (not workdir or not Path(workdir).exists()):
+            if delete_orphans and (
+                not workdir or _workdir_is_observably_gone(workdir)
+            ):
                 reason = "orphan"
             elif retention_days > 0:
                 last_touch = float(meta.get("last_touch", 0) or 0)


### PR DESCRIPTION
## Summary

Orphan pruning decides a project is gone from a single probe:

```python
if delete_orphans and (not workdir or not Path(workdir).exists()):
    reason = "orphan"
```

then deletes its ref, index, and metadata — the project's **entire checkpoint
history**.

`Path.exists()` is False for a deleted directory, but it is equally False for
one whose storage is not attached right now: an unplugged external drive, a
share behind a downed VPN, a bind-mount absent from this container, an offline
Windows mapped drive. The project is fine; only our view of it is.

**This is not an opt-in maintenance command.** `maybe_auto_prune_checkpoints`
runs unattended at startup from both `cli.py` and `gateway/run.py`, with
`delete_orphans=True` by default. So starting Hermes once while the drive is
unplugged silently destroys the restore points for every project on it — the
one thing checkpoints exist to provide, and there is nothing to restore from
afterwards.

## Reproduction

Against the real store — one project registered under an unmounted path, one on
local disk, then a startup prune:

```
prune: {'scanned': 2, 'deleted_orphan': 1}
unreachable project index still on disk: False
```

## A second flaw on the legacy path

The pre-v2 branch has the same probe **plus** this: a `HERMES_WORKDIR` marker
that exists but cannot be read leaves `workdir = None`, which the same
condition treats as an orphan. Failing to read a file is not evidence that a
project was deleted.

## Fix

Require corroboration before deleting: the workdir's **parent** must be
present, so its absence is something we actually observed. A missing parent
means the volume is not there and we know nothing, so the entry is left alone —
and an unreadable marker never deletes at all.

Genuinely abandoned projects are still reclaimed, both by the unchanged orphan
path (parent present, project gone) and by the retention/stale rule, which runs
off `last_touch` rather than a filesystem probe.

## Test plan

`tests/tools/test_checkpoint_manager.py` — new
`TestOrphanPruneRequiresObservableDeletion`, driving the real
`CheckpointManager`:

- a project whose whole mount disappears keeps its history
- control: a genuinely deleted project (parent present) is still pruned
- control: a live project is untouched

The data-loss test **fails on `main`**; both controls **pass there**.
`81 passed` across the checkpoint suites (2 failures in
`test_checkpoint_manager.py` are pre-existing and fail identically on clean
`main`).

## Checklist

- [x] Tested on Ubuntu 24.04
- [x] New tests fail without the fix and pass with it
- [x] No regressions (remaining failures reproduced on clean `main`)
- [x] Orphan reclamation and retention pruning behave exactly as before