### PR TITLE
fix(lsp): reuse rust-analyzer across Cargo workspace members

### DIFF
--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import tomllib
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
@@ -851,7 +852,39 @@ def _root_go(file_path: str, workspace: str) -> Optional[str]:
 
 
 def _root_rust(file_path: str, workspace: str) -> Optional[str]:
-    return _root_or_workspace(file_path, workspace, ["Cargo.toml", "Cargo.lock"])
+    """Resolve Rust files to the enclosing Cargo workspace when present.
+
+    A workspace member has its own ``Cargo.toml``, but rust-analyzer must
+    start from the manifest that declares ``[workspace]`` so it loads the
+    whole workspace once instead of starting one server per member.
+    """
+    current = os.path.abspath(file_path)
+    if os.path.isfile(current):
+        current = os.path.dirname(current)
+    workspace_root = os.path.abspath(workspace) if workspace else None
+    nearest_cargo: Optional[str] = None
+
+    while True:
+        manifest = os.path.join(current, "Cargo.toml")
+        if os.path.isfile(manifest):
+            if nearest_cargo is None:
+                nearest_cargo = current
+            try:
+                with open(manifest, "rb") as handle:
+                    manifest_data = tomllib.load(handle)
+            except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
+                manifest_data = {}
+            if isinstance(manifest_data.get("workspace"), dict):
+                return current
+
+        if workspace_root and current == workspace_root:
+            break
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+
+    return nearest_cargo or workspace
 
 
 def _root_ruby(file_path: str, workspace: str) -> Optional[str]:

--- a/tests/agent/lsp/test_servers.py
+++ b/tests/agent/lsp/test_servers.py
@@ -1,0 +1,70 @@
+"""Tests for language-server definitions and project-root resolution."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent.lsp.servers import _root_rust
+
+
+def test_root_rust_uses_enclosing_cargo_workspace(tmp_path: Path):
+    repo = tmp_path / "repo"
+    workspace = repo / "native"
+    workspace.mkdir(parents=True)
+    (workspace / "Cargo.toml").write_text(
+        '[workspace]\nmembers = ["crates/cli", "crates/engine"]\n',
+        encoding="utf-8",
+    )
+
+    roots = set()
+    for name in ("cli", "engine"):
+        member = workspace / "crates" / name
+        source = member / "src" / "main.rs"
+        source.parent.mkdir(parents=True)
+        source.write_text("fn main() {}\n", encoding="utf-8")
+        (member / "Cargo.toml").write_text(
+            f'[package]\nname = "{name}"\nversion = "0.1.0"\n',
+            encoding="utf-8",
+        )
+        roots.add(_root_rust(str(source), str(repo)))
+
+    assert roots == {str(workspace)}
+
+
+def test_root_rust_uses_nearest_enclosing_workspace(tmp_path: Path):
+    repo = tmp_path / "repo"
+    nested = repo / "independent"
+    member = nested / "crates" / "app"
+    source = member / "src" / "main.rs"
+    source.parent.mkdir(parents=True)
+    source.write_text("fn main() {}\n", encoding="utf-8")
+    (repo / "Cargo.toml").write_text(
+        '[workspace]\nexclude = ["independent"]\n',
+        encoding="utf-8",
+    )
+    (nested / "Cargo.toml").write_text(
+        '[workspace]\nmembers = ["crates/app"]\n',
+        encoding="utf-8",
+    )
+    (member / "Cargo.toml").write_text(
+        '[package]\nname = "app"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+
+    assert _root_rust(str(source), str(repo)) == str(nested)
+
+
+def test_root_rust_falls_back_within_supplied_workspace(tmp_path: Path):
+    outer = tmp_path / "outer"
+    repo = outer / "repo"
+    member = repo / "crate"
+    source = member / "src" / "lib.rs"
+    source.parent.mkdir(parents=True)
+    source.write_text("", encoding="utf-8")
+    (outer / "Cargo.toml").write_text("[workspace]\n", encoding="utf-8")
+    (member / "Cargo.toml").write_text(
+        '[package]\nname = "standalone"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+
+    assert _root_rust(str(source), str(repo)) == str(member)
+    assert _root_rust(str(repo / "untracked.rs"), str(repo)) == str(repo)


### PR DESCRIPTION
## Summary

- resolve Rust language-server roots to the nearest enclosing Cargo manifest that declares `[workspace]`
- preserve the nearest `Cargo.toml` fallback for standalone crates and the supplied workspace fallback when no manifest exists
- cover two member crates sharing one root, independent nested workspaces, and workspace-boundary fallbacks

## Root cause

`_root_rust` used the generic nearest-marker resolver. In a Cargo workspace, each member crate has its own `Cargo.toml`, so edits in different members produced different Hermes client keys even though rust-analyzer then discovered and indexed the same workspace from each key.

The resolver now parses manifests while walking upward and returns the first valid `[workspace]` definition, matching Cargo's nearest enclosing workspace discovery.

## Impact

Hermes reuses one rust-analyzer client for all member crates in a Cargo workspace instead of spawning a duplicate full-workspace analyzer for every member directory touched.

## Validation

- `scripts/run_tests.sh tests/agent/lsp/test_servers.py tests/agent/lsp/test_workspace.py -q` — 15 passed, 0 failed
- `.venv/bin/python -m ruff check agent/lsp/servers.py tests/agent/lsp/test_servers.py` — all checks passed
- mutation check: restoring the old nearest-marker behavior fails `test_root_rust_uses_enclosing_cargo_workspace`; continuing past the nearest `[workspace]` fails `test_root_rust_uses_nearest_enclosing_workspace`

Tested on Linux with Python 3.12.
