### PR TITLE
fix(telegram): publish sanitized runtime receipt

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -605,6 +605,12 @@ class PlatformConfig:
     # Platform-specific settings
     extra: Dict[str, Any] = field(default_factory=dict)
 
+    # Runtime-only provenance for the token's immediate source. Kept last to
+    # preserve the dataclass's legacy positional constructor contract. This is
+    # intentionally excluded from to_dict(): it describes how the running
+    # process resolved the credential, not durable user configuration.
+    credential_source: Optional[str] = None
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "enabled": self.enabled,
@@ -666,6 +672,7 @@ class PlatformConfig:
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
+            credential_source="config_file" if data.get("token") else None,
             api_key=data.get("api_key"),
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
@@ -1722,6 +1729,9 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if telegram_token:
         telegram_config = _enable_from_env(Platform.TELEGRAM)
         telegram_config.token = telegram_token
+        telegram_config.credential_source = (
+            "profile_env" if current_secret_scope() is not None else "process_env"
+        )
     
     # Reply threading mode for Telegram (off/first/all)
     telegram_reply_mode = getenv("TELEGRAM_REPLY_TO_MODE", "").lower()

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2792,25 +2792,43 @@ class BasePlatformAdapter(ABC):
     def set_fatal_error_handler(self, handler: Callable[["BasePlatformAdapter"], Awaitable[None] | None]) -> None:
         self._fatal_error_handler = handler
 
-    def _mark_connected(self) -> None:
+    def _mark_connected(self, *, platform_runtime: Any = None) -> None:
         self._running = True
         self._fatal_error_code = None
         self._fatal_error_message = None
         self._fatal_error_retryable = True
-        self._write_runtime_status_safe("connected", platform_state="connected", error_code=None, error_message=None)
+        self._write_runtime_status_safe(
+            "connected",
+            platform_state="connected",
+            error_code=None,
+            error_message=None,
+            platform_runtime=platform_runtime,
+        )
 
     def _mark_disconnected(self) -> None:
         self._running = False
         if self.has_fatal_error:
             return
-        self._write_runtime_status_safe("disconnected", platform_state="disconnected", error_code=None, error_message=None)
+        self._write_runtime_status_safe(
+            "disconnected",
+            platform_state="disconnected",
+            error_code=None,
+            error_message=None,
+            platform_runtime=None,
+        )
 
     def _set_fatal_error(self, code: str, message: str, *, retryable: bool) -> None:
         self._running = False
         self._fatal_error_code = code
         self._fatal_error_message = message
         self._fatal_error_retryable = retryable
