### PR TITLE
fix(cron): quarantine context-free test fixtures before agent startup

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -17,17 +17,31 @@ from typing import Any, Dict, List, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
+from cron.jobs import get_cron_dir
 
 EXECUTIONS_FILE = get_hermes_home().resolve() / "cron" / "executions.db"
+_IMPORT_EXECUTIONS_FILE = EXECUTIONS_FILE
 MAX_TERMINAL_EXECUTIONS = 1000
 _TERMINAL_STATES = ("completed", "failed", "unknown")
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
 
 
+def _execution_file() -> Path:
+    """Resolve the ledger beside the active profile/store at call time.
+
+    Preserve the long-standing ``EXECUTIONS_FILE`` monkeypatch surface for
+    tests/embedders while avoiding an import-time default-profile freeze.
+    """
+    if EXECUTIONS_FILE != _IMPORT_EXECUTIONS_FILE:
+        return Path(EXECUTIONS_FILE)
+    return get_cron_dir() / "executions.db"
+
+
 def _connect() -> sqlite3.Connection:
-    EXECUTIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(EXECUTIONS_FILE, timeout=5)
+    executions_file = _execution_file()
+    executions_file.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(executions_file, timeout=5)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA busy_timeout=5000")
     conn.execute("PRAGMA journal_mode=WAL")

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -115,6 +115,11 @@ _CONTEXT_FREE_FIXTURE_PAIRS = frozenset(
         ("w", "echo hi"),
     }
 )
