### PR TITLE
fix(state): drop orphan FTS triggers on startup to prevent silent message persist failures

### DIFF
--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -135,6 +135,55 @@ class SessionSchemaMixin:
         ).fetchone()
         return int(row[0] if not isinstance(row, sqlite3.Row) else row[0])
 
+    @staticmethod
+    def _drop_orphan_fts_triggers(cursor: sqlite3.Cursor) -> bool:
+        """Drop non-canonical triggers that write to a Hermes FTS table.
+
+        Legacy code paths or manual DDL may have created duplicate triggers
+        under alternate names (e.g. messages_ai, messages_ad) that write to
+        the same FTS virtual table as the canonical triggers. Two triggers
+        writing to the same FTS5 table on every INSERT causes constraint
+        failures that roll back the entire transaction, making message
+        persistence silently fail.
+
+        Only triggers whose SQL references one of Hermes' FTS virtual tables
+        are eligible for removal; unrelated application triggers on messages
+        must survive startup cleanup.
+
+        Returns True if any orphan FTS triggers were found and dropped (caller
+        should rebuild FTS indexes since data may have been silently lost).
+        """
+        known = set(_FTS_TRIGGERS) | set(_FTS_CJK_TRIGGERS)
+        rows = cursor.execute(
+            "SELECT name, sql FROM sqlite_master "
+            "WHERE type = 'trigger' AND tbl_name = 'messages'"
+        ).fetchall()
+
+        orphan_rows = []
+        for row in rows:
+            name = row["name"] if isinstance(row, sqlite3.Row) else row[0]
+            sql = row["sql"] if isinstance(row, sqlite3.Row) else row[1]
+            sql_lower = (sql or "").lower()
+            if (
+                name not in known
+                and ("messages_fts" in sql_lower
+                     or "messages_fts_trigram" in sql_lower
+                     or "messages_fts_cjk" in sql_lower)
+            ):
+                orphan_rows.append(name)
+
+        for name in orphan_rows:
+            try:
+                quoted_name = '"' + name.replace('"', '""') + '"'
+                cursor.execute(f"DROP TRIGGER IF EXISTS {quoted_name}")
+                logger.warning(
+                    "Dropped orphan FTS trigger on messages table: %s", name
+                )
+            except sqlite3.OperationalError:
+                pass
+
+        return bool(orphan_rows)
+
 
     @staticmethod
     def _fts_update_trigger_needs_narrowing(sql: Optional[str]) -> bool:
@@ -1151,8 +1200,10 @@ class SessionSchemaMixin:
                     self._trigram_available = False
                     self._fts_cjk_available = False
             elif legacy_fts:
+                had_orphans = self._drop_orphan_fts_triggers(cursor)
                 triggers_need_repair = (
-                    self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
+                    had_orphans
+                    or self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
                 )
                 self._fts_enabled = self._ensure_fts_schema(
                     cursor, "messages_fts", LEGACY_FTS_SQL
@@ -1167,8 +1218,10 @@ class SessionSchemaMixin:
                             cursor, include_trigram=trigram_enabled
                         )
             else:
+                had_orphans = self._drop_orphan_fts_triggers(cursor)
                 triggers_need_repair = (
-                    self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
+                    had_orphans
+                    or self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
                 )
                 self._fts_enabled = self._ensure_fts_schema(
                     cursor, "messages_fts", FTS_SQL

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4621,3 +4621,64 @@ class TestFts5SanitizerCharacterClass:
         # text; keep % intact there (pre-existing contract).
         sanitized = self._sanitize("完成50%")
         assert "%" in sanitized
+
+
+def test_startup_removes_orphan_fts_triggers_but_preserves_other_triggers(tmp_path):
+    """Startup cleanup must be limited to duplicate FTS triggers."""
+    from hermes_state import SessionDB
+    import hermes_state_common
+    
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    
+    # Create base schema
+    conn.executescript(hermes_state_common.SCHEMA_SQL)
+    
+    # Create canonical FTS trigger (should be preserved)
+    conn.execute(
+        "CREATE TRIGGER IF NOT EXISTS messages_fts_insert "
+        "AFTER INSERT ON messages BEGIN "
+        "INSERT INTO messages_fts(rowid, content) VALUES(NEW.id, NEW.content); END"
+    )
+    
+    # Create orphan FTS trigger (should be removed - references messages_fts)
+    conn.execute(
+        "CREATE TRIGGER IF NOT EXISTS messages_ai "
+        "AFTER INSERT ON messages BEGIN "
+        "INSERT INTO messages_fts(rowid, content) VALUES(NEW.id, NEW.content); END"
+    )
+    
+    # Create legitimate non-FTS trigger (should be preserved - doesn't reference FTS tables)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS audit_log (event TEXT)"
+    )
+    conn.execute(
+        "CREATE TRIGGER IF NOT EXISTS messages_audit "
+        "AFTER INSERT ON messages BEGIN "
+        "INSERT INTO audit_log(event) VALUES('message_created'); END"
+    )
+    conn.commit()
+    conn.close()
+    
+    # Open SessionDB - triggers startup cleanup
+    db = SessionDB(db_path)
+    
+    # Verify: orphan FTS trigger removed
+    orphan = db._conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND name='messages_ai'"
+    ).fetchone()
+    assert orphan is None, "Orphan FTS trigger should be removed"
+    
+    # Verify: canonical trigger preserved
+    canonical = db._conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND name='messages_fts_insert'"
+    ).fetchone()
+    assert canonical is not None, "Canonical FTS trigger should be preserved"
+    
+    # Verify: legitimate non-FTS trigger preserved
+    audit = db._conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND name='messages_audit'"
+    ).fetchone()
+    assert audit is not None, "Non-FTS trigger should be preserved"
+    
+    db.close()


### PR DESCRIPTION
### Problem

If orphan FTS triggers exist on the `messages` table (triggers that write to `messages_fts` or `messages_fts_trigram` but aren't in the canonical `_FTS_TRIGGERS` set), every `append_message` call fails silently — the second trigger hits a rowid conflict on the FTS virtual table, which rolls back the entire transaction. Sessions run normally but zero messages are persisted, `message_count` stays at 0.

### Why the existing self-heal didn't catch it

`_fts_trigger_count` only checks whether the 6 known triggers are present. Extra triggers under different names are invisible to this check. `_drop_fts_triggers` also only drops the 6 known names.

### Fix

Add `_drop_orphan_fts_triggers()` — queries `sqlite_master` for all triggers on the `messages` table and drops any not in `_FTS_TRIGGERS`. Called during startup before the existing trigger count check. If orphans are found, forces `triggers_need_repair = True` to rebuild FTS indexes.

### Testing

- `tests/test_hermes_state.py`: 384 passed
- `tests/gateway/test_session.py`: 1 pre-existing failure unrelated to this change

### Notes

- The cleanup is aggressive: any trigger on `messages` not in `_FTS_TRIGGERS` gets dropped. If legitimate non-FTS triggers are added to this table in the future, `_FTS_TRIGGERS` or the cleanup logic will need updating.
- Orphan triggers may result from snapshot restores, older versions, or manual DDL — the fix doesn't assume a specific source.
