### PR TITLE
fix(codex): preserve adaptive no-byte TTFB default

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -152,6 +152,40 @@ def openai_codex_stale_timeout_floor(est_tokens: int) -> float:
     return 0.0
 
 
+def _codex_adaptive_watchdog_timeout(estimated_tokens: int) -> float:
+    if estimated_tokens > 100_000:
+        return 180.0
+    if estimated_tokens > 50_000:
+        return 120.0
+    if estimated_tokens > 10_000:
+        return 60.0
+    return 12.0
+
+
+def _compute_codex_ttfb_timeout(
+    *,
+    estimated_tokens: int,
+    configured_timeout: float,
+    disable_above_tokens: float,
+    strict: bool,
+    max_seconds: float,
+) -> tuple[bool, float]:
+    """Return whether the no-byte watchdog is enabled and its timeout."""
+    if configured_timeout <= 0:
+        return False, configured_timeout
+
+    timeout = configured_timeout
+    if (
+        not strict
+        and disable_above_tokens > 0
+        and estimated_tokens >= disable_above_tokens
+    ):
+        timeout = max(timeout, _codex_adaptive_watchdog_timeout(estimated_tokens))
+    if max_seconds > 0:
+        timeout = min(timeout, max_seconds)
+    return True, timeout
+
+
 def _validated_openrouter_provider_sort(raw_sort: Any) -> Optional[str]:
     """Return a normalized OpenRouter provider.sort value or None."""
     if not isinstance(raw_sort, str):
@@ -685,14 +719,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
     ):
         _stale_timeout = min(_stale_timeout, _codex_hard_timeout)
 
-    if _est_tokens_for_codex_watchdog > 100_000:
-        _codex_idle_timeout_default = 180.0
-    elif _est_tokens_for_codex_watchdog > 50_000:
-        _codex_idle_timeout_default = 120.0
-    elif _est_tokens_for_codex_watchdog > 10_000:
-        _codex_idle_timeout_default = 60.0
-    else:
-        _codex_idle_timeout_default = 12.0
+    _codex_idle_timeout_default = _codex_adaptive_watchdog_timeout(
+        _est_tokens_for_codex_watchdog
+    )
 
     # No-byte TTFB cutoff. The OpenAI SDK's own streaming read timeout is far
     # longer (openai 2.x DEFAULT_TIMEOUT.read = 600s), so a tight 12s default
@@ -701,15 +730,17 @@ def interruptible_api_call(agent, api_kwargs: dict):
     # clear normal backend admission / prompt prefill, short enough to still
     # reconnect promptly when the socket is genuinely wedged. Set
     # HERMES_CODEX_TTFB_TIMEOUT_SECONDS=0 to disable this watchdog entirely.
+    # HERMES_CODEX_TTFB_MAX_SECONDS caps the adaptive timeout only when set to
+    # a positive value; leaving it unset preserves every adaptive tier.
     _ttfb_enabled = _codex_watchdog_enabled
     _ttfb_timeout = _env_float("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", 120.0)
-    if _ttfb_timeout <= 0:
-        _ttfb_enabled = False
-    elif _openai_codex_backend:
+    if _openai_codex_backend:
         _ttfb_disable_above = _env_float("HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS", 10_000.0)
         _ttfb_strict = os.environ.get("HERMES_CODEX_TTFB_STRICT", "").strip().lower() in {
             "1", "true", "yes", "on"
         }
+        _ttfb_cap = _env_float("HERMES_CODEX_TTFB_MAX_SECONDS", 0.0)
+        _scaled_ttfb_timeout = _ttfb_timeout
         if (
             not _ttfb_strict
             and _ttfb_disable_above > 0
@@ -726,17 +757,28 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     f"{_est_tokens_for_codex_watchdog:,}",
                     _ttfb_disable_above,
                 )
