### PR TITLE
fix(gateway): suppress pre-API compression chatter

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -81,6 +81,7 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|auto-lowered\s+compression\s+threshold"
     r"|compacting\s+context\s+[—-]\s+summarizing\s+earlier\s+conversation"
     r"|preflight\s+compression"
+    r"|pre[- ]api\s+compression"
     r"|session\s+compressed\s+\d+\s+times"
     r"|rate\s+limited\.\s+waiting\s+\d"
     r"|retrying\s+in\s+\d"

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -30,6 +30,10 @@ CHAT_PLATFORMS = [
 
 NOISY_STATUS_MESSAGES = [
     "🗜️ Preflight compression check before sending...",
+    (
+        "📦 Pre-API compression: ~123,456 tokens near the context/output limit. "
+        "Compacting before the next model call."
+    ),
     "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
     "⚠️  Session compressed 12 times — accuracy may degrade. Consider /new to start fresh.",
     "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
@@ -66,6 +70,12 @@ def test_programmatic_surfaces_keep_raw_status():
         assert (
             _prepare_gateway_status_message(platform, "lifecycle", message) == message
         )
+
+
+@pytest.mark.parametrize("message", ["still on it", "⏳ Working — 3 min"])
+def test_telegram_status_keeps_legitimate_heartbeat_messages(message):
+    """The compression filter must not swallow user-facing work heartbeats."""
+    assert _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", message) == message
 
 
 @pytest.mark.parametrize("platform", CHAT_PLATFORMS)


### PR DESCRIPTION
Summary:
- suppress the current Pre-API compression lifecycle message on human-facing chat gateways
- pin the exact production wording in the gateway noise-filter regression data
- verify legitimate generic and elapsed-time heartbeat messages still pass through

Why:
The filter covered older preflight compression wording, but the emitted status now says Pre-API compression, so internal compaction lifecycle chatter was visible in Telegram.

Tests:
- venv/bin/pytest -q tests/gateway/test_telegram_noise_filter.py
- 227 passed