### PR TITLE
fix(agent): checkpoint every terminal call, not just regex-matched ones (#69171)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -33,7 +33,6 @@ from agent.display import (
     _detect_tool_failure,
 )
 from agent.tool_dispatch_helpers import (
-    _is_destructive_command,
     _is_multimodal_tool_result,
     _multimodal_text_summary,
     _append_subdir_hint_to_multimodal,
@@ -73,6 +72,21 @@ def _ensure_file_checkpoint(
     resolved_path = _resolve_path_for_task(file_path, effective_task_id or "default")
     work_dir = agent._checkpoint_mgr.get_working_dir_for_path(str(resolved_path))
     agent._checkpoint_mgr.ensure_checkpoint(work_dir, f"before {function_name}")
+
+
+def _ensure_terminal_checkpoint(agent, function_args: dict) -> None:
+    """Checkpoint the terminal working dir before every terminal call.
+
+    Correctness must not depend on a command classifier: absolute paths
+    (/bin/rm), find -delete, interpreters, aliases, and functions all mutate
+    the working dir without matching the destructive-command regex, so gating
+    on it left those changes unprotected (#69171). ensure_checkpoint is
+    per-turn idempotent, so this snapshots once per working dir per turn and is
+    a cheap no-op thereafter.
+    """
+    command = function_args.get("command", "")
+    cwd = function_args.get("workdir") or os.getenv("TERMINAL_CWD", os.getcwd())
+    agent._checkpoint_mgr.ensure_checkpoint(cwd, f"before terminal: {command[:60]}")
 
 
 def _budget_for_agent(agent) -> BudgetConfig:
@@ -614,14 +628,7 @@ def _begin_tool_execution(
 
     if function_name == "terminal" and agent._checkpoint_mgr.enabled:
         try:
-            command = function_args.get("command", "")
-            if _is_destructive_command(command):
-                cwd = function_args.get("workdir") or os.getenv(
-                    "TERMINAL_CWD", os.getcwd()
-                )
-                agent._checkpoint_mgr.ensure_checkpoint(
-                    cwd, f"before terminal: {command[:60]}"
-                )
+            _ensure_terminal_checkpoint(agent, function_args)
         except Exception:
             pass
 

--- a/tests/agent/test_tool_executor_checkpoint_paths.py
+++ b/tests/agent/test_tool_executor_checkpoint_paths.py
@@ -2,7 +2,7 @@
 
 from types import SimpleNamespace
 
-from agent.tool_executor import _ensure_file_checkpoint
+from agent.tool_executor import _ensure_file_checkpoint, _ensure_terminal_checkpoint
 from tools.checkpoint_manager import CheckpointManager
 
 
@@ -38,3 +38,66 @@ def test_relative_file_checkpoint_uses_task_workspace(tmp_path, monkeypatch):
 
     assert manager.list_checkpoints(str(workspace_cwd))
     assert manager.list_checkpoints(str(process_cwd)) == []
+
+
+def _make_terminal_agent(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "tools.checkpoint_manager.CHECKPOINT_BASE",
+        tmp_path / "checkpoints",
+    )
+    manager = CheckpointManager(enabled=True)
+    return SimpleNamespace(_checkpoint_mgr=manager), manager
+
+
+def test_terminal_checkpoint_fires_for_bypassing_command(tmp_path, monkeypatch):
+    """A command the destructive-string classifier can't recognize must still
+    establish a checkpoint for its working dir (#69171)."""
+    work_dir = tmp_path / "project"
+    work_dir.mkdir()
+    (work_dir / "victim.txt").write_text("keep me\n")
+
+    agent, manager = _make_terminal_agent(tmp_path, monkeypatch)
+
+    # Absolute-path rm — bypasses the _is_destructive_command regex.
+    _ensure_terminal_checkpoint(
+        agent, {"command": "/bin/rm victim.txt", "workdir": str(work_dir)}
+    )
+
+    assert manager.list_checkpoints(str(work_dir))
+
+
+def test_terminal_checkpoint_fires_for_innocuous_command(tmp_path, monkeypatch):
+    """Correctness no longer depends on the command string: even a read-only
+    command checkpoints the working dir once per turn (#69171)."""
+    work_dir = tmp_path / "project"
+    work_dir.mkdir()
+    (work_dir / "a.txt").write_text("x\n")
+
+    agent, manager = _make_terminal_agent(tmp_path, monkeypatch)
+
+    _ensure_terminal_checkpoint(agent, {"command": "ls -la", "workdir": str(work_dir)})
+
+    assert manager.list_checkpoints(str(work_dir))
+
+
+def test_terminal_checkpoint_dedups_within_turn(tmp_path, monkeypatch):
+    """ensure_checkpoint is per-turn idempotent, so repeated terminal calls in
+    the same turn don't stack extra snapshots for the same dir (#69171)."""
+    work_dir = tmp_path / "project"
+    work_dir.mkdir()
+    (work_dir / "a.txt").write_text("x\n")
+
+    agent, manager = _make_terminal_agent(tmp_path, monkeypatch)
+
+    _ensure_terminal_checkpoint(agent, {"command": "ls", "workdir": str(work_dir)})
+    before = len(manager.list_checkpoints(str(work_dir)))
+    _ensure_terminal_checkpoint(agent, {"command": "cat a.txt", "workdir": str(work_dir)})
+    after = len(manager.list_checkpoints(str(work_dir)))
+
+    assert before == after == 1
+
+    # A fresh turn resets the dedup set and allows a new snapshot.
+    manager.new_turn()
+    (work_dir / "a.txt").write_text("y\n")
+    _ensure_terminal_checkpoint(agent, {"command": "echo hi", "workdir": str(work_dir)})
+    assert len(manager.list_checkpoints(str(work_dir))) == 2


### PR DESCRIPTION
## Summary

With filesystem checkpoints enabled, a `terminal` call only established a checkpoint when `_is_destructive_command()` recognized the command string. That regex can't classify arbitrary shell, so `/rollback` protection depended on spelling. Commands that mutate the working dir *without* matching it went unprotected:

```sh
/bin/rm victim.txt
find . -name victim.txt -delete
python -c "from pathlib import Path; Path('victim.txt').unlink()"
```

## Fix

Drop the `_is_destructive_command` gate at both terminal dispatch sites (the sequential preflight and the concurrent path in `agent/tool_executor.py`) and always `ensure_checkpoint()` before an unblocked `terminal` call when checkpoints are enabled.

This is cheap because `CheckpointManager.ensure_checkpoint` is already **per-turn idempotent** — it tracks `_checkpointed_dirs` and `new_turn()` clears it, so a working dir is snapshotted at most once per turn regardless of how many terminal calls run. Checkpoint correctness now depends on the terminal tool's capability, not on an incomplete command-string classifier — matching the issue's expected behavior.

The two previously-duplicated inline blocks are extracted into `_ensure_terminal_checkpoint()`, mirroring the existing `_ensure_file_checkpoint()`, which also gives the behavior a unit-testable surface. `_is_destructive_command` is no longer imported by `tool_executor.py` (it remains defined/exported in `agent/tool_dispatch_helpers.py`).

Scope, per the issue, is limited to files inside the terminal working directory eligible for the shadow-Git snapshot; side effects outside it and protection of the checkpoint store itself are tracked separately.

## Tests

`tests/agent/test_tool_executor_checkpoint_paths.py`:

- a bypassing command (`/bin/rm victim.txt`) now establishes a checkpoint;
- an innocuous command (`ls`) does too — correctness no longer depends on the string;
- per-turn dedup holds: repeated calls in one turn don't stack snapshots, and `new_turn()` allows a fresh one.

Ran the checkpoint suites (`test_checkpoint_manager`, `test_tool_executor_checkpoint_paths`, `gateway/test_checkpoint_config`) — 83 passed.

Fixes #69171
