### PR TITLE
fix(desktop): dedupe sidebar workspace ordering

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/order.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.test.ts
@@ -37,6 +37,16 @@ describe('orderByIds', () => {
     const items = [{ id: 'fresh' }, { id: 'a' }, { id: 'b' }]
     expect(orderByIds(items, id, ['b', 'a'])).toEqual([{ id: 'fresh' }, { id: 'b' }, { id: 'a' }])
   })
+
+  it('emits one item for duplicate persisted order ids', () => {
+    const items = [{ id: 'a' }, { id: 'b' }]
+    expect(orderByIds(items, id, ['b', 'b', 'a'])).toEqual([{ id: 'b' }, { id: 'a' }])
+  })
+
+  it('emits one item for duplicate live ids, including fresh items', () => {
+    const items = [{ id: 'fresh' }, { id: 'fresh' }, { id: 'a' }, { id: 'a' }]
+    expect(orderByIds(items, id, ['a'])).toEqual([{ id: 'fresh' }, { id: 'a' }])
+  })
 })
 
 describe('reconcileOrderIds', () => {
@@ -50,6 +60,18 @@ describe('reconcileOrderIds', () => {
 
   it('puts newly-seen ids ahead of the retained saved order', () => {
     expect(reconcileOrderIds(['fresh', 'a', 'b'], ['b', 'a', 'gone'])).toEqual(['fresh', 'b', 'a'])
+  })
+
+  it('deduplicates current and persisted ids while dropping stale ids', () => {
+    expect(reconcileOrderIds(['fresh', 'fresh', 'a', 'a', 'b'], ['b', 'b', 'gone', 'a', 'a'])).toEqual([
+      'fresh',
+      'b',
+      'a'
+    ])
+  })
+
+  it('deduplicates current ids when there is no saved order', () => {
+    expect(reconcileOrderIds(['a', 'a', 'b', 'a'], [])).toEqual(['a', 'b'])
   })
 })
 

--- a/apps/desktop/src/app/chat/sidebar/order.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.ts
@@ -1,10 +1,10 @@
 /** New ids first, then ids still present in the persisted order. */
 export function reconcileFreshFirst(currentIds: string[], orderIds: string[]): string[] {
   const current = new Set(currentIds)
-  const retained = orderIds.filter(id => current.has(id))
+  const retained = [...new Set(orderIds.filter(id => current.has(id)))]
   const retainedSet = new Set(retained)
 
-  return [...currentIds.filter(id => !retainedSet.has(id)), ...retained]
+  return [...new Set(currentIds.filter(id => !retainedSet.has(id))), ...retained]
 }
 
 export function resolveManualSessionOrderIds(currentIds: string[], orderIds: string[], manual: boolean): string[] {
@@ -35,7 +35,7 @@ export function orderByIds<T>(items: T[], getId: (item: T) => string, orderIds: 
   for (const id of orderIds) {
     const item = byId.get(id)
 
-    if (item) {
+    if (item && !seen.has(id)) {
       ordered.push(item)
       seen.add(id)
     }
@@ -46,7 +46,14 @@ export function orderByIds<T>(items: T[], getId: (item: T) => string, orderIds: 
   // these at the TOP instead of burying them beneath the saved order —
   // otherwise a brand-new session sinks to the bottom of the sidebar and reads
   // as "my latest session never showed up".
-  const fresh = items.filter(item => !seen.has(getId(item)))
+  const fresh: T[] = []
+  for (const item of items) {
+    const itemId = getId(item)
+    if (!seen.has(itemId)) {
+      fresh.push(item)
+      seen.add(itemId)
+    }
+  }
 
   return fresh.length ? [...fresh, ...ordered] : ordered
 }
@@ -58,7 +65,7 @@ export function reconcileOrderIds(currentIds: string[], orderIds: string[]): str
   }
 
   if (!orderIds.length) {
-    return currentIds
+    return [...new Set(currentIds)]
   }
 
   return reconcileFreshFirst(currentIds, orderIds)


### PR DESCRIPTION
## Summary

- Ensure sidebar workspace ordering emits each repository/workspace ID at most once, including malformed persisted order arrays and duplicate live items.
- Reconcile stored ordering arrays to insertion-ordered unique IDs so the existing persistence flow self-heals duplicated state.
- Preserve the existing no-order reference-identity contract, fresh-first ordering, and stale-ID removal behavior.

## Root cause

`orderByIds()` emitted a matching item once for every occurrence of an ID in the persisted order. If `hermes.desktop.workspaceParentOrder` contained duplicate IDs, the sidebar rendered duplicate repository rows. The helper also did not protect against duplicate IDs in the live item array.

## Test plan

- `npm test -- src/app/chat/sidebar/order.test.ts` — 14/14 passed
- `npx tsc --ignoreConfig --noEmit --strict --skipLibCheck --target ES2022 --module NodeNext --moduleResolution NodeNext src/app/chat/sidebar/order.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
