### PR TITLE
fix(compression): prevent stale-budget retry loops

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2023,7 +2023,6 @@ def init_agent(
         _active_base_url = _normalize_route_base_url(_active_route_url)
         _route_mismatch = bool(
             _configured_base_url
-            and _active_base_url
             and _configured_base_url != _active_base_url
         )
         if not _configured_base_url:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -174,6 +174,19 @@ def _provider_default_routes(provider: str) -> set[str]:
     return routes
 
 
+def _normalize_custom_provider_name(value: Any) -> str:
+    """Mirror runtime normalization for a requested custom-provider identity."""
+    return str(value or "").strip().lower().replace(" ", "-")
+
+
+def _custom_provider_runtime_ids(value: Any) -> set[str]:
+    """Return raw/menu identities that runtime accepts for a configured name."""
+    normalized = _normalize_custom_provider_name(value)
+    if not normalized:
+        return set()
+    return {normalized, f"custom:{normalized}"}
+
+
 def _build_codex_gpt5_autoraise_notice(
     autoraise: Dict[str, Any], context_length: Optional[int] = None
 ) -> str:
@@ -1901,17 +1914,98 @@ def init_agent(
         _configured_base_url = _normalize_route_base_url(
             _model_cfg.get("base_url")
         )
-        if not _configured_base_url and _configured_provider.lower().startswith("custom:"):
-            _configured_custom_name = _configured_provider.split(":", 1)[1].lower()
-            for _provider_entry in _custom_providers:
-                if not isinstance(_provider_entry, dict):
-                    continue
-                if str(_provider_entry.get("name") or "").strip().lower() != _configured_custom_name:
-                    continue
-                _configured_base_url = _normalize_route_base_url(
-                    _provider_entry.get("base_url")
+        _configured_provider_norm = _normalize_custom_provider_name(
+            _configured_provider
+        )
+        _custom_provider_candidate = bool(_configured_provider_norm)
+        _runtime_first_provider_ids = {
+            "auto",
+            "moa",
+            "vertex",
+            "google-vertex",
+            "vertex-ai",
+            "gcp-vertex",
+            "vertexai",
+        }
+        if _configured_provider_norm in _runtime_first_provider_ids:
+            _custom_provider_candidate = False
+        elif (
+            _custom_provider_candidate
+            and _configured_provider_norm != "custom"
+            and not _configured_provider_norm.startswith("custom:")
+        ):
+            try:
+                from hermes_cli.auth import resolve_provider as resolve_auth_provider
+
+                _resolved_auth_provider = resolve_auth_provider(
+                    _configured_provider_norm
                 )
-                break
+                _custom_provider_candidate = (
+                    str(_resolved_auth_provider or "").strip().lower()
+                    != _configured_provider_norm
+                )
+            except Exception:
+                pass
+        if not _configured_base_url and _custom_provider_candidate:
+            _configured_custom_provider = _normalize_custom_provider_name(
+                _configured_provider
+            )
+            _user_providers = _agent_cfg.get("providers")
+            _disabled_custom_provider_ids: set[str] = set()
+            if isinstance(_user_providers, dict):
+                from hermes_cli.config import is_provider_enabled
+
+                for _provider_key, _provider_entry in _user_providers.items():
+                    if not isinstance(_provider_entry, dict):
+                        continue
+                    _entry_name = str(
+                        _provider_entry.get("name") or ""
+                    ).strip()
+                    _entry_provider_ids = _custom_provider_runtime_ids(
+                        _provider_key
+                    ) | _custom_provider_runtime_ids(_entry_name)
+                    if not is_provider_enabled(_provider_entry):
+                        _disabled_custom_provider_ids.update(
+                            provider_id
+                            for provider_id in _entry_provider_ids
+                            if provider_id
+                        )
+                        continue
+                    if _configured_custom_provider not in _entry_provider_ids:
+                        continue
+                    _configured_base_url = _normalize_route_base_url(
+                        _provider_entry.get("api")
+                        or _provider_entry.get("url")
+                        or _provider_entry.get("base_url")
+                    )
+                    if _configured_base_url:
+                        break
+            if not _configured_base_url:
+                for _provider_entry in _custom_providers:
+                    if not isinstance(_provider_entry, dict):
+                        continue
+                    _entry_name = str(
+                        _provider_entry.get("name") or ""
+                    ).strip()
+                    _entry_provider_key = str(
+                        _provider_entry.get("provider_key") or ""
+                    ).strip().lower()
+                    _entry_provider_ids = _custom_provider_runtime_ids(
+                        _entry_name
+                    ) | _custom_provider_runtime_ids(_entry_provider_key)
+                    if (
+                        _entry_provider_key
+                        and _custom_provider_runtime_ids(_entry_provider_key)
+                        & _disabled_custom_provider_ids
+                    ):
+                        continue
+                    if _configured_custom_provider not in _entry_provider_ids:
+                        continue
+                    _configured_base_url = _normalize_route_base_url(
+                        _provider_entry.get("base_url")
+                    )
+                    if _configured_base_url:
+                        break
         _active_route_url = str(agent.base_url or "")
         _requested_route_url = str(base_url or "")
         if "?" in _requested_route_url.split("#", 1)[0]:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -28,7 +28,7 @@ import time
 import uuid
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
-from urllib.parse import urlparse, parse_qs, urlunparse
+from urllib.parse import parse_qs, urlparse, urlsplit, urlunparse, urlunsplit
 
 from agent.context_compressor import ContextCompressor
 from agent.iteration_budget import IterationBudget
@@ -66,6 +66,112 @@ def _ra():
     """
     import run_agent
     return run_agent
+
+
+def _normalize_route_base_url(base_url: Any) -> str:
+    """Canonicalize an endpoint URL for model-route identity comparisons."""
+    raw = str(base_url or "")
+    if not raw:
+        return ""
+    if any(ord(char) <= 0x20 for char in raw):
+        return raw
+    had_query_delimiter = "?" in raw.split("#", 1)[0]
+    try:
+        parsed = urlsplit(raw)
+        hostname = parsed.hostname
+        if not parsed.scheme or not hostname:
+            return raw
+        scheme = parsed.scheme.lower()
+        if "%" in hostname:
+            address, zone = hostname.split("%", 1)
+            host = f"{address.lower()}%{zone}"
+        else:
+            host = hostname.lower()
+        port = parsed.port
+    except (TypeError, ValueError):
+        return raw
+
+    route_host = parsed.netloc.rsplit("@", 1)[-1]
+    if route_host.startswith("[") or ":" in host:
+        host = f"[{host}]"
+    if port is not None and (scheme, port) not in {("http", 80), ("https", 443)}:
+        host = f"{host}:{port}"
+    if "@" in parsed.netloc:
+        host = f"{parsed.netloc.rsplit('@', 1)[0]}@{host}"
+
+    path = parsed.path
+    if path.endswith("/") and not had_query_delimiter:
+        path = path[:-1]
+
+    normalized = urlunsplit(
+        (
+            scheme,
+            host,
+            path,
+            parsed.query,
+            "",
+        )
+    )
+    if had_query_delimiter and not parsed.query:
+        normalized += "?"
+    return normalized
+
+
+def _provider_default_routes(provider: str) -> set[str]:
+    """Return known exact default routes for a canonical provider id."""
+    routes: set[str] = set()
+    try:
+        from hermes_cli.providers import HERMES_OVERLAYS, get_provider
+
+        overlay = HERMES_OVERLAYS.get(provider)
+        provider_def = get_provider(provider)
+        for value in (
+            getattr(overlay, "base_url_override", ""),
+            getattr(provider_def, "base_url", ""),
+        ):
+            route = _normalize_route_base_url(value)
+            if route:
+                routes.add(route)
+    except Exception:
+        pass
+
+    try:
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(provider)
+        route = _normalize_route_base_url(
+            getattr(profile, "base_url", "")
+        )
+        if route:
+            routes.add(route)
+    except Exception:
+        pass
+
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        from hermes_cli.models import normalize_provider as normalize_model_provider
+        from hermes_cli.providers import normalize_provider as normalize_registry_provider
+
+        for provider_id, config in PROVIDER_REGISTRY.items():
+            canonical_id = normalize_registry_provider(
+                normalize_model_provider(provider_id)
+            )
+            if canonical_id != provider:
+                continue
+            route = _normalize_route_base_url(
+                getattr(config, "inference_base_url", "")
+            )
+            if route:
+                routes.add(route)
+    except Exception:
+        pass
+
+    if provider == "gemini":
+        routes.update(
+            f"{route.rstrip('/')}/openai"
+            for route in list(routes)
+        )
+    return routes
 
 
 def _build_codex_gpt5_autoraise_notice(
@@ -1792,7 +1898,9 @@ def init_agent(
             except Exception:
                 pass
         _configured_provider = str(_model_cfg.get("provider") or "").strip()
-        _configured_base_url = str(_model_cfg.get("base_url") or "").rstrip("/")
+        _configured_base_url = _normalize_route_base_url(
+            _model_cfg.get("base_url")
+        )
         if not _configured_base_url and _configured_provider.lower().startswith("custom:"):
             _configured_custom_name = _configured_provider.split(":", 1)[1].lower()
             for _provider_entry in _custom_providers:
@@ -1800,11 +1908,25 @@ def init_agent(
                     continue
                 if str(_provider_entry.get("name") or "").strip().lower() != _configured_custom_name:
                     continue
-                _configured_base_url = str(
-                    _provider_entry.get("base_url") or ""
-                ).rstrip("/")
+                _configured_base_url = _normalize_route_base_url(
+                    _provider_entry.get("base_url")
+                )
                 break
-        _active_base_url = str(agent.base_url or "").rstrip("/")
+        _active_route_url = str(agent.base_url or "")
+        _requested_route_url = str(base_url or "")
+        if "?" in _requested_route_url.split("#", 1)[0]:
+            try:
+                _requested_parts = urlparse(_requested_route_url)
+                _requested_without_query = urlunparse(
+                    _requested_parts._replace(query="")
+                )
+                if _normalize_route_base_url(
+                    _requested_without_query
+                ) == _normalize_route_base_url(_active_route_url):
+                    _active_route_url = _requested_route_url
+            except (TypeError, ValueError):
+                pass
+        _active_base_url = _normalize_route_base_url(_active_route_url)
         _route_mismatch = bool(
             _configured_base_url
             and _active_base_url
@@ -1812,19 +1934,43 @@ def init_agent(
         )
         if not _configured_base_url:
             _active_provider = str(agent.provider or "").strip()
+            _normalize_provider_fn = None
+            _normalize_registry_provider_fn = None
             try:
-                from hermes_cli.models import normalize_provider
+                from hermes_cli.models import normalize_provider as _normalize_provider_fn
 
-                _configured_provider = normalize_provider(_configured_provider)
-                _active_provider = normalize_provider(_active_provider)
+                _configured_provider = _normalize_provider_fn(_configured_provider)
+                _active_provider = _normalize_provider_fn(_active_provider)
             except Exception:
                 _configured_provider = _configured_provider.lower()
                 _active_provider = _active_provider.lower()
-            _route_mismatch = bool(
-                _configured_provider
-                and _active_provider
-                and _configured_provider != _active_provider
-            )
+            try:
+                from hermes_cli.providers import (
+                    normalize_provider as _normalize_registry_provider_fn,
+                )
+
+                _configured_provider = _normalize_registry_provider_fn(
+                    _configured_provider
+                )
+                _active_provider = _normalize_registry_provider_fn(
+                    _active_provider
+                )
+            except Exception:
+                pass
+            if _active_base_url:
+                _configured_routes = _provider_default_routes(
+                    _configured_provider
+                )
+                _route_mismatch = bool(
+                    not _configured_routes
+                    or _active_base_url not in _configured_routes
+                )
+            else:
+                _route_mismatch = bool(
+                    _configured_provider
+                    and _active_provider
+                    and _configured_provider != _active_provider
+                )
         _model_mismatch = bool(
             _configured_default_runtime_model
             and _configured_default_runtime_model != _active_runtime_model

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -28,7 +28,7 @@ import time
 import uuid
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
-from urllib.parse import parse_qs, urlparse, urlsplit, urlunparse, urlunsplit
+from urllib.parse import parse_qs, urlparse, urlunparse
 
 from agent.context_compressor import ContextCompressor
 from agent.iteration_budget import IterationBudget
@@ -48,6 +48,7 @@ from agent.tool_guardrails import (
     ToolGuardrailDecision,
 )
 from hermes_cli.config import cfg_get
+from hermes_cli.route_identity import normalize_route_base_url
 from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import get_hermes_home
 from utils import base_url_host_matches, is_truthy_value
@@ -70,51 +71,7 @@ def _ra():
 
 def _normalize_route_base_url(base_url: Any) -> str:
     """Canonicalize an endpoint URL for model-route identity comparisons."""
-    raw = str(base_url or "")
-    if not raw:
-        return ""
-    if any(ord(char) <= 0x20 for char in raw):
-        return raw
-    had_query_delimiter = "?" in raw.split("#", 1)[0]
-    try:
-        parsed = urlsplit(raw)
-        hostname = parsed.hostname
-        if not parsed.scheme or not hostname:
-            return raw
-        scheme = parsed.scheme.lower()
-        if "%" in hostname:
-            address, zone = hostname.split("%", 1)
-            host = f"{address.lower()}%{zone}"
-        else:
-            host = hostname.lower()
-        port = parsed.port
-    except (TypeError, ValueError):
-        return raw
-
-    route_host = parsed.netloc.rsplit("@", 1)[-1]
-    if route_host.startswith("[") or ":" in host:
-        host = f"[{host}]"
-    if port is not None and (scheme, port) not in {("http", 80), ("https", 443)}:
-        host = f"{host}:{port}"
-    if "@" in parsed.netloc:
-        host = f"{parsed.netloc.rsplit('@', 1)[0]}@{host}"
-
-    path = parsed.path
-    if path.endswith("/") and not had_query_delimiter:
-        path = path[:-1]
-
-    normalized = urlunsplit(
-        (
-            scheme,
-            host,
-            path,
-            parsed.query,
-            "",
-        )
-    )
-    if had_query_delimiter and not parsed.query:
-        normalized += "?"
-    return normalized
+    return normalize_route_base_url(base_url)
 
 
 def _provider_default_routes(provider: str) -> set[str]:
@@ -172,6 +129,54 @@ def _provider_default_routes(provider: str) -> set[str]:
             for route in list(routes)
         )
     return routes
+
+
+def _context_route_mismatch(
+    configured_base_url: Any,
+    active_base_url: Any,
+    configured_provider: Any,
+    active_provider: Any,
+    *,
+    already_normalized: bool = False,
+) -> bool:
+    """Return whether a context pin's configured route differs from runtime."""
+    if already_normalized:
+        configured_route = str(configured_base_url or "")
+        active_route = str(active_base_url or "")
+    else:
+        configured_route = _normalize_route_base_url(configured_base_url)
+        active_route = _normalize_route_base_url(active_base_url)
+    if configured_route:
+        return configured_route != active_route
+
+    configured_provider = str(configured_provider or "").strip()
+    active_provider = str(active_provider or "").strip()
+    if not configured_provider:
+        return False
+    try:
+        from hermes_cli.models import normalize_provider as normalize_model_provider
+
+        configured_provider = normalize_model_provider(configured_provider)
+        active_provider = normalize_model_provider(active_provider)
+    except Exception:
+        configured_provider = configured_provider.lower()
+        active_provider = active_provider.lower()
+    try:
+        from hermes_cli.providers import normalize_provider as normalize_registry_provider
+
+        configured_provider = normalize_registry_provider(configured_provider)
+        active_provider = normalize_registry_provider(active_provider)
+    except Exception:
+        pass
+
+    if active_route:
+        configured_routes = _provider_default_routes(configured_provider)
+        return not configured_routes or active_route not in configured_routes
+    return bool(
+        configured_provider
+        and active_provider
+        and configured_provider != active_provider
+    )
 
 
 def _normalize_custom_provider_name(value: Any) -> str:
@@ -2021,49 +2026,13 @@ def init_agent(
             except (TypeError, ValueError):
                 pass
         _active_base_url = _normalize_route_base_url(_active_route_url)
-        _route_mismatch = bool(
-            _configured_base_url
-            and _configured_base_url != _active_base_url
+        _route_mismatch = _context_route_mismatch(
+            _configured_base_url,
+            _active_base_url,
+            _configured_provider,
+            agent.provider,
+            already_normalized=True,
         )
-        if not _configured_base_url:
-            _active_provider = str(agent.provider or "").strip()
-            _normalize_provider_fn = None
-            _normalize_registry_provider_fn = None
-            try:
-                from hermes_cli.models import normalize_provider as _normalize_provider_fn
-
-                _configured_provider = _normalize_provider_fn(_configured_provider)
-                _active_provider = _normalize_provider_fn(_active_provider)
-            except Exception:
-                _configured_provider = _configured_provider.lower()
-                _active_provider = _active_provider.lower()
-            try:
-                from hermes_cli.providers import (
-                    normalize_provider as _normalize_registry_provider_fn,
-                )
-
-                _configured_provider = _normalize_registry_provider_fn(
-                    _configured_provider
-                )
-                _active_provider = _normalize_registry_provider_fn(
-                    _active_provider
-                )
-            except Exception:
-                pass
-            if _active_base_url:
-                _configured_routes = _provider_default_routes(
-                    _configured_provider
-                )
-                _route_mismatch = bool(
-                    not _configured_routes
-                    or _active_base_url not in _configured_routes
-                )
-            else:
-                _route_mismatch = bool(
-                    _configured_provider
-                    and _active_provider
-                    and _configured_provider != _active_provider
-                )
         _model_mismatch = bool(
             _configured_default_runtime_model
             and _configured_default_runtime_model != _active_runtime_model
@@ -2102,11 +2071,11 @@ def init_agent(
         # Surface a clear warning if the user set a context_length but it
         # wasn't a valid positive int — the helper silently skips those.
         if _config_context_length is None:
-            _target = agent.base_url.rstrip("/") if agent.base_url else ""
+            _target = _normalize_route_base_url(agent.base_url)
             for _cp_entry in _custom_providers:
                 if not isinstance(_cp_entry, dict):
                     continue
-                _cp_url = (_cp_entry.get("base_url") or "").rstrip("/")
+                _cp_url = _normalize_route_base_url(_cp_entry.get("base_url"))
                 if _target and _cp_url == _target:
                     _cp_models = _cp_entry.get("models", {})
                     if isinstance(_cp_models, dict):

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1757,8 +1757,9 @@ def init_agent(
             )
             _config_context_length = None
 
-    # Resolve custom_providers list once for reuse below (startup
-    # context-length override and plugin context-engine init).
+    # Resolve custom_providers once before route-scoping a global context pin:
+    # a named custom provider may keep its base URL only in this list rather
+    # than repeating it under ``model``.
     try:
         from hermes_cli.config import get_compatible_custom_providers
         _custom_providers = get_compatible_custom_providers(_agent_cfg)
@@ -1766,6 +1767,79 @@ def init_agent(
         _custom_providers = _agent_cfg.get("custom_providers")
         if not isinstance(_custom_providers, list):
             _custom_providers = []
+
+    # ``model.context_length`` describes the configured default model. A
+    # process launched directly with ``--model`` / ``-m`` has already replaced
+    # ``agent.model`` before this initializer loads config, so carrying the
+    # default model's explicit window into that different runtime is stale. The
+    # live switch/fallback paths already clear this override; keep direct-start
+    # overrides consistent with them and let provider metadata resolve the
+    # active model's window instead.
+    if _config_context_length is not None and isinstance(_model_cfg, dict):
+        _configured_default_model = str(_model_cfg.get("default") or "").strip()
+        _configured_default_runtime_model = _configured_default_model
+        _active_runtime_model = agent.model
+        if _configured_default_model:
+            try:
+                from hermes_cli.model_normalize import normalize_model_for_provider
+
+                _configured_default_runtime_model = normalize_model_for_provider(
+                    _configured_default_model, agent.provider
+                )
+                _active_runtime_model = normalize_model_for_provider(
+                    agent.model, agent.provider
+                )
+            except Exception:
+                pass
+        _configured_provider = str(_model_cfg.get("provider") or "").strip()
+        _configured_base_url = str(_model_cfg.get("base_url") or "").rstrip("/")
+        if not _configured_base_url and _configured_provider.lower().startswith("custom:"):
+            _configured_custom_name = _configured_provider.split(":", 1)[1].lower()
+            for _provider_entry in _custom_providers:
+                if not isinstance(_provider_entry, dict):
+                    continue
+                if str(_provider_entry.get("name") or "").strip().lower() != _configured_custom_name:
+                    continue
+                _configured_base_url = str(
+                    _provider_entry.get("base_url") or ""
+                ).rstrip("/")
+                break
+        _active_base_url = str(agent.base_url or "").rstrip("/")
+        _route_mismatch = bool(
+            _configured_base_url
+            and _active_base_url
+            and _configured_base_url != _active_base_url
+        )
+        if not _configured_base_url:
+            _active_provider = str(agent.provider or "").strip()
+            try:
+                from hermes_cli.models import normalize_provider
+
+                _configured_provider = normalize_provider(_configured_provider)
+                _active_provider = normalize_provider(_active_provider)
+            except Exception:
+                _configured_provider = _configured_provider.lower()
+                _active_provider = _active_provider.lower()
+            _route_mismatch = bool(
+                _configured_provider
+                and _active_provider
+                and _configured_provider != _active_provider
+            )
+        _model_mismatch = bool(
+            _configured_default_runtime_model
+            and _configured_default_runtime_model != _active_runtime_model
+        )
+        if _model_mismatch or _route_mismatch:
+            _ra().logger.debug(
+                "Ignoring model.context_length=%s for startup runtime %s at %s "
+                "(configured default is %s at %s)",
+                _config_context_length,
+                agent.model,
+                _active_base_url or agent.provider,
+                _configured_default_model,
+                _configured_base_url or _model_cfg.get("provider"),
+            )
+            _config_context_length = None
 
     # Store for reuse by _check_compression_model_feasibility (auxiliary
     # compression model context-length detection needs the same list).

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -436,6 +436,19 @@ def check_compression_model_feasibility(agent: Any) -> None:
             old_threshold = threshold
             new_threshold = aux_context
             agent.context_compressor.threshold_tokens = new_threshold
+            # ``tail_token_budget`` is derived from the trigger threshold, not
+            # directly from the model window. Keep it in lockstep with this
+            # just-in-time correction exactly as ContextCompressor.update_model()
+            # does. Leaving the old budget behind can make the tail's 1.5x soft
+            # ceiling wider than the lowered trigger, so compression preserves
+            # nearly the entire request and repeatedly re-fires.
+            summary_target_ratio = getattr(
+                agent.context_compressor, "summary_target_ratio", None
+            )
+            if isinstance(summary_target_ratio, (int, float)):
+                agent.context_compressor.tail_token_budget = int(
+                    new_threshold * summary_target_ratio
+                )
             # Keep threshold_percent in sync so future main-model
             # context_length changes (update_model) re-derive from a
             # sensible number rather than the original too-high value.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -33,6 +33,7 @@ from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
 from agent.turn_context import (
+    _compression_warrants_another_preflight_pass,
     build_turn_context,
     compose_user_api_content,
     reanchor_current_turn_user_idx,
@@ -684,6 +685,8 @@ def run_conversation(
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
     compression_attempts = 0
+    _last_preflight_pressure: Optional[int] = None
+    _preflight_compression_blocked = _ctx.preflight_compression_blocked
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
     # Last composed answer intentionally held back by a verification gate. If
     # that continuation consumes the remaining budget, this is the best
@@ -1125,6 +1128,37 @@ def run_conversation(
         # LLM cooldown + anti-thrash guards (#11529). compression_attempts is a
         # hard per-turn backstop shared with the overflow error handlers.
         _compressor = agent.context_compressor
+        _preflight_threshold = int(
+            getattr(_compressor, "threshold_tokens", 0) or 0
+        )
+        # A previous mid-turn preflight pass deliberately continued the loop so
+        # API-only context and all sanitization could be rebuilt. Compare that
+        # fully assembled request with the fully assembled request that caused
+        # the pass. Raw ``messages`` are not equivalent here: they omit
+        # api_content/plugin injections, prefills, MoA context, and ephemeral
+        # system text.
+        _previous_preflight_pressure = _last_preflight_pressure
+        _last_preflight_pressure = None
+        if (
+            _previous_preflight_pressure is not None
+            and request_pressure_tokens >= _preflight_threshold
+            and not _compression_warrants_another_preflight_pass(
+                _previous_preflight_pressure,
+                request_pressure_tokens,
+                _preflight_threshold,
+            )
+        ):
+            # Stop proactive retries for this turn without consuming the
+            # shared overflow-recovery budget. If the provider proves the
+            # request truly does not fit, its error handler may still compact
+            # with that stronger signal.
+            _preflight_compression_blocked = True
+            logger.warning(
+                "Pre-API compression made insufficient progress: ~%s -> "
+                "~%s request tokens; skipping additional preflight passes",
+                f"{_previous_preflight_pressure:,}",
+                f"{request_pressure_tokens:,}",
+            )
         _defer_preflight = getattr(
             _compressor, "should_defer_preflight_to_real_usage", lambda _t: False
         )
@@ -1135,6 +1169,7 @@ def run_conversation(
             agent.compression_enabled
             and len(messages) > 1
             and compression_attempts < 3
+            and not _preflight_compression_blocked
             and not _defer_preflight(request_pressure_tokens)
             and not _compression_cooldown
             and _compressor.should_compress(request_pressure_tokens)
@@ -1153,6 +1188,7 @@ def run_conversation(
                 f"📦 Pre-API compression: ~{request_pressure_tokens:,} tokens "
                 f"near the context/output limit. Compacting before the next model call."
             )
+            _last_preflight_pressure = request_pressure_tokens
             messages, active_system_prompt = agent._compress_context(
                 messages,
                 system_message,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -210,6 +210,23 @@ def _compression_made_progress(
     return orig_tokens > 0 and new_tokens < orig_tokens * 0.95
 
 
+def _compression_warrants_another_preflight_pass(
+    orig_tokens: int, new_tokens: int, threshold_tokens: int
+) -> bool:
+    """Whether an over-threshold request merits another immediate summary.
+
+    Row-count progress is enough to prove that a compression boundary was real,
+    but not enough to justify another expensive pass before trying the provider.
+    Continue only when the request remains over threshold *and* the previous pass
+    materially reduced its estimated token pressure (>5%).
+    """
+    return (
+        new_tokens >= threshold_tokens
+        and orig_tokens > 0
+        and new_tokens < orig_tokens * 0.95
+    )
+
+
 def _should_run_preflight_estimate(
     messages: List[Dict[str, Any]],
     protect_first_n: int,
@@ -263,6 +280,8 @@ class TurnContext:
     plugin_user_context: str = ""
     # External-memory prefetch result, reused across loop iterations.
     ext_prefetch_cache: str = ""
+    # Turn-start preflight already proved an immediate retry ineffective.
+    preflight_compression_blocked: bool = False
 
 
 def build_turn_context(
@@ -565,6 +584,7 @@ def build_turn_context(
     # See ``_should_run_preflight_estimate`` for the OR semantics that fix
     # issue #27405 (a few very large messages slipping past the count gate).
     _preflight_compressed = False
+    _preflight_compression_blocked = False
     if agent.compression_enabled and _should_run_preflight_estimate(
         messages,
         agent.context_compressor.protect_first_n,
@@ -664,6 +684,7 @@ def build_turn_context(
                 if not _compression_made_progress(
                     _orig_len, len(messages), _orig_tokens, _preflight_tokens
                 ):
+                    _preflight_compression_blocked = True
                     break  # Cannot compress further: neither rows nor tokens moved
                 conversation_history = conversation_history_after_compression(
                     agent, messages
@@ -674,6 +695,19 @@ def build_turn_context(
                 agent._last_content_tools_all_housekeeping = False
                 agent._mute_post_response = False
                 if not _compressor.should_compress(_preflight_tokens):
+                    break
+                if not _compression_warrants_another_preflight_pass(
+                    _orig_tokens,
+                    _preflight_tokens,
+                    _compressor.threshold_tokens,
+                ):
+                    _preflight_compression_blocked = True
+                    logger.warning(
+                        "Preflight compression made insufficient progress: "
+                        "~%s -> ~%s request tokens; skipping additional passes",
+                        f"{_orig_tokens:,}",
+                        f"{_preflight_tokens:,}",
+                    )
                     break
 
     if _preflight_compressed:
@@ -899,4 +933,5 @@ def build_turn_context(
         should_review_memory=should_review_memory,
         plugin_user_context=plugin_user_context,
         ext_prefetch_cache=ext_prefetch_cache,
+        preflight_compression_blocked=_preflight_compression_blocked,
     )

--- a/cli.py
+++ b/cli.py
@@ -8174,17 +8174,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     def _clear_persisted_context_for_model_switch(self, result) -> None:
         """Drop a global context pin when its configured owner changes."""
         try:
-            from agent.agent_init import _context_route_mismatch
             from hermes_cli.config import load_config_readonly
+            from hermes_cli.route_identity import should_clear_context_pin
 
             config = load_config_readonly()
             model_cfg = config.get("model", {}) if isinstance(config, dict) else {}
             if not isinstance(model_cfg, dict) or "context_length" not in model_cfg:
                 return
-            configured_model = model_cfg.get("default") or model_cfg.get("model")
-            if (
-                configured_model and configured_model != result.new_model
-            ) or _context_route_mismatch(
+            if should_clear_context_pin(
+                model_cfg.get("default") or model_cfg.get("model"),
+                result.new_model,
                 model_cfg.get("base_url"),
                 result.base_url,
                 model_cfg.get("provider"),

--- a/cli.py
+++ b/cli.py
@@ -8171,6 +8171,29 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         scroll_offset = max(0, min(scroll_offset, n - visible))
         return scroll_offset, visible
 
+    def _clear_persisted_context_for_model_switch(self, result) -> None:
+        """Drop a global context pin when its configured owner changes."""
+        try:
+            from agent.agent_init import _context_route_mismatch
+            from hermes_cli.config import load_config_readonly
+
+            config = load_config_readonly()
+            model_cfg = config.get("model", {}) if isinstance(config, dict) else {}
+            if not isinstance(model_cfg, dict) or "context_length" not in model_cfg:
+                return
+            configured_model = model_cfg.get("default") or model_cfg.get("model")
+            if (
+                configured_model and configured_model != result.new_model
+            ) or _context_route_mismatch(
+                model_cfg.get("base_url"),
+                result.base_url,
+                model_cfg.get("provider"),
+                result.target_provider,
+            ):
+                save_config_value("model.context_length", None)
+        except Exception:
+            save_config_value("model.context_length", None)
+
     def _apply_model_switch_result(self, result, persist_global: bool) -> None:
         if not result.success:
             _cprint(f"  ✗ {result.error_message}")
@@ -8289,6 +8312,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if result.warning_message:
             _cprint(f"    ⚠ {result.warning_message}")
         if persist_global:
+            HermesCLI._clear_persisted_context_for_model_switch(self, result)
             save_config_value("model.default", result.new_model)
             if result.provider_changed:
                 save_config_value("model.provider", result.target_provider)
@@ -8635,6 +8659,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         # Persistence
         if persist_global:
+            HermesCLI._clear_persisted_context_for_model_switch(self, result)
             save_config_value("model.default", result.new_model)
             if result.provider_changed:
                 save_config_value("model.provider", result.target_provider)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11897,9 +11897,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _msg_config_ctx = None
                 if _msg_config_ctx is not None and isinstance(_msg_model_cfg, dict):
                     try:
-                        from agent.agent_init import _context_route_mismatch
+                        from hermes_cli.route_identity import should_clear_context_pin
 
-                        if _context_route_mismatch(
+                        if should_clear_context_pin(
+                            None,  # model match already checked above
+                            None,
                             _msg_model_cfg.get("base_url"),
                             _msg_base_url,
                             _msg_model_cfg.get("provider"),
@@ -12462,12 +12464,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                 if _hyg_config_context_length is not None:
                     try:
-                        from agent.agent_init import _context_route_mismatch
+                        from hermes_cli.route_identity import should_clear_context_pin
 
-                        if (
-                            _hyg_configured_model
-                            and _hyg_model != _hyg_configured_model
-                        ) or _context_route_mismatch(
+                        if should_clear_context_pin(
+                            _hyg_configured_model,
+                            _hyg_model,
                             _hyg_configured_base_url,
                             _hyg_base_url,
                             _hyg_configured_provider,
@@ -13797,11 +13798,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if config_context_length is not None:
             try:
-                from agent.agent_init import _context_route_mismatch
+                from hermes_cli.route_identity import should_clear_context_pin
 
-                if (
-                    configured_model and model != configured_model
-                ) or _context_route_mismatch(
+                if should_clear_context_pin(
+                    configured_model,
+                    model,
                     configured_base_url,
                     base_url,
                     configured_provider,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11895,6 +11895,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 if _msg_model != _msg_configured_model:
                     _msg_config_ctx = None
+                if _msg_config_ctx is not None and isinstance(_msg_model_cfg, dict):
+                    try:
+                        from agent.agent_init import _context_route_mismatch
+
+                        if _context_route_mismatch(
+                            _msg_model_cfg.get("base_url"),
+                            _msg_base_url,
+                            _msg_model_cfg.get("provider"),
+                            _msg_runtime.get("provider"),
+                        ):
+                            _msg_config_ctx = None
+                    except Exception:
+                        _msg_config_ctx = None
                 if _msg_custom_providers and _msg_base_url:
                     try:
                         from hermes_cli.config import get_custom_provider_context_length
@@ -12389,6 +12402,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _hyg_provider = None
             _hyg_base_url = None
             _hyg_api_key = None
+            _hyg_configured_model = None
+            _hyg_configured_provider = None
+            _hyg_configured_base_url = None
             _hyg_data = {}
             try:
                 _hyg_data = _load_gateway_config()
@@ -12428,6 +12444,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             except (TypeError, ValueError):
                                 pass
 
+                _hyg_configured_model = _hyg_model
+                _hyg_configured_provider = _hyg_provider
+                _hyg_configured_base_url = _hyg_base_url
+
                 try:
                     _hyg_model, _hyg_runtime = self._resolve_session_agent_runtime(
                         source=source,
@@ -12440,31 +12460,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception:
                     pass
 
+                if _hyg_config_context_length is not None:
+                    try:
+                        from agent.agent_init import _context_route_mismatch
+
+                        if (
+                            _hyg_configured_model
+                            and _hyg_model != _hyg_configured_model
+                        ) or _context_route_mismatch(
+                            _hyg_configured_base_url,
+                            _hyg_base_url,
+                            _hyg_configured_provider,
+                            _hyg_provider,
+                        ):
+                            _hyg_config_context_length = None
+                    except Exception:
+                        _hyg_config_context_length = None
+
                 # Check custom_providers per-model context_length
                 # (same fallback as run_agent.py lines 1171-1189).
                 # Must run after runtime resolution so _hyg_base_url is set.
                 if _hyg_config_context_length is None and _hyg_base_url:
                     try:
                         try:
-                            from hermes_cli.config import get_compatible_custom_providers as _gw_gcp
+                            from hermes_cli.config import (
+                                get_compatible_custom_providers as _gw_gcp,
+                                get_custom_provider_context_length as _gw_gccl,
+                            )
                             _hyg_custom_providers = _gw_gcp(_hyg_data)
                         except Exception:
                             _hyg_custom_providers = _hyg_data.get("custom_providers")
                             if not isinstance(_hyg_custom_providers, list):
                                 _hyg_custom_providers = []
-                        for _cp in _hyg_custom_providers:
-                            if not isinstance(_cp, dict):
-                                continue
-                            _cp_url = (_cp.get("base_url") or "").rstrip("/")
-                            if _cp_url and _cp_url == _hyg_base_url.rstrip("/"):
-                                _cp_models = _cp.get("models", {})
-                                if isinstance(_cp_models, dict):
-                                    _cp_model_cfg = _cp_models.get(_hyg_model, {})
-                                    if isinstance(_cp_model_cfg, dict):
-                                        _cp_ctx = _cp_model_cfg.get("context_length")
-                                        if _cp_ctx is not None:
-                                            _hyg_config_context_length = int(_cp_ctx)
-                                break
+                        _hyg_custom_ctx = _gw_gccl(
+                            model=_hyg_model,
+                            base_url=_hyg_base_url,
+                            custom_providers=_hyg_custom_providers,
+                        )
+                        if _hyg_custom_ctx:
+                            _hyg_config_context_length = int(_hyg_custom_ctx)
                     except (TypeError, ValueError):
                         pass
             except Exception:
@@ -13724,12 +13758,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         api_key = None
         custom_provs = None
         data = None
+        configured_model = None
+        configured_provider = None
+        configured_base_url = None
 
         try:
             data = _load_gateway_config()
             if data:
                 model_cfg = data.get("model", {})
                 if isinstance(model_cfg, dict):
+                    configured_model = model_cfg.get("default") or model_cfg.get("model")
                     raw_ctx = model_cfg.get("context_length")
                     if raw_ctx is not None:
                         try:
@@ -13738,6 +13776,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             pass
                     provider = model_cfg.get("provider") or None
                     base_url = model_cfg.get("base_url") or None
+                    configured_provider = provider
+                    configured_base_url = base_url
                 try:
                     from hermes_cli.config import get_compatible_custom_providers
                     custom_provs = get_compatible_custom_providers(data)
@@ -13746,49 +13786,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             pass
 
-        # Also check custom_providers for context_length when top-level model.context_length is not set
-        if config_context_length is None and data:
-            try:
-                custom_providers = data.get("custom_providers", [])
-                if custom_providers:
-                    for cp in custom_providers:
-                        if not isinstance(cp, dict):
-                            continue
-                        cp_model = cp.get("model") or ""
-                        cp_models = cp.get("models") or {}
-                        # Match provider model to current model
-                        if cp_model and cp_model == model:
-                            raw_cp_ctx = cp.get("context_length")
-                            if raw_cp_ctx is not None:
-                                try:
-                                    config_context_length = int(raw_cp_ctx)
-                                    break
-                                except (TypeError, ValueError):
-                                    pass
-                        # Also check per-model context_length
-                        if isinstance(cp_models, dict):
-                            model_entry = cp_models.get(model)
-                            if isinstance(model_entry, dict):
-                                model_ctx = model_entry.get("context_length")
-                            else:
-                                model_ctx = model_entry
-                            if model_ctx is not None and isinstance(model_ctx, (int, float)):
-                                try:
-                                    config_context_length = int(model_ctx)
-                                    break
-                                except (TypeError, ValueError):
-                                    pass
-            except Exception:
-                pass
-
         # Resolve runtime credentials for probing
         try:
             runtime = _resolve_runtime_agent_kwargs()
-            provider = provider or runtime.get("provider")
-            base_url = base_url or runtime.get("base_url")
+            provider = runtime.get("provider") or provider
+            base_url = runtime.get("base_url") or base_url
             api_key = runtime.get("api_key")
         except Exception:
             pass
+
+        if config_context_length is not None:
+            try:
+                from agent.agent_init import _context_route_mismatch
+
+                if (
+                    configured_model and model != configured_model
+                ) or _context_route_mismatch(
+                    configured_base_url,
+                    base_url,
+                    configured_provider,
+                    provider,
+                ):
+                    config_context_length = None
+            except Exception:
+                config_context_length = None
+
+        if config_context_length is None and custom_provs and base_url:
+            try:
+                from hermes_cli.config import get_custom_provider_context_length
+
+                custom_ctx = get_custom_provider_context_length(
+                    model=model,
+                    base_url=base_url,
+                    custom_providers=custom_provs,
+                )
+                if custom_ctx:
+                    config_context_length = custom_ctx
+            except Exception:
+                pass
 
         context_length = get_model_context_length(
             model,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1730,16 +1730,12 @@ class GatewaySlashCommandsMixin:
                                     _persist_model_cfg = {}
                                     _persist_cfg["model"] = _persist_model_cfg
                                 try:
-                                    from agent.agent_init import _context_route_mismatch
+                                    from hermes_cli.route_identity import should_clear_context_pin
 
-                                    _old_default = (
+                                    if should_clear_context_pin(
                                         _persist_model_cfg.get("default")
-                                        or _persist_model_cfg.get("model")
-                                    )
-                                    if (
-                                        _old_default
-                                        and _old_default != result.new_model
-                                    ) or _context_route_mismatch(
+                                        or _persist_model_cfg.get("model"),
+                                        result.new_model,
                                         _persist_model_cfg.get("base_url"),
                                         result.base_url,
                                         _persist_model_cfg.get("provider"),
@@ -2062,12 +2058,11 @@ class GatewaySlashCommandsMixin:
                         model_cfg = {}
                         cfg["model"] = model_cfg
                     try:
-                        from agent.agent_init import _context_route_mismatch
+                        from hermes_cli.route_identity import should_clear_context_pin
 
-                        old_default = model_cfg.get("default") or model_cfg.get("model")
-                        if (
-                            old_default and old_default != result.new_model
-                        ) or _context_route_mismatch(
+                        if should_clear_context_pin(
+                            model_cfg.get("default") or model_cfg.get("model"),
+                            result.new_model,
                             model_cfg.get("base_url"),
                             result.base_url,
                             model_cfg.get("provider"),

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1729,6 +1729,25 @@ class GatewaySlashCommandsMixin:
                                 else:
                                     _persist_model_cfg = {}
                                     _persist_cfg["model"] = _persist_model_cfg
+                                try:
+                                    from agent.agent_init import _context_route_mismatch
+
+                                    _old_default = (
+                                        _persist_model_cfg.get("default")
+                                        or _persist_model_cfg.get("model")
+                                    )
+                                    if (
+                                        _old_default
+                                        and _old_default != result.new_model
+                                    ) or _context_route_mismatch(
+                                        _persist_model_cfg.get("base_url"),
+                                        result.base_url,
+                                        _persist_model_cfg.get("provider"),
+                                        result.target_provider,
+                                    ):
+                                        _persist_model_cfg.pop("context_length", None)
+                                except Exception:
+                                    _persist_model_cfg.pop("context_length", None)
                                 _persist_model_cfg["default"] = result.new_model
                                 _persist_model_cfg["provider"] = result.target_provider
                                 # Named providers always resolve base_url/api_mode fresh,
@@ -1764,6 +1783,7 @@ class GatewaySlashCommandsMixin:
                         mi = result.model_info
                         from hermes_cli.model_switch import resolve_display_context_length
                         _sw_config_ctx = None
+                        _sw_model_cfg = {}
                         try:
                             _sw_cfg = _load_gateway_config()
                             _sw_model_cfg = _sw_cfg.get("model", {})
@@ -1773,6 +1793,8 @@ class GatewaySlashCommandsMixin:
                                     _sw_config_ctx = int(_sw_raw)
                         except Exception:
                             pass
+                        if not isinstance(_sw_model_cfg, dict):
+                            _sw_model_cfg = {}
                         ctx = resolve_display_context_length(
                             result.new_model,
                             result.target_provider,
@@ -1781,6 +1803,12 @@ class GatewaySlashCommandsMixin:
                             model_info=mi,
                             custom_providers=custom_provs,
                             config_context_length=_sw_config_ctx,
+                            configured_model=(
+                                _sw_model_cfg.get("default")
+                                or _sw_model_cfg.get("model")
+                            ),
+                            configured_provider=_sw_model_cfg.get("provider"),
+                            configured_base_url=_sw_model_cfg.get("base_url"),
                         )
                         if ctx:
                             lines.append(t("gateway.model.context_label", tokens=f"{ctx:,}"))
@@ -2033,6 +2061,21 @@ class GatewaySlashCommandsMixin:
                     else:
                         model_cfg = {}
                         cfg["model"] = model_cfg
+                    try:
+                        from agent.agent_init import _context_route_mismatch
+
+                        old_default = model_cfg.get("default") or model_cfg.get("model")
+                        if (
+                            old_default and old_default != result.new_model
+                        ) or _context_route_mismatch(
+                            model_cfg.get("base_url"),
+                            result.base_url,
+                            model_cfg.get("provider"),
+                            result.target_provider,
+                        ):
+                            model_cfg.pop("context_length", None)
+                    except Exception:
+                        model_cfg.pop("context_length", None)
                     model_cfg["default"] = result.new_model
                     model_cfg["provider"] = result.target_provider
                     # See the picker handler above for why custom providers need an
@@ -2064,6 +2107,7 @@ class GatewaySlashCommandsMixin:
             mi = result.model_info
             from hermes_cli.model_switch import resolve_display_context_length
             _sw2_config_ctx = None
+            _sw2_model_cfg = {}
             try:
                 _sw2_cfg = _load_gateway_config()
                 _sw2_model_cfg = _sw2_cfg.get("model", {})
@@ -2073,6 +2117,8 @@ class GatewaySlashCommandsMixin:
                         _sw2_config_ctx = int(_sw2_raw)
             except Exception:
                 pass
+            if not isinstance(_sw2_model_cfg, dict):
+                _sw2_model_cfg = {}
             ctx = resolve_display_context_length(
                 result.new_model,
                 result.target_provider,
@@ -2081,6 +2127,12 @@ class GatewaySlashCommandsMixin:
                 model_info=mi,
                 custom_providers=custom_provs,
                 config_context_length=_sw2_config_ctx,
+                configured_model=(
+                    _sw2_model_cfg.get("default")
+                    or _sw2_model_cfg.get("model")
+                ),
+                configured_provider=_sw2_model_cfg.get("provider"),
+                configured_base_url=_sw2_model_cfg.get("base_url"),
             )
             if ctx:
                 lines.append(t("gateway.model.context_label", tokens=f"{ctx:,}"))

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5228,6 +5228,8 @@ def providers_dict_to_custom_providers(providers_dict: Any) -> List[Dict[str, An
 
     custom_providers: List[Dict[str, Any]] = []
     for key, entry in providers_dict.items():
+        if isinstance(entry, dict) and not is_provider_enabled(entry):
+            continue
         normalized = _normalize_custom_provider_entry(entry, provider_key=str(key))
         if normalized is not None:
             custom_providers.append(normalized)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple, Set
 
+from hermes_cli.route_identity import normalize_route_base_url
 from hermes_cli.secret_prompt import masked_secret_prompt
 
 logger = logging.getLogger(__name__)
@@ -5315,16 +5316,11 @@ def get_custom_provider_tls_settings(
     if not base_url or not isinstance(custom_providers, list):
         return {}
 
-    # Case-insensitive compare: elsewhere custom_providers are keyed on a
-    # lowercased base_url (see get_compatible_custom_providers dedup), and
-    # scheme/host are case-insensitive anyway — so a config entry written as
-    # https://Ollama.Example.com/v1 must still match a lowercased runtime
-    # base_url. Exact match after rstrip('/') + lower() (no prefix/substring).
-    target_url = (base_url or "").rstrip("/").lower()
+    target_url = normalize_route_base_url(base_url)
     for entry in custom_providers:
         if not isinstance(entry, dict):
             continue
-        entry_url = (entry.get("base_url") or "").rstrip("/").lower()
+        entry_url = normalize_route_base_url(entry.get("base_url"))
         if not entry_url or entry_url != target_url:
             continue
         out: Dict[str, Any] = {}
@@ -5376,10 +5372,9 @@ def get_custom_provider_extra_headers(
 ) -> Dict[str, str]:
     """Return ``extra_headers`` from a matching ``providers`` / ``custom_providers`` entry.
 
-    Matches the entry whose ``base_url`` equals *base_url* (trailing-slash and
-    case insensitive, mirroring :func:`get_custom_provider_tls_settings`) and
-    returns its ``extra_headers`` dict, or ``{}`` when no entry matches or the
-    entry declares none.
+    Matches the entry whose normalized route identity equals *base_url*,
+    mirroring :func:`get_custom_provider_tls_settings`, and returns its
+    ``extra_headers`` dict, or ``{}`` when no entry matches or declares none.
 
     SECURITY: header values routinely carry credentials (Cloudflare Access
     service tokens, proxy auth, custom bearer schemes). Callers must never
@@ -5393,11 +5388,11 @@ def get_custom_provider_extra_headers(
     if not base_url or not isinstance(custom_providers, list):
         return {}
 
-    target_url = (base_url or "").rstrip("/").lower()
+    target_url = normalize_route_base_url(base_url)
     for entry in custom_providers:
         if not isinstance(entry, dict):
             continue
-        entry_url = (entry.get("base_url") or "").rstrip("/").lower()
+        entry_url = normalize_route_base_url(entry.get("base_url"))
         if not entry_url or entry_url != target_url:
             continue
         return normalize_extra_headers(entry.get("extra_headers"))
@@ -5435,9 +5430,9 @@ def get_custom_provider_context_length(
 ) -> Optional[int]:
     """Look up a per-model ``context_length`` override from ``custom_providers``.
 
-    Matches any entry whose ``base_url`` equals ``base_url`` (trailing-slash
-    insensitive) and returns ``custom_providers[i].models.<model>.context_length``
-    if present and valid.  Returns ``None`` when no override applies.
+    Matches any entry whose normalized route identity equals ``base_url`` and
+    returns ``custom_providers[i].models.<model>.context_length`` if present and
+    valid.  Returns ``None`` when no override applies.
 
     This is the single source of truth for custom-provider context overrides,
     used by:
@@ -5464,14 +5459,14 @@ def get_custom_provider_context_length(
     if not isinstance(custom_providers, list):
         return None
 
-    target_url = (base_url or "").rstrip("/")
+    target_url = normalize_route_base_url(base_url)
     if not target_url:
         return None
 
     for entry in custom_providers:
         if not isinstance(entry, dict):
             continue
-        entry_url = (entry.get("base_url") or "").rstrip("/")
+        entry_url = normalize_route_base_url(entry.get("base_url"))
         if not entry_url or entry_url != target_url:
             continue
         models = entry.get("models")

--- a/hermes_cli/context_switch_guard.py
+++ b/hermes_cli/context_switch_guard.py
@@ -69,6 +69,9 @@ def merge_preflight_compression_warning(
     messages: Optional[List[dict]] = None,
     custom_providers: list | None = None,
     config_context_length: int | None = None,
+    configured_model: str | None = None,
+    configured_provider: str | None = None,
+    configured_base_url: str | None = None,
 ) -> None:
     """If the next user message will likely preflight-compress, append a warning."""
     if not result.success or agent is None:
@@ -89,6 +92,21 @@ def merge_preflight_compression_warning(
         model_info=result.model_info,
         custom_providers=custom_providers,
         config_context_length=config_context_length,
+        configured_model=(
+            configured_model
+            if configured_model is not None
+            else getattr(agent, "model", None)
+        ),
+        configured_provider=(
+            configured_provider
+            if configured_provider is not None
+            else getattr(agent, "provider", None)
+        ),
+        configured_base_url=(
+            configured_base_url
+            if configured_base_url is not None
+            else getattr(agent, "base_url", None)
+        ),
     )
     if not new_ctx:
         return
@@ -141,12 +159,18 @@ def enrich_model_switch_warnings_for_gateway(
         return
 
     cfg_ctx = None
+    configured_model = None
+    configured_provider = None
+    configured_base_url = None
     if load_gateway_config is not None:
         try:
             cfg = load_gateway_config()
             model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
             if isinstance(model_cfg, dict) and model_cfg.get("context_length") is not None:
                 cfg_ctx = int(model_cfg["context_length"])
+                configured_model = model_cfg.get("default") or model_cfg.get("model")
+                configured_provider = model_cfg.get("provider")
+                configured_base_url = model_cfg.get("base_url")
         except Exception:
             pass
 
@@ -166,4 +190,7 @@ def enrich_model_switch_warnings_for_gateway(
         messages=messages,
         custom_providers=custom_providers,
         config_context_length=cfg_ctx,
+        configured_model=configured_model,
+        configured_provider=configured_provider,
+        configured_base_url=configured_base_url,
     )

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -863,11 +863,11 @@ def resolve_display_context_length(
         configured_model or configured_provider or configured_base_url
     ):
         try:
-            from agent.agent_init import _context_route_mismatch
+            from hermes_cli.route_identity import should_clear_context_pin
 
-            if (
-                configured_model and configured_model != model
-            ) or _context_route_mismatch(
+            if should_clear_context_pin(
+                configured_model,
+                model,
                 configured_base_url,
                 base_url,
                 configured_provider,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -838,6 +838,9 @@ def resolve_display_context_length(
     model_info: Optional[ModelInfo] = None,
     custom_providers: list | None = None,
     config_context_length: int | None = None,
+    configured_model: str | None = None,
+    configured_provider: str | None = None,
+    configured_base_url: str | None = None,
 ) -> Optional[int]:
     """Resolve the context length to show in /model output.
 
@@ -856,6 +859,24 @@ def resolve_display_context_length(
     Prefer the provider-aware value; fall back to ``model_info.context_window``
     only if the resolver returns nothing.
     """
+    if config_context_length is not None and (
+        configured_model or configured_provider or configured_base_url
+    ):
+        try:
+            from agent.agent_init import _context_route_mismatch
+
+            if (
+                configured_model and configured_model != model
+            ) or _context_route_mismatch(
+                configured_base_url,
+                base_url,
+                configured_provider,
+                provider,
+            ):
+                config_context_length = None
+        except Exception:
+            config_context_length = None
+
     try:
         from agent.model_metadata import get_model_context_length
         ctx = get_model_context_length(

--- a/hermes_cli/route_identity.py
+++ b/hermes_cli/route_identity.py
@@ -45,3 +45,32 @@ def normalize_route_base_url(base_url: Any) -> str:
     if had_query_delimiter and not parsed.query:
         normalized += "?"
     return normalized
+
+
+def should_clear_context_pin(
+    configured_model: Any,
+    active_model: Any,
+    configured_base_url: Any,
+    active_base_url: Any,
+    configured_provider: Any,
+    active_provider: Any,
+) -> bool:
+    """True when a configured ``model.context_length`` pin no longer matches its runtime route.
+
+    Fail-closed: any error during route comparison returns ``True`` (drop the pin)
+    so a stale window never silently inflates the compression threshold.
+    """
+    configured_model = str(configured_model or "").strip()
+    if configured_model and configured_model != str(active_model or "").strip():
+        return True
+    try:
+        from agent.agent_init import _context_route_mismatch
+
+        return _context_route_mismatch(
+            configured_base_url,
+            active_base_url,
+            configured_provider,
+            active_provider,
+        )
+    except Exception:
+        return True

--- a/hermes_cli/route_identity.py
+++ b/hermes_cli/route_identity.py
@@ -1,0 +1,47 @@
+"""Fail-closed URL identity normalization for model/provider routes."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+
+def normalize_route_base_url(base_url: Any) -> str:
+    """Canonicalize only proven-equivalent endpoint URL components."""
+    raw = str(base_url or "")
+    if not raw:
+        return ""
+    if any(ord(char) <= 0x20 for char in raw):
+        return raw
+    had_query_delimiter = "?" in raw.split("#", 1)[0]
+    try:
+        parsed = urlsplit(raw)
+        hostname = parsed.hostname
+        if not parsed.scheme or not hostname:
+            return raw
+        scheme = parsed.scheme.lower()
+        if "%" in hostname:
+            address, zone = hostname.split("%", 1)
+            host = f"{address.lower()}%{zone}"
+        else:
+            host = hostname.lower()
+        port = parsed.port
+    except (TypeError, ValueError):
+        return raw
+
+    route_host = parsed.netloc.rsplit("@", 1)[-1]
+    if route_host.startswith("[") or ":" in host:
+        host = f"[{host}]"
+    if port is not None and (scheme, port) not in {("http", 80), ("https", 443)}:
+        host = f"{host}:{port}"
+    if "@" in parsed.netloc:
+        host = f"{parsed.netloc.rsplit('@', 1)[0]}@{host}"
+
+    path = parsed.path
+    if path.endswith("/") and not had_query_delimiter:
+        path = path[:-1]
+
+    normalized = urlunsplit((scheme, host, path, parsed.query, ""))
+    if had_query_delimiter and not parsed.query:
+        normalized += "?"
+    return normalized

--- a/run_agent.py
+++ b/run_agent.py
@@ -4770,18 +4770,18 @@ class AIAgent:
                 pass
 
             self._anthropic_api_key = runtime_key
-            self._anthropic_base_url = runtime_base
+            self._anthropic_base_url = runtime_base.rstrip("/") if isinstance(runtime_base, str) else runtime_base
             self._anthropic_client = build_anthropic_client(
-                runtime_key, runtime_base,
+                runtime_key, self._anthropic_base_url,
                 timeout=get_provider_request_timeout(self.provider, self.model),
             )
             self._is_anthropic_oauth = _is_oauth_token(runtime_key) if self.provider == "anthropic" else False
             self.api_key = runtime_key
-            self.base_url = runtime_base
+            self.base_url = runtime_base.rstrip("/") if isinstance(runtime_base, str) else runtime_base
             return
 
         self.api_key = runtime_key
-        self.base_url = runtime_base
+        self.base_url = runtime_base.rstrip("/") if isinstance(runtime_base, str) else runtime_base
         self._client_kwargs["api_key"] = self.api_key
         self._client_kwargs["base_url"] = self.base_url
         self._client_kwargs.pop("ssl_verify", None)

--- a/run_agent.py
+++ b/run_agent.py
@@ -4656,7 +4656,12 @@ class AIAgent:
         self._is_anthropic_oauth = _is_oauth_token(new_token) if self.provider == "anthropic" else False
         return True
 
-    def _apply_client_headers_for_base_url(self, base_url: str) -> None:
+    def _apply_client_headers_for_base_url(
+        self,
+        base_url: str,
+        *,
+        apply_user_headers: bool = True,
+    ) -> None:
         from agent.auxiliary_client import (
             build_nvidia_nim_headers,
             build_or_headers,
@@ -4696,10 +4701,10 @@ class AIAgent:
             else:
                 self._client_kwargs.pop("default_headers", None)
 
-        # User-configured overrides win over URL/profile defaults — keep them
-        # applied across credential swaps and client rebuilds, not just at
-        # first construction.
-        self._apply_user_default_headers()
+        # User-configured overrides win over URL/profile defaults for the same
+        # route. A credential swap to another endpoint must not inherit them.
+        if apply_user_headers:
+            self._apply_user_default_headers()
 
         # Per-provider extra HTTP headers (providers.<name>.extra_headers /
         # custom_providers[].extra_headers) — applied last so the most
@@ -4750,6 +4755,11 @@ class AIAgent:
     def _swap_credential(self, entry) -> None:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         runtime_base = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or self.base_url
+        from hermes_cli.route_identity import normalize_route_base_url
+
+        route_changed = normalize_route_base_url(self.base_url) != normalize_route_base_url(
+            runtime_base
+        )
 
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, _is_oauth_token
@@ -4771,10 +4781,32 @@ class AIAgent:
             return
 
         self.api_key = runtime_key
-        self.base_url = runtime_base.rstrip("/") if isinstance(runtime_base, str) else runtime_base
+        self.base_url = runtime_base
         self._client_kwargs["api_key"] = self.api_key
         self._client_kwargs["base_url"] = self.base_url
-        self._apply_client_headers_for_base_url(self.base_url)
+        self._client_kwargs.pop("ssl_verify", None)
+        self._client_kwargs.pop("ssl_ca_cert", None)
+        try:
+            from hermes_cli.config import (
+                apply_custom_provider_tls_to_client_kwargs,
+                get_compatible_custom_providers,
+                load_config_readonly,
+            )
+
+            apply_custom_provider_tls_to_client_kwargs(
+                self._client_kwargs,
+                str(self.base_url or ""),
+                get_compatible_custom_providers(load_config_readonly()),
+            )
+        except Exception:
+            logger.debug(
+                "custom-provider TLS resolution skipped on credential rotation",
+                exc_info=True,
+            )
+        self._apply_client_headers_for_base_url(
+            self.base_url,
+            apply_user_headers=not route_changed,
+        )
         self._replace_primary_openai_client(reason="credential_rotation")
 
     def _recover_with_credential_pool(

--- a/tests/agent/test_compression_progress.py
+++ b/tests/agent/test_compression_progress.py
@@ -14,7 +14,10 @@ progress.
 
 from __future__ import annotations
 
-from agent.turn_context import _compression_made_progress
+from agent.turn_context import (
+    _compression_made_progress,
+    _compression_warrants_another_preflight_pass,
+)
 
 
 class TestCompressionMadeProgress:
@@ -83,4 +86,27 @@ class TestCompressionMadeProgress:
         """Degenerate estimate (0 tokens) must not be read as a token win."""
         assert _compression_made_progress(
             orig_len=10, new_len=10, orig_tokens=0, new_tokens=0
+        ) is False
+
+
+class TestCompressionWarrantsAnotherPreflightPass:
+    def test_material_reduction_above_threshold_allows_another_pass(self):
+        assert _compression_warrants_another_preflight_pass(
+            orig_tokens=400_000,
+            new_tokens=350_000,
+            threshold_tokens=272_000,
+        ) is True
+
+    def test_marginal_reduction_above_threshold_stops(self):
+        assert _compression_warrants_another_preflight_pass(
+            orig_tokens=350_000,
+            new_tokens=345_000,
+            threshold_tokens=272_000,
+        ) is False
+
+    def test_clearing_threshold_needs_no_additional_pass(self):
+        assert _compression_warrants_another_preflight_pass(
+            orig_tokens=280_000,
+            new_tokens=250_000,
+            threshold_tokens=272_000,
         ) is False

--- a/tests/gateway/test_context_ref_expansion_runtime.py
+++ b/tests/gateway/test_context_ref_expansion_runtime.py
@@ -359,3 +359,54 @@ async def test_at_reference_ignores_global_context_for_session_model_override(mo
         event=MessageEvent(text="@file:note", source=source), source=source, history=[]
     )
     assert captured["config_context_length"] is None
+
+
+@pytest.mark.asyncio
+async def test_at_reference_ignores_global_context_for_runtime_route_override(monkeypatch):
+    """Context expansion must not inherit a global pin from another route."""
+    runner = _make_runner()
+    source = _source()
+    captured = {}
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "model": {
+                "default": "shared-model",
+                "provider": "custom",
+                "base_url": "https://large.example/v1",
+                "context_length": 1_048_576,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        runner,
+        "_resolve_session_agent_runtime",
+        lambda **_kwargs: (
+            "shared-model",
+            {
+                "provider": "custom",
+                "api_key": "test",
+                "base_url": "https://small.example/v1",
+            },
+        ),
+    )
+
+    import agent.context_references as ctx_mod
+    import agent.model_metadata as model_meta_mod
+
+    async def _fake_get_context(_model, **kwargs):
+        captured["config_context_length"] = kwargs["config_context_length"]
+        return 32_768
+
+    async def _passthrough(message, **_kwargs):
+        return ContextReferenceResult(message=message, original_message=message)
+
+    monkeypatch.setattr(model_meta_mod, "get_model_context_length_async", _fake_get_context)
+    monkeypatch.setattr(ctx_mod, "preprocess_context_references_async", _passthrough)
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="@file:note", source=source), source=source, history=[]
+    )
+    assert captured["config_context_length"] is None

--- a/tests/gateway/test_model_command_flat_string_config.py
+++ b/tests/gateway/test_model_command_flat_string_config.py
@@ -145,7 +145,11 @@ async def test_model_global_persists_when_config_has_proper_dict_model(tmp_path,
     cfg_path = _setup_isolated_home(
         tmp_path,
         monkeypatch,
-        {"default": "old-model", "provider": "openai-codex"},
+        {
+            "default": "old-model",
+            "provider": "openai-codex",
+            "context_length": 1_048_576,
+        },
     )
 
     result = await _make_runner()._handle_model_command(
@@ -156,6 +160,7 @@ async def test_model_global_persists_when_config_has_proper_dict_model(tmp_path,
     written = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     assert written["model"]["default"] == "gpt-5.5"
     assert written["model"]["provider"] == "openrouter"
+    assert "context_length" not in written["model"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_model_picker_persist.py
+++ b/tests/gateway/test_model_picker_persist.py
@@ -167,6 +167,7 @@ async def _drive_picker(runner, event):
             "default": "old-model",
             "provider": "custom",
             "base_url": "https://api.custom.example/v1",
+            "context_length": 1_048_576,
             "api_key": "sk-stale",
             "api_mode": "anthropic_messages",
         },
@@ -197,6 +198,7 @@ async def test_picker_tap_global_flag_persists(tmp_path, monkeypatch, seed_model
     assert "base_url" not in written["model"]
     assert "api_key" not in written["model"]
     assert "api_mode" not in written["model"]
+    assert "context_length" not in written["model"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -87,6 +87,60 @@ class TestFormatSessionInfo:
             info = runner._format_session_info()
         assert "1.0M" in info
 
+    def test_custom_context_is_scoped_to_active_runtime_route(self, runner, tmp_path):
+        config = """
+model:
+  default: shared-model
+  provider: custom
+custom_providers:
+  - name: large-route
+    base_url: https://example.com/v1//
+    models:
+      shared-model:
+        context_length: 1048576
+"""
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            config,
+            "shared-model",
+            {
+                "provider": "custom",
+                "base_url": "https://example.com/v1",
+                "api_key": "k",
+            },
+        )
+
+        with p1, p2, p3:
+            info = runner._format_session_info()
+
+        assert "1.0M" not in info
+        assert "(config)" not in info
+
+    def test_global_context_is_scoped_to_active_runtime_route(self, runner, tmp_path):
+        config = """
+model:
+  default: shared-model
+  provider: custom
+  base_url: https://large.example/v1
+  context_length: 1048576
+"""
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            config,
+            "shared-model",
+            {
+                "provider": "custom",
+                "base_url": "https://small.example/v1",
+                "api_key": "k",
+            },
+        )
+
+        with p1, p2, p3:
+            info = runner._format_session_info()
+
+        assert "1.0M" not in info
+        assert "(config)" not in info
+
     def test_missing_config(self, runner, tmp_path):
         """No config.yaml should not crash."""
         p1, p2, p3 = _patch_info(tmp_path, None,  # don't create config

--- a/tests/hermes_cli/test_apply_model_switch_result_context.py
+++ b/tests/hermes_cli/test_apply_model_switch_result_context.py
@@ -150,3 +150,54 @@ def test_picker_path_falls_back_to_model_info_when_resolver_empty(monkeypatch):
     assert "1,050,000" in ctx_line, (
         f"resolver-empty path should fall back to ModelInfo, got: {ctx_line!r}"
     )
+
+
+def test_global_switch_clears_context_pin_owned_by_previous_route(monkeypatch):
+    import cli as cli_mod
+
+    writes = []
+    monkeypatch.setattr(cli_mod, "_cprint", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "save_config_value",
+        lambda key, value: writes.append((key, value)),
+    )
+    cli = _StubCLI()
+    cli.model = "shared-model"
+    cli.provider = "custom"
+    # Runtime may already diverge from persisted config through a session override.
+    cli.base_url = "https://small.example/v1"
+    result = ModelSwitchResult(
+        success=True,
+        new_model="shared-model",
+        target_provider="custom",
+        provider_changed=False,
+        api_key="",
+        base_url="https://small.example/v1",
+        api_mode="chat_completions",
+        warning_message="",
+        provider_label="Custom",
+        resolved_via_alias=False,
+        capabilities=None,
+        model_info=_FakeModelInfo(),
+        is_global=True,
+    )
+
+    configured = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom",
+            "base_url": "https://large.example/v1",
+            "context_length": 1_048_576,
+        }
+    }
+    with (
+        patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=256_000,
+        ),
+        patch("hermes_cli.config.load_config_readonly", return_value=configured),
+    ):
+        cli_mod.HermesCLI._apply_model_switch_result(cli, result, True)
+
+    assert ("model.context_length", None) in writes

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1404,6 +1404,22 @@ class TestCustomProviderCompatibility:
         assert compatible[0]["provider_key"] == "openai-direct"
         assert compatible[0]["api_mode"] == "codex_responses"
 
+    def test_disabled_provider_is_excluded_from_compatibility_projection(self):
+        """Compatibility fallback must not resurrect a disabled modern entry."""
+        compatible = get_compatible_custom_providers(
+            {
+                "providers": {
+                    "route-key": {
+                        "name": "Route Key",
+                        "api": "https://disabled.example/v1",
+                        "enabled": False,
+                    }
+                }
+            }
+        )
+
+        assert compatible == []
+
     def test_compatible_custom_providers_prefers_base_url_then_url_then_api(self, tmp_path):
         """URL field precedence is base_url > url > api (PR #9332)."""
         config_path = tmp_path / "config.yaml"

--- a/tests/hermes_cli/test_context_switch_guard.py
+++ b/tests/hermes_cli/test_context_switch_guard.py
@@ -103,3 +103,36 @@ def test_merge_appends_to_existing_warning(monkeypatch):
     merge_preflight_compression_warning(result, agent=agent)
     assert "expensive" in result.warning_message
     assert "preflight compression" in result.warning_message
+
+
+def test_cross_route_switch_does_not_inherit_current_context_pin(monkeypatch):
+    def _resolve_metadata(*_args, **kwargs):
+        return kwargs["config_context_length"] or 32_000
+
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        _resolve_metadata,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.context_switch_guard._estimate_tokens",
+        lambda *a, **k: 90_000,
+    )
+    cc = _compressor(monkeypatch, context_length=1_048_576)
+    agent = SimpleNamespace(
+        model="shared-model",
+        provider="custom",
+        context_compressor=cc,
+        compression_enabled=True,
+        conversation_history=[],
+        base_url="https://large.example/v1",
+        api_key="",
+    )
+    result = _result(model="shared-model")
+
+    merge_preflight_compression_warning(
+        result,
+        agent=agent,
+        config_context_length=1_048_576,
+    )
+
+    assert "preflight compression" in result.warning_message

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -55,6 +55,21 @@ class TestGetCustomProviderContextLength:
             == 500_000
         )
 
+    def test_extra_trailing_segment_is_route_significant(self):
+        custom = [
+            {
+                "base_url": "https://example.invalid/v1//",
+                "models": {"m": {"context_length": 500_000}},
+            }
+        ]
+
+        assert (
+            get_custom_provider_context_length(
+                "m", "https://example.invalid/v1", custom
+            )
+            is None
+        )
+
     def test_returns_none_when_url_does_not_match(self):
         custom = [
             {

--- a/tests/hermes_cli/test_custom_provider_extra_headers.py
+++ b/tests/hermes_cli/test_custom_provider_extra_headers.py
@@ -101,6 +101,20 @@ def test_get_custom_provider_extra_headers_no_match_returns_empty():
     ) == {}
 
 
+def test_get_custom_provider_extra_headers_preserves_extra_path_segment():
+    providers = [
+        {
+            "base_url": "https://llm.internal.example.com/v1//",
+            "extra_headers": {"Authorization": "secret"},
+        }
+    ]
+
+    assert get_custom_provider_extra_headers(
+        "https://llm.internal.example.com/v1",
+        custom_providers=providers,
+    ) == {}
+
+
 def test_apply_extra_headers_merges_onto_existing_defaults():
     client_kwargs = {
         "api_key": "x",

--- a/tests/hermes_cli/test_custom_provider_tls.py
+++ b/tests/hermes_cli/test_custom_provider_tls.py
@@ -70,3 +70,17 @@ def test_get_custom_provider_tls_settings_no_substring_bypass():
         "https://ollama.example.com.attacker.test/v1",
         custom_providers=providers,
     ) == {}
+
+
+def test_get_custom_provider_tls_settings_preserves_extra_path_segment():
+    providers = [
+        {
+            "base_url": "https://ollama.example.com/v1//",
+            "ssl_verify": False,
+        }
+    ]
+
+    assert get_custom_provider_tls_settings(
+        "https://ollama.example.com/v1",
+        custom_providers=providers,
+    ) == {}

--- a/tests/hermes_cli/test_model_switch_context_display.py
+++ b/tests/hermes_cli/test_model_switch_context_display.py
@@ -173,3 +173,21 @@ class TestResolveDisplayContextLength:
             "The fix ensures custom_providers is passed so per-model overrides "
             "are honored."
         )
+
+    def test_global_context_is_scoped_to_configured_route(self):
+        with patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=256_000,
+        ) as resolver:
+            ctx = resolve_display_context_length(
+                "shared-model",
+                "custom",
+                base_url="https://small.example/v1",
+                config_context_length=1_048_576,
+                configured_model="shared-model",
+                configured_provider="custom",
+                configured_base_url="https://large.example/v1",
+            )
+
+        assert ctx == 256_000
+        assert resolver.call_args.kwargs["config_context_length"] is None

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1154,6 +1154,25 @@ def test_named_custom_provider_does_not_shadow_builtin_provider(monkeypatch):
     assert resolved["requested_provider"] == "nous"
 
 
+def test_disabled_named_custom_provider_is_not_compatibility_fallback(monkeypatch):
+    """Disabled modern entries stay unavailable through the legacy projection."""
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "route-key": {
+                    "name": "Route Key",
+                    "api": "https://disabled.example/v1",
+                    "enabled": False,
+                }
+            }
+        },
+    )
+
+    assert rp._get_named_custom_provider("custom:route-key") is None
+
+
 def test_nous_pool_entry_refreshes_expired_agent_key(monkeypatch):
     stale_token = _fake_invoke_jwt(ttl_seconds=-60)
     fresh_token = _fake_invoke_jwt(ttl_seconds=3600)

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -1079,6 +1079,73 @@ class TestPreflightCompression:
         assert result["final_response"] == "After marginal preflight"
         assert mock_compress.call_count == 1
 
+    @pytest.mark.parametrize(
+        "rows_removed",
+        [pytest.param(0, id="no-op"), pytest.param(1, id="marginal")],
+    )
+    def test_provider_overflow_recovers_after_blocked_turn_start_preflight(
+        self, agent, rows_removed
+    ):
+        """The proactive retry block must not consume provider-overflow recovery."""
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 130_000
+
+        big_history = []
+        for i in range(20):
+            big_history.append(
+                {"role": "user", "content": f"Message {i} padded text"}
+            )
+            big_history.append(
+                {"role": "assistant", "content": f"Response {i} padded text"}
+            )
+
+        agent.client.chat.completions.create.side_effect = [
+            _make_413_error(),
+            _mock_response(content="Recovered after overflow", finish_reason="stop"),
+        ]
+
+        compress_calls = 0
+
+        def _compress(messages, *_args, **_kwargs):
+            nonlocal compress_calls
+            compress_calls += 1
+            if compress_calls == 1:
+                kept = messages[:-rows_removed] if rows_removed else messages
+                return kept, agent._cached_system_prompt
+            return (
+                [{"role": "user", "content": "hello"}],
+                "compressed after provider overflow",
+            )
+
+        with (
+            patch(
+                "agent.turn_context.estimate_request_tokens_rough",
+                return_value=144_669,
+            ),
+            patch(
+                "agent.conversation_loop.estimate_request_tokens_rough",
+                return_value=144_669,
+            ),
+            patch(
+                "agent.conversation_loop.estimate_messages_tokens_rough",
+                return_value=144_669,
+            ),
+            patch.object(
+                agent, "_compress_context", side_effect=_compress
+            ) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "hello", conversation_history=big_history
+            )
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered after overflow"
+        assert mock_compress.call_count == 2
+
 
 class TestToolResultPreflightCompression:
     """Compression should trigger when tool results push context past the threshold."""

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -987,9 +987,17 @@ class TestPreflightCompression:
         with (
             patch("agent.turn_context.estimate_request_tokens_rough", return_value=144_669),
             patch("agent.conversation_loop.estimate_request_tokens_rough", return_value=144_669),
+            patch(
+                "agent.conversation_loop.estimate_messages_tokens_rough",
+                return_value=144_669,
+            ),
             # Compression no-ops (returns input unchanged) — mirrors an aux
             # summary-model timeout where the messages can't be reduced.
-            patch.object(agent, "_compress_context", side_effect=lambda msgs, *a, **k: (msgs, agent._cached_system_prompt)),
+            patch.object(
+                agent,
+                "_compress_context",
+                side_effect=lambda msgs, *a, **k: (msgs, agent._cached_system_prompt),
+            ) as mock_compress,
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
@@ -997,6 +1005,10 @@ class TestPreflightCompression:
             result = agent.run_conversation("hello", conversation_history=big_history)
 
         assert result["completed"] is True
+        # A no-op pass cannot become more effective by immediately summarizing
+        # the same request twice more. Proceed to the provider/recovery path
+        # after one attempt instead of spending the full three-pass budget.
+        assert mock_compress.call_count == 1
         # The display token count was revised up to the fresh preflight estimate,
         # not left at the stale 74_400.
         assert agent.context_compressor.last_prompt_tokens == 144_669
@@ -1029,6 +1041,43 @@ class TestPreflightCompression:
 
         # Smaller estimate must not overwrite the larger tracked value.
         assert agent.context_compressor.last_prompt_tokens == 160_000
+
+    def test_preflight_stops_after_marginal_compression(self, agent):
+        """Do not spend three summary calls removing one row per pass."""
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 130_000
+
+        big_history = []
+        for i in range(20):
+            big_history.append({"role": "user", "content": f"Message {i} padded text"})
+            big_history.append({"role": "assistant", "content": f"Response {i} padded text"})
+
+        ok_resp = _mock_response(content="After marginal preflight", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+
+        def _drop_one_row(messages, *_args, **_kwargs):
+            return messages[:-1], agent._cached_system_prompt
+
+        with (
+            patch("agent.turn_context.estimate_request_tokens_rough", return_value=144_669),
+            patch("agent.conversation_loop.estimate_request_tokens_rough", return_value=144_669),
+            patch(
+                "agent.conversation_loop.estimate_messages_tokens_rough",
+                return_value=144_669,
+            ),
+            patch.object(
+                agent, "_compress_context", side_effect=_drop_one_row
+            ) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=big_history)
+
+        assert result["completed"] is True
+        assert result["final_response"] == "After marginal preflight"
+        assert mock_compress.call_count == 1
 
 
 class TestToolResultPreflightCompression:
@@ -1071,6 +1120,59 @@ class TestToolResultPreflightCompression:
 
         mock_compress.assert_called_once()
         assert result["completed"] is True
+
+    def test_mid_turn_retry_compares_fully_assembled_requests(self, agent):
+        """API-only context must not make marginal compression look effective."""
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 130_000
+
+        tc = SimpleNamespace(
+            id="tc1", type="function",
+            function=SimpleNamespace(name="web_search", arguments='{"query":"test"}'),
+        )
+        tool_resp = _mock_response(
+            content="",
+            finish_reason="stop",
+            tool_calls=[tc],
+        )
+        ok_resp = _mock_response(
+            content="Done after one compression", finish_reason="stop"
+        )
+        agent.client.chat.completions.create.side_effect = [tool_resp, ok_resp]
+
+        # First provider request is small. The tool result pushes the fully
+        # assembled request over threshold; rebuilding after compression only
+        # trims it from 150K to 148K. Raw-message estimation is much smaller,
+        # which previously made the no-op pass look successful and allowed two
+        # more immediate summaries.
+        assembled_estimates = iter(
+            [1_000, 150_000, 148_000, 148_000, 148_000]
+        )
+
+        with (
+            patch(
+                "agent.conversation_loop.estimate_messages_tokens_rough",
+                side_effect=lambda *_a, **_k: next(assembled_estimates),
+            ),
+            patch("run_agent.handle_function_call", return_value="x" * 100_000),
+            patch.object(
+                agent,
+                "_compress_context",
+                side_effect=lambda msgs, *_a, **_k: (
+                    msgs,
+                    agent._cached_system_prompt,
+                ),
+            ) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Done after one compression"
+        assert mock_compress.call_count == 1
 
     def test_anthropic_prompt_too_long_safety_net(self, agent):
         """Anthropic 'prompt is too long' error triggers compression as safety net."""

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -57,6 +57,10 @@ def _make_agent(
     compressor = MagicMock(spec=ContextCompressor)
     compressor.context_length = main_context
     compressor.threshold_tokens = int(main_context * threshold_percent)
+    compressor.summary_target_ratio = 0.20
+    compressor.tail_token_budget = int(
+        compressor.threshold_tokens * compressor.summary_target_ratio
+    )
     agent.context_compressor = compressor
 
     return agent
@@ -96,6 +100,11 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
     assert agent._compression_warning is not None
     # Threshold on the live compressor was actually lowered to aux_context.
     assert agent.context_compressor.threshold_tokens == 80_000
+    # Every threshold-derived budget must move with it. Keeping the original
+    # 20K tail here would protect 25% of the lowered threshold instead of the
+    # configured 20%, and larger real-world mismatches can make the tail's 1.5x
+    # soft ceiling wider than the entire compression trigger.
+    assert agent.context_compressor.tail_token_budget == 16_000
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=32_768)

--- a/tests/run_agent/test_credential_rotation_route_settings.py
+++ b/tests/run_agent/test_credential_rotation_route_settings.py
@@ -104,6 +104,8 @@ def test_credential_rotation_does_not_carry_global_headers_across_routes():
 
 
 def test_credential_rotation_preserves_route_significant_trailing_segments():
+    """Route identity comparison uses normalize_route_base_url, but the stored
+    base_url is stripped like every other assignment site (__init__, switch_model)."""
     agent = SimpleNamespace(
         api_mode="chat_completions",
         provider="custom",
@@ -127,5 +129,5 @@ def test_credential_rotation_preserves_route_significant_trailing_segments():
     with patch("hermes_cli.config.load_config_readonly", return_value={}):
         AIAgent._swap_credential(agent, entry)
 
-    assert agent.base_url == "https://b.example/v1//"
-    assert agent._client_kwargs["base_url"] == "https://b.example/v1//"
+    assert agent.base_url == "https://b.example/v1"
+    assert agent._client_kwargs["base_url"] == "https://b.example/v1"

--- a/tests/run_agent/test_credential_rotation_route_settings.py
+++ b/tests/run_agent/test_credential_rotation_route_settings.py
@@ -1,0 +1,131 @@
+"""Credential rotation must not carry route-scoped TLS policy."""
+
+from types import MethodType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def test_credential_rotation_replaces_route_scoped_tls_settings():
+    agent = SimpleNamespace(
+        api_mode="chat_completions",
+        provider="custom",
+        model="shared-model",
+        api_key="old",
+        base_url="https://a.example/v1",
+        _client_kwargs={
+            "api_key": "old",
+            "base_url": "https://a.example/v1",
+            "ssl_verify": False,
+            "ssl_ca_cert": "/a.pem",
+        },
+        _apply_client_headers_for_base_url=MagicMock(),
+        _replace_primary_openai_client=MagicMock(),
+    )
+    entry = SimpleNamespace(
+        runtime_api_key="new",
+        access_token="",
+        runtime_base_url="https://b.example/v1",
+        base_url="https://b.example/v1",
+    )
+    config = {
+        "custom_providers": [
+            {
+                "name": "b",
+                "base_url": "https://b.example/v1",
+                "ssl_verify": True,
+            }
+        ]
+    }
+
+    with patch("hermes_cli.config.load_config_readonly", return_value=config):
+        AIAgent._swap_credential(agent, entry)
+
+    assert agent._client_kwargs["ssl_verify"] is True
+    assert "ssl_ca_cert" not in agent._client_kwargs
+    agent._replace_primary_openai_client.assert_called_once_with(
+        reason="credential_rotation"
+    )
+
+
+def test_credential_rotation_does_not_carry_global_headers_across_routes():
+    agent = SimpleNamespace(
+        api_mode="chat_completions",
+        provider="custom",
+        model="shared-model",
+        api_key="old",
+        base_url="https://a.example/v1",
+        _client_kwargs={
+            "api_key": "old",
+            "base_url": "https://a.example/v1",
+            "default_headers": {"Authorization": "old-secret"},
+        },
+        _replace_primary_openai_client=MagicMock(),
+    )
+    agent._apply_client_headers_for_base_url = MethodType(
+        AIAgent._apply_client_headers_for_base_url,
+        agent,
+    )
+    agent._apply_user_default_headers = MethodType(
+        AIAgent._apply_user_default_headers,
+        agent,
+    )
+    entry = SimpleNamespace(
+        runtime_api_key="new",
+        access_token="",
+        runtime_base_url="https://b.example/v1",
+        base_url="https://b.example/v1",
+    )
+    config = {
+        "model": {
+            "default_headers": {"Authorization": "global-secret"},
+        },
+        "custom_providers": [
+            {
+                "name": "b",
+                "base_url": "https://b.example/v1",
+                "extra_headers": {"X-Route": "b"},
+            }
+        ],
+    }
+
+    with (
+        patch("hermes_cli.config.load_config_readonly", return_value=config),
+        patch(
+            "hermes_cli.config.get_compatible_custom_providers",
+            return_value=config["custom_providers"],
+        ),
+    ):
+        AIAgent._swap_credential(agent, entry)
+
+    headers = agent._client_kwargs["default_headers"]
+    assert "Authorization" not in headers
+    assert headers["X-Route"] == "b"
+
+
+def test_credential_rotation_preserves_route_significant_trailing_segments():
+    agent = SimpleNamespace(
+        api_mode="chat_completions",
+        provider="custom",
+        model="shared-model",
+        api_key="old",
+        base_url="https://a.example/v1",
+        _client_kwargs={
+            "api_key": "old",
+            "base_url": "https://a.example/v1",
+        },
+        _apply_client_headers_for_base_url=MagicMock(),
+        _replace_primary_openai_client=MagicMock(),
+    )
+    entry = SimpleNamespace(
+        runtime_api_key="new",
+        access_token="",
+        runtime_base_url="https://b.example/v1//",
+        base_url="https://b.example/v1//",
+    )
+
+    with patch("hermes_cli.config.load_config_readonly", return_value={}):
+        AIAgent._swap_credential(agent, entry)
+
+    assert agent.base_url == "https://b.example/v1//"
+    assert agent._client_kwargs["base_url"] == "https://b.example/v1//"

--- a/tests/run_agent/test_invalid_context_length_warning.py
+++ b/tests/run_agent/test_invalid_context_length_warning.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 
-def _build_agent(model_cfg, custom_providers=None, model="anthropic/claude-opus-4.6"):
+def _build_agent(model_cfg, custom_providers=None, model=None):
     """Build an AIAgent with the given model config."""
     cfg = {"model": model_cfg}
     if custom_providers is not None:
@@ -21,7 +21,7 @@ def _build_agent(model_cfg, custom_providers=None, model="anthropic/claude-opus-
         from run_agent import AIAgent
 
         agent = AIAgent(
-            model=model,
+            model=model or model_cfg.get("default") or "anthropic/claude-opus-4.6",
             api_key="test-key-1234567890",
             base_url=base_url,
             quiet_mode=True,

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -473,6 +473,27 @@ def test_direct_start_drops_context_when_query_path_slash_changes():
     assert agent.context_compressor.config_context_length is None
 
 
+def test_direct_start_drops_context_when_empty_query_path_slash_changes():
+    """An empty query still preserves the path slash immediately before it."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom",
+            "base_url": "https://example.com/v1/?",
+            "context_length": 1_048_576,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://example.com/v1?",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+
+
 def test_direct_start_drops_context_when_active_query_changes():
     """Query parameters remain part of the effective route identity."""
     cfg = {
@@ -608,12 +629,17 @@ def test_direct_start_preserves_context_for_registry_provider_alias():
         }
     }
 
-    agent = _make_direct_start_agent(
-        cfg,
-        model="kimi-k3",
-        provider="kimi-coding",
-        base_url="https://api.kimi.com/coding",
-    )
+    routed_client = MagicMock(api_key="fake-test-token", base_url="")
+    with patch(
+        "agent.auxiliary_client.resolve_provider_client",
+        return_value=(routed_client, "kimi-k3"),
+    ):
+        agent = _make_direct_start_agent(
+            cfg,
+            model="kimi-k3",
+            provider="kimi-coding",
+            base_url="",
+        )
 
     assert agent.context_compressor.config_context_length == 1_048_576
 

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -248,6 +248,32 @@ def test_direct_start_same_model_on_different_route_drops_context_override():
     assert agent.context_compressor.context_length == 272_000
 
 
+def test_direct_start_drops_context_when_configured_route_has_no_active_url():
+    """A configured endpoint cannot own a runtime whose endpoint is unknown."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom",
+            "base_url": "https://large.example/v1",
+            "context_length": 1_048_576,
+        }
+    }
+    routed_client = MagicMock(api_key="fake-test-token", base_url="")
+
+    with patch(
+        "agent.auxiliary_client.resolve_provider_client",
+        return_value=(routed_client, "shared-model"),
+    ):
+        agent = _make_direct_start_agent(
+            cfg,
+            model="shared-model",
+            provider="custom",
+            base_url="",
+        )
+
+    assert agent.context_compressor.config_context_length is None
+
+
 def test_direct_start_preserves_context_for_bare_aggregator_model():
     """Aggregator normalization must compare both sides, not rewrite one side."""
     cfg = {

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -578,6 +578,28 @@ def test_direct_start_drops_context_when_url_userinfo_changes():
     assert agent.context_compressor.config_context_length is None
 
 
+@pytest.mark.parametrize("suffix", [" ", "\t", "\n", "\r", "%20"])
+def test_direct_start_drops_context_for_trailing_url_data(suffix):
+    """Whitespace, controls, and encoded spaces remain route-significant."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom",
+            "base_url": f"https://example.com/v1{suffix}",
+            "context_length": 1_048_576,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://example.com/v1",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+
+
 def test_direct_start_drops_context_when_ipv6_zone_case_changes():
     """IPv6 address hex is case-insensitive, but its zone identifier is not."""
     cfg = {

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -52,6 +52,14 @@ def test_route_url_normalization_preserves_malformed_trailing_slash():
 
 
 @pytest.mark.parametrize(
+    "raw",
+    ["http://[bad/v1/", "example.com/v1/", "https:///v1/"],
+)
+def test_route_url_normalization_keeps_unparseable_routes_byte_exact(raw):
+    assert _normalize_route_base_url(raw) == raw
+
+
+@pytest.mark.parametrize(
     ("configured", "active"),
     [
         ("http://EXAMPLE.COM:80/v1/", "http://example.com/v1"),
@@ -571,6 +579,34 @@ def test_direct_start_drops_context_when_extra_trailing_segment_changes():
             "base_url": "https://example.com/v1//",
             "context_length": 1_048_576,
         }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://example.com/v1",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+
+
+def test_direct_start_does_not_reapply_custom_context_across_extra_slash():
+    """Per-model custom overrides use the same fail-closed route identity."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom",
+        },
+        "custom_providers": [
+            {
+                "name": "large-route",
+                "base_url": "https://example.com/v1//",
+                "models": {
+                    "shared-model": {"context_length": 1_048_576}
+                },
+            }
+        ],
     }
 
     agent = _make_direct_start_agent(

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from run_agent import AIAgent
 from agent.agent_init import _normalize_route_base_url
 from agent.context_compressor import ContextCompressor
@@ -47,6 +49,41 @@ def test_route_url_normalization_preserves_malformed_trailing_slash():
     assert _normalize_route_base_url(
         "http://[bad/v1/"
     ) != _normalize_route_base_url("http://[bad/v1")
+
+
+@pytest.mark.parametrize(
+    ("configured", "active"),
+    [
+        ("http://EXAMPLE.COM:80/v1/", "http://example.com/v1"),
+        (
+            "https://EXAMPLE.COM:443/v1/#configured-fragment",
+            "https://example.com/v1#active-fragment",
+        ),
+        ("http://[2001:DB8::1]:80/v1/", "http://[2001:db8::1]/v1"),
+    ],
+)
+def test_route_url_normalization_accepts_isolated_safe_equivalences(
+    configured, active
+):
+    """Default ports, fragments, and IPv6 hex case do not change HTTP routes."""
+    assert _normalize_route_base_url(configured) == _normalize_route_base_url(active)
+
+
+@pytest.mark.parametrize(
+    ("configured", "active"),
+    [
+        ("https://example.com/V1", "https://example.com/v1"),
+        ("https://example.com:8443/v1", "https://example.com/v1"),
+        ("https://example.com/v1?tenant=large", "https://example.com/v1"),
+        ("http://example.com/v1", "https://example.com/v1"),
+        ("https://example.com:notaport/v1", "https://example.com/v1"),
+    ],
+)
+def test_route_url_normalization_preserves_significant_components(
+    configured, active
+):
+    """Path case, route data, schemes, and ambiguous ports stay distinct."""
+    assert _normalize_route_base_url(configured) != _normalize_route_base_url(active)
 
 
 def _make_direct_start_agent(

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -6,6 +6,41 @@ from run_agent import AIAgent
 from agent.context_compressor import ContextCompressor
 
 
+class _StubStartupCompressor:
+    def __init__(self, *args, **kwargs):
+        self.context_length = kwargs.get("config_context_length") or 272_000
+        self.config_context_length = kwargs.get("config_context_length")
+        self.threshold_tokens = int(self.context_length * 0.95)
+        self.threshold_percent = 0.95
+
+    def get_tool_schemas(self):
+        return []
+
+    def on_session_start(self, *args, **kwargs):
+        return None
+
+
+def _make_direct_start_agent(
+    cfg: dict, *, model: str, provider: str, base_url: str
+) -> AIAgent:
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("agent.agent_init.ContextCompressor", new=_StubStartupCompressor),
+    ):
+        return AIAgent(
+            model=model,
+            provider=provider,
+            api_key="fake-test-token",
+            base_url=base_url,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
 def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
     """Build a minimal AIAgent with a context_compressor, skipping __init__."""
     agent = AIAgent.__new__(AIAgent)
@@ -73,3 +108,151 @@ def test_switch_model_without_config_context_length():
         mock_ctx_len.assert_called_once()
         call_kwargs = mock_ctx_len.call_args.kwargs
         assert call_kwargs.get("config_context_length") is None
+
+
+def test_direct_start_model_override_does_not_inherit_profile_context_length():
+    """A CLI ``--model`` startup override must not inherit another model's window."""
+    cfg = {
+        "model": {
+            "default": "kimi-k3",
+            "provider": "custom:kimi-coding-1m",
+            "base_url": "https://api.kimi.com/coding",
+            "context_length": 1_048_576,
+        },
+        "custom_providers": [
+            {
+                "name": "kimi-coding-1m",
+                "base_url": "https://api.kimi.com/coding",
+                "models": {"kimi-k3": {"context_length": 1_048_576}},
+            }
+        ],
+    }
+    agent = _make_direct_start_agent(
+        cfg,
+        model="gpt-5.6-sol",
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+    assert agent.context_compressor.context_length == 272_000
+
+
+def test_direct_start_preserves_context_for_normalized_default_model_alias():
+    """Equivalent vendor-prefixed defaults still own their explicit window."""
+    cfg = {
+        "model": {
+            "default": "openai/gpt-5.6-sol",
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "context_length": 272_000,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="gpt-5.6-sol",
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert agent.context_compressor.config_context_length == 272_000
+    assert agent.context_compressor.context_length == 272_000
+
+
+def test_direct_start_same_model_on_different_route_drops_context_override():
+    """Context pins are route-specific even when the model slug is unchanged."""
+    cfg = {
+        "model": {
+            "default": "gpt-5.6-sol",
+            "provider": "custom:large-sol-route",
+            "base_url": "https://large-sol.example/v1",
+            "context_length": 1_048_576,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="gpt-5.6-sol",
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+    assert agent.context_compressor.context_length == 272_000
+
+
+def test_direct_start_preserves_context_for_bare_aggregator_model():
+    """Aggregator normalization must compare both sides, not rewrite one side."""
+    cfg = {
+        "model": {
+            "default": "gpt-5.4",
+            "provider": "openrouter",
+            "context_length": 1_000_000,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="gpt-5.4",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert agent.context_compressor.config_context_length == 1_000_000
+
+
+def test_direct_start_preserves_context_for_provider_alias():
+    """Canonical provider aliases identify the same route when no URL is pinned."""
+    cfg = {
+        "model": {
+            "default": "gemini-2.5-pro",
+            "provider": "google",
+            "context_length": 1_000_000,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="gemini-2.5-pro",
+        provider="gemini",
+        base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+    )
+
+    assert agent.context_compressor.config_context_length == 1_000_000
+
+
+def test_direct_start_named_custom_route_resolves_configured_base_url():
+    """Named custom providers must not collapse to one generic custom route."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom:large-route",
+            "context_length": 1_048_576,
+        },
+        "custom_providers": [
+            {
+                "name": "large-route",
+                "base_url": "https://large.example/v1",
+            }
+        ],
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://small.example/v1",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+    assert agent.context_compressor.context_length == 272_000
+
+    matching_agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://large.example/v1",
+    )
+
+    assert matching_agent.context_compressor.config_context_length == 1_048_576

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 from run_agent import AIAgent
+from agent.agent_init import _normalize_route_base_url
 from agent.context_compressor import ContextCompressor
 
 
@@ -18,6 +19,34 @@ class _StubStartupCompressor:
 
     def on_session_start(self, *args, **kwargs):
         return None
+
+
+def test_route_url_normalization_preserves_path_slash_before_query():
+    """A path slash before a query changes OpenAI SDK URL joining."""
+    assert _normalize_route_base_url(
+        "https://example.com/v1/?tenant=large"
+    ) != _normalize_route_base_url("https://example.com/v1?tenant=large")
+
+
+def test_route_url_normalization_preserves_trailing_whitespace():
+    """Whitespace can alter the request target and must not collapse routes."""
+    assert _normalize_route_base_url(
+        "https://example.com/v1 "
+    ) != _normalize_route_base_url("https://example.com/v1")
+
+
+def test_route_url_normalization_preserves_bracketed_host_syntax():
+    """Invalid bracketed host syntax must not collapse onto a valid DNS host."""
+    assert _normalize_route_base_url(
+        "http://[v1.Foo]/v1"
+    ) != _normalize_route_base_url("http://v1.foo/v1")
+
+
+def test_route_url_normalization_preserves_malformed_trailing_slash():
+    """Malformed URLs are kept byte-exact rather than partially normalized."""
+    assert _normalize_route_base_url(
+        "http://[bad/v1/"
+    ) != _normalize_route_base_url("http://[bad/v1")
 
 
 def _make_direct_start_agent(
@@ -202,6 +231,295 @@ def test_direct_start_preserves_context_for_bare_aggregator_model():
     assert agent.context_compressor.config_context_length == 1_000_000
 
 
+def test_direct_start_drops_context_for_same_provider_custom_base_url():
+    """An explicit endpoint override changes the route even if provider matches."""
+    cfg = {
+        "model": {
+            "default": "gpt-5.4",
+            "provider": "openrouter",
+            "context_length": 1_000_000,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="gpt-5.4",
+        provider="openrouter",
+        base_url="https://small.example/v1",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+
+
+def test_direct_start_drops_context_for_provider_name_lookalike_host():
+    """A hostname containing a provider domain is not that provider's route."""
+    cfg = {
+        "model": {
+            "default": "gpt-5.4",
+            "provider": "openrouter",
+            "context_length": 1_000_000,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="gpt-5.4",
+        provider="openrouter",
+        base_url="https://evil-openrouter.ai/v1",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+
+
+def test_direct_start_preserves_context_for_codex_default_endpoint():
+    """ChatGPT's Codex endpoint belongs to the openai-codex route."""
+    cfg = {
+        "model": {
+            "default": "gpt-5.6-sol",
+            "provider": "openai-codex",
+            "context_length": 272_000,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="gpt-5.6-sol",
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert agent.context_compressor.config_context_length == 272_000
+
+
+def test_direct_start_drops_context_for_codex_wrong_path():
+    """A known host with a different route path is not the Codex endpoint."""
+    cfg = {
+        "model": {
+            "default": "gpt-5.6-sol",
+            "provider": "openai-codex",
+            "context_length": 272_000,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="gpt-5.6-sol",
+        provider="openai-codex",
+        base_url="https://chatgpt.com/unrelated",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+
+
+def test_direct_start_drops_context_for_overridden_provider_wrong_path():
+    """Providers with an explicit default route require that complete route."""
+    cfg = {
+        "model": {
+            "default": "grok-4",
+            "provider": "xai",
+            "context_length": 256_000,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="grok-4",
+        provider="xai",
+        base_url="https://api.x.ai/not-v1",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+
+
+def test_direct_start_preserves_context_for_equivalent_base_url_spellings():
+    """Route identity ignores URL casing, default ports, and trailing slashes."""
+    cfg = {
+        "model": {
+            "default": "gpt-5.4",
+            "provider": "openrouter",
+            "base_url": "HTTPS://OPENROUTER.AI:443/api/v1/",
+            "context_length": 1_000_000,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="gpt-5.4",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert agent.context_compressor.config_context_length == 1_000_000
+
+
+def test_direct_start_drops_context_when_path_parameter_segment_changes():
+    """Trailing-slash normalization must not move params to another segment."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom",
+            "base_url": "https://example.com/v1/;tenant=large",
+            "context_length": 1_048_576,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://example.com/v1;tenant=large",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+
+
+def test_direct_start_drops_context_when_empty_path_parameter_changes():
+    """An explicit empty path-parameter delimiter is not discarded."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom",
+            "base_url": "https://example.com/v1;",
+            "context_length": 1_048_576,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://example.com/v1",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+
+
+def test_direct_start_drops_context_when_empty_query_delimiter_changes():
+    """An explicit empty query changes OpenAI SDK base-URL joining semantics."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom",
+            "base_url": "https://example.com/v1?",
+            "context_length": 1_048_576,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://example.com/v1",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+
+
+def test_direct_start_drops_context_when_active_query_changes():
+    """Query parameters remain part of the effective route identity."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom",
+            "base_url": "https://example.com/v1",
+            "context_length": 1_048_576,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://example.com/v1?tenant=small",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+
+
+def test_direct_start_preserves_context_for_matching_query_route():
+    """SDK query extraction must not hide an otherwise matching route."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom",
+            "base_url": "https://example.com/v1?tenant=large",
+            "context_length": 1_048_576,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://example.com/v1?tenant=large",
+    )
+
+    assert agent.context_compressor.config_context_length == 1_048_576
+
+
+def test_direct_start_drops_context_when_extra_trailing_segment_changes():
+    """Only one conventional trailing slash is ignored for route identity."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom",
+            "base_url": "https://example.com/v1//",
+            "context_length": 1_048_576,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://example.com/v1",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+
+
+def test_direct_start_drops_context_when_url_userinfo_changes():
+    """Credentials embedded in a URL remain part of route identity."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom",
+            "base_url": "https://large-tenant:secret@example.com/v1",
+            "context_length": 1_048_576,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://small-tenant:secret@example.com/v1",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+
+
+def test_direct_start_drops_context_when_ipv6_zone_case_changes():
+    """IPv6 address hex is case-insensitive, but its zone identifier is not."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom",
+            "base_url": "http://[FE80::1%25ETH0]/v1",
+            "context_length": 1_048_576,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="http://[fe80::1%25eth0]/v1",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+
+
 def test_direct_start_preserves_context_for_provider_alias():
     """Canonical provider aliases identify the same route when no URL is pinned."""
     cfg = {
@@ -220,6 +538,66 @@ def test_direct_start_preserves_context_for_provider_alias():
     )
 
     assert agent.context_compressor.config_context_length == 1_000_000
+
+
+def test_direct_start_preserves_context_for_registry_provider_alias():
+    """Legacy and models.dev provider IDs may identify the same route."""
+    cfg = {
+        "model": {
+            "default": "kimi-k3",
+            "provider": "kimi-for-coding",
+            "context_length": 1_048_576,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="kimi-k3",
+        provider="kimi-coding",
+        base_url="https://api.kimi.com/coding",
+    )
+
+    assert agent.context_compressor.config_context_length == 1_048_576
+
+
+def test_direct_start_preserves_context_for_profile_route_on_shared_host():
+    """Exact provider-profile routes disambiguate providers sharing a hostname."""
+    cfg = {
+        "model": {
+            "default": "gpt-5.4",
+            "provider": "opencode-zen",
+            "context_length": 1_000_000,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="gpt-5.4",
+        provider="opencode",
+        base_url="https://opencode.ai/zen/v1",
+    )
+
+    assert agent.context_compressor.config_context_length == 1_000_000
+
+
+def test_direct_start_drops_context_for_profile_wrong_path():
+    """A shared hostname cannot substitute for a profile's complete route."""
+    cfg = {
+        "model": {
+            "default": "gpt-5.4",
+            "provider": "opencode-go",
+            "context_length": 1_000_000,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="gpt-5.4",
+        provider="opencode-go",
+        base_url="https://opencode.ai/unrelated",
+    )
+
+    assert agent.context_compressor.config_context_length is None
 
 
 def test_direct_start_named_custom_route_resolves_configured_base_url():

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -452,6 +452,27 @@ def test_direct_start_drops_context_when_empty_query_delimiter_changes():
     assert agent.context_compressor.config_context_length is None
 
 
+def test_direct_start_drops_context_when_query_path_slash_changes():
+    """A path slash before a query remains part of the effective SDK route."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom",
+            "base_url": "https://example.com/v1/?tenant=large",
+            "context_length": 1_048_576,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://example.com/v1?tenant=large",
+    )
+
+    assert agent.context_compressor.config_context_length is None
+
+
 def test_direct_start_drops_context_when_active_query_changes():
     """Query parameters remain part of the effective route identity."""
     cfg = {

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -610,10 +610,16 @@ def test_direct_start_named_custom_route_resolves_configured_base_url():
         },
         "custom_providers": [
             {
-                "name": "large-route",
-                "base_url": "https://large.example/v1",
+                "name": "Large Route",
+                "base_url": "https://legacy-large.example/v1",
             }
         ],
+        "providers": {
+            "large-route": {
+                "name": "Large Route",
+                "api": "https://large.example/v1",
+            }
+        },
     }
 
     agent = _make_direct_start_agent(
@@ -630,7 +636,219 @@ def test_direct_start_named_custom_route_resolves_configured_base_url():
         cfg,
         model="shared-model",
         provider="custom",
-        base_url="https://large.example/v1",
+        base_url="HTTPS://LARGE.EXAMPLE:443/v1/",
     )
 
     assert matching_agent.context_compressor.config_context_length == 1_048_576
+
+    legacy_agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://legacy-large.example/v1",
+    )
+
+    assert legacy_agent.context_compressor.config_context_length is None
+
+
+def test_direct_start_named_custom_provider_key_uses_canonical_slug():
+    """Raw, canonical, and prefixed provider keys/names share runtime identity."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom:Route Key",
+            "context_length": 1_048_576,
+        },
+        "providers": {
+            "Route Key": {
+                "name": "Friendly Label",
+                "api": "https://key.example/v1",
+            },
+            "custom:Prefixed Key": {
+                "name": "custom:Prefixed Label",
+                "api": "https://prefixed.example/v1",
+            },
+        },
+    }
+
+    for configured_provider in (
+        "custom:Route Key",
+        "custom:Friendly Label",
+        "Route Key",
+        "route-key",
+        "Friendly Label",
+        "friendly-label",
+    ):
+        cfg["model"]["provider"] = configured_provider
+        agent = _make_direct_start_agent(
+            cfg,
+            model="shared-model",
+            provider="custom",
+            base_url="https://key.example/v1",
+        )
+
+        assert agent.context_compressor.config_context_length == 1_048_576
+
+    for configured_provider in (
+        "custom:Prefixed Key",
+        "custom:Prefixed Label",
+        "custom:custom:Prefixed Key",
+        "custom:custom:Prefixed Label",
+    ):
+        cfg["model"]["provider"] = configured_provider
+        agent = _make_direct_start_agent(
+            cfg,
+            model="shared-model",
+            provider="custom",
+            base_url="https://prefixed.example/v1",
+        )
+
+        assert agent.context_compressor.config_context_length == 1_048_576
+
+    for configured_provider in (
+        "custom: Prefixed Key",
+        "custom:\tPrefixed Key",
+    ):
+        cfg["model"]["provider"] = configured_provider
+        agent = _make_direct_start_agent(
+            cfg,
+            model="shared-model",
+            provider="custom",
+            base_url="https://prefixed.example/v1",
+        )
+
+        assert agent.context_compressor.config_context_length is None
+
+
+def test_direct_start_named_custom_raw_legacy_display_name_matches():
+    """Legacy display names accepted by runtime also identify the scoped route."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "Legacy Route",
+            "context_length": 1_048_576,
+        },
+        "custom_providers": [
+            {
+                "name": "Legacy Route",
+                "base_url": "https://legacy.example/v1",
+            }
+        ],
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://legacy.example/v1",
+    )
+
+    assert agent.context_compressor.config_context_length == 1_048_576
+
+
+def test_direct_start_literal_bare_custom_entry_matches_runtime():
+    """A providers.custom entry makes bare custom a complete route identity."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom",
+            "context_length": 1_048_576,
+        },
+        "providers": {
+            "custom": {
+                "api": "https://literal.example/v1",
+            }
+        },
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://literal.example/v1",
+    )
+
+    assert agent.context_compressor.config_context_length == 1_048_576
+
+
+def test_direct_start_disabled_modern_custom_falls_back_only_to_legacy():
+    """Disabled modern entries cannot retain pins, but legacy fallback can."""
+    cfg = {
+        "model": {
+            "default": "shared-model",
+            "provider": "custom:route-key",
+            "context_length": 1_048_576,
+        },
+        "providers": {
+            "route-key": {
+                "name": "Route Key",
+                "api": "https://disabled.example/v1",
+                "enabled": False,
+            }
+        },
+    }
+
+    disabled_agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://disabled.example/v1",
+    )
+    assert disabled_agent.context_compressor.config_context_length is None
+
+    cfg["custom_providers"] = [
+        {
+            "name": "Route Key",
+            "base_url": "https://legacy.example/v1",
+        }
+    ]
+    legacy_agent = _make_direct_start_agent(
+        cfg,
+        model="shared-model",
+        provider="custom",
+        base_url="https://legacy.example/v1",
+    )
+    assert legacy_agent.context_compressor.config_context_length == 1_048_576
+
+
+def test_direct_start_runtime_first_provider_names_require_explicit_custom_prefix():
+    """Auto, MoA, and Vertex routes cannot be shadowed by raw custom names."""
+    for provider_name in (
+        "auto",
+        "moa",
+        "vertex",
+        "google-vertex",
+        "vertex-ai",
+        "gcp-vertex",
+        "vertexai",
+    ):
+        base_url = f"https://{provider_name}.shadow.example/v1"
+        cfg = {
+            "model": {
+                "default": "shared-model",
+                "provider": provider_name,
+                "context_length": 1_048_576,
+            },
+            "providers": {
+                provider_name: {
+                    "api": base_url,
+                }
+            },
+        }
+
+        raw_agent = _make_direct_start_agent(
+            cfg,
+            model="shared-model",
+            provider="custom",
+            base_url=base_url,
+        )
+        assert raw_agent.context_compressor.config_context_length is None
+
+        cfg["model"]["provider"] = f"custom:{provider_name}"
+        custom_agent = _make_direct_start_agent(
+            cfg,
+            model="shared-model",
+            provider="custom",
+            base_url=base_url,
+        )
+        assert custom_agent.context_compressor.config_context_length == 1_048_576


### PR DESCRIPTION
## Summary
Prevents a compression death spiral where stale `model.context_length` pins, stale `tail_token_budget`, and ineffective preflight compression retries could waste all 3 summary calls on marginal or zero progress.

Based on #68899 by @cucurigoo — cherry-picked with authorship preserved.

## Changes from original PR
- **C2 fix**: Restored `.rstrip('/')` on `base_url` in `_swap_credential` (both anthropic and OpenAI paths) to match every other assignment site. Route identity comparison still uses `normalize_route_base_url` which handles trailing slash correctly for comparisons.
- **W1 fix**: Extracted `should_clear_context_pin()` into `hermes_cli/route_identity.py`, consolidating 7 copy-pasted call sites across `cli.py`, `gateway/run.py`, `gateway/slash_commands.py`, and `hermes_cli/model_switch.py` into a single fail-closed helper.
- Updated `test_credential_rotation_preserves_route_significant_trailing_segments` to reflect the restored rstrip.

## What the PR does (3 bugs fixed)
1. **Stale tail_token_budget**: Auxiliary feasibility lowers the compression threshold but `tail_token_budget` stayed derived from the old threshold — the tail's 1.5x soft ceiling could exceed the entire corrected trigger.
2. **Stale context_length on startup override**: A direct `--model` startup override inherited `model.context_length` from the configured default route for a different model. Now scoped via route identity comparison.
3. **Preflight retry loops**: Turn-start and mid-turn preflight loops could spend all 3 summary calls on marginal progress. Now requires >5% token reduction before retrying, preserving provider-overflow recovery budget.

Plus: route-scoped context_length pinning across model switches, credential rotation TLS/header isolation, `normalize_route_base_url` module, and disabled-provider exclusion from compatibility projection.

## Validation
| | Before | After |
|---|---|---|
| Focused test suite | 2 pre-existing failures | 2 pre-existing failures (Qwen OAuth, same on origin/main) |
| All PR tests | — | 536 passed |
| E2E should_clear_context_pin | — | 7/7 passed |

Closes #68899
