### PR TITLE
fix(honcho): cache clients per config identity so multiplexed profiles don't share the first-built workspace

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -18,6 +18,7 @@ import os
 import logging
 import hashlib
 import ipaddress
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.parse import urlparse
@@ -854,15 +855,26 @@ class HonchoClientConfig:
         return self.workspace_id
 
 
-_honcho_client_slot: SingletonSlot = SingletonSlot()
-_cached_timeout: float | None = None
-# Memo for the honcho.json-derived timeout, keyed on the file's mtime_ns so
-# the staleness check on every get_honcho_client() call costs one stat()
-# instead of a JSON parse. mtime -1 = file absent; (None, None) = not yet
-# populated. config.yaml needs no such memo: load_config_readonly() is
+# Honcho clients are cached per config identity, not as one process-wide
+# singleton. A single slot was correct while one process served one profile,
+# but a multiplexed gateway (gateway.multiplex_profiles) serves many profiles
+# from one process, each potentially with its own honcho.json and workspace.
+# With a single slot, whichever profile built first pinned its workspace_id
+# for every other profile's memory (#69123) — the same first-config-wins
+# staleness trap as #57347, one field over. Each identity keeps its own SingletonSlot
+# so the build-once-under-race guarantee (#24759) holds per client. The maps
+# are bounded by the number of distinct identities (profiles) in the process.
+_honcho_client_slots: dict[tuple, SingletonSlot] = {}
+_honcho_client_slots_lock = threading.Lock()
+_cached_timeouts: dict[tuple, float] = {}
+# Memo for the honcho.json-derived timeout, keyed on the resolved config path
+# and its mtime_ns so the staleness check on every get_honcho_client() call
+# costs one stat() instead of a JSON parse. mtime -1 = file absent. Keyed by
+# path because multiplexed profiles resolve different honcho.json files from
+# one process. config.yaml needs no such memo: load_config_readonly() is
 # internally cached on both the user and managed files' signatures, and a
 # bespoke key here would have to duplicate that invalidation logic.
-_honcho_json_timeout_memo: tuple[int | None, float | None] = (None, None)
+_honcho_json_timeout_memo: dict[str, tuple[int, float | None]] = {}
 
 
 def _config_yaml_timeout() -> float | None:
@@ -882,16 +894,17 @@ def _config_yaml_timeout() -> float | None:
 
 
 def _honcho_json_timeout() -> float | None:
-    """Read timeout/requestTimeout from honcho.json (host block wins), memoized on mtime."""
-    global _honcho_json_timeout_memo
+    """Read timeout/requestTimeout from honcho.json (host block wins), memoized on path+mtime."""
     try:
         path = resolve_config_path()
+        path_key = str(path)
         try:
             mtime_ns: int = path.stat().st_mtime_ns
         except OSError:
             mtime_ns = -1
-        if _honcho_json_timeout_memo[0] == mtime_ns:
-            return _honcho_json_timeout_memo[1]
+        memo = _honcho_json_timeout_memo.get(path_key)
+        if memo is not None and memo[0] == mtime_ns:
+            return memo[1]
 
         timeout = None
         if mtime_ns != -1:
@@ -903,7 +916,7 @@ def _honcho_json_timeout() -> float | None:
                 raw.get("timeout"),
                 raw.get("requestTimeout"),
             )
-        _honcho_json_timeout_memo = (mtime_ns, timeout)
+        _honcho_json_timeout_memo[path_key] = (mtime_ns, timeout)
         return timeout
     except Exception:
         return None
@@ -946,7 +959,9 @@ def _apply_fresh_oauth_token(config: HonchoClientConfig) -> None:
         logger.warning("Honcho OAuth pre-build refresh failed", exc_info=True)
 
 
