### PR TITLE
feat(telegram): support copy text buttons

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -20,7 +20,7 @@ import threading
 import time
 from contextvars import ContextVar
 from datetime import datetime, timezone
-from typing import Dict, List, Optional, Set, Any
+from typing import Dict, List, Optional, Set, Any, cast
 
 logger = logging.getLogger(__name__)
 
@@ -207,7 +207,9 @@ async def _shutdown_abandoned_app(app) -> None:
             logger.debug("Abandoned Telegram request shutdown failed", exc_info=True)
 
 try:
+    import telegram as _telegram
     from telegram import Update, Bot, Message, InlineKeyboardButton, InlineKeyboardMarkup
+    CopyTextButton: Any = getattr(_telegram, "CopyTextButton", None)
     try:
         from telegram import LinkPreviewOptions
     except ImportError:
@@ -230,6 +232,7 @@ except ImportError:
     Message = Any
     InlineKeyboardButton = Any
     InlineKeyboardMarkup = Any
+    CopyTextButton = None
     LinkPreviewOptions = None
     Application = Any
     CommandHandler = Any
@@ -373,7 +376,7 @@ def check_telegram_requirements() -> bool:
     so the adapter's class-level type aliases get rebound.
     """
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
-    global InlineKeyboardMarkup, LinkPreviewOptions, Application
+    global InlineKeyboardMarkup, CopyTextButton, LinkPreviewOptions, Application
     global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
@@ -384,8 +387,10 @@ def check_telegram_requirements() -> bool:
     except Exception:
         return False
     try:
+        import telegram as _telegram
         from telegram import Update as _Update, Bot as _Bot, Message as _Message
         from telegram import InlineKeyboardButton as _IKB, InlineKeyboardMarkup as _IKM
+        _CTB: Any = getattr(_telegram, "CopyTextButton", None)
         try:
             from telegram import LinkPreviewOptions as _LPO
         except ImportError:
@@ -405,6 +410,7 @@ def check_telegram_requirements() -> bool:
     Message = _Message
     InlineKeyboardButton = _IKB
     InlineKeyboardMarkup = _IKM
+    CopyTextButton = _CTB
     LinkPreviewOptions = _LPO
     Application = _App
     CommandHandler = _CH
@@ -467,6 +473,36 @@ def _separate_chunk_indicator_from_fence(text: str) -> str:
     closing fence.
     """
     return _CHUNK_INDICATOR_ON_FENCE_RE.sub(r'```\n\g<indicator>', text)
+
+
+_COPY_BUTTON_LINE_RE = re.compile(
+    r'^\s*COPY_BUTTON:\s*(?P<label>[^|\n]{1,64})\|(?P<text>[^\n]{1,256})\s*$',
+    re.MULTILINE,
+)
+
+
+def _extract_copy_buttons(content: str) -> tuple[str, list[tuple[str, str]]]:
+    """Strip valid ``COPY_BUTTON: label | text`` lines and return buttons.
+
+    Invalid markers stay visible so malformed or unsupported requests never
+    silently remove user-facing content.
+    """
+    if not content or "COPY_BUTTON:" not in content:
+        return content, []
+
+    buttons: list[tuple[str, str]] = []
+
+    def _replace(match: re.Match[str]) -> str:
+        label = match.group("label").strip()
+        text = match.group("text").strip()
+        if not label or not text or len(text) > 256 or len(buttons) >= 20:
+            return match.group(0)
+        buttons.append((label, text))
+        return ""
+
+    stripped = _COPY_BUTTON_LINE_RE.sub(_replace, content)
+    stripped = re.sub(r'\n{3,}', '\n\n', stripped).strip()
+    return stripped, buttons
 
 
 # ---------------------------------------------------------------------------
@@ -1464,6 +1500,19 @@ class TelegramAdapter(BasePlatformAdapter):
         if LinkPreviewOptions is not None:
             return {"link_preview_options": LinkPreviewOptions(is_disabled=True)}
         return {"disable_web_page_preview": True}
