### PR TITLE
fix(desktop): reduce long-history streaming work

### DIFF
--- a/apps/desktop/scripts/perf/README.md
+++ b/apps/desktop/scripts/perf/README.md
@@ -19,6 +19,14 @@ npm run perf                  # attaches, runs the CI suite, gates on baseline
 # One scenario, with a CPU profile:
 npm run perf -- stream --cpuprofile --tokens 800
 
+# Report-only stream over a preloaded 200-turn transcript. The harness verifies
+# the source count, waits two paints plus a configurable settle delay, then starts
+# recorders; slower machines may still include residual mount/highlight work:
+npm run perf -- stream-history --spawn --prod
+
+# Stronger local stress point (1000 turns / 2000 messages):
+npm run perf -- stream-history --spawn --prod --historyTurns 1000
+
 # Representative PRODUCTION numbers (minified React, not the ~3x-slower dev build):
 npm run perf -- cold-start stream keystroke transcript --spawn --prod
 

--- a/apps/desktop/scripts/perf/scenarios/index.mjs
+++ b/apps/desktop/scripts/perf/scenarios/index.mjs
@@ -7,11 +7,13 @@ import keystroke from './keystroke.mjs'
 import profileSwitch from './profile-switch.mjs'
 import sessionSwitch from './session-switch.mjs'
 import stream from './stream.mjs'
