### PR TITLE
fix(discord): resolve outbound @Name mentions to real <@id> (opt-in)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2866,6 +2866,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
                 return result
 
+            # Resolve readable @Name references into real <@id> mentions (opt-in
+            # via DISCORD_RESOLVE_MENTIONS) so the model can actually ping a user or
+            # another bot by name; a bare "@Name" from an LLM is otherwise inert text.
+            content = await self._resolve_outbound_mentions(content, channel)
             # Format and split message if needed
             formatted = self.format_message(content)
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
@@ -4783,6 +4787,46 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to get chat info for %s: %s", self.name, chat_id, e, exc_info=True)
             return {"name": str(chat_id), "type": "dm", "error": str(e)}
+
+    async def _resolve_outbound_mentions(self, content: str, channel: Any) -> str:
+        """Rewrite readable ``@Name`` references in an OUTGOING message into real
+        Discord mentions (``<@id>``) so the bot can actually ping a user or another
+        bot by name. Opt-in via ``DISCORD_RESOLVE_MENTIONS`` (unset/false = no change).
+
+        LLMs reliably emit a friendly ``@Display Name`` instead of the raw ``<@id>``
+        Discord requires, so without this a bot's attempt to tag someone is inert
+        plain text. Matching is against the guild's own members (name / display_name /
+        global_name, case-insensitive, longest name first so ``@neko bot`` wins over a
+        member named ``neko``); ``@everyone``/roles stay governed by ``allowed_mentions``.
+        """
+        if os.getenv("DISCORD_RESOLVE_MENTIONS", "false").strip().lower() not in ("1", "true", "yes"):
+            return content
+        if not content or "@" not in content:
+            return content
+        guild = getattr(channel, "guild", None)
+        if guild is None:
+            return content
+        pairs = []
+        seen = set()
+        for member in (getattr(guild, "members", None) or []):
+            uid = str(member.id)
+            for nm in (getattr(member, "display_name", None),
+                       getattr(member, "global_name", None),
+                       getattr(member, "name", None)):
+                key = (nm.lower(), uid) if nm else None
+                if nm and key not in seen:
+                    seen.add(key)
+                    pairs.append((nm, uid))
+        # Longest names first so "@neko bot" resolves before a member named "neko".
+        pairs.sort(key=lambda p: len(p[0]), reverse=True)
+        for nm, uid in pairs:
+            token = f"<@{uid}>"
+            if token in content:
+                continue  # already a real mention
+            pat = re.compile(r"(?<![\w<@])@" + re.escape(nm) + r"(?![\w])", re.IGNORECASE)
+            if pat.search(content):
+                content = pat.sub(token, content)
+        return content
 
     async def _resolve_allowed_usernames(self) -> None:
         """

--- a/tests/gateway/test_discord_outbound_mentions.py
+++ b/tests/gateway/test_discord_outbound_mentions.py
@@ -1,0 +1,87 @@
+"""Unit tests for the Discord adapter's opt-in outbound mention resolution.
+
+The method is AST-extracted and executed in isolation so the test needs no live
+Discord client or the adapter's heavier imports.
+"""
+import ast
+import asyncio
+import os
+import re
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_root = _HERE
+for _ in range(6):
+    if os.path.isdir(os.path.join(_root, "plugins", "platforms", "discord")):
+        break
+    _root = os.path.dirname(_root)
+_ADAPTER = os.path.join(_root, "plugins", "platforms", "discord", "adapter.py")
+
+
+def _load_resolver():
+    fn = next(
+        n for n in ast.walk(ast.parse(open(_ADAPTER).read()))
+        if isinstance(n, ast.AsyncFunctionDef) and n.name == "_resolve_outbound_mentions"
+    )
+    mod = ast.fix_missing_locations(ast.Module(body=[fn], type_ignores=[]))
+    ns = {"os": os, "re": re, "Any": object}
+    exec(compile(mod, _ADAPTER, "exec"), ns)
+    return ns["_resolve_outbound_mentions"]
+
+
+class _Member:
+    def __init__(self, id, display_name=None, name=None, global_name=None):
+        self.id = id
+        self.display_name = display_name
+        self.name = name
+        self.global_name = global_name
+
+
+class _Guild:
+    def __init__(self, members):
+        self.members = members
+
+
+class _Channel:
+    def __init__(self, guild):
+        self.guild = guild
+
+
+def _run(content, flag="true"):
+    resolve = _load_resolver()
+    guild = _Guild([
+        _Member(200, display_name="Support Bot", name="supportbot"),
+        _Member(300, display_name="Alice", name="alice"),
+        _Member(400, display_name="Al", name="al"),
+    ])
+    ch = _Channel(guild)
+    if flag is None:
+        os.environ.pop("DISCORD_RESOLVE_MENTIONS", None)
+    else:
+        os.environ["DISCORD_RESOLVE_MENTIONS"] = flag
+    return asyncio.run(resolve(object(), content, ch))
+
+
+@pytest.mark.parametrize("content,expected", [
+    ("@Support Bot can you take this?", "<@200> can you take this?"),   # multi-word name
+    ("@support bot pls", "<@200> pls"),                                 # case-insensitive
+    ("hey @Alice and @Support Bot", "hey <@300> and <@200>"),           # multiple, longest-first
+    ("<@200> already tagged", "<@200> already tagged"),                 # already a real mention
+    ("mail me@example.com", "mail me@example.com"),                     # not a mention (word-char before @)
+    ("@Nobody here", "@Nobody here"),                                   # unknown name untouched
+])
+def test_resolves_when_enabled(content, expected):
+    assert _run(content, "true") == expected
+
+
+def test_noop_when_disabled():
+    assert _run("@Support Bot hi", "false") == "@Support Bot hi"
+
+
+def test_noop_when_unset():
+    assert _run("@Support Bot hi", None) == "@Support Bot hi"
+
+
+def test_shorter_name_still_resolves_alone():
+    assert _run("ping @Al now", "true") == "ping <@400> now"

--- a/tests/gateway/test_discord_outbound_mentions.py
+++ b/tests/gateway/test_discord_outbound_mentions.py
@@ -1,33 +1,15 @@
 """Unit tests for the Discord adapter's opt-in outbound mention resolution.
 
