### PR TITLE
fix(update): reconcile fleet restarts

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9422,6 +9422,82 @@ def _write_update_planned_stop_marker(profile_path: Path, pid: int) -> bool:
         return False
 
 
+def _run_update_systemctl(
+    command: list[str],
+    *,
+    scope: str,
+    unit: str,
+    timeout: float,
+    failures: dict[tuple[str, str], str],
+) -> subprocess.CompletedProcess | None:
+    """Run one per-unit systemctl command without aborting the fleet loop."""
+    try:
+        return subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        failures[(scope, unit)] = f"systemctl timed out ({exc.cmd or command})"
+        print(
+            f"  ⚠ systemctl timed out for {scope}-scope {unit} "
+            f"({exc.cmd or command}); continuing with remaining gateways"
+        )
+        return None
+
+
+def _reconcile_updated_systemd_gateways(
+    discovered: dict[tuple[str, str], tuple[list[str], int]],
+    failures: dict[tuple[str, str], str],
+) -> None:
+    """Replace attempt failures with the final active/PID state of each unit."""
+    for (scope, unit), (scope_cmd, previous_pid) in discovered.items():
+        result = _run_update_systemctl(
+            scope_cmd
+            + [
+                "show",
+                unit,
+                "--property=ActiveState,MainPID",
+                "--no-pager",
+            ],
+            scope=scope,
+            unit=unit,
+            timeout=5,
+            failures=failures,
+        )
+        if result is None:
+            continue
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "unknown error").strip()
+            failures[(scope, unit)] = f"could not verify final state: {detail}"
+            continue
+
+        properties = {}
+        for line in (result.stdout or "").splitlines():
+            if "=" in line:
+                key, value = line.split("=", 1)
+                properties[key] = value.strip()
+        try:
+            current_pid = int(properties.get("MainPID", "0") or 0)
+        except ValueError:
+            current_pid = 0
+
+        if properties.get("ActiveState") != "active":
+            failures[(scope, unit)] = "service is not active after the update"
+        elif previous_pid > 0 and current_pid == previous_pid:
+            failures[(scope, unit)] = (
+                f"still running pre-update PID {previous_pid}"
+            )
+        elif previous_pid > 0 and current_pid <= 0:
+            failures[(scope, unit)] = "active service has no verifiable MainPID"
+        elif previous_pid > 0 or (scope, unit) not in failures:
+            # A changed PID proves that even a timed-out restart completed.
+            # With no initial PID, keep any earlier failure because there is
+            # no evidence that the active process was replaced.
+            failures.pop((scope, unit), None)
+
+
 def _wait_for_windows_update_gateway_exit(
     pids: list[int], *, timeout: float
 ) -> set[int]:
@@ -10895,7 +10971,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print("  Code and Python deps are updated, but the dashboard/TUI may")
             print("  be in a mixed state until the Node deps are rebuilt.")
         else:
-            print("✓ Update complete!")
+            print("✓ Code and dependencies updated.")
 
         # Curator first-run heads-up. Only prints when curator is enabled AND
         # has never run — i.e. the window where the ticker would otherwise
@@ -10977,6 +11053,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _exit_code_path.write_text("0")
             except OSError:
                 pass
+
+        gateway_restart_failures: dict[tuple[str, str], str] = {}
+        gateway_restart_scope_failures: list[str] = []
+        gateway_restart_phase_error: Exception | None = None
 
         # Auto-restart ALL gateways after update.
         # The code update (git pull) is shared across all profiles, so every
@@ -11171,6 +11251,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
             killed_pids = set()
             relaunched_profiles = []
             externally_supervised_profiles = []
+            discovered_systemd_units: dict[
+                tuple[str, str], tuple[list[str], int]
+            ] = {}
 
             # --- Systemd services (Linux) ---
             # Discover all hermes-gateway* units (default + profiles)
@@ -11208,14 +11291,20 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             if not unit.endswith(".service"):
                                 continue
                             svc_name = unit.removesuffix(".service")
+                            unit_key = (scope, svc_name)
+                            discovered_systemd_units[unit_key] = (scope_cmd, 0)
                             # Check if active
-                            check = subprocess.run(
+                            check = _run_update_systemctl(
                                 scope_cmd + ["is-active", svc_name],
-                                capture_output=True,
-                                text=True,
+                                scope=scope,
+                                unit=svc_name,
                                 timeout=5,
+                                failures=gateway_restart_failures,
                             )
+                            if check is None:
+                                continue
                             if check.stdout.strip() != "active":
+                                discovered_systemd_units.pop(unit_key, None)
                                 continue
 
                             # Resolve how we may run manage-units verbs
@@ -11255,6 +11344,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                 FileNotFoundError,
                             ):
                                 _main_pid = 0
