### PR TITLE
fix(gateway): suppress the duplicate clarify tool-progress bubble (#69175)

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -645,6 +645,21 @@ def verb_drops_preview(tool_name: str) -> bool:
     return tool_name in _TOOL_VERBS_NO_PREVIEW
 
 
+# Tools that deliver their own complete, purpose-built prompt to the chat via a
+# dedicated adapter callback, rather than relying on a generic tool-progress
+# bubble.  ``clarify`` sends its full question (and any choices) through the
+# adapter's ``send_clarify`` callback (see gateway/run.py
+# ``_clarify_callback_sync``); the extra "❓ Asking …" tool-progress bubble was a
+# verbatim duplicate of that prompt (#69175).
+_TOOL_SELF_RENDERED_PROGRESS: frozenset[str] = frozenset({"clarify"})
+
+
+def tool_renders_own_progress(tool_name: str) -> bool:
+    """Whether the tool emits its own chat message and should therefore skip the
+    generic tool-progress bubble (which would just duplicate it)."""
+    return tool_name in _TOOL_SELF_RENDERED_PROGRESS
+
+
 def build_status_phrase(tool_name: str, args: dict | None, max_len: int = 49) -> str | None:
     """Build a short present-tense status phrase for platform status surfaces.
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19408,6 +19408,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if event_type not in {"tool.started",}:
                 return
 
+            # Some tools deliver their own complete prompt to the chat via a
+            # dedicated adapter callback (clarify → send_clarify).  Their
+            # generic tool-progress bubble ("❓ Asking …") is a verbatim
+            # duplicate of that prompt, so skip it here. (#69175)
+            from agent.display import tool_renders_own_progress
+            if tool_renders_own_progress(tool_name):
+                return
+
             # Suppress tool-progress bubbles once the user has sent `stop`.
             # When the LLM response carries N parallel tool calls, the agent
             # fires N "tool.started" events back-to-back before checking for

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -10,8 +10,10 @@ from agent.display import (
     capture_local_edit_snapshot,
     extract_edit_diff,
     get_cute_tool_message,
+    get_tool_verb,
     redact_tool_args_for_display,
     set_tool_preview_max_len,
+    tool_renders_own_progress,
     _render_inline_unified_diff,
     _summarize_rendered_diff_sections,
     render_edit_diff_with_delta,
@@ -551,3 +553,21 @@ class TestBuildStatusPhrase:
         from agent.display import build_status_phrase
         phrase = build_status_phrase("skills_list", {"category": "devops"})
         assert phrase == "is listing skills…"
+
+
+class TestToolRendersOwnProgress:
+    """`clarify` sends its own full prompt via send_clarify, so its generic
+    tool-progress bubble must be suppressed to avoid a duplicate message
+    (#69175)."""
+
+    def test_clarify_renders_own_progress(self):
+        assert tool_renders_own_progress("clarify") is True
+
+    def test_regular_tools_do_not_render_own_progress(self):
+        for name in ("terminal", "read_file", "web_search", "delegate_task", "memory"):
+            assert tool_renders_own_progress(name) is False
+
+    def test_clarify_verb_still_defined(self):
+        # Suppression happens at the progress-bubble layer only; the verb
+        # mapping (used by the ephemeral status line) is intentionally intact.
+        assert get_tool_verb("clarify") == "Asking"


### PR DESCRIPTION
## Summary

When tool progress is enabled, a `clarify` call renders **two** near-identical messages in chat:

1. The generic tool-progress bubble — `❓ Asking <question>` — built from `get_tool_verb("clarify")` → `"Asking"` in `progress_callback`.
2. The full clarify prompt sent by the tool's own callback (`send_clarify`, scheduled from `_clarify_callback_sync` in `gateway/run.py`).

The bubble is a verbatim duplicate of the prompt, so the user sees the same clarify question twice (#69175).

## Fix

`clarify` already owns its chat rendering via the adapter's `send_clarify` callback, so its generic progress bubble is always redundant. This PR:

- adds `agent.display.tool_renders_own_progress()` — a small predicate mirroring the existing `verb_drops_preview()` idiom — backed by a `_TOOL_SELF_RENDERED_PROGRESS` frozenset marking tools that deliver their own complete prompt via a dedicated adapter callback;
- gates `progress_callback` in `gateway/run.py` on it, right after the `tool.started` filter, so the duplicate bubble is skipped.

Scope is deliberately narrow:

- the ephemeral live status line (Slack `setStatus`) and `log`-mode stdout logging are **unaffected** — they run before this gate;
- the `clarify` verb mapping (`"Asking"`) is left intact, so nothing else that reads the verb changes.

## Tests

- `tests/agent/test_display.py::TestToolRendersOwnProgress` — the predicate is `True` for `clarify`, `False` for regular tools, and the verb mapping stays defined.
- Ran `tests/agent/test_display.py` plus the gateway clarify suites (`test_clarify_active_session_bypass`, `test_telegram_clarify_buttons`, `test_discord_clarify_buttons`) — 106 passed, no regressions.

Fixes #69175
