### PR TITLE
feat(cli): add structured usage reporting

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -9,7 +9,12 @@ from typing import TYPE_CHECKING, Any, Optional
 import httpx
 
 from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
-from hermes_cli.auth import AuthError, _read_codex_tokens, resolve_codex_runtime_credentials
+from hermes_cli.auth import (
+    AuthError,
+    _read_codex_tokens,
+    is_rate_limited_auth_error,
+    resolve_codex_runtime_credentials,
+)
 from hermes_cli.runtime_provider import resolve_runtime_provider
 
 if TYPE_CHECKING:
@@ -28,6 +33,14 @@ class AccountUsageWindow:
     used_percent: Optional[float] = None
     reset_at: Optional[datetime] = None
     detail: Optional[str] = None
+    id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class AccountUsageMetric:
+    name: str
+    value: float
+    unit: str = "usd"
 
 
 @dataclass(frozen=True)
@@ -40,6 +53,7 @@ class AccountUsageSnapshot:
     windows: tuple[AccountUsageWindow, ...] = ()
     details: tuple[str, ...] = ()
     unavailable_reason: Optional[str] = None
+    metrics: tuple[AccountUsageMetric, ...] = ()
 
     @property
     def available(self) -> bool:
@@ -479,6 +493,7 @@ def _resolve_codex_usage_credentials(
     # The ``account_id`` (for the ``ChatGPT-Account-Id`` header) is read
     # best-effort: a partial/missing singleton token store must not sink an
     # otherwise-usable resolver credential and force a header-less pool fallback.
+    resolver_error: Optional[AuthError] = None
     try:
         creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
         account_id: Optional[str] = None
@@ -490,7 +505,8 @@ def _resolve_codex_usage_credentials(
             # Pool-only creds carry no singleton account_id; header is optional.
             logger.debug("codex ▸ /usage account_id read failed (best-effort)", exc_info=True)
         return creds["api_key"], str(creds.get("base_url", "") or "").strip(), account_id
-    except AuthError:
+    except AuthError as exc:
+        resolver_error = exc
         logger.debug("codex ▸ /usage runtime resolver returned no creds; trying pool", exc_info=True)
 
     # Tier 3: direct pool select. Reached only when the resolver itself raises
@@ -503,7 +519,14 @@ def _resolve_codex_usage_credentials(
     pool = load_pool("openai-codex")
     entry = pool.select()
     if entry is None:
-        raise RuntimeError("No available openai-codex credential in credential pool")
+        if resolver_error is not None and is_rate_limited_auth_error(resolver_error):
+            raise resolver_error
+        raise AuthError(
+            "No available openai-codex credential in credential pool",
+            provider="openai-codex",
+            code="credentials_missing",
+            relogin_required=True,
+        )
     return entry.runtime_api_key, str(entry.runtime_base_url or base_url or "").strip(), None
 
 
@@ -525,19 +548,24 @@ def _fetch_codex_account_usage(
     payload = response.json() or {}
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
-    for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
+    for key, window_id, label in (
+        ("primary_window", "five_hour", "Session"),
+        ("secondary_window", "weekly", "Weekly"),
+    ):
         window = rate_limit.get(key) or {}
         used = window.get("used_percent")
         if used is None:
             continue
         windows.append(
             AccountUsageWindow(
+                id=window_id,
                 label=label,
                 used_percent=float(used),
                 reset_at=_parse_dt(window.get("reset_at")),
             )
         )
     details: list[str] = []
+    metrics: list[AccountUsageMetric] = []
     reset_credits = payload.get("rate_limit_reset_credits") or {}
     banked = reset_credits.get("available_count")
     if isinstance(banked, (int, float)) and int(banked) > 0:
@@ -551,6 +579,7 @@ def _fetch_codex_account_usage(
         balance = credits.get("balance")
         if isinstance(balance, (int, float)):
             details.append(f"Credits balance: ${float(balance):.2f}")
+            metrics.append(AccountUsageMetric("credit_balance", float(balance)))
         elif credits.get("unlimited"):
             details.append("Credits balance: unlimited")
     return AccountUsageSnapshot(
@@ -559,6 +588,7 @@ def _fetch_codex_account_usage(
         fetched_at=_utc_now(),
         plan=_title_case_slug(payload.get("plan_type")),
         windows=tuple(windows),
+        metrics=tuple(metrics),
         details=tuple(details),
     )
 
@@ -773,6 +803,7 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
         used = float(util) * 100 if float(util) <= 1 else float(util)
         windows.append(
             AccountUsageWindow(
+                id=key,
                 label=label,
                 used_percent=used,
                 reset_at=_parse_dt(window.get("resets_at")),
@@ -825,7 +856,9 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
             key_data = {}
     total_credits = float(credits.get("total_credits") or 0.0)
     total_usage = float(credits.get("total_usage") or 0.0)
-    details = [f"Credits balance: ${max(0.0, total_credits - total_usage):.2f}"]
+    credit_balance = max(0.0, total_credits - total_usage)
+    details = [f"Credits balance: ${credit_balance:.2f}"]
+    metrics = [AccountUsageMetric("credit_balance", round(credit_balance, 10))]
     windows: list[AccountUsageWindow] = []
     limit = key_data.get("limit")
     limit_remaining = key_data.get("limit_remaining")
@@ -845,12 +878,14 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
             detail_parts.append(f"resets {limit_reset}")
         windows.append(
             AccountUsageWindow(
+                id="api_key_quota",
                 label="API key quota",
                 used_percent=used_percent,
                 detail=" • ".join(detail_parts),
             )
         )
     if isinstance(usage, (int, float)):
+        metrics.append(AccountUsageMetric("api_key_usage_total", float(usage)))
         usage_parts = [f"API key usage: ${float(usage):.2f} total"]
         for value, label in (
             (key_data.get("usage_daily"), "today"),
@@ -860,11 +895,20 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
             if isinstance(value, (int, float)) and float(value) > 0:
                 usage_parts.append(f"${float(value):.2f} {label}")
         details.append(" • ".join(usage_parts))
+    for key, name in (
+        ("usage_daily", "api_key_usage_daily"),
+        ("usage_weekly", "api_key_usage_weekly"),
+        ("usage_monthly", "api_key_usage_monthly"),
+    ):
+        value = key_data.get(key)
+        if isinstance(value, (int, float)):
+            metrics.append(AccountUsageMetric(name, float(value)))
     return AccountUsageSnapshot(
         provider="openrouter",
         source="credits_api",
         fetched_at=_utc_now(),
         windows=tuple(windows),
+        metrics=tuple(metrics),
         details=tuple(details),
     )
 
@@ -874,6 +918,7 @@ def fetch_account_usage(
     *,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
+    report_failures: bool = False,
 ) -> Optional[AccountUsageSnapshot]:
     normalized = str(provider or "").strip().lower()
     if normalized in {"", "auto", "custom"}:
@@ -885,6 +930,24 @@ def fetch_account_usage(
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
+    except AuthError as exc:
+        if not is_rate_limited_auth_error(exc):
+            return None
+        if report_failures:
+            return AccountUsageSnapshot(
+                provider=normalized,
+                source="provider_api",
+                fetched_at=_utc_now(),
+                unavailable_reason="Provider usage could not be fetched.",
+            )
+        return None
     except Exception:
+        if report_failures:
+            return AccountUsageSnapshot(
+                provider=normalized,
+                source="provider_api",
+                fetched_at=_utc_now(),
+                unavailable_reason="Provider usage could not be fetched.",
+            )
         return None
     return None

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -435,6 +435,7 @@ from hermes_cli.subcommands.memory import build_memory_parser
 from hermes_cli.subcommands.acp import build_acp_parser
 from hermes_cli.subcommands.tools import build_tools_parser
 from hermes_cli.subcommands.insights import build_insights_parser
+from hermes_cli.usage import build_usage_parser
 from hermes_cli.subcommands.skills import build_skills_parser
 from hermes_cli.subcommands.pairing import build_pairing_parser
 from hermes_cli.subcommands.plugins import build_plugins_parser
@@ -13100,7 +13101,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "model", "pairing", "pets", "plugins", "portal", "postinstall", "profile",
         "project", "proxy",
         "prompt-size",
-        "send", "sessions", "setup",
+        "send", "sessions", "setup", "usage",
         "skin", "skills", "slack", "status", "tools", "uninstall", "update",
         "version", "webhook", "whatsapp", "whatsapp-cloud", "chat", "secrets", "security",
         # Help-ish invocations — plugin commands not being listed in
@@ -15353,6 +15354,11 @@ def main():
     # insights command  (parser built in hermes_cli/subcommands/insights.py)
     # =========================================================================
     build_insights_parser(subparsers, cmd_insights=cmd_insights)
+
+    # =========================================================================
+    # usage command
+    # =========================================================================
+    build_usage_parser(subparsers)
 
     # =========================================================================
     # claw command  (parser built in hermes_cli/subcommands/claw.py)

--- a/hermes_cli/usage.py
+++ b/hermes_cli/usage.py
@@ -1,0 +1,543 @@
+"""Standalone human and JSON account/session usage reporting."""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+from contextlib import redirect_stderr, redirect_stdout
+from datetime import datetime, timezone
+from io import StringIO
+from typing import Any
+
+from agent.account_usage import fetch_account_usage
+from hermes_cli.nous_account import get_nous_portal_account_info
+from hermes_state import SessionDB
+
+SCHEMA_VERSION = 1
+V1_PROVIDER_METRICS = frozenset({
+    "credit_balance",
+    "api_key_usage_total",
+    "api_key_usage_daily",
+    "api_key_usage_weekly",
+    "api_key_usage_monthly",
+})
+
+
+def build_usage_parser(subparsers, *, cmd_usage_handler=None):
+    """Register the standalone ``hermes usage`` command."""
+    parser = subparsers.add_parser(
+        "usage",
+        help="Show local session usage and live account allowances",
+        description=(
+            "Show provider and Nous Portal usage using live network account checks. "
+            "Without --session or --latest-session, this command does not select a "
+            "persisted session. Use --json for schema-versioned JSON."
+        ),
+    )
+    selectors = parser.add_mutually_exclusive_group()
+    selectors.add_argument(
+        "--session",
+        metavar="ID",
+        help="Include a persisted session by exact ID or unique prefix",
+    )
+    selectors.add_argument(
+        "--latest-session",
+        action="store_true",
+        help="Include the latest visible, non-cron session",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the stable schema-versioned JSON envelope",
+    )
+    parser.set_defaults(func=cmd_usage_handler or cmd_usage)
+    return parser
+
+
+def _rfc3339_utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _empty_session(status: str = "not_requested") -> dict[str, Any]:
+    return {
+        "status": status,
+        "kind": None,
+        "id": None,
+        "source": None,
+        "model": None,
+        "provider": None,
+        "started_at": None,
+        "ended_at": None,
+        "duration_seconds": None,
+        "message_count": None,
+        "api_calls": None,
+        "tokens": {
+            "input": None,
+            "output": None,
+            "reasoning": None,
+            "prompt": None,
+            "completion": None,
+            "total": None,
+        },
+        "context": {
+            "status": "not_applicable",
+            "used_tokens": None,
+            "limit_tokens": None,
+            "used_percent": None,
+            "compression_count": None,
+            "breakdown_status": "not_applicable",
+            "breakdown": [],
+        },
+    }
+
+
+def _empty_provider_account(
+    status: str = "not_configured", provider: str | None = None
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "provider": provider,
+        "plan": None,
+        "fetched_at": None,
+        "windows": [],
+        "metrics": [],
+    }
+
+
+def _empty_nous_account(status: str = "not_connected") -> dict[str, Any]:
+    return {
+        "status": status,
+        "access": None,
+        "plan": None,
+        "fetched_at": None,
+        "subscription": {
+            "remaining_usd": None,
+            "allowance_usd": None,
+            "used_percent": None,
+            "renews_at": None,
+        },
+        "topup": {"remaining_usd": None},
+        "total_spendable_usd": None,
+    }
+
+
+def _resolve_configured_provider() -> str | None:
+    from hermes_cli.auth import AuthError, resolve_provider
+    from hermes_cli.config import load_config
+
+    configured = ((load_config().get("model") or {}).get("provider") or "").strip()
+    try:
+        return resolve_provider(configured or None)
+    except AuthError as exc:
+        if exc.code == "no_provider_configured":
+            return None
+        raise
+
+
+def _warning(code: str, source: str, message: str) -> dict[str, str]:
+    return {"code": code, "source": source, "message": message}
+
+
+def _collect_nous_account(warnings: list[dict[str, str]]) -> dict[str, Any]:
+    try:
+        account = get_nous_portal_account_info(force_fresh=True)
+    except TimeoutError:
+        warnings.append(
+            _warning("nous_timeout", "nous", "Nous Portal usage timed out.")
+        )
+        return _empty_nous_account("unavailable")
+    except Exception:
+        warnings.append(
+            _warning("nous_unavailable", "nous", "Nous Portal usage is unavailable.")
+        )
+        return _empty_nous_account("unavailable")
+    if not account.logged_in:
+        if (
+            account.source == "inference_key"
+            and account.error == "portal_oauth_missing"
+        ):
+            return _empty_nous_account("not_connected")
+        if account.error:
+            warnings.append(
+                _warning(
+                    "nous_unavailable", "nous", "Nous Portal usage is unavailable."
+                )
+            )
+            return _empty_nous_account("unavailable")
+        return _empty_nous_account("not_connected")
+    if account.error:
+        warnings.append(
+            _warning("nous_unavailable", "nous", "Nous Portal usage is unavailable.")
+        )
+        return _empty_nous_account("unavailable")
+
+    result = _empty_nous_account("ok")
+    result["fetched_at"] = _rfc3339_utc_now()
+    subscription = account.subscription
+    access_info = account.paid_service_access_info
+    allowance = getattr(subscription, "monthly_credits", None)
+    remaining = getattr(access_info, "subscription_credits_remaining", None)
+    if remaining is None:
+        remaining = getattr(subscription, "credits_remaining", None)
+    topup = getattr(access_info, "purchased_credits_remaining", None)
+    total = getattr(access_info, "total_usable_credits", None)
+    has_subscription = bool(
+        getattr(access_info, "has_active_subscription", False)
+        or (isinstance(allowance, (int, float)) and allowance > 0)
+    )
+    has_topup = isinstance(topup, (int, float)) and topup > 0
+
+    if has_subscription and has_topup:
+        access = "subscription_and_topup"
+    elif has_subscription and account.paid_service_access is True:
+        access = "subscription"
+    elif has_topup:
+        access = "topup_only"
+    elif account.paid_service_access is False:
+        access = "depleted" if has_subscription else "free"
+    else:
+        access = "unknown"
+        result["status"] = "partial"
+
+    result["access"] = access
+    result["plan"] = getattr(subscription, "plan", None)
+    result["subscription"]["remaining_usd"] = _finite_number(remaining)
+    result["subscription"]["allowance_usd"] = _finite_number(allowance)
+    if (
+        result["subscription"]["allowance_usd"] is not None
+        and result["subscription"]["allowance_usd"] > 0
+        and result["subscription"]["remaining_usd"] is not None
+    ):
+        used = (
+            1
+            - result["subscription"]["remaining_usd"]
+            / result["subscription"]["allowance_usd"]
+        ) * 100
+        result["subscription"]["used_percent"] = min(100.0, max(0.0, used))
+    result["subscription"]["renews_at"] = _rfc3339_timestamp(
+        getattr(subscription, "current_period_end", None)
+    )
+    result["topup"]["remaining_usd"] = _finite_number(topup)
+    result["total_spendable_usd"] = _finite_number(total)
+    if result["total_spendable_usd"] is None:
+        amounts = (
+            result["subscription"]["remaining_usd"],
+            result["topup"]["remaining_usd"],
+        )
+        if any(value is not None for value in amounts):
+            result["total_spendable_usd"] = sum(value or 0.0 for value in amounts)
+    if result["total_spendable_usd"] is None and access in {"free", "depleted"}:
+        result["total_spendable_usd"] = 0.0
+    return result
+
+
+def _finite_number(value: Any) -> float | None:
+    if isinstance(value, (int, float)) and math.isfinite(float(value)):
+        return float(value)
+    return None
+
+
+def _timestamp(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        return (
+            datetime
+            .fromtimestamp(float(value), timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _rfc3339_timestamp(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _persisted_session(row: dict[str, Any]) -> dict[str, Any]:
+    result = _empty_session("ok")
+    started_at = _timestamp(row.get("started_at"))
+    ended_at = _timestamp(row.get("ended_at"))
+    duration = None
+    if row.get("started_at") is not None and row.get("ended_at") is not None:
+        duration = max(0.0, float(row["ended_at"]) - float(row["started_at"]))
+    result.update({
+        "kind": "persisted",
+        "id": row.get("id"),
+        "source": row.get("source"),
+        "model": row.get("model"),
+        "provider": row.get("billing_provider"),
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "duration_seconds": duration,
+        "message_count": row.get("message_count"),
+        "api_calls": row.get("api_call_count"),
+    })
+    result["tokens"].update({
+        "input": row.get("input_tokens"),
+        "output": row.get("output_tokens"),
+        "reasoning": row.get("reasoning_tokens"),
+    })
+    return result
+
+
+def _select_session(
+    session_id: str | None, latest_session: bool
+) -> tuple[dict[str, Any], int]:
+    if session_id is None and not latest_session:
+        return _empty_session(), 0
+    if session_id == "":
+        return _empty_session("not_found"), 2
+
+    db = SessionDB()
+    try:
+        row = None
+        if latest_session:
+            rows = db.list_sessions_rich(
+                exclude_sources=["cron"],
+                limit=1,
+                min_message_count=1,
+                order_by_last_active=True,
+                compact_rows=True,
+            )
+            projected = rows[0] if rows else None
+            if projected is None:
+                return _empty_session("not_found"), 2
+            row = db.get_session(projected["id"])
+            if row is None:
+                return _empty_session("not_found"), 2
+        else:
+            resolved_id = db.resolve_session_id(session_id or "")
+            if resolved_id is None:
+                matches = db.find_session_ids_by_prefix(session_id or "", limit=2)
+                if len(matches) > 1:
+                    return _empty_session("ambiguous"), 2
+                if not matches:
+                    return _empty_session("not_found"), 2
+                resolved_id = matches[0]
+            row = db.get_session(resolved_id)
+            if row is None:
+                return _empty_session("not_found"), 2
+        route = db.get_latest_main_model_usage(row["id"])
+        if route:
+            row = dict(row)
+            row["model"] = route.get("model") or row.get("model")
+            row["billing_provider"] = route.get("billing_provider") or row.get(
+                "billing_provider"
+            )
+        return _persisted_session(row), 0
+    finally:
+        db.close()
+
+
+def _collect_provider_account(
+    provider: str | None, warnings: list[dict[str, str]]
+) -> dict[str, Any]:
+    if not provider:
+        return _empty_provider_account("not_configured")
+    if provider not in {"openai-codex", "anthropic", "openrouter"}:
+        return _empty_provider_account("unsupported", provider)
+    snapshot = fetch_account_usage(provider, report_failures=True)
+    if snapshot is None:
+        return _empty_provider_account("unauthenticated", provider)
+    if snapshot.unavailable_reason:
+        warnings.append(
+            _warning(
+                "provider_unavailable",
+                "provider",
+                f"{provider} account usage is unavailable.",
+            )
+        )
+        result = _empty_provider_account("unavailable", provider)
+        result["fetched_at"] = _timestamp(snapshot.fetched_at.timestamp())
+        return result
+
+    result = _empty_provider_account("ok", provider)
+    result["plan"] = snapshot.plan
+    result["fetched_at"] = _timestamp(snapshot.fetched_at.timestamp())
+    for window in snapshot.windows:
+        used = window.used_percent
+        if used is not None and math.isfinite(float(used)):
+            used = min(100.0, max(0.0, float(used)))
+        else:
+            used = None
+        result["windows"].append({
+            "id": window.id,
+            "label": window.label,
+            "used_percent": used,
+            "remaining_percent": None if used is None else 100.0 - used,
+            "resets_at": (
+                _timestamp(window.reset_at.timestamp()) if window.reset_at else None
+            ),
+        })
+    for metric in snapshot.metrics:
+        if metric.name in V1_PROVIDER_METRICS and math.isfinite(float(metric.value)):
+            result["metrics"].append({
+                "name": metric.name,
+                "value": float(metric.value),
+                "unit": "usd",
+            })
+    return result
+
+
+def collect_usage(
+    *, session_id: str | None = None, latest_session: bool = False
+) -> tuple[dict[str, Any], int]:
+    warnings: list[dict[str, str]] = []
+    try:
+        session, exit_code = _select_session(session_id, latest_session)
+    except Exception:
+        session = _empty_session("unavailable")
+        exit_code = 1
+        warnings.append(
+            _warning("session_unavailable", "session", "Session usage is unavailable.")
+        )
+    if exit_code == 2:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": _rfc3339_utc_now(),
+            "session": session,
+            "accounts": {
+                "provider": _empty_provider_account("not_requested"),
+                "nous": _empty_nous_account("not_requested"),
+            },
+            "warnings": [],
+        }, exit_code
+
+    if session["status"] == "ok":
+        provider = session["provider"]
+    elif session["status"] == "not_requested":
+        provider = _resolve_configured_provider()
+    else:
+        provider = None
+    accounts = {
+        "provider": _collect_provider_account(provider, warnings),
+        "nous": _collect_nous_account(warnings),
+    }
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": _rfc3339_utc_now(),
+        "session": session,
+        "accounts": accounts,
+        "warnings": warnings,
+    }
+    return report, exit_code
+
+
+def render_human(report: dict[str, Any]) -> str:
+    """Render the canonical report without exposing raw provider payloads."""
+    session = report["session"]
+    provider = report["accounts"]["provider"]
+    nous = report["accounts"]["nous"]
+    lines = ["Session usage"]
+    if session["status"] == "ok":
+        lines.extend([
+            f"  Session: {session['id']} ({session['source'] or 'unknown'})",
+            f"  Route: {session['provider'] or 'unknown'} / {session['model'] or 'unknown'}",
+            f"  API calls: {_display(session['api_calls'])}",
+            (
+                "  Tokens: "
+                f"{_display(session['tokens']['input'])} input, "
+                f"{_display(session['tokens']['output'])} output, "
+                f"{_display(session['tokens']['reasoning'])} reasoning"
+            ),
+            "  Context: not applicable for persisted standalone sessions",
+        ])
+    elif session["status"] == "not_requested":
+        lines.append("  Not requested. Use --session ID or --latest-session.")
+    else:
+        lines.append(f"  {session['status'].replace('_', ' ')}")
+
+    lines.extend(["", "Provider account"])
+    if provider["status"] == "ok":
+        heading = provider["provider"]
+        if provider["plan"]:
+            heading += f" ({provider['plan']})"
+        lines.append(f"  {heading}")
+        for window in provider["windows"]:
+            remaining = window["remaining_percent"]
+            summary = window["label"]
+            if remaining is not None:
+                summary += f": {remaining:g}% remaining"
+            if window["resets_at"]:
+                summary += f", resets {window['resets_at']}"
+            lines.append(f"  {summary}")
+        for metric in provider["metrics"]:
+            lines.append(f"  {metric['name']}: {metric['value']:g} {metric['unit']}")
+    elif provider["status"] == "not_configured":
+        lines.append(
+            "  No runtime provider configured. Run hermes login or hermes model."
+        )
+    elif provider["status"] == "unauthenticated":
+        lines.append("  Provider is not authenticated. Run hermes login.")
+    else:
+        lines.append(f"  {provider['status'].replace('_', ' ')}")
+
+    lines.extend(["", "Nous Portal"])
+    if nous["status"] in {"ok", "partial"}:
+        lines.append(f"  Access: {nous['access'] or 'partial'}")
+        if nous["plan"]:
+            lines.append(f"  Plan: {nous['plan']}")
+        if nous["total_spendable_usd"] is not None:
+            lines.append(f"  Spendable: ${nous['total_spendable_usd']:.2f}")
+    elif nous["status"] == "not_connected":
+        lines.append("  Not connected. Run hermes login nous.")
+    else:
+        lines.append(f"  {nous['status'].replace('_', ' ')}")
+
+    if report["warnings"]:
+        lines.extend(["", "Warnings"])
+        lines.extend(f"  {warning['message']}" for warning in report["warnings"])
+    return "\n".join(lines)
+
+
+def _display(value: Any) -> str:
+    return "unknown" if value is None else f"{value:,}"
+
+
+def _run_usage_command(args) -> tuple[dict[str, Any], int]:
+    try:
+        return collect_usage(
+            session_id=getattr(args, "session", None),
+            latest_session=bool(getattr(args, "latest_session", False)),
+        )
+    except Exception:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": _rfc3339_utc_now(),
+            "session": _empty_session("unavailable"),
+            "accounts": {
+                "provider": _empty_provider_account("unavailable"),
+                "nous": _empty_nous_account("unavailable"),
+            },
+            "warnings": [
+                _warning(
+                    "usage_unavailable", "usage", "Usage reporting is unavailable."
+                )
+            ],
+        }, 1
+
+
+def cmd_usage(args) -> None:
+    if args.json:
+        with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+            report, exit_code = _run_usage_command(args)
+    else:
+        report, exit_code = _run_usage_command(args)
+    if args.json:
+        print(json.dumps(report, allow_nan=False))
+    else:
+        print(render_human(report))
+        if exit_code == 1:
+            print("Usage reporting encountered a local error.", file=sys.stderr)
+    raise SystemExit(exit_code)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3348,21 +3348,41 @@ class SessionDB:
         if exact:
             return exact["id"]
 
+        matches = self.find_session_ids_by_prefix(session_id_or_prefix, limit=2)
+        if len(matches) == 1:
+            return matches[0]
+        return None
+
+    def find_session_ids_by_prefix(
+        self, session_id_prefix: str, *, limit: int = 2
+    ) -> List[str]:
+        """Return session IDs matching a literal prefix, newest first."""
         escaped = (
-            session_id_or_prefix
+            session_id_prefix
             .replace("\\", "\\\\")
             .replace("%", "\\%")
             .replace("_", "\\_")
         )
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT id FROM sessions WHERE id LIKE ? ESCAPE '\\' ORDER BY started_at DESC LIMIT 2",
-                (f"{escaped}%",),
-            )
-            matches = [row["id"] for row in cursor.fetchall()]
-        if len(matches) == 1:
-            return matches[0]
-        return None
+            rows = self._conn.execute(
+                "SELECT id FROM sessions WHERE id LIKE ? ESCAPE '\\' "
+                "ORDER BY started_at DESC LIMIT ?",
+                (f"{escaped}%", limit),
+            ).fetchall()
+        return [row["id"] for row in rows]
+
+    def get_latest_main_model_usage(
+        self, session_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Return the session's most recently active main-loop model route."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM session_model_usage "
+                "WHERE session_id = ? AND task = '' "
+                "ORDER BY last_seen DESC, first_seen DESC LIMIT 1",
+                (session_id,),
+            ).fetchone()
+        return dict(row) if row else None
 
     # Maximum length for session titles
     MAX_TITLE_LENGTH = 100

--- a/tests/hermes_cli/test_usage_command.py
+++ b/tests/hermes_cli/test_usage_command.py
@@ -1,0 +1,770 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+import pytest
+
+from agent.account_usage import (
+    AccountUsageMetric,
+    AccountUsageSnapshot,
+    AccountUsageWindow,
+)
+from hermes_state import SessionDB
+from hermes_cli import usage
+from hermes_cli.auth import AuthError
+from hermes_cli.nous_account import (
+    NousPaidServiceAccessInfo,
+    NousPortalAccountInfo,
+    NousPortalSubscriptionInfo,
+)
+
+
+def test_default_json_report_does_not_select_a_persisted_session(monkeypatch, capsys):
+    monkeypatch.setattr(
+        usage,
+        "SessionDB",
+        lambda: pytest.fail("default usage must not open the session database"),
+    )
+    monkeypatch.setattr(usage, "_resolve_configured_provider", lambda: None)
+    monkeypatch.setattr(
+        usage, "_collect_nous_account", lambda warnings: usage._empty_nous_account()
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        usage.cmd_usage(
+            argparse.Namespace(json=True, session=None, latest_session=False)
+        )
+
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+    assert exc.value.code == 0
+    assert captured.err == ""
+    assert report["schema_version"] == 1
+    assert report["session"]["status"] == "not_requested"
+    assert report["session"]["id"] is None
+    assert report["accounts"]["provider"]["status"] == "not_configured"
+    assert report["warnings"] == []
+
+
+def _run_json(args, capsys):
+    with pytest.raises(SystemExit) as exc:
+        usage.cmd_usage(args)
+    captured = capsys.readouterr()
+    return exc.value.code, json.loads(captured.out), captured.err
+
+
+def test_session_selectors_are_explicit_and_latest_uses_user_facing_projection(
+    tmp_path, monkeypatch, capsys
+):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("visible-older", source="tui")
+    db.append_message("visible-older", "user", "hello")
+    db.create_session("visible-newest", source="cli")
+    db.append_message("visible-newest", "user", "hello")
+    db.create_session("cron-newest", source="cron")
+    db.append_message("cron-newest", "user", "scheduled")
+    db.create_session("shared-prefix-one", source="cli")
+    db.create_session("shared-prefix-two", source="cli")
+
+    monkeypatch.setattr(usage, "SessionDB", lambda: db)
+    monkeypatch.setattr(db, "close", lambda: None)
+    monkeypatch.setattr(
+        usage,
+        "_resolve_configured_provider",
+        lambda: pytest.fail(
+            "selected providerless sessions must not use runtime config"
+        ),
+    )
+    monkeypatch.setattr(
+        usage, "_collect_nous_account", lambda warnings: usage._empty_nous_account()
+    )
+
+    code, exact, err = _run_json(
+        argparse.Namespace(json=True, session="visible-older", latest_session=False),
+        capsys,
+    )
+    assert (code, err) == (0, "")
+    assert exact["session"]["id"] == "visible-older"
+
+    code, prefix, _ = _run_json(
+        argparse.Namespace(json=True, session="visible-new", latest_session=False),
+        capsys,
+    )
+    assert code == 0
+    assert prefix["session"]["id"] == "visible-newest"
+
+    code, latest, _ = _run_json(
+        argparse.Namespace(json=True, session=None, latest_session=True), capsys
+    )
+    assert code == 0
+    assert latest["session"]["id"] == "visible-newest"
+
+    monkeypatch.setattr(
+        usage,
+        "_collect_provider_account",
+        lambda provider: pytest.fail("invalid selectors must not start account calls"),
+        raising=False,
+    )
+    code, missing, _ = _run_json(
+        argparse.Namespace(json=True, session="missing", latest_session=False), capsys
+    )
+    assert code == 2
+    assert missing["session"]["status"] == "not_found"
+    assert missing["accounts"]["provider"]["status"] == "not_requested"
+    assert missing["accounts"]["nous"]["status"] == "not_requested"
+
+    code, empty, _ = _run_json(
+        argparse.Namespace(json=True, session="", latest_session=False), capsys
+    )
+    assert code == 2
+    assert empty["session"]["status"] == "not_found"
+
+    code, ambiguous, _ = _run_json(
+        argparse.Namespace(json=True, session="shared-prefix", latest_session=False),
+        capsys,
+    )
+    assert code == 2
+    assert ambiguous["session"]["status"] == "ambiguous"
+
+    db.close()
+
+
+def test_latest_session_reloads_the_projected_id_for_durable_counters(monkeypatch):
+    class FakeDB:
+        def list_sessions_rich(self, **kwargs):
+            assert kwargs == {
+                "exclude_sources": ["cron"],
+                "limit": 1,
+                "min_message_count": 1,
+                "order_by_last_active": True,
+                "compact_rows": True,
+            }
+            return [{"id": "compression-tip", "api_call_count": 1}]
+
+        def get_session(self, session_id):
+            assert session_id == "compression-tip"
+            return {
+                "id": session_id,
+                "source": "cli",
+                "model": "durable-model",
+                "billing_provider": "anthropic",
+                "message_count": 4,
+                "api_call_count": 3,
+                "input_tokens": 99,
+                "output_tokens": 7,
+                "reasoning_tokens": 2,
+            }
+
+        def get_latest_main_model_usage(self, session_id):
+            return None
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(usage, "SessionDB", FakeDB)
+
+    session, code = usage._select_session(None, True)
+
+    assert code == 0
+    assert session["id"] == "compression-tip"
+    assert session["api_calls"] == 3
+    assert session["tokens"]["input"] == 99
+
+
+def test_latest_compression_continuation_reports_tip_counters(
+    tmp_path, monkeypatch, capsys
+):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id="root", source="cli", model="root-model")
+    db.append_message("root", "user", "root")
+    db.update_token_counts(
+        "root",
+        input_tokens=11,
+        output_tokens=2,
+        api_call_count=1,
+        model="root-model",
+        billing_provider="openrouter",
+    )
+    db.end_session("root", end_reason="compression")
+    db.create_session(
+        session_id="tip",
+        source="cli",
+        model="tip-model",
+        parent_session_id="root",
+    )
+    db.append_message("tip", "user", "tip")
+    db.update_token_counts(
+        "tip",
+        input_tokens=99,
+        output_tokens=8,
+        api_call_count=3,
+        model="tip-model",
+        billing_provider="anthropic",
+    )
+    monkeypatch.setattr(usage, "SessionDB", lambda: db)
+    monkeypatch.setattr(db, "close", lambda: None)
+    monkeypatch.setattr(
+        usage,
+        "_collect_provider_account",
+        lambda provider, warnings: usage._empty_provider_account("ok", provider),
+    )
+    monkeypatch.setattr(
+        usage,
+        "_collect_nous_account",
+        lambda warnings: usage._empty_nous_account(),
+    )
+
+    code, report, err = _run_json(
+        argparse.Namespace(json=True, session=None, latest_session=True), capsys
+    )
+
+    assert (code, err) == (0, "")
+    selected = report["session"]
+    assert selected["id"] == "tip"
+    assert selected["tokens"]["input"] == 99
+    assert selected["api_calls"] == 3
+    assert (selected["provider"], selected["model"]) == (
+        "anthropic",
+        "tip-model",
+    )
+
+
+def test_persisted_session_uses_durable_counters_and_latest_main_route(
+    tmp_path, monkeypatch, capsys
+):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(
+        "persisted",
+        source="discord",
+        model="old-model",
+    )
+    db.update_token_counts(
+        "persisted",
+        input_tokens=10,
+        output_tokens=4,
+        reasoning_tokens=1,
+        api_call_count=1,
+        model="old-model",
+        billing_provider="openrouter",
+    )
+    db.update_token_counts(
+        "persisted",
+        input_tokens=20,
+        output_tokens=6,
+        reasoning_tokens=2,
+        api_call_count=1,
+        model="new-model",
+        billing_provider="anthropic",
+    )
+
+    monkeypatch.setattr(usage, "SessionDB", lambda: db)
+    monkeypatch.setattr(db, "close", lambda: None)
+    monkeypatch.setattr(usage, "_resolve_configured_provider", lambda: "openrouter")
+    provider_calls = []
+    monkeypatch.setattr(
+        usage,
+        "fetch_account_usage",
+        lambda provider, report_failures=True: provider_calls.append(provider),
+    )
+    monkeypatch.setattr(
+        usage, "_collect_nous_account", lambda warnings: usage._empty_nous_account()
+    )
+
+    code, report, err = _run_json(
+        argparse.Namespace(json=True, session="persisted", latest_session=False),
+        capsys,
+    )
+
+    session = report["session"]
+    assert (code, err) == (0, "")
+    assert session["provider"] == "anthropic"
+    assert session["model"] == "new-model"
+    assert session["api_calls"] == 2
+    assert session["tokens"]["input"] == 30
+    assert session["tokens"]["output"] == 10
+    assert session["tokens"]["reasoning"] == 3
+    assert session["tokens"]["prompt"] is None
+    assert session["tokens"]["completion"] is None
+    assert session["tokens"]["total"] is None
+    assert session["duration_seconds"] is None
+    assert session["context"]["status"] == "not_applicable"
+    assert provider_calls == ["anthropic"]
+
+    db.close()
+
+
+def test_account_failure_is_partial_and_structured_provider_data_is_allowlisted(
+    monkeypatch, capsys
+):
+    forbidden = [
+        "secret-token",
+        "user@example.com",
+        "did:privy:private-user",
+        "org-private",
+        "client-private",
+        "product-private",
+        "pool-label-private",
+        "https://private.example/api",
+        "/private/repository/path",
+        "private-branch",
+        "private-session-title",
+        "raw-provider-detail",
+    ]
+    sentinel = " ".join(forbidden)
+    snapshot = AccountUsageSnapshot(
+        provider="openrouter",
+        source="credits_api",
+        fetched_at=datetime(2026, 7, 22, 2, 29, 59, tzinfo=timezone.utc),
+        plan="payg",
+        windows=(
+            AccountUsageWindow(
+                id="api_key_quota",
+                label="API key quota",
+                used_percent=25.0,
+                reset_at=datetime(2026, 8, 1, tzinfo=timezone.utc),
+            ),
+        ),
+        metrics=(
+            AccountUsageMetric("credit_balance", 9.99, unit=sentinel),
+            AccountUsageMetric("api_key_usage_total", float("nan")),
+            AccountUsageMetric("raw-provider-detail", 123.0),
+        ),
+        details=(sentinel,),
+    )
+    monkeypatch.setattr(usage, "SessionDB", lambda: pytest.fail("no selector"))
+    monkeypatch.setattr(usage, "_resolve_configured_provider", lambda: "openrouter")
+    monkeypatch.setattr(
+        usage,
+        "fetch_account_usage",
+        lambda provider, report_failures=True: snapshot,
+    )
+    monkeypatch.setattr(
+        usage,
+        "get_nous_portal_account_info",
+        lambda force_fresh=True: (_ for _ in ()).throw(TimeoutError(sentinel)),
+    )
+
+    code, report, err = _run_json(
+        argparse.Namespace(json=True, session=None, latest_session=False), capsys
+    )
+
+    assert (code, err) == (0, "")
+    assert report["accounts"]["provider"] == {
+        "status": "ok",
+        "provider": "openrouter",
+        "plan": "payg",
+        "fetched_at": "2026-07-22T02:29:59Z",
+        "windows": [
+            {
+                "id": "api_key_quota",
+                "label": "API key quota",
+                "used_percent": 25.0,
+                "remaining_percent": 75.0,
+                "resets_at": "2026-08-01T00:00:00Z",
+            }
+        ],
+        "metrics": [{"name": "credit_balance", "value": 9.99, "unit": "usd"}],
+    }
+    assert report["accounts"]["nous"]["status"] == "unavailable"
+    assert report["warnings"] == [
+        {
+            "code": "nous_timeout",
+            "source": "nous",
+            "message": "Nous Portal usage timed out.",
+        }
+    ]
+    serialized = json.dumps(report, allow_nan=False)
+    assert all(value not in serialized for value in forbidden)
+    assert all(value not in err for value in forbidden)
+
+
+def test_logged_out_nous_error_is_unavailable_with_a_sanitized_warning(monkeypatch):
+    sentinel = "private/path user@example.com"
+    monkeypatch.setattr(
+        usage,
+        "get_nous_portal_account_info",
+        lambda force_fresh=True: NousPortalAccountInfo(
+            logged_in=False,
+            source="account_api",
+            fresh=False,
+            error=sentinel,
+        ),
+    )
+    warnings = []
+
+    result = usage._collect_nous_account(warnings)
+
+    assert result["status"] == "unavailable"
+    assert warnings == [
+        {
+            "code": "nous_unavailable",
+            "source": "nous",
+            "message": "Nous Portal usage is unavailable.",
+        }
+    ]
+    assert sentinel not in json.dumps({"account": result, "warnings": warnings})
+
+
+@pytest.mark.parametrize(
+    ("paid", "has_subscription", "topup", "expected_access", "expected_status"),
+    [
+        (True, True, 5.0, "subscription_and_topup", "ok"),
+        (True, True, 0.0, "subscription", "ok"),
+        (True, False, 5.0, "topup_only", "ok"),
+        (False, False, 0.0, "free", "ok"),
+        (False, True, 0.0, "depleted", "ok"),
+        (True, False, 0.0, "unknown", "partial"),
+    ],
+)
+def test_nous_account_access_states(
+    monkeypatch,
+    paid,
+    has_subscription,
+    topup,
+    expected_access,
+    expected_status,
+):
+    subscription = (
+        NousPortalSubscriptionInfo(
+            plan="Pro",
+            monthly_credits=100.0,
+            credits_remaining=40.0,
+            current_period_end="2026-08-01T02:00:00+02:00",
+        )
+        if has_subscription
+        else None
+    )
+    access = NousPaidServiceAccessInfo(
+        paid_access=paid,
+        has_active_subscription=has_subscription,
+        active_subscription_is_paid=has_subscription,
+        subscription_credits_remaining=(40.0 if has_subscription else None),
+        purchased_credits_remaining=topup,
+        total_usable_credits=(40.0 if has_subscription else 0.0) + topup,
+    )
+    account = NousPortalAccountInfo(
+        logged_in=True,
+        source="account_api",
+        fresh=True,
+        subscription=subscription,
+        paid_service_access=paid,
+        paid_service_access_info=access,
+    )
+    monkeypatch.setattr(
+        usage, "get_nous_portal_account_info", lambda force_fresh=True: account
+    )
+
+    warnings = []
+    result = usage._collect_nous_account(warnings)
+
+    assert warnings == []
+    assert result["status"] == expected_status
+    assert result["access"] == expected_access
+    if has_subscription:
+        assert result["subscription"] == {
+            "remaining_usd": 40.0,
+            "allowance_usd": 100.0,
+            "used_percent": 60.0,
+            "renews_at": "2026-08-01T00:00:00Z",
+        }
+    assert result["topup"]["remaining_usd"] == topup
+
+
+def test_nous_account_helper_can_resolve_credential_pool_auth(monkeypatch):
+    account = NousPortalAccountInfo(
+        logged_in=True,
+        source="account_api",
+        fresh=True,
+        paid_service_access=False,
+        paid_service_access_info=NousPaidServiceAccessInfo(
+            paid_access=False,
+            total_usable_credits=0.0,
+        ),
+    )
+    calls = []
+    monkeypatch.setattr(
+        usage,
+        "get_nous_portal_account_info",
+        lambda force_fresh=True: calls.append(force_fresh) or account,
+    )
+
+    result = usage._collect_nous_account([])
+
+    assert calls == [True]
+    assert result["status"] == "ok"
+    assert result["access"] == "free"
+    assert result["total_spendable_usd"] == 0.0
+
+
+def test_nous_inference_key_without_portal_oauth_is_not_connected(monkeypatch):
+    monkeypatch.setattr(
+        usage,
+        "get_nous_portal_account_info",
+        lambda force_fresh=True: NousPortalAccountInfo(
+            logged_in=False,
+            source="inference_key",
+            fresh=False,
+            error="portal_oauth_missing",
+        ),
+    )
+    warnings = []
+
+    result = usage._collect_nous_account(warnings)
+
+    assert result["status"] == "not_connected"
+    assert warnings == []
+
+
+@pytest.mark.parametrize(
+    ("has_subscription", "expected_access"),
+    [(False, "free"), (True, "depleted")],
+)
+def test_known_free_or_depleted_nous_balance_is_zero(
+    monkeypatch, has_subscription, expected_access
+):
+    monkeypatch.setattr(
+        usage,
+        "get_nous_portal_account_info",
+        lambda force_fresh=True: NousPortalAccountInfo(
+            logged_in=True,
+            source="account_api",
+            fresh=True,
+            paid_service_access=False,
+            paid_service_access_info=NousPaidServiceAccessInfo(
+                paid_access=False,
+                has_active_subscription=has_subscription,
+            ),
+        ),
+    )
+
+    result = usage._collect_nous_account([])
+
+    assert result["status"] == "ok"
+    assert result["access"] == expected_access
+    assert result["total_spendable_usd"] == 0.0
+
+
+def test_usage_parser_registers_mutually_exclusive_session_selectors():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    usage_parser = usage.build_usage_parser(subparsers)
+
+    args = parser.parse_args(["usage", "--json", "--session", "abc"])
+    assert args.command == "usage"
+    assert args.json is True
+    assert args.session == "abc"
+    assert args.latest_session is False
+    assert args.func is usage.cmd_usage
+    help_text = " ".join(usage_parser.format_help().split())
+    assert "does not select a persisted session" in help_text
+    assert "live network account checks" in help_text
+    assert "schema-versioned JSON" in help_text
+
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["usage", "--session", "abc", "--latest-session"])
+    assert exc.value.code == 2
+
+
+def test_json_mode_suppresses_dependency_stdout(monkeypatch, capsys):
+    snapshot = AccountUsageSnapshot(
+        provider="openrouter",
+        source="credits_api",
+        fetched_at=datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(usage, "_resolve_configured_provider", lambda: "openrouter")
+    monkeypatch.setattr(
+        usage,
+        "fetch_account_usage",
+        lambda provider, report_failures=True: (
+            print("credential refresh"),
+            print("credential warning", file=sys.stderr),
+            snapshot,
+        )[-1],
+    )
+    monkeypatch.setattr(
+        usage,
+        "_collect_nous_account",
+        lambda warnings: usage._empty_nous_account(),
+    )
+
+    code, report, err = _run_json(
+        argparse.Namespace(json=True, session=None, latest_session=False), capsys
+    )
+
+    assert (code, err) == (0, "")
+    assert report["schema_version"] == 1
+    assert report["accounts"]["provider"]["status"] == "ok"
+
+
+def test_local_session_failure_is_sanitized_and_operational(monkeypatch, capsys):
+    sentinel = "private/path user@example.com"
+    monkeypatch.setattr(
+        usage, "SessionDB", lambda: (_ for _ in ()).throw(RuntimeError(sentinel))
+    )
+    monkeypatch.setattr(usage, "_resolve_configured_provider", lambda: None)
+    monkeypatch.setattr(
+        usage,
+        "_collect_nous_account",
+        lambda warnings: usage._empty_nous_account(),
+    )
+
+    code, report, err = _run_json(
+        argparse.Namespace(json=True, session="abc", latest_session=False), capsys
+    )
+
+    assert (code, err) == (1, "")
+    assert report["session"]["status"] == "unavailable"
+    assert report["warnings"] == [
+        {
+            "code": "session_unavailable",
+            "source": "session",
+            "message": "Session usage is unavailable.",
+        }
+    ]
+    assert sentinel not in json.dumps(report)
+
+
+def test_unexpected_handler_failure_still_emits_one_sanitized_json_envelope(
+    monkeypatch, capsys
+):
+    sentinel = "private/path user@example.com secret-token"
+    monkeypatch.setattr(
+        usage,
+        "collect_usage",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError(sentinel)),
+    )
+
+    code, report, err = _run_json(
+        argparse.Namespace(json=True, session=None, latest_session=False), capsys
+    )
+
+    assert (code, err) == (1, "")
+    assert report["schema_version"] == 1
+    assert report["session"]["status"] == "unavailable"
+    assert report["accounts"]["provider"]["status"] == "unavailable"
+    assert report["accounts"]["nous"]["status"] == "unavailable"
+    assert report["warnings"] == [
+        {
+            "code": "usage_unavailable",
+            "source": "usage",
+            "message": "Usage reporting is unavailable.",
+        }
+    ]
+    assert sentinel not in json.dumps(report)
+
+
+def test_runtime_provider_resolution_failure_is_a_sanitized_local_failure(
+    monkeypatch, capsys
+):
+    sentinel = "private-config-path user@example.com"
+    monkeypatch.setattr(
+        usage,
+        "_resolve_configured_provider",
+        lambda: (_ for _ in ()).throw(RuntimeError(sentinel)),
+    )
+
+    code, report, err = _run_json(
+        argparse.Namespace(json=True, session=None, latest_session=False), capsys
+    )
+
+    assert (code, err) == (1, "")
+    assert report["session"]["status"] == "unavailable"
+    assert report["warnings"][0]["code"] == "usage_unavailable"
+    assert sentinel not in json.dumps(report)
+
+
+def test_human_report_has_stable_sections_and_actionable_empty_hints(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr(usage, "_resolve_configured_provider", lambda: None)
+    monkeypatch.setattr(
+        usage,
+        "_collect_nous_account",
+        lambda warnings: usage._empty_nous_account(),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        usage.cmd_usage(
+            argparse.Namespace(json=False, session=None, latest_session=False)
+        )
+
+    output = capsys.readouterr().out
+    assert exc.value.code == 0
+    assert "Session usage" in output
+    assert "Provider account" in output
+    assert "Nous Portal" in output
+    assert "--session ID" in output
+    assert "hermes login" in output
+
+
+def test_human_local_failure_writes_only_a_concise_sanitized_error(monkeypatch, capsys):
+    sentinel = "private/path user@example.com secret-token"
+    monkeypatch.setattr(
+        usage,
+        "collect_usage",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError(sentinel)),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        usage.cmd_usage(
+            argparse.Namespace(json=False, session=None, latest_session=False)
+        )
+
+    captured = capsys.readouterr()
+    assert exc.value.code == 1
+    assert captured.err == "Usage reporting encountered a local error.\n"
+    assert sentinel not in captured.out + captured.err
+
+
+def test_runtime_provider_auto_resolves_when_config_has_no_explicit_provider(
+    monkeypatch,
+):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": {}})
+    calls = []
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_provider",
+        lambda requested: calls.append(requested) or "openai-codex",
+    )
+
+    assert usage._resolve_configured_provider() == "openai-codex"
+    assert calls == [None]
+
+
+def test_runtime_provider_no_configuration_is_not_an_operational_failure(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": {}})
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_provider",
+        lambda requested: (_ for _ in ()).throw(
+            AuthError("none configured", code="no_provider_configured")
+        ),
+    )
+
+    assert usage._resolve_configured_provider() is None
+
+
+def test_blank_slate_real_command_returns_not_configured_json(tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+
+    completed = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "usage", "--json"],
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    assert completed.stderr == ""
+    assert completed.stdout.count("\n") == 1
+    report = json.loads(completed.stdout)
+    assert report["session"]["status"] == "not_requested"
+    assert report["accounts"]["provider"]["status"] == "not_configured"

--- a/tests/hermes_cli/test_usage_command.py
+++ b/tests/hermes_cli/test_usage_command.py
@@ -751,6 +751,29 @@ def test_blank_slate_real_command_returns_not_configured_json(tmp_path):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
     env = os.environ.copy()
+    env["OPENROUTER_API_KEY"] = "ambient-provider-credential"
+    credential_suffixes = (
+        "_API_KEY",
+        "_TOKEN",
+        "_SECRET",
+        "_PASSWORD",
+        "_CREDENTIALS",
+        "_ACCESS_KEY",
+        "_SECRET_ACCESS_KEY",
+        "_PRIVATE_KEY",
+        "_OAUTH_TOKEN",
+    )
+    credential_names = {
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "FAL_KEY",
+    }
+    for name in tuple(env):
+        if name in credential_names or name.endswith(credential_suffixes):
+            env.pop(name)
+    env["HOME"] = str(tmp_path)
+    env["USERPROFILE"] = str(tmp_path)
     env["HERMES_HOME"] = str(hermes_home)
 
     completed = subprocess.run(

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -1,11 +1,13 @@
 from datetime import datetime, timezone
 
 from agent.account_usage import (
+    AccountUsageMetric,
     AccountUsageSnapshot,
     AccountUsageWindow,
     fetch_account_usage,
     render_account_usage_lines,
 )
+from hermes_cli.auth import AuthError, CODEX_RATE_LIMITED_CODE
 
 
 class _Response:
@@ -90,9 +92,49 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert snapshot.plan == "Pro"
     assert len(snapshot.windows) == 2
     assert snapshot.windows[0].label == "Session"
+    assert snapshot.windows[0].id == "five_hour"
+    assert snapshot.windows[1].id == "weekly"
     assert snapshot.windows[0].used_percent == 15.0
     assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
     assert "Credits balance: $12.50" in snapshot.details
+    assert snapshot.metrics == (AccountUsageMetric("credit_balance", 12.5),)
+
+
+def test_fetch_account_usage_codex_without_credentials_is_unauthenticated(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_codex_runtime_credentials",
+        lambda refresh_if_expiring=True: (_ for _ in ()).throw(
+            AuthError("no credentials", provider="openai-codex")
+        ),
+    )
+    monkeypatch.setattr(
+        "agent.credential_pool.load_pool",
+        lambda provider: type("Pool", (), {"select": lambda self: None})(),
+    )
+
+    assert fetch_account_usage("openai-codex", report_failures=True) is None
+
+
+def test_fetch_account_usage_codex_rate_limit_remains_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_codex_runtime_credentials",
+        lambda refresh_if_expiring=True: (_ for _ in ()).throw(
+            AuthError(
+                "rate limited",
+                provider="openai-codex",
+                code=CODEX_RATE_LIMITED_CODE,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "agent.credential_pool.load_pool",
+        lambda provider: type("Pool", (), {"select": lambda self: None})(),
+    )
+
+    snapshot = fetch_account_usage("openai-codex", report_failures=True)
+
+    assert snapshot is not None
+    assert snapshot.unavailable_reason == "Provider usage could not be fetched."
 
 
 def test_render_account_usage_lines_includes_reset_and_provider():
@@ -158,7 +200,15 @@ def test_fetch_account_usage_openrouter_uses_limit_remaining_and_ignores_depreca
             label="API key quota",
             used_percent=30.0,
             detail="$70.00 of $100.00 remaining • resets monthly",
+            id="api_key_quota",
         ),
+    )
+    assert snapshot.metrics == (
+        AccountUsageMetric("credit_balance", 289.08),
+        AccountUsageMetric("api_key_usage_total", 12.5),
+        AccountUsageMetric("api_key_usage_daily", 0.5),
+        AccountUsageMetric("api_key_usage_weekly", 2.0),
+        AccountUsageMetric("api_key_usage_monthly", 8.0),
     )
     assert "Credits balance: $289.08" in snapshot.details
     assert "API key usage: $12.50 total • $0.50 today • $2.00 this week • $8.00 this month" in snapshot.details

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -83,6 +83,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes pets` | Browse, install, and select [petdex](../user-guide/features/pets.md) animated pets shown across the CLI, TUI, and desktop app. Subcommands: `list`, `install`, `select`, `show`, `off`, `scale`, `remove`, `doctor`. |
 | `hermes sessions` | Browse, export, prune, rename, and delete sessions. |
 | `hermes insights` | Show token/cost/activity analytics. |
+| `hermes usage` | Show standalone local session usage, provider account limits, and Nous Portal credits. |
 | `hermes claw` | OpenClaw migration helpers. |
 | `hermes dashboard` | Launch the web dashboard for managing config, API keys, and sessions. |
 | `hermes desktop` (alias `gui`) | Build and launch the native Electron desktop app. |
@@ -1390,6 +1391,55 @@ hermes insights [--days N] [--source platform]
 |--------|-------------|
 | `--days <n>` | Analyze the last `n` days (default: 30). |
 | `--source <platform>` | Filter by source such as `cli`, `telegram`, or `discord`. |
+
+## `hermes usage`
+
+```bash
+hermes usage [--session ID | --latest-session] [--json]
+```
+
+`hermes usage` is a standalone snapshot, so it does not inherit the active session from another CLI, TUI, desktop, gateway, cron, or delegated process.
+Without a selector, the session section reports `not_requested` and no persisted session is read.
+
+| Option | Description |
+|--------|-------------|
+| `--session <id>` | Include a persisted session selected by exact ID or unique ID prefix. |
+| `--latest-session` | Include the latest visible, non-cron session with at least one message. |
+| `--json` | Emit one schema-versioned JSON document for scripts and automation. |
+
+The human view always contains three sections:
+
+- **Session usage** shows durable persisted counters, timestamps, source, and the latest main-loop model/provider route when a session was explicitly selected.
+- **Provider account** shows live allowance windows for supported configured providers (`openai-codex`, `anthropic`, and `openrouter`).
+- **Nous Portal** shows safe subscription, top-up, and total spendable credit information when a Nous account is connected.
+
+Persisted sessions do not contain a reliable live context-window snapshot.
+Their context status is therefore `not_applicable`, and prompt, completion, and total token fields remain `null` rather than being guessed.
+
+JSON output has top-level fields `schema_version`, `generated_at`, `session`, `accounts`, and `warnings`.
+Unavailable values remain present as `null` or empty arrays so consumers can rely on a stable shape.
+Timestamps are RFC 3339 UTC strings, percentages are numeric values from 0 through 100, and monetary values are numeric USD amounts.
+Provider payloads are allowlisted into normalized windows and metrics; raw payloads, credentials, user or organisation identifiers, email addresses, filesystem paths, and arbitrary exception text are never emitted.
+
+Account failures are partial results and exit successfully with a warning.
+An unreadable local session store exits with status 1, while invalid, unknown, or ambiguous session selectors exit with status 2.
+In JSON mode, handler-level failures still emit one valid JSON document on stdout and leave stderr empty.
+
+Examples:
+
+```bash
+# Account status only; no persisted session is selected
+hermes usage
+
+# Add one persisted session by exact ID or unique prefix
+hermes usage --session 2f7a9c
+
+# Add the latest visible non-cron session
+hermes usage --latest-session
+
+# Stable machine-readable envelope
+hermes usage --latest-session --json
+```
 
 ## `hermes claw`
 


### PR DESCRIPTION
## What

Adds a standalone `hermes usage` command with human-readable and schema-versioned JSON output.

The command reports explicitly selected persisted-session telemetry, normalized provider-account limits, and Nous Portal billing state from one shared result model.

## Why

Operators and automation need one stable, privacy-safe command for usage data without invoking the agent loop or implicitly selecting a persisted session.

Prior art reviewed: #21814, #21839, and #33094.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Changes

- Adds `hermes usage`, `--json`, `--session ID`, and `--latest-session`.
- Reports durable session counters and the latest main-loop provider/model route.
- Normalizes OpenAI Codex, Anthropic, OpenRouter, and Nous account data behind a strict v1 output allowlist.
- Preserves distinct not-configured, unauthenticated, unavailable, free, paid, depleted, and unknown states.
- Keeps JSON stdout to exactly one document and sanitizes handler failures.
- Documents the command, selectors, exit codes, and stable output sections.

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_usage_command.py tests/test_account_usage.py tests/agent/test_account_usage.py tests/hermes_cli/test_startup_plugin_gating.py tests/test_hermes_state.py -q` - 467 passed.
- Ruff checks pass for every changed Python file.
- Ruff formatting passes for the two new Python files.
- `ty` passes for `hermes_cli/usage.py`.
- `git diff --check` passes.
- Real CLI subprocess smokes pass for help, default JSON, blank-slate configuration, missing session, and empty latest-session behavior.
- The full canonical suite reached 43,843 passing tests but remained red on 42 tests in 17 unrelated files plus nine ACP collection errors.
- A clean detached `upstream/main` worktree reproduced the exact same 42 failures and nine collection errors under this macOS environment.

## Screenshots

Not applicable. This is a terminal command with behavior covered by command-boundary tests.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have searched existing issues and pull requests.
- [x] I have performed a self-review of my code.
- [x] I have added comments where the logic is non-obvious.
- [x] I have added or updated documentation where needed.
- [x] I have added tests that prove the requested behavior.
- [ ] I have run the full test suite and all tests pass locally.
  The focused and changed-path gates pass; the remaining full-suite failures reproduce identically on clean upstream under this environment.
