### PR TITLE
fix(agent): fill empty user/assistant content in pre-API sanitizer to prevent strict-provider 400s

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2844,8 +2844,34 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: removed %d duplicate tool_call_id reference(s)",
             removed_dupes,
         )
-    return messages
 
+    # 4. Fill empty / None content on user & assistant messages. Some
+    # providers (kimi-k3 via bufan.live, glm via zhipu) reject a user message
+    # whose content is an empty string or None with HTTP 400
+    # "user message must have content". Empty-content user turns can arise
+    # from context compression edge cases, host-injected placeholders, or
+    # session-resume artifacts. Patching here on the per-call API copy keeps
+    # the persisted trajectory byte-stable while giving the provider a
+    # non-empty payload it will accept.
+    _EMPTY_CONTENT_PLACEHOLDER = "[empty]"
+    patched_content = 0
+    final_messages: List[Dict[str, Any]] = []
+    for msg in messages:
+        role = msg.get("role")
+        if role in ("user", "assistant") and "tool_calls" not in msg:
+            content = msg.get("content")
+            if content is None or (isinstance(content, str) and not content.strip()):
+                msg = {**msg, "content": _EMPTY_CONTENT_PLACEHOLDER}
+                patched_content += 1
+        final_messages.append(msg)
+    if patched_content:
+        messages = final_messages
+        _ra().logger.warning(
+            "Pre-call sanitizer: filled empty content on %d message(s) with placeholder",
+            patched_content,
+        )
+
+    return messages
 
 
 def looks_like_codex_intermediate_ack(

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -334,3 +334,105 @@ class TestGetToolCallNameStatic:
     def test_object_without_function_attr(self):
         tc = types.SimpleNamespace(id="call_1")
         assert AIAgent._get_tool_call_name_static(tc) == ""
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — empty content guard in _sanitize_api_messages
+#
+# Strict OpenAI-compatible providers (Kimi/Moonshot, GLM/Zhipu) reject user
+# or assistant messages whose content is None or an empty/whitespace-only
+# string with HTTP 400 "user message must have content".  Empty content can
+# arise from context-compression edge cases, session-resume artifacts, or
+# host-injected placeholders.  The sanitizer fills such messages with a
+# non-empty placeholder on the per-call API copy, keeping the persisted
+# trajectory byte-stable.
+# ---------------------------------------------------------------------------
+
+class TestEmptyContentGuard:
+    """Tests for the empty-content placeholder guard."""
+
+    def test_empty_string_user_content_is_patched(self):
+        msgs = [{"role": "user", "content": ""}]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["content"] == "[empty]"
+
+    def test_whitespace_only_user_content_is_patched(self):
+        msgs = [{"role": "user", "content": "   \n\t  "}]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["content"] == "[empty]"
+
+    def test_none_user_content_is_patched(self):
+        msgs = [{"role": "user", "content": None}]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["content"] == "[empty]"
+
+    def test_empty_assistant_content_is_patched(self):
+        msgs = [{"role": "assistant", "content": ""}]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["content"] == "[empty]"
+
+    def test_none_assistant_content_is_patched(self):
+        msgs = [{"role": "assistant", "content": None}]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["content"] == "[empty]"
+
+    def test_assistant_with_tool_calls_is_not_patched(self):
+        """An assistant message carrying tool_calls may legitimately have
+        empty content — the tool_calls ARE the payload.  The guard must
+        skip such messages."""
+        msgs = [{
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "c1", "function": {"name": "f", "arguments": "{}"}}],
+        }]
+        out = AIAgent._sanitize_api_messages(msgs)
+        # content should remain None — tool_calls present
+        assert out[0].get("content") is None
+
+    def test_tool_result_empty_content_is_not_patched(self):
+        """Tool results are not user/assistant messages; the guard must
+        not touch them even if their content is empty."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "c1", "function": {"name": "f", "arguments": "{}"}}],
+            },
+            {"role": "tool", "content": "", "tool_call_id": "c1"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[-1]["content"] == ""
+
+    def test_multimodal_list_content_is_not_patched(self):
+        """A multimodal user message (content is a list of content parts)
+        must not be replaced with a string placeholder."""
+        msgs = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert isinstance(out[0]["content"], list)
+
+    def test_normal_content_is_not_patched(self):
+        """Messages with real content must be left untouched."""
+        msgs = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["content"] == "You are helpful."
+        assert out[1]["content"] == "Hello"
+        assert out[2]["content"] == "Hi there"
+
+    def test_mixed_batch_only_empties_are_patched(self):
+        """In a batch containing both empty and non-empty messages, only
+        the empty ones should be patched."""
+        msgs = [
+            {"role": "user", "content": "real question"},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": None},
+            {"role": "user", "content": "another real question"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["content"] == "real question"
+        assert out[1]["content"] == "[empty]"
+        assert out[2]["content"] == "[empty]"
+        assert out[3]["content"] == "another real question"


### PR DESCRIPTION
## Summary

Strict OpenAI-compatible providers (Kimi/Moonshot, GLM/Zhipu) reject user or assistant messages whose `content` is an empty string or `None` with HTTP 400 `"user message must have content"`.

Empty content can arise from:
- **Context-compression edge cases** — summary replaces turns, leaves stubs with empty content
- **Session-resume artifacts** — corrupted/partial persistence
- **Host-injected placeholders** — empty user turns from platform gateways

## The Gap

`sanitize_api_messages()` is the **provider-agnostic final chokepoint** before every LLM call. It already has 4 guards:
1. Role allowlist (drop invalid roles)
2. Empty `tool_calls` array cleanup
3. Orphaned tool result repair
4. Duplicate `tool_call_id` dedup

**But there is no guard for empty `content` on user/assistant messages.**

## Existing fixes (complementary, not overlapping)

| Commit/PR | Scope | Covers this gap? |
|-----------|-------|-----------------|
| `3f95e741a` (Teknium, #3322) | Anthropic adapter only | ❌ No — OpenAI-compatible path not covered |
| `b4c2c4f92` (neo) | MoA advisory view only | ❌ No — main conversation loop not covered |
| #63200, #31582, #31175, #66509 | Assistant + tool_calls empty content | ❌ No — these fix assistant-with-tool_calls, not user messages |

This PR fills the gap at the **shared** sanitizer level, covering all providers in one place.

## Changes

**`agent/agent_runtime_helpers.py`** — Added a 5th guard at the end of `sanitize_api_messages()`:
- Scans all messages for `role` in `("user", "assistant")` without `tool_calls`
- If `content` is `None`, empty string, or whitespace-only → replaced with `"[empty]"` placeholder
- Operates on the **per-call API copy** only — persisted trajectory stays byte-stable
- Assistant messages WITH `tool_calls` are skipped (their payload is the tool_calls; #63200 handles that separately)
- Multimodal list content is untouched (non-string types skipped)
- Logs a warning when patches are applied

**`tests/run_agent/test_agent_guardrails.py`** — Added `TestEmptyContentGuard` class with 10 regression tests:
- Empty string user content → patched ✅
- Whitespace-only user content → patched ✅  
- None user content → patched ✅
- Empty assistant content → patched ✅
- None assistant content → patched ✅
- Assistant with tool_calls → **NOT** patched ✅
- Tool result empty content → **NOT** patched ✅
- Multimodal list content → **NOT** patched ✅
- Normal content → **NOT** patched ✅
- Mixed batch → only empties patched ✅

## Test Results

```
47 passed in 1.20s  (37 existing + 10 new, zero regressions)
```

## Real-world impact

This was discovered in production: a Hermes bot fleet running Kimi-K3 and GLM-5.2 via an OpenAI-compatible gateway would intermittently 400 after context compression, killing the session. The fallback chain also failed because the same malformed request was sent to all providers. This guard prevents the 400 at the source.

Related issues: #66429, #63200, #53638