### PR TITLE
fix(worktree): canonicalize repo_root to main worktree to prevent nested worktrees

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1533,6 +1533,37 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True) -> Optional[D
         print("  cd into your project repo first, then run hermes -w")
         return None
 
+    # Canonicalize repo_root to the MAIN working tree so worktrees are never
+    # created nested inside another worktree. When a session starts *inside* a
+    # linked worktree, both `_git_repo_root()` and the WebUI's
+    # `find_git_repo_root()` use `git rev-parse --show-toplevel`, which returns
+    # that worktree's own root — not the canonical clone. The new worktree would
+    # then be created under <worktree>/.worktrees/, digging one level deeper for
+    # every session spawned from a worktree session (recursive nesting).
+    # `--git-common-dir` always resolves to the main repo's .git even from a
+    # linked worktree; its parent is the canonical clone root. Only redirect for
+    # a normal (non-bare) clone whose common git dir is a ".git" directory —
+    # bare repos / unusual layouts are left untouched (prior behavior).
+    try:
+        _common = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse",
+             "--path-format=absolute", "--git-common-dir"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if _common.returncode == 0:
+            _cdir = _normalize_git_bash_path(_common.stdout.strip())
+            if _cdir and os.path.basename(os.path.normpath(_cdir)) == ".git":
+                _canonical = os.path.dirname(os.path.normpath(_cdir))
+                if _canonical and _canonical != repo_root:
+                    logger.debug(
+                        "worktree: redirecting repo_root %s -> canonical %s "
+                        "(session started inside a worktree)",
+                        repo_root, _canonical,
+                    )
+                    repo_root = _canonical
+    except Exception as e:
+        logger.debug("Could not canonicalize repo_root to main worktree: %s", e)
+
     short_id = uuid.uuid4().hex[:8]
     wt_name = f"hermes-{short_id}"
     branch_name = f"hermes/{wt_name}"

--- a/tests/cli/test_worktree_security.py
+++ b/tests/cli/test_worktree_security.py
@@ -128,3 +128,40 @@ class TestWorktreeIncludeSecurity:
             assert (linked_dir / "lib" / "marker.txt").read_text() == "venv marker"
         finally:
             _force_remove_worktree(info)
+
+
+class TestWorktreeNestingCanonicalization:
+    """A session started inside a linked worktree must not create the next
+    worktree nested inside that worktree — it belongs under the main clone."""
+
+    def test_setup_from_inside_worktree_uses_main_clone(self, git_repo):
+        import cli as cli_mod
+
+        # First worktree, created the normal way from the main clone.
+        first = None
+        second = None
+        try:
+            first = cli_mod._setup_worktree(str(git_repo))
+            assert first is not None
+            first_path = Path(first["path"]).resolve()
+            # Sanity: the first worktree lives under the main clone.
+            assert first_path.parent == (git_repo / ".worktrees").resolve()
+
+            # Now emulate a session that STARTS inside that linked worktree:
+            # pass the worktree's own path as repo_root, exactly as
+            # find_git_repo_root()/`git rev-parse --show-toplevel` would report
+            # from inside a linked worktree.
+            second = cli_mod._setup_worktree(str(first_path))
+            assert second is not None
+            second_path = Path(second["path"]).resolve()
+
+            # The new worktree must be created under the MAIN clone, not nested
+            # inside the first worktree (which would be
+            # <first>/.worktrees/... — the recursive-nesting bug).
+            assert second_path.parent == (git_repo / ".worktrees").resolve()
+            assert Path(second["repo_root"]).resolve() == git_repo.resolve()
+            # Explicitly assert it is NOT nested inside the first worktree.
+            assert (first_path / ".worktrees") not in second_path.parents
+        finally:
+            _force_remove_worktree(second)
+            _force_remove_worktree(first)


### PR DESCRIPTION
## Problem

When a Hermes session starts **inside a linked git worktree**, creating a new
session/worktree from that context nests the new worktree one level deeper for
every generation, instead of placing it under the canonical clone.

Root cause: both the CLI's `_git_repo_root()` and the WebUI's
`find_git_repo_root()` resolve the repo via `git rev-parse --show-toplevel`,
which from inside a linked worktree returns *that worktree's own root*, not the
main clone. `_setup_worktree()` then creates the new worktree under
`<worktree>/.worktrees/…`, so a session spawned from a worktree session lands at
`.worktrees/hermes-A/.worktrees/hermes-B`, and so on recursively.

WebUI symptom: creating a new conversation from inside an existing
worktree-backed session fails worktree creation and silently falls back to a
plain session — the toast reads *"Worktree unavailable here — created a normal
session."*

## Fix

Before choosing the worktree location in `_setup_worktree()`, resolve
`git rev-parse --path-format=absolute --git-common-dir`. That always points at
the **main** repo's `.git` even from a linked worktree; its parent is the
canonical clone root. Redirect `repo_root` there.

- Guarded to only redirect for a normal (non-bare) clone whose common git dir is
  a `.git` directory — bare repos and unusual layouts keep prior behavior.
- Fully fail-soft: any error in the probe leaves `repo_root` untouched, so this
  can never block worktree creation.

## Test evidence

Added a regression test in `tests/cli/test_worktree_security.py`
(`TestWorktreeNestingCanonicalization`) that calls the real
`cli._setup_worktree` from inside a linked worktree and asserts the new worktree
lands under the main clone, not nested.

- **RED** without the fix: reproduces the bug —
  `.worktrees/hermes-A/.worktrees/hermes-B`.
- **GREEN** with the fix.
- Full worktree suite: `64 passed`
  (`test_worktree.py`, `test_worktree_security.py`, `test_worktree_sync_base.py`).
- `ruff check` clean (repo config, ruff 0.15.10).
