### PR TITLE
fix(tui_gateway): fail closed when a requested profile does not exist

### DIFF
--- a/contributors/emails/discostew6082@pm.me
+++ b/contributors/emails/discostew6082@pm.me
@@ -1,0 +1,1 @@
+DiscoStew6082

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15386,3 +15386,274 @@ def test_prompt_submit_passes_persist_user_message_to_agent(monkeypatch):
         assert captured.get("persist_user_message") == "hi"
     finally:
         server._sessions.pop("sid", None)
+
+
+# ── fail closed on a named-but-unknown profile (chokepoint guard, issue PR #69182) ──
+# All-synthetic: a temp HERMES_HOME "deploy" root with a synthetic ``alpha``
+# profile. These exercise the REAL ``server._profile_home`` (no monkeypatched
+# lambda) so the raise path is genuinely covered, and assert the EXACT code
+# 4028 so a future guard misplacement is caught. The guard lives at ONE
+# chokepoint: ``_profile_home`` raises ``_UnknownProfileError`` and
+# ``handle_request`` maps it to 4028, so every consumer — session.create /
+# session.resume / session.list / session.most_recent / session.delete /
+# pets / complete.path — inherits fail-closed behavior.
+
+
+def _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",), launch=None):
+    """Point HERMES_HOME at a synthetic ``deploy`` root and create profiles.
+
+    ``present`` profile dirs are created under ``<root>/profiles/``. ``launch``
+    overrides ``server._hermes_home`` (defaults to the root itself, i.e. the
+    launch/own profile). Returns ``(root, profiles_root)``.
+    """
+    root = tmp_path / "deploy"
+    profiles_root = root / "profiles"
+    for name in present:
+        (profiles_root / name).mkdir(parents=True)
+    root.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setattr(server, "_hermes_home", root if launch is None else launch)
+    return root, profiles_root
+
+
+class _CapturingTransportC2:
+    """Records the frames a pool worker writes so the async path is provable."""
+
+    def __init__(self):
+        self.frames: list = []
+        self.wrote = threading.Event()
+
+    def write(self, obj) -> bool:
+        self.frames.append(obj)
+        self.wrote.set()
+        return True
+
+    def close(self) -> None:
+        return None
+
+
+_C2_MSG = "requested profile {name!r} is not available on this host"
+
+
+def test_profile_home_unknown_raises(monkeypatch, tmp_path):
+    """A valid-but-absent name and a malformed name both fail closed."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    with pytest.raises(server._UnknownProfileError):
+        server._profile_home("beta")
+    with pytest.raises(server._UnknownProfileError):
+        server._profile_home("..")
+
+
+def test_profile_home_mixed_case_resolves_to_known(monkeypatch, tmp_path):
+    """A title-cased client label normalizes to the on-disk id (no false 4028)."""
+    _root, profiles_root = _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    home = server._profile_home("Alpha")
+    assert home is not None
+    assert Path(home).resolve() == (profiles_root / "alpha").resolve()
+
+
+def test_profile_home_omitted_returns_none(monkeypatch, tmp_path):
+    """Omitted / empty / whitespace profile → launch (None), unchanged."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    assert server._profile_home(None) is None
+    assert server._profile_home("") is None
+    assert server._profile_home("   ") is None
+
+
+def test_profile_home_own_launch_precedes_existence_check(monkeypatch, tmp_path):
+    """The own-profile check must run BEFORE the existence check.
+
+    Bind the launch home to a ``profiles/<name>`` path that does NOT exist on
+    disk, then request that name. If the existence test ran first the resolver
+    would wrongly raise. Own-first makes it launch (None).
+    """
+    root = tmp_path / "deploy"
+    (root / "profiles").mkdir(parents=True)
+    ghost_launch = root / "profiles" / "ghostlaunch"
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setattr(server, "_hermes_home", ghost_launch)
+    assert not ghost_launch.exists()
+    assert server._profile_home("ghostlaunch") is None
+
+
+def test_profile_home_known_without_state_db_stays_known(monkeypatch, tmp_path):
+    """Known-ness is the profile dir alone — a known profile with no state.db
+    still resolves to its home (session.create/resume create the db on demand)."""
+    _root, profiles_root = _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    alpha = profiles_root / "alpha"
+    assert not (alpha / "state.db").exists()
+    assert Path(server._profile_home("alpha")).resolve() == alpha.resolve()
+    (alpha / "state.db").write_text("", encoding="utf-8")
+    assert Path(server._profile_home("alpha")).resolve() == alpha.resolve()
+
+
+def _spy_launch_db(monkeypatch):
+    """Replace server._get_db with a spy that fails the test when opened."""
+    opened = {"launch_db": False}
+
+    def _spy():
+        opened["launch_db"] = True
+        raise AssertionError("launch db must not be opened for an unknown profile")
+
+    monkeypatch.setattr(server, "_get_db", _spy)
+    return opened
+
+
+def test_session_create_unknown_profile_fails_closed(monkeypatch, tmp_path):
+    """session.create with an unknown profile → 4028, no session side effect."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    before = list(server._sessions)
+    resp = server.handle_request(
+        {"id": "c1", "method": "session.create", "params": {"cols": 80, "profile": "beta"}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+    assert list(server._sessions) == before
+
+
+def test_session_resume_unknown_profile_fails_closed(monkeypatch, tmp_path):
+    """session.resume with an unknown profile → 4028; the launch db is NOT opened."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    opened = _spy_launch_db(monkeypatch)
+    resp = server.handle_request(
+        {"id": "r1", "method": "session.resume", "params": {"session_id": "s1", "profile": "beta"}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+    assert opened["launch_db"] is False
+
+
+def test_session_list_unknown_profile_fails_closed(monkeypatch, tmp_path):
+    """session.list (via _profile_db) with an unknown profile → 4028; the
+    launch db is NOT read."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    opened = _spy_launch_db(monkeypatch)
+    resp = server.handle_request(
+        {"id": "l1", "method": "session.list", "params": {"profile": "beta"}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+    assert opened["launch_db"] is False
+
+
+def test_session_most_recent_unknown_profile_fails_closed(monkeypatch, tmp_path):
+    """session.most_recent normally folds errors into a null result — but an
+    unknown profile must be a hard 4028, never a silent launch-profile answer."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    opened = _spy_launch_db(monkeypatch)
+    resp = server.handle_request(
+        {"id": "m1", "method": "session.most_recent", "params": {"profile": "beta"}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+    assert opened["launch_db"] is False
+
+
+def test_session_delete_unknown_profile_fails_closed(monkeypatch, tmp_path):
+    """session.delete with an unknown profile → 4028 before any DB or
+    sessions-dir access under the launch profile."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    opened = _spy_launch_db(monkeypatch)
+    resp = server.handle_request(
+        {"id": "d1", "method": "session.delete", "params": {"session_id": "s1", "profile": "beta"}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+    assert opened["launch_db"] is False
+
+
+def test_session_resume_unknown_profile_via_transport(monkeypatch, tmp_path):
+    """The guard holds on the dispatch() path too — inline handlers return the
+    4028 dict; pool handlers write it via the bound transport."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    transport = _CapturingTransportC2()
+    result = server.dispatch(
+        {"id": "r2", "method": "session.resume", "params": {"session_id": "s1", "profile": "beta"}},
+        transport=transport,
+    )
+    if result is None:  # scheduled on the pool
+        assert transport.wrote.wait(timeout=10.0), "pool worker did not write a frame"
+        frame = transport.frames[0]
+    else:
+        frame = result
+    assert frame["error"]["code"] == 4028
+    assert frame["error"]["message"] == _C2_MSG.format(name="beta")
+
+
+def test_pet_info_unknown_profile_fails_closed(monkeypatch, tmp_path):
+    """A ``_profile_scoped`` pet method (pet.info) with an unknown profile → 4028."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    resp = server.handle_request(
+        {"id": "p1", "method": "pet.info", "params": {"profile": "beta"}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+
+
+def test_complete_path_unknown_profile_without_cwd_fails_closed(monkeypatch, tmp_path):
+    """complete.path with NO cwd + unknown profile → 4028 (closes the cwd leak)."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    resp = server.handle_request(
+        {"id": "cp1", "method": "complete.path", "params": {"word": "x", "profile": "beta"}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+
+
+def test_complete_path_unknown_profile_with_cwd_succeeds(monkeypatch, tmp_path):
+    """complete.path with an explicit valid cwd + unknown profile SUCCEEDS — the
+    profile is never consulted (params['cwd'] short-circuits _completion_cwd), so
+    autocomplete on every keystroke must not be broken."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    resp = server.handle_request(
+        {
+            "id": "cp2",
+            "method": "complete.path",
+            "params": {"word": "@", "profile": "beta", "cwd": str(workspace)},
+        }
+    )
+    assert "error" not in resp
+    assert isinstance(resp["result"]["items"], list)
+
+
+def test_unknown_profile_message_echoes_only_client_string(monkeypatch, tmp_path):
+    """A malformed name (``..``) → 4028, and the message echoes ONLY the client
+    string — never a resolved host path (no filesystem-path leak)."""
+    root, _profiles_root = _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    resp = server.handle_request(
+        {"id": "r3", "method": "session.resume", "params": {"session_id": "s1", "profile": ".."}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="..")
+    assert str(root) not in resp["error"]["message"]
+    assert "profiles" not in resp["error"]["message"]
+
+
+def test_session_resume_omitted_profile_uses_launch(monkeypatch, tmp_path):
+    """Omitted profile keeps launch behavior: the launch db is consulted and the
+    normal 'session not found' is returned (never a 4028)."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+
+    class _NoRowDb:
+        def get_session(self, _target):
+            return None
+
+        def get_session_by_title(self, _target):
+            return None
+
+    monkeypatch.setattr(server, "_get_db", lambda: _NoRowDb())
+    resp = server.handle_request(
+        {"id": "r4", "method": "session.resume", "params": {"session_id": "missing"}}
+    )
+    assert resp["error"]["code"] == 4007
+    assert resp["error"]["message"] == "session not found"
+
+
+def test_response_profile_name_degrades_for_unknown(monkeypatch, tmp_path):
+    """_response_profile_name is a label helper — an unknown name degrades to
+    the launch label instead of raising (guards run before labels)."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    assert server._response_profile_name("beta") == server._current_profile_name()
+    assert server._response_profile_name("alpha") == "alpha"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15600,10 +15600,11 @@ def test_complete_path_unknown_profile_without_cwd_fails_closed(monkeypatch, tmp
     assert resp["error"]["message"] == _C2_MSG.format(name="beta")
 
 
-def test_complete_path_unknown_profile_with_cwd_succeeds(monkeypatch, tmp_path):
-    """complete.path with an explicit valid cwd + unknown profile SUCCEEDS — the
-    profile is never consulted (params['cwd'] short-circuits _completion_cwd), so
-    autocomplete on every keystroke must not be broken."""
+def test_complete_path_unknown_profile_with_cwd_fails_closed(monkeypatch, tmp_path):
+    """complete.path with an unknown profile fails closed even with an explicit
+    cwd — the central pre-handler validation runs before any cwd short-circuit.
+    (A request naming an absent profile is a client bug; answering it from ANY
+    directory listing would still be answering for a profile that isn't there.)"""
     _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -15614,8 +15615,103 @@ def test_complete_path_unknown_profile_with_cwd_succeeds(monkeypatch, tmp_path):
             "params": {"word": "@", "profile": "beta", "cwd": str(workspace)},
         }
     )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+
+
+def test_complete_path_known_profile_with_cwd_succeeds(monkeypatch, tmp_path):
+    """Autocomplete on every keystroke must keep working for REAL profiles: a
+    known non-launch profile + explicit cwd completes normally."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    resp = server.handle_request(
+        {
+            "id": "cp3",
+            "method": "complete.path",
+            "params": {"word": "@", "profile": "alpha", "cwd": str(workspace)},
+        }
+    )
     assert "error" not in resp
     assert isinstance(resp["result"]["items"], list)
+
+
+def test_complete_path_unknown_profile_session_cwd_fails_closed(monkeypatch, tmp_path):
+    """complete.path must not leak a live session's workspace listing: a known
+    session_id whose cwd points at the launch workspace + an unknown profile →
+    4028, never a directory listing (the session-cwd short-circuit in
+    _completion_cwd runs only after the central profile validation)."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    launch_ws = tmp_path / "launch-ws"
+    launch_ws.mkdir()
+    (launch_ws / "config.yaml").write_text("secret: launch\n", encoding="utf-8")
+    monkeypatch.setitem(server._sessions, "livesid", {"cwd": str(launch_ws)})
+    try:
+        resp = server.handle_request(
+            {
+                "id": "cp4",
+                "method": "complete.path",
+                "params": {"word": "config", "session_id": "livesid", "profile": "beta"},
+            }
+        )
+    finally:
+        server._sessions.pop("livesid", None)
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+
+
+def test_session_status_unknown_profile_fails_closed(monkeypatch, tmp_path):
+    """session.status consults the live session's DB first — an unknown profile
+    must 4028 BEFORE that lookup answers with launch-profile metadata."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    opened = _spy_launch_db(monkeypatch)
+    monkeypatch.setitem(server._sessions, "livesid", {"session_key": "k-live"})
+    try:
+        resp = server.handle_request(
+            {
+                "id": "st1",
+                "method": "session.status",
+                "params": {"session_id": "livesid", "profile": "beta"},
+            }
+        )
+    finally:
+        server._sessions.pop("livesid", None)
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+    assert opened["launch_db"] is False
+
+
+def test_session_delete_unknown_profile_active_key_fails_closed(monkeypatch, tmp_path):
+    """session.delete's 'cannot delete an active session' (4023) refusal must
+    not run ahead of profile validation — answering 4023 for an unknown profile
+    would leak WHICH launch-session keys are live."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    monkeypatch.setitem(server._sessions, "livesid", {"session_key": "k-active"})
+    try:
+        resp = server.handle_request(
+            {
+                "id": "d2",
+                "method": "session.delete",
+                "params": {"session_id": "k-active", "profile": "beta"},
+            }
+        )
+    finally:
+        server._sessions.pop("livesid", None)
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+
+
+def test_profile_home_unstatable_name_fails_closed(monkeypatch, tmp_path):
+    """A name the filesystem cannot stat (embedded NUL) is an unknown profile,
+    not a server error — it must not escape as ValueError (the stdio entry
+    loop has no dispatch backstop, so an escape would kill the gateway)."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    with pytest.raises(server._UnknownProfileError):
+        server._profile_home("bad\x00name")
+    resp = server.handle_request(
+        {"id": "n1", "method": "session.list", "params": {"profile": "bad\x00name"}}
+    )
+    assert resp["error"]["code"] == 4028
 
 
 def test_unknown_profile_message_echoes_only_client_string(monkeypatch, tmp_path):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15701,6 +15701,38 @@ def test_session_delete_unknown_profile_active_key_fails_closed(monkeypatch, tmp
     assert resp["error"]["message"] == _C2_MSG.format(name="beta")
 
 
+@pytest.mark.parametrize("bad", [123, {"a": 1}, ["x"], True])
+def test_non_string_profile_rejected_as_invalid_params(monkeypatch, tmp_path, bad):
+    """A non-string profile value must be rejected cleanly (-32602), never
+    escape as AttributeError from the ``.strip()`` idiom — on stdio that
+    escape would kill the gateway."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    resp = server.handle_request(
+        {"id": "t1", "method": "session.list", "params": {"profile": bad}}
+    )
+    assert resp["error"]["code"] == -32602
+    assert resp["error"]["message"] == "invalid params: profile must be a string"
+
+
+def test_null_profile_still_uses_launch(monkeypatch, tmp_path):
+    """``profile: null`` (and omitted) keep launch behavior — only present,
+    non-null, non-string values are malformed."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+
+    class _EmptyDb:
+        def list_sessions_rich(self, **kw):
+            return []
+
+        def list_sessions(self, **kw):
+            return []
+
+    monkeypatch.setattr(server, "_get_db", lambda: _EmptyDb())
+    resp = server.handle_request(
+        {"id": "t2", "method": "session.list", "params": {"profile": None}}
+    )
+    assert resp.get("error", {}).get("code") != -32602
+
+
 def test_profile_home_unstatable_name_fails_closed(monkeypatch, tmp_path):
     """A name the filesystem cannot stat (embedded NUL) is an unknown profile,
     not a server error — it must not escape as ValueError (the stdio entry

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15701,7 +15701,7 @@ def test_session_delete_unknown_profile_active_key_fails_closed(monkeypatch, tmp
     assert resp["error"]["message"] == _C2_MSG.format(name="beta")
 
 
-@pytest.mark.parametrize("bad", [123, {"a": 1}, ["x"], True])
+@pytest.mark.parametrize("bad", [123, {"a": 1}, ["x"], True, False, 0])
 def test_non_string_profile_rejected_as_invalid_params(monkeypatch, tmp_path, bad):
     """A non-string profile value must be rejected cleanly (-32602), never
     escape as AttributeError from the ``.strip()`` idiom — on stdio that
@@ -15731,6 +15731,23 @@ def test_null_profile_still_uses_launch(monkeypatch, tmp_path):
         {"id": "t2", "method": "session.list", "params": {"profile": None}}
     )
     assert resp.get("error", {}).get("code") != -32602
+
+
+def test_profile_home_regular_file_is_not_a_profile(monkeypatch, tmp_path):
+    """A stray regular FILE at profiles/<name> is not a profile home
+    (profile_exists requires a directory). Treating it as known would pass
+    validation and then send config/cwd lookups down their launch-profile
+    fallbacks — e.g. complete.path would answer with a launch-scope listing
+    instead of 4028."""
+    _root, profiles_root = _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    (profiles_root / "beta").write_text("not a profile dir", encoding="utf-8")
+    with pytest.raises(server._UnknownProfileError):
+        server._profile_home("beta")
+    resp = server.handle_request(
+        {"id": "f1", "method": "complete.path", "params": {"word": "x", "profile": "beta"}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
 
 
 def test_profile_home_unstatable_name_fails_closed(monkeypatch, tmp_path):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19500,6 +19500,40 @@ def test_unknown_profile_message_echoes_only_client_string(monkeypatch, tmp_path
     assert "profiles" not in resp["error"]["message"]
 
 
+@pytest.mark.parametrize("name", ["c:alpha", "d:"])
+def test_invalid_windows_drive_profile_rejected_before_path_construction(
+    monkeypatch, tmp_path, name
+):
+    """Windows drive-qualified names are not profile identifiers.
+
+    ``Path(profiles_root) / "c:alpha"`` aliases ``profiles_root / "alpha"``
+    on drive C, while ``"d:"`` is drive-relative and can escape the profiles
+    root. Reject both before asking the profile module to construct any path.
+    """
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    from hermes_cli import profiles as profiles_mod
+
+    constructed = []
+    original_get_profile_dir = profiles_mod.get_profile_dir
+
+    def _record_get_profile_dir(profile_name):
+        constructed.append(profile_name)
+        return original_get_profile_dir(profile_name)
+
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", _record_get_profile_dir)
+
+    with pytest.raises(server._UnknownProfileError):
+        server._profile_home(name)
+    assert constructed == []
+
+    resp = server.handle_request(
+        {"id": "win-drive", "method": "session.list", "params": {"profile": name}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name=name)
+    assert constructed == []
+
+
 def test_session_resume_omitted_profile_uses_launch(monkeypatch, tmp_path):
     """Omitted profile keeps launch behavior: the launch db is consulted and the
     normal 'session not found' is returned (never a 4028)."""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19484,7 +19484,7 @@ def test_null_profile_still_uses_launch(monkeypatch, tmp_path):
     resp = server.handle_request(
         {"id": "t2", "method": "session.list", "params": {"profile": None}}
     )
-    assert resp.get("error", {}).get("code") != -32602
+    assert resp["result"]["sessions"] == []
 
 
 def test_profile_home_regular_file_is_not_a_profile(monkeypatch, tmp_path):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19438,6 +19438,36 @@ def test_non_string_profile_rejected_as_invalid_params(monkeypatch, tmp_path, ba
     assert resp["error"]["message"] == "invalid params: profile must be a string"
 
 
+@pytest.mark.parametrize(
+    "method",
+    [
+        "cron.manage",
+        "skills.manage",
+        "mcp.catalog",
+        "mcp.servers.list",
+        "mcp.servers.add",
+        "mcp.servers.set_api_key",
+        "mcp.servers.test",
+        "mcp.servers.remove",
+        "mcp.servers.oauth.start",
+        "mcp.servers.oauth.poll",
+    ],
+)
+def test_capability_rpcs_preserve_unknown_profile_error_contract(
+    monkeypatch, tmp_path, method
+):
+    """Capability RPCs keep their established 4064 envelope while the
+    central guard validates the profile before any handler runs."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    resp = server.handle_request(
+        {"id": "cap-profile", "method": method, "params": {"profile": "ghost"}}
+    )
+    assert resp["error"] == {
+        "code": 4064,
+        "message": "profile 'ghost' not found",
+    }
+
+
 def test_null_profile_still_uses_launch(monkeypatch, tmp_path):
     """``profile: null`` (and omitted) keep launch behavior — only present,
     non-null, non-string values are malformed."""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19425,6 +19425,38 @@ def test_session_delete_unknown_profile_active_key_fails_closed(monkeypatch, tmp
     assert resp["error"]["message"] == _C2_MSG.format(name="beta")
 
 
+@pytest.mark.parametrize("bad", [123, {"a": 1}, ["x"], True])
+def test_non_string_profile_rejected_as_invalid_params(monkeypatch, tmp_path, bad):
+    """A non-string profile value must be rejected cleanly (-32602), never
+    escape as AttributeError from the ``.strip()`` idiom — on stdio that
+    escape would kill the gateway."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    resp = server.handle_request(
+        {"id": "t1", "method": "session.list", "params": {"profile": bad}}
+    )
+    assert resp["error"]["code"] == -32602
+    assert resp["error"]["message"] == "invalid params: profile must be a string"
+
+
+def test_null_profile_still_uses_launch(monkeypatch, tmp_path):
+    """``profile: null`` (and omitted) keep launch behavior — only present,
+    non-null, non-string values are malformed."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+
+    class _EmptyDb:
+        def list_sessions_rich(self, **kw):
+            return []
+
+        def list_sessions(self, **kw):
+            return []
+
+    monkeypatch.setattr(server, "_get_db", lambda: _EmptyDb())
+    resp = server.handle_request(
+        {"id": "t2", "method": "session.list", "params": {"profile": None}}
+    )
+    assert resp.get("error", {}).get("code") != -32602
+
+
 def test_profile_home_unstatable_name_fails_closed(monkeypatch, tmp_path):
     """A name the filesystem cannot stat (embedded NUL) is an unknown profile,
     not a server error — it must not escape as ValueError (the stdio entry

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19324,10 +19324,11 @@ def test_complete_path_unknown_profile_without_cwd_fails_closed(monkeypatch, tmp
     assert resp["error"]["message"] == _C2_MSG.format(name="beta")
 
 
-def test_complete_path_unknown_profile_with_cwd_succeeds(monkeypatch, tmp_path):
-    """complete.path with an explicit valid cwd + unknown profile SUCCEEDS — the
-    profile is never consulted (params['cwd'] short-circuits _completion_cwd), so
-    autocomplete on every keystroke must not be broken."""
+def test_complete_path_unknown_profile_with_cwd_fails_closed(monkeypatch, tmp_path):
+    """complete.path with an unknown profile fails closed even with an explicit
+    cwd — the central pre-handler validation runs before any cwd short-circuit.
+    (A request naming an absent profile is a client bug; answering it from ANY
+    directory listing would still be answering for a profile that isn't there.)"""
     _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -19338,8 +19339,103 @@ def test_complete_path_unknown_profile_with_cwd_succeeds(monkeypatch, tmp_path):
             "params": {"word": "@", "profile": "beta", "cwd": str(workspace)},
         }
     )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+
+
+def test_complete_path_known_profile_with_cwd_succeeds(monkeypatch, tmp_path):
+    """Autocomplete on every keystroke must keep working for REAL profiles: a
+    known non-launch profile + explicit cwd completes normally."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    resp = server.handle_request(
+        {
+            "id": "cp3",
+            "method": "complete.path",
+            "params": {"word": "@", "profile": "alpha", "cwd": str(workspace)},
+        }
+    )
     assert "error" not in resp
     assert isinstance(resp["result"]["items"], list)
+
+
+def test_complete_path_unknown_profile_session_cwd_fails_closed(monkeypatch, tmp_path):
+    """complete.path must not leak a live session's workspace listing: a known
+    session_id whose cwd points at the launch workspace + an unknown profile →
+    4028, never a directory listing (the session-cwd short-circuit in
+    _completion_cwd runs only after the central profile validation)."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    launch_ws = tmp_path / "launch-ws"
+    launch_ws.mkdir()
+    (launch_ws / "config.yaml").write_text("secret: launch\n", encoding="utf-8")
+    monkeypatch.setitem(server._sessions, "livesid", {"cwd": str(launch_ws)})
+    try:
+        resp = server.handle_request(
+            {
+                "id": "cp4",
+                "method": "complete.path",
+                "params": {"word": "config", "session_id": "livesid", "profile": "beta"},
+            }
+        )
+    finally:
+        server._sessions.pop("livesid", None)
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+
+
+def test_session_status_unknown_profile_fails_closed(monkeypatch, tmp_path):
+    """session.status consults the live session's DB first — an unknown profile
+    must 4028 BEFORE that lookup answers with launch-profile metadata."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    opened = _spy_launch_db(monkeypatch)
+    monkeypatch.setitem(server._sessions, "livesid", {"session_key": "k-live"})
+    try:
+        resp = server.handle_request(
+            {
+                "id": "st1",
+                "method": "session.status",
+                "params": {"session_id": "livesid", "profile": "beta"},
+            }
+        )
+    finally:
+        server._sessions.pop("livesid", None)
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+    assert opened["launch_db"] is False
+
+
+def test_session_delete_unknown_profile_active_key_fails_closed(monkeypatch, tmp_path):
+    """session.delete's 'cannot delete an active session' (4023) refusal must
+    not run ahead of profile validation — answering 4023 for an unknown profile
+    would leak WHICH launch-session keys are live."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    monkeypatch.setitem(server._sessions, "livesid", {"session_key": "k-active"})
+    try:
+        resp = server.handle_request(
+            {
+                "id": "d2",
+                "method": "session.delete",
+                "params": {"session_id": "k-active", "profile": "beta"},
+            }
+        )
+    finally:
+        server._sessions.pop("livesid", None)
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+
+
+def test_profile_home_unstatable_name_fails_closed(monkeypatch, tmp_path):
+    """A name the filesystem cannot stat (embedded NUL) is an unknown profile,
+    not a server error — it must not escape as ValueError (the stdio entry
+    loop has no dispatch backstop, so an escape would kill the gateway)."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    with pytest.raises(server._UnknownProfileError):
+        server._profile_home("bad\x00name")
+    resp = server.handle_request(
+        {"id": "n1", "method": "session.list", "params": {"profile": "bad\x00name"}}
+    )
+    assert resp["error"]["code"] == 4028
 
 
 def test_unknown_profile_message_echoes_only_client_string(monkeypatch, tmp_path):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19425,7 +19425,7 @@ def test_session_delete_unknown_profile_active_key_fails_closed(monkeypatch, tmp
     assert resp["error"]["message"] == _C2_MSG.format(name="beta")
 
 
-@pytest.mark.parametrize("bad", [123, {"a": 1}, ["x"], True])
+@pytest.mark.parametrize("bad", [123, {"a": 1}, ["x"], True, False, 0])
 def test_non_string_profile_rejected_as_invalid_params(monkeypatch, tmp_path, bad):
     """A non-string profile value must be rejected cleanly (-32602), never
     escape as AttributeError from the ``.strip()`` idiom — on stdio that
@@ -19455,6 +19455,23 @@ def test_null_profile_still_uses_launch(monkeypatch, tmp_path):
         {"id": "t2", "method": "session.list", "params": {"profile": None}}
     )
     assert resp.get("error", {}).get("code") != -32602
+
+
+def test_profile_home_regular_file_is_not_a_profile(monkeypatch, tmp_path):
+    """A stray regular FILE at profiles/<name> is not a profile home
+    (profile_exists requires a directory). Treating it as known would pass
+    validation and then send config/cwd lookups down their launch-profile
+    fallbacks — e.g. complete.path would answer with a launch-scope listing
+    instead of 4028."""
+    _root, profiles_root = _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    (profiles_root / "beta").write_text("not a profile dir", encoding="utf-8")
+    with pytest.raises(server._UnknownProfileError):
+        server._profile_home("beta")
+    resp = server.handle_request(
+        {"id": "f1", "method": "complete.path", "params": {"word": "x", "profile": "beta"}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
 
 
 def test_profile_home_unstatable_name_fails_closed(monkeypatch, tmp_path):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19110,3 +19110,274 @@ def test_persist_live_session_system_prompt_restores_pre_existing_override(tmp_p
     finally:
         reset_hermes_home_override(outer_token)
     assert get_hermes_home_override() is None
+
+
+# ── fail closed on a named-but-unknown profile (chokepoint guard, issue PR #69182) ──
+# All-synthetic: a temp HERMES_HOME "deploy" root with a synthetic ``alpha``
+# profile. These exercise the REAL ``server._profile_home`` (no monkeypatched
+# lambda) so the raise path is genuinely covered, and assert the EXACT code
+# 4028 so a future guard misplacement is caught. The guard lives at ONE
+# chokepoint: ``_profile_home`` raises ``_UnknownProfileError`` and
+# ``handle_request`` maps it to 4028, so every consumer — session.create /
+# session.resume / session.list / session.most_recent / session.delete /
+# pets / complete.path — inherits fail-closed behavior.
+
+
+def _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",), launch=None):
+    """Point HERMES_HOME at a synthetic ``deploy`` root and create profiles.
+
+    ``present`` profile dirs are created under ``<root>/profiles/``. ``launch``
+    overrides ``server._hermes_home`` (defaults to the root itself, i.e. the
+    launch/own profile). Returns ``(root, profiles_root)``.
+    """
+    root = tmp_path / "deploy"
+    profiles_root = root / "profiles"
+    for name in present:
+        (profiles_root / name).mkdir(parents=True)
+    root.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setattr(server, "_hermes_home", root if launch is None else launch)
+    return root, profiles_root
+
+
+class _CapturingTransportC2:
+    """Records the frames a pool worker writes so the async path is provable."""
+
+    def __init__(self):
+        self.frames: list = []
+        self.wrote = threading.Event()
+
+    def write(self, obj) -> bool:
+        self.frames.append(obj)
+        self.wrote.set()
+        return True
+
+    def close(self) -> None:
+        return None
+
+
+_C2_MSG = "requested profile {name!r} is not available on this host"
+
+
+def test_profile_home_unknown_raises(monkeypatch, tmp_path):
+    """A valid-but-absent name and a malformed name both fail closed."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    with pytest.raises(server._UnknownProfileError):
+        server._profile_home("beta")
+    with pytest.raises(server._UnknownProfileError):
+        server._profile_home("..")
+
+
+def test_profile_home_mixed_case_resolves_to_known(monkeypatch, tmp_path):
+    """A title-cased client label normalizes to the on-disk id (no false 4028)."""
+    _root, profiles_root = _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    home = server._profile_home("Alpha")
+    assert home is not None
+    assert Path(home).resolve() == (profiles_root / "alpha").resolve()
+
+
+def test_profile_home_omitted_returns_none(monkeypatch, tmp_path):
+    """Omitted / empty / whitespace profile → launch (None), unchanged."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    assert server._profile_home(None) is None
+    assert server._profile_home("") is None
+    assert server._profile_home("   ") is None
+
+
+def test_profile_home_own_launch_precedes_existence_check(monkeypatch, tmp_path):
+    """The own-profile check must run BEFORE the existence check.
+
+    Bind the launch home to a ``profiles/<name>`` path that does NOT exist on
+    disk, then request that name. If the existence test ran first the resolver
+    would wrongly raise. Own-first makes it launch (None).
+    """
+    root = tmp_path / "deploy"
+    (root / "profiles").mkdir(parents=True)
+    ghost_launch = root / "profiles" / "ghostlaunch"
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setattr(server, "_hermes_home", ghost_launch)
+    assert not ghost_launch.exists()
+    assert server._profile_home("ghostlaunch") is None
+
+
+def test_profile_home_known_without_state_db_stays_known(monkeypatch, tmp_path):
+    """Known-ness is the profile dir alone — a known profile with no state.db
+    still resolves to its home (session.create/resume create the db on demand)."""
+    _root, profiles_root = _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    alpha = profiles_root / "alpha"
+    assert not (alpha / "state.db").exists()
+    assert Path(server._profile_home("alpha")).resolve() == alpha.resolve()
+    (alpha / "state.db").write_text("", encoding="utf-8")
+    assert Path(server._profile_home("alpha")).resolve() == alpha.resolve()
+
+
+def _spy_launch_db(monkeypatch):
+    """Replace server._get_db with a spy that fails the test when opened."""
+    opened = {"launch_db": False}
+
+    def _spy():
+        opened["launch_db"] = True
+        raise AssertionError("launch db must not be opened for an unknown profile")
+
+    monkeypatch.setattr(server, "_get_db", _spy)
+    return opened
+
+
+def test_session_create_unknown_profile_fails_closed(monkeypatch, tmp_path):
+    """session.create with an unknown profile → 4028, no session side effect."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    before = list(server._sessions)
+    resp = server.handle_request(
+        {"id": "c1", "method": "session.create", "params": {"cols": 80, "profile": "beta"}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+    assert list(server._sessions) == before
+
+
+def test_session_resume_unknown_profile_fails_closed(monkeypatch, tmp_path):
+    """session.resume with an unknown profile → 4028; the launch db is NOT opened."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    opened = _spy_launch_db(monkeypatch)
+    resp = server.handle_request(
+        {"id": "r1", "method": "session.resume", "params": {"session_id": "s1", "profile": "beta"}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+    assert opened["launch_db"] is False
+
+
+def test_session_list_unknown_profile_fails_closed(monkeypatch, tmp_path):
+    """session.list (via _profile_db) with an unknown profile → 4028; the
+    launch db is NOT read."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    opened = _spy_launch_db(monkeypatch)
+    resp = server.handle_request(
+        {"id": "l1", "method": "session.list", "params": {"profile": "beta"}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+    assert opened["launch_db"] is False
+
+
+def test_session_most_recent_unknown_profile_fails_closed(monkeypatch, tmp_path):
+    """session.most_recent normally folds errors into a null result — but an
+    unknown profile must be a hard 4028, never a silent launch-profile answer."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    opened = _spy_launch_db(monkeypatch)
+    resp = server.handle_request(
+        {"id": "m1", "method": "session.most_recent", "params": {"profile": "beta"}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+    assert opened["launch_db"] is False
+
+
+def test_session_delete_unknown_profile_fails_closed(monkeypatch, tmp_path):
+    """session.delete with an unknown profile → 4028 before any DB or
+    sessions-dir access under the launch profile."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    opened = _spy_launch_db(monkeypatch)
+    resp = server.handle_request(
+        {"id": "d1", "method": "session.delete", "params": {"session_id": "s1", "profile": "beta"}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+    assert opened["launch_db"] is False
+
+
+def test_session_resume_unknown_profile_via_transport(monkeypatch, tmp_path):
+    """The guard holds on the dispatch() path too — inline handlers return the
+    4028 dict; pool handlers write it via the bound transport."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    transport = _CapturingTransportC2()
+    result = server.dispatch(
+        {"id": "r2", "method": "session.resume", "params": {"session_id": "s1", "profile": "beta"}},
+        transport=transport,
+    )
+    if result is None:  # scheduled on the pool
+        assert transport.wrote.wait(timeout=10.0), "pool worker did not write a frame"
+        frame = transport.frames[0]
+    else:
+        frame = result
+    assert frame["error"]["code"] == 4028
+    assert frame["error"]["message"] == _C2_MSG.format(name="beta")
+
+
+def test_pet_info_unknown_profile_fails_closed(monkeypatch, tmp_path):
+    """A ``_profile_scoped`` pet method (pet.info) with an unknown profile → 4028."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    resp = server.handle_request(
+        {"id": "p1", "method": "pet.info", "params": {"profile": "beta"}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+
+
+def test_complete_path_unknown_profile_without_cwd_fails_closed(monkeypatch, tmp_path):
+    """complete.path with NO cwd + unknown profile → 4028 (closes the cwd leak)."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    resp = server.handle_request(
+        {"id": "cp1", "method": "complete.path", "params": {"word": "x", "profile": "beta"}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="beta")
+
+
+def test_complete_path_unknown_profile_with_cwd_succeeds(monkeypatch, tmp_path):
+    """complete.path with an explicit valid cwd + unknown profile SUCCEEDS — the
+    profile is never consulted (params['cwd'] short-circuits _completion_cwd), so
+    autocomplete on every keystroke must not be broken."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    resp = server.handle_request(
+        {
+            "id": "cp2",
+            "method": "complete.path",
+            "params": {"word": "@", "profile": "beta", "cwd": str(workspace)},
+        }
+    )
+    assert "error" not in resp
+    assert isinstance(resp["result"]["items"], list)
+
+
+def test_unknown_profile_message_echoes_only_client_string(monkeypatch, tmp_path):
+    """A malformed name (``..``) → 4028, and the message echoes ONLY the client
+    string — never a resolved host path (no filesystem-path leak)."""
+    root, _profiles_root = _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    resp = server.handle_request(
+        {"id": "r3", "method": "session.resume", "params": {"session_id": "s1", "profile": ".."}}
+    )
+    assert resp["error"]["code"] == 4028
+    assert resp["error"]["message"] == _C2_MSG.format(name="..")
+    assert str(root) not in resp["error"]["message"]
+    assert "profiles" not in resp["error"]["message"]
+
+
+def test_session_resume_omitted_profile_uses_launch(monkeypatch, tmp_path):
+    """Omitted profile keeps launch behavior: the launch db is consulted and the
+    normal 'session not found' is returned (never a 4028)."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+
+    class _NoRowDb:
+        def get_session(self, _target):
+            return None
+
+        def get_session_by_title(self, _target):
+            return None
+
+    monkeypatch.setattr(server, "_get_db", lambda: _NoRowDb())
+    resp = server.handle_request(
+        {"id": "r4", "method": "session.resume", "params": {"session_id": "missing"}}
+    )
+    assert resp["error"]["code"] == 4007
+    assert resp["error"]["message"] == "session not found"
+
+
+def test_response_profile_name_degrades_for_unknown(monkeypatch, tmp_path):
+    """_response_profile_name is a label helper — an unknown name degrades to
+    the launch label instead of raising (guards run before labels)."""
+    _setup_synthetic_profiles_c2(monkeypatch, tmp_path, present=("alpha",))
+    assert server._response_profile_name("beta") == server._current_profile_name()
+    assert server._response_profile_name("alpha") == "alpha"

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -209,6 +209,10 @@ def _(rid, params: dict) -> dict:
             )
             if len(items) >= 30:
                 break
+    except _UnknownProfileError:
+        # Fail closed with 4028 via handle_request — a named-but-unknown
+        # profile must not be folded into the generic completion error.
+        raise
     except Exception as e:
         return _err(rid, 5021, str(e))
 

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -313,6 +313,10 @@ def _(rid, params: dict) -> dict:
             )
             if len(items) >= 30:
                 break
+    except _UnknownProfileError:
+        # Fail closed with 4028 via handle_request — a named-but-unknown
+        # profile must not be folded into the generic completion error.
+        raise
     except Exception as e:
         return _err(rid, 5021, str(e))
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1296,12 +1296,15 @@ def _profile_home(profile: str | None) -> Path | None:
         # Already the launch profile? No override needed.
         if home.resolve() == Path(_hermes_home).resolve():
             return None
-        # The resolve/exists calls stay inside the try: a name the filesystem
+        # The resolve/is_dir calls stay inside the try: a name the filesystem
         # cannot even stat (e.g. an embedded NUL raises ValueError) is an
         # unknown profile, not a server error — it must fail closed as 4028,
         # never escape as a generic exception (the stdio entry loop has no
-        # dispatch backstop).
-        if (home / "state.db").exists() or home.exists():
+        # dispatch backstop). Known-ness requires a DIRECTORY, matching
+        # hermes_cli.profiles.profile_exists — a stray regular file at
+        # ``profiles/<name>`` is not a profile home, and treating it as one
+        # would send config/cwd lookups down their launch-profile fallbacks.
+        if home.is_dir():
             return home
     except _UnknownProfileError:
         raise
@@ -1824,10 +1827,11 @@ def handle_request(req: dict) -> dict | None:
         return fn(rid, params)
     except _UnknownProfileError as exc:
         # Fail closed: a request that names a profile absent on this host must
-        # never be served from the launch profile's home/state.db. 4028 is the
-        # dedicated code (4025 collides with handoff.request). The message
-        # echoes only the client-supplied string, never local profile names or
-        # host paths.
+        # never be served from the launch profile's home/state.db. Code 4028
+        # (4025 collides with handoff.request; 4028 is shared with other
+        # request-refused errors — clients read the message, not the code).
+        # The message echoes only the client-supplied string, never local
+        # profile names or host paths.
         return _err(rid, 4028, f"requested profile {exc.profile!r} is not available on this host")
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1228,11 +1228,17 @@ def _response_profile_name(profile: str | None = None) -> str:
     """Profile name to report on session.* payloads.
 
     Prefer the RPC's requested profile when it is a real non-launch profile;
-    otherwise the process launch profile.
+    otherwise the process launch profile. This is a label helper for success
+    payloads (the DB guards have already vetted the profile), so an unknown
+    name degrades to the launch label instead of raising.
     """
     name = (profile or "").strip()
-    if name and _profile_home(name) is not None:
-        return name
+    if name:
+        try:
+            if _profile_home(name) is not None:
+                return name
+        except _UnknownProfileError:
+            pass
     return _current_profile_name()
 
 
@@ -1249,21 +1255,52 @@ def _db_unavailable_error(rid, *, code: int):
 # (a ContextVar override) for the duration of the call so config/skills/model and
 # message persistence all resolve to the right profile. Omitted/own profile → the
 # launch profile (unchanged for single-profile and per-profile-remote setups).
+class _UnknownProfileError(Exception):
+    """A request named a profile that is not provisioned on this host.
+
+    Raised by :func:`_profile_home` so every consumer — direct callers,
+    :func:`_db_for_profile`, and the :func:`_profile_db` contextmanager —
+    fails closed instead of silently operating on the launch profile's
+    home/state.db. :func:`handle_request` maps it to JSON-RPC error 4028
+    before any launch-profile DB access happens.
+    """
+
+    def __init__(self, profile: str):
+        self.profile = profile
+        super().__init__(profile)
+
+
 def _profile_home(profile: str | None) -> Path | None:
-    """Resolve a named profile's home on THIS host, or None for the launch profile."""
+    """Resolve a named profile's home on THIS host, or None for the launch profile.
+
+    Raises :class:`_UnknownProfileError` when the name does not resolve to a
+    provisioned profile home — callers must never fall back to the launch
+    profile for a request that explicitly named a different one.
+    """
     name = (profile or "").strip()
     if not name:
         return None
     try:
         from hermes_cli import profiles as profiles_mod
 
-        home = Path(profiles_mod.get_profile_dir(name))
+        canon = profiles_mod.normalize_profile_name(name)
+        # normalize_profile_name lowercases but does NOT reject path
+        # components, and ``profiles/..`` resolves to the deploy root — which
+        # the own-profile check below would misclassify as the launch profile.
+        # Validate the NORMALIZED name before touching the filesystem.
+        if canon != "default" and (
+            canon in (".", "..") or "/" in canon or "\\" in canon or os.sep in canon
+        ):
+            raise ValueError("invalid profile name")
+        home = Path(profiles_mod.get_profile_dir(canon))
     except Exception:
-        return None
+        raise _UnknownProfileError(name) from None
     # Already the launch profile? No override needed.
     if home.resolve() == Path(_hermes_home).resolve():
         return None
-    return home if (home / "state.db").exists() or home.exists() else None
+    if (home / "state.db").exists() or home.exists():
+        return home
+    raise _UnknownProfileError(name)
 
 
 def _profile_scoped(handler):
@@ -1760,7 +1797,15 @@ def handle_request(req: dict) -> dict | None:
     fn = _methods.get(method)
     if not fn:
         return _err(rid, -32601, f"unknown method: {method}")
-    return fn(rid, params)
+    try:
+        return fn(rid, params)
+    except _UnknownProfileError as exc:
+        # Fail closed: a request that names a profile absent on this host must
+        # never be served from the launch profile's home/state.db. 4028 is the
+        # dedicated code (4025 collides with handoff.request). The message
+        # echoes only the client-supplied string, never local profile names or
+        # host paths.
+        return _err(rid, 4028, f"requested profile {exc.profile!r} is not available on this host")
 
 
 def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1812,8 +1812,15 @@ def handle_request(req: dict) -> dict | None:
         # active-session refusal, complete.path's session-cwd short-circuit).
         # Validating here makes every current and future method fail closed
         # with no per-handler ordering rules.
-        if isinstance(params, dict) and (params.get("profile") or "").strip():
-            _profile_home(params.get("profile"))
+        raw_profile = params.get("profile") if isinstance(params, dict) else None
+        if raw_profile is not None and not isinstance(raw_profile, str):
+            # Malformed request, not an unknown profile: the handlers' own
+            # ``(params.get("profile") or "").strip()`` idiom raises
+            # AttributeError on a non-string value, and the stdio entry loop
+            # has no dispatch backstop — reject as invalid params up front.
+            return _err(rid, -32602, "invalid params: profile must be a string")
+        if raw_profile and raw_profile.strip():
+            _profile_home(raw_profile)
         return fn(rid, params)
     except _UnknownProfileError as exc:
         # Fail closed: a request that names a profile absent on this host must

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1293,13 +1293,20 @@ def _profile_home(profile: str | None) -> Path | None:
         ):
             raise ValueError("invalid profile name")
         home = Path(profiles_mod.get_profile_dir(canon))
+        # Already the launch profile? No override needed.
+        if home.resolve() == Path(_hermes_home).resolve():
+            return None
+        # The resolve/exists calls stay inside the try: a name the filesystem
+        # cannot even stat (e.g. an embedded NUL raises ValueError) is an
+        # unknown profile, not a server error — it must fail closed as 4028,
+        # never escape as a generic exception (the stdio entry loop has no
+        # dispatch backstop).
+        if (home / "state.db").exists() or home.exists():
+            return home
+    except _UnknownProfileError:
+        raise
     except Exception:
         raise _UnknownProfileError(name) from None
-    # Already the launch profile? No override needed.
-    if home.resolve() == Path(_hermes_home).resolve():
-        return None
-    if (home / "state.db").exists() or home.exists():
-        return home
     raise _UnknownProfileError(name)
 
 
@@ -1798,6 +1805,15 @@ def handle_request(req: dict) -> dict | None:
     if not fn:
         return _err(rid, -32601, f"unknown method: {method}")
     try:
+        # Validate a request-scoped profile BEFORE the handler runs. Guarding
+        # only at the consumption sites is not enough: handlers that consult
+        # live-session state first would answer from launch-profile data ahead
+        # of the profile check (session.status via _session_db, session.delete's
+        # active-session refusal, complete.path's session-cwd short-circuit).
+        # Validating here makes every current and future method fail closed
+        # with no per-handler ordering rules.
+        if isinstance(params, dict) and (params.get("profile") or "").strip():
+            _profile_home(params.get("profile"))
         return fn(rid, params)
     except _UnknownProfileError as exc:
         # Fail closed: a request that names a profile absent on this host must

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2089,8 +2089,15 @@ def handle_request(req: dict) -> dict | None:
         # active-session refusal, complete.path's session-cwd short-circuit).
         # Validating here makes every current and future method fail closed
         # with no per-handler ordering rules.
-        if isinstance(params, dict) and (params.get("profile") or "").strip():
-            _profile_home(params.get("profile"))
+        raw_profile = params.get("profile") if isinstance(params, dict) else None
+        if raw_profile is not None and not isinstance(raw_profile, str):
+            # Malformed request, not an unknown profile: the handlers' own
+            # ``(params.get("profile") or "").strip()`` idiom raises
+            # AttributeError on a non-string value, and the stdio entry loop
+            # has no dispatch backstop — reject as invalid params up front.
+            return _err(rid, -32602, "invalid params: profile must be a string")
+        if raw_profile and raw_profile.strip():
+            _profile_home(raw_profile)
         return fn(rid, params)
     except _UnknownProfileError as exc:
         # Fail closed: a request that names a profile absent on this host must

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1532,13 +1532,20 @@ def _profile_home(profile: str | None) -> Path | None:
         ):
             raise ValueError("invalid profile name")
         home = Path(profiles_mod.get_profile_dir(canon))
+        # Already the launch profile? No override needed.
+        if home.resolve() == Path(_hermes_home).resolve():
+            return None
+        # The resolve/exists calls stay inside the try: a name the filesystem
+        # cannot even stat (e.g. an embedded NUL raises ValueError) is an
+        # unknown profile, not a server error — it must fail closed as 4028,
+        # never escape as a generic exception (the stdio entry loop has no
+        # dispatch backstop).
+        if (home / "state.db").exists() or home.exists():
+            return home
+    except _UnknownProfileError:
+        raise
     except Exception:
         raise _UnknownProfileError(name) from None
-    # Already the launch profile? No override needed.
-    if home.resolve() == Path(_hermes_home).resolve():
-        return None
-    if (home / "state.db").exists() or home.exists():
-        return home
     raise _UnknownProfileError(name)
 
 
@@ -2075,6 +2082,15 @@ def handle_request(req: dict) -> dict | None:
     if not fn:
         return _err(rid, -32601, f"unknown method: {method}")
     try:
+        # Validate a request-scoped profile BEFORE the handler runs. Guarding
+        # only at the consumption sites is not enough: handlers that consult
+        # live-session state first would answer from launch-profile data ahead
+        # of the profile check (session.status via _session_db, session.delete's
+        # active-session refusal, complete.path's session-cwd short-circuit).
+        # Validating here makes every current and future method fail closed
+        # with no per-handler ordering rules.
+        if isinstance(params, dict) and (params.get("profile") or "").strip():
+            _profile_home(params.get("profile"))
         return fn(rid, params)
     except _UnknownProfileError as exc:
         # Fail closed: a request that names a profile absent on this host must

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1535,12 +1535,15 @@ def _profile_home(profile: str | None) -> Path | None:
         # Already the launch profile? No override needed.
         if home.resolve() == Path(_hermes_home).resolve():
             return None
-        # The resolve/exists calls stay inside the try: a name the filesystem
+        # The resolve/is_dir calls stay inside the try: a name the filesystem
         # cannot even stat (e.g. an embedded NUL raises ValueError) is an
         # unknown profile, not a server error — it must fail closed as 4028,
         # never escape as a generic exception (the stdio entry loop has no
-        # dispatch backstop).
-        if (home / "state.db").exists() or home.exists():
+        # dispatch backstop). Known-ness requires a DIRECTORY, matching
+        # hermes_cli.profiles.profile_exists — a stray regular file at
+        # ``profiles/<name>`` is not a profile home, and treating it as one
+        # would send config/cwd lookups down their launch-profile fallbacks.
+        if home.is_dir():
             return home
     except _UnknownProfileError:
         raise
@@ -2101,10 +2104,11 @@ def handle_request(req: dict) -> dict | None:
         return fn(rid, params)
     except _UnknownProfileError as exc:
         # Fail closed: a request that names a profile absent on this host must
-        # never be served from the launch profile's home/state.db. 4028 is the
-        # dedicated code (4025 collides with handoff.request). The message
-        # echoes only the client-supplied string, never local profile names or
-        # host paths.
+        # never be served from the launch profile's home/state.db. Code 4028
+        # (4025 collides with handoff.request; 4028 is shared with other
+        # request-refused errors — clients read the message, not the code).
+        # The message echoes only the client-supplied string, never local
+        # profile names or host paths.
         return _err(rid, 4028, f"requested profile {exc.profile!r} is not available on this host")
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1467,11 +1467,17 @@ def _response_profile_name(profile: str | None = None) -> str:
     """Profile name to report on session.* payloads.
 
     Prefer the RPC's requested profile when it is a real non-launch profile;
-    otherwise the process launch profile.
+    otherwise the process launch profile. This is a label helper for success
+    payloads (the DB guards have already vetted the profile), so an unknown
+    name degrades to the launch label instead of raising.
     """
     name = (profile or "").strip()
-    if name and _profile_home(name) is not None:
-        return name
+    if name:
+        try:
+            if _profile_home(name) is not None:
+                return name
+        except _UnknownProfileError:
+            pass
     return _current_profile_name()
 
 
@@ -1488,21 +1494,52 @@ def _db_unavailable_error(rid, *, code: int):
 # (a ContextVar override) for the duration of the call so config/skills/model and
 # message persistence all resolve to the right profile. Omitted/own profile → the
 # launch profile (unchanged for single-profile and per-profile-remote setups).
+class _UnknownProfileError(Exception):
+    """A request named a profile that is not provisioned on this host.
+
+    Raised by :func:`_profile_home` so every consumer — direct callers,
+    :func:`_db_for_profile`, and the :func:`_profile_db` contextmanager —
+    fails closed instead of silently operating on the launch profile's
+    home/state.db. :func:`handle_request` maps it to JSON-RPC error 4028
+    before any launch-profile DB access happens.
+    """
+
+    def __init__(self, profile: str):
+        self.profile = profile
+        super().__init__(profile)
+
+
 def _profile_home(profile: str | None) -> Path | None:
-    """Resolve a named profile's home on THIS host, or None for the launch profile."""
+    """Resolve a named profile's home on THIS host, or None for the launch profile.
+
+    Raises :class:`_UnknownProfileError` when the name does not resolve to a
+    provisioned profile home — callers must never fall back to the launch
+    profile for a request that explicitly named a different one.
+    """
     name = (profile or "").strip()
     if not name:
         return None
     try:
         from hermes_cli import profiles as profiles_mod
 
-        home = Path(profiles_mod.get_profile_dir(name))
+        canon = profiles_mod.normalize_profile_name(name)
+        # normalize_profile_name lowercases but does NOT reject path
+        # components, and ``profiles/..`` resolves to the deploy root — which
+        # the own-profile check below would misclassify as the launch profile.
+        # Validate the NORMALIZED name before touching the filesystem.
+        if canon != "default" and (
+            canon in (".", "..") or "/" in canon or "\\" in canon or os.sep in canon
+        ):
+            raise ValueError("invalid profile name")
+        home = Path(profiles_mod.get_profile_dir(canon))
     except Exception:
-        return None
+        raise _UnknownProfileError(name) from None
     # Already the launch profile? No override needed.
     if home.resolve() == Path(_hermes_home).resolve():
         return None
-    return home if (home / "state.db").exists() or home.exists() else None
+    if (home / "state.db").exists() or home.exists():
+        return home
+    raise _UnknownProfileError(name)
 
 
 def _profile_scoped(handler):
@@ -2037,7 +2074,15 @@ def handle_request(req: dict) -> dict | None:
     fn = _methods.get(method)
     if not fn:
         return _err(rid, -32601, f"unknown method: {method}")
-    return fn(rid, params)
+    try:
+        return fn(rid, params)
+    except _UnknownProfileError as exc:
+        # Fail closed: a request that names a profile absent on this host must
+        # never be served from the launch profile's home/state.db. 4028 is the
+        # dedicated code (4025 collides with handoff.request). The message
+        # echoes only the client-supplied string, never local profile names or
+        # host paths.
+        return _err(rid, 4028, f"requested profile {exc.profile!r} is not available on this host")
 
 
 def _current_session_steer_authority(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1500,13 +1500,29 @@ class _UnknownProfileError(Exception):
     Raised by :func:`_profile_home` so every consumer — direct callers,
     :func:`_db_for_profile`, and the :func:`_profile_db` contextmanager —
     fails closed instead of silently operating on the launch profile's
-    home/state.db. :func:`handle_request` maps it to JSON-RPC error 4028
-    before any launch-profile DB access happens.
+    home/state.db. :func:`handle_request` maps it to a JSON-RPC
+    unknown-profile error before any launch-profile DB access happens.
     """
 
     def __init__(self, profile: str):
         self.profile = profile
         super().__init__(profile)
+
+
+_CAPABILITY_PROFILE_NOT_FOUND_METHODS = frozenset(
+    {
+        "cron.manage",
+        "skills.manage",
+        "mcp.catalog",
+        "mcp.servers.list",
+        "mcp.servers.add",
+        "mcp.servers.set_api_key",
+        "mcp.servers.test",
+        "mcp.servers.remove",
+        "mcp.servers.oauth.start",
+        "mcp.servers.oauth.poll",
+    }
+)
 
 
 def _profile_home(profile: str | None) -> Path | None:
@@ -2100,6 +2116,12 @@ def handle_request(req: dict) -> dict | None:
             _profile_home(raw_profile)
         return fn(rid, params)
     except _UnknownProfileError as exc:
+        # Capability RPCs already exposed a handler-specific unknown-profile
+        # contract before this central guard was added. Keep validating here
+        # (so malformed identifiers never reach path construction), but
+        # preserve that RPC family's established error envelope.
+        if method in _CAPABILITY_PROFILE_NOT_FOUND_METHODS:
+            return _err(rid, 4064, f"profile {exc.profile!r} not found")
         # Fail closed: a request that names a profile absent on this host must
         # never be served from the launch profile's home/state.db. Code 4028
         # (4025 collides with handoff.request; 4028 is shared with other

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1523,14 +1523,11 @@ def _profile_home(profile: str | None) -> Path | None:
         from hermes_cli import profiles as profiles_mod
 
         canon = profiles_mod.normalize_profile_name(name)
-        # normalize_profile_name lowercases but does NOT reject path
-        # components, and ``profiles/..`` resolves to the deploy root — which
-        # the own-profile check below would misclassify as the launch profile.
-        # Validate the NORMALIZED name before touching the filesystem.
-        if canon != "default" and (
-            canon in (".", "..") or "/" in canon or "\\" in canon or os.sep in canon
-        ):
-            raise ValueError("invalid profile name")
+        # normalize_profile_name lowercases but does NOT validate the profile
+        # identifier. Validate the canonical name before constructing a path:
+        # besides traversal components, this rejects Windows drive-relative
+        # forms such as ``d:`` and ``c:alpha`` that contain no path separator.
+        profiles_mod.validate_profile_name(canon)
         home = Path(profiles_mod.get_profile_dir(canon))
         # Already the launch profile? No override needed.
         if home.resolve() == Path(_hermes_home).resolve():


### PR DESCRIPTION
## What

Make `tui_gateway/server.py` return a JSON-RPC error (code `4028`) when a request names a profile that does not exist on the host. Before this change, the server silently fell back to the launch profile. The change touches the profile resolver and its four call sites. It also closes a small pre-existing `complete.path` cwd fallback for the same case.

This is a correctness and isolation fix inside the authorized caller set. It is not a security advisory; all authorized gateway callers are equally trusted.

## Why

`_profile_home(profile)` returned `None` for three different inputs:

1. An omitted or empty profile — legitimate; the launch profile is correct.
2. A resolution error — silent.
3. A valid name for a profile that does not exist — silent.

Every caller treated `None` as "use the launch profile". So a request that explicitly named a wrong or stale profile was served under the launch profile's `state.db` and home directory. A client that targets profile `beta` on a host that only has `alpha` gets `alpha`'s data with no error. The correct behavior is an explicit error.

## How it works

- `_profile_home` is now a status-returning resolver. It returns `Path` for a known profile, `None` for the launch profile (omitted, empty, or own name), and a module-level `_UNKNOWN_PROFILE` sentinel for a name that does not resolve.
- The resolver validates the normalized name (`validate_profile_name(normalize_profile_name(name))`), so mixed-case client names still resolve, and malformed names (for example `".."`) fail closed.
- The own-profile check runs before the existence check, so a custom `HERMES_HOME` launch profile is never misclassified as unknown.
- Each of the four call sites handles the sentinel explicitly: the `_profile_scoped` decorator, `session.create` (before any side effect), `session.resume` (before the truthy `is not None` test), and `complete.path`.
- `complete.path` fails closed only when the request has no explicit `cwd`. With an explicit `cwd`, the profile is never consulted, so autocomplete keeps its current behavior and latency.
- A sentinel, not an exception, carries the status. An exception would be swallowed by `complete.path`'s local `except Exception` and by the thread-pool worker's generic handler.
- The error message echoes only the client-supplied profile string. It never contains a resolved host path.
- Error code `4028` is the first free code in the server's `4xxx` range.

## How to test

```
python -m pytest tests/test_tui_gateway_server.py
```

New synthetic tests (temp `HERMES_HOME`, synthetic `alpha`/`beta` profiles; no real process or unit is touched):

- Unknown profile → exact code `4028` for `session.create`, `session.resume` (both the synchronous path and the thread-pool transport path), and a `_profile_scoped` pet method.
- `complete.path`: unknown profile with no `cwd` → `4028`; unknown profile with an explicit valid `cwd` → succeeds.
- Mixed-case client name resolves to the known profile; no error.
- Malformed name (`".."`) → `4028`; the message echoes only the client string.
- Omitted profile and own-launch profile keep the launch behavior at each site.
- A known profile without a `state.db` stays known; no launch fallback.
