### PR TITLE
fix(telegram): group authz fallback + command sender identity (salvage of #67816)

### DIFF
--- a/contributors/emails/nyaruko@hermes
+++ b/contributors/emails/nyaruko@hermes
@@ -1,0 +1,1 @@
+tsuk1nose

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -357,6 +357,24 @@ class GatewayAuthorizationMixin:
                     if "*" in allowed_group_ids or source.chat_id in allowed_group_ids:
                         return True
 
+            # Fallback: also check adapter-level config (config.yaml)
+            # for platforms.<platform>.extra.group_allowed_chats.
+            # The Telegram observe-unmentioned mode strips user_id from
+            # triggered group messages (_apply_telegram_group_observe_attribution),
+            # so the env-var-only check above misses config.yaml-configured
+            # allowlists.  Read the live adapter's config.extra as a fallback.
+            try:
+                adapter = self._adapter_for_source(source)
+                if adapter is not None:
+                    extra = getattr(getattr(adapter, "config", None), "extra", None) or {}
+                    adapter_group_allowed = extra.get("group_allowed_chats")
+                    if adapter_group_allowed:
+                        allowed = {str(c).strip() for c in adapter_group_allowed if str(c).strip()}
+                        if "*" in allowed or source.chat_id in allowed:
+                            return True
+            except Exception:
+                pass
+
         # Bots admitted by {PLATFORM}_ALLOW_BOTS bypass the human allowlist (#4466).
         # Checked before the no-user-id guard below: some platforms deliver
         # bot/automation traffic with no user_id at all -- e.g. Slack Workflow
@@ -525,6 +543,21 @@ class GatewayAuthorizationMixin:
                     )
                 if effective_policy == "allowlist":
                     return True
+            # Some adapters (e.g. Telegram) gate access via config.extra.allow_from /
+            # group_allow_from at intake but do not override enforces_own_access_policy.
+            # Check their allowlist here so config.yaml-configured allow_from works
+            # without requiring a separate {PLATFORM}_ALLOWED_USERS env var.
+            adapter = self._adapter_for_source(source)
+            if adapter is not None:
+                extra = getattr(getattr(adapter, "config", None), "extra", None) or {}
+                if source.chat_type in {"group", "forum"}:
+                    adapter_allow = extra.get("group_allow_from")
+                else:
+                    adapter_allow = extra.get("allow_from")
+                if adapter_allow:
+                    allowed = {str(u).strip() for u in adapter_allow if str(u).strip()}
+                    if user_id in allowed or "*" in allowed:
+                        return True
             # No allowlists configured -- check global allow-all flag
             return _auth_env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
 

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -43,6 +43,21 @@ def _auth_env(name: str, default: str = "") -> str:
     return (os.getenv(name) or default).strip()
 
 
+def _coerce_allow_set(raw) -> set[str]:
+    """Parse allowlist values from config or env var into a set of strings.
+
+    Handles both list inputs (YAML sequences) and comma-separated string
+    inputs (env vars or scalar YAML values).  A scalar string is split on
+    commas so ``allow_from: "123,456"`` yields ``{"123", "456"}``, not
+    ``{"1", "2", "3", ",", ...}``.
+    """
+    if raw is None:
+        return set()
+    if isinstance(raw, list):
+        return {str(part).strip() for part in raw if str(part).strip()}
+    return {part.strip() for part in str(raw).split(",") if part.strip()}
+
+
 class GatewayAuthorizationMixin:
     """User/chat authorization methods for ``GatewayRunner``."""
 
@@ -369,7 +384,7 @@ class GatewayAuthorizationMixin:
                     extra = getattr(getattr(adapter, "config", None), "extra", None) or {}
                     adapter_group_allowed = extra.get("group_allowed_chats")
                     if adapter_group_allowed:
-                        allowed = {str(c).strip() for c in adapter_group_allowed if str(c).strip()}
+                        allowed = _coerce_allow_set(adapter_group_allowed)
                         if "*" in allowed or source.chat_id in allowed:
                             return True
             except Exception:
