### PR TITLE
feat: prompt-codec local densify provider plugin

### DIFF
--- a/plugins/model-providers/README.md
+++ b/plugins/model-providers/README.md
@@ -25,6 +25,13 @@ User plugins at `$HERMES_HOME/plugins/model-providers/<name>/` override
 bundled plugins of the same name — last-writer-wins in
 `register_provider()`. Drop a file there to replace a built-in.
 
+## prompt-codec (local densify)
+
+Bundled profile `prompt_codec` targets `http://127.0.0.1:8787/v1`. Install the
+proxy from https://github.com/jwaynelowry/prompt-codec. Complementary to Hermes
+`compression:` / ContextCompressor — densify runs on every outbound request;
+do not disable mid-session compaction.
+
 ## Adding a new provider
 
 1. Create `plugins/model-providers/<your_provider>/__init__.py`:

--- a/plugins/model-providers/prompt-codec/__init__.py
+++ b/plugins/model-providers/prompt-codec/__init__.py
@@ -1,0 +1,74 @@
+"""prompt-codec densify proxy provider profile.
+
+Routes Hermes chat completions through a local OpenAI-compatible densify
+proxy (default http://127.0.0.1:8787/v1) that rewrites prompts with
+fence-safe rules + optional Ollama/MLX refine before they hit paid APIs.
+
+This does NOT replace Hermes ContextCompressor / compression: — densify
+runs on every outbound request; context compaction still runs mid-session.
+
+Install proxy: https://github.com/jwaynelowry/prompt-codec
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class PromptCodecProfile(ProviderProfile):
+    """OpenAI-compatible densify sidecar (chat_completions transport)."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        **ctx: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        # Forward reasoning_effort=none so thinking-capable upstream models
+        # (and the local densify encoder when Hermes probes) do not burn the
+        # output budget. Harmless if the endpoint ignores the field.
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+        if reasoning_config and isinstance(reasoning_config, dict):
+            effort = (reasoning_config.get("effort") or "").strip().lower()
+            enabled = reasoning_config.get("enabled", True)
+            if effort == "none" or enabled is False:
+                top_level["reasoning_effort"] = "none"
+            elif effort:
+                top_level["reasoning_effort"] = effort
+        return extra_body, top_level
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        if not (base_url or self.base_url):
+            return None
+        return super().fetch_models(api_key=api_key, base_url=base_url, timeout=timeout)
+
+
+prompt_codec = PromptCodecProfile(
+    name="prompt_codec",
+    aliases=(
+        "prompt-codec",
+        "densify",
+        "promptcodec",
+    ),
+    display_name="Prompt Codec (local densify)",
+    description=(
+        "Local densify proxy on :8787 — shrinks outbound prompts before paid "
+        "APIs. Requires prompt-codec + Ollama/MLX. Stacks with Hermes compression."
+    ),
+    signup_url="https://github.com/jwaynelowry/prompt-codec",
+    env_vars=("X_API_KEY",),
+    base_url="http://127.0.0.1:8787/v1",
+    default_aux_model="",
+)
+
+register_provider(prompt_codec)

--- a/plugins/model-providers/prompt-codec/plugin.yaml
+++ b/plugins/model-providers/prompt-codec/plugin.yaml
@@ -1,0 +1,5 @@
+name: prompt-codec-provider
+kind: model-provider
+version: 1.0.0
+description: Local densify proxy — compress outbound prompts before paid APIs (complementary to Hermes context compression)
+author: Wayne Lowry


### PR DESCRIPTION
## Summary
- Add `plugins/model-providers/prompt-codec/` so Hermes can route chat completions through a local densify proxy (`http://127.0.0.1:8787/v1` by default).
- Document that this is **complementary** to Hermes `compression:` / `ContextCompressor` — densify shrinks every outbound request; mid-session compaction still owns history pruning.
- Point setup at https://github.com/jwaynelowry/prompt-codec (Ollama/MLX encoder, optional launchd).

## Why
Paid token spend on fluffy tool dumps and thank-you prose is expensive. A loopback OpenAI-compatible densify sidecar keeps Hermes’s prompt-cache prefixes byte-stable (`llm_scope: last_user`) while cutting tokens before xAI/OpenAI.

## Test plan
- [ ] Fresh Hermes: plugin appears in provider discovery / model picker aliases (`prompt_codec`, `densify`)
- [ ] With `prompt-codec proxy` running + Ollama `gemma4:e4b-mlx`, set `model.provider: custom:prompt_codec` and complete one chat turn
- [ ] Confirm Hermes context compression remains enabled and unaffected
- [ ] Proxy down → clear connection error (no silent hang)

Related docs recipe: https://github.com/NousResearch/hermes-agent/pull/68835

Made with [Cursor](https://cursor.com)