+# The leaked fixture batch was created during this bounded incident window.
+# Requiring the historical creation timestamp prevents a future legitimate job
+# with the same concise name/prompt pair from being treated as test debris.
+_CONTEXT_FREE_FIXTURE_CREATED_AFTER = "2026-07-16T00:00:00+00:00"
+_CONTEXT_FREE_FIXTURE_CREATED_BEFORE = "2026-07-18T00:00:00+00:00"
 _CONTEXT_FIELDS = (
     "script",
     "skills",
@@ -200,6 +205,11 @@ def use_cron_store(home: Union[str, Path]):
 def get_cron_output_dir() -> Path:
     """Return the output directory for the active cron store context."""
     return _current_cron_store().output_dir
+
+
+def get_cron_dir() -> Path:
+    """Return the cron directory for the active profile/store context."""
+    return _current_cron_store().cron_dir
 
 
 # Fallback stale-recovery window for a one-shot's running-claim (#59229) when
@@ -1459,7 +1469,7 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
 
 def context_free_fixture_reason(job: Dict[str, Any]) -> Optional[str]:
-    """Return a quarantine reason for a known trivial prompt with no contract."""
+    """Return a quarantine reason for one known historical fixture record."""
     if not isinstance(job, dict) or job.get("no_agent"):
         return None
     name = " ".join(str(job.get("name") or "").strip().lower().split())
@@ -1468,9 +1478,25 @@ def context_free_fixture_reason(job: Dict[str, Any]) -> Optional[str]:
         return None
     if any(job.get(field) for field in _CONTEXT_FIELDS):
         return None
+    deliver = str(job.get("deliver") or "").strip().lower()
+    if deliver not in {"", "local", "origin"} or job.get("attach_to_session"):
+        return None
+    try:
+        created_at = _ensure_aware(datetime.fromisoformat(str(job.get("created_at") or "")))
+        incident_start = _ensure_aware(
+            datetime.fromisoformat(_CONTEXT_FREE_FIXTURE_CREATED_AFTER)
+        )
+        incident_end = _ensure_aware(
+            datetime.fromisoformat(_CONTEXT_FREE_FIXTURE_CREATED_BEFORE)
+        )
+    except (TypeError, ValueError):
+        return None
+    if not incident_start <= created_at < incident_end:
+        return None
     return (
-        f"context-free fixture prompt {prompt!r} has no script, skill, workdir, "
-        "upstream context, origin, explicit model/provider, or narrowed toolset"
+        f"historical context-free fixture prompt {prompt!r} has no script, skill, "
+        "workdir, upstream context, origin, explicit model/provider, narrowed "
+        "toolset, external delivery, or attached session"
     )
 
 
@@ -2221,6 +2247,10 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                             needs_save = True
                             break
 
+                # Mark only the returned copy, never the persisted record. The
+                # scheduler uses this provenance bit to reject a due snapshot
+                # whose authoritative store row is deleted before dispatch.
+                job["_persisted_due_snapshot"] = True
                 due.append(job)
         except Exception:
             logger.exception(

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1711,8 +1711,12 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
         logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)
 
 
-def claim_dispatch(job_id: str) -> bool:
+def claim_dispatch(job_id: str, *, require_persisted: bool = False) -> bool:
     """Atomically claim a finite one-shot job dispatch BEFORE execution.
+
+    ``require_persisted`` is used by scheduler/provider dispatch. If the row was
+    deleted after admission reloaded it, the missing row rejects the dispatch
+    instead of preserving the direct handed-in-job compatibility path.
 
     Increments ``repeat.completed`` under the cross-process jobs lock and
     persists the claim immediately, so that if the tick dies mid-execution
@@ -1766,6 +1770,12 @@ def claim_dispatch(job_id: str) -> bool:
             )
             return True
 
+        if require_persisted:
+            logger.info(
+                "claim_dispatch: job_id %s was removed after admission — rejecting",
+                job_id,
+            )
+            return False
         logger.debug(
             "claim_dispatch: job_id %s not in store — proceeding without claim "
             "(handed-in job dict; nothing to persist a claim against)",

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -101,6 +101,33 @@ _JOBS_LOCK_TIMEOUT_SECONDS = 30.0
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
 
+# Exact name/prompt pairs used by historical cron unit fixtures. A July 2026
+# isolation regression left recurring copies in a live store; each copy had no
+# task context yet constructed SessionDB/AIAgent and spent model tokens every
+# day. Pairing the prompt with its fixture name avoids quarantining a legitimate
+# concise job whose user-visible instruction happens to be ``build`` or ``x``.
+_CONTEXT_FREE_FIXTURE_PAIRS = frozenset(
+    {
+        ("claim job", "x"),
+        ("paused job", "x"),
+        ("daily build", "build"),
+        ("hourly build", "build"),
+        ("w", "echo hi"),
+    }
+)
+_CONTEXT_FIELDS = (
+    "script",
+    "skills",
+    "skill",
+    "workdir",
+    "context_from",
+    "origin",
+    "model",
+    "provider",
+    "base_url",
+    "enabled_toolsets",
+)
+
 
 @dataclass(frozen=True)
 class _CronStorePaths:
@@ -1429,6 +1456,57 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             save_jobs(jobs)
             return _normalize_job_record(jobs[i])
     return None
+
+
+def context_free_fixture_reason(job: Dict[str, Any]) -> Optional[str]:
+    """Return a quarantine reason for a known trivial prompt with no contract."""
+    if not isinstance(job, dict) or job.get("no_agent"):
+        return None
+    name = " ".join(str(job.get("name") or "").strip().lower().split())
+    prompt = " ".join(str(job.get("prompt") or "").strip().lower().split())
+    if (name, prompt) not in _CONTEXT_FREE_FIXTURE_PAIRS:
+        return None
+    if any(job.get(field) for field in _CONTEXT_FIELDS):
+        return None
+    return (
+        f"context-free fixture prompt {prompt!r} has no script, skill, workdir, "
+        "upstream context, origin, explicit model/provider, or narrowed toolset"
+    )
+
+
+def quarantine_context_free_fixture_job(
+    job_id: str,
+) -> Tuple[Optional[Dict[str, Any]], Optional[str], bool]:
+    """Atomically reload and pause a context-free fixture job.
+
+    Returns ``(current_job, reason, changed)``. The reload and predicate check
+    happen under the jobs lock so a stale due-job snapshot cannot pause a job
+    that the user has since edited into a meaningful task.
+    """
+    with _jobs_lock():
+        jobs = load_jobs()
+        for index, raw_job in enumerate(jobs):
+            if raw_job.get("id") != job_id:
+                continue
+            current = _normalize_job_record(raw_job)
+            reason = context_free_fixture_reason(current)
+            if not reason:
+                return current, None, False
+            if not current.get("enabled", True) or current.get("state") == "paused":
+                return current, reason, False
+            updated = copy.deepcopy(raw_job)
+            updated.update(
+                {
+                    "enabled": False,
+                    "state": "paused",
+                    "paused_at": _hermes_now().isoformat(),
+                    "paused_reason": f"auto-quarantined by cron admission fuse: {reason}",
+                }
+            )
+            jobs[index] = updated
+            save_jobs(jobs)
+            return _normalize_job_record(updated), reason, True
+    return None, None, False
 
 
 def pause_job(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, Any]]:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3851,15 +3851,23 @@ def run_one_job(
         # use advance_next_run) and infinite/no-repeat jobs. This lives here in
         # the shared body so BOTH the built-in ticker and the external provider
         # (Chronos fire_due) get at-most-times semantics.
-        if not claim_dispatch(job["id"]):
+        dispatch_claimed = (
+            claim_dispatch(job["id"], require_persisted=True)
+            if require_persisted
+            else claim_dispatch(job["id"])
+        )
+        if not dispatch_claimed:
             logger.info(
-                "Job '%s': one-shot dispatch limit reached — skipping",
+                "Job '%s': dispatch claim rejected — missing row or one-shot limit reached",
                 job.get("name", job["id"]),
             )
             finish_execution(
                 execution_id,
                 success=False,
-                error="Dispatch claim rejected; execution was not started.",
+                error=(
+                    "Dispatch claim rejected; persisted job was removed or the "
+                    "one-shot execution limit was reached."
+                ),
             )
             return True  # not an error — already handled/removed
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -277,13 +277,22 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run, claim_dispatch, heartbeat_run_claim
+from cron.jobs import (
+    advance_next_run,
+    claim_dispatch,
+    get_due_jobs,
+    heartbeat_run_claim,
+    mark_job_run,
+    quarantine_context_free_fixture_job,
+    save_job_output,
+)
 from cron.executions import create_execution, finish_execution, mark_execution_running
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
+
 
 # Canonical silence tokens recognized in cron output.  Cron's contract is
 # intentionally looser than the gateway's exact-whole-response rule: the cron
@@ -3727,6 +3736,57 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
     if not execution_id:
         execution_id = create_execution(job["id"], source="direct")["id"]
     try:
+        # Re-read the persisted job under the store lock before admission. A
+        # due-job snapshot can race a user edit; the current record is the
+        # authority for both quarantine and execution.
+        current_job, fixture_reason, quarantined_now = (
+            quarantine_context_free_fixture_job(job["id"])
+        )
+        if current_job is not None:
+            current_execution_id = job.get("execution_id")
+            job = dict(current_job)
+            if current_execution_id:
+                job["execution_id"] = current_execution_id
+
+        if fixture_reason:
+            mark_execution_running(execution_id)
+            if quarantined_now:
+                paused_reason = job.get("paused_reason") or (
+                    f"auto-quarantined by cron admission fuse: {fixture_reason}"
+                )
+                job_name = str(
+                    job.get("name") or job.get("prompt") or job["id"] or "cron job"
+                )
+                quarantined_doc = (
+                    f"# Cron Job: {job_name}\n\n"
+                    f"**Job ID:** {job['id']}\n"
+                    f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+                    "**Status:** QUARANTINED\n\n"
+                    f"{paused_reason}. No session or agent was constructed.\n"
+                )
+                save_job_output(job["id"], quarantined_doc)
+                _notify_provider_jobs_changed()
+                logger.warning(
+                    "Job '%s' (ID: %s): %s",
+                    job_name,
+                    job["id"],
+                    paused_reason,
+                )
+            finish_execution(execution_id, success=True, error=None)
+            return True
+
+        # A stale due snapshot can also race a manual pause. Do not execute a
+        # current record that is already inactive.
+        if current_job is not None and (
+            not job.get("enabled", True) or job.get("state") == "paused"
+        ):
+            finish_execution(
+                execution_id,
+                success=False,
+                error="Job was paused or disabled before execution started.",
+            )
+            return True
+
         # Pre-run dispatch claim (issue #38758): atomically commit a finite
         # one-shot's dispatch BEFORE its side effect runs, so a tick that dies
         # mid-execution (gateway kill, OOM, segfault, hard-timeout) cannot

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3717,12 +3717,23 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
         logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
-def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:
+def run_one_job(
+    job: dict,
+    *,
+    adapters=None,
+    loop=None,
+    verbose: bool = False,
+    require_persisted: bool = False,
+) -> bool:
     """Run ONE due job end-to-end: execute → save output → deliver → mark.
 
     This is the shared firing body extracted from ``tick``'s per-job closure so
     that BOTH the built-in ticker and an external provider's ``fire_due`` (e.g.
     Chronos) run the identical sequence — no duplicated correctness.
