### PR TITLE
feat(cron): mention operator on failed deliveries

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -87,6 +87,32 @@ def _set_cron_session_title(session_db, session_id, base_title):
         return deduped
 
 
+def _cron_failure_mention_for_delivery(job: dict, cfg: dict | None = None) -> str:
+    """Return the optional mention prefix for failed cron deliveries."""
+    mention = (job or {}).get("failure_mention")
+    if mention is None:
+        try:
+            if cfg is None:
+                cfg = load_config() or {}
+            cron_cfg = (cfg.get("cron", {}) or {}) if isinstance(cfg, dict) else {}
+            mention = cron_cfg.get("failure_mention")
+        except Exception:
+            mention = None
+    text = str(mention or "").strip()
+    return text
+
+
+def _with_cron_failure_mention(job: dict, content: str, cfg: dict | None = None) -> str:
+    """Prefix failed cron delivery content with the configured mention, if any."""
+    mention = _cron_failure_mention_for_delivery(job, cfg)
+    if not mention:
+        return content
+    body = content or ""
+    if body.lstrip().startswith(mention):
+        return body
+    return f"{mention}\n{body}" if body.strip() else mention
+
+
 def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     """Return a compact one-line failure message for chat delivery.
 
@@ -3819,7 +3845,10 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             # Deliver the final response to the origin/target chat.
             # If the agent responded with [SILENT], skip delivery (but
             # output is already saved above).  Failed jobs always deliver.
-            deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
+            deliver_content = final_response if success else _with_cron_failure_mention(
+                job,
+                _summarize_cron_failure_for_delivery(job, error),
+            )
             # Treat whitespace-only final responses the same as empty
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2672,6 +2672,34 @@ class TestSilentDelivery:
             tick(verbose=False)
         deliver_mock.assert_called_once()
 
+    def test_failed_job_prefixes_configured_failure_mention(self):
+        """Failed jobs can mention an operator without mentioning on success."""
+        mention = "<@U07UP5A50G2>"
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(False, "# output", "", "some error")), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"failure_mention": mention}}), \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_called_once()
+        assert deliver_mock.call_args.args[1].startswith(mention + "\n")
+
+    def test_successful_job_does_not_prefix_failure_mention(self):
+        """Configured failure mentions must not notify on successful runs."""
+        mention = "<@U07UP5A50G2>"
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "all good", None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"failure_mention": mention}}), \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_called_once()
+        assert not deliver_mock.call_args.args[1].startswith(mention)
+
     def test_output_saved_even_when_delivery_suppressed(self):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# full output", "[SILENT]", None)), \


### PR DESCRIPTION
## What does this PR do?

Adds an optional cron failure mention prefix so operators can be notified only when scheduled jobs fail, without adding mentions to successful cron deliveries.

The scheduler now resolves `failure_mention` from the job first, then falls back to `cron.failure_mention` in config. Successful runs keep their existing delivery behavior.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added cron failure mention helpers in `cron/scheduler.py`.
- Prefix failed cron delivery summaries with the configured mention.
- Added scheduler tests proving failed jobs mention the operator and successful jobs do not.

## How to Test

1. Configure `cron.failure_mention` or set `failure_mention` on a job.
2. Run a failing cron job and verify the delivered failure summary starts with the mention.
3. Run a successful cron job and verify no mention is prefixed.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 LTS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/cron/test_scheduler.py -q
=== Summary: 1 files, 224 tests passed, 0 failed (100% complete) in 17.5s (8 workers) ===
```