### PR TITLE
fix(providers): select extra headers by provider key

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1316,6 +1316,7 @@ def init_agent(
                 client_kwargs,
                 _cp_base_url,
                 _cp_entries,
+                provider_key=agent.provider,
             )
         except Exception:
             logger.debug("custom-provider TLS resolution skipped", exc_info=True)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1652,12 +1652,15 @@ def get_custom_provider_extra_headers(
     base_url: str,
     custom_providers: Optional[List[Dict[str, Any]]] = None,
     config: Optional[Dict[str, Any]] = None,
+    provider_key: Optional[str] = None,
 ) -> Dict[str, str]:
-    """Return ``extra_headers`` from a matching ``providers`` / ``custom_providers`` entry.
+    """Return ``extra_headers`` for the selected custom provider.
 
-    Matches the entry whose normalized route identity equals *base_url*,
-    mirroring :func:`get_custom_provider_tls_settings`, and returns its
-    ``extra_headers`` dict, or ``{}`` when no entry matches or declares none.
+    When ``provider_key`` identifies a named ``custom:<provider_key>`` route,
+    match that key before matching ``base_url``. This is important because
+    multiple providers may intentionally share one base URL but have different
+    credentials and headers. Without the key, the first URL match wins for
+    backwards compatibility.
 
     SECURITY: header values routinely carry credentials (Cloudflare Access
     service tokens, proxy auth, custom bearer schemes). Callers must never
