### PR TITLE
fix(tools): support CPython 3.14 ThreadPoolExecutor internals in DaemonThreadPoolExecutor

### DIFF
--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -33,12 +33,19 @@ from concurrent.futures.thread import _worker
 
 __all__ = ["DaemonThreadPoolExecutor"]
 
+# CPython 3.14 reworked ThreadPoolExecutor internals: per-worker state
+# (initializer/initargs) moved into a WorkerContext built by the new
+# ``prepare_context()`` classmethod, and ``_worker`` now takes
+# ``(executor_ref, ctx, work_queue)`` instead of
+# ``(executor_ref, work_queue, initializer, initargs)``.
+_HAS_WORKER_CONTEXT = hasattr(ThreadPoolExecutor, "prepare_context")
+
 
 class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
+        # Mirrors CPython's implementation (3.8–3.14) with two changes:
         # daemon=True and no _threads_queues registration.
         if self._idle_semaphore.acquire(timeout=0):
             return
@@ -49,15 +56,25 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
+            if _HAS_WORKER_CONTEXT:
+                # CPython 3.14+ worker signature.
+                worker_args = (
+                    weakref.ref(self, weakref_cb),
+                    self._create_worker_context(),
+                    self._work_queue,
+                )
+            else:
+                # CPython 3.8–3.13 worker signature.
+                worker_args = (
                     weakref.ref(self, weakref_cb),
                     self._work_queue,
                     self._initializer,
                     self._initargs,
-                ),
+                )
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=worker_args,
                 daemon=True,
             )
             t.start()


### PR DESCRIPTION
## Problem

`DaemonThreadPoolExecutor._adjust_thread_count` mirrors CPython 3.8–3.13 `ThreadPoolExecutor` internals (`self._initializer` / `self._initargs` and the 5-arg `_worker` signature). CPython 3.14 moved per-worker state into a `WorkerContext` built by the new `prepare_context()` classmethod and changed `_worker` to `(executor_ref, ctx, work_queue)`.

Under Python 3.14 every `submit()` dies on first dispatch:

```
AttributeError: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'
```

This breaks all concurrent tool batches and background memory sync. Reproduces on pure `main`: `tests/tools/test_daemon_pool.py`, `tests/agent/test_memory_async_sync.py`, and the `TestSegmentedDispatchIntegration` cluster all fail under a 3.14 interpreter.

## Fix

Branch on `hasattr(ThreadPoolExecutor, "prepare_context")` and pass the matching worker args on each interpreter family, keeping `daemon=True` and the deliberately-skipped `_threads_queues` registration on both.

## Testing

- Python 3.14.6: `tests/tools/test_daemon_pool.py`, `tests/agent/test_memory_async_sync.py`, `tests/run_agent/test_tool_batch_segmentation.py` — 38 passed, 1 skipped (all failed before on 3.14).
- The 3.8–3.13 path is untouched (same attributes/signature as before, now behind the feature check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)