### PR TITLE
[Bob] fix: redact subagent final response and close pre_verify gate for non-edit turns

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -62,6 +62,7 @@ from agent.model_metadata import (
 )
 from agent.process_bootstrap import _install_safe_stdio
 from agent.prompt_caching import apply_anthropic_cache_control
+from agent.redact import redact_sensitive_text
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
     is_zai_coding_overload_error,
@@ -5485,9 +5486,13 @@ def run_conversation(
                     truncated_response_parts = []
                     length_continue_retries = 0
                 
-                final_response = agent._strip_think_blocks(final_response).strip()
+                final_response = redact_sensitive_text(
+                    agent._strip_think_blocks(final_response).strip(),
+                    force=True,
+                )
                 
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                final_msg["content"] = final_response
 
                 # Pop thinking-only prefill and empty-response retry
                 # scaffolding before appending either a final response or a
@@ -5571,12 +5576,17 @@ def run_conversation(
                 # default continuation cost.
                 _verify_nudge2 = None
                 _edited = sorted(getattr(agent, "_turn_file_mutation_paths", set()) or [])
+                _is_subagent_report = getattr(agent, "_delegate_depth", 0) > 0
                 _attempt = getattr(agent, "_pre_verify_nudges", 0)
                 try:
                     from agent.verify_hooks import max_verify_nudges
                     from hermes_cli.plugins import get_pre_verify_continue_message, has_hook
 
-                    if _edited and has_hook("pre_verify") and _attempt < max_verify_nudges():
+                    if (
+                        (_edited or _is_subagent_report)
+                        and has_hook("pre_verify")
+                        and _attempt < max_verify_nudges()
+                    ):
                         # Posture is fixed for the session — resolve once + cache.
                         coding = getattr(agent, "_resolved_is_coding", None)
                         if coding is None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5195,6 +5195,7 @@ class AIAgent:
             else:
                 # Defensive: legacy callers without the scrubber attribute.
                 text = sanitize_context(text)
+            text = redact_sensitive_text(text, force=True)
             # Only strip leading newlines on the first delta — mid-stream "\n" is legitimate markdown.
             if not prepended_break and not getattr(
                 self, "_current_streamed_assistant_text", ""

--- a/tests/run_agent/test_verification_continuation_budget.py
+++ b/tests/run_agent/test_verification_continuation_budget.py
@@ -105,6 +105,67 @@ def test_pre_verify_preserves_composed_report_at_budget_limit(agent, monkeypatch
     assert not result["messages"][1].get("_pre_verify_synthetic")
 
 
+def test_pre_verify_sanitizes_substantive_subagent_report_before_output_gate(
+    agent,
+    monkeypatch,
+):
+    # Given: a completed audit report contains synthetic credential-shaped
+    # terminology, while a retry would return only a promise-shaped response.
+    agent.max_iterations = 2
+    agent.iteration_budget.max_total = 2
+    agent._delegate_depth = 1
+    synthetic_secret = "synthetic-secret-value-123456"
+    report = (
+        "Audit findings:\n"
+        "- SEC-17 in agent/output.py: redaction preserved 3 evidence records.\n"
+        f"- Synthetic fixture OPENAI_API_KEY={synthetic_secret} exercised the output gate."
+    )
+    promise = "곧 안전하게 정리해서 결과를 제공하겠습니다."
+    streamed: list[str] = []
+    agent.stream_delta_callback = streamed.append
+
+    def streaming_model_call(_api_kwargs, *, on_first_delta=None):
+        if on_first_delta:
+            on_first_delta()
+        agent._fire_stream_delta(report)
+        return _response(report)
+
+    agent._interruptible_streaming_api_call = streaming_model_call
+    seen: list[str] = []
+
+    def output_gate(**kwargs):
+        candidate = kwargs["final_response"]
+        seen.append(candidate)
+        if synthetic_secret in candidate:
+            return "sanitize the completed report and return its evidence now"
+        return None
+
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "0")
+
+    # When: the subagent candidate passes through the final-output gate.
+    with (
+        patch("hermes_cli.plugins.has_hook", side_effect=lambda name: name == "pre_verify"),
+        patch("hermes_cli.plugins.get_pre_verify_continue_message", side_effect=output_gate),
+        patch("agent.verify_hooks.max_verify_nudges", return_value=2),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("audit the output safety path")
+
+    # Then: the same-turn result is sanitized evidence, never the canned retry.
+    final_response = result["final_response"]
+    streamed_response = "".join(streamed)
+    assert synthetic_secret not in streamed_response
+    assert "SEC-17" in streamed_response
+    assert "agent/output.py" in streamed_response
+    assert "3 evidence records" in streamed_response
+    assert synthetic_secret not in final_response
+    assert "SEC-17" in final_response
+    assert "agent/output.py" in final_response
+    assert "3 evidence records" in final_response
+    assert final_response != promise
+    assert len(seen) == 1
+
+
 def test_intermediate_ack_uses_summary_instead_of_premature_text(agent, monkeypatch):
     agent.valid_tool_names = ["web_search"]
     agent._intent_ack_continuation = True


### PR DESCRIPTION
## Problem
A delegation transcript showed a subagent's completed audit report get replaced by a canned Korean promise-shaped string ('다시 확인해서 말하겠다') instead of recovering the real evidence in the same turn, whenever the final-output gate flagged the response (e.g. it contained credential-shaped text). Full evidence remained in child transcripts but never reached the parent's final answer.

## Root cause (two independent gaps)
1. Sensitive final text reached `pre_verify` finalization and stream callbacks **before** forced redaction, so a retry triggered by the output gate had no sanitized text to fall back to.
2. The `pre_verify` recovery gate only fired `if _edited` (turn file mutations present) — so read-only/audit subagent turns, exactly the reported scenario, never invoked the recovery hook at all, regardless of what the output gate said.

## Fix
- `agent/conversation_loop.py`: redact the finalized response through `agent.redact.redact_sensitive_text(..., force=True)` before `pre_verify` runs; also fire the `pre_verify` gate when the turn is a subagent report (`_delegate_depth > 0`), not just when files were edited.
- `run_agent.py`: redact every streamed delta the same way, so the live UI can't leak the raw text before the final-response redaction lands.

## Testing
- New regression: `test_pre_verify_sanitizes_substantive_subagent_report_before_output_gate` — a delegated-depth streamed audit containing synthetic credential-shaped text; asserts sanitized evidence (`SEC-17`, file path, evidence count) survives in both the streamed and final response, and the canned promise is never emitted.
- `tests/run_agent/test_verification_continuation_budget.py`: 10/10 passed
- `tests/run_agent/` (full): 2117 passed, 7 skipped, 0 failed
- `ruff check`: clean
- `py_compile`, `git diff --check`: passed

All verification run in an isolated py3.11 venv against a clean rebase of current `main` (the original diff had drifted 200+ commits from main; this PR is the isolated, re-verified fix).