### PR TITLE
feat(junie-acp): add JetBrains Junie coding agent via ACP

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -655,8 +655,9 @@ def init_agent(
     if (
         api_mode is None
         and agent.api_mode == "chat_completions"
-        and agent.provider != "copilot-acp"
+        and agent.provider not in {"copilot-acp", "junie-acp"}
         and not str(agent.base_url or "").lower().startswith("acp://copilot")
+        and not str(agent.base_url or "").lower().startswith("acp://junie")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
         and (
@@ -1099,7 +1100,7 @@ def init_agent(
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
             if _provider_timeout is not None:
                 client_kwargs["timeout"] = _provider_timeout
-            if agent.provider == "copilot-acp":
+            if agent.provider in {"copilot-acp", "junie-acp"}:
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1873,6 +1873,17 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
+    if agent.provider == "junie-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://junie"):
+        from agent.junie_acp_client import JunieACPClient
+
+        client = JunieACPClient(**client_kwargs)
+        _ra().logger.info(
+            "Junie ACP client created (%s, shared=%s) %s",
+            reason,
+            shared,
+            agent._client_log_context(),
+        )
+        return client
     if agent.provider == "gemini":
         from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -295,6 +295,10 @@ _PROVIDER_ALIASES = {
     "github-models": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    # JetBrains Junie (ACP coding agent)
+    "jetbrains-junie-acp": "junie-acp",
+    "junie-acp-agent": "junie-acp",
+    "junie": "junie-acp",
     "tencent": "tencent-tokenhub",
     "tokenhub": "tencent-tokenhub",
     "tencent-cloud": "tencent-tokenhub",
@@ -1634,6 +1638,12 @@ def _maybe_wrap_anthropic(
     try:
         from agent.copilot_acp_client import CopilotACPClient
         if _safe_isinstance(client_obj, CopilotACPClient):
+            return client_obj
+    except ImportError:
+        pass
+    try:
+        from agent.junie_acp_client import JunieACPClient
+        if _safe_isinstance(client_obj, JunieACPClient):
             return client_obj
     except ImportError:
         pass
@@ -4606,6 +4616,12 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
             return sync_client, model
     except ImportError:
         pass
+    try:
+        from agent.junie_acp_client import JunieACPClient
+        if isinstance(sync_client, JunieACPClient):
+            return sync_client, model
+    except ImportError:
+        pass
 
     async_kwargs = {
         "api_key": sync_client.api_key,
@@ -5263,26 +5279,31 @@ def resolve_provider_client(
             or _read_main_model(),
             provider,
         )
-        if provider == "copilot-acp":
+        if provider in {"copilot-acp", "junie-acp"}:
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()
             command = str(creds.get("command", "")).strip() or None
             args = list(creds.get("args") or [])
             if not final_model:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but no model "
-                    "was provided or configured"
+                    "resolve_provider_client: %s requested but no model "
+                    "was provided or configured",
+                    provider,
                 )
                 return None, None
             if not api_key or not base_url:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but external "
-                    "process credentials are incomplete"
+                    "resolve_provider_client: %s requested but external "
+                    "process credentials are incomplete",
+                    provider,
                 )
                 return None, None
-            from agent.copilot_acp_client import CopilotACPClient
+            if provider == "junie-acp":
+                from agent.junie_acp_client import JunieACPClient as _ACPClient
+            else:
+                from agent.copilot_acp_client import CopilotACPClient as _ACPClient
 
-            client = CopilotACPClient(
+            client = _ACPClient(
                 api_key=api_key,
                 base_url=base_url,
                 command=command,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1451,8 +1451,9 @@ def run_conversation(
                 # stream.  Mirror the ACP exclusion used for Responses
                 # API upgrade (lines ~1083-1085).
                 elif (
-                    agent.provider in {"copilot-acp"}
+                    agent.provider in {"copilot-acp", "junie-acp"}
                     or str(agent.base_url or "").lower().startswith("acp://copilot")
+                    or str(agent.base_url or "").lower().startswith("acp://junie")
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
                 ):
                     _use_streaming = False

--- a/agent/junie_acp_client.py
+++ b/agent/junie_acp_client.py
@@ -1,0 +1,1169 @@
+"""OpenAI-compatible shim that forwards Hermes requests to `junie --acp=true`.
+
+This adapter lets Hermes treat the JetBrains Junie CLI's ACP server as a
+chat-style backend. Each request starts a short-lived ACP session, sends the
+formatted conversation as a single prompt, collects text chunks, and converts
+the result back into the minimal shape Hermes expects from an OpenAI client.
+
+The JSON-RPC / stdio plumbing is delegated to the official Agent Client
+Protocol Python SDK (``agent-client-protocol``): Hermes acts as an ACP *client*
+(:class:`acp.ClientSideConnection`) driving the Junie agent subprocess, and a
+small :class:`_HermesClient` implements the client-side callbacks (fs reads/
+writes, permission prompts, and streamed ``session/update`` notifications).
+
+The SDK is asyncio-native, but Hermes calls ``chat.completions.create`` on a
+synchronous code path (see ``agent/chat_completion_helpers.py``). We therefore
+own a dedicated asyncio event loop on a background daemon thread and bridge each
+request with :func:`asyncio.run_coroutine_threadsafe`.
+
+Junie specifics (vs Copilot):
+  * launched as ``junie --acp=true`` (Copilot uses ``copilot --acp --stdio``);
+  * auth is supplied via ``--auth <token>`` / ``JUNIE_API_KEY`` rather than
+    being wholly owned by the CLI;
+  * Junie wraps each JSON-RPC message with an extra
+    ``"type": "com.agentclientprotocol.rpc.*"`` envelope field, which the SDK's
+    parser simply ignores (messages are matched by ``id`` / ``method``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import contextlib
+import json
+import logging
+import os
+from collections import deque
+import shlex
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from agent.file_safety import get_read_block_error, is_write_denied
+from agent.redact import redact_sensitive_text
+
+logger = logging.getLogger(__name__)
+
+# The ACP SDK is an optional dependency (the ``acp`` extra). Import lazily-ish:
+# module import must succeed for the pure helpers below (imported by tests and
+# by callers that only touch resolution logic), but actually driving a Junie
+# subprocess requires the SDK. ``_require_acp`` raises a clear, actionable error
+# when it is missing.
+try:  # pragma: no cover - trivial import guard
+    import acp as _acp  # noqa: N813
+    from acp.exceptions import RequestError
+    from acp.schema import (
+        AllowedOutcome,
+        ClientCapabilities,
+        DeniedOutcome,
+        FileSystemCapabilities,
+        Implementation,
+        ReadTextFileResponse,
+        RequestPermissionResponse,
+    )
+
+    _ACP_IMPORT_ERROR: Exception | None = None
+except Exception as _exc:  # pragma: no cover - only hit without the extra
+    _acp = None  # type: ignore[assignment]
+    _ACP_IMPORT_ERROR = _exc
+
+
+ACP_MARKER_BASE_URL = "acp://junie"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+# Used when the caller passes an explicit "no timeout" (httpx.Timeout(None)):
+# a long-but-finite ceiling so a legitimate long coding run isn't cut at 900s
+# but a truly hung subprocess still eventually unblocks.
+_NO_TIMEOUT_FALLBACK_SECONDS = 3600.0
+# Handshake (JVM cold start) can be slow; give initialize/session-setup room.
+_HANDSHAKE_TIMEOUT_SECONDS = 90.0
+# Per-call caps inside a turn so a wedged (but still "alive") reused process
+# fails fast on session/new — recovering on a fresh process — instead of
+# hanging the whole request until the outer turn timeout.
+_SESSION_NEW_TIMEOUT_SECONDS = 60.0
+_CONFIG_OPTION_TIMEOUT_SECONDS = 15.0
+# stdin reader buffer for the agent subprocess. Junie streams large tool_call
+# payloads (file contents) on a single line; the SDK default (64KB) would raise
+# LimitOverrunError, so match the SDK's own 50MB ceiling for multimodal data.
+_STDIO_LIMIT_BYTES = 50 * 1024 * 1024
+# After session/prompt returns, wait until Junie has been quiet for this long
+# before finalizing — the ACP completion response can precede a trailing
+# agent_message_chunk / task finalization, and the latency that matters is the
+# real subprocess stdout-flush / GC delay (NOT in-process dispatch), so keep the
+# original conservative gap. Capped by ``_SETTLE_MAX_SECONDS``. Tests override
+# both to tiny values (see tests/agent/test_junie_acp_client.py:_make_client).
+_SETTLE_QUIET_GAP_SECONDS = 2.5
+_SETTLE_MAX_SECONDS = 20.0
+
+# Junie's ACP session/update kinds that report tool activity. Unlike an OpenAI
+# model, Junie is an autonomous agent that EXECUTES its own tools and reports
+# them here (status pending -> in_progress -> completed/failed) — these are NOT
+# delegation requests for Hermes to run. We consume them for observability, not
+# to fabricate OpenAI tool_calls (see JunieACPClient._create_chat_completion).
+_TOOL_UPDATE_KINDS = ("tool_call", "tool_call_update")
+
+# Model values that mean "let Junie use its own default" — the provider
+# sentinel/aliases, not real Junie model ids. These are NOT forwarded to
+# session/set_config_option{model}.
+_MODEL_PASSTHROUGH_SENTINELS = frozenset({
+    "junie-acp", "junie", "jetbrains-junie-acp", "junie-acp-agent", "",
+})
+
+# Prefer approving *once*: only grant persistent auto-approval if a request
+# offers no single-shot option (see _choose_permission_option).
+_ALLOW_OPTION_KINDS = ("allow_once", "allow_always")
+
+
+def _client_capabilities() -> Any:
+    """The ClientCapabilities Hermes advertises to Junie (fs on, no terminal)."""
+    return ClientCapabilities(
+        fs=FileSystemCapabilities(read_text_file=True, write_text_file=True),
+        terminal=False,
+    )
+
+
+def _client_info() -> Any:
+    return Implementation(name="hermes-agent", title="Hermes Agent", version="0.0.0")
+
+
+def _require_acp() -> None:
+    if _acp is None:
+        raise RuntimeError(
+            "The Agent Client Protocol SDK is required for the junie-acp provider. "
+            "Install it with `pip install 'hermes-agent[acp]'` (or "
+            "`pip install agent-client-protocol`)."
+        ) from _ACP_IMPORT_ERROR
+
+
+def _rough_tokens(text: str | None) -> int:
+    """Rough token estimate (~4 chars/token). Used only as a fallback when
+    Junie does not report usage; see JunieACPClient._create_chat_completion."""
+    return len(text) // 4 if text else 0
+
+
+def _resolve_command() -> str:
+    return (
+        os.getenv("HERMES_JUNIE_ACP_COMMAND", "").strip()
+        or os.getenv("JUNIE_CLI_PATH", "").strip()
+        or "junie"
+    )
+
+
+def _resolve_args() -> list[str]:
+    raw = os.getenv("HERMES_JUNIE_ACP_ARGS", "").strip()
+    args = shlex.split(raw) if raw else ["--acp=true", "--skip-update-check"]
+    # Inject auth from the environment when the caller hasn't already supplied
+    # a token via --auth. Junie accepts a JetBrains/Junie token (perm-...).
+    if "--auth" not in args and not any(a.startswith("--auth=") for a in args):
+        token = os.getenv("JUNIE_API_KEY", "").strip()
+        if token:
+            args = args + ["--auth", token]
+    return args
+
+
+def _resolve_permission_policy() -> str:
+    """How the client answers Junie's session/request_permission requests.
+
+    "deny" (default, safe): reject every request (Junie can't act without
+    explicit consent — matters only when Brave Mode is OFF). "allow": approve
+    once. This is the seam a future Hermes-approval bridge would replace.
+    """
+    val = os.getenv("HERMES_JUNIE_ACP_PERMISSION", "").strip().lower()
+    return "allow" if val in ("allow", "allow_once", "yes", "1", "true") else "deny"
+
+
+def _resolve_brave_override() -> bool | None:
+    """Optional override for Junie's Brave Mode (auto-execute without asking).
+
+    Returns True/False to force it via session/set_config_option, or None to
+    leave Junie on its own persisted/default setting.
+    """
+    val = os.getenv("HERMES_JUNIE_ACP_BRAVE", "").strip().lower()
+    if val in ("on", "1", "true", "yes"):
+        return True
+    if val in ("off", "0", "false", "no"):
+        return False
+    return None
+
+
+def _resolve_home_dir() -> str:
+    """Return a stable HOME for child ACP processes."""
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        return home
+
+    expanded = os.path.expanduser("~")
+    if expanded and expanded != "~":
+        return expanded
+
+    try:
+        import pwd
+
+        resolved = pwd.getpwuid(os.getuid()).pw_dir.strip()  # windows-footgun: ok — POSIX fallback inside try/except (pwd import fails on Windows)
+        if resolved:
+            return resolved
+    except Exception:
+        pass
+
+    # Last resort: /tmp (writable on any POSIX system). Avoids crashing the
+    # subprocess with no HOME; callers can set HERMES_HOME explicitly if they
+    # need a different writable dir.
+    return "/tmp"
+
+
+def _build_subprocess_env() -> dict[str, str]:
+    env = os.environ.copy()
+    home = _resolve_home_dir()
+    env["HOME"] = home
+    from hermes_constants import apply_subprocess_home_env
+    apply_subprocess_home_env(env)
+    return env
+
+
+def _choose_permission_option(options: list[dict[str, Any]], policy: str) -> str | None:
+    """Pick the optionId to approve for a session/request_permission request.
+
+    Returns None to reject (``policy="deny"`` or no allow-kind option offered).
+    "allow" means approve *once*: prefer an allow_once option and only fall back
+    to allow_always if the request offers no single-shot option — never grant
+    persistent auto-approval just because it happened to be listed first.
+    """
+    if policy != "allow":
+        return None
+    opts = [o for o in options if isinstance(o, dict)]
+    for kind in _ALLOW_OPTION_KINDS:
+        for opt in opts:
+            if str(opt.get("kind", "")).lower() == kind:
+                chosen = opt.get("optionId") or opt.get("id")
+                if chosen:
+                    return str(chosen)
+    return None
+
+
+def _format_messages_as_prompt(
+    messages: list[dict[str, Any]],
+    model: str | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: Any = None,
+) -> str:
+    # Junie is an autonomous coding agent: it runs its OWN tools (read/edit/
+    # execute) inside the ACP session and reports them via native tool_call
+    # notifications. We therefore do NOT ask it to emit OpenAI-style tool
+    # calls; it should just do the work and answer. Hermes' own tool schemas
+    # are irrelevant to Junie's execution, so we don't inject them.
+    del tools, tool_choice  # accepted for OpenAI-client compatibility; unused
+    sections: list[str] = [
+        "You are being used as the active ACP coding agent backend for Hermes.",
+        "Use your own tools to complete the task, then answer normally.",
+    ]
+    if model:
+        sections.append(f"Hermes requested model hint: {model}")
+
+    transcript: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "unknown").strip().lower()
+        if role == "tool":
+            role = "tool"
+        elif role not in {"system", "user", "assistant"}:
+            role = "context"
+
+        content = message.get("content")
+        rendered = _render_message_content(content)
+        if not rendered:
+            continue
+
+        label = {
+            "system": "System",
+            "user": "User",
+            "assistant": "Assistant",
+            "tool": "Tool",
+            "context": "Context",
+        }.get(role, role.title())
+        transcript.append(f"{label}:\n{rendered}")
+
+    if transcript:
+        sections.append("Conversation transcript:\n\n" + "\n\n".join(transcript))
+
+    sections.append("Continue the conversation from the latest user request.")
+    return "\n\n".join(section.strip() for section in sections if section and section.strip())
+
+
+def _render_message_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, dict):
+        if "text" in content:
+            return str(content.get("text") or "").strip()
+        if "content" in content and isinstance(content.get("content"), str):
+            return str(content.get("content") or "").strip()
+        return json.dumps(content, ensure_ascii=True)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text.strip())
+        return "\n".join(parts).strip()
+    return str(content).strip()
+
+
+def _chunk_text(content: Any) -> str:
+    """Extract text from a session/update content that may be a dict or a list
+    of {type,text} blocks."""
+    if isinstance(content, dict):
+        return str(content.get("text") or "")
+    if isinstance(content, list):
+        return "".join(
+            str(b.get("text") or "") for b in content if isinstance(b, dict)
+        )
+    return ""
+
+
+def _tool_update_text(update: dict[str, Any]) -> str:
+    """Best-effort plain-text extraction from an ACP tool_call content list."""
+    parts: list[str] = []
+    for block in update.get("content") or []:
+        if not isinstance(block, dict):
+            continue
+        inner = block.get("content")
+        if isinstance(inner, dict) and isinstance(inner.get("text"), str):
+            parts.append(inner["text"])
+        elif isinstance(block.get("text"), str):
+            parts.append(block["text"])
+    return "\n".join(p for p in parts if p and p.strip()).strip()
+
+
+def _merge_tool_update(store: dict[str, dict[str, Any]], update: dict[str, Any]) -> None:
+    """Fold a tool_call / tool_call_update notification into ``store`` by id.
+
+    Junie streams a ``tool_call`` (first-seen) then zero or more
+    ``tool_call_update`` messages sharing the same ``toolCallId`` as the tool
+    progresses (pending -> in_progress -> completed/failed). We keep the latest
+    non-empty value for each field so ``store`` ends up with the final state.
+    """
+    tcid = str(update.get("toolCallId") or f"tool_{len(store)}")
+    entry = store.setdefault(tcid, {"id": tcid})
+    for field in ("title", "kind", "status"):
+        val = update.get(field)
+        if val:
+            entry[field] = val
+    text = _tool_update_text(update)
+    if text:
+        entry["result"] = text
+    locations = update.get("locations")
+    if locations:
+        entry["locations"] = locations
+
+
+def _render_tool_activity(tool_events: dict[str, dict[str, Any]]) -> str:
+    """Render captured tool activity as a compact, human-readable summary.
+
+    Surfaced via the assistant message's ``reasoning`` so the operator can see
+    what Junie actually did, without misrepresenting completed actions as
+    OpenAI tool_calls Hermes must execute.
+    """
+    lines: list[str] = []
+    for ev in tool_events.values():
+        kind = ev.get("kind", "tool")
+        status = ev.get("status", "")
+        title = ev.get("title", "")
+        head = f"[{kind}] {title}".strip()
+        if status:
+            head = f"{head} ({status})"
+        lines.append(head)
+        result = ev.get("result")
+        if result:
+            snippet = result if len(result) <= 500 else result[:500] + "…"
+            lines.append(f"    → {snippet}")
+    return "\n".join(lines).strip()
+
+
+def _ensure_path_within_cwd(path_text: str, cwd: str) -> Path:
+    candidate = Path(path_text)
+    if not candidate.is_absolute():
+        raise PermissionError("ACP file-system paths must be absolute.")
+    resolved = candidate.resolve()
+    root = Path(cwd).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise PermissionError(f"Path '{resolved}' is outside the session cwd '{root}'.") from exc
+    return resolved
+
+
+def _read_text_file_content(
+    path_text: str, cwd: str, *, line: int | None, limit: int | None
+) -> str:
+    """Safely read a file for an fs/read_text_file request.
+
+    Enforces path-within-cwd, honors Hermes' read-blocklist, redacts secrets,
+    and applies ACP line/limit pagination (honoring ``limit`` even from the top
+    so a paginated read doesn't return the whole file).
+    """
+    path = _ensure_path_within_cwd(path_text, cwd)
+    block_error = get_read_block_error(str(path))
+    if block_error:
+        raise PermissionError(block_error)
+    try:
+        content = path.read_text()
+    except FileNotFoundError:
+        content = ""
+    has_line = isinstance(line, int) and line > 1
+    has_limit = isinstance(limit, int) and limit > 0
+    if has_line or has_limit:
+        lines = content.splitlines(keepends=True)
+        start = line - 1 if has_line else 0
+        end = start + limit if has_limit else None
+        content = "".join(lines[start:end])
+    if content:
+        content = redact_sensitive_text(content, force=True)
+    return content
+
+
+def _write_text_file(path_text: str, cwd: str, content: str) -> None:
+    """Safely write a file for an fs/write_text_file request.
+
+    Enforces path-within-cwd and Hermes' write-deny policy (protected
+    system/credential files).
+    """
+    path = _ensure_path_within_cwd(path_text, cwd)
+    if is_write_denied(str(path)):
+        raise PermissionError(
+            f"Write denied: '{path}' is a protected system/credential file."
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+# --------------------------------------------------------------------------- #
+# Live model discovery for the /model picker                                  #
+# --------------------------------------------------------------------------- #
+# Junie advertises its selectable models in the session/new response's
+# ``config_options`` (the ``model`` Select option). Discovering them live keeps
+# the picker in sync with whatever the account/CLI actually offers, without
+# hardcoding ids into _PROVIDER_MODELS (which would make detect_provider_for_model
+# mis-resolve claude/gemini/gpt ids to junie-acp). Cached because each probe
+# spawns Junie (JVM cold start).
+_MODEL_CACHE_TTL_SECONDS = 6 * 3600
+# Negative results (unauthed / offline / timeout) are cached in-memory only, for
+# a short window, so a wedged /model picker doesn't re-spawn Junie on every open
+# — but a fresh process (or a re-auth after this window) re-probes promptly.
+_MODEL_NEG_TTL_SECONDS = 300
+# key -> (ts, ids); an empty ids list is a cached negative result.
+_model_cache: dict[str, tuple[float, list[str]]] = {}
+
+
+def _account_fingerprint(args: list[str]) -> str:
+    """Short, non-reversible tag for the Junie account behind these args.
+
+    Keys the model cache so switching accounts (different --auth token /
+    JUNIE_API_KEY) doesn't serve the previous account's catalog. Only the hash
+    is ever stored — never the raw token, on disk or in memory.
+    """
+    import hashlib
+
+    token = ""
+    for i, a in enumerate(args):
+        if a == "--auth" and i + 1 < len(args):
+            token = args[i + 1]
+            break
+        if a.startswith("--auth="):
+            token = a.split("=", 1)[1]
+            break
+    if not token:
+        token = os.getenv("JUNIE_API_KEY", "").strip()
+    if not token:
+        return "noauth"
+    return hashlib.sha256(token.encode("utf-8", "ignore")).hexdigest()[:12]
+
+
+def _model_cache_key(command: str, args: list[str]) -> str:
+    return f"{command}#{_account_fingerprint(args)}"
+
+
+def _extract_model_ids(config_options: Any) -> list[str]:
+    """Pull the ``model`` config option's advertised value ids (current first)."""
+    for opt in config_options or []:
+        data = opt.model_dump(by_alias=True, exclude_none=True) if hasattr(opt, "model_dump") else dict(opt)
+        if data.get("id") != "model" and data.get("configId") != "model":
+            continue
+        ids: list[str] = []
+        for o in data.get("options") or []:
+            if isinstance(o, dict):
+                val = o.get("value") or o.get("valueId") or o.get("optionId")
+                if val:
+                    ids.append(str(val))
+        current = data.get("currentValue")
+        if current and current in ids:
+            ids = [current] + [i for i in ids if i != current]
+        return ids
+    return []
+
+
+def _model_disk_cache_path() -> Path:
+    from hermes_constants import get_hermes_home
+    return Path(get_hermes_home()) / "junie_acp_models_cache.json"
+
+
+def _load_model_disk_cache(key: str) -> tuple[float, list[str]] | None:
+    """Return ``(stored_ts, ids)`` for ``key`` or None. Freshness is judged by
+    the caller against the original timestamp (so loading never re-stamps the
+    TTL). Only positive (non-empty) results are ever on disk."""
+    try:
+        path = _model_disk_cache_path()
+        if not path.exists():
+            return None
+        blob = json.loads(path.read_text())
+        entry = blob.get(key)
+        if not entry:
+            return None
+        ids = entry.get("ids")
+        if not (isinstance(ids, list) and ids):
+            return None
+        return float(entry.get("ts", 0)), [str(i) for i in ids]
+    except Exception:
+        return None
+
+
+def _save_model_disk_cache(key: str, ids: list[str]) -> None:
+    # ``key`` = "<command>#<account-hash>": never persists the raw --auth token.
+    # Negatives are NOT written (they live in-memory only) so a fresh process
+    # after re-auth re-probes immediately instead of honoring a stale miss.
+    if not ids:
+        return
+    try:
+        path = _model_disk_cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        blob = {}
+        if path.exists():
+            with contextlib.suppress(Exception):
+                blob = json.loads(path.read_text())
+        if not isinstance(blob, dict):
+            blob = {}
+        blob[key] = {"ts": time.time(), "ids": ids}
+        path.write_text(json.dumps(blob))
+    except Exception:
+        pass
+
+
+async def _afetch_junie_models(command: str, args: list[str], cwd: str) -> list[str]:
+    handler = _HermesClient(cwd=cwd, permission_policy="deny")
+    async with contextlib.AsyncExitStack() as stack:
+        conn, _proc = await stack.enter_async_context(
+            _acp.spawn_agent_process(
+                handler, command, *args,
+                env=_build_subprocess_env(), cwd=cwd,
+                transport_kwargs={"limit": _STDIO_LIMIT_BYTES},
+            )
+        )
+        await conn.initialize(
+            protocol_version=_acp.PROTOCOL_VERSION,
+            client_capabilities=_client_capabilities(),
+            client_info=_client_info(),
+        )
+        session = await conn.new_session(cwd=cwd, mcp_servers=[])
+        return _extract_model_ids(getattr(session, "config_options", None))
+
+
+def fetch_junie_models(
+    *,
+    command: str | None = None,
+    args: list[str] | None = None,
+    cwd: str | None = None,
+    timeout: float = 20.0,
+    force_refresh: bool = False,
+) -> list[str] | None:
+    """Return the models Junie advertises over ACP, or None if unavailable.
+
+    Spawns ``junie --acp=true`` and reads the ``model`` config option from the
+    session/new response. Positive results are cached in-memory + on disk (6h,
+    keyed per account); failures (SDK missing, CLI absent, not authed, timeout)
+    return None and are negatively cached in-memory for a short window so the
+    /model picker doesn't re-spawn a JVM on every open. Callers fall back to the
+    curated sentinel list on None.
+    """
+    if _acp is None:
+        return None
+    command = command or _resolve_command()
+    args = list(args if args is not None else _resolve_args())
+    cwd = str(Path(cwd or os.getcwd()).resolve())
+    key = _model_cache_key(command, args)
+    now = time.time()
+
+    def _fresh(ts: float, ids: list[str]) -> bool:
+        ttl = _MODEL_CACHE_TTL_SECONDS if ids else _MODEL_NEG_TTL_SECONDS
+        return (now - ts) < ttl
+
+    if not force_refresh:
+        mem = _model_cache.get(key)
+        if mem and _fresh(*mem):
+            return mem[1] or None
+        disk = _load_model_disk_cache(key)  # positives only; original ts preserved
+        if disk and _fresh(*disk):
+            _model_cache[key] = disk  # keep the disk timestamp — don't re-stamp the TTL
+            return disk[1] or None
+
+    async def _runner() -> list[str]:
+        return await asyncio.wait_for(_afetch_junie_models(command, args, cwd), timeout)
+
+    try:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            ids = asyncio.run(_runner())
+        else:
+            # Called from within a running loop: run on a private loop thread.
+            # (This still blocks the caller — provider_model_ids is a sync API —
+            # but avoids the "asyncio.run() inside a running loop" error.)
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+                ids = ex.submit(lambda: asyncio.run(_runner())).result(timeout + 5)
+    except Exception as exc:
+        logger.debug("fetch_junie_models failed: %s", exc)
+        ids = []  # negative cache below so we don't re-spawn Junie every open
+
+    _model_cache[key] = (time.time(), ids)
+    if ids:
+        _save_model_disk_cache(key, ids)
+        return ids
+    return None
+
+
+class _ACPChatCompletions:
+    def __init__(self, client: "JunieACPClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ACPChatNamespace:
+    def __init__(self, client: "JunieACPClient"):
+        self.completions = _ACPChatCompletions(client)
+
+
+class _HermesClient:
+    """Client-side ACP callbacks Hermes exposes to the Junie agent.
+
+    Implements the parts of :class:`acp.Client` that Junie exercises: streamed
+    ``session/update`` notifications (text / thought / tool activity), the
+    ``session/request_permission`` prompt, and sandboxed ``fs/read_text_file`` /
+    ``fs/write_text_file``. Terminal methods are intentionally unimplemented —
+    the SDK router treats them as optional and returns a null default.
+
+    One instance is reused across turns on the client's event loop; per-turn
+    collection buffers are installed by :meth:`begin_turn` and cleared by
+    :meth:`end_turn`, so notifications are single-threaded on that loop and need
+    no locking.
+    """
+
+    def __init__(self, *, cwd: str, permission_policy: str):
+        self._cwd = cwd
+        self._policy = permission_policy
+        self._session_id: str | None = None
+        self._text_parts: list[str] | None = None
+        self._reasoning_parts: list[str] | None = None
+        self._tool_events: dict[str, dict[str, Any]] | None = None
+        self._last_activity = 0.0
+
+    def begin_turn(
+        self,
+        session_id: str,
+        text_parts: list[str],
+        reasoning_parts: list[str],
+        tool_events: dict[str, dict[str, Any]],
+    ) -> None:
+        self._session_id = session_id
+        self._text_parts = text_parts
+        self._reasoning_parts = reasoning_parts
+        self._tool_events = tool_events
+        self._last_activity = time.monotonic()
+
+    def end_turn(self) -> None:
+        self._session_id = None
+        self._text_parts = None
+        self._reasoning_parts = None
+        self._tool_events = None
+
+    async def settle(self, quiet_gap: float, max_wait: float) -> None:
+        """Wait until Junie has been quiet for ``quiet_gap`` (capped at
+        ``max_wait``) so a trailing chunk after the completion isn't lost."""
+        if max_wait <= 0:
+            return
+        deadline = time.monotonic() + max_wait
+        while time.monotonic() < deadline:
+            if time.monotonic() - self._last_activity >= quiet_gap:
+                return
+            await asyncio.sleep(0.05)
+
+    async def session_update(self, session_id: str, update: Any, **_: Any) -> None:
+        # One reused process serves many sessions over one connection. Drop
+        # updates belonging to a *different* session (e.g. a straggler chunk
+        # from a previous turn) so a prior answer can't leak into this turn.
+        if self._session_id is not None and session_id and session_id != self._session_id:
+            return
+        self._last_activity = time.monotonic()
+        data = update.model_dump(by_alias=True, exclude_none=True) if hasattr(update, "model_dump") else dict(update)
+        kind = str(data.get("sessionUpdate") or "").strip()
+        if kind in _TOOL_UPDATE_KINDS:
+            # Native structured tool activity — captured for observability, NOT
+            # turned into OpenAI tool_calls.
+            if self._tool_events is not None:
+                _merge_tool_update(self._tool_events, data)
+            return
+        chunk_text = _chunk_text(data.get("content"))
+        if kind == "agent_message_chunk" and chunk_text and self._text_parts is not None:
+            self._text_parts.append(chunk_text)
+        elif kind == "agent_thought_chunk" and chunk_text and self._reasoning_parts is not None:
+            self._reasoning_parts.append(chunk_text)
+
+    async def request_permission(
+        self, options: list[Any], session_id: str, tool_call: Any, **_: Any
+    ) -> Any:
+        opt_dicts = [
+            (o.model_dump(by_alias=True, exclude_none=True) if hasattr(o, "model_dump") else dict(o))
+            for o in (options or [])
+        ]
+        tc = tool_call.model_dump(by_alias=True, exclude_none=True) if hasattr(tool_call, "model_dump") else dict(tool_call or {})
+        title = tc.get("title") or tc.get("toolCallId") or "?"
+        chosen = _choose_permission_option(opt_dicts, self._policy)
+        if chosen:
+            logger.info("Junie ACP permission ALLOW: %s (option=%s)", title, chosen)
+            return RequestPermissionResponse(outcome=AllowedOutcome(option_id=chosen, outcome="selected"))
+        logger.info("Junie ACP permission DENY: %s (policy=%s)", title, self._policy)
+        return RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
+
+    async def read_text_file(
+        self, path: str, session_id: str, limit: int | None = None, line: int | None = None, **_: Any
+    ) -> Any:
+        try:
+            content = _read_text_file_content(path, self._cwd, line=line, limit=limit)
+        except Exception as exc:
+            raise RequestError.invalid_params({"details": str(exc)}) from exc
+        return ReadTextFileResponse(content=content)
+
+    async def write_text_file(self, content: str, path: str, session_id: str, **_: Any) -> None:
+        try:
+            _write_text_file(path, self._cwd, content or "")
+        except Exception as exc:
+            raise RequestError.invalid_params({"details": str(exc)}) from exc
+        return None
+
+    async def ext_method(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        raise RequestError.method_not_found(method)
+
+    async def ext_notification(self, method: str, params: dict[str, Any]) -> None:
+        return None
+
+
+class JunieACPClient:
+    """Minimal OpenAI-client-compatible facade for JetBrains Junie ACP."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        acp_command: str | None = None,
+        acp_args: list[str] | None = None,
+        acp_cwd: str | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        permission_policy: str | None = None,
+        brave_mode: bool | None = None,
+        **_: Any,
+    ):
+        self.api_key = api_key or "junie-acp"
+        self.base_url = base_url or ACP_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._acp_command = acp_command or command or _resolve_command()
+        self._acp_args = list(acp_args or args or _resolve_args())
+        self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
+        self._permission_policy = permission_policy or _resolve_permission_policy()
+        # None => don't override Junie's own Brave Mode setting.
+        self._brave_override = brave_mode if brave_mode is not None else _resolve_brave_override()
+        self.chat = _ACPChatNamespace(self)
+        self.is_closed = False
+
+        # Persistent subprocess reused across requests (avoids Junie/JVM cold
+        # start on every Hermes step). One process handles many independent
+        # sessions; we open a fresh session per request and re-send the full
+        # transcript, so we never rely on Junie's cross-turn memory matching
+        # Hermes' history (no divergence risk).
+        self._handler = _HermesClient(cwd=self._acp_cwd, permission_policy=self._permission_policy)
+        # SDK objects live on a dedicated event loop running on a daemon thread.
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._loop_thread: threading.Thread | None = None
+        self._conn: Any = None  # acp.ClientSideConnection
+        self._proc: Any = None  # asyncio subprocess.Process
+        self._exit_stack: contextlib.AsyncExitStack | None = None
+        self._initialized = False
+        # Last lines of the subprocess's stderr, surfaced in failure messages so
+        # a crash/auth-rejection gives an actionable reason (not an opaque
+        # timeout/connection error).
+        self._stderr_tail: deque[str] = deque(maxlen=40)
+        # Overridable for tests (fast settle); production keeps the safe gap.
+        self._settle_quiet_gap = _SETTLE_QUIET_GAP_SECONDS
+        self._settle_max = _SETTLE_MAX_SECONDS
+        # True once session/prompt has been dispatched this turn — gates the
+        # no-replay retry policy (Junie may already have applied side effects).
+        self._prompt_in_flight = False
+        self._req_lock = threading.Lock()
+
+    # ---- lifecycle ---------------------------------------------------------
+
+    def close(self) -> None:
+        self.is_closed = True
+        loop = self._loop
+        if loop is not None and not loop.is_closed():
+            try:
+                self._submit(self._aclose_proc(), timeout=5.0)
+            except Exception:
+                pass
+            loop.call_soon_threadsafe(loop.stop)
+        thread = self._loop_thread
+        if thread is not None:
+            thread.join(timeout=3.0)
+        if loop is not None and not loop.is_closed() and not (thread and thread.is_alive()):
+            # Release the loop's selector/selfpipe fds once its thread has
+            # stopped (avoids ResourceWarning: unclosed event loop).
+            with contextlib.suppress(Exception):
+                loop.close()
+        self._loop = None
+        self._loop_thread = None
+
+    def _stderr_suffix(self) -> str:
+        text = "\n".join(self._stderr_tail).strip()
+        return f" (Junie stderr: {text})" if text else ""
+
+    def _ensure_loop(self) -> asyncio.AbstractEventLoop:
+        loop = self._loop
+        if loop is not None and not loop.is_closed() and self._loop_thread and self._loop_thread.is_alive():
+            return loop
+        _require_acp()
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=loop.run_forever, name="junie-acp-loop", daemon=True)
+        thread.start()
+        self._loop = loop
+        self._loop_thread = thread
+        return loop
+
+    def _submit(self, coro: Any, *, timeout: float) -> Any:
+        """Run ``coro`` on the background loop and block until it finishes."""
+        loop = self._loop
+        if loop is None:
+            raise RuntimeError("Junie ACP event loop is not running.")
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        try:
+            return future.result(timeout)
+        except concurrent.futures.TimeoutError as exc:
+            future.cancel()
+            raise TimeoutError("Timed out waiting for the Junie ACP subprocess.") from exc
+
+    async def _aensure_proc(self) -> None:
+        """Spawn + handshake the Junie subprocess on demand, reusing a live one."""
+        if (
+            self._conn is not None
+            and self._proc is not None
+            and getattr(self._proc, "returncode", 0) is None
+            and self._initialized
+        ):
+            return
+
+        await self._aclose_proc()
+
+        stack = contextlib.AsyncExitStack()
+        try:
+            conn, proc = await stack.enter_async_context(
+                _acp.spawn_agent_process(
+                    self._handler,
+                    self._acp_command,
+                    *self._acp_args,
+                    env=_build_subprocess_env(),
+                    cwd=self._acp_cwd,
+                    transport_kwargs={"limit": _STDIO_LIMIT_BYTES},
+                )
+            )
+        except FileNotFoundError as exc:
+            await stack.aclose()
+            raise RuntimeError(
+                f"Could not start Junie ACP command '{self._acp_command}'. "
+                "Install the JetBrains Junie CLI or set HERMES_JUNIE_ACP_COMMAND/JUNIE_CLI_PATH."
+            ) from exc
+
+        self._exit_stack = stack
+        self._conn = conn
+        self._proc = proc
+        self._stderr_tail = deque(maxlen=40)
+        if getattr(proc, "stderr", None) is not None:
+            asyncio.ensure_future(self._adrain_stderr(proc))
+        # If the subprocess dies (crash / self-exit), close the connection so any
+        # in-flight request is rejected promptly instead of blocking until the
+        # turn's wall-clock timeout. The SDK rejects outstanding futures on
+        # close(); a clean stdout EOF alone would not.
+        asyncio.ensure_future(self._awatch_proc(proc, conn))
+        await conn.initialize(
+            protocol_version=_acp.PROTOCOL_VERSION,
+            client_capabilities=_client_capabilities(),
+            client_info=_client_info(),
+        )
+        self._initialized = True
+        self.is_closed = False
+
+    async def _adrain_stderr(self, proc: Any) -> None:
+        stream = getattr(proc, "stderr", None)
+        if stream is None:
+            return
+        try:
+            async for raw in stream:
+                line = raw.decode("utf-8", "replace").rstrip("\n") if isinstance(raw, (bytes, bytearray)) else str(raw).rstrip("\n")
+                if line:
+                    self._stderr_tail.append(line)
+        except Exception:
+            return
+
+    async def _awatch_proc(self, proc: Any, conn: Any) -> None:
+        try:
+            await proc.wait()
+        except Exception:
+            return
+        # Only tear down if this is still the active process (a respawn may have
+        # already replaced it).
+        if conn is self._conn:
+            self._initialized = False
+        with contextlib.suppress(Exception):
+            await conn.close()
+
+    async def _aclose_proc(self) -> None:
+        self._initialized = False
+        stack = self._exit_stack
+        self._exit_stack = None
+        self._conn = None
+        self._proc = None
+        if stack is not None:
+            with contextlib.suppress(Exception):
+                await stack.aclose()
+
+    # ---- request path ------------------------------------------------------
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        **_: Any,
+    ) -> Any:
+        prompt_text = _format_messages_as_prompt(
+            messages or [],
+            model=model,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+        # Normalise timeout: run_agent.py may pass an httpx.Timeout object
+        # (used natively by the OpenAI SDK) rather than a plain float.
+        if timeout is None:
+            _effective_timeout = _DEFAULT_TIMEOUT_SECONDS
+        elif isinstance(timeout, (int, float)):
+            _effective_timeout = float(timeout)
+        else:
+            _candidates = [
+                getattr(timeout, attr, None)
+                for attr in ("read", "write", "connect", "pool", "timeout")
+            ]
+            _numeric = [float(v) for v in _candidates if isinstance(v, (int, float))]
+            # An httpx.Timeout with every component None means "no timeout".
+            _effective_timeout = max(_numeric) if _numeric else _NO_TIMEOUT_FALLBACK_SECONDS
+
+        response_text, reasoning_text, tool_events, usage_obj = self._run_prompt(
+            prompt_text,
+            timeout_seconds=_effective_timeout,
+            model=model,
+        )
+
+        # Junie executes its own tools and reports them as completed activity;
+        # they are NOT delegation requests, so we never surface them as OpenAI
+        # tool_calls (that would make Hermes try to re-run finished work).
+        # Instead we log them and fold a readable summary into `reasoning`.
+        activity = _render_tool_activity(tool_events)
+        if tool_events:
+            for ev in tool_events.values():
+                logger.info(
+                    "Junie ACP tool activity: kind=%s status=%s title=%s",
+                    ev.get("kind"), ev.get("status"), ev.get("title"),
+                )
+        combined_reasoning = "\n\n".join(
+            p for p in (
+                (f"Junie tool activity:\n{activity}" if activity else ""),
+                reasoning_text or "",
+            ) if p
+        ).strip() or None
+
+        usage = self._build_usage(prompt_text, response_text, reasoning_text, usage_obj)
+        assistant_message = SimpleNamespace(
+            content=response_text.strip(),
+            tool_calls=[],
+            reasoning=combined_reasoning,
+            reasoning_content=combined_reasoning,
+            reasoning_details=None,
+        )
+        choice = SimpleNamespace(message=assistant_message, finish_reason="stop")
+        return SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+            model=model or "junie-acp",
+        )
+
+    @staticmethod
+    def _build_usage(
+        prompt_text: str, response_text: str, reasoning_text: str, usage_obj: Any
+    ) -> SimpleNamespace:
+        """Prefer Junie's own token counts (PromptResponse.usage) and fall back
+        to a ~4-chars/token estimate. ACP historically reported no counts, which
+        froze the context gauge at 0% and starved the compressor; either source
+        keeps both working."""
+        prompt_tokens = completion_tokens = cached = 0
+        if usage_obj is not None:
+            prompt_tokens = int(getattr(usage_obj, "input_tokens", 0) or 0)
+            completion_tokens = int(getattr(usage_obj, "output_tokens", 0) or 0)
+            completion_tokens += int(getattr(usage_obj, "thought_tokens", 0) or 0)
+            cached = int(getattr(usage_obj, "cached_read_tokens", 0) or 0)
+        if prompt_tokens <= 0 and completion_tokens <= 0:
+            prompt_tokens = _rough_tokens(prompt_text)
+            completion_tokens = _rough_tokens(response_text) + _rough_tokens(reasoning_text)
+        return SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=cached),
+        )
+
+    def _run_prompt(
+        self, prompt_text: str, *, timeout_seconds: float, model: str | None = None
+    ) -> tuple[str, str, dict[str, dict[str, Any]], Any]:
+        # Serialize requests: one shared connection + process.
+        with self._req_lock:
+            self._ensure_loop()
+            last_exc: BaseException | None = None
+            for attempt in (1, 2):
+                self._prompt_in_flight = False
+                try:
+                    self._submit(self._aensure_proc(), timeout=_HANDSHAKE_TIMEOUT_SECONDS)
+                    # Give the turn a bit more wall-clock than the prompt itself
+                    # so the post-prompt settle can complete before we bail.
+                    turn_timeout = timeout_seconds + self._settle_max + 5.0
+                    return self._submit(
+                        self._ado_turn(prompt_text, timeout_seconds, model=model),
+                        timeout=turn_timeout,
+                    )
+                except (TimeoutError, RuntimeError, OSError, ConnectionError) as exc:
+                    last_exc = exc
+                    self._safe_close_proc()
+                    # Junie is autonomous: once session/prompt is dispatched it may
+                    # already have edited files / run commands. Never replay a
+                    # dispatched prompt — that would double-apply side effects.
+                    # Only retry failures that happened BEFORE the prompt was sent
+                    # (e.g. a stale reused subprocess died on session/new).
+                    if self._prompt_in_flight:
+                        logger.warning("Junie ACP turn failed after prompt dispatch; not retrying: %s", exc)
+                        raise
+                    logger.warning(
+                        "Junie ACP turn failed before prompt (attempt %d/2), respawning: %s", attempt, exc
+                    )
+                except Exception as exc:
+                    # RequestError (SDK) and any other agent-side failure.
+                    last_exc = exc
+                    self._safe_close_proc()
+                    if self._prompt_in_flight:
+                        logger.warning("Junie ACP turn failed after prompt dispatch; not retrying: %s", exc)
+                        raise RuntimeError(f"Junie ACP prompt failed: {exc}{self._stderr_suffix()}") from exc
+                    logger.warning(
+                        "Junie ACP turn failed before prompt (attempt %d/2), respawning: %s", attempt, exc
+                    )
+            assert last_exc is not None
+            # Exhausted the pre-prompt retries — surface Junie's stderr (auth
+            # rejection, missing runtime, …) so the failure is actionable.
+            suffix = self._stderr_suffix()
+            if suffix:
+                raise RuntimeError(f"Junie ACP failed to start: {last_exc}{suffix}") from last_exc
+            raise last_exc
+
+    def _safe_close_proc(self) -> None:
+        with contextlib.suppress(Exception):
+            self._submit(self._aclose_proc(), timeout=5.0)
+
+    async def _ado_turn(
+        self, prompt_text: str, timeout_seconds: float, model: str | None = None
+    ) -> tuple[str, str, dict[str, dict[str, Any]], Any]:
+        # Cap session/new so a wedged-but-alive reused process fails fast here
+        # (pre-prompt → safe to respawn+retry) instead of hanging the whole turn.
+        session = await asyncio.wait_for(
+            self._conn.new_session(cwd=self._acp_cwd, mcp_servers=[]),
+            min(_SESSION_NEW_TIMEOUT_SECONDS, timeout_seconds),
+        )
+        session_id = str(getattr(session, "session_id", "") or "").strip()
+        if not session_id:
+            raise RuntimeError("Junie ACP did not return a sessionId.")
+
+        # Forward the requested model to Junie via its ACP config. Skip the
+        # "junie-acp" provider sentinel / aliases (those mean "use Junie's own
+        # default"); only real Junie model ids (gemini-3-flash-preview,
+        # claude-opus-4-8, gpt-5.x, …) are set. Best-effort: an unknown id or a
+        # set failure must not abort the prompt.
+        requested = (model or "").strip()
+        if requested and requested.lower() not in _MODEL_PASSTHROUGH_SENTINELS:
+            try:
+                await asyncio.wait_for(
+                    self._conn.set_config_option(config_id="model", session_id=session_id, value=requested),
+                    _CONFIG_OPTION_TIMEOUT_SECONDS,
+                )
+                logger.info("Junie ACP model set to %s", requested)
+            except Exception as exc:
+                logger.warning("Junie ACP set model %s failed: %s", requested, exc)
+
+        # Optionally force Junie's Brave Mode. Junie accepts a boolean
+        # (true -> ON, false -> OFF) for backward compatibility; best-effort.
+        if self._brave_override is not None:
+            try:
+                await asyncio.wait_for(
+                    self._conn.set_config_option(
+                        config_id="brave_mode", session_id=session_id, value=bool(self._brave_override)
+                    ),
+                    _CONFIG_OPTION_TIMEOUT_SECONDS,
+                )
+                logger.info("Junie ACP brave_mode set to %s", self._brave_override)
+            except Exception as exc:
+                logger.warning("Junie ACP set brave_mode failed: %s", exc)
+
+        text_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        tool_events: dict[str, dict[str, Any]] = {}
+        self._handler.begin_turn(session_id, text_parts, reasoning_parts, tool_events)
+        # Mark dispatch so _run_prompt won't replay a prompt Junie may have
+        # already acted on (see the retry guard).
+        self._prompt_in_flight = True
+        usage_obj: Any = None
+        try:
+            result = await self._conn.prompt(
+                prompt=[_acp.text_block(prompt_text)], session_id=session_id
+            )
+            usage_obj = getattr(result, "usage", None)
+            # The ACP completion response can precede a trailing message chunk;
+            # settle until Junie is quiet so we don't truncate the answer.
+            await self._handler.settle(self._settle_quiet_gap, min(self._settle_max, timeout_seconds))
+        finally:
+            self._handler.end_turn()
+        # A fresh session is opened per request (we re-send the full transcript),
+        # so we don't rely on Junie's cross-turn memory; sessions are left for
+        # the persistent process to reap, matching the original client.
+        return "".join(text_parts), "".join(reasoning_parts), tool_events, usage_obj

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -48,7 +48,7 @@ def _resolve_requests_verify() -> bool | str:
 # Only these are stripped — Ollama-style "model:tag" colons (e.g. "qwen3.5:27b")
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
-    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp", "junie-acp",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek", "deepinfra",
     "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita",
     "qwen-oauth",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -96,6 +96,7 @@ MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
+DEFAULT_JUNIE_ACP_BASE_URL = "acp://junie"
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
@@ -231,6 +232,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    "junie-acp": ProviderConfig(
+        id="junie-acp",
+        name="JetBrains Junie ACP",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_JUNIE_ACP_BASE_URL,
+        base_url_env_var="JUNIE_ACP_BASE_URL",
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -1772,6 +1780,8 @@ def resolve_provider(
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
+        # JetBrains Junie (ACP coding agent)
+        "jetbrains-junie-acp": "junie-acp", "junie-acp-agent": "junie-acp", "junie": "junie-acp",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
@@ -6376,19 +6386,80 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
+# Per-provider launch specs for external-process (local subprocess) providers.
+# Keeps each ACP-agent integration independent: copilot-acp and junie-acp
+# resolve their command/args/auth from their own env vars with their own
+# defaults, so changes to one cannot affect the other.
+_EXTERNAL_PROCESS_SPECS: Dict[str, Dict[str, Any]] = {
+    "copilot-acp": {
+        "command_env_vars": ("HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH"),
+        "default_command": "copilot",
+        "args_env_var": "HERMES_COPILOT_ACP_ARGS",
+        "default_args": ["--acp", "--stdio"],
+        "auth_env_vars": (),
+        "auth_flag": None,
+        "missing_cli_hint": (
+            "Install GitHub Copilot CLI or set "
+            "HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+        ),
+    },
+    "junie-acp": {
+        "command_env_vars": ("HERMES_JUNIE_ACP_COMMAND", "JUNIE_CLI_PATH"),
+        "default_command": "junie",
+        "args_env_var": "HERMES_JUNIE_ACP_ARGS",
+        "default_args": ["--acp=true", "--skip-update-check"],
+        "auth_env_vars": ("JUNIE_API_KEY",),
+        "auth_flag": "--auth",
+        "missing_cli_hint": (
+            "Install the JetBrains Junie CLI or set "
+            "HERMES_JUNIE_ACP_COMMAND/JUNIE_CLI_PATH."
+        ),
+    },
+}
+
+
+def _resolve_external_process_launch(provider_id: str, *, include_auth: bool = True) -> Dict[str, Any]:
+    """Resolve command + args for a subprocess provider.
+
+    ``include_auth=True`` injects the auth token into args (for the actual
+    subprocess launch). ``include_auth=False`` omits it — use for status /
+    display paths so the secret never lands in a dict that might be logged or
+    serialized.
+    """
+    spec = _EXTERNAL_PROCESS_SPECS.get(provider_id, _EXTERNAL_PROCESS_SPECS["copilot-acp"])
+    command = ""
+    for env_var in spec["command_env_vars"]:
+        command = os.getenv(env_var, "").strip()
+        if command:
+            break
+    if not command:
+        command = spec["default_command"]
+
+    raw_args = os.getenv(spec["args_env_var"], "").strip()
+    args = shlex.split(raw_args) if raw_args else list(spec["default_args"])
+
+    auth_flag = spec.get("auth_flag")
+    if include_auth and auth_flag and auth_flag not in args and not any(
+        a.startswith(f"{auth_flag}=") for a in args
+    ):
+        for env_var in spec.get("auth_env_vars", ()):
+            token = os.getenv(env_var, "").strip()
+            if token:
+                args = args + [auth_flag, token]
+                break
+    return {"command": command, "args": args, "missing_cli_hint": spec["missing_cli_hint"]}
+
+
 def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for providers that run a local subprocess."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    # Status is a display/serialization surface — never embed the auth token.
+    launch = _resolve_external_process_launch(provider_id, include_auth=False)
+    command = launch["command"]
+    args = launch["args"]
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
@@ -6423,7 +6494,7 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_qwen_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
+    if target in {"copilot-acp", "junie-acp"}:
         return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
@@ -6606,25 +6677,21 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    launch = _resolve_external_process_launch(provider_id)
+    command = launch["command"]
+    args = launch["args"]
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            f"Could not find the CLI command '{command}' for provider "
+            f"'{provider_id}'. {launch['missing_cli_hint']}",
             provider=provider_id,
-            code="missing_copilot_cli",
+            code="missing_external_cli",
         )
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": provider_id,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -750,6 +750,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_named_custom,
     _model_flow_copilot,
     _model_flow_copilot_acp,
+    _model_flow_junie_acp,
     _model_flow_kimi,
     _model_flow_stepfun,
     _model_flow_bedrock_api_key,
@@ -3324,6 +3325,8 @@ def select_provider_and_model(args=None):
         _model_flow_minimax_oauth(config, current_model, args=args)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "junie-acp":
+        _model_flow_junie_acp(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":
@@ -13157,6 +13160,7 @@ def _build_provider_choices() -> list[str]:
         # Fallback: static list guarantees the CLI always works
         return [
             "auto", "openrouter", "nous", "openai-codex", "xai-oauth", "copilot-acp", "copilot",
+            "junie-acp",
             "anthropic", "gemini", "vertex", "xai", "bedrock", "azure-foundry",
             "ollama-cloud", "huggingface", "zai", "kimi-coding", "kimi-coding-cn",
             "stepfun", "minimax", "minimax-cn", "kilocode", "novita", "xiaomi", "arcee",

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -79,6 +79,7 @@ _DOT_TO_HYPHEN_PROVIDERS: frozenset[str] = frozenset({
 _STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset({
     "copilot",
     "copilot-acp",
+    "junie-acp",
     "openai-codex",
 })
 

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1925,6 +1925,84 @@ def _model_flow_copilot_acp(config, current_model=""):
 
     print(f"Default model set to: {selected} (via {pconfig.name})")
 
+
+def _model_flow_junie_acp(config, current_model=""):
+    """JetBrains Junie ACP flow using the local Junie CLI (`junie --acp=true`)."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+        get_external_process_provider_status,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.models import _PROVIDER_MODELS
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "junie-acp"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = status.get("resolved_command") or status.get("command") or "junie"
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+
+    print("  JetBrains Junie ACP delegates Hermes turns to `junie --acp=true`.")
+    print("  Hermes starts a Junie ACP subprocess for each request.")
+    print("  The model you pick is a hint — Junie selects its own model in-session.")
+    print(f"  Command: {resolved_command}")
+    print(f"  Backend marker: {effective_base}")
+    print("  Auth: set JUNIE_API_KEY (perm-...) or pass --auth via HERMES_JUNIE_ACP_ARGS.")
+    print()
+
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+        print(
+            "  Set HERMES_JUNIE_ACP_COMMAND or JUNIE_CLI_PATH if the Junie CLI is installed elsewhere."
+        )
+        return
+
+    effective_base = creds.get("base_url") or effective_base
+
+    model_list = _PROVIDER_MODELS.get("junie-acp", [])
+    if model_list:
+        selected = _prompt_model_selection(
+            model_list,
+            current_model=current_model or provider_id,
+            confirm_provider=provider_id,
+            confirm_base_url=effective_base,
+            confirm_api_key="",
+        )
+    else:
+        try:
+            selected = input("Model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if not selected:
+        print("No change.")
+        return
+
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    clear_model_endpoint_credentials(model, clear_api_mode=False)
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
+
 def _model_flow_kimi(config, current_model=""):
     """Kimi / Moonshot model selection with automatic endpoint routing.
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2091,10 +2091,20 @@ def list_authenticated_providers(
                     has_creds = True
             except Exception as exc:
                 logger.debug("Anthropic external creds check failed: %s", exc)
+        # external_process providers (ACP coding agents: copilot-acp, junie-acp)
+        # have no env-var/OAuth credentials — they're "authenticated" when their
+        # local CLI resolves. Without this they never appear in the /model picker.
+        if not has_creds and overlay.auth_type == "external_process":
+            try:
+                from hermes_cli.auth import get_external_process_provider_status
+                if get_external_process_provider_status(hermes_slug).get("configured"):
+                    has_creds = True
+            except Exception as exc:
+                logger.debug("external_process status check failed for %s: %s", hermes_slug, exc)
         if not has_creds:
             continue
 
-        if hermes_slug in {"openai-codex", "copilot", "copilot-acp"}:
+        if hermes_slug in {"openai-codex", "copilot", "copilot-acp", "junie-acp"}:
             # Use live OAuth-backed discovery so the gateway /model picker
             # matches what the user's authenticated Codex/Copilot backend
             # actually serves — including ChatGPT-Pro-only Codex slugs

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -271,6 +271,15 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    # Only the provider sentinel — like copilot-acp. Junie picks its own model
+    # via ACP configOptions; a specific model is passed with `-m <id>` and
+    # forwarded verbatim (session/set_config_option{model}), NOT drawn from this
+    # list. Listing real ids here would make detect_provider_for_model()
+    # mis-resolve claude/gemini/gpt models to junie-acp (breaks anthropic/openai
+    # resolution — see the gateway/detect tests).
+    "junie-acp": [
+        "junie-acp",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -1079,6 +1088,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
+    ProviderEntry("junie-acp",      "JetBrains Junie ACP",      "JetBrains Junie ACP (Spawns junie --acp=true)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
     ProviderEntry("vertex",         "Google Vertex AI",         "Google Vertex AI (Gemini via GCP; OAuth2 service account or ADC, GCP billing/quotas)"),
@@ -1157,6 +1167,7 @@ PROVIDER_GROUPS: dict[str, tuple[str, str, list[str]]] = {
     "qwen":     ("Qwen",            "Qwen Cloud / DashScope, Coding Plan & Qwen CLI OAuth", ["alibaba", "alibaba-coding-plan", "qwen-oauth"]),
     "opencode": ("OpenCode",        "Zen pay-as-you-go or Go subscription",            ["opencode-zen", "opencode-go"]),
     "copilot":  ("GitHub Copilot",  "GitHub token API or copilot --acp process",       ["copilot", "copilot-acp"]),
+    "junie":    ("JetBrains Junie",  "Junie CLI coding agent via ACP subprocess",       ["junie-acp"]),
 }
 
 # Reverse index: member slug -> group_id. Built once at import.
@@ -1241,6 +1252,10 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    # JetBrains Junie (ACP coding agent)
+    "jetbrains-junie-acp": "junie-acp",
+    "junie-acp-agent": "junie-acp",
+    "junie": "junie-acp",
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",
@@ -2461,6 +2476,21 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             pass
         if normalized == "copilot-acp":
             return list(_PROVIDER_MODELS.get("copilot", []))
+    if normalized == "junie-acp":
+        # Live catalog from the Junie ACP subprocess (session/new config_options).
+        # Cached + best-effort; NOT added to _PROVIDER_MODELS, so
+        # detect_provider_for_model() still reverse-maps claude/gemini/gpt ids to
+        # their real providers (see commit 09fb55ac6). Falls back to the sentinel.
+        try:
+            from agent.junie_acp_client import fetch_junie_models
+
+            live = fetch_junie_models(force_refresh=force_refresh)
+            if live:
+                sentinel = list(_PROVIDER_MODELS.get("junie-acp", []))
+                return sentinel + [m for m in live if m not in sentinel]
+        except Exception:
+            pass
+        return list(_PROVIDER_MODELS.get("junie-acp", []))
     if normalized == "nous":
         # Try live Nous Portal /models endpoint
         try:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -94,6 +94,17 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "junie-acp": HermesOverlay(
+        # The ACP subprocess client (agent/junie_acp_client.py) is selected by
+        # provider name before api_mode/transport is consulted, so this value
+        # is inert on the request path. We still set openai_chat so that
+        # determine_api_mode() -> "chat_completions" stays consistent with the
+        # junie-acp ProviderProfile and runtime_provider.py's forced api_mode.
+        transport="openai_chat",
+        auth_type="external_process",
+        base_url_override="acp://junie",
+        base_url_env_var="JUNIE_ACP_BASE_URL",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -296,6 +307,11 @@ ALIASES: Dict[str, str] = {
     "github": "github-copilot",
     "github-copilot-acp": "copilot-acp",
 
+    # jetbrains-junie (ACP coding-agent subprocess)
+    "jetbrains-junie-acp": "junie-acp",
+    "junie-acp-agent": "junie-acp",
+    "junie": "junie-acp",
+
     # opencode (models.dev ID for OpenCode Zen)
     "opencode-zen": "opencode",
     "zen": "opencode",
@@ -382,6 +398,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "junie-acp": "JetBrains Junie ACP",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1879,10 +1879,10 @@ def resolve_runtime_provider(
                 "requested_provider": requested_provider,
             }
 
-    if provider == "copilot-acp":
+    if provider in {"copilot-acp", "junie-acp"}:
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -74,6 +74,9 @@ _DEFAULT_PROVIDER_MODELS = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "junie-acp": [
+        "junie-acp",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9492,6 +9492,23 @@ def _copilot_acp_status() -> Dict[str, Any]:
     }
 
 
+def _junie_acp_status() -> Dict[str, Any]:
+    """Status for junie-acp — credentials are owned by the Junie CLI.
+
+    Like copilot-acp/claude-code: no cheap programmatic probe for the ACP
+    subprocess, so this is a read-only "managed by the Junie CLI" card and
+    Hermes never claims a login state it can't verify.
+    """
+    return {
+        "logged_in": False,
+        "source": "junie_cli",
+        "source_label": "Managed by the JetBrains Junie CLI",
+        "token_preview": None,
+        "expires_at": None,
+        "has_refresh_token": False,
+    }
+
+
 # Explicit, hand-tuned OAuth/account provider cards. These carry the bits that
 # can't be derived from the unified provider catalog: the OAuth ``flow`` shape,
 # the per-provider ``status_fn``, the ``cli_command`` fallback, and curated
@@ -9561,6 +9578,14 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "cli_command": "copilot /login",
         "docs_url": "https://docs.github.com/en/copilot",
         "status_fn": _copilot_acp_status,
+    },
+    {
+        "id": "junie-acp",
+        "name": "JetBrains Junie (ACP)",
+        "flow": "external",
+        "cli_command": "junie",
+        "docs_url": "https://junie.jetbrains.com/docs/junie-cli.html",
+        "status_fn": _junie_acp_status,
     },
     # ── Anthropic / Claude entries sit at the bottom: the API-key path
     # first, then the subscription OAuth path (which only works with extra

--- a/plugins/model-providers/junie-acp/__init__.py
+++ b/plugins/model-providers/junie-acp/__init__.py
@@ -1,0 +1,44 @@
+"""JetBrains Junie ACP provider profile.
+
+junie-acp uses an external ACP subprocess — NOT the standard transport.
+Hermes spawns ``junie --acp=true`` and speaks the Agent Client Protocol to it.
+Unlike the ``copilot-acp`` provider (which hand-rolls JSON-RPC over stdio), the
+Junie path drives the official Agent Client Protocol Python SDK
+(``agent-client-protocol``, the ``[acp]`` extra). The profile captures auth +
+endpoint metadata; the actual subprocess driving lives in
+``agent/junie_acp_client.py`` and the routing that selects it lives in
+``agent/agent_runtime_helpers.py`` / ``agent/auxiliary_client.py``
+(``provider == "junie-acp"``).
+
+This provider is intentionally independent of ``copilot-acp`` so upstream
+changes to the Copilot path cannot break the Junie integration.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class JunieACPProfile(ProviderProfile):
+    """JetBrains Junie ACP — external process, no REST models endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Model listing is handled by the ACP subprocess."""
+        return None
+
+
+junie_acp = JunieACPProfile(
+    name="junie-acp",
+    aliases=("jetbrains-junie-acp", "junie-acp-agent", "junie"),
+    api_mode="chat_completions",  # ACP subprocess uses chat_completions routing
+    env_vars=(),  # Managed by the ACP subprocess (auth via --auth / JUNIE_API_KEY)
+    base_url="acp://junie",  # ACP internal scheme
+    auth_type="external_process",
+)
+
+register_provider(junie_acp)

--- a/plugins/model-providers/junie-acp/plugin.yaml
+++ b/plugins/model-providers/junie-acp/plugin.yaml
@@ -1,0 +1,5 @@
+name: junie-acp-provider
+kind: model-provider
+version: 1.0.0
+description: JetBrains Junie via ACP subprocess
+author: JetBrains

--- a/skills/autonomous-ai-agents/claude-code/SKILL.md
+++ b/skills/autonomous-ai-agents/claude-code/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [Coding-Agent, Claude, Anthropic, Code-Review, Refactoring, PTY, Automation]
-    related_skills: [codex, hermes-agent, opencode]
+    related_skills: [junie, codex, hermes-agent, opencode]
 ---
 
 # Claude Code — Hermes Orchestration Guide

--- a/skills/autonomous-ai-agents/codex/SKILL.md
+++ b/skills/autonomous-ai-agents/codex/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [Coding-Agent, Codex, OpenAI, Code-Review, Refactoring]
-    related_skills: [claude-code, hermes-agent]
+    related_skills: [claude-code, junie, hermes-agent]
 ---
 
 # Codex CLI

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   hermes:
     tags: [hermes, setup, configuration, multi-agent, spawning, cli, gateway, development]
     homepage: https://github.com/NousResearch/hermes-agent
-    related_skills: [claude-code, codex, opencode]
+    related_skills: [claude-code, junie, codex, opencode]
 ---
 
 # Hermes Agent

--- a/skills/autonomous-ai-agents/junie/SKILL.md
+++ b/skills/autonomous-ai-agents/junie/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: junie
+description: "Delegate coding to the JetBrains Junie CLI (plan, implement, review)."
+version: 1.0.0
+author: Hermes Agent + JetBrains
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Coding-Agent, Junie, JetBrains, Plan-Mode, Code-Review, PTY, Automation]
+    related_skills: [claude-code, codex, hermes-agent, opencode]
+---
+
+# Junie — Hermes Orchestration Guide
+
+Delegate coding tasks to [JetBrains Junie](https://junie.jetbrains.com/docs/junie-cli.html) — JetBrains' autonomous, LLM-agnostic coding agent CLI — via the Hermes terminal. Junie reads/edits files, runs commands, plans before acting, and reviews diffs. It brings its own agent harness (plan mode, code review, orchestrated sub-agents), so you delegate a *goal*, not step-by-step tool calls.
+
+> Note: this is the **delegation** skill — Hermes (on any model) drives the `junie` CLI as a tool. It is distinct from the `junie-acp` **provider**, where Junie *is* the model backend driving Hermes. Use this skill when your current agent wants to hand a coding subtask to Junie.
+
+## Prerequisites
+
+- **Install:** `curl -fsSL https://junie.jetbrains.com/install.sh | bash` (EAP: `install-eap.sh`). Also PowerShell on Windows. Binary lands at `~/.local/bin/junie`.
+- **Auth (pick one):**
+  - JetBrains/Junie token: `export JUNIE_API_KEY='perm-...'` (generate at https://junie.jetbrains.com/tokens) or pass `--auth "$JUNIE_API_KEY"`.
+  - Interactive login: run `junie` once and sign in via the Account screen (browser).
+  - **BYOK** (bring your own model key): `--openai-api-key`, `--anthropic-api-key`, `--google-api-key`, `--grok-api-key`, `--openrouter-api-key`, or a LiteLLM proxy (`--litellm-url` + `--litellm-api-key`).
+- **Version:** `junie --version`. Add `--skip-update-check` in automation to avoid the startup update check.
+
+## Two Orchestration Modes
+
+### Mode 1: Headless / Non-Interactive (PREFERRED for most tasks)
+
+One-shot: give Junie a task, it works autonomously and exits. No PTY, no prompts.
+
+```
+terminal(command="junie --auth=\"$JUNIE_API_KEY\" --skip-update-check --output-format json --json-output-file result.json 'Add error handling to all API calls in src/'", workdir="/path/to/project", timeout=180)
+```
+
+- The task is the positional arg (or `--task "..."`).
+- `--output-format text|json|json-stream`; prefer **`json` + `--json-output-file result.json`** then read the file — plain `text` output carries ANSI color codes that are messy to parse.
+- `--input-format text|json` accepts structured/piped input.
+- `-p, --project <dir>` sets the project dir (or just set `workdir`). ⚠️ In Junie `-p` means **project**, not print — there is no `-p` print flag like Claude Code.
+
+**When to use:** bug fixes, features, refactors, CI/CD automation, structured extraction. Junie runs its own plan→implement→verify loop internally.
+
+### Mode 2: Interactive PTY via tmux — Multi-Turn Sessions
+
+```
+terminal(command="tmux new-session -d -s junie-work -x 140 -y 40")
+terminal(command="tmux send-keys -t junie-work 'cd /path/to/project && junie' Enter")
+# wait for the welcome screen (~5s), then send the task
+terminal(command="sleep 6 && tmux send-keys -t junie-work 'Refactor the auth module to use JWT' Enter")
+# monitor
+terminal(command="sleep 15 && tmux capture-pane -t junie-work -p -S -60")
+# follow-up
+terminal(command="tmux send-keys -t junie-work 'Now add unit tests for the JWT code' Enter")
+# exit
+terminal(command="tmux send-keys -t junie-work '/exit' Enter")
+```
+
+**When to use:** iterative work, human-in-the-loop, exploratory sessions, or to use Junie's slash commands (`/plan`, `/review`, `/usage`).
+
+## Junie-Specific Capabilities
+
+- **Plan mode** — `--plan` (or `/plan` in a session): read-only analysis that proposes a plan before editing. Approve/refine, then implement. Good for risky or large changes.
+- **Code review** — `--review` (or `/review`): reviews a git diff (vs main, last commit, or a described scope). Requires a git repo.
+- **Orchestrated mode** — `--goal "..."` runs a multi-step task decomposed across sub-agents (plan → code → review → git). CLI/TUI only.
+- **Model control** — `--model <id>` (e.g. `claude-opus-4-8`, `gemini-3-flash-preview`, `gpt-5.x`, `grok-4.3`), `--effort low|medium|high`, `--provider <byok>`.
+- **Brave Mode** — `--brave` executes commands without asking (interactive). Otherwise Junie asks before acting.
+- **MCP** — Junie is an MCP client: configure servers in `.junie/mcp/mcp.json` (project) or `~/.junie/mcp/mcp.json` (user); `/mcp` lists them.
+- **Skills / commands / guidelines** — user-authored, loaded from `~/.junie/` and `.junie/` (Junie does not auto-create skills or persist cross-session memory in the CLI).
+
+## Session Continuation
+
+- `--resume` resumes the last session; `--session-id <id>` follows a specific one.
+
+## Pitfalls & Gotchas
+
+- **ANSI in text output:** use `--output-format json --json-output-file` for clean, parseable results in automation.
+- **Cold start:** the first invocation pays a JVM/agent startup cost (several seconds). Interactive tmux sessions reuse the process across turns.
+- **Auth in automation:** pass `--auth "$JUNIE_API_KEY"` (perm-...) explicitly, or ensure `JUNIE_API_KEY` is in the process env; headless runs won't open a browser login.
+- **`--goal` is CLI/TUI only** and not available in headless JSON pipelines the same way — for scripted use prefer a plain task or `--plan`.
+- **No `-p` print flag:** `-p` is `--project`. Non-interactive is simply the positional task.
+
+## Rules for Hermes Agents
+
+1. Prefer Mode 1 (headless JSON) for anything scriptable; reach for tmux only when you need multi-turn interaction.
+2. Always run inside the target project (`workdir` / `--project`), and set `--skip-update-check` in automation.
+3. For large or destructive changes, run `--plan` first, inspect the plan, then implement.
+4. Read `result.json` for the outcome rather than scraping colored terminal text.

--- a/skills/autonomous-ai-agents/opencode/SKILL.md
+++ b/skills/autonomous-ai-agents/opencode/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [Coding-Agent, OpenCode, Autonomous, Refactoring, Code-Review]
-    related_skills: [claude-code, codex, hermes-agent]
+    related_skills: [claude-code, junie, codex, hermes-agent]
 ---
 
 # OpenCode CLI

--- a/tests/agent/fake_junie_acp_agent.py
+++ b/tests/agent/fake_junie_acp_agent.py
@@ -1,0 +1,181 @@
+"""A minimal fake `junie --acp=true` agent, speaking ACP via the official SDK.
+
+Spawned as a real subprocess by the Junie ACP client tests so the client's SDK
+integration (handshake, session lifecycle, streaming, permission + fs bridges,
+process reuse / respawn, retry) is exercised end-to-end instead of mocked.
+
+Behaviour is driven entirely by ``FAKE_JUNIE_*`` environment variables so each
+test can shape a scenario without editing this file. Every handled method is
+appended as one JSON line to ``$FAKE_JUNIE_LOG`` for assertions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from typing import Any
+
+import acp
+from acp.exceptions import RequestError
+from acp.schema import (
+    InitializeResponse,
+    NewSessionResponse,
+    PromptResponse,
+    SetSessionConfigOptionResponse,
+    Usage,
+)
+
+_LOG_PATH = os.environ.get("FAKE_JUNIE_LOG", "")
+
+
+def _log(record: dict[str, Any]) -> None:
+    if not _LOG_PATH:
+        return
+    with open(_LOG_PATH, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
+
+
+def _flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+class FakeJunieAgent:
+    def __init__(self) -> None:
+        self._conn: acp.AgentSideConnection | None = None
+        self._session_count = 0
+        self._prompt_count = 0
+
+    def on_connect(self, conn: acp.AgentSideConnection) -> None:
+        self._conn = conn
+
+    async def initialize(self, protocol_version: int, **_: Any) -> InitializeResponse:
+        _log({"method": "initialize", "pid": os.getpid()})
+        return InitializeResponse(protocol_version=1)
+
+    async def new_session(self, cwd: str, mcp_servers: Any = None, **_: Any) -> NewSessionResponse:
+        # Cross-process one-shot failure: the first process to reach new_session
+        # errors (leaving a sentinel); a freshly respawned process succeeds.
+        if _flag("FAKE_JUNIE_FAIL_SESSION_NEW_ONCE"):
+            sentinel = os.environ.get("FAKE_JUNIE_SESSION_SENTINEL", "")
+            if sentinel and not os.path.exists(sentinel):
+                with open(sentinel, "w", encoding="utf-8") as fh:
+                    fh.write("used")
+                _log({"method": "session/new", "result": "error"})
+                raise RequestError.internal_error({"details": "stale session/new"})
+        self._session_count += 1
+        sid = f"s{self._session_count}"
+        _log({"method": "session/new", "session": sid})
+        return NewSessionResponse(session_id=sid)
+
+    async def set_config_option(
+        self, config_id: str, session_id: str, value: Any, **_: Any
+    ) -> SetSessionConfigOptionResponse:
+        if _flag("FAKE_JUNIE_FAIL_MODEL") and config_id == "model":
+            _log({"method": "session/set_config_option", "configId": config_id, "result": "error"})
+            raise RequestError.invalid_params({"details": "unknown model"})
+        _log({"method": "session/set_config_option", "configId": config_id, "value": value})
+        return SetSessionConfigOptionResponse(config_options=[])
+
+    async def prompt(self, prompt: Any, session_id: str, message_id: str | None = None, **_: Any) -> PromptResponse:
+        self._prompt_count += 1
+        _log({"method": "session/prompt", "session": session_id, "count": self._prompt_count})
+        assert self._conn is not None
+
+        if _flag("FAKE_JUNIE_FAIL_PROMPT"):
+            raise RequestError.internal_error({"details": "prompt failed mid-turn"})
+
+        # Optional: ask the client for permission and record what it answered.
+        if _flag("FAKE_JUNIE_ASK_PERMISSION"):
+            resp = await self._conn.request_permission(
+                options=[{"optionId": "yes", "name": "Allow once", "kind": "allow_once"}],
+                session_id=session_id,
+                tool_call={"toolCallId": "consent", "title": "Do the thing"},
+            )
+            outcome = resp.outcome.model_dump(by_alias=True) if hasattr(resp.outcome, "model_dump") else resp.outcome
+            _log({"method": "permission_outcome", "outcome": outcome})
+
+        # Optional: read a file through the client's sandboxed fs bridge.
+        read_path = os.environ.get("FAKE_JUNIE_READ_PATH", "")
+        if read_path:
+            r = await self._conn.read_text_file(path=read_path, session_id=session_id)
+            _log({"method": "fs_read_result", "content": r.content})
+
+        # Optional: attempt a write through the client's fs bridge.
+        write_path = os.environ.get("FAKE_JUNIE_WRITE_PATH", "")
+        if write_path:
+            try:
+                await self._conn.write_text_file(
+                    content=os.environ.get("FAKE_JUNIE_WRITE_CONTENT", "hi"),
+                    path=write_path,
+                    session_id=session_id,
+                )
+                _log({"method": "fs_write_result", "ok": True})
+            except RequestError as exc:
+                _log({"method": "fs_write_result", "ok": False, "error": str(exc)})
+
+        # Optional: stream native tool activity (never becomes an OpenAI tool_call).
+        if _flag("FAKE_JUNIE_EMIT_TOOLCALL"):
+            await self._conn.session_update(
+                session_id=session_id,
+                update={"sessionUpdate": "tool_call", "toolCallId": "t1",
+                        "title": 'Found "*"', "kind": "other", "status": "pending"},
+            )
+            await self._conn.session_update(
+                session_id=session_id,
+                update={"sessionUpdate": "tool_call_update", "toolCallId": "t1", "status": "completed",
+                        "content": [{"type": "content", "content": {"type": "text", "text": "gamma.log\n"}}]},
+            )
+
+        # Optional: stream a thought chunk (surfaces as reasoning).
+        if _flag("FAKE_JUNIE_EMIT_THOUGHT"):
+            await self._conn.session_update(
+                session_id=session_id,
+                update={"sessionUpdate": "agent_thought_chunk", "content": {"type": "text", "text": "thinking..."}},
+            )
+
+        prefix = os.environ.get("FAKE_JUNIE_ANSWER_PREFIX", "ANSWER")
+        await self._conn.session_update(
+            session_id=session_id,
+            update={"sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": f"{prefix}{self._prompt_count}"}},
+        )
+
+        usage = None
+        if _flag("FAKE_JUNIE_USAGE"):
+            usage = Usage(input_tokens=123, output_tokens=45, total_tokens=168)
+
+        response = PromptResponse(stop_reason="end_turn", usage=usage)
+
+        if _flag("FAKE_JUNIE_EXIT_AFTER_PROMPT"):
+            # Emulate the process dying between turns so the client must respawn.
+            asyncio.get_running_loop().call_later(0.05, os._exit, 0)
+
+        return response
+
+    async def close_session(self, session_id: str, **_: Any) -> None:
+        _log({"method": "session/close", "session": session_id})
+        return None
+
+    async def cancel(self, session_id: str, **_: Any) -> None:
+        _log({"method": "session/cancel", "session": session_id})
+
+    async def authenticate(self, method_id: str, **_: Any) -> None:
+        return None
+
+    async def load_session(self, *a: Any, **k: Any) -> None:
+        return None
+
+    async def ext_method(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        raise RequestError.method_not_found(method)
+
+    async def ext_notification(self, method: str, params: dict[str, Any]) -> None:
+        return None
+
+
+def main() -> None:
+    asyncio.run(acp.run_agent(FakeJunieAgent()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent/test_junie_acp_client.py
+++ b/tests/agent/test_junie_acp_client.py
@@ -1,0 +1,569 @@
+"""Tests for the JetBrains Junie ACP client shim.
+
+The client drives a Junie agent subprocess over the Agent Client Protocol
+Python SDK. The behaviour-critical paths (persistent-process reuse, model/brave
+forwarding, no-replay-after-dispatch, fs/permission safety, tool activity) are
+exercised end-to-end against ``fake_junie_acp_agent.py`` — a real subprocess
+speaking ACP via the same SDK — rather than mocked, so the SDK wiring is under
+test too. Pure helpers and the OpenAI-shape conversion are unit-tested directly.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import agent.junie_acp_client as junie_mod
+from agent.junie_acp_client import (
+    JunieACPClient,
+    _HermesClient,
+    _choose_permission_option,
+    _extract_model_ids,
+    _merge_tool_update,
+    _render_tool_activity,
+    _resolve_args,
+    _resolve_brave_override,
+    _resolve_command,
+    _resolve_permission_policy,
+    fetch_junie_models,
+)
+
+_FAKE_AGENT = str(Path(__file__).with_name("fake_junie_acp_agent.py"))
+
+
+def _read_log(path: str) -> list[dict]:
+    if not os.path.exists(path):
+        return []
+    with open(path, encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+def _make_client(cwd: str, **kwargs) -> JunieACPClient:
+    """A JunieACPClient wired to the in-repo fake agent, settling fast."""
+    client = JunieACPClient(
+        acp_cwd=cwd,
+        command=sys.executable,
+        args=[_FAKE_AGENT],
+        **kwargs,
+    )
+    client._settle_quiet_gap = 0.05
+    client._settle_max = 2.0
+    return client
+
+
+# --------------------------------------------------------------------------- #
+# Pure launch / resolution helpers                                            #
+# --------------------------------------------------------------------------- #
+class JunieLaunchResolutionTests(unittest.TestCase):
+    def test_default_command_and_args(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(_resolve_command(), "junie")
+            self.assertEqual(_resolve_args(), ["--acp=true", "--skip-update-check"])
+
+    def test_command_override(self) -> None:
+        with patch.dict(os.environ, {"HERMES_JUNIE_ACP_COMMAND": "/opt/junie"}, clear=True):
+            self.assertEqual(_resolve_command(), "/opt/junie")
+        with patch.dict(os.environ, {"JUNIE_CLI_PATH": "/usr/bin/junie"}, clear=True):
+            self.assertEqual(_resolve_command(), "/usr/bin/junie")
+
+    def test_auth_injected_from_env(self) -> None:
+        with patch.dict(os.environ, {"JUNIE_API_KEY": "perm-token"}, clear=True):
+            args = _resolve_args()
+        self.assertIn("--auth", args)
+        self.assertEqual(args[args.index("--auth") + 1], "perm-token")
+
+    def test_explicit_auth_arg_not_double_injected(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"HERMES_JUNIE_ACP_ARGS": "--acp=true --auth explicit", "JUNIE_API_KEY": "perm-token"},
+            clear=True,
+        ):
+            args = _resolve_args()
+        self.assertEqual(args.count("--auth"), 1)
+        self.assertIn("explicit", args)
+        self.assertNotIn("perm-token", args)
+
+    def test_default_policy_is_deny(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(_resolve_permission_policy(), "deny")
+
+    def test_permission_policy_env(self) -> None:
+        with patch.dict(os.environ, {"HERMES_JUNIE_ACP_PERMISSION": "allow"}, clear=True):
+            self.assertEqual(_resolve_permission_policy(), "allow")
+        with patch.dict(os.environ, {"HERMES_JUNIE_ACP_PERMISSION": "deny"}, clear=True):
+            self.assertEqual(_resolve_permission_policy(), "deny")
+
+    def test_brave_override_env_parsing(self) -> None:
+        for on in ("on", "1", "true", "yes"):
+            with patch.dict(os.environ, {"HERMES_JUNIE_ACP_BRAVE": on}, clear=True):
+                self.assertIs(_resolve_brave_override(), True)
+        for off in ("off", "0", "false", "no"):
+            with patch.dict(os.environ, {"HERMES_JUNIE_ACP_BRAVE": off}, clear=True):
+                self.assertIs(_resolve_brave_override(), False)
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(_resolve_brave_override())
+
+    def test_constructor_override_beats_env(self) -> None:
+        with patch.dict(os.environ, {"HERMES_JUNIE_ACP_BRAVE": "off"}, clear=True):
+            client = JunieACPClient(acp_cwd="/tmp", brave_mode=True)
+        self.assertIs(client._brave_override, True)
+
+    def test_brave_default_is_no_override(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            client = JunieACPClient(acp_cwd="/tmp")
+        self.assertIsNone(client._brave_override)
+
+
+# --------------------------------------------------------------------------- #
+# Permission-option selection (pure)                                          #
+# --------------------------------------------------------------------------- #
+class ChoosePermissionOptionTests(unittest.TestCase):
+    _ALLOW_ONCE = [{"optionId": "yes", "name": "Allow", "kind": "allow_once"}]
+
+    def test_deny_policy_never_selects(self) -> None:
+        self.assertIsNone(_choose_permission_option(self._ALLOW_ONCE, "deny"))
+
+    def test_allow_selects_allow_once(self) -> None:
+        self.assertEqual(_choose_permission_option(self._ALLOW_ONCE, "allow"), "yes")
+
+    def test_allow_without_allow_option_returns_none(self) -> None:
+        opts = [{"optionId": "no", "name": "Deny", "kind": "reject_once"}]
+        self.assertIsNone(_choose_permission_option(opts, "allow"))
+
+    def test_allow_prefers_allow_once_over_allow_always(self) -> None:
+        opts = [
+            {"optionId": "always", "kind": "allow_always"},  # listed first
+            {"optionId": "once", "kind": "allow_once"},
+        ]
+        self.assertEqual(_choose_permission_option(opts, "allow"), "once")
+
+
+# --------------------------------------------------------------------------- #
+# Client-side ACP callbacks (fs + permission bridge), tested directly         #
+# --------------------------------------------------------------------------- #
+class HermesClientHandlerTests(unittest.TestCase):
+    def _handler(self, cwd: str, policy: str = "deny") -> _HermesClient:
+        return _HermesClient(cwd=cwd, permission_policy=policy)
+
+    def test_request_permission_denies_by_default(self) -> None:
+        from acp.schema import PermissionOption, ToolCallUpdate
+
+        h = self._handler("/tmp", policy="deny")
+        resp = asyncio.run(h.request_permission(
+            options=[PermissionOption(kind="allow_once", name="Allow", option_id="yes")],
+            session_id="s",
+            tool_call=ToolCallUpdate(tool_call_id="t", title="x"),
+        ))
+        self.assertEqual(resp.outcome.model_dump(by_alias=True)["outcome"], "cancelled")
+
+    def test_request_permission_allow_selects_option(self) -> None:
+        from acp.schema import PermissionOption, ToolCallUpdate
+
+        h = self._handler("/tmp", policy="allow")
+        resp = asyncio.run(h.request_permission(
+            options=[PermissionOption(kind="allow_once", name="Allow", option_id="yes")],
+            session_id="s",
+            tool_call=ToolCallUpdate(tool_call_id="t", title="x"),
+        ))
+        dumped = resp.outcome.model_dump(by_alias=True)
+        self.assertEqual(dumped["outcome"], "selected")
+        self.assertEqual(dumped["optionId"], "yes")
+
+    def test_read_text_file_redacts_sensitive_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            secret = root / "config.env"
+            secret.write_text("OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012")
+            h = self._handler(str(root))
+            with patch("agent.redact._REDACT_ENABLED", True):
+                resp = asyncio.run(h.read_text_file(path=str(secret), session_id="s"))
+        self.assertNotIn("abc123def456", resp.content)
+        self.assertIn("OPENAI_API_KEY=", resp.content)
+
+    def test_read_text_file_honors_limit_at_top(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            f = root / "big.txt"
+            f.write_text("".join(f"line{i}\n" for i in range(100)))
+            h = self._handler(str(root))
+            with patch("agent.redact._REDACT_ENABLED", False):
+                resp = asyncio.run(h.read_text_file(path=str(f), session_id="s", line=1, limit=3))
+        self.assertEqual(resp.content, "line0\nline1\nline2\n")
+
+    def test_read_outside_cwd_is_rejected(self) -> None:
+        from acp.exceptions import RequestError
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "workspace"
+            root.mkdir()
+            outside = Path(tmpdir) / "secret.txt"
+            outside.write_text("nope")
+            h = self._handler(str(root))
+            with self.assertRaises(RequestError):
+                asyncio.run(h.read_text_file(path=str(outside), session_id="s"))
+
+    def test_write_text_file_respects_safe_root(self) -> None:
+        from acp.exceptions import RequestError
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            safe_root = root / "workspace"
+            safe_root.mkdir()
+            outside = root / "outside.txt"
+            h = self._handler(str(root))
+            with patch.dict(os.environ, {"HERMES_WRITE_SAFE_ROOT": str(safe_root)}, clear=False):
+                with self.assertRaises(RequestError):
+                    asyncio.run(h.write_text_file(content="should-not-write", path=str(outside), session_id="s"))
+            self.assertFalse(outside.exists())
+
+
+# --------------------------------------------------------------------------- #
+# OpenAI-shape conversion (patch the ACP turn, assert the response mapping)   #
+# --------------------------------------------------------------------------- #
+class OpenAIShapeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = JunieACPClient(acp_cwd="/tmp")
+
+    def test_completion_never_fabricates_openai_tool_calls(self) -> None:
+        events: dict = {}
+        _merge_tool_update(events, {
+            "sessionUpdate": "tool_call", "toolCallId": "t1", "title": 'Found "*"',
+            "kind": "other", "status": "pending",
+        })
+        _merge_tool_update(events, {
+            "sessionUpdate": "tool_call_update", "toolCallId": "t1", "status": "completed",
+            "content": [{"type": "content", "content": {"type": "text", "text": "gamma.log\n"}}],
+        })
+        with patch.object(self.client, "_run_prompt", return_value=("Here are the files.", "", events, None)):
+            resp = self.client._create_chat_completion(model="junie-acp", messages=[])
+        choice = resp.choices[0]
+        self.assertEqual(choice.finish_reason, "stop")
+        self.assertEqual(choice.message.tool_calls, [])
+        self.assertEqual(choice.message.content, "Here are the files.")
+        self.assertIn("Junie tool activity", choice.message.reasoning)
+        self.assertIn("gamma.log", choice.message.reasoning)
+
+    def test_usage_prefers_reported_counts(self) -> None:
+        from types import SimpleNamespace
+        reported = SimpleNamespace(input_tokens=123, output_tokens=45, thought_tokens=5, cached_read_tokens=10)
+        with patch.object(self.client, "_run_prompt", return_value=("resp", "", {}, reported)):
+            resp = self.client._create_chat_completion(model="junie-acp", messages=[{"role": "user", "content": "q"}])
+        u = resp.usage
+        self.assertEqual(u.prompt_tokens, 123)
+        self.assertEqual(u.completion_tokens, 50)  # output + thought
+        self.assertEqual(u.total_tokens, 173)
+        self.assertEqual(u.prompt_tokens_details.cached_tokens, 10)
+
+    def test_usage_falls_back_to_estimate(self) -> None:
+        with patch.object(self.client, "_run_prompt", return_value=("some response text here", "", {}, None)):
+            resp = self.client._create_chat_completion(
+                model="junie-acp",
+                messages=[{"role": "user", "content": "a fairly long user question to size the prompt"}],
+            )
+        u = resp.usage
+        self.assertGreater(u.prompt_tokens, 0)
+        self.assertGreater(u.completion_tokens, 0)
+        self.assertEqual(u.total_tokens, u.prompt_tokens + u.completion_tokens)
+
+    def test_literal_tool_call_text_is_not_parsed(self) -> None:
+        poison = 'Sure — <tool_call>{"id":"x","type":"function","function":{"name":"rm","arguments":"{}"}}</tool_call> done.'
+        with patch.object(self.client, "_run_prompt", return_value=(poison, "", {}, None)):
+            resp = self.client._create_chat_completion(model="junie-acp", messages=[])
+        choice = resp.choices[0]
+        self.assertEqual(choice.message.tool_calls, [])
+        self.assertEqual(choice.finish_reason, "stop")
+        self.assertIn("<tool_call>", choice.message.content)
+
+
+# --------------------------------------------------------------------------- #
+# Native tool-activity helpers                                                #
+# --------------------------------------------------------------------------- #
+class ToolActivityHelperTests(unittest.TestCase):
+    def test_tool_call_then_update_merge_by_id(self) -> None:
+        events: dict = {}
+        _merge_tool_update(events, {
+            "sessionUpdate": "tool_call", "toolCallId": "id1", "title": 'Found "*"',
+            "kind": "other", "status": "pending",
+        })
+        _merge_tool_update(events, {
+            "sessionUpdate": "tool_call_update", "toolCallId": "id1", "status": "completed",
+            "content": [{"type": "content", "content": {"type": "text", "text": "alpha\ngamma.log\n"}}],
+        })
+        self.assertEqual(len(events), 1)
+        ev = events["id1"]
+        self.assertEqual(ev["status"], "completed")
+        self.assertEqual(ev["kind"], "other")
+        self.assertEqual(ev["title"], 'Found "*"')
+        self.assertIn("gamma.log", ev["result"])
+
+    def test_render_tool_activity_is_readable(self) -> None:
+        events: dict = {}
+        _merge_tool_update(events, {"sessionUpdate": "tool_call", "toolCallId": "id1",
+                                    "title": "list", "kind": "other", "status": "completed",
+                                    "content": [{"type": "content", "content": {"type": "text", "text": "gamma.log"}}]})
+        rendered = _render_tool_activity(events)
+        self.assertIn("[other]", rendered)
+        self.assertIn("completed", rendered)
+        self.assertIn("gamma.log", rendered)
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end against the fake ACP agent subprocess                            #
+# --------------------------------------------------------------------------- #
+class JunieEndToEndTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.cwd = self._tmp.name
+        self.log = os.path.join(self.cwd, "calls.log")
+
+    def _client(self, **kwargs) -> JunieACPClient:
+        client = _make_client(self.cwd, **kwargs)
+        self.addCleanup(client.close)
+        return client
+
+    def _ask(self, client: JunieACPClient, text: str, model: str = "junie-acp"):
+        return client.chat.completions.create(
+            model=model, messages=[{"role": "user", "content": text}], timeout=30
+        )
+
+    def test_process_reused_across_two_calls(self) -> None:
+        with patch.dict(os.environ, {"FAKE_JUNIE_LOG": self.log}, clear=False):
+            client = self._client()
+            r1 = self._ask(client, "hi 1")
+            r2 = self._ask(client, "hi 2")
+        self.assertEqual(r1.choices[0].message.content, "ANSWER1")
+        self.assertEqual(r2.choices[0].message.content, "ANSWER2")
+        self.assertEqual(r1.choices[0].finish_reason, "stop")
+        log = _read_log(self.log)
+        self.assertEqual(sum(1 for e in log if e["method"] == "initialize"), 1)
+        self.assertEqual(sum(1 for e in log if e["method"] == "session/new"), 2)
+        self.assertEqual(sum(1 for e in log if e["method"] == "session/prompt"), 2)
+
+    def test_dead_process_is_respawned(self) -> None:
+        with patch.dict(os.environ, {"FAKE_JUNIE_LOG": self.log, "FAKE_JUNIE_EXIT_AFTER_PROMPT": "1"}, clear=False):
+            client = self._client()
+            r1 = self._ask(client, "x")
+            self.assertEqual(r1.choices[0].message.content, "ANSWER1")
+            r2 = self._ask(client, "y")
+        # Fresh process → its own counter restarts at 1.
+        self.assertEqual(r2.choices[0].message.content, "ANSWER1")
+        log = _read_log(self.log)
+        self.assertEqual(sum(1 for e in log if e["method"] == "initialize"), 2)
+
+    def test_real_model_is_forwarded_via_set_config_option(self) -> None:
+        with patch.dict(os.environ, {"FAKE_JUNIE_LOG": self.log}, clear=False):
+            client = self._client()
+            self._ask(client, "x", model="claude-opus-4-8")
+        sets = [(e.get("configId"), e.get("value")) for e in _read_log(self.log)
+                if e["method"] == "session/set_config_option"]
+        self.assertIn(("model", "claude-opus-4-8"), sets)
+
+    def test_provider_sentinel_model_is_not_forwarded(self) -> None:
+        for sentinel in ("junie-acp", "junie", "jetbrains-junie-acp", "junie-acp-agent", ""):
+            log = os.path.join(self.cwd, f"calls_{sentinel or 'empty'}.log")
+            with patch.dict(os.environ, {"FAKE_JUNIE_LOG": log}, clear=False):
+                client = self._client()
+                self._ask(client, "x", model=sentinel)
+                client.close()
+            model_sets = [e for e in _read_log(log)
+                          if e["method"] == "session/set_config_option" and e.get("configId") == "model"]
+            self.assertFalse(model_sets, f"sentinel {sentinel!r} should not set a model")
+
+    def test_model_set_failure_does_not_abort_turn(self) -> None:
+        with patch.dict(os.environ, {"FAKE_JUNIE_LOG": self.log, "FAKE_JUNIE_FAIL_MODEL": "1"}, clear=False):
+            client = self._client()
+            resp = self._ask(client, "x", model="no-such-model")
+        self.assertEqual(resp.choices[0].message.content, "ANSWER1")
+        self.assertEqual(resp.choices[0].finish_reason, "stop")
+
+    def test_brave_override_sends_set_config_option(self) -> None:
+        with patch.dict(os.environ, {"FAKE_JUNIE_LOG": self.log}, clear=False):
+            client = self._client(brave_mode=False)
+            self._ask(client, "x")
+        sets = [(e.get("configId"), e.get("value")) for e in _read_log(self.log)
+                if e["method"] == "session/set_config_option"]
+        self.assertIn(("brave_mode", False), sets)
+
+    def test_no_replay_after_prompt_dispatch(self) -> None:
+        with patch.dict(os.environ, {"FAKE_JUNIE_LOG": self.log, "FAKE_JUNIE_FAIL_PROMPT": "1"}, clear=False):
+            client = self._client()
+            with self.assertRaises(RuntimeError):
+                self._ask(client, "x")
+        log = _read_log(self.log)
+        self.assertEqual(sum(1 for e in log if e["method"] == "session/prompt"), 1)   # dispatched once
+        self.assertEqual(sum(1 for e in log if e["method"] == "initialize"), 1)        # no respawn
+
+    def test_retry_before_prompt_respawns(self) -> None:
+        sentinel = os.path.join(self.cwd, "session_new.sentinel")
+        with patch.dict(os.environ, {
+            "FAKE_JUNIE_LOG": self.log,
+            "FAKE_JUNIE_FAIL_SESSION_NEW_ONCE": "1",
+            "FAKE_JUNIE_SESSION_SENTINEL": sentinel,
+        }, clear=False):
+            client = self._client()
+            resp = self._ask(client, "x")
+        self.assertEqual(resp.choices[0].message.content, "ANSWER1")
+        log = _read_log(self.log)
+        self.assertEqual(sum(1 for e in log if e["method"] == "initialize"), 2)  # respawned
+        self.assertEqual(sum(1 for e in log if e["method"] == "session/prompt"), 1)
+
+    def test_tool_activity_surfaced_as_reasoning_not_tool_calls(self) -> None:
+        with patch.dict(os.environ, {"FAKE_JUNIE_LOG": self.log, "FAKE_JUNIE_EMIT_TOOLCALL": "1"}, clear=False):
+            client = self._client()
+            resp = self._ask(client, "list files")
+        choice = resp.choices[0]
+        self.assertEqual(choice.message.tool_calls, [])
+        self.assertIn("Junie tool activity", choice.message.reasoning or "")
+        self.assertIn("gamma.log", choice.message.reasoning or "")
+
+    def test_thought_chunk_surfaced_as_reasoning(self) -> None:
+        with patch.dict(os.environ, {"FAKE_JUNIE_LOG": self.log, "FAKE_JUNIE_EMIT_THOUGHT": "1"}, clear=False):
+            client = self._client()
+            resp = self._ask(client, "think")
+        self.assertIn("thinking...", resp.choices[0].message.reasoning or "")
+
+    def test_usage_from_prompt_response(self) -> None:
+        with patch.dict(os.environ, {"FAKE_JUNIE_LOG": self.log, "FAKE_JUNIE_USAGE": "1"}, clear=False):
+            client = self._client()
+            resp = self._ask(client, "x")
+        self.assertEqual(resp.usage.prompt_tokens, 123)
+        self.assertEqual(resp.usage.completion_tokens, 45)
+
+    def test_permission_bridge_denies_by_default(self) -> None:
+        with patch.dict(os.environ, {"FAKE_JUNIE_LOG": self.log, "FAKE_JUNIE_ASK_PERMISSION": "1"}, clear=False):
+            client = self._client()  # default policy: deny
+            self._ask(client, "x")
+        outcomes = [e["outcome"] for e in _read_log(self.log) if e["method"] == "permission_outcome"]
+        self.assertTrue(outcomes)
+        self.assertEqual(outcomes[0]["outcome"], "cancelled")
+
+    def test_permission_bridge_allows_when_policy_allow(self) -> None:
+        with patch.dict(os.environ, {"FAKE_JUNIE_LOG": self.log, "FAKE_JUNIE_ASK_PERMISSION": "1"}, clear=False):
+            client = self._client(permission_policy="allow")
+            self._ask(client, "x")
+        outcomes = [e["outcome"] for e in _read_log(self.log) if e["method"] == "permission_outcome"]
+        self.assertTrue(outcomes)
+        self.assertEqual(outcomes[0]["outcome"], "selected")
+        self.assertEqual(outcomes[0]["optionId"], "yes")
+
+    def test_fs_read_bridge_redacts_and_sandboxes(self) -> None:
+        secret = os.path.join(self.cwd, "config.env")
+        Path(secret).write_text("OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012")
+        with patch.dict(os.environ, {"FAKE_JUNIE_LOG": self.log, "FAKE_JUNIE_READ_PATH": secret}, clear=False):
+            with patch("agent.redact._REDACT_ENABLED", True):
+                client = self._client()
+                self._ask(client, "read it")
+        reads = [e["content"] for e in _read_log(self.log) if e["method"] == "fs_read_result"]
+        self.assertTrue(reads)
+        self.assertIn("OPENAI_API_KEY=", reads[0])
+        self.assertNotIn("abc123def456", reads[0])
+
+
+# --------------------------------------------------------------------------- #
+# session_update routing + cross-session filtering (handler, direct)          #
+# --------------------------------------------------------------------------- #
+class SessionUpdateRoutingTests(unittest.TestCase):
+    def _turn(self):
+        h = _HermesClient(cwd="/tmp", permission_policy="deny")
+        text, reasoning, tools = [], [], {}
+        h.begin_turn("current", text, reasoning, tools)
+        return h, text, reasoning, tools
+
+    @staticmethod
+    def _msg(kind, content):
+        return {"sessionUpdate": kind, "content": content}
+
+    def test_stale_session_update_is_dropped(self):
+        # A straggler chunk tagged with a different session must not leak in.
+        h, text, _r, _t = self._turn()
+        asyncio.run(h.session_update(
+            session_id="OTHER", update=self._msg("agent_message_chunk", {"type": "text", "text": "leak"})))
+        self.assertEqual(text, [])
+
+    def test_matching_session_update_is_kept(self):
+        h, text, _r, _t = self._turn()
+        asyncio.run(h.session_update(
+            session_id="current", update=self._msg("agent_message_chunk", {"type": "text", "text": "ok"})))
+        self.assertEqual(text, ["ok"])
+
+    def test_list_form_chunk_content_is_extracted(self):
+        h, text, _r, _t = self._turn()
+        asyncio.run(h.session_update(
+            session_id="current",
+            update=self._msg("agent_message_chunk", [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}])))
+        self.assertEqual(text, ["ab"])
+
+    def test_thought_chunk_routes_to_reasoning_not_text(self):
+        h, text, reasoning, _t = self._turn()
+        asyncio.run(h.session_update(
+            session_id="current", update=self._msg("agent_thought_chunk", {"type": "text", "text": "hmm"})))
+        self.assertEqual(reasoning, ["hmm"])
+        self.assertEqual(text, [])
+
+    def test_tool_update_routes_to_tool_events_not_text(self):
+        h, text, reasoning, tools = self._turn()
+        asyncio.run(h.session_update(
+            session_id="current",
+            update={"sessionUpdate": "tool_call", "toolCallId": "t1", "title": "x", "kind": "other", "status": "pending"}))
+        self.assertEqual(text, [])
+        self.assertEqual(reasoning, [])
+        self.assertIn("t1", tools)
+
+
+# --------------------------------------------------------------------------- #
+# Live model discovery from ACP config_options                                #
+# --------------------------------------------------------------------------- #
+class ModelDiscoveryTests(unittest.TestCase):
+    def test_extract_model_ids_current_first(self) -> None:
+        config_options = [
+            {"id": "brave_mode", "type": "select", "options": [{"value": "on"}]},
+            {"id": "model", "type": "select", "currentValue": "claude-fable-5",
+             "options": [
+                 {"value": "claude-opus-4-8", "name": "Opus 4.8"},
+                 {"value": "claude-fable-5", "name": "Fable 5"},
+                 {"value": "gpt-5.4", "name": "GPT-5.4"},
+             ]},
+        ]
+        ids = _extract_model_ids(config_options)
+        self.assertEqual(ids[0], "claude-fable-5")  # currentValue promoted
+        self.assertEqual(set(ids), {"claude-opus-4-8", "claude-fable-5", "gpt-5.4"})
+
+    def test_extract_model_ids_no_model_option(self) -> None:
+        self.assertEqual(_extract_model_ids([{"id": "brave_mode", "options": []}]), [])
+
+    def test_fetch_junie_models_returns_none_on_failure(self) -> None:
+        async def _boom(*a, **k):
+            raise RuntimeError("no junie here")
+
+        junie_mod._model_cache.clear()
+        with patch.object(junie_mod, "_afetch_junie_models", _boom), \
+             patch.object(junie_mod, "_load_model_disk_cache", lambda cmd: None), \
+             patch.object(junie_mod, "_save_model_disk_cache", lambda cmd, ids: None):
+            self.assertIsNone(fetch_junie_models(command="junie", args=[], force_refresh=True))
+
+    def test_fetch_junie_models_caches_in_memory(self) -> None:
+        calls = {"n": 0}
+
+        async def _ok(command, args, cwd):
+            calls["n"] += 1
+            return ["claude-fable-5", "gpt-5.4"]
+
+        junie_mod._model_cache.clear()
+        with patch.object(junie_mod, "_afetch_junie_models", _ok), \
+             patch.object(junie_mod, "_load_model_disk_cache", lambda cmd: None), \
+             patch.object(junie_mod, "_save_model_disk_cache", lambda cmd, ids: None):
+            first = fetch_junie_models(command="junie", args=[], force_refresh=True)
+            second = fetch_junie_models(command="junie", args=[])  # served from cache
+        self.assertEqual(first, ["claude-fable-5", "gpt-5.4"])
+        self.assertEqual(second, first)
+        self.assertEqual(calls["n"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hermes_cli/test_junie_acp_setup.py
+++ b/tests/hermes_cli/test_junie_acp_setup.py
@@ -1,0 +1,120 @@
+"""Phase-2 tests for the junie-acp provider: recognition + interactive flow.
+
+Covers what the runtime-path tests (tests/agent/test_junie_acp_client.py) do
+not: that `hermes model` / setup machinery recognizes junie-acp and that the
+interactive model flow writes the right config.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import models as M
+from hermes_cli import providers as P
+from hermes_cli.provider_catalog import provider_catalog_by_slug
+
+
+def test_junie_acp_is_canonical_provider():
+    slugs = {e.slug for e in M.CANONICAL_PROVIDERS}
+    assert "junie-acp" in slugs
+
+
+def test_junie_acp_in_provider_catalog_with_label():
+    by = provider_catalog_by_slug()
+    assert "junie-acp" in by
+    assert by["junie-acp"].label
+    assert by["junie-acp"].description
+
+
+@pytest.mark.parametrize("alias", ["junie", "jetbrains-junie-acp", "junie-acp-agent"])
+def test_junie_aliases_resolve(alias):
+    assert P.ALIASES.get(alias) == "junie-acp"
+    full = P.resolve_provider_full(alias)
+    assert full is not None
+
+
+def test_junie_acp_static_catalog_is_sentinel_only():
+    # The STATIC reverse-map must stay sentinel-only so detect_provider_for_model
+    # doesn't mis-resolve real claude/gemini/gpt ids to junie-acp (commit
+    # 09fb55ac6). Live discovery (below) is layered on top without touching it.
+    assert M._PROVIDER_MODELS["junie-acp"] == ["junie-acp"]
+
+
+def test_junie_acp_falls_back_to_sentinel_when_discovery_unavailable(monkeypatch):
+    # No Junie CLI / not authed / offline -> fetch returns None -> sentinel only.
+    monkeypatch.setattr("agent.junie_acp_client.fetch_junie_models", lambda **_: None)
+    ids = M.provider_model_ids("junie-acp", force_refresh=True)
+    assert ids == ["junie-acp"]
+
+
+def test_junie_acp_live_models_are_merged_sentinel_first(monkeypatch):
+    # When Junie advertises models over ACP, the picker surfaces them — with the
+    # sentinel kept first — without duplicating it if Junie also returns it.
+    monkeypatch.setattr(
+        "agent.junie_acp_client.fetch_junie_models",
+        lambda **_: ["claude-fable-5", "claude-opus-4-8", "junie-acp"],
+    )
+    ids = M.provider_model_ids("junie-acp", force_refresh=True)
+    assert ids[0] == "junie-acp"
+    assert ids == ["junie-acp", "claude-fable-5", "claude-opus-4-8"]
+
+
+def test_junie_acp_provider_model_ids(monkeypatch):
+    monkeypatch.setattr("agent.junie_acp_client.fetch_junie_models", lambda **_: None)
+    ids = M.provider_model_ids("junie-acp")
+    assert "junie-acp" in ids
+
+
+def test_junie_acp_flow_writes_config(monkeypatch):
+    """The interactive flow persists provider/base_url/api_mode correctly."""
+    import hermes_cli.auth as auth
+    from hermes_cli.model_setup_flows import _model_flow_junie_acp
+    from hermes_cli.config import load_config
+
+    monkeypatch.setattr(
+        auth, "get_external_process_provider_status",
+        lambda pid: {"resolved_command": "/usr/bin/junie", "command": "junie",
+                     "base_url": "acp://junie"},
+    )
+    monkeypatch.setattr(
+        auth, "resolve_external_process_provider_credentials",
+        lambda pid: {"base_url": "acp://junie", "command": "/usr/bin/junie",
+                     "args": ["--acp=true"]},
+    )
+    monkeypatch.setattr(auth, "_prompt_model_selection", lambda *a, **k: "gemini-3-flash-preview")
+
+    _model_flow_junie_acp({}, current_model="")
+
+    cfg = load_config()
+    assert isinstance(cfg["model"], dict)
+    assert cfg["model"]["provider"] == "junie-acp"
+    assert cfg["model"]["base_url"] == "acp://junie"
+    assert cfg["model"]["api_mode"] == "chat_completions"
+
+
+def test_junie_acp_flow_missing_cli_does_not_write(monkeypatch):
+    """When the Junie CLI can't be resolved, the flow bails without writing."""
+    import hermes_cli.auth as auth
+    from hermes_cli.model_setup_flows import _model_flow_junie_acp
+    from hermes_cli.config import load_config
+
+    monkeypatch.setattr(
+        auth, "get_external_process_provider_status",
+        lambda pid: {"command": "junie", "base_url": "acp://junie"},
+    )
+
+    def _raise(pid):
+        raise RuntimeError("Could not find the CLI command 'junie'")
+
+    monkeypatch.setattr(auth, "resolve_external_process_provider_credentials", _raise)
+    # Selection must never be reached.
+    monkeypatch.setattr(
+        auth, "_prompt_model_selection",
+        lambda *a, **k: pytest.fail("should not prompt when CLI is missing"),
+    )
+
+    _model_flow_junie_acp({}, current_model="")
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if isinstance(model, dict):
+        assert model.get("provider") != "junie-acp"


### PR DESCRIPTION
## What does this PR do?

Adds **JetBrains Junie** as a native coding-agent provider (`junie-acp`), driven over the **Agent Client Protocol** using the `agent-client-protocol` SDK (already vendored as the `[acp]` extra). Hermes spawns `junie --acp=true` and talks to it as an ACP *client*, exposing Junie through the standard chat surface so it can be selected like any other model/provider.

Junie is an autonomous agent that runs its **own** tools inside the ACP session. This integration treats it accordingly: its `tool_call` notifications are surfaced as read-only *activity* in the assistant `reasoning`, never fabricated as OpenAI `tool_calls` (so Hermes never tries to re-run finished work). The path is kept independent of `copilot-acp` so changes to one can't break the other.

## Related Issue

N/A — new optional provider integration. Happy to open a tracking issue if preferred.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **New provider client** `agent/junie_acp_client.py`: drives `acp.ClientSideConnection` from a dedicated background asyncio loop, bridged to Hermes' synchronous chat-completions call path. Persistent subprocess reuse, a fresh ACP session per turn, and a no-replay-after-prompt-dispatch retry guard (Junie may already have applied side effects).
- **Safety bridge** (client-side ACP callbacks): deny-by-default `session/request_permission` (configurable); sandboxed `fs/read_text_file` + `fs/write_text_file` (path-within-cwd enforcement, write-deny for protected files, secret redaction on read).
- **Provider wiring**: `plugins/model-providers/junie-acp/` profile + aliases (`junie`, `jetbrains-junie-acp`, `junie-acp-agent`); routing in `agent/agent_runtime_helpers.py` / `agent/auxiliary_client.py`; setup / model-picker / dashboard in `hermes_cli/` (`models.py`, `providers.py`, `model_setup_flows.py`, `model_switch.py`, `setup.py`, `web_server.py`, `auth.py`, `model_normalize.py`, `runtime_provider.py`, `main.py`); `agent/model_metadata.py`, `agent/agent_init.py`, `agent/conversation_loop.py`.
- **Model handling**: `-m <id>` forwarded to Junie via `session/set_config_option{model}`; optional Brave Mode override. The `/model` picker lists Junie's **live** advertised models (read from `session/new` `config_options`) layered over the provider sentinel — **without** adding real ids to the static `_PROVIDER_MODELS` reverse-map, so `detect_provider_for_model` still resolves `claude/gemini/gpt` ids to their real providers. The live catalog is cached per account (hashed token, never stored raw) and negatively cached in-memory to avoid re-spawning the JVM on every picker open.
- **Observability/robustness**: token usage from `PromptResponse.usage` (with a ~4-chars/token estimate fallback so the context gauge + compressor work), 50 MB stdio buffer, a process-death watcher that rejects in-flight requests instead of hanging, per-call `session/new` + `set_config_option` timeouts, and captured subprocess stderr in failure messages.
- **Skill**: adds a `junie` autonomous-ai-agents delegation skill and cross-links it from the sibling skills' `related_skills`.
- **Tests**: `tests/agent/test_junie_acp_client.py` runs end-to-end against a real SDK-based fake agent subprocess (`tests/agent/fake_junie_acp_agent.py`); `tests/hermes_cli/test_junie_acp_setup.py` covers provider recognition, the interactive flow, and picker behavior.

Configuration is env-driven: `HERMES_JUNIE_ACP_COMMAND` / `JUNIE_CLI_PATH`, `JUNIE_API_KEY`, `HERMES_JUNIE_ACP_PERMISSION` (`deny` default / `allow`), `HERMES_JUNIE_ACP_BRAVE` (`on`/`off`).

## How to Test

1. Install the ACP extra and the JetBrains Junie CLI: `pip install 'hermes-agent[acp]'`; ensure `junie` is on `PATH` and authenticated (or set `JUNIE_API_KEY`).
2. Run the suites: `pytest tests/agent/test_junie_acp_client.py tests/hermes_cli/test_junie_acp_setup.py -q` → 59 passed.
3. Live: `hermes --provider junie-acp -m junie-acp chat`, ask a question, confirm Junie answers over ACP. Open `/model` to see Junie's live model catalog. Junie's tool activity appears in the assistant reasoning, not as Hermes tool calls.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(junie-acp): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the junie-acp + provider-resolution suites (green); did not run the entire suite in my environment -->
- [x] I've added tests for my changes (end-to-end against a real SDK-based fake ACP agent, plus setup/flow coverage)
- [x] I've tested on my platform: macOS 15 (Darwin), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (added the `junie` skill `SKILL.md`; cross-linked sibling skills) — README/`docs/` N/A
- [x] cli-config.yaml.example — N/A (provider is env-var driven, no new config keys)
- [x] CONTRIBUTING.md / AGENTS.md — N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact — POSIX + Windows HOME/`pwd` fallback handled; stdio transport via the SDK
