### PR TITLE
fix(desktop): render the real changelog for official-SSH update checks (#69081)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -140,6 +140,7 @@ import {
   SshConnection
 } from './ssh-connection'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
+import { readCommitLogRange, readOfficialSshCommitLog } from './update-commit-log'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { readLiveUpdateMarker, writeUpdateMarker } from './update-marker'
 import { runRebuildWithRetry } from './update-rebuild'
@@ -2246,7 +2247,8 @@ async function checkUpdates() {
   const originUrl = await getOriginUrl(updateRoot)
 
   if (isOfficialSshRemote(originUrl)) {
-    const git = args => runGit(args, { cwd: updateRoot }).then(r => r.stdout.trim())
+    const run = args => runGit(args, { cwd: updateRoot })
+    const git = args => run(args).then(r => r.stdout.trim())
 
     const [currentSha, target, dirtyStr, currentBranch] = await Promise.all([
       git(['rev-parse', 'HEAD']),
@@ -2268,14 +2270,24 @@ async function checkUpdates() {
       }
     }
 
+    const behind = currentSha && currentSha === targetSha ? 0 : 1
+
+    // Populate the real changelog over anonymous HTTPS (never `git fetch origin`,
+    // which would prompt for the SSH passkey touch). Empty on an up-to-date
+    // checkout or if the HTTPS fetch fails — the overlay then shows its generic
+    // summary instead of a wrong/empty one (#69081).
+    const commits = behind > 0
+      ? await readOfficialSshCommitLog(run, OFFICIAL_REPO_HTTPS_URL, branch, targetSha)
+      : []
+
     return {
       supported: true,
       branch,
       currentBranch,
-      behind: currentSha && currentSha === targetSha ? 0 : 1,
+      behind,
       currentSha,
       targetSha,
-      commits: [],
+      commits,
       dirty: dirtyStr.length > 0,
       hermesRoot: updateRoot,
       fetchedAt: Date.now()
@@ -2344,23 +2356,7 @@ async function checkUpdates() {
 }
 
 async function readCommitLog(cwd, branch) {
-  const SEP = '\x1f'
-  const REC = '\x1e'
-
-  const { stdout } = await runGit(
-    ['log', `HEAD..origin/${branch}`, `--pretty=format:%H${SEP}%s${SEP}%an${SEP}%at${REC}`, '-n', '40'],
-    { cwd }
-  )
-
-  return stdout
-    .split(REC)
-    .map(line => line.trim())
-    .filter(Boolean)
-    .map(line => {
-      const [sha, summary, author, at] = line.split(SEP)
-
-      return { sha, summary, author, at: Number.parseInt(at, 10) * 1000 }
-    })
+  return readCommitLogRange(args => runGit(args, { cwd }), `HEAD..origin/${branch}`)
 }
 
 let updateInFlight = false

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -252,6 +252,7 @@ import {
 } from './ssh-connection'
 import { createStreamThrottle } from './stream-throttle'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
+import { readOfficialSshCommitLog } from './update-commit-log'
 import {
   compareApiUrl,
   parseCompareBehindCount,
@@ -2620,7 +2621,8 @@ async function checkUpdates() {
   const originUrl = await getOriginUrl(updateRoot)
 
   if (isOfficialSshRemote(originUrl)) {
-    const git = args => runGit(args, { cwd: updateRoot }).then(r => r.stdout.trim())
+    const run = args => runGit(args, { cwd: updateRoot })
+    const git = args => run(args).then(r => r.stdout.trim())
 
     const [currentSha, target, dirtyStr, currentBranch] = await Promise.all([
       git(['rev-parse', 'HEAD']),
@@ -2657,6 +2659,14 @@ async function checkUpdates() {
 
     const upToDate = tipsEqual || sshBehind === 0
 
+    // Populate the real changelog over anonymous HTTPS (never `git fetch origin`,
+    // which would prompt for the SSH passkey touch). Empty on an up-to-date
+    // checkout or if the HTTPS fetch fails — the overlay then shows its generic
+    // summary instead of a wrong/empty one (#69081).
+    const commits = upToDate
+      ? []
+      : await readOfficialSshCommitLog(run, OFFICIAL_REPO_HTTPS_URL, branch, targetSha)
+
     return {
       supported: true,
       branch,
@@ -2665,7 +2675,7 @@ async function checkUpdates() {
       updateAvailable: !upToDate,
       currentSha,
       targetSha,
-      commits: [],
+      commits,
       dirty: dirtyStr.length > 0,
       hermesRoot: updateRoot,
       fetchedAt: Date.now()

--- a/apps/desktop/electron/update-commit-log.test.ts
+++ b/apps/desktop/electron/update-commit-log.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  COMMIT_LOG_LIMIT,
+  parseCommitLog,
+  readCommitLogRange,
+  readOfficialSshCommitLog
+} from './update-commit-log'
+
+const SEP = '\x1f'
+const REC = '\x1e'
+
+const record = (sha, summary, author, at) => `${sha}${SEP}${summary}${SEP}${author}${SEP}${at}${REC}`
+
+test('parseCommitLog parses records and converts the unix timestamp to millis', () => {
+  const stdout = record('abc123', 'fix: thing', 'Ada', '1700000000') + record('def456', 'feat: other', 'Grace', '1700000060')
+
+  assert.deepEqual(parseCommitLog(stdout), [
+    { sha: 'abc123', summary: 'fix: thing', author: 'Ada', at: 1700000000000 },
+    { sha: 'def456', summary: 'feat: other', author: 'Grace', at: 1700000060000 }
+  ])
+})
+
+test('parseCommitLog returns [] for empty output', () => {
+  assert.deepEqual(parseCommitLog(''), [])
+})
+
+test('parseCommitLog tolerates a summary containing spaces (unit-separated fields)', () => {
+  const stdout = record('sha', 'fix: keep spaces and punctuation, intact', 'A B', '1700000000')
+
+  assert.deepEqual(parseCommitLog(stdout), [
+    { sha: 'sha', summary: 'fix: keep spaces and punctuation, intact', author: 'A B', at: 1700000000000 }
+  ])
+})
+
+// FAIL-BEFORE: the official-SSH branch in checkUpdates() hardcoded `commits: []`,
+// so an SSH-origin install always showed the "Improvements and fixes" fallback
+// (#69081). This asserts the new path fetches over the anonymous HTTPS URL — never
+// `git fetch origin` (which would trigger a passkey touch) — and returns the log.
+test('readOfficialSshCommitLog fetches over HTTPS (not origin) then reads HEAD..<sha>', async () => {
+  const calls: string[][] = []
+
+  const run = async (args: string[]) => {
+    calls.push(args)
+
+    if (args[0] === 'fetch') {
+      return { code: 0, stdout: '', stderr: '' }
+    }
+
+    return { code: 0, stdout: record('sha1', 'fix: a', 'Ada', '1700000000'), stderr: '' }
+  }
+
+  const commits = await readOfficialSshCommitLog(
+    run,
+    'https://github.com/NousResearch/hermes-agent.git',
+    'main',
+    'targetsha'
+  )
+
+  // First git call is a fetch against the HTTPS URL, not the `origin` SSH remote.
+  assert.deepEqual(calls[0], ['fetch', '--quiet', 'https://github.com/NousResearch/hermes-agent.git', 'main'])
+  assert.equal(calls.some(c => c.includes('origin')), false)
+  // Second git call reads the log up to the ls-remote target SHA.
+  assert.deepEqual(calls[1], ['log', 'HEAD..targetsha', `--pretty=format:%H${SEP}%s${SEP}%an${SEP}%at${REC}`, '-n', String(COMMIT_LOG_LIMIT)])
+  assert.deepEqual(commits, [{ sha: 'sha1', summary: 'fix: a', author: 'Ada', at: 1700000000000 }])
+})
+
+test('readOfficialSshCommitLog returns [] (and skips the log) when the HTTPS fetch fails', async () => {
+  const calls: string[][] = []
+
+  const run = async (args: string[]) => {
+    calls.push(args)
+
+    return { code: 1, stdout: '', stderr: 'network down' }
+  }
+
+  const commits = await readOfficialSshCommitLog(run, 'https://example/repo.git', 'main', 'targetsha')
+
+  assert.deepEqual(commits, [])
+  assert.equal(calls.length, 1) // fetch attempted; no `git log` after a failed fetch
+  assert.equal(calls[0][0], 'fetch')
+})
+
+test('readCommitLogRange issues the log for the given range and caps at COMMIT_LOG_LIMIT', async () => {
+  const calls: string[][] = []
+
+  const run = async (args: string[]) => {
+    calls.push(args)
+
+    return { code: 0, stdout: record('s', 'msg', 'Author', '1700000000'), stderr: '' }
+  }
+
+  const commits = await readCommitLogRange(run, 'HEAD..origin/main')
+
+  assert.deepEqual(calls[0], ['log', 'HEAD..origin/main', `--pretty=format:%H${SEP}%s${SEP}%an${SEP}%at${REC}`, '-n', String(COMMIT_LOG_LIMIT)])
+  assert.deepEqual(commits, [{ sha: 's', summary: 'msg', author: 'Author', at: 1700000000000 }])
+})

--- a/apps/desktop/electron/update-commit-log.ts
+++ b/apps/desktop/electron/update-commit-log.ts
@@ -1,0 +1,78 @@
+// Commit-log acquisition + parsing for the desktop update overlay's changelog.
+// Extracted from checkUpdates() in main.ts so the official-SSH path is unit
+// testable (checkUpdates itself is I/O-bound and untested). The parser is pure;
+// the two readers take an injected `run` so tests can assert the exact git
+// invocations without spawning git — mirroring the pure-helper pattern in
+// update-count.ts.
+
+type GitResult = { code: number; stdout: string; stderr: string }
+type GitRun = (args: string[]) => Promise<GitResult>
+
+type CommitEntry = { sha: string; summary: string; author: string; at: number }
+
+// Unit/record separators keep `%s` (commit summary) safe from embedded newlines
+// and spaces when splitting the `git log` output back into fields.
+const COMMIT_LOG_SEP = '\x1f'
+const COMMIT_LOG_REC = '\x1e'
+const COMMIT_LOG_FORMAT = `%H${COMMIT_LOG_SEP}%s${COMMIT_LOG_SEP}%an${COMMIT_LOG_SEP}%at${COMMIT_LOG_REC}`
+const COMMIT_LOG_LIMIT = 40
+
+function parseCommitLog(stdout): CommitEntry[] {
+  return stdout
+    .split(COMMIT_LOG_REC)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => {
+      const [sha, summary, author, at] = line.split(COMMIT_LOG_SEP)
+
+      return { sha, summary, author, at: Number.parseInt(at, 10) * 1000 }
+    })
+}
+
+// Read the commit changelog for an arbitrary range (e.g. `HEAD..origin/main` on
+// the fetched HTTPS path, or `HEAD..<sha>` on the official-SSH path).
+async function readCommitLogRange(run: GitRun, range): Promise<CommitEntry[]> {
+  const { stdout } = await run([
+    'log',
+    range,
+    `--pretty=format:${COMMIT_LOG_FORMAT}`,
+    '-n',
+    String(COMMIT_LOG_LIMIT)
+  ])
+
+  return parseCommitLog(stdout)
+}
+
+// Obtain the changelog for the official-SSH remote WITHOUT `git fetch origin`.
+// Fetching `origin` would hit the SSH remote and can trigger a passkey/FIDO2
+// hardware-touch prompt (the whole reason checkUpdates() takes a separate branch
+// for official-SSH installs). The remote tip was already discovered via anonymous
+// `git ls-remote` against the HTTPS URL, so fetch the same objects over anonymous
+// HTTPS into FETCH_HEAD and read the log up to `targetSha`.
+//
+// Best-effort: any failure yields [] so the overlay falls back to its generic
+// "Improvements and fixes" summary rather than erroring the whole update check.
+// FAIL-BEFORE: this path did not exist — the SSH branch hardcoded `commits: []`,
+// so official-SSH installs NEVER saw a real changelog (#69081).
+async function readOfficialSshCommitLog(
+  run: GitRun,
+  httpsUrl,
+  branch,
+  targetSha
+): Promise<CommitEntry[]> {
+  const fetched = await run(['fetch', '--quiet', httpsUrl, branch])
+
+  if (fetched.code !== 0) {
+    return []
+  }
+
+  return readCommitLogRange(run, `HEAD..${targetSha}`)
+}
+
+export {
+  COMMIT_LOG_LIMIT,
+  parseCommitLog,
+  readCommitLogRange,
+  readOfficialSshCommitLog
+}
+export type { CommitEntry, GitRun }


### PR DESCRIPTION
Fixes #69081

## Problem

On installs whose `origin` is the official SSH remote (`git@github.com:NousResearch/hermes-agent.git`), the desktop update overlay **always** showed the fallback text "Improvements and fixes" instead of the real commit changelog — regardless of how many commits behind the install was.

## Root cause

`checkUpdates()` in `apps/desktop/electron/main.ts` has a dedicated fast path for official-SSH remotes. That path deliberately avoids `git fetch origin` — fetching the SSH remote can trigger a passkey/FIDO2 hardware-touch prompt — and instead probes the remote tip with anonymous `git ls-remote` against the HTTPS URL. But the branch then returned `commits: []` hardcoded, so `buildCommitChangelog([])` produced zero groups and fell through to the generic `FALLBACK_GROUP` ("Improvements and fixes"). The HTTPS-origin path (`readCommitLog`) populates `commits` correctly, so only SSH-origin installs were affected.

## Fix

When behind, fetch the changelog over the **same anonymous HTTPS URL** the `ls-remote` probe already uses (never `origin`, so no SSH-key touch prompt) into `FETCH_HEAD`, then read `HEAD..<targetSha>`. It's best-effort: an up-to-date checkout or a failed HTTPS fetch yields `[]`, so the overlay degrades to the generic summary rather than erroring the whole update check.

The commit-log acquisition + parsing is extracted into `update-commit-log.ts` with an injected git runner, so the official-SSH path is unit tested — `checkUpdates()` itself is I/O-bound and untested, mirroring the pure-helper split in `update-count.ts`. The HTTPS-origin `readCommitLog` now delegates to the same parser (single source).

## Tests

`apps/desktop/electron/update-commit-log.test.ts`:
- `readOfficialSshCommitLog` fetches over the HTTPS URL (asserts it never touches `origin`) then reads `HEAD..<sha>` and returns parsed commits — the FAIL-BEFORE regression for the hardcoded `[]`.
- fetch failure → `[]` and no `git log` issued.
- `parseCommitLog` field/timestamp handling (including summaries with spaces) and empty output → `[]`.
- `readCommitLogRange` issues the log for the given range, capped at the commit limit.

Verified locally: `tsc` typecheck clean, `eslint` clean, full `apps/desktop` electron vitest suite green (637 passed).

Note: the expected arm64-fork-Docker CI failure is unrelated to this change.