### PR TITLE
feat(mem0): add api_format option for cloud-hosted Mem0 services

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -16,8 +16,13 @@ Secret (lives in $HERMES_HOME/.env or the environment):
 Behavioral settings (live in $HERMES_HOME/mem0.json, set via `hermes memory
 setup`):
   mode               — Backend mode: "platform" (default) or "oss"
-  host               — Self-hosted Mem0 server URL (alt: MEM0_HOST env var).
-                       When set, routes to the self-hosted HTTP backend.
+  host               — Self-hosted or cloud-hosted Mem0 server URL (alt:
+                       MEM0_HOST env var). When set, routes to the HTTP
+                       backend instead of the cloud API.
+  api_format         — HTTP API format when host is set: "selfhosted"
+                       (default, Docker dashboard: X-API-Key + bare routes)
+                       or "cloud" (managed services like Volcengine:
+                       Token auth + /v1/ routes with trailing slashes).
   user_id            — Canonical user identifier. When set, it is applied
                        uniformly across every gateway (CLI, Telegram, Slack,
                        Discord, …) so the same human gets one merged memory
@@ -282,7 +287,8 @@ class Mem0MemoryProvider(MemoryProvider):
                 return OSSBackend(self._config.get("oss", {}))
             if self._host:
                 from ._backend import SelfHostedBackend
-                return SelfHostedBackend(self._api_key, self._host)
+                api_fmt = self._config.get("api_format", "selfhosted") if self._config else "selfhosted"
+                return SelfHostedBackend(self._api_key, self._host, api_format=api_fmt)
             from ._backend import PlatformBackend
             return PlatformBackend(self._api_key)
         except Exception as e:
@@ -389,7 +395,8 @@ class Mem0MemoryProvider(MemoryProvider):
         if self._mode == "oss":
             mode_label = "OSS (self-hosted)"
         elif self._host:
-            mode_label = "self-hosted (HTTP API)"
+            api_fmt = self._config.get("api_format", "selfhosted") if self._config else "selfhosted"
+            mode_label = "cloud-hosted (HTTP API)" if api_fmt == "cloud" else "self-hosted (HTTP API)"
         else:
             mode_label = "platform (cloud API)"
         # Rerank is a Mem0 Platform feature only.

--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -81,25 +81,36 @@ class PlatformBackend(Mem0Backend):
 
 
 class SelfHostedBackend(Mem0Backend):
-    """Direct HTTP backend for a self-hosted Mem0 server (the FastAPI ``server/``).
+    """Direct HTTP backend for a self-hosted or cloud-hosted Mem0 server.
 
     mem0.MemoryClient can't be reused for self-hosted: it is hardwired to the
