### PR TITLE
fix(gateway): sanitize reply-to context by stripping Markdown before injection (#69060)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3056,6 +3056,37 @@ def _reconnect_backoff(attempt: int) -> int:
     return min(30 * (2 ** (attempt - 1)), _RECONNECT_BACKOFF_CAP)
 
 
+def _sanitize_reply_snippet(text: str | None, max_len: int = 500) -> str:
+    """Sanitize reply-to text for injection into the agent prompt.
+
+    Strips Markdown formatting so the agent receives clean plaintext
+    rather than raw table delimiters, emphasis markers, or other syntax
+    that would be confusing when truncated mid-structure (issue #69060).
+    Truncates at a word boundary with an ellipsis when the text is long.
+    """
+    import re
+
+    from gateway.platforms.helpers import strip_markdown
+
+    if not text:
+        return ""
+    # Strip Markdown table rows (separator lines like |---|---|)
+    text = re.sub(r"^\|[-| :]+\|\s*$", "", text, flags=re.MULTILINE)
+    # Clean up table cell pipes: "| val 1 | val 2 |" → "val 1 val 2"
+    text = re.sub(r"(?:^|\s)\|", " ", text, flags=re.MULTILINE)
+    text = re.sub(r"\|(?:\s|$)", " ", text)
+    plain = strip_markdown(text)
+    # Collapse runs of whitespace / newlines into single spaces
+    plain = " ".join(plain.split())
+    if len(plain) <= max_len:
+        return plain
+    # Truncate at the last space before max_len to avoid cutting words
+    truncated = plain[:max_len].rsplit(" ", 1)[0]
+    if not truncated:
+        truncated = plain[:max_len]
+    return truncated + "…"
+
+
 class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
     """
     Main gateway controller.
@@ -11838,7 +11869,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # is referencing. History can contain the same or similar text
             # multiple times, and without an explicit pointer the agent has to
             # guess (or answer for both subjects). Token overhead is minimal.
-            reply_snippet = event.reply_to_text[:500]
+            reply_snippet = _sanitize_reply_snippet(event.reply_to_text)
             if getattr(event, "reply_to_is_own_message", False):
                 message_text = (
                     f'[Replying to your previous message: "{reply_snippet}"]\n\n'

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -178,5 +178,81 @@ async def test_reply_snippet_truncated_to_500_chars():
     )
 
     assert result is not None
-    assert result.startswith('[Replying to: "' + "x" * 500 + '"]')
+    # After sanitization, the snippet is truncated at word boundary with ellipsis.
+    # For a single long word "x"*800, the truncation falls back to max_len chars.
     assert "x" * 501 not in result
+    assert "…" in result
+
+
+@pytest.mark.asyncio
+async def test_reply_snippet_strips_markdown_formatting():
+    """Markdown tables, emphasis, code blocks, and links should be stripped
+    to plaintext before injection (issue #69060)."""
+    runner = _make_runner()
+    source = _source()
+    md_text = (
+        "**Bold** and *italic* text.\n\n"
+        "| Col A | Col B |\n|---|---|\n| val 1 | val 2 |\n\n"
+        "Read [this link](https://example.com) and `code` here.\n\n"
+        "```python\nprint('hello')\n```"
+    )
+    event = MessageEvent(
+        text="my reply",
+        source=source,
+        reply_to_message_id="99",
+        reply_to_text=md_text,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    # No raw markdown delimiters should survive
+    assert "|---|" not in result
+    assert "**" not in result
+    assert "```" not in result
+    # Content words should still be present
+    assert "Bold" in result
+    assert "italic" in result
+    assert "val 1" in result or "val 2" in result
+    assert "this link" in result
+    assert "code" in result
+
+
+@pytest.mark.asyncio
+async def test_reply_snippet_truncates_at_word_boundary():
+    """Long plaintext snippets should truncate at a word boundary and append
+    an ellipsis rather than cutting mid-word."""
+    runner = _make_runner()
+    source = _source()
+    # Build a long message with real words
+    long_text = " ".join(["word"] * 200)  # 200 words, ~800 chars
+    event = MessageEvent(
+        text="follow-up",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text=long_text,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    # The snippet is truncated with an ellipsis inside the quotes
+    assert "…" in result
+    # The ellipsis appears before the closing quote
+    assert '…"]' in result
+    # Total reply snippet should be <= 500 chars + ellipsis overhead
+    import re
+    snippet_match = re.search(r'Replying to.*?"(.+?)"', result)
+    assert snippet_match is not None
+    snippet = snippet_match.group(1)
+    assert snippet.endswith("…")
+    # Should not end mid-word
+    assert not snippet.removesuffix("…").endswith("wor")


### PR DESCRIPTION
## Summary

- Strips Markdown formatting (tables, bold, italic, code blocks, links) from reply-to context before injecting it into the agent prompt
- Collapses whitespace and truncates at word boundaries with ellipsis
- Prevents malformed truncated Markdown syntax from confusing the agent

## Problem

When a user replies to a long assistant message (especially one containing tables, code blocks, or other formatting), the raw Markdown was injected verbatim into the agent prompt. For long messages, this was truncated mid-structure, leaving partial table pipes, unmatched emphasis markers, or broken code fences in the prompt. The agent would then treat the malformed syntax as a new instruction, sometimes abandoning the active task.

## Changes

- **`gateway/run.py`**: Added `_sanitize_reply_snippet()` helper that:
  - Strips Markdown table separator rows (`|---|---|`)
  - Cleans table cell pipes into plain text
  - Applies `strip_markdown()` from `gateway.platforms.helpers` for bold, italic, code blocks, headings, and links
  - Collapses whitespace into single spaces
  - Truncates at word boundary with `…` when exceeding 500 chars
- **`tests/gateway/test_reply_to_injection.py`**: Added tests for Markdown stripping and word-boundary truncation

## Test plan

- [x] All 8 existing + new tests pass
- [ ] Manual test: reply to a long Markdown message in Telegram and verify the agent receives clean plaintext context

Fixes #69060