-        self._write_runtime_status_safe("fatal", platform_state="fatal", error_code=code, error_message=message)
+        self._write_runtime_status_safe(
+            "fatal",
+            platform_state="fatal",
+            error_code=code,
+            error_message=message,
+            platform_runtime=None,
+        )
 
     def _write_runtime_status_safe(self, context: str, **kwargs) -> None:
         """Write runtime status; log first failure per context at warning, rest at debug.

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -37,6 +37,30 @@ _RUNTIME_STATUS_FILE = "gateway_state.json"
 _LOCKS_DIRNAME = "gateway-locks"
 _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
+_PLATFORM_RUNTIME_FIELDS = frozenset(
+    {
+        "credential_source",
+        "authenticated",
+        "bot_id",
+        "bot_username",
+        "transport_mode",
+        "transport_ready",
+        "verified_at",
+    }
+)
+_PLATFORM_RUNTIME_CREDENTIAL_SOURCES = frozenset(
+    {
+        "managed_env",
+        "bitwarden",
+        "onepassword",
+        "config_file",
+        "profile_env",
+        "process_env",
+        "missing",
+        "unknown",
+    }
+)
+_PLATFORM_RUNTIME_TRANSPORT_MODES = frozenset({"polling", "webhook"})
 _GATEWAY_LOCK_FILENAME = "gateway.lock"
 _gateway_lock_handle = None
 # Windows byte-range locks are mandatory for other readers. Lock a byte well
@@ -982,12 +1006,20 @@ def write_runtime_status(
     platform_state: Any = _UNSET,
     error_code: Any = _UNSET,
     error_message: Any = _UNSET,
+    platform_runtime: Any = _UNSET,
     served_profiles: Any = _UNSET,
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
-    payload = _read_json_file(path) or _build_runtime_status_record()
     current_record = _build_pid_record()
+    payload = _read_json_file(path)
+    if payload is None or (
+        payload.get("pid") != current_record["pid"]
+        or payload.get("start_time") != current_record["start_time"]
+    ):
+        # Volatile authentication/readiness evidence belongs to one exact
+        # process incarnation. Never rebind an old receipt to a new PID/start.
+        payload = _build_runtime_status_record()
     payload.setdefault("platforms", {})
     payload["kind"] = current_record["kind"]
     payload["pid"] = current_record["pid"]
@@ -1008,6 +1040,12 @@ def write_runtime_status(
         # for a single-profile gateway. Lets `hermes status` show per-profile
         # coverage without a second probe.
         payload["served_profiles"] = list(served_profiles or [])
+        if len(payload["served_profiles"]) > 1:
+            # One platforms.<name>.runtime object cannot truthfully identify
+            # several profile-specific adapters for the same platform.
+            for existing_platform in payload["platforms"].values():
+                if isinstance(existing_platform, dict):
+                    existing_platform.pop("runtime", None)
 
     if platform is not _UNSET:
         platform_payload = payload["platforms"].get(platform, {})
@@ -1017,10 +1055,70 @@ def write_runtime_status(
             platform_payload["error_code"] = error_code
         if error_message is not _UNSET:
             platform_payload["error_message"] = error_message
+        if platform_runtime is not _UNSET:
+            sanitized_runtime = _sanitize_platform_runtime_receipt(platform_runtime)
+            served = payload.get("served_profiles")
+            multiplexed = isinstance(served, list) and len(served) > 1
+            if sanitized_runtime is None or multiplexed:
+                platform_payload.pop("runtime", None)
+            else:
+                platform_payload["runtime"] = sanitized_runtime
         platform_payload["updated_at"] = _utc_now_iso()
         payload["platforms"][platform] = platform_payload
 
     _write_json_file(path, payload)
+
+
+def _sanitize_platform_runtime_receipt(value: Any) -> Optional[dict[str, Any]]:
+    """Validate and copy the fixed public platform-runtime receipt.
+
+    Platform receipts are operator-facing evidence. They may contain public bot
+    identity and transport metadata, but never credentials, URLs, opaque SDK
+    payloads, errors, or future fields. ``None`` explicitly clears a stale
+    receipt.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError("platform runtime receipt must be an object or null")
+    unknown_fields = set(value) - _PLATFORM_RUNTIME_FIELDS
+    if unknown_fields:
+        raise ValueError("platform runtime receipt contains an unapproved field")
+    if set(value) != _PLATFORM_RUNTIME_FIELDS:
+        raise ValueError("platform runtime receipt is missing required fields")
+
+    if value["credential_source"] not in _PLATFORM_RUNTIME_CREDENTIAL_SOURCES:
+        raise ValueError("platform runtime receipt credential source is invalid")
+    if type(value["authenticated"]) is not bool:
+        raise ValueError("platform runtime receipt authenticated must be boolean")
+    if not isinstance(value["bot_id"], str) or len(value["bot_id"]) > 128:
+        raise ValueError("platform runtime receipt bot_id must be a short string")
+    if value["bot_username"] is not None and (
+        not isinstance(value["bot_username"], str)
+        or len(value["bot_username"]) > 128
+    ):
+        raise ValueError(
+            "platform runtime receipt bot_username must be a short string or null"
+        )
+    if value["transport_mode"] not in _PLATFORM_RUNTIME_TRANSPORT_MODES:
+        raise ValueError("platform runtime receipt transport mode is invalid")
+    if type(value["transport_ready"]) is not bool:
+        raise ValueError("platform runtime receipt transport_ready must be boolean")
+    if not isinstance(value["verified_at"], str):
+        raise ValueError("platform runtime receipt verified_at must be a timestamp")
+    try:
+        verified_at = datetime.fromisoformat(
+            value["verified_at"].replace("Z", "+00:00")
+        )
+    except ValueError as exc:
+        raise ValueError(
+            "platform runtime receipt verified_at must be a timestamp"
+        ) from exc
+    if verified_at.tzinfo is None:
+        raise ValueError(
+            "platform runtime receipt verified_at must include a timezone"
+        )
+    return dict(value)
 
 
 def read_runtime_status(path: Optional[Path] = None) -> Optional[dict[str, Any]]:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -836,7 +836,33 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def _mark_connected(self) -> None:
         self._drop_delayed_deliveries = False
