### PR TITLE
fix(api-server): resume run history by session id

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6504,6 +6504,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
         conversation_history: List[Dict[str, str]] = []
+        conversation_history_provided = "conversation_history" in body
         raw_history = body.get("conversation_history")
         if raw_history:
             if not isinstance(raw_history, list):
@@ -6546,7 +6547,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
         requested_session_id = body.get("session_id")
-        if not conversation_history and requested_session_id:
+        if (
+            not conversation_history_provided
+            and not conversation_history
+            and requested_session_id
+        ):
             requested_session_id, session_id_err = self._parse_session_continuation_id(
                 requested_session_id
             )

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2104,6 +2104,51 @@ class APIServerAdapter(BasePlatformAdapter):
     # that the sanitized form is safe to pass into Honcho / state.db.
     _MAX_SESSION_HEADER_LEN = 256
 
+    def _parse_session_continuation_id(
+        self, raw: Any
+    ) -> tuple[Optional[str], Optional["web.Response"]]:
+        """Validate a caller-supplied session ID before loading its transcript."""
+        if raw is None:
+            return None, None
+        if not isinstance(raw, str):
+            return None, web.json_response(
+                _openai_error("Invalid session ID", code="invalid_session_id"),
+                status=400,
+            )
+        session_id = raw.strip()
+        if not session_id:
+            return None, None
+
+        # Session continuation exposes persisted conversation history. Keep
+        # every transport behind the same explicit API-key boundary rather
+        # than relying on _check_auth's unsupported no-key/manual-wiring path.
+        if not self._api_key:
+            logger.warning(
+                "Session continuation rejected: no API key configured. "
+                "Set API_SERVER_KEY to enable session continuity."
+            )
+            return None, web.json_response(
+                _openai_error(
+                    "Session continuation requires API key authentication. "
+                    "Configure API_SERVER_KEY to enable this feature."
+                ),
+                status=403,
+            )
+
+        from gateway.session import _is_path_unsafe
+
+        if re.search(r'[\r\n\x00]', session_id) or _is_path_unsafe(session_id):
+            return None, web.json_response(
+                _openai_error("Invalid session ID", code="invalid_session_id"),
+                status=400,
+            )
+        if len(session_id) > self._MAX_SESSION_HEADER_LEN:
+            return None, web.json_response(
+                _openai_error("Session ID too long", code="invalid_session_id"),
+                status=400,
+            )
+        return session_id, None
+
     def _parse_session_key_header(
         self, request: "web.Request"
     ) -> tuple[Optional[str], Optional["web.Response"]]:
@@ -4091,37 +4136,12 @@ class APIServerAdapter(BasePlatformAdapter):
         # only allowed when the API key is configured and the request is
         # authenticated.  Without this gate, any unauthenticated client could
         # read arbitrary session history by guessing/enumerating session IDs.
-        provided_session_id = request.headers.get("X-Hermes-Session-Id", "").strip()
+        provided_session_id, session_id_err = self._parse_session_continuation_id(
+            request.headers.get("X-Hermes-Session-Id")
+        )
+        if session_id_err is not None:
+            return session_id_err
         if provided_session_id:
-            if not self._api_key:
-                logger.warning(
-                    "Session continuation via X-Hermes-Session-Id rejected: "
-                    "no API key configured.  Set API_SERVER_KEY to enable "
-                    "session continuity."
-                )
-                return web.json_response(
-                    _openai_error(
-                        "Session continuation requires API key authentication. "
-                        "Configure API_SERVER_KEY to enable this feature."
-                    ),
-                    status=403,
-                )
-            # Sanitize: reject control characters that could enable header
-            # injection, and path-traversal-shaped IDs that would escape the
-            # sessions directory when interpolated into on-disk artifact
-            # filenames (session snapshots, request dumps). Mirrors the native
-            # gateway's entry-boundary guard (gateway.session._is_path_unsafe).
-            from gateway.session import _is_path_unsafe
-            if re.search(r'[\r\n\x00]', provided_session_id) or _is_path_unsafe(provided_session_id):
-                return web.json_response(
-                    {"error": {"message": "Invalid session ID", "type": "invalid_request_error"}},
-                    status=400,
-                )
-            if len(provided_session_id) > self._MAX_SESSION_HEADER_LEN:
-                return web.json_response(
-                    {"error": {"message": "Session ID too long", "type": "invalid_request_error"}},
-                    status=400,
-                )
             session_id = provided_session_id
             try:
                 db = await self._ensure_session_db_async()
