### PR TITLE
fix(gateway): report multiplexed profile coverage

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7412,7 +7412,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             pass
         try:
             from gateway.status import write_runtime_status
-            write_runtime_status(gateway_state="starting", exit_reason=None)
+            # A new PID must not inherit multiplex coverage from the previous
+            # process while its adapters are still starting. The final served
+            # set is written only after secondary startup succeeds.
+            write_runtime_status(
+                gateway_state="starting", exit_reason=None, served_profiles=[]
+            )
         except Exception:
             pass
 
@@ -9386,11 +9391,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         only point that sees every profile's resolved credentials together.
         """
         if not getattr(self.config, "multiplex_profiles", False):
+            # ``write_runtime_status`` merges with the previous record. Clear
+            # coverage explicitly so a multiplex -> single-profile restart
+            # cannot leave the old secondary profiles looking served by the
+            # new live PID.
+            try:
+                from gateway.status import write_runtime_status
+
+                write_runtime_status(served_profiles=[])
+            except Exception:
+                logger.debug("could not clear served_profiles", exc_info=True)
             return 0
 
         try:
             from hermes_cli.profiles import profiles_to_serve, get_active_profile_name
         except Exception:
+            try:
+                from gateway.status import write_runtime_status
+
+                write_runtime_status(served_profiles=[])
+            except Exception:
+                logger.debug("could not clear served_profiles", exc_info=True)
             return 0
 
         active = get_active_profile_name() or "default"

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -94,6 +94,50 @@ class ProfileGatewayProcess:
     pid: int
 
 
+@dataclass(frozen=True)
+class DefaultMultiplexGateway:
+    """A live default-profile gateway and the profiles it currently serves."""
+
+    pid: int
+    served_profiles: tuple[str, ...]
+
+
+def get_default_multiplex_gateway() -> DefaultMultiplexGateway | None:
+    """Return live default-gateway multiplex coverage, if it can be proven.
+
+    ``served_profiles`` is persisted by the running gateway. Treat it as
+    authoritative only when the same runtime record still identifies a live
+    default-profile gateway process; a stale state file must never make a dead
+    gateway look available to secondary profiles.
+    """
+    try:
+        from gateway.status import get_runtime_status_running_pid, read_runtime_status
+        from hermes_constants import get_default_hermes_root
+
+        default_root = get_default_hermes_root()
+        runtime = read_runtime_status(default_root / "gateway_state.json")
+        pid = get_runtime_status_running_pid(runtime, expected_home=default_root)
+        if not pid or not isinstance(runtime, dict):
+            return None
+
+        raw_profiles = runtime.get("served_profiles")
+        if not isinstance(raw_profiles, (list, tuple)):
+            return None
+        served_profiles = tuple(
+            dict.fromkeys(
+                name
+                for value in raw_profiles
+                if isinstance(value, str) and (name := value.strip())
+            )
+        )
+        if len(served_profiles) < 2:
+            return None
+        return DefaultMultiplexGateway(pid=pid, served_profiles=served_profiles)
+    except Exception:
+        logger.debug("Default multiplexer status probe failed", exc_info=True)
+        return None
+
+
 def _get_service_pids() -> set:
     """Return PIDs currently managed by systemd or launchd gateway services.
 
@@ -1452,15 +1496,22 @@ def _gateway_list() -> None:
         return
 
     current = get_active_profile_name()
+    multiplex = get_default_multiplex_gateway()
 
     print("Gateways:")
     for prof in profiles:
-        marker = "✓" if prof.gateway_running else "✗"
+        profile_multiplexer = (
+            multiplex
+            if multiplex is not None and prof.name in multiplex.served_profiles
+            else None
+        )
+        marker = "✓" if prof.gateway_running or profile_multiplexer else "✗"
         label = prof.name
         if prof.name == current:
             label += " (current)"
         parts = [f"  {marker} {label:<24s}"]
         if prof.gateway_running:
+            pid = None
             try:
                 from gateway.status import get_running_pid
 
@@ -1469,6 +1520,12 @@ def _gateway_list() -> None:
                     parts.append(f"PID {pid}")
             except Exception:
                 pass
