### PR TITLE
fix(file_operations): add -E flag to grep fallback for extended regex support

### DIFF
--- a/tests/tools/test_search_error_guard.py
+++ b/tests/tools/test_search_error_guard.py
@@ -167,8 +167,9 @@ class TestSearchContentNewlineWarning:
         )
 
         assert res.error is None
-        assert res.total_count == 0
-        assert res.warning is not None
+        # needle matches 5 files; no warning because total_count != 0
+        assert res.total_count == 5
+        assert res.warning is None
 
     def test_literal_backslash_n_pattern_does_not_warn(self, match_tree):
         res = _ops(match_tree).search(

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2302,7 +2302,7 @@ class ShellFileOperations(FileOperations):
     def _search_with_grep(self, pattern: str, path: str, file_glob: Optional[str],
                           limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
         """Fallback search using grep."""
-        cmd_parts = ["grep", "-rnH"]  # -H forces filename even for single-file searches
+        cmd_parts = ["grep", "-rnHE"]  # -H forces filename even for single-file searches; -E enables extended regex (| as alternation)
         
         # Exclude hidden directories (matching ripgrep's default behavior).
         # This prevents searching inside .hub/index-cache/, .git/, etc.


### PR DESCRIPTION
`_search_with_grep` constructs a `grep -rnH` command, which runs in basic regex mode where `|` is treated as a literal character, not an alternation operator. When ripgrep is not available on the system, `search_files` calls with patterns like `"A|B"` silently return 0 results.

Adding `-E` enables extended regex mode, making `grep` behave consistently with `rg` (ripgrep), which defaults to extended regex.

Also fixed the corresponding test that was asserting the buggy behavior (expecting 0 results when `|` should match alternatives).