+
+    def _copy_buttons_markup(self, buttons: list[tuple[str, str]]) -> Optional[Any]:
+        """Build Telegram copy-to-clipboard inline keyboard markup."""
+        if not buttons or CopyTextButton is None:
+            return None
+        button_cls = cast(Any, InlineKeyboardButton)
+        copy_text_cls = cast(Any, CopyTextButton)
+        markup_cls = cast(Any, InlineKeyboardMarkup)
+        rows = [
+            [button_cls(label, copy_text=copy_text_cls(text=text))]
+            for label, text in buttons[:20]
+        ]
+        return markup_cls(rows)
 
     # ------------------------------------------------------------------
     # Bot API 10.1 Rich Messages (sendRichMessage)
@@ -4034,14 +4083,23 @@ class TelegramAdapter(BasePlatformAdapter):
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
+
+        copy_markup = None
+        if CopyTextButton is not None:
+            content, copy_buttons = _extract_copy_buttons(content)
+            if copy_buttons and not content.strip():
+                content = "Copy buttons"
+            copy_markup = self._copy_buttons_markup(copy_buttons)
+        elif "COPY_BUTTON:" in content:
+            logger.warning(
+                "[%s] COPY_BUTTON markers requested but CopyTextButton is unavailable",
+                self.name,
+            )
         
         try:
-            # Bot API 10.1 rich fast-path: send the raw agent markdown via
-            # sendRichMessage so tables/task lists/etc. render natively. Falls
-            # through to the legacy MarkdownV2 path on permanent/capability
-            # errors or DM-topic routing skips; returns directly on success or
-            # on a transient failure (which must NOT be legacy-resent).
-            if self._should_attempt_rich(content, metadata=metadata):
+            # Rich messages do not currently carry reply_markup through this
+            # adapter path. Keep copy-button messages on sendMessage instead.
+            if copy_markup is None and self._should_attempt_rich(content, metadata=metadata):
                 rich_result = await self._try_send_rich(chat_id, content, reply_to, metadata)
                 if rich_result is not None:
                     if rich_result.success:
@@ -4150,6 +4208,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
+                                **({"reply_markup": copy_markup} if copy_markup is not None and i == len(chunks) - 1 else {}),
                             )
                         except Exception as md_error:
                             # Markdown parsing failed, try plain text
@@ -4164,6 +4223,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
+                                    **({"reply_markup": copy_markup} if copy_markup is not None and i == len(chunks) - 1 else {}),
                                 )
                             else:
                                 raise
@@ -4399,6 +4459,18 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
+        copy_markup = None
+        if finalize and CopyTextButton is not None:
+            content, copy_buttons = _extract_copy_buttons(content)
+            if copy_buttons and not content.strip():
+                content = "Copy buttons"
+            copy_markup = self._copy_buttons_markup(copy_buttons)
+        elif finalize and "COPY_BUTTON:" in content:
+            logger.warning(
+                "[%s] COPY_BUTTON markers requested but CopyTextButton is unavailable",
+                self.name,
+            )
+
         # Rich finalize (Bot API 10.1): when the completed content has
         # constructs the legacy MarkdownV2 edit degrades (tables → bullet
         # lists, task lists, <details>, block math) and rich is available,
@@ -4409,7 +4481,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # table that exceeds the MarkdownV2 limit must not be split into legacy
         # chunks.  Falls back to the legacy edit path (overflow split included)
         # on capability/permanent rejection.
-        if finalize and self._rich_eligible(content):
+        if finalize and copy_markup is None and self._rich_eligible(content):
             rich_result = await self._try_edit_rich(
                 chat_id, message_id, content, metadata=metadata,
             )
@@ -4432,7 +4504,12 @@ class TelegramAdapter(BasePlatformAdapter):
         if utf16_len(content) > self.MAX_MESSAGE_LENGTH:
             if finalize:
                 return await self._edit_overflow_split(
-                    chat_id, message_id, content, finalize=finalize, metadata=metadata,
+                    chat_id,
+                    message_id,
+                    content,
+                    finalize=finalize,
+                    metadata=metadata,
+                    reply_markup=copy_markup,
                 )
             content = self._truncate_stream_overflow_preview(content)
             _saturated_preview = True
@@ -4468,6 +4545,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     message_id=int(message_id),
                     text=formatted,
                     parse_mode=ParseMode.MARKDOWN_V2,
