### PR TITLE
fix: pass explicit basename to send_document and fix silent error handling in Telegram media send

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1302,6 +1302,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                             "Telegram caption-fallback send failed for missing media: %s",
                             _sanitize_error_text(_cap_err),
                         )
+                        warnings.append(_sanitize_error_text(_cap_err))
                 continue
 
             ext = os.path.splitext(media_path)[1].lower()
@@ -1342,7 +1343,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                             )
                         else:
                             last_msg = await bot.send_document(
-                                chat_id=int_chat_id, document=f, **media_kwargs
+                                chat_id=int_chat_id, document=f, filename=os.path.basename(media_path), **media_kwargs
                             )
                     except Exception as media_err:
                         if _is_telegram_thread_not_found(media_err) and media_kwargs.get("message_thread_id"):
@@ -1373,7 +1374,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                 )
                             else:
                                 last_msg = await bot.send_document(
-                                    chat_id=int_chat_id, document=f, **media_kwargs
+                                    chat_id=int_chat_id, document=f, filename=os.path.basename(media_path), **media_kwargs
                                 )
                         elif media_kwargs.get("parse_mode") and (
                             "parse" in str(media_err).lower()
@@ -1402,9 +1403,17 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                 last_msg = await bot.send_video(
                                     chat_id=int_chat_id, video=f, **media_kwargs
                                 )
+                            elif ext in _VOICE_EXTS and is_voice:
+                                last_msg = await bot.send_voice(
+                                    chat_id=int_chat_id, voice=f, **media_kwargs
+                                )
+                            elif ext in _TELEGRAM_SEND_AUDIO_EXTS:
+                                last_msg = await bot.send_audio(
+                                    chat_id=int_chat_id, audio=f, **media_kwargs
+                                )
                             else:
                                 last_msg = await bot.send_document(
-                                    chat_id=int_chat_id, document=f, **media_kwargs
+                                    chat_id=int_chat_id, document=f, filename=os.path.basename(media_path), **media_kwargs
                                 )
                         else:
                             raise


### PR DESCRIPTION
## Problem

When Hermes sends a document via Telegram's `send_document`, the `python-telegram-bot` library derives the filename from the file object if none is provided. For temp files or truncated paths, this can result in a garbled or missing filename — causing silent delivery failure on some platforms (#67552).

Additionally, two error-handling gaps were identified during review (previously on #68107, now split into this clean PR):

1. **Caption-fallback failure is invisible to the agent.** When the caption-fallback send fails (the file is gone and the caption text is sent alone), the error is logged via `logger.warning` but never appended to the `warnings` list — the agent never knows it happened.

2. **Voice/audio files silently downgraded on caption parse error.** The caption parse retry block was missing the `_VOICE_EXTS` and `_TELEGRAM_SEND_AUDIO_EXTS` type checks that exist in the primary `try` block and the thread-not-found retry block. If an audio or voice file encounters a caption parse error, it falls through to `send_document` instead of `send_voice`/`send_audio`.

## Fix

Three changes in `tools/send_message_tool.py`:

1. **Explicit `filename` for `send_document`:** Added `filename=os.path.basename(media_path)` to all three `send_document` call sites (primary send, thread-not-found retry, and caption-parse retry).

2. **Caption-fallback warning propagation:** Added `warnings.append(_sanitize_error_text(_cap_err))` alongside the existing `logger.warning` call in the caption-fallback exception handler.

3. **Voice/audio handling in caption parse retry:** Added the missing `elif ext in _VOICE_EXTS and is_voice:` and `elif ext in _TELEGRAM_SEND_AUDIO_EXTS:` branches to the caption parse retry block, matching the structure of the primary and thread-not-found retry blocks.

Fixes #67552