@@ -550,12 +565,12 @@ class GatewayAuthorizationMixin:
             adapter = self._adapter_for_source(source)
             if adapter is not None:
                 extra = getattr(getattr(adapter, "config", None), "extra", None) or {}
-                if source.chat_type in {"group", "forum"}:
+                if source.chat_type in {"group", "forum", "channel"}:
                     adapter_allow = extra.get("group_allow_from")
                 else:
                     adapter_allow = extra.get("allow_from")
                 if adapter_allow:
-                    allowed = {str(u).strip() for u in adapter_allow if str(u).strip()}
+                    allowed = _coerce_allow_set(adapter_allow)
                     if user_id in allowed or "*" in allowed:
                         return True
             # No allowlists configured -- check global allow-all flag

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1013,8 +1013,13 @@ class TelegramAdapter(BasePlatformAdapter):
         if not user_id:
             return True
 
-        # Adapter-level allow_from: when set, it is the sole authority.
-        adapter_allow_from = self.config.extra.get("allow_from")
+        # Adapter-level allow_from / group_allow_from: when set, they are the
+        # sole authority.  Group chats use group_allow_from; DMs use allow_from.
+        chat_type = source.chat_type or ""
+        if chat_type in ("group", "forum"):
+            adapter_allow_from = self.config.extra.get("group_allow_from")
+        else:
+            adapter_allow_from = self.config.extra.get("allow_from")
         if adapter_allow_from is not None:
             allowed = {str(u).strip() for u in adapter_allow_from if str(u).strip()}
             return user_id in allowed or "*" in allowed
@@ -7775,9 +7780,15 @@ class TelegramAdapter(BasePlatformAdapter):
         observe_prompt = self._telegram_group_observe_channel_prompt()
         channel_prompt = f"{event.channel_prompt}\n\n{observe_prompt}" if event.channel_prompt else observe_prompt
         if event.message_type == MessageType.COMMAND:
+            # Commands must retain the original source (with user_id) so
+            # slash-access control (_check_slash_access) can identify the
+            # sender.  Replacing the source with an anonymised shared source
+            # (user_id=None) causes admin-only commands like /new to be
+            # denied even when the sender is an admin, because
+            # SlashAccessPolicy.is_admin(None) is always False.
+            # Still inject channel_prompt for group context.
             return dataclasses.replace(
                 event,
-                source=shared_source,
                 channel_prompt=channel_prompt,
             )
         return dataclasses.replace(
@@ -9394,7 +9405,7 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
         if isinstance(allowed_users, list):
             allowed_users = ",".join(str(v) for v in allowed_users)
         os.environ["TELEGRAM_ALLOWED_USERS"] = str(allowed_users)
-    group_allowed_users = telegram_cfg.get("group_allow_from")
+    group_allowed_users = telegram_cfg.get("group_allow_from") or _telegram_extra.get("group_allow_from")
     if group_allowed_users is not None and not os.getenv("TELEGRAM_GROUP_ALLOWED_USERS"):
         if isinstance(group_allowed_users, list):
             group_allowed_users = ",".join(str(v) for v in group_allowed_users)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -250,6 +250,7 @@ import sys
 from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
+from gateway.authz_mixin import _coerce_allow_set
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -1016,12 +1017,12 @@ class TelegramAdapter(BasePlatformAdapter):
         # Adapter-level allow_from / group_allow_from: when set, they are the
         # sole authority.  Group chats use group_allow_from; DMs use allow_from.
         chat_type = source.chat_type or ""
-        if chat_type in ("group", "forum"):
+        if chat_type in ("group", "forum", "channel"):
             adapter_allow_from = self.config.extra.get("group_allow_from")
         else:
             adapter_allow_from = self.config.extra.get("allow_from")
         if adapter_allow_from is not None:
-            allowed = {str(u).strip() for u in adapter_allow_from if str(u).strip()}
+            allowed = _coerce_allow_set(adapter_allow_from)
             return user_id in allowed or "*" in allowed
 
         # Test/custom injection only. The class method named
@@ -9410,7 +9411,7 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
         if isinstance(group_allowed_users, list):
             group_allowed_users = ",".join(str(v) for v in group_allowed_users)
         os.environ["TELEGRAM_GROUP_ALLOWED_USERS"] = str(group_allowed_users)
-    group_allowed_chats = telegram_cfg.get("group_allowed_chats")
+    group_allowed_chats = telegram_cfg.get("group_allowed_chats") or _telegram_extra.get("group_allowed_chats")
     if group_allowed_chats is not None and not os.getenv("TELEGRAM_GROUP_ALLOWED_CHATS"):
         if isinstance(group_allowed_chats, list):
             group_allowed_chats = ",".join(str(v) for v in group_allowed_chats)

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -74,7 +74,7 @@ def _make_message(text="hello", *, from_user_id=111, chat_id=-100, chat_type="gr
 @pytest.mark.asyncio
 async def test_unauthorized_user_blocked_before_event_building():
     """Unauthorized user's message should be blocked before _build_message_event."""
-    adapter = _make_adapter(allow_from=["222"])  # Only user 222 allowed
+    adapter = _make_adapter(group_allow_from=["222"])  # Only user 222 allowed in groups
 
     build_called = False
     original_build = adapter._build_message_event
@@ -88,7 +88,7 @@ async def test_unauthorized_user_blocked_before_event_building():
 
     update = SimpleNamespace(
         update_id=1,
-        message=_make_message(from_user_id=111),  # User 111 NOT in allow_from
+        message=_make_message(from_user_id=111, chat_type="group"),  # User 111 NOT in group_allow_from
         effective_message=None,
     )
 
@@ -100,7 +100,7 @@ async def test_unauthorized_user_blocked_before_event_building():
 @pytest.mark.asyncio
 async def test_authorized_user_processed_normally():
     """Authorized user's message should pass the auth check and build an event."""
-    adapter = _make_adapter(allow_from=["111"])
+    adapter = _make_adapter(group_allow_from=["111"])
 
     build_called = False
     original_build = adapter._build_message_event
@@ -114,7 +114,7 @@ async def test_authorized_user_processed_normally():
 
     update = SimpleNamespace(
         update_id=1,
-        message=_make_message(from_user_id=111),
+        message=_make_message(from_user_id=111, chat_type="group"),
         effective_message=None,
     )
 
@@ -155,12 +155,12 @@ async def test_channel_post_passes_auth():
 @pytest.mark.asyncio
 async def test_command_from_unauthorized_user_blocked():
     """Commands from unauthorized users should be blocked."""
-    adapter = _make_adapter(allow_from=["222"])
+    adapter = _make_adapter(group_allow_from=["222"])
     adapter.handle_message = AsyncMock()
 
     update = SimpleNamespace(
         update_id=1,
-        message=_make_message(text="/start", from_user_id=111),
+        message=_make_message(text="/start", from_user_id=111, chat_type="group"),
         effective_message=None,
     )
 
@@ -172,12 +172,12 @@ async def test_command_from_unauthorized_user_blocked():
 @pytest.mark.asyncio
 async def test_command_from_authorized_user_processed():
     """Commands from authorized users should be processed."""
-    adapter = _make_adapter(allow_from=["111"])
+    adapter = _make_adapter(group_allow_from=["111"])
     adapter.handle_message = AsyncMock()
 
     update = SimpleNamespace(
         update_id=1,
-        message=_make_message(text="/start", from_user_id=111),
+        message=_make_message(text="/start", from_user_id=111, chat_type="group"),
         effective_message=None,
     )
 
@@ -189,9 +189,9 @@ async def test_command_from_authorized_user_processed():
 @pytest.mark.asyncio
 async def test_location_from_unauthorized_user_blocked():
     """Location messages from unauthorized users should be blocked."""
-    adapter = _make_adapter(allow_from=["222"])
+    adapter = _make_adapter(group_allow_from=["222"])
 
-    msg = _make_message(from_user_id=111)
+    msg = _make_message(from_user_id=111, chat_type="group")
     msg.text = None
     msg.location = SimpleNamespace(latitude=53.3498, longitude=-6.2603)
 
@@ -206,13 +206,24 @@ async def test_location_from_unauthorized_user_blocked():
 
 
 def test_is_user_authorized_from_message_allow_from():
-    """_is_user_authorized_from_message should respect adapter-level allow_from."""
+    """_is_user_authorized_from_message should respect adapter-level allow_from for DMs."""
     adapter = _make_adapter(allow_from=["111", "222"])
 
-    msg = _make_message(from_user_id=111)
+    msg = _make_message(from_user_id=111, chat_type="dm")
     assert adapter._is_user_authorized_from_message(msg) is True
 
-    msg = _make_message(from_user_id=333)
+    msg = _make_message(from_user_id=333, chat_type="dm")
+    assert adapter._is_user_authorized_from_message(msg) is False
+
+
+def test_is_user_authorized_from_message_group_allow_from():
+    """_is_user_authorized_from_message should respect adapter-level group_allow_from for groups."""
+    adapter = _make_adapter(group_allow_from=["111", "222"])
+
+    msg = _make_message(from_user_id=111, chat_type="group")
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+    msg = _make_message(from_user_id=333, chat_type="group")
     assert adapter._is_user_authorized_from_message(msg) is False
 
 
@@ -357,7 +368,7 @@ async def test_media_from_removed_user_blocked_before_event_building(monkeypatch
 async def test_unmentioned_group_text_from_removed_user_not_observed():
     """Removed users must not persist unmentioned group text into observed context."""
     adapter = _make_adapter(
-        allow_from=["222"],
+        group_allow_from=["222"],
         allowed_chats=["-100"],
         group_allowed_chats=["-100"],
         require_mention=True,
@@ -378,7 +389,7 @@ async def test_unmentioned_group_text_from_removed_user_not_observed():
 async def test_unmentioned_group_location_from_removed_user_not_observed():
     """Removed users must not persist unmentioned group locations into observed context."""
     adapter = _make_adapter(
-        allow_from=["222"],
+        group_allow_from=["222"],
         allowed_chats=["-100"],
         group_allowed_chats=["-100"],
         require_mention=True,

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -346,7 +346,9 @@ def test_observed_group_context_preserves_slash_command_text_for_dispatch():
 
     assert attributed.text == "/new@hermes_bot"
     assert attributed.get_command() == "new"
-    assert attributed.source.user_id is None
+    # Commands preserve sender identity for slash-access control (#67816).
+    assert attributed.source.user_id == "111"
+    assert attributed.source.user_name == "Alice"
     assert "observed Telegram group context" in attributed.channel_prompt
 
 


### PR DESCRIPTION
## Summary

Salvage of PR #67816 (Telegram group authz fixes) with review findings addressed.

Original PR fixes 4 Telegram auth bugs:
1. config.yaml `group_allowed_chats` not honored for observe-mode group messages with stripped user_id
2. config.yaml `allow_from`/`group_allow_from` not honored at gateway authz
3. `group_allow_from` in `extra:` block not bridged to env
4. Admin slash commands denied in observe-mode groups because source was anonymized

## Changes

- Cherry-picked contributor commit `62aedef7` (authorship preserved)
- **fix:** Update `test_observed_group_context_preserves_slash_command_text_for_dispatch` to assert `user_id` is preserved for COMMAND messages (new correct behavior)
- **fix:** Add `_coerce_allow_set` helper to handle both list and comma-separated string allowlist inputs (prevents character-by-character iteration bug when YAML has scalar `allow_from: "123,456"`)
- **fix:** Include `"channel"` in `chat_type` checks for group-scoped authorization (aligns with surrounding code at line 344, 528)
- **fix:** Add `_telegram_extra` fallback for `group_allowed_chats` (consistent with `group_allow_from` fallback)
- **chore:** Add AUTHOR_MAP entry for `nyaruko@hermes` → `tsuk1nose`

## Validation

| Test | Result |
|------|--------|
| `tests/gateway/test_telegram_group_gating.py` | 55 passed |
| Authz-related gateway tests (5 files) | 111 passed |
| E2E verification script (17 checks) | 17 passed |

## Credit

- Original PR: #67816 by @tsuk1nose
- Salvage + fixes: @kshitijk4poor