+                    **({"reply_markup": copy_markup} if copy_markup is not None else {}),
                 )
             except Exception as fmt_err:
                 # "Message is not modified" is a no-op, not an error
@@ -4485,6 +4563,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     chat_id=normalize_telegram_chat_id(chat_id),
                     message_id=int(message_id),
                     text=_plain,
+                    **({"reply_markup": copy_markup} if copy_markup is not None else {}),
                 )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -4502,7 +4581,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 if finalize:
                     return await self._edit_overflow_split(
-                        chat_id, message_id, content, finalize=finalize, metadata=metadata,
+                        chat_id,
+                        message_id,
+                        content,
+                        finalize=finalize,
+                        metadata=metadata,
+                        reply_markup=copy_markup,
                     )
                 # Mid-stream: truncate and retry instead of splitting (#48648).
                 truncated = self._truncate_stream_overflow_preview(content)
@@ -4538,6 +4622,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         chat_id=normalize_telegram_chat_id(chat_id),
                         message_id=int(message_id),
                         text=content,
+                        **({"reply_markup": copy_markup} if copy_markup is not None else {}),
                     )
                     return SendResult(success=True, message_id=message_id)
                 except Exception as retry_err:
@@ -4607,6 +4692,7 @@ class TelegramAdapter(BasePlatformAdapter):
         *,
         finalize: bool,
         metadata: Optional[Dict[str, Any]] = None,