-The method is AST-extracted and executed in isolation so the test needs no live
-Discord client or the adapter's heavier imports.
+Exercises the real method on an init-bypassed adapter instance so the test
+rides the module's real import path (it would fail if adapter.py stopped
+importing re/os), without reading or exec'ing the adapter source.
 """
-import ast
 import asyncio
 import os
-import re
 
 import pytest
 
-_HERE = os.path.dirname(os.path.abspath(__file__))
-_root = _HERE
-for _ in range(6):
-    if os.path.isdir(os.path.join(_root, "plugins", "platforms", "discord")):
-        break
-    _root = os.path.dirname(_root)
-_ADAPTER = os.path.join(_root, "plugins", "platforms", "discord", "adapter.py")
-
-
-def _load_resolver():
-    fn = next(
-        n for n in ast.walk(ast.parse(open(_ADAPTER).read()))
-        if isinstance(n, ast.AsyncFunctionDef) and n.name == "_resolve_outbound_mentions"
-    )
-    mod = ast.fix_missing_locations(ast.Module(body=[fn], type_ignores=[]))
-    ns = {"os": os, "re": re, "Any": object}
-    exec(compile(mod, _ADAPTER, "exec"), ns)
-    return ns["_resolve_outbound_mentions"]
+from plugins.platforms.discord.adapter import DiscordAdapter
 
 
 class _Member:
@@ -49,7 +31,9 @@ class _Channel:
 
 
 def _run(content, flag="true"):
-    resolve = _load_resolver()
+    # Bypass the heavy __init__ (needs a live client); the method under test
+    # reads no instance state, only the env flag and channel.guild.members.
+    adapter = object.__new__(DiscordAdapter)
     guild = _Guild([
         _Member(200, display_name="Support Bot", name="supportbot"),
         _Member(300, display_name="Alice", name="alice"),
@@ -60,7 +44,7 @@ def _run(content, flag="true"):
         os.environ.pop("DISCORD_RESOLVE_MENTIONS", None)
     else:
         os.environ["DISCORD_RESOLVE_MENTIONS"] = flag
-    return asyncio.run(resolve(object(), content, ch))
+    return asyncio.run(adapter._resolve_outbound_mentions(content, ch))
 
 
 @pytest.mark.parametrize("content,expected", [


### PR DESCRIPTION
## What

Adds **opt-in** outbound mention resolution to the Discord adapter. When `DISCORD_RESOLVE_MENTIONS` is enabled, a bot's readable `@Display Name` in an outgoing message is rewritten to a real `<@id>` mention so it actually pings.

Fixes #ISSUE.

## Why

An LLM reliably writes `@Name` rather than the raw `<@123...>` Discord requires, so an agent's attempt to tag a user, or hand off to another bot, currently comes out as inert plain text. The **Feishu** adapter already resolves mentions on outbound; this brings Discord to parity, reusing the guild-member name→ID matching the Discord adapter already has in `_resolve_allowed_usernames`.

## How

- New `_resolve_outbound_mentions(content, channel)`: matches guild members by `name` / `display_name` / `global_name` (case-insensitive, longest name first so `@Support Bot` wins over a member named `Support`) and rewrites `@Name` → `<@id>`.
- Called once in `send()`, before `format_message()`.
- **Opt-in and inert by default**: with `DISCORD_RESOLVE_MENTIONS` unset/false the method returns the content unchanged, so behavior is byte-identical for every existing deployment.
- Only user mentions are produced; `@everyone`/roles remain governed by the existing `allowed_mentions` safe defaults. Already-formed `<@id>`, emails (`me@host`), and unknown names are left untouched.

## Tests

Unit tests cover: name→mention, case-insensitivity, multiple names in one message, flag-off no-op, already-real mention untouched, and email / unknown-name left alone.
