### PR TITLE
fix(agent): finalize code-skew exits safely

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -37,6 +37,7 @@ from agent.turn_context import (
     compose_user_api_content,
     reanchor_current_turn_user_idx,
 )
+from agent.turn_finalizer import finalize_turn
 from agent.turn_retry_state import TurnRetryState
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
@@ -5841,7 +5842,6 @@ def run_conversation(
     # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn
     # (god-file decomposition Phase 1 step 4). Behavior-neutral: the assembled
     # result dict is returned exactly as before.
-    from agent.turn_finalizer import finalize_turn
     return finalize_turn(
         agent,
         final_response=final_response,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -191,6 +191,83 @@ def _custom_unit_to_cp(s: str, budget: int, len_fn) -> int:
     return lo
 
 
+def find_structural_split(text: str, cp_limit: int) -> int:
+    """Pick a markdown-structure-aware split index inside ``text[:cp_limit]``.
+
+    Overflow splits used to cut at the last newline regardless of what that
+    newline sat inside, bisecting pipe tables and code fences across two
+    messages — neither fragment could render. Returns the codepoint index to
+    cut at (``chunk = text[:idx]``), or ``-1`` when no structurally sound cut
+    exists in the window and the caller should use its legacy newline/space/
+    hard-cut fallbacks.
+
+    Preference order:
+      1. last blank line outside a code fence (paragraph boundary) in the
+         trailing half of the window;
+      2. last fence-outside newline that doesn't bisect a pipe-table run, in
+         the trailing half;
+      3. the same, anywhere past an eighth of the window — a short head
+         message beats slicing a table in two.
+    """
+    if cp_limit <= 0 or not text:
+        return -1
+    region = text[:cp_limit]
+    half = cp_limit // 2
+    eighth = max(1, cp_limit // 8)
+
+    lines = region.split("\n")
+    if len(lines) < 2:
+        return -1
+    offsets = []
+    pos = 0
+    for ln in lines:
+        offsets.append(pos)
+        pos += len(ln) + 1
+
+    # fence_at[i]: fence state while ON line i — i.e. before processing its
+    # own marker. An opening ``` line is "outside" (state False), its body
+    # and the closing ``` line are "inside" (True).
+    fence_at = []
+    in_fence = False
+    for ln in lines:
+        fence_at.append(in_fence)
+        stripped = ln.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+
+    def _is_row(i: int) -> bool:
+        return not fence_at[i] and lines[i].lstrip().startswith("|")
+
+    best_para = -1
+    best_nl = -1
+    for i in range(len(lines) - 1):
+        nl_pos = offsets[i] + len(lines[i])
+        # fence_at[i + 1] is True for every newline from "right after the
+        # opening marker" through "right before the closing marker" — the
+        # only cuts that would strand an unclosed fence. The newline after a
+        # closing marker (fence_at False again) is a fine boundary.
+        if fence_at[i + 1]:
+            continue
+        # Resolve the following line from the FULL text, not the window —
+        # the window's last line is truncated and can read as blank (or as a
+        # non-row) when the real continuation is a table row.
+        next_start = nl_pos + 1
+        next_end = text.find("\n", next_start)
+        next_line = text[next_start : next_end if next_end != -1 else len(text)]
+        if not next_line.strip():
+            best_para = nl_pos
+        if not (_is_row(i) and next_line.lstrip().startswith("|")):
+            best_nl = nl_pos
+
+    if best_para >= half:
+        return best_para
+    if best_nl >= half:
+        return best_nl
+    if best_nl >= eighth:
+        return best_nl
+    return -1
+
+
 def is_network_accessible(host: str) -> bool:
     """Return True if *host* would expose the server beyond loopback.
 
@@ -5850,9 +5927,13 @@ class BasePlatformAdapter(ABC):
             else:
                 _cp_limit = headroom
             region = remaining[:_cp_limit]
-            split_at = region.rfind("\n")
-            if split_at < _cp_limit // 2:
-                split_at = region.rfind(" ")
+            # Structure-aware first: never bisect a pipe table or cut just
+            # after a fence opening when a paragraph/newline boundary exists.
+            split_at = find_structural_split(remaining, _cp_limit)
+            if split_at < 0:
+                split_at = region.rfind("\n")
+                if split_at < _cp_limit // 2:
+                    split_at = region.rfind(" ")
             if split_at < 1:
                 # Consume at least one codepoint. Without the max(1, …) floor,
                 # a zero _cp_limit — reachable when max_length is 0/1, or under

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19446,6 +19446,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else {"thread_id": _progress_thread_id}
         ) if _progress_thread_id else None
         _progress_metadata = _non_conversational_metadata(_progress_metadata, platform=source.platform)
+        if source.platform == Platform.SLACK:
+            # Mark tool-progress bubbles so the Slack adapter can render them
+            # in the muted context style (rich_blocks) instead of full-size
+            # text + code fences. Other platforms are untouched.
+            _progress_metadata = {**(_progress_metadata or {}), "progress_surface": True}
         _progress_reply_to = (
             event_message_id
             if source.platform in (Platform.FEISHU, Platform.MATTERMOST) and source.thread_id and event_message_id

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -26,6 +26,7 @@ from typing import Any, Callable, Optional
 
 from gateway.platforms.base import BasePlatformAdapter as _BasePlatformAdapter
 from gateway.platforms.base import _custom_unit_to_cp
+from gateway.platforms.base import find_structural_split
 from gateway.platforms.base import MEDIA_TAG_CLEANUP_RE
 from gateway.config import (
     DEFAULT_STREAMING_EDIT_INTERVAL as _DEFAULT_STREAMING_EDIT_INTERVAL,
@@ -729,9 +730,16 @@ class GatewayStreamConsumer:
                         _cp_budget = _custom_unit_to_cp(
                             self._accumulated, _safe_limit, _len_fn,
                         )
-                        split_at = self._accumulated.rfind("\n", 0, _cp_budget)
-                        if split_at < _safe_limit // 2:
-                            split_at = _safe_limit
+                        # Structure-aware cut: this sealed chunk becomes its
+                        # own message forever — bisecting a table or fence
+                        # here leaves both halves permanently unrenderable.
+                        split_at = find_structural_split(
+                            self._accumulated, _cp_budget,
+                        )
+                        if split_at < 0:
+                            split_at = self._accumulated.rfind("\n", 0, _cp_budget)
+                            if split_at < _safe_limit // 2:
+                                split_at = _safe_limit
                         chunk = self._accumulated[:split_at]
                         # finalize=True so the adapter applies platform-specific
                         # rich-text markup (e.g. Telegram MarkdownV2). This
@@ -992,9 +1000,11 @@ class GatewayStreamConsumer:
         remaining = text
         while len_fn(remaining) > limit:
             _cp_budget = _custom_unit_to_cp(remaining, limit, len_fn)
-            split_at = remaining.rfind("\n", 0, _cp_budget)
-            if split_at < limit // 2:
-                split_at = limit
+            split_at = find_structural_split(remaining, _cp_budget)
+            if split_at < 0:
+                split_at = remaining.rfind("\n", 0, _cp_budget)
+                if split_at < limit // 2:
+                    split_at = limit
             chunks.append(remaining[:split_at])
             remaining = remaining[split_at:].lstrip("\n")
         if remaining:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4168,6 +4168,10 @@ class SlackAdapter(BasePlatformAdapter):
             _title = (title or "Confirm")[:150]
             budget = 3000 - len(f"*{_title}*\n\n") - len("...")
             body = message[:budget] + "..." if len(message) > budget else message
+            # The caller passes CommonMark (``**bold**``); Slack mrkdwn wants
+            # ``*bold*``. Convert here — the adapter is the mrkdwn boundary —
+            # or the section renders literal double asterisks.
+            body = self.format_message(body)
             # Encode session_key and confirm_id into the button value so the
             # callback handler can resolve without extra bookkeeping.
             value = f"{session_key}|{confirm_id}"

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1403,6 +1403,43 @@ class SlackAdapter(BasePlatformAdapter):
             return self._team_clients[team_id]
         return self._app.client  # fallback to primary
 
+    @staticmethod
+    def _is_blocks_rejection(exc: Exception) -> bool:
+        """True when the API refused the ``blocks`` payload specifically."""
+        err = str(exc).lower()
+        return any(
+            code in err
+            for code in (
+                "invalid_blocks",
+                "invalid_blocks_format",
+                "invalid_arguments",
+                "unsupported_block",
+                "block_mismatch",
+            )
+        )
+
+    async def _post_with_block_fallback(self, client, kwargs: Dict[str, Any]):
+        """``chat.postMessage`` that survives a rejected ``blocks`` payload.
+
+        A workspace/API tier that refuses a block type (e.g. the newer
+        ``table`` block) must degrade that one message to its ``text``
+        fallback — not lose it. Non-block errors propagate unchanged.
+        """
+        try:
+            return await client.chat_postMessage(**kwargs)
+        except Exception as exc:
+            if "blocks" not in kwargs or not self._is_blocks_rejection(exc):
+                raise
+            logger.warning(
+                "[Slack] blocks payload rejected (%s); resending as plain text",
+                exc,
+            )
+            logger.debug(
+                "[Slack] rejected blocks payload: %r", kwargs.get("blocks")
+            )
+            retry_kwargs = {k: v for k, v in kwargs.items() if k != "blocks"}
+            return await client.chat_postMessage(**retry_kwargs)
+
     async def send(
         self,
         chat_id: str,
@@ -1477,9 +1514,12 @@ class SlackAdapter(BasePlatformAdapter):
                     if broadcast and i == 0:
                         kwargs["reply_broadcast"] = True
 
-                last_result = await self._get_client(
-                    chat_id, team_id=self._metadata_team_id(metadata)
-                ).chat_postMessage(**kwargs)
+                last_result = await self._post_with_block_fallback(
+                    self._get_client(
+                        chat_id, team_id=self._metadata_team_id(metadata)
+                    ),
+                    kwargs,
+                )
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
@@ -1575,9 +1615,26 @@ class SlackAdapter(BasePlatformAdapter):
                 blocks = self._maybe_blocks(content)
                 if blocks:
                     update_kwargs["blocks"] = blocks
-            await self._get_client(
+            client = self._get_client(
                 chat_id, team_id=self._metadata_team_id(metadata)
-            ).chat_update(**update_kwargs)
+            )
+            try:
+                await client.chat_update(**update_kwargs)
+            except Exception as exc:
+                if "blocks" not in update_kwargs or not self._is_blocks_rejection(exc):
+                    raise
+                logger.warning(
+                    "[Slack] blocks payload rejected on edit (%s); keeping plain text",
+                    exc,
+                )
+                logger.debug(
+                    "[Slack] rejected blocks payload: %r",
+                    update_kwargs.get("blocks"),
+                )
+                retry_kwargs = {
+                    k: v for k, v in update_kwargs.items() if k != "blocks"
+                }
+                await client.chat_update(**retry_kwargs)
             if finalize:
                 await self.stop_typing(chat_id, metadata=metadata)
             return SendResult(success=True, message_id=message_id)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -58,6 +58,8 @@ from gateway.platforms.base import (
 try:  # sibling module; support both package and flat plugin-dir import
     from .block_kit import (
         blocks_fallback_text,
+        demote_tables,
+        has_table_block,
         progress_context_blocks,
         render_blocks,
         segment_blocks,
@@ -65,6 +67,8 @@ try:  # sibling module; support both package and flat plugin-dir import
 except ImportError:  # pragma: no cover - plugin loaded outside package context
     from block_kit import (  # type: ignore
         blocks_fallback_text,
+        demote_tables,
+        has_table_block,
         progress_context_blocks,
         render_blocks,
         segment_blocks,
@@ -1427,22 +1431,40 @@ class SlackAdapter(BasePlatformAdapter):
     async def _post_with_block_fallback(self, client, kwargs: Dict[str, Any]):
         """``chat.postMessage`` that survives a rejected ``blocks`` payload.
 
-        A workspace/API tier that refuses a block type (e.g. the newer
-        ``table`` block) must degrade that one message to its ``text``
-        fallback — not lose it. Non-block errors propagate unchanged.
+        A workspace/API tier that refuses a block type (usually the newer
+        ``table`` block) must not lose the message. First retry demotes any
+        native ``table`` block to aligned monospace (keeping every other
+        block), so a rejected table degrades to a lined-up grid rather than
+        raw pipes; only if that *also* fails do we drop blocks entirely and
+        resend the ``text`` fallback. Non-block errors propagate unchanged.
         """
         try:
             return await client.chat_postMessage(**kwargs)
         except Exception as exc:
             if "blocks" not in kwargs or not self._is_blocks_rejection(exc):
                 raise
-            logger.warning(
-                "[Slack] blocks payload rejected (%s); resending as plain text",
-                exc,
-            )
             logger.debug(
                 "[Slack] rejected blocks payload: %r", kwargs.get("blocks")
             )
+            if has_table_block(kwargs["blocks"]):
+                logger.warning(
+                    "[Slack] blocks rejected (%s); retrying with monospace tables",
+                    exc,
+                )
+                demoted = {**kwargs, "blocks": demote_tables(kwargs["blocks"])}
+                try:
+                    return await client.chat_postMessage(**demoted)
+                except Exception as exc2:
+                    if not self._is_blocks_rejection(exc2):
+                        raise
+                    logger.warning(
+                        "[Slack] monospace retry also rejected (%s); plain text", exc2
+                    )
+            else:
+                logger.warning(
+                    "[Slack] blocks payload rejected (%s); resending as plain text",
+                    exc,
+                )
             retry_kwargs = {k: v for k, v in kwargs.items() if k != "blocks"}
             return await client.chat_postMessage(**retry_kwargs)
 
@@ -1649,18 +1671,42 @@ class SlackAdapter(BasePlatformAdapter):
             except Exception as exc:
                 if "blocks" not in update_kwargs or not self._is_blocks_rejection(exc):
                     raise
-                logger.warning(
-                    "[Slack] blocks payload rejected on edit (%s); keeping plain text",
-                    exc,
-                )
                 logger.debug(
                     "[Slack] rejected blocks payload: %r",
                     update_kwargs.get("blocks"),
                 )
-                retry_kwargs = {
-                    k: v for k, v in update_kwargs.items() if k != "blocks"
-                }
-                await client.chat_update(**retry_kwargs)
+                # Same degradation ladder as send(): demote native tables to
+                # aligned monospace first (keeps the rest of the blocks), and
+                # only drop to plain text if that is rejected too.
+                demoted_ok = False
+                if has_table_block(update_kwargs["blocks"]):
+                    logger.warning(
+                        "[Slack] blocks rejected on edit (%s); retrying monospace tables",
+                        exc,
+                    )
+                    demoted = {
+                        **update_kwargs,
+                        "blocks": demote_tables(update_kwargs["blocks"]),
+                    }
+                    try:
+                        await client.chat_update(**demoted)
+                        demoted_ok = True
+                    except Exception as exc2:
+                        if not self._is_blocks_rejection(exc2):
+                            raise
+                        logger.warning(
+                            "[Slack] monospace retry also rejected on edit (%s)", exc2
+                        )
+                else:
+                    logger.warning(
+                        "[Slack] blocks payload rejected on edit (%s); plain text",
+                        exc,
+                    )
+                if not demoted_ok:
+                    retry_kwargs = {
+                        k: v for k, v in update_kwargs.items() if k != "blocks"
+                    }
+                    await client.chat_update(**retry_kwargs)
             if finalize:
                 await self.stop_typing(chat_id, metadata=metadata)
             return SendResult(success=True, message_id=message_id)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -490,6 +490,11 @@ class SlackAdapter(BasePlatformAdapter):
     # ``reply_in_thread: false`` path in ``_handle_slack_message``).  So a
     # continuable cron delivered flat here continues in-context on a plain reply.
     supports_inchannel_continuable = True
+    # Thread history is optional Slack API enrichment. It must never keep an
+    # @mention from reaching the gateway if conversations.replies is slow.
+    THREAD_CONTEXT_FETCH_TIMEOUT_SECONDS = 3.0
+    THREAD_PARENT_FETCH_TIMEOUT_SECONDS = 1.0
+    USER_NAME_FETCH_TIMEOUT_SECONDS = 2.0
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.SLACK)
@@ -535,6 +540,9 @@ class SlackAdapter(BasePlatformAdapter):
         self._THREAD_CACHE_TTL = 60.0
         # Track message IDs that should get reaction lifecycle (DMs / @mentions).
         self._reacting_message_ids: set = set()
+        # Direct mentions get an :eyes: acknowledgement before optional thread
+        # enrichment. This prevents on_processing_start from adding it twice.
+        self._early_reaction_message_ids: set = set()
         # Track active Assistant statuses by (team_id, channel_id, thread_ts)
         # so cleanup cannot clear an overlapping Slack Connect workspace.
         self._active_status_threads: Dict[Tuple[str, str, str], Dict[str, str]] = {}
@@ -2539,6 +2547,12 @@ class SlackAdapter(BasePlatformAdapter):
         ts = getattr(event, "message_id", None)
         if not ts or ts not in self._reacting_message_ids:
             return
+        early_reactions = getattr(self, "_early_reaction_message_ids", set())
+        if ts in early_reactions:
+            # The adapter already acknowledged this direct mention before
+            # optional thread enrichment ran, so avoid a duplicate API call.
+            early_reactions.discard(ts)
+            return
         channel_id = getattr(event.source, "chat_id", None)
         if channel_id:
             await self._add_reaction(
@@ -2555,6 +2569,7 @@ class SlackAdapter(BasePlatformAdapter):
         if not ts or ts not in self._reacting_message_ids:
             return
         self._reacting_message_ids.discard(ts)
+        getattr(self, "_early_reaction_message_ids", set()).discard(ts)
         channel_id = getattr(event.source, "chat_id", None)
         if not channel_id:
             return
@@ -3412,6 +3427,10 @@ class SlackAdapter(BasePlatformAdapter):
         self, event: dict, payload: Optional[dict] = None
     ) -> None:
         """Handle an incoming Slack message event."""
+        intake_started_at = time.monotonic()
+        thread_context_seconds = 0.0
+        identity_lookup_seconds = 0.0
+        parent_lookup_seconds = 0.0
         # Dedup: Slack Socket Mode can redeliver events after reconnects (#4777)
         event_ts = event.get("ts", "")
         if event_ts and self._dedup.is_duplicate(event_ts):
@@ -3710,6 +3729,19 @@ class SlackAdapter(BasePlatformAdapter):
                     for t in to_remove:
                         self._mentioned_threads.discard(t)
 
+        # Acknowledge a direct mention immediately after routing/access checks.
+        # Thread context below is optional enrichment and must not make a
+        # received mention look dropped while Slack API calls are slow.
+        _should_react = (is_one_to_one_dm or is_mentioned) and self._reactions_enabled()
+        if _should_react and ts:
+            self._reacting_message_ids.add(ts)
+            self._early_reaction_message_ids.add(ts)
+            # _add_reaction catches its own failures; do not block dispatch on
+            # a best-effort UI acknowledgement.
+            asyncio.create_task(
+                self._add_reaction(channel_id, ts, "eyes", str(team_id or ""))
+            )
+
         # When entering a thread for the first time (no existing session),
         # fetch thread context so the agent understands the conversation.
         if is_thread_reply and not self._has_active_session_for_thread(
@@ -3718,12 +3750,25 @@ class SlackAdapter(BasePlatformAdapter):
             user_id=user_id,
             team_id=team_id,
         ):
-            thread_context = await self._fetch_thread_context(
-                channel_id=channel_id,
-                thread_ts=event_thread_ts,
-                current_ts=ts,
-                team_id=team_id,
-            )
+            context_started_at = time.monotonic()
+            try:
+                thread_context = await asyncio.wait_for(
+                    self._fetch_thread_context(
+                        channel_id=channel_id,
+                        thread_ts=str(event_thread_ts),
+                        current_ts=ts,
+                        team_id=team_id,
+                    ),
+                    timeout=self.THREAD_CONTEXT_FETCH_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[Slack] Thread context fetch timed out after %.1fs; "
+                    "continuing with the triggering message",
+                    self.THREAD_CONTEXT_FETCH_TIMEOUT_SECONDS,
+                )
+                thread_context = ""
+            thread_context_seconds = time.monotonic() - context_started_at
             if thread_context:
                 text = thread_context + text
 
@@ -3985,10 +4030,23 @@ class SlackAdapter(BasePlatformAdapter):
             else:
                 msg_type = MessageType.DOCUMENT
 
-        # Resolve user display name (cached after first lookup)
-        user_name = await self._resolve_user_name(
-            user_id, chat_id=channel_id, team_id=team_id
-        )
+        # Resolve user display name (cached after first lookup). This is display
+        # decoration rather than a routing requirement, so use the Slack ID if
+        # users.info is slow instead of blocking the agent turn.
+        identity_started_at = time.monotonic()
+        try:
+            user_name = await asyncio.wait_for(
+                self._resolve_user_name(user_id, chat_id=channel_id, team_id=team_id),
+                timeout=self.USER_NAME_FETCH_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[Slack] users.info timed out after %.1fs for %s; using user ID",
+                self.USER_NAME_FETCH_TIMEOUT_SECONDS,
+                user_id,
+            )
+            user_name = user_id
+        identity_lookup_seconds = time.monotonic() - identity_started_at
 
         # Slack's AI Agent Messages tab shows visible app threads; title the
         # first DM thread turn from the user's prompt when Slack AI APIs are
@@ -4041,17 +4099,29 @@ class SlackAdapter(BasePlatformAdapter):
         # available to avoid redundant conversations.replies calls.
         reply_to_text = None
         if thread_ts and thread_ts != ts:
+            parent_started_at = time.monotonic()
             try:
                 reply_to_text = (
-                    await self._fetch_thread_parent_text(
-                        channel_id=channel_id,
-                        thread_ts=thread_ts,
-                        team_id=team_id,
+                    await asyncio.wait_for(
+                        self._fetch_thread_parent_text(
+                            channel_id=channel_id,
+                            thread_ts=thread_ts,
+                            team_id=team_id,
+                        ),
+                        timeout=self.THREAD_PARENT_FETCH_TIMEOUT_SECONDS,
                     )
                     or None
                 )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[Slack] Thread parent fetch timed out after %.1fs; "
+                    "continuing without reply context",
+                    self.THREAD_PARENT_FETCH_TIMEOUT_SECONDS,
+                )
+                reply_to_text = None
             except Exception:  # pragma: no cover - defensive
                 reply_to_text = None
+            parent_lookup_seconds = time.monotonic() - parent_started_at
 
         msg_event = MessageEvent(
             text=text,
@@ -4072,14 +4142,6 @@ class SlackAdapter(BasePlatformAdapter):
             },
         )
 
-        # Only react when bot is directly addressed (1:1 DM or @mention).
-        # MPIMs are shared surfaces: reacting to every group-DM message (even
-        # when unmentioned) is visible noise to the whole group, so they must
-        # be @mentioned to earn a reaction — same as any channel.
-        _should_react = (is_one_to_one_dm or is_mentioned) and self._reactions_enabled()
-        if _should_react:
-            self._reacting_message_ids.add(ts)
-
         # App-context is per-turn, user-controlled Slack UI state. Surface it
         # with the inbound user message rather than storing it on SessionSource:
         # putting it in the cached system prompt would rebuild the agent whenever
@@ -4092,6 +4154,18 @@ class SlackAdapter(BasePlatformAdapter):
                 f"{msg_event.text}"
             )
 
+        if is_thread_reply:
+            logger.info(
+                "[Slack] Thread intake ready: channel=%s thread=%s message=%s "
+                "total=%.3fs context=%.3fs identity=%.3fs parent=%.3fs",
+                channel_id,
+                thread_ts,
+                ts,
+                time.monotonic() - intake_started_at,
+                thread_context_seconds,
+                identity_lookup_seconds,
+                parent_lookup_seconds,
+            )
         await self.handle_message(msg_event)
 
     # ----- Approval button support (Block Kit) -----

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -62,6 +62,7 @@ try:  # sibling module; support both package and flat plugin-dir import
         has_table_block,
         progress_context_blocks,
         render_blocks,
+        sanitize_blocks,
         segment_blocks,
     )
 except ImportError:  # pragma: no cover - plugin loaded outside package context
@@ -71,11 +72,48 @@ except ImportError:  # pragma: no cover - plugin loaded outside package context
         has_table_block,
         progress_context_blocks,
         render_blocks,
+        sanitize_blocks,
         segment_blocks,
     )
 
 
 logger = logging.getLogger(__name__)
+
+
+# Methods whose ``blocks`` kwarg is sanitized at the send boundary.
+_SANITIZED_SEND_METHODS = frozenset(
+    {"chat_postMessage", "chat_update", "chat_postEphemeral"}
+)
+
+
+class _SanitizingClient:
+    """Transparent proxy over a Slack ``WebClient`` that runs every outbound
+    ``blocks`` payload through :func:`sanitize_blocks` before the send.
+
+    This is the single send-boundary choke point: every builder — the agent
+    reply path, exec-approval, slash-confirm, and anything added later —
+    obtains its client via ``_get_client()``, so all of them are protected
+    from the structural mistakes Slack rejects with ``invalid_blocks`` (a
+    single bad node fails the WHOLE message). Non-send attributes pass through
+    untouched, so reads (``conversations_history`` etc.) are unaffected.
+    """
+
+    __slots__ = ("_client",)
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._client, name)
+        if name not in _SANITIZED_SEND_METHODS or not callable(attr):
+            return attr
+
+        async def _send(*args: Any, **kwargs: Any) -> Any:
+            if isinstance(kwargs.get("blocks"), list):
+                kwargs["blocks"] = sanitize_blocks(kwargs["blocks"])
+            return await attr(*args, **kwargs)
+
+        return _send
 
 # ContextVar carrying the user_id of the slash-command invoker.
 # Set in _handle_slash_command, read in send() to match the correct
@@ -1405,13 +1443,20 @@ class SlackAdapter(BasePlatformAdapter):
         )
 
     def _get_client(self, chat_id: str, team_id: Optional[str] = None) -> Any:
-        """Return the workspace-specific WebClient for a channel."""
+        """Return the workspace-specific WebClient for a channel.
+
+        Wrapped in a :class:`_SanitizingClient` so EVERY outbound send —
+        current or future, from any builder — passes its ``blocks`` through
+        :func:`sanitize_blocks` at this single choke point. A structurally
+        invalid block (empty text object, ``null`` column setting) otherwise
+        fails the whole message with ``invalid_blocks``.
+        """
         if team_id and team_id in self._team_clients:
-            return self._team_clients[team_id]
+            return _SanitizingClient(self._team_clients[team_id])
         team_id = self._channel_team.get(chat_id)
         if team_id and team_id in self._team_clients:
-            return self._team_clients[team_id]
-        return self._app.client  # fallback to primary
+            return _SanitizingClient(self._team_clients[team_id])
+        return _SanitizingClient(self._app.client)  # fallback to primary
 
     @staticmethod
     def _is_blocks_rejection(exc: Exception) -> bool:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -56,9 +56,13 @@ from gateway.platforms.base import (
 )
 
 try:  # sibling module; support both package and flat plugin-dir import
-    from .block_kit import render_blocks
+    from .block_kit import blocks_fallback_text, render_blocks, segment_blocks
 except ImportError:  # pragma: no cover - plugin loaded outside package context
-    from block_kit import render_blocks  # type: ignore
+    from block_kit import (  # type: ignore
+        blocks_fallback_text,
+        render_blocks,
+        segment_blocks,
+    )
 
 
 logger = logging.getLogger(__name__)
@@ -1437,21 +1441,36 @@ class SlackAdapter(BasePlatformAdapter):
             # Controlled via platform config: gateway.slack.reply_broadcast
             broadcast = self.config.extra.get("reply_broadcast", False)
 
-            # Block Kit (opt-in): render the primary message as structured
-            # blocks. Only applied to a single-chunk message — a >39k response
-            # that had to be split is pathological for Block Kit's 50-block /
-            # 3000-char limits, so those fall back to plain text. The ``text``
-            # field is always kept as the notification/accessibility fallback.
-            blocks = self._maybe_blocks(content) if len(chunks) == 1 else None
+            # Block Kit (opt-in): render the message as structured blocks.
+            # Content too structured for one message (50-block cap) is sent
+            # as several block messages split at header/divider boundaries —
+            # NOT flattened back to plain mrkdwn. Only a >39k response that
+            # truncate_message had to split stays on the plain-text path (its
+            # text chunks and block segments couldn't be paired coherently).
+            # The ``text`` field is always kept as the notification/
+            # accessibility fallback.
+            segments = self._maybe_block_segments(content) if len(chunks) == 1 else None
 
-            for i, chunk in enumerate(chunks):
+            if segments:
+                # (fallback text, blocks) per outgoing message. A single
+                # segment keeps the full mrkdwn as fallback (legacy shape);
+                # multi-segment messages each carry their own slice.
+                outgoing = (
+                    [(chunks[0], segments[0])]
+                    if len(segments) == 1
+                    else [(blocks_fallback_text(seg), seg) for seg in segments]
+                )
+            else:
+                outgoing = [(chunk, None) for chunk in chunks]
+
+            for i, (chunk, seg) in enumerate(outgoing):
                 kwargs = {
                     "channel": chat_id,
                     "text": chunk,
                     "mrkdwn": True,
                 }
-                if blocks and i == 0:
-                    kwargs["blocks"] = blocks
+                if seg:
+                    kwargs["blocks"] = seg
                 if thread_ts:
                     kwargs["thread_ts"] = thread_ts
                     # Only broadcast the first chunk of the first reply
@@ -2066,22 +2085,43 @@ class SlackAdapter(BasePlatformAdapter):
             return blocks
         return [*blocks, self._feedback_block()]
 
-    def _maybe_blocks(self, content: str) -> Optional[list]:
-        """Render ``content`` to Block Kit blocks when the feature is enabled.
+    def _maybe_block_segments(self, content: str) -> Optional[list]:
+        """Render ``content`` to a list of message-sized Block Kit segments.
 
-        Returns ``None`` when rich blocks are disabled, or when the renderer
-        declines (empty / too complex / unexpected shape) — the caller then
-        falls back to the plain ``text`` payload. A ``text`` fallback is ALWAYS
-        sent alongside blocks, so this can safely return ``None`` at any time.
+        Each segment holds <= 50 blocks (Slack's per-message cap); content too
+        structured for one message is split at header/divider boundaries and
+        sent as several messages instead of flattening back to plain mrkdwn.
+        Returns ``None`` when rich blocks are disabled or the renderer
+        declines — the caller then falls back to the plain ``text`` payload.
+        A ``text`` fallback is ALWAYS sent alongside blocks, so this can
+        safely return ``None`` at any time.
         """
         if not self._rich_blocks_enabled():
             return None
         try:
             blocks = render_blocks(content, mrkdwn_fn=self.format_message)
-            return self._append_feedback_block(blocks)
+            if not blocks:
+                return None
+            segments = segment_blocks(blocks)
+            appended = self._append_feedback_block(segments[-1])
+            if appended:
+                segments[-1] = appended
+            return segments
         except Exception:  # pragma: no cover - renderer already guards itself
             logger.debug("[Slack] block render failed; using plain text", exc_info=True)
             return None
+
+    def _maybe_blocks(self, content: str) -> Optional[list]:
+        """Single-message variant of :meth:`_maybe_block_segments`.
+
+        Used by ``edit_message`` — an edit can only restyle the one message it
+        targets, so content that segments into multiple messages declines
+        (returns ``None``) and the edit keeps its plain-text payload.
+        """
+        segments = self._maybe_block_segments(content)
+        if segments and len(segments) == 1:
+            return segments[0]
+        return None
 
     def format_message(self, content: str) -> str:
         """Convert standard markdown to Slack mrkdwn format.

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1492,13 +1492,18 @@ class SlackAdapter(BasePlatformAdapter):
             # text chunks and block segments couldn't be paired coherently).
             # The ``text`` field is always kept as the notification/
             # accessibility fallback.
-            progress_blocks = self._maybe_progress_blocks(content, metadata)
-            if progress_blocks and len(chunks) == 1:
-                segments = [progress_blocks]
+            # Canary gate: when rich_blocks_channels is set, only those
+            # channels render blocks; every other channel stays plain text.
+            if self._rich_blocks_enabled(chat_id):
+                progress_blocks = self._maybe_progress_blocks(content, metadata)
+                if progress_blocks and len(chunks) == 1:
+                    segments = [progress_blocks]
+                else:
+                    segments = (
+                        self._maybe_block_segments(content) if len(chunks) == 1 else None
+                    )
             else:
-                segments = (
-                    self._maybe_block_segments(content) if len(chunks) == 1 else None
-                )
+                segments = None
 
             if segments:
                 # (fallback text, blocks) per outgoing message. A single
@@ -1626,13 +1631,16 @@ class SlackAdapter(BasePlatformAdapter):
             # runs — the consumer's edit debounce keeps the render cost
             # bounded). Feedback buttons only ever belong on the final
             # frame. ``text`` is kept as the fallback either way.
-            progress_blocks = self._maybe_progress_blocks(content, metadata)
-            if progress_blocks:
-                update_kwargs["blocks"] = progress_blocks
-            elif finalize or self._rich_blocks_streaming_enabled():
-                blocks = self._maybe_blocks(content, with_feedback=finalize)
-                if blocks:
-                    update_kwargs["blocks"] = blocks
+            # Canary gate: only channels in rich_blocks_channels (when set)
+            # render blocks; every other channel keeps its plain-text edit.
+            if self._rich_blocks_enabled(chat_id):
+                progress_blocks = self._maybe_progress_blocks(content, metadata)
+                if progress_blocks:
+                    update_kwargs["blocks"] = progress_blocks
+                elif finalize or self._rich_blocks_streaming_enabled():
+                    blocks = self._maybe_blocks(content, with_feedback=finalize)
+                    if blocks:
+                        update_kwargs["blocks"] = blocks
             client = self._get_client(
                 chat_id, team_id=self._metadata_team_id(metadata)
             )
@@ -2104,7 +2112,7 @@ class SlackAdapter(BasePlatformAdapter):
 
     # ----- Markdown → mrkdwn conversion -----
 
-    def _rich_blocks_enabled(self) -> bool:
+    def _rich_blocks_enabled(self, chat_id: Optional[str] = None) -> bool:
         """Whether to render outbound agent messages as Slack Block Kit blocks.
 
         Opt-in via ``platforms.slack.extra.rich_blocks`` (config.yaml). Default
@@ -2113,11 +2121,39 @@ class SlackAdapter(BasePlatformAdapter):
         (headers, dividers, true nested lists via ``rich_text``, and native
         Block Kit ``table`` blocks with per-column alignment); over-limit
         tables fall back to aligned monospace.
+
+        Canary scoping: when ``rich_blocks_channels`` is non-empty, only those
+        channel IDs render blocks (everyone else stays plain text). ``chat_id``
+        is ``None`` on internal helper calls; the ``send``/``edit_message``
+        entry points pass it and enforce membership there, so gating happens
+        once at the top rather than in every helper.
         """
         raw = self.config.extra.get("rich_blocks")
         if raw is None:
             return False
-        return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+        if str(raw).strip().lower() not in {"1", "true", "yes", "on"}:
+            return False
+        channels = self._rich_blocks_channels()
+        if channels and chat_id is not None:
+            return chat_id in channels
+        return True
+
+    def _rich_blocks_channels(self) -> set:
+        """Channel-ID allowlist for rich Block Kit rendering (canary rollout).
+
+        Reads ``platforms.slack.extra.rich_blocks_channels`` (a YAML list or a
+        comma-separated string) or ``SLACK_RICH_BLOCKS_CHANNELS``. Empty means
+        no restriction — every channel renders blocks (backward compatible).
+        Mirrors the parsing of :meth:`_slack_allowed_channels`.
+        """
+        raw = self.config.extra.get("rich_blocks_channels")
+        if raw is None:
+            raw = os.getenv("SLACK_RICH_BLOCKS_CHANNELS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        if isinstance(raw, str) and raw.strip():
+            return {part.strip() for part in raw.split(",") if part.strip()}
+        return set()
 
     def _rich_blocks_streaming_enabled(self) -> bool:
         """Whether intermediate streaming edits also render Block Kit.

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -56,10 +56,16 @@ from gateway.platforms.base import (
 )
 
 try:  # sibling module; support both package and flat plugin-dir import
-    from .block_kit import blocks_fallback_text, render_blocks, segment_blocks
+    from .block_kit import (
+        blocks_fallback_text,
+        progress_context_blocks,
+        render_blocks,
+        segment_blocks,
+    )
 except ImportError:  # pragma: no cover - plugin loaded outside package context
     from block_kit import (  # type: ignore
         blocks_fallback_text,
+        progress_context_blocks,
         render_blocks,
         segment_blocks,
     )
@@ -1486,7 +1492,13 @@ class SlackAdapter(BasePlatformAdapter):
             # text chunks and block segments couldn't be paired coherently).
             # The ``text`` field is always kept as the notification/
             # accessibility fallback.
-            segments = self._maybe_block_segments(content) if len(chunks) == 1 else None
+            progress_blocks = self._maybe_progress_blocks(content, metadata)
+            if progress_blocks and len(chunks) == 1:
+                segments = [progress_blocks]
+            else:
+                segments = (
+                    self._maybe_block_segments(content) if len(chunks) == 1 else None
+                )
 
             if segments:
                 # (fallback text, blocks) per outgoing message. A single
@@ -1607,13 +1619,17 @@ class SlackAdapter(BasePlatformAdapter):
                 "ts": message_id,
                 "text": formatted,
             }
-            # Blocks on the FINAL edit always; on intermediate streaming
-            # frames only when rich_blocks_streaming is enabled (tables and
-            # headers then render live during long runs — the consumer's edit
-            # debounce keeps the render cost bounded). Feedback buttons only
-            # ever belong on the final frame. ``text`` is kept as the
-            # fallback either way.
-            if finalize or self._rich_blocks_streaming_enabled():
+            # Tool-progress bubbles render as muted context blocks on every
+            # edit. Answer messages get blocks on the FINAL edit always; on
+            # intermediate streaming frames only when rich_blocks_streaming
+            # is enabled (tables and headers then render live during long
+            # runs — the consumer's edit debounce keeps the render cost
+            # bounded). Feedback buttons only ever belong on the final
+            # frame. ``text`` is kept as the fallback either way.
+            progress_blocks = self._maybe_progress_blocks(content, metadata)
+            if progress_blocks:
+                update_kwargs["blocks"] = progress_blocks
+            elif finalize or self._rich_blocks_streaming_enabled():
                 blocks = self._maybe_blocks(content, with_feedback=finalize)
                 if blocks:
                     update_kwargs["blocks"] = blocks
@@ -2120,6 +2136,45 @@ class SlackAdapter(BasePlatformAdapter):
         if raw is None:
             return False
         return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+    def _progress_context_lines(self) -> Optional[int]:
+        """Context-style rendering budget for tool-progress bubbles.
+
+        ``None`` = styling disabled (plain path); an int = keep that many
+        trailing lines (0 = keep all). Configured via
+        ``platforms.slack.extra.progress_context_lines`` — default 10 when
+        rich_blocks is on; "off"/"false" disables.
+        """
+        if not self._rich_blocks_enabled():
+            return None
+        raw = self.config.extra.get("progress_context_lines")
+        if raw is None:
+            return 10
+        s = str(raw).strip().lower()
+        if s in {"off", "false", "no", "none"}:
+            return None
+        try:
+            return max(0, int(s))
+        except ValueError:
+            return 10
+
+    def _maybe_progress_blocks(
+        self, content: str, metadata: Optional[Dict[str, Any]]
+    ) -> Optional[list]:
+        """Context blocks for tool-progress bubbles, or None for normal path."""
+        if not metadata or not metadata.get("progress_surface"):
+            return None
+        max_lines = self._progress_context_lines()
+        if max_lines is None:
+            return None
+        try:
+            return progress_context_blocks(content, max_lines)
+        except Exception:  # pragma: no cover - renderer already guards itself
+            logger.debug(
+                "[Slack] progress context render failed; using plain text",
+                exc_info=True,
+            )
+            return None
 
     def _feedback_buttons_enabled(self) -> bool:
         """Whether to include Slack AI feedback buttons on final responses."""

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1607,12 +1607,14 @@ class SlackAdapter(BasePlatformAdapter):
                 "ts": message_id,
                 "text": formatted,
             }
-            # Only render Block Kit on the FINAL edit. Intermediate streaming
-            # edits stay plain mrkdwn — re-deriving a full block layout on every
-            # progressive flush would be wasteful and jittery. ``text`` is kept
-            # as the fallback either way.
-            if finalize:
-                blocks = self._maybe_blocks(content)
+            # Blocks on the FINAL edit always; on intermediate streaming
+            # frames only when rich_blocks_streaming is enabled (tables and
+            # headers then render live during long runs — the consumer's edit
+            # debounce keeps the render cost bounded). Feedback buttons only
+            # ever belong on the final frame. ``text`` is kept as the
+            # fallback either way.
+            if finalize or self._rich_blocks_streaming_enabled():
+                blocks = self._maybe_blocks(content, with_feedback=finalize)
                 if blocks:
                     update_kwargs["blocks"] = blocks
             client = self._get_client(
@@ -2101,6 +2103,24 @@ class SlackAdapter(BasePlatformAdapter):
             return False
         return str(raw).strip().lower() in {"1", "true", "yes", "on"}
 
+    def _rich_blocks_streaming_enabled(self) -> bool:
+        """Whether intermediate streaming edits also render Block Kit.
+
+        Opt-in via ``platforms.slack.extra.rich_blocks_streaming``; requires
+        ``rich_blocks``. chat.update REMOVES a message's blocks whenever
+        ``text`` is sent without them, so throttling to every Nth frame would
+        flip the message rich→plain→rich between frames. When enabled, every
+        streaming frame renders blocks — the consumer's own edit debounce is
+        the effective throttle, and the render is a pure in-process function
+        (no extra API calls).
+        """
+        if not self._rich_blocks_enabled():
+            return False
+        raw = self.config.extra.get("rich_blocks_streaming")
+        if raw is None:
+            return False
+        return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
     def _feedback_buttons_enabled(self) -> bool:
         """Whether to include Slack AI feedback buttons on final responses."""
         raw = self.config.extra.get("feedback_buttons")
@@ -2142,7 +2162,9 @@ class SlackAdapter(BasePlatformAdapter):
             return blocks
         return [*blocks, self._feedback_block()]
 
-    def _maybe_block_segments(self, content: str) -> Optional[list]:
+    def _maybe_block_segments(
+        self, content: str, with_feedback: bool = True
+    ) -> Optional[list]:
         """Render ``content`` to a list of message-sized Block Kit segments.
 
         Each segment holds <= 50 blocks (Slack's per-message cap); content too
@@ -2160,22 +2182,23 @@ class SlackAdapter(BasePlatformAdapter):
             if not blocks:
                 return None
             segments = segment_blocks(blocks)
-            appended = self._append_feedback_block(segments[-1])
-            if appended:
-                segments[-1] = appended
+            if with_feedback:
+                appended = self._append_feedback_block(segments[-1])
+                if appended:
+                    segments[-1] = appended
             return segments
         except Exception:  # pragma: no cover - renderer already guards itself
             logger.debug("[Slack] block render failed; using plain text", exc_info=True)
             return None
 
-    def _maybe_blocks(self, content: str) -> Optional[list]:
+    def _maybe_blocks(self, content: str, with_feedback: bool = True) -> Optional[list]:
         """Single-message variant of :meth:`_maybe_block_segments`.
 
         Used by ``edit_message`` — an edit can only restyle the one message it
         targets, so content that segments into multiple messages declines
         (returns ``None``) and the edit keeps its plain-text payload.
         """
-        segments = self._maybe_block_segments(content)
+        segments = self._maybe_block_segments(content, with_feedback=with_feedback)
         if segments and len(segments) == 1:
             return segments[0]
         return None

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -580,10 +580,10 @@ def render_blocks(
 
         if not blocks:
             return None
-        if len(blocks) > MAX_BLOCKS:
-            # Too structurally complex to express safely — let the caller fall
-            # back to plain text rather than truncating and losing content.
-            return None
+        # NOTE: the list may exceed MAX_BLOCKS. Callers that put blocks on a
+        # single message must run the list through segment_blocks() — bailing
+        # out here used to flatten every long structured answer (raw pipe
+        # tables, unstyled headers) back to plain mrkdwn.
         return blocks
     except Exception:
         # Never let a rendering bug drop a message.
@@ -605,3 +605,92 @@ def _split_text(text: str, limit: int) -> List[str]:
     if remaining:
         out.append(remaining)
     return out
+
+
+# ----------------------------------------------------------------------------
+# Multi-message segmentation — Slack caps a message at MAX_BLOCKS blocks
+# ----------------------------------------------------------------------------
+
+
+def segment_blocks(
+    blocks: List[Block], max_blocks: int = MAX_BLOCKS
+) -> List[List[Block]]:
+    """Split a block list into message-sized segments of <= ``max_blocks``.
+
+    Prefers cutting before a ``header`` or ``divider`` (boundaries a reader
+    already perceives as section breaks) within the trailing third of the
+    window; hard-cuts at the cap when no such boundary exists.  A divider
+    that would open the next segment is dropped — the message break itself
+    is the visual separator.
+    """
+    if len(blocks) <= max_blocks:
+        return [blocks]
+    segments: List[List[Block]] = []
+    rest = blocks
+    while len(rest) > max_blocks:
+        cut = max_blocks
+        for i in range(max_blocks, max(1, max_blocks * 2 // 3) - 1, -1):
+            if rest[i].get("type") in ("header", "divider"):
+                cut = i
+                break
+        segments.append(rest[:cut])
+        rest = rest[cut:]
+        if rest and rest[0].get("type") == "divider":
+            rest = rest[1:]
+    if rest:
+        segments.append(rest)
+    return segments
+
+
+def _rich_text_plain(block: Block) -> str:
+    """Plain-text projection of a rich_text block (for the ``text`` fallback)."""
+    parts: List[str] = []
+
+    def walk(elements: List[Dict[str, Any]]) -> None:
+        for el in elements:
+            t = el.get("type")
+            if t == "text":
+                parts.append(el.get("text", ""))
+            elif t == "link":
+                parts.append(el.get("text") or el.get("url", ""))
+            elif t == "user":
+                parts.append(f"<@{el.get('user_id', '')}>")
+            elif t == "channel":
+                parts.append(f"<#{el.get('channel_id', '')}>")
+            elif t == "broadcast":
+                parts.append(f"@{el.get('range', '')}")
+            elif t == "emoji":
+                parts.append(f":{el.get('name', '')}:")
+            elif isinstance(el.get("elements"), list):
+                walk(el["elements"])
+                if t in ("rich_text_section", "rich_text_preformatted", "rich_text_quote"):
+                    parts.append("\n")
+
+    walk(block.get("elements", []))
+    return "".join(parts).strip()
+
+
+def blocks_fallback_text(segment: List[Block], limit: int = 39000) -> str:
+    """Derive the notification/accessibility ``text`` fallback for a segment.
+
+    Slack requires a non-empty ``text`` alongside ``blocks``; mobile
+    notifications read ONLY this field, so it should carry the segment's
+    actual content, not a placeholder.
+    """
+    parts: List[str] = []
+    for b in segment:
+        t = b.get("type")
+        if t == "header":
+            parts.append(b.get("text", {}).get("text", ""))
+        elif t == "section":
+            parts.append(b.get("text", {}).get("text", ""))
+        elif t == "rich_text":
+            parts.append(_rich_text_plain(b))
+        elif t == "table":
+            rows = b.get("rows", [])
+            ncols = len(rows[0]) if rows else 0
+            parts.append(f"[table {len(rows)}x{ncols}]")
+    out = "\n".join(p for p in parts if p).strip()
+    if len(out) > limit:
+        out = out[: limit - 1] + "…"
+    return out or " "

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -911,3 +911,53 @@ def demote_tables(blocks: List[Block]) -> List[Block]:
 def has_table_block(blocks: List[Block]) -> bool:
     """True if any block in the list is a native ``table`` block."""
     return any(b.get("type") == "table" for b in blocks)
+
+
+# ----------------------------------------------------------------------------
+# Send-boundary sanitizer — a single defensive pass over ANY outbound blocks
+# ----------------------------------------------------------------------------
+
+_MIN_TEXT = " "  # Slack rejects a zero-length text object/element.
+
+
+def _sanitize_node(node: Any) -> Any:
+    """Recursively repair the structural mistakes Slack rejects outright.
+
+    Slack validates the WHOLE ``blocks`` array; a single bad node fails the
+    entire message (``invalid_blocks``) and the rich render is lost. This
+    fixes, anywhere in the tree, regardless of which builder produced it:
+
+    * empty ``text`` strings on text / plain_text / mrkdwn objects → a space
+      ("must be more than 0 characters");
+    * ``null`` entries in a table's ``column_settings`` → ``{}`` (an object)
+      ("must provide an object [.../column_settings/N]").
+
+    Pure and idempotent — returns new structures, never mutates the input.
+    """
+    if isinstance(node, dict):
+        out = {k: _sanitize_node(v) for k, v in node.items()}
+        if out.get("type") in ("text", "plain_text", "mrkdwn"):
+            if not (isinstance(out.get("text"), str) and out["text"]):
+                out["text"] = _MIN_TEXT
+        cs = out.get("column_settings")
+        if isinstance(cs, list):
+            out["column_settings"] = [
+                c if isinstance(c, dict) else {} for c in cs
+            ]
+        return out
+    if isinstance(node, list):
+        return [_sanitize_node(x) for x in node]
+    return node
+
+
+def sanitize_blocks(blocks: List[Block]) -> List[Block]:
+    """Send-boundary guard: repair invalid_blocks-triggering mistakes in a
+    blocks payload from ANY source (render_blocks, exec-approval, slash-confirm,
+    or a future builder). Never raises — returns the input unchanged on an
+    unexpected shape, so it can wrap every outbound send safely."""
+    if not isinstance(blocks, list):
+        return blocks
+    try:
+        return [_sanitize_node(b) for b in blocks]
+    except Exception:  # pragma: no cover - must never break a send
+        return blocks

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -201,7 +201,14 @@ def _inline_elements(text: str) -> List[Dict[str, Any]]:
         emit_text(s, dict(style) if style else None)
 
     walk(text, {})
-    return elements or [{"type": "text", "text": text}]
+    # Slack rejects a rich_text ``text`` element whose string is empty
+    # ("must be more than 0 characters") — and one bad element (e.g. an empty
+    # table cell) fails the ENTIRE blocks payload. Drop zero-length text
+    # elements and guarantee at least one non-empty element in the run.
+    elements = [
+        el for el in elements if el.get("type") != "text" or el.get("text")
+    ]
+    return elements or [{"type": "text", "text": " "}]
 
 
 # ----------------------------------------------------------------------------
@@ -223,12 +230,15 @@ def _divider_block() -> Block:
 
 def _preformatted_block(text: str) -> Block:
     # rich_text_preformatted renders monospace; used for code fences + tables.
+    # Slack rejects a zero-length text element (an empty code fence would fail
+    # the whole payload), so fall back to a single space.
+    body = text.rstrip("\n") or " "
     return {
         "type": "rich_text",
         "elements": [
             {
                 "type": "rich_text_preformatted",
-                "elements": [{"type": "text", "text": text.rstrip("\n")}],
+                "elements": [{"type": "text", "text": body}],
             }
         ],
     }
@@ -712,7 +722,7 @@ def _pack_elements(
         cur.append(el)
         cur_len += elen
     flush()
-    return out or [[{"type": "text", "text": ""}]]
+    return out or [[{"type": "text", "text": " "}]]
 
 
 # ----------------------------------------------------------------------------

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -670,6 +670,51 @@ def _rich_text_plain(block: Block) -> str:
     return "".join(parts).strip()
 
 
+_FENCE_COLLAPSE_RE = re.compile(r"```[^\n]*\n?([\s\S]*?)```")
+
+
+def progress_context_blocks(content: str, max_lines: int = 10) -> Optional[List[Block]]:
+    """Render a tool-progress transcript as a small-print ``context`` block.
+
+    Long agentic runs accumulate dozens of tool-activity lines (terminal
+    fences, "Reading file…" rows) that visually drown the actual answer.
+    This collapses fenced commands to single-line inline code, keeps only
+    the trailing ``max_lines`` lines (0 = keep all; the full transcript
+    stays in the message's ``text`` fallback), and renders the result in
+    Slack's muted context style.
+    """
+    if not content or not content.strip():
+        return None
+
+    def _collapse(m: "re.Match[str]") -> str:
+        body = m.group(1).strip("\n")
+        first = body.splitlines()[0].strip() if body else ""
+        more = " …" if "\n" in body else ""
+        return f"`{first}{more}`" if first else "`…`"
+
+    text = _FENCE_COLLAPSE_RE.sub(_collapse, content)
+    lines = [ln for ln in (raw.rstrip() for raw in text.split("\n")) if ln.strip()]
+    if not lines:
+        return None
+    if max_lines > 0 and len(lines) > max_lines:
+        elided = len(lines) - max_lines
+        lines = lines[-max_lines:]
+        lines.insert(0, f"_… {elided} earlier steps_")
+    joined = "\n".join(lines)
+    # mrkdwn control-character escaping (backticks already delimit code).
+    joined = (
+        joined.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    )
+    if len(joined) > MAX_SECTION_TEXT:
+        joined = "…" + joined[-(MAX_SECTION_TEXT - 1):]
+    return [
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": joined}],
+        }
+    ]
+
+
 def blocks_fallback_text(segment: List[Block], limit: int = 39000) -> str:
     """Derive the notification/accessibility ``text`` fallback for a segment.
 

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -73,12 +73,29 @@ def _indent_level(spaces: str) -> int:
 # Inline markdown → rich_text elements
 # ----------------------------------------------------------------------------
 
-# Order matters: code first (opaque), then links, then emphasis.
+# Order matters: code first (opaque), then Slack entities, then markdown
+# links, then bare URLs, then emphasis.
 _INLINE_CODE_RE = re.compile(r"`([^`]+)`")
 _LINK_RE = re.compile(r"(?<!!)\[([^\]]+)\]\(([^()\s]+(?:\([^()]*\)[^()\s]*)*)\)")
 _BOLD_RE = re.compile(r"(?:\*\*|__)(.+?)(?:\*\*|__)")
 _ITALIC_RE = re.compile(r"(?<![\*_])(?:\*|_)(?![\*_\s])(.+?)(?<![\*_\s])(?:\*|_)(?![\*_])")
 _STRIKE_RE = re.compile(r"~~(.+?)~~")
+# Manual Slack entities the agent (or upstream text) may already contain:
+# user/channel/usergroup mentions, broadcasts, and <url|label> links.  In
+# mrkdwn these render natively; inside rich_text ``text`` elements they would
+# show up literally, so they must map to their dedicated element types.
+_SLACK_ENTITY_RE = re.compile(
+    r"<("
+    r"@[UW][A-Z0-9]+"
+    r"|#C[A-Z0-9]+(?:\|[^>]*)?"
+    r"|!(?:here|channel|everyone)"
+    r"|!subteam\^[A-Z0-9]+(?:\|[^>]*)?"
+    r"|(?:https?|mailto|tel):[^>|]+(?:\|[^>]+)?"
+    r")>"
+)
+_BARE_URL_RE = re.compile(r"https?://[^\s<>|]+")
+# Prose punctuation commonly glued to the end of a bare URL (incl. CJK).
+_URL_TRAILING_PUNCT = ").,;:!?。，；：！？）】」』\"'”’"
 
 
 def _inline_elements(text: str) -> List[Dict[str, Any]]:
@@ -99,28 +116,73 @@ def _inline_elements(text: str) -> List[Dict[str, Any]]:
         elements.append(el)
 
     # Tokenize by the highest-priority markers first using a single scan.
-    # We recursively split on code, then links, then emphasis to keep spans
-    # from overlapping incorrectly.
+    # We recursively split on code, then Slack entities, then markdown links,
+    # then bare URLs, then emphasis to keep spans from overlapping incorrectly.
     def walk(s: str, style: Dict[str, bool]) -> None:
         pos = 0
         # inline code is opaque — no nested styling
         for m in _INLINE_CODE_RE.finditer(s):
-            _walk_links(s[pos:m.start()], style)
+            _walk_entities(s[pos:m.start()], style)
             code_style = dict(style)
             code_style["code"] = True
             emit_text(m.group(1), code_style or None)
             pos = m.end()
+        _walk_entities(s[pos:], style)
+
+    def _walk_entities(s: str, style: Dict[str, bool]) -> None:
+        pos = 0
+        for m in _SLACK_ENTITY_RE.finditer(s):
+            _walk_links(s[pos:m.start()], style)
+            elements.append(_entity_element(m.group(1), style))
+            pos = m.end()
         _walk_links(s[pos:], style)
+
+    def _entity_element(body: str, style: Dict[str, bool]) -> Dict[str, Any]:
+        el: Dict[str, Any]
+        if body.startswith("@"):
+            el = {"type": "user", "user_id": body[1:]}
+        elif body.startswith("#"):
+            el = {"type": "channel", "channel_id": body[1:].split("|", 1)[0]}
+        elif body.startswith("!subteam^"):
+            el = {
+                "type": "usergroup",
+                "usergroup_id": body[len("!subteam^"):].split("|", 1)[0],
+            }
+        elif body.startswith("!"):
+            # broadcast takes no style property
+            return {"type": "broadcast", "range": body[1:]}
+        else:
+            url, _, label = body.partition("|")
+            el = {"type": "link", "url": url}
+            if label:
+                el["text"] = label
+        if style and el["type"] == "link":
+            el["style"] = dict(style)
+        return el
 
     def _walk_links(s: str, style: Dict[str, bool]) -> None:
         pos = 0
         for m in _LINK_RE.finditer(s):
-            _walk_emphasis(s[pos:m.start()], style)
+            _walk_bare_urls(s[pos:m.start()], style)
             link_el: Dict[str, Any] = {"type": "link", "url": m.group(2), "text": m.group(1)}
             if style:
                 link_el["style"] = dict(style)
             elements.append(link_el)
             pos = m.end()
+        _walk_bare_urls(s[pos:], style)
+
+    def _walk_bare_urls(s: str, style: Dict[str, bool]) -> None:
+        pos = 0
+        for m in _BARE_URL_RE.finditer(s):
+            url = m.group(0).rstrip(_URL_TRAILING_PUNCT)
+            if not url:
+                continue
+            _walk_emphasis(s[pos:m.start()], style)
+            link_el: Dict[str, Any] = {"type": "link", "url": url}
+            if style:
+                link_el["style"] = dict(style)
+            elements.append(link_el)
+            pos = m.start() + len(url)
         _walk_emphasis(s[pos:], style)
 
     def _walk_emphasis(s: str, style: Dict[str, bool]) -> None:
@@ -215,6 +277,21 @@ def _list_block(items: List[Tuple[int, bool, str]]) -> Block:
 
 def _section_block(text: str) -> Block:
     return {"type": "section", "text": {"type": "mrkdwn", "text": text}}
+
+
+def _rich_para_block(text: str) -> Block:
+    """Paragraph as a rich_text block.
+
+    Explicit style objects render reliably where mrkdwn's word-boundary
+    emphasis parsing fails — e.g. ``*bold*`` glued to CJK punctuation shows
+    literal asterisks in a mrkdwn section but renders bold here.
+    """
+    return {
+        "type": "rich_text",
+        "elements": [
+            {"type": "rich_text_section", "elements": _inline_elements(text)}
+        ],
+    }
 
 
 # ----------------------------------------------------------------------------
@@ -351,9 +428,10 @@ def render_blocks(
 
     Args:
         markdown: The agent's response text (standard markdown).
-        mrkdwn_fn: Optional callable converting a markdown paragraph to Slack
-            mrkdwn for ``section`` blocks (the adapter passes
-            ``format_message``).  When ``None``, the raw paragraph text is used.
+        mrkdwn_fn: Accepted for backwards compatibility; unused. Paragraphs
+            are rendered as ``rich_text`` (explicit style objects) instead of
+            mrkdwn sections, so emphasis adjacent to CJK punctuation — which
+            mrkdwn's word-boundary parser refuses to style — renders reliably.
 
     Returns:
         A list of Block Kit block dicts, or ``None`` when the content is empty,
@@ -363,7 +441,7 @@ def render_blocks(
     if not markdown or not markdown.strip():
         return None
 
-    fmt = mrkdwn_fn or (lambda s: s)
+    del mrkdwn_fn  # kept in the signature for callers; no longer used
 
     try:
         blocks: List[Block] = []
@@ -379,10 +457,11 @@ def render_blocks(
             para.clear()
             if not text:
                 return
-            rendered = fmt(text)
-            # Split oversized sections on the 3000-char limit.
-            for chunk in _split_text(rendered, MAX_SECTION_TEXT):
-                blocks.append(_section_block(chunk))
+            # rich_text (not mrkdwn section): explicit style objects survive
+            # CJK-adjacent emphasis that mrkdwn's word-boundary parser drops.
+            # Split oversized paragraphs on the 3000-char text-object limit.
+            for chunk in _split_text(text, MAX_SECTION_TEXT):
+                blocks.append(_rich_para_block(chunk))
 
         while i < n:
             line = lines[i]

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -29,6 +29,7 @@ adapter state — so it is trivially unit-testable.
 from __future__ import annotations
 
 import re
+import unicodedata
 from typing import Any, Dict, List, Optional, Tuple
 
 # Slack Block Kit hard limits (https://docs.slack.dev/reference/block-kit/blocks)
@@ -301,8 +302,23 @@ def _table_block(rows: List[str], sep_line: str) -> Optional[Block]:
     return block
 
 
+def _display_width(s: str) -> int:
+    """Monospace display width of ``s``: East Asian Wide/Fullwidth chars
+    occupy two columns in Slack's code font, everything else one."""
+    return sum(2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1 for ch in s)
+
+
+def _pad_display(s: str, width: int) -> str:
+    """Right-pad ``s`` with spaces to ``width`` display columns."""
+    return s + " " * max(0, width - _display_width(s))
+
+
 def _render_table(rows: List[str]) -> str:
-    """Render markdown pipe-table rows as aligned monospace text (fallback)."""
+    """Render markdown pipe-table rows as aligned monospace text (fallback).
+
+    Column widths are computed in display columns, not codepoints, so CJK
+    cell content (two columns per glyph in the monospace font) stays aligned.
+    """
     parsed: List[List[str]] = []
     for r in rows:
         cells = _split_row(r)
@@ -312,10 +328,10 @@ def _render_table(rows: List[str]) -> str:
     ncols = max(len(r) for r in parsed)
     for r in parsed:
         r.extend([""] * (ncols - len(r)))
-    widths = [max(len(r[c]) for r in parsed) for c in range(ncols)]
+    widths = [max(_display_width(r[c]) for r in parsed) for c in range(ncols)]
     out_lines = []
     for ri, r in enumerate(parsed):
-        line = " | ".join(r[c].ljust(widths[c]) for c in range(ncols))
+        line = " | ".join(_pad_display(r[c], widths[c]) for c in range(ncols))
         out_lines.append(line.rstrip())
         if ri == 0:  # header underline
             out_lines.append("-+-".join("-" * widths[c] for c in range(ncols)))

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -379,7 +379,7 @@ def _table_block(rows: List[str], sep_line: str) -> Optional[Block]:
     return block
 
 
-def _display_width(s: str) -> int:
+def _display_width(s: str, wide_ambiguous: bool = False) -> int:
     """Monospace display width of ``s`` in Slack's code font.
 
     East Asian Wide/Fullwidth chars occupy two columns; combining marks and
@@ -388,18 +388,44 @@ def _display_width(s: str) -> int:
     decomposed ``e`` + U+0301 from being counted as two columns and drifting
     the table — full grapheme clustering (multi-codepoint ZWJ emoji) is still
     approximate, since the stdlib can't cluster them.
+
+    ``wide_ambiguous`` widens East Asian *Ambiguous* ("A") codepoints —
+    arrows (→), check/cross marks (✓ ✗ ×), the ellipsis (…), roman numerals
+    (①), Greek/Cyrillic — to two columns. In a CJK font context Slack renders
+    these at two columns, so a table that already contains CJK must count them
+    as two or every row with an arrow/✓ drifts. Pure-ASCII tables keep them at
+    one (the width they actually render at without a CJK font).
     """
     width = 0
     for ch in s:
         if unicodedata.combining(ch) or unicodedata.category(ch) in ("Mn", "Me", "Cf"):
             continue
-        width += 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
+        eaw = unicodedata.east_asian_width(ch)
+        if eaw in ("W", "F") or (wide_ambiguous and eaw == "A"):
+            width += 2
+        else:
+            width += 1
     return width
 
 
-def _pad_display(s: str, width: int) -> str:
+def _pad_display(s: str, width: int, wide_ambiguous: bool = False) -> str:
     """Right-pad ``s`` with spaces to ``width`` display columns."""
-    return s + " " * max(0, width - _display_width(s))
+    return s + " " * max(0, width - _display_width(s, wide_ambiguous))
+
+
+def _has_east_asian_wide(rows: List[List[str]]) -> bool:
+    """True if any cell holds a Wide/Fullwidth (CJK) codepoint.
+
+    Used to decide whether East Asian *Ambiguous* glyphs should be measured
+    at two columns: a table with CJK is rendered in a CJK font, where they are
+    two wide; an all-Latin table is not.
+    """
+    return any(
+        unicodedata.east_asian_width(ch) in ("W", "F")
+        for r in rows
+        for cell in r
+        for ch in cell
+    )
 
 
 def _render_table(rows: List[str]) -> str:
@@ -407,6 +433,8 @@ def _render_table(rows: List[str]) -> str:
 
     Column widths are computed in display columns, not codepoints, so CJK
     cell content (two columns per glyph in the monospace font) stays aligned.
+    When the table contains any CJK, East Asian *Ambiguous* glyphs (arrows,
+    ✓/✗, …) are also counted as two columns so those rows don't drift.
     """
     parsed: List[List[str]] = []
     for r in rows:
@@ -417,10 +445,15 @@ def _render_table(rows: List[str]) -> str:
     ncols = max(len(r) for r in parsed)
     for r in parsed:
         r.extend([""] * (ncols - len(r)))
-    widths = [max(_display_width(r[c]) for r in parsed) for c in range(ncols)]
+    wide_amb = _has_east_asian_wide(parsed)
+    widths = [
+        max(_display_width(r[c], wide_amb) for r in parsed) for c in range(ncols)
+    ]
     out_lines = []
     for ri, r in enumerate(parsed):
-        line = " | ".join(_pad_display(r[c], widths[c]) for c in range(ncols))
+        line = " | ".join(
+            _pad_display(r[c], widths[c], wide_amb) for c in range(ncols)
+        )
         out_lines.append(line.rstrip())
         if ri == 0:  # header underline
             out_lines.append("-+-".join("-" * widths[c] for c in range(ncols)))
@@ -471,9 +504,20 @@ def render_blocks(
                 return
             # rich_text (not mrkdwn section): explicit style objects survive
             # CJK-adjacent emphasis that mrkdwn's word-boundary parser drops.
-            # Split oversized paragraphs on the 3000-char text-object limit.
-            for chunk in _split_text(text, MAX_SECTION_TEXT):
-                blocks.append(_rich_para_block(chunk))
+            # Parse inline markup ONCE, then split the resulting element list
+            # on the 3000-char text-object limit — splitting the raw string
+            # (old behaviour) could bisect a ``**bold**`` span and strand
+            # literal asterisks at the seam. Splitting parsed elements never
+            # can: each half keeps its style object.
+            for section_elems in _pack_elements(_inline_elements(text), MAX_SECTION_TEXT):
+                blocks.append(
+                    {
+                        "type": "rich_text",
+                        "elements": [
+                            {"type": "rich_text_section", "elements": section_elems}
+                        ],
+                    }
+                )
 
         while i < n:
             line = lines[i]
@@ -611,12 +655,64 @@ def _split_text(text: str, limit: int) -> List[str]:
     while len(remaining) > limit:
         cut = remaining.rfind("\n", 0, limit)
         if cut <= 0:
+            cut = remaining.rfind(" ", 0, limit)  # avoid cutting mid-word
+        if cut <= 0:
             cut = limit
         out.append(remaining[:cut])
         remaining = remaining[cut:].lstrip("\n")
     if remaining:
         out.append(remaining)
     return out
+
+
+def _element_len(el: Dict[str, Any]) -> int:
+    """Approximate character cost of a rich_text child element."""
+    t = el.get("type")
+    if t == "text":
+        return len(el.get("text", ""))
+    if t == "link":
+        return len(el.get("text") or el.get("url", ""))
+    return 1  # user/channel/broadcast/emoji render short — count nominally
+
+
+def _pack_elements(
+    elements: List[Dict[str, Any]], limit: int
+) -> List[List[Dict[str, Any]]]:
+    """Pack parsed inline elements into <= ``limit``-char rich_text sections.
+
+    Splits *between* elements, and only ever splits *inside* a plain ``text``
+    element (preserving its style on both halves) — never inside a link or a
+    styled span, so no ``**``/`` ` `` markup can leak at a seam. One section is
+    always returned so the caller can build at least one block.
+    """
+    out: List[List[Dict[str, Any]]] = []
+    cur: List[Dict[str, Any]] = []
+    cur_len = 0
+
+    def flush() -> None:
+        nonlocal cur, cur_len
+        if cur:
+            out.append(cur)
+            cur = []
+            cur_len = 0
+
+    for el in elements:
+        elen = _element_len(el)
+        # A single text run longer than the limit: split its text, keeping
+        # style, into standalone sections.
+        if el.get("type") == "text" and elen > limit:
+            flush()
+            for piece in _split_text(el.get("text", ""), limit):
+                seg = dict(el)
+                seg["text"] = piece
+                out.append([seg])
+            continue
+        if cur and cur_len + elen > limit:
+            flush()
+        cur.append(el)
+        cur_len += elen
+    flush()
+    return out or [[{"type": "text", "text": ""}]]
 
 
 # ----------------------------------------------------------------------------
@@ -751,3 +847,57 @@ def blocks_fallback_text(segment: List[Block], limit: int = 39000) -> str:
     if len(out) > limit:
         out = out[: limit - 1] + "…"
     return out or " "
+
+
+# ----------------------------------------------------------------------------
+# Table-block demotion — native ``table`` block → aligned monospace
+# ----------------------------------------------------------------------------
+
+
+def _cell_plain(cell: Block) -> str:
+    """Plain-text of a native table cell (a ``rich_text`` block), single line."""
+    return " ".join(_rich_text_plain(cell).split())
+
+
+def _table_block_to_preformatted(table: Block) -> Block:
+    """Render a native ``table`` block as an aligned-monospace preformatted block.
+
+    Used when a workspace/app tier rejects the native ``table`` block: instead
+    of dropping the grid to raw text, re-render it as the same CJK-aligned
+    monospace table :func:`_render_table` produces, so the columns still line
+    up. Pure block→block transform — needs no source markdown.
+    """
+    grid = [[_cell_plain(c) for c in row] for row in table.get("rows", [])]
+    if not grid:
+        return _preformatted_block("")
+    ncols = max((len(r) for r in grid), default=0)
+    for r in grid:
+        r.extend([""] * (ncols - len(r)))
+    wide = _has_east_asian_wide(grid)
+    widths = [max(_display_width(r[c], wide) for r in grid) for c in range(ncols)]
+    lines: List[str] = []
+    for ri, r in enumerate(grid):
+        line = " | ".join(_pad_display(r[c], widths[c], wide) for c in range(ncols))
+        lines.append(line.rstrip())
+        if ri == 0:
+            lines.append("-+-".join("-" * widths[c] for c in range(ncols)))
+    return _preformatted_block("\n".join(lines))
+
+
+def demote_tables(blocks: List[Block]) -> List[Block]:
+    """Replace every native ``table`` block with a monospace preformatted one.
+
+    The retry path when a ``blocks`` payload is rejected: keeps all the other
+    rich structure (headers, lists, styled text) and only demotes the block
+    type workspaces most often refuse, so a rejected message degrades to an
+    *aligned* table rather than losing its blocks entirely (raw pipes).
+    """
+    return [
+        _table_block_to_preformatted(b) if b.get("type") == "table" else b
+        for b in blocks
+    ]
+
+
+def has_table_block(blocks: List[Block]) -> bool:
+    """True if any block in the list is a native ``table`` block."""
+    return any(b.get("type") == "table" for b in blocks)

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -285,12 +285,12 @@ def _table_block(rows: List[str], sep_line: str) -> Optional[Block]:
         return None
 
     aligns = _parse_alignment(sep_line)
-    column_settings: List[Optional[Dict[str, Any]]] = []
+    column_settings: List[Dict[str, Any]] = []
     for c in range(min(ncols, MAX_TABLE_COLS)):
         align = aligns[c] if c < len(aligns) else "left"
-        # Only emit a setting when it differs from the default (left, no wrap);
-        # use null to skip a column, per the Slack schema.
-        column_settings.append({"align": align} if align != "left" else None)
+        # Slack validates every array entry as an object; emitting ``null`` for
+        # default-left columns makes the whole table payload invalid.
+        column_settings.append({"align": align})
 
     block: Block = {
         "type": "table",

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -380,9 +380,21 @@ def _table_block(rows: List[str], sep_line: str) -> Optional[Block]:
 
 
 def _display_width(s: str) -> int:
-    """Monospace display width of ``s``: East Asian Wide/Fullwidth chars
-    occupy two columns in Slack's code font, everything else one."""
-    return sum(2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1 for ch in s)
+    """Monospace display width of ``s`` in Slack's code font.
+
+    East Asian Wide/Fullwidth chars occupy two columns; combining marks and
+    other zero-width formatting codepoints (accent marks, ZWJ, variation
+    selectors) occupy none; everything else one. Zeroing combiners keeps a
+    decomposed ``e`` + U+0301 from being counted as two columns and drifting
+    the table — full grapheme clustering (multi-codepoint ZWJ emoji) is still
+    approximate, since the stdlib can't cluster them.
+    """
+    width = 0
+    for ch in s:
+        if unicodedata.combining(ch) or unicodedata.category(ch) in ("Mn", "Me", "Cf"):
+            continue
+        width += 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
+    return width
 
 
 def _pad_display(s: str, width: int) -> str:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -2113,3 +2113,72 @@ class TestMediaFallbackDoesNotLeakHostPath:
         sent_text = adapter.sent[0]["content"]
         assert "Here's the daily summary." in sent_text
         assert self.SENSITIVE_PATH not in sent_text
+
+
+# ---------------------------------------------------------------------------
+# find_structural_split
+# ---------------------------------------------------------------------------
+
+
+class TestFindStructuralSplit:
+    def test_no_usable_boundary_returns_minus_one(self):
+        from gateway.platforms.base import find_structural_split
+
+        assert find_structural_split("", 100) == -1
+        assert find_structural_split("a" * 200, 100) == -1  # no newline at all
+
+    def test_prefers_paragraph_boundary(self):
+        from gateway.platforms.base import find_structural_split
+
+        text = "A" * 60 + "\n\n" + "B" * 60
+        cut = find_structural_split(text, 100)
+        assert cut == 60
+        assert text[:cut] == "A" * 60
+
+    def test_does_not_bisect_table_run(self):
+        from gateway.platforms.base import find_structural_split
+
+        head = "intro\n" * 10  # 60 chars, newline before the table at 59
+        table = "\n".join("| a | b |" for _ in range(20))
+        text = head + table
+        cut = find_structural_split(text, len(head) + 50)
+        assert cut == 59  # the newline separating intro from the table
+        assert text[cut:].lstrip("\n").startswith("|")
+
+    def test_never_cuts_inside_open_fence(self):
+        from gateway.platforms.base import find_structural_split
+
+        text = "p" * 20 + "\n\n```python\n" + "code line\n" * 30 + "```\ndone"
+        cut = find_structural_split(text, 100)
+        # only structurally sound cut is before the fence opens
+        assert 0 < cut <= text.index("```")
+
+    def test_cut_after_closed_fence_is_allowed(self):
+        from gateway.platforms.base import find_structural_split
+
+        text = "```\n" + "code line\n" * 20 + "```\n" + "tail " * 10
+        closing_nl = text.index("\n", text.index("```", 4))
+        cut = find_structural_split(text, len(text) - 10)
+        # the newline right after the closing fence is the best boundary
+        assert cut == closing_nl
+
+    def test_prose_tail_returns_minus_one_for_legacy_space_cut(self):
+        from gateway.platforms.base import find_structural_split
+
+        # Tiny fenced head, then one long prose line: the only newline sits
+        # far below an eighth of the window, and prose can be space-cut by
+        # the legacy fallback — declining is the right call.
+        text = "```\ncode\n```\n" + "tail " * 30
+        assert find_structural_split(text, len(text) - 10) == -1
+
+
+class TestTruncateMessageStructural:
+    def test_table_stays_whole_across_chunks(self):
+        head = "intro line\n" * 15
+        rows = "\n".join(f"| row{i} | value{i} |" for i in range(8))
+        msg = head + rows
+        chunks = BasePlatformAdapter.truncate_message(msg, max_length=200)
+        assert len(chunks) == 2
+        assert "|" not in chunks[0]  # table not started in chunk 1
+        for i in range(8):
+            assert f"| row{i} |" in chunks[1]  # table whole in chunk 2

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -443,8 +443,20 @@ async def test_run_agent_progress_uses_event_message_id_for_slack_dm(monkeypatch
 
     assert result["final_response"] == "done"
     assert adapter.sent
-    assert adapter.sent[0]["metadata"] == {"thread_id": "1234567890.000001"}
-    assert all(call["metadata"] == {"thread_id": "1234567890.000001"} for call in adapter.typing)
+    # progress_surface marks Slack tool-progress bubbles for the adapter's
+    # muted context-block rendering; threading metadata is unchanged.
+    assert adapter.sent[0]["metadata"] == {
+        "thread_id": "1234567890.000001",
+        "progress_surface": True,
+    }
+    assert all(
+        call["metadata"]
+        in (
+            {"thread_id": "1234567890.000001"},
+            {"thread_id": "1234567890.000001", "progress_surface": True},
+        )
+        for call in adapter.typing
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3120,6 +3120,40 @@ class TestReactions:
         assert "1234567890.000001" not in adapter._reacting_message_ids
 
     @pytest.mark.asyncio
+    async def test_thread_context_timeout_still_dispatches_and_acknowledges(self, adapter):
+        """A stalled optional thread fetch cannot make an @mention disappear."""
+        adapter.THREAD_CONTEXT_FETCH_TIMEOUT_SECONDS = 0.01
+        adapter._app.client.reactions_add = AsyncMock()
+        adapter._resolve_user_name = AsyncMock(return_value="Tyler")
+        adapter._fetch_thread_parent_text = AsyncMock(return_value="")
+
+        async def stalled_thread_context(**_kwargs):
+            await asyncio.sleep(1)
+            return "unreachable context"
+
+        adapter._fetch_thread_context = stalled_thread_context
+        event = {
+            "text": "<@U_BOT> hello",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "team": "T123",
+            "ts": "1234567890.000010",
+            "thread_ts": "1234567890.000001",
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_awaited_once()
+        received = adapter.handle_message.await_args.args[0]
+        assert received.text == "hello"
+        assert received.reply_to_message_id == "1234567890.000001"
+        assert "1234567890.000010" in adapter._reacting_message_ids
+        adapter._app.client.reactions_add.assert_any_await(
+            channel="C123", timestamp="1234567890.000010", name="eyes"
+        )
+
+    @pytest.mark.asyncio
     async def test_reactions_failure_outcome(self, adapter):
         """Failed processing should add :x: instead of :white_check_mark:."""
         adapter._app.client.reactions_add = AsyncMock()

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -182,6 +182,40 @@ class TestSlackExecApproval:
 
 
 # ===========================================================================
+# send_slash_confirm — CommonMark body must be converted to Slack mrkdwn
+# ===========================================================================
+
+class TestSlackSlashConfirmMrkdwn:
+    """The three-option confirm body (``/new`` etc.) arrives as CommonMark
+    (``**bold**``); Slack mrkdwn needs ``*bold*``, so the section must be run
+    through format_message or it renders literal double asterisks."""
+
+    @pytest.mark.asyncio
+    async def test_double_asterisk_body_becomes_single(self):
+        adapter = _make_adapter()
+        client = adapter._team_clients["T1"]
+        client.chat_postMessage = AsyncMock(return_value={"ts": "1.2"})
+        adapter._get_client = MagicMock(return_value=client)
+        message = (
+            "⚠️ **Confirm /new**\n\n"
+            "This starts a fresh session.\n\n"
+            "Choose:\n"
+            "• **Approve Once** — proceed this time only\n"
+            "• **Cancel** — keep current conversation\n\n"
+            "_Text fallback: reply `!approve` or `!cancel`._"
+        )
+        res = await adapter.send_slash_confirm("C1", "/new", message, "sess", "1")
+        assert res.success
+        section = client.chat_postMessage.await_args.kwargs["blocks"][0]["text"]["text"]
+        assert "**" not in section            # no literal CommonMark bold
+        assert "*Approve Once*" in section     # converted to Slack bold
+        assert "`!approve`" in section         # inline code preserved
+        # buttons still present
+        types = [b["type"] for b in client.chat_postMessage.await_args.kwargs["blocks"]]
+        assert "actions" in types
+
+
+# ===========================================================================
 # _handle_approval_action — button click handler
 # ===========================================================================
 

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -250,6 +250,13 @@ class TestTables:
         assert _display_width("指标") == 4
         assert _display_width("p75 值") == 6
 
+    def test_display_width_ignores_zero_width_combiners(self):
+        # decomposed é (e + combining acute) is one printed column, not two;
+        # a ZWJ between two letters adds nothing.
+        assert _display_width("é") == 1
+        assert _display_width("café") == 4  # precomposed é stays one column
+        assert _display_width("a‍b") == 2  # ZWJ is zero-width
+
     def test_cjk_fallback_alignment_uses_display_width(self):
         rows = [
             "| 指标 | 判断 |",

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -358,3 +358,48 @@ class TestSegmentBlocks:
         assert blocks_fallback_text([{"type": "divider"}]).strip() != "" or (
             blocks_fallback_text([{"type": "divider"}]) == " "
         )
+
+
+class TestProgressContextBlocks:
+    def test_empty_returns_none(self):
+        from plugins.platforms.slack.block_kit import progress_context_blocks
+
+        assert progress_context_blocks("") is None
+        assert progress_context_blocks("   \n ") is None
+
+    def test_fence_collapses_to_inline_code(self):
+        from plugins.platforms.slack.block_kit import progress_context_blocks
+
+        content = "💻 terminal\n```\nset -e && make build\nmake test\n```"
+        [block] = progress_context_blocks(content)
+        assert block["type"] == "context"
+        text = block["elements"][0]["text"]
+        # multi-line command collapses to its first line as inline code;
+        # & is mrkdwn-escaped (Slack renders &amp; back as & inside code)
+        assert "`set -e &amp;&amp; make build …`" in text
+        assert "```" not in text
+
+    def test_keeps_only_trailing_lines_with_elision_note(self):
+        from plugins.platforms.slack.block_kit import progress_context_blocks
+
+        content = "\n".join(f"📖 Reading file{i}.csv" for i in range(25))
+        [block] = progress_context_blocks(content, max_lines=10)
+        text = block["elements"][0]["text"]
+        lines = text.split("\n")
+        assert len(lines) == 11  # elision note + 10 kept lines
+        assert "15 earlier steps" in lines[0]
+        assert lines[-1].endswith("file24.csv")
+
+    def test_zero_keeps_all_lines(self):
+        from plugins.platforms.slack.block_kit import progress_context_blocks
+
+        content = "\n".join(f"line{i}" for i in range(25))
+        [block] = progress_context_blocks(content, max_lines=0)
+        assert len(block["elements"][0]["text"].split("\n")) == 25
+
+    def test_control_chars_escaped(self):
+        from plugins.platforms.slack.block_kit import progress_context_blocks
+
+        [block] = progress_context_blocks("fetch <https://e.io> & parse")
+        text = block["elements"][0]["text"]
+        assert "&lt;" in text and "&amp;" in text

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -7,6 +7,8 @@ from plugins.platforms.slack.block_kit import (
     _display_width,
     _render_table,
     blocks_fallback_text,
+    demote_tables,
+    has_table_block,
     render_blocks,
     segment_blocks,
 )
@@ -410,3 +412,66 @@ class TestProgressContextBlocks:
         [block] = progress_context_blocks("fetch <https://e.io> & parse")
         text = block["elements"][0]["text"]
         assert "&lt;" in text and "&amp;" in text
+
+
+class TestAmbiguousWidthAlignment:
+    def test_ambiguous_width_wide_in_cjk_table(self):
+        # Arrows/✓/… are East Asian "Ambiguous": two columns in a CJK font.
+        # A table that contains CJK must count them as two or rows drift.
+        rows = ["| 名称 | 状态 |", "| 首页→详情 | ✓ 好 |", "| API… | 差 |"]
+        out = _render_table(rows)
+        lines = out.split("\n")
+        data_lines = [lines[0]] + lines[2:]
+        cols = {
+            _display_width(line[: line.index("|")], wide_ambiguous=True)
+            for line in data_lines
+        }
+        assert len(cols) == 1  # first separator aligned across all rows
+
+    def test_ascii_table_keeps_ambiguous_one_column(self):
+        assert _display_width("a→b") == 3  # no CJK context: → is one column
+        assert _display_width("甲→乙", wide_ambiguous=True) == 6  # CJK: → is two
+
+
+class TestLongParagraphSplit:
+    def test_split_preserves_bold_across_seam(self):
+        # A >3000-char paragraph full of bold spans must split WITHOUT
+        # bisecting a ``**...**`` span into literal asterisks.
+        big = "说明 **关键指标** 数据 " * 300
+        blocks = render_blocks(big)
+        assert len(blocks) > 1
+        assert "**" not in str(blocks)  # no leaked markup at any seam
+        bolds = {
+            el["text"]
+            for b in blocks
+            for sec in b["elements"]
+            for el in sec["elements"]
+            if el.get("style", {}).get("bold")
+        }
+        assert bolds == {"关键指标"}  # every bold span intact
+
+
+class TestDemoteTables:
+    _TABLE_MD = "| 指标 | 判断 |\n|------|------|\n| LCP | 良好 |\n| INP | 需改进 |"
+
+    def test_has_table_block(self):
+        blocks = render_blocks(self._TABLE_MD)
+        assert has_table_block(blocks)
+        assert not has_table_block(render_blocks("just text"))
+
+    def test_demote_converts_table_to_monospace(self):
+        blocks = render_blocks(self._TABLE_MD)
+        demoted = demote_tables(blocks)
+        assert not has_table_block(demoted)
+        # the table became an aligned monospace preformatted block
+        pre = [b for b in demoted if b["type"] == "rich_text"]
+        assert pre and pre[0]["elements"][0]["type"] == "rich_text_preformatted"
+        text = pre[0]["elements"][0]["elements"][0]["text"]
+        assert "指标" in text and "LCP" in text and "|" in text  # a grid, not raw md
+
+    def test_demote_keeps_other_blocks(self):
+        blocks = render_blocks(f"# Title\n\n{self._TABLE_MD}\n\nafter")
+        demoted = demote_tables(blocks)
+        types = [b["type"] for b in demoted]
+        assert "header" in types  # non-table blocks untouched
+        assert not has_table_block(demoted)

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -19,12 +19,14 @@ class TestRenderBlocksBasics:
         assert render_blocks("") is None
         assert render_blocks("   \n  ") is None
 
-    def test_plain_paragraph_is_section(self):
+    def test_plain_paragraph_is_rich_text(self):
         blocks = render_blocks("just a plain sentence")
         assert blocks is not None
         assert len(blocks) == 1
-        assert blocks[0]["type"] == "section"
-        assert blocks[0]["text"]["type"] == "mrkdwn"
+        assert blocks[0]["type"] == "rich_text"
+        section = blocks[0]["elements"][0]
+        assert section["type"] == "rich_text_section"
+        assert section["elements"][0] == {"type": "text", "text": "just a plain sentence"}
 
     def test_header_becomes_header_block(self):
         blocks = render_blocks("# Title")
@@ -91,6 +93,48 @@ class TestInlineFormatting:
             if el.get("style", {}).get("bold")
         ]
         assert styled, "expected a bold-styled text element in the list item"
+
+    def test_cjk_adjacent_bold_gets_explicit_style(self):
+        """Regression: mrkdwn refuses ``*bold*`` glued to CJK punctuation
+        (no word boundary), so ``**7.39 GB**，`` showed literal asterisks.
+        rich_text style objects don't depend on boundary parsing.
+        """
+        blocks = render_blocks("预计扫描 **7.39 GB**，仍在 10 GB 限制内")
+        section = blocks[0]["elements"][0]
+        bold = [
+            el for el in section["elements"]
+            if el.get("style", {}).get("bold")
+        ]
+        assert bold and bold[0]["text"] == "7.39 GB"
+        assert "**" not in str(blocks)
+
+    def test_user_mention_becomes_user_element(self):
+        blocks = render_blocks("ping <@U012AB3CD> about this")
+        section = blocks[0]["elements"][0]
+        users = [el for el in section["elements"] if el["type"] == "user"]
+        assert users == [{"type": "user", "user_id": "U012AB3CD"}]
+
+    def test_broadcast_and_channel_entities(self):
+        blocks = render_blocks("<!here> see <#C024BE7LR|general>")
+        section = blocks[0]["elements"][0]
+        types = {el["type"] for el in section["elements"]}
+        assert "broadcast" in types
+        assert {"type": "channel", "channel_id": "C024BE7LR"} in section["elements"]
+
+    def test_bare_url_becomes_link_element(self):
+        blocks = render_blocks("详见 https://example.com/x。")
+        section = blocks[0]["elements"][0]
+        links = [el for el in section["elements"] if el["type"] == "link"]
+        # trailing CJK full stop is prose, not part of the URL
+        assert links == [{"type": "link", "url": "https://example.com/x"}]
+        tail = section["elements"][-1]
+        assert tail == {"type": "text", "text": "。"}
+
+    def test_manual_slack_link_with_label(self):
+        blocks = render_blocks("open <https://e.io/a|the dashboard> now")
+        section = blocks[0]["elements"][0]
+        links = [el for el in section["elements"] if el["type"] == "link"]
+        assert links == [{"type": "link", "url": "https://e.io/a", "text": "the dashboard"}]
 
     def test_blank_line_separated_ordered_items_stay_in_one_list(self):
         """Regression: blank lines between ordered items must not reset numbering.
@@ -237,13 +281,19 @@ class TestTables:
 
 
 class TestLimits:
-    def test_oversized_section_is_split_under_limit(self):
+    def test_oversized_paragraph_is_split_under_limit(self):
         big = "word " * 2000  # ~10000 chars, single paragraph
         blocks = render_blocks(big)
         assert blocks is not None
+        assert len(blocks) > 1  # split across multiple paragraph blocks
         for b in blocks:
-            if b["type"] == "section":
-                assert len(b["text"]["text"]) <= MAX_SECTION_TEXT
+            assert b["type"] == "rich_text"
+            total = sum(
+                len(el.get("text", ""))
+                for sec in b["elements"]
+                for el in sec["elements"]
+            )
+            assert total <= MAX_SECTION_TEXT
 
     def test_too_many_blocks_returns_none(self):
         # 60 dividers => 60 blocks > MAX_BLOCKS => decline (caller uses text)

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -6,7 +6,9 @@ from plugins.platforms.slack.block_kit import (
     MAX_SECTION_TEXT,
     _display_width,
     _render_table,
+    blocks_fallback_text,
     render_blocks,
+    segment_blocks,
 )
 
 
@@ -295,12 +297,64 @@ class TestLimits:
             )
             assert total <= MAX_SECTION_TEXT
 
-    def test_too_many_blocks_returns_none(self):
-        # 60 dividers => 60 blocks > MAX_BLOCKS => decline (caller uses text)
+    def test_over_max_blocks_returns_full_list_for_segmentation(self):
+        # 60 dividers => 60 blocks. The renderer no longer declines; callers
+        # segment the list into multiple messages via segment_blocks().
         md = "\n\n".join(["---"] * (MAX_BLOCKS + 10))
-        assert render_blocks(md) is None
+        blocks = render_blocks(md)
+        assert blocks is not None
+        assert len(blocks) == MAX_BLOCKS + 10
 
     def test_never_raises_on_garbage(self):
         for junk in ["```unterminated\ncode", "| broken | table", "> ", "#" * 10]:
             # must not raise; either blocks or None
             render_blocks(junk)
+
+
+def _section(i):
+    return {"type": "section", "text": {"type": "mrkdwn", "text": f"s{i}"}}
+
+
+class TestSegmentBlocks:
+    def test_under_cap_single_segment(self):
+        blocks = [_section(i) for i in range(10)]
+        assert segment_blocks(blocks) == [blocks]
+
+    def test_hard_cut_at_cap_without_boundary(self):
+        blocks = [_section(i) for i in range(120)]
+        segments = segment_blocks(blocks)
+        assert all(len(s) <= MAX_BLOCKS for s in segments)
+        # nothing lost, order preserved
+        flat = [b for s in segments for b in s]
+        assert flat == blocks
+
+    def test_prefers_header_boundary(self):
+        header = {"type": "header", "text": {"type": "plain_text", "text": "h"}}
+        blocks = [_section(i) for i in range(40)] + [header] + [
+            _section(i) for i in range(19)
+        ]  # 60 blocks, header at index 40 (inside the trailing-third window)
+        segments = segment_blocks(blocks)
+        assert len(segments[0]) == 40
+        assert segments[1][0]["type"] == "header"
+
+    def test_leading_divider_dropped_after_cut(self):
+        divider = {"type": "divider"}
+        blocks = [_section(i) for i in range(50)] + [divider] + [_section(99)]
+        segments = segment_blocks(blocks)
+        # cut lands on the divider; the next segment must not open with it —
+        # the message break itself is the separator
+        assert len(segments) == 2
+        assert segments[1] == [_section(99)]
+
+    def test_fallback_text_extracts_content(self):
+        md = "# 标题\n\n预计扫描 **7.39 GB**，详见 https://e.io/x"
+        segments = segment_blocks(render_blocks(md))
+        text = blocks_fallback_text(segments[0])
+        assert "标题" in text
+        assert "7.39 GB" in text
+        assert "**" not in text  # plain projection, no markup
+
+    def test_fallback_text_never_empty(self):
+        assert blocks_fallback_text([{"type": "divider"}]).strip() != "" or (
+            blocks_fallback_text([{"type": "divider"}]) == " "
+        )

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -4,6 +4,8 @@ from plugins.platforms.slack.block_kit import (
     MAX_BLOCKS,
     MAX_HEADER_TEXT,
     MAX_SECTION_TEXT,
+    _display_width,
+    _render_table,
     render_blocks,
 )
 
@@ -196,6 +198,29 @@ class TestTables:
         row = "|" + "|".join("v" for _ in range(25)) + "|"
         blocks = render_blocks(f"{header}\n{sep}\n{row}")
         assert blocks[0]["type"] == "rich_text"
+
+    def test_display_width_counts_cjk_as_two_columns(self):
+        assert _display_width("LCP") == 3
+        assert _display_width("指标") == 4
+        assert _display_width("p75 值") == 6
+
+    def test_cjk_fallback_alignment_uses_display_width(self):
+        rows = [
+            "| 指标 | 判断 |",
+            "| LCP | 良好 |",
+            "| INP | Needs Improvement |",
+        ]
+        out = _render_table(rows)
+        lines = out.split("\n")
+        data_lines = [lines[0]] + lines[2:]  # lines[1] is the header underline
+        # The first column separator must sit at the same display column on
+        # every row; with len()-based padding the CJK header row drifts.
+        prefix_cols = {
+            _display_width(line[: line.index("|")]) for line in data_lines
+        }
+        assert len(prefix_cols) == 1
+        # Header underline spans the display width of the widest cell (指标 = 4).
+        assert lines[1].startswith("-" * 4)
 
     def test_escaped_pipe_not_a_column_separator(self):
         md = (

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -475,3 +475,36 @@ class TestDemoteTables:
         types = [b["type"] for b in demoted]
         assert "header" in types  # non-table blocks untouched
         assert not has_table_block(demoted)
+
+
+class TestNoEmptyTextElements:
+    """Slack rejects a zero-length rich_text ``text`` element ('must be more
+    than 0 characters') and one bad element fails the WHOLE blocks payload —
+    the message then degrades to plain text. Empty table cells / code fences
+    must never emit an empty text element."""
+
+    @staticmethod
+    def _has_empty_text(obj):
+        if isinstance(obj, dict):
+            if obj.get("type") == "text" and obj.get("text", "") == "":
+                return True
+            return any(TestNoEmptyTextElements._has_empty_text(v) for v in obj.values())
+        if isinstance(obj, list):
+            return any(TestNoEmptyTextElements._has_empty_text(x) for x in obj)
+        return False
+
+    def test_empty_table_cells_no_empty_text(self):
+        md = "| A | B |\n|---|---|\n| x |  |\n|  | y |"
+        assert not self._has_empty_text(render_blocks(md))
+
+    def test_all_empty_row_no_empty_text(self):
+        md = "| A | B |\n|---|---|\n|  |  |"
+        assert not self._has_empty_text(render_blocks(md))
+
+    def test_empty_code_fence_no_empty_text(self):
+        assert not self._has_empty_text(render_blocks("```\n\n```"))
+
+    def test_inline_elements_empty_string(self):
+        from plugins.platforms.slack.block_kit import _inline_elements
+        els = _inline_elements("")
+        assert els and all(e.get("text") for e in els if e.get("type") == "text")

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -10,6 +10,7 @@ from plugins.platforms.slack.block_kit import (
     demote_tables,
     has_table_block,
     render_blocks,
+    sanitize_blocks,
     segment_blocks,
 )
 
@@ -508,3 +509,50 @@ class TestNoEmptyTextElements:
         from plugins.platforms.slack.block_kit import _inline_elements
         els = _inline_elements("")
         assert els and all(e.get("text") for e in els if e.get("type") == "text")
+
+
+class TestSanitizeBlocks:
+    """Send-boundary guard: repair invalid_blocks-triggering mistakes from ANY
+    builder before the payload leaves the process."""
+
+    def test_empty_text_element_floored(self):
+        blocks = [{"type": "rich_text", "elements": [
+            {"type": "rich_text_section", "elements": [{"type": "text", "text": ""}]}
+        ]}]
+        out = sanitize_blocks(blocks)
+        el = out[0]["elements"][0]["elements"][0]
+        assert el["text"] == " "
+
+    def test_empty_mrkdwn_and_plain_text_floored(self):
+        blocks = [
+            {"type": "section", "text": {"type": "mrkdwn", "text": ""}},
+            {"type": "header", "text": {"type": "plain_text", "text": ""}},
+        ]
+        out = sanitize_blocks(blocks)
+        assert out[0]["text"]["text"] == " "
+        assert out[1]["text"]["text"] == " "
+
+    def test_null_column_settings_coerced_to_object(self):
+        blocks = [{"type": "table", "rows": [], "column_settings": [None, {"align": "right"}, None]}]
+        out = sanitize_blocks(blocks)
+        assert out[0]["column_settings"] == [{}, {"align": "right"}, {}]
+
+    def test_valid_blocks_unchanged(self):
+        blocks = render_blocks("# Title\n\nsome **bold** text")
+        assert sanitize_blocks(blocks) == blocks  # idempotent no-op on clean input
+
+    def test_idempotent(self):
+        blocks = [{"type": "rich_text", "elements": [
+            {"type": "rich_text_section", "elements": [{"type": "text", "text": ""}]}
+        ]}]
+        once = sanitize_blocks(blocks)
+        assert sanitize_blocks(once) == once
+
+    def test_never_raises_and_passes_non_list(self):
+        assert sanitize_blocks(None) is None
+        assert sanitize_blocks("nope") == "nope"
+
+    def test_does_not_mutate_input(self):
+        blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": ""}}]
+        sanitize_blocks(blocks)
+        assert blocks[0]["text"]["text"] == ""  # original untouched

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -159,8 +159,9 @@ class TestTables:
         )
         blocks = render_blocks(md)
         cs = blocks[0]["column_settings"]
-        # left is default -> null; center/right emitted
-        assert cs[0] is None
+        # Slack requires each column setting to be an object; an explicit
+        # left alignment is valid while null entries are rejected by the API.
+        assert cs[0] == {"align": "left"}
         assert cs[1] == {"align": "center"}
         assert cs[2] == {"align": "right"}
 

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -31,6 +31,50 @@ def _make_adapter(extra=None):
 RICH_MD = "# Title\n\n- a\n  - nested\n\n---\n\nbody text"
 
 
+class TestRichBlocksCanary:
+    """rich_blocks_channels scopes rich rendering to selected channels."""
+
+    @pytest.mark.asyncio
+    async def test_listed_channel_gets_blocks(self):
+        adapter, client = _make_adapter(
+            {"rich_blocks": True, "rich_blocks_channels": ["C1"]}
+        )
+        await adapter.send("C1", RICH_MD)
+        assert client.chat_postMessage.await_args.kwargs.get("blocks")
+
+    @pytest.mark.asyncio
+    async def test_unlisted_channel_stays_plain_text(self):
+        adapter, client = _make_adapter(
+            {"rich_blocks": True, "rich_blocks_channels": ["C1"]}
+        )
+        await adapter.send("C2", RICH_MD)
+        kwargs = client.chat_postMessage.await_args.kwargs
+        assert "blocks" not in kwargs
+        assert kwargs["text"]  # message content survives as plain text
+
+    @pytest.mark.asyncio
+    async def test_csv_form_parsed(self):
+        adapter, client = _make_adapter(
+            {"rich_blocks": True, "rich_blocks_channels": "C1, C3"}
+        )
+        await adapter.send("C3", RICH_MD)
+        assert client.chat_postMessage.await_args.kwargs.get("blocks")
+
+    @pytest.mark.asyncio
+    async def test_empty_list_renders_everywhere(self):
+        adapter, client = _make_adapter({"rich_blocks": True})
+        await adapter.send("C2", RICH_MD)
+        assert client.chat_postMessage.await_args.kwargs.get("blocks")
+
+    @pytest.mark.asyncio
+    async def test_edit_gated_by_channel(self):
+        adapter, client = _make_adapter(
+            {"rich_blocks": True, "rich_blocks_channels": ["C1"]}
+        )
+        await adapter.edit_message("C2", "111.222", RICH_MD, finalize=True)
+        assert "blocks" not in client.chat_update.await_args.kwargs
+
+
 class TestSendMessageBlocks:
     @pytest.mark.asyncio
     async def test_disabled_by_default_no_blocks(self):

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -104,6 +104,45 @@ class TestSendMessageBlocks:
         assert "blocks" not in client.chat_postMessage.await_args.kwargs
 
 
+class TestBlocksRejectionFallback:
+    @pytest.mark.asyncio
+    async def test_send_retries_without_blocks_on_invalid_blocks(self):
+        adapter, client = _make_adapter({"rich_blocks": True})
+        client.chat_postMessage = AsyncMock(
+            side_effect=[
+                Exception("The request to the Slack API failed. (error: invalid_blocks)"),
+                {"ts": "1.2"},
+            ]
+        )
+        res = await adapter.send("C1", RICH_MD)
+        assert res.success
+        calls = client.chat_postMessage.await_args_list
+        assert "blocks" in calls[0].kwargs
+        assert "blocks" not in calls[1].kwargs
+        assert calls[1].kwargs["text"]  # message content survives as plain text
+
+    @pytest.mark.asyncio
+    async def test_send_non_block_error_propagates(self):
+        adapter, client = _make_adapter({"rich_blocks": True})
+        client.chat_postMessage = AsyncMock(side_effect=Exception("ratelimited"))
+        res = await adapter.send("C1", RICH_MD)
+        assert not res.success
+        assert len(client.chat_postMessage.await_args_list) == 1
+
+    @pytest.mark.asyncio
+    async def test_finalize_edit_retries_without_blocks(self):
+        adapter, client = _make_adapter({"rich_blocks": True})
+        client.chat_update = AsyncMock(
+            side_effect=[Exception("invalid_blocks"), {"ok": True}]
+        )
+        res = await adapter.edit_message("C1", "111.222", RICH_MD, finalize=True)
+        assert res.success
+        calls = client.chat_update.await_args_list
+        assert "blocks" in calls[0].kwargs
+        # text-only chat.update removes the rejected blocks and renders text
+        assert "blocks" not in calls[1].kwargs
+
+
 class TestEditMessageBlocks:
     @pytest.mark.asyncio
     async def test_intermediate_edit_no_blocks(self):

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -337,3 +337,47 @@ class TestEditMessageBlocks:
         adapter, client = _make_adapter()  # rich_blocks off
         await adapter.edit_message("C1", "111.222", RICH_MD, finalize=True)
         assert "blocks" not in client.chat_update.await_args.kwargs
+
+
+class TestSanitizingClientProxy:
+    """_get_client wraps the WebClient so every send sanitizes its blocks —
+    the single send-boundary choke point protecting all builders."""
+
+    @pytest.mark.asyncio
+    async def test_get_client_sanitizes_blocks_on_send(self):
+        from unittest.mock import AsyncMock, MagicMock
+        from plugins.platforms.slack.adapter import _SanitizingClient
+
+        raw = MagicMock()
+        raw.chat_postMessage = AsyncMock(return_value={"ts": "1.2"})
+        proxy = _SanitizingClient(raw)
+        bad = [
+            {"type": "section", "text": {"type": "mrkdwn", "text": ""}},
+            {"type": "table", "rows": [], "column_settings": [None]},
+        ]
+        await proxy.chat_postMessage(channel="C1", text="t", blocks=bad)
+        sent = raw.chat_postMessage.await_args.kwargs["blocks"]
+        assert sent[0]["text"]["text"] == " "          # empty mrkdwn floored
+        assert sent[1]["column_settings"] == [{}]        # null coerced to object
+
+    @pytest.mark.asyncio
+    async def test_proxy_passes_through_non_send_methods(self):
+        from unittest.mock import AsyncMock, MagicMock
+        from plugins.platforms.slack.adapter import _SanitizingClient
+
+        raw = MagicMock()
+        raw.conversations_history = AsyncMock(return_value={"messages": []})
+        proxy = _SanitizingClient(raw)
+        res = await proxy.conversations_history(channel="C1")
+        assert res == {"messages": []}
+
+    @pytest.mark.asyncio
+    async def test_proxy_send_without_blocks_is_untouched(self):
+        from unittest.mock import AsyncMock, MagicMock
+        from plugins.platforms.slack.adapter import _SanitizingClient
+
+        raw = MagicMock()
+        raw.chat_postMessage = AsyncMock(return_value={"ts": "1.2"})
+        proxy = _SanitizingClient(raw)
+        await proxy.chat_postMessage(channel="C1", text="plain only")
+        assert "blocks" not in raw.chat_postMessage.await_args.kwargs

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -138,6 +138,58 @@ class TestStreamingBlocks:
         assert "blocks" not in client.chat_update.await_args.kwargs
 
 
+PROGRESS_MD = "💻 terminal\n```\nset -e && make build\n```\n📖 Reading data.csv"
+
+
+class TestProgressSurface:
+    @pytest.mark.asyncio
+    async def test_progress_send_renders_context_blocks(self):
+        adapter, client = _make_adapter({"rich_blocks": True})
+        await adapter.send(
+            "C1", PROGRESS_MD, metadata={"progress_surface": True}
+        )
+        kwargs = client.chat_postMessage.await_args.kwargs
+        assert [b["type"] for b in kwargs["blocks"]] == ["context"]
+        assert kwargs["text"]  # full transcript stays in the fallback
+
+    @pytest.mark.asyncio
+    async def test_progress_edit_renders_context_blocks_without_finalize(self):
+        adapter, client = _make_adapter({"rich_blocks": True})
+        await adapter.edit_message(
+            "C1", "1.2", PROGRESS_MD,
+            finalize=False, metadata={"progress_surface": True},
+        )
+        kwargs = client.chat_update.await_args.kwargs
+        assert [b["type"] for b in kwargs["blocks"]] == ["context"]
+
+    @pytest.mark.asyncio
+    async def test_progress_styling_can_be_disabled(self):
+        adapter, client = _make_adapter(
+            {"rich_blocks": True, "progress_context_lines": "off"}
+        )
+        await adapter.send(
+            "C1", PROGRESS_MD, metadata={"progress_surface": True}
+        )
+        blocks = client.chat_postMessage.await_args.kwargs.get("blocks")
+        # falls through to the normal rich render (no context block)
+        assert blocks and all(b["type"] != "context" for b in blocks)
+
+    @pytest.mark.asyncio
+    async def test_normal_messages_unaffected_by_metadata_absence(self):
+        adapter, client = _make_adapter({"rich_blocks": True})
+        await adapter.send("C1", PROGRESS_MD)
+        blocks = client.chat_postMessage.await_args.kwargs.get("blocks")
+        assert blocks and all(b["type"] != "context" for b in blocks)
+
+    @pytest.mark.asyncio
+    async def test_progress_requires_rich_blocks(self):
+        adapter, client = _make_adapter()  # rich_blocks off
+        await adapter.send(
+            "C1", PROGRESS_MD, metadata={"progress_surface": True}
+        )
+        assert "blocks" not in client.chat_postMessage.await_args.kwargs
+
+
 class TestBlocksRejectionFallback:
     @pytest.mark.asyncio
     async def test_send_retries_without_blocks_on_invalid_blocks(self):

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -104,6 +104,40 @@ class TestSendMessageBlocks:
         assert "blocks" not in client.chat_postMessage.await_args.kwargs
 
 
+class TestStreamingBlocks:
+    @pytest.mark.asyncio
+    async def test_intermediate_edit_renders_blocks_when_enabled(self):
+        adapter, client = _make_adapter(
+            {"rich_blocks": True, "rich_blocks_streaming": True}
+        )
+        await adapter.edit_message("C1", "111.222", RICH_MD, finalize=False)
+        kwargs = client.chat_update.await_args.kwargs
+        assert "blocks" in kwargs and kwargs["blocks"]
+        assert kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_intermediate_frames_never_carry_feedback_buttons(self):
+        adapter, client = _make_adapter(
+            {
+                "rich_blocks": True,
+                "rich_blocks_streaming": True,
+                "feedback_buttons": True,
+            }
+        )
+        await adapter.edit_message("C1", "1.2", RICH_MD, finalize=False)
+        blocks = client.chat_update.await_args.kwargs["blocks"]
+        assert all(b["type"] != "context_actions" for b in blocks)
+        await adapter.edit_message("C1", "1.2", RICH_MD, finalize=True)
+        blocks = client.chat_update.await_args.kwargs["blocks"]
+        assert blocks[-1]["type"] == "context_actions"
+
+    @pytest.mark.asyncio
+    async def test_streaming_flag_requires_rich_blocks(self):
+        adapter, client = _make_adapter({"rich_blocks_streaming": True})
+        await adapter.edit_message("C1", "1.2", RICH_MD, finalize=False)
+        assert "blocks" not in client.chat_update.await_args.kwargs
+
+
 class TestBlocksRejectionFallback:
     @pytest.mark.asyncio
     async def test_send_retries_without_blocks_on_invalid_blocks(self):

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -53,13 +53,18 @@ class TestSendMessageBlocks:
         assert "divider" in types
 
     @pytest.mark.asyncio
-    async def test_enabled_but_unrenderable_falls_back_to_text(self):
-        # 60 dividers -> renderer returns None -> no blocks kwarg, text stands
+    async def test_over_block_cap_sends_multiple_block_messages(self):
+        # 60 headed sections -> >50 blocks -> split into several messages,
+        # each <= 50 blocks with its own text fallback (never flat mrkdwn)
         adapter, client = _make_adapter({"rich_blocks": True})
-        await adapter.send("C1", "\n\n".join(["---"] * 60))
-        kwargs = client.chat_postMessage.await_args.kwargs
-        assert "blocks" not in kwargs
-        assert kwargs["text"]
+        md = "\n\n".join(f"# t{i}\n\npara {i}" for i in range(35))  # 70 blocks
+        await adapter.send("C1", md)
+        calls = client.chat_postMessage.await_args_list
+        assert len(calls) >= 2
+        for c in calls:
+            assert c.kwargs["blocks"]
+            assert len(c.kwargs["blocks"]) <= 50
+            assert c.kwargs["text"].strip()
 
     @pytest.mark.asyncio
     async def test_string_true_coerced(self):

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -260,6 +260,41 @@ class TestBlocksRejectionFallback:
         assert len(client.chat_postMessage.await_args_list) == 1
 
     @pytest.mark.asyncio
+    async def test_rejected_table_retries_with_monospace_then_keeps_blocks(self):
+        # A table-bearing message rejected once must retry with the table
+        # DEMOTED to aligned monospace (keeping blocks), not dropped to raw text.
+        adapter, client = _make_adapter({"rich_blocks": True})
+        client.chat_postMessage = AsyncMock(
+            side_effect=[Exception("invalid_blocks"), {"ts": "1.2"}]
+        )
+        md = "| 指标 | 判断 |\n|------|------|\n| LCP | 良好 |"
+        res = await adapter.send("C1", md)
+        assert res.success
+        calls = client.chat_postMessage.await_args_list
+        assert len(calls) == 2
+        assert any(b.get("type") == "table" for b in calls[0].kwargs["blocks"])
+        assert all(b.get("type") != "table" for b in calls[1].kwargs["blocks"])
+        assert "blocks" in calls[1].kwargs  # blocks kept, not stripped to text
+
+    @pytest.mark.asyncio
+    async def test_rejected_table_twice_falls_back_to_text(self):
+        adapter, client = _make_adapter({"rich_blocks": True})
+        client.chat_postMessage = AsyncMock(
+            side_effect=[
+                Exception("invalid_blocks"),
+                Exception("invalid_blocks"),
+                {"ts": "1.2"},
+            ]
+        )
+        md = "| 指标 | 判断 |\n|------|------|\n| LCP | 良好 |"
+        res = await adapter.send("C1", md)
+        assert res.success
+        calls = client.chat_postMessage.await_args_list
+        assert len(calls) == 3
+        assert "blocks" not in calls[2].kwargs  # finally plain text
+        assert calls[2].kwargs["text"]
+
+    @pytest.mark.asyncio
     async def test_finalize_edit_retries_without_blocks(self):
         adapter, client = _make_adapter({"rich_blocks": True})
         client.chat_update = AsyncMock(

--- a/tests/test_agent_code_skew.py
+++ b/tests/test_agent_code_skew.py
@@ -6,7 +6,54 @@ process, which imports ``run_agent`` directly rather than going through the
 gateway.  See #68178.
 """
 
+from types import SimpleNamespace
+
 import pytest
+
+
+class TestCodeSkewFinalization:
+    def test_code_skew_returns_a_finalized_result_without_entering_the_agent_loop(self, monkeypatch):
+        """A detected code skew must return the restart-required result cleanly."""
+        from agent import conversation_loop
+
+        turn_context = SimpleNamespace(
+            user_message="hello",
+            original_user_message="hello",
+            messages=[],
+            conversation_history=[],
+            active_system_prompt="",
+            effective_task_id="task",
+            turn_id="turn",
+            current_turn_user_idx=0,
+            should_review_memory=False,
+            plugin_user_context=None,
+            ext_prefetch_cache=None,
+        )
+        monkeypatch.setattr(
+            conversation_loop,
+            "build_turn_context",
+            lambda *_args, **_kwargs: turn_context,
+        )
+        monkeypatch.setattr(
+            conversation_loop,
+            "finalize_turn",
+            lambda _agent, **kwargs: kwargs,
+            raising=False,
+        )
+
+        agent = SimpleNamespace(
+            api_mode="",
+            max_iterations=1,
+            iteration_budget=SimpleNamespace(remaining=1),
+            _budget_grace_call=False,
+            _check_code_skew_before_turn=lambda: "boot revision differs from source revision",
+        )
+
+        result = conversation_loop.run_conversation(agent, "hello")
+
+        assert result["failed"] is True
+        assert result["_turn_exit_reason"] == "code_skew_detected"
+        assert "please restart the application" in result["final_response"].lower()
 
 
 class TestAgentCodeSkewCaching:


### PR DESCRIPTION
## Summary
- import `finalize_turn` at module scope so the code-skew early-return path can finalize a response
- add a regression test that exercises the code-skew guard before the agent loop

## Validation
- `venv/bin/python -m pytest tests/test_agent_code_skew.py -q` (7 passed)
- `venv/bin/python -m py_compile agent/conversation_loop.py agent/turn_finalizer.py`
- `git diff --check`