+
+    ``require_persisted`` is set by scheduler/provider dispatch paths. It makes
+    deletion after due-job snapshotting authoritative while preserving the
+    documented direct handed-in-job behavior for embedders and focused tests.
 
     It does NOT decide whether the job is due, claim it, or compute the next
     run — those are the caller's concern (``tick`` advances ``next_run_at``
@@ -3734,14 +3745,48 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
     """
     execution_id = job.get("execution_id")
     if not execution_id:
-        execution_id = create_execution(job["id"], source="direct")["id"]
+        try:
+            execution_id = create_execution(job["id"], source="direct")["id"]
+        except Exception as ledger_error:
+            logger.error(
+                "Job '%s' rejected before execution: could not create audit claim: %s",
+                job.get("id", "?"),
+                ledger_error,
+            )
+            return False
+
+    def _finish_admission_rejection(detail: str) -> None:
+        """Best-effort terminal audit write that must never enable execution."""
+        try:
+            finish_execution(execution_id, success=False, error=detail)
+        except Exception as ledger_error:
+            logger.error(
+                "Job '%s': could not record admission rejection: %s",
+                job.get("id", "?"),
+                ledger_error,
+            )
+
     try:
         # Re-read the persisted job under the store lock before admission. A
         # due-job snapshot can race a user edit; the current record is the
-        # authority for both quarantine and execution.
-        current_job, fixture_reason, quarantined_now = (
-            quarantine_context_free_fixture_job(job["id"])
-        )
+        # authority for both quarantine and execution. Store/lock failures are
+        # admission failures, never reasons to continue into the agent path.
+        try:
+            current_job, fixture_reason, quarantined_now = (
+                quarantine_context_free_fixture_job(job["id"])
+            )
+        except Exception as admission_error:
+            detail = f"Cron admission check failed before execution: {admission_error}"
+            _finish_admission_rejection(detail)
+            logger.error("Job '%s': %s", job.get("id", "?"), detail)
+            return False
+
+        if require_persisted and current_job is None:
+            detail = "Job no longer exists in the active cron store; execution was rejected."
+            _finish_admission_rejection(detail)
+            logger.info("Job '%s': %s", job.get("id", "?"), detail)
+            return True
+
         if current_job is not None:
             current_execution_id = job.get("execution_id")
             job = dict(current_job)
@@ -3749,11 +3794,12 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                 job["execution_id"] = current_execution_id
 
         if fixture_reason:
-            mark_execution_running(execution_id)
+            paused_reason = job.get("paused_reason") or (
+                f"auto-quarantined by cron admission fuse: {fixture_reason}"
+            )
+            detail = f"Cron admission rejected before execution: {paused_reason}"
+            _finish_admission_rejection(detail)
             if quarantined_now:
-                paused_reason = job.get("paused_reason") or (
-                    f"auto-quarantined by cron admission fuse: {fixture_reason}"
-                )
                 job_name = str(
                     job.get("name") or job.get("prompt") or job["id"] or "cron job"
                 )
@@ -3764,15 +3810,28 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                     "**Status:** QUARANTINED\n\n"
                     f"{paused_reason}. No session or agent was constructed.\n"
                 )
-                save_job_output(job["id"], quarantined_doc)
-                _notify_provider_jobs_changed()
+                try:
+                    save_job_output(job["id"], quarantined_doc)
+                except Exception as receipt_error:
+                    logger.error(
+                        "Job '%s': quarantine receipt could not be saved: %s",
+                        job["id"],
+                        receipt_error,
+                    )
+                try:
+                    _notify_provider_jobs_changed()
+                except Exception as notify_error:
+                    logger.error(
+                        "Job '%s': provider could not be notified of quarantine: %s",
+                        job["id"],
+                        notify_error,
+                    )
                 logger.warning(
                     "Job '%s' (ID: %s): %s",
                     job_name,
                     job["id"],
                     paused_reason,
                 )
-            finish_execution(execution_id, success=True, error=None)
             return True
 
         # A stale due snapshot can also race a manual pause. Do not execute a
@@ -3780,10 +3839,8 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         if current_job is not None and (
             not job.get("enabled", True) or job.get("state") == "paused"
         ):
-            finish_execution(
-                execution_id,
-                success=False,
-                error="Job was paused or disabled before execution started.",
+            _finish_admission_rejection(
+                "Job was paused or disabled before execution started."
             )
             return True
 
@@ -4040,7 +4097,13 @@ def tick(
             module-level ``run_one_job`` so ``tick`` and external providers
             (Chronos ``fire_due``) use the identical execute→save→deliver→mark
             body."""