-        super()._mark_connected()
+        super()._mark_connected(platform_runtime=self._telegram_runtime_receipt())
+
+    def _telegram_runtime_receipt(self) -> dict[str, Any]:
+        """Build the fixed, secret-free Telegram runtime receipt."""
+        bot = getattr(self, "_bot", None)
+        bot_id = getattr(bot, "id", None)
+        bot_username = getattr(bot, "username", None)
+        return {
+            "credential_source": (
+                getattr(self.config, "credential_source", None) or "unknown"
+            ),
+            "authenticated": bot_id is not None,
+            "bot_id": str(bot_id) if bot_id is not None else "",
+            "bot_username": str(bot_username) if bot_username else None,
+            "transport_mode": (
+                "webhook" if getattr(self, "_webhook_mode", False) else "polling"
+            ),
+            "transport_ready": not getattr(self, "_send_path_degraded", False),
+            "verified_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+    def _publish_telegram_runtime_receipt(self, context: str) -> None:
+        """Persist an authenticated transport-readiness transition."""
+        self._write_runtime_status_safe(
+            context,
+            platform_runtime=self._telegram_runtime_receipt(),
+        )
 
     def _mark_disconnected(self) -> None:
         self._drop_delayed_deliveries = True
@@ -2060,10 +2086,13 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         if generation != self._polling_generation:
             return
+        was_degraded = getattr(self, "_send_path_degraded", False)
         self._polling_progress_event.set()
         self._polling_network_error_count = 0
         self._polling_conflict_count = 0
         self._send_path_degraded = False
+        if was_degraded and getattr(self, "_running", False):
+            self._publish_telegram_runtime_receipt("polling-progress")
 
     def _observe_polling_request_result(self, request, generation, result):
         """Record getUpdates progress from an observed do_request result.
@@ -2255,6 +2284,8 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return
         self._send_path_degraded = True
+        if getattr(self, "_running", False):
+            self._publish_telegram_runtime_receipt("polling-degraded")
         logger.warning(
             "[%s] Telegram polling degraded (%s); gateway stays alive and will retry. Error: %s",
             self.name, reason, _redact_telegram_error_text(error),
@@ -2358,6 +2389,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
         self._polling_network_error_count += 1
         self._send_path_degraded = True
+        if getattr(self, "_running", False):
+            self._publish_telegram_runtime_receipt("polling-network-error")
         attempt = self._polling_network_error_count
 
         if attempt > MAX_NETWORK_RETRIES:
@@ -2850,6 +2883,9 @@ class TelegramAdapter(BasePlatformAdapter):
         # retry attempt instead of returning silently, and only escalate to
         # fatal after all retries are exhausted.
         self._polling_conflict_count += 1
+        self._send_path_degraded = True
+        if getattr(self, "_running", False):
+            self._publish_telegram_runtime_receipt("polling-conflict")
 
         MAX_CONFLICT_RETRIES = 5
         # Delay grows with each attempt: 15s, 25s, 35s, 45s, 55s.

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -7,6 +7,8 @@ import time
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from gateway import status
 
 
@@ -669,6 +671,104 @@ class TestGatewayRuntimeStatus:
         assert payload["platforms"]["discord"]["state"] == "connected"
         assert payload["platforms"]["discord"]["error_code"] is None
         assert payload["platforms"]["discord"]["error_message"] is None
+
+    def test_write_runtime_status_records_sanitized_platform_receipt(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        receipt = {
+            "credential_source": "profile_env",
+            "authenticated": True,
+            "bot_id": "123456789",
+            "bot_username": "fleet_test_bot",
+            "transport_mode": "polling",
+            "transport_ready": True,
+            "verified_at": "2026-07-22T08:30:00+00:00",
+        }
+
+        status.write_runtime_status(
+            platform="telegram",
+            platform_state="connected",
+            platform_runtime=receipt,
+        )
+
+        payload = status.read_runtime_status()
+        assert payload["platforms"]["telegram"]["runtime"] == receipt
+        assert "token" not in json.dumps(payload).lower()
+
+    def test_write_runtime_status_rejects_secret_bearing_platform_receipt(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        with pytest.raises(ValueError, match="unapproved"):
+            status.write_runtime_status(
+                platform="telegram",
+                platform_runtime={"bot_token": "123456:secret"},
+            )
+
+        payload = status.read_runtime_status()
+        assert payload is None
+
+    def test_write_runtime_status_drops_stale_receipt_on_process_rollover(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "gateway_state.json").write_text(
+            json.dumps(
+                {
+                    "pid": 99999,
+                    "start_time": 1,
+                    "platforms": {
+                        "telegram": {
+                            "state": "connected",
+                            "runtime": {
+                                "credential_source": "profile_env",
+                                "authenticated": True,
+                                "bot_id": "123",
+                                "bot_username": "old_bot",
+                                "transport_mode": "polling",
+                                "transport_ready": True,
+                                "verified_at": "2026-07-22T08:30:00+00:00",
+                            },
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        status.write_runtime_status(gateway_state="starting")
+
+        payload = status.read_runtime_status()
+        assert payload["pid"] == os.getpid()
+        assert payload["platforms"] == {}
+
+    def test_multiplexed_status_never_persists_ambiguous_runtime_receipt(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        receipt = {
+            "credential_source": "profile_env",
+            "authenticated": True,
+            "bot_id": "123",
+            "bot_username": "fleet_test_bot",
+            "transport_mode": "polling",
+            "transport_ready": True,
+            "verified_at": "2026-07-22T08:30:00+00:00",
+        }
+        status.write_runtime_status(
+            platform="telegram",
+            platform_runtime=receipt,
+        )
+        status.write_runtime_status(served_profiles=["default", "secondary"])
+        status.write_runtime_status(
+            platform="telegram",
+            platform_runtime=receipt,
+        )
+
+        payload = status.read_runtime_status()
+        assert "runtime" not in payload["platforms"]["telegram"]
 
 
 class TestGetProcessStartTime:

--- a/tests/gateway/test_telegram_runtime_receipt.py
+++ b/tests/gateway/test_telegram_runtime_receipt.py
@@ -1,0 +1,111 @@
+"""Telegram publishes a token-free receipt after real transport startup."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.secret_scope import reset_secret_scope, set_secret_scope
+from gateway.config import GatewayConfig, Platform, PlatformConfig, _apply_env_overrides
+from gateway.status import read_runtime_status
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def test_connected_telegram_adapter_publishes_runtime_receipt(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(
+        enabled=True,
+        token="123456:never-persist-this-secret",
+        credential_source="profile_env",
+    )
+    adapter._bot = SimpleNamespace(id=123456789, username="fleet_test_bot")
+    adapter._webhook_mode = False
+    adapter._send_path_degraded = False
+    adapter._drop_delayed_deliveries = True
+    adapter._fatal_error_code = None
+    adapter._fatal_error_message = None
+    adapter._fatal_error_retryable = True
+    adapter._status_write_logged = set()
+
+    adapter._mark_connected()
+
+    payload = read_runtime_status()
+    platform = payload["platforms"]["telegram"]
+    assert platform["state"] == "connected"
+    assert platform["runtime"]["credential_source"] == "profile_env"
+    assert platform["runtime"]["authenticated"] is True
+    assert platform["runtime"]["bot_id"] == "123456789"
+    assert platform["runtime"]["bot_username"] == "fleet_test_bot"
+    assert platform["runtime"]["transport_mode"] == "polling"
+    assert platform["runtime"]["transport_ready"] is True
+    assert platform["runtime"]["verified_at"]
+    assert "never-persist-this-secret" not in json.dumps(payload)
+
+    adapter._mark_disconnected()
+
+    disconnected = read_runtime_status()["platforms"]["telegram"]
+    assert disconnected["state"] == "disconnected"
+    assert "runtime" not in disconnected
+
+
+def test_platform_config_tracks_token_origin_without_serializing_it(monkeypatch):
+    configured = PlatformConfig.from_dict({"enabled": True, "token": "yaml-secret"})
+    assert configured.credential_source == "config_file"
+    assert "credential_source" not in configured.to_dict()
+
+
+def test_profile_scoped_telegram_token_is_attributed_to_profile_env():
+    scope_token = set_secret_scope({"TELEGRAM_BOT_TOKEN": "profile-secret"})
+    try:
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+    finally:
+        reset_secret_scope(scope_token)
+
+    telegram = config.platforms[Platform.TELEGRAM]
+    assert telegram.token == "profile-secret"
+    assert telegram.credential_source == "profile_env"
+
+
+def test_process_telegram_token_is_attributed_to_process_env(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "process-secret")
+    config = GatewayConfig()
+
+    _apply_env_overrides(config)
+
+    telegram = config.platforms[Platform.TELEGRAM]
+    assert telegram.token == "process-secret"
+    assert telegram.credential_source == "process_env"
+
+
+def test_polling_progress_refreshes_transport_readiness(monkeypatch):
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(
+        enabled=True,
+        token="123456:never-persist-this-secret",
+        credential_source="profile_env",
+    )
+    adapter._bot = SimpleNamespace(id=123456789, username="fleet_test_bot")
+    adapter._webhook_mode = False
+    adapter._running = True
+    adapter._polling_teardown_started = False
+    adapter._polling_progress_accepting = True
+    adapter._polling_generation = 7
+    adapter._polling_progress_event = asyncio.Event()
+    adapter._polling_network_error_count = 1
+    adapter._polling_conflict_count = 1
+    adapter._send_path_degraded = True
+    status_writer = MagicMock()
+    monkeypatch.setattr(adapter, "_write_runtime_status_safe", status_writer)
+
+    adapter._record_polling_progress(7)
+
+    status_writer.assert_called_once()
+    receipt = status_writer.call_args.kwargs["platform_runtime"]
+    assert receipt["transport_ready"] is True
+    assert "never-persist-this-secret" not in json.dumps(receipt)


### PR DESCRIPTION
## What does this PR do?

Publishes a sanitized, token-free Telegram runtime receipt into gateway status after Telegram authentication succeeds. Fleet health can then distinguish a connected bot with proven runtime identity from a process that is merely alive.

The receipt records only credential provenance, authentication state, bot ID/username, transport mode/readiness, and verification time. Status persistence uses a fixed public allowlist, drops evidence on process rollover, suppresses ambiguous multiplex receipts, and disconnect/fatal paths clear stale receipts atomically. Polling degradation and recovery refresh readiness instead of leaving a stale green receipt.

## Related Issue

No linked issue; this closes a runtime observability gap found during a live Fleet health audit.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/config.py`: retain runtime-only credential provenance without serializing it back into configuration.
- `gateway/status.py`: accept and strictly sanitize a platform runtime receipt before persisting it.
- `gateway/platforms/base.py`: persist connection state and receipt creation/clearing in one atomic lifecycle write.
- `plugins/platforms/telegram/adapter.py`: publish the receipt only after authenticated connection and clear it on disconnect/fatal failure.
- `tests/gateway/test_status.py` and `tests/gateway/test_telegram_runtime_receipt.py`: cover persistence, secret rejection, Telegram adapter output, config-file provenance, and secret-scope environment provenance.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_status.py tests/gateway/test_telegram_runtime_receipt.py -q`.
2. Confirm 135 tests pass.
3. Start a Telegram gateway and inspect the status file: `platforms.telegram.runtime` should contain the sanitized receipt and no token value.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing PRs and found no duplicate runtime-status receipt change.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass. The repository requires `scripts/run_tests.sh`; the focused 135 tests pass. A broader local compatibility sample is limited by the installed runtime environment lacking `pytest-asyncio`; hosted CI remains authoritative for async coverage.
- [x] I've added tests for my changes.
- [x] I've tested on macOS (Apple Silicon).

### Documentation & Housekeeping

- [x] Documentation N/A — this adds runtime status evidence without changing user configuration.
- [x] `cli-config.yaml.example` N/A — no serialized config key was added.
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A — no workflow or architecture contract changed.
- [x] Cross-platform impact considered — implementation uses Python standard-library types and existing gateway abstractions.
- [x] Tool descriptions/schemas N/A — no tool API changed.

## Screenshots / Logs

Screenshots are not applicable because the change has no rendered UI. Executable proof: the canonical test runner reports `2 files, 135 tests passed, 0 failed`. The synchronous compatibility surface adds 195 further passing tests across the platform base and Telegram recovery files; async cases cannot run in the installed runtime because `pytest-asyncio` is absent.
