### PR TITLE
fix(gateway): hard-exit CLI runner after graceful teardown

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4975,6 +4975,17 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
     except Exception as _be:
         logger.debug("respawn-storm breaker check failed (non-fatal): %s", _be)
 
+    def _hard_exit_after_gateway_teardown(code: int) -> None:
+        # ``hermes gateway run`` enters through this CLI wrapper, not through
+        # ``gateway.run.main()``.  Mirror that module's wedge-proof exit path:
+        # once start_gateway() has completed graceful teardown, bypass Python
+        # finalization so non-daemon worker threads (notably in-flight cron
+        # ThreadPoolExecutor jobs) cannot keep the old gateway alive and delay a
+        # service-managed /restart by minutes.
+        from gateway.run import _exit_after_graceful_shutdown
+
+        _exit_after_graceful_shutdown(code)
+
     success = False
     try:
         success = asyncio.run(start_gateway(replace=replace, verbosity=verbosity))
@@ -4994,7 +5005,13 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
             code=getattr(e, "code", None),
             traceback=_traceback.format_exc(),
         )
-        raise
+        if e.code is None:
+            _code = 0
+        elif isinstance(e.code, int):
+            _code = e.code
+        else:
+            _code = 1
+        _hard_exit_after_gateway_teardown(_code)
     except BaseException as e:
         # Absolutely everything else: Exception, asyncio.CancelledError,
         # even exotic BaseException subclasses. We want the cause logged.
@@ -5007,8 +5024,9 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
         raise
     if not success:
         _exit_diag("gateway.exit_nonzero")
-        sys.exit(1)
+        _hard_exit_after_gateway_teardown(1)
     _exit_diag("gateway.exit_clean")
+    _hard_exit_after_gateway_teardown(0)
 
 
 # =============================================================================

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4998,7 +4998,8 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
             traceback=_traceback.format_exc(),
         )
         print("\nGateway stopped.")
