### PR TITLE
fix(gateway): fail closed when canonical routing state cannot load

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1260,7 +1260,11 @@ class SessionStore:
         # Primary: state.db gateway_routing table. getattr: some tests build
         # partially-initialized stores without __init__ (same pattern as
         # _prune_stale_sessions_locked).
-        loaded_entries: Dict[str, SessionEntry] = {}
+        # Preserve entries already seeded by the live runtime (for example,
+        # background-process origin metadata cached before the first lazy load).
+        # Canonical rows below overwrite the same keys; this is not legacy-disk
+        # fallback and remains available even when the canonical table is empty.
+        loaded_entries: Dict[str, SessionEntry] = dict(self._entries)
         canonical_read_succeeded = False
         _db = getattr(self, "_db", None)
         if _db:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1583,13 +1583,18 @@ class SessionStore:
 
     @staticmethod
     def _routing_payload_signature(entry_dict: Dict[str, Any]) -> str:
-        """Order-insensitive signature of a routing payload for change detection.
+        """Order-insensitive JSON signature for routing change detection.
 
         Computed identically at load (baseline capture) and at save (live
         comparison) so an entry that was loaded and never mutated compares
         equal and is not re-upserted over a sibling's concurrent update.
+        Round-trip through the normal JSON encoder first: metadata accepts any
+        JSON-serializable mapping, including mixed integer/string keys that
+        ``sort_keys=True`` cannot compare directly. The round-trip also matches
+        the canonical table's JSON object-key coercion semantics.
         """
-        return json.dumps(entry_dict, sort_keys=True)
+        normalized = json.loads(json.dumps(entry_dict))
+        return json.dumps(normalized, sort_keys=True, separators=(",", ":"))
 
     def _persist_routing_data(self, data: Dict[str, Any], generation: int) -> None:
         """Serialize all whole-index writers through one durable write lock."""

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1188,6 +1188,16 @@ class SessionStore:
         # re-upserted, so a save/prune can no longer clobber a sibling writer's
         # concurrent update to a row this store merely loaded and left alone.
         self._persisted_routing_payloads: Dict[str, str] = {}
+        # Exact raw canonical payload this store observed/owns for each key:
+        # {session_key -> entry_json byte-for-byte as stored in gateway_routing}.
+        # Seeded from the direct canonical read and legacy insert-if-absent
+        # winners, and refreshed to what was actually written after each upsert.
+        # Deletes are compare-and-delete against this value, so an owned key is
+        # removed only while the DB still holds the payload we observed; a
+        # sibling's concurrent same-key rewrite no longer matches and survives.
+        # Kept separate from the normalized change-detection signatures above:
+        # a signature is order-insensitive and is NOT a valid SQL CAS operand.
+        self._persisted_routing_raw: Dict[str, str] = {}
         self._inflight_lock = threading.Lock()
         self._inflight_sessions: Dict[str, _SessionFlight] = {}
         # An unscoped pre-migration Slack key can represent at most one
@@ -1305,6 +1315,9 @@ class SessionStore:
         # still upserts them. Signatures are computed the same way as at save
         # time so an unmutated entry compares equal and is not re-upserted.
         persisted_payloads: Dict[str, str] = {}
+        # Exact raw payload observed per proven-canonical key, for compare-and-
+        # delete. Populated in lockstep with persisted_payloads.
+        persisted_raw: Dict[str, str] = {}
         canonical_read_succeeded = False
         _db = getattr(self, "_db", None)
         # An existing canonical store that failed to open at construction must
@@ -1348,6 +1361,9 @@ class SessionStore:
                         persisted_payloads[key] = self._routing_payload_signature(
                             entry.to_dict()
                         )
+                        # The exact bytes the table holds — the CAS operand a
+                        # later delete of this key must still match.
+                        persisted_raw[key] = entry_json
                     except (ValueError, KeyError, TypeError) as e:
                         logger.warning(
                             "Invalid canonical routing entry %r: %s", key, e
@@ -1451,6 +1467,10 @@ class SessionStore:
                     persisted_payloads[key] = self._routing_payload_signature(
                         candidate.to_dict()
                     )
+                    # The authoritative stored value is whatever won the
+                    # insert-if-absent race — exactly the bytes now in the
+                    # table, so it is the correct CAS operand for this key.
+                    persisted_raw[key] = authoritative_json
                 loaded_entries[key] = candidate
                 imported += 1
 
@@ -1472,6 +1492,7 @@ class SessionStore:
         # untouched. Seed before the startup prune so its save computes the
         # pruned keys as the delete set.
         self._persisted_routing_payloads = persisted_payloads
+        self._persisted_routing_raw = persisted_raw
 
         # Prune any sessions.json entries that point to sessions already ended
         # in state.db. A hard gateway crash (exit code 1) skips the graceful
@@ -1616,11 +1637,16 @@ class SessionStore:
                         # payload matches the persisted baseline is left alone,
                         # so a sibling's concurrent update to a row we merely
                         # loaded survives. Delete only owned keys that have since
-                        # disappeared (pruned/reset). Foreign rows a sibling
-                        # inserted after our load are never named or deleted, so
-                        # a save can no longer clobber a concurrent write
-                        # (#9006 concurrency follow-up).
+                        # disappeared (pruned/reset), and compare-and-delete each
+                        # such key against the exact payload we observed:
+                        # if a sibling rewrote that same key after our load it no
+                        # longer matches, so its newer route survives our stale
+                        # delete. Foreign rows a sibling inserted after our load
+                        # are never named or deleted either, so a save can no
+                        # longer clobber a concurrent write (#9006 concurrency
+                        # follow-up).
                         baseline = getattr(self, "_persisted_routing_payloads", {})
+                        raw_baseline = getattr(self, "_persisted_routing_raw", {})
                         new_signatures = {
                             k: self._routing_payload_signature(v)
                             for k, v in data.items()
@@ -1630,17 +1656,36 @@ class SessionStore:
                             for k, sig in new_signatures.items()
                             if baseline.get(k) != sig
                         }
-                        delete_keys = [k for k in baseline if k not in data]
+                        # CAS operand per delete: the raw payload we last saw the
+                        # table hold. Skip an owned key we somehow lack a raw
+                        # baseline for rather than fall back to an unconditional
+                        # delete that could clobber a sibling.
+                        delete_expected = {
+                            k: raw_baseline[k]
+                            for k in baseline
+                            if k not in data and k in raw_baseline
+                        }
                         replacer(
                             upserts,
                             scope=self._routing_scope(),
-                            delete_keys=delete_keys,
+                            delete_expected=delete_expected,
                         )
                         db_saved = True
                         # New baseline is exactly the keys the live index now
                         # holds. Unchanged owned keys keep their signature,
                         # upserted keys adopt the new one, deleted keys drop out.
                         self._persisted_routing_payloads = new_signatures
+                        # Refresh the raw CAS baseline in lockstep: upserted keys
+                        # now hold exactly the bytes we wrote; unchanged keys keep
+                        # their last observed payload; deleted keys drop out.
+                        self._persisted_routing_raw = {
+                            k: (
+                                upserts[k]
+                                if k in upserts
+                                else raw_baseline.get(k, json.dumps(data[k]))
+                            )
+                            for k in data
+                        }
                     except Exception as exc:
                         logger.warning(
                             "gateway.session: state.db routing save failed: %s", exc

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1248,8 +1248,9 @@ class SessionStore:
 
         Read order (#9006 follow-up): the ``gateway_routing`` table in
         state.db is the primary source; sessions.json is the legacy import
-        path for pre-migration installs (its entries are folded in for keys
-        the DB doesn't have, then persisted to the DB on the next _save).
+        path for pre-migration installs. A successful canonical read is
+        required before legacy entries can seed absent keys, and each seed is
+        an insert-if-absent transaction that returns the authoritative value.
         """
         if self._loaded:
             return
@@ -1259,70 +1260,115 @@ class SessionStore:
         # Primary: state.db gateway_routing table. getattr: some tests build
         # partially-initialized stores without __init__ (same pattern as
         # _prune_stale_sessions_locked).
-        db_had_entries = False
+        loaded_entries: Dict[str, SessionEntry] = {}
+        canonical_read_succeeded = False
         _db = getattr(self, "_db", None)
         if _db:
             loader = getattr(_db, "load_gateway_routing_entries", None)
             if callable(loader):
                 try:
-                    for key, entry_json in loader(scope=self._routing_scope()).items():
-                        try:
-                            entry_data = json.loads(entry_json)
-                            if isinstance(entry_data, dict):
-                                self._entries[key] = SessionEntry.from_dict(entry_data)
-                        except (ValueError, KeyError, TypeError) as e:
-                            logger.warning(
-                                "Skipping invalid routing entry %r: %s", key, e
-                            )
-                    db_had_entries = bool(self._entries)
+                    canonical_rows = loader(scope=self._routing_scope())
                 except Exception as e:
                     logger.warning(
                         "gateway.session: state.db routing load failed: %s", e
                     )
+                    raise
+                for key, entry_json in canonical_rows.items():
+                    try:
+                        entry_data = json.loads(entry_json)
+                        if not isinstance(entry_data, dict):
+                            raise TypeError(
+                                "canonical routing entry must decode to an object"
+                            )
+                        loaded_entries[key] = SessionEntry.from_dict(entry_data)
+                    except (ValueError, KeyError, TypeError) as e:
+                        logger.warning(
+                            "Invalid canonical routing entry %r: %s", key, e
+                        )
+                        raise
+                canonical_read_succeeded = True
 