-                _ttfb_timeout = _large_request_ttfb_timeout
-        _ttfb_cap = _env_float("HERMES_CODEX_TTFB_MAX_SECONDS", 120.0)
-        if _ttfb_cap > 0 and _ttfb_timeout > _ttfb_cap:
+                _scaled_ttfb_timeout = _large_request_ttfb_timeout
+        _computed_ttfb_enabled, _ttfb_timeout = _compute_codex_ttfb_timeout(
+            estimated_tokens=_est_tokens_for_codex_watchdog,
+            configured_timeout=_ttfb_timeout,
+            disable_above_tokens=_ttfb_disable_above,
+            strict=_ttfb_strict,
+            max_seconds=_ttfb_cap,
+        )
+        _ttfb_enabled = _codex_watchdog_enabled and _computed_ttfb_enabled
+        if (
+            _ttfb_cap > 0
+            and _scaled_ttfb_timeout > _ttfb_cap
+        ):
             logger.info(
                 "Capping openai-codex no-byte TTFB timeout from %.0fs to %.0fs "
                 "(context=~%s tokens). Set HERMES_CODEX_TTFB_MAX_SECONDS to tune.",
-                _ttfb_timeout,
+                _scaled_ttfb_timeout,
                 _ttfb_cap,
                 f"{_est_tokens_for_codex_watchdog:,}",
             )