+            if multiplex and prof.name == "default" and pid == multiplex.pid:
+                parts.append(f"serves {len(multiplex.served_profiles)} profiles")
+        elif profile_multiplexer:
+            parts.append(
+                f"served by default multiplexer (PID {profile_multiplexer.pid})"
+            )
         else:
             parts.append("not running")
         print(" — ".join(parts))
@@ -7185,6 +7242,20 @@ def _gateway_command_inner(args):
         full = getattr(args, "full", False)
         system = getattr(args, "system", False)
         snapshot = get_gateway_runtime_snapshot(system=system)
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            active_profile = get_active_profile_name()
+        except Exception:
+            active_profile = "default"
+        multiplex = get_default_multiplex_gateway()
+        profile_multiplexer = (
+            multiplex
+            if not snapshot.running
+            and multiplex is not None
+            and active_profile in multiplex.served_profiles
+            else None
+        )
 
         # Check for service first
         _windows_service_installed = False
@@ -7192,7 +7263,16 @@ def _gateway_command_inner(args):
             from hermes_cli import gateway_windows
 
             _windows_service_installed = gateway_windows.is_installed()
-        if supports_systemd_services() and (
+        if profile_multiplexer:
+            print(
+                "✓ Gateway is running via the default-profile multiplexer "
+                f"(PID: {profile_multiplexer.pid})"
+            )
+            print(
+                f"  Profiles served: {', '.join(profile_multiplexer.served_profiles)}"
+            )
+            print("  Manage it from the default profile: hermes gateway status")
+        elif supports_systemd_services() and (
             get_systemd_unit_path(system=False).exists()
             or get_systemd_unit_path(system=True).exists()
         ):
@@ -7212,6 +7292,8 @@ def _gateway_command_inner(args):
             if pids:
                 print(f"✓ Gateway is running (PID: {', '.join(map(str, pids))})")
                 print("  (Running manually, not as a system service)")
+                if multiplex and active_profile == "default" and multiplex.pid in pids:
+                    print(f"  Profiles served: {', '.join(multiplex.served_profiles)}")
                 runtime_lines = _runtime_health_lines()
                 if runtime_lines:
                     print()

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -490,21 +490,43 @@ def show_status(args):
     print(color("◆ Gateway Service", Colors.CYAN, Colors.BOLD))
 
     try:
-        from hermes_cli.gateway import get_gateway_runtime_snapshot, _format_gateway_pids
+        from hermes_cli.gateway import (
+            _format_gateway_pids,
+            get_default_multiplex_gateway,
+            get_gateway_runtime_snapshot,
+        )
+        from hermes_cli.profiles import get_active_profile_name
 
         snapshot = get_gateway_runtime_snapshot()
-        is_running = snapshot.running
+        multiplex = get_default_multiplex_gateway()
+        active_profile = get_active_profile_name()
+        profile_multiplexer = (
+            multiplex
+            if not snapshot.running
+            and multiplex is not None
+            and active_profile in multiplex.served_profiles
+            else None
+        )
+        is_running = snapshot.running or bool(profile_multiplexer)
         print(f"  Status:       {check_mark(is_running)} {'running' if is_running else 'stopped'}")
-        print(f"  Manager:      {snapshot.manager}")
-        if snapshot.gateway_pids:
+        manager = "default-profile multiplexer" if profile_multiplexer else snapshot.manager
+        print(f"  Manager:      {manager}")
+        if profile_multiplexer:
+            print(f"  PID(s):       {profile_multiplexer.pid}")
+        elif snapshot.gateway_pids:
             print(f"  PID(s):       {_format_gateway_pids(snapshot.gateway_pids)}")
-        if snapshot.has_process_service_mismatch:
-            print("  Service:      installed but not managing the current running gateway")
-        elif _is_termux() and not snapshot.gateway_pids:
-            print("  Start with:   hermes gateway")
-            print("  Note:         Android may stop background jobs when Termux is suspended")
-        elif snapshot.service_installed and not snapshot.service_running:
-            print("  Service:      installed but stopped")
+        if multiplex and (
+            profile_multiplexer or multiplex.pid in snapshot.gateway_pids
+        ):
+            print(f"  Profiles:     {', '.join(multiplex.served_profiles)}")
+        if not profile_multiplexer:
+            if snapshot.has_process_service_mismatch:
+                print("  Service:      installed but not managing the current running gateway")
+            elif _is_termux() and not snapshot.gateway_pids:
+                print("  Start with:   hermes gateway")
+                print("  Note:         Android may stop background jobs when Termux is suspended")
+            elif snapshot.service_installed and not snapshot.service_running:
+                print("  Service:      installed but stopped")
     except Exception:
         if _is_termux():
             print(f"  Status:       {color('unknown', Colors.DIM)}")

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -393,6 +393,23 @@ class TestSecondaryProfileConfigHandling:
     """Secondary config errors degrade only when the profile is safe to skip."""
 
     @pytest.mark.asyncio
+    async def test_nonmultiplex_start_clears_stale_served_profiles(self, monkeypatch):
+        from gateway.config import GatewayConfig
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=False)
+        writes = []
+        monkeypatch.setattr(
+            "gateway.status.write_runtime_status",
+            lambda **kwargs: writes.append(kwargs),
+        )
+
+        connected = await runner._start_secondary_profile_adapters()
+
+        assert connected == 0
+        assert writes == [{"served_profiles": []}]
+
+    @pytest.mark.asyncio
     async def test_secondary_webhook_uses_degradable_error(self, monkeypatch):
         from gateway.run import SecondaryPortBindingConfigError
         from gateway.config import GatewayConfig, Platform, PlatformConfig

