### PR TITLE
fix(memory): separate document_id/memory_id in supermemory forget

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -276,6 +276,22 @@ def _is_trivial_message(text: str) -> bool:
     return bool(_TRIVIAL_RE.match((text or "").strip()))
 
 
+def _is_not_found_error(exc: Exception) -> bool:
+    """True only for a 404/Not-Found response — never for auth, network, or 5xx.
+
+    Duck-typed because the supermemory SDK's exception hierarchy isn't a
+    stable import surface here (lazy-installed). Checked defensively so a
+    legacy-id forget only falls through to the document-delete path when the
+    memory truly doesn't exist, not on any other failure (see issue #69103).
+    """
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+    if status == 404:
+        return True
+    return exc.__class__.__name__ in {"NotFoundError", "NotFound"}
+
+
 class _SupermemoryClient:
     def __init__(self, api_key: str, timeout: float, container_tag: str,
                  search_mode: str = "hybrid", base_url: str = ""):
@@ -331,7 +347,11 @@ class _SupermemoryClient:
         if custom_id:
             kwargs["custom_id"] = custom_id
         result = self._client.documents.add(**kwargs)
-        return {"id": getattr(result, "id", "")}
+        document_id = getattr(result, "id", "")
+        # `id` is a deprecated alias of `document_id`, kept for back-compat.
+        # documents and memories are different resources with different
+        # delete semantics — see forget_by_legacy_id (issue #69103).
+        return {"document_id": document_id, "id": document_id}
 
     def search_memories(self, query: str, *, limit: int = 5,
                         container_tag: Optional[str] = None,
@@ -344,8 +364,12 @@ class _SupermemoryClient:
         response = self._client.search.memories(**kwargs)
         results = []
         for item in (getattr(response, "results", None) or []):
+            memory_id = getattr(item, "id", "")
             results.append({
-                "id": getattr(item, "id", ""),
+                # `id` is a deprecated alias of `memory_id` — this id belongs
+                # to the memories resource, distinct from a store() document_id.
+                "id": memory_id,
+                "memory_id": memory_id,
                 "memory": getattr(item, "memory", "") or "",
                 "similarity": getattr(item, "similarity", None),
                 "updated_at": getattr(item, "updated_at", None) or getattr(item, "updatedAt", None),
@@ -382,17 +406,55 @@ class _SupermemoryClient:
         tag = container_tag or self._container_tag
         self._client.memories.forget(container_tag=tag, id=memory_id)
 
+    def forget_document(self, document_id: str) -> None:
+        self._client.documents.delete(id=document_id)
+
+    def forget_by_legacy_id(self, legacy_id: str, *, container_tag: Optional[str] = None) -> dict:
+        """Back-compat for the old single `id` field (issue #69103).
+
+        store() returns a document_id but the original forget(id=...) contract
+        treated it as a memory_id. Try the memory-forget path first (matches
+        the pre-fix behavior for ids that came from search()); only on a 404
+        Not-Found retry as a document delete. Any other error (auth, network,
+        5xx) propagates — it does not prove the id is the wrong type.
+        """
+        try:
+            self.forget_memory(legacy_id, container_tag=container_tag)
+            return {"forgotten": True, "id": legacy_id, "resource": "memory"}
+        except Exception as exc:
+            if not _is_not_found_error(exc):
+                raise
+            self.forget_document(legacy_id)
+            return {"forgotten": True, "id": legacy_id, "resource": "document"}
+
     def forget_by_query(self, query: str, *, container_tag: Optional[str] = None) -> dict:
+        """Preview only — never deletes.
+
+        Auto-deleting the top search hit was the additional finding in
+        issue #69103: a single fuzzy match is not sufficient grounds to
+        permanently remove a memory. This always returns candidates for the
+        caller to review; an explicit second call with the chosen
+        `memory_id` (via forget_memory) is what actually deletes.
+        """
         results = self.search_memories(query, limit=5, container_tag=container_tag)
         if not results:
-            return {"success": False, "message": "No matching memory found to forget."}
-        target = results[0]
-        memory_id = target.get("id", "")
-        if not memory_id:
-            return {"success": False, "message": "Best matching memory has no id."}
-        self.forget_memory(memory_id, container_tag=container_tag)
-        preview = (target.get("memory") or "")[:100]
-        return {"success": True, "message": f'Forgot: "{preview}"', "id": memory_id}
+            return {"success": False, "message": "No matching memory found."}
+        candidates = [
+            {
+                "memory_id": r.get("memory_id") or r.get("id", ""),
+                "memory": (r.get("memory") or "")[:100],
+                "similarity": r.get("similarity"),
+            }
+            for r in results
+        ]
+        return {
+            "success": False,
+            "message": (
+                f"Found {len(candidates)} candidate(s), none deleted. "
+                "Call supermemory_forget again with memory_id to confirm deletion."
+            ),
+            "candidates": candidates,
+        }
 
     def ingest_conversation(self, session_id: str, messages: list[dict], metadata: dict | None = None) -> None:
         payload: dict = {
@@ -506,12 +568,17 @@ SEARCH_SCHEMA = {
 
 FORGET_SCHEMA = {
     "name": "supermemory_forget",
-    "description": "Forget a memory by exact id or by best-match query.",
+    "description": (
+        "Forget a memory by exact document_id/memory_id/id, or preview candidates by query. "
+        "query never deletes — it returns candidate memory_ids; call again with memory_id to confirm deletion."
+    ),
     "parameters": {
         "type": "object",
         "properties": {
-            "id": {"type": "string", "description": "Exact memory id to delete."},
-            "query": {"type": "string", "description": "Query used to find the memory to forget."},
+            "document_id": {"type": "string", "description": "Exact document_id returned by supermemory_store to permanently delete."},
+            "memory_id": {"type": "string", "description": "Exact memory_id returned by supermemory_search, or by a prior query preview, to forget."},
+            "id": {"type": "string", "description": "Deprecated: legacy id field, ambiguous between document_id and memory_id. Prefer document_id or memory_id."},
+            "query": {"type": "string", "description": "Preview only: finds candidate memories matching this query without deleting anything. Returns memory_id candidates — pass one back via memory_id to confirm deletion."},
         },
     },
 }
@@ -941,7 +1008,12 @@ class SupermemoryMemoryProvider(MemoryProvider):
         try:
             result = self._client.add_memory(content, metadata=metadata, entity_context=self._entity_context, container_tag=tag)
             preview = content[:80] + ("..." if len(content) > 80 else "")
-            resp: dict[str, Any] = {"saved": True, "id": result.get("id", ""), "preview": preview}
+            resp: dict[str, Any] = {
+                "saved": True,
+                "document_id": result.get("document_id", result.get("id", "")),
+                "id": result.get("id", ""),
+                "preview": preview,
+            }
             if tag:
                 resp["container_tag"] = tag
             return json.dumps(resp)
@@ -964,7 +1036,11 @@ class SupermemoryMemoryProvider(MemoryProvider):
             results = self._client.search_memories(query, limit=limit, container_tag=tag)
             formatted = []
             for item in results:
-                entry: dict[str, Any] = {"id": item.get("id", ""), "content": item.get("memory", "")}
+                entry: dict[str, Any] = {
+                    "memory_id": item.get("memory_id", item.get("id", "")),
+                    "id": item.get("id", ""),
+                    "content": item.get("memory", ""),
+                }
                 if item.get("similarity") is not None:
                     try:
                         entry["similarity"] = round(float(item["similarity"]) * 100)
@@ -979,18 +1055,25 @@ class SupermemoryMemoryProvider(MemoryProvider):
             return tool_error(f"Search failed: {exc}")
 
     def _tool_forget(self, args: dict) -> str:
-        memory_id = str(args.get("id") or "").strip()
+        document_id = str(args.get("document_id") or "").strip()
+        memory_id = str(args.get("memory_id") or "").strip()
+        legacy_id = str(args.get("id") or "").strip()
         query = str(args.get("query") or "").strip()
-        if not memory_id and not query:
-            return tool_error("Provide either id or query")
+        if not document_id and not memory_id and not legacy_id and not query:
+            return tool_error("Provide document_id, memory_id, id, or query")
         try:
             tag = self._resolve_tool_container_tag(args)
         except ValueError as exc:
             return tool_error(str(exc))
         try:
+            if document_id:
+                self._client.forget_document(document_id)
+                return json.dumps({"forgotten": True, "document_id": document_id})
             if memory_id:
                 self._client.forget_memory(memory_id, container_tag=tag)
-                return json.dumps({"forgotten": True, "id": memory_id})
+                return json.dumps({"forgotten": True, "memory_id": memory_id})
+            if legacy_id:
+                return json.dumps(self._client.forget_by_legacy_id(legacy_id, container_tag=tag))
             return json.dumps(self._client.forget_by_query(query, container_tag=tag))
         except Exception as exc:
             return tool_error(f"Forget failed: {exc}")

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -29,7 +29,8 @@ class FakeClient:
         self.profile_response = {"static": [], "dynamic": [], "search_results": []}
         self.ingest_calls = []
         self.forgotten_ids = []
-        self.forget_by_query_response = {"success": True, "message": "Forgot"}
+        self.forgotten_document_ids = []
+        self.forget_by_query_response = {"success": False, "message": "Found 0 candidate(s), none deleted.", "candidates": []}
 
     def add_memory(self, content, metadata=None, *, entity_context="",
                    container_tag=None, custom_id=None):
@@ -50,6 +51,13 @@ class FakeClient:
 
     def forget_memory(self, memory_id, *, container_tag=None):
         self.forgotten_ids.append(memory_id)
+
+    def forget_document(self, document_id):
+        self.forgotten_document_ids.append(document_id)
+
+    def forget_by_legacy_id(self, legacy_id, *, container_tag=None):
+        self.forgotten_ids.append(legacy_id)
+        return {"forgotten": True, "id": legacy_id, "resource": "memory"}
 
     def forget_by_query(self, query, *, container_tag=None):
         return self.forget_by_query_response
@@ -275,6 +283,7 @@ def test_store_tool_returns_saved_payload(provider):
     result = json.loads(provider.handle_tool_call("supermemory_store", {"content": "Jordan likes concise docs"}))
     assert result["saved"] is True
     assert result["id"] == "mem_123"
+    assert result["document_id"] == "mem_123"
 
 
 def test_search_tool_formats_results(provider):
@@ -287,16 +296,37 @@ def test_search_tool_formats_results(provider):
 
 
 def test_forget_tool_by_id(provider):
+    """Legacy `id` field routes through forget_by_legacy_id (issue #69103)."""
     result = json.loads(provider.handle_tool_call("supermemory_forget", {"id": "m1"}))
-    assert result == {"forgotten": True, "id": "m1"}
+    assert result == {"forgotten": True, "id": "m1", "resource": "memory"}
     assert provider._client.forgotten_ids == ["m1"]
 
 
+def test_forget_tool_by_document_id(provider):
+    result = json.loads(provider.handle_tool_call("supermemory_forget", {"document_id": "doc_1"}))
+    assert result == {"forgotten": True, "document_id": "doc_1"}
+    assert provider._client.forgotten_document_ids == ["doc_1"]
+    assert provider._client.forgotten_ids == []
+
+
+def test_forget_tool_by_memory_id(provider):
+    result = json.loads(provider.handle_tool_call("supermemory_forget", {"memory_id": "mem_1"}))
+    assert result == {"forgotten": True, "memory_id": "mem_1"}
+    assert provider._client.forgotten_ids == ["mem_1"]
+    assert provider._client.forgotten_document_ids == []
+
+
 def test_forget_tool_by_query(provider):
-    provider._client.forget_by_query_response = {"success": True, "message": "Forgot one", "id": "m7"}
+    """query is a preview-only pass-through to forget_by_query; real
+    preview-vs-delete semantics are covered at the client level."""
+    provider._client.forget_by_query_response = {
+        "success": False,
+        "message": "Found 1 candidate(s), none deleted.",
+        "candidates": [{"memory_id": "m7", "memory": "that thing", "similarity": 0.9}],
+    }
     result = json.loads(provider.handle_tool_call("supermemory_forget", {"query": "that thing"}))
-    assert result["success"] is True
-    assert result["id"] == "m7"
+    assert result["success"] is False
+    assert result["candidates"][0]["memory_id"] == "m7"
 
 
 def test_profile_tool_formats_sections(provider):
@@ -723,6 +753,167 @@ def test_post_setup_writes_config_and_prints_summary(monkeypatch, tmp_path, caps
     assert "✓ Connected" in out
     assert "3 profile facts" in out
     assert "Memory provider: supermemory" in out
+
+
+# -- issue #69103: document_id/memory_id contract + legacy id fallback --------
+
+
+def _install_stub_sdk(monkeypatch, *, not_found_ids=None, search_results=None):
+    """Wire a minimal stand-in for the supermemory SDK into _SupermemoryClient.
+
+    Exercises the real client methods (not FakeClient) so the 404-only
+    fallback and document/memory routing are verified against something
+    shaped like the actual SDK surface (documents.add/delete,
+    memories.forget, search.memories), not just a provider-level test double.
+    """
+    import sys
+    import types
+
+    from plugins.memory.supermemory import _SupermemoryClient
+
+    not_found_ids = not_found_ids or set()
+
+    class _StubDocuments:
+        def __init__(self):
+            self.added = []
+            self.deleted = []
+
+        def add(self, **kwargs):
+            self.added.append(kwargs)
+            return types.SimpleNamespace(id="doc_1")
+
+        def delete(self, id):
+            self.deleted.append(id)
+
+    class _StubMemories:
+        def __init__(self):
+            self.forgotten = []
+
+        def forget(self, container_tag, id):
+            if id in not_found_ids:
+                err = type("NotFoundError", (Exception,), {})("not found")
+                err.status_code = 404
+                raise err
+            self.forgotten.append(id)
+
+    class _StubSearchNamespace:
+        def memories(self, **kwargs):
+            return types.SimpleNamespace(results=search_results or [])
+
+    created = {}
+
+    class StubSupermemorySDK:
+        def __init__(self, **kwargs):
+            self.documents = _StubDocuments()
+            self.memories = _StubMemories()
+            self.search = _StubSearchNamespace()
+            created["instance"] = self
+
+    module = types.ModuleType("supermemory")
+    module.Supermemory = StubSupermemorySDK
+    monkeypatch.setitem(sys.modules, "supermemory", module)
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *args, **kwargs: None)
+
+    client = _SupermemoryClient(api_key="test-key", timeout=1.0, container_tag="hermes")
+    return client, created["instance"]
+
+
+def test_add_memory_returns_document_id(monkeypatch):
+    client, sdk = _install_stub_sdk(monkeypatch)
+    result = client.add_memory("hello world")
+    assert result == {"document_id": "doc_1", "id": "doc_1"}
+    assert sdk.documents.added[0]["content"] == "hello world"
+
+
+def test_search_memories_returns_memory_id(monkeypatch):
+    import types
+    item = types.SimpleNamespace(id="mem_9", memory="a fact", similarity=0.5, updated_at=None, metadata=None)
+    client, _sdk = _install_stub_sdk(monkeypatch, search_results=[item])
+    results = client.search_memories("q")
+    assert results[0]["memory_id"] == "mem_9"
+    assert results[0]["id"] == "mem_9"
+
+
+def test_forget_by_legacy_id_uses_memory_path_when_found(monkeypatch):
+    client, sdk = _install_stub_sdk(monkeypatch)
+    result = client.forget_by_legacy_id("mem_5")
+    assert result == {"forgotten": True, "id": "mem_5", "resource": "memory"}
+    assert sdk.memories.forgotten == ["mem_5"]
+    assert sdk.documents.deleted == []
+
+
+def test_forget_by_legacy_id_falls_back_to_document_on_404(monkeypatch):
+    """Root cause of #69103: a store()-issued document_id passed to forget(id=...)
+    404s against the memories endpoint; the fallback must land on documents.delete."""
+    client, sdk = _install_stub_sdk(monkeypatch, not_found_ids={"doc_1"})
+    result = client.forget_by_legacy_id("doc_1")
+    assert result == {"forgotten": True, "id": "doc_1", "resource": "document"}
+    assert sdk.documents.deleted == ["doc_1"]
+    assert sdk.memories.forgotten == []
+
+
+@pytest.mark.parametrize("status_code", [401, 403, 500, 503])
+def test_forget_by_legacy_id_does_not_fallback_on_non_404(monkeypatch, status_code):
+    client, sdk = _install_stub_sdk(monkeypatch)
+
+    def raise_error(container_tag, id):
+        err = RuntimeError(f"status {status_code}")
+        err.status_code = status_code
+        raise err
+
+    monkeypatch.setattr(sdk.memories, "forget", raise_error)
+    with pytest.raises(RuntimeError):
+        client.forget_by_legacy_id("mem_5")
+    assert sdk.documents.deleted == []
+
+
+def test_forget_by_legacy_id_does_not_fallback_on_timeout(monkeypatch):
+    client, sdk = _install_stub_sdk(monkeypatch)
+
+    def raise_timeout(container_tag, id):
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(sdk.memories, "forget", raise_timeout)
+    with pytest.raises(TimeoutError):
+        client.forget_by_legacy_id("mem_5")
+    assert sdk.documents.deleted == []
+
+
+def test_forget_by_query_never_deletes_even_a_clear_top_match(monkeypatch):
+    """Two-step confirm (issue #69103 additional finding): query is preview-only,
+    regardless of how confident the top match is."""
+    import types
+    item = types.SimpleNamespace(id="mem_1", memory="fact one", similarity=0.98, updated_at=None, metadata=None)
+    client, sdk = _install_stub_sdk(monkeypatch, search_results=[item])
+    result = client.forget_by_query("fact")
+    assert result["success"] is False
+    assert result["candidates"] == [{"memory_id": "mem_1", "memory": "fact one", "similarity": 0.98}]
+    assert sdk.memories.forgotten == []
+
+
+def test_forget_by_query_returns_all_candidates(monkeypatch):
+    import types
+    item1 = types.SimpleNamespace(id="mem_1", memory="fact one", similarity=0.81, updated_at=None, metadata=None)
+    item2 = types.SimpleNamespace(id="mem_2", memory="fact two", similarity=0.80, updated_at=None, metadata=None)
+    client, sdk = _install_stub_sdk(monkeypatch, search_results=[item1, item2])
+    result = client.forget_by_query("fact")
+    assert len(result["candidates"]) == 2
+    assert sdk.memories.forgotten == []
+
+
+def test_forget_by_query_then_confirm_by_memory_id_deletes(monkeypatch):
+    """Full two-step flow: preview via query, then confirm via explicit memory_id."""
+    import types
+    item = types.SimpleNamespace(id="mem_1", memory="fact one", similarity=0.98, updated_at=None, metadata=None)
+    client, sdk = _install_stub_sdk(monkeypatch, search_results=[item])
+
+    preview = client.forget_by_query("fact")
+    assert preview["success"] is False
+    assert sdk.memories.forgotten == []
+
+    chosen_id = preview["candidates"][0]["memory_id"]
+    client.forget_memory(chosen_id)
+    assert sdk.memories.forgotten == [chosen_id]
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits not enforced on Windows")

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -541,7 +541,7 @@ Semantic long-term memory with profile recall, semantic search, explicit memory 
 | **Data storage** | Supermemory Cloud or self-hosted |
 | **Cost** | Supermemory pricing (cloud) / free (self-hosted) |
 
-**Tools:** `supermemory_store` (save explicit memories), `supermemory_search` (semantic similarity search), `supermemory_forget` (forget by ID or best-match query), `supermemory_profile` (persistent profile + recent context)
+**Tools:** `supermemory_store` (save explicit memories, returns `document_id`), `supermemory_search` (semantic similarity search, returns `memory_id`), `supermemory_forget` (delete by exact `document_id`/`memory_id`; `query` is preview-only — it never deletes, it returns candidate `memory_id`s to confirm with a follow-up call), `supermemory_profile` (persistent profile + recent context)
 
 **Setup:**
 ```bash

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
@@ -471,7 +471,7 @@ hermes config set memory.provider byterover
 | **数据存储** | Supermemory 云端或自托管 |
 | **费用** | 云端按 Supermemory 定价 / 自托管免费 |
 
-**工具：** `supermemory_store`（保存显式记忆）、`supermemory_search`（语义相似度搜索）、`supermemory_forget`（按 ID 或最佳匹配查询遗忘）、`supermemory_profile`（持久化 profile + 近期上下文）
+**工具：** `supermemory_store`（保存显式记忆，返回 `document_id`）、`supermemory_search`（语义相似度搜索，返回 `memory_id`）、`supermemory_forget`（按精确的 `document_id`/`memory_id` 删除；`query` 仅作预览——不会直接删除，会返回候选 `memory_id` 供后续确认调用）、`supermemory_profile`（持久化 profile + 近期上下文）
 
 **安装：**
 ```bash


### PR DESCRIPTION
## Bug

Fixes #69103.

`supermemory_store` returns a **document** id (from `documents.add()`), but
`supermemory_forget(id=...)` always called `memories.forget()` — a different
resource with different delete semantics (permanent vs. soft-delete). Any id
issued by `store()` 404'd when passed back to `forget()`. The generic `id`
field erased which resource type the value belonged to, so callers had no
way to pick the right delete operation.

Additional finding (independent of the 404): `forget(query=...)` deleted the
top fuzzy search match with no confirmation step.

## Root-cause fix

Make the resource type explicit in the contract instead of patching around
the symptom:

- `add_memory()` now returns `document_id` (`id` kept as a deprecated alias)
- `search_memories()` results carry `memory_id` (`id` kept as a deprecated alias)
- `forget(document_id=...)` → `documents.delete` only
- `forget(memory_id=...)` → `memories.forget` only
- Legacy `forget(id=...)` tries the memory-forget path first (matches the
  original single-`id` contract); **only** on a real 404 does it retry as a
  document delete. Auth/network/5xx errors propagate instead of triggering
  a second, potentially destructive call — a non-404 failure is not proof
  the id is the wrong type.
- `forget(query=...)` is now **preview-only**: it never deletes. It returns
  candidate `memory_id`s and the message tells the caller to confirm with a
  follow-up `forget(memory_id=...)` call. This closes the additional finding
  — a fuzzy top-1 match is no longer sufficient grounds to delete.

`id` stays as a deprecated alias on read paths for backward compatibility;
it's documented as ambiguous and slated for removal in a future breaking change.

## Docs

Updated the tool list description in
`website/docs/user-guide/features/memory-providers.md` (and its zh-Hans
translation) to describe the new `document_id`/`memory_id` contract and the
preview-only `query` behavior.

## Test plan

- [x] `pytest tests/plugins/memory/test_supermemory_provider.py` — 58 passed, 1 skipped (Windows-only POSIX mode-bit test)
- [x] New tests cover: `store()` returning `document_id`; `search()` returning `memory_id`; `forget(document_id=...)` calling only `documents.delete`; `forget(memory_id=...)` calling only `memories.forget`; legacy-`id` fallback triggers only on 404 and *not* on 401/403/500/503/timeout; `forget(query=...)` never deletes even on a clear top match and requires the confirm-by-`memory_id` follow-up

 