### PR TITLE
fix(kanban): prevent worker session routing leaks

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8532,11 +8532,12 @@ def _default_spawn(
 
     prompt = f"work kanban task {task.id}"
     env = dict(os.environ)
-    # The gateway dispatcher is detached from any conversation. Strip stale
-    # HERMES_SESSION_* mirrors so a worker cannot inherit another chat/topic
-    # and auto-subscribe child tasks there.
-    from tools.environments.local import _inject_session_context_env
-    _inject_session_context_env(env)
+    # The dispatcher is detached from every conversation. Its worker must never
+    # inherit routing mirrored by a previous gateway turn, even before the first
+    # session binds ContextVars in this process.
+    from gateway.session_context import _VAR_MAP
+    for key in _VAR_MAP:
+        env.pop(key, None)
 
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml
     # (fallback_providers, toolsets, agent settings, etc.) instead of the root

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8532,6 +8532,11 @@ def _default_spawn(
 
     prompt = f"work kanban task {task.id}"
     env = dict(os.environ)
+    # The gateway dispatcher is detached from any conversation. Strip stale
+    # HERMES_SESSION_* mirrors so a worker cannot inherit another chat/topic
+    # and auto-subscribe child tasks there.
+    from tools.environments.local import _inject_session_context_env
+    _inject_session_context_env(env)
 
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml
     # (fallback_providers, toolsets, agent settings, etc.) instead of the root

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3096,16 +3096,26 @@ class TestSharedBoardPaths:
         assert kb.kanban_db_path() == default_home / "kanban.db"
         assert kb.workspaces_root() == default_home / "kanban" / "workspaces"
 
-    def test_dispatcher_spawn_injects_kanban_db_and_workspaces_root(
+    def test_dispatcher_spawn_injects_kanban_paths_without_stale_session(
         self, tmp_path, monkeypatch
     ):
-        # The dispatcher's `_default_spawn` must inject HERMES_KANBAN_DB
-        # and HERMES_KANBAN_WORKSPACES_ROOT into the worker env so the
-        # worker converges on the dispatcher's paths even when the
-        # `-p <profile>` flag rewrites HERMES_HOME.
+        # The dispatcher must pin board paths while stripping any unrelated
+        # HERMES_SESSION_* identity inherited from the long-lived gateway.
         default_home = tmp_path / ".hermes"
         default_home.mkdir()
         self._set_home(monkeypatch, tmp_path, default_home)
+
+        from gateway import session_context as sc
+
+        monkeypatch.setattr(sc, "_session_context_engaged", True)
+        sc.reset_session_vars()
+        for key, value in {
+            "HERMES_SESSION_PLATFORM": "telegram",
+            "HERMES_SESSION_CHAT_ID": "-100123",
+            "HERMES_SESSION_THREAD_ID": "12",
+            "HERMES_SESSION_KEY": "agent:main:telegram:group:-100123:12",
+        }.items():
+            monkeypatch.setenv(key, value)
 
         captured = {}
 
@@ -3144,6 +3154,13 @@ class TestSharedBoardPaths:
         )
         assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
         assert env["HERMES_KANBAN_BRANCH"] == "wt/t_dispatch_env"
+        for key in (
+            "HERMES_SESSION_PLATFORM",
+            "HERMES_SESSION_CHAT_ID",
+            "HERMES_SESSION_THREAD_ID",
+            "HERMES_SESSION_KEY",
+        ):
+            assert key not in env
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3107,15 +3107,11 @@ class TestSharedBoardPaths:
 
         from gateway import session_context as sc
 
-        monkeypatch.setattr(sc, "_session_context_engaged", True)
+        # A dispatcher can launch before the gateway binds its first session.
+        monkeypatch.setattr(sc, "_session_context_engaged", False)
         sc.reset_session_vars()
-        for key, value in {
-            "HERMES_SESSION_PLATFORM": "telegram",
-            "HERMES_SESSION_CHAT_ID": "-100123",
-            "HERMES_SESSION_THREAD_ID": "12",
-            "HERMES_SESSION_KEY": "agent:main:telegram:group:-100123:12",
-        }.items():
-            monkeypatch.setenv(key, value)
+        for key in sc._VAR_MAP:
+            monkeypatch.setenv(key, "stale-routing-value")
 
         captured = {}
 
@@ -3154,12 +3150,7 @@ class TestSharedBoardPaths:
         )
         assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
         assert env["HERMES_KANBAN_BRANCH"] == "wt/t_dispatch_env"
-        for key in (
-            "HERMES_SESSION_PLATFORM",
-            "HERMES_SESSION_CHAT_ID",
-            "HERMES_SESSION_THREAD_ID",
-            "HERMES_SESSION_KEY",
-        ):
+        for key in sc._VAR_MAP:
             assert key not in env
 
 


### PR DESCRIPTION
## Summary

- unconditionally remove every registered `HERMES_SESSION_*` / cron delivery-routing key from gateway-dispatched Kanban worker environments
- prevent stale routing inherited from the gateway process from making worker-created child tasks auto-subscribe an unrelated chat or topic
- preserve Kanban board, workspace, task, branch, profile, model, and credential propagation
- extend the existing dispatcher regression to cover dispatch before the gateway binds its first session

## Reproduction

A long-lived gateway had stale Telegram topic routing mirrored in `os.environ`. `_default_spawn()` copied that process environment directly into a detached Kanban worker. When that worker called `kanban_create`, `get_session_env()` treated the inherited Telegram context as its origin and auto-subscribed the child task. The task's terminal completion then woke the unrelated topic.

The first candidate reused the normal ContextVar bridge, but independent review found that its sanitizer preserves fallback environment values before session-context engagement. The updated regression sets the engagement latch to false, injects every key in the canonical routing registry, and proves the detached worker receives none of them.

## Tests

```text
python -m pytest tests/hermes_cli/test_kanban_db.py tests/tools/test_local_env_session_leak.py tests/gateway/test_session_context_inheritance.py -q -o 'addopts='
248 passed
```

The exact high-severity review reproducer failed before the updated production change and passes afterward. The 16 failures observed only when collecting all Kanban test modules into one non-canonical process were test-order/isolation issues: all 23 affected tests pass when their owning files/subsets run independently.

Also verified:

```text
git diff --check
python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py
```

## Risk / rollback

Low risk. Detached Kanban workers have no conversation delivery ownership; explicit Kanban notification subscriptions remain stored in the board DB and are unaffected. The change strips only the existing session/delivery routing registry before reapplying the worker's board/profile/task pins. Revert the two commits to roll back.
