### PR TITLE
fix(compression): enforce end-to-end wall-clock deadlines

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -46,6 +46,7 @@ import hashlib
 import inspect
 import json
 import logging
+import math
 import os
 import re
 import threading
@@ -3571,6 +3572,37 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
     return False
 
 
+class AuxiliaryWallClockTimeout(TimeoutError):
+    """Raised before an auxiliary request that would start past its deadline."""
+
+
+def _create_chat_completion_with_deadline(
+    client: Any,
+    kwargs: Dict[str, Any],
+    wall_clock_deadline: Optional[float],
+) -> Any:
+    """Start one sync request only while the shared wall-clock budget remains."""
+    request_kwargs = kwargs
+    if wall_clock_deadline is not None:
+        remaining = wall_clock_deadline - time.monotonic()
+        if remaining <= 0:
+            raise AuxiliaryWallClockTimeout(
+                "Auxiliary wall-clock deadline exceeded before starting another request"
+            )
+
+        # SDK timeouts are inactivity based. Capping them cannot stop a
+        # byte-trickling request, but it prevents a late retry from receiving a
+        # fresh full timeout while the caller's watchdog handles the hard cap.
+        request_kwargs = dict(kwargs)
+        request_timeout = request_kwargs.get("timeout")
+        if isinstance(request_timeout, (int, float)) and not isinstance(
+            request_timeout, bool
+        ):
+            request_kwargs["timeout"] = min(float(request_timeout), remaining)
+
+    return client.chat.completions.create(**request_kwargs)
+
+
 def _retry_same_provider_sync(
     *,
     task: Optional[str],
@@ -3588,6 +3620,7 @@ def _retry_same_provider_sync(
     effective_timeout: float,
     effective_extra_body: dict,
     reasoning_config: Optional[dict],
+    wall_clock_deadline: Optional[float] = None,
 ) -> Any:
     if task == "vision":
         _, retry_client, retry_model = resolve_vision_provider_client(
@@ -3627,7 +3660,10 @@ def _retry_same_provider_sync(
     if _is_anthropic_compat_endpoint(resolved_provider, retry_base):
         retry_kwargs["messages"] = _convert_openai_images_to_anthropic(retry_kwargs["messages"])
     return _validate_llm_response(
-        retry_client.chat.completions.create(**retry_kwargs), task,
+        _create_chat_completion_with_deadline(
+            retry_client, retry_kwargs, wall_clock_deadline
+        ),
+        task,
     )
 
 
@@ -3835,6 +3871,7 @@ def _call_fallback_candidate_sync(
     effective_timeout: float,
     effective_extra_body: dict,
     reasoning_config: Optional[dict],
+    wall_clock_deadline: Optional[float] = None,
 ) -> Optional[Any]:
     """Call one fallback candidate with stale-credential recovery.
 
@@ -3873,7 +3910,11 @@ def _call_fallback_candidate_sync(
         base_url=fb_base)
     try:
         return _validate_llm_response(
-            fb_client.chat.completions.create(**fb_kwargs), task)
+            _create_chat_completion_with_deadline(
+                fb_client, fb_kwargs, wall_clock_deadline
+            ),
+            task,
+        )
     except Exception as fb_err:
         if not _is_auth_error(fb_err):
             raise
@@ -3890,7 +3931,11 @@ def _call_fallback_candidate_sync(
                     base_url=str(getattr(retry_client, "base_url", "") or fb_base))
                 try:
                     return _validate_llm_response(
-                        retry_client.chat.completions.create(**retry_kwargs), task)
+                        _create_chat_completion_with_deadline(
+                            retry_client, retry_kwargs, wall_clock_deadline
+                        ),
+                        task,
+                    )
                 except Exception as retry_err:
                     if not _is_auth_error(retry_err):
                         raise
@@ -6442,6 +6487,50 @@ def _effective_aux_timeout(task: str, timeout: Optional[float]) -> float:
     return effective
 
 
+def _get_task_wall_clock_timeout(task: str) -> Optional[float]:
+    """Resolve an opt-in total deadline for an auxiliary task.
+
+    ``auxiliary.<task>.timeout`` is an SDK/transport inactivity timeout; it does
+    not bound total request duration while a provider keeps sending bytes. A
+    positive ``wall_clock_timeout`` adds that separate bound. Disabled values
+    preserve the historical call path exactly.
+    """
+    if not task:
+        return None
+
+    raw = _get_auxiliary_task_config(task).get("wall_clock_timeout")
+    if raw is None or raw == "":
+        return None
+    try:
+        configured = float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Ignoring invalid auxiliary.%s.wall_clock_timeout=%r; expected a "
+            "non-negative number",
+            task,
+            raw,
+        )
+        return None
+    if not math.isfinite(configured) or configured <= 0:
+        return None
+
+    # A total deadline shorter than the task's effective per-operation timeout
+    # would expire before one legitimate transport timeout can complete. Clamp
+    # against the canonical resolver so compression includes its 300s floor.
+    effective_inactivity_timeout = _effective_aux_timeout(task, None)
+    if configured < effective_inactivity_timeout:
+        logger.warning(
+            "auxiliary.%s.wall_clock_timeout=%.1fs is below the effective "
+            "inactivity timeout %.1fs; clamped to %.1fs",
+            task,
+            configured,
+            effective_inactivity_timeout,
+            effective_inactivity_timeout,
+        )
+        return effective_inactivity_timeout
+    return configured
+
+
 def _get_task_extra_body(task: str) -> Dict[str, Any]:
     """Read auxiliary.<task>.extra_body and return a shallow copy when valid.
 
@@ -6919,6 +7008,7 @@ def call_llm(
     max_tokens: int = None,
     tools: list = None,
     timeout: float = None,
+    wall_clock_deadline: Optional[float] = None,
     extra_body: dict = None,
     reasoning_config: Optional[dict] = None,
     api_mode: str = None,
@@ -6943,6 +7033,8 @@ def call_llm(
         max_tokens: Max output tokens (handles max_tokens vs max_completion_tokens).
         tools: Tool definitions (for function calling).
         timeout: Request timeout in seconds (None = read from auxiliary.{task}.timeout config).
+        wall_clock_deadline: Optional absolute monotonic deadline shared by all
+              synchronous retries and fallback candidates.
         extra_body: Additional request body fields.
         reasoning_config: Optional Hermes reasoning config for direct model calls
               such as MoA reference/aggregator slots.
@@ -7077,7 +7169,9 @@ def call_llm(
         kwargs["stream"] = True
         if stream_options:
             kwargs["stream_options"] = stream_options
-        return client.chat.completions.create(**kwargs)
+        return _create_chat_completion_with_deadline(
+            client, kwargs, wall_clock_deadline
+        )
 
     # Handle unsupported temperature, max_tokens vs max_completion_tokens retry,
     # then payment fallback.
@@ -7100,8 +7194,10 @@ def call_llm(
         # for the transient retry every auxiliary task shares. (PR #16587)
         try:
             return _validate_llm_response(
-                client.chat.completions.create(**kwargs), task,
-                provider=resolved_provider, base_url=_base_info)
+                _create_chat_completion_with_deadline(
+                    client, kwargs, wall_clock_deadline
+                ),
+                task, provider=resolved_provider, base_url=_base_info)
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise
@@ -7133,7 +7229,11 @@ def call_llm(
                 time.sleep(_backoff)
                 try:
                     return _validate_llm_response(
-                        client.chat.completions.create(**kwargs), task)
+                        _create_chat_completion_with_deadline(
+                            client, kwargs, wall_clock_deadline
+                        ),
+                        task,
+                    )
                 except Exception as retry_transient:
                     if not _is_transient_transport_error(retry_transient):
                         raise
@@ -7141,6 +7241,8 @@ def call_llm(
             # Retries exhausted — fall through to first_err fallback handling.
             raise _last_transient
     except Exception as first_err:
+        if isinstance(first_err, AuxiliaryWallClockTimeout):
+            raise
         if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
             retry_kwargs = dict(kwargs)
             retry_kwargs.pop("temperature", None)
@@ -7150,7 +7252,11 @@ def call_llm(
             )
             try:
                 return _validate_llm_response(
-                    client.chat.completions.create(**retry_kwargs), task)
+                    _create_chat_completion_with_deadline(
+                        client, retry_kwargs, wall_clock_deadline
+                    ),
+                    task,
+                )
             except Exception as retry_err:
                 retry_err_str = str(retry_err)
                 # If retry still fails, fall through to the max_tokens /
@@ -7188,7 +7294,11 @@ def call_llm(
             kwargs.pop("max_completion_tokens", None)
             try:
                 return _validate_llm_response(
-                    client.chat.completions.create(**kwargs), task)
+                    _create_chat_completion_with_deadline(
+                        client, kwargs, wall_clock_deadline
+                    ),
+                    task,
+                )
             except Exception as retry_err:
                 # If the max_tokens retry also hits a payment or connection
                 # error, fall through to the fallback chain below.
@@ -7218,7 +7328,11 @@ def call_llm(
                 kwargs["model"] = healed_model
                 try:
                     return _validate_llm_response(
-                        client.chat.completions.create(**kwargs), task)
+                        _create_chat_completion_with_deadline(
+                            client, kwargs, wall_clock_deadline
+                        ),
+                        task,
+                    )
                 except Exception as retry_err:
                     first_err = retry_err
 
@@ -7251,7 +7365,11 @@ def call_llm(
                     kwargs["model"] = refreshed_model
                 try:
                     return _validate_llm_response(
-                        refreshed_client.chat.completions.create(**kwargs), task)
+                        _create_chat_completion_with_deadline(
+                            refreshed_client, kwargs, wall_clock_deadline
+                        ),
+                        task,
+                    )
                 except Exception as retry_err:
                     if not (
                         _is_auth_error(retry_err)
@@ -7279,7 +7397,11 @@ def call_llm(
                 if refreshed_model and refreshed_model != kwargs.get("model"):
                     kwargs["model"] = refreshed_model
                 return _validate_llm_response(
-                    refreshed_client.chat.completions.create(**kwargs), task)
+                    _create_chat_completion_with_deadline(
+                        refreshed_client, kwargs, wall_clock_deadline
+                    ),
+                    task,
+                )
 
         # ── Auth refresh retry ───────────────────────────────────────
         auth_refresh_provider = _auth_refresh_provider_for_route(
@@ -7312,6 +7434,7 @@ def call_llm(
                     effective_timeout=effective_timeout,
                     effective_extra_body=effective_extra_body,
                     reasoning_config=reasoning_config,
+                    wall_clock_deadline=wall_clock_deadline,
                 )
 
         # ── Same-provider credential-pool recovery ─────────────────────
@@ -7328,7 +7451,11 @@ def call_llm(
             if _is_rate_limit_error(first_err) and not _is_payment_error(first_err):
                 try:
                     return _validate_llm_response(
-                        client.chat.completions.create(**kwargs), task)
+                        _create_chat_completion_with_deadline(
+                            client, kwargs, wall_clock_deadline
+                        ),
+                        task,
+                    )
                 except Exception as retry_err:
                     if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
                         raise
@@ -7355,6 +7482,7 @@ def call_llm(
                         effective_timeout=effective_timeout,
                         effective_extra_body=effective_extra_body,
                         reasoning_config=reasoning_config,
+                        wall_clock_deadline=wall_clock_deadline,
                     )
                 except Exception as retry2_err:
                     # The rotated key also hit a quota/auth wall.  Mark it
@@ -7477,7 +7605,8 @@ def call_llm(
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, effective_timeout=effective_timeout,
                     effective_extra_body=effective_extra_body,
-                    reasoning_config=reasoning_config)
+                    reasoning_config=reasoning_config,
+                    wall_clock_deadline=wall_clock_deadline)
                 if fb_resp is not None:
                     return fb_resp
                 # The candidate had a stale/unrefreshable credential and was
@@ -7492,7 +7621,8 @@ def call_llm(
                         temperature=temperature, max_tokens=max_tokens,
                         tools=tools, effective_timeout=effective_timeout,
                         effective_extra_body=effective_extra_body,
-                        reasoning_config=reasoning_config)
+                        reasoning_config=reasoning_config,
+                        wall_clock_deadline=wall_clock_deadline)
                     if fb_resp is not None:
                         return fb_resp
             # All fallback layers exhausted — emit a single user-visible

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -16,15 +16,23 @@ Improvements over v2:
   - Richer tool call/result detail in summarizer input
 """
 
+import contextvars
 import hashlib
 import json
 import logging
 import sqlite3
 import re
+import threading
 import time
 from typing import Any, Dict, List, Optional
 
-from agent.auxiliary_client import call_llm, _is_connection_error, aux_interrupt_protection
+from agent.auxiliary_client import (
+    AuxiliaryWallClockTimeout,
+    _get_task_wall_clock_timeout,
+    _is_connection_error,
+    aux_interrupt_protection,
+    call_llm,
+)
 from agent.context_engine import ContextEngine, sanitize_memory_context
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.model_metadata import (
@@ -36,6 +44,72 @@ from agent.redact import redact_sensitive_text
 from agent.turn_context import drop_stale_api_content
 
 logger = logging.getLogger(__name__)
+
+
+_WALL_CLOCK_DEADLINE_UNSET = object()
+
+
+class SummaryWallClockTimeout(TimeoutError):
+    """Raised when the complete compression-summary workflow exceeds its limit."""
+
+
+def _call_llm_with_wall_clock(
+    call_kwargs: Dict[str, Any],
+    deadline: float,
+):
+    """Run one summary call behind an absolute wall-clock deadline.
+
+    The OpenAI-compatible SDK timeout is inactivity-based, so a byte-trickling
+    response can outlive it indefinitely. The worker is daemonized because the
+    shared cached client cannot be safely closed from this watchdog. It may
+    finish late, but it only writes to this helper's private outcome container.
+    """
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise SummaryWallClockTimeout(
+            "Context compression wall-clock timeout exceeded before summary retry"
+        )
+
+    call_kwargs = {**call_kwargs, "wall_clock_deadline": deadline}
+    outcome: Dict[str, Any] = {}
+    caller_context = contextvars.copy_context()
+
+    def _run() -> None:
+        try:
+            # Interrupt protection is thread-local, so it must be entered on
+            # the worker that invokes the auxiliary client (#23975).
+            with aux_interrupt_protection():
+                outcome["response"] = call_llm(**call_kwargs)
+        except AuxiliaryWallClockTimeout as exc:
+            # Preserve the compressor's typed network-failure classification;
+            # a raw TimeoutError would enter cooldown without aborting safely.
+            outcome["exception"] = SummaryWallClockTimeout(str(exc))
+        except BaseException as exc:  # Re-raise on the waiting caller thread.
+            outcome["exception"] = exc
+
+    worker = threading.Thread(
+        target=caller_context.run,
+        args=(_run,),
+        name="hermes-compression-summary",
+        daemon=True,
+    )
+    worker.start()
+    worker.join(remaining)
+    if worker.is_alive():
+        logger.warning(
+            "Context compression wall-clock timeout exceeded after %.1fs; "
+            "daemon summary worker %s is still running and its late result "
+            "will be discarded",
+            remaining,
+            worker.name,
+        )
+        raise SummaryWallClockTimeout(
+            f"Context compression wall-clock timeout exceeded after {remaining:.1f}s"
+        )
+
+    if "exception" in outcome:
+        raise outcome["exception"]
+    return outcome["response"]
 
 
 _SUMMARY_PERMANENT_QUOTA_MARKERS: tuple[str, ...] = (
@@ -2146,6 +2220,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         turns_to_summarize: List[Dict[str, Any]],
         focus_topic: Optional[str] = None,
         memory_context: str = "",
+        _wall_clock_deadline: Any = _WALL_CLOCK_DEADLINE_UNSET,
     ) -> Optional[str]:
         """Generate a structured summary of conversation turns.
 
@@ -2171,6 +2246,17 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
                 self._summary_failure_cooldown_until - now,
             )
             return None
+
+        # Resolve once for the complete workflow. Recursive fallback to the main
+        # model receives the same absolute deadline; ``None`` means the opt-in
+        # guard is disabled and preserves the historical inline call path.
+        if _wall_clock_deadline is _WALL_CLOCK_DEADLINE_UNSET:
+            _wall_clock_timeout = _get_task_wall_clock_timeout("compression")
+            _wall_clock_deadline = (
+                time.monotonic() + _wall_clock_timeout
+                if _wall_clock_timeout is not None
+                else None
+            )
 
         summary_budget = self._compute_summary_budget(turns_to_summarize)
         content_to_summarize = self._serialize_for_summary(turns_to_summarize)
@@ -2384,8 +2470,14 @@ This compaction should PRIORITISE preserving all information related to the focu
             # aborts the summary and compression falls back to a degraded static
             # marker, losing the real handoff (#23975). Re-entrant: a main-model
             # retry (_generate_summary recursion) re-enters harmlessly.
-            with aux_interrupt_protection():
-                response = call_llm(**call_kwargs)
+            if _wall_clock_deadline is None:
+                with aux_interrupt_protection():
+                    response = call_llm(**call_kwargs)
+            else:
+                response = _call_llm_with_wall_clock(
+                    call_kwargs,
+                    _wall_clock_deadline,
+                )
             # ``_validate_llm_response`` only guarantees ``choices[0].message``
             # exists, not that it's an object with ``.content``. Some
             # OpenAI-compatible proxies / local backends return a dict- or
@@ -2472,7 +2564,8 @@ This compaction should PRIORITISE preserving all information related to the focu
                 or "does not exist" in _err_str
                 or "no available channel" in _err_str
             )
-            _is_timeout = (
+            _is_wall_clock_timeout = isinstance(e, SummaryWallClockTimeout)
+            _is_timeout = _is_wall_clock_timeout or (
                 _status in {408, 429, 502, 504}
                 or "timeout" in _err_str
                 or "timed out" in _err_str
@@ -2496,7 +2589,13 @@ This compaction should PRIORITISE preserving all information related to the focu
             # transient network events; treat them like a timeout so we fall
             # back to the main model instead of entering a 60-second cooldown.
             # See issue #18458.
-            _is_streaming_closed = _is_connection_error(e)
+            _is_streaming_closed = (
+                not _is_wall_clock_timeout and _is_connection_error(e)
+            )
+            if _is_wall_clock_timeout:
+                # Deliberately reuse the existing preserve-and-abort path for
+                # terminal network failures. Do not rely on exception naming.
+                self._last_summary_network_failure = True
             # Authentication, permission, and exhausted-quota failures are NOT
             # transient or fixable by retrying the same request. Flag them so
             # compress() preserves the session instead of rotating into a
@@ -2540,6 +2639,7 @@ This compaction should PRIORITISE preserving all information related to the focu
                     turns_to_summarize,
                     focus_topic=focus_topic,
                     memory_context=memory_context,
+                    _wall_clock_deadline=_wall_clock_deadline,
                 )  # retry immediately
 
             # Unknown-error best-effort retry on main model.  Losing N turns of
@@ -2561,6 +2661,7 @@ This compaction should PRIORITISE preserving all information related to the focu
                     turns_to_summarize,
                     focus_topic=focus_topic,
                     memory_context=memory_context,
+                    _wall_clock_deadline=_wall_clock_deadline,
                 )
 
             # Transient errors (timeout, rate limit, network, JSON decode,
@@ -2602,7 +2703,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             # placeholder marker — retrying once the network recovers is
             # strictly better than dropping context (#29559, #25585). Mirrors
             # the auth-failure carve-out; independent of abort_on_summary_failure.
-            if _is_streaming_closed:
+            if _is_streaming_closed or _is_wall_clock_timeout:
                 self._last_summary_network_failure = True
             logger.warning(
                 "Failed to generate context summary: %s. "

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1652,6 +1652,7 @@ DEFAULT_CONFIG = {
             "base_url": "",
             "api_key": "",
             "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
+            "wall_clock_timeout": 0,  # seconds — opt-in total workflow deadline; 0 disables it
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
         },

--- a/tests/agent/test_compression_wall_clock.py
+++ b/tests/agent/test_compression_wall_clock.py
@@ -1,0 +1,422 @@
+"""Regression tests for opt-in compression wall-clock deadlines."""
+
+import contextvars
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.auxiliary_client import (
+    AuxiliaryWallClockTimeout,
+    _call_fallback_candidate_sync,
+    _aux_interrupt_protected,
+    _get_task_wall_clock_timeout,
+    call_llm,
+)
+from agent.context_compressor import (
+    ContextCompressor,
+    SummaryWallClockTimeout,
+    _call_llm_with_wall_clock,
+)
+
+
+def _ok_response(content: str = "summary"):
+    message = SimpleNamespace(content=content)
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+@pytest.fixture()
+def compressor():
+    with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+        return ContextCompressor(
+            model="main/model",
+            threshold_percent=0.85,
+            protect_first_n=1,
+            protect_last_n=1,
+            quiet_mode=True,
+        )
+
+
+def test_wall_clock_timeout_disabled_values_preserve_existing_behavior():
+    for raw in (None, 0, "0", ""):
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"wall_clock_timeout": raw},
+        ):
+            assert _get_task_wall_clock_timeout("compression") is None
+
+
+def test_default_config_disables_compression_wall_clock_timeout():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["auxiliary"]["compression"]["wall_clock_timeout"] == 0
+
+
+def test_wall_clock_timeout_above_effective_floor_is_preserved():
+    with patch(
+        "agent.auxiliary_client._get_auxiliary_task_config",
+        return_value={"timeout": 120, "wall_clock_timeout": 600},
+    ):
+        assert _get_task_wall_clock_timeout("compression") == 600.0
+
+
+def test_wall_clock_timeout_clamps_to_effective_compression_floor(caplog):
+    with patch(
+        "agent.auxiliary_client._get_auxiliary_task_config",
+        return_value={"timeout": 120, "wall_clock_timeout": 30},
+    ):
+        assert _get_task_wall_clock_timeout("compression") == 300.0
+    assert "clamped" in caplog.text.lower()
+
+
+def test_disabled_deadline_uses_existing_inline_call(compressor):
+    with (
+        patch("agent.context_compressor._get_task_wall_clock_timeout", return_value=None),
+        patch("agent.context_compressor.call_llm", return_value=_ok_response("inline")) as call,
+        patch("agent.context_compressor._call_llm_with_wall_clock") as guarded,
+    ):
+        result = compressor._generate_summary([{"role": "user", "content": "hello"}])
+
+    assert "inline" in result
+    call.assert_called_once()
+    guarded.assert_not_called()
+
+
+def test_worker_propagates_context_and_interrupt_protection():
+    marker = contextvars.ContextVar("compression_deadline_test", default="missing")
+    marker.set("parent")
+    observed = {}
+
+    def fake_call_llm(**_kwargs):
+        observed["context"] = marker.get()
+        observed["protected"] = _aux_interrupt_protected()
+        observed["deadline"] = _kwargs["wall_clock_deadline"]
+        return _ok_response()
+
+    deadline = time.monotonic() + 1.0
+    with patch("agent.context_compressor.call_llm", side_effect=fake_call_llm):
+        response = _call_llm_with_wall_clock({}, deadline)
+
+    assert response.choices[0].message.content == "summary"
+    assert observed == {
+        "context": "parent",
+        "protected": True,
+        "deadline": deadline,
+    }
+
+
+def test_worker_maps_auxiliary_deadline_timeout_before_summary_classification():
+    with patch(
+        "agent.context_compressor.call_llm",
+        side_effect=AuxiliaryWallClockTimeout("deadline expired"),
+    ):
+        with pytest.raises(SummaryWallClockTimeout, match="deadline expired"):
+            _call_llm_with_wall_clock({}, time.monotonic() + 1.0)
+
+
+def test_worker_timeout_is_bounded_and_late_result_is_discarded():
+    release = threading.Event()
+    finished = threading.Event()
+
+    def slow_call_llm(**_kwargs):
+        release.wait(timeout=1.0)
+        finished.set()
+        return _ok_response("late")
+
+    started = time.monotonic()
+    with patch("agent.context_compressor.call_llm", side_effect=slow_call_llm):
+        with pytest.raises(SummaryWallClockTimeout, match="timeout"):
+            _call_llm_with_wall_clock({}, started + 0.05)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.25
+    release.set()
+    assert finished.wait(timeout=1.0)
+
+
+def test_wall_clock_timeout_is_explicitly_classified_and_cooled_down(compressor):
+    with (
+        patch("agent.context_compressor._get_task_wall_clock_timeout", return_value=1.0),
+        patch(
+            "agent.context_compressor._call_llm_with_wall_clock",
+            side_effect=SummaryWallClockTimeout("compression wall-clock timeout exceeded"),
+        ) as guarded,
+    ):
+        assert compressor._generate_summary([{"role": "user", "content": "hello"}]) is None
+        assert compressor._last_summary_network_failure is True
+        assert compressor._consecutive_timeout_failures == 1
+        assert compressor._summary_failure_cooldown_until > time.monotonic()
+        # The cooldown must prevent an immediate second worker.
+        assert compressor._generate_summary([{"role": "user", "content": "again"}]) is None
+
+    guarded.assert_called_once()
+
+
+def test_one_deadline_spans_summary_model_and_main_model_fallback(compressor):
+    compressor.summary_model = "aux/model"
+    deadlines = []
+
+    class UnavailableError(Exception):
+        status_code = 503
+
+    def guarded_call(_call_kwargs, deadline):
+        deadlines.append(deadline)
+        if len(deadlines) == 1:
+            raise UnavailableError("auxiliary model unavailable")
+        raise SummaryWallClockTimeout("compression wall-clock timeout exceeded")
+
+    with (
+        patch("agent.context_compressor._get_task_wall_clock_timeout", return_value=600.0),
+        patch(
+            "agent.context_compressor._call_llm_with_wall_clock",
+            side_effect=guarded_call,
+        ),
+    ):
+        result = compressor._generate_summary([{"role": "user", "content": "hello"}])
+
+    assert result is None
+    assert len(deadlines) == 2
+    assert deadlines[0] == deadlines[1]
+    assert compressor._last_summary_network_failure is True
+
+
+def test_wall_clock_timeout_preserves_messages_under_default_abort_policy(compressor):
+    messages = [
+        {"role": "user" if index % 2 == 0 else "assistant", "content": f"message {index}"}
+        for index in range(10)
+    ]
+
+    with (
+        patch("agent.context_compressor._get_task_wall_clock_timeout", return_value=1.0),
+        patch(
+            "agent.context_compressor._call_llm_with_wall_clock",
+            side_effect=SummaryWallClockTimeout("compression wall-clock timeout exceeded"),
+        ),
+    ):
+        result = compressor.compress(messages)
+
+    assert result == messages
+    assert compressor._last_compress_aborted is True
+    assert compressor._last_summary_fallback_used is False
+    assert compressor._last_summary_dropped_count == 0
+
+
+def test_deadline_exhausted_on_recursive_entry_is_caught(compressor):
+    compressor.summary_model = "aux/model"
+    exhausted = time.monotonic() - 1.0
+
+    with patch(
+        "agent.context_compressor._get_task_wall_clock_timeout",
+        return_value=MagicMock(),
+    ):
+        result = compressor._generate_summary(
+            [{"role": "user", "content": "hello"}],
+            _wall_clock_deadline=exhausted,
+        )
+
+    assert result is None
+    assert compressor._last_summary_network_failure is True
+
+
+def _routing_patches(primary_client, *, provider="auto"):
+    return (
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=(provider, "primary-model", None, None, None),
+        ),
+        patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(primary_client, "primary-model"),
+        ),
+        patch(
+            "agent.auxiliary_client._validate_llm_response",
+            side_effect=lambda response, _task, **_kwargs: response,
+        ),
+        patch("agent.auxiliary_client._get_task_extra_body", return_value={}),
+    )
+
+
+def _controlled_clock(*values):
+    times = iter(values)
+    last = values[-1]
+    return lambda: next(times, last)
+
+
+def test_real_call_llm_stops_transient_retry_after_deadline():
+    primary = MagicMock()
+    primary.base_url = "https://primary.example/v1"
+    primary.chat.completions.create.side_effect = ConnectionError(
+        "connection reset by peer"
+    )
+    p1, p2, p3, p4 = _routing_patches(primary)
+
+    with (
+        p1,
+        p2,
+        p3,
+        p4,
+        patch(
+            "agent.auxiliary_client._is_transient_transport_error",
+            side_effect=lambda exc: isinstance(exc, ConnectionError),
+        ),
+        patch("agent.auxiliary_client._is_timeout_error", return_value=False),
+        patch("agent.auxiliary_client._transient_retry_count", return_value=1),
+        patch("agent.auxiliary_client.time.sleep"),
+        patch(
+            "agent.auxiliary_client.time.monotonic",
+            side_effect=_controlled_clock(10.0, 12.0),
+        ),
+    ):
+        with pytest.raises(AuxiliaryWallClockTimeout):
+            call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+                timeout=30.0,
+                wall_clock_deadline=11.0,
+            )
+
+    assert primary.chat.completions.create.call_count == 1
+    assert primary.chat.completions.create.call_args.kwargs["timeout"] == pytest.approx(
+        1.0
+    )
+
+
+def test_real_call_llm_stops_fallback_request_after_deadline():
+    primary = MagicMock()
+    primary.base_url = "https://primary.example/v1"
+    primary.chat.completions.create.side_effect = ConnectionError("connection lost")
+    fallback = MagicMock()
+    fallback.base_url = "https://fallback.example/v1"
+    p1, p2, p3, p4 = _routing_patches(primary)
+
+    with (
+        p1,
+        p2,
+        p3,
+        p4,
+        patch(
+            "agent.auxiliary_client._is_transient_transport_error",
+            side_effect=lambda exc: isinstance(exc, ConnectionError),
+        ),
+        patch("agent.auxiliary_client._transient_retry_count", return_value=0),
+        patch(
+            "agent.auxiliary_client._is_connection_error",
+            side_effect=lambda exc: isinstance(exc, ConnectionError),
+        ),
+        patch("agent.auxiliary_client._recoverable_pool_provider", return_value=None),
+        patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+            return_value=(fallback, "fallback-model", "fallback"),
+        ),
+        patch(
+            "agent.auxiliary_client.time.monotonic",
+            side_effect=_controlled_clock(10.0, 12.0),
+        ),
+    ):
+        with pytest.raises(AuxiliaryWallClockTimeout):
+            call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+                timeout=30.0,
+                wall_clock_deadline=11.0,
+            )
+
+    assert primary.chat.completions.create.call_count == 1
+    fallback.chat.completions.create.assert_not_called()
+
+
+def test_real_call_llm_stops_pool_retry_after_deadline():
+    class RateLimitError(Exception):
+        pass
+
+    primary = MagicMock()
+    primary.base_url = "https://primary.example/v1"
+    primary.chat.completions.create.side_effect = RateLimitError("rate limited")
+    p1, p2, p3, p4 = _routing_patches(primary, provider="openai-codex")
+
+    with (
+        p1,
+        p2,
+        p3,
+        p4,
+        patch("agent.auxiliary_client._is_transient_transport_error", return_value=False),
+        patch(
+            "agent.auxiliary_client._is_rate_limit_error",
+            side_effect=lambda exc: isinstance(exc, RateLimitError),
+        ),
+        patch("agent.auxiliary_client._is_payment_error", return_value=False),
+        patch("agent.auxiliary_client._is_auth_error", return_value=False),
+        patch(
+            "agent.auxiliary_client._recoverable_pool_provider",
+            return_value="openai-codex",
+        ),
+        patch(
+            "agent.auxiliary_client.time.monotonic",
+            side_effect=_controlled_clock(10.0, 12.0),
+        ),
+    ):
+        with pytest.raises(AuxiliaryWallClockTimeout):
+            call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+                timeout=30.0,
+                wall_clock_deadline=11.0,
+            )
+
+    assert primary.chat.completions.create.call_count == 1
+
+
+def test_fallback_auth_refresh_cannot_start_after_deadline():
+    class AuthError(Exception):
+        pass
+
+    fallback = MagicMock()
+    fallback.base_url = "https://fallback.example/v1"
+    fallback.chat.completions.create.side_effect = AuthError("expired token")
+    refreshed = MagicMock()
+    refreshed.base_url = "https://refreshed.example/v1"
+
+    with (
+        patch("agent.auxiliary_client._fallback_entry_timeout", return_value=None),
+        patch(
+            "agent.auxiliary_client._validate_llm_response",
+            side_effect=lambda response, _task, **_kwargs: response,
+        ),
+        patch(
+            "agent.auxiliary_client._is_auth_error",
+            side_effect=lambda exc: isinstance(exc, AuthError),
+        ),
+        patch(
+            "agent.auxiliary_client._auth_refresh_provider_for_route",
+            return_value="custom",
+        ),
+        patch("agent.auxiliary_client._refresh_provider_credentials", return_value=True),
+        patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(refreshed, "refreshed-model"),
+        ),
+        patch(
+            "agent.auxiliary_client.time.monotonic",
+            side_effect=_controlled_clock(10.0, 12.0),
+        ),
+    ):
+        with pytest.raises(AuxiliaryWallClockTimeout):
+            _call_fallback_candidate_sync(
+                fallback,
+                "fallback-model",
+                "fallback_chain[0](custom)",
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+                temperature=0.3,
+                max_tokens=500,
+                tools=None,
+                effective_timeout=30.0,
+                effective_extra_body={},
+                reasoning_config=None,
+                wall_clock_deadline=11.0,
+            )
+
+    assert fallback.chat.completions.create.call_count == 1
+    refreshed.chat.completions.create.assert_not_called()

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -755,7 +755,25 @@ auxiliary:
     model: ""                                       # Empty = use main chat model. Override with e.g. "google/gemini-3-flash-preview" for cheaper/faster compression.
     provider: "auto"                                # Provider: "auto", "openrouter", "nous", "codex", "main", etc.
     base_url: null                                  # Custom OpenAI-compatible endpoint (overrides provider)
