### PR TITLE
feat(image_gen): add Alibaba DashScope (Wan 2.7) image generation provider

### DIFF
--- a/plugins/image_gen/alibaba/__init__.py
+++ b/plugins/image_gen/alibaba/__init__.py
@@ -1,0 +1,512 @@
+"""Alibaba Cloud DashScope image generation backend.
+
+Exposes Alibaba's Wan 2.7 image models (``wan2.7-image-pro``, ``wan2.7-image``)
+as an :class:`ImageGenProvider` implementation via the DashScope
+``image-generation/generation`` API.
+
+Features:
+- Text-to-image generation (up to 4K on wan2.7-image-pro)
+- Image editing with up to 9 reference images (URL or base64)
+- Thinking mode for enhanced quality (text-to-image only)
+- Configurable output size, seed, watermark, and color palette
+- Ephemeral OSS URLs materialised to local cache
+
+Selection precedence (first hit wins):
+1. ``DASHSCOPE_IMAGE_MODEL`` env var
+2. ``image_gen.alibaba.model`` in ``config.yaml``
+3. :data:`DEFAULT_MODEL`
+
+API reference:
+https://www.alibabacloud.com/help/en/model-studio/wan-image-generation-and-editing-api-reference
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    normalize_reference_images,
+    resolve_aspect_ratio,
+    save_url_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Model catalog
+# ---------------------------------------------------------------------------
+
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "wan2.7-image-pro": {
+        "display": "Wan 2.7 Image Pro",
+        "speed": "~5-20s",
+        "strengths": "4K text-to-image, thinking mode, image editing (up to 9 refs)",
+        "price": "token-plan",
+    },
+    "wan2.7-image": {
+        "display": "Wan 2.7 Image",
+        "speed": "~5-15s",
+        "strengths": "Fast text-to-image and image editing (up to 9 refs)",
+        "price": "token-plan",
+    },
+}
+
+DEFAULT_MODEL = "wan2.7-image-pro"
+
+# Aspect ratio → DashScope size string mapping.
+# The API accepts preset strings ("1K", "2K", "4K") or explicit "WxH".
+# We use explicit dimensions for deterministic aspect ratios.
+_SIZES = {
+    "landscape": "1280*720",
+    "square": "1024*1024",
+    "portrait": "720*1280",
+}
+
+# Maximum reference images the DashScope API accepts per request.
+_MAX_REFERENCE_IMAGES = 9
+
+# Default request timeout in seconds. Wan 2.7 with thinking_mode can take
+# 20-30s; 4K generation can take longer.
+_REQUEST_TIMEOUT = 180
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def _load_alibaba_image_config() -> Dict[str, Any]:
+    """Read ``image_gen.alibaba`` from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        alibaba_section = section.get("alibaba") if isinstance(section, dict) else None
+        return alibaba_section if isinstance(alibaba_section, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load image_gen.alibaba config: %s", exc)
+        return {}
+
+
+def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+    """Decide which model to use and return ``(model_id, meta)``."""
+    env_override = os.environ.get("DASHSCOPE_IMAGE_MODEL", "").strip()
+    if env_override and env_override in _MODELS:
+        return env_override, _MODELS[env_override]
+
+    cfg = _load_alibaba_image_config()
+    candidate = cfg.get("model") if isinstance(cfg.get("model"), str) else None
+    if candidate and candidate in _MODELS:
+        return candidate, _MODELS[candidate]
+
+    return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _resolve_base_url() -> str:
+    """Resolve the DashScope API base URL.
+
+    Precedence:
+    1. ``image_gen.alibaba.base_url`` in config.yaml
+    2. ``DASHSCOPE_BASE_URL`` env var (shared with the LLM provider)
+    3. Default international endpoint
+
+    The image-generation endpoint is derived from the base URL by replacing
+    the ``/compatible-mode/v1`` suffix (used by the LLM chat API) with the
+    native DashScope path, or appending to the MaaS root.
+    """
+    cfg = _load_alibaba_image_config()
+    configured = cfg.get("base_url") if isinstance(cfg.get("base_url"), str) else None
+    if configured and configured.strip():
+        return configured.strip().rstrip("/")
+
+    env_url = os.environ.get("DASHSCOPE_BASE_URL", "").strip()
+    if env_url:
+        return env_url.rstrip("/")
+
+    return "https://dashscope-intl.aliyuncs.com/api/v1"
+
+
+def _image_generation_endpoint(base_url: str) -> str:
+    """Derive the image-generation endpoint from the base URL.
+
+    Handles three base URL shapes:
+    - ``https://dashscope-intl.aliyuncs.com/api/v1`` (standard)
+    - ``https://dashscope-intl.aliyuncs.com/compatible-mode/v1`` (LLM compat)
+    - ``https://{workspace}.maas.aliyuncs.com/compatible-mode/v1`` (token plan)
+    - ``https://{workspace}.maas.aliyuncs.com/api/v1`` (token plan native)
+    """
+    url = base_url.rstrip("/")
+    # Strip the compatible-mode/v1 suffix if present
+    if url.endswith("/compatible-mode/v1"):
+        url = url[: -len("/compatible-mode/v1")]
+    # Strip trailing /api/v1 if present (we'll re-add the full path)
+    if url.endswith("/api/v1"):
+        url = url[: -len("/api/v1")]
+    return f"{url}/api/v1/services/aigc/image-generation/generation"
+
+
+def _resolve_api_key() -> str:
+    """Read the DashScope API key from the environment."""
+    return os.environ.get("DASHSCOPE_API_KEY", "").strip()
+
+
+def _resolve_size(aspect: str) -> str:
+    """Map aspect ratio to a DashScope size string.
+
+    wan2.7-image-pro supports 4K for text-to-image only. Image editing
+    and image set generation are capped at 2K. We use explicit pixel
+    dimensions for deterministic aspect ratios. Users can override via
+    ``image_gen.alibaba.size`` in config.yaml (e.g. "2K", "4K", "1280*720").
+    """
+    cfg = _load_alibaba_image_config()
+    configured_size = cfg.get("size") if isinstance(cfg.get("size"), str) else None
+    if configured_size and configured_size.strip():
+        return configured_size.strip()
+
+    return _SIZES.get(aspect, _SIZES["square"])
+
+
+def _image_to_content_item(source: str) -> Dict[str, str]:
+    """Convert an image source (URL or local path) to a DashScope content item.
+
+    DashScope accepts:
+    - Public HTTPS URLs
+    - Base64 data URIs: ``data:{MIME};base64,{data}``
+
+    Local file paths are read and encoded into a data URI.
+    """
+    source = source.strip()
+    lower = source.lower()
+    if lower.startswith(("http://", "https://", "data:")):
+        return {"image": source}
+
+    # Local file path → base64 data URI.
+    from agent.file_safety import raise_if_read_blocked
+
+    raise_if_read_blocked(source)
+    path = Path(source).expanduser()
+    with path.open("rb") as fh:
+        raw = fh.read()
+    ext = (path.suffix.lstrip(".") or "png").lower()
+    if ext == "jpg":
+        ext = "jpeg"
+    b64 = base64.b64encode(raw).decode("utf-8")
+    return {"image": f"data:image/{ext};base64,{b64}"}
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class AlibabaImageGenProvider(ImageGenProvider):
+    """Alibaba Cloud DashScope Wan 2.7 image generation backend."""
+
+    @property
+    def name(self) -> str:
+        return "alibaba"
+
+    @property
+    def display_name(self) -> str:
+        return "Alibaba (Wan 2.7)"
+
+    def is_available(self) -> bool:
+        return bool(_resolve_api_key())
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": model_id,
+                "display": meta.get("display", model_id),
+                "speed": meta.get("speed", ""),
+                "strengths": meta.get("strengths", ""),
+                "price": meta.get("price", ""),
+            }
+            for model_id, meta in _MODELS.items()
+        ]
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Alibaba Wan 2.7 (image)",
+            "badge": "paid",
+            "tag": (
+                "wan2.7-image-pro / wan2.7-image — text-to-image (4K) and "
+                "image editing; uses DASHSCOPE_API_KEY"
+            ),
+            "env_vars": [
+                {
+                    "key": "DASHSCOPE_API_KEY",
+                    "prompt": "DashScope API key",
+                    "url": "https://www.alibabacloud.com/help/en/model-studio/get-api-key",
+                },
+            ],
+        }
+
+    def capabilities(self) -> Dict[str, Any]:
+        return {
+            "modalities": ["text", "image"],
+            "max_reference_images": _MAX_REFERENCE_IMAGES,
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        *,
+        image_url: Optional[str] = None,
+        reference_image_urls: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Generate an image (text-to-image) or edit source images (image-to-image).
+
+        Routing: when ``image_url`` or ``reference_image_urls`` are provided,
+        the images are included in the content array for image editing;
+        otherwise text-to-image.
+        """
+        api_key = _resolve_api_key()
+        if not api_key:
+            return error_response(
+                error=(
+                    "DASHSCOPE_API_KEY not set. Run `hermes tools` → Image "
+                    "Generation → Alibaba to configure, or set the env var."
+                ),
+                error_type="missing_api_key",
+                provider="alibaba",
+                aspect_ratio=aspect_ratio,
+            )
+
+        model_id, meta = _resolve_model()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+
+        # Collect source images (image_url first, then references).
+        source_images: List[str] = []
+        if isinstance(image_url, str) and image_url.strip():
+            source_images.append(image_url.strip())
+        refs = normalize_reference_images(reference_image_urls)
+        if refs:
+            source_images.extend(refs)
+
+        if len(source_images) > _MAX_REFERENCE_IMAGES:
+            return error_response(
+                error=(
+                    f"DashScope supports at most {_MAX_REFERENCE_IMAGES} "
+                    f"reference images per request, got {len(source_images)}"
+                ),
+                error_type="too_many_references",
+                provider="alibaba",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        is_edit = bool(source_images)
+        modality = "image" if is_edit else "text"
+        size = _resolve_size(aspect)
+
+        # Build the content array.
+        content: List[Dict[str, str]] = []
+        for source in source_images:
+            try:
+                content.append(_image_to_content_item(source))
+            except Exception as exc:
+                return error_response(
+                    error=f"Could not load source image '{source}': {exc}",
+                    error_type="io_error",
+                    provider="alibaba",
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+        content.append({"text": (prompt or "").strip()})
+
+        # Build parameters.
+        parameters: Dict[str, Any] = {
+            "size": size,
+            "n": 1,
+            "watermark": False,
+        }
+
+        # thinking_mode is only effective for text-to-image without image input.
+        if not is_edit and model_id == "wan2.7-image-pro":
+            cfg = _load_alibaba_image_config()
+            thinking = cfg.get("thinking_mode")
+            parameters["thinking_mode"] = bool(thinking) if thinking is not None else True
+
+        # Optional seed from config.
+        cfg = _load_alibaba_image_config()
+        seed = cfg.get("seed")
+        if isinstance(seed, int) and 0 <= seed <= 2147483647:
+            parameters["seed"] = seed
+
+        payload: Dict[str, Any] = {
+            "model": model_id,
+            "input": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": content,
+                    }
+                ]
+            },
+            "parameters": parameters,
+        }
+
+        base_url = _resolve_base_url()
+        endpoint = _image_generation_endpoint(base_url)
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "X-DashScope-Async": "enable",
+        }
+
+        try:
+            response = requests.post(
+                endpoint,
+                headers=headers,
+                json=payload,
+                timeout=_REQUEST_TIMEOUT,
+            )
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            resp = exc.response
+            status = resp.status_code if resp is not None else 0
+            try:
+                body = resp.json() if resp is not None else {}
+                err_msg = body.get("message", "") or body.get("error", {}).get("message", "")
+                if not err_msg and resp is not None:
+                    err_msg = resp.text[:300]
+            except Exception:
+                err_msg = resp.text[:300] if resp is not None else str(exc)
+            logger.error("DashScope image gen failed (%d): %s", status, err_msg)
+            return error_response(
+                error=f"DashScope image generation failed ({status}): {err_msg}",
+                error_type="api_error",
+                provider="alibaba",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.Timeout:
+            return error_response(
+                error=f"DashScope image generation timed out ({_REQUEST_TIMEOUT}s)",
+                error_type="timeout",
+                provider="alibaba",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.ConnectionError as exc:
+            return error_response(
+                error=f"DashScope connection error: {exc}",
+                error_type="connection_error",
+                provider="alibaba",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            result = response.json()
+        except Exception as exc:
+            return error_response(
+                error=f"DashScope returned invalid JSON: {exc}",
+                error_type="invalid_response",
+                provider="alibaba",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        # Parse response — DashScope returns output.choices[].message.content[]
+        # with items of type "image" containing an "image" URL.
+        output = result.get("output", {})
+        choices = output.get("choices", [])
+        if not choices:
+            return error_response(
+                error="DashScope returned no image data (empty choices)",
+                error_type="empty_response",
+                provider="alibaba",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        message = choices[0].get("message", {})
+        content_items = message.get("content", [])
+        image_url_result: Optional[str] = None
+        for item in content_items:
+            if isinstance(item, dict) and item.get("type") == "image":
+                image_url_result = item.get("image")
+                break
+            # Some responses use {"image": "url"} without "type"
+            if isinstance(item, dict) and "image" in item:
+                image_url_result = item["image"]
+                break
+
+        if not image_url_result:
+            return error_response(
+                error="DashScope response contained no image URL",
+                error_type="empty_response",
+                provider="alibaba",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        # DashScope returns ephemeral OSS URLs that expire. Materialise
+        # locally so downstream consumers (Telegram send_photo, browser
+        # fetch) have a stable file path.
+        try:
+            saved_path = save_url_image(
+                image_url_result,
+                prefix=f"dashscope_{model_id.replace('.', '_')}",
+            )
+        except Exception as exc:
+            logger.warning(
+                "DashScope image URL could not be cached (%s); returning bare URL.",
+                exc,
+            )
+            image_ref = image_url_result
+        else:
+            image_ref = str(saved_path)
+
+        extra: Dict[str, Any] = {"size": size}
+        debug_info = output.get("debug_info")
+        if isinstance(debug_info, list) and debug_info:
+            first_debug = debug_info[0]
+            if isinstance(first_debug, dict):
+                for key in ("actual_seed", "output_W", "output_H", "inference_cost"):
+                    if key in first_debug:
+                        extra[key] = first_debug[key]
+
+        return success_response(
+            image=image_ref,
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider="alibaba",
+            modality=modality,
+            extra=extra,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+
+def register(ctx: Any) -> None:
+    """Register this provider with the image gen registry."""
+    ctx.register_image_gen_provider(AlibabaImageGenProvider())

--- a/plugins/image_gen/alibaba/plugin.yaml
+++ b/plugins/image_gen/alibaba/plugin.yaml
@@ -1,0 +1,7 @@
+name: alibaba
+version: 1.0.0
+description: "Alibaba Cloud DashScope image generation backend (Wan 2.7). Text-to-image (4K) and image editing with up to 9 reference images."
+author: Magnus Hedemark
+kind: backend
+requires_env:
+  - DASHSCOPE_API_KEY

--- a/tests/plugins/image_gen/test_alibaba_provider.py
+++ b/tests/plugins/image_gen/test_alibaba_provider.py
@@ -1,0 +1,658 @@
+#!/usr/bin/env python3
+"""Tests for Alibaba DashScope image generation provider."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fake_api_key(monkeypatch, tmp_path):
+    """Ensure DASHSCOPE_API_KEY is set for all tests."""
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "sk-test-key-12345")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    try:
+        import hermes_cli.config as cfg_mod
+
+        if hasattr(cfg_mod, "_invalidate_load_config_cache"):
+            cfg_mod._invalidate_load_config_cache()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Provider class tests
+# ---------------------------------------------------------------------------
+
+
+class TestAlibabaImageGenProvider:
+    def test_name(self):
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        provider = AlibabaImageGenProvider()
+        assert provider.name == "alibaba"
+
+    def test_display_name(self):
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        provider = AlibabaImageGenProvider()
+        assert provider.display_name == "Alibaba (Wan 2.7)"
+
+    def test_is_available_with_key(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "sk-xxx")
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        provider = AlibabaImageGenProvider()
+        assert provider.is_available() is True
+
+    def test_is_available_without_key(self, monkeypatch):
+        monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        provider = AlibabaImageGenProvider()
+        assert provider.is_available() is False
+
+    def test_list_models(self):
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        provider = AlibabaImageGenProvider()
+        models = provider.list_models()
+        assert len(models) >= 2
+        ids = {m["id"] for m in models}
+        assert "wan2.7-image-pro" in ids
+        assert "wan2.7-image" in ids
+
+    def test_default_model(self):
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        provider = AlibabaImageGenProvider()
+        assert provider.default_model() == "wan2.7-image-pro"
+
+    def test_get_setup_schema(self):
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        provider = AlibabaImageGenProvider()
+        schema = provider.get_setup_schema()
+        assert schema["name"] == "Alibaba Wan 2.7 (image)"
+        assert schema["badge"] == "paid"
+        assert len(schema["env_vars"]) == 1
+        assert schema["env_vars"][0]["key"] == "DASHSCOPE_API_KEY"
+
+    def test_capabilities(self):
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        caps = AlibabaImageGenProvider().capabilities()
+        assert caps["modalities"] == ["text", "image"]
+        assert caps["max_reference_images"] == 9
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_default_model(self):
+        from plugins.image_gen.alibaba import _resolve_model
+
+        model_id, meta = _resolve_model()
+        assert model_id == "wan2.7-image-pro"
+
+    def test_env_override_model(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_IMAGE_MODEL", "wan2.7-image")
+        from plugins.image_gen.alibaba import _resolve_model
+
+        model_id, _ = _resolve_model()
+        assert model_id == "wan2.7-image"
+
+    def test_env_override_invalid_falls_back(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_IMAGE_MODEL", "nonexistent-model")
+        from plugins.image_gen.alibaba import _resolve_model
+
+        model_id, _ = _resolve_model()
+        assert model_id == "wan2.7-image-pro"
+
+    def test_default_base_url(self, monkeypatch):
+        monkeypatch.delenv("DASHSCOPE_BASE_URL", raising=False)
+        from plugins.image_gen.alibaba import _resolve_base_url
+
+        assert _resolve_base_url() == "https://dashscope-intl.aliyuncs.com/api/v1"
+
+    def test_env_base_url(self, monkeypatch):
+        monkeypatch.setenv(
+            "DASHSCOPE_BASE_URL",
+            "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+        )
+        from plugins.image_gen.alibaba import _resolve_base_url
+
+        assert (
+            _resolve_base_url()
+            == "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Endpoint derivation tests
+# ---------------------------------------------------------------------------
+
+
+class TestEndpointDerivation:
+    def test_standard_api_v1(self):
+        from plugins.image_gen.alibaba import _image_generation_endpoint
+
+        url = _image_generation_endpoint("https://dashscope-intl.aliyuncs.com/api/v1")
+        assert url == (
+            "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/"
+            "image-generation/generation"
+        )
+
+    def test_compatible_mode_v1(self):
+        from plugins.image_gen.alibaba import _image_generation_endpoint
+
+        url = _image_generation_endpoint(
+            "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+        )
+        assert url == (
+            "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/"
+            "image-generation/generation"
+        )
+
+    def test_token_plan_compatible_mode(self):
+        from plugins.image_gen.alibaba import _image_generation_endpoint
+
+        url = _image_generation_endpoint(
+            "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
+        )
+        assert url == (
+            "https://token-plan.ap-southeast-1.maas.aliyuncs.com/api/v1/services/aigc/"
+            "image-generation/generation"
+        )
+
+    def test_token_plan_native_api(self):
+        from plugins.image_gen.alibaba import _image_generation_endpoint
+
+        url = _image_generation_endpoint(
+            "https://token-plan.ap-southeast-1.maas.aliyuncs.com/api/v1"
+        )
+        assert url == (
+            "https://token-plan.ap-southeast-1.maas.aliyuncs.com/api/v1/services/aigc/"
+            "image-generation/generation"
+        )
+
+    def test_trailing_slash_stripped(self):
+        from plugins.image_gen.alibaba import _image_generation_endpoint
+
+        url = _image_generation_endpoint(
+            "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/"
+        )
+        assert url == (
+            "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/"
+            "image-generation/generation"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Image content item tests
+# ---------------------------------------------------------------------------
+
+
+class TestImageToContentItem:
+    def test_https_url_passthrough(self):
+        from plugins.image_gen.alibaba import _image_to_content_item
+
+        item = _image_to_content_item("https://example.com/image.png")
+        assert item == {"image": "https://example.com/image.png"}
+
+    def test_data_uri_passthrough(self):
+        from plugins.image_gen.alibaba import _image_to_content_item
+
+        uri = "data:image/png;base64,abc123"
+        item = _image_to_content_item(uri)
+        assert item == {"image": uri}
+
+    def test_local_file_to_base64(self, tmp_path):
+        from plugins.image_gen.alibaba import _image_to_content_item
+
+        img = tmp_path / "test.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+        item = _image_to_content_item(str(img))
+        assert item["image"].startswith("data:image/png;base64,")
+
+    def test_local_jpg_extension_mapped(self, tmp_path):
+        from plugins.image_gen.alibaba import _image_to_content_item
+
+        img = tmp_path / "test.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0")
+        item = _image_to_content_item(str(img))
+        assert item["image"].startswith("data:image/jpeg;base64,")
+
+    def test_tilde_expansion(self, tmp_path, monkeypatch):
+        from plugins.image_gen.alibaba import _image_to_content_item
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+        item = _image_to_content_item("~/pic.png")
+        assert item["image"].startswith("data:image/png;base64,")
+
+
+# ---------------------------------------------------------------------------
+# Generate tests
+# ---------------------------------------------------------------------------
+
+
+def _mock_dashscope_response(image_url="https://oss.example.com/image.png"):
+    """Build a mock response matching the DashScope image-generation API."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {
+        "request_id": "test-req-123",
+        "output": {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "image", "image": image_url}
+                        ],
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "debug_info": [
+                {
+                    "actual_seed": 42,
+                    "output_W": 1024,
+                    "output_H": 1024,
+                    "inference_cost": 5.5,
+                }
+            ],
+        },
+    }
+    return mock_resp
+
+
+class TestGenerate:
+    def test_missing_api_key(self, monkeypatch):
+        monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        provider = AlibabaImageGenProvider()
+        result = provider.generate(prompt="test")
+        assert result["success"] is False
+        assert result["error_type"] == "missing_api_key"
+        assert "DASHSCOPE_API_KEY" in result["error"]
+
+    def test_successful_text_to_image(self):
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        mock_resp = _mock_dashscope_response()
+
+        with patch("plugins.image_gen.alibaba.requests.post", return_value=mock_resp):
+            with patch(
+                "plugins.image_gen.alibaba.save_url_image",
+                return_value=Path("/tmp/dashscope_test.png"),
+            ):
+                provider = AlibabaImageGenProvider()
+                result = provider.generate(prompt="A cat playing piano")
+
+        assert result["success"] is True
+        assert result["image"] == "/tmp/dashscope_test.png"
+        assert result["provider"] == "alibaba"
+        assert result["model"] == "wan2.7-image-pro"
+        assert result["modality"] == "text"
+
+    def test_successful_image_edit(self):
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        mock_resp = _mock_dashscope_response()
+
+        with patch("plugins.image_gen.alibaba.requests.post", return_value=mock_resp) as mock_post:
+            with patch(
+                "plugins.image_gen.alibaba.save_url_image",
+                return_value=Path("/tmp/dashscope_edit.png"),
+            ):
+                provider = AlibabaImageGenProvider()
+                result = provider.generate(
+                    prompt="Make the sky purple",
+                    image_url="https://example.com/photo.png",
+                )
+
+        assert result["success"] is True
+        assert result["modality"] == "image"
+        # Verify the image was included in the content array
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        content = payload["input"]["messages"][0]["content"]
+        assert content[0] == {"image": "https://example.com/photo.png"}
+        assert content[1] == {"text": "Make the sky purple"}
+
+    def test_multiple_reference_images(self):
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        mock_resp = _mock_dashscope_response()
+
+        with patch("plugins.image_gen.alibaba.requests.post", return_value=mock_resp) as mock_post:
+            with patch(
+                "plugins.image_gen.alibaba.save_url_image",
+                return_value=Path("/tmp/dashscope_multi.png"),
+            ):
+                provider = AlibabaImageGenProvider()
+                result = provider.generate(
+                    prompt="Combine these styles",
+                    image_url="https://example.com/ref1.png",
+                    reference_image_urls=[
+                        "https://example.com/ref2.png",
+                        "https://example.com/ref3.png",
+                    ],
+                )
+
+        assert result["success"] is True
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        content = payload["input"]["messages"][0]["content"]
+        # 3 images + 1 text = 4 items
+        assert len(content) == 4
+
+    def test_too_many_references(self):
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        provider = AlibabaImageGenProvider()
+        result = provider.generate(
+            prompt="too many",
+            reference_image_urls=[f"https://example.com/img{i}.png" for i in range(10)],
+        )
+        assert result["success"] is False
+        assert result["error_type"] == "too_many_references"
+
+    def test_api_error(self):
+        import requests as req_lib
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+        mock_resp.text = "Access denied"
+        mock_resp.json.return_value = {
+            "code": "AccessDenied.Unpurchased",
+            "message": "Access to model denied.",
+        }
+        mock_resp.raise_for_status.side_effect = req_lib.HTTPError(response=mock_resp)
+
+        with patch("plugins.image_gen.alibaba.requests.post", return_value=mock_resp):
+            provider = AlibabaImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "403" in result["error"]
+        assert "Access to model denied" in result["error"]
+
+    def test_timeout(self):
+        import requests as req_lib
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        with patch(
+            "plugins.image_gen.alibaba.requests.post",
+            side_effect=req_lib.Timeout(),
+        ):
+            provider = AlibabaImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "timeout"
+
+    def test_connection_error(self):
+        import requests as req_lib
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        with patch(
+            "plugins.image_gen.alibaba.requests.post",
+            side_effect=req_lib.ConnectionError("DNS failure"),
+        ):
+            provider = AlibabaImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "connection_error"
+
+    def test_empty_choices(self):
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"output": {"choices": []}}
+
+        with patch("plugins.image_gen.alibaba.requests.post", return_value=mock_resp):
+            provider = AlibabaImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+
+    def test_no_image_in_content(self):
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "output": {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "I cannot generate that."}],
+                        }
+                    }
+                ]
+            }
+        }
+
+        with patch("plugins.image_gen.alibaba.requests.post", return_value=mock_resp):
+            provider = AlibabaImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+
+    def test_url_cached_locally(self):
+        """Ephemeral OSS URLs must be materialised to local cache."""
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        oss_url = "https://dashscope-463f.oss-accelerate.aliyuncs.com/test.png?Expires=123"
+        mock_resp = _mock_dashscope_response(image_url=oss_url)
+
+        with patch("plugins.image_gen.alibaba.requests.post", return_value=mock_resp):
+            with patch(
+                "plugins.image_gen.alibaba.save_url_image",
+                return_value=Path("/tmp/dashscope_cached.png"),
+            ) as mock_save:
+                provider = AlibabaImageGenProvider()
+                result = provider.generate(prompt="test")
+
+        assert result["success"] is True
+        assert result["image"] == "/tmp/dashscope_cached.png"
+        assert "oss-accelerate" not in result["image"]
+        mock_save.assert_called_once()
+        call_args = mock_save.call_args
+        assert call_args[0][0] == oss_url
+
+    def test_url_fallback_on_cache_failure(self):
+        """If caching fails, return the bare URL rather than erroring."""
+        import requests as req_lib
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        oss_url = "https://dashscope-463f.oss-accelerate.aliyuncs.com/test.png"
+        mock_resp = _mock_dashscope_response(image_url=oss_url)
+
+        with patch("plugins.image_gen.alibaba.requests.post", return_value=mock_resp):
+            with patch(
+                "plugins.image_gen.alibaba.save_url_image",
+                side_effect=req_lib.HTTPError("404"),
+            ):
+                provider = AlibabaImageGenProvider()
+                result = provider.generate(prompt="test")
+
+        assert result["success"] is True
+        assert result["image"] == oss_url
+
+    def test_auth_header(self):
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        mock_resp = _mock_dashscope_response()
+
+        with patch("plugins.image_gen.alibaba.requests.post", return_value=mock_resp) as mock_post:
+            with patch(
+                "plugins.image_gen.alibaba.save_url_image",
+                return_value=Path("/tmp/test.png"),
+            ):
+                provider = AlibabaImageGenProvider()
+                provider.generate(prompt="test")
+
+        call_args = mock_post.call_args
+        headers = call_args.kwargs.get("headers") or call_args[1].get("headers")
+        assert "Bearer sk-test-key-12345" in headers["Authorization"]
+        assert headers["X-DashScope-Async"] == "enable"
+
+    def test_payload_structure(self):
+        """Verify the wire payload matches the DashScope API contract."""
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        mock_resp = _mock_dashscope_response()
+
+        with patch("plugins.image_gen.alibaba.requests.post", return_value=mock_resp) as mock_post:
+            with patch(
+                "plugins.image_gen.alibaba.save_url_image",
+                return_value=Path("/tmp/test.png"),
+            ):
+                provider = AlibabaImageGenProvider()
+                provider.generate(prompt="A blue circle")
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["model"] == "wan2.7-image-pro"
+        assert "input" in payload
+        assert "messages" in payload["input"]
+        msg = payload["input"]["messages"][0]
+        assert msg["role"] == "user"
+        assert isinstance(msg["content"], list)
+        # Last content item should be the text prompt
+        assert msg["content"][-1] == {"text": "A blue circle"}
+        # Parameters should include size and n
+        assert "parameters" in payload
+        assert payload["parameters"]["n"] == 1
+        assert "size" in payload["parameters"]
+
+    def test_thinking_mode_enabled_for_pro_t2i(self):
+        """thinking_mode defaults to True for wan2.7-image-pro text-to-image."""
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        mock_resp = _mock_dashscope_response()
+
+        with patch("plugins.image_gen.alibaba.requests.post", return_value=mock_resp) as mock_post:
+            with patch(
+                "plugins.image_gen.alibaba.save_url_image",
+                return_value=Path("/tmp/test.png"),
+            ):
+                provider = AlibabaImageGenProvider()
+                provider.generate(prompt="test")
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["parameters"]["thinking_mode"] is True
+
+    def test_thinking_mode_absent_for_edit(self):
+        """thinking_mode must not be sent for image editing."""
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        mock_resp = _mock_dashscope_response()
+
+        with patch("plugins.image_gen.alibaba.requests.post", return_value=mock_resp) as mock_post:
+            with patch(
+                "plugins.image_gen.alibaba.save_url_image",
+                return_value=Path("/tmp/test.png"),
+            ):
+                provider = AlibabaImageGenProvider()
+                provider.generate(
+                    prompt="edit this",
+                    image_url="https://example.com/photo.png",
+                )
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert "thinking_mode" not in payload["parameters"]
+
+    def test_debug_info_in_extra(self):
+        """Debug info from the API response is surfaced in the result."""
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        mock_resp = _mock_dashscope_response()
+
+        with patch("plugins.image_gen.alibaba.requests.post", return_value=mock_resp):
+            with patch(
+                "plugins.image_gen.alibaba.save_url_image",
+                return_value=Path("/tmp/test.png"),
+            ):
+                provider = AlibabaImageGenProvider()
+                result = provider.generate(prompt="test")
+
+        assert result["actual_seed"] == 42
+        assert result["output_W"] == 1024
+        assert result["output_H"] == 1024
+
+    def test_response_without_type_field(self):
+        """Handle responses where content items use {"image": url} without "type"."""
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "output": {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": [
+                                {"image": "https://oss.example.com/no-type.png"}
+                            ],
+                        }
+                    }
+                ]
+            }
+        }
+
+        with patch("plugins.image_gen.alibaba.requests.post", return_value=mock_resp):
+            with patch(
+                "plugins.image_gen.alibaba.save_url_image",
+                return_value=Path("/tmp/no-type.png"),
+            ):
+                provider = AlibabaImageGenProvider()
+                result = provider.generate(prompt="test")
+
+        assert result["success"] is True
+        assert result["image"] == "/tmp/no-type.png"
+
+
+# ---------------------------------------------------------------------------
+# Registration test
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_register(self):
+        from plugins.image_gen.alibaba import AlibabaImageGenProvider, register
+
+        mock_ctx = MagicMock()
+        register(mock_ctx)
+        mock_ctx.register_image_gen_provider.assert_called_once()
+        provider = mock_ctx.register_image_gen_provider.call_args[0][0]
+        assert isinstance(provider, AlibabaImageGenProvider)
+        assert provider.name == "alibaba"


### PR DESCRIPTION
## What does this PR do?

Adds a new image_gen plugin for Alibaba Cloud's DashScope API, exposing the Wan 2.7 image models (`wan2.7-image-pro`, `wan2.7-image`) through the existing `ImageGenProvider` ABC.

Users who already have `DASHSCOPE_API_KEY` configured for LLM inference (the existing `alibaba` model-provider plugin) get image generation with zero additional setup — the provider reuses the same key and base URL.

## Related Issue

N/A — new provider addition.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/image_gen/alibaba/__init__.py` — New provider implementing `ImageGenProvider` ABC:
  - Text-to-image generation (up to 4K on wan2.7-image-pro)
  - Image editing with up to 9 reference images (URL or base64 data URI)
  - Thinking mode for enhanced quality (text-to-image only, pro model)
  - Configurable output size, seed, and watermark via `image_gen.alibaba` in config.yaml
  - Ephemeral OSS URLs materialised to local cache via `save_url_image()`
  - Endpoint derivation handles standard DashScope, compatible-mode, and token-plan MaaS base URLs
  - Local file paths converted to base64 data URIs with `raise_if_read_blocked()` credential guard
- `plugins/image_gen/alibaba/plugin.yaml` — Plugin manifest (`kind: backend`, `requires_env: DASHSCOPE_API_KEY`)
- `tests/plugins/image_gen/test_alibaba_provider.py` — 42 tests covering provider metadata, config resolution, endpoint derivation, image content encoding, generate success/error paths, URL caching, payload structure, and plugin registration

## How to Test

1. Set `DASHSCOPE_API_KEY` in `~/.hermes/.env`
2. Set `image_gen.provider: alibaba` in `~/.hermes/config.yaml`
3. Run `hermes tools` → Image Generation → verify Alibaba appears in the provider picker
4. Use the `image_generate` tool with a prompt — verify image is generated and cached locally
5. Run `scripts/run_tests.sh tests/plugins/image_gen/test_alibaba_provider.py -q` — 42 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(image_gen): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/plugins/image_gen/ tests/agent/test_image_gen_registry.py -q` and all tests pass (247 passed, 0 failed)
- [x] I've added tests for my changes (42 tests)
- [x] I've tested on my platform: macOS 26.6

### Documentation & Housekeeping

- [x] N/A — no new config keys requiring `cli-config.yaml.example` changes (uses existing `image_gen.alibaba` section pattern)
- [x] N/A — no architecture or workflow changes
- [x] Cross-platform: uses `pathlib.Path`, `requests`, no platform-specific code