+        reply_markup: Optional[Any] = None,
     ) -> SendResult:
         """Split an oversized edit across the existing message + continuations.
 
@@ -4626,9 +4712,10 @@ class TelegramAdapter(BasePlatformAdapter):
             content, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
         )
         if len(chunks) <= 1:
-            # Defensive: shouldn't happen given the caller's pre-flight, but
-            # if truncate_message returned a single chunk just edit normally.
+            # Reactive overflow can be caused by MarkdownV2 expansion even when
+            # raw content is one chunk. Keep the final keyboard on that edit.
             chunks = [content]
+        first_chunk_markup = reply_markup if len(chunks) == 1 else None
 
         # Step 1 — edit the existing message with the first chunk.
         first_chunk = chunks[0]
@@ -4645,6 +4732,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         message_id=int(message_id),
                         text=formatted,
                         parse_mode=ParseMode.MARKDOWN_V2,
+                        **({"reply_markup": first_chunk_markup} if first_chunk_markup is not None else {}),
                     )
                 except Exception as fmt_err:
                     if "not modified" not in str(fmt_err).lower():
@@ -4657,6 +4745,7 @@ class TelegramAdapter(BasePlatformAdapter):
                             chat_id=normalize_telegram_chat_id(chat_id),
                             message_id=int(message_id),
                             text=_strip_mdv2(first_chunk),
+                            **({"reply_markup": first_chunk_markup} if first_chunk_markup is not None else {}),
                         )
             else:
                 await self._bot.edit_message_text(
@@ -4687,8 +4776,9 @@ class TelegramAdapter(BasePlatformAdapter):
         delivered_chunks = [first_chunk]
         prev_id = message_id
         thread_id = self._metadata_thread_id(metadata)
-        for chunk in chunks[1:]:
+        for chunk_index, chunk in enumerate(chunks[1:], start=1):
             sent_msg = None
+            chunk_markup = reply_markup if chunk_index == len(chunks) - 1 else None
             reply_to_id = int(prev_id) if prev_id else None
             thread_kwargs = self._thread_kwargs_for_send(
                 chat_id,
@@ -4716,6 +4806,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         **thread_kwargs,
                         **self._link_preview_kwargs(),
                         **self._notification_kwargs(metadata),
+                        **({"reply_markup": chunk_markup} if chunk_markup is not None else {}),
                     )
                     break
                 except Exception as send_err:
@@ -4737,6 +4828,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 **retry_thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
+                                **({"reply_markup": chunk_markup} if chunk_markup is not None else {}),
                             )
                             break
                         except Exception as _retry_err:

--- a/tests/gateway/test_telegram_copy_buttons.py
+++ b/tests/gateway/test_telegram_copy_buttons.py
@@ -1,0 +1,287 @@
+"""Tests for Telegram copy-to-clipboard inline buttons."""
+
+import sys
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_telegram_mock():
+    try:
+        import telegram  # noqa: F401
+        if hasattr(telegram, "__file__"):
+            return
+    except ImportError:
+        pass
+
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules[name] = mod
+    sys.modules["telegram.error"] = mod.error
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram import adapter as telegram_adapter
+from plugins.platforms.telegram.adapter import TelegramAdapter, _extract_copy_buttons
+
+
+@pytest.fixture(autouse=True)
+def _unload_adapter_after_test():
+    """Let later tests that inject fake telegram modules import a fresh adapter."""
+    yield
+    sys.modules.pop("plugins.platforms.telegram.adapter", None)
+    pkg = sys.modules.get("plugins.platforms.telegram")
+    if pkg is not None and getattr(pkg, "adapter", None) is telegram_adapter:
+        try:
+            delattr(pkg, "adapter")
+        except AttributeError:
+            pass
+
+
+class FakeCopyTextButton:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class FakeInlineKeyboardButton:
+    def __init__(self, text: str, **kwargs):
+        self.text = text
+        self.kwargs = kwargs
+
+
+class FakeInlineKeyboardMarkup:
+    def __init__(self, rows):
+        self.rows = rows
+
+
+def _make_adapter(monkeypatch):
+    monkeypatch.setattr(telegram_adapter, "CopyTextButton", FakeCopyTextButton)
+    monkeypatch.setattr(telegram_adapter, "InlineKeyboardButton", FakeInlineKeyboardButton)
+    monkeypatch.setattr(telegram_adapter, "InlineKeyboardMarkup", FakeInlineKeyboardMarkup)
+
+    config = PlatformConfig(enabled=True, token="test-token", extra={})
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+def test_extract_copy_buttons_strips_valid_markers_only():
+    content = (
+        "VNC 주소\n"
+        "COPY_BUTTON: Mac mini IP | 100.96.33.123\n"
+        "body remains\n"
+        "COPY_BUTTON: bad | \n"
+    )
+
+    stripped, buttons = _extract_copy_buttons(content)
+
+    assert buttons == [("Mac mini IP", "100.96.33.123")]
+    assert "COPY_BUTTON: Mac mini IP" not in stripped
+    assert "body remains" in stripped
+    assert "COPY_BUTTON: bad |" in stripped
+
+
+@pytest.mark.asyncio
+async def test_send_attaches_copy_text_keyboard_and_strips_markers(monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+    mock_msg = MagicMock()
+    mock_msg.message_id = 123
+    bot = cast(Any, adapter._bot)
+    bot.send_message = AsyncMock(return_value=mock_msg)
+
+    result = await adapter.send(
+        chat_id="12345",
+        content=(
+            "VNC 주소\n"
+            "COPY_BUTTON: Mac mini IP | 100.96.33.123\n"
+            "COPY_BUTTON: MacBook VNC | 100.99.47.75:5900"
+        ),
+    )
+
+    assert result.success is True
+    kwargs = bot.send_message.call_args.kwargs
+    assert "COPY_BUTTON:" not in kwargs["text"]
+    assert "VNC 주소" in kwargs["text"]
+
+    markup = kwargs["reply_markup"]
+    assert isinstance(markup, FakeInlineKeyboardMarkup)
+    assert len(markup.rows) == 2
+    first = markup.rows[0][0]
+    second = markup.rows[1][0]
+    assert first.text == "Mac mini IP"
+    assert first.kwargs["copy_text"].text == "100.96.33.123"
+    assert second.text == "MacBook VNC"
+    assert second.kwargs["copy_text"].text == "100.99.47.75:5900"
+
+
+@pytest.mark.asyncio
+async def test_copy_button_only_message_gets_safe_fallback_text(monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+    mock_msg = MagicMock()
+    mock_msg.message_id = 124
+    bot = cast(Any, adapter._bot)
+    bot.send_message = AsyncMock(return_value=mock_msg)
+
+    result = await adapter.send(
+        chat_id="12345",
+        content="COPY_BUTTON: MacBook IP | 100.99.47.75",
+    )
+
+    assert result.success is True
+    kwargs = bot.send_message.call_args.kwargs
+    assert kwargs["text"] == "Copy buttons"
+    assert kwargs["reply_markup"].rows[0][0].kwargs["copy_text"].text == "100.99.47.75"
+
+
+@pytest.mark.asyncio
+async def test_send_leaves_markers_visible_when_copy_text_button_unavailable(monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+    monkeypatch.setattr(telegram_adapter, "CopyTextButton", None)
+    mock_msg = MagicMock()
+    mock_msg.message_id = 125
+    bot = cast(Any, adapter._bot)
+    bot.send_message = AsyncMock(return_value=mock_msg)
+
+    result = await adapter.send(
+        chat_id="12345",
+        content="VNC\nCOPY_BUTTON: MacBook IP | 100.99.47.75",
+    )
+
+    assert result.success is True
+    kwargs = bot.send_message.call_args.kwargs
+    assert "COPY\\_BUTTON: MacBook IP \\| 100\\.99\\.47\\.75" in kwargs["text"]
+    assert "reply_markup" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_finalize_edit_attaches_copy_text_keyboard_and_strips_markers(monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+    bot = cast(Any, adapter._bot)
+    bot.edit_message_text = AsyncMock(return_value=None)
+
+    result = await adapter.edit_message(
+        chat_id="12345",
+        message_id="777",
+        content=(
+            "VNC 주소\n"
+            "COPY_BUTTON: Mac mini IP | 100.96.33.123\n"
+            "COPY_BUTTON: MacBook VNC | 100.99.47.75:5900"
+        ),
+        finalize=True,
+    )
+
+    assert result.success is True
+    kwargs = bot.edit_message_text.call_args.kwargs
+    assert kwargs["message_id"] == 777
+    assert "COPY_BUTTON:" not in kwargs["text"]
+    assert "VNC 주소" in kwargs["text"]
+    assert kwargs["reply_markup"].rows[0][0].kwargs["copy_text"].text == "100.96.33.123"
+    assert kwargs["reply_markup"].rows[1][0].kwargs["copy_text"].text == "100.99.47.75:5900"
+
+
+@pytest.mark.asyncio
+async def test_finalize_overflow_attaches_copy_keyboard_to_last_continuation(monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+    cast(Any, adapter).MAX_MESSAGE_LENGTH = 80
+    bot = cast(Any, adapter._bot)
+    bot.edit_message_text = AsyncMock(return_value=None)
+
+    next_message_id = iter(range(778, 900))
+
+    async def _send_message(**kwargs):
+        message = MagicMock()
+        message.message_id = next(next_message_id)
+        return message
+
+    bot.send_message = AsyncMock(side_effect=_send_message)
+    content = "word " * 80 + "\nCOPY_BUTTON: Copy endpoint | https://example.test/path"
+
+    result = await adapter.edit_message(
+        chat_id="12345",
+        message_id="777",
+        content=content,
+        finalize=True,
+    )
+
+    assert result.success is True
+    assert bot.send_message.call_count > 0
+    assert "reply_markup" not in bot.edit_message_text.call_args.kwargs
+    for call in bot.send_message.call_args_list[:-1]:
+        assert "reply_markup" not in call.kwargs
+    final_kwargs = bot.send_message.call_args_list[-1].kwargs
+    assert final_kwargs["reply_markup"].rows[0][0].kwargs["copy_text"].text == "https://example.test/path"
+    delivered_text = bot.edit_message_text.call_args.kwargs["text"] + "".join(
+        call.kwargs["text"] for call in bot.send_message.call_args_list
+    )
+    assert "COPY_BUTTON:" not in delivered_text
+
+
+@pytest.mark.asyncio
+async def test_finalize_edit_flood_retry_preserves_copy_keyboard(monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+    bot = cast(Any, adapter._bot)
+
+    class RetryAfter(Exception):
+        retry_after = 0
+
+    bot.edit_message_text = AsyncMock(
+        side_effect=[Exception("Markdown parse failed"), RetryAfter("retry after"), None]
+    )
+
+    result = await adapter.edit_message(
+        chat_id="12345",
+        message_id="777",
+        content="Endpoint\nCOPY_BUTTON: Copy endpoint | https://example.test/path",
+        finalize=True,
+    )
+
+    assert result.success is True
+    retry_kwargs = bot.edit_message_text.call_args_list[-1].kwargs
+    assert "COPY_BUTTON:" not in retry_kwargs["text"]
+    assert retry_kwargs["reply_markup"].rows[0][0].kwargs["copy_text"].text == "https://example.test/path"
+
+
+@pytest.mark.asyncio
+async def test_finalize_reactive_overflow_single_chunk_preserves_copy_keyboard(monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+    cast(Any, adapter).MAX_MESSAGE_LENGTH = 80
+    adapter.format_message = MagicMock(return_value="x" * 100)
+    bot = cast(Any, adapter._bot)
+    bot.edit_message_text = AsyncMock(
+        side_effect=[Exception("message too long"), Exception("message too long"), None]
+    )
+
+    result = await adapter.edit_message(
+        chat_id="12345",
+        message_id="777",
+        content="Endpoint\nCOPY_BUTTON: Copy endpoint | https://example.test/path",
+        finalize=True,
+    )
+
+    assert result.success is True
+    final_kwargs = bot.edit_message_text.call_args_list[-1].kwargs
+    assert final_kwargs["reply_markup"].rows[0][0].kwargs["copy_text"].text == "https://example.test/path"

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -990,6 +990,30 @@ gateway:
 
 When enabled, Hermes attaches Telegram's `LinkPreviewOptions(is_disabled=True)` to every outgoing message and falls back to the legacy `disable_web_page_preview` parameter on older `python-telegram-bot` versions.
 
+**Copy-to-clipboard buttons.** Telegram supports inline keyboard buttons that copy a short string to the user's clipboard. To attach copy buttons to a Telegram reply, include one marker line per button in the assistant's final text:
+
+```text
+COPY_BUTTON: Button label | text copied to clipboard
+```
+
+Hermes removes valid marker lines from the visible message and renders them as [`CopyTextButton`](https://core.telegram.org/bots/api#copytextbutton) inline buttons. This is useful for IP addresses, one-line commands, invite codes, URLs, and other mobile handoff values that are awkward to select from a Telegram message.
+
+```text
+Server address: 100.96.33.123
+
+COPY_BUTTON: Copy IP | 100.96.33.123
+COPY_BUTTON: Copy VNC address | 100.96.33.123:5900
+```
+
+Marker constraints follow Telegram's copy button limits:
+
+- the label must be 1-64 characters and cannot contain `|`
+- the copied text must be 1-256 characters
+- Hermes renders at most 20 buttons per message
+- invalid marker lines are left as ordinary text instead of being silently dropped
+
+Copy buttons are attached on normal sends and streaming final edits, including final responses split over Telegram's 4,096 UTF-16-unit limit. Hermes places the keyboard on the final visible chunk. Copy-button replies use the MarkdownV2 path instead of the rich-message path because the rich raw endpoint used here does not carry `reply_markup`.
+
 ## Group Allowlisting
 
 Telegram groups and forum chats have two orthogonal gates you can configure:


### PR DESCRIPTION
## Summary
- add Telegram `COPY_BUTTON: label | text` markers that render as Bot API `CopyTextButton` inline keyboard buttons
- keep malformed markers visible and preserve compatibility when `CopyTextButton` is unavailable
- support normal sends, short streaming-final edits, and final responses split over Telegram's 4,096 UTF-16-unit limit
- attach overflow keyboards only to the final visible continuation and preserve them through plain/reply fallback paths
- document syntax, limits, and delivery behavior

Replaces #59445 with a clean Telegram-only branch from current `main`. The unrelated Codex usage, credential telemetry, and network circuit-breaker commits are intentionally excluded.

## Test Plan
- [x] RED: overflow final test failed because the last continuation had no `reply_markup`
- [x] `uv run --with pytest --with pytest-asyncio --extra messaging python -m pytest tests/gateway/test_telegram_copy_buttons.py tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_telegram_overflow_partial.py -q -o 'addopts='` — 148 passed
- [x] `uv run --extra dev ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_copy_buttons.py`
- [x] `uv run --extra messaging python -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_copy_buttons.py`
- [x] `git diff --check`
- [x] changed-line security scan — 0 findings