-        return
+        _hard_exit_after_gateway_teardown(0)
+        return  # unreachable in production (os._exit); guard for test stubs
     except SystemExit as e:
         _exit_diag(
             "asyncio.run.SystemExit",

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -63,6 +63,10 @@ def test_run_gateway_exits_cleanly_on_keyboard_interrupt(monkeypatch, capsys):
     _install_fake_gateway_run(monkeypatch, fake_start_gateway)
     monkeypatch.setattr(gateway.asyncio, "run", fake_asyncio_run)
 
+    # KeyboardInterrupt now uses the same hard-exit backstop as all other
+    # exit paths (instead of a bare ``return``).  The test stub's
+    # _exit_after_graceful_shutdown is a no-op for code 0, so run_gateway()
+    # returns normally — but the real implementation would call os._exit(0).
     gateway.run_gateway()
 
     out = capsys.readouterr().out

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -17,6 +17,12 @@ import hermes_cli.gateway as gateway
 def _install_fake_gateway_run(monkeypatch, start_gateway):
     module = ModuleType("gateway.run")
     module.start_gateway = start_gateway
+
+    def _exit_after_graceful_shutdown(code):
+        if code:
+            raise SystemExit(code)
+
+    setattr(module, "_exit_after_graceful_shutdown", _exit_after_graceful_shutdown)
     monkeypatch.setitem(sys.modules, "gateway.run", module)
     # ``run_gateway()`` calls ``refresh_systemd_unit_if_needed()`` on every
     # invocation so that restart settings stay current after exit-code-75
@@ -119,6 +125,7 @@ def test_gateway_run_subprocess_preserves_daemon_exit_codes(
 
         fake_run = types.ModuleType("gateway.run")
         fake_run.start_gateway = start_gateway
+        setattr(fake_run, "_exit_after_graceful_shutdown", sys.exit)
         sys.modules["gateway.run"] = fake_run
 
         gateway_cli._guard_official_docker_root_gateway = lambda: None

--- a/tests/hermes_cli/test_gateway_run_hard_exit.py
+++ b/tests/hermes_cli/test_gateway_run_hard_exit.py
@@ -1,0 +1,87 @@
+"""Regression tests for CLI gateway run exit behavior.
+
+``hermes gateway run`` enters through hermes_cli.gateway, not gateway.run.main().
+After graceful teardown it must use the same hard-exit backstop as gateway.run.main()
+so Python finalization does not wait on non-daemon worker threads (for example
+in-flight cron ThreadPoolExecutor jobs) and delay service-managed restarts.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+
+class _HardExitObserved(BaseException):
+    def __init__(self, code: int):
+        super().__init__(code)
+        self.code = code
+
+
+def _prepare(monkeypatch):
+    import hermes_cli.gateway as gateway_cli
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_cli, "_guard_official_docker_root_gateway", lambda: None)
+    monkeypatch.setattr(gateway_cli, "_guard_named_profile_under_multiplexer", lambda force=False: None)
+    monkeypatch.setattr(gateway_cli, "_guard_supervised_gateway_conflict", lambda force=False: None)
+    monkeypatch.setattr(gateway_cli, "_guard_existing_gateway_process_conflict", lambda replace=False: None)
+    monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway_cli.sys, "stdin", types.SimpleNamespace(isatty=lambda: False))
+    monkeypatch.setenv("HERMES_GATEWAY_EXIT_DIAG", "0")
+
+    async def _start_gateway(*args, **kwargs):  # pragma: no cover - never awaited by fake run
+        return True
+
+    def _hard_exit(code: int) -> None:
+        raise _HardExitObserved(code)
+
+    monkeypatch.setattr(gateway_run, "start_gateway", _start_gateway)
+    monkeypatch.setattr(gateway_run, "_exit_after_graceful_shutdown", _hard_exit)
+    return gateway_cli
+
+
+def test_run_gateway_hard_exits_after_clean_return(monkeypatch):
+    gateway_cli = _prepare(monkeypatch)
+
+    def _fake_run(coro):
+        coro.close()
+        return True
+
+    monkeypatch.setattr(gateway_cli.asyncio, "run", _fake_run)
+
+    with pytest.raises(_HardExitObserved) as excinfo:
+        gateway_cli.run_gateway()
+
+    assert excinfo.value.code == 0
+
+
+def test_run_gateway_hard_exits_after_service_restart_systemexit(monkeypatch):
+    gateway_cli = _prepare(monkeypatch)
+
+    def _fake_run(coro):
+        coro.close()
+        raise SystemExit(75)
+
+    monkeypatch.setattr(gateway_cli.asyncio, "run", _fake_run)
+
+    with pytest.raises(_HardExitObserved) as excinfo:
+        gateway_cli.run_gateway()
+
+    assert excinfo.value.code == 75
+
+
+def test_run_gateway_hard_exits_after_failed_return(monkeypatch):
+    gateway_cli = _prepare(monkeypatch)
+
+    def _fake_run(coro):
+        coro.close()
+        return False
+
+    monkeypatch.setattr(gateway_cli.asyncio, "run", _fake_run)
+
+    with pytest.raises(_HardExitObserved) as excinfo:
+        gateway_cli.run_gateway()
+
+    assert excinfo.value.code == 1

--- a/tests/hermes_cli/test_gateway_run_hard_exit.py
+++ b/tests/hermes_cli/test_gateway_run_hard_exit.py
@@ -85,3 +85,23 @@ def test_run_gateway_hard_exits_after_failed_return(monkeypatch):
         gateway_cli.run_gateway()
 
     assert excinfo.value.code == 1
+
+
+def test_run_gateway_hard_exits_after_keyboard_interrupt(monkeypatch):
+    """KeyboardInterrupt (console Ctrl+C) must also hard-exit, not return.
+
+    A bare ``return`` would let Python finalization join non-daemon worker
+    threads, the same wedge this backstop prevents on the other exit paths.
+    """
+    gateway_cli = _prepare(monkeypatch)
+
+    def _fake_run(coro):
+        coro.close()
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(gateway_cli.asyncio, "run", _fake_run)
+
+    with pytest.raises(_HardExitObserved) as excinfo:
+        gateway_cli.run_gateway()
+
+    assert excinfo.value.code == 0


### PR DESCRIPTION
## Summary
Routes `hermes gateway run` exits through the same `os._exit` backstop (`_exit_after_graceful_shutdown`) that `gateway.run.main()` already uses, so Python finalization can't hang on non-daemon worker threads (cron ThreadPoolExecutor jobs) and delay a service-managed `/restart`.

Follow-up: the KeyboardInterrupt (console Ctrl+C) path was the only exit path that still used bare `return` instead of the hard-exit backstop. Now all 4 exit paths (clean return, failed return, SystemExit, KeyboardInterrupt) route through `_hard_exit_after_gateway_teardown`.

Salvage of #68495 by @web3blind — cherry-picked with authorship preserved, plus a follow-up commit completing the bug class.

Closes #68495

## Changes
- `hermes_cli/gateway.py`: add `_hard_exit_after_gateway_teardown()` that calls `_exit_after_graceful_shutdown` from `gateway.run`; route SystemExit, clean/failed returns, AND KeyboardInterrupt through it
- `tests/hermes_cli/test_gateway_run_hard_exit.py`: regression tests for all 4 exit paths
- `tests/hermes_cli/test_gateway.py`: update test stubs for the new exit helper

## Validation
| | Before | After |
|---|---|---|
| Clean return | `sys.exit(0)` (soft) | `_exit_after_graceful_shutdown(0)` (hard) |
| Failed return | `sys.exit(1)` (soft) | `_exit_after_graceful_shutdown(1)` (hard) |
| SystemExit(75) | `raise` (soft) | `_exit_after_graceful_shutdown(75)` (hard) |
| KeyboardInterrupt | `return` (soft) | `_exit_after_graceful_shutdown(0)` (hard) |

- 61 tests passed (4 new + 57 existing)
- 25 cron tests passed
- E2E verified all 4 exit paths with real imports
- CI green on original PR #68495 (all 8 test slices + e2e + Docker)


## Infographic

![PR #69102 — Hard-Exit CLI Runner](file:///tmp/infographic-69102.html)
