### PR TITLE
fix(cli): make chat -q delegation completion-safe

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -17703,6 +17703,13 @@ def main(
     
     # Handle single query mode
     if query or image:
+        # A single-query CLI process exits after printing one response; there
+        # is no persistent prompt loop to drain a later background completion.
+        # Match ``hermes -z`` and mark the channel stateless before any agent
+        # turn can dispatch delegate_task/notify_on_complete work.
+        from gateway.session_context import declare_stateless_channel
+
+        declare_stateless_channel()
         if not cli._claim_active_session("cli", stderr=bool(quiet)):
             sys.exit(1)
         try:

--- a/gateway/readiness.py
+++ b/gateway/readiness.py
@@ -86,6 +86,15 @@ def _probe_gateway(runtime_status: dict[str, Any]) -> dict[str, Any]:
     return _check(status, state=state, connected_platforms=connected, platforms=configured)
 
 
+def _probe_orphaned_async_delegation_completions() -> int:
+    try:
+        from tools.async_delegation import count_orphaned_pending_completions
+
+        return max(0, int(count_orphaned_pending_completions()))
+    except Exception:
+        return 0
+
+
 def collect_runtime_readiness(
     *,
     configured_model: str,
@@ -102,6 +111,7 @@ def collect_runtime_readiness(
     """
     home = get_hermes_home()
     runtime = runtime_status if isinstance(runtime_status, dict) else {}
+    orphaned_async_completions = _probe_orphaned_async_delegation_completions()
     checks = {
         "state_db": _probe_state_db(home),
         "config": _probe_config(home),
@@ -109,10 +119,11 @@ def collect_runtime_readiness(
         "disk": _probe_disk(home),
         "gateway": _probe_gateway(runtime),
         "background_queues": _check(
-            "ok",
+            "degraded" if orphaned_async_completions else "ok",
             active_api_runs=max(0, int(active_api_runs)),
             process_completions=max(0, int(process_completion_queue_depth)),
             active_delegations=max(0, int(active_delegations)),
+            orphaned_async_delegation_completions=orphaned_async_completions,
         ),
     }
     overall = "ok" if all(item.get("status") == "ok" for item in checks.values()) else "degraded"

--- a/tests/cli/test_chat_q_delegation_lifecycle.py
+++ b/tests/cli/test_chat_q_delegation_lifecycle.py
@@ -1,0 +1,185 @@
+"""Process-level regression coverage for chat -q delegation lifecycle."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_single_query_delegation_probe(tmp_path: Path) -> dict:
+    """Run cli.main(query=...) in a fresh interpreter with a fake CLI/agent.
+
+    The subprocess boundary is intentional: this catches regressions where the
+    one-shot CLI process would dispatch a background delegation handle and then
+    exit before any later completion could be drained.
+    """
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    script = textwrap.dedent(
+        r'''
+        import json
+        import threading
+        from types import SimpleNamespace
+
+        import cli as cli_mod
+        import tools.delegate_tool as delegate_tool
+        from gateway.session_context import reset_session_vars
+        from tools import async_delegation
+
+        observed = {}
+
+        class FakeChild:
+            _delegate_role = "leaf"
+            _subagent_id = "child-1"
+            session_id = "child-session"
+            model = "test-model"
+            session_prompt_tokens = 0
+            session_completion_tokens = 0
+            session_reasoning_tokens = 0
+            session_estimated_cost_usd = 0.0
+            tool_progress_callback = None
+
+            def close(self):
+                pass
+
+        class FakeAgent:
+            def __init__(self):
+                self._delegate_depth = 0
+                self._interrupt_requested = False
+                self._active_children = []
+                self._active_children_lock = threading.Lock()
+                self._memory_manager = None
+                self.context_compressor = None
+                self.enabled_toolsets = []
+                self.valid_tool_names = []
+                self.model = "test-model"
+                self.provider = "test-provider"
+                self.session_id = "single-query-parent"
+                self.session_prompt_tokens = 0
+                self.session_estimated_cost_usd = 0.0
+                self.session_cost_source = "none"
+                self.session_cost_status = "unknown"
+
+        class FakeCLI:
+            def __init__(self, **_kwargs):
+                self.console = SimpleNamespace(print=lambda *_a, **_kw: None)
+                self.session_id = "single-query-parent"
+                self.agent = FakeAgent()
+
+            def _claim_active_session(self, surface, *, stderr=False):
+                return True
+
+            def _show_security_advisories(self):
+                pass
+
+            def _print_exit_summary(self, clear_screen=True):
+                pass
+
+            def chat(self, query, images=None):
+                payload = delegate_tool.delegate_task(
+                    goal="child work that the one-shot process cannot deliver later",
+                    context="process-level regression probe",
+                    background=True,
+                    parent_agent=self.agent,
+                )
+                observed["payload"] = json.loads(payload)
+                return "done"
+
+        def fake_build_child_agent(**_kwargs):
+            return FakeChild()
+
+        def fake_run_single_child(task_index, goal, child=None, parent_agent=None, **_kwargs):
+            return {
+                "task_index": task_index,
+                "status": "completed",
+                "summary": "inline child result",
+                "api_calls": 0,
+                "duration_seconds": 0.0,
+                "model": "test-model",
+                "exit_reason": "completed",
+            }
+
+        delegate_tool._build_child_agent = fake_build_child_agent
+        delegate_tool._run_single_child = fake_run_single_child
+        delegate_tool._resolve_delegation_credentials = lambda _cfg, _parent: {
+            "model": "test-model",
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "request_overrides": None,
+            "max_output_tokens": None,
+            "command": None,
+            "args": None,
+        }
+        cli_mod.HermesCLI = FakeCLI
+        cli_mod.atexit.register = lambda *_a, **_kw: None
+        cli_mod._finalize_single_query = lambda _cli: None
+
+        reset_session_vars()
+        cli_mod.main(query="delegate in one-shot mode", quiet=False, toolsets="delegation")
+
+        with async_delegation._DB_LOCK, async_delegation._connect() as conn:
+            durable_rows = conn.execute(
+                "SELECT delegation_id, state, delivery_state, delivery_attempts "
+                "FROM async_delegations ORDER BY delegation_id"
+            ).fetchall()
+        print(json.dumps({
+            "delegate_payload": observed["payload"],
+            "durable_rows": durable_rows,
+            "active_async_delegations": async_delegation.active_count(),
+        }, sort_keys=True))
+        '''
+    )
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("HERMES_KANBAN")
+    }
+    env["HERMES_HOME"] = str(hermes_home)
+    env["PYTHONPATH"] = str(REPO_ROOT)
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            "single-query delegation probe failed "
+            f"(rc={result.returncode})\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    for line in reversed(result.stdout.splitlines()):
+        if line.startswith("{"):
+            return json.loads(line)
+    pytest.fail(f"probe did not print JSON payload\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+
+
+def test_chat_q_process_runs_background_delegation_inline(tmp_path):
+    """A one-shot chat -q process must not dispatch an undeliverable child.
+
+    Top-level model delegation normally forces background dispatch. In the
+    single-query CLI process, that would hand back a handle and then terminate
+    before the completion queue can be drained. The live process path must bind
+    stateless delivery before chat starts, making delegate_task run inline.
+    """
+    probe = _run_single_query_delegation_probe(tmp_path)
+
+    payload = probe["delegate_payload"]
+    assert payload.get("status") != "dispatched"
+    assert payload["results"][0]["summary"] == "inline child result"
+    assert "ran SYNCHRONOUSLY" in payload["note"]
+    assert probe["durable_rows"] == []
+    assert probe["active_async_delegations"] == 0

--- a/tests/cli/test_chat_q_exit_clear.py
+++ b/tests/cli/test_chat_q_exit_clear.py
@@ -116,6 +116,142 @@ def test_single_query_main_skips_clear_on_exit_summary(monkeypatch):
     )
 
 
+def test_single_query_main_declares_stateless_before_human_chat(monkeypatch):
+    """Human-facing ``chat -q`` must not advertise async completion delivery."""
+    from gateway.session_context import async_delivery_supported, reset_session_vars
+
+    calls = []
+    observed = []
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.console = SimpleNamespace(print=lambda *_a, **_kw: calls.append("query-label"))
+            self.session_id = "sq-human"
+            self.agent = SimpleNamespace(session_id="sq-human", platform="cli")
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            calls.append(("claim", surface, stderr))
+            return True
+
+        def _show_security_advisories(self):
+            calls.append("advisories")
+
+        def chat(self, query, images=None):
+            observed.append(async_delivery_supported())
+            calls.append(("chat", query, images))
+            return "done"
+
+        def _print_exit_summary(self, clear_screen=True):
+            calls.append(("summary", clear_screen))
+
+    reset_session_vars()
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "_finalize_single_query",
+        lambda fake_cli: calls.append(("finalize", fake_cli.session_id)),
+    )
+
+    try:
+        cli_mod.main(query="hello", quiet=False, toolsets="terminal")
+    finally:
+        reset_session_vars()
+
+    assert observed == [False]
+    assert ("chat", "hello", None) in calls
+
+
+def test_quiet_single_query_declares_stateless_before_agent_dispatch(monkeypatch):
+    """Fully quiet ``-Q -q`` must bind stateless delivery before run_conversation."""
+    from gateway.session_context import async_delivery_supported, reset_session_vars
+
+    calls = []
+    observed = []
+
+    class FakeAgent:
+        session_id = "sq-quiet"
+
+        def run_conversation(self, user_message, conversation_history):
+            observed.append(async_delivery_supported())
+            calls.append(("run_conversation", user_message, conversation_history))
+            return {"final_response": "done"}
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.session_id = "sq-quiet"
+            self.agent = FakeAgent()
+            self.conversation_history = []
+            self.provider = ""
+            self.model = ""
+            self._active_agent_route_signature = "base"
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            calls.append(("claim", surface, stderr))
+            return True
+
+        def _ensure_runtime_credentials(self):
+            calls.append("credentials")
+            return True
+
+        def _resolve_turn_agent_config(self, effective_query):
+            calls.append(("route", effective_query))
+            return {
+                "signature": "base",
+                "model": None,
+                "runtime": None,
+                "request_overrides": None,
+            }
+
+        def _init_agent(self, **_kwargs):
+            calls.append("init-agent")
+            return True
+
+    reset_session_vars()
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "_finalize_single_query",
+        lambda fake_cli: calls.append(("finalize", fake_cli.session_id)),
+    )
+
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            cli_mod.main(query="hello", quiet=True, toolsets="terminal")
+    finally:
+        reset_session_vars()
+
+    assert exc_info.value.code == 0
+    assert observed == [False]
+    assert ("run_conversation", "hello", []) in calls
+
+
+def test_interactive_main_keeps_async_delivery_supported(monkeypatch):
+    """Interactive CLI stays capable of draining async completions in-process."""
+    from gateway.session_context import async_delivery_supported, reset_session_vars
+
+    observed = []
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.session_id = "interactive"
+
+        def run(self):
+            observed.append(async_delivery_supported())
+
+    reset_session_vars()
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_a, **_kw: None)
+
+    try:
+        cli_mod.main(toolsets="terminal")
+    finally:
+        reset_session_vars()
+
+    assert observed == [True]
+
+
 # ── Verify interactive mode still clears ────────────────────────────────────
 
 def test_print_exit_summary_still_clears_in_interactive_path(monkeypatch):