@@ -6525,7 +6545,19 @@ class APIServerAdapter(BasePlatformAdapter):
                         )
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
-        session_id = body.get("session_id") or stored_session_id
+        requested_session_id = body.get("session_id")
+        if not conversation_history and requested_session_id:
+            requested_session_id, session_id_err = self._parse_session_continuation_id(
+                requested_session_id
+            )
+            if session_id_err is not None:
+                return session_id_err
+            if requested_session_id:
+                conversation_history = await self._conversation_history_for_session(
+                    requested_session_id
+                )
+
+        session_id = requested_session_id or stored_session_id
         route = self._resolve_route(body.get("model"))
         agent_overrides = _request_agent_overrides(body, virtual_model=self._model_name)
         selection_error = self._request_route_conflict_error(

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -274,8 +274,17 @@ class TestStartRun:
         assert auth_adapter._run_statuses == {}
 
     @pytest.mark.asyncio
-    async def test_explicit_history_takes_precedence_over_session_db(self, auth_adapter):
-        explicit_history = [{"role": "user", "content": "client-provided history"}]
+    @pytest.mark.parametrize(
+        "explicit_history",
+        [
+            [{"role": "user", "content": "client-provided history"}],
+            [],
+        ],
+        ids=["populated", "empty"],
+    )
+    async def test_explicit_history_takes_precedence_over_session_db(
+        self, auth_adapter, explicit_history
+    ):
         app = _create_runs_app(auth_adapter)
         with (
             patch.object(

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -11,7 +11,7 @@ Covers:
 import asyncio
 import threading
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
@@ -24,6 +24,7 @@ from gateway.platforms.api_server import (
     cors_middleware,
     security_headers_middleware,
 )
+from hermes_state import SessionDB
 from tools import approval as approval_mod
 
 
@@ -146,17 +147,17 @@ class TestStartRun:
                 assert status["object"] == "hermes.run"
 
     @pytest.mark.asyncio
-    async def test_start_binds_chat_id_for_delegation_wake_target(self, adapter):
+    async def test_start_binds_chat_id_for_delegation_wake_target(self, auth_adapter):
         """/v1/runs must bind the raw session id as the api_server chat_id
         (like every other agent-entry route does via _run_agent): the async
         delegation dispatch reads HERMES_SESSION_CHAT_ID to pick its wake
         self-post target, and an empty binding forces background delegations
         on this route back to synchronous execution."""
-        app = _create_runs_app(adapter)
+        app = _create_runs_app(auth_adapter)
         captured = {}
 
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_create_agent") as mock_create:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
                 mock_agent = MagicMock()
 
                 def _capture_run(user_message=None, conversation_history=None, task_id=None):
@@ -174,13 +175,17 @@ class TestStartRun:
                 resp = await cli.post(
                     "/v1/runs",
                     json={"input": "hello", "session_id": "runs-raw-sid"},
+                    headers={"Authorization": "Bearer sk-secret"},
                 )
                 assert resp.status == 202
                 data = await resp.json()
                 run_id = data["run_id"]
 
                 for _ in range(40):
-                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status_resp = await cli.get(
+                        f"/v1/runs/{run_id}",
+                        headers={"Authorization": "Bearer sk-secret"},
+                    )
                     status = await status_resp.json()
                     if status["status"] == "completed":
                         break
@@ -190,6 +195,125 @@ class TestStartRun:
             "runs route must bind chat_id so delegation dispatch sees a wake target"
         )
 
+    @pytest.mark.asyncio
+    async def test_start_with_session_id_loads_persisted_history(self, auth_adapter, tmp_path):
+        db = SessionDB(tmp_path / "state.db")
+        auth_adapter._session_db = db
+        session_id = db.create_session("continued-session", "api_server")
+        db.append_message(session_id, "user", "earlier question")
+        db.append_message(session_id, "assistant", "earlier answer")
+
+        app = _create_runs_app(auth_adapter)
+        try:
+            async with TestClient(TestServer(app)) as cli:
+                with patch.object(auth_adapter, "_create_agent") as mock_create:
+                    mock_agent = MagicMock()
+                    mock_agent.run_conversation.return_value = {"final_response": "done"}
+                    mock_agent.session_prompt_tokens = 0
+                    mock_agent.session_completion_tokens = 0
+                    mock_agent.session_total_tokens = 0
+                    mock_create.return_value = mock_agent
+
+                    resp = await cli.post(
+                        "/v1/runs",
+                        json={"input": "follow-up", "session_id": session_id},
+                        headers={"Authorization": "Bearer sk-secret"},
+                    )
+                    assert resp.status == 202
+                    await resp.json()
+                    for _ in range(20):
+                        if mock_agent.run_conversation.called:
+                            break
+                        await asyncio.sleep(0.01)
+
+                    assert mock_agent.run_conversation.called
+                    loaded_history = mock_agent.run_conversation.call_args.kwargs[
+                        "conversation_history"
+                    ]
+                    assert [
+                        {"role": message["role"], "content": message["content"]}
+                        for message in loaded_history
+                    ] == [
+                        {"role": "user", "content": "earlier question"},
+                        {"role": "assistant", "content": "earlier answer"},
+                    ]
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    async def test_session_history_fallback_requires_configured_api_key(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs",
+                json={"input": "follow-up", "session_id": "private-session"},
+            )
+
+        assert resp.status == 403
+        assert adapter._run_streams == {}
+        assert adapter._run_statuses == {}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "session_id",
+        ["../../private", "/absolute", "..\\windows", "bad\x00id", 123, "x" * 257],
+    )
+    async def test_session_history_fallback_rejects_invalid_id(
+        self, auth_adapter, session_id
+    ):
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs",
+                json={"input": "follow-up", "session_id": session_id},
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+
+        assert resp.status == 400
+        assert auth_adapter._run_streams == {}
+        assert auth_adapter._run_statuses == {}
+
+    @pytest.mark.asyncio
+    async def test_explicit_history_takes_precedence_over_session_db(self, auth_adapter):
+        explicit_history = [{"role": "user", "content": "client-provided history"}]
+        app = _create_runs_app(auth_adapter)
+        with (
+            patch.object(
+                auth_adapter,
+                "_conversation_history_for_session",
+                new_callable=AsyncMock,
+            ) as mock_load_history,
+            patch.object(auth_adapter, "_create_agent") as mock_create,
+        ):
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "done"}
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            mock_create.return_value = mock_agent
+
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "follow-up",
+                        "session_id": "continued-session",
+                        "conversation_history": explicit_history,
+                    },
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert resp.status == 202
+                await resp.json()
+                for _ in range(20):
+                    if mock_agent.run_conversation.called:
+                        break
+                    await asyncio.sleep(0.01)
+
+        assert mock_agent.run_conversation.called
+        mock_load_history.assert_not_awaited()
+        assert mock_agent.run_conversation.call_args.kwargs[
+            "conversation_history"
+        ] == explicit_history
 
     @pytest.mark.asyncio
     async def test_start_rejects_conflicting_route_and_request_provider(self):