-def _refresh_cached_oauth(client: "Honcho", config: HonchoClientConfig | None) -> None:
+def _refresh_cached_oauth(
+    client: "Honcho", config: HonchoClientConfig | None, slot: SingletonSlot
+) -> None:
     """Rotate the cached client's Bearer in place when its OAuth token is stale.
 
     If the SDK shape changed and the in-place rotation can't apply, the slot is
@@ -958,34 +973,78 @@ def _refresh_cached_oauth(client: "Honcho", config: HonchoClientConfig | None) -
         host = config.host if config is not None else resolve_active_host()
         token, refreshed = oauth.ensure_fresh_token(resolve_config_path(), host)
         if refreshed and token and not oauth.apply_token_to_client(client, token):
-            _honcho_client_slot.reset()
+            slot.reset()
     except Exception:
         logger.warning("Honcho OAuth cached refresh failed", exc_info=True)
 
 
-def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
-    """Get or create the Honcho client singleton.
+def _client_cache_key(config: HonchoClientConfig | None) -> tuple:
+    """Cache identity for a Honcho client build.
 
-    When no config is provided, attempts to load ~/.honcho/config.json
-    first, falling back to environment variables.
+    Explicit configs key on the connection fields ``_build`` embeds in the
+    client (host, workspace, base_url, environment). ``api_key`` is
+    deliberately excluded: OAuth rotation refreshes the cached client's
+    Bearer in place (``_refresh_cached_oauth``), and keying on the token
+    would strand one client per rotation instead.
 
-    Thread-safe: the client is built exactly once even under concurrent
-    first calls (double-checked locking via ``SingletonSlot``), so racing
-    threads can't each construct a client and leak the loser's connection.
+    Ambient callers (``config=None``) key on what ``from_global_config()``
+    resolves from — the active honcho.json path and host key. Both follow
+    the multiplexer's per-turn HERMES_HOME override, so routed profiles get
+    distinct clients, and the key stays cheap (path resolution + profile
+    name, no JSON parse) on the per-memory-access hot path
+    (``HonchoSessionManager.honcho``).
     """
-    global _cached_timeout
-    cached = _honcho_client_slot.peek()
+    if config is not None:
+        return (
+            "explicit",
+            config.host,
+            config.workspace_id,
+            config.base_url or "",
+            config.environment,
+        )
+    return ("ambient", str(resolve_config_path()), resolve_active_host())
+
+
+def _client_slot_for(key: tuple) -> SingletonSlot:
+    with _honcho_client_slots_lock:
+        slot = _honcho_client_slots.get(key)
+        if slot is None:
+            slot = SingletonSlot()
+            _honcho_client_slots[key] = slot
+        return slot
+
+
+def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
+    """Get or create the Honcho client for this config identity.
+
+    When no config is provided, attempts to load the ambient honcho.json
+    (profile-local first) and falls back to environment variables.
+
+    Clients are cached per config identity (``_client_cache_key``), so a
+    multiplexed gateway serving several profiles from one process gets one
+    client per profile's workspace instead of sharing whichever profile
+    built first. Single-profile processes see one key and keep the old
+    singleton behavior.
+
+    Thread-safe: each identity's client is built exactly once even under
+    concurrent first calls (double-checked locking via ``SingletonSlot``),
+    so racing threads can't each construct a client and leak the loser's
+    connection.
+    """
+    key = _client_cache_key(config)
+    slot = _client_slot_for(key)
+    cached = slot.peek()
     if cached is not None:
         # Detect timeout config changes in long-lived processes (gateway,
         # dashboard).  If the user changed the timeout after the client was
         # built, rebuild with the new value.
         new_timeout = _resolve_timeout_from_sources(config)
-        if new_timeout != _cached_timeout:
-            _honcho_client_slot.reset()
-            _cached_timeout = None
+        if new_timeout != _cached_timeouts.get(key):
+            slot.reset()
+            _cached_timeouts.pop(key, None)
             cached = None
         else:
-            _refresh_cached_oauth(cached, config)
+            _refresh_cached_oauth(cached, config, slot)
             return cached
 
     if config is None:
@@ -1097,16 +1156,15 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
         if resolved_timeout is not None:
             kwargs["timeout"] = resolved_timeout
 
-        global _cached_timeout
-        _cached_timeout = resolved_timeout
+        _cached_timeouts[key] = resolved_timeout
         return Honcho(**kwargs)
 
