### PR TITLE
docs(contributing): fix stale project-structure diagram in CONTRIBUTING.es.md

### DIFF
--- a/CONTRIBUTING.es.md
+++ b/CONTRIBUTING.es.md
@@ -174,7 +174,7 @@ hermes-agent/
 │   ├── code_execution_tool.py    # Python sandboxado con acceso a herramientas vía RPC
 │   ├── session_search_tool.py    # Búsqueda en conversaciones pasadas con FTS5 + ventanas ancladas
 │   ├── cronjob_tools.py          # Gestión de tareas programadas
-│   ├── skill_tools.py            # Búsqueda, carga y gestión de habilidades
+│   ├── skills_tool.py             # Búsqueda, carga y gestión de habilidades
 │   └── environments/             # Backends de ejecución del terminal
 │       ├── base.py                   # ABC BaseEnvironment
 │       ├── local.py, docker.py, ssh.py, singularity.py, modal.py, daytona.py
@@ -182,9 +182,10 @@ hermes-agent/
 ├── gateway/                  # Gateway de mensajería
 │   ├── run.py                    # GatewayRunner — ciclo de vida de plataformas, enrutamiento de mensajes, cron
 │   ├── config.py                 # Resolución de configuración de plataformas
-│   ├── session.py                # Almacén de sesiones, prompts de contexto, políticas de reset
-│   └── platforms/                # Adaptadores de plataformas
-│       ├── telegram.py, discord_adapter.py, slack.py, whatsapp.py
+│   └── session.py                # Almacén de sesiones, prompts de contexto, políticas de reset
+│
+├── plugins/platforms/        # Adaptadores de canales (telegram, discord, slack, whatsapp, etc.)
+│   └── <platform>/adapter.py     # Un subdirectorio por plataforma, p. ej. plugins/platforms/telegram/adapter.py
 │
 ├── scripts/                  # Scripts del instalador y puente
 │   ├── install.sh                # Instalador Linux/macOS


### PR DESCRIPTION
## What does this PR do?

Fixes two stale entries in `CONTRIBUTING.es.md`'s project-structure diagram that no longer match the actual file layout — same corrections as open #68582, applied to the Spanish locale only.

## Related Issue

Fixes # (none filed — mirrors #68582 for Spanish; confirmed by checking the actual file paths on disk)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `CONTRIBUTING.es.md` — `tools/skill_tools.py` → `tools/skills_tool.py` (the actual filename on disk; Spanish comment kept).
- `CONTRIBUTING.es.md` — the `gateway/platforms/` entry (listing `telegram.py, discord_adapter.py, slack.py, whatsapp.py`) no longer matches the layout; channel adapters now live under `plugins/platforms/<name>/adapter.py`. Replaced the stale entry with a `plugins/platforms/` entry describing the current layout. Gateway section now ends with `session.py` only.

## How to Test

```
ls tools/skills_tool.py                      # exists
ls tools/skill_tools.py 2>&1                 # No such file or directory
ls gateway/platforms/telegram.py 2>&1        # No such file or directory
ls plugins/platforms/telegram/adapter.py     # exists
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`docs(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (English fix is open as #68582; this PR is the Spanish mirror only)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] N/A — docs-only change, no code paths affected
- [x] N/A — docs-only change, no tests applicable
- [x] I've tested on my platform: macOS — N/A for a docs-only change

### Documentation & Housekeeping

- [x] I've updated relevant documentation — this PR *is* the documentation update
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (Spanish CONTRIBUTING.es.md only; English covered by #68582)
- [x] I've considered cross-platform impact — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A


Made with [Cursor](https://cursor.com)