+import streamHistory from './stream-history.mjs'
 import submit from './submit.mjs'
 import transcript from './transcript.mjs'
 
 export const SCENARIOS = {
   [stream.name]: stream,
+  [streamHistory.name]: streamHistory,
   [keystroke.name]: keystroke,
   [transcript.name]: transcript,
   [coldStart.name]: coldStart,

--- a/apps/desktop/scripts/perf/scenarios/stream-history.mjs
+++ b/apps/desktop/scripts/perf/scenarios/stream-history.mjs
@@ -1,0 +1,13 @@
+import stream from './stream.mjs'
+
+export default {
+  name: 'stream-history',
+  tier: 'manual',
+  description: 'Synthetic token stream over a preloaded long transcript.',
+  run(cdp, opts = {}) {
+    return stream.run(cdp, {
+      ...opts,
+      historyTurns: opts.historyTurns ?? 200
+    })
+  }
+}

--- a/apps/desktop/scripts/perf/scenarios/stream.mjs
+++ b/apps/desktop/scripts/perf/scenarios/stream.mjs
@@ -119,6 +119,8 @@ export default {
     const tokens = Number(opts.tokens ?? 400)
     const intervalMs = Number(opts.intervalMs ?? 16)
     const flushMinMs = Number(opts.flushMinMs ?? 33)
+    const historyTurns = Number(opts.historyTurns ?? 0)
+    const historySettleMs = Number(opts.historySettleMs ?? 1500)
     // Realistic default: a short markdown paragraph ending in a blank line, so
     // blocks SETTLE as they stream — exactly how real LLM output behaves, and
     // what block-memoization is designed for (only the growing tail re-renders).
@@ -130,6 +132,25 @@ export default {
     const real = Boolean(opts.real)
 
     await cdp.send('Runtime.enable')
+
+    if (historyTurns > 0) {
+      if (real) {
+        throw new Error('--historyTurns is only supported by the synthetic stream scenario')
+      }
+
+      // Preload history before recorders start, then allow a configurable
+      // delay. Source count is verified below; slower renderers may still have
+      // residual mount/highlight work when recording begins.
+      await cdp.eval(`window.__PERF_DRIVE__.loadTranscript(${historyTurns})`)
+      await sleep(historySettleMs)
+      const mountedMessages = Number(await cdp.eval('window.__PERF_DRIVE__.snapshotMsgs()'))
+      const expectedMessages = historyTurns * 2
+
+      if (mountedMessages !== expectedMessages) {
+        throw new Error(`expected ${expectedMessages} preloaded history messages, got ${mountedMessages}`)
+      }
+    }
+
     await cdp.eval(RECORDERS)
 
     if (real) {
@@ -177,7 +198,19 @@ export default {
       )
       await sleep(200)
       await cdp.eval('window.__MO__.arm()')
-      await sleep(tokens * intervalMs + 1500)
+      const syntheticTimeoutMs = Number(opts.timeoutMs ?? Math.max(tokens * intervalMs + 10000, 120000))
+      const deadline = Date.now() + syntheticTimeoutMs
+
+      while (Date.now() < deadline && (await cdp.eval('window.__PERF_DRIVE__.streaming()'))) {
+        await sleep(50)
+      }
+
+      if (await cdp.eval('window.__PERF_DRIVE__.streaming()')) {
+        throw new Error('synthetic stream did not finish before the timeout')
+      }
+
+      // Include the final commit and paint after the driver reports idle.
+      await sleep(250)
     }
 
     const data = JSON.parse(await cdp.eval(COLLECT))
@@ -186,6 +219,9 @@ export default {
       await cdp.eval('window.__PERF_DRIVE__.reset()')
     }
 
-    return analyze(data, real ? 0 : 500)
+    const result = analyze(data, real ? 0 : 500)
+    result.detail.historyTurns = historyTurns
+
+    return result
   }
 }

--- a/apps/desktop/src/app/chat/perf-probe.tsx
+++ b/apps/desktop/src/app/chat/perf-probe.tsx
@@ -1,5 +1,6 @@
 import { Profiler, type ProfilerOnRenderCallback, type ReactNode } from 'react'
 
+import { updateChatMessageAt } from '@/lib/chat-messages'
 import { $gateway } from '@/store/gateway'
 import { $messages, setBusy, setMessages } from '@/store/session'
 
@@ -24,7 +25,13 @@ declare global {
     }
     __PERF_DRIVE__?: {
       /** Inject an assistant message and grow it by `chunk` every `intervalMs`. Returns a stop handle. */
-      stream: (opts?: { chunk?: string; intervalMs?: number; totalTokens?: number }) => SyntheticDriverHandle
+      stream: (opts?: {
+        chunk?: string
+        intervalMs?: number
+        totalTokens?: number
+        flushMinMs?: number
+      }) => SyntheticDriverHandle
+      streaming: () => boolean
       /**
        * Replace the transcript with `turns` synthetic user/assistant pairs of
        * realistic mixed markdown, then resolve with the ms elapsed from the
@@ -159,6 +166,7 @@ if (typeof window !== 'undefined' && !window.__PERF_DRIVE__) {
 
   window.__PERF_DRIVE__ = {
     snapshotMsgs: () => $messages.get().length,
+    streaming: () => activeHandle !== null,
     connected: () => {
       try {
         return $gateway.get()?.connectionState === 'open'
@@ -242,22 +250,20 @@ if (typeof window !== 'undefined' && !window.__PERF_DRIVE__) {
           return
         }
 
-        setMessages(prev =>
-          prev.map(m => {
-            if (m.id !== msgId) {
-              return m
-            }
+        setMessages(prev => {
+          const index = prev.at(-1)?.id === msgId ? prev.length - 1 : prev.findIndex(message => message.id === msgId)
 
-            const head = m.parts.slice(0, -1)
-            const last = m.parts.at(-1)
+          return updateChatMessageAt(prev, index, message => {
+            const head = message.parts.slice(0, -1)
+            const last = message.parts.at(-1)
             const lastText = last && last.type === 'text' ? last.text : ''
 
             return {
-              ...m,
+              ...message,
               parts: [...head, { type: 'text', text: lastText + delta }]
             }
           })
-        )
+        })
       }
 
       const flushNow = () => {
@@ -281,10 +287,7 @@ if (typeof window !== 'undefined' && !window.__PERF_DRIVE__) {
 
         const since = performance.now() - lastFlushAt
         const wait = Math.max(0, flushMinMs - since)
-        flushHandle =
-          wait <= 0 && typeof requestAnimationFrame === 'function'
-            ? requestAnimationFrame(flushNow)
-            : (setTimeout(flushNow, wait) as unknown as number)
+        flushHandle = setTimeout(flushNow, wait) as unknown as number
       }
 
       const handle: SyntheticDriverHandle = {
@@ -297,7 +300,6 @@ if (typeof window !== 'undefined' && !window.__PERF_DRIVE__) {
 
           if (flushHandle !== null) {
             clearTimeout(flushHandle)
-            cancelAnimationFrame?.(flushHandle)
           }
 
           flushHandle = null
@@ -309,7 +311,11 @@ if (typeof window !== 'undefined' && !window.__PERF_DRIVE__) {
 
           activeHandle = null
           // Mark message finalized.
-          setMessages(prev => prev.map(m => (m.id === msgId ? { ...m, pending: false } : m)))
+          setMessages(prev => {
+            const index = prev.at(-1)?.id === msgId ? prev.length - 1 : prev.findIndex(message => message.id === msgId)
+
+            return updateChatMessageAt(prev, index, message => ({ ...message, pending: false }))
+          })
           setBusy(false)
         }
       }

--- a/apps/desktop/src/app/chat/runtime-repository.test.tsx
+++ b/apps/desktop/src/app/chat/runtime-repository.test.tsx
@@ -1,0 +1,93 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { type ChatMessage, getChatMessageListUpdate, updateChatMessageAt } from '@/lib/chat-messages'
+
+import { runtimeMessageRepositoryDelta, useRuntimeMessageRepository } from './runtime-repository'
+
+function message(id: string, role: ChatMessage['role'], text: string, pending = false): ChatMessage {
+  return {
+    id,
+    role,
+    parts: [{ type: 'text', text }],
+    pending
+  }
+}
+
+describe('useRuntimeMessageRepository', () => {
+  it('requires the exact predecessor when updates are batched', () => {
+    const messages = [message('user-1', 'user', 'Question'), message('assistant-1', 'assistant', 'A', true)]
+    const first = updateChatMessageAt(messages, 1, current => message(current.id, current.role, 'AB', true))
+    const second = updateChatMessageAt(first, 1, current => message(current.id, current.role, 'ABC', true))
+
+    expect(getChatMessageListUpdate(messages, second)).toBeNull()
+    expect(getChatMessageListUpdate(first, second)).toMatchObject({
+      index: 1,
+      previousMessage: first[1],
+      message: second[1]
+    })
+    expect(getChatMessageListUpdate(messages, first)).not.toBeNull()
+  })
+
+  it('preserves settled runtime message identity when only the streaming tail changes', () => {
+    const user = message('user-1', 'user', 'Question')
+    const settled = message('assistant-1', 'assistant', 'Settled answer')
+    const streaming = message('assistant-2', 'assistant', 'A', true)
+
+    const { result, rerender } = renderHook(
+      ({ messages }: { messages: ChatMessage[] }) => useRuntimeMessageRepository(messages),
+      { initialProps: { messages: [user, settled, streaming] } }
+    )
+
+    const initialRepository = result.current
+    const nextStreaming = message('assistant-2', 'assistant', 'AB', true)
+
+    rerender({ messages: [user, settled, nextStreaming] })
+
+    expect(result.current.messages[0]?.message).toBe(initialRepository.messages[0]?.message)
+    expect(result.current.messages[1]?.message).toBe(initialRepository.messages[1]?.message)
+    expect(result.current.messages[2]?.message).not.toBe(initialRepository.messages[2]?.message)
+    expect(result.current.messages.map(item => item.parentId)).toEqual([null, 'user-1', 'assistant-1'])
+    expect(result.current.headId).toBe('assistant-2')
+  })
+
+  it('forwards an annotated pending-tail update without rebuilding settled repository items', () => {
+    const messages = [
+      message('user-1', 'user', 'Question'),
+      message('assistant-1', 'assistant', 'Settled answer'),
+      message('assistant-2', 'assistant', 'A', true)
+    ]
+
+    const { result, rerender } = renderHook(
+      ({ messages: nextMessages }: { messages: ChatMessage[] }) => useRuntimeMessageRepository(nextMessages),
+      { initialProps: { messages } }
+    )
+
+    const initialRepository = result.current
+    const nextMessages = updateChatMessageAt(messages, 2, current => message(current.id, current.role, 'AB', true))
+
+    rerender({ messages: nextMessages })
+
+    expect(result.current.messages).toBe(initialRepository.messages)
+    expect(result.current[runtimeMessageRepositoryDelta]?.message.content).toEqual([{ type: 'text', text: 'AB' }])
+    expect(result.current[runtimeMessageRepositoryDelta]?.parentId).toBe('assistant-1')
+  })
+
+  it('falls back to a complete repository when the tail settles', () => {
+    const messages = [message('user-1', 'user', 'Question'), message('assistant-1', 'assistant', 'A', true)]
+
+    const { result, rerender } = renderHook(
+      ({ messages: nextMessages }: { messages: ChatMessage[] }) => useRuntimeMessageRepository(nextMessages),
+      { initialProps: { messages } }
+    )
+
+    const initialRepository = result.current
+    const nextMessages = updateChatMessageAt(messages, 1, current => message(current.id, current.role, 'Done', false))
+
+    rerender({ messages: nextMessages })
+
+    expect(result.current.messages).not.toBe(initialRepository.messages)
+    expect(result.current[runtimeMessageRepositoryDelta]).toBeUndefined()
+    expect(result.current.messages.at(-1)?.message.status).toEqual({ type: 'complete', reason: 'stop' })
+  })
+})

--- a/apps/desktop/src/app/chat/runtime-repository.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.ts
@@ -1,8 +1,24 @@
-import { ExportedMessageRepository, type ThreadMessage } from '@assistant-ui/react'
+import type { ExportedMessageRepository, ThreadMessage } from '@assistant-ui/react'
 import { useMemo, useRef } from 'react'
 
-import type { ChatMessage } from '@/lib/chat-messages'
+import { type ChatMessage, getChatMessageListUpdate } from '@/lib/chat-messages'
 import { coalesceToolOnlyAssistants, createToolMergeCache, toRuntimeMessage } from '@/lib/chat-runtime'
+
+export const runtimeMessageRepositoryDelta = Symbol('runtimeMessageRepositoryDelta')
+
+export type RuntimeMessageRepository = ExportedMessageRepository & {
+  [runtimeMessageRepositoryDelta]?: {
+    message: ThreadMessage
+    parentId: string | null
+  }
+}
+
+type RepositoryCache = {
+  repository: RuntimeMessageRepository
+  source: ChatMessage[]
+  tailItem: { message: ThreadMessage; parentId: string | null } | null
+  tailSource: ChatMessage | null
+}
 
 /**
  * ChatMessage[] -> assistant-ui message repository, with a WeakMap identity
@@ -10,11 +26,54 @@ import { coalesceToolOnlyAssistants, createToolMergeCache, toRuntimeMessage } fr
  * tool-only assistant turns into their neighbour). Shared by the main chat's
  * runtime boundary and session tiles — one transcript pipeline, N surfaces.
  */
-export function useRuntimeMessageRepository(messages: ChatMessage[]): ExportedMessageRepository {
+export function useRuntimeMessageRepository(messages: ChatMessage[]): RuntimeMessageRepository {
   const cacheRef = useRef(new WeakMap<ChatMessage, ThreadMessage>())
   const toolMergeCacheRef = useRef(createToolMergeCache())
+  const repositoryCacheRef = useRef<RepositoryCache | null>(null)
 
   return useMemo(() => {
+    const previous = repositoryCacheRef.current
+    const update = previous ? getChatMessageListUpdate(previous.source, messages) : null
+    const nextTail = messages.at(-1) ?? null
+
+    // Stream deltas replace only the pending tail. The provenance attached by
+    // updateChatMessageAt lets us forward that one normalized record without
+    // rescanning/coalescing the settled transcript. Completion, branch changes,
+    // hydration, and arbitrary edits fail closed to the full reconcile below.
+    if (
+      previous &&
+      update &&
+      update.index === messages.length - 1 &&
+      update.previousMessage === previous.tailSource &&
+      update.previousMessage.pending &&
+      update.message.pending &&
+      update.previousMessage.id === update.message.id &&
+      update.previousMessage.role === update.message.role &&
+      update.previousMessage.hidden === update.message.hidden &&
+      update.previousMessage.branchGroupId === update.message.branchGroupId &&
+      previous.tailItem?.message.id === update.message.id &&
+      previous.repository.headId === update.message.id
+    ) {
+      const cachedMessage = cacheRef.current.get(update.message)
+      const runtimeMessage = cachedMessage ?? toRuntimeMessage(update.message)
+
+      if (!cachedMessage) {
+        cacheRef.current.set(update.message, runtimeMessage)
+      }
+
+      const tailItem = { message: runtimeMessage, parentId: previous.tailItem.parentId }
+
+      const repository: RuntimeMessageRepository = {
+        headId: update.message.id,
+        messages: previous.repository.messages,
+        [runtimeMessageRepositoryDelta]: tailItem
+      }
+
+      repositoryCacheRef.current = { repository, source: messages, tailItem, tailSource: nextTail }
+
+      return repository
+    }
+
     const items: { message: ThreadMessage; parentId: string | null }[] = []
     const branchParentByGroup = new Map<string, string | null>()
     let visibleParentId: string | null = null
@@ -46,6 +105,13 @@ export function useRuntimeMessageRepository(messages: ChatMessage[]): ExportedMe
       }
     }
 
-    return ExportedMessageRepository.fromBranchableArray(items, { headId })
+    // toRuntimeMessage already returns normalized ThreadMessage objects. Keep
+    // those cached references intact instead of normalizing the whole history a
+    // second time on every streamed delta.
+    const repository: RuntimeMessageRepository = { headId, messages: items }
+    const tailItem = nextTail && items.at(-1)?.message.id === nextTail.id ? (items.at(-1) ?? null) : null
+    repositoryCacheRef.current = { repository, source: messages, tailItem, tailSource: nextTail }
+
+    return repository
   }, [messages])
 }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -13,6 +13,7 @@ import {
   mergeFinalAssistantText,
   reasoningPart,
   renderMediaTags,
+  updateChatMessageAt,
   upsertToolPart
 } from '@/lib/chat-messages'
 import {
@@ -103,7 +104,10 @@ export function useMessageStream({
           const prev = state.messages
           let nextMessages: ChatMessage[]
 
-          if (!prev.some(m => m.id === streamId)) {
+          const lastIndex = prev.length - 1
+          const streamIndex = prev[lastIndex]?.id === streamId ? lastIndex : prev.findIndex(m => m.id === streamId)
+
+          if (streamIndex === -1) {
             nextMessages = [
               ...prev,
               {
@@ -115,15 +119,11 @@ export function useMessageStream({
               }
             ]
           } else {
-            nextMessages = prev.map(m =>
-              m.id === streamId
-                ? {
-                    ...m,
-                    parts: transform(m.parts, m),
-                    pending: opts.pending ? opts.pending(m) : true
-                  }
-                : m
-            )
+            nextMessages = updateChatMessageAt(prev, streamIndex, message => ({
+              ...message,
+              parts: transform(message.parts, message),
+              pending: opts.pending ? opts.pending(message) : true
+            }))
           }
 
           return {

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -1,4 +1,4 @@
-import { ThreadPrimitive, useAuiEvent, useAuiState } from '@assistant-ui/react'
+import { type ThreadMessage, ThreadPrimitive, useAuiEvent, useAuiState } from '@assistant-ui/react'
 import {
   type ComponentProps,
   type CSSProperties,
@@ -15,6 +15,10 @@ import {
 import { useStickToBottom } from 'use-stick-to-bottom'
 
 import { useI18n } from '@/i18n'
+import {
+  getThreadMessageListToken,
+  getThreadMessageListUpdate
+} from '@/lib/incremental-external-store-runtime'
 import { cn } from '@/lib/utils'
 import {
   onScrollToBottomRequest,
@@ -129,6 +133,36 @@ export function firstVisibleGroupIndex(groups: readonly MessageGroup[], budget: 
 // old turns, not this small live tail).
 export const LIVE_TAIL_GROUPS = 6
 
+const messageStructureSignatures = new WeakMap<object, string>()
+
+function messageStructureSignature(messages: readonly ThreadMessage[]): string {
+  const update = getThreadMessageListUpdate(messages)
+  const currentToken = getThreadMessageListToken(messages)
+  const previousSignature = update ? messageStructureSignatures.get(update.previousToken) : undefined
+  const previousLength = update?.previousMessage.content?.length ?? 1
+  const nextLength = update?.message.content?.length ?? 1
+
+  if (
+    update &&
+    previousSignature &&
+    update.previousMessage.id === update.message.id &&
+    update.previousMessage.role === update.message.role &&
+    previousLength === nextLength
+  ) {
+    messageStructureSignatures.set(currentToken, previousSignature)
+
+    return previousSignature
+  }
+
+  const signature = messages
+    .map((message, index) => `${index}:${message.id}:${message.role}:${message.content?.length ?? 1}`)
+    .join('\n')
+
+  messageStructureSignatures.set(currentToken, signature)
+
+  return signature
+}
+
 /** True when a visible group is old enough to virtualize (outside the live tail). */
 export function isVirtualizedGroup(indexInVisible: number, visibleCount: number, liveTail = LIVE_TAIL_GROUPS): boolean {
   return indexInVisible < visibleCount - liveTail
@@ -141,11 +175,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   loadingIndicator,
   sessionKey
 }) => {
-  const messageSignature = useAuiState(s =>
-    s.thread.messages
-      .map((message, index) => `${index}:${message.id}:${message.role}:${message.content?.length ?? 1}`)
-      .join('\n')
-  )
+  const messageSignature = useAuiState(s => messageStructureSignature(s.thread.messages))
 
   const { t } = useI18n()
   const groups = buildGroups(messageSignature)

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-dom.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-dom.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { activeTimelineIndexInViewport } from './timeline-dom'
+
+function rect(top: number): DOMRect {
+  return { bottom: top, height: 0, left: 0, right: 0, top, width: 0, x: 0, y: top, toJSON: () => ({}) }
+}
+
+function messageNode(id: string, top: number): HTMLElement {
+  const node = document.createElement('div')
+  node.dataset.messageId = id
+  node.getBoundingClientRect = vi.fn(() => rect(top))
+
+  return node
+}
+
+describe('activeTimelineIndexInViewport', () => {
+  it('bounds geometry reads to the rendered-node search depth', () => {
+    const viewport = document.createElement('div')
+    viewport.getBoundingClientRect = vi.fn(() => rect(100))
+    const unrelated = messageNode('assistant-42', 70)
+
+    const rendered = Array.from({ length: 128 }, (_, offset) =>
+      messageNode(`user-${872 + offset}`, 100 + (offset - 64) * 20)
+    )
+
+    viewport.append(unrelated, ...rendered)
+    const entryIndexById = new Map(Array.from({ length: 1_000 }, (_, index) => [`user-${index}`, index]))
+    const querySelectorAll = vi.spyOn(viewport, 'querySelectorAll')
+
+    expect(activeTimelineIndexInViewport(viewport, entryIndexById)).toBe(936)
+    expect(querySelectorAll).toHaveBeenCalledOnce()
+    expect(unrelated.getBoundingClientRect).not.toHaveBeenCalled()
+
+    const geometryReads = rendered.reduce(
+      (total, node) => total + vi.mocked(node.getBoundingClientRect).mock.calls.length,
+      0
+    )
+
+    expect(geometryReads).toBeLessThanOrEqual(8)
+  })
+
+  it('falls back to the first rendered timeline entry, then zero when none are rendered', () => {
+    const viewport = document.createElement('div')
+    viewport.getBoundingClientRect = vi.fn(() => rect(100))
+    viewport.append(messageNode('user-8', 240), messageNode('user-9', 480))
+
+    const entryIndexById = new Map([
+      ['user-8', 8],
+      ['user-9', 9]
+    ])
+
+    expect(activeTimelineIndexInViewport(viewport, entryIndexById)).toBe(8)
+    expect(activeTimelineIndexInViewport(document.createElement('div'), entryIndexById)).toBe(0)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-dom.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-dom.ts
@@ -1,0 +1,49 @@
+const MESSAGE_SELECTOR = '[data-message-id]'
+
+/**
+ * Resolve the active timeline prompt from the bounded set of message nodes that
+ * is actually rendered. The transcript can contain thousands of entries while
+ * ThreadMessageList keeps only a small part budget in the DOM, so querying once
+ * and filtering through the timeline index avoids one selector scan per turn.
+ */
+export function activeTimelineIndexInViewport(
+  viewport: HTMLElement,
+  entryIndexById: ReadonlyMap<string, number>,
+  slack = 8
+): number {
+  const rendered: { index: number; node: HTMLElement }[] = []
+
+  for (const node of viewport.querySelectorAll<HTMLElement>(MESSAGE_SELECTOR)) {
+    const id = node.dataset.messageId
+    const index = id ? entryIndexById.get(id) : undefined
+
+    if (index !== undefined) {
+      rendered.push({ index, node })
+    }
+  }
+
+  if (rendered.length === 0) {
+    return 0
+  }
+
+  // Message roots follow transcript order, and each turn bounds its sticky user
+  // root, so their vertical positions remain monotonic. Binary-search the last
+  // prompt at/above the viewport edge instead of forcing layout for every root.
+  const edge = viewport.getBoundingClientRect().top + slack
+  let low = 0
+  let high = rendered.length - 1
+  let active = -1
+
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2)
+
+    if (rendered[middle].node.getBoundingClientRect().top <= edge) {
+      active = middle
+      low = middle + 1
+    } else {
+      high = middle - 1
+    }
+  }
+
+  return active === -1 ? rendered[0].index : rendered[active].index
+}

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
@@ -1,15 +1,15 @@
-import { useAuiState } from '@assistant-ui/react'
+import { type ThreadMessage, useAuiState } from '@assistant-ui/react'
 import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { triggerHaptic } from '@/lib/haptics'
+import {
+  getThreadMessageListToken,
+  getThreadMessageListUpdate
+} from '@/lib/incremental-external-store-runtime'
 import { cn } from '@/lib/utils'
 
-import {
-  activeTimelineIndex,
-  deriveTimelineEntries,
-  type TimelineEntry,
-  type TimelineSourceMessage
-} from './timeline-data'
+import { deriveTimelineEntries, type TimelineEntry, type TimelineSourceMessage } from './timeline-data'
+import { activeTimelineIndexInViewport } from './timeline-dom'
 
 const MIN_ENTRIES = 4
 const VIEWPORT = '[data-slot="aui_thread-viewport"]'
@@ -54,6 +54,33 @@ function userPromptText(content: unknown): string {
   }
 
   return out
+}
+
+const timelineSourceSignatures = new WeakMap<object, string>()
+
+function timelineSourceSignature(messages: readonly ThreadMessage[]): string {
+  const update = getThreadMessageListUpdate(messages)
+  const currentToken = getThreadMessageListToken(messages)
+  const previousSignature = update ? timelineSourceSignatures.get(update.previousToken) : undefined
+
+  if (update && update.previousMessage.role !== 'user' && update.message.role !== 'user' && previousSignature) {
+    timelineSourceSignatures.set(currentToken, previousSignature)
+
+    return previousSignature
+  }
+
+  const rows: TimelineSourceMessage[] = []
+
+  for (const message of messages) {
+    if (message.role === 'user') {
+      rows.push({ id: message.id, role: 'user', text: userPromptText(message.content) })
+    }
+  }
+
+  const signature = JSON.stringify(rows)
+  timelineSourceSignatures.set(currentToken, signature)
+
+  return signature
 }
 
 /** Index-keyed ref-array setter — `ref={listRef(refs, i)}`. */
@@ -117,24 +144,14 @@ function scrollToPrompt(id: string) {
 
 /** Right-edge prompt rail — hover previews, click to jump. ≥4 user turns only. */
 export const ThreadTimeline: FC = () => {
-  const sourceSignature = useAuiState(s => {
-    const rows: TimelineSourceMessage[] = []
-
-    for (const message of s.thread.messages) {
-      if (message.role !== 'user') {
-        continue
-      }
-
-      rows.push({ id: message.id, role: 'user', text: userPromptText(message.content) })
-    }
-
-    return JSON.stringify(rows)
-  })
+  const sourceSignature = useAuiState(s => timelineSourceSignature(s.thread.messages))
 
   const entries = useMemo(
     () => deriveTimelineEntries(JSON.parse(sourceSignature) as TimelineSourceMessage[]),
     [sourceSignature]
   )
+
+  const entryIndexById = useMemo(() => new Map(entries.map((entry, index) => [entry.id, index])), [entries])
 
   const [activeIndex, setActiveIndex] = useState(0)
   const [open, setOpen] = useState(false)
@@ -178,7 +195,7 @@ export const ThreadTimeline: FC = () => {
   useEffect(() => {
     const viewport = document.querySelector<HTMLElement>(VIEWPORT)
 
-    if (!viewport || entries.length === 0) {
+    if (!viewport || entryIndexById.size === 0) {
       return
     }
 
@@ -186,16 +203,7 @@ export const ThreadTimeline: FC = () => {
 
     const compute = () => {
       raf = 0
-
-      const top = viewport.getBoundingClientRect().top
-
-      const offsets = entries.map(entry => {
-        const node = viewport.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(entry.id)}"]`)
-
-        return node ? node.getBoundingClientRect().top - top : null
-      })
-
-      const next = activeTimelineIndex(offsets)
+      const next = activeTimelineIndexInViewport(viewport, entryIndexById)
 
       setActiveIndex(prev => (prev === next ? prev : next))
     }
@@ -207,11 +215,11 @@ export const ThreadTimeline: FC = () => {
     }
 
     // Initial compute rides the same rAF batching as scroll. A sync call here
-    // reads getBoundingClientRect for every user message while other commit
-    // effects are still writing styles — on a session switch that interleaving
-    // forces a full reflow per read on a large transcript. One rAF later the
-    // reads batch into a single layout pass, and back-to-back entries updates
-    // (prefetch paint, then resume reconcile) coalesce into one compute.
+    // reads rendered message geometry while other commit effects are still
+    // writing styles — on a session switch that interleaving can force repeated
+    // reflow. One rAF later the reads batch into a single layout pass, and
+    // back-to-back entries updates (prefetch paint, then resume reconcile)
+    // coalesce into one compute.
     onScroll()
     viewport.addEventListener('scroll', onScroll, { passive: true })
 
@@ -222,7 +230,7 @@ export const ThreadTimeline: FC = () => {
         cancelAnimationFrame(raf)
       }
     }
-  }, [entries])
+  }, [entryIndexById])
 
   if (entries.length < MIN_ENTRIES) {
     return null

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -6,11 +6,13 @@ import {
   appendReasoningPart,
   chatMessageText,
   collectUnspokenTurnSpeech,
+  getChatMessageListUpdate,
   mergeFinalAssistantText,
   preserveLocalAssistantErrors,
   reasoningPart,
   renderMediaTags,
   toChatMessages,
+  updateChatMessageAt,
   upsertToolPart
 } from './chat-messages'
 
@@ -226,6 +228,50 @@ describe('interleaved reasoning/text coalescing', () => {
 })
 
 describe('preserveLocalAssistantErrors', () => {
+  it('preserves single-tail provenance through same-session publication', () => {
+    const currentMessages: ChatMessage[] = [
+      { id: 'user-1', parts: [{ text: 'question', type: 'text' }], role: 'user' },
+      { id: 'assistant-1', parts: [{ text: 'A', type: 'text' }], role: 'assistant', pending: true }
+    ]
+
+    const nextMessages = updateChatMessageAt(currentMessages, 1, message => ({
+      ...message,
+      parts: [{ text: 'AB', type: 'text' }]
+    }))
+
+    const published = preserveLocalAssistantErrors(nextMessages, currentMessages)
+
+    expect(published).toBe(nextMessages)
+    expect(getChatMessageListUpdate(currentMessages, published)).toMatchObject({ index: 1, message: nextMessages[1] })
+  })
+
+  it('reuses a coalesced source snapshot so the following delta regains provenance', () => {
+    const initial: ChatMessage[] = [
+      { id: 'user-1', parts: [{ text: 'question', type: 'text' }], role: 'user' },
+      { id: 'assistant-1', parts: [{ text: 'A', type: 'text' }], role: 'assistant', pending: true }
+    ]
+
+    const intermediate = updateChatMessageAt(initial, 1, message => ({
+      ...message,
+      parts: [{ text: 'AB', type: 'text' }]
+    }))
+
+    const coalesced = updateChatMessageAt(intermediate, 1, message => ({
+      ...message,
+      parts: [{ text: 'ABC', type: 'text' }]
+    }))
+
+    const published = preserveLocalAssistantErrors(coalesced, initial)
+    expect(published).toBe(coalesced)
+
+    const following = updateChatMessageAt(coalesced, 1, message => ({
+      ...message,
+      parts: [{ text: 'ABCD', type: 'text' }]
+    }))
+
+    expect(getChatMessageListUpdate(published, following)).toMatchObject({ index: 1, message: following[1] })
+  })
+
   it('preserves a local user+error pair when hydration omits the failed turn', () => {
     const nextMessages: ChatMessage[] = [
       {

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -26,6 +26,77 @@ export type ChatMessage = {
   attachmentRefs?: string[]
 }
 
+export type ChatMessageListUpdate = {
+  index: number
+  message: ChatMessage
+  previousMessage: ChatMessage
+}
+
+type StoredChatMessageListUpdate = ChatMessageListUpdate & { previousToken: object }
+
+const chatMessageListUpdates = new WeakMap<ChatMessage[], StoredChatMessageListUpdate>()
+const chatMessageListTokens = new WeakMap<ChatMessage[], object>()
+
+function chatMessageListToken(messages: ChatMessage[]): object {
+  const existing = chatMessageListTokens.get(messages)
+
+  if (existing) {
+    return existing
+  }
+
+  const token = {}
+  chatMessageListTokens.set(messages, token)
+
+  return token
+}
+
+/**
+ * Replace one message while recording the exact predecessor list. Consumers
+ * that maintain their own normalized repository can use this provenance for an
+ * O(1) update instead of rediscovering the changed item by scanning history.
+ */
+export function updateChatMessageAt(
+  messages: ChatMessage[],
+  index: number,
+  update: (message: ChatMessage) => ChatMessage
+): ChatMessage[] {
+  const previousMessage = messages[index]
+
+  if (!previousMessage) {
+    return messages
+  }
+
+  const message = update(previousMessage)
+
+  if (message === previousMessage) {
+    return messages
+  }
+
+  const next = messages.slice()
+  next[index] = message
+  chatMessageListUpdates.set(next, {
+    index,
+    message,
+    previousMessage,
+    previousToken: chatMessageListToken(messages)
+  })
+
+  return next
+}
+
+export function getChatMessageListUpdate(
+  previous: ChatMessage[],
+  current: ChatMessage[]
+): ChatMessageListUpdate | null {
+  const update = chatMessageListUpdates.get(current)
+
+  if (update?.previousToken !== chatMessageListToken(previous)) {
+    return null
+  }
+
+  return update
+}
+
 export type GatewayEventPayload = {
   text?: string
   rendered?: string
@@ -974,7 +1045,35 @@ export function preserveLocalAssistantErrors(
   nextMessages: ChatMessage[],
   currentMessages: ChatMessage[]
 ): ChatMessage[] {
+  const update = getChatMessageListUpdate(currentMessages, nextMessages)
+
+  // Same-session streaming changes exactly one message. All untouched local
+  // errors are already present by identity, so preserve the tagged array and
+  // avoid the authoritative hydration scans on the per-delta path.
+  if (update) {
+    const next = update.message
+    const local = update.previousMessage
+
+    if (
+      next.role === 'assistant' &&
+      !next.error &&
+      !next.hidden &&
+      local.role === 'assistant' &&
+      local.error &&
+      !local.hidden
+    ) {
+      return updateChatMessageAt(nextMessages, update.index, message => ({
+        ...message,
+        error: local.error,
+        pending: false
+      }))
+    }
+
+    return nextMessages
+  }
+
   const localById = new Map(currentMessages.map(message => [message.id, message]))
+  let mergedChanged = false
 
   const mergedNextMessages = nextMessages.map(message => {
     if (message.role !== 'assistant' || message.error || message.hidden) {
@@ -986,6 +1085,8 @@ export function preserveLocalAssistantErrors(
     if (!local || local.role !== 'assistant' || !local.error || local.hidden) {
       return message
     }
+
+    mergedChanged = true
 
     return {
       ...message,
@@ -1031,7 +1132,7 @@ export function preserveLocalAssistantErrors(
   }
 
   if (preserveIds.size === 0) {
-    return mergedNextMessages
+    return mergedChanged ? mergedNextMessages : nextMessages
   }
 
   const preserved = currentMessages

--- a/apps/desktop/src/lib/incremental-external-store-runtime.test.ts
+++ b/apps/desktop/src/lib/incremental-external-store-runtime.test.ts
@@ -1,0 +1,324 @@
+import { type ExportedMessageRepository, fromThreadMessageLike, type ThreadMessage } from '@assistant-ui/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  type RuntimeMessageRepository,
+  runtimeMessageRepositoryDelta
+} from '@/app/chat/runtime-repository'
+
+import {
+  getThreadMessageListToken,
+  getThreadMessageListUpdate,
+  syncRepositoryIncrementally
+} from './incremental-external-store-runtime'
+
+function message(id: string, text: string): ThreadMessage {
+  return fromThreadMessageLike({ role: 'assistant', content: [{ type: 'text', text }] }, id, {
+    type: 'complete',
+    reason: 'stop'
+  })
+}
+
+function repositoryMock(existing: ExportedMessageRepository) {
+  const repository = {
+    addOrUpdateMessage: vi.fn(),
+    deleteMessage: vi.fn(),
+    export: vi.fn(() => existing),
+    getMessage: vi.fn((id: string) => {
+      const item = existing.messages.find(({ message: existingMessage }) => existingMessage.id === id)
+
+      if (!item) {
+        throw new Error(`Missing message: ${id}`)
+      }
+
+      return { ...item, index: existing.messages.indexOf(item) }
+    }),
+    getMessages: vi.fn(() => existing.messages.map(item => item.message)),
+    headId: existing.headId,
+    resetHead: vi.fn()
+  }
+
+  return repository
+}
+
+describe('syncRepositoryIncrementally', () => {
+  it('does not rewrite stable messages or reset an unchanged head', () => {
+    const first = message('assistant-1', 'first')
+    const tail = message('assistant-2', 'tail')
+
+    const incoming: ExportedMessageRepository = {
+      headId: tail.id,
+      messages: [
+        { message: first, parentId: null },
+        { message: tail, parentId: first.id }
+      ]
+    }
+
+    const repository = repositoryMock(incoming)
+
+    syncRepositoryIncrementally(repository as unknown as Parameters<typeof syncRepositoryIncrementally>[0], incoming)
+
+    expect(repository.addOrUpdateMessage).not.toHaveBeenCalled()
+    expect(repository.deleteMessage).not.toHaveBeenCalled()
+    expect(repository.resetHead).not.toHaveBeenCalled()
+    expect(repository.getMessages).toHaveBeenCalledOnce()
+  })
+
+  it('updates only the changed stream message', () => {
+    const first = message('assistant-1', 'first')
+    const previousTail = message('assistant-2', 'A')
+    const nextTail = message('assistant-2', 'AB')
+
+    const existing: ExportedMessageRepository = {
+      headId: previousTail.id,
+      messages: [
+        { message: first, parentId: null },
+        { message: previousTail, parentId: first.id }
+      ]
+    }
+
+    const incoming: ExportedMessageRepository = {
+      headId: nextTail.id,
+      messages: [
+        { message: first, parentId: null },
+        { message: nextTail, parentId: first.id }
+      ]
+    }
+
+    const repository = repositoryMock(existing)
+
+    syncRepositoryIncrementally(repository as unknown as Parameters<typeof syncRepositoryIncrementally>[0], incoming)
+
+    expect(repository.addOrUpdateMessage).toHaveBeenCalledOnce()
+    expect(repository.addOrUpdateMessage).toHaveBeenCalledWith(first.id, nextTail)
+    expect(repository.deleteMessage).not.toHaveBeenCalled()
+    expect(repository.resetHead).not.toHaveBeenCalled()
+  })
+
+  it('applies a pending-tail delta without exporting or scanning the settled repository', () => {
+    const first = message('assistant-1', 'first')
+    const previousTail = message('assistant-2', 'A')
+    const nextTail = message('assistant-2', 'AB')
+
+    const existing: ExportedMessageRepository = {
+      headId: previousTail.id,
+      messages: [
+        { message: first, parentId: null },
+        { message: previousTail, parentId: first.id }
+      ]
+    }
+
+    const incoming: RuntimeMessageRepository = {
+      headId: nextTail.id,
+      messages: existing.messages,
+      [runtimeMessageRepositoryDelta]: { message: nextTail, parentId: first.id }
+    }
+
+    const repository = repositoryMock(existing)
+    const visibleMessages = existing.messages.map(item => item.message)
+
+    const messages = syncRepositoryIncrementally(
+      repository as unknown as Parameters<typeof syncRepositoryIncrementally>[0],
+      incoming,
+      visibleMessages
+    )
+
+    expect(repository.export).not.toHaveBeenCalled()
+    expect(repository.getMessages).not.toHaveBeenCalled()
+    expect(repository.getMessage).toHaveBeenCalledOnce()
+    expect(repository.addOrUpdateMessage).toHaveBeenCalledOnce()
+    expect(repository.addOrUpdateMessage).toHaveBeenCalledWith(first.id, nextTail)
+    expect(repository.deleteMessage).not.toHaveBeenCalled()
+    expect(repository.resetHead).not.toHaveBeenCalled()
+    expect(getThreadMessageListUpdate(messages)).toMatchObject({
+      index: 1,
+      message: nextTail,
+      previousMessage: previousTail
+    })
+  })
+
+  it('falls back to authoritative reconcile when a same-id delta is based on an uncommitted snapshot', () => {
+    const root = message('assistant-1', 'root')
+    const previousTail = message('assistant-2', 'tail')
+    const nextRoot = message('assistant-1', 'updated root')
+    const nextTail = message('assistant-2', 'updated tail')
+
+    const existing: ExportedMessageRepository = {
+      headId: previousTail.id,
+      messages: [
+        { message: root, parentId: null },
+        { message: previousTail, parentId: root.id }
+      ]
+    }
+
+    const repository = repositoryMock(existing)
+
+    const incoming: RuntimeMessageRepository = {
+      headId: nextTail.id,
+      messages: [
+        { message: nextRoot, parentId: null },
+        { message: previousTail, parentId: nextRoot.id }
+      ],
+      [runtimeMessageRepositoryDelta]: { message: nextTail, parentId: nextRoot.id }
+    }
+
+    syncRepositoryIncrementally(
+      repository as unknown as Parameters<typeof syncRepositoryIncrementally>[0],
+      incoming,
+      existing.messages.map(item => item.message),
+      false
+    )
+
+    expect(repository.export).toHaveBeenCalledOnce()
+    expect(repository.addOrUpdateMessage).toHaveBeenCalledWith(null, nextRoot)
+    expect(repository.addOrUpdateMessage).toHaveBeenCalledWith(nextRoot.id, nextTail)
+  })
+
+  it('records consecutive visible-tail provenance without retaining predecessor arrays', () => {
+    const first = message('assistant-1', 'first')
+    const initialTail = message('assistant-2', 'A')
+    const nextTail = message('assistant-2', 'AB')
+    const finalTail = message('assistant-2', 'ABC')
+
+    const initial: ExportedMessageRepository = {
+      headId: initialTail.id,
+      messages: [
+        { message: first, parentId: null },
+        { message: initialTail, parentId: first.id }
+      ]
+    }
+
+    const firstRepository = repositoryMock(initial)
+
+    const firstMessages = syncRepositoryIncrementally(
+      firstRepository as unknown as Parameters<typeof syncRepositoryIncrementally>[0],
+      {
+        headId: nextTail.id,
+        messages: initial.messages,
+        [runtimeMessageRepositoryDelta]: { message: nextTail, parentId: first.id }
+      }
+    )
+
+    const firstUpdate = getThreadMessageListUpdate(firstMessages)
+    const initialVisibleMessages = firstRepository.getMessages.mock.results[0]?.value as ThreadMessage[]
+
+    expect(firstUpdate).toMatchObject({
+      previousToken: getThreadMessageListToken(initialVisibleMessages),
+      previousMessage: initialTail,
+      message: nextTail
+    })
+    expect(firstUpdate?.previousToken).not.toBe(initialVisibleMessages)
+
+    const afterFirst: ExportedMessageRepository = {
+      headId: nextTail.id,
+      messages: [
+        { message: first, parentId: null },
+        { message: nextTail, parentId: first.id }
+      ]
+    }
+
+    const secondRepository = repositoryMock(afterFirst)
+    secondRepository.getMessages.mockReturnValue(firstMessages as ThreadMessage[])
+
+    const secondMessages = syncRepositoryIncrementally(
+      secondRepository as unknown as Parameters<typeof syncRepositoryIncrementally>[0],
+      {
+        headId: finalTail.id,
+        messages: afterFirst.messages,
+        [runtimeMessageRepositoryDelta]: { message: finalTail, parentId: first.id }
+      }
+    )
+
+    expect(getThreadMessageListUpdate(secondMessages)).toMatchObject({
+      index: 1,
+      previousToken: getThreadMessageListToken(firstMessages),
+      previousMessage: nextTail,
+      message: finalTail
+    })
+  })
+
+  it('removes messages missing from an authoritative snapshot and moves the head', () => {
+    const first = message('assistant-1', 'first')
+    const staleTail = message('assistant-2', 'stale')
+
+    const existing: ExportedMessageRepository = {
+      headId: staleTail.id,
+      messages: [
+        { message: first, parentId: null },
+        { message: staleTail, parentId: first.id }
+      ]
+    }
+
+    const incoming: ExportedMessageRepository = {
+      headId: first.id,
+      messages: [{ message: first, parentId: null }]
+    }
+
+    const repository = repositoryMock(existing)
+
+    syncRepositoryIncrementally(repository as unknown as Parameters<typeof syncRepositoryIncrementally>[0], incoming)
+
+    expect(repository.deleteMessage).toHaveBeenCalledOnce()
+    expect(repository.deleteMessage).toHaveBeenCalledWith(staleTail.id)
+    expect(repository.addOrUpdateMessage).not.toHaveBeenCalled()
+    expect(repository.resetHead).toHaveBeenCalledOnce()
+    expect(repository.resetHead).toHaveBeenCalledWith(first.id)
+  })
+
+  it('rebuilds a fully disjoint transcript from leaves to root', () => {
+    const oldRoot = message('old-1', 'old root')
+    const oldTail = message('old-2', 'old tail')
+    const next = message('new-1', 'new')
+
+    const existing: ExportedMessageRepository = {
+      headId: oldTail.id,
+      messages: [
+        { message: oldRoot, parentId: null },
+        { message: oldTail, parentId: oldRoot.id }
+      ]
+    }
+
+    const incoming: ExportedMessageRepository = {
+      headId: next.id,
+      messages: [{ message: next, parentId: null }]
+    }
+
+    const repository = repositoryMock(existing)
+
+    syncRepositoryIncrementally(repository as unknown as Parameters<typeof syncRepositoryIncrementally>[0], incoming)
+
+    expect(repository.deleteMessage.mock.calls).toEqual([[oldTail.id], [oldRoot.id]])
+    expect(repository.addOrUpdateMessage).toHaveBeenCalledOnce()
+    expect(repository.addOrUpdateMessage).toHaveBeenCalledWith(null, next)
+    expect(repository.resetHead).toHaveBeenCalledWith(next.id)
+  })
+
+  it('updates a stable message when its branch parent changes', () => {
+    const root = message('assistant-1', 'root')
+    const branch = message('assistant-2', 'branch')
+
+    const existing: ExportedMessageRepository = {
+      headId: branch.id,
+      messages: [
+        { message: root, parentId: null },
+        { message: branch, parentId: root.id }
+      ]
+    }
+
+    const incoming: ExportedMessageRepository = {
+      headId: branch.id,
+      messages: [
+        { message: root, parentId: null },
+        { message: branch, parentId: null }
+      ]
+    }
+
+    const repository = repositoryMock(existing)
+
+    syncRepositoryIncrementally(repository as unknown as Parameters<typeof syncRepositoryIncrementally>[0], incoming)
+
+    expect(repository.addOrUpdateMessage).toHaveBeenCalledOnce()
+    expect(repository.addOrUpdateMessage).toHaveBeenCalledWith(null, branch)
+    expect(repository.resetHead).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/incremental-external-store-runtime.ts
+++ b/apps/desktop/src/lib/incremental-external-store-runtime.ts
@@ -7,6 +7,7 @@ import {
 } from '@assistant-ui/core/internal'
 import {
   type AssistantRuntime,
+  type ExportedMessageRepository,
   type ExternalStoreAdapter,
   fromThreadMessageLike,
   generateId,
@@ -15,7 +16,39 @@ import {
 } from '@assistant-ui/react'
 import { useEffect, useMemo, useState } from 'react'
 
+import {
+  type RuntimeMessageRepository,
+  runtimeMessageRepositoryDelta
+} from '@/app/chat/runtime-repository'
+
 const EMPTY_ARRAY = Object.freeze([])
+
+export type ThreadMessageListUpdate = {
+  index: number
+  message: ThreadMessage
+  previousToken: object
+  previousMessage: ThreadMessage
+}
+
+const threadMessageListUpdates = new WeakMap<readonly ThreadMessage[], ThreadMessageListUpdate>()
+const threadMessageListTokens = new WeakMap<readonly ThreadMessage[], object>()
+
+export function getThreadMessageListToken(messages: readonly ThreadMessage[]): object {
+  const existing = threadMessageListTokens.get(messages)
+
+  if (existing) {
+    return existing
+  }
+
+  const token = {}
+  threadMessageListTokens.set(messages, token)
+
+  return token
+}
+
+export function getThreadMessageListUpdate(messages: readonly ThreadMessage[]): ThreadMessageListUpdate | null {
+  return threadMessageListUpdates.get(messages) ?? null
+}
 
 const shallowEqual = (a: object, b: object): boolean => {
   const aKeys = Object.keys(a)
@@ -35,13 +68,67 @@ const shallowEqual = (a: object, b: object): boolean => {
 
 const getThreadListAdapter = (store: ExternalStoreAdapter) => store.adapters?.threadList ?? {}
 
-function syncRepositoryIncrementally(
-  runtime: ExternalStoreThreadRuntimeCore,
-  messageRepository: NonNullable<ExternalStoreAdapter['messageRepository']>
+export function syncRepositoryIncrementally(
+  repository: ExternalStoreThreadRuntimeCore['repository'],
+  messageRepository: NonNullable<ExternalStoreAdapter['messageRepository']> | RuntimeMessageRepository,
+  visibleMessages?: readonly ThreadMessage[],
+  allowDelta = true
 ): readonly ThreadMessage[] {
-  const repository = (runtime as unknown as { repository: ExternalStoreThreadRuntimeCore['repository'] }).repository
+  const delta = (messageRepository as RuntimeMessageRepository)[runtimeMessageRepositoryDelta]
+
+  if (delta && allowDelta) {
+    let existing: ReturnType<typeof repository.getMessage> | null = null
+
+    try {
+      existing = repository.getMessage(delta.message.id)
+    } catch {
+      // A concurrent render may prepare a delta against a snapshot that never
+      // commits. Fall through to authoritative reconcile rather than throwing.
+    }
+
+    if (existing) {
+      const headId = messageRepository.headId ?? delta.message.id
+      const messages = visibleMessages ?? repository.getMessages()
+
+      const canReplaceVisibleMessage =
+        existing.parentId === delta.parentId &&
+        repository.headId === headId &&
+        messages[existing.index]?.id === delta.message.id
+
+      if (existing.message === delta.message) {
+        return messages
+      }
+
+      repository.addOrUpdateMessage(delta.parentId, delta.message)
+
+      if (canReplaceVisibleMessage) {
+        const nextMessages = messages.with(existing.index, delta.message)
+        threadMessageListUpdates.set(nextMessages, {
+          index: existing.index,
+          message: delta.message,
+          previousMessage: existing.message,
+          previousToken: getThreadMessageListToken(messages)
+        })
+
+        return nextMessages
+      }
+
+      if (repository.headId !== headId) {
+        repository.resetHead(headId)
+      }
+
+      return repository.getMessages()
+    }
+  }
+
   const incomingIds = new Set(messageRepository.messages.map(({ message }) => message.id))
+
+  if (delta) {
+    incomingIds.add(delta.message.id)
+  }
+
   const existing = repository.export().messages
+  const existingById = new Map(existing.map(item => [item.message.id, item]))
 
   // A thread switch swaps in a fully-DISJOINT transcript (no id carries over).
   // Reconciling two unrelated trees in place — grafting the new chain onto the
@@ -51,26 +138,40 @@ function syncRepositoryIncrementally(
     for (const { message } of [...existing].reverse()) {
       repository.deleteMessage(message.id)
     }
+
+    existingById.clear()
   }
 
   for (const { message, parentId } of messageRepository.messages) {
-    repository.addOrUpdateMessage(parentId, message)
+    const previous = existingById.get(message.id)
+
+    if (!previous || previous.message !== message || previous.parentId !== parentId) {
+      repository.addOrUpdateMessage(parentId, message)
+    }
   }
 
-  for (const { message } of repository.export().messages) {
+  if (delta) {
+    repository.addOrUpdateMessage(delta.parentId, delta.message)
+  }
+
+  for (const { message } of existingById.values()) {
     if (!incomingIds.has(message.id)) {
       repository.deleteMessage(message.id)
     }
   }
 
-  const headId = messageRepository.headId ?? messageRepository.messages.at(-1)?.message.id ?? null
+  const headId = messageRepository.headId ?? delta?.message.id ?? messageRepository.messages.at(-1)?.message.id ?? null
 
-  repository.resetHead(headId)
+  if (repository.headId !== headId) {
+    repository.resetHead(headId)
+  }
 
   return repository.getMessages()
 }
 
 class IncrementalExternalStoreThreadRuntimeCore extends ExternalStoreThreadRuntimeCore {
+  private appliedRepositoryMessages: ExportedMessageRepository['messages'] | undefined
+
   override __internal_setAdapter(store: ExternalStoreAdapter): void {
     if (!store.messageRepository) {
       super.__internal_setAdapter(store)
@@ -137,7 +238,16 @@ class IncrementalExternalStoreThreadRuntimeCore extends ExternalStoreThreadRunti
       self._assistantOptimisticId = null
     }
 
-    const messages = syncRepositoryIncrementally(this, store.messageRepository)
+    const allowDelta = store.messageRepository.messages === this.appliedRepositoryMessages
+
+    const messages = syncRepositoryIncrementally(
+      this.repository,
+      store.messageRepository,
+      self._messages,
+      allowDelta
+    )
+
+    this.appliedRepositoryMessages = store.messageRepository.messages
 
     if (messages.length > 0) {
       this.ensureInitialized()
@@ -146,6 +256,8 @@ class IncrementalExternalStoreThreadRuntimeCore extends ExternalStoreThreadRunti
     if ((oldStore?.isRunning ?? false) !== (store.isRunning ?? false)) {
       self._notifyEventSubscribers(store.isRunning ? 'runStart' : 'runEnd', {})
     }
+
+    let repositoryChangedAfterSync = false
 
     // metadata.isOptimistic keeps this placeholder ephemeral: core evicts
     // off-branch optimistic messages on head moves and omits them from export().
@@ -158,10 +270,17 @@ class IncrementalExternalStoreThreadRuntimeCore extends ExternalStoreThreadRunti
         })
       )
       self._assistantOptimisticId = optimisticId
+      repositoryChangedAfterSync = true
     }
 
-    this.repository.resetHead(self._assistantOptimisticId ?? messages.at(-1)?.id ?? null)
-    self._messages = this.repository.getMessages()
+    const headId = self._assistantOptimisticId ?? store.messageRepository.headId ?? messages.at(-1)?.id ?? null
+
+    if (this.repository.headId !== headId) {
+      this.repository.resetHead(headId)
+      repositoryChangedAfterSync = true
+    }
+
+    self._messages = repositoryChangedAfterSync ? this.repository.getMessages() : messages
     self._notifySubscribers()
   }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #69120.

Desktop stream rendering currently repeats several dominant transcript-sized scans for every incoming delta. This PR records single-message updates at the source, forwards validated pending-tail deltas without re-exporting/re-indexing the settled repository, keeps historical runtime messages reference-stable, and limits timeline geometry work to rendered prompts. Completion, authoritative replay, deletion, branch changes, and session changes still use the complete reconcile path.

The immutable source and visible-message arrays still require shallow reference copies; this PR targets the measured conversion, repository traversal, signature, and DOM-layout costs rather than replacing the Desktop transcript data structure.

It also adds a report-only `stream-history` performance scenario. History is mounted before recorders start; the harness verifies the source message count, waits for two paints, and applies a configurable settle period before measuring subsequent streaming.

Draft #68724 is complementary: it removes `requestAnimationFrame` from production delta flushing for hidden windows. This PR does not change that production scheduler. Its synthetic perf driver also uses timer-only flushing, so it does not reintroduce a hidden-window rAF dependency.

## Related Issue

Fixes #69120

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/runtime-repository.ts`
  - preserve the normalized `ThreadMessage` objects produced by the existing conversion cache instead of recreating the complete branch array;
  - forward strictly validated pending-tail updates as a single repository delta.
- `apps/desktop/src/app/session/hooks/use-message-stream/index.ts`
  - update the active tail directly and attach predecessor provenance, avoiding a JavaScript callback over every settled message.
- `apps/desktop/src/lib/chat-messages.ts`
  - preserve single-tail provenance through same-session local-error reconciliation; authoritative hydration still uses the complete merge path.
- `apps/desktop/src/lib/incremental-external-store-runtime.ts`
  - apply validated tail deltas via direct repository lookup without exporting/indexing both complete repositories;
  - compare message identity and `parentId` on complete reconciles, avoid duplicate full exports, and reset the head only when necessary;
  - retain authoritative deletion and disjoint-session replacement semantics.
- `apps/desktop/src/components/assistant-ui/thread/timeline.tsx`
  - replace one DOM selector per historical timeline entry with one bounded rendered-node scan;
  - use binary geometry lookup for the active rendered prompt;
  - retain the previous user-prompt signature when a runtime notification changes only the assistant tail.
- `apps/desktop/src/components/assistant-ui/thread/list.tsx`
  - retain unchanged grouping metadata for text-only assistant-tail growth.
- `apps/desktop/scripts/perf/scenarios/stream-history.mjs`
  - add a report-only long-history stream scenario with source-count verification, a configurable settle delay, and deterministic completion waiting.
- Regression tests cover pending-tail provenance and direct delta application, completion fallback, reference stability, authoritative deletion, session replacement, branch-parent changes, `headId`, and logarithmically bounded timeline geometry reads.

## How to Test

1. Run the Desktop correctness/build gate:

```bash
cd apps/desktop
NODE_OPTIONS='--max-old-space-size=8192 --no-webstorage' LANG=C.UTF-8 LC_ALL=C.UTF-8 npm run check
```

2. Run lint:

```bash
cd apps/desktop
NODE_OPTIONS='--max-old-space-size=8192 --no-webstorage' LANG=C.UTF-8 LC_ALL=C.UTF-8 npm run lint
```

3. Run the production history benchmark:

```bash
cd apps/desktop
npm run perf -- stream-history --spawn --prod --runs 5 --historyTurns 200
npm run perf -- stream-history --spawn --prod --runs 5 --historyTurns 1000
```

Median of five runs on the same Linux/Wayland machine:

| Preloaded history | Metric | Before | After | Change |
|---|---|---:|---:|---:|
| 400 messages | frame p95 | 54.9 ms | 32.4 ms | -41.0% |
| 400 messages | frame p99 | 61.9 ms | 37.7 ms | -39.1% |
| 400 messages | frames >33 ms | 338 | 27 | -92.0% |
| 400 messages | max long task | 387 ms | 133 ms | -65.6% |
| 2,000 messages | frame p95 | 209.0 ms | 91.9 ms | -56.0% |
| 2,000 messages | frame p99 | 234.9 ms | 108.1 ms | -54.0% |
| 2,000 messages | frames >33 ms | 481 | 390 | -18.9% |
| 2,000 messages | max long task | 591 ms | 226 ms | -61.8% |

Empty-history control remained within run-to-run noise: frame p95 `22.4 ms` before and `23.2 ms` after, with one frame over 33 ms in each sample.

The benchmark was recorded around base `a2c2ec63322b791d6d1a7a024640064d96e7f0ae`. The branch was subsequently rebased onto current `main` (`91546b8337068891cc0a6b834d89d0d9270fb3ec`) to resolve the PR's merge conflict. The only rebase conflict was the import list in `apps/desktop/src/lib/chat-messages.test.ts`; it preserves both current-main's `collectUnspokenTurnSpeech` import and this PR's `getChatMessageListUpdate` import. The published rebased head is `854075304e540c0605e0b762b5d0ac4e5a4ff985`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: this PR changes only Desktop TypeScript/React and its performance harness; the complete Desktop gate below passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 7.1.4-1-cachyos, Wayland, Node.js 25.4.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the Desktop perf README documents `stream-history`
- [x] `cli-config.yaml.example` update is N/A — no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A — no contributor workflow changed
- [x] I've considered cross-platform impact — production changes use browser/TypeScript APIs; the Windows checker found no applicable scanned files; perf results are explicitly Linux/Wayland and are not compared with the committed macOS ARM baseline
- [x] Tool descriptions/schemas update is N/A — no Hermes tool behavior changed

## Screenshots / Logs

Initial local verification on the pre-rebase base `3e953ed815ffb1e35277a77eb3e764d39dcf36f7`:

- `npm run check` — PASS (typecheck, complete Desktop Vitest suite, production build, and Linux package)
- `npm run lint` — PASS with 9 existing warnings outside the changed files and 0 errors
- `python scripts/check-windows-footguns.py --diff origin/main` — no applicable files (`0` scanned)
- `git diff --check` — PASS
- focused regressions for production provenance publication, repository identity, bounded provenance lifetime, stale-delta fallback, incremental reconcile, and timeline DOM bounds — PASS (`56` tests)

Post-rebase validation on `91546b8337068891cc0a6b834d89d0d9270fb3ec`:

- focused Desktop Vitest: the four changed test files — PASS (`56` tests)
- `npm --workspace apps/desktop run typecheck` — PASS
- ESLint on every changed `.ts`/`.tsx` file — PASS
- `npm --workspace apps/desktop run build` — PASS (CSS and bundle-size warnings only)
- `git diff --check` — PASS

No UI screenshot is included because the change intentionally preserves rendering and interaction output; the reproducible artifact is the report-only performance scenario and its JSON metrics.