-        # Legacy import: sessions.json (pre-migration installs, or entries
-        # written by an older gateway after a downgrade). Only fills keys the
-        # DB didn't provide — DB entries win.
+        # Legacy fallback/import: without SQLite, sessions.json remains the
+        # only available routing index. With SQLite, only a proven successful
+        # canonical read may proceed, and every absent key is resolved through
+        # an atomic insert-if-absent/read-authority transaction.
         sessions_file = self.sessions_dir / "sessions.json"
+        legacy_data = None
         if sessions_file.exists():
             try:
                 with open(sessions_file, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-                imported = 0
-                for key, entry_data in data.items():
-                    # Keys starting with "_" are documentation/metadata sentinels
-                    # (e.g. the "_README" note written by _save), not session
-                    # entries. Skip them so they never reach SessionEntry.from_dict.
-                    if key.startswith("_"):
-                        continue
-                    if key in self._entries:
-                        continue
-                    # Skip non-dict entries (corrupted sessions.json, e.g. a
-                    # bare bool or string where a dict is expected). Without
-                    # this, from_dict raises TypeError on `"origin" in data`
-                    # which escapes the inner except (ValueError, KeyError) and
-                    # aborts loading ALL remaining sessions (#46994).
-                    if not isinstance(entry_data, dict):
-                        logger.warning(
-                            "Skipping invalid session entry %r: "
-                            "expected dict, got %s",
-                            key, type(entry_data).__name__,
-                        )
-                        continue
-                    try:
-                        self._entries[key] = SessionEntry.from_dict(entry_data)
-                        imported += 1
-                    except (ValueError, KeyError, TypeError) as e:
-                        logger.warning("Skipping invalid session entry %r: %s", key, e)
-                if imported and db_had_entries:
-                    logger.info(
-                        "gateway.session: imported %d legacy sessions.json "
-                        "entr%s missing from state.db routing table",
-                        imported, "y" if imported == 1 else "ies",
-                    )
+                    legacy_data = json.load(f)
+                if not isinstance(legacy_data, dict):
+                    raise TypeError("sessions.json must contain an object")
             except Exception as e:
                 print(f"[gateway] Warning: Failed to load sessions: {e}")
+                legacy_data = None
 
+        imported = 0
+        if legacy_data is not None and (not _db or canonical_read_succeeded):
+            for key, entry_data in legacy_data.items():
+                # Keys starting with "_" are documentation/metadata sentinels
+                # (e.g. the "_README" note written by _save), not session
+                # entries. Skip them so they never reach SessionEntry.from_dict.
+                if key.startswith("_"):
+                    continue
+                if key in loaded_entries:
+                    continue
+                # Skip non-dict entries (corrupted sessions.json, e.g. a bare
+                # bool or string where a dict is expected).
+                if not isinstance(entry_data, dict):
+                    logger.warning(
+                        "Skipping invalid session entry %r: expected dict, got %s",
+                        key,
+                        type(entry_data).__name__,
+                    )
+                    continue
+                try:
+                    candidate = SessionEntry.from_dict(entry_data)
+                except (ValueError, KeyError, TypeError) as e:
+                    logger.warning("Skipping invalid session entry %r: %s", key, e)
+                    continue
+
+                if _db:
+                    inserter = getattr(
+                        _db, "insert_gateway_routing_entry_if_absent", None
+                    )
+                    if not callable(inserter):
+                        raise RuntimeError(
+                            "canonical routing store cannot seed absent entries"
+                        )
+                    authoritative_json = inserter(
+                        key,
+                        json.dumps(candidate.to_dict()),
+                        scope=self._routing_scope(),
+                    )
+                    try:
+                        authoritative_data = json.loads(authoritative_json)
+                        if not isinstance(authoritative_data, dict):
+                            raise TypeError(
+                                "canonical routing entry must decode to an object"
+                            )
+                        candidate = SessionEntry.from_dict(authoritative_data)
+                    except (ValueError, KeyError, TypeError) as e:
+                        logger.warning(
+                            "Invalid canonical routing entry %r after legacy "
+                            "insert: %s",
+                            key,
+                            e,
+                        )
+                        raise
+                loaded_entries[key] = candidate
+                imported += 1
+
+        if imported:
+            logger.info(
+                "gateway.session: imported %d legacy sessions.json entr%s "
+                "missing from state.db routing table",
+                imported,
+                "y" if imported == 1 else "ies",
+            )
+
+        self._entries = loaded_entries
         self._loaded = True
 
         # Prune any sessions.json entries that point to sessions already ended

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1178,6 +1178,13 @@ class SessionStore:
         self._save_lock = threading.Lock()
         self._routing_generation = 0
         self._persisted_routing_generation = 0
+        # Keys this store owns in the canonical routing table (seeded from the
+        # canonical read, updated on every persist). A whole-index save deletes
+        # only owned keys that have since disappeared from the in-memory index
+        # (pruned/reset sessions); rows the store never owned — e.g. a sibling
+        # writer's concurrent insert into the same scope — are left untouched
+        # so a save/prune can no longer clobber another connection's write.
+        self._persisted_routing_keys: set[str] = set()
         self._inflight_lock = threading.Lock()
         self._inflight_sessions: Dict[str, _SessionFlight] = {}
         # An unscoped pre-migration Slack key can represent at most one
@@ -1204,11 +1211,35 @@ class SessionStore:
         
         # Initialize SQLite session database
         self._db = None
+        # Set when the canonical store (state.db) is present on disk but its
+        # SessionDB construction/schema/open failed. This is distinct from a
+        # genuinely absent/unavailable store: an existing-but-unopenable
+        # canonical routing index must fail closed on load rather than let the
+        # legacy sessions.json mirror silently become authoritative (#9006
+        # fail-closed follow-up). A construction failure with no state.db on
+        # disk (SQLite itself missing, pre-SQLite legacy install) keeps the
+        # historical JSONL degradation path.
+        self._canonical_store_open_failed = False
         try:
             from hermes_state import SessionDB
             self._db = SessionDB()
         except Exception as e:
-            print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
+            canonical_path = None
+            try:
+                from hermes_state import _default_db_path
+                canonical_path = _default_db_path()
+            except Exception:
+                canonical_path = None
+            if canonical_path is not None and canonical_path.exists():
+                self._canonical_store_open_failed = True
+                logger.error(
+                    "[gateway] canonical routing store %s is present but failed "
+                    "to open (%s); refusing legacy sessions.json fallback",
+                    canonical_path,
+                    e,
+                )
+            else:
+                print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
 
     def _has_active_processes_safe(self, session_key: str, *, context: str) -> bool:
         """Return whether a session has active work, failing closed on registry errors."""
@@ -1267,6 +1298,16 @@ class SessionStore:
         loaded_entries: Dict[str, SessionEntry] = dict(self._entries)
         canonical_read_succeeded = False
         _db = getattr(self, "_db", None)
+        # An existing canonical store that failed to open at construction must
+        # not degrade to the legacy sessions.json mirror — that would let stale
+        # routing override a broken-but-present canonical index. Fail closed and
+        # leave the store unloaded so a later retry (after the DB heals) can
+        # read the authoritative rows (#9006).
+        if _db is None and getattr(self, "_canonical_store_open_failed", False):
+            raise RuntimeError(
+                "canonical routing store is present but failed to open; refusing "
+                "to serve the legacy sessions.json fallback"
+            )
         if _db:
             loader = getattr(_db, "load_gateway_routing_entries", None)
             if callable(loader):
@@ -1284,7 +1325,17 @@ class SessionStore:
                             raise TypeError(
                                 "canonical routing entry must decode to an object"
                             )
-                        loaded_entries[key] = SessionEntry.from_dict(entry_data)
+                        entry = SessionEntry.from_dict(entry_data)
+                        # The table key IS the routing key; a payload whose
+                        # session_key disagrees is an inconsistent row (manual
+                        # edit, partial write, cross-key corruption). Fail closed
+                        # rather than route under a key the entry does not claim.
+                        if entry.session_key != key:
+                            raise ValueError(
+                                "canonical routing key does not match entry "
+                                f"session_key {entry.session_key!r}"
+                            )
+                        loaded_entries[key] = entry
                     except (ValueError, KeyError, TypeError) as e:
                         logger.warning(
                             "Invalid canonical routing entry %r: %s", key, e
@@ -1333,6 +1384,19 @@ class SessionStore:
                     logger.warning("Skipping invalid session entry %r: %s", key, e)
                     continue
 
+                # Never seed a canonical row under a key the entry does not
+                # claim: it would later trip the canonical key/session_key
+                # consistency check and fail the whole load closed. Skip the
+                # inconsistent legacy entry (best-effort import) instead.
+                if candidate.session_key != key:
+                    logger.warning(
+                        "Skipping legacy session entry %r: session_key %r "
+                        "disagrees with its routing key",
+                        key,
+                        candidate.session_key,
+                    )
+                    continue
+
                 if _db:
                     inserter = getattr(
                         _db, "insert_gateway_routing_entry_if_absent", None
@@ -1374,6 +1438,12 @@ class SessionStore:
 
         self._entries = loaded_entries
         self._loaded = True
+        # The canonical read observed exactly these keys; the store now owns
+        # them. A later whole-index save deletes only owned keys that vanish
+        # from the in-memory index (below, or via prune/reset) and leaves any
+        # concurrently-inserted foreign key untouched. Seed before the startup
+        # prune so its save computes the pruned keys as the delete set.
+        self._persisted_routing_keys = set(loaded_entries.keys())
 
         # Prune any sessions.json entries that point to sessions already ended
         # in state.db. A hard gateway crash (exit code 1) skips the graceful
@@ -1498,11 +1568,21 @@ class SessionStore:
                 replacer = getattr(_db, "replace_gateway_routing_entries", None)
                 if callable(replacer):
                     try:
+                        # Reconcile instead of blank-replacing the scope: upsert
+                        # the current index and delete only owned keys that have
+                        # since disappeared (pruned/reset). Foreign rows a
+                        # sibling writer inserted after our load are neither
+                        # named nor deleted, so a save can no longer clobber a
+                        # concurrent write (#9006 concurrency follow-up).
+                        owned = getattr(self, "_persisted_routing_keys", set())
+                        new_keys = set(data.keys())
                         replacer(
                             {k: json.dumps(v) for k, v in data.items()},
                             scope=self._routing_scope(),
+                            delete_keys=list(owned - new_keys),
                         )
                         db_saved = True
+                        self._persisted_routing_keys = new_keys
                     except Exception as exc:
                         logger.warning(
                             "gateway.session: state.db routing save failed: %s", exc

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1178,13 +1178,16 @@ class SessionStore:
         self._save_lock = threading.Lock()
         self._routing_generation = 0
         self._persisted_routing_generation = 0
-        # Keys this store owns in the canonical routing table (seeded from the
-        # canonical read, updated on every persist). A whole-index save deletes
-        # only owned keys that have since disappeared from the in-memory index
-        # (pruned/reset sessions); rows the store never owned — e.g. a sibling
-        # writer's concurrent insert into the same scope — are left untouched
-        # so a save/prune can no longer clobber another connection's write.
-        self._persisted_routing_keys: set[str] = set()
+        # Baseline of what this store believes each key currently holds in the
+        # canonical routing table: {session_key -> canonical payload signature}.
+        # Seeded from the canonical read (and legacy seeds) and refreshed on
+        # every persist. Its keys are the set this store owns. A whole-index
+        # save upserts only keys whose live payload differs from this baseline
+        # and deletes only owned keys that have since disappeared from the
+        # in-memory index (pruned/reset). An unchanged row is therefore never
+        # re-upserted, so a save/prune can no longer clobber a sibling writer's
+        # concurrent update to a row this store merely loaded and left alone.
+        self._persisted_routing_payloads: Dict[str, str] = {}
         self._inflight_lock = threading.Lock()
         self._inflight_sessions: Dict[str, _SessionFlight] = {}
         # An unscoped pre-migration Slack key can represent at most one
@@ -1296,6 +1299,12 @@ class SessionStore:
         # Canonical rows below overwrite the same keys; this is not legacy-disk
         # fallback and remains available even when the canonical table is empty.
         loaded_entries: Dict[str, SessionEntry] = dict(self._entries)
+        # Canonical-backed baseline for the keys we prove are in the table
+        # (canonical rows + successful legacy seeds). Pre-seeded live entries
+        # not backed by the table are deliberately omitted so the first save
+        # still upserts them. Signatures are computed the same way as at save
+        # time so an unmutated entry compares equal and is not re-upserted.
+        persisted_payloads: Dict[str, str] = {}
         canonical_read_succeeded = False
         _db = getattr(self, "_db", None)
         # An existing canonical store that failed to open at construction must
@@ -1336,6 +1345,9 @@ class SessionStore:
                                 f"session_key {entry.session_key!r}"
                             )
                         loaded_entries[key] = entry
+                        persisted_payloads[key] = self._routing_payload_signature(
+                            entry.to_dict()
+                        )
                     except (ValueError, KeyError, TypeError) as e:
                         logger.warning(
                             "Invalid canonical routing entry %r: %s", key, e
@@ -1417,6 +1429,17 @@ class SessionStore:
                                 "canonical routing entry must decode to an object"
                             )
                         candidate = SessionEntry.from_dict(authoritative_data)
+                        # Losing the insert-if-absent race adopts whatever row
+                        # already filled the slot. That winner must still honor
+                        # the table-key/session_key invariant enforced on the
+                        # direct canonical load above — a raced writer can seed a
+                        # payload claiming a different key. Fail closed rather
+                        # than route under a key the entry disclaims.
+                        if candidate.session_key != key:
+                            raise ValueError(
+                                "canonical routing key does not match entry "
+                                f"session_key {candidate.session_key!r}"
+                            )
                     except (ValueError, KeyError, TypeError) as e:
                         logger.warning(
                             "Invalid canonical routing entry %r after legacy "
@@ -1425,6 +1448,9 @@ class SessionStore:
                             e,
                         )
                         raise
+                    persisted_payloads[key] = self._routing_payload_signature(
+                        candidate.to_dict()
+                    )
                 loaded_entries[key] = candidate
                 imported += 1
 
@@ -1438,12 +1464,14 @@ class SessionStore:
 
         self._entries = loaded_entries
         self._loaded = True
-        # The canonical read observed exactly these keys; the store now owns
-        # them. A later whole-index save deletes only owned keys that vanish
-        # from the in-memory index (below, or via prune/reset) and leaves any
-        # concurrently-inserted foreign key untouched. Seed before the startup
-        # prune so its save computes the pruned keys as the delete set.
-        self._persisted_routing_keys = set(loaded_entries.keys())
+        # The canonical read (plus any legacy seeds) observed exactly these
+        # keys at these payloads; the store now owns them. A later whole-index
+        # save upserts only keys whose payload has since changed locally and
+        # deletes only owned keys that vanish from the in-memory index (below,
+        # or via prune/reset), leaving any concurrently-updated sibling row
+        # untouched. Seed before the startup prune so its save computes the
+        # pruned keys as the delete set.
+        self._persisted_routing_payloads = persisted_payloads
 
         # Prune any sessions.json entries that point to sessions already ended
         # in state.db. A hard gateway crash (exit code 1) skips the graceful
@@ -1553,6 +1581,16 @@ class SessionStore:
             self._routing_generation,
         )
 
+    @staticmethod
+    def _routing_payload_signature(entry_dict: Dict[str, Any]) -> str:
+        """Order-insensitive signature of a routing payload for change detection.
+
+        Computed identically at load (baseline capture) and at save (live
+        comparison) so an entry that was loaded and never mutated compares
+        equal and is not re-upserted over a sibling's concurrent update.
+        """
+        return json.dumps(entry_dict, sort_keys=True)
+
     def _persist_routing_data(self, data: Dict[str, Any], generation: int) -> None:
         """Serialize all whole-index writers through one durable write lock."""
         save_lock = getattr(self, "_save_lock", None)
@@ -1568,21 +1606,36 @@ class SessionStore:
                 replacer = getattr(_db, "replace_gateway_routing_entries", None)
                 if callable(replacer):
                     try:
-                        # Reconcile instead of blank-replacing the scope: upsert
-                        # the current index and delete only owned keys that have
-                        # since disappeared (pruned/reset). Foreign rows a
-                        # sibling writer inserted after our load are neither
-                        # named nor deleted, so a save can no longer clobber a
-                        # concurrent write (#9006 concurrency follow-up).
-                        owned = getattr(self, "_persisted_routing_keys", set())
-                        new_keys = set(data.keys())
+                        # Reconcile instead of blank-replacing the scope, and
+                        # upsert only genuinely local writes: a key whose live
+                        # payload matches the persisted baseline is left alone,
+                        # so a sibling's concurrent update to a row we merely
+                        # loaded survives. Delete only owned keys that have since
+                        # disappeared (pruned/reset). Foreign rows a sibling
+                        # inserted after our load are never named or deleted, so
+                        # a save can no longer clobber a concurrent write
+                        # (#9006 concurrency follow-up).
+                        baseline = getattr(self, "_persisted_routing_payloads", {})
+                        new_signatures = {
+                            k: self._routing_payload_signature(v)
+                            for k, v in data.items()
+                        }
+                        upserts = {
+                            k: json.dumps(data[k])
+                            for k, sig in new_signatures.items()
+                            if baseline.get(k) != sig
+                        }
+                        delete_keys = [k for k in baseline if k not in data]
                         replacer(
-                            {k: json.dumps(v) for k, v in data.items()},
+                            upserts,
                             scope=self._routing_scope(),
-                            delete_keys=list(owned - new_keys),
+                            delete_keys=delete_keys,
                         )
                         db_saved = True
-                        self._persisted_routing_keys = new_keys
+                        # New baseline is exactly the keys the live index now
+                        # holds. Unchanged owned keys keep their signature,
+                        # upserted keys adopt the new one, deleted keys drop out.
+                        self._persisted_routing_payloads = new_signatures
                     except Exception as exc:
                         logger.warning(
                             "gateway.session: state.db routing save failed: %s", exc

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1246,8 +1246,8 @@ class SessionStore:
             if canonical_path is not None and canonical_path.exists():
                 self._canonical_store_open_failed = True
                 logger.error(
-                    "[gateway] canonical routing store %s is present but failed "
-                    "to open (%s); refusing legacy sessions.json fallback",
+                    "[gateway] canonical routing store %s is present but unavailable "
+                    "(%s); refusing legacy sessions.json fallback",
                     canonical_path,
                     e,
                 )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2870,6 +2870,36 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         self._execute_write(_do)
 
+    def insert_gateway_routing_entry_if_absent(
+        self, session_key: str, entry_json: str, *, scope: str = ""
+    ) -> str:
+        """Seed a routing key once and return its authoritative stored value.
+
+        The insert and read share one ``BEGIN IMMEDIATE`` transaction so a
+        legacy importer that loses the insert race observes the competing
+        canonical row instead of overwriting it with its stale candidate.
+        """
+        if not session_key or not entry_json:
+            raise ValueError("session_key and entry_json are required")
+
+        def _do(conn):
+            conn.execute(
+                """INSERT INTO gateway_routing (scope, session_key, entry_json, updated_at)
+                   VALUES (?, ?, ?, ?)
+                   ON CONFLICT(scope, session_key) DO NOTHING""",
+                (scope, session_key, entry_json, time.time()),
+            )
+            row = conn.execute(
+                "SELECT entry_json FROM gateway_routing "
+                "WHERE scope = ? AND session_key = ?",
+                (scope, session_key),
+            ).fetchone()
+            if row is None:
+                raise RuntimeError("gateway routing insert did not produce a row")
+            return str(row["entry_json"])
+
+        return self._execute_write(_do)
+
     def replace_gateway_routing_entries(
         self, entries: Dict[str, str], *, scope: str = ""
     ) -> None:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2901,23 +2901,41 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return self._execute_write(_do)
 
     def replace_gateway_routing_entries(
-        self, entries: Dict[str, str], *, scope: str = ""
+        self,
+        entries: Dict[str, str],
+        *,
+        scope: str = "",
+        delete_keys: Optional[List[str]] = None,
     ) -> None:
-        """Atomically replace the routing index for *scope* with *entries*.
+        """Reconcile the routing index for *scope* in one write transaction.
 
-        Mirrors the sessions.json full-rewrite semantics: keys absent from
-        *entries* are removed (pruned/reset sessions disappear from the
-        index).  Runs as a single write transaction.  Other scopes are
-        untouched.
+        Upserts every ``session_key -> entry_json`` in *entries* and removes
+        the keys named in *delete_keys* (the keys the caller pruned/reset since
+        its last save).  Rows for keys the caller does not name are left
+        untouched — a whole-index save therefore no longer deletes a sibling
+        writer's concurrent insert into the same scope (#9006 concurrency
+        follow-up).  Other scopes are untouched.
+
+        A key present in both *entries* and *delete_keys* is upserted (the live
+        index wins); the delete is skipped for it.  ``delete_keys=None`` (the
+        default) upserts *entries* without removing anything.
         """
         now = time.time()
+        to_delete = [k for k in (delete_keys or ()) if k and k not in entries]
 
         def _do(conn):
-            conn.execute("DELETE FROM gateway_routing WHERE scope = ?", (scope,))
+            if to_delete:
+                conn.executemany(
+                    "DELETE FROM gateway_routing WHERE scope = ? AND session_key = ?",
+                    [(scope, k) for k in to_delete],
+                )
             if entries:
                 conn.executemany(
-                    "INSERT INTO gateway_routing (scope, session_key, entry_json, updated_at) "
-                    "VALUES (?, ?, ?, ?)",
+                    """INSERT INTO gateway_routing (scope, session_key, entry_json, updated_at)
+                       VALUES (?, ?, ?, ?)
+                       ON CONFLICT(scope, session_key) DO UPDATE SET
+                           entry_json = excluded.entry_json,
+                           updated_at = excluded.updated_at""",
                     [(scope, k, v, now) for k, v in entries.items() if k and v],
                 )
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2905,29 +2905,38 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         entries: Dict[str, str],
         *,
         scope: str = "",
-        delete_keys: Optional[List[str]] = None,
+        delete_expected: Optional[Dict[str, str]] = None,
     ) -> None:
         """Reconcile the routing index for *scope* in one write transaction.
 
-        Upserts every ``session_key -> entry_json`` in *entries* and removes
-        the keys named in *delete_keys* (the keys the caller pruned/reset since
-        its last save).  Rows for keys the caller does not name are left
-        untouched — a whole-index save therefore no longer deletes a sibling
-        writer's concurrent insert into the same scope (#9006 concurrency
-        follow-up).  Other scopes are untouched.
+        Upserts every ``session_key -> entry_json`` in *entries*.  For each
+        ``session_key -> expected_json`` in *delete_expected* the row is
+        deleted only when its stored ``entry_json`` still equals
+        *expected_json* — a compare-and-delete guard.  A sibling writer that
+        changed that same key after the caller's snapshot no longer matches, so
+        its newer route survives and the caller's stale delete becomes a no-op
+        (#9006 concurrency follow-up).  Rows for keys the caller does not name
+        are left untouched, so a whole-index save also never deletes a sibling's
+        concurrent insert into the same scope.  Other scopes are untouched.
 
-        A key present in both *entries* and *delete_keys* is upserted (the live
-        index wins); the delete is skipped for it.  ``delete_keys=None`` (the
-        default) upserts *entries* without removing anything.
+        A key present in both *entries* and *delete_expected* is upserted (the
+        live index wins); the delete is skipped for it.  ``delete_expected=None``
+        (the default) upserts *entries* without removing anything.  Deletes and
+        upserts share one transaction so the reconcile is atomic.
         """
         now = time.time()
-        to_delete = [k for k in (delete_keys or ()) if k and k not in entries]
+        to_delete = [
+            (k, expected)
+            for k, expected in (delete_expected or {}).items()
+            if k and expected is not None and k not in entries
+        ]
 
         def _do(conn):
             if to_delete:
                 conn.executemany(
-                    "DELETE FROM gateway_routing WHERE scope = ? AND session_key = ?",
-                    [(scope, k) for k in to_delete],
+                    "DELETE FROM gateway_routing "
+                    "WHERE scope = ? AND session_key = ? AND entry_json = ?",
+                    [(scope, k, expected) for k, expected in to_delete],
                 )
             if entries:
                 conn.executemany(

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1628,6 +1628,42 @@ class TestGatewayRoutingTable:
         competitor.close()
         store._db.close()
 
+    def test_competing_writer_key_mismatch_fails_closed(self, tmp_path):
+        """When legacy seeding loses the insert-if-absent race, the authoritative
+        canonical winner must still satisfy the table-key/session_key invariant.
+        A raced writer that filled the slot with a payload claiming a different
+        key fails the load closed rather than routing under a disclaimed key."""
+        import hermes_state
+
+        key = "agent:main:telegram:dm:chat-1"
+        self._write_legacy_entry(tmp_path, key, "legacy-session")
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        competitor = hermes_state.SessionDB()
+        # Poison payload: table key is `key`, but session_key claims another.
+        poison = self._entry_data("agent:main:telegram:dm:other", "poison-session")
+        real_insert = store._db.insert_gateway_routing_entry_if_absent
+        raced = False
+
+        def insert_after_competitor(session_key, entry_json, *, scope=""):
+            nonlocal raced
+            if not raced:
+                raced = True
+                competitor.save_gateway_routing_entry(
+                    session_key, json.dumps(poison), scope=scope
+                )
+            return real_insert(session_key, entry_json, scope=scope)
+
+        store._db.insert_gateway_routing_entry_if_absent = insert_after_competitor
+        with pytest.raises(ValueError, match="does not match entry session_key"):
+            store._ensure_loaded()
+
+        assert raced is True
+        assert store._loaded is False
+        assert store._entries == {}
+        competitor.close()
+        store._db.close()
+
     def test_construction_failure_with_present_store_fails_closed(self, tmp_path):
         """An existing canonical store that fails to open must NOT authorize the
         legacy sessions.json mirror — construction failure fails closed."""
@@ -1727,6 +1763,59 @@ class TestGatewayRoutingTable:
         store._save()
         rows = store._db.load_gateway_routing_entries(scope=scope)
         assert set(rows) == {key_b}
+        competitor.close()
+        store._db.close()
+
+    def test_loaded_sibling_row_update_survives_ordinary_save(self, tmp_path):
+        """A row included in the canonical load snapshot must not be re-upserted
+        unchanged: a sibling's concurrent update to that row survives the next
+        whole-index save, while a genuine local edit to another loaded row still
+        persists and an owned removal still deletes (#9006 concurrency
+        follow-up)."""
+        import hermes_state
+
+        scope = str(tmp_path.resolve())
+        key_a = "agent:main:telegram:dm:chatA"
+        key_b = "agent:main:telegram:dm:chatB"
+
+        db = hermes_state.SessionDB()
+        db.save_gateway_routing_entry(
+            key_a, json.dumps(self._entry_data(key_a, "sessionA")), scope=scope
+        )
+        db.save_gateway_routing_entry(
+            key_b, json.dumps(self._entry_data(key_b, "sessionB")), scope=scope
+        )
+        db.close()
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._ensure_loaded()
+        # Both rows are part of the load snapshot (unlike a post-load foreign
+        # insert), so both sit in the stale in-memory index.
+        assert set(store._entries) == {key_a, key_b}
+
+        # A sibling updates B AFTER our load; our in-memory B is now stale.
+        competitor = hermes_state.SessionDB()
+        competitor.save_gateway_routing_entry(
+            key_b, json.dumps(self._entry_data(key_b, "sessionB2")), scope=scope
+        )
+
+        # A genuine local edit to A triggers a whole-index save.
+        store._entries[key_a].session_id = "sessionA2"
+        store._save()
+
+        rows = store._db.load_gateway_routing_entries(scope=scope)
+        # The sibling's B update survives — unchanged B was not re-upserted...
+        assert json.loads(rows[key_b])["session_id"] == "sessionB2"
+        # ...while the genuine local change to A is persisted.
+        assert json.loads(rows[key_a])["session_id"] == "sessionA2"
+
+        # An owned key removed from the index is still deleted, and B still
+        # keeps the sibling value across the delete-driven save.
+        del store._entries[key_a]
+        store._save()
+        rows = store._db.load_gateway_routing_entries(scope=scope)
+        assert set(rows) == {key_b}
+        assert json.loads(rows[key_b])["session_id"] == "sessionB2"
         competitor.close()
         store._db.close()
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1385,6 +1385,54 @@ class TestGatewayRoutingTable:
         assert recovered.session_id == entry.session_id
         restarted._db.close()
 
+    def test_successful_empty_canonical_load_preserves_live_entry(self, tmp_path):
+        key = "agent:main:telegram:group:-100:42"
+        live = SessionEntry.from_dict(self._entry_data(key, "live-session"))
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._entries[key] = live
+
+        store._ensure_loaded()
+
+        assert store._entries[key] is live
+        assert store._entries[key].session_id == "live-session"
+        store._db.close()
+
+    def test_canonical_row_overwrites_conflicting_live_entry(self, tmp_path):
+        import hermes_state
+
+        key = "agent:main:telegram:group:-100:42"
+        canonical = self._entry_data(key, "canonical-session")
+        db = hermes_state.SessionDB()
+        db.save_gateway_routing_entry(
+            key, json.dumps(canonical), scope=str(tmp_path.resolve())
+        )
+        db.close()
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._entries[key] = SessionEntry.from_dict(
+            self._entry_data(key, "live-stale-session")
+        )
+        store._ensure_loaded()
+
+        assert store._entries[key].session_id == "canonical-session"
+        store._db.close()
+
+    def test_canonical_load_failure_retains_live_entry_for_retry(self, tmp_path):
+        key = "agent:main:telegram:group:-100:42"
+        live = SessionEntry.from_dict(self._entry_data(key, "live-session"))
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._entries[key] = live
+        store._db.load_gateway_routing_entries = MagicMock(
+            side_effect=RuntimeError("canonical unavailable")
+        )
+
+        with pytest.raises(RuntimeError, match="canonical unavailable"):
+            store._ensure_loaded()
+
+        assert store._loaded is False
+        assert store._entries[key] is live
+        store._db.close()
+
     def test_transient_canonical_load_failure_fails_closed_then_retries(self, tmp_path):
         """A failed DB read must not make the legacy mirror authoritative."""
         import hermes_state

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1628,3 +1628,152 @@ class TestGatewayRoutingTable:
         competitor.close()
         store._db.close()
 
+    def test_construction_failure_with_present_store_fails_closed(self, tmp_path):
+        """An existing canonical store that fails to open must NOT authorize the
+        legacy sessions.json mirror — construction failure fails closed."""
+        import hermes_state
+
+        key = "agent:main:telegram:dm:chat-1"
+        canonical = self._entry_data(key, "canonical-session")
+        self._write_legacy_entry(tmp_path, key, "stale-legacy-session")
+
+        db = hermes_state.SessionDB()
+        db.save_gateway_routing_entry(
+            key, json.dumps(canonical), scope=str(tmp_path.resolve())
+        )
+        db.close()
+        assert (tmp_path / "state.db").exists()
+
+        # SessionDB construction/schema/open now fails while state.db is present.
+        with patch(
+            "hermes_state.SessionDB",
+            side_effect=hermes_state.sqlite3.DatabaseError("schema migration failed"),
+        ):
+            store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+
+        assert store._db is None
+        assert store._canonical_store_open_failed is True
+
+        with pytest.raises(RuntimeError, match="present but failed to open"):
+            store._ensure_loaded()
+        assert store._loaded is False
+        # The stale legacy entry never became authoritative.
+        assert store._entries == {}
+
+    def test_construction_failure_without_store_allows_legacy_fallback(self, tmp_path):
+        """A genuinely absent canonical store keeps the historical JSONL
+        fallback — proving the fail-closed path is distinguishable from an
+        unavailable store."""
+        import hermes_state
+
+        key = "agent:main:telegram:dm:chat-1"
+        self._write_legacy_entry(tmp_path, key, "legacy-session")
+        assert not (tmp_path / "state.db").exists()
+
+        with patch(
+            "hermes_state.SessionDB",
+            side_effect=hermes_state.sqlite3.DatabaseError("sqlite unavailable"),
+        ):
+            store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+
+        assert store._db is None
+        assert store._canonical_store_open_failed is False
+
+        store._ensure_loaded()
+        assert store._entries[key].session_id == "legacy-session"
+
+    def test_concurrent_foreign_row_survives_save_but_owned_removal_deletes(
+        self, tmp_path
+    ):
+        """A sibling writer's insert/update after our load must survive the next
+        whole-index save, while an owned key removed from the index is still
+        deleted (reconcile, not blank-replace) (#9006 concurrency follow-up)."""
+        import hermes_state
+
+        scope = str(tmp_path.resolve())
+        key_a = "agent:main:telegram:dm:chatA"
+        key_b = "agent:main:telegram:dm:chatB"
+
+        db = hermes_state.SessionDB()
+        db.save_gateway_routing_entry(
+            key_a, json.dumps(self._entry_data(key_a, "sessionA")), scope=scope
+        )
+        db.close()
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._ensure_loaded()
+        assert set(store._entries) == {key_a}
+
+        competitor = hermes_state.SessionDB()
+        # Foreign INSERT after our load snapshot.
+        competitor.save_gateway_routing_entry(
+            key_b, json.dumps(self._entry_data(key_b, "sessionB")), scope=scope
+        )
+        store._save()
+        rows = store._db.load_gateway_routing_entries(scope=scope)
+        assert set(rows) == {key_a, key_b}
+        assert json.loads(rows[key_b])["session_id"] == "sessionB"
+
+        # Foreign UPDATE of the same different row after our load.
+        competitor.save_gateway_routing_entry(
+            key_b, json.dumps(self._entry_data(key_b, "sessionB2")), scope=scope
+        )
+        store._save()
+        rows = store._db.load_gateway_routing_entries(scope=scope)
+        assert json.loads(rows[key_b])["session_id"] == "sessionB2"  # not reverted
+
+        # An OWNED key removed from the in-memory index is still deleted.
+        del store._entries[key_a]
+        store._save()
+        rows = store._db.load_gateway_routing_entries(scope=scope)
+        assert set(rows) == {key_b}
+        competitor.close()
+        store._db.close()
+
+    def test_canonical_key_session_key_mismatch_fails_closed(self, tmp_path):
+        """A canonical row whose payload session_key disagrees with its table
+        key is inconsistent and must fail the load closed, not route under a key
+        the entry does not claim."""
+        import hermes_state
+
+        scope = str(tmp_path.resolve())
+        table_key = "agent:main:telegram:dm:chatX"
+        payload = self._entry_data("agent:main:telegram:dm:chatY", "sessionX")
+
+        db = hermes_state.SessionDB()
+        db.save_gateway_routing_entry(table_key, json.dumps(payload), scope=scope)
+        db.close()
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        with pytest.raises(ValueError, match="does not match entry session_key"):
+            store._ensure_loaded()
+        assert store._loaded is False
+        assert store._entries == {}
+        store._db.close()
+
+    def test_legacy_key_session_key_mismatch_is_skipped_not_seeded(self, tmp_path):
+        """An inconsistent legacy entry is skipped, so it never seeds a poison
+        canonical row that would later fail every load closed."""
+        good = "agent:main:telegram:dm:chatGood"
+        bad_key = "agent:main:telegram:dm:chatBad"
+        (tmp_path / "sessions.json").write_text(
+            json.dumps(
+                {
+                    good: self._entry_data(good, "good-session"),
+                    bad_key: self._entry_data(
+                        "agent:main:telegram:dm:other", "bad-session"
+                    ),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._ensure_loaded()
+
+        assert store._entries[good].session_id == "good-session"
+        assert bad_key not in store._entries
+        rows = store._db.load_gateway_routing_entries(scope=store._routing_scope())
+        assert set(rows) == {good}
+        store._db.close()
+

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1372,6 +1372,27 @@ class TestGatewayRoutingTable:
         assert rehydrated.model_override == {"model": "test-model"}
         restarted._db.close()
 
+    def test_mixed_json_mapping_keys_persist_to_canonical_store(self, tmp_path):
+        """Change detection accepts every mapping the JSON encoder accepts."""
+        config = GatewayConfig(write_sessions_json=False)
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+        entry = store.get_or_create_session(self._source())
+
+        assert store.set_session_metadata(
+            entry.session_key,
+            "mixed_mapping",
+            {1: "integer key", "2": "string key"},
+        )
+        assert store._db is not None
+        store._db.close()
+
+        restarted = SessionStore(sessions_dir=tmp_path, config=config)
+        assert restarted.get_session_metadata(
+            entry.session_key, "mixed_mapping"
+        ) == {"1": "integer key", "2": "string key"}
+        assert restarted._db is not None
+        restarted._db.close()
+
     def test_write_sessions_json_false_stops_producing_file(self, tmp_path):
         config = GatewayConfig(write_sessions_json=False)
         store = SessionStore(sessions_dir=tmp_path, config=config)

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1840,6 +1840,102 @@ class TestGatewayRoutingTable:
         competitor.close()
         store._db.close()
 
+    def test_sibling_same_key_update_survives_owned_removal(self, tmp_path):
+        """A sibling's concurrent update to the SAME key we own must survive when
+        we remove that key locally and save. The delete has to be CAS-guarded on
+        the payload this store observed — an unconditional key-only delete would
+        erase the sibling's newer route (#9006 concurrency follow-up)."""
+        import hermes_state
+
+        scope = str(tmp_path.resolve())
+        key = "agent:main:telegram:dm:chatA"
+
+        db = hermes_state.SessionDB()
+        db.save_gateway_routing_entry(
+            key, json.dumps(self._entry_data(key, "sessionA")), scope=scope
+        )
+        db.close()
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._ensure_loaded()
+        assert set(store._entries) == {key}
+
+        # A sibling updates the SAME key AFTER our load; our in-memory copy of
+        # that key is now stale, and so is the payload we believe the DB holds.
+        competitor = hermes_state.SessionDB()
+        competitor.save_gateway_routing_entry(
+            key, json.dumps(self._entry_data(key, "sessionA2")), scope=scope
+        )
+
+        # We drop the owned key locally and save. The delete must not clobber the
+        # sibling's newer value the store never observed.
+        del store._entries[key]
+        store._save()
+
+        rows = store._db.load_gateway_routing_entries(scope=scope)
+        assert set(rows) == {key}  # NOT deleted — payload no longer ours
+        assert json.loads(rows[key])["session_id"] == "sessionA2"
+        competitor.close()
+        store._db.close()
+
+    def test_sibling_same_key_update_survives_stale_prune(self, tmp_path):
+        """The hourly ``prune_old_entries`` path must also CAS-guard same-key
+        deletes: a sibling's newer route for a key we prune on a stale
+        ``updated_at`` survives instead of being erased."""
+        import hermes_state
+
+        scope = str(tmp_path.resolve())
+        key = "agent:main:telegram:dm:chatA"
+
+        db = hermes_state.SessionDB()
+        db.save_gateway_routing_entry(
+            key, json.dumps(self._entry_data(key, "sessionA")), scope=scope
+        )
+        db.close()
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._ensure_loaded()
+
+        competitor = hermes_state.SessionDB()
+        competitor.save_gateway_routing_entry(
+            key, json.dumps(self._entry_data(key, "sessionA2")), scope=scope
+        )
+
+        # _entry_data's updated_at is far older than one day, so this key prunes.
+        removed = store.prune_old_entries(max_age_days=1)
+        assert removed == 1  # locally pruned
+
+        rows = store._db.load_gateway_routing_entries(scope=scope)
+        assert json.loads(rows[key])["session_id"] == "sessionA2"  # sibling wins
+        competitor.close()
+        store._db.close()
+
+    def test_unchanged_owned_key_still_deletes_on_removal(self, tmp_path):
+        """CAS-guarding must not over-preserve: an owned key whose DB payload is
+        still exactly what we observed is deleted when removed locally."""
+        import hermes_state
+
+        scope = str(tmp_path.resolve())
+        key = "agent:main:telegram:dm:chatA"
+
+        db = hermes_state.SessionDB()
+        db.save_gateway_routing_entry(
+            key, json.dumps(self._entry_data(key, "sessionA")), scope=scope
+        )
+        db.close()
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._ensure_loaded()
+        assert set(store._entries) == {key}
+
+        # No sibling touched the row: the DB still holds exactly our payload.
+        del store._entries[key]
+        store._save()
+
+        rows = store._db.load_gateway_routing_entries(scope=scope)
+        assert rows == {}
+        store._db.close()
+
     def test_canonical_key_session_key_mismatch_fails_closed(self, tmp_path):
         """A canonical row whose payload session_key disagrees with its table
         key is inconsistent and must fail the load closed, not route under a key

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1335,6 +1335,21 @@ class TestGatewayRoutingTable:
             user_id=user_id,
         )
 
+    def _entry_data(self, session_key, session_id):
+        return {
+            "session_key": session_key,
+            "session_id": session_id,
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+        }
+
+    def _write_legacy_entry(self, tmp_path, session_key, session_id):
+        entry_data = self._entry_data(session_key, session_id)
+        (tmp_path / "sessions.json").write_text(
+            json.dumps({session_key: entry_data}), encoding="utf-8"
+        )
+        return entry_data
+
     def test_index_survives_restart_without_sessions_json(self, tmp_path):
         """Full SessionEntry state rehydrates from state.db alone."""
         config = GatewayConfig()
@@ -1370,4 +1385,198 @@ class TestGatewayRoutingTable:
         assert recovered.session_id == entry.session_id
         restarted._db.close()
 
+    def test_transient_canonical_load_failure_fails_closed_then_retries(self, tmp_path):
+        """A failed DB read must not make the legacy mirror authoritative."""
+        import hermes_state
+
+        key = "agent:main:telegram:dm:chat-1"
+        canonical = self._entry_data(key, "canonical-session")
+        self._write_legacy_entry(tmp_path, key, "stale-legacy-session")
+
+        db = hermes_state.SessionDB()
+        scope = str(tmp_path.resolve())
+        db.save_gateway_routing_entry(key, json.dumps(canonical), scope=scope)
+        db.close()
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        real_load = store._db.load_gateway_routing_entries
+        calls = 0
+
+        def fail_once(*, scope):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise RuntimeError("transient routing read failure")
+            return real_load(scope=scope)
+
+        store._db.load_gateway_routing_entries = fail_once
+        with pytest.raises(RuntimeError, match="transient routing read failure"):
+            store._ensure_loaded()
+
+        assert store._loaded is False
+        assert store._entries == {}
+        assert json.loads(real_load(scope=scope)[key]) == canonical
+
+        store._ensure_loaded()
+        assert store._entries[key].session_id == "canonical-session"
+        assert calls == 2
+        store._db.close()
+
+    def test_transient_canonical_parse_failure_preserves_row_and_retries(
+        self, tmp_path
+    ):
+        """A parse failure cannot authorize sessions.json to replace the DB row."""
+        import hermes_state
+
+        key = "agent:main:telegram:dm:chat-1"
+        canonical = self._entry_data(key, "canonical-session")
+        self._write_legacy_entry(tmp_path, key, "stale-legacy-session")
+
+        db = hermes_state.SessionDB()
+        scope = str(tmp_path.resolve())
+        db.save_gateway_routing_entry(key, json.dumps(canonical), scope=scope)
+        db.close()
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        real_json_loads = json.loads
+        calls = 0
+
+        def fail_once(payload, *args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise ValueError("transient canonical parse failure")
+            return real_json_loads(payload, *args, **kwargs)
+
+        with patch("gateway.session.json.loads", side_effect=fail_once):
+            with pytest.raises(ValueError, match="transient canonical parse failure"):
+                store._ensure_loaded()
+            assert store._loaded is False
+            assert store._entries == {}
+            store._ensure_loaded()
+
+        assert store._entries[key].session_id == "canonical-session"
+        assert real_json_loads(
+            store._db.load_gateway_routing_entries(scope=scope)[key]
+        ) == canonical
+        store._db.close()
+
+    def test_absent_legacy_key_is_seeded_once_during_successful_load(self, tmp_path):
+        """A proven-empty canonical slot is seeded immediately and only once."""
+        key = "agent:main:telegram:dm:chat-1"
+        self._write_legacy_entry(tmp_path, key, "legacy-session")
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._ensure_loaded()
+        scope = store._routing_scope()
+        stored = store._db.load_gateway_routing_entries(scope=scope)
+        assert json.loads(stored[key])["session_id"] == "legacy-session"
+        store._db.close()
+
+        self._write_legacy_entry(tmp_path, key, "later-stale-session")
+        restarted = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        restarted._ensure_loaded()
+        assert restarted._entries[key].session_id == "legacy-session"
+        restarted._db.close()
+
+    def test_legacy_seed_persists_only_sanitized_entry_data(self, tmp_path):
+        key = "agent:main:telegram:dm:chat-1"
+        entry_data = self._entry_data(key, "legacy-session")
+        entry_data["model_override"] = {
+            "model": "safe-model",
+            "api_key": "must-not-persist",
+            "api_mode": "responses",
+        }
+        (tmp_path / "sessions.json").write_text(
+            json.dumps({key: entry_data}), encoding="utf-8"
+        )
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._ensure_loaded()
+
+        persisted = store._db.load_gateway_routing_entries(
+            scope=store._routing_scope()
+        )[key]
+        assert "must-not-persist" not in persisted
+        assert json.loads(persisted)["model_override"] == {"model": "safe-model"}
+        store._db.close()
+
+    def test_non_object_legacy_json_does_not_block_canonical_load(self, tmp_path):
+        import hermes_state
+
+        key = "agent:main:telegram:dm:chat-1"
+        canonical = self._entry_data(key, "canonical-session")
+        (tmp_path / "sessions.json").write_text("[]", encoding="utf-8")
+
+        db = hermes_state.SessionDB()
+        db.save_gateway_routing_entry(
+            key, json.dumps(canonical), scope=str(tmp_path.resolve())
+        )
+        db.close()
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._ensure_loaded()
+        assert store._entries[key].session_id == "canonical-session"
+        store._db.close()
+
+    def test_legacy_import_cas_failure_is_retryable_and_idempotent(self, tmp_path):
+        key = "agent:main:telegram:dm:chat-1"
+        self._write_legacy_entry(tmp_path, key, "legacy-session")
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        real_insert = store._db.insert_gateway_routing_entry_if_absent
+        calls = 0
+
+        def fail_once(session_key, entry_json, *, scope=""):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise RuntimeError("transient routing CAS failure")
+            return real_insert(session_key, entry_json, scope=scope)
+
+        store._db.insert_gateway_routing_entry_if_absent = fail_once
+        with pytest.raises(RuntimeError, match="transient routing CAS failure"):
+            store._ensure_loaded()
+        assert store._loaded is False
+        assert store._entries == {}
+
+        store._ensure_loaded()
+        store._ensure_loaded()
+        assert calls == 2
+        assert store._entries[key].session_id == "legacy-session"
+        assert len(store._db.load_gateway_routing_entries(scope=store._routing_scope())) == 1
+        store._db.close()
+
+    def test_competing_writer_wins_legacy_import_cas(self, tmp_path):
+        """Import adopts the canonical winner when another writer fills the slot."""
+        import hermes_state
+
+        key = "agent:main:telegram:dm:chat-1"
+        self._write_legacy_entry(tmp_path, key, "legacy-session")
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        scope = store._routing_scope()
+        competitor = hermes_state.SessionDB()
+        competing = self._entry_data(key, "competing-session")
+        real_insert = store._db.insert_gateway_routing_entry_if_absent
+        raced = False
+
+        def insert_after_competitor(session_key, entry_json, *, scope=""):
+            nonlocal raced
+            if not raced:
+                raced = True
+                competitor.save_gateway_routing_entry(
+                    session_key, json.dumps(competing), scope=scope
+                )
+            return real_insert(session_key, entry_json, scope=scope)
+
+        store._db.insert_gateway_routing_entry_if_absent = insert_after_competitor
+        store._ensure_loaded()
+
+        assert raced is True
+        assert store._entries[key].session_id == "competing-session"
+        persisted = store._db.load_gateway_routing_entries(scope=scope)
+        assert json.loads(persisted[key]) == competing
+        competitor.close()
+        store._db.close()
 

--- a/tests/gateway/test_session_load_bool.py
+++ b/tests/gateway/test_session_load_bool.py
@@ -57,30 +57,32 @@ class TestSessionLoadBoolCorruption:
 
     def test_bool_entry_skipped_not_fatal(self, tmp_path):
         """A bool entry must not crash the loop or block other sessions."""
+        valid_key = "agent:main:telegram:dm:123456"
         data = {
             "_README": "test sentinel",
             "corrupted_key": True,
-            "valid_key": self._valid_entry(),
+            valid_key: self._valid_entry(),
         }
         store = self._make_store(tmp_path, data)
         store._ensure_loaded()
 
         # The valid entry must still be loaded
-        assert "valid_key" in store._entries
-        assert store._entries["valid_key"].session_id == "20260101_120000_abc12345"
+        assert valid_key in store._entries
+        assert store._entries[valid_key].session_id == "20260101_120000_abc12345"
         # The corrupted entry must NOT be loaded
         assert "corrupted_key" not in store._entries
 
     def test_string_entry_skipped(self, tmp_path):
         """A string entry must also be skipped without crashing."""
+        valid_key = "agent:main:telegram:dm:123456"
         data = {
             "bad_string": "not a dict",
-            "valid_key": self._valid_entry("20260101_130000_def67890"),
+            valid_key: self._valid_entry("20260101_130000_def67890"),
         }
         store = self._make_store(tmp_path, data)
         store._ensure_loaded()
 
-        assert "valid_key" in store._entries
+        assert valid_key in store._entries
         assert "bad_string" not in store._entries
 
 

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -57,6 +57,10 @@ def _db_returning(rows: dict) -> MagicMock:
     """SessionDB mock where get_session maps session_id -> row dict."""
     db = MagicMock()
     db.get_session.side_effect = lambda sid: rows.get(sid)
+    db.load_gateway_routing_entries.return_value = {}
+    db.insert_gateway_routing_entry_if_absent.side_effect = (
+        lambda _key, entry_json, *, scope="": entry_json
+    )
     return db
 
 

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -166,13 +166,18 @@ class TestPruneSaveConcurrencySafety:
         stale_key = "agent:main:telegram:dm:stale"
         foreign_key = "agent:main:telegram:dm:foreign"
 
+        # Build the owned entries once; the DB is seeded from exactly these
+        # bytes and the store's post-load baseline mirrors them, the way a real
+        # _ensure_loaded captures both _entries and the raw CAS operand from the
+        # same stored payload.
+        live_entry = _make_entry(live_key, "sid_live")
+        stale_entry = _make_entry(stale_key, "sid_stale")
+        live_json = json.dumps(live_entry.to_dict())
+        stale_json = json.dumps(stale_entry.to_dict())
+
         db = hermes_state.SessionDB()
-        db.save_gateway_routing_entry(
-            live_key, json.dumps(_make_entry(live_key, "sid_live").to_dict()), scope=scope
-        )
-        db.save_gateway_routing_entry(
-            stale_key, json.dumps(_make_entry(stale_key, "sid_stale").to_dict()), scope=scope
-        )
+        db.save_gateway_routing_entry(live_key, live_json, scope=scope)
+        db.save_gateway_routing_entry(stale_key, stale_json, scope=scope)
         # sid_stale reads as ended so startup pruning removes it; every other
         # session_id is absent from the sessions table (get_session -> None,
         # kept).
@@ -184,12 +189,14 @@ class TestPruneSaveConcurrencySafety:
         store = _make_store_with_db(tmp_path, db)
         # Model the post-load snapshot: the store read and now owns both rows
         # at exactly these payloads (the persistence baseline).
-        live_entry = _make_entry(live_key, "sid_live")
-        stale_entry = _make_entry(stale_key, "sid_stale")
         store._entries = {live_key: live_entry, stale_key: stale_entry}
         store._persisted_routing_payloads = {
-            live_key: json.dumps(live_entry.to_dict(), sort_keys=True),
-            stale_key: json.dumps(stale_entry.to_dict(), sort_keys=True),
+            live_key: store._routing_payload_signature(live_entry.to_dict()),
+            stale_key: store._routing_payload_signature(stale_entry.to_dict()),
+        }
+        store._persisted_routing_raw = {
+            live_key: live_json,
+            stale_key: stale_json,
         }
 
         # A sibling connection inserts a DIFFERENT row after the load snapshot.
@@ -225,17 +232,16 @@ class TestPruneSaveConcurrencySafety:
         stale_key = "agent:main:telegram:dm:stale"
         sibling_key = "agent:main:telegram:dm:sibling"
 
+        # Build the owned entries once so the DB bytes and the store's raw CAS
+        # baseline are byte-identical, the way a real load captures them.
+        stale_entry = _make_entry(stale_key, "sid_stale")
+        sibling_entry = _make_entry(sibling_key, "sid_sibling")
+        stale_json = json.dumps(stale_entry.to_dict())
+        sibling_json = json.dumps(sibling_entry.to_dict())
+
         db = hermes_state.SessionDB()
-        db.save_gateway_routing_entry(
-            stale_key,
-            json.dumps(_make_entry(stale_key, "sid_stale").to_dict()),
-            scope=scope,
-        )
-        db.save_gateway_routing_entry(
-            sibling_key,
-            json.dumps(_make_entry(sibling_key, "sid_sibling").to_dict()),
-            scope=scope,
-        )
+        db.save_gateway_routing_entry(stale_key, stale_json, scope=scope)
+        db.save_gateway_routing_entry(sibling_key, sibling_json, scope=scope)
         real_get = db.get_session
         db.get_session = lambda sid: (
             {"end_reason": "agent_close", "id": sid}
@@ -246,12 +252,14 @@ class TestPruneSaveConcurrencySafety:
         store = _make_store_with_db(tmp_path, db)
         # Model the post-load snapshot: BOTH rows were read and are owned at
         # exactly these payloads (baseline captured from the same objects).
-        stale_entry = _make_entry(stale_key, "sid_stale")
-        sibling_entry = _make_entry(sibling_key, "sid_sibling")
         store._entries = {stale_key: stale_entry, sibling_key: sibling_entry}
         store._persisted_routing_payloads = {
             stale_key: store._routing_payload_signature(stale_entry.to_dict()),
             sibling_key: store._routing_payload_signature(sibling_entry.to_dict()),
+        }
+        store._persisted_routing_raw = {
+            stale_key: stale_json,
+            sibling_key: sibling_json,
         }
 
         # A sibling connection UPDATES the loaded sibling row after our snapshot.
@@ -270,6 +278,56 @@ class TestPruneSaveConcurrencySafety:
         # The loaded sibling row was unchanged locally, so it must not have been
         # re-upserted over the sibling writer's newer value.
         assert json.loads(rows[sibling_key])["session_id"] == "sid_sibling2"
+        competitor.close()
+        db.close()
+
+    def test_prune_save_preserves_concurrent_same_key_update(
+        self, tmp_path, monkeypatch
+    ):
+        """Startup stale-prune of an owned key must CAS-guard its delete: if a
+        sibling rewrote that SAME key after our load snapshot, the
+        prune-triggered save must not erase the sibling's newer route. Our
+        in-memory copy still points at the ended session, so the key still prunes
+        locally — but the delete no longer matches what the table now holds.
+        """
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        scope = str(tmp_path.resolve())
+        stale_key = "agent:main:telegram:dm:stale"
+
+        stale_entry = _make_entry(stale_key, "sid_stale")
+        stale_json = json.dumps(stale_entry.to_dict())
+
+        db = hermes_state.SessionDB()
+        db.save_gateway_routing_entry(stale_key, stale_json, scope=scope)
+        real_get = db.get_session
+        db.get_session = lambda sid: (
+            {"end_reason": "agent_close", "id": sid}
+            if sid == "sid_stale"
+            else real_get(sid)
+        )
+
+        store = _make_store_with_db(tmp_path, db)
+        store._entries = {stale_key: stale_entry}
+        store._persisted_routing_payloads = {
+            stale_key: store._routing_payload_signature(stale_entry.to_dict()),
+        }
+        store._persisted_routing_raw = {stale_key: stale_json}
+
+        # A sibling rewrites the SAME key AFTER our snapshot with a live session.
+        competitor = hermes_state.SessionDB()
+        competitor.save_gateway_routing_entry(
+            stale_key,
+            json.dumps(_make_entry(stale_key, "sid_stale_live").to_dict()),
+            scope=scope,
+        )
+
+        store._prune_stale_sessions_locked()
+
+        rows = db.load_gateway_routing_entries(scope=scope)
+        # Payload no longer ours -> stale delete is a no-op, sibling route lives.
+        assert json.loads(rows[stale_key])["session_id"] == "sid_stale_live"
         competitor.close()
         db.close()
 

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -182,12 +182,15 @@ class TestPruneSaveConcurrencySafety:
         )
 
         store = _make_store_with_db(tmp_path, db)
-        # Model the post-load snapshot: the store read and now owns both rows.
-        store._entries = {
-            live_key: _make_entry(live_key, "sid_live"),
-            stale_key: _make_entry(stale_key, "sid_stale"),
+        # Model the post-load snapshot: the store read and now owns both rows
+        # at exactly these payloads (the persistence baseline).
+        live_entry = _make_entry(live_key, "sid_live")
+        stale_entry = _make_entry(stale_key, "sid_stale")
+        store._entries = {live_key: live_entry, stale_key: stale_entry}
+        store._persisted_routing_payloads = {
+            live_key: json.dumps(live_entry.to_dict(), sort_keys=True),
+            stale_key: json.dumps(stale_entry.to_dict(), sort_keys=True),
         }
-        store._persisted_routing_keys = {live_key, stale_key}
 
         # A sibling connection inserts a DIFFERENT row after the load snapshot.
         competitor = hermes_state.SessionDB()
@@ -204,6 +207,69 @@ class TestPruneSaveConcurrencySafety:
         assert set(rows) == {live_key, foreign_key}
         assert stale_key not in rows  # owned + removed -> deleted
         assert json.loads(rows[foreign_key])["session_id"] == "sid_foreign"
+        competitor.close()
+        db.close()
+
+    def test_prune_save_preserves_already_loaded_sibling_update(
+        self, tmp_path, monkeypatch
+    ):
+        """A row that was part of the load snapshot must not be re-upserted
+        unchanged by a prune-triggered save: a sibling's concurrent update to
+        that loaded row survives, while the pruned owned key is still deleted.
+        """
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        scope = str(tmp_path.resolve())
+
+        stale_key = "agent:main:telegram:dm:stale"
+        sibling_key = "agent:main:telegram:dm:sibling"
+
+        db = hermes_state.SessionDB()
+        db.save_gateway_routing_entry(
+            stale_key,
+            json.dumps(_make_entry(stale_key, "sid_stale").to_dict()),
+            scope=scope,
+        )
+        db.save_gateway_routing_entry(
+            sibling_key,
+            json.dumps(_make_entry(sibling_key, "sid_sibling").to_dict()),
+            scope=scope,
+        )
+        real_get = db.get_session
+        db.get_session = lambda sid: (
+            {"end_reason": "agent_close", "id": sid}
+            if sid == "sid_stale"
+            else real_get(sid)
+        )
+
+        store = _make_store_with_db(tmp_path, db)
+        # Model the post-load snapshot: BOTH rows were read and are owned at
+        # exactly these payloads (baseline captured from the same objects).
+        stale_entry = _make_entry(stale_key, "sid_stale")
+        sibling_entry = _make_entry(sibling_key, "sid_sibling")
+        store._entries = {stale_key: stale_entry, sibling_key: sibling_entry}
+        store._persisted_routing_payloads = {
+            stale_key: json.dumps(stale_entry.to_dict(), sort_keys=True),
+            sibling_key: json.dumps(sibling_entry.to_dict(), sort_keys=True),
+        }
+
+        # A sibling connection UPDATES the loaded sibling row after our snapshot.
+        competitor = hermes_state.SessionDB()
+        competitor.save_gateway_routing_entry(
+            sibling_key,
+            json.dumps(_make_entry(sibling_key, "sid_sibling2").to_dict()),
+            scope=scope,
+        )
+
+        # Pruning the stale key triggers the whole-index save immediately.
+        store._prune_stale_sessions_locked()
+
+        rows = db.load_gateway_routing_entries(scope=scope)
+        assert stale_key not in rows  # owned + removed -> deleted
+        # The loaded sibling row was unchanged locally, so it must not have been
+        # re-upserted over the sibling writer's newer value.
+        assert json.loads(rows[sibling_key])["session_id"] == "sid_sibling2"
         competitor.close()
         db.close()
 

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -150,3 +150,60 @@ class TestEnsureLoadedCallsPrune:
 
         assert "dm_key" not in store._entries
 
+
+class TestPruneSaveConcurrencySafety:
+    """A prune-triggered whole-index save must not clobber a sibling writer's
+    concurrent insert into the same routing scope (#9006 concurrency follow-up).
+    """
+
+    def test_prune_save_preserves_concurrent_foreign_row(self, tmp_path, monkeypatch):
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        scope = str(tmp_path.resolve())
+
+        live_key = "agent:main:telegram:dm:live"
+        stale_key = "agent:main:telegram:dm:stale"
+        foreign_key = "agent:main:telegram:dm:foreign"
+
+        db = hermes_state.SessionDB()
+        db.save_gateway_routing_entry(
+            live_key, json.dumps(_make_entry(live_key, "sid_live").to_dict()), scope=scope
+        )
+        db.save_gateway_routing_entry(
+            stale_key, json.dumps(_make_entry(stale_key, "sid_stale").to_dict()), scope=scope
+        )
+        # sid_stale reads as ended so startup pruning removes it; every other
+        # session_id is absent from the sessions table (get_session -> None,
+        # kept).
+        real_get = db.get_session
+        db.get_session = lambda sid: (
+            {"end_reason": "agent_close", "id": sid} if sid == "sid_stale" else real_get(sid)
+        )
+
+        store = _make_store_with_db(tmp_path, db)
+        # Model the post-load snapshot: the store read and now owns both rows.
+        store._entries = {
+            live_key: _make_entry(live_key, "sid_live"),
+            stale_key: _make_entry(stale_key, "sid_stale"),
+        }
+        store._persisted_routing_keys = {live_key, stale_key}
+
+        # A sibling connection inserts a DIFFERENT row after the load snapshot.
+        competitor = hermes_state.SessionDB()
+        competitor.save_gateway_routing_entry(
+            foreign_key,
+            json.dumps(_make_entry(foreign_key, "sid_foreign").to_dict()),
+            scope=scope,
+        )
+
+        # Pruning the stale key triggers the whole-index save immediately.
+        store._prune_stale_sessions_locked()
+
+        rows = db.load_gateway_routing_entries(scope=scope)
+        assert set(rows) == {live_key, foreign_key}
+        assert stale_key not in rows  # owned + removed -> deleted
+        assert json.loads(rows[foreign_key])["session_id"] == "sid_foreign"
+        competitor.close()
+        db.close()
+

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -250,8 +250,8 @@ class TestPruneSaveConcurrencySafety:
         sibling_entry = _make_entry(sibling_key, "sid_sibling")
         store._entries = {stale_key: stale_entry, sibling_key: sibling_entry}
         store._persisted_routing_payloads = {
-            stale_key: json.dumps(stale_entry.to_dict(), sort_keys=True),
-            sibling_key: json.dumps(sibling_entry.to_dict(), sort_keys=True),
+            stale_key: store._routing_payload_signature(stale_entry.to_dict()),
+            sibling_key: store._routing_payload_signature(sibling_entry.to_dict()),
         }
 
         # A sibling connection UPDATES the loaded sibling row after our snapshot.


### PR DESCRIPTION
## Summary

Fail closed when canonical conversation-routing state cannot be loaded, instead of silently rebuilding from legacy session mappings and potentially routing work onto the wrong durable session.

The refreshed implementation also makes canonical routing reconciliation safe under concurrent gateway writers.

## Problem

The session store treats `state.db` routing state as authoritative. A load/decode/schema failure previously fell through to the legacy compatibility path, which could resurrect stale mappings precisely when the canonical source was unavailable.

Whole-index persistence could also overwrite or delete another gateway connection's newer routing rows after loading an older snapshot.

This remains a prerequisite for the broader session-routing hardening tracked in #31692.

## Fix

- distinguish genuine canonical-state absence from open/schema/load failure;
- allow legacy fallback only when canonical state is genuinely absent;
- fail closed on malformed, unreadable, or key-inconsistent canonical rows;
- seed legacy-only keys with atomic insert-if-absent/read-authority semantics;
- preserve live/pre-seeded entries during a successful canonical load;
- upsert only locally changed rows, preserving sibling inserts and updates;
- compare-and-delete owned rows against the exact payload observed, so a stale prune/reset cannot erase a sibling's newer same-key route;
- keep normalized change signatures separate from exact SQL CAS payloads, including mixed JSON mapping-key compatibility;
- retain transactional, scope-limited reconciliation.

## Verification

- focused routing/corruption suite — **238 passed**
- 11-file reset/recovery regression suite — **55 passed**
- `python scripts/check-windows-footguns.py --all` — **PASS**
- `git diff origin/main...HEAD --check` — **PASS**
- Codex read-only semantic review — **APPROVED: no P0/P1/P2 findings**
- Final replay onto current `origin/main` was patch-identical by `git range-diff`; the focused suites were rerun on the pushed head.

## Scope

Five files only:

- `gateway/session.py`
- `hermes_state.py`
- `tests/gateway/test_session.py`
- `tests/gateway/test_session_store_stale_prune.py`
- `tests/gateway/test_session_load_bool.py`

This PR does not include the broader continuity feature work from #31692.