--- a/tests/gateway/test_readiness.py
+++ b/tests/gateway/test_readiness.py
@@ -38,6 +38,33 @@ def test_collect_runtime_readiness_reports_healthy_local_runtime(tmp_path, monke
     assert result["checks"]["disk"]["status"] in {"ok", "degraded"}
 
 
+def test_collect_runtime_readiness_degrades_on_orphaned_async_completion(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from tools import async_delegation
+
+    monkeypatch.setattr(
+        async_delegation,
+        "count_orphaned_pending_completions",
+        lambda: 2,
+    )
+
+    result = collect_runtime_readiness(
+        configured_model="test/model",
+        runtime_status={"gateway_state": "running"},
+    )
+
+    background = result["checks"]["background_queues"]
+    assert result["status"] == "degraded"
+    assert background["status"] == "degraded"
+    assert background["orphaned_async_delegation_completions"] == 2
+
+
 def test_collect_runtime_readiness_degrades_on_invalid_config_and_stopped_gateway(
     tmp_path, monkeypatch
 ):

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -469,6 +469,44 @@ def test_in_tool_stall_uses_higher_threshold(monkeypatch):
     assert evt["status"] == "completed"
 
 
+def test_orphaned_pending_completion_count_reports_dead_zero_attempt_owner(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    for index, delegation_id in enumerate(("deleg_orphan", "deleg_attempted", "deleg_live")):
+        record = {
+            "delegation_id": delegation_id,
+            "session_key": "owner",
+            "origin_ui_session_id": "",
+            "parent_session_id": None,
+            "dispatched_at": float(index + 1),
+        }
+        ad._persist_dispatch(record)
+        ad._persist_completion(
+            {
+                "delegation_id": delegation_id,
+                "status": "completed",
+                "completed_at": float(index + 2),
+            },
+            {"status": "completed", "summary": delegation_id},
+        )
+
+    with ad._DB_LOCK, ad._connect() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=?, owner_started_at=NULL "
+            "WHERE delegation_id IN (?, ?)",
+            (99999999, "deleg_orphan", "deleg_attempted"),
+        )
+        conn.execute(
+            "UPDATE async_delegations SET delivery_attempts=1 "
+            "WHERE delegation_id=?",
+            ("deleg_attempted",),
+        )
+
+    assert ad.count_orphaned_pending_completions() == 1
+
+
 def test_real_process_restart_restores_owned_completion_once(tmp_path):
     """Real-import E2E: a fresh interpreter restores a prior process's result."""
     repo = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))