@@ -1672,12 +1675,20 @@ def get_custom_provider_extra_headers(
         return {}
 
     target_url = normalize_route_base_url(base_url)
+    selected_key = (provider_key or "").strip().lower()
+    if selected_key.startswith("custom:"):
+        selected_key = selected_key.split(":", 1)[1].strip()
+
     for entry in custom_providers:
         if not isinstance(entry, dict):
             continue
         entry_url = normalize_route_base_url(entry.get("base_url"))
         if not entry_url or entry_url != target_url:
             continue
+        if selected_key:
+            entry_key = str(entry.get("provider_key", "") or "").strip().lower()
+            if entry_key != selected_key:
+                continue
         return normalize_extra_headers(entry.get("extra_headers"))
     return {}
 
@@ -1687,6 +1698,7 @@ def apply_custom_provider_extra_headers_to_client_kwargs(
     base_url: str,
     custom_providers: Optional[List[Dict[str, Any]]] = None,
     config: Optional[Dict[str, Any]] = None,
+    provider_key: Optional[str] = None,
 ) -> None:
     """Merge per-provider ``extra_headers`` onto OpenAI client ``default_headers``.
 
@@ -1697,7 +1709,12 @@ def apply_custom_provider_extra_headers_to_client_kwargs(
 
     SECURITY: values may carry credentials — never log them.
     """
-    extra_headers = get_custom_provider_extra_headers(base_url, custom_providers, config)
+    extra_headers = get_custom_provider_extra_headers(
+        base_url,
+        custom_providers,
+        config,
+        provider_key=provider_key,
+    )
     if not extra_headers:
         return
     merged = dict(client_kwargs.get("default_headers") or {})

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1678,6 +1678,8 @@ def get_custom_provider_extra_headers(
     selected_key = (provider_key or "").strip().lower()
     if selected_key.startswith("custom:"):
         selected_key = selected_key.split(":", 1)[1].strip()
+    else:
+        selected_key = ""
 
     for entry in custom_providers:
         if not isinstance(entry, dict):
@@ -1686,8 +1688,11 @@ def get_custom_provider_extra_headers(
         if not entry_url or entry_url != target_url:
             continue
         if selected_key:
-            entry_key = str(entry.get("provider_key", "") or "").strip().lower()
-            if entry_key != selected_key:
+            entry_keys = {
+                str(entry.get("provider_key", "") or "").strip().lower(),
+                str(entry.get("name", "") or "").strip().lower(),
+            }
+            if selected_key not in entry_keys:
                 continue
         return normalize_extra_headers(entry.get("extra_headers"))
     return {}

--- a/run_agent.py
+++ b/run_agent.py
@@ -5295,7 +5295,9 @@ class AIAgent:
                 )
 
                 apply_custom_provider_extra_headers_to_client_kwargs(
-                    self._client_kwargs, base_url,
+                    self._client_kwargs,
+                    base_url,
+                    provider_key=self.provider,
                 )
             except Exception:
                 logger.debug("custom-provider extra_headers skipped", exc_info=True)

--- a/tests/hermes_cli/test_custom_provider_extra_headers.py
+++ b/tests/hermes_cli/test_custom_provider_extra_headers.py
@@ -42,6 +42,94 @@ def test_normalize_entry_keeps_extra_headers():
 
 
 
+
+def test_shared_base_url_matches_named_provider_identity():
+    providers = [
+        {
+            "provider_key": "first",
+            "name": "first",
+            "base_url": "https://shared.example.com/v1",
+            "extra_headers": {"X-Route": "first"},
+        },
+        {
+            "provider_key": "second",
+            "name": "second",
+            "base_url": "https://shared.example.com/v1",
+            "extra_headers": {"X-Route": "second"},
+        },
+    ]
+
+    assert get_custom_provider_extra_headers(
+        "https://shared.example.com/v1",
+        custom_providers=providers,
+        provider_key="custom:second",
+    ) == {"X-Route": "second"}
+
+
+def test_shared_base_url_matches_legacy_custom_provider_name():
+    providers = [
+        {
+            "name": "first",
+            "base_url": "https://shared.example.com/v1",
+            "extra_headers": {"X-Route": "first"},
+        },
+        {
+            "name": "second",
+            "base_url": "https://shared.example.com/v1",
+            "extra_headers": {"X-Route": "second"},
+        },
+    ]
+
+    assert get_custom_provider_extra_headers(
+        "https://shared.example.com/v1",
+        custom_providers=providers,
+        provider_key="custom:second",
+    ) == {"X-Route": "second"}
+
+
+def test_identity_does_not_fall_back_to_wrong_shared_url_entry():
+    providers = [
+        {
+            "name": "first",
+            "base_url": "https://shared.example.com/v1",
+            "extra_headers": {"X-Route": "first"},
+        }
+    ]
+
+    assert get_custom_provider_extra_headers(
+        "https://shared.example.com/v1",
+        custom_providers=providers,
+        provider_key="custom:missing",
+    ) == {}
+
+
+def test_apply_extra_headers_selects_named_provider_on_shared_route():
+    client_kwargs = {"default_headers": {"X-Keep": "1"}}
+    providers = [
+        {
+            "provider_key": "first",
+            "base_url": "https://shared.example.com/v1",
+            "extra_headers": {"X-Route": "first"},
+        },
+        {
+            "provider_key": "second",
+            "base_url": "https://shared.example.com/v1",
+            "extra_headers": {"X-Route": "second"},
+        },
+    ]
+
+    apply_custom_provider_extra_headers_to_client_kwargs(
+        client_kwargs,
+        "https://shared.example.com/v1",
+        custom_providers=providers,
+        provider_key="custom:second",
+    )
+    assert client_kwargs["default_headers"] == {
+        "X-Keep": "1",
+        "X-Route": "second",
+    }
+
+
 def test_fetch_api_models_sends_extra_headers_to_models_probe(monkeypatch):
     captured = {}
 

--- a/tests/run_agent/test_custom_provider_extra_headers_routing.py
+++ b/tests/run_agent/test_custom_provider_extra_headers_routing.py
@@ -23,6 +23,26 @@ def _shared_provider_config():
     }
 
 
+def test_initial_client_construction_selects_active_provider_headers():
+    config = _shared_provider_config()
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("run_agent.OpenAI", return_value=MagicMock()),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://shared.example.com/v1",
+            model="shared-model",
+            provider="custom:selected",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent._client_kwargs["default_headers"] == {"X-Route": "selected"}
+
+
 def test_client_rebuild_selects_headers_for_active_provider():
     agent = SimpleNamespace(
         api_mode="chat_completions",

--- a/tests/run_agent/test_custom_provider_extra_headers_routing.py
+++ b/tests/run_agent/test_custom_provider_extra_headers_routing.py
@@ -1,0 +1,79 @@
+"""Behavioral coverage for custom-provider ``extra_headers`` route identity."""
+
+from types import MethodType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _shared_provider_config():
+    return {
+        "providers": {
+            "first": {
+                "name": "First",
+                "base_url": "https://shared.example.com/v1",
+                "extra_headers": {"X-Route": "first"},
+            },
+            "selected": {
+                "name": "Selected",
+                "base_url": "https://shared.example.com/v1",
+                "extra_headers": {"X-Route": "selected"},
+            },
+        }
+    }
+
+
+def test_client_rebuild_selects_headers_for_active_provider():
+    agent = SimpleNamespace(
+        api_mode="chat_completions",
+        provider="custom:selected",
+        _client_kwargs={},
+    )
+    agent._apply_user_default_headers = MagicMock()
+
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value=_shared_provider_config(),
+    ):
+        AIAgent._apply_client_headers_for_base_url(
+            agent,
+            "https://shared.example.com/v1",
+            apply_user_headers=False,
+        )
+
+    assert agent._client_kwargs["default_headers"] == {"X-Route": "selected"}
+
+
+def test_credential_rotation_keeps_active_provider_identity():
+    agent = SimpleNamespace(
+        api_mode="chat_completions",
+        provider="custom:selected",
+        model="shared-model",
+        api_key="old",
+        base_url="https://shared.example.com/v1",
+        _client_kwargs={
+            "api_key": "old",
+            "base_url": "https://shared.example.com/v1",
+        },
+        _replace_primary_openai_client=MagicMock(),
+    )
+    agent._apply_client_headers_for_base_url = MethodType(
+        AIAgent._apply_client_headers_for_base_url,
+        agent,
+    )
+    agent._apply_user_default_headers = MagicMock()
+    entry = SimpleNamespace(
+        runtime_api_key="new",
+        access_token="",
+        runtime_base_url="https://shared.example.com/v1",
+        base_url="https://shared.example.com/v1",
+    )
+    config = _shared_provider_config()
+
+    with (
+        patch("hermes_cli.config.load_config_readonly", return_value=config),
+        patch("hermes_cli.config.load_config", return_value=config),
+    ):
+        AIAgent._swap_credential(agent, entry)
+
+    assert agent._client_kwargs["default_headers"] == {"X-Route": "selected"}


### PR DESCRIPTION
## Summary

Fix per-provider `extra_headers` selection when multiple named custom providers share the same `base_url`.

Previously, `get_custom_provider_extra_headers()` matched only by URL and returned the first matching entry. A request using `custom:second` could therefore receive `custom:first`'s headers—or no headers at all—depending on config order.

This change:
- adds optional `provider_key` matching before the existing normalized URL match
- passes the active provider identity from initial client construction and client rebuilds
- preserves the existing URL-only fallback when no provider key is supplied
- adds regression coverage for two providers sharing one endpoint

## Reproduction

Configure two providers with the same endpoint but different headers:

```yaml
providers:
  first:
    base_url: https://api.example.com/v1
  second:
    base_url: https://api.example.com/v1
    extra_headers:
      User-Agent: required-client
```

Select `custom:second`. Before this fix, URL-only lookup stopped at `first`, so `second.extra_headers` was ignored.

## Tests

```bash
nix develop --command bash -lc \
  'scripts/run_tests.sh tests/hermes_cli/test_custom_provider_extra_headers.py'
```

Result: **13 passed, 0 failed**.

## Related work

This is complementary to #20666 and #57667: those address propagation/validation of `extra_headers`; this fixes runtime ambiguity when multiple provider entries share one base URL.

## Checklist

- [x] Read the contributing guide
- [x] Searched existing issues and PRs
- [x] Conventional commit used
- [x] Focused bug fix only
- [x] Regression tests added and passing
- [x] Documentation/config examples: N/A (no new config key)
- [x] Cross-platform impact considered: pure config matching logic
