### PR TITLE
fix(agent): contain corrupted mutation arguments

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -260,6 +260,23 @@ class ToolCallGuardrailController:
             self._halt_decision = decision
             return decision
 
+        same_tool_count = self._same_tool_failure_counts.get(tool_name, 0)
+        if same_tool_count >= self.config.same_tool_failure_halt_after:
+            decision = ToolGuardrailDecision(
+                action="block",
+                code="same_tool_failure_block",
+                message=(
+                    f"Blocked {tool_name}: it failed {same_tool_count} times this turn. "
+                    "The last failure was delivered to the model; stop using this tool "
+                    "for the turn and choose a different approach."
+                ),
+                tool_name=tool_name,
+                count=same_tool_count,
+                signature=signature,
+            )
+            self._halt_decision = decision
+            return decision
+
         if self._is_idempotent(tool_name):
             record = self._no_progress.get(signature)
             if record is not None:
@@ -302,21 +319,6 @@ class ToolCallGuardrailController:
 
             same_count = self._same_tool_failure_counts.get(tool_name, 0) + 1
             self._same_tool_failure_counts[tool_name] = same_count
-
-            if self.config.hard_stop_enabled and same_count >= self.config.same_tool_failure_halt_after:
-                decision = ToolGuardrailDecision(
-                    action="halt",
-                    code="same_tool_failure_halt",
-                    message=(
-                        f"Stopped {tool_name}: it failed {same_count} times this turn. "
-                        "Stop retrying the same failing tool path and choose a different approach."
-                    ),
-                    tool_name=tool_name,
-                    count=same_count,
-                    signature=signature,
-                )
-                self._halt_decision = decision
-                return decision
 
             if self.config.warnings_enabled and exact_count >= self.config.exact_failure_warn_after:
                 return ToolGuardrailDecision(

--- a/run_agent.py
+++ b/run_agent.py
@@ -3049,44 +3049,30 @@ class AIAgent:
 
     @classmethod
     def _format_file_mutation_failure_footer(cls, failed: Dict[str, Dict[str, Any]]) -> str:
-        """Render the per-turn failed-mutation dict as a user-facing footer.
+        """Render a safe aggregate advisory for failed file mutations.
 
-        Displays up to 10 paths with their first error preview, then a
-        count of any additional failures.  Returns an empty string when
-        the dict is empty so callers can concatenate unconditionally.
-
-        Every file path that reaches the user-facing text — both the bullet
-        path and any path echoed inside the tool's error preview — is
-        backtick-wrapped via ``_neutralize_footer_paths`` so the gateway's
-        bare-path media extractor can never auto-attach a protected file
-        (e.g. ``~/.hermes/config.yaml``) to a messaging channel (#35584).
+        Tool-call arguments and error previews are untrusted model/provider data:
+        a corrupted argument can contain a plausible but false path.  Keep those
+        details in the tool transcript rather than echoing them after an otherwise
+        complete final answer.  The footer reports only aggregate counts by tool.
         """
         if not failed:
             return ""
-        lines = [
+        tool_counts: Dict[str, int] = {}
+        for info in failed.values():
+            tool = str(info.get("tool") or "file mutation")
+            tool_counts[tool] = tool_counts.get(tool, 0) + 1
+        breakdown = ", ".join(
+            f"{count} {tool}" for tool, count in sorted(tool_counts.items())
+        )
+        return (
             "⚠️ File-mutation verifier: "
             f"{len(failed)} file-mutation target(s) failed and were not later "
             "confirmed successful under the same path. Other edits may still "
-            "have succeeded this turn. Run `git status` or `read_file` to confirm."
-        ]
-        shown = 0
-        for path, info in failed.items():
-            if shown >= 10:
-                break
-            preview = (info.get("error_preview") or "").strip()
-            tool = info.get("tool") or "patch"
-            if preview:
-                lines.append(f"  • `{path}` — [{tool}] {preview}")
-            else:
-                lines.append(f"  • `{path}` — [{tool}] failed")
-            shown += 1
-        remaining = len(failed) - shown
-        if remaining > 0:
-            lines.append(f"  • … and {remaining} more")
-        # Neutralize any path the preview text echoed (the bullet path is
-        # already backticked above; the lookbehind keeps it from being
-        # double-wrapped).
-        return cls._neutralize_footer_paths("\n".join(lines))
+            "have succeeded this turn. Inspect the tool transcript, then run "
+            "`git status` or `read_file` to confirm. "
+            f"Failed calls by tool: {breakdown}."
+        )
 
     def _turn_completion_explainer_enabled(self) -> bool:
         """Check whether the end-of-turn completion explainer footer is on.

--- a/run_agent.py
+++ b/run_agent.py
@@ -3065,9 +3065,9 @@ class AIAgent:
             return ""
         lines = [
             "⚠️ File-mutation verifier: "
-            f"{len(failed)} file(s) were NOT modified this turn despite any "
-            "wording above that may suggest otherwise. Run `git status` or "
-            "`read_file` to confirm."
+            f"{len(failed)} file-mutation target(s) failed and were not later "
+            "confirmed successful under the same path. Other edits may still "
+            "have succeeded this turn. Run `git status` or `read_file` to confirm."
         ]
         shown = 0
         for path, info in failed.items():

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -167,7 +167,7 @@ def test_same_tool_varying_args_warns_by_default_without_halting():
     assert controller.halt_decision is None
 
 
-def test_hard_stop_enabled_halts_same_tool_varying_args_failure_streak():
+def test_hard_stop_enabled_warns_at_same_tool_threshold_then_blocks_next_call():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(
             hard_stop_enabled=True,
@@ -183,9 +183,14 @@ def test_hard_stop_enabled_halts_same_tool_varying_args_failure_streak():
     assert second.action == "warn"
     assert second.code == "same_tool_failure_warning"
     third = controller.after_call("terminal", {"command": "cmd-3"}, '{"exit_code":1}', failed=True)
-    assert third.action == "halt"
-    assert third.code == "same_tool_failure_halt"
+    assert third.action == "warn"
+    assert third.code == "same_tool_failure_warning"
     assert third.count == 3
+
+    blocked = controller.before_call("terminal", {"command": "cmd-4"})
+    assert blocked.action == "block"
+    assert blocked.code == "same_tool_failure_block"
+    assert blocked.count == 3
 
 
 def test_idempotent_no_progress_repeated_result_warns_without_blocking_by_default():

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -311,26 +311,39 @@ class TestFormatFooter:
         )
         assert "1 file-mutation target(s) failed" in out
         assert "file(s) were NOT modified" not in out
-        assert "/tmp/a.md" in out
-        assert "Could not find old_string" in out
+        assert "/tmp/a.md" not in out
+        assert "Could not find old_string" not in out
+        assert "Failed calls by tool: 1 patch" in out
         assert "git status" in out  # user-actionable hint
 
-    def test_truncation_at_10_entries(self):
+    def test_corrupted_tool_arguments_are_not_echoed(self):
+        corrupted_path = (
+            "/Usershashed/karthik/GDrive - 33rd Avenue JR/"
+            "hermes-agent_jeeves/projects/jarvis-san-pdf -gmail-incident/PROGRESS.md"
+        )
+        corrupted_preview = f"Failed to write {corrupted_path}"
+
+        out = AIAgent._format_file_mutation_failure_footer(
+            {corrupted_path: {"tool": "write_file", "error_preview": corrupted_preview}},
+        )
+
+        assert "1 file-mutation target(s) failed" in out
+        assert corrupted_path not in out
+        assert corrupted_preview not in out
+
+    def test_many_failures_are_aggregated_without_untrusted_details(self):
         failed = {
             f"/tmp/f{i}.md": {"tool": "patch", "error_preview": "err"}
             for i in range(15)
         }
         out = AIAgent._format_file_mutation_failure_footer(failed)
         assert "15 file-mutation target(s) failed" in out
-        assert "… and 5 more" in out
-        # Ten file bullets + header + "and X more" line
-        lines = out.split("\n")
-        bullet_lines = [ln for ln in lines if ln.lstrip().startswith("•")]
-        assert len(bullet_lines) == 11  # 10 shown + 1 summary
+        assert "Failed calls by tool: 15 patch" in out
+        assert "/tmp/f0.md" not in out
+        assert "err" not in out
 
-    def test_paths_are_backtick_wrapped(self):
-        """Footer paths must be inline-code wrapped so the gateway's bare-path
-        media extractor can't auto-attach them (#35584 defense-in-depth)."""
+    def test_sensitive_paths_and_error_previews_are_not_rendered(self):
+        """Untrusted details cannot leak or become gateway attachments."""
         out = AIAgent._format_file_mutation_failure_footer(
             {"/home/u/.hermes/config.yaml": {
                 "tool": "patch",
@@ -340,16 +353,9 @@ class TestFormatFooter:
                 ),
             }},
         )
-        # Path still human-readable.
-        assert "/home/u/.hermes/config.yaml" in out
-        # Bullet path is backticked.
-        assert "`/home/u/.hermes/config.yaml`" in out
-        # The path echoed inside the preview is ALSO backticked (the real
-        # file_operations.py denial message embeds it in single quotes, which
-        # do NOT block the gateway extractor's regex).
-        assert "'`/home/u/.hermes/config.yaml`'" in out
-        # No double-backticking anywhere.
-        assert "``" not in out
+        assert "/home/u/.hermes/config.yaml" not in out
+        assert "protected system/credential file" not in out
+        assert "Failed calls by tool: 1 patch" in out
 
     def test_footer_path_not_extracted_by_gateway(self):
         """End-to-end: the gateway's extract_local_files must NOT pull a

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -309,7 +309,8 @@ class TestFormatFooter:
         out = AIAgent._format_file_mutation_failure_footer(
             {"/tmp/a.md": {"tool": "patch", "error_preview": "Could not find old_string"}},
         )
-        assert "1 file(s) were NOT modified" in out
+        assert "1 file-mutation target(s) failed" in out
+        assert "file(s) were NOT modified" not in out
         assert "/tmp/a.md" in out
         assert "Could not find old_string" in out
         assert "git status" in out  # user-actionable hint
@@ -320,7 +321,7 @@ class TestFormatFooter:
             for i in range(15)
         }
         out = AIAgent._format_file_mutation_failure_footer(failed)
-        assert "15 file(s) were NOT modified" in out
+        assert "15 file-mutation target(s) failed" in out
         assert "… and 5 more" in out
         # Ten file bullets + header + "and X more" line
         lines = out.split("\n")

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -37,6 +37,25 @@ class TestExactMatch:
 
 
 class TestWhitespaceDifference:
+    def test_corrupted_single_line_anchor_is_rejected(self):
+        """A similar single line must not authorize a destructive replacement."""
+        content = '    file_path = "/data/_workspaces/lit-822/inputs/thread.pdf"'
+        corrupted = (
+            '    file_pathchl = "/usz data/_work AH spaces/'
+            'lit-Х sunset822/inputs/thread.pdf"'
+        )
+
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content,
+            corrupted,
+            '    file_path = "/data/_workspaces/workspace/inputs/thread.pdf"',
+        )
+
+        assert new == content
+        assert count == 0
+        assert strategy is None
+        assert err is not None
+
     def test_extra_spaces_match(self):
         content = "def  foo(  x,  y  ):"
         new, count, _, err = fuzzy_find_and_replace(content, "def foo( x, y ):", "def bar(x, y):")
@@ -83,6 +102,71 @@ class TestWhitespaceDifference:
         # "foo   +" normalized to "foo +" matches; trailing spaces consumed
         # Result: "a = XY bar"
         assert "XY" in new and "bar" in new
+
+
+class TestSingleLineCompatibility:
+    """Corpus for safe normalization and unsafe approximate single-line edits."""
+
+    def test_safe_normalization_strategies_remain_available(self):
+        cases = [
+            ("value = 1", "value = 1", "exact"),
+            ("    value = 1", "  value = 1  ", "line_trimmed"),
+            ("value  =  1", "value = 1", "whitespace_normalized"),
+            ("\tvalue = 1", "\\tvalue = 1", "escape_normalized"),
+            ("value—fallback", "value--fallback", "unicode_normalized"),
+        ]
+
+        for content, old_string, expected_strategy in cases:
+            new, count, strategy, err = fuzzy_find_and_replace(
+                content, old_string, "updated = True",
+            )
+
+            assert err is None, (content, old_string, err)
+            assert count == 1, (content, old_string, strategy)
+            assert strategy == expected_strategy
+            assert "updated = True" in new
+
+    def test_approximate_corruption_is_rejected(self):
+        cases = [
+            (
+                '    file_path = "/data/_workspaces/lit-822/inputs/thread.pdf"',
+                '    file_pathchl = "/usz data/_work AH spaces/'
+                'lit-Х sunset822/inputs/thread.pdf"',
+            ),
+            (
+                "    assert response.status_code == 413",
+                "    assert response Ghoul.status_code ==shire 413",
+            ),
+            (
+                '    assert payload["error"] == "path_outside_allowed_roots"',
+                '    assert payload["error cumin"] == "path_outside_allowed_roots/gl"',
+            ),
+        ]
+
+        for content, corrupted in cases:
+            new, count, strategy, err = fuzzy_find_and_replace(
+                content, corrupted, "CORRUPTED REPLACEMENT",
+            )
+
+            assert new == content
+            assert count == 0
+            assert strategy is None
+            assert err is not None
+
+
+class TestContextAwareCompatibility:
+    def test_multiline_approximate_match_remains_available(self):
+        content = "alpha_value = 1\nbeta_value = 2"
+        old_string = "alpha_value = 1;\nbeta_value = 2;"
+
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content, old_string, "updated = True",
+        )
+
+        assert err is None
+        assert count == 1
+        assert strategy == "context_aware"
+        assert new == "updated = True"
 
 
 class TestIndentDifference:

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -696,13 +696,16 @@ def _strategy_block_anchor(content: str, pattern: str) -> List[Tuple[int, int]]:
 def _strategy_context_aware(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
     Strategy 9: Line-by-line similarity with 50% threshold.
-    
+
     Finds blocks where at least 50% of lines have high similarity.
+    Single-line patterns are excluded: earlier normalization strategies cover
+    safe formatting drift, while approximate one-line matches provide too
+    little context to authorize a replacement.
     """
     pattern_lines = pattern.split('\n')
     content_lines = content.split('\n')
-    
-    if not pattern_lines:
+
+    if len(pattern_lines) < 2:
         return []
     
     matches = []

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1411,7 +1411,7 @@ For unattended gateway / server deployments, enable hard stops so a stuck agent 
 ```yaml
 tool_loop_guardrails:
   warnings_enabled: true       # inject warnings into tool results (default: true)
-  hard_stop_enabled: false     # also BLOCK the call past the hard-stop threshold (default: false)
+  hard_stop_enabled: false     # also BLOCK the next call past the threshold (default: false)
   warn_after:
     exact_failure: 2           # identical failing call repeated N times
     same_tool_failure: 3       # same tool failing N times (different args)
@@ -1422,7 +1422,7 @@ tool_loop_guardrails:
     idempotent_no_progress: 5
 ```
 
-`hard_stop_enabled` defaults to `false` because interactive sessions have a human in the loop. In unattended deployments (gateway, cron, kanban workers) set it to `true` so repeated failures are blocked rather than only warned. See also [Docker / unattended deployments](docker.md).
+`hard_stop_enabled` defaults to `false` because interactive sessions have a human in the loop. In unattended deployments (gateway, cron, kanban workers) set it to `true` so repeated failures are blocked rather than only warned. The failure that reaches a hard-stop threshold is still returned to the model; if it attempts that tool again, the next call is blocked before execution. This gives the model one chance to choose a different tool or report the blocker. See also [Docker / unattended deployments](docker.md).
 
 ## TTS Configuration
 


### PR DESCRIPTION
## Summary
- reject approximate single-line fuzzy patch anchors while retaining safe normalization and multiline compatibility
- allow one recovery turn when the same-tool failure threshold is reached
- keep malformed mutation paths and raw tool errors out of final user-facing verifier footers

## Verification
- `uv run --no-sync pytest tests/run_agent/test_file_mutation_verifier.py tests/agent/test_tool_guardrails.py tests/tools/test_fuzzy_match.py -q -o 'addopts='`
- 112 passed
- incident-shaped regression covers the malformed `Usershashed` / `33rd Avenue JR` path