--- a/tests/tools/test_async_delegation_fd_leak.py
+++ b/tests/tools/test_async_delegation_fd_leak.py
@@ -79,6 +79,28 @@ def test_ledger_operations_close_every_connection(monkeypatch, tmp_path):
     assert set(opened) == set(closed)
 
 
+def test_orphan_count_readiness_probe_closes_read_only_connection(monkeypatch, tmp_path):
+    """The read-only orphan diagnostic must close its readiness-probe connection."""
+    _point_ledger(monkeypatch, tmp_path)
+    with ad._transaction() as conn:
+        conn.execute(
+            """INSERT INTO async_delegations
+               (delegation_id, origin_session, state, dispatched_at,
+                completed_at, updated_at, event_json, delivery_state,
+                delivery_attempts, owner_pid)
+               VALUES ('orphaned', 'session', 'completed', 1.0,
+                       2.0, 2.0, '{}', 'pending', 0, 424242)"""
+        )
+    opened, closed = _track_connections(monkeypatch)
+    monkeypatch.setattr(ad, "_owner_process_alive", lambda _pid, _started_at: False)
+
+    assert ad.count_orphaned_pending_completions() == 1
+
+    assert opened, "expected the readiness probe to open a connection"
+    assert len(opened) == len(closed)
+    assert set(opened) == set(closed)
+
+
 def test_schema_init_failure_still_closes_connection(monkeypatch, tmp_path):
     """A PRAGMA/DDL failure after connect() must still close the connection."""
     _point_ledger(monkeypatch, tmp_path)

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -43,7 +43,7 @@ import threading
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager
+from contextlib import closing, contextmanager
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
@@ -385,7 +385,7 @@ def count_orphaned_pending_completions() -> int:
         return 0
     try:
         uri = f"file:{path.as_posix()}?mode=ro"
