### PR TITLE
fix: scope terminal approval exemptions

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -167,6 +167,64 @@ class TestDetectDangerousRm:
                 assert "delete" in desc.lower(), command
 
 
+class TestKanbanWorkspaceRecursiveCleanup:
+    @pytest.mark.parametrize("flags", ("-rf", "-r -f"))
+    def test_single_literal_descendant_is_not_gated(self, monkeypatch, tmp_path, flags):
+        workspace = tmp_path / "task-workspace"
+        target = workspace / "generated" / "cache"
+        workspace.mkdir()
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+
+        assert detect_dangerous_command(f"rm {flags} {target}") == (
+            False,
+            None,
+            None,
+        )
+
+    @pytest.mark.parametrize(
+        "command_factory",
+        (
+            lambda workspace, target, outside: f"rm -rf {workspace}",
+            lambda workspace, target, outside: f"rm -rf {outside}",
+            lambda workspace, target, outside: f"rm -rf {target} {outside}",
+            lambda workspace, target, outside: f"rm -rf {target}; touch {outside}",
+            lambda workspace, target, outside: f"rm -rf {target} && touch {outside}",
+            lambda workspace, target, outside: "rm -rf $TARGET",
+            lambda workspace, target, outside: "rm -rf ~/generated",
+            lambda workspace, target, outside: f"rm -rf {workspace}/*",
+            lambda workspace, target, outside: f"rm -rf {workspace}/item[0]",
+            lambda workspace, target, outside: f"rm -rf {workspace}/{{one,two}}",
+            lambda workspace, target, outside: "rm -rf $(pwd)",
+            lambda workspace, target, outside: f"rm -rf -- {target}",
+            lambda workspace, target, outside: f"sudo rm -rf {target}",
+        ),
+    )
+    def test_ambiguous_or_out_of_scope_variants_remain_gated(
+        self, monkeypatch, tmp_path, command_factory,
+    ):
+        workspace = tmp_path / "task-workspace"
+        target = workspace / "generated"
+        outside = tmp_path / "outside"
+        workspace.mkdir()
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+        monkeypatch.chdir(workspace)
+
+        command = command_factory(workspace, target, outside)
+
+        assert detect_dangerous_command(command)[0] is True, command
+
+    def test_symlink_resolving_outside_workspace_remains_gated(self, monkeypatch, tmp_path):
+        workspace = tmp_path / "task-workspace"
+        outside = tmp_path / "outside"
+        workspace.mkdir()
+        outside.mkdir()
+        link = workspace / "linked-outside"
+        link.symlink_to(outside, target_is_directory=True)
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+
+        assert detect_dangerous_command(f"rm -rf {link}")[0] is True
+
+
 class TestWindowsShellDestructiveCommands:
     def test_cmd_del_requires_approval(self):
         dangerous, key, desc = detect_dangerous_command(
@@ -320,6 +378,106 @@ class TestSafeCommand:
         assert is_dangerous is False
         assert key is None
         assert desc is None
+
+
+class TestReadOnlyProfileConfigInspection:
+    @pytest.mark.parametrize(
+        "command_factory",
+        (
+            lambda config: f"cat {config}",
+            lambda config: f"head -n 20 {config}",
+            lambda config: f"tail -n +1 {config}",
+            lambda config: f"grep -n approvals {config}",
+            lambda config: f"rg -n approvals {config}",
+            lambda config: f"sed -n '1,80p' {config}",
+        ),
+    )
+    def test_strict_inspection_allowlist_skips_approval_routing(
+        self, monkeypatch, tmp_path, command_factory,
+    ):
+        hermes_home = tmp_path / "profile-home"
+        config = hermes_home / "config.yaml"
+        hermes_home.mkdir()
+        config.write_text("approvals:\n  mode: manual\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(approval_module, "_get_approval_mode", lambda: "manual")
+        monkeypatch.setattr(approval_module, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval_module, "_is_gateway_approval_context", lambda: False)
+        scanner_calls = []
+
+        def warn(command):
+            scanner_calls.append(command)
+            return {
+                "action": "warn",
+                "findings": [{"rule_id": "sensitive-read", "title": "Sensitive read"}],
+                "summary": "profile config inspected",
+            }
+
+        monkeypatch.setattr("tools.tirith_security.check_command_security", warn)
+
+        result = approval_module.check_all_command_guards(
+            command_factory(config),
+            "local",
+            approval_callback=lambda *_args, **_kwargs: "deny",
+        )
+
+        assert result["approved"] is True
+        assert scanner_calls == []
+
+    @pytest.mark.parametrize(
+        "command_factory",
+        (
+            lambda config, other: f"cat {config} {other}",
+            lambda config, other: f"cat {config} > {other}",
+            lambda config, other: f"cat {config}; touch {other}",
+            lambda config, other: f"rg --pre 'sh -c touch' approvals {config}",
+            lambda config, other: f"python -c 'print(open(\"{config}\").read())'",
+        ),
+    )
+    def test_non_allowlisted_variants_still_reach_approval(
+        self, monkeypatch, tmp_path, command_factory,
+    ):
+        hermes_home = tmp_path / "profile-home"
+        config = hermes_home / "config.yaml"
+        other = tmp_path / "other"
+        hermes_home.mkdir()
+        config.write_text("approvals: {}\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(approval_module, "_get_approval_mode", lambda: "manual")
+        monkeypatch.setattr(approval_module, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval_module, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(
+            "tools.tirith_security.check_command_security",
+            lambda _command: {
+                "action": "warn",
+                "findings": [{"rule_id": "inspection-review", "title": "Review"}],
+                "summary": "not a strict read-only inspection",
+            },
+        )
+
+        result = approval_module.check_all_command_guards(
+            command_factory(config, other),
+            "local",
+            approval_callback=lambda *_args, **_kwargs: "deny",
+        )
+
+        assert result["approved"] is False
+
+    @pytest.mark.parametrize(
+        "command_factory",
+        (
+            lambda config: f"echo 'approvals: {{mode: off}}' > {config}",
+            lambda config: f"sed -i 's/manual/off/' {config}",
+            lambda config: f"cp /tmp/replacement {config}",
+        ),
+    )
+    def test_profile_config_writes_remain_gated(self, monkeypatch, tmp_path, command_factory):
+        hermes_home = tmp_path / "profile-home"
+        config = hermes_home / "config.yaml"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert detect_dangerous_command(command_factory(config))[0] is True
 
 
 def _clear_session(key):
@@ -2328,6 +2486,7 @@ class TestApprovalTimeoutIsNotConsent:
         assert "do NOT retry" in msg.lower() or "Do NOT retry" in msg
         assert "rephrase" in msg.lower()
         assert "different command" in msg.lower()
+        assert "read-only inspection" in msg.lower()
 
     def test_explicit_deny_carries_same_no_consent_shape(self, monkeypatch):
         """An explicit /deny must produce the same shape as timeout —
@@ -2362,6 +2521,7 @@ class TestApprovalTimeoutIsNotConsent:
         assert "Silence is not consent" not in r["message"]  # this one IS denied, not timed-out
         assert "NOT consented" in r["message"]
         assert "rephrase" in r["message"].lower()
+        assert "read-only inspection" in r["message"].lower()
 
     def test_timeout_emits_post_hook_with_timeout_outcome(self, monkeypatch):
         """Plugins must be able to distinguish timeout from explicit deny.

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1985,6 +1985,30 @@ def _is_verification_artifact_cleanup(command: str) -> bool:
     return re.fullmatch(r"hermes-(?:verify|ad-hoc)-[A-Za-z0-9_.-]+", basename) is not None
 
 
+def _is_kanban_workspace_recursive_cleanup(command: str) -> bool:
+    workspace_value = os.getenv("HERMES_KANBAN_WORKSPACE", "").strip()
+    if not workspace_value or re.search(r"[;&|<>\n\r`$~*?\[\]{}]", command):
+        return False
+    try:
+        argv = shlex.split(command, posix=True)
+    except ValueError:
+        return False
+    if not (
+        len(argv) == 3 and argv[:2] == ["rm", "-rf"]
+        or len(argv) == 4 and argv[:3] == ["rm", "-r", "-f"]
+    ):
+        return False
+
+    workspace = os.path.realpath(os.path.abspath(workspace_value))
+    target = os.path.realpath(os.path.abspath(argv[-1]))
+    if target == workspace:
+        return False
+    try:
+        return os.path.commonpath((workspace, target)) == workspace
+    except ValueError:
+        return False
+
+
 def detect_dangerous_command(command: str) -> tuple:
     """Check if a command matches any dangerous patterns.
 
@@ -1993,7 +2017,7 @@ def detect_dangerous_command(command: str) -> tuple:
     """
     if _command_parser_limit_exceeded(command):
         return (True, _PARSER_LIMIT_DESCRIPTION, _PARSER_LIMIT_DESCRIPTION)
-    if _is_verification_artifact_cleanup(command):
+    if _is_verification_artifact_cleanup(command) or _is_kanban_workspace_recursive_cleanup(command):
         return (False, None, None)
 
     for command_variant in _command_detection_variants(command):
@@ -2874,6 +2898,51 @@ def _should_skip_container_guards(env_type: str, has_host_access: bool = False) 
     return env_type in ("singularity", "modal", "daytona")
 
 
+def _is_read_only_profile_config_inspection(command: str) -> bool:
+    if re.search(r"[;&|<>\n\r`]|\$\(", command):
+        return False
+    try:
+        argv = shlex.split(command, posix=True)
+    except ValueError:
+        return False
+    if len(argv) < 2:
+        return False
+
+    from hermes_constants import get_hermes_home
+
+    config_token = argv[-1]
+    active_config = os.path.realpath(get_hermes_home() / "config.yaml")
+    expanded_config = os.path.realpath(os.path.expandvars(os.path.expanduser(config_token)))
+    if expanded_config != active_config or config_token in argv[:-1]:
+        return False
+
+    executable = argv[0]
+    if executable == "cat":
+        return len(argv) == 2
+    if executable in {"head", "tail"}:
+        return (
+            len(argv) == 4
+            and argv[1] == "-n"
+            and re.fullmatch(r"\+?\d+", argv[2]) is not None
+        )
+    if executable == "grep":
+        return len(argv) >= 3
+    if executable == "rg":
+        unsafe_options = ("--pre", "--hostname-bin")
+        return len(argv) >= 3 and not any(
+            option == unsafe or option.startswith(f"{unsafe}=")
+            for option in argv[1:-1]
+            for unsafe in unsafe_options
+        )
+    if executable == "sed":
+        return (
+            len(argv) == 4
+            and argv[1] == "-n"
+            and re.fullmatch(r"(?:\d+|\$)(?:,(?:\d+|\$))?p", argv[2]) is not None
+        )
+    return False
+
+
 def check_dangerous_command(command: str, env_type: str,
                             approval_callback=None,
                             has_host_access: bool = False) -> dict:
@@ -3234,6 +3303,9 @@ def check_all_command_guards(command: str, env_type: str,
     if _command_matches_permanent_allowlist(command):
         return {"approved": True, "message": None}
 
+    if _is_read_only_profile_config_inspection(command):
+        return {"approved": True, "message": None}
+
     is_cli = _is_interactive_cli()
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
@@ -3513,7 +3585,9 @@ def check_all_command_guards(command: str, env_type: str,
                         f"BLOCKED: Command {reason}.{reason_addendum} The user "
                         f"has NOT consented to this action. Do NOT retry this "
                         f"command, do NOT rephrase it, and do NOT attempt the "
-                        f"same outcome via a different command. Stop the "
+                        f"same destructive or irreversible action via a different "
+                        f"command. Safe read-only inspection or discovery is "
+                        f"allowed. Otherwise, stop the "
                         f"current workflow and wait for the user to respond "
                         f"before taking any further destructive or "
                         f"irreversible action.{timeout_addendum}"
@@ -3606,8 +3680,10 @@ def check_all_command_guards(command: str, env_type: str,
             "message": (
                 "BLOCKED: User denied this command. The user has NOT consented "
                 "to this action. Do NOT retry this command, do NOT rephrase "
-                "it, and do NOT attempt the same outcome via a different "
-                "command. Stop the current workflow and wait for the user "
+                "it, and do NOT attempt the same destructive or irreversible "
+                "action via a different command. Safe read-only inspection or "
+                "discovery is allowed. Otherwise, stop the current workflow "
+                "and wait for the user "
                 "to respond before taking any further destructive or "
                 "irreversible action."
             ),


### PR DESCRIPTION
## Summary
- allow only strict read-only active-profile config inspection commands through terminal approval
- allow only single-target recursive cleanup under the current Kanban task workspace
- preserve hardline, sensitive-write, and ambiguous-command protections; clarify that a denied destructive action does not block read-only discovery

## Verification
- `python -m pytest tests/tools/test_approval.py -q -o "addopts=" -k "KanbanWorkspaceRecursiveCleanup or ReadOnlyProfileConfigInspection or ApprovalTimeoutIsNotConsent"`
- `python -m pytest tests/tools/test_tirith_security.py -q -o "addopts="`
- `python -m pytest tests/agent/test_tool_guardrails.py -q -o "addopts="`
- `python -m py_compile tools/approval.py`

Known baseline: the full `tests/tools/test_approval.py` run has one pre-existing macOS tempdir canonicalization failure in `test_nonrecursive_verification_artifact_cleanup`; this PR does not touch that path.