### PR TITLE
fix(tools): bound Windows Git Bash startup probe like git probes

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 import sys
-from typing import Sequence
+from typing import Mapping, Optional, Sequence
 
 __all__ = [
     "IS_WINDOWS",
@@ -39,6 +39,7 @@ __all__ = [
     "windows_detach_flags_without_breakaway",
     "windows_hide_flags",
     "windows_detach_popen_kwargs",
+    "bounded_captured_run",
     "bounded_git_probe",
 ]
 
@@ -237,18 +238,19 @@ def windows_detach_popen_kwargs() -> dict:
 
 
 # -----------------------------------------------------------------------------
-# Bounded, fail-open git probing (Windows post-kill deadlock guard)
+# Bounded, fail-open probing (Windows post-kill deadlock guard)
 # -----------------------------------------------------------------------------
 
 
-def _kill_git_process_tree(proc: "subprocess.Popen") -> None:
+def _kill_process_tree(proc: "subprocess.Popen") -> None:
     """Best-effort terminate *proc* and, on Windows, its descendants.
 
-    ``proc.kill()`` alone only terminates the PATH-resolved ``git`` launcher; a
-    suspended descendant ``git.exe`` can survive holding duplicates of the
-    captured pipe handles, which keeps the pipes from reaching EOF and leaks two
-    reader threads + the process per fired timeout. ``taskkill /T /F`` takes the
-    whole tree down so the bounded drain that follows can actually reach EOF.
+    ``proc.kill()`` alone only terminates the PATH-resolved launcher; a
+    suspended descendant (``git.exe``, MSYS ``true``/``cat``, ...) can survive
+    holding duplicates of the captured pipe handles, which keeps the pipes from
+    reaching EOF and leaks two reader threads + the process per fired timeout.
+    ``taskkill /T /F`` takes the whole tree down so the bounded drain that
+    follows can actually reach EOF.
 
     All failures are swallowed — this is cleanup on an already-failing path, and
     the caller's contract is to fail open. ``kill()`` can raise (access denied,
@@ -276,56 +278,87 @@ def _kill_git_process_tree(proc: "subprocess.Popen") -> None:
             pass
 
 
-def bounded_git_probe(argv: Sequence[str], *, timeout: float) -> str:
-    """Run a short, throwaway ``git`` probe and return stripped stdout, or ``""``
-    on ANY failure (nonzero exit, timeout, spawn error, decode error).
+# Back-compat alias for the original git-probe name.
+_kill_git_process_tree = _kill_process_tree
 
-    This is the shared, deadlock-safe replacement for
-    ``subprocess.run(["git", ...], timeout=...)`` at fail-open probe call sites
-    (``tui_gateway.git_probe.run_git``, ``agent.coding_context._git``).
+
+def bounded_captured_run(
+    argv: Sequence[str],
+    *,
+    timeout: float,
+    env: Optional[Mapping[str, str]] = None,
+) -> subprocess.CompletedProcess:
+    """Deadlock-safe ``subprocess.run(..., capture_output=True, text=True, timeout=)``.
+
+    Shared replacement for short fail-open probes that previously used
+    ``subprocess.run(timeout=...)`` (``bounded_git_probe``, Windows Git Bash
+    ``_bash_starts``, ...).
 
     Why not ``subprocess.run``: on Windows, ``run()``'s post-timeout cleanup
-    calls an *unbounded* ``communicate()`` after killing git. Killing the
-    PATH-resolved launcher can leave a suspended descendant ``git.exe`` holding
-    duplicates of the captured stdout/stderr handles, so the pipes never reach
-    EOF and the reader-thread join blocks forever. On the Desktop agent-build
-    path (``_start_agent_build → _session_info → branch() → run_git``) that turned
-    an optional branch label into ``agent initialization timed out``
-    (issues #68609 / #66037).
+    calls an *unbounded* ``communicate()`` after killing the child. Killing only
+    the launcher can leave a suspended descendant holding duplicates of the
+    captured stdout/stderr handles, so the pipes never reach EOF and the
+    reader-thread join blocks forever — turning an optional probe into a hung
+    tool/session startup (issues #68609 / #66037; same class for Git Bash
+    ``true``/``cat`` children under Mandatory ASLR / stuck MSYS spawns).
 
     The bounded flow: an explicit ``communicate(timeout)``, then on any failure a
-    tree-kill (see :func:`_kill_git_process_tree`) plus a bounded 1s post-kill
+    tree-kill (see :func:`_kill_process_tree`) plus a bounded 1s post-kill
     drain; if the pipes are still held after that, they're abandoned (the orphaned
     reader threads are daemonic and cost nothing).
 
-    The normal-path spawn contract mirrors the previous ``run`` call byte-for-byte:
-    PIPE/PIPE/DEVNULL, ``text`` with UTF-8 ``errors="replace"`` decoding, and the
-    hidden-window ``creationflags`` on Windows only.
+    Spawn contract: PIPE/PIPE/DEVNULL, ``text`` with UTF-8 ``errors="replace"``,
+    and hidden-window ``creationflags`` on Windows only. ``stdin`` is always
+    ``DEVNULL`` so ACP/TUI JSON-RPC hosts that keep stdin open cannot stall the
+    probe.
+
+    On timeout / communicate failure returns ``CompletedProcess`` with
+    ``returncode=-1`` and empty streams (does not raise). Spawn failures
+    (``FileNotFoundError``, ...) propagate so callers can distinguish "not
+    installed" from "timed out".
     """
-    _popen_kwargs = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {}
+    _popen_kwargs: dict = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {}
+    if env is not None:
+        _popen_kwargs["env"] = dict(env)
+    proc = subprocess.Popen(
+        list(argv),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        **_popen_kwargs,
+    )
     try:
-        proc = subprocess.Popen(
-            list(argv),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            stdin=subprocess.DEVNULL,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            **_popen_kwargs,
-        )
-    except Exception:
-        return ""
-    try:
-        stdout, _ = proc.communicate(timeout=timeout)
+        stdout, stderr = proc.communicate(timeout=timeout)
     except Exception:
         # Timeout OR any other communicate() failure (torn-down pipe, decode
         # error): terminate the child + descendants and drain bounded. Leaving
         # it running would leak the same suspended-descendant class this guards.
-        _kill_git_process_tree(proc)
+        _kill_process_tree(proc)
         try:
             proc.communicate(timeout=1)
         except Exception:
             pass
+        return subprocess.CompletedProcess(list(argv), -1, "", "")
+    return subprocess.CompletedProcess(
+        list(argv),
+        proc.returncode if proc.returncode is not None else -1,
+        stdout or "",
+        stderr or "",
+    )
+
+
+def bounded_git_probe(argv: Sequence[str], *, timeout: float) -> str:
+    """Run a short, throwaway ``git`` probe and return stripped stdout, or ``""``
+    on ANY failure (nonzero exit, timeout, spawn error, decode error).
+
+    Thin fail-open wrapper around :func:`bounded_captured_run` for
+    ``tui_gateway.git_probe.run_git`` and ``agent.coding_context._git``.
+    """
+    try:
+        result = bounded_captured_run(argv, timeout=timeout)
+    except Exception:
         return ""
-    return stdout.strip() if proc.returncode == 0 else ""
+    return result.stdout.strip() if result.returncode == 0 else ""

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -289,6 +289,83 @@ def test_bounded_git_probe_spawn_failure_returns_empty(monkeypatch):
     assert _subprocess_compat.bounded_git_probe(["git", "-C", "/repo", "status"], timeout=1.5) == ""
 
 
+def test_bounded_captured_run_fast_path_spawn_contract_windows(monkeypatch):
+    """``bounded_captured_run`` keeps PIPE/PIPE/DEVNULL + hide flags on Windows."""
+    from hermes_cli import _subprocess_compat
+
+    spawns = []
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            spawns.append((cmd, kwargs))
+            self.returncode = 0
+
+        def communicate(self, timeout=None):
+            return ("ok\n", "warn\n")
+
+        def kill(self):  # pragma: no cover
+            raise AssertionError("kill() must not run when the child returns in time")
+
+    monkeypatch.setattr(_subprocess_compat, "IS_WINDOWS", True)
+    monkeypatch.setattr(_subprocess_compat, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+    monkeypatch.setattr(_subprocess_compat.subprocess, "Popen", _FakePopen)
+
+    result = _subprocess_compat.bounded_captured_run(
+        ["bash", "--noprofile", "--norc", "-c", "true"], timeout=15
+    )
+    assert result.returncode == 0
+    assert result.stdout == "ok\n"
+    assert result.stderr == "warn\n"
+    assert len(spawns) == 1
+    _cmd, kwargs = spawns[0]
+    assert kwargs["stdout"] == subprocess.PIPE
+    assert kwargs["stderr"] == subprocess.PIPE
+    assert kwargs["stdin"] == subprocess.DEVNULL
+    assert kwargs["text"] is True
+    assert kwargs["encoding"] == "utf-8"
+    assert kwargs["errors"] == "replace"
+    assert kwargs["creationflags"] == _CREATE_NO_WINDOW
+
+
+def test_bounded_captured_run_timeout_tree_kills_on_windows(monkeypatch):
+    """Timeout path must tree-kill + bounded drain, returning returncode=-1."""
+    from hermes_cli import _subprocess_compat
+
+    events = []
+    taskkills = []
+
+    class _HangingPopen:
+        def __init__(self, cmd, **kwargs):
+            self.returncode = None
+            self.pid = 5150
+
+        def communicate(self, timeout=None):
+            events.append(f"comm:{timeout}")
+            if timeout != 1:
+                raise subprocess.TimeoutExpired(cmd="bash", timeout=timeout)
+            return ("", "")
+
+        def kill(self):
+            events.append("kill")
+
+    def fake_run(cmd, **kwargs):
+        taskkills.append((cmd, kwargs))
+        return _Completed()
+
+    monkeypatch.setattr(_subprocess_compat, "IS_WINDOWS", True)
+    monkeypatch.setattr(_subprocess_compat, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+    monkeypatch.setattr(_subprocess_compat.subprocess, "Popen", _HangingPopen)
+    monkeypatch.setattr(_subprocess_compat.subprocess, "run", fake_run)
+
+    result = _subprocess_compat.bounded_captured_run(["bash", "-c", "true"], timeout=15)
+    assert result.returncode == -1
+    assert result.stdout == ""
+    assert result.stderr == ""
+    assert events == ["comm:15", "kill", "comm:1"]
+    kills = [c for c, _ in taskkills if c and c[0] == "taskkill"]
+    assert kills == [["taskkill", "/T", "/F", "/PID", "5150"]], taskkills
+
+
 def test_tui_gateway_git_probe_delegates_to_bounded_probe(monkeypatch):
     """run_git wires cwd/args through the shared bounded helper (hidden-window
     flags reach the spawn on Windows) and preserves its own timeout."""

--- a/tests/tools/test_find_shell.py
+++ b/tests/tools/test_find_shell.py
@@ -9,6 +9,7 @@ import os
 import platform
 import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -116,6 +117,112 @@ class TestFindBashUnchanged:
         assert len(result) > 0
 
 
+def _run_with_retained_stdin(cmd, *, env, cwd, timeout=10):
+    """Run *cmd* while keeping the stdin writer open (ACP JSON-RPC-like).
+
+    Unlike ``subprocess.run(input="")``, this does not close the pipe writer
+    until the child exits — so a nested probe that inherits stdin and reads
+    from it will hang unless it was spawned with ``stdin=DEVNULL``.
+    """
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=cwd,
+        env=env,
+    )
+    try:
+        try:
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+            stderr = proc.stderr.read() if proc.stderr else ""
+            raise AssertionError(
+                f"helper hung under retained stdin writer (stderr={stderr!r})"
+            )
+        stdout = proc.stdout.read() if proc.stdout else ""
+        stderr = proc.stderr.read() if proc.stderr else ""
+        return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
+    finally:
+        if proc.stdin:
+            proc.stdin.close()
+
+
+class TestBashStartsBoundedProbe:
+    """Windows tool startup hangs if ``_bash_starts`` uses unbounded run()."""
+
+    def test_bash_starts_uses_bounded_captured_run(self, tmp_path, monkeypatch):
+        import tools.environments.local as local_mod
+
+        bash = tmp_path / "bash"
+        bash.write_text("", encoding="utf-8")
+        bash.chmod(0o755)
+        local_mod._bash_starts_cache.clear()
+        captured: dict = {}
+
+        def _fake_bounded(argv, *, timeout, env=None):
+            captured["argv"] = list(argv)
+            captured["timeout"] = timeout
+            captured["env"] = env
+            return subprocess.CompletedProcess(list(argv), 0, "", "")
+
+        monkeypatch.setattr(local_mod, "bounded_captured_run", _fake_bounded)
+        assert local_mod._bash_starts(str(bash)) is True
+        assert captured["timeout"] == 15
+        assert captured["argv"][:3] == [str(bash), "--noprofile", "--norc"]
+        assert "-c" in captured["argv"]
+
+    def test_bash_starts_timeout_fails_open(self, tmp_path, monkeypatch):
+        import tools.environments.local as local_mod
+
+        bash = tmp_path / "bash"
+        bash.write_text("", encoding="utf-8")
+        bash.chmod(0o755)
+        local_mod._bash_starts_cache.clear()
+        local_mod._bash_probe_details_cache.clear()
+
+        def _fake_bounded(argv, *, timeout, env=None):
+            return subprocess.CompletedProcess(list(argv), -1, "", "")
+
+        monkeypatch.setattr(local_mod, "bounded_captured_run", _fake_bounded)
+        assert local_mod._bash_starts(str(bash)) is False
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="shebang fake-bash is not CreateProcess-executable on Windows",
+    )
+    def test_bash_starts_returns_under_retained_stdin(self, tmp_path):
+        """Regression: retained open stdin must not stall the bash probe."""
+        fake_bash = tmp_path / "bash"
+        fake_bash.write_text(
+            "#!{}\n"
+            "import sys\n"
+            "# Block if stdin is an open pipe with no EOF (inherited ACP stdin).\n"
+            "sys.stdin.buffer.read(1)\n"
+            "sys.exit(0)\n".format(sys.executable),
+            encoding="utf-8",
+        )
+        fake_bash.chmod(0o755)
+
+        helper = (
+            "from tools.environments.local import _bash_starts, _bash_starts_cache\n"
+            "_bash_starts_cache.clear()\n"
+            f"print(_bash_starts({str(fake_bash)!r}))\n"
+        )
+        repo_root = str(Path(__file__).resolve().parents[2])
+        proc = _run_with_retained_stdin(
+            [sys.executable, "-c", helper],
+            env={**os.environ, "PYTHONPATH": repo_root},
+            cwd=repo_root,
+            timeout=10,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert proc.stdout.strip() == "True"
+
+
 class TestFindBashSkipsBrokenCustomPath:
     """Stale HERMES_GIT_BASH_PATH must not brick Windows terminal startup."""
 
@@ -153,15 +260,16 @@ class TestGitBashExternalProgramProbe:
         local_mod._bash_probe_details_cache.clear()
         calls = []
 
-        def fake_run(argv, **kwargs):
-            calls.append((argv, kwargs))
-            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+        def fake_bounded(argv, *, timeout, env=None):
+            calls.append((list(argv), timeout, env))
+            return subprocess.CompletedProcess(list(argv), 0, stdout="", stderr="")
 
-        monkeypatch.setattr(local_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(local_mod, "bounded_captured_run", fake_bounded)
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
 
         assert local_mod._bash_starts(r"C:\Git\bin\bash.exe") is True
         assert calls[0][0][-1] == "/usr/bin/true; /usr/bin/cat --version >/dev/null"
+        assert calls[0][1] == 15
 
     def test_aslr_failure_surfaces_targeted_windows_command(
         self, tmp_path, monkeypatch

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -14,7 +14,7 @@ import time
 from pathlib import Path
 
 from tools.environments.base import BaseEnvironment, _pipe_stdin
-from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli._subprocess_compat import bounded_captured_run, windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
 
@@ -804,12 +804,14 @@ def _bash_starts(bash: str) -> bool:
         return cached
 
     try:
-        result = subprocess.run(
+        # Same Windows post-timeout deadlock class as git probes: bash -c
+        # spawns MSYS ``true``/``cat`` children; ``subprocess.run(timeout=)``
+        # can hang forever in unbounded post-kill communicate(). Use the
+        # shared bounded Popen + tree-kill + 1s drain helper instead.
+        # stdin=DEVNULL is part of that contract (ACP/TUI JSON-RPC hosts).
+        result = bounded_captured_run(
             [bash, "--noprofile", "--norc", "-c", _BASH_EXTERNAL_PROGRAM_PROBE],
-            capture_output=True,
-            text=True,
             timeout=15,
-            creationflags=windows_hide_flags() if _IS_WINDOWS else 0,
         )
         ok = result.returncode == 0
         if not ok:


### PR DESCRIPTION
## What does this PR do?

On Windows, `_bash_starts` used `subprocess.run(..., timeout=15)` to probe Git Bash.
After a timeout, `run()`'s post-kill cleanup does an *unbounded* `communicate()`. If a
suspended MSYS child (`true` / `cat`) still holds the captured pipe handles, the
reader-thread join blocks forever — so the first terminal/file tool call can hang
session/tool startup.

This matches the deadlock class already fixed for git probes in #68997. This PR
extracts a shared `bounded_captured_run` (Popen + tree-kill + bounded 1s drain,
`stdin=DEVNULL`) and routes `_bash_starts` through it. `bounded_git_probe` becomes a
thin fail-open wrapper on the same helper.

## Related Issue

Related to #68609 / #66037 (same Windows post-kill pipe-drain deadlock class).
Supersedes the closed #67499 approach (stdin-only) with the full bounded cleanup.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/_subprocess_compat.py` — add `bounded_captured_run`; refactor `bounded_git_probe` onto it; generalize process-tree kill helper
- `tools/environments/local.py` — `_bash_starts()` uses `bounded_captured_run` instead of `subprocess.run(timeout=...)`
- `tests/test_windows_subprocess_no_window_flags.py` — spawn contract + Windows tree-kill coverage for `bounded_captured_run`
- `tests/tools/test_find_shell.py` — `_bash_starts` uses bounded helper; timeout fails open; retained-stdin regression (POSIX)

## How to Test

1. `scripts/run_tests.sh tests/tools/test_find_shell.py tests/test_windows_subprocess_no_window_flags.py -q`
2. Unit: mock `Popen` / `bounded_captured_run` and assert timeout path tree-kills + returns `returncode=-1` without hanging
3. Manual (Windows): force a slow/stuck Git Bash probe path; tool startup must return within the probe budget instead of hanging forever

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 unit + WSL `run_tests.sh` for the two files above

### Documentation & Housekeeping

- [x] Documentation - N/A
- [x] `cli-config.yaml.example` - N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` - N/A
- [x] Cross-platform impact considered - yes (Windows hang fix; POSIX probes unchanged in behavior)
- [x] Tool descriptions/schemas - N/A

## Screenshots / Logs

N/A — hang is absence of progress after probe timeout; covered by bounded cleanup unit tests.
