### PR TITLE
fix(agent): validate JSON type in sanitize_tool_call_arguments (#58057)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -306,8 +306,22 @@ def sanitize_tool_call_arguments(
                 continue
 
             try:
-                json.loads(arguments)
+                parsed = json.loads(arguments)
             except json.JSONDecodeError:
+                parsed = None  # handled below
+
+            if parsed is not None and not isinstance(parsed, dict):
+                # Arguments parsed as JSON but are not an object (e.g. a
+                # JSON array like [{"mode": "replace"}]).  Strict providers
+                # reject non-object arguments with HTTP 400.  Unwrap
+                # single-element arrays; anything else falls back to "{}".
+                if isinstance(parsed, list) and len(parsed) == 1 and isinstance(parsed[0], dict):
+                    function["arguments"] = json.dumps(parsed[0])
+                    parsed = parsed[0]  # still valid, skip corruption path
+                else:
+                    parsed = None  # fall through to corruption repair
+
+            if parsed is None:
                 # Use the canonical ``call_id || id`` precedence so both the
                 # scan for an existing tool result and any inserted stub key
                 # on the same id the rest of the pipeline uses. Keying on bare

--- a/tests/agent/test_sanitize_tool_call_arguments.py
+++ b/tests/agent/test_sanitize_tool_call_arguments.py
@@ -1,0 +1,79 @@
+"""Tests for sanitize_tool_call_arguments() type validation (issue #58057).
+
+When a model emits function.arguments as a JSON array instead of an object,
+strict OpenAI-compatible providers reject with HTTP 400. The sanitizer must
+detect non-dict JSON and either unwrap single-element arrays or fall back
+to "{}" with a corruption marker.
+"""
+import json
+
+import pytest
+
+from agent.agent_runtime_helpers import sanitize_tool_call_arguments
+
+
+def _make_msg(tc_id: str, arguments: str) -> dict:
+    return {
+        "role": "assistant",
+        "tool_calls": [{"id": tc_id, "function": {"name": "fn", "arguments": arguments}}],
+    }
+
+
+class TestSanitizeToolCallArgumentTypes:
+    """validate that non-dict JSON arguments are caught and repaired."""
+
+    def test_valid_dict_passes_through(self):
+        msgs = [_make_msg("tc1", '{"key": "value"}')]
+        assert sanitize_tool_call_arguments(msgs) == 0
+        assert json.loads(msgs[0]["tool_calls"][0]["function"]["arguments"]) == {"key": "value"}
+
+    def test_single_element_array_unwrapped(self):
+        """A single-element array [{...}] should be unwrapped to its dict."""
+        msgs = [_make_msg("tc2", '[{"mode": "replace", "path": "config.yaml"}]')]
+        assert sanitize_tool_call_arguments(msgs) == 0
+        args = json.loads(msgs[0]["tool_calls"][0]["function"]["arguments"])
+        assert isinstance(args, dict)
+        assert args == {"mode": "replace", "path": "config.yaml"}
+
+    def test_multi_element_array_repaired(self):
+        """Multi-element arrays cannot be safely unwrapped — repair to {}."""
+        msgs = [_make_msg("tc3", '[{"a": 1}, {"b": 2}]')]
+        assert sanitize_tool_call_arguments(msgs) == 1
+        assert msgs[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+
+    def test_array_of_non_dicts_repaired(self):
+        """Array of primitives is not a valid arguments dict."""
+        msgs = [_make_msg("tc4", '["foo", "bar"]')]
+        assert sanitize_tool_call_arguments(msgs) == 1
+        assert msgs[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+
+    def test_bare_string_repaired(self):
+        msgs = [_make_msg("tc5", '"just a string"')]
+        assert sanitize_tool_call_arguments(msgs) == 1
+        assert msgs[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+
+    def test_bare_number_repaired(self):
+        msgs = [_make_msg("tc6", "42")]
+        assert sanitize_tool_call_arguments(msgs) == 1
+        assert msgs[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+
+    def test_bare_null_repaired(self):
+        msgs = [_make_msg("tc7", "null")]
+        assert sanitize_tool_call_arguments(msgs) == 1
+        assert msgs[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+
+    def test_invalid_json_repaired(self):
+        msgs = [_make_msg("tc8", "not json at all")]
+        assert sanitize_tool_call_arguments(msgs) == 1
+        assert msgs[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+
+    def test_empty_string_repaired(self):
+        msgs = [_make_msg("tc9", "")]
+        assert sanitize_tool_call_arguments(msgs) == 0  # handled before JSON parse
+        assert msgs[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+
+    def test_single_element_array_with_non_dict_repaired(self):
+        """Single-element array with a non-dict element should be repaired."""
+        msgs = [_make_msg("tc10", '["not a dict"]')]
+        assert sanitize_tool_call_arguments(msgs) == 1
+        assert msgs[0]["tool_calls"][0]["function"]["arguments"] == "{}"


### PR DESCRIPTION
## Summary

- Validate that `sanitize_tool_call_arguments()` checks the **type** of parsed JSON, not just validity
- Single-element arrays `[{...}]` are automatically unwrapped to their dict element
- Multi-element arrays, bare strings, numbers, null, and other non-dict types fall back to `"{}"` with corruption marker
- 10 unit tests covering all type validation edge cases

## Problem

`sanitize_tool_call_arguments()` in `agent/agent_runtime_helpers.py` only checked whether `function.arguments` could be parsed as `json.loads()`. It did not validate that the parsed result is a `dict` (JSON object). When a model emits arguments as a JSON array (`[{"mode": "replace"}]`), it passes validation but is rejected by strict OpenAI-compatible endpoints with a non-retryable HTTP 400 `InvalidParameter`. The malformed `tool_call` is persisted to `state.db` and replayed on every subsequent API call, permanently killing the conversation session.

This was observed with `glm-5.2` on Volcengine Ark, but the bug class affects any strict OpenAI-compatible provider.

## Changes

**`agent/agent_runtime_helpers.py`:**
- After `json.loads(arguments)`, check `isinstance(parsed, dict)`
- Single-element arrays with a dict element: unwrap automatically (`[{...}]` → `{...}`)
- Other non-dict types: fall through to existing corruption repair (set `"{}"`, insert marker)

**`tests/agent/test_sanitize_tool_call_arguments.py`** (new):
- 10 tests: valid dict, single-element array unwrap, multi-element array, array of primitives, bare string, bare number, bare null, invalid JSON, empty string, single-element non-dict array

## Test plan

- [x] 10/10 new tests pass
- [x] 459 existing sanitize-related tests pass (3 pre-existing failures unrelated)

Fixes #58057
