### PR TITLE
fix(desktop): preserve pre-tool assistant text on turn complete

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -218,6 +218,36 @@ describe('useMessageStream interim text sealing', () => {
     expect(texts[0]).toBe('partial streamed answer continued')
   })
 
+  it('preserves pre-tool narration when tools arrive without message.interim (#46606)', async () => {
+    // Some runs never emit message.interim before tool.start. Text + tools then
+    // share one streaming bubble; message.complete only carries the last reply.
+    // Completing must not erase the sealed pre-tool half of the bubble.
+    await mountStream()
+    await start()
+
+    await delta('Planning the approach before I touch any files.')
+    await act(() =>
+      handleEvent!({
+        payload: { name: 'read_file', tool_id: 'tc-1', arguments: '{}' },
+        session_id: SID,
+        type: 'tool.start'
+      })
+    )
+    await act(() =>
+      handleEvent!({
+        payload: { name: 'read_file', tool_id: 'tc-1', result: '{"ok":true}' },
+        session_id: SID,
+        type: 'tool.complete'
+      })
+    )
+    await delta('Here is the fix after reading the file.')
+    await complete('Here is the fix after reading the file.')
+
+    const texts = assistantMessages()
+    expect(texts.some(t => t.includes('Planning the approach before I touch any files.'))).toBe(true)
+    expect(texts.some(t => t.includes('Here is the fix after reading the file.'))).toBe(true)
+  })
+
   it('ignores malformed message.interim payload', async () => {
     await mountStream()
     await start()

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -789,17 +789,89 @@ describe('upsertToolPart', () => {
 })
 
 describe('mergeFinalAssistantText', () => {
-  it('removes all text parts and appends the final text', () => {
+  it('removes open-segment text parts and appends the final text', () => {
     const parts = [
       { type: 'text' as const, text: 'streamed delta 1' },
-      { type: 'text' as const, text: 'streamed delta 2' },
-      { type: 'tool-call' as const, toolCallId: 'tc1', toolName: 'terminal', args: {} as never, argsText: '{}' }
+      { type: 'text' as const, text: 'streamed delta 2' }
     ]
 
     const result = mergeFinalAssistantText(parts, 'final answer')
 
     expect(result.filter(p => p.type === 'text')).toHaveLength(1)
     expect(result.filter(p => p.type === 'text')[0]).toMatchObject({ text: 'final answer' })
+  })
+
+  it('preserves pre-tool narration when final text is only the last segment (#46606)', () => {
+    // Live multi-step turn without a reliable message.interim seal: text → tool
+    // → text lives in one bubble. message.complete carries only the last model
+    // reply. Replacing every text part erased the first half until restart.
+    const parts = [
+      { type: 'text' as const, text: 'Planning the approach before I touch any files.' },
+      {
+        type: 'tool-call' as const,
+        toolCallId: 'tc1',
+        toolName: 'read_file',
+        args: {} as never,
+        argsText: '{}'
+      },
+      { type: 'text' as const, text: 'streamed trailing answer' }
+    ]
+
+    const result = mergeFinalAssistantText(parts, 'Here is the fix after reading the file.')
+
+    expect(result.map(p => p.type)).toEqual(['text', 'tool-call', 'text'])
+    expect(result[0]).toMatchObject({ text: 'Planning the approach before I touch any files.' })
+    expect(result[2]).toMatchObject({ text: 'Here is the fix after reading the file.' })
+  })
+
+  it('preserves multiple sealed segments across several tool calls (#46606)', () => {
+    const parts = [
+      { type: 'text' as const, text: 'First I will search.' },
+      {
+        type: 'tool-call' as const,
+        toolCallId: 'tc1',
+        toolName: 'search_files',
+        args: {} as never,
+        argsText: '{}'
+      },
+      { type: 'text' as const, text: 'Now reading the hit.' },
+      {
+        type: 'tool-call' as const,
+        toolCallId: 'tc2',
+        toolName: 'read_file',
+        args: {} as never,
+        argsText: '{}'
+      },
+      { type: 'text' as const, text: 'partial final' }
+    ]
+
+    const result = mergeFinalAssistantText(parts, 'All done.')
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts: result })).toBe(
+      'First I will search.Now reading the hit.All done.'
+    )
+    expect(result.filter(p => p.type === 'tool-call')).toHaveLength(2)
+  })
+
+  it('does not duplicate sealed narration when final already includes it', () => {
+    const parts = [
+      { type: 'text' as const, text: 'Let me check the files.' },
+      {
+        type: 'tool-call' as const,
+        toolCallId: 'tc1',
+        toolName: 'terminal',
+        args: {} as never,
+        argsText: '{}'
+      },
+      { type: 'text' as const, text: 'streamed' }
+    ]
+
+    const result = mergeFinalAssistantText(parts, 'Let me check the files. Everything looks good.')
+
+    expect(result.filter(p => p.type === 'text')).toHaveLength(1)
+    expect(result.filter(p => p.type === 'text')[0]).toMatchObject({
+      text: 'Let me check the files. Everything looks good.'
+    })
     expect(result.some(p => p.type === 'tool-call')).toBe(true)
   })
 
@@ -847,5 +919,24 @@ describe('mergeFinalAssistantText', () => {
 
     expect(result.filter(p => p.type === 'text')).toHaveLength(0)
     expect(result.filter(p => p.type === 'reasoning')).toHaveLength(1)
+  })
+
+  it('keeps sealed pre-tool text when final text is empty', () => {
+    const parts = [
+      { type: 'text' as const, text: 'I will run the check now.' },
+      {
+        type: 'tool-call' as const,
+        toolCallId: 'tc1',
+        toolName: 'terminal',
+        args: {} as never,
+        argsText: '{}'
+      },
+      { type: 'text' as const, text: 'streamed incomplete' }
+    ]
+
+    const result = mergeFinalAssistantText(parts, '')
+
+    expect(result.map(p => p.type)).toEqual(['text', 'tool-call'])
+    expect(result[0]).toMatchObject({ text: 'I will run the check now.' })
   })
 })

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -853,7 +853,7 @@ describe('mergeFinalAssistantText', () => {
     expect(result.filter(p => p.type === 'tool-call')).toHaveLength(2)
   })
 
-  it('does not duplicate sealed narration when final already includes it', () => {
+  it('does not duplicate sealed narration when final is sealed prefix + more', () => {
     const parts = [
       { type: 'text' as const, text: 'Let me check the files.' },
       {
@@ -873,6 +873,53 @@ describe('mergeFinalAssistantText', () => {
       text: 'Let me check the files. Everything looks good.'
     })
     expect(result.some(p => p.type === 'tool-call')).toBe(true)
+  })
+
+  it('keeps short sealed openers even when the final starts the same way', () => {
+    // "OK." is a common pre-tool ack. A final that also starts with "OK." is not
+    // a full-transcript restatement of the sealed half — keep both segments.
+    const parts = [
+      { type: 'text' as const, text: 'OK.' },
+      {
+        type: 'tool-call' as const,
+        toolCallId: 'tc1',
+        toolName: 'terminal',
+        args: {} as never,
+        argsText: '{}'
+      },
+      { type: 'text' as const, text: 'streamed' }
+    ]
+
+    const result = mergeFinalAssistantText(parts, 'OK. Everything looks fine after the check.')
+
+    expect(result.map(p => p.type)).toEqual(['text', 'tool-call', 'text'])
+    expect(result[0]).toMatchObject({ text: 'OK.' })
+    expect(result[2]).toMatchObject({ text: 'OK. Everything looks fine after the check.' })
+  })
+
+  it('does not wipe sealed text when final only mentions it mid-string', () => {
+    const parts = [
+      { type: 'text' as const, text: 'I will search for the config next.' },
+      {
+        type: 'tool-call' as const,
+        toolCallId: 'tc1',
+        toolName: 'search_files',
+        args: {} as never,
+        argsText: '{}'
+      },
+      { type: 'text' as const, text: 'streamed' }
+    ]
+
+    const result = mergeFinalAssistantText(
+      parts,
+      'After the tool ran I will search for the config next. Then we can edit it.'
+    )
+
+    expect(result.map(p => p.type)).toEqual(['text', 'tool-call', 'text'])
+    expect(result[0]).toMatchObject({ text: 'I will search for the config next.' })
+    expect(result[2]).toMatchObject({
+      text: 'After the tool ran I will search for the config next. Then we can edit it.'
+    })
   })
 
   it('drops reasoning that the final text fully covers (reasoning ⊆ final)', () => {

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -142,41 +142,98 @@ export function chatMessageText(message: ChatMessage): string {
 const normalizeWs = (value: string) => value.replace(/\s+/g, ' ').trim()
 
 /**
+ * True for parts that bound streaming segments (tool calls, images, …).
+ * Text/reasoning accumulate within a segment; a boundary seals earlier
+ * narration so `message.complete` cannot wipe it (#46606).
+ */
+function isStreamSegmentBoundary(part: ChatMessagePart): boolean {
+  return part.type !== 'text' && part.type !== 'reasoning'
+}
+
+function sealedPrefixText(parts: readonly ChatMessagePart[]): string {
+  return normalizeWs(
+    parts
+      .filter((part): part is Extract<ChatMessagePart, { type: 'text' }> => part.type === 'text')
+      .map(part => part.text)
+      .join('')
+  )
+}
+
+/**
  * Merge the final assistant text into a message's parts.
  *
- * - Removes all existing `text` parts (they were streamed deltas, now superseded
- *   by the authoritative final response).
+ * Streaming parts are segmented by non-text boundaries (tool-call, image, …):
+ *
+ * - Only the **last** open segment's streamed `text` is superseded by the
+ *   authoritative final response (the current LLM completion).
+ * - Text that appears **before** a boundary is sealed. Gateway
+ *   `message.complete` payloads are typically just the last model reply, not
+ *   the full multi-step transcript. Replacing every text part therefore
+ *   erased pre-tool narration on turn completion while the same content still
+ *   lived in `state.db` and reappeared after restart (#46606).
+ * - If the final text already restates the sealed prefix (full-transcript
+ *   complete / previewed reuse), fall back to replacing all text so we do not
+ *   duplicate narration.
  * - Keeps `reasoning` parts, but drops one that the final text fully covers
  *   (reasoning ⊆ final) — the final restates it. A short final ("Done.") must
  *   NOT swallow a longer reasoning block that merely starts with it (#61447).
  * - Keeps all other part types (tool-call, image, etc.).
- * - Appends the final text as a new text part.
+ * - Appends the final text as a new text part on the open segment.
  */
 export function mergeFinalAssistantText(parts: ChatMessagePart[], finalText: string): ChatMessagePart[] {
   const dedupeReference = normalizeWs(finalText)
 
-  const kept = parts.filter(part => {
-    if (part.type === 'text') {
-      // Sealed text parts were already finalized into their own bubbles —
-      // this filter only runs on the LAST streaming bubble, so there are no
-      // sealed parts here. All text parts are streamed deltas that get
-      // replaced by the authoritative final text.
-      return false
+  const replaceOpenSegment = (segment: ChatMessagePart[]): ChatMessagePart[] => {
+    const kept = segment.filter(part => {
+      if (part.type === 'text') {
+        // Open-segment text is streamed deltas superseded by finalText.
+        return false
+      }
+
+      if (part.type !== 'reasoning' || !dedupeReference) {
+        return true
+      }
+
+      // Reasoning is a restatement only when the final FULLY covers it.
+      // The reverse direction is not considered — a short final must not
+      // swallow a longer reasoning block (#61447).
+      const r = normalizeWs(part.text)
+
+      return !(r && dedupeReference.startsWith(r))
+    })
+
+    return finalText ? [...kept, assistantTextPart(finalText)] : kept
+  }
+
+  let lastBoundary = -1
+
+  for (let index = 0; index < parts.length; index += 1) {
+    if (isStreamSegmentBoundary(parts[index])) {
+      lastBoundary = index
     }
+  }
 
-    if (part.type !== 'reasoning' || !dedupeReference) {
-      return true
-    }
+  // Single open segment (no tools/images yet) — legacy full replace.
+  if (lastBoundary < 0) {
+    return replaceOpenSegment(parts)
+  }
 
-    // Reasoning is a restatement only when the final FULLY covers it.
-    // The reverse direction is not considered — a short final must not
-    // swallow a longer reasoning block (#61447).
-    const r = normalizeWs(part.text)
+  const prefix = parts.slice(0, lastBoundary + 1)
+  const suffix = parts.slice(lastBoundary + 1)
+  const sealedText = sealedPrefixText(prefix)
 
-    return !(r && dedupeReference.startsWith(r))
-  })
+  // Final already restates sealed narration → avoid "Planning." + "Planning. Done."
+  if (
+    sealedText &&
+    dedupeReference &&
+    (dedupeReference === sealedText ||
+      dedupeReference.startsWith(sealedText) ||
+      dedupeReference.includes(sealedText))
+  ) {
+    return replaceOpenSegment(parts)
+  }
 
-  return finalText ? [...kept, assistantTextPart(finalText)] : kept
+  return [...prefix, ...replaceOpenSegment(suffix)]
 }
 
 const ATTACHED_CONTEXT_MARKER_RE = /(?:^|\n)--- Attached Context ---\s*\n/

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -160,6 +160,38 @@ function sealedPrefixText(parts: readonly ChatMessagePart[]): string {
 }
 
 /**
+ * True when `finalNorm` is the sealed prefix itself, or a full-transcript
+ * complete that starts with that prefix and continues.
+ *
+ * Deliberately NOT a bare substring check: short sealed phrases like "OK."
+ * often appear inside a later reply. Treating that as a full restatement would
+ * wipe multi-step narration that should stay visible.
+ */
+function finalRestatesSealedPrefix(finalNorm: string, sealedNorm: string): boolean {
+  if (!finalNorm || !sealedNorm) {
+    return false
+  }
+
+  if (finalNorm === sealedNorm) {
+    return true
+  }
+
+  // Require a real prefix (not a mid-string hit) and enough sealed content that
+  // a coincidence is unlikely. Short openers like "OK." / "Sure." stay sealed.
+  const MIN_SEALED_CHARS = 20
+
+  if (sealedNorm.length < MIN_SEALED_CHARS || !finalNorm.startsWith(sealedNorm)) {
+    return false
+  }
+
+  const rest = finalNorm.slice(sealedNorm.length)
+
+  // Empty rest handled by === above. Continuation should look like more prose
+  // after the sealed block, not a glued different word ("files" + "ystem").
+  return rest.length === 0 || /^[\s.!?,:;)\]]/.test(rest)
+}
+
+/**
  * Merge the final assistant text into a message's parts.
  *
  * Streaming parts are segmented by non-text boundaries (tool-call, image, …):
@@ -173,12 +205,15 @@ function sealedPrefixText(parts: readonly ChatMessagePart[]): string {
  *   lived in `state.db` and reappeared after restart (#46606).
  * - If the final text already restates the sealed prefix (full-transcript
  *   complete / previewed reuse), fall back to replacing all text so we do not
- *   duplicate narration.
+ *   duplicate narration. See `finalRestatesSealedPrefix`.
  * - Keeps `reasoning` parts, but drops one that the final text fully covers
  *   (reasoning ⊆ final) — the final restates it. A short final ("Done.") must
  *   NOT swallow a longer reasoning block that merely starts with it (#61447).
  * - Keeps all other part types (tool-call, image, etc.).
  * - Appends the final text as a new text part on the open segment.
+ *
+ * Callers are responsible for image-echo stripping on `finalText` before
+ * calling this helper (see `use-message-stream`).
  */
 export function mergeFinalAssistantText(parts: ChatMessagePart[], finalText: string): ChatMessagePart[] {
   const dedupeReference = normalizeWs(finalText)
@@ -223,13 +258,7 @@ export function mergeFinalAssistantText(parts: ChatMessagePart[], finalText: str
   const sealedText = sealedPrefixText(prefix)
 
   // Final already restates sealed narration → avoid "Planning." + "Planning. Done."
-  if (
-    sealedText &&
-    dedupeReference &&
-    (dedupeReference === sealedText ||
-      dedupeReference.startsWith(sealedText) ||
-      dedupeReference.includes(sealedText))
-  ) {
+  if (finalRestatesSealedPrefix(dedupeReference, sealedText)) {
     return replaceOpenSegment(parts)
   }
 


### PR DESCRIPTION
## What does this PR do?

Desktop was dropping the first half of multi-step assistant turns once the turn finished.

You would see the model narrate, call tools, answer - then on message.complete the pre-tool narration vanished. It was still in state.db and came back after restart. Display-only bug.

mergeFinalAssistantText replaced every text part in the live bubble with the complete payload. That payload is usually only the last model reply. When earlier narration shared the bubble with tools and message.interim never sealed it first, the pre-tool half got wiped.

## Related issue

Fixes the pre-tool narration wipe path described on #46606 (see mxcrowe's comment).

Does not claim to fix pure long-message head truncation / live render bounds. Separate problem.

## Type of change

- [x] Bug fix

## Changes

- apps/desktop/src/lib/chat-messages.ts - segment-aware mergeFinalAssistantText: tool/image parts seal earlier text; only the open trailing segment is replaced by the final reply. Full-transcript dedupe only when the final is the sealed prefix itself or a real long-enough prefix continuation (no bare substring match, so short "OK." openers do not wipe the turn).
- Unit tests for multi-tool segments, empty final, full-transcript dedupe, short-opener false positive, mid-string mention false positive.
- Stream test: deltas + tools without message.interim, then complete - both halves stay.

Image-echo stripping stays on the caller (use-message-stream), same as main today.

## Why this instead of #53350

Same bug class. Different shape:

| | #53350 | this PR |
|--|--------|---------|
| Hook | new reconcileCompletedTextParts + complete path | extends existing mergeFinalAssistantText |
| Fits current main | older use-message-stream.ts layout | matches today's index.ts choke point |
| No-interim path | yes | yes + stream test |
| Multi-tool sealed segments | partial | explicit test |
| Short-prefix false positive | n/a (always keeps head) | guarded (min length + real prefix) |

Happy to close this if you prefer #53350's shape, or pull any of their cases over. Just pick one.

## How to test

```bash
cd apps/desktop
npx vitest run src/lib/chat-messages.test.ts src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
```

51 passed here.

Manual: model that narrates, tools, then answers. Pre-tool text should still be there after the turn settles. Plain text-only turns should still collapse to the final reply.

## Checklist

- [x] Contributing guide / conventional commits
- [x] Searched existing PRs (related: #53350, closed #61447 - different semantics, not a blind dupe)
- [x] Scoped to this fix
- [x] Tests added
- [x] Desktop-only pure TS; macOS shares the same path
