### PR TITLE
fix(desktop): keep task status card opaque on scroll

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/index.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { $threadScrolledUp, resetThreadScroll } from '@/store/thread-scroll'
+
+import { ComposerStatusStack } from './index'
+
+class TestResizeObserver {
+  disconnect() {}
+  observe() {}
+  unobserve() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+
+describe('ComposerStatusStack scroll treatment', () => {
+  beforeEach(() => {
+    $threadScrolledUp.set(true)
+  })
+
+  afterEach(() => {
+    cleanup()
+    resetThreadScroll()
+  })
+
+  it('dims only the status content while keeping the dock card opaque', () => {
+    const view = render(
+      <MemoryRouter>
+        <I18nProvider configClient={null} initialLocale="en">
+          <ComposerStatusStack queue={<div>Queued task</div>} sessionId={null} />
+        </I18nProvider>
+      </MemoryRouter>
+    )
+
+    const card = view.container.querySelector<HTMLElement>('[class*="bg-(--composer-fill)"]')
+    const dimmedContent = screen.getByText('Queued task').closest<HTMLElement>('.opacity-30')
+
+    expect(card).not.toBeNull()
+    expect(card?.classList.contains('opacity-30')).toBe(false)
+    expect(dimmedContent).not.toBeNull()
+    expect(dimmedContent).not.toBe(card)
+    expect(card?.contains(dimmedContent)).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -241,14 +241,19 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
             composerDockCard('top'),
             // Inset (mx-2) so the stack reads slightly narrower than the composer
             // surface below it — the original look.
-            'mx-2 overflow-hidden rounded-b-none border-b border-b-transparent pt-0.5',
-            'transition-opacity duration-200 ease-out',
-            scrolledUp ? 'opacity-30 group-hover/composer:opacity-100' : 'opacity-100'
+            'mx-2 overflow-hidden rounded-b-none border-b border-b-transparent pt-0.5'
           )}
         >
-          {sections.map(section => (
-            <div key={section.key}>{section.node}</div>
-          ))}
+          <div
+            className={cn(
+              'transition-opacity duration-200 ease-out',
+              scrolledUp ? 'opacity-30 group-hover/composer:opacity-100' : 'opacity-100'
+            )}
+          >
+            {sections.map(section => (
+              <div key={section.key}>{section.node}</div>
+            ))}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop task/status card becoming visually interleaved with chat history when the user scrolls up.

`ComposerStatusStack` applied `opacity-30` to the same element that receives `composerDockCard('top')`. Because that helper paints `--composer-fill` and backdrop blur, dimming the card also made its backdrop transparent.

This PR keeps the dock card opaque and moves the scroll-dependent opacity to an inner content wrapper. Current `main` has since moved the status stack in-flow under the composer dock. The review salvage preserves that layout and wraps only `sections.map(...)` in the fade layer.

## Related Issue

Fixes #69027

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/status-stack/index.tsx`
  - Preserve the current in-flow composer-dock layout.
  - Keep opacity classes off the shared-fill dock card.
  - Apply scroll dimming to an inner wrapper around the status sections only.
- `apps/desktop/src/app/chat/composer/status-stack/index.test.tsx`
  - Verify the element painting `--composer-fill` remains opaque.
  - Verify the dimmed content is a separate descendant of the card.

## How to Test

1. Run `npm run test:ui --workspace apps/desktop -- src/app/chat/composer/status-stack/index.test.tsx`.
2. Run `npm run test:ui --workspace apps/desktop`.
3. Open a desktop chat with a visible task/status stack, scroll away from the bottom, and confirm the content dims without chat text showing through the card.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched open and closed PRs/issues to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run the full Python repository suite — not rerun for this renderer-only review update
- [x] I've added a behavior-focused regression test
- [x] I've tested on my platform: macOS 26.5.1, Node.js 22.22.3; no Windows hardware validation

### Documentation & Housekeeping

- [x] Relevant documentation update — N/A; behavior-only UI fix
- [x] `cli-config.yaml.example` update — N/A; no config changes
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow changes
- [x] Cross-platform impact considered — renderer-only DOM/CSS layering; no OS APIs or paths changed
- [x] Tool descriptions/schemas update — N/A; no tool changes

## Validation

After rebasing onto current `main` (`98105f31f`), head `db5f2d41b`:

- Focused regression: **1 passed**.
- `npm run test:ui`: **357 files passed; 3,158 tests passed**.
- `npm run typecheck`: passed.
- `npm run lint`: passed with 0 errors (74 existing warnings).
- `git diff --check`: clean.

The full UI suite emits the existing jsdom `HTMLCanvasElement.getContext()` warnings but completes successfully.

## Screenshots / Logs

No screenshot attached. The regression test asserts the relevant DOM/class invariant directly.