### PR TITLE
fix(gateway): strip_markdown leaves !prefix on image alt text

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -182,6 +182,7 @@ class TextBatchAggregator:
 # ─── Markdown Stripping ──────────────────────────────────────────────────────
 
 # Pre-compiled regexes for performance
+_RE_IMAGE = re.compile(r"!\[([^\]]*)\]\([^\)]*\)")  # must precede _RE_LINK
 _RE_BOLD = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
 _RE_ITALIC_STAR = re.compile(r"\*(.+?)\*", re.DOTALL)
 _RE_BOLD_UNDER = re.compile(r"\b__(?![\s_])(.+?)(?<![\s_])__\b", re.DOTALL)
@@ -190,6 +191,8 @@ _RE_CODE_BLOCK = re.compile(r"```[a-zA-Z0-9_+-]*\n?")
 _RE_INLINE_CODE = re.compile(r"`(.+?)`")
 _RE_HEADING = re.compile(r"^#{1,6}\s+", re.MULTILINE)
 _RE_LINK = re.compile(r"\[([^\]]+)\]\([^\)]+\)")
+_RE_BLOCKQUOTE = re.compile(r"^>\s?", re.MULTILINE)
+_RE_STRIKETHROUGH = re.compile(r"~~(.+?)~~", re.DOTALL)
 _RE_MULTI_NEWLINE = re.compile(r"\n{3,}")
 
 
@@ -199,6 +202,7 @@ def strip_markdown(text: str) -> str:
     Replaces the identical ``_strip_markdown()`` functions previously
     duplicated in sms.py, bluebubbles.py, and feishu.py.
     """
+    text = _RE_IMAGE.sub(r"\1", text)       # ![alt](url) → alt  (before links)
     text = _RE_BOLD.sub(r"\1", text)
     text = _RE_ITALIC_STAR.sub(r"\1", text)
     text = _RE_BOLD_UNDER.sub(r"\1", text)
@@ -207,6 +211,8 @@ def strip_markdown(text: str) -> str:
     text = _RE_INLINE_CODE.sub(r"\1", text)
     text = _RE_HEADING.sub("", text)
     text = _RE_LINK.sub(r"\1", text)
+    text = _RE_BLOCKQUOTE.sub("", text)
+    text = _RE_STRIKETHROUGH.sub(r"\1", text)
     text = _RE_MULTI_NEWLINE.sub("\n\n", text)
     return text.strip()
 

--- a/tests/gateway/test_helpers_strip_markdown.py
+++ b/tests/gateway/test_helpers_strip_markdown.py
@@ -1,0 +1,78 @@
+"""Tests for gateway.platforms.helpers.strip_markdown."""
+from gateway.platforms.helpers import strip_markdown
+
+
+def test_image_stripped_to_alt_text():
+    """Images ![alt](url) should become alt text, not !alt."""
+    assert strip_markdown("![photo](https://example.com/img.png)") == "photo"
+
+
+def test_image_with_empty_alt():
+    """Images with empty alt text should collapse cleanly."""
+    assert strip_markdown("![](https://example.com/img.png)") == ""
+
+
+def test_link_stripped_to_display_text():
+    """Links [text](url) should become text."""
+    assert strip_markdown("[click here](https://example.com)") == "click here"
+
+
+def test_image_before_link_no_interference():
+    """Image and link regexes should not interfere."""
+    text = "See ![diagram](https://img.png) and [docs](https://docs.com)"
+    result = strip_markdown(text)
+    assert result == "See diagram and docs"
+
+
+def test_bold_and_italic():
+    assert strip_markdown("**bold** and *italic*") == "bold and italic"
+
+
+def test_strikethrough():
+    assert strip_markdown("~~deleted~~ kept") == "deleted kept"
+
+
+def test_blockquote():
+    assert strip_markdown("> quoted text") == "quoted text"
+
+
+def test_heading():
+    assert strip_markdown("## Section Title") == "Section Title"
+
+
+def test_inline_code_preserves_content():
+    assert strip_markdown("Run `pip install foo`") == "Run pip install foo"
+
+
+def test_code_block_removed():
+    text = "```python\nprint('hello')\n```"
+    result = strip_markdown(text)
+    assert "python" not in result
+    assert "print" in result
+
+
+def test_multi_newline_collapsed():
+    text = "a\n\n\n\nb"
+    assert strip_markdown(text) == "a\n\nb"
+
+
+def test_combined_markdown():
+    """Complex mixed markdown should be stripped cleanly."""
+    text = (
+        "## Title\n\n"
+        "Hello **world**, see ![img](http://x.png) and [link](http://x.com).\n\n"
+        "> A quote with *emphasis*.\n\n"
+        "~~old~~ new and `code`."
+    )
+    result = strip_markdown(text)
+    assert "##" not in result
+    assert "**" not in result
+    assert "![" not in result
+    assert "![img]" not in result
+    assert "img" in result
+    assert "link" in result
+    assert ">" not in result.split("\n")[0]
+    assert "~~" not in result
+    assert "old" in result
+    assert "new" in result
+    assert "code" in result


### PR DESCRIPTION
## Summary

- Fix `strip_markdown()` leaving a stray `!` prefix on image alt text (`![alt](url)` → `!alt` instead of `alt`)
- Add blockquote (`> text`) and strikethrough (`~~text~~`) stripping
- Add 12 unit tests for `strip_markdown()`

## Problem

The `strip_markdown()` function in `gateway/platforms/helpers.py` was missing an image regex. When processing `![alt text](url)`, the link regex `[alt text](url)` matched and replaced with `alt text`, but the leading `!` was not consumed. Result: `!alt text` instead of `alt text`.

This affected all platforms using `strip_markdown()`: SMS, iMessage (photon), Feishu, QQ, BlueBubbles, and the reply-to context sanitizer.

## Changes

**`gateway/platforms/helpers.py`:**
- Add `_RE_IMAGE` regex to match `![alt](url)` → `alt` (must apply before `_RE_LINK`)
- Add `_RE_BLOCKQUOTE` regex to strip `> ` prefixes from blockquotes
- Add `_RE_STRIKETHROUGH` regex to strip `~~text~~` → `text`
- Inline code: keep content (no change), just strip backtick delimiters

**`tests/gateway/test_helpers_strip_markdown.py`** (new):
- 12 tests covering image, link, blockquote, strikethrough, heading, bold/italic, code blocks, inline code, multi-newline collapse, and combined markdown

## Test plan

- [x] 128 tests pass (new + existing photon, IRC, bluebubbles, reply-to injection tests)
- [ ] Verify SMS/iMessage/Feishu rendering with image markdown