-        with sqlite3.connect(uri, uri=True, timeout=1.0) as conn:
+        with closing(sqlite3.connect(uri, uri=True, timeout=1.0)) as conn:
             rows = conn.execute(
                 """SELECT owner_pid, owner_started_at
                    FROM async_delegations

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -341,6 +341,70 @@ def recover_abandoned_delegations() -> int:
     return recovered
 
 
+def _owner_process_alive(pid: Any, started_at: Any) -> bool:
+    """Best-effort liveness check for the process that owns a durable row."""
+    if not pid:
+        return False
+    try:
+        pid_int = int(pid)
+    except (TypeError, ValueError):
+        return False
+    try:
+        from gateway.status import _pid_exists, get_process_start_time
+    except Exception:
+        # Diagnostics must not create false alarms when liveness helpers are
+        # unavailable; treat the owner as alive unless we can prove otherwise.
+        return True
+    if not _pid_exists(pid_int):
+        return False
+    if started_at is None:
+        return True
+    try:
+        current_start = get_process_start_time(pid_int)
+    except Exception:
+        return True
+    if current_start is None:
+        return True
+    try:
+        return int(current_start) == int(started_at)
+    except (TypeError, ValueError):
+        return True
+
+
+def count_orphaned_pending_completions() -> int:
+    """Count completed async-delegation events nobody has tried to deliver.
+
+    This is a read-only health diagnostic for existing status/readiness
+    surfaces. It flags terminal async delegation records whose completion event
+    is durable, still pending, has spent zero delivery attempts, and belongs to
+    an owner process that is provably gone. It never calls ``_connect()`` so a
+    health poll cannot create ``state.db`` or migrate schema as a side effect.
+    """
+    path = _db_path()
+    if not path.exists():
+        return 0
+    try:
+        uri = f"file:{path.as_posix()}?mode=ro"
+        with sqlite3.connect(uri, uri=True, timeout=1.0) as conn:
+            rows = conn.execute(
+                """SELECT owner_pid, owner_started_at
+                   FROM async_delegations
+                   WHERE state NOT IN ('running', 'finalizing')
+                     AND delivery_state='pending'
+                     AND delivery_attempts=0
+                     AND event_json IS NOT NULL"""
+            ).fetchall()
+    except sqlite3.OperationalError:
+        return 0
+    except Exception:
+        logger.debug("async delegation orphan diagnostic failed", exc_info=True)
+        return 0
+    return sum(
+        1 for owner_pid, owner_started_at in rows
+        if owner_pid and not _owner_process_alive(owner_pid, owner_started_at)
+    )
+
+
 def restore_undelivered_completions(target_queue) -> int:
     """Enqueue durable pending completions as fresh turns after process start.
 


### PR DESCRIPTION
## What does this PR do?

One-shot `hermes chat -q` / `-Q -q` processes can currently advertise detached async delivery even though the process exits after its single response. A top-level `delegate_task` can therefore return a background handle, leave a durable completion pending, and exit before any later turn can consume it. Dispatcher-spawned Kanban workers use this same finite `chat -q` entry point.

This PR binds the existing stateless delivery capability before any single-query agent turn starts. That makes delegation reuse the existing synchronous aggregation fallback on finite one-shot CLI surfaces, while interactive CLI and gateway sessions keep their current asynchronous behavior.

It also adds a read-only readiness diagnostic for terminal async-delegation completions that are still pending with zero delivery attempts after their recorded owner process is provably gone.

## Related Issue

Fixes #63169

Overlap note: #63218 addresses the Kanban-specific form of this lifecycle mismatch. This branch binds the actual finite `chat -q` entry point, so the same invariant covers both dispatcher workers and ordinary one-shot CLI use; it applies cleanly to current `main` and does not add a Kanban-specific capability branch.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: call `declare_stateless_channel()` at the single-query boundary before `chat -q`, `-Q -q`, or image-query agent dispatch.
- `tests/cli/test_chat_q_exit_clear.py`: cover human one-shot, fully quiet one-shot, and interactive CLI capability preservation.
- `tests/cli/test_chat_q_delegation_lifecycle.py`: run a fresh-process boundary regression proving a requested background delegation completes inline, creates no durable async row, and leaves no active delegation.
- `tools/async_delegation.py`: add a conservative, read-only orphan count that never creates or migrates `state.db` during a health poll.
- `gateway/readiness.py`: expose the bounded orphan count through the existing `background_queues` readiness check.
- Add deterministic async-delegation and readiness tests for dead/live/reused PID and DB-error behavior.

No model-facing tool, tool schema, config key, environment variable, outbound telemetry, or broad lifecycle refactor is added.

## How to Test

1. On the parent revision, remove/revert the `declare_stateless_channel()` call and run the process-boundary test. The delegation payload is `status=dispatched`, reproducing the unkeepable async promise.
2. On this branch, run:

   ```bash
   python -m pytest \
     tests/cli/test_chat_q_delegation_lifecycle.py \
     tests/cli/test_chat_q_exit_clear.py \
     tests/cli/test_cli_async_delegation_delivery.py \
     tests/cli/test_cli_delegate_background_notice.py \
     tests/tools/test_async_delegation.py \
     tests/gateway/test_readiness.py \
     tests/gateway/test_api_server.py::TestHealthDetailedEndpoint \
     -o 'addopts=' -q
   ```

   Result on macOS 26.3.1 / Python 3.11.15: **56 passed**.

3. Additional checks:

   ```text
   ruff check <7 changed Python files>                  PASS
   scripts/check-windows-footguns.py <7 changed files> PASS
   python -m compileall -q <7 changed files>            PASS
   git diff --check                                     PASS
   ```

4. Full-suite note: `scripts/run_tests.sh` completed with 23 failures in 12 unrelated files plus one `test_api_server.py` runner cleanup/collection issue. The exact failing 13-file subset reproduced unchanged on a detached clean `origin/main` worktree at `3e953ed81`; failures are current macOS/environment baselines (`/tmp` vs `/private/tmp`, unavailable `systemctl`/Linux socket semantics, existing profile aliases, and unrelated credential/tool tests). The changed-surface API-server subset above passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing issues and PRs and documented the overlap with #63218
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — full-suite baseline failures reproduced unchanged on clean `origin/main`; all 56 changed-surface tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.3.1, Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation update — N/A; runtime contract comments and tests document the behavior
- [x] `cli-config.yaml.example` update — N/A; no config changes
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; existing capability and synchronous fallback are reused
- [x] Cross-platform impact considered; Windows-footgun scan passes for all changed files
- [x] Tool descriptions/schemas update — N/A; no model-facing schema change

## Screenshots / Logs

Not applicable; this is a process-lifecycle and readiness behavior change covered by subprocess and deterministic unit tests.