-    cloud API — ``Authorization: Token`` auth and a ``GET /v1/ping/`` validation
+    cloud API — ``Authorization: *** auth and a ``GET /v1/ping/`` validation
     call in ``__init__`` that the self-hosted server does not expose (it would
-    404 before any real request). This client talks to that server directly,
-    using its actual contract: ``X-API-Key`` auth and the ``/memories`` /
-    ``/search`` routes.
+    404 before any real request). This client talks to that server directly.
+
+    Two API formats are supported via ``api_format``:
+
+    - ``"selfhosted"`` (default): ``X-API-Key`` auth, bare routes
+      (``/search``, ``/memories``, ``/memories/{id}``). Used by the
+      Mem0 Docker dashboard server.
+
+    - ``"cloud"``: ``Authorization: Token`` auth, ``/v1/`` routes with
+      trailing slashes (``/v1/memories/search/``, ``/v1/memories/``,
+      ``/v1/memories/{id}/``). Used by managed Mem0 services pinned to
+      mem0ai 0.1.x compatibility (e.g. Volcengine).
     """
 
-    def __init__(self, api_key: str, host: str, transport=None):
+    def __init__(self, api_key: str, host: str, transport=None, api_format: str = "selfhosted"):
         import httpx
 
+        self._api_format = api_format
         headers = {"Content-Type": "application/json"}
-        if api_key:
-            headers["X-API-Key"] = api_key  # omitted only for AUTH_DISABLED servers
-        # Connect-level retries smooth over transient blips so a single
-        # dropped SYN doesn't count toward the provider failure breaker.
-        # ``transport`` is injectable for tests (httpx.MockTransport).
+        if api_format == "cloud":
+            if api_key:
+                headers["Authorization"] = f"Token {api_key}"
+        else:
+            if api_key:
+                headers["X-API-Key"] = api_key  # omitted only for AUTH_DISABLED servers
         if transport is None:
             transport = httpx.HTTPTransport(retries=2)
         self._client = httpx.Client(
@@ -113,11 +124,11 @@ class SelfHostedBackend(Mem0Backend):
         return resp.json() if resp.content else {}
 
     def search(self, query: str, *, filters: dict, top_k: int = 10, rerank: bool = False) -> list[dict]:
-        # rerank is a platform-only feature; the self-hosted /search ignores it.
         body: dict[str, Any] = {"query": query, "top_k": top_k}
         if filters:
-            body["filters"] = filters  # user_id belongs in filters (top-level is deprecated)
-        return _unwrap_results(self._json("POST", "/search", json=body))
+            body["filters"] = filters
+        path = "/v1/memories/search/" if self._api_format == "cloud" else "/search"
+        return _unwrap_results(self._json("POST", path, json=body))
 
     def add(
         self,
@@ -134,16 +145,27 @@ class SelfHostedBackend(Mem0Backend):
             "agent_id": agent_id,
             "infer": infer,
         }
+        # Cloud-compatible services (e.g. Volcengine) reject infer=False
+        # without async_mode=False.
+        if self._api_format == "cloud" and not infer:
+            body["async_mode"] = False
         if metadata:
             body["metadata"] = metadata
-        return self._json("POST", "/memories", json=body)
+        path = "/v1/memories/" if self._api_format == "cloud" else "/memories"
+        return self._json("POST", path, json=body)
 
     def update(self, memory_id: str, text: str) -> dict:
-        self._json("PUT", f"/memories/{memory_id}", json={"text": text})
+        if self._api_format == "cloud":
+            self._json("PUT", f"/v1/memories/{memory_id}/", json={"text": text})
+        else:
+            self._json("PUT", f"/memories/{memory_id}", json={"text": text})
         return {"result": "Memory updated.", "memory_id": memory_id}
 
     def delete(self, memory_id: str) -> dict:
-        self._json("DELETE", f"/memories/{memory_id}")
+        if self._api_format == "cloud":
+            self._json("DELETE", f"/v1/memories/{memory_id}/")
+        else:
+            self._json("DELETE", f"/memories/{memory_id}")
         return {"result": "Memory deleted.", "memory_id": memory_id}
 
     def close(self) -> None:

--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -410,6 +410,13 @@ def _setup_selfhosted(hermes_home: str, config: dict, flags: dict[str, str]) -> 
     provider_config["user_id"] = user_id
     provider_config["agent_id"] = agent_id
 
+    # Detect cloud-compatible API format (Volcengine, etc.) based on host pattern
+    if "volces.com" in host or "volcengine" in host:
+        provider_config["api_format"] = "cloud"
+        print("  Detected Volcengine host — using cloud API format (Token auth + /v1/ routes)")
+    else:
+        provider_config.setdefault("api_format", "selfhosted")
+
     from hermes_cli.config import save_config
     config["memory"]["provider"] = "mem0"
     save_config(config)


### PR DESCRIPTION
## Summary

Add `api_format` config key to `mem0.json` to support managed Mem0 services (e.g. Volcengine) that expose a cloud-compatible REST API instead of the self-hosted Docker dashboard format.

## Problem

Hermes `SelfHostedBackend` was designed for the Mem0 Docker dashboard server, using:
- `X-API-Key` auth header
- Bare routes: `/search`, `/memories`, `/memories/{id}`

Managed Mem0 services like [Volcengine Mem0](https://www.volcengine.com/docs/86722/1852874) use a different API format:
- `Authorization: Token <key>` auth
- Versioned routes with trailing slashes: `/v1/memories/search/`, `/v1/memories/`, `/v1/memories/{id}/`
- `infer=False` requires `async_mode=False` (otherwise returns 400)

This mismatch causes 404 errors on every mem0 operation when configured against a Volcengine host.

Additionally, the standard `PlatformBackend` (mem0ai SDK `MemoryClient`) cannot be used either, because:
- mem0ai ≥ 2.0.10 (required by Hermes) uses `/v3/` routes
- Volcengine only supports `/v1/` routes (pinned to mem0ai 0.1.118 compatibility per [docs](https://www.volcengine.com/docs/86722/1962141))

## Solution

Add an `api_format` field to `mem0.json` (default: `"selfhosted"`):

| `api_format` | Auth | Routes | Trailing slash | `async_mode` quirk |
|---|---|---|---|---|
| `"selfhosted"` (default) | `X-API-Key` | `/search`, `/memories`, `/memories/{id}` | No | None |
| `"cloud"` | `Authorization: Token` | `/v1/memories/search/`, `/v1/memories/`, `/v1/memories/{id}/` | Yes | `infer=False` → add `async_mode=False` |

### Changes

- **`_backend.py`**: `SelfHostedBackend.__init__` gains `api_format` param. All routes and auth headers branch on it.
- **`__init__.py`**: `_create_backend()` reads `api_format` from config and passes it through. `system_prompt_block()` shows the correct label.
- **`_setup.py`**: Self-hosted setup wizard auto-detects Volcengine hosts (`*.volces.com`) and sets `api_format: "cloud"`.

### Usage

```json
// ~/.hermes/mem0.json
{
  "host": "https://mem0-xxx.mem0.volces.com:8000",
  "api_format": "cloud",
  "user_id": "eden",
  "agent_id": "hermes"
}
```

Or via setup wizard (auto-detected):
```bash
hermes memory setup mem0 --mode selfhosted --host https://mem0-xxx.mem0.volces.com:8000 --api-key <key>
# → "Detected Volcengine host — using cloud API format"
```

### Testing

Verified against a live Volcengine Mem0 instance:
- ✅ `search` — returns ranked results
- ✅ `add` (infer=False) — synchronous store, returns memory_id
- ✅ `add` (infer=True) — async store, returns event_id
- ✅ `update` — updates by memory_id
- ✅ `delete` — deletes by memory_id

### Backward compatibility

- Default `api_format` is `"selfhosted"` — existing self-hosted Docker users are unaffected
- No changes to Platform or OSS backends
- The `api_format` key is optional; `mem0.json` files without it behave exactly as before