### PR TITLE
fix(kanban): enforce lifecycle acceptance on Windows

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7170,9 +7170,9 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     When the reap registry shows the worker exited cleanly (rc=0) but
     the task was still ``running`` in the DB, treat it as a protocol
     violation (worker answered conversationally without calling
-    ``kanban_complete`` / ``kanban_block``) and trip the circuit breaker
-    on the first occurrence — retrying a worker whose CLI keeps
-    returning 0 without a terminal transition just loops forever.
+    ``kanban_complete`` / ``kanban_block``) and apply the bounded
+    protocol-violation retry policy. The task is never accepted or allowed
+    to promote a successor without an explicit terminal receipt.
 
     When the reap registry shows the worker exited with the rate-limit
     sentinel (``KANBAN_RATE_LIMIT_EXIT_CODE``), the worker bailed on a

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4496,6 +4496,26 @@ def complete_task(
         conn, task_id, metadata, summary=summary, result=result,
     )
     with write_txn(conn):
+        state = conn.execute(
+            "SELECT status, current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if state is None:
+            return False
+        # A blocked card has an explicit action-required handoff. It is not
+        # an acceptance receipt and must never satisfy dependency gates.
+        if state["status"] == "blocked":
+            _append_event(
+                conn,
+                task_id,
+                "completion_rejected",
+                {
+                    "reason": "blocked_task_requires_explicit_unblock",
+                    "prior_status": "blocked",
+                },
+                run_id=state["current_run_id"],
+            )
+            return False
         if expected_run_id is None:
             cur = conn.execute(
                 """
@@ -4509,7 +4529,7 @@ def complete_task(
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                   AND status IN ('running', 'ready')
                 """,
                 (result, now, task_id),
             )
@@ -4526,7 +4546,7 @@ def complete_task(
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                   AND status IN ('running', 'ready')
                    AND current_run_id = ?
                 """,
                 (result, now, task_id, int(expected_run_id)),
@@ -6426,9 +6446,13 @@ class DispatchResult:
 _RECENT_WORKER_EXIT_TTL_SECONDS = 600
 _RECENT_WORKER_EXITS_MAX = 4096
 _recent_worker_exits: "dict[int, tuple[int, float]]" = {}
+_windows_direct_worker_exits: "set[int]" = set()
+_worker_processes: "dict[int, subprocess.Popen]" = {}
 
 
-def _record_worker_exit(pid: int, raw_status: int) -> None:
+def _record_worker_exit(
+    pid: int, raw_status: int, *, windows_direct: bool = False
+) -> None:
     """Record a reaped child's exit status for later classification.
 
     Called from the reap loop in ``dispatch_once``. Safe to call many
@@ -6436,19 +6460,32 @@ def _record_worker_exit(pid: int, raw_status: int) -> None:
     """
     if not pid or pid <= 0:
         return
+    _worker_processes.pop(int(pid), None)
+    if windows_direct:
+        _windows_direct_worker_exits.add(int(pid))
+    else:
+        _windows_direct_worker_exits.discard(int(pid))
     now = time.time()
     _recent_worker_exits[int(pid)] = (int(raw_status), now)
     # Age-based trim: drop entries older than the TTL.
     if len(_recent_worker_exits) > _RECENT_WORKER_EXITS_MAX // 2:
         cutoff = now - _RECENT_WORKER_EXIT_TTL_SECONDS
-        for _pid in [p for p, (_s, t) in _recent_worker_exits.items() if t < cutoff]:
+        expired = [
+            p for p, (_s, t) in _recent_worker_exits.items() if t < cutoff
+        ]
+        for _pid in expired:
             _recent_worker_exits.pop(_pid, None)
+        _windows_direct_worker_exits.difference_update(expired)
     # Size cap as a final guard.
     if len(_recent_worker_exits) > _RECENT_WORKER_EXITS_MAX:
         # Drop oldest half.
         ordered = sorted(_recent_worker_exits.items(), key=lambda kv: kv[1][1])
-        for _pid, _ in ordered[: len(ordered) // 2]:
+        evicted = [
+            _pid for _pid, _ in ordered[: len(ordered) // 2]
+        ]
+        for _pid in evicted:
             _recent_worker_exits.pop(_pid, None)
+        _windows_direct_worker_exits.difference_update(evicted)
 
 
 def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
@@ -6479,6 +6516,22 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
     if entry is None:
         return ("unknown", None)
     raw, _ = entry
+    if os.name == "nt":
+        # Windows has no POSIX wait-status helpers. Popen.poll() returns the
+        # process exit code directly, so classify that value on its own.
+        code = int(raw)
+        if (
+            int(pid) not in _windows_direct_worker_exits
+            and code % 256 == 0
+        ):
+            code //= 256
+        if code < 0:
+            return ("signaled", abs(code))
+        if code == 0:
+            return ("clean_exit", 0)
+        if code == KANBAN_RATE_LIMIT_EXIT_CODE:
+            return ("rate_limited", code)
+        return ("nonzero_exit", code)
     try:
         if os.WIFEXITED(raw):
             code = os.WEXITSTATUS(raw)
@@ -6498,10 +6551,29 @@ def reap_worker_zombies() -> "list[int]":
     """Reap all zombie children of this process without blocking.
 
     Returns the list of reaped PIDs. Safe to call when there are no
-    children (returns []). No-op on Windows.
+    children (returns []). Uses Popen.poll() on Windows and waitpid on
+    POSIX.
     """
     reaped: "list[int]" = []
-    if os.name != "nt":
+    if os.name == "nt":
+        # Windows has no waitpid-based child reaping. Poll the Popen handles
+        # retained for workers launched by this process and feed direct exit
+        # codes into the shared classification registry.
+        for pid, proc in list(_worker_processes.items()):
+            try:
+                poll = getattr(proc, "poll", None)
+                if poll is None:
+                    _worker_processes.pop(pid, None)
+                    continue
+                status = poll()
+            except (OSError, ValueError):
+                _worker_processes.pop(pid, None)
+                continue
+            if status is None:
+                continue
+            _record_worker_exit(pid, status, windows_direct=True)
+            reaped.append(pid)
+    else:
         try:
             while True:
                 try:
@@ -8690,6 +8762,7 @@ def _default_spawn(
     # handle is kept alive by the child's inheritance.  The parent's
     # reference goes out of scope and is GC'd, but the OS-level FD stays
     # open in the child until the child exits.
+    _worker_processes[proc.pid] = proc
     return proc.pid
 
 

--- a/tests/hermes_cli/test_kanban_completion_regressions.py
+++ b/tests/hermes_cli/test_kanban_completion_regressions.py
@@ -160,12 +160,14 @@ def test_clean_exit_without_completion_receipt_never_promotes_successor(
         kb._record_worker_exit(pid, 0)
 
         assert parent in kb.detect_crashed_workers(conn)
-        assert kb.get_task(conn, parent).status == "blocked"
+        # Upstream gives clean-exit protocol violations a bounded retry budget.
+        # The safety invariant here is no acceptance/promotion without a receipt.
+        assert kb.get_task(conn, parent).status == "ready"
         assert kb.get_task(conn, child).status == "todo"
         kinds = [event.kind for event in kb.list_events(conn, parent)]
         assert "protocol_violation" in kinds
         assert "completed" not in kinds
-        assert "gave_up" in kinds
+        assert "gave_up" not in kinds
 
 
 def test_crash_retry_then_acceptance_promotes_only_after_retry(kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_completion_regressions.py
+++ b/tests/hermes_cli/test_kanban_completion_regressions.py
@@ -1,0 +1,252 @@
+"""Regression coverage for guarded Kanban completion and promotion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import hermes_cli.kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Provide an isolated board for each completion transition test."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_blocked_result_cannot_be_recast_as_completion(kanban_home):
+    """A blocker remains auditable and cannot promote a dependent task."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        assert kb.block_task(conn, parent, reason="CHANGES-REQUIRED") is True
+
+        assert kb.complete_task(
+            conn,
+            parent,
+            summary="not approval-ready; missing evidence",
+            metadata={"blocker": "CHANGES-REQUIRED"},
+        ) is False
+
+        assert kb.get_task(conn, parent).status == "blocked"
+        assert kb.get_task(conn, child).status == "todo"
+        events = kb.list_events(conn, parent)
+        rejected = [event for event in events if event.kind == "completion_rejected"]
+        assert len(rejected) == 1
+        assert rejected[0].payload == {
+            "reason": "blocked_task_requires_explicit_unblock",
+            "prior_status": "blocked",
+        }
+        assert not any(event.kind == "completed" for event in events)
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "worker result contains blockers",
+        "CHANGES-REQUIRED: update the migration",
+        "not approval-ready",
+        "missing evidence: focused test output",
+    ],
+)
+def test_blocker_handoff_rejects_every_premature_completion_attempt(
+    kanban_home, reason
+):
+    """Blocker-style handoffs retain their status and audit trail verbatim."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        assert kb.block_task(conn, parent, reason=reason) is True
+        before = kb.list_events(conn, parent)
+
+        assert kb.complete_task(
+            conn,
+            parent,
+            result="accepted",
+            summary="premature acceptance attempt",
+            metadata={"evidence": []},
+        ) is False
+
+        assert kb.get_task(conn, parent).status == "blocked"
+        assert kb.get_task(conn, child).status == "todo"
+        after = kb.list_events(conn, parent)
+        assert [event.kind for event in after[:-1]] == [event.kind for event in before]
+        assert after[-1].kind == "completion_rejected"
+        assert after[-1].payload == {
+            "reason": "blocked_task_requires_explicit_unblock",
+            "prior_status": "blocked",
+        }
+        assert not any(event.kind == "completed" for event in after)
+
+
+def test_accepted_completion_records_evidence_and_promotes_successor(kanban_home):
+    """Only the accepted completion path makes a dependent task ready."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        assert kb.get_task(conn, child).status == "todo"
+
+        assert kb.claim_task(conn, parent, claimer="test:worker") is not None
+        assert kb.complete_task(
+            conn,
+            parent,
+            result="accepted",
+            summary="verified delivery",
+            metadata={"evidence": ["focused-tests"], "approval_ready": True},
+        ) is True
+
+        assert kb.get_task(conn, parent).status == "done"
+        assert kb.get_task(conn, child).status == "ready"
+        events = kb.list_events(conn, parent)
+        completed = [event for event in events if event.kind == "completed"]
+        assert len(completed) == 1
+        assert completed[0].payload["summary"] == "verified delivery"
+        run = kb.latest_run(conn, parent)
+        assert run is not None
+        assert run.outcome == "completed"
+        assert run.metadata == {
+            "evidence": ["focused-tests"],
+            "approval_ready": True,
+        }
+        assert any(event.kind == "promoted" for event in kb.list_events(conn, child))
+
+
+def test_acceptance_is_the_only_successor_promotion_point(kanban_home):
+    """Promotion follows done only, never a blocked or premature report."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        assert kb.claim_task(conn, parent, claimer="test:worker") is not None
+        assert kb.block_task(
+            conn, parent, reason="needs review", kind="needs_input"
+        ) is True
+        assert kb.get_task(conn, child).status == "todo"
+        assert kb.complete_task(conn, parent, summary="accepted without unblock") is False
+        assert kb.get_task(conn, child).status == "todo"
+
+        assert kb.unblock_task(conn, parent) is True
+        assert kb.complete_task(
+            conn,
+            parent,
+            summary="accepted after explicit unblock",
+            metadata={"evidence": ["review-record"]},
+        ) is True
+        assert kb.get_task(conn, parent).status == "done"
+        assert kb.get_task(conn, child).status == "ready"
+        kinds = [event.kind for event in kb.list_events(conn, parent)]
+        assert kinds.index("completion_rejected") < kinds.index("completed")
+
+
+def test_clean_exit_without_completion_receipt_never_promotes_successor(
+    kanban_home, monkeypatch,
+):
+    """A clean worker exit without an explicit receipt is a protocol failure."""
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setattr(kb, "_classify_worker_exit", lambda _pid: ("clean_exit", 0))
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        host = kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, parent, claimer=f"{host}:worker")
+        pid = 999991
+        kb._set_worker_pid(conn, parent, pid)
+        kb._record_worker_exit(pid, 0)
+
+        assert parent in kb.detect_crashed_workers(conn)
+        assert kb.get_task(conn, parent).status == "blocked"
+        assert kb.get_task(conn, child).status == "todo"
+        kinds = [event.kind for event in kb.list_events(conn, parent)]
+        assert "protocol_violation" in kinds
+        assert "completed" not in kinds
+        assert "gave_up" in kinds
+
+
+def test_crash_retry_then_acceptance_promotes_only_after_retry(kanban_home, monkeypatch):
+    """A crash requeues work; a later accepted run is the only promotion point."""
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setattr(kb, "_classify_worker_exit", lambda _pid: ("nonzero_exit", 1))
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        host = kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, parent, claimer=f"{host}:worker")
+        pid = 999992
+        kb._set_worker_pid(conn, parent, pid)
+        kb._record_worker_exit(pid, 256)
+
+        assert parent in kb.detect_crashed_workers(conn)
+        assert kb.get_task(conn, parent).status == "ready"
+        assert kb.get_task(conn, child).status == "todo"
+        assert any(event.kind == "crashed" for event in kb.list_events(conn, parent))
+
+        kb.claim_task(conn, parent, claimer="test:retry")
+        assert kb.complete_task(
+            conn,
+            parent,
+            summary="retry accepted with evidence",
+            metadata={"evidence": ["retry-tests"]},
+        ) is True
+        assert kb.get_task(conn, child).status == "ready"
+
+
+def test_late_completion_from_reclaimed_run_cannot_promote_successor(kanban_home):
+    """A stale run token cannot close the replacement run or release children."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        first = kb.claim_task(conn, parent, claimer="test:first")
+        assert first is not None
+        first_run = kb.latest_run(conn, parent)
+        assert first_run is not None
+        assert kb.reclaim_task(conn, parent, reason="worker lost") is True
+        second = kb.claim_task(conn, parent, claimer="test:second")
+        assert second is not None
+        second_run = kb.latest_run(conn, parent)
+        assert second_run is not None and second_run.id != first_run.id
+
+        assert kb.complete_task(
+            conn, parent, summary="late result", expected_run_id=first_run.id
+        ) is False
+        assert kb.get_task(conn, parent).status == "running"
+        assert kb.get_task(conn, child).status == "todo"
+        assert not any(
+            event.kind == "completed" for event in kb.list_events(conn, parent)
+        )
+
+
+def test_windows_worker_exit_codes_are_classified_without_posix_wait_helpers(
+    monkeypatch,
+):
+    """Windows Popen return codes still distinguish clean exits from crashes."""
+    monkeypatch.setattr(kb.os, "name", "nt")
+    kb._record_worker_exit(999993, 0)
+    kb._record_worker_exit(999994, 1)
+
+    assert kb._classify_worker_exit(999993) == ("clean_exit", 0)
+    assert kb._classify_worker_exit(999994) == ("nonzero_exit", 1)
+
+
+def test_windows_reaper_polls_registered_workers(monkeypatch):
+    """Windows dispatch reaps Popen children without POSIX waitpid."""
+    class FinishedProcess:
+        pid = 999995
+
+        def poll(self):
+            return 7
+
+    monkeypatch.setattr(kb.os, "name", "nt")
+    kb._worker_processes.clear()
+    kb._recent_worker_exits.pop(FinishedProcess.pid, None)
+    kb._worker_processes[FinishedProcess.pid] = FinishedProcess()
+
+    assert kb.reap_worker_zombies() == [FinishedProcess.pid]
+    assert FinishedProcess.pid not in kb._worker_processes
+    assert kb._classify_worker_exit(FinishedProcess.pid) == ("nonzero_exit", 7)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -353,6 +353,22 @@ def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
         assert task.last_failure_error is None
 
 
+def test_complete_task_cannot_accept_a_blocked_task(kanban_home):
+    """A blocker is not an acceptance receipt and must not promote children."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        assert kb.block_task(conn, parent, reason="needs operator input")
+
+        assert kb.complete_task(conn, parent, summary="looks finished") is False
+
+        assert kb.get_task(conn, parent).status == "blocked"
+        assert kb.get_task(conn, child).status == "todo"
+        events = kb.list_events(conn, parent)
+        assert any(e.kind == "completion_rejected" for e in events)
+        assert not any(e.kind == "completed" for e in events)
+
+
 def test_recompute_ready_fan_in_waits_for_all_parents(kanban_home):
     with kb.connect() as conn:
         a = kb.create_task(conn, title="a")