+                            discovered_systemd_units[unit_key] = (
+                                scope_cmd,
+                                _main_pid,
+                            )
 
                             _graceful_ok = False
                             if _main_pid > 0:
@@ -11295,18 +11388,22 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                 # auto-restart still relaunches the unit after
                                 # RestartSec, no privileges required.
                                 if _manage_cmd is not None:
-                                    subprocess.run(
+                                    if _run_update_systemctl(
                                         _manage_cmd + ["reset-failed", svc_name],
-                                        capture_output=True,
-                                        text=True,
+                                        scope=scope,
+                                        unit=svc_name,
                                         timeout=10,
-                                    )
-                                    subprocess.run(
+                                        failures=gateway_restart_failures,
+                                    ) is None:
+                                        continue
+                                    if _run_update_systemctl(
                                         _manage_cmd + ["start", svc_name],
-                                        capture_output=True,
-                                        text=True,
+                                        scope=scope,
+                                        unit=svc_name,
                                         timeout=15,
-                                    )
+                                        failures=gateway_restart_failures,
+                                    ) is None:
+                                        continue
                                     # Short poll: the gateway should be up
                                     # within a few seconds now that we
                                     # bypassed RestartSec.
@@ -11359,6 +11456,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             # — it flashes and dies before the user can
                             # answer.  Skip with clear instructions instead.
                             if _manage_cmd is None:
+                                gateway_restart_failures[unit_key] = (
+                                    "restart requires non-interactive root access"
+                                )
                                 print(
                                     f"  ⚠ {svc_name} is a system service and restarting it needs root.\n"
                                     f"    Restart it manually to load the new version:\n"
@@ -11384,18 +11484,23 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             # the restart idempotent.  Mirrors the recovery
                             # path in `hermes gateway restart`
                             # (`systemd_restart()`) as of PR #20949.
-                            subprocess.run(
+                            if _run_update_systemctl(
                                 _manage_cmd + ["reset-failed", svc_name],
-                                capture_output=True,
-                                text=True,
+                                scope=scope,
+                                unit=svc_name,
                                 timeout=10,
-                            )
-                            restart = subprocess.run(
+                                failures=gateway_restart_failures,
+                            ) is None:
+                                continue
+                            restart = _run_update_systemctl(
                                 _manage_cmd + ["restart", svc_name],
-                                capture_output=True,
-                                text=True,
+                                scope=scope,
+                                unit=svc_name,
                                 timeout=15,
+                                failures=gateway_restart_failures,
                             )
+                            if restart is None:
+                                continue
                             if restart.returncode == 0:
                                 # Verify the service actually survived the
                                 # restart.  systemctl restart returns 0 even
@@ -11416,18 +11521,22 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                     print(
                                         f"  ⚠ {svc_name} died after restart, retrying..."
                                     )
-                                    subprocess.run(
+                                    if _run_update_systemctl(
                                         _manage_cmd + ["reset-failed", svc_name],
-                                        capture_output=True,
-                                        text=True,
+                                        scope=scope,
+                                        unit=svc_name,
                                         timeout=10,
-                                    )
-                                    subprocess.run(
+                                        failures=gateway_restart_failures,
+                                    ) is None:
+                                        continue
+                                    if _run_update_systemctl(
                                         _manage_cmd + ["restart", svc_name],
-                                        capture_output=True,
-                                        text=True,
+                                        scope=scope,
+                                        unit=svc_name,
                                         timeout=15,
-                                    )
+                                        failures=gateway_restart_failures,
+                                    ) is None:
+                                        continue
                                     if _wait_for_service_active(
                                         scope_cmd,
                                         svc_name,
@@ -11436,6 +11545,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                         restarted_services.append(svc_name)
                                         print(f"  ✓ {svc_name} recovered on retry")
                                     else:
+                                        gateway_restart_failures[unit_key] = (
+                                            "service failed to stay active after restart"
+                                        )
                                         _scope_flag = "--user " if scope == "user" else ""
                                         _sudo_hint = "sudo " if scope == "system" else ""
                                         print(
@@ -11446,20 +11558,29 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                             f"      {_sudo_hint}systemctl {_scope_flag}restart {svc_name}"
                                         )
                             else:
+                                gateway_restart_failures[unit_key] = (
+                                    (restart.stderr or "systemctl restart failed").strip()
+                                )
                                 print(
                                     f"  ⚠ Failed to restart {svc_name}: {restart.stderr.strip()}"
                                 )
                     except FileNotFoundError:
                         pass
                     except subprocess.TimeoutExpired as exc:
-                        # Don't swallow this silently — a wedged systemctl
-                        # call here used to make the whole restart phase
-                        # vanish with no output (June 2026 report).
+                        # Per-unit calls are isolated by
+                        # _run_update_systemctl. Reaching this handler means
+                        # discovery itself timed out, so this scope cannot be
+                        # reconciled exactly.
+                        gateway_restart_scope_failures.append(scope)
                         print(
-                            f"  ⚠ systemctl timed out during the {scope}-scope "
-                            f"gateway restart ({exc.cmd if exc.cmd else 'unknown command'}). "
-                            f"Check the gateway with: hermes gateway status"
+                            f"  ⚠ systemctl timed out listing {scope}-scope gateway units "
+                            f"({exc.cmd if exc.cmd else 'unknown command'})"
                         )
+
+                _reconcile_updated_systemd_gateways(
+                    discovered_systemd_units,
+                    gateway_restart_failures,
+                )
 
             # --- Launchd services (macOS) ---
             if is_macos():
@@ -11632,7 +11753,29 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 logger.debug("Post-restart survivor sweep failed: %s", _sweep_exc)
 
         except Exception as e:
+            gateway_restart_phase_error = e
             logger.debug("Gateway restart during update failed: %s", e)
+
+        gateway_restart_incomplete = bool(
+            gateway_restart_failures
+            or gateway_restart_scope_failures
+            or gateway_restart_phase_error
+        )
+        if gateway_restart_incomplete:
+            print()
+            print("⚠ Update incomplete — some gateways may still run old code:")
+            for (scope, unit), reason in gateway_restart_failures.items():
+                print(f"    - {scope}/{unit}: {reason}")
+            for scope in gateway_restart_scope_failures:
+                print(f"    - {scope} scope: unit discovery timed out")
+            if gateway_restart_phase_error is not None:
+                print(f"    - restart phase: {gateway_restart_phase_error}")
+            print("  Restart the listed units before continuing to use the fleet.")
+            if gateway_mode:
+                try:
+                    (get_hermes_home() / ".update_exit_code").write_text("1")
+                except OSError:
+                    pass
 
         _resume_windows_gateways_after_update(_windows_gateway_resume)
 
@@ -11681,6 +11824,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print("    Node.js dependency refresh did not complete.")
         else:
             _kill_stale_dashboard_processes()
+
+        if gateway_restart_incomplete:
+            sys.exit(1)
+        if not node_failures:
+            print()
+            print("✓ Update complete!")
 
         print()
         print("Tip: You can now select a provider and model:")

--- a/tests/hermes_cli/test_update_fleet_restart_timeout.py
+++ b/tests/hermes_cli/test_update_fleet_restart_timeout.py
@@ -1,0 +1,88 @@
+"""Regression tests for isolated systemd fleet restarts (#68523)."""
+
+import subprocess
+
+from hermes_cli import main as hermes_main
+
+
+def test_per_unit_timeout_does_not_skip_later_gateways(monkeypatch, capsys):
+    units = [
+        "hermes-gateway-one",
+        "hermes-gateway-two",
+        "hermes-gateway-three",
+    ]
+    calls = []
+
+    def fake_run(command, **_kwargs):
+        unit = command[-1]
+        calls.append(unit)
+        if unit == "hermes-gateway-two":
+            raise subprocess.TimeoutExpired(command, timeout=15)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    failures = {}
+    restarted = []
+
+    for unit in units:
+        result = hermes_main._run_update_systemctl(
+            ["systemctl", "--user", "restart", unit],
+            scope="user",
+            unit=unit,
+            timeout=15,
+            failures=failures,
+        )
+        if result is not None:
+            restarted.append(unit)
+
+    assert calls == units
+    assert restarted == ["hermes-gateway-one", "hermes-gateway-three"]
+    assert list(failures) == [("user", "hermes-gateway-two")]
+    assert "continuing with remaining gateways" in capsys.readouterr().out
+
+
+def test_reconciliation_clears_completed_timeout_and_keeps_stale_pid(monkeypatch):
+    unit = "hermes-gateway-shared"
+    discovered = {
+        ("user", unit): (["systemctl", "--user"], 101),
+        ("system", unit): (["systemctl"], 201),
+    }
+    failures = {
+        ("user", unit): "systemctl timed out",
+        ("system", unit): "systemctl timed out",
+    }
+
+    def fake_run(command, **_kwargs):
+        is_user = "--user" in command
+        pid = 102 if is_user else 201
+        stdout = f"ActiveState=active\nMainPID={pid}\n"
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    hermes_main._reconcile_updated_systemd_gateways(discovered, failures)
+
+    assert ("user", unit) not in failures
+    assert failures[("system", unit)] == "still running pre-update PID 201"
+
+
+def test_reconciliation_keeps_unverifiable_timeout_without_initial_pid(monkeypatch):
+    key = ("user", "hermes-gateway-unknown")
+    failures = {key: "systemctl timed out"}
+
+    def fake_run(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="ActiveState=active\nMainPID=999\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    hermes_main._reconcile_updated_systemd_gateways(
+        {key: (["systemctl", "--user"], 0)},
+        failures,
+    )
+
+    assert failures[key] == "systemctl timed out"


### PR DESCRIPTION
## What does this PR do?

Fixes the fleet-restart control flow used by `hermes update` on Linux hosts that run multiple profile-backed systemd gateways from one shared checkout.

The updater previously treated `subprocess.TimeoutExpired` as a scope-level failure. If one per-unit `systemctl restart` timed out, control jumped out of the entire user/system loop. Every unit discovered after the timed-out unit was skipped even though the shared checkout had already been updated.

Skipped gateways kept their pre-update `sys.modules` cache while later lazy imports came from the post-update checkout. That mixed-generation process could fail far away from the update itself with signature mismatches such as:

```text
TypeError: redact_sensitive_text() got an unexpected keyword argument
'redact_url_credentials'
```

This PR changes the restart contract from "best-effort scope restart" to:

1. isolate failures to one `(systemd scope, unit)`;
2. continue processing every remaining discovered unit;
3. reconcile each originally active unit against its pre-update PID;
4. report exact stale or unverifiable survivors;
5. return a failing update result instead of announcing full success.

### Control flow

Before:

```text
for scope in (user, system):
    try:
        discover units
        for unit in units:
            restart unit       # TimeoutExpired escapes the unit loop
    except TimeoutExpired:
        warn                   # all later units in this scope are skipped
```

After:

```text
discover active units and snapshot MainPID
for scope/unit:
    run per-unit systemctl operation
    if it times out:
        record the scoped failure
        continue with the next unit

for every originally active scope/unit:
    read final ActiveState/MainPID
    classify the actual survivor state

report incomplete + exit 1, or print Update complete
```

## Related Issue

Fixes #68523

Related but distinct: #68300 covers one cross-module import failure; this PR fixes the updater behavior that can leave an entire fleet on mixed code.

Alternative implementation reviewed: #68561. That PR isolates the unit loop around a callback. This implementation additionally performs PID reconciliation, preserves user/system scope in failure identities, treats discovery/phase failures as incomplete updates, and delays the full-success message until reconciliation finishes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

### `hermes_cli/main.py`

#### Per-unit timeout isolation

`_run_update_systemctl()` is the single boundary for systemctl operations that belong to an already-discovered unit. It:

- executes with the existing capture/text/timeout behavior;
- catches `subprocess.TimeoutExpired` for that unit only;
- records a human-readable reason under `(scope, unit)`;
- prints that the remaining fleet will continue;
- returns `None`, allowing the caller to move to the next unit.

The active check, graceful-restart shortcut (`reset-failed` + `start`), hard restart, and retry path all use this boundary. A timeout in any of those current per-unit calls can no longer escape the fleet loop.

#### Scoped discovery state

Every unit that was active before the update is stored as:

```python
(scope, unit) -> (scope_cmd, previous_main_pid)
```

The scope is part of the identity because user and system service managers may both contain a unit with the same name. Keeping only `svc_name` would make the final warning ambiguous and could incorrectly deduplicate two different services.

#### Final reconciliation

`_reconcile_updated_systemd_gateways()` performs a read-only `systemctl show` for every originally active unit and requests `ActiveState` plus `MainPID`.

| Final observation | Classification |
| --- | --- |
| `show` times out or fails | unverifiable failure |
| service is not active | restart failure |
| `MainPID` equals the pre-update PID | stale survivor |
| active service has no usable `MainPID` | unverifiable failure |
| active service has a different PID | restart confirmed |
| initial PID was unavailable and an earlier failure exists | fail closed; there is no proof of replacement |

This also avoids a false positive: `systemctl restart` may time out at the CLI boundary after systemd has already accepted/completed the job. If reconciliation observes an active replacement PID, the earlier attempt failure is cleared.

The existing `gateway.code_skew` fingerprint is process-local and is not exposed as a per-unit updater query. Comparing the pre/post `MainPID` uses information already available from systemd and proves the property the update requires: the old Python process was replaced.

#### Complete vs incomplete update semantics

The updater now records three failure classes:

- exact scoped unit failures;
- scope discovery timeouts, where exact units cannot be enumerated safely;
- unexpected restart-phase exceptions.

When any class remains after reconciliation:

- the warning lists each known `scope/unit` and reason;
- gateway-triggered updates overwrite `.update_exit_code` with `1`;
- the CLI exits with status `1`;
- `✓ Update complete!` is not printed.

When reconciliation succeeds, the full-success message is emitted only after the gateway restart phase has completed. Existing Node dependency partial-update behavior remains unchanged.

### `tests/hermes_cli/test_update_fleet_restart_timeout.py`

Adds regression coverage for:

1. a timeout on the middle unit while proving the later unit is still processed;
2. reconciliation clearing a timed-out attempt when the final PID changed;
3. reconciliation retaining a failure when no initial PID exists to prove replacement;
4. user/system scope separation for identically named units.

## Why this approach?

- **Surgical:** existing graceful drain, retry, privilege, launchd, and manual-process flows remain in place.
- **Fail-safe:** uncertainty after the checkout changes is reported as incomplete rather than silently accepted.
- **No new core surface:** the implementation uses existing subprocess and systemd data; it adds no model tool, config key, environment variable, service, or IPC protocol.
- **Actual state over attempt state:** reporting is based on the final process identity, not only on whether one subprocess invocation raised.
- **Cross-platform containment:** the new operations remain behind `supports_systemd_services()`; Windows and macOS restart mechanisms are unchanged.

The cost is one additional read-only `systemctl show` per originally active systemd gateway during an actual code update. This is bounded by the discovered fleet and occurs only in the post-update restart phase.

## How to Test

### Automated regression

```bash
python -m pytest tests/hermes_cli/test_update_fleet_restart_timeout.py -q
```

Expected:

```text
3 passed
```

### Static validation

```bash
python -m py_compile \
  hermes_cli/main.py \
  tests/hermes_cli/test_update_fleet_restart_timeout.py

python -m ruff check \
  hermes_cli/main.py \
  tests/hermes_cli/test_update_fleet_restart_timeout.py

git diff --check
```

### Existing updater flows

Two representative full updater-flow tests were also executed and passed:

- `TestCmdUpdateBranchFallback::test_update_uses_current_branch_when_on_remote`
- `TestCmdUpdateMigrationPrompt::test_version_bump_only_applies_silently_without_prompt`

### Linux fleet fault injection (recommended final maintainer validation)

On a disposable Linux host with at least three active `hermes-gateway*.service` units sharing one checkout:

1. arrange for the middle unit's managed restart call to exceed the updater timeout;
2. run `hermes update`;
3. confirm restart attempts still occur for every later discovered unit;
4. confirm successfully replaced units have a new `MainPID`;
5. confirm the unresolved unit is reported as `user/<unit>` or `system/<unit>`;
6. confirm the command exits non-zero and does not print `✓ Update complete!`;
7. restart the unresolved unit manually and verify all gateways run the updated checkout.

This live multi-unit Linux fault injection has not been performed in the contributor environment; CI and local tests exercise the control flow with mocked systemctl results.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs and reviewed the alternative #68561
- [x] My PR contains only changes related to this fix (two files, one logical change)
- [ ] I've run `pytest tests/ -q` and all tests pass — full CI is still running
- [x] I've added regression tests for the reported failure and reconciliation behavior
- [x] I've tested on my platform: Windows 11, Python 3.11, with mocked Linux systemd subprocess results

### Documentation & Housekeeping

- [x] Documentation update: N/A — no user-facing configuration or command syntax changed
- [x] `cli-config.yaml.example`: N/A — no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no architecture or workflow contract changed
- [x] Cross-platform impact considered — the implementation is gated to systemd; Windows/macOS paths are unchanged
- [x] Tool descriptions/schemas: N/A — no model tool surface changed

## Screenshots / Logs

Representative incomplete-update output:

```text
⚠ systemctl timed out for user-scope hermes-gateway-xiaomo5 (...);
  continuing with remaining gateways

⚠ Update incomplete — some gateways may still run old code:
    - user/hermes-gateway-xiaomo5: still running pre-update PID 12345
  Restart the listed units before continuing to use the fleet.
```
