### PR TITLE
fix(tui): prompt.submit's truncate_before_user_ordinal reads fresh history

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8040,48 +8040,104 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         differs.
         """
 
-        active_clause = " AND active = 1" if active_only else ""
-
         def _do(conn):
-            session = conn.execute(
-                "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
-                (session_id,),
-            ).fetchone()
-            if (
-                session is not None
-                and session["ended_at"] is not None
-                and session["end_reason"] == "compression"
-            ):
-                raise CompressionSessionClosedError(session_id)
-            if archive_dropped:
-                # Content-preserving UPDATE: the rows keep their FTS entries
-                # (the messages_fts triggers fire on INSERT / DELETE / UPDATE
-                # of content columns, not on `active`), so the replaced turns
-                # stay readable via get_messages(include_inactive=True) and
-                # searchable with include_inactive=True after the rewrite.
-                conn.execute(
-                    "UPDATE messages SET active = 0 "
-                    "WHERE session_id = ? AND active = 1",
-                    (session_id,),
-                )
-            else:
-                conn.execute(
-                    f"DELETE FROM messages WHERE session_id = ?{active_clause}",
-                    (session_id,),
-                )
-            conn.execute(
-                "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?",
-                (session_id,),
-            )
-            total_messages, total_tool_calls = self._insert_message_rows(
-                conn, session_id, messages
-            )
-            conn.execute(
-                "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
-                (total_messages, total_tool_calls, session_id),
+            self._replace_messages_in_transaction(
+                conn,
+                session_id,
+                messages,
+                active_only=active_only,
+                archive_dropped=archive_dropped,
             )
 
         self._execute_write(_do)
+
+    def _replace_messages_in_transaction(
+        self,
+        conn: sqlite3.Connection,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        *,
+        active_only: bool,
+        archive_dropped: bool = False,
+    ) -> None:
+        """Replace a transcript using the caller's open write transaction."""
+        session = conn.execute(
+            "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
+            (session_id,),
+        ).fetchone()
+        if (
+            session is not None
+            and session["ended_at"] is not None
+            and session["end_reason"] == "compression"
+        ):
+            raise CompressionSessionClosedError(session_id)
+        if archive_dropped:
+            # Content-preserving UPDATE: the rows keep their FTS entries
+            # because only the active marker changes.
+            conn.execute(
+                "UPDATE messages SET active = 0 "
+                "WHERE session_id = ? AND active = 1",
+                (session_id,),
+            )
+        else:
+            active_clause = " AND active = 1" if active_only else ""
+            conn.execute(
+                f"DELETE FROM messages WHERE session_id = ?{active_clause}",
+                (session_id,),
+            )
+        conn.execute(
+            "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?",
+            (session_id,),
+        )
+        total_messages, total_tool_calls = self._insert_message_rows(
+            conn, session_id, messages
+        )
+        conn.execute(
+            "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
+            (total_messages, total_tool_calls, session_id),
+        )
+
+    def replace_active_messages_if_unchanged(
+        self,
+        session_id: str,
+        expected_messages: List[Dict[str, Any]],
+        messages: List[Dict[str, Any]],
+        *,
+        archive_dropped: bool = False,
+    ) -> bool:
+        """Conditionally rewrite the active tip transcript.
+
+        The current model-fed projection is compared with ``expected_messages``
+        inside the same ``BEGIN IMMEDIATE`` transaction that performs the
+        rewrite. If another process appended or rewrote rows after the caller's
+        read, return ``False`` without deleting anything.
+        """
+
+        def _do(conn):
+            rows = conn.execute(
+                f"SELECT {self._CONVERSATION_ROW_COLUMNS} "
+                "FROM messages WHERE session_id = ? AND active = 1 ORDER BY id",
+                (session_id,),
+            ).fetchall()
+            current_messages = self._rows_to_conversation(
+                rows,
+                session_id=session_id,
+                include_ancestors=False,
+                repair_alternation=True,
+                include_row_ids=True,
+            )
+            if current_messages != expected_messages:
+                return False
+            self._replace_messages_in_transaction(
+                conn,
+                session_id,
+                messages,
+                active_only=True,
+                archive_dropped=archive_dropped,
+            )
+            return True
+
+        return bool(self._execute_write(_do))
 
     def has_archived_messages(self, session_id: str) -> bool:
         """Return True if the session has any soft-archived (``active = 0``) rows.

--- a/tests/hermes_state/test_replace_messages_archive_siblings.py
+++ b/tests/hermes_state/test_replace_messages_archive_siblings.py
@@ -11,7 +11,8 @@ sites, fixed here:
   Now passes ``active_only=True`` unconditionally.
 - ``tui_gateway/methods_prompt.py`` edit/regenerate truncation: bare
   ``replace_messages`` deleted the archived transcript on every
-  edit/regenerate of a compacted session.  Now ``active_only=True``.
+  edit/regenerate of a compacted session. It now uses an atomic conditional
+  active-only rewrite and archives the replaced live rows.
 
 Behavior contract on a fresh (never-compacted) session: every row is
 ``active=1``, so the active-only replace is identical to the full replace —
@@ -125,20 +126,22 @@ class TestAcpPersistPreservesArchives:
 
 
 class TestTuiPromptTruncationPreservesArchives:
-    def test_truncation_source_uses_active_only(self):
-        """The edit/regenerate persistence call must pass active_only=True."""
+    def test_truncation_source_uses_conditional_active_replace(self):
+        """The edit/regenerate write must stay atomic, active-only, and recoverable."""
         import inspect
         import tui_gateway.methods_prompt as mp
 
         src = inspect.getsource(mp)
-        # The truncation write is the only replace_messages call in the module;
-        # it must carry active_only=True.
+        # The helper name pins active-only behavior; archive_dropped preserves
+        # the replaced live rows instead of hard-deleting them.
         import re
-        calls = re.findall(r"db\.replace_messages\([^)]*\)", src, re.S)
-        assert calls, "expected the truncation replace_messages call"
+        calls = re.findall(
+            r"db\.replace_active_messages_if_unchanged\([^)]*\)", src, re.S
+        )
+        assert calls, "expected the conditional truncation rewrite"
         for call in calls:
-            assert "active_only=True" in call, (
-                f"bare replace_messages in methods_prompt — #80216 class: {call}"
+            assert "archive_dropped=True" in call, (
+                f"hard-delete conditional rewrite in methods_prompt — #80216 class: {call}"
             )
 
     def test_truncation_write_keeps_archived_rows(self, state_db):
@@ -148,10 +151,18 @@ class TestTuiPromptTruncationPreservesArchives:
         _seed_compacted_session(state_db, sid)
         assert _archived_count(state_db, sid) == 4
 
+        expected, _display = state_db.get_resume_conversations(sid)
         truncated = [{"role": "user", "content": "kept head"}]
-        state_db.replace_messages(sid, truncated, active_only=True)
+        replaced = state_db.replace_active_messages_if_unchanged(
+            sid,
+            expected,
+            truncated,
+            archive_dropped=True,
+        )
 
-        assert _archived_count(state_db, sid) == 4
+        assert replaced is True
+        # Four compacted rows plus the three replaced live rows survive.
+        assert _archived_count(state_db, sid) == 7
         live = [
             m for m in state_db.get_messages_as_conversation(sid)
             if m.get("role") in ("user", "assistant")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -612,6 +612,65 @@ class TestTimestampPreservation:
         assert [m["timestamp"] for m in msgs_out] == [100.0, 200.0, 300.0]
         assert self._raw_timestamps(db, "s1") == [100.0, 200.0, 300.0]
 
+    def test_conditional_active_replace_rejects_stale_snapshot(self, db):
+        """A concurrent append must survive a stale transcript rewrite."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="first")
+        db.append_message("s1", role="assistant", content="first reply")
+        expected, _display = db.get_resume_conversations("s1")
+
+        db.append_message("s1", role="user", content="concurrent")
+        replaced = db.replace_active_messages_if_unchanged(
+            "s1",
+            expected,
+            [],
+            archive_dropped=True,
+        )
+
+        assert replaced is False
+        assert [
+            message["content"]
+            for message in db.get_messages_as_conversation("s1")
+        ] == ["first", "first reply", "concurrent"]
+        with db._lock:
+            archived_count = db._conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE session_id = ? AND active = 0",
+                ("s1",),
+            ).fetchone()[0]
+        assert archived_count == 0
+
+    def test_conditional_active_replace_commits_matching_snapshot(self, db):
+        """An unchanged active projection may be rewritten atomically."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="first")
+        db.append_message("s1", role="assistant", content="first reply")
+        db.append_message("s1", role="user", content="second")
+        expected, _display = db.get_resume_conversations("s1")
+
+        replaced = db.replace_active_messages_if_unchanged(
+            "s1",
+            expected,
+            expected[:2],
+            archive_dropped=True,
+        )
+
+        assert replaced is True
+        assert [
+            message["content"]
+            for message in db.get_messages_as_conversation("s1")
+        ] == ["first", "first reply"]
+        with db._lock:
+            archived = db._conn.execute(
+                "SELECT content FROM messages "
+                "WHERE session_id = ? AND active = 0 ORDER BY id",
+                ("s1",),
+            ).fetchall()
+        assert [row["content"] for row in archived] == [
+            "first",
+            "first reply",
+            "second",
+        ]
+
 
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4552,14 +4552,16 @@ def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
     replaced = []
 
     class _FakeDB:
-        def get_messages_as_conversation(
-            self, _session_id, repair_alternation=False
-        ):
-            assert repair_alternation is True
-            return list(history)
+        def get_resume_conversations(self, _session_id):
+            return list(history), list(history)
 
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_active_messages_if_unchanged(
+            self, key, expected_messages, messages, *, archive_dropped=False
+        ):
+            assert expected_messages == history
+            assert archive_dropped is True
             replaced.append((key, list(messages)))
+            return True
 
     history = [
         {"role": "user", "content": "first"},
@@ -4645,14 +4647,16 @@ def test_prompt_submit_empty_truncation_allowed_with_confirm(monkeypatch):
             self._target()
 
     class _FakeDB:
-        def get_messages_as_conversation(
-            self, _session_id, repair_alternation=False
-        ):
-            assert repair_alternation is True
-            return list(history)
+        def get_resume_conversations(self, _session_id):
+            return list(history), list(history)
 
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_active_messages_if_unchanged(
+            self, key, expected_messages, messages, *, archive_dropped=False
+        ):
+            assert expected_messages == history
+            assert archive_dropped is True
             replaced.append((key, list(messages)))
+            return True
 
     history = [
         {"role": "user", "content": "first"},
@@ -9630,12 +9634,16 @@ def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
         def __init__(self):
             self.replaced = []
 
-        def get_messages_as_conversation(self, session_id, repair_alternation=False):
-            assert repair_alternation is True
-            return list(original_history)
+        def get_resume_conversations(self, session_id):
+            return list(original_history), list(original_history)
 
-        def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
+        def replace_active_messages_if_unchanged(
+            self, session_id, expected_messages, messages, *, archive_dropped=False
+        ):
+            assert expected_messages == original_history
+            assert archive_dropped is True
             self.replaced.append((session_id, list(messages)))
+            return True
 
     stub_db = _StubDb()
 
@@ -9691,7 +9699,13 @@ def test_prompt_submit_refuses_turn_when_truncate_persist_fails(monkeypatch):
     server._sessions["trunc-fail-sid"] = sess
 
     class _FailDb:
-        def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
+        def get_resume_conversations(self, session_id):
+            return list(original_history), list(original_history)
+
+        def replace_active_messages_if_unchanged(
+            self, session_id, expected_messages, messages, *, archive_dropped=False
+        ):
+            assert archive_dropped is True
             raise OSError("disk full")
 
     monkeypatch.setattr(server, "_get_db", lambda: _FailDb())
@@ -9787,12 +9801,16 @@ def test_prompt_submit_truncate_ordinal_refreshes_external_writes(monkeypatch):
         def __init__(self):
             self.replaced = []
 
-        def get_messages_as_conversation(self, session_id, repair_alternation=False):
-            assert repair_alternation is True
-            return list(fresh_history)
+        def get_resume_conversations(self, session_id):
+            return list(fresh_history), list(fresh_history)
 
-        def replace_messages(self, session_id, messages):
+        def replace_active_messages_if_unchanged(
+            self, session_id, expected_messages, messages, *, archive_dropped=False
+        ):
+            assert expected_messages == fresh_history
+            assert archive_dropped is True
             self.replaced.append((session_id, list(messages)))
+            return True
 
     stub_db = _StubDb()
 
@@ -9811,6 +9829,7 @@ def test_prompt_submit_truncate_ordinal_refreshes_external_writes(monkeypatch):
                     "session_id": "sid",
                     "text": "edited second",
                     "truncate_before_user_ordinal": 1,
+                    "confirm_truncate": True,
                 },
             }
         )
@@ -9823,6 +9842,90 @@ def test_prompt_submit_truncate_ordinal_refreshes_external_writes(monkeypatch):
         assert stub_db.replaced == [("session-key", fresh_history[:2])]
     finally:
         server._sessions.pop("sid", None)
+
+
+def test_prompt_submit_truncate_conflicts_on_append_after_refresh(
+    monkeypatch, tmp_path
+):
+    """An append between the authoritative read and rewrite must survive."""
+
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_key = db.create_session("race", "tui")
+    for role, content in (
+        ("user", "first"),
+        ("assistant", "first reply"),
+        ("user", "second"),
+        ("assistant", "second reply"),
+    ):
+        db.append_message(session_key, role, content)
+    initial_history, _display = db.get_resume_conversations(session_key)
+
+    original_replace = db.replace_active_messages_if_unchanged
+    appended = False
+
+    def _append_then_replace(
+        session_id, expected_messages, messages, *, archive_dropped=False
+    ):
+        nonlocal appended
+        if not appended:
+            appended = True
+            db.append_message(session_id, "user", "concurrent third")
+        return original_replace(
+            session_id,
+            expected_messages,
+            messages,
+            archive_dropped=archive_dropped,
+        )
+
+    monkeypatch.setattr(
+        db,
+        "replace_active_messages_if_unchanged",
+        _append_then_replace,
+    )
+    session = _session(history=list(initial_history))
+    session["session_key"] = session_key
+    server._sessions["sid"] = session
+
+    try:
+        monkeypatch.setattr(server, "_get_db", lambda: db)
+        monkeypatch.setattr(
+            server,
+            "_start_agent_build",
+            lambda *args, **kwargs: pytest.fail("must not start a turn"),
+        )
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "sid",
+                    "text": "edited second",
+                    "truncate_before_user_ordinal": 1,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+
+        assert resp["error"]["code"] == 4091
+        assert "reload and retry" in resp["error"]["message"]
+        assert server._sessions["sid"]["history"] == initial_history
+        assert server._sessions["sid"]["running"] is False
+        assert [
+            message["content"]
+            for message in db.get_messages_as_conversation(session_key)
+        ] == [
+            "first",
+            "first reply",
+            "second",
+            "second reply",
+            "concurrent third",
+        ]
+    finally:
+        server._sessions.pop("sid", None)
+        db.close()
 
 
 def test_prompt_submit_truncate_ordinal_excludes_display_ancestors(monkeypatch, tmp_path):
@@ -9894,6 +9997,7 @@ def test_prompt_submit_truncate_ordinal_excludes_display_ancestors(monkeypatch, 
                     "text": "edited current",
                     # One ancestor user + the two current-segment users.
                     "truncate_before_user_ordinal": 2,
+                    "confirm_truncate": True,
                 },
             }
         )
@@ -9928,12 +10032,15 @@ def test_prompt_submit_truncate_fails_closed_when_fresh_read_fails(monkeypatch):
     replaced = []
 
     class _StubDb:
-        def get_messages_as_conversation(self, session_id, repair_alternation=False):
-            assert repair_alternation is True
+        def get_resume_conversations(self, session_id):
             raise RuntimeError("database unavailable")
 
-        def replace_messages(self, session_id, messages):
+        def replace_active_messages_if_unchanged(
+            self, session_id, expected_messages, messages, *, archive_dropped=False
+        ):
+            assert archive_dropped is True
             replaced.append((session_id, list(messages)))
+            return True
 
     server._sessions["sid"] = _session(history=list(stale_history))
 
@@ -9953,6 +10060,7 @@ def test_prompt_submit_truncate_fails_closed_when_fresh_read_fails(monkeypatch):
                     "session_id": "sid",
                     "text": "edited first",
                     "truncate_before_user_ordinal": 0,
+                    "confirm_truncate": True,
                 },
             }
         )
@@ -9977,11 +10085,14 @@ def test_prompt_submit_truncate_fails_closed_when_replace_fails(monkeypatch):
     ]
 
     class _StubDb:
-        def get_messages_as_conversation(self, session_id, repair_alternation=False):
-            assert repair_alternation is True
-            return list(history)
+        def get_resume_conversations(self, session_id):
+            return list(history), list(history)
 
-        def replace_messages(self, session_id, messages):
+        def replace_active_messages_if_unchanged(
+            self, session_id, expected_messages, messages, *, archive_dropped=False
+        ):
+            assert expected_messages == history
+            assert archive_dropped is True
             raise RuntimeError("database is read-only")
 
     server._sessions["sid"] = _session(history=list(history))
@@ -10002,12 +10113,13 @@ def test_prompt_submit_truncate_fails_closed_when_replace_fails(monkeypatch):
                     "session_id": "sid",
                     "text": "edited second",
                     "truncate_before_user_ordinal": 1,
+                    "confirm_truncate": True,
                 },
             }
         )
 
-        assert resp["error"]["code"] == 5000
-        assert "failed to truncate session history" in resp["error"]["message"]
+        assert resp["error"]["code"] == 5008
+        assert "failed to persist history truncation" in resp["error"]["message"]
         assert server._sessions["sid"]["history"] == history
         assert server._sessions["sid"]["history_version"] == 0
         assert server._sessions["sid"]["running"] is False
@@ -10072,12 +10184,16 @@ def test_prompt_submit_truncate_ordinal_skips_display_kind_rows(monkeypatch):
         def __init__(self):
             self.replaced = []
 
-        def get_messages_as_conversation(self, session_id, repair_alternation=False):
-            assert repair_alternation is True
-            return list(original_history)
+        def get_resume_conversations(self, session_id):
+            return list(original_history), list(original_history)
 
-        def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
+        def replace_active_messages_if_unchanged(
+            self, session_id, expected_messages, messages, *, archive_dropped=False
+        ):
+            assert expected_messages == original_history
+            assert archive_dropped is True
             self.replaced.append((session_id, list(messages)))
+            return True
 
     stub_db = _StubDb()
 
@@ -17216,8 +17332,16 @@ def test_personality_marker_does_not_shift_truncate_ordinal(monkeypatch):
         def __init__(self):
             self.replaced = []
 
-        def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
+        def get_resume_conversations(self, session_id):
+            return list(history_before), list(history_before)
+
+        def replace_active_messages_if_unchanged(
+            self, session_id, expected_messages, messages, *, archive_dropped=False
+        ):
+            assert expected_messages == history_before
+            assert archive_dropped is True
             self.replaced.append((session_id, list(messages)))
+            return True
 
     session = _session(
         agent=_Agent(),
@@ -17303,6 +17427,12 @@ def test_prompt_submit_truncation_archives_instead_of_deleting(monkeypatch):
     """
 
     captured = {}
