### PR TITLE
feat(kilocode): expose Auto Efficient in model picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -495,6 +495,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "openai/gpt-5.4",
         "google/gemini-3-pro-preview",
         "google/gemini-3-flash-preview",
+        "kilo-auto/efficient",
     ],
     # Alibaba DashScope Coding platform (coding-intl) — default endpoint.
     # Supports Qwen models + third-party providers (GLM, Kimi, MiniMax).

--- a/tests/hermes_cli/test_kilocode_auto_efficient.py
+++ b/tests/hermes_cli/test_kilocode_auto_efficient.py
@@ -1,0 +1,80 @@
+"""Regression coverage for Kilo Auto Efficient model discovery."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.model_normalize import normalize_model_for_provider
+from hermes_cli.model_switch import list_authenticated_providers
+from hermes_cli.models import provider_model_ids, validate_requested_model
+
+
+@pytest.mark.parametrize(
+    "models_dev_models",
+    [[], ["anthropic/claude-sonnet-4.6"]],
+)
+def test_kilocode_catalog_keeps_auto_efficient(models_dev_models):
+    """The curated Kilo model remains available when models.dev omits it."""
+    with (
+        patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": "", "base_url": "https://api.kilo.ai/api/gateway"},
+        ),
+        patch(
+            "agent.models_dev.list_agentic_models",
+            return_value=models_dev_models,
+        ),
+    ):
+        models = provider_model_ids("kilocode")
+
+    assert "kilo-auto/efficient" in models
+
+
+def test_kilocode_picker_includes_auto_efficient():
+    """Authenticated Kilo users can discover Auto Efficient in the picker."""
+    with (
+        patch.dict(os.environ, {"KILOCODE_API_KEY": "test-key"}, clear=True),
+        patch(
+            "agent.models_dev.fetch_models_dev",
+            return_value={"kilo": {"env": ["KILOCODE_API_KEY"]}},
+        ),
+        patch(
+            "agent.models_dev.list_agentic_models",
+            return_value=["anthropic/claude-sonnet-4.6"],
+        ),
+        patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": "", "base_url": "https://api.kilo.ai/api/gateway"},
+        ),
+        patch("hermes_cli.models.get_curated_nous_model_ids", return_value=[]),
+        patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            side_effect=provider_model_ids,
+        ),
+    ):
+        rows = list_authenticated_providers(
+            current_provider="kilocode",
+            max_models=None,
+        )
+
+    kilo = next(row for row in rows if row["slug"] == "kilocode")
+    assert "kilo-auto/efficient" in kilo["models"]
+
+
+def test_kilocode_auto_efficient_is_valid_and_preserved():
+    """Validation accepts the Kilo-managed model ID without rewriting it."""
+    requested = "kilo-auto/efficient"
+    normalized = normalize_model_for_provider(requested, "kilocode")
+
+    with patch(
+        "hermes_cli.models.fetch_api_models",
+        return_value=["anthropic/claude-sonnet-4.6"],
+    ):
+        result = validate_requested_model(normalized, "kilocode")
+
+    assert normalized == requested
+    assert result["accepted"] is True
+    assert result["persist"] is True
+    assert result["recognized"] is True
+    assert "corrected_model" not in result

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -259,6 +259,10 @@ hermes chat --provider tencent-tokenhub --model hy3-preview
 hermes chat --provider arcee --model trinity-large-thinking
 # Requires: ARCEEAI_API_KEY in ~/.hermes/.env
 
+# Kilo Code (Auto Efficient routing)
+hermes chat --provider kilocode --model kilo-auto/efficient
+# Requires: KILOCODE_API_KEY in ~/.hermes/.env
+
 # GMI Cloud
 # Use the exact model ID returned by GMI's /v1/models endpoint.
 hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
@@ -266,6 +270,8 @@ hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
 ```
 
 Fireworks uses its native slash-form catalog IDs, such as `accounts/fireworks/models/kimi-k2p6`. Run `hermes model`, choose **Fireworks AI**, and select from the live catalog or enter another Fireworks model ID. The default endpoint is `https://api.fireworks.ai/inference/v1`; configure a different endpoint through `model.base_url` in `config.yaml`, not `.env`.
+
+`kilo-auto/efficient` is a Kilo-managed routing tier. Kilo chooses the underlying model for each request, so the model used may change over time.
 
 Or set the provider permanently in `config.yaml`:
 ```yaml


### PR DESCRIPTION
Fixes #68213

## What does this PR do?

Adds Kilo Auto Efficient (`kilo-auto/efficient`) to the Kilo Code model picker.

Kilo's live catalog and models.dev may not list this managed routing tier. Hermes now keeps it in the curated Kilo catalog, so users can still discover, select, and validate it. Existing Kilo model order stays unchanged.

## Related Issue

Fixes #68213

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `kilo-auto/efficient` to the curated Kilo Code model list without changing the existing model order.
- Keep the model visible when models.dev is unavailable or does not list it.
- Verify that the picker includes the model and validation preserves the exact model ID.
- Document the CLI command and explain that Kilo chooses the underlying model.

## How to Test

1. Add `KILOCODE_API_KEY` to `~/.hermes/.env`.
2. Run `hermes model` and choose Kilo Code.
3. Confirm `kilo-auto/efficient` appears in the model list.

Verification run locally:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kilocode_auto_efficient.py tests/hermes_cli/test_models_dev_preferred_merge.py tests/hermes_cli/test_overlay_slug_resolution.py tests/hermes_cli/test_model_validation.py -q
# 114 passed

scripts/run_tests.sh tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_doctor.py tests/hermes_cli/test_inventory.py tests/hermes_cli/test_models.py tests/hermes_cli/test_provider_catalog.py tests/hermes_cli/test_web_server.py -q
# 888 passed

ruff check hermes_cli/models.py tests/hermes_cli/test_kilocode_auto_efficient.py
# All checks passed (Ruff 0.15.10)

python scripts/check-windows-footguns.py --diff origin/main
# No Windows footguns found

git diff --check
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, focused pytest

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update is N/A; no architecture or workflow changed
- [x] Cross-platform impact is N/A; this only changes a model catalog entry, tests, and documentation
- [x] Tool description/schema update is N/A