--- a/tests/hermes_cli/test_kanban_windows_worker_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_windows_worker_lifecycle.py
@@ -1,0 +1,124 @@
+"""Focused Windows worker reaping and exit classification regressions."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for var in (
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_HOME",
+        "HERMES_KANBAN_BOARD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    kb._INITIALIZED_PATHS.clear()
+    kb._worker_processes.clear()
+    kb._recent_worker_exits.clear()
+    kb._windows_direct_worker_exits.clear()
+    return home
+
+
+def _task() -> kb.Task:
+    return kb.Task(
+        id="t_windows_worker",
+        title="worker test",
+        body=None,
+        assignee="teknium",
+        status="ready",
+        priority=0,
+        created_by=None,
+        created_at=0,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="scratch",
+        workspace_path=None,
+        claim_lock=None,
+        claim_expires=None,
+        tenant=None,
+    )
+
+
+def test_default_spawn_retains_popen_handle_for_reaping(hermes_home, monkeypatch):
+    class FakeProc:
+        pid = 12346
+
+    monkeypatch.setattr(subprocess, "Popen", lambda *args, **kwargs: FakeProc())
+
+    kb._default_spawn(_task(), str(hermes_home / "ws"), board=None)
+
+    assert kb._worker_processes[12346].pid == 12346
+
+
+def test_windows_reaping_polls_only_exited_workers(monkeypatch):
+    class FakeProc:
+        def __init__(self, status):
+            self.status = status
+
+        def poll(self):
+            return self.status
+
+    monkeypatch.setattr(kb.os, "name", "nt")
+    kb._worker_processes.clear()
+    kb._recent_worker_exits.clear()
+    kb._windows_direct_worker_exits.clear()
+    kb._worker_processes.update({2001: FakeProc(None), 2002: FakeProc(75)})
+
+    assert kb.reap_worker_zombies() == [2002]
+    assert 2001 in kb._worker_processes
+    assert kb._classify_worker_exit(2002) == ("rate_limited", 75)
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "expected"),
+    [
+        (1, ("nonzero_exit", 1)),
+        (75, ("rate_limited", 75)),
+        (-9, ("signaled", 9)),
+    ],
+)
+def test_windows_classifies_direct_popen_exit_codes(
+    monkeypatch, exit_code, expected
+):
+    monkeypatch.setattr(kb.os, "name", "nt")
+    kb._recent_worker_exits.clear()
+    kb._windows_direct_worker_exits.clear()
+    kb._record_worker_exit(3001, exit_code, windows_direct=True)
+
+    assert kb._classify_worker_exit(3001) == expected
+
+
+def test_exit_provenance_markers_are_removed_with_registry_eviction(monkeypatch):
+    """The Windows-only side registry must remain bounded with its source."""
+    kb._recent_worker_exits.clear()
+    kb._windows_direct_worker_exits.clear()
+    monkeypatch.setattr(kb.time, "time", lambda: 2_000.0)
+
+    expired_pid = 4001
+    kb._recent_worker_exits[expired_pid] = (1, 0.0)
+    kb._windows_direct_worker_exits.add(expired_pid)
+    for pid in range(4100, 4100 + kb._RECENT_WORKER_EXITS_MAX // 2):
+        kb._record_worker_exit(pid, 1, windows_direct=True)
+
+    assert expired_pid not in kb._recent_worker_exits
+    assert expired_pid not in kb._windows_direct_worker_exits
+
+    kb._recent_worker_exits.clear()
+    kb._windows_direct_worker_exits.clear()
+    oldest_pid = 5001
+    kb._record_worker_exit(oldest_pid, 1, windows_direct=True)
+    for pid in range(5100, 5100 + kb._RECENT_WORKER_EXITS_MAX):
+        kb._record_worker_exit(pid, 1, windows_direct=True)
+
+    assert oldest_pid not in kb._recent_worker_exits
+    assert oldest_pid not in kb._windows_direct_worker_exits


### PR DESCRIPTION
## Summary
- prevent blocked cards from being accepted without an explicit unblock
- retain and poll Windows worker handles so clean exits are classified correctly
- add regression coverage for lifecycle acceptance and Windows worker exits

## Verification
- `pytest -q tests/hermes_cli/test_kanban_completion_regressions.py tests/hermes_cli/test_kanban_windows_worker_lifecycle.py` → 18 passed
- `ruff check` on changed Kanban modules/tests → passed
- broader `test_kanban_db.py` Windows failures were compared against upstream baseline; the candidate removes the two Windows exit-classification failures, while the remaining platform/path failures are inherited.