+    history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "first reply"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "second reply"},
+    ]
 
     class _Agent:
         def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
@@ -17323,20 +17453,20 @@ def test_prompt_submit_truncation_archives_instead_of_deleting(monkeypatch):
             self._target()
 
     class _StubDb:
-        def replace_messages(
-            self, session_id, messages, active_only=False, archive_dropped=False
+        def get_resume_conversations(self, session_id):
+            return list(history), list(history)
+
+        def replace_active_messages_if_unchanged(
+            self, session_id, expected_messages, messages, *, archive_dropped=False
         ):
-            captured["active_only"] = active_only
+            assert expected_messages == history
+            captured["conditional"] = True
             captured["archive_dropped"] = archive_dropped
+            return True
 
     server._sessions["archive-trunc-sid"] = _session(
         agent=_Agent(),
-        history=[
-            {"role": "user", "content": "first"},
-            {"role": "assistant", "content": "first reply"},
-            {"role": "user", "content": "second"},
-            {"role": "assistant", "content": "second reply"},
-        ],
+        history=list(history),
     )
 
     try:
@@ -17364,7 +17494,8 @@ def test_prompt_submit_truncation_archives_instead_of_deleting(monkeypatch):
         assert captured.get("archive_dropped") is True, (
             "a rewind must soft-archive the turns it drops, not DELETE them"
         )
-        # #80216: still must not touch rows archived by an earlier compaction.
-        assert captured.get("active_only") is True
+        # The conditional helper always rewrites only active rows, preserving
+        # rows archived by an earlier compaction (#80216).
+        assert captured.get("conditional") is True
     finally:
         server._sessions.pop("archive-trunc-sid", None)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9618,6 +9618,9 @@ def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
         def __init__(self):
             self.replaced = []
 
+        def get_messages_as_conversation(self, session_id, repair_alternation=False):
+            return list(original_history)
+
         def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
             self.replaced.append((session_id, list(messages)))
 
@@ -9713,7 +9716,7 @@ def test_prompt_submit_refuses_turn_when_truncate_persist_fails(monkeypatch):
         server._sessions.pop("trunc-fail-sid", None)
 
 
-def test_prompt_submit_truncate_ordinal_reflects_concurrent_writer(monkeypatch):
+def test_prompt_submit_truncate_ordinal_refreshes_external_writes(monkeypatch):
     """truncate_before_user_ordinal must be checked against the CURRENT
     DB row set, not this TUI process's possibly-stale in-memory history.
 
@@ -9771,7 +9774,7 @@ def test_prompt_submit_truncate_ordinal_reflects_concurrent_writer(monkeypatch):
         def __init__(self):
             self.replaced = []
 
-        def get_messages_as_conversation(self, session_id, include_ancestors=True):
+        def get_messages_as_conversation(self, session_id):
             return list(fresh_history)
 
         def replace_messages(self, session_id, messages):
@@ -9804,6 +9807,134 @@ def test_prompt_submit_truncate_ordinal_reflects_concurrent_writer(monkeypatch):
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert seen["history"] == fresh_history[:2]
         assert stub_db.replaced == [("session-key", fresh_history[:2])]
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_prompt_submit_truncate_ordinal_excludes_display_ancestors(monkeypatch, tmp_path):
+    """A display-lineage ordinal must truncate only the current DB segment."""
+
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_id = db.create_session("parent", "tui")
+    db.append_message(parent_id, "user", "pre-compression")
+    db.append_message(parent_id, "assistant", "pre-compression reply")
+    db.end_session(parent_id, "compression")
+    tip_id = db.create_session("tip", "tui", parent_session_id=parent_id)
+    db.append_message(tip_id, "user", "summary")
+    db.append_message(tip_id, "assistant", "summary reply")
+
+    # Capture the TUI's working copy, then simulate a completed write from a
+    # second client to the same continuation segment.
+    stale_segment = db.get_messages_as_conversation(tip_id)
+    db.append_message(tip_id, "user", "current")
+    db.append_message(tip_id, "assistant", "current reply")
+    seen = {}
+
+    class _Agent:
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+            seen["history"] = list(conversation_history or [])
+            return {
+                "final_response": "edited reply",
+                "messages": [
+                    *(conversation_history or []),
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "edited reply"},
+                ],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    session = _session(agent=_Agent(), history=stale_segment)
+    session["session_key"] = tip_id
+    session["display_history_prefix"] = db.get_ancestor_display_prefix(tip_id)
+    server._sessions["sid"] = session
+
+    try:
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+        monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
+        monkeypatch.setattr(server, "_emit", lambda *a: None)
+        monkeypatch.setattr(server, "_get_db", lambda: db)
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "sid",
+                    "text": "edited current",
+                    # One ancestor user + the two current-segment users.
+                    "truncate_before_user_ordinal": 2,
+                },
+            }
+        )
+
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert [message["content"] for message in seen["history"]] == [
+            "summary",
+            "summary reply",
+        ]
+        assert [
+            message["content"] for message in db.get_messages_as_conversation(tip_id)
+        ] == ["summary", "summary reply"]
+        assert [
+            message["content"] for message in db.get_messages_as_conversation(parent_id)
+        ] == ["pre-compression", "pre-compression reply"]
+    finally:
+        server._sessions.pop("sid", None)
+        db.close()
+
+
+def test_prompt_submit_truncate_fails_closed_when_fresh_read_fails(monkeypatch):
+    """A failed authoritative read must not overwrite DB rows from stale memory."""
+
+    stale_history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "first reply"},
+    ]
+    replaced = []
+
+    class _StubDb:
+        def get_messages_as_conversation(self, session_id):
+            raise RuntimeError("database unavailable")
+
+        def replace_messages(self, session_id, messages):
+            replaced.append((session_id, list(messages)))
+
+    server._sessions["sid"] = _session(history=list(stale_history))
+
+    try:
+        monkeypatch.setattr(server, "_get_db", lambda: _StubDb())
+        monkeypatch.setattr(
+            server,
+            "_start_agent_build",
+            lambda *args, **kwargs: pytest.fail("must not start a turn"),
+        )
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "sid",
+                    "text": "edited first",
+                    "truncate_before_user_ordinal": 0,
+                },
+            }
+        )
+
+        assert resp["error"]["code"] == 5000
+        assert "failed to load current session history" in resp["error"]["message"]
+        assert server._sessions["sid"]["history"] == stale_history
+        assert server._sessions["sid"]["running"] is False
+        assert replaced == []
     finally:
         server._sessions.pop("sid", None)
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9939,6 +9939,54 @@ def test_prompt_submit_truncate_fails_closed_when_fresh_read_fails(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_prompt_submit_truncate_fails_closed_when_replace_fails(monkeypatch):
+    """A failed authoritative write must leave memory unchanged and start no turn."""
+
+    history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "first reply"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "second reply"},
+    ]
+
+    class _StubDb:
+        def get_messages_as_conversation(self, session_id):
+            return list(history)
+
+        def replace_messages(self, session_id, messages):
+            raise RuntimeError("database is read-only")
+
+    server._sessions["sid"] = _session(history=list(history))
+
+    try:
+        monkeypatch.setattr(server, "_get_db", lambda: _StubDb())
+        monkeypatch.setattr(
+            server,
+            "_start_agent_build",
+            lambda *args, **kwargs: pytest.fail("must not start a turn"),
+        )
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "sid",
+                    "text": "edited second",
+                    "truncate_before_user_ordinal": 1,
+                },
+            }
+        )
+
+        assert resp["error"]["code"] == 5000
+        assert "failed to truncate session history" in resp["error"]["message"]
+        assert server._sessions["sid"]["history"] == history
+        assert server._sessions["sid"]["history_version"] == 0
+        assert server._sessions["sid"]["running"] is False
+    finally:
+        server._sessions.pop("sid", None)
+
+
 # ---------------------------------------------------------------------------
 # session.interrupt must only cancel pending prompts owned by the calling
 # session — it must not blast-resolve clarify/sudo/secret prompts on

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9834,6 +9834,12 @@ def test_prompt_submit_truncate_ordinal_excludes_display_ancestors(monkeypatch, 
     parent_id = db.create_session("parent", "tui")
     db.append_message(parent_id, "user", "pre-compression")
     db.append_message(parent_id, "assistant", "pre-compression reply")
+    db.append_message(
+        parent_id,
+        "user",
+        "background agent finished",
+        display_kind="async_delegation_complete",
+    )
     db.end_session(parent_id, "compression")
     tip_id = db.create_session("tip", "tui", parent_session_id=parent_id)
     db.append_message(tip_id, "user", "summary")
@@ -9902,7 +9908,11 @@ def test_prompt_submit_truncate_ordinal_excludes_display_ancestors(monkeypatch, 
         ] == ["summary", "summary reply"]
         assert [
             message["content"] for message in db.get_messages_as_conversation(parent_id)
-        ] == ["pre-compression", "pre-compression reply"]
+        ] == [
+            "pre-compression",
+            "pre-compression reply",
+            "background agent finished",
+        ]
     finally:
         server._sessions.pop("sid", None)
         db.close()
@@ -10048,19 +10058,23 @@ def test_prompt_submit_truncate_ordinal_skips_display_kind_rows(monkeypatch):
     original_history = [
         {"role": "user", "content": "first"},
         {"role": "assistant", "content": "first reply"},
-        {"role": "user", "content": "second"},
-        {"role": "assistant", "content": "second reply"},
         {
             "role": "user",
             "content": "background agent finished",
             "display_kind": "async_delegation_complete",
         },
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "second reply"},
     ]
     server._sessions["sid"] = _session(agent=_Agent(), history=original_history)
 
     class _StubDb:
         def __init__(self):
             self.replaced = []
+
+        def get_messages_as_conversation(self, session_id, repair_alternation=False):
+            assert repair_alternation is True
+            return list(original_history)
 
         def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
             self.replaced.append((session_id, list(messages)))
@@ -10074,8 +10088,8 @@ def test_prompt_submit_truncate_ordinal_skips_display_kind_rows(monkeypatch):
         monkeypatch.setattr(server, "_emit", lambda *a: None)
         monkeypatch.setattr(server, "_get_db", lambda: stub_db)
 
-        # ordinal=1 means "truncate before the 2nd-from-last real user turn"
-        # which is "first". The display_kind marker must NOT shift the ordinal.
+        # ordinal=1 means "truncate before the second real user turn".
+        # The display_kind marker between the two turns must NOT become ordinal 1.
         resp = server.handle_request(
             {
                 "id": "1",
@@ -10090,16 +10104,14 @@ def test_prompt_submit_truncate_ordinal_skips_display_kind_rows(monkeypatch):
         )
         assert resp.get("result"), f"got error: {resp.get('error')}"
 
-        # With display_kind filter: user_indices = [0, 2] (indices of "first" and "second").
-        # ordinal=1 → user_indices[1] = 2, truncated = history[:2] = [first, first reply].
-        # Without the filter: user_indices = [0, 2, 4] (includes the marker),
-        # ordinal=1 → user_indices[1] = 2, same result by luck — but ordinal=0
-        # would truncate to history[:0] vs history[:0], and higher ordinals shift.
-        assert seen["history"] == original_history[:2], (
-            f"Expected truncation to first 2 messages, got {seen['history']}"
+        # With the filter: user_indices = [0, 3], so the marker remains in the
+        # prefix before the second real turn. Without it user_indices = [0, 2, 3]
+        # and ordinal=1 incorrectly targets the marker.
+        assert seen["history"] == original_history[:3], (
+            f"Expected truncation to first 3 messages, got {seen['history']}"
         )
-        assert stub_db.replaced == [("session-key", original_history[:2])], (
-            f"Expected DB replace with first 2 messages, got {stub_db.replaced}"
+        assert stub_db.replaced == [("session-key", original_history[:3])], (
+            f"Expected DB replace with first 3 messages, got {stub_db.replaced}"
         )
     finally:
         server._sessions.pop("sid", None)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9701,13 +9701,111 @@ def test_prompt_submit_refuses_turn_when_truncate_persist_fails(monkeypatch):
         )
         assert "error" in resp
         assert resp["error"]["code"] == 5008
-        assert "truncat" in resp["error"]["message"].lower() or "persist" in resp["error"]["message"].lower()
+        assert (
+            "truncat" in resp["error"]["message"].lower()
+            or "persist" in resp["error"]["message"].lower()
+        )
         # Memory left intact — same list contents as before the refused cut.
         assert sess["history"] == original_history
         assert sess["history_version"] == 0
         assert sess.get("running") is not True
     finally:
         server._sessions.pop("trunc-fail-sid", None)
+
+
+def test_prompt_submit_truncate_ordinal_reflects_concurrent_writer(monkeypatch):
+    """truncate_before_user_ordinal must be checked against the CURRENT
+    DB row set, not this TUI process's possibly-stale in-memory history.
+
+    session["history"] is only refreshed on resume — it does not track
+    writes made by another client sharing this same session_key (e.g. the
+    REST gateway used by a web UI). If a second user turn lands in the DB
+    that way after this TUI last refreshed, an ordinal that is valid
+    against the CURRENT session must not be rejected as "no longer in
+    session history" just because the stale in-memory copy is shorter.
+    """
+
+    seen = {}
+
+    class _Agent:
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            seen["prompt"] = prompt
+            seen["history"] = conversation_history
+            return {
+                "final_response": "edited reply",
+                "messages": [
+                    *(conversation_history or []),
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "edited reply"},
+                ],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    # What this TUI process still has in memory from its last resume.
+    stale_history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "first reply"},
+    ]
+    server._sessions["sid"] = _session(agent=_Agent(), history=stale_history)
+
+    # What is actually in the DB right now — a second exchange landed here
+    # via another client (e.g. webui's REST gateway) after this TUI's last
+    # refresh, so ordinal=1 ("the second user turn") is valid against the
+    # DB even though the stale in-memory copy only has one user turn.
+    fresh_history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "first reply"},
+        {"role": "user", "content": "second (from another client)"},
+        {"role": "assistant", "content": "second reply (from another client)"},
+    ]
+
+    class _StubDb:
+        def __init__(self):
+            self.replaced = []
+
+        def get_messages_as_conversation(self, session_id, include_ancestors=True):
+            return list(fresh_history)
+
+        def replace_messages(self, session_id, messages):
+            self.replaced.append((session_id, list(messages)))
+
+    stub_db = _StubDb()
+
+    try:
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+        monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
+        monkeypatch.setattr(server, "_emit", lambda *a: None)
+        monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "sid",
+                    "text": "edited second",
+                    "truncate_before_user_ordinal": 1,
+                },
+            }
+        )
+        # Before the fix this was rejected with 4018 ("target user message
+        # is no longer in session history") because ordinal=1 is out of
+        # range for the 1-user-turn stale in-memory copy — even though it
+        # is perfectly valid against the DB's actual 2-user-turn history.
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert seen["history"] == fresh_history[:2]
+        assert stub_db.replaced == [("session-key", fresh_history[:2])]
+    finally:
+        server._sessions.pop("sid", None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4552,6 +4552,12 @@ def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
     replaced = []
 
     class _FakeDB:
+        def get_messages_as_conversation(
+            self, _session_id, repair_alternation=False
+        ):
+            assert repair_alternation is True
+            return list(history)
+
         def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
             replaced.append((key, list(messages)))
 
@@ -4639,6 +4645,12 @@ def test_prompt_submit_empty_truncation_allowed_with_confirm(monkeypatch):
             self._target()
 
     class _FakeDB:
+        def get_messages_as_conversation(
+            self, _session_id, repair_alternation=False
+        ):
+            assert repair_alternation is True
+            return list(history)
+
         def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
             replaced.append((key, list(messages)))
 
@@ -9619,6 +9631,7 @@ def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
             self.replaced = []
 
         def get_messages_as_conversation(self, session_id, repair_alternation=False):
+            assert repair_alternation is True
             return list(original_history)
 
         def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
@@ -9732,7 +9745,7 @@ def test_prompt_submit_truncate_ordinal_refreshes_external_writes(monkeypatch):
 
     class _Agent:
         def run_conversation(
-            self, prompt, conversation_history=None, stream_callback=None
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
         ):
             seen["prompt"] = prompt
             seen["history"] = conversation_history
@@ -9774,7 +9787,8 @@ def test_prompt_submit_truncate_ordinal_refreshes_external_writes(monkeypatch):
         def __init__(self):
             self.replaced = []
 
-        def get_messages_as_conversation(self, session_id):
+        def get_messages_as_conversation(self, session_id, repair_alternation=False):
+            assert repair_alternation is True
             return list(fresh_history)
 
         def replace_messages(self, session_id, messages):
@@ -9833,7 +9847,9 @@ def test_prompt_submit_truncate_ordinal_excludes_display_ancestors(monkeypatch, 
     seen = {}
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             seen["history"] = list(conversation_history or [])
             return {
                 "final_response": "edited reply",
@@ -9902,7 +9918,8 @@ def test_prompt_submit_truncate_fails_closed_when_fresh_read_fails(monkeypatch):
     replaced = []
 
     class _StubDb:
-        def get_messages_as_conversation(self, session_id):
+        def get_messages_as_conversation(self, session_id, repair_alternation=False):
+            assert repair_alternation is True
             raise RuntimeError("database unavailable")
 
         def replace_messages(self, session_id, messages):
@@ -9950,7 +9967,8 @@ def test_prompt_submit_truncate_fails_closed_when_replace_fails(monkeypatch):
     ]
 
     class _StubDb:
-        def get_messages_as_conversation(self, session_id):
+        def get_messages_as_conversation(self, session_id, repair_alternation=False):
+            assert repair_alternation is True
             return list(history)
 
         def replace_messages(self, session_id, messages):

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -227,11 +227,14 @@ def _(rid, params: dict) -> dict:
                 if message.get("role") == "user" and not message.get("display_kind")
             )
             segment_ordinal = ordinal - prefix_user_count
+            expected_history = list(history)
             if db is not None and session.get("session_key"):
                 try:
-                    history = db.get_messages_as_conversation(
-                        session["session_key"], repair_alternation=True
+                    raw_history, _display_history = db.get_resume_conversations(
+                        session["session_key"]
                     )
+                    expected_history = list(raw_history)
+                    history = sanitize_replay_history(raw_history)
                 except Exception as exc:
                     # This path immediately performs a destructive transcript
                     # replacement. If the authoritative read fails, do not fall
@@ -291,25 +294,14 @@ def _(rid, params: dict) -> dict:
             # Fail closed: refuse the turn and leave memory/DB unchanged.
             if (db := _get_db()) is not None:
                 try:
-                    # active_only=True: replace only the live (active=1) rows.
-                    # In-place compaction (#38763) keeps the pre-compaction
-                    # transcript as active=0/compacted=1 rows under this same
-                    # session key; a bare replace_messages() would DELETE that
-                    # durable archive on every edit/regenerate — the same bug
-                    # class #80216 fixed for /retry. On an uncompacted session
-                    # all rows are active=1, so this is behaviorally identical
-                    # to the full replace.
-                    # archive_dropped: a rewind overwrites turns the user may
-                    # not have meant to drop, and this write is the last step
-                    # before they are gone — three reported incidents ended
-                    # here with nothing to restore from (#70516, #80763,
-                    # #82756). Soft-archiving keeps them on disk (active=0) and
-                    # in the FTS index, so a mis-aimed cut is recoverable
-                    # instead of terminal. The live transcript is unchanged.
-                    db.replace_messages(
+                    # Compare and rewrite inside one transaction so a writer
+                    # cannot append between the refresh and truncation. Soft-
+                    # archive the replaced active rows so a mis-aimed rewind
+                    # remains recoverable without touching compacted history.
+                    replaced = db.replace_active_messages_if_unchanged(
                         session["session_key"],
+                        expected_history,
                         truncated,
-                        active_only=True,
                         archive_dropped=True,
                     )
                 except Exception as exc:
@@ -326,6 +318,12 @@ def _(rid, params: dict) -> dict:
                         rid,
                         5008,
                         f"failed to persist history truncation: {exc}",
+                    )
+                if not replaced:
+                    return _err(
+                        rid,
+                        4091,
+                        "session history changed while editing; reload and retry",
                     )
             session["history"] = truncated
             session["history_version"] = int(session.get("history_version", 0)) + 1

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -181,7 +181,7 @@ def _(rid, params: dict) -> dict:
                 ordinal = int(truncate_user_ordinal)
             except (TypeError, ValueError):
                 return _err(rid, 4004, "truncate_before_user_ordinal must be an integer")
-            history = session.get("history", [])
+            history = list(session.get("history", []))
             # An ordinal alone is not consent. A client that carries a leftover
             # ordinal into an ORDINARY submit sends a request that is
             # indistinguishable, field by field, from a real rewind — same
@@ -207,18 +207,46 @@ def _(rid, params: dict) -> dict:
                     "an ordinary prompt.submit must not drop session history "
                     "(update your Hermes client if a rewind was intended)",
                 )
+            if ordinal < 0:
+                return _err(rid, 4018, "target user message is no longer in session history")
+            # session["history"] is only refreshed on resume (session.resume) —
+            # it does not track writes made by other clients sharing this same
+            # session_key (e.g. the REST gateway used by a web UI). Re-read the
+            # current segment from the DB before truncating so replace_messages
+            # does not operate on a stale in-memory snapshot.
+            #
+            # The Desktop ordinal is based on the full displayed lineage, while
+            # session["history"] and the model context contain only the current
+            # segment. Subtract the immutable ancestor display prefix instead of
+            # loading ancestors into `history`: persisting those rows into the
+            # tip would duplicate compressed history on every later resume.
+            db = _get_db()
+            prefix_user_count = sum(
+                1
+                for message in session.get("display_history_prefix", [])
+                if message.get("role") == "user" and not message.get("display_kind")
+            )
+            segment_ordinal = ordinal - prefix_user_count
+            if db is not None and session.get("session_key"):
+                try:
+                    history = db.get_messages_as_conversation(
+                        session["session_key"], repair_alternation=True
+                    )
+                except Exception as exc:
+                    # This path immediately performs a destructive transcript
+                    # replacement. If the authoritative read fails, do not fall
+                    # back to the stale snapshot and risk overwriting newer rows.
+                    return _err(rid, 5000, f"failed to load current session history: {exc}")
             user_indices = [
                 i for i, m in enumerate(history)
                 if m.get("role") == "user" and not m.get("display_kind")
             ]
-            # Reject out-of-range ordinals on BOTH ends. A negative value would
-            # otherwise sail past the upper-bound check and hit Python's negative
-            # indexing below (user_indices[-1] -> the LAST user turn), silently
-            # truncating history to everything before it and persisting that loss
-            # via replace_messages — an unrecoverable overwrite of the session DB.
-            if ordinal < 0 or ordinal >= len(user_indices):
+            # An ordinal that points into the display-only ancestor prefix is
+            # not editable from this continuation segment. Reject it on the same
+            # stale-target path as an ordinal beyond the current segment.
+            if segment_ordinal < 0 or segment_ordinal >= len(user_indices):
                 return _err(rid, 4018, "target user message is no longer in session history")
-            truncated = history[: user_indices[ordinal]]
+            truncated = history[: user_indices[segment_ordinal]]
             # Second gate, on top of confirm_truncate: ordinal 0 resolves to
             # history[:0] == [] and replace_messages() DELETEs every durable
             # row. A confirmed rewind that happens to erase the whole


### PR DESCRIPTION
## Summary

Fixes #69107 — `prompt.submit`'s `truncate_before_user_ordinal` (the Desktop/TUI edit-and-regenerate flow) computed the truncation point from `session["history"]`, which can remain stale while another REST-gateway-backed client writes new turns to the same durable session.

An ordinal valid against the current SessionDB state was therefore rejected with `4018 "target user message is no longer in session history"`. Because the same path performs a destructive `replace_messages(...)`, using the stale snapshot could also discard newer rows.

## Root cause

The gateway's in-memory history is refreshed on resume and after its own turns, but it is not authoritative for writes made by another client.

Compressed sessions add an identity wrinkle: Desktop ordinals are based on the full displayed lineage, while the model-fed working history contains only the current continuation segment. Loading ancestors into the replacement history would duplicate compressed rows in the tip session.

## Fix

- Re-read the current session segment from `SessionDB` with `repair_alternation=True`, matching the model-fed resume projection, immediately before validating and applying the truncation.
- Translate the full-display user ordinal to the current-segment ordinal using `display_history_prefix`, without copying ancestor rows into the tip.
- Fail closed without mutating in-memory history or starting a turn if either the authoritative DB read or destructive replacement fails.
- Persist the truncation before committing it to `session["history"]`, so a SQLite/FTS/ENOSPC failure cannot leave memory and durable history diverged.
- Preserve the current `main` predicate that excludes `display_kind` timeline rows from both current-segment and ancestor-prefix user ordinals.
- Follow the latest prompt-handler split by applying the change in `tui_gateway/methods_prompt.py` without restoring the mechanically extracted handler in `server.py`.
- Preserve the existing `4018` behavior for negative, ancestor-only, or otherwise out-of-range targets, and preserve the newer `confirm_empty_truncate` guard for intentional first-turn rewinds.

## Scope

This PR intentionally fixes the concrete edit/regenerate correctness and data-loss path only. It does not add a live transcript subscription or choose new cross-client UI behavior; that broader UX remains a separate follow-up in #69107.

## Relationship to #72876

#72876 independently proposes write-before-memory failure handling for `replace_messages()`. The current head of this PR already includes that behavior and its regression coverage, in addition to the authoritative history refresh, compressed-lineage ordinal translation, resume-projection preservation, and fail-closed DB-read path. The implementations therefore substantially overlap; this PR covers #72876's failure mode as part of the broader stale cross-client history fix.

## Testing

- Regression test for a completed write from another client that previously produced `4018`.
- Real-`SessionDB` compression-lineage test proving only the current segment is truncated while ancestor rows remain unchanged.
- Failure-path tests proving DB read and replacement errors leave memory/version unchanged and do not start a turn.
- Existing empty-truncation and ordinary truncation tests updated to exercise the authoritative read contract.
- Rebased onto current `main` (`5a23e3c52`): `python -m pytest tests/test_tui_gateway_server.py -q` → **498 passed**.
- `python -m py_compile tui_gateway/methods_prompt.py tests/test_tui_gateway_server.py` — clean.
- `git diff --check` — clean.

## Review focus

The highest-risk invariant is that the displayed full-lineage ordinal must resolve to the current segment without ever copying ancestor rows into the destructive replacement. The real-SessionDB lineage regression test pins that behavior. Both authoritative-read and replacement failures are fail-closed before the turn starts.


