### PR TITLE
feat: support `underlying_provider` in `custom_providers` for reverse-proxy endpoints

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2238,6 +2238,28 @@ def get_model_context_length(
         except Exception:
             pass  # fall through to probing
 
+    # 0c.5. custom_providers underlying_provider override.
+    # When a custom_providers entry declares ``underlying_provider``
+    # (e.g. ``openai-codex``), the custom endpoint is a reverse proxy
+    # for that provider.  The proxy's /models endpoint reports the
+    # model-native context window, not the proxy provider's enforced
+    # cap — so skip the custom-endpoint /models probe at step 2 and
+    # route directly through the underlying provider's resolution path
+    # at step 5 instead.
+    # See issue #67919.
+    _underlying_provider: str | None = None
+    if custom_providers and base_url and provider in ("", "custom"):
+        try:
+            from hermes_cli.config import get_custom_provider_underlying_provider
+            underlying = get_custom_provider_underlying_provider(
+                base_url=base_url,
+                custom_providers=custom_providers,
+            )
+            if underlying:
+                _underlying_provider = underlying
+        except Exception:
+            pass  # fall through to normal probing
+
     # Malformed user-provided URLs (for example an unmatched IPv6 bracket)
     # make urllib.parse raise. Context resolution should treat those as an
     # unknown endpoint rather than crashing before the inference layer can
@@ -2415,7 +2437,10 @@ def get_model_context_length(
     # /models endpoint may report a provider-imposed limit (e.g. Copilot
     # returns 128k) instead of the model's full context (400k).  models.dev
     # has the correct per-provider values and is checked at step 5+.
-    if _is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url):
+    # Also skip when `_underlying_provider` is set (step 0c.5): the custom
+    # endpoint is a proxy for a known provider and its /models response
+    # would report the model-native window, not the proxy's enforced cap.
+    if _is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url) and not _underlying_provider:
         context_length = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
         if context_length is not None:
             return context_length
@@ -2478,7 +2503,10 @@ def get_model_context_length(
     # since the same model can have different context limits per provider
     # (e.g. claude-opus-4.6 is 1M on Anthropic but 128K on GitHub Copilot).
     # If provider is generic (openrouter/custom/empty), try to infer from URL.
-    effective_provider = provider
+    # When `_underlying_provider` is set (step 0c.5), use it as the
+    # effective provider — the custom endpoint is a proxy for a known
+    # provider and should use that provider's resolution path instead.
+    effective_provider = _underlying_provider or provider
     if not effective_provider or effective_provider in {"openrouter", "custom"}:
         if base_url:
             inferred = _infer_provider_from_url(base_url)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5487,6 +5487,48 @@ def get_custom_provider_context_length(
     return None
 
 
+def get_custom_provider_underlying_provider(
+    base_url: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Return the configured ``underlying_provider`` for a custom provider endpoint.
+
+    Matches any entry whose ``base_url`` equals ``base_url`` (trailing-slash
+    insensitive). Returns the value of ``underlying_provider`` if present,
+    or ``None``.
+
+    Used by ``get_model_context_length`` so that a custom provider proxying
+    a known provider (e.g., Codex OAuth) can skip the custom-endpoint /models
+    probe and go directly to the provider-aware resolution path, avoiding
+    the model-native context window that the proxy's /models would return.
+    """
+    if not base_url:
+        return None
+    if custom_providers is None:
+        try:
+            custom_providers = get_compatible_custom_providers(config)
+        except Exception:
+            if config is None:
+                return None
+            raw = config.get("custom_providers")
+            custom_providers = raw if isinstance(raw, list) else []
+    if not isinstance(custom_providers, list):
+        return None
+
+    target_url = base_url.rstrip("/")
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = (entry.get("base_url") or "").rstrip("/")
+        if not entry_url or entry_url != target_url:
+            continue
+        underlying = entry.get("underlying_provider")
+        if isinstance(underlying, str) and underlying.strip():
+            return underlying.strip()
+    return None
+
+
 def _coerce_config_version(value: Any) -> int:
     """Return a safe integer config version, treating invalid values as legacy."""
     if isinstance(value, bool):
@@ -5572,6 +5614,9 @@ _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
     "context_length", "rate_limit_delay", "extra_body",
     "ssl_ca_cert", "ssl_verify",
+    # underlying_provider declares the real provider behind a reverse proxy
+    # (e.g. "openai-codex") so Hermes can resolve context length correctly.
+    "underlying_provider",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",


### PR DESCRIPTION
## Problem

When a `custom_providers` entry is a reverse proxy for a known provider (e.g. a forwarding proxy to Codex OAuth), Hermes's `get_model_context_length()` resolves the context window from the custom endpoint's `/v1/models` response — which returns the **model-native** context length (e.g. `gpt-5.5` = 1.05M). The upstream proxy provider (Codex OAuth) enforces a **lower** cap (272K).

Hermes fills past 272K, the upstream returns 502 / context-limit errors, and the user gets:

> API call failed after 3 retries: HTTP 502: 当前对话已达到模型上下文窗口上限

## Solution

Add an optional `underlying_provider` field to `custom_providers[]` list entries. When set (e.g. `underlying_provider: openai-codex`), the context length resolution:

1. **Skips** the custom-endpoint `/v1/models` probe at step 2 (the proxy's response reflects the model-native window, not the actual enforced cap)
2. **Routes** through the underlying provider's resolution path at step 5 instead (Codex OAuth's live `/models` probe + fallback dict)

### Usage

```yaml
custom_providers:
  - name: lucen
    base_url: https://lucen.cc/v1
    underlying_provider: openai-codex    # ← new field
    models:
      - gpt-5.5
      - gpt-5.3-codex
```

When `underlying_provider: openai-codex` is set:
1. Step 0c.5 sets `_underlying_provider = "openai-codex"`
2. Step 2 skips the custom endpoint probe (`and not _underlying_provider`)
3. Step 5 sets `effective_provider = "openai-codex"` which triggers `_resolve_codex_oauth_context_length()` → returns the correct 272K cap

### Files changed

- **`agent/model_metadata.py`** — step 0c.5: detect `underlying_provider` from custom_providers config, skip step 2 probe, set `effective_provider`
- **`hermes_cli/config.py`** — `get_custom_provider_underlying_provider()` helper + `underlying_provider` in `_VALID_CUSTOM_PROVIDER_FIELDS`

### Backward compatibility

- `underlying_provider` is **optional** — existing configs behave identically
- Unrecognized provider names fall through to the normal probe chain as before

Closes #67919