@@ -267,10 +391,10 @@ class TestStartRun:
 class TestRunStatus:
 
     @pytest.mark.asyncio
-    async def test_status_reflects_explicit_session_id(self, adapter):
-        app = _create_runs_app(adapter)
+    async def test_status_reflects_explicit_session_id(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_create_agent") as mock_create:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
                 mock_agent = MagicMock()
                 mock_agent.run_conversation.return_value = {"final_response": "done"}
                 mock_agent.session_prompt_tokens = 0
@@ -281,12 +405,16 @@ class TestRunStatus:
                 resp = await cli.post(
                     "/v1/runs",
                     json={"input": "hello", "session_id": "space-session"},
+                    headers={"Authorization": "Bearer sk-secret"},
                 )
                 data = await resp.json()
                 run_id = data["run_id"]
 
                 for _ in range(20):
-                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status_resp = await cli.get(
+                        f"/v1/runs/{run_id}",
+                        headers={"Authorization": "Bearer sk-secret"},
+                    )
                     status = await status_resp.json()
                     if status["status"] == "completed":
                         break


### PR DESCRIPTION
## What does this PR do?

Restores persisted SessionDB history when `POST /v1/runs` continues an existing `session_id` without supplying another history source.

Before this change, the run was created and persisted under the requested session, but `AIAgent.run_conversation()` received an empty `conversation_history`. Follow-up turns therefore behaved like first turns even while the durable transcript kept growing.

The fallback runs only after the existing history sources, preserving this precedence:

1. Explicit `conversation_history`
2. Stored `previous_response_id`
3. History embedded in a multi-message `input`
4. Persisted SessionDB history for `session_id`

SessionDB continuation uses the same boundary as `X-Hermes-Session-Id`: a configured/authenticated API key is required, and the session ID is type-, length-, control-character-, and path-safety-validated before any transcript read. The shared parser keeps both transports on one policy.

## Relationship to #20295

#20295 identified the same root parity gap. This PR is a current-`main` salvage that incorporates the follow-up requirements from its sweeper review:

- uses `_conversation_history_for_session()` instead of a synchronous direct SQLite read;
- applies the existing API-key and session-ID continuation boundary;
- includes a seeded real-SessionDB HTTP regression test;
- proves explicit request history takes precedence over the DB fallback.

## Why the existing API documentation stays unchanged

The current documentation says that `session_id` is surfaced in run status so external UIs can correlate runs with their own conversations. That remains true after this PR: the status and correlation behavior are unchanged.

This fix fills the missing server-side continuation step when the same ID already names a persisted Hermes session and the request provides no stronger history source. The request and response shapes do not change, so no documentation wording change is included.

## Related Issue

Fixes #62732

#69204 independently reported the same bug and is labeled as a duplicate of #62732.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security hardening for the continuation path
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

- Add SessionDB history as the final fallback in `APIServerAdapter._handle_runs`.
- Share API-key and session-ID validation between header and Runs continuation.
- Add real SessionDB, auth, invalid-ID, and explicit-precedence regression coverage.

## How to Test

```bash
python -m pytest \
  tests/gateway/test_api_server_runs.py \
  tests/gateway/test_session_api.py \
  tests/gateway/test_api_server.py::TestSessionIdHeader -q
```

Result after rebasing onto current `main` (`5a23e3c52`): `39 passed` (`25` Runs + `12` Session API + `2` Session-ID header contract).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs and compared #20295
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on macOS with Python 3.12

### Documentation & Housekeeping

- [x] Relevant documentation — N/A; existing Runs API wording remains accurate
- [x] `cli-config.yaml.example` — N/A; no config changes
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; no architecture/workflow changes
- [x] Cross-platform impact considered — platform-neutral Python/SQLite path
- [x] Tool descriptions/schemas — N/A
