### PR TITLE
fix(tools): preserve raw paths and regex escapes for ripgrep on Windows

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -461,6 +461,13 @@ class TestShellFileOpsHelpers:
     def test_escape_shell_arg_simple(self, file_ops):
         assert file_ops._escape_shell_arg("hello") == "'hello'"
 
+    def test_escape_shell_raw_preserves_backslashes_and_paths(self, monkeypatch, file_ops):
+        import tools.environments.local as local_mod
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert file_ops._escape_shell_raw(r"\d+") == r"'\d+'"
+        assert file_ops._escape_shell_raw(r"C:\Users\alice\notes.txt") == r"'C:\Users\alice\notes.txt'"
+        assert file_ops._escape_shell_raw("C:/Users/alice/notes.txt") == "'C:/Users/alice/notes.txt'"
+
     def test_escape_shell_arg_with_quotes(self, file_ops):
         result = file_ops._escape_shell_arg("it's")
         assert "'" in result
@@ -695,6 +702,25 @@ class TestSearchPathValidation:
         result = ops.search("pattern", path="/some/path")
         assert result.error is not None
         assert "search failed" in result.error.lower() or "Search error" in result.error
+
+    def test_search_rg_preserves_windows_drive_paths(self, mock_env):
+        """search() should preserve Windows drive letters and regex backslashes for ripgrep command."""
+        executed_command = []
+        def side_effect(command, **kwargs):
+            if "test -e" in command:
+                return {"output": "exists", "returncode": 0}
+            if "command -v" in command:
+                return {"output": "yes", "returncode": 0}
+            executed_command.append(command)
+            return {"output": "", "returncode": 1}
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.search(r"\d+", path="C:/Users/ADMIN/AppData/Local/hermes/config.yaml")
+        assert result.error is None
+        assert len(executed_command) == 1
+        # It should preserve both the raw regex '\d+' and native Windows path
+        assert r"'\d+'" in executed_command[0]
+        assert "'C:/Users/ADMIN/AppData/Local/hermes/config.yaml'" in executed_command[0]
 
 
 class TestSearchFilesFallbackHiddenPaths:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -975,6 +975,16 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    def _escape_shell_raw(self, arg: str) -> str:
+        """Escape a string for safe use in shell commands without translating paths.
+
+        Useful for search patterns, python code snippets, and native Windows CLI
+        tool paths (like ripgrep) where backslashes or drive letters (C:/...)
+        should be preserved directly.
+        """
+        # Use single quotes and escape any single quotes in the string
+        return "'" + arg.replace("'", "'\"'\"'") + "'"
+
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
         """Write ``content`` to ``path`` atomically via temp-file + rename.
 
@@ -1320,12 +1330,12 @@ class ShellFileOperations(FileOperations):
             "    print(str(exc), file=sys.stderr); sys.exit(1)\n"
         )
 
-        result = self._exec(f"python3 -c {self._escape_shell_arg(snippet)}")
+        result = self._exec(f"python3 -c {self._escape_shell_raw(snippet)}")
 
         # Fall back to ``python`` (Windows / older systems where there's no
         # ``python3`` symlink but a ``python`` binary is on PATH).
         if result.exit_code != 0 and "python3" in (result.stdout or ""):
-            result = self._exec(f"python -c {self._escape_shell_arg(snippet)}")
+            result = self._exec(f"python -c {self._escape_shell_raw(snippet)}")
 
         if result.exit_code != 0:
             return WriteResult(error=f"Failed to delete {path}: {(result.stdout or '').strip() or 'unknown error'}")
@@ -2218,7 +2228,7 @@ class ShellFileOperations(FileOperations):
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
             f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_shell_arg(path)} 2>/dev/null "
+            f"{self._escape_shell_raw(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
@@ -2229,7 +2239,7 @@ class ShellFileOperations(FileOperations):
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
                 f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_shell_arg(path)} 2>/dev/null "
+                f"{self._escape_shell_raw(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
@@ -2284,8 +2294,8 @@ class ShellFileOperations(FileOperations):
             cmd_parts.append("-c")  # Count per file
         
         # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        cmd_parts.append(self._escape_shell_raw(pattern))
+        cmd_parts.append(self._escape_shell_raw(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,
@@ -2414,8 +2424,8 @@ class ShellFileOperations(FileOperations):
             cmd_parts.append("-c")
         
         # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        cmd_parts.append(self._escape_shell_raw(pattern))
+        cmd_parts.append(self._escape_shell_raw(path))
         
         # Fetch generously so we can compute total before slicing
         fetch_limit = limit + offset + (200 if context > 0 else 0)


### PR DESCRIPTION
Fixes an issue on Windows where search_files with ripgrep failed with `rg: /c/...: The system cannot find the path specified. (os error 3)`.

### Root Cause
When searching paths or executing non-path strings across Git Bash MSYS on Windows, `_escape_shell_arg` previously ran `_bash_safe_path()` on all arguments. This converted drive roots (`C:/...`, `B:/...`) into POSIX paths (`/c/...`, `/b/...`) and mangled backslashes in regex search queries (such as `\d+` becoming `/d+`).

While POSIX shell builtins require MSYS path conversion, native Windows binaries like `rg.exe` expect native drive paths (`C:/...`) and raw regex strings.

### Solution
1. Added `_escape_shell_raw` to quote non-path arguments and native CLI tool arguments without running MSYS path translation.
2. Updated `_search_with_rg` and `_search_files_rg` to use `_escape_shell_raw` for search patterns, python scripts, and ripgrep search paths.
3. Added unit test coverage for `_escape_shell_raw` and Windows path preservation in ripgrep search execution.