-            _ttfb_timeout = _ttfb_cap
+    elif _ttfb_timeout <= 0:
+        _ttfb_enabled = False
 
     _codex_idle_enabled = _codex_watchdog_enabled
     _codex_idle_timeout = _env_float(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -742,7 +742,8 @@ def interruptible_api_call(agent, api_kwargs: dict):
         _ttfb_cap = _env_float("HERMES_CODEX_TTFB_MAX_SECONDS", 0.0)
         _scaled_ttfb_timeout = _ttfb_timeout
         if (
-            not _ttfb_strict
+            _ttfb_timeout > 0
+            and not _ttfb_strict
             and _ttfb_disable_above > 0
             and _est_tokens_for_codex_watchdog >= _ttfb_disable_above
         ):

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -190,6 +190,33 @@ def test_ttfb_includes_silent_hang_hint_for_gpt_5_5(tmp_path, monkeypatch):
         stop["flag"] = True
 
 
+@pytest.mark.parametrize(
+    ("configured_timeout", "strict", "max_seconds", "expected"),
+    [
+        (120.0, False, 0.0, (True, 180.0)),
+        (120.0, False, 150.0, (True, 150.0)),
+        (0.0, False, 0.0, (False, 0.0)),
+        (120.0, True, 0.0, (True, 120.0)),
+    ],
+    ids=["adaptive-default", "explicit-cap", "disabled", "strict"],
+)
+def test_large_request_codex_ttfb_timeout_policy(
+    configured_timeout, strict, max_seconds, expected
+):
+    """The >100k tier adapts unless an operator disables, caps, or makes it strict."""
+    from agent import chat_completion_helpers as h
+
+    result = h._compute_codex_ttfb_timeout(
+        estimated_tokens=100_001,
+        configured_timeout=configured_timeout,
+        disable_above_tokens=10_000.0,
+        strict=strict,
+        max_seconds=max_seconds,
+    )
+
+    assert result == expected
+
+
 def test_ttfb_high_env_is_capped_for_openai_codex(tmp_path, monkeypatch):
     """A stale local env value like 90s must not make openai-codex wait 90s
     before reconnecting when the backend emits no SSE frames."""

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -578,6 +578,35 @@ def test_ttfb_disabled_via_env_zero(tmp_path, monkeypatch):
     assert "codex_ttfb_kill" not in closes
 
 
+def test_disabled_large_codex_ttfb_logs_no_scale_or_cap_claims(
+    tmp_path, monkeypatch, caplog
+):
+    """Disabled TTFB must not claim adaptive scaling or capping."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0")
+    monkeypatch.setenv("HERMES_CODEX_TTFB_MAX_SECONDS", "150")
+
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(agent, "_abort_request_openai_client", lambda *a, **k: None)
+    monkeypatch.setattr(agent, "_close_request_openai_client", lambda *a, **k: None)
+
+    sentinel = SimpleNamespace(ok=True)
+    monkeypatch.setattr(agent, "_run_codex_stream", lambda *a, **k: sentinel)
+
+    api_kwargs = {"model": "gpt-5.5", "input": "x" * (186_804 * 4)}
+    assert h.estimate_request_context_tokens(api_kwargs) == 186_804
+
+    with caplog.at_level("INFO", logger=h.__name__):
+        resp = h.interruptible_api_call(agent, api_kwargs)
+
+    assert resp is sentinel
+    assert "Scaling openai-codex no-byte TTFB" not in caplog.text
+    assert "Capping openai-codex no-byte TTFB" not in caplog.text
+
+
 def test_large_codex_request_waits_instead_of_ttfb_reconnect(tmp_path, monkeypatch):
     """Large Codex inputs can legitimately take longer than the small-request
     first-byte cutoff before the first SSE frame. Scale the TTFB timeout up


### PR DESCRIPTION
## Summary

Preserve the adaptive OpenAI Codex no-byte TTFB timeout for large requests.

Requests above 100k estimated tokens currently scale from 120s to 180s, then are immediately capped back to 120s by the implicit default of `HERMES_CODEX_TTFB_MAX_SECONDS`. This defeats the adaptive tier introduced by #64594 and can surface as `No response from provider` on a healthy provider after a zero-event connection stall.

The maximum now applies only when an operator explicitly configures a positive value. Without an explicit maximum, the >100k-token adaptive tier remains 180s.

The timeout policy is extracted into a small pure helper so the default, cap, strict, and disabled semantics are directly testable. Disabled mode also emits no misleading scaling or capping logs.

## Production reproduction

Observed on `openai-codex` / `gpt-5.6-sol`:

```text
context=~186,804 tokens
Scaling openai-codex no-byte TTFB watchdog from 120s to 180s
Capping openai-codex no-byte TTFB timeout from 180s to 120s
```

The WebUI returned `No response from provider` after roughly 2m28. A later probe against the same provider and model returned normally, consistent with the documented intermittent zero-event Codex connection mode rather than an auth or model-availability failure.

## Behavior preserved

- Explicit positive `HERMES_CODEX_TTFB_MAX_SECONDS` values still cap the adaptive timeout.
- `HERMES_CODEX_TTFB_TIMEOUT_SECONDS=0` still disables the watchdog.
- Disabled mode emits neither scaling nor capping claims.
- Strict mode retains the configured timeout instead of scaling it.
- `HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS=0` disables adaptation and preserves the configured timeout.
- Configured timeouts already above an adaptive tier are not lowered unless an explicit positive cap requests it.
- Non-Codex behavior is unchanged.
- The independent absolute Codex hard timeout is unchanged.
- No provider, model, or credential fallback behavior is added or changed.

## Tests

Canonical Hermes test harness:

```bash
scripts/run_tests.sh \
  tests/agent/test_codex_ttfb_watchdog.py \
  tests/agent/test_non_stream_stale_timeout.py -q
```

Result: **41 passed**.

Independent review also exercised an integrated 186,804-token matrix:

- default adaptive: `120s → 180s`, scaling log only;
- explicit cap 150: accurate `180s → 150s` cap;
- strict: no adaptive log;
- disabled (`0`): no scale/cap claims;
- non-Codex: no Codex policy logs.

Additional checks:

```bash
uv run --extra dev ruff check \
  agent/chat_completion_helpers.py \
  tests/agent/test_codex_ttfb_watchdog.py

git diff --check 7de554277de632364c74fcf8641daa58a9a977d9..901319fe0f4ac2116a6fb4a248ec164dc2350ad7
```

Both pass.

Fixes the remaining implicit-cap contradiction in the size-aware no-byte TTFB policy from #64594 / #61778.