### PR TITLE
fix(gateway): declare webhook sessions stateless so background delegations run inline (#69145)

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -147,6 +147,20 @@ def check_webhook_requirements() -> bool:
 class WebhookAdapter(BasePlatformAdapter):
     """Generic webhook receiver that triggers agent runs from HTTP POSTs."""
 
+    # A webhook delivery is one-shot: the ``delivery_id`` is baked into the
+    # session key and ``on_processing_complete`` ends the session the moment the
+    # run finishes, so the per-delivery session can never receive a second turn.
+    # That means a background delegation whose result arrives after the turn ends
+    # has no live parent session to wake — the completion re-injection is dropped
+    # by the #55578 fail-closed guard and the subagent's work is stranded (the
+    # exact symptom #53027/#63142 described, on the gateway/webhook surface —
+    # #69145).  Declaring the channel stateless makes ``delegate_task``
+    # background=True fall back to synchronous inline execution so the result
+    # returns within the turn, mirroring what #66617 did for ``hermes -z``
+    # one-shot and cron (which also set ``async_delivery=False``).  The API
+    # server adapter sets this same flag for the same reason.
+    supports_async_delivery: bool = False
+
     # No human is present to answer a "session restored — what next?" prompt:
     # webhook runs are event-triggered.  The startup auto-resume turn must
     # instruct the model to FINISH the interrupted work instead of emitting an

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -148,6 +148,20 @@ def _validate_svix_signature(body: bytes, secret: str, msg_id: str, timestamp: s
 class WebhookAdapter(BasePlatformAdapter):
     """Generic webhook receiver that triggers agent runs from HTTP POSTs."""
 
+    # A webhook delivery is one-shot: the ``delivery_id`` is baked into the
+    # session key and ``on_processing_complete`` ends the session the moment the
+    # run finishes, so the per-delivery session can never receive a second turn.
+    # That means a background delegation whose result arrives after the turn ends
+    # has no live parent session to wake — the completion re-injection is dropped
+    # by the #55578 fail-closed guard and the subagent's work is stranded (the
+    # exact symptom #53027/#63142 described, on the gateway/webhook surface —
+    # #69145).  Declaring the channel stateless makes ``delegate_task``
+    # background=True fall back to synchronous inline execution so the result
+    # returns within the turn, mirroring what #66617 did for ``hermes -z``
+    # one-shot and cron (which also set ``async_delivery=False``).  The API
+    # server adapter sets this same flag for the same reason.
+    supports_async_delivery: bool = False
+
     # Event-triggered, no human present: startup auto-resume must FINISH the interrupted work, not ask "what next?".
     # The startup auto-resume turn must instruct the model to FINISH the interrupted work instead of
     # emitting an interactive acknowledgement that abandons the task (#57056).

--- a/tests/gateway/test_async_delivery_capability.py
+++ b/tests/gateway/test_async_delivery_capability.py
@@ -205,6 +205,15 @@ class TestAdapterCapabilityFlag:
 
         assert APIServerAdapter.supports_async_delivery is False
 
+    def test_webhook_false(self):
+        """A webhook delivery is one-shot: ``on_processing_complete`` ends the
+        per-delivery session the moment the run finishes, so a late background
+        delegation completion has no live parent to wake (#69145). The adapter
+        must therefore declare async delivery unsupported, like the API server."""
+        from gateway.platforms.webhook import WebhookAdapter
+
+        assert WebhookAdapter.supports_async_delivery is False
+
     def test_api_server_bind_chokepoint_hardwires_no_delivery(self):
         """Every API-server agent-entry path binds through
         _bind_api_server_session, which hardwires async_delivery=False — a new
@@ -240,6 +249,65 @@ class TestAdapterCapabilityFlag:
             session_key="shared-key",
             async_delivery=True,
         )
+        try:
+            assert async_delivery_supported() is True
+        finally:
+            clear_session_vars(tokens)
+
+
+# ---------------------------------------------------------------------------
+# Gateway binding: the webhook adapter's flag reaches the per-turn contextvar
+# ---------------------------------------------------------------------------
+
+class TestWebhookSessionBindsStateless:
+    """End-to-end wiring: ``GatewayRunner._set_session_env`` must propagate the
+    webhook adapter's ``supports_async_delivery=False`` into the session
+    contextvar so ``delegate_task`` background=True falls back to sync (#69145).
+
+    Without the adapter flag, the webhook path bound ``async_delivery=True``
+    (base default), background delegations dispatched detached, and their
+    completions were dropped after ``on_processing_complete`` ended the session.
+    """
+
+    def _runner_with(self, adapters):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.adapters = adapters
+        return runner
+
+    def _context(self, platform):
+        from gateway.session import SessionContext, SessionSource
+
+        source = SessionSource(platform=platform, chat_id="delivery-1")
+        return SessionContext(source=source, connected_platforms=[], home_channels={})
+
+    def test_webhook_binds_no_async_delivery(self):
+        from gateway.config import Platform
+        from gateway.platforms.webhook import WebhookAdapter
+
+        # object.__new__ avoids the adapter's heavy __init__; the capability is
+        # a class attribute, so the real flag is what flows through.
+        adapter = object.__new__(WebhookAdapter)
+        runner = self._runner_with({Platform.WEBHOOK: adapter})
+        tokens = runner._set_session_env(self._context(Platform.WEBHOOK))
+        try:
+            assert async_delivery_supported() is False
+        finally:
+            clear_session_vars(tokens)
+
+    def test_delivering_platform_still_binds_async_delivery(self):
+        """Control: a platform whose adapter keeps the base default stays
+        supported — the fix must not disable delivery for real channels."""
+        from gateway.config import Platform
+
+        # A delivering adapter keeps the base default (True); the getattr in
+        # _set_session_env must read it and bind async_delivery=True.
+        class _DeliveringAdapter:
+            supports_async_delivery = True
+
+        runner = self._runner_with({Platform.TELEGRAM: _DeliveringAdapter()})
+        tokens = runner._set_session_env(self._context(Platform.TELEGRAM))
         try:
             assert async_delivery_supported() is True
         finally:

--- a/tests/gateway/test_async_delivery_capability.py
+++ b/tests/gateway/test_async_delivery_capability.py
@@ -156,6 +156,15 @@ class TestStatelessChannelForcesSyncDelegation:
 class TestAdapterCapabilityFlag:
 
 
+    def test_webhook_false(self):
+        """A webhook delivery is one-shot: ``on_processing_complete`` ends the
+        per-delivery session the moment the run finishes, so a late background
+        delegation completion has no live parent to wake (#69145). The adapter
+        must therefore declare async delivery unsupported, like the API server."""
+        from gateway.platforms.webhook import WebhookAdapter
+
+        assert WebhookAdapter.supports_async_delivery is False
+
     def test_api_server_bind_chokepoint_hardwires_no_delivery(self):
         """Every API-server agent-entry path binds through
         _bind_api_server_session, which hardwires async_delivery=False — a new
@@ -169,6 +178,65 @@ class TestAdapterCapabilityFlag:
         try:
             assert async_delivery_supported() is False
             assert get_session_env("HERMES_SESSION_PLATFORM") == "api_server"
+        finally:
+            clear_session_vars(tokens)
+
+
+# ---------------------------------------------------------------------------
+# Gateway binding: the webhook adapter's flag reaches the per-turn contextvar
+# ---------------------------------------------------------------------------
+
+class TestWebhookSessionBindsStateless:
+    """End-to-end wiring: ``GatewayRunner._set_session_env`` must propagate the
+    webhook adapter's ``supports_async_delivery=False`` into the session
+    contextvar so ``delegate_task`` background=True falls back to sync (#69145).
+
+    Without the adapter flag, the webhook path bound ``async_delivery=True``
+    (base default), background delegations dispatched detached, and their
+    completions were dropped after ``on_processing_complete`` ended the session.
+    """
+
+    def _runner_with(self, adapters):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.adapters = adapters
+        return runner
+
+    def _context(self, platform):
+        from gateway.session import SessionContext, SessionSource
+
+        source = SessionSource(platform=platform, chat_id="delivery-1")
+        return SessionContext(source=source, connected_platforms=[], home_channels={})
+
+    def test_webhook_binds_no_async_delivery(self):
+        from gateway.config import Platform
+        from gateway.platforms.webhook import WebhookAdapter
+
+        # object.__new__ avoids the adapter's heavy __init__; the capability is
+        # a class attribute, so the real flag is what flows through.
+        adapter = object.__new__(WebhookAdapter)
+        runner = self._runner_with({Platform.WEBHOOK: adapter})
+        tokens = runner._set_session_env(self._context(Platform.WEBHOOK))
+        try:
+            assert async_delivery_supported() is False
+        finally:
+            clear_session_vars(tokens)
+
+    def test_delivering_platform_still_binds_async_delivery(self):
+        """Control: a platform whose adapter keeps the base default stays
+        supported — the fix must not disable delivery for real channels."""
+        from gateway.config import Platform
+
+        # A delivering adapter keeps the base default (True); the getattr in
+        # _set_session_env must read it and bind async_delivery=True.
+        class _DeliveringAdapter:
+            supports_async_delivery = True
+
+        runner = self._runner_with({Platform.TELEGRAM: _DeliveringAdapter()})
+        tokens = runner._set_session_env(self._context(Platform.TELEGRAM))
+        try:
+            assert async_delivery_supported() is True
         finally:
             clear_session_vars(tokens)
 


### PR DESCRIPTION
## Summary

Fixes #69145. A webhook delivery is **one-shot**: the `delivery_id` is baked into the session key and `WebhookAdapter.on_processing_complete` ends the per-delivery session the moment the run finishes (`gateway/platforms/webhook.py`), so the parent session can never receive a second turn.

When the parent agent calls `delegate_task` (forced `background=True` at top level), the subagent's result arrives tens of seconds later — after `ended_at` is set — and the completion re-injection is dropped by the #55578 fail-closed guard:

```
Async-delegation completion pinned to session <id>, which is ended —
dropping injection instead of resurrecting it (#55578 fail-closed;
result remains in the delegation records).
```

The subagent's work is fully persisted to the delegation records, but the parent is never woken, so it never summarizes or posts back. The user sees only the "waiting for the subagent's result" placeholder — the #53027 / #63142 symptom, now on the gateway/webhook surface.

## Root cause

#66617 (merged Jul 18) fixed this for `hermes -z` one-shot and cron by declaring a **stateless channel** (`async_delivery=False`) so `delegate_task` falls back to synchronous inline execution. But it only touched `hermes_cli/oneshot.py` and `cron/scheduler.py` — the gateway webhook runner was not covered.

`GatewayRunner._set_session_env` already propagates each adapter's `supports_async_delivery` into the `_SESSION_ASYNC_DELIVERY` contextvar. `APIServerAdapter` sets it `False` for exactly this reason; `WebhookAdapter` inherited the base default `True`, so webhook sessions bound `async_delivery=True` and dispatched detached children whose completions could never be delivered.

## Fix

Set `supports_async_delivery = False` on `WebhookAdapter` (one class attribute, mirroring `APIServerAdapter`). Top-level background delegations on a webhook session now run inline and return within the turn.

`MSGraphWebhookAdapter` is intentionally left unchanged: it is subscription-based (persistent Teams/Outlook conversations) and does **not** end sessions per-delivery, so it genuinely supports async delivery.

## Tests

`tests/gateway/test_async_delivery_capability.py`:
- `test_webhook_false` — locks the class-attribute invariant.
- `TestWebhookSessionBindsStateless` — end-to-end wiring through `GatewayRunner._set_session_env`: a webhook session binds `async_delivery_supported() == False`, while a delivering adapter still binds `True` (the fix must not disable delivery for real channels).

Full `tests/gateway/test_webhook_adapter.py`, `test_webhook_session_close.py`, and `test_async_delivery_capability.py` pass (116 + 18). Preflight gates green vs `upstream/main`.
