### PR TITLE
fix(gateway): make launchd restart PID-safe

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1960,6 +1960,27 @@ from gateway.whatsapp_identity import (
 logger = logging.getLogger(__name__)
 
 
+def _log_external_restart_initiator() -> None:
+    try:
+        from gateway.status import consume_external_restart_request_for_self
+
+        initiator = consume_external_restart_request_for_self()
+    except (OSError, ValueError) as exc:
+        logger.debug("External restart initiator marker check failed: %s", exc)
+        return
+    if initiator is None:
+        return
+    logger.info(
+        "External restart initiator: request_id=%s caller_pid=%s caller_ppid=%s "
+        "argv_classification=%s requested_at=%s",
+        initiator.request_id,
+        initiator.caller_pid,
+        initiator.caller_ppid,
+        initiator.argv_classification,
+        initiator.requested_at,
+    )
+
+
 _OWN_POLICY_OPEN_ENV = {
     Platform.WECOM: ("WECOM_DM_POLICY", "WECOM_GROUP_POLICY", "WECOM_ALLOW_ALL_USERS"),
     Platform.WEIXIN: ("WEIXIN_DM_POLICY", "WEIXIN_GROUP_POLICY", "WEIXIN_ALLOW_ALL_USERS"),
@@ -22706,6 +22727,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # Set up signal handlers
     def shutdown_signal_handler(received_signal=None):
         nonlocal _signal_initiated_shutdown
+        _log_external_restart_initiator()
         # Planned --replace takeover check: when a sibling gateway is
         # taking over via --replace, it wrote a marker naming this PID
         # before sending SIGTERM. If present, treat the signal as a
@@ -22800,6 +22822,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         asyncio.create_task(runner.stop())
 
     def restart_signal_handler():
+        _log_external_restart_initiator()
         runner.request_restart(detached=False, via_service=True)
     
     loop = asyncio.get_running_loop()

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -21,10 +21,12 @@ import subprocess
 import sys
 import threading
 import time
+import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from hermes_constants import get_hermes_home, _get_platform_default_hermes_home
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple, Optional, Sequence
 from utils import atomic_json_write
 
 if sys.platform == "win32":
@@ -1427,6 +1429,20 @@ _TAKEOVER_MARKER_FILENAME = ".gateway-takeover.json"
 _TAKEOVER_MARKER_TTL_S = 60  # Marker older than this is treated as stale
 _PLANNED_STOP_MARKER_FILENAME = ".gateway-planned-stop.json"
 _PLANNED_STOP_MARKER_TTL_S = 60
+_EXTERNAL_RESTART_MARKER_FILENAME = ".gateway-restart-request.json"
+_EXTERNAL_RESTART_MARKER_TTL_S = 300
+_RESTART_ARGV_CLASSIFICATIONS = frozenset(
+    {"gateway_restart", "update", "setup", "service_manager", "other"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalRestartInitiator:
+    request_id: str
+    caller_pid: int
+    caller_ppid: int
+    argv_classification: str
+    requested_at: str
 
 
 def _get_takeover_marker_path(hermes_home: Optional[Path] = None) -> Path:
@@ -1445,6 +1461,23 @@ def _get_planned_stop_marker_path() -> Path:
     return home / _PLANNED_STOP_MARKER_FILENAME
 
 
+def _get_external_restart_marker_path() -> Path:
+    return _get_process_hermes_home() / _EXTERNAL_RESTART_MARKER_FILENAME
+
+
+def _classify_restart_argv(argv: Sequence[str]) -> str:
+    tokens = {token.lower() for token in argv[1:]}
+    if "update" in tokens:
+        return "update"
+    if "setup" in tokens:
+        return "setup"
+    if "gateway" in tokens and "restart" in tokens:
+        return "gateway_restart"
+    if "service" in tokens and "restart" in tokens:
+        return "service_manager"
+    return "other"
+
+
 def _marker_is_stale(written_at: str, ttl_s: int) -> bool:
     try:
         written_dt = datetime.fromisoformat(written_at)
@@ -1454,16 +1487,16 @@ def _marker_is_stale(written_at: str, ttl_s: int) -> bool:
         return True
 
 
-def _consume_pid_marker_for_self(
+def _consume_pid_marker_record_for_self(
     path: Path,
     *,
     pid_field: str,
     start_time_field: str,
     ttl_s: int,
-) -> bool:
+) -> dict[str, Any] | None:
     record = _read_json_file(path)
     if not record:
-        return False
+        return None
 
     try:
         target_pid = int(record[pid_field])
@@ -1474,14 +1507,14 @@ def _consume_pid_marker_for_self(
             path.unlink(missing_ok=True)
         except OSError:
             pass
-        return False
+        return None
 
     if _marker_is_stale(written_at, ttl_s):
         try:
             path.unlink(missing_ok=True)
         except OSError:
             pass
-        return False
+        return None
 
     # Cross-profile guard (#29092): new markers explicitly name the verified
     # TARGET home.  That permits a deliberate cross-HERMES_HOME --replace while
@@ -1494,13 +1527,13 @@ def _consume_pid_marker_for_self(
         if not isinstance(target_home, str) or not _same_hermes_home(
             target_home, our_home
         ):
-            return False
+            return None
     else:
         replacer_home = record.get("replacer_hermes_home")
         if replacer_home is not None and not _same_hermes_home(
             replacer_home, our_home
         ):
-            return False
+            return None
 
     our_pid = os.getpid()
     our_start_time = _get_process_start_time(our_pid)
@@ -1528,7 +1561,25 @@ def _consume_pid_marker_for_self(
     except OSError:
         pass
 
-    return matches
+    return record if matches else None
+
+
+def _consume_pid_marker_for_self(
+    path: Path,
+    *,
+    pid_field: str,
+    start_time_field: str,
+    ttl_s: int,
+) -> bool:
+    return (
+        _consume_pid_marker_record_for_self(
+            path,
+            pid_field=pid_field,
+            start_time_field=start_time_field,
+            ttl_s=ttl_s,
+        )
+        is not None
+    )
 
 
 def write_takeover_marker(
@@ -2001,6 +2052,81 @@ def clear_planned_stop_marker() -> None:
         _get_planned_stop_marker_path().unlink(missing_ok=True)
     except OSError:
         pass
+
+
+def write_external_restart_request(
+    target_pid: int, *, argv: Sequence[str] | None = None
+) -> bool:
+    """Persist safe caller evidence before requesting an external restart."""
+    try:
+        record = {
+            "target_pid": target_pid,
+            "target_start_time": _get_process_start_time(target_pid),
+            "request_id": uuid.uuid4().hex,
+            "caller_pid": os.getpid(),
+            "caller_ppid": os.getppid(),
+            "argv_classification": _classify_restart_argv(
+                sys.argv if argv is None else argv
+            ),
+            "written_at": _utc_now_iso(),
+        }
+        _write_json_file(_get_external_restart_marker_path(), record)
+        return True
+    except (OSError, PermissionError):
+        return False
+
+
+def consume_external_restart_request_for_self() -> ExternalRestartInitiator | None:
+    """Consume a fresh restart marker that targets the current process."""
+    path = _get_external_restart_marker_path()
+    claimed_path = path.with_name(f"{path.name}.{uuid.uuid4().hex}.claim")
+    try:
+        os.replace(path, claimed_path)
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return None
+    try:
+        record = _consume_pid_marker_record_for_self(
+            claimed_path,
+            pid_field="target_pid",
+            start_time_field="target_start_time",
+            ttl_s=_EXTERNAL_RESTART_MARKER_TTL_S,
+        )
+        if record is None:
+            return None
+        try:
+            request_id = str(record["request_id"])
+            caller_pid = int(record["caller_pid"])
+            caller_ppid = int(record["caller_ppid"])
+            argv_classification = str(record["argv_classification"])
+            requested_at = str(record["written_at"])
+            request_id_is_valid = uuid.UUID(request_id).hex == request_id
+        except (KeyError, TypeError, ValueError, AttributeError):
+            return None
+
+        valid = (
+            request_id_is_valid
+            and caller_pid > 0
+            and caller_ppid >= 0
+            and argv_classification in _RESTART_ARGV_CLASSIFICATIONS
+        )
+        if not valid:
+            return None
+        return ExternalRestartInitiator(
+            request_id=request_id,
+            caller_pid=caller_pid,
+            caller_ppid=caller_ppid,
+            argv_classification=argv_classification,
+            requested_at=requested_at,
+        )
+    except OSError:
+        return None
+    finally:
+        try:
+            claimed_path.unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 def get_running_pid(

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -277,6 +277,9 @@ def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
         return False
     if pid <= 0:
         return False
+    from gateway.status import write_external_restart_request
+
+    write_external_restart_request(pid)
     try:
         os.kill(pid, signal.SIGUSR1)  # windows-footgun: ok — POSIX signal, guarded by hasattr(signal, 'SIGUSR1') above
     except ProcessLookupError:
@@ -4347,30 +4350,40 @@ def launchd_stop():
 
 
 def _wait_for_gateway_exit(
-    timeout: float = 10.0, force_after: float | None = 5.0
+    timeout: float = 10.0,
+    force_after: float | None = 5.0,
+    *,
+    target_pid: int | None = None,
+    target_start_time: int | None = None,
 ) -> bool:
-    """Wait for the gateway process (by saved PID) to exit.
+    """Wait for one captured gateway PID to exit.
 
-    Uses the PID from the gateway.pid file — not launchd labels — so this
-    works correctly when multiple gateway instances run under separate
-    HERMES_HOME directories.
+    Capturing once prevents a service-manager replacement from retargeting
+    the wait or force-kill through a rewritten gateway.pid file.
 
     Args:
         timeout: Total seconds to wait before giving up.
         force_after: Seconds of graceful waiting before escalating to force-kill.
     """
     import time
-    from gateway.status import get_running_pid
+    from gateway.status import get_process_start_time, get_running_pid
+
+    pid = target_pid if target_pid is not None else get_running_pid()
+    if pid is None:
+        return True
+    if target_pid is None:
+        target_start_time = get_process_start_time(pid)
 
     deadline = time.monotonic() + timeout
     force_deadline = (
-        (time.monotonic() + force_after) if force_after is not None else None
+        time.monotonic() + force_after
+        if force_after is not None
+        else float("inf")
     )
     force_sent = False
 
     while time.monotonic() < deadline:
-        pid = get_running_pid()
-        if pid is None:
+        if not _gateway_process_matches(pid, target_start_time):
             return True  # Process exited cleanly.
 
         if (
@@ -4379,6 +4392,8 @@ def _wait_for_gateway_exit(
             and time.monotonic() >= force_deadline
         ):
             # Grace period expired — force-kill the specific PID.
+            if not _gateway_process_matches(pid, target_start_time):
+                return True
             try:
                 terminate_pid(pid, force=True)
                 print(f"⚠ Gateway PID {pid} did not exit gracefully; sent SIGKILL")
@@ -4389,23 +4404,40 @@ def _wait_for_gateway_exit(
         time.sleep(0.3)
 
     # Timed out even after force-kill.
-    remaining_pid = get_running_pid()
-    if remaining_pid is not None:
+    if _gateway_process_matches(pid, target_start_time):
         print(
-            f"⚠ Gateway PID {remaining_pid} still running after {timeout}s — restart may fail"
+            f"⚠ Gateway PID {pid} still running after {timeout}s — restart may fail"
         )
         return False
     return True
+
+
+def _gateway_process_matches(pid: int, start_time: int | None) -> bool:
+    from gateway.status import _pid_exists, get_process_start_time
+
+    if not _pid_exists(pid):
+        return False
+    if start_time is None:
+        return True
+    current_start_time = get_process_start_time(pid)
+    return current_start_time is None or current_start_time == start_time
 
 
 def launchd_restart():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
     drain_timeout = _get_restart_drain_timeout()
-    from gateway.status import get_running_pid
+    from gateway.status import (
+        get_process_start_time,
+        get_running_pid,
+        write_external_restart_request,
+    )
 
     try:
         pid = get_running_pid()
+        start_time = get_process_start_time(pid) if pid is not None else None
+        if pid is not None:
+            write_external_restart_request(pid)
         if pid is not None and _request_gateway_self_restart(pid):
             print("✓ Service restart requested")
             _clear_launchd_unsupported_marker()
@@ -4426,12 +4458,22 @@ def launchd_restart():
             except (ProcessLookupError, PermissionError, OSError):
                 pid = None
             if pid is not None:
-                exited = _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
+                exited = _wait_for_gateway_exit(
+                    timeout=drain_timeout,
+                    force_after=None,
+                    target_pid=pid,
+                    target_start_time=start_time,
+                )
                 if not exited:
                     print(
                         f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart"
                     )
-        subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
+                    if _gateway_process_matches(pid, start_time):
+                        try:
+                            terminate_pid(pid, force=True)
+                        except (ProcessLookupError, PermissionError, OSError):
+                            pass
+        subprocess.run(["launchctl", "kickstart", target], check=True, timeout=90)
         print("✓ Service restarted")
         _clear_launchd_unsupported_marker()
     except subprocess.CalledProcessError as e:
@@ -7171,6 +7213,14 @@ def _gateway_command_inner(args):
                 sys.exit(1)
 
             # Manual restart: stop only this profile's gateway
+            from gateway.status import (
+                get_running_pid,
+                write_external_restart_request,
+            )
+
+            running_pid = get_running_pid()
+            if running_pid is not None:
+                write_external_restart_request(running_pid)
             if stop_profile_gateway():
                 print("✓ Stopped gateway for this profile")
 

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1659,6 +1659,11 @@ def restart() -> None:
     doesn't produce a running gateway.
     """
     _assert_windows()
+    from gateway.status import get_running_pid, write_external_restart_request
+
+    pid = get_running_pid()
+    if pid is not None:
+        write_external_restart_request(pid)
 
     stop()
 

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -918,6 +918,11 @@ class S6ServiceManager:
             GatewayNotRegisteredError: no service directory for ``name``.
             S6CommandError: s6-svc exited non-zero for any other reason.
         """
+        pid = self._supervised_pid(name)
+        if pid is not None:
+            from gateway.status import write_external_restart_request
+
+            write_external_restart_request(pid)
         self._run_svc("-t", "restart", name)
         _write_gateway_desired_state(name, "running")
 

--- a/tests/gateway/test_external_restart_initiator.py
+++ b/tests/gateway/test_external_restart_initiator.py
@@ -1,0 +1,79 @@
+import logging
+import os
+
+from gateway import run as gateway_run
+from gateway import status
+
+
+def test_external_restart_initiator_round_trips_into_shutdown_log(
+    tmp_path, monkeypatch, caplog
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 42)
+
+    status.write_external_restart_request(
+        os.getpid(),
+        argv=["hermes", "gateway", "restart", "--token", "super-secret"],
+    )
+    marker = tmp_path / ".gateway-restart-request.json"
+    persisted = marker.read_text(encoding="utf-8")
+    assert "super-secret" not in persisted
+    assert "--token" not in persisted
+
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        gateway_run._log_external_restart_initiator()
+
+    assert not marker.exists()
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert f"caller_pid={os.getpid()}" in message
+    assert f"caller_ppid={os.getppid()}" in message
+    assert "argv_classification=gateway_restart" in message
+    assert "request_id=" in message
+    assert "requested_at=" in message
+    assert "super-secret" not in message
+
+
+def test_external_restart_consume_preserves_marker_written_after_claim(
+    tmp_path, monkeypatch
+):
+    # Given: a restart marker and a newer writer that runs immediately after
+    # the consumer reads the claimed marker.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 42)
+    status.write_external_restart_request(
+        os.getpid(), argv=["hermes", "gateway", "restart"]
+    )
+    marker = tmp_path / ".gateway-restart-request.json"
+    real_read_json_file = status._read_json_file
+    wrote_new_marker = False
+    claimed_paths = []
+
+    def read_then_write_new_marker(path):
+        nonlocal wrote_new_marker
+        claimed_paths.append(path)
+        record = real_read_json_file(path)
+        if not wrote_new_marker:
+            wrote_new_marker = True
+            status.write_external_restart_request(
+                os.getpid(), argv=["hermes", "update"]
+            )
+        return record
+
+    monkeypatch.setattr(status, "_read_json_file", read_then_write_new_marker)
+
+    # When: the original marker is consumed.
+    original = status.consume_external_restart_request_for_self()
+
+    # Then: the newer canonical marker survives and remains consumable.
+    assert original is not None
+    assert original.argv_classification == "gateway_restart"
+    assert marker.exists()
+    newer = status.consume_external_restart_request_for_self()
+    assert newer is not None
+    assert newer.argv_classification == "update"
+    assert not marker.exists()
+    assert len(claimed_paths) == 2
+    assert claimed_paths[0].parent == marker.parent
+    assert claimed_paths[1].parent == marker.parent
+    assert claimed_paths[0] != claimed_paths[1]

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -645,6 +645,35 @@ def test_gateway_restart_on_windows_preserves_failure_fallback(monkeypatch):
     assert calls == ["restart", "stop", "wait", "run"]
 
 
+def test_unmanaged_gateway_restart_writes_initiator_before_stop(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "is_windows", lambda: False)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+    monkeypatch.setattr(
+        "gateway.status.write_external_restart_request",
+        lambda pid: calls.append(("marker", pid)) or True,
+    )
+    monkeypatch.setattr(
+        gateway,
+        "stop_profile_gateway",
+        lambda: calls.append(("stop", 321)) or True,
+    )
+    monkeypatch.setattr(gateway, "_wait_for_gateway_exit", lambda **kwargs: None)
+    monkeypatch.setattr(gateway, "run_gateway", lambda **kwargs: calls.append(("run", 321)))
+
+    args = SimpleNamespace(gateway_command="restart", system=False, all=False)
+    gateway.gateway_command(args)
+
+    assert calls == [
+        ("marker", 321),
+        ("stop", 321),
+        ("run", 321),
+    ]
+
+
 def test_systemd_status_warns_when_linger_disabled(monkeypatch, tmp_path, capsys):
     unit_path = tmp_path / "hermes-gateway.service"
     unit_path.write_text("[Unit]\n")
@@ -1149,16 +1178,16 @@ class TestWaitForGatewayExit:
         """Process exits after a couple of polls — no SIGKILL needed."""
         poll_count = 0
 
-        def mock_get_running_pid():
+        def mock_pid_exists(pid):
             nonlocal poll_count
             poll_count += 1
-            return 12345 if poll_count <= 2 else None
+            return poll_count <= 2
 
-        monkeypatch.setattr("gateway.status.get_running_pid", mock_get_running_pid)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 12345)
+        monkeypatch.setattr("gateway.status._pid_exists", mock_pid_exists)
         monkeypatch.setattr("time.sleep", lambda _: None)
 
         gateway._wait_for_gateway_exit(timeout=10.0, force_after=999.0)
-        # Should have polled until None was returned.
         assert poll_count == 3
 
     def test_force_kills_after_grace_period(self, monkeypatch):
@@ -1177,13 +1206,10 @@ class TestWaitForGatewayExit:
         def mock_terminate(pid, force=False):
             kills.append((pid, force))
 
-        # get_running_pid returns the PID until kill is sent, then None
-        def mock_get_running_pid():
-            return None if kills else 42
-
         monkeypatch.setattr("time.monotonic", fake_monotonic)
         monkeypatch.setattr("time.sleep", lambda _: None)
-        monkeypatch.setattr("gateway.status.get_running_pid", mock_get_running_pid)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 42)
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: not kills)
         monkeypatch.setattr(gateway, "terminate_pid", mock_terminate)
 
         gateway._wait_for_gateway_exit(timeout=10.0, force_after=5.0)
@@ -1204,6 +1230,7 @@ class TestWaitForGatewayExit:
         monkeypatch.setattr("time.monotonic", fake_monotonic)
         monkeypatch.setattr("time.sleep", lambda _: None)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: 99)
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
         monkeypatch.setattr(gateway, "terminate_pid", mock_terminate)
 
         # Should not raise — ProcessLookupError means it's already gone.

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -624,6 +624,10 @@ class TestGatewayStopCleanup:
 
 
 class TestLaunchdServiceRecovery:
+    @pytest.fixture(autouse=True)
+    def _isolate_external_restart_marker(self, monkeypatch):
+        monkeypatch.setattr(status, "write_external_restart_request", lambda pid: True)
+
     def test_get_restart_drain_timeout_prefers_env_then_config_then_default(self, monkeypatch):
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
         monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})
@@ -854,7 +858,7 @@ class TestLaunchdServiceRecovery:
 
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
-        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda **kwargs: True)
         monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: calls.append(("term", pid, force)))
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
@@ -871,7 +875,7 @@ class TestLaunchdServiceRecovery:
 
         assert calls == [
             ("term", 321, False),
-            ["launchctl", "kickstart", "-k", target],
+            ["launchctl", "kickstart", target],
         ]
         # The drain can silently hold for the full budget (180s default); the
         # desktop updater streams this output as its only progress feedback,
@@ -902,6 +906,137 @@ class TestLaunchdServiceRecovery:
 
         assert calls == [("self", 321)]
         assert "restart requested" in capsys.readouterr().out.lower()
+
+    def test_launchd_restart_does_not_kill_keepalive_replacement(
+        self, monkeypatch
+    ):
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+        running_pid = 321
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 0.0)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: running_pid)
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+
+        def fake_terminate(pid, force=False):
+            nonlocal running_pid
+            calls.append(("term", pid, force))
+            if pid == 321 and not force:
+                running_pid = 654
+
+        monkeypatch.setattr(gateway_cli, "terminate_pid", fake_terminate)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, **kwargs: calls.append(cmd)
+            or SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [
+            ("term", 321, False),
+            ["launchctl", "kickstart", target],
+        ]
+
+    def test_launchd_restart_does_not_kill_reused_pid(self, monkeypatch):
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+        calls = []
+        start_times = iter((100, 200))
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 0.0)
+        monkeypatch.setattr(
+            gateway_cli, "_request_gateway_self_restart", lambda pid: False
+        )
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
+        monkeypatch.setattr(
+            "gateway.status.get_process_start_time", lambda pid: next(start_times)
+        )
+        monkeypatch.setattr(
+            "gateway.status.write_external_restart_request", lambda pid: True
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "terminate_pid",
+            lambda pid, force=False: calls.append(("term", pid, force)),
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, **kwargs: calls.append(cmd)
+            or SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [
+            ("term", 321, False),
+            ["launchctl", "kickstart", target],
+        ]
+
+    def test_launchd_restart_force_kills_only_original_pid_after_drain_timeout(
+        self, monkeypatch
+    ):
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 180.0)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 654)
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
+        monkeypatch.setattr(
+            "gateway.status.get_process_start_time", lambda pid: None
+        )
+
+        def fake_wait(*, timeout, force_after, target_pid, target_start_time):
+            calls.append(
+                ("wait", target_pid, target_start_time, timeout, force_after)
+            )
+            return False
+
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", fake_wait)
+        monkeypatch.setattr(
+            gateway_cli,
+            "terminate_pid",
+            lambda pid, force=False: calls.append(("term", pid, force)),
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, **kwargs: calls.append(cmd)
+            or SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [
+            ("term", 654, False),
+            ("wait", 654, None, 180.0, None),
+            ("term", 654, True),
+            ["launchctl", "kickstart", target],
+        ]
+
+    def test_launchd_restart_writes_initiator_before_self_restart_signal(
+        self, monkeypatch
+    ):
+        calls = []
+
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+        monkeypatch.setattr(
+            "gateway.status.write_external_restart_request",
+            lambda pid: calls.append(("marker", pid)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda pid: calls.append(("signal", pid)) or True,
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [("marker", 321), ("signal", 321)]
 
     def test_launchd_stop_uses_bootout_not_kill(self, monkeypatch):
         """launchd_stop must bootout the service so KeepAlive doesn't respawn it."""
@@ -1112,12 +1247,12 @@ class TestLaunchdServiceRecovery:
 
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
         monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
-        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda **kwargs: True)
         monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
 
         def fake_run(cmd, check=False, **kwargs):
-            if cmd == ["launchctl", "kickstart", "-k", target]:
+            if cmd == ["launchctl", "kickstart", target]:
                 raise gateway_cli.subprocess.CalledProcessError(
                     5, cmd, stderr="Input/output error"
                 )
@@ -1148,7 +1283,7 @@ class TestLaunchdServiceRecovery:
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
         monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
         monkeypatch.setattr(
-            gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True
+            gateway_cli, "_wait_for_gateway_exit", lambda **kwargs: True
         )
         monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
@@ -1158,7 +1293,7 @@ class TestLaunchdServiceRecovery:
         def fake_run(cmd, check=False, **kwargs):
             if cmd and cmd[0] == "launchctl":
                 calls.append(cmd)
-            if cmd == ["launchctl", "kickstart", "-k", target]:
+            if cmd == ["launchctl", "kickstart", target] and calls.count(cmd) == 1:
                 raise gateway_cli.subprocess.CalledProcessError(
                     3, cmd, stderr="Could not find service"
                 )
@@ -1169,7 +1304,7 @@ class TestLaunchdServiceRecovery:
         gateway_cli.launchd_restart()
 
         assert calls == [
-            ["launchctl", "kickstart", "-k", target],
+            ["launchctl", "kickstart", target],
             ["launchctl", "bootout", target],
             ["launchctl", "bootstrap", domain, str(plist_path)],
             ["launchctl", "kickstart", target],
@@ -1539,6 +1674,26 @@ class TestGatewayServiceDetection:
         assert gateway_cli._is_service_running() is False
 
 class TestGatewaySystemServiceRouting:
+    def test_graceful_restart_writes_initiator_before_sigusr1(self, monkeypatch):
+        calls = []
+
+        monkeypatch.setattr(
+            "gateway.status.write_external_restart_request",
+            lambda pid: calls.append(("marker", pid)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli.os,
+            "kill",
+            lambda pid, sig: calls.append(("signal", pid, sig)),
+        )
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+
+        assert gateway_cli._graceful_restart_via_sigusr1(654, 17.0) is True
+        assert calls == [
+            ("marker", 654),
+            ("signal", 654, gateway_cli.signal.SIGUSR1),
+        ]
+
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):
         calls = []
 

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -702,6 +702,41 @@ def test_uninstall_access_denied_declined_keeps_task_and_cleans_files(monkeypatc
 # ---------------------------------------------------------------------------
 
 
+def test_restart_writes_initiator_before_stopping_running_gateway(monkeypatch):
+    events = []
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(
+        "gateway.status.get_running_pid",
+        lambda: 99999,
+    )
+    monkeypatch.setattr(
+        "gateway.status.write_external_restart_request",
+        lambda pid: events.append(("marker", pid)) or True,
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "stop",
+        lambda: events.append(("stop", 99999)),
+    )
+    monkeypatch.setattr(gateway_windows, "_wait_for_gateway_absent", lambda **kwargs: True)
+    monkeypatch.setattr(gateway_windows.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        gateway_windows,
+        "start",
+        lambda: events.append(("start", 99999)),
+    )
+    monkeypatch.setattr(gateway_windows, "_wait_for_gateway_ready", lambda **kwargs: True)
+
+    gateway_windows.restart()
+
+    assert events == [
+        ("marker", 99999),
+        ("stop", 99999),
+        ("start", 99999),
+    ]
+
+
 def test_stop_writes_planned_stop_marker_before_killing(monkeypatch):
     """stop() must write the planned-stop marker BEFORE any kill signal.
 

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -1072,6 +1072,32 @@ def test_s6_stop_writes_planned_stop_marker(monkeypatch, s6_scandir):
     ), f"s6-svc -d not invoked; saw: {svc_calls}"
 
 
+def test_s6_restart_writes_initiator_before_restart_signal(monkeypatch, s6_scandir):
+    import subprocess as _sp
+
+    (s6_scandir / "gateway-coder").mkdir()
+    events = []
+
+    def _fake(cmd, **kw):
+        command = list(cmd)
+        executable = command[0].removeprefix("/command/")
+        if executable == "s6-svstat":
+            return _sp.CompletedProcess(cmd, 0, "up (pid 9090) 5 seconds\n", "")
+        if executable == "s6-svc":
+            events.append(("signal", command[1]))
+        return _sp.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("subprocess.run", _fake)
+    monkeypatch.setattr(
+        "gateway.status.write_external_restart_request",
+        lambda pid: events.append(("marker", pid)) or True,
+    )
+
+    S6ServiceManager(scandir=s6_scandir).restart("gateway-coder")
+
+    assert events == [("marker", 9090), ("signal", "-t")]
+
+
 def test_s6_stop_tolerates_marker_write_failure(monkeypatch, s6_scandir):
     """A marker-write failure must not block the stop (best-effort)."""
     import subprocess as _sp


### PR DESCRIPTION
## Summary
- bind launchd drain and forced termination to the original PID plus process start-time identity
- replace `launchctl kickstart -k` with non-destructive `kickstart`, so KeepAlive replacements survive
- record and atomically consume redacted external-restart initiator evidence across service paths

## Verification
- launchd PID-race regressions: 9 passed
- attribution + Windows/S6 regressions: 109 passed
- gateway CLI tests: 58 passed
- Ruff, compileall, and `git diff --check`: passed

No live gateway restart performed.