### PR TITLE
fix(cli): wait for MCP discovery in one-shot mode

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -254,6 +254,7 @@ def _run_agent(
     # Imports are local so they don't run when hermes is invoked for
     # other commands (keeps top-level CLI startup cheap).
     from hermes_cli.config import load_config
+    from hermes_cli.mcp_startup import wait_for_mcp_discovery
     from hermes_cli.models import detect_provider_for_model
     from hermes_cli.runtime_provider import resolve_runtime_provider
     from hermes_cli.tools_config import _get_platform_tools
@@ -326,6 +327,12 @@ def _run_agent(
     toolsets_list = _normalize_toolsets(toolsets)
     if toolsets_list is None and use_config_toolsets:
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
+
+    # CLI startup discovers MCP servers in the background. Match the normal
+    # chat path's bounded wait before AIAgent snapshots the tool registry;
+    # otherwise a fast one-shot can permanently miss every configured MCP
+    # tool and incorrectly tell the caller that none are available.
+    wait_for_mcp_discovery()
 
     session_db = _create_session_db_for_oneshot()
     # Read the effective fallback chain from profile config so oneshot workers

--- a/tests/hermes_cli/test_oneshot_mcp_discovery.py
+++ b/tests/hermes_cli/test_oneshot_mcp_discovery.py
@@ -1,0 +1,40 @@
+import sys
+import types
+
+from hermes_cli import mcp_startup, oneshot
+
+
+def test_oneshot_waits_for_mcp_discovery_before_agent_tool_snapshot(monkeypatch):
+    events = []
+
+    class FakeAgent:
+        def __init__(self, **_kwargs):
+            events.append("agent")
+
+        def chat(self, prompt):
+            assert prompt == "use mcp"
+            return "done"
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    monkeypatch.setattr(mcp_startup, "wait_for_mcp_discovery", lambda: events.append("wait"))
+    monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"default": "test-model", "provider": "test-provider"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "api_key": "test",
+            "base_url": "https://example.invalid",
+            "provider": "test-provider",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_args: {"aivex-hq"})
+
+    assert oneshot._run_agent("use mcp") == "done"
+    assert events == ["wait", "agent"]


### PR DESCRIPTION
## Summary

Match normal CLI chat behavior by applying the existing bounded MCP discovery wait before one-shot mode constructs AIAgent and snapshots tools.

Without this wait, hermes -z can immediately conclude that configured MCP tools do not exist while background discovery is still running.

## Verification

- scripts/run_tests.sh tests/hermes_cli/test_oneshot_mcp_discovery.py
- 1 passed
- live reproduction: normal chat sees MCP tools while one-shot misses them before this change