+    timeout: 120                                    # Per-operation/inactivity timeout; effective minimum is 300s
+    wall_clock_timeout: 0                           # Total summary-workflow deadline; 0/null/unset disables it
 ```
+
+`auxiliary.compression.timeout` is an SDK/transport inactivity timeout, not a
+total request-duration limit. A provider that keeps sending response bytes can
+therefore run longer than this value. Set `wall_clock_timeout` to a positive
+number to opt into a total deadline spanning auxiliary retries, provider
+fallbacks, and the compressor's main-model fallback. Values below the effective
+inactivity timeout are clamped upward (compression currently has a 300-second
+minimum). When the total deadline expires, Hermes preserves the original
+messages, pauses summary retries on the normal timeout cooldown ladder, and
+continues without rotating the session.
+
+Enabling the deadline trades eventual summary success for bounded interaction
+latency. A timed-out daemon request may continue in the background until its
+transport inactivity timeout fires, and preserving an already oversized
+transcript can leave the next model request near its hard context limit. Leave
+the setting disabled unless that tradeoff is preferable for your provider.
 
 :::info Legacy config migration
 Older configs with `compression.summary_model`, `compression.summary_provider`, and `compression.summary_base_url` are automatically migrated to `auxiliary.compression.*` on first load (config version 17). No manual action needed.


### PR DESCRIPTION
## Summary

- add an opt-in `auxiliary.compression.wall_clock_timeout` with a disabled-by-default value of `0`
- enforce one monotonic deadline across the compression worker, synchronous `call_llm` retries/fallbacks, and main-model fallback recursion
- preserve the complete transcript and use the existing timeout cooldown path when the deadline expires
- document inactivity-timeout versus total-deadline semantics and add routing regressions

## Why

`auxiliary.compression.timeout` is an SDK/transport inactivity timeout. A
provider that keeps sending bytes can therefore keep a compression summary
alive far beyond the configured value.

A caller-only timeout is also insufficient: an orphaned `call_llm` worker
could later start same-provider retries or fallback-provider requests. This
change carries one absolute deadline through every synchronous request start
and refuses to start another request after the deadline.

This is a current-`main` replacement for the approach in #41397 and addresses
its outstanding routing review finding. It also revisits the underlying
wall-clock gap discussed in the closed #24147 without restoring that PR's
blanket executor design.

## Behavior

- the feature is disabled by default, preserving the historical inline path
- positive values below the effective compression inactivity timeout are
  clamped upward; compression retains its existing 300-second floor
- requests started before the deadline receive an SDK timeout capped to the
  remaining budget
- the daemon watchdog bounds caller-visible latency even if an in-flight
  response keeps trickling bytes
- late results are discarded and cannot mutate compressor/session state
- deadline expiry preserves all messages, avoids static drop-middle fallback
  and session rotation, and enters the existing 60/300/900-second cooldown

## Testing

- `tests/agent/test_compression_wall_clock.py`: 16 passed
- auxiliary routing/regression suites: 363 passed
- context-compressor and deadline suites: 198 passed
- config suites: 203 passed
- Ruff: passed
- `compileall`: passed
- `git diff --check`: passed