-            return run_one_job(job, adapters=adapters, loop=loop, verbose=verbose)
+            return run_one_job(
+                job,
+                adapters=adapters,
+                loop=loop,
+                verbose=verbose,
+                require_persisted=bool(job.get("_persisted_due_snapshot")),
+            )
 
         # Partition due jobs: those with a per-job workdir mutate
         # os.environ["TERMINAL_CWD"] inside run_job, which is process-global, so

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -110,7 +110,12 @@ class CronScheduler(ABC):
         if job is None:
             return False  # job removed (e.g. repeat-N exhausted) between arm and fire
         job["execution_id"] = create_execution(job_id, source=self.name)["id"]
-        return run_one_job(job, adapters=adapters, loop=loop)
+        return run_one_job(
+            job,
+            adapters=adapters,
+            loop=loop,
+            require_persisted=True,
+        )
 
     def reconcile(self) -> None:
         """Converge the external registry toward jobs.json (the desired state):

--- a/tests/cron/test_fixture_job_admission.py
+++ b/tests/cron/test_fixture_job_admission.py
@@ -345,6 +345,49 @@ def test_deleted_persisted_snapshot_is_rejected_before_agent_path():
     assert "no longer exists" in (ledger["error"] or "").lower()
 
 
+def test_delete_between_admission_reload_and_dispatch_claim_is_rejected():
+    job = create_job(
+        name="legitimate report",
+        schedule="every 60m",
+        prompt="Summarize the local report.",
+    )
+    assert trigger_job(job["id"]) is not None
+    snapshot = next(item for item in get_due_jobs() if item["id"] == job["id"])
+    original_admission = scheduler.quarantine_context_free_fixture_job
+
+    def delete_after_reload(job_id):
+        result = original_admission(job_id)
+        assert remove_job(job_id) is True
+        return result
+
+    with (
+        patch.object(
+            scheduler,
+            "quarantine_context_free_fixture_job",
+            side_effect=delete_after_reload,
+        ),
+        patch.object(
+            scheduler, "run_job", side_effect=AssertionError("agent path reached")
+        ) as run_mock,
+        patch.object(scheduler, "mark_job_run") as mark_mock,
+    ):
+        assert (
+            run_one_job(
+                snapshot,
+                require_persisted=bool(snapshot["_persisted_due_snapshot"]),
+            )
+            is True
+        )
+
+    run_mock.assert_not_called()
+    mark_mock.assert_not_called()
+    ledger = latest_execution(job["id"])
+    assert ledger is not None
+    assert ledger["status"] == "failed"
+    assert ledger["started_at"] is None
+    assert "dispatch claim rejected" in (ledger["error"] or "").lower()
+
+
 def test_quarantine_execution_ledger_follows_context_local_profile(tmp_path):
     profile_home = tmp_path / "profile"
     with use_cron_store(profile_home):

--- a/tests/cron/test_fixture_job_admission.py
+++ b/tests/cron/test_fixture_job_admission.py
@@ -1,0 +1,202 @@
+"""Fail-closed admission tests for context-free cron fixtures.
+
+Regression: stale tests created recurring jobs named ``claim job`` with prompt
+``x`` in the live store. Each fire constructed SessionDB/AIAgent and spent model
+tokens despite carrying no task contract.
+"""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+import cron.scheduler as scheduler
+from cron.jobs import context_free_fixture_reason, create_job, get_job, update_job
+from cron.scheduler import SILENT_MARKER, run_one_job
+from hermes_time import now as hermes_now
+
+
+def _fixture_job(**updates):
+    job = {
+        "id": "fixture-job",
+        "name": "claim job",
+        "prompt": "x",
+        "script": None,
+        "skills": None,
+        "skill": None,
+        "workdir": None,
+        "context_from": None,
+        "origin": None,
+        "model": None,
+        "provider": None,
+        "base_url": None,
+        "enabled_toolsets": None,
+        "no_agent": False,
+    }
+    job.update(updates)
+    return job
+
+
+def test_context_free_fixture_is_detected():
+    for name, prompt in (
+        ("claim job", "x"),
+        ("paused job", "x"),
+        ("daily build", "build"),
+        ("hourly build", "build"),
+        ("w", "echo hi"),
+    ):
+        reason = context_free_fixture_reason(_fixture_job(name=name, prompt=prompt))
+        assert reason is not None, (name, prompt)
+        assert "context-free fixture prompt" in reason
+
+
+def test_meaningful_job_context_prevents_quarantine():
+    meaningful = [
+        {"script": "collector.py"},
+        {"skills": ["overnight-assistant-operations"]},
+        {"skill": "overnight-assistant-operations"},
+        {"workdir": "/tmp/project"},
+        {"context_from": ["upstream-job"]},
+        {"origin": {"platform": "discord", "chat_id": "123"}},
+        {"model": "gpt-5.6-terra"},
+        {"provider": "openai-codex"},
+        {"base_url": "https://inference.example.test/v1"},
+        {"enabled_toolsets": ["file"]},
+        {"no_agent": True},
+    ]
+    for updates in meaningful:
+        assert context_free_fixture_reason(_fixture_job(**updates)) is None, updates
+
+
+def test_non_fixture_prompt_is_not_detected():
+    assert (
+        context_free_fixture_reason(
+            _fixture_job(
+                prompt="Summarize the latest local report and save a review card."
+            )
+        )
+        is None
+    )
+
+
+def test_known_prompt_with_unrelated_name_is_not_detected():
+    """A concise legitimate job must not be quarantined by prompt alone."""
+    assert (
+        context_free_fixture_reason(
+            _fixture_job(name="Project build reminder", prompt="build")
+        )
+        is None
+    )
+
+
+def test_stale_fixture_snapshot_does_not_pause_updated_meaningful_job():
+    created = create_job(name="claim job", schedule="0 7 * * *", prompt="x")
+    stale_snapshot = dict(created)
+    updated = update_job(
+        created["id"],
+        {
+            "prompt": "Summarize the local report for review.",
+            "origin": {"platform": "discord", "chat_id": "123"},
+        },
+    )
+    assert updated is not None
+
+    with (
+        patch.object(
+            scheduler,
+            "run_job",
+            return_value=(True, "# receipt", SILENT_MARKER, None),
+        ) as run_mock,
+        patch.object(scheduler, "_deliver_result") as deliver_mock,
+    ):
+        assert run_one_job(stale_snapshot) is True
+
+    stored = get_job(created["id"])
+    assert stored is not None
+    assert stored["enabled"] is True
+    assert stored["state"] != "paused"
+    assert run_mock.call_args.args[0]["prompt"] == updated["prompt"]
+    deliver_mock.assert_not_called()
+
+
+def test_run_one_job_keeps_one_shot_fixture_paused_and_saves_receipt():
+    run_at = (hermes_now() + timedelta(minutes=5)).isoformat()
+    job = create_job(name="claim job", schedule=run_at, prompt="x")
+
+    with (
+        patch.object(
+            scheduler, "run_job", side_effect=AssertionError("agent path reached")
+        ),
+        patch.object(scheduler, "mark_job_run") as mark_mock,
+        patch.object(scheduler, "_deliver_result") as deliver_mock,
+        patch.object(
+            scheduler, "save_job_output", wraps=scheduler.save_job_output
+        ) as save_mock,
+    ):
+        assert run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["enabled"] is False
+    assert stored["state"] == "paused"
+    assert "context-free fixture prompt" in (stored["paused_reason"] or "")
+    mark_mock.assert_not_called()
+    deliver_mock.assert_not_called()
+    save_mock.assert_called_once()
+    saved_doc = save_mock.call_args.args[1]
+    assert "QUARANTINED" in saved_doc
+
+
+def test_recurring_fixture_quarantine_preserves_repeat_and_is_idempotent():
+    job = create_job(
+        name="daily build",
+        schedule="every 60m",
+        prompt="build",
+        repeat=3,
+    )
+    original_repeat = dict(job["repeat"])
+
+    with (
+        patch.object(
+            scheduler, "run_job", side_effect=AssertionError("agent path reached")
+        ),
+        patch.object(scheduler, "claim_dispatch") as claim_mock,
+        patch.object(scheduler, "mark_job_run") as mark_mock,
+        patch.object(scheduler, "_deliver_result") as deliver_mock,
+        patch.object(
+            scheduler, "save_job_output", wraps=scheduler.save_job_output
+        ) as save_mock,
+        patch.object(scheduler, "_notify_provider_jobs_changed") as notify_mock,
+    ):
+        assert run_one_job(dict(job)) is True
+        assert run_one_job(dict(job)) is True
+
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["enabled"] is False
+    assert stored["state"] == "paused"
+    assert stored["repeat"] == original_repeat
+    claim_mock.assert_not_called()
+    mark_mock.assert_not_called()
+    deliver_mock.assert_not_called()
+    save_mock.assert_called_once()
+    notify_mock.assert_called_once()
+
+
+def test_scripted_job_with_fixture_pair_still_executes_normally():
+    job = create_job(
+        name="daily build",
+        schedule="every 60m",
+        prompt="build",
+        script="collector.py",
+    )
+    with patch.object(
+        scheduler,
+        "run_job",
+        return_value=(True, "# script receipt", SILENT_MARKER, None),
+    ) as run_mock:
+        assert run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["enabled"] is True
+    assert stored["state"] != "paused"
+    run_mock.assert_called_once()

--- a/tests/cron/test_fixture_job_admission.py
+++ b/tests/cron/test_fixture_job_admission.py
@@ -9,9 +9,20 @@ from datetime import timedelta
 from unittest.mock import patch
 
 import cron.scheduler as scheduler
-from cron.jobs import context_free_fixture_reason, create_job, get_job, update_job
+from cron.executions import latest_execution
+from cron.jobs import (
+    context_free_fixture_reason,
+    create_job,
+    get_job,
+    remove_job,
+    update_job,
+    use_cron_store,
+)
 from cron.scheduler import SILENT_MARKER, run_one_job
 from hermes_time import now as hermes_now
+
+
+HISTORICAL_FIXTURE_CREATED_AT = "2026-07-16T12:00:00+00:00"
 
 
 def _fixture_job(**updates):
@@ -30,9 +41,20 @@ def _fixture_job(**updates):
         "base_url": None,
         "enabled_toolsets": None,
         "no_agent": False,
+        "deliver": "local",
+        "attach_to_session": None,
+        "created_at": HISTORICAL_FIXTURE_CREATED_AT,
     }
     job.update(updates)
     return job
+
+
+def _mark_historical_fixture(job):
+    updated = update_job(
+        job["id"], {"created_at": HISTORICAL_FIXTURE_CREATED_AT}
+    )
+    assert updated is not None
+    return updated
 
 
 def test_context_free_fixture_is_detected():
@@ -60,6 +82,8 @@ def test_meaningful_job_context_prevents_quarantine():
         {"provider": "openai-codex"},
         {"base_url": "https://inference.example.test/v1"},
         {"enabled_toolsets": ["file"]},
+        {"deliver": "discord:#ops"},
+        {"attach_to_session": True},
         {"no_agent": True},
     ]
     for updates in meaningful:
@@ -87,8 +111,20 @@ def test_known_prompt_with_unrelated_name_is_not_detected():
     )
 
 
+def test_same_fixture_pair_created_outside_incident_window_is_not_detected():
+    """A future legitimate concise job must not match the historical batch."""
+    assert (
+        context_free_fixture_reason(
+            _fixture_job(created_at="2026-07-21T12:00:00+00:00")
+        )
+        is None
+    )
+
+
 def test_stale_fixture_snapshot_does_not_pause_updated_meaningful_job():
-    created = create_job(name="claim job", schedule="0 7 * * *", prompt="x")
+    created = _mark_historical_fixture(
+        create_job(name="claim job", schedule="0 7 * * *", prompt="x")
+    )
     stale_snapshot = dict(created)
     updated = update_job(
         created["id"],
@@ -119,7 +155,9 @@ def test_stale_fixture_snapshot_does_not_pause_updated_meaningful_job():
 
 def test_run_one_job_keeps_one_shot_fixture_paused_and_saves_receipt():
     run_at = (hermes_now() + timedelta(minutes=5)).isoformat()
-    job = create_job(name="claim job", schedule=run_at, prompt="x")
+    job = _mark_historical_fixture(
+        create_job(name="claim job", schedule=run_at, prompt="x")
+    )
 
     with (
         patch.object(
@@ -143,14 +181,106 @@ def test_run_one_job_keeps_one_shot_fixture_paused_and_saves_receipt():
     save_mock.assert_called_once()
     saved_doc = save_mock.call_args.args[1]
     assert "QUARANTINED" in saved_doc
+    ledger = latest_execution(job["id"])
+    assert ledger is not None
+    assert ledger["status"] == "failed"
+    assert ledger["started_at"] is None
+    assert "admission rejected" in (ledger["error"] or "").lower()
+
+
+def test_quarantine_receipt_failure_preserves_one_shot_and_notifies_provider():
+    run_at = (hermes_now() + timedelta(minutes=5)).isoformat()
+    job = _mark_historical_fixture(
+        create_job(name="claim job", schedule=run_at, prompt="x")
+    )
+    original_repeat = dict(job["repeat"])
+
+    with (
+        patch.object(
+            scheduler, "run_job", side_effect=AssertionError("agent path reached")
+        ),
+        patch.object(
+            scheduler, "save_job_output", side_effect=OSError("receipt disk full")
+        ),
+        patch.object(scheduler, "mark_job_run") as mark_mock,
+        patch.object(scheduler, "_notify_provider_jobs_changed") as notify_mock,
+    ):
+        assert run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["state"] == "paused"
+    assert stored["repeat"] == original_repeat
+    mark_mock.assert_not_called()
+    notify_mock.assert_called_once()
+    ledger = latest_execution(job["id"])
+    assert ledger is not None
+    assert ledger["status"] == "failed"
+    assert ledger["started_at"] is None
+
+
+def test_quarantine_ledger_failure_cannot_fall_through_to_repeat_accounting():
+    run_at = (hermes_now() + timedelta(minutes=5)).isoformat()
+    job = _mark_historical_fixture(
+        create_job(name="claim job", schedule=run_at, prompt="x")
+    )
+    original_repeat = dict(job["repeat"])
+
+    with (
+        patch.object(
+            scheduler, "run_job", side_effect=AssertionError("agent path reached")
+        ),
+        patch.object(
+            scheduler, "finish_execution", side_effect=OSError("ledger disk full")
+        ),
+        patch.object(scheduler, "mark_job_run") as mark_mock,
+        patch.object(scheduler, "_notify_provider_jobs_changed") as notify_mock,
+    ):
+        assert run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["state"] == "paused"
+    assert stored["repeat"] == original_repeat
+    mark_mock.assert_not_called()
+    notify_mock.assert_called_once()
+
+
+def test_admission_store_failure_rejects_before_agent_and_repeat_accounting():
+    job = _mark_historical_fixture(
+        create_job(name="claim job", schedule="0 7 * * *", prompt="x")
+    )
+
+    with (
+        patch.object(
+            scheduler,
+            "quarantine_context_free_fixture_job",
+            side_effect=OSError("jobs store unavailable"),
+        ),
+        patch.object(
+            scheduler, "run_job", side_effect=AssertionError("agent path reached")
+        ) as run_mock,
+        patch.object(scheduler, "mark_job_run") as mark_mock,
+    ):
+        assert run_one_job(job) is False
+
+    run_mock.assert_not_called()
+    mark_mock.assert_not_called()
+    ledger = latest_execution(job["id"])
+    assert ledger is not None
+    assert ledger["status"] == "failed"
+    assert ledger["started_at"] is None
+    assert "admission check failed" in (ledger["error"] or "").lower()
 
 
 def test_recurring_fixture_quarantine_preserves_repeat_and_is_idempotent():
-    job = create_job(
-        name="daily build",
-        schedule="every 60m",
-        prompt="build",
-        repeat=3,
+    job = _mark_historical_fixture(
+        create_job(
+            name="daily build",
+            schedule="every 60m",
+            prompt="build",
+            repeat=3,
+        )
     )
     original_repeat = dict(job["repeat"])
 
@@ -181,12 +311,55 @@ def test_recurring_fixture_quarantine_preserves_repeat_and_is_idempotent():
     notify_mock.assert_called_once()
 
 
+def test_deleted_persisted_snapshot_is_rejected_before_agent_path():
+    job = _mark_historical_fixture(
+        create_job(name="claim job", schedule="0 7 * * *", prompt="x")
+    )
+    assert remove_job(job["id"]) is True
+
+    with (
+        patch.object(
+            scheduler, "run_job", side_effect=AssertionError("agent path reached")
+        ) as run_mock,
+        patch.object(scheduler, "mark_job_run") as mark_mock,
+    ):
+        assert run_one_job(job, require_persisted=True) is True
+
+    run_mock.assert_not_called()
+    mark_mock.assert_not_called()
+    ledger = latest_execution(job["id"])
+    assert ledger is not None
+    assert ledger["status"] == "failed"
+    assert ledger["started_at"] is None
+    assert "no longer exists" in (ledger["error"] or "").lower()
+
+
+def test_quarantine_execution_ledger_follows_context_local_profile(tmp_path):
+    profile_home = tmp_path / "profile"
+    with use_cron_store(profile_home):
+        job = _mark_historical_fixture(
+            create_job(name="claim job", schedule="0 7 * * *", prompt="x")
+        )
+        with patch.object(
+            scheduler, "run_job", side_effect=AssertionError("agent path reached")
+        ):
+            assert run_one_job(job) is True
+
+        ledger = latest_execution(job["id"])
+        assert ledger is not None
+        assert ledger["status"] == "failed"
+
+    assert (profile_home / "cron" / "executions.db").exists()
+
+
 def test_scripted_job_with_fixture_pair_still_executes_normally():
-    job = create_job(
-        name="daily build",
-        schedule="every 60m",
-        prompt="build",
-        script="collector.py",
+    job = _mark_historical_fixture(
+        create_job(
+            name="daily build",
+            schedule="every 60m",
+            prompt="build",
+            script="collector.py",
+        )
     )
     with patch.object(
         scheduler,

--- a/tests/cron/test_fixture_job_admission.py
+++ b/tests/cron/test_fixture_job_admission.py
@@ -13,8 +13,10 @@ from cron.executions import latest_execution
 from cron.jobs import (
     context_free_fixture_reason,
     create_job,
+    get_due_jobs,
     get_job,
     remove_job,
+    trigger_job,
     update_job,
     use_cron_store,
 )
@@ -315,6 +317,9 @@ def test_deleted_persisted_snapshot_is_rejected_before_agent_path():
     job = _mark_historical_fixture(
         create_job(name="claim job", schedule="0 7 * * *", prompt="x")
     )
+    assert trigger_job(job["id"]) is not None
+    snapshot = next(item for item in get_due_jobs() if item["id"] == job["id"])
+    assert snapshot["_persisted_due_snapshot"] is True
     assert remove_job(job["id"]) is True
 
     with (
@@ -323,7 +328,13 @@ def test_deleted_persisted_snapshot_is_rejected_before_agent_path():
         ) as run_mock,
         patch.object(scheduler, "mark_job_run") as mark_mock,
     ):
-        assert run_one_job(job, require_persisted=True) is True
+        assert (
+            run_one_job(
+                snapshot,
+                require_persisted=bool(snapshot["_persisted_due_snapshot"]),
+            )
+            is True
+        )
 
     run_mock.assert_not_called()
     mark_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- recognize only five exact historical fixture name/prompt pairs when they carry no task context
- atomically pause them in the live store before dispatch ownership, SessionDB, or AIAgent startup
- preserve a local scheduler receipt and notify provider-backed cron views when quarantine changes state
- keep ordinary jobs, script jobs, context-bearing tasks, and same-prompt tasks under unrelated names runnable

## Why
A pytest isolation regression can copy recurring unit fixtures into a user cron store. Once due, the scheduler otherwise constructs a real agent and spends model calls on prompts such as `x`, `build`, or `echo hi`. Cleanup is necessary but insufficient; the firing path needs a fail-closed admission fuse.

## Verification
- `HERMES_HOME=<external-temp> pytest tests/cron/test_fixture_job_admission.py -q -o addopts=` — 8 passed
- `HERMES_HOME=<external-temp> pytest tests/cron -q -o addopts=` — 738 passed, 2 existing warnings
- live cron store SHA-256 unchanged across both test runs

## False-positive boundary
The classifier requires an exact historical `(name, prompt)` pair *and* absence of skills, script, context chaining, toolset selection, workdir, or origin. A prompt like `build` under another name is not quarantined.