### PR TITLE
fix(agent): strip inherited Authorization header in Gemini native client (Bug 1 of #69031)

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -643,8 +643,18 @@ class GeminiNativeClient:
         self.close()
 
     def _headers(self) -> Dict[str, str]:
-        return {"Content-Type": "application/json", "Accept": "application/json", "x-goog-api-key": self.api_key,
-                "User-Agent": f"{_API_CLIENT} (gemini-native)", "X-Goog-Api-Client": _API_CLIENT, **self._default_headers}
+        headers = {"Content-Type": "application/json", "Accept": "application/json", "x-goog-api-key": self.api_key,
+                   "User-Agent": f"{_API_CLIENT} (gemini-native)", "X-Goog-Api-Client": _API_CLIENT, **self._default_headers}
+        # This client authenticates to Google's native v1beta endpoint via
+        # ``x-goog-api-key``.  An ``Authorization: Bearer`` header inherited
+        # through ``default_headers`` (e.g. copied from an OpenAI-compat or
+        # aggregator profile) makes Google treat the call as an OAuth2 flow and
+        # reject the API key with 401 Unauthorized.  Strip any Authorization
+        # header (case-insensitively -- ``default_headers`` is caller-supplied)
+        # so the API-key auth always wins.
+        for key in [k for k in headers if k.lower() == "authorization"]:
+            del headers[key]
+        return headers
 
     @staticmethod
     def _advance_stream_iterator(iterator: Iterator[_GeminiStreamChunk]) -> tuple[bool, Optional[_GeminiStreamChunk]]:

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -968,6 +968,15 @@ class GeminiNativeClient:
             "X-Goog-Api-Client": f"hermes-agent/{_HERMES_VERSION}",
         }
         headers.update(self._default_headers)
+        # This client authenticates to Google's native v1beta endpoint via
+        # ``x-goog-api-key``.  An ``Authorization: Bearer`` header inherited
+        # through ``default_headers`` (e.g. copied from an OpenAI-compat or
+        # aggregator profile) makes Google treat the call as an OAuth2 flow and
+        # reject the API key with 401 Unauthorized.  Strip any Authorization
+        # header (case-insensitively — ``default_headers`` is caller-supplied)
+        # so the API-key auth always wins.
+        for key in [k for k in headers if k.lower() == "authorization"]:
+            del headers[key]
         return headers
 
     @staticmethod

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -454,11 +454,48 @@ def test_build_gemini_request_does_not_raise_when_thinking_is_disabled():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Inherited Authorization header is stripped (native auth is x-goog-api-key)
+# ---------------------------------------------------------------------------
 
 
+def test_inherited_authorization_header_is_stripped():
+    """An Authorization header from default_headers must not reach Google.
+
+    The native v1beta endpoint authenticates via ``x-goog-api-key``.  A stray
+    ``Authorization: Bearer`` (inherited from an OpenAI-compat / aggregator
+    profile) makes Google treat the call as OAuth2 and reject the API key with
+    401 Unauthorized, so it is dropped while the API key is preserved.
+    """
+    from agent.gemini_native_adapter import GeminiNativeClient
+
+    client = GeminiNativeClient(
+        api_key="AIza-test",
+        model="gemini-2.0-flash",
+        default_headers={"Authorization": "Bearer inherited-token"},
+    )
+    headers = client._headers()
+
+    assert "Authorization" not in headers
+    assert "authorization" not in headers
+    assert headers["x-goog-api-key"] == "AIza-test"
 
 
+def test_authorization_header_stripped_case_insensitively():
+    """default_headers is caller-supplied, so any casing must be removed."""
+    from agent.gemini_native_adapter import GeminiNativeClient
 
+    client = GeminiNativeClient(
+        api_key="AIza-test",
+        model="gemini-2.0-flash",
+        default_headers={"AUTHORIZATION": "Bearer x", "X-Custom": "keep"},
+    )
+    headers = client._headers()
+
+    assert not any(k.lower() == "authorization" for k in headers)
+    # Unrelated default headers are still forwarded.
+    assert headers["X-Custom"] == "keep"
+    assert headers["x-goog-api-key"] == "AIza-test"
 
 
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -253,9 +253,46 @@ def test_stream_event_translation_emits_tool_call_delta_with_stable_index():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Inherited Authorization header is stripped (native auth is x-goog-api-key)
+# ---------------------------------------------------------------------------
 
 
+def test_inherited_authorization_header_is_stripped():
+    """An Authorization header from default_headers must not reach Google.
+
+    The native v1beta endpoint authenticates via ``x-goog-api-key``.  A stray
+    ``Authorization: Bearer`` (inherited from an OpenAI-compat / aggregator
+    profile) makes Google treat the call as OAuth2 and reject the API key with
+    401 Unauthorized, so it is dropped while the API key is preserved.
+    """
+    from agent.gemini_native_adapter import GeminiNativeClient
+
+    client = GeminiNativeClient(
+        api_key="AIza-test",
+        model="gemini-2.0-flash",
+        default_headers={"Authorization": "Bearer inherited-token"},
+    )
+    headers = client._headers()
+
+    assert "Authorization" not in headers
+    assert "authorization" not in headers
+    assert headers["x-goog-api-key"] == "AIza-test"
 
 
+def test_authorization_header_stripped_case_insensitively():
+    """default_headers is caller-supplied, so any casing must be removed."""
+    from agent.gemini_native_adapter import GeminiNativeClient
 
+    client = GeminiNativeClient(
+        api_key="AIza-test",
+        model="gemini-2.0-flash",
+        default_headers={"AUTHORIZATION": "Bearer x", "X-Custom": "keep"},
+    )
+    headers = client._headers()
+
+    assert not any(k.lower() == "authorization" for k in headers)
+    # Unrelated default headers are still forwarded.
+    assert headers["X-Custom"] == "keep"
+    assert headers["x-goog-api-key"] == "AIza-test"
 


### PR DESCRIPTION
## Problem

Setting a Gemini `base_url` to the native v1beta endpoint
(`https://generativelanguage.googleapis.com/v1beta`) can fail with a persistent
`401 Unauthorized`, even with a valid API key.

Root cause is in `GeminiNativeClient._headers()` (`agent/gemini_native_adapter.py`):
the client builds correct native auth via `x-goog-api-key`, then does
`headers.update(self._default_headers)`. When `default_headers` carries an
inherited `Authorization: Bearer …` — which happens when the profile was copied
from an OpenAI-compat/aggregator config, since `default_headers` is forwarded
verbatim from `client_kwargs` at `agent/agent_runtime_helpers.py` — Google's API
server sees the `Authorization` header, treats the call as an OAuth2 flow, and
rejects the API-key auth with `401`.

## Fix

After merging `default_headers`, strip any `Authorization` header before the
request goes out. The native client authenticates **only** via `x-goog-api-key`,
so an `Authorization` header is never correct for it. The removal is
case-insensitive because `default_headers` is caller-supplied (`Authorization`,
`authorization`, `AUTHORIZATION` all get dropped); unrelated custom headers are
left untouched.

```python
headers.update(self._default_headers)
for key in [k for k in headers if k.lower() == "authorization"]:
    del headers[key]
return headers
```

## Tests

`tests/agent/test_gemini_native_adapter.py`:

- `test_inherited_authorization_header_is_stripped` — an inherited
  `Authorization: Bearer` is removed while `x-goog-api-key` is preserved.
- `test_authorization_header_stripped_case_insensitively` — mixed-case
  `AUTHORIZATION` is removed, and an unrelated `X-Custom` default header still
  forwards.

All existing header tests continue to pass.

## Scope

This addresses **Bug 1** of #69031 (the `401` auth-header leak). The issue also
reports **Bug 2** (HTTP 400 `INVALID_ARGUMENT` when a `type: "array"` tool
parameter lacks an `items` field, rejected by Gemini's schema validator). That
one is a separate, independent change in `agent/gemini_schema.py` and involves a
semantic choice for the default `items` type, so I've kept it out of this PR to
keep the change focused and low-risk; it can land as a follow-up. Flagging so the
issue isn't assumed fully closed by this alone.

Fixes #69031 (Bug 1)
