### PR TITLE
fix(desktop): remove composer input backdrop blur

### DIFF
--- a/apps/desktop/src/app/chat/composer/fallback.test.tsx
+++ b/apps/desktop/src/app/chat/composer/fallback.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { composerInputSurface } from '@/components/chat/composer-dock'
+
+import { ChatBarFallback } from './index'
+
+const hasBackdropFilter = (classes: string) =>
+  classes.includes('backdrop-blur') || classes.includes('backdrop-saturate') || classes.includes('backdrop-filter')
+
+describe('ChatBarFallback', () => {
+  it('uses the same filter-free surface treatment as the hydrated composer', () => {
+    const { container } = render(<ChatBarFallback />)
+    const paint = container.querySelector<HTMLElement>('[aria-hidden="true"]')
+
+    expect(paint).not.toBeNull()
+    expect(paint?.className).toContain(composerInputSurface)
+    expect(hasBackdropFilter(paint?.className ?? '')).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -2,7 +2,7 @@ import { ComposerPrimitive } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
 import { type ClipboardEvent, type FormEvent, type KeyboardEvent, useCallback, useEffect, useMemo, useRef } from 'react'
 
-import { composerFill, composerFloatingStrip, composerSurfaceGlass } from '@/components/chat/composer-dock'
+import { composerFloatingStrip, composerInputSurface } from '@/components/chat/composer-dock'
 import { Button } from '@/components/ui/button'
 import { Slot as ContribSlot } from '@/contrib/react/slot'
 import { useI18n } from '@/i18n'
@@ -1183,11 +1183,7 @@ export function ChatBar({
               >
                 <div
                   aria-hidden
-                  className={cn(
-                    'pointer-events-none absolute inset-0 -z-10 rounded-[inherit]',
-                    composerFill,
-                    composerSurfaceGlass
-                  )}
+                  className={cn('pointer-events-none absolute inset-0 -z-10 rounded-[inherit]', composerInputSurface)}
                 />
                 <CodingStatusRow
                   onBranchOff={handleBranchOff}
@@ -1298,11 +1294,7 @@ export function ChatBarFallback() {
       <div className="composer-fallback-surface relative isolate h-(--composer-fallback-height) w-full rounded-[inherit] border border-[color-mix(in_srgb,var(--dt-composer-ring)_calc(18%*var(--composer-ring-strength)),var(--dt-input))]">
         <div
           aria-hidden
-          className={cn(
-            'pointer-events-none absolute inset-0 -z-10 rounded-[inherit]',
-            composerFill,
-            composerSurfaceGlass
-          )}
+          className={cn('pointer-events-none absolute inset-0 -z-10 rounded-[inherit]', composerInputSurface)}
         />
       </div>
     </div>

--- a/apps/desktop/src/components/chat/composer-dock.test.ts
+++ b/apps/desktop/src/components/chat/composer-dock.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  composerDockCard,
+  composerFill,
+  composerInputSurface,
+  composerPanelCard
+} from '@/components/chat/composer-dock'
+
+const hasBackdropFilter = (classes: string) =>
+  classes.includes('backdrop-blur') || classes.includes('backdrop-saturate') || classes.includes('backdrop-filter')
+
+describe('composer surface treatments', () => {
+  it('keeps the frequently repainting input surface free of backdrop filters', () => {
+    expect(composerInputSurface).toContain(composerFill)
+    expect(hasBackdropFilter(composerInputSurface)).toBe(false)
+  })
+
+  it('retains the glass treatment on non-input composer chrome', () => {
+    expect(hasBackdropFilter(composerDockCard())).toBe(true)
+    expect(hasBackdropFilter(composerPanelCard)).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/chat/composer-dock.ts
+++ b/apps/desktop/src/components/chat/composer-dock.ts
@@ -7,11 +7,17 @@ import { cn } from '@/lib/utils'
  */
 export const composerFill = 'bg-(--composer-fill)'
 
-/** Backdrop treatment for the composer input surface. Harmless when the fill
+const composerFillTransition = 'transition-[background-color] duration-150 ease-out'
+
+/** Paint for the frequently repainting editable surface. Keep backdrop filters
+ *  off this hot path so typing does not re-blur the transcript each frame. */
+export const composerInputSurface = cn(composerFill, composerFillTransition)
+
+/** Backdrop treatment for non-input composer chrome. Harmless when the fill
  *  goes opaque (drawer open) — nothing shows through to blur. */
 export const composerSurfaceGlass = cn(
   'backdrop-blur-[0.75rem] backdrop-saturate-[1.12] [-webkit-backdrop-filter:blur(0.75rem)_saturate(1.12)]',
-  'transition-[background-color] duration-150 ease-out'
+  composerFillTransition
 )
 
 const composerDockEdge = (edge: 'bottom' | 'top') =>


### PR DESCRIPTION
## Summary

- remove backdrop filtering from the frequently repainting editable composer surface
- use the same filter-free treatment before and after hydration
- retain the existing glass treatment on non-input composer chrome

## Root cause

The editable input reused `composerSurfaceGlass`, coupling its translucent surface to backdrop blur. The first version of this PR changed only the hydrated composer, leaving the fallback glassy and causing a visible blur-to-no-blur transition during hydration.

Both surfaces now use `composerInputSurface`; docked status chrome, completion panels, and other non-input surfaces retain their existing glass treatment.

## Validation

- `npm run test:ui --workspace apps/desktop -- src/components/chat/composer-dock.test.ts src/app/chat/composer/fallback.test.tsx` — 3 passed
- Desktop typecheck, targeted ESLint, Prettier, and production build — passed
- GitHub required CI on `b5bf7d455b` — passed; merge state `CLEAN`

I also ran a GPU-enabled Electron A/B profile on Windows using a 220-row transcript and six alternating 180-frame streaming runs. It did not show a stable performance difference: median total Paint was 30.0 ms with blur versus 31.4 ms without, Raster was 20.3 ms versus 20.5 ms, and p95 frame intervals were about 5.7 ms in both modes. This does not validate the reported macOS Apple Silicon benefit, so the visual tradeoff still needs a design-owner decision or a macOS profile.

Tested on Windows with Node 22.23.1.

Fixes #69130