--- a/tests/gateway/test_multiplex_lifecycle.py
+++ b/tests/gateway/test_multiplex_lifecycle.py
@@ -29,6 +29,31 @@ class TestServedProfilesStatus:
         finally:
             importlib.reload(status)
 
+    def test_starting_status_clears_prior_multiplex_coverage(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import importlib
+        import gateway.status as status
+
+        importlib.reload(status)
+        try:
+            status.write_runtime_status(
+                gateway_state="running", served_profiles=["default", "coder"]
+            )
+
+            # Mirrors GatewayRunner.start(): the new process clears coverage
+            # before any primary or secondary adapters begin connecting.
+            status.write_runtime_status(
+                gateway_state="starting", exit_reason=None, served_profiles=[]
+            )
+
+            rec = status.read_runtime_status()
+            assert rec.get("gateway_state") == "starting"
+            assert rec.get("served_profiles") == []
+        finally:
+            importlib.reload(status)
+
 
 class TestNamedProfileMultiplexerGuard:
     """_guard_named_profile_under_multiplexer is inert unless all conditions hold."""

--- a/tests/hermes_cli/test_gateway_multiplex_status.py
+++ b/tests/hermes_cli/test_gateway_multiplex_status.py
@@ -1,0 +1,148 @@
+from types import SimpleNamespace
+
+
+def test_default_multiplexer_probe_requires_live_runtime(monkeypatch, tmp_path):
+    from gateway import status as runtime_status
+    from hermes_cli import gateway
+
+    runtime = {
+        "pid": 4321,
+        "gateway_state": "running",
+        "served_profiles": ["default", "coder", "coder", ""],
+    }
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: tmp_path
+    )
+    monkeypatch.setattr(runtime_status, "read_runtime_status", lambda path: runtime)
+    monkeypatch.setattr(
+        runtime_status,
+        "get_runtime_status_running_pid",
+        lambda record, expected_home=None: 4321,
+    )
+
+    coverage = gateway.get_default_multiplex_gateway()
+
+    assert coverage == gateway.DefaultMultiplexGateway(
+        pid=4321, served_profiles=("default", "coder")
+    )
+
+    monkeypatch.setattr(
+        runtime_status,
+        "get_runtime_status_running_pid",
+        lambda record, expected_home=None: None,
+    )
+    assert gateway.get_default_multiplex_gateway() is None
+
+
+def test_gateway_list_marks_profiles_served_by_default_multiplexer(
+    monkeypatch, capsys, tmp_path
+):
+    from gateway import status as runtime_status
+    from hermes_cli import gateway
+    from hermes_cli import profiles as profiles_mod
+
+    profiles = [
+        SimpleNamespace(name="default", path=tmp_path, gateway_running=True),
+        SimpleNamespace(
+            name="coder", path=tmp_path / "profiles" / "coder", gateway_running=False
+        ),
+        SimpleNamespace(
+            name="idle", path=tmp_path / "profiles" / "idle", gateway_running=False
+        ),
+    ]
+    monkeypatch.setattr(profiles_mod, "list_profiles", lambda: profiles)
+    monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "coder")
+    monkeypatch.setattr(runtime_status, "get_running_pid", lambda *a, **k: 4321)
+    monkeypatch.setattr(
+        gateway,
+        "get_default_multiplex_gateway",
+        lambda: gateway.DefaultMultiplexGateway(
+            pid=4321, served_profiles=("default", "coder")
+        ),
+    )
+
+    gateway._gateway_list()
+
+    output = capsys.readouterr().out
+    assert "default" in output
+    assert "PID 4321" in output
+    assert "serves 2 profiles" in output
+    assert "coder (current)" in output
+    assert "served by default multiplexer (PID 4321)" in output
+    assert "✗ idle" in output and "not running" in output
+
+
+def test_gateway_status_reports_secondary_profile_coverage(monkeypatch, capsys):
+    from hermes_cli import gateway
+    from hermes_cli import profiles as profiles_mod
+
+    monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "coder")
+    monkeypatch.setattr(
+        gateway,
+        "get_gateway_runtime_snapshot",
+        lambda system=False: gateway.GatewayRuntimeSnapshot(manager="manual process"),
+    )
+    monkeypatch.setattr(
+        gateway,
+        "get_default_multiplex_gateway",
+        lambda: gateway.DefaultMultiplexGateway(
+            pid=4321, served_profiles=("default", "coder")
+        ),
+    )
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "is_windows", lambda: False)
+    monkeypatch.setattr(gateway, "_print_other_profiles_gateway_status", lambda: None)
+
+    gateway.gateway_command(
+        SimpleNamespace(gateway_command="status", deep=False, full=False, system=False)
+    )
+
+    output = capsys.readouterr().out
+    assert "running via the default-profile multiplexer (PID: 4321)" in output
+    assert "Profiles served: default, coder" in output
+    assert "Gateway is not running" not in output
+
+
+def test_hermes_status_reports_secondary_profile_coverage(
+    monkeypatch, capsys, tmp_path
+):
+    from hermes_cli import gateway
+    from hermes_cli import profiles as profiles_mod
+    from hermes_cli import status as status_mod
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env")
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "test-model"})
+    monkeypatch.setattr(
+        status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex"
+    )
+    monkeypatch.setattr(
+        status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex"
+    )
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex")
+    monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "coder")
+    monkeypatch.setattr(
+        gateway,
+        "get_gateway_runtime_snapshot",
+        lambda: gateway.GatewayRuntimeSnapshot(manager="manual process"),
+    )
+    monkeypatch.setattr(
+        gateway,
+        "get_default_multiplex_gateway",
+        lambda: gateway.DefaultMultiplexGateway(
+            pid=4321, served_profiles=("default", "coder")
+        ),
+    )
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    gateway_section = capsys.readouterr().out.split("◆ Gateway Service", 1)[1].split(
+        "◆ Scheduled Jobs", 1
+    )[0]
+    assert "Status:       ✓ running" in gateway_section
+    assert "Manager:      default-profile multiplexer" in gateway_section
+    assert "PID(s):       4321" in gateway_section
+    assert "Profiles:     default, coder" in gateway_section
+    assert "stopped" not in gateway_section


### PR DESCRIPTION
## Summary

- report named profiles as running when they are covered by a live default-profile gateway multiplexer
- gate multiplex coverage on a live PID and clear stale coverage during startup and when multiplexing is disabled
- add regression coverage for `hermes gateway list`, `hermes gateway status`, and `hermes status`

## Verification

- 63 focused tests passed on the final amended commit
- 137 multiplex/status tests passed in the prior focused run
- Ruff passed
- Independent verification passed
- Broader run: 260 passed, 1 skipped; remaining host-only failures were reproduced on the baseline