-    return _honcho_client_slot.get(_build)
+    return slot.get(_build)
 
 
 def reset_honcho_client() -> None:
-    """Reset the Honcho client singleton (useful for testing)."""
-    global _cached_timeout, _honcho_json_timeout_memo
-    _honcho_client_slot.reset()
-    _cached_timeout = None
-    _honcho_json_timeout_memo = (None, None)
+    """Reset all cached Honcho clients (useful for testing)."""
+    with _honcho_client_slots_lock:
+        _honcho_client_slots.clear()
+    _cached_timeouts.clear()
+    _honcho_json_timeout_memo.clear()

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -1002,17 +1002,26 @@ class TestResolveSessionNameLengthLimit:
 
 
 class TestResetHonchoClient:
-    def test_reset_clears_singleton(self):
+    def test_reset_clears_all_cached_clients(self):
         import plugins.memory.honcho.client as mod
+        from plugins.plugin_utils import SingletonSlot
 
-        # Seed the cached client through the slot's public surface, then
-        # verify reset_honcho_client() clears it. (The client is cached in
-        # mod._honcho_client_slot, a thread-safe SingletonSlot, not a bare
-        # module global anymore — see #24759.)
-        mod._honcho_client_slot.get(lambda: MagicMock())
-        assert mod._honcho_client_slot.peek() is not None
+        # Seed cached clients for two identities through the slot map's
+        # public surface, then verify reset_honcho_client() clears them all.
+        # (Clients are cached per config identity in mod._honcho_client_slots
+        # — one thread-safe SingletonSlot per identity — so multiplexed
+        # profiles don't share whichever client built first; see #24759 for
+        # the slot primitive.)
+        for key in (("explicit", "hermes", "ws-a", "", "production"),
+                    ("explicit", "hermes", "ws-b", "", "production")):
+            slot = SingletonSlot()
+            slot.get(lambda: MagicMock())
+            with mod._honcho_client_slots_lock:
+                mod._honcho_client_slots[key] = slot
+            assert slot.peek() is not None
         reset_honcho_client()
-        assert mod._honcho_client_slot.peek() is None
+        with mod._honcho_client_slots_lock:
+            assert not mod._honcho_client_slots
 
 
 class TestDialecticDepthParsing:

--- a/tests/test_honcho_client_multiplex_isolation.py
+++ b/tests/test_honcho_client_multiplex_isolation.py
@@ -1,0 +1,169 @@
+"""Per-profile client isolation for get_honcho_client() under multiplexing.
+
+A multiplexed gateway (``gateway.multiplex_profiles``) serves many profiles
+from one process: each turn enters ``_profile_runtime_scope``, which points
+``get_hermes_home()`` at the routed profile's home, so profile-local
+honcho.json files (and their workspaces) resolve per turn. The client cache
+must key on that identity — with a single first-config-wins slot, whichever
+profile built first pinned its ``workspace_id`` for every other profile's
+memory, silently merging tenants into one workspace (#69123).
+
+These tests pin the per-identity cache: distinct workspaces get distinct
+clients (explicit configs and ambient HERMES_HOME-override resolution alike),
+while same-identity callers keep sharing one build.
+"""
+
+import json
+import sys
+import threading
+import types
+
+import pytest
+
+from plugins.memory.honcho import client as honcho_client
+from plugins.memory.honcho.client import (
+    HonchoClientConfig,
+    get_honcho_client,
+    reset_honcho_client,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    reset_honcho_client()
+    yield
+    reset_honcho_client()
+
+
+def _install_fake_honcho_sdk(monkeypatch, build_count, build_lock):
+    """Make `from honcho import Honcho` resolve to a counting fake."""
+
+    class _FakeHoncho:
+        def __init__(self, **kwargs):
+            with build_lock:
+                build_count["n"] += 1
+            self.kwargs = kwargs
+
+    fake_mod = types.ModuleType("honcho")
+    fake_mod.Honcho = _FakeHoncho
+    monkeypatch.setitem(sys.modules, "honcho", fake_mod)
+    # Pin the timeout axis to the default so identity keying is the only
+    # variable under test.
+    monkeypatch.setattr(
+        honcho_client, "_resolve_optional_float", lambda *a, **k: None, raising=False
+    )
+
+
+def test_distinct_workspace_configs_get_distinct_clients(monkeypatch):
+    build_count = {"n": 0}
+    build_lock = threading.Lock()
+    _install_fake_honcho_sdk(monkeypatch, build_count, build_lock)
+
+    config_a = HonchoClientConfig(
+        api_key="test-key", workspace_id="brand-a", environment="production"
+    )
+    config_b = HonchoClientConfig(
+        api_key="test-key", workspace_id="brand-b", environment="production"
+    )
+
+    client_a = get_honcho_client(config_a)
+    client_b = get_honcho_client(config_b)
+
+    assert client_a is not client_b, "distinct workspaces must not share a client"
+    assert client_a.kwargs["workspace_id"] == "brand-a"
+    assert client_b.kwargs["workspace_id"] == "brand-b"
+    assert build_count["n"] == 2
+
+    # Same identity keeps sharing one build.
+    assert get_honcho_client(config_a) is client_a
+    assert get_honcho_client(config_b) is client_b
+    assert build_count["n"] == 2
+
+
+def test_concurrent_distinct_configs_build_once_each(monkeypatch):
+    build_count = {"n": 0}
+    build_lock = threading.Lock()
+    _install_fake_honcho_sdk(monkeypatch, build_count, build_lock)
+
+    configs = [
+        HonchoClientConfig(
+            api_key="test-key", workspace_id=f"ws-{i}", environment="production"
+        )
+        for i in range(2)
+    ]
+
+    barrier = threading.Barrier(20)
+    results: dict[str, list] = {"ws-0": [], "ws-1": []}
+    results_lock = threading.Lock()
+
+    def worker(config):
+        barrier.wait()
+        c = get_honcho_client(config)
+        with results_lock:
+            results[config.workspace_id].append(c)
+
+    threads = [
+        threading.Thread(target=worker, args=(configs[i % 2],)) for i in range(20)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert build_count["n"] == 2, "one build per identity, even under races"
+    for workspace_id, clients in results.items():
+        assert len(clients) == 10
+        assert all(c is clients[0] for c in clients), (
+            f"all callers of {workspace_id} share one client"
+        )
+        assert clients[0].kwargs["workspace_id"] == workspace_id
+
+
+def _write_profile_home(tmp_path, name, workspace):
+    home = tmp_path / name
+    home.mkdir()
+    (home / "honcho.json").write_text(
+        json.dumps({"workspace": workspace, "apiKey": "test-key"}),
+        encoding="utf-8",
+    )
+    return home
+
+
+def test_ambient_resolution_follows_hermes_home_override(monkeypatch, tmp_path):
+    """The multiplex scenario: config=None resolved under per-turn home overrides.
+
+    ``HonchoSessionManager.honcho`` calls ``get_honcho_client()`` with no
+    config on every memory access; under the multiplexer the ambient
+    honcho.json is profile-local. Two profiles with different workspaces
+    must get two clients — not whichever built first.
+    """
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    build_count = {"n": 0}
+    build_lock = threading.Lock()
+    _install_fake_honcho_sdk(monkeypatch, build_count, build_lock)
+    monkeypatch.delenv("HERMES_HONCHO_HOST", raising=False)
+    monkeypatch.delenv("HONCHO_TIMEOUT", raising=False)
+
+    home_a = _write_profile_home(tmp_path, "profile-a", "brand-a")
+    home_b = _write_profile_home(tmp_path, "profile-b", "brand-b")
+
+    def under_home(home):
+        token = set_hermes_home_override(home)
+        try:
+            return get_honcho_client()
+        finally:
+            reset_hermes_home_override(token)
+
+    client_a = under_home(home_a)
+    client_b = under_home(home_b)
+
+    assert client_a is not client_b, "profiles must not share the first-built client"
+    assert client_a.kwargs["workspace_id"] == "brand-a"
+    assert client_b.kwargs["workspace_id"] == "brand-b"
+    assert build_count["n"] == 2
+
+    # Re-entering a profile's scope reuses its cached client.
+    assert under_home(home_a) is client_a
+    assert under_home(home_b) is client_b
+    assert build_count["n"] == 2


### PR DESCRIPTION
## What does this PR do?

Fixes cross-profile Honcho memory bleed under `gateway.multiplex_profiles` (#69123) by caching Honcho clients **per config identity** instead of in one process-wide first-config-wins slot.

The multiplexer's per-turn isolation (`_profile_runtime_scope`) already resolves each routed profile's own `honcho.json` — `resolve_config_path()` and `HonchoClientConfig.from_global_config()` follow the HERMES_HOME contextvar correctly. But `get_honcho_client()` cached a single client with `workspace_id` baked in at construction and never compared the resolved config against the cached client (the only staleness check was the timeout, #57347). So whichever profile built first pinned its workspace for every other profile's memory, and the per-memory-access hot path (`HonchoSessionManager.honcho` → `get_honcho_client()` with no config) migrated even correctly-initialized sessions onto the first-built client.

**Fix:**
- Cache keyed by config identity:
  - explicit configs → `(host, workspace_id, base_url, environment)`. `api_key` is deliberately excluded so in-place OAuth rotation (`_refresh_cached_oauth`) keeps refreshing the cached client instead of stranding one client per token.
  - ambient callers (`config=None`) → `(resolve_config_path(), resolve_active_host())` — both follow the multiplexer's HERMES_HOME override, and the key stays cheap (path resolution + profile name, no JSON parse) on the hot path.
- One `SingletonSlot` per key preserves the build-once-under-concurrent-first-call guarantee (#24759) per client.
- Per-key cached timeouts preserve the #57347 rebuild-on-timeout-change behavior.
- `_honcho_json_timeout_memo` becomes path-keyed: it memoized a single file's mtime globally, so alternating profiles would have thrashed it and skewed the staleness check.

Single-profile processes resolve one key and keep the exact prior behavior. The slot map is bounded by the number of distinct identities (profiles) in the process.

## Related Issue

Fixes #69123

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/honcho/client.py` — replace `_honcho_client_slot`/`_cached_timeout` singletons with identity-keyed maps (`_honcho_client_slots`, `_cached_timeouts`); add `_client_cache_key()` / `_client_slot_for()`; make `_honcho_json_timeout_memo` path-keyed; `_refresh_cached_oauth` resets the owning slot; `reset_honcho_client()` clears all maps.
- `tests/test_honcho_client_multiplex_isolation.py` — new regression tests: distinct explicit workspaces get distinct clients; concurrent first calls build once per identity; ambient (`config=None`) resolution under `set_hermes_home_override` — the multiplex scenario — returns each profile's own workspace client.
- `tests/honcho_plugin/test_client.py` — `TestResetHonchoClient` updated for the keyed cache.

## How to Test

1. `pytest tests/test_honcho_client_multiplex_isolation.py -q` — 3 passed on this branch; the same tests fail 3/3 on current `main` (clients share the first-built `workspace_id`), demonstrating the bug.
2. `pytest tests/honcho_plugin/ tests/test_honcho_client_config.py tests/test_honcho_startup_fail_open.py tests/test_honcho_session_context.py tests/test_honcho_client_concurrency.py tests/test_honcho_client_multiplex_isolation.py -q` — 455 passed.
3. `pytest tests/agent/test_memory_user_id.py -q` (references the changed module) — 14 passed.

Test-scope note: the change is confined to `plugins/memory/honcho/client.py` module internals; the full local suite on macOS hits environment-dependent failures in unrelated areas (they reproduce on a clean `origin/main` checkout — e.g. `tests/acp/test_edit_approval.py` fails there too), so the runs above cover every suite that imports the changed module. `ruff check` passes on the touched files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the honcho-related suites and the tests referencing the changed module — all pass (see test-scope note above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated; no user-facing config change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python module internals, path keys use `str(Path)` consistently
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
