### PR TITLE
fix(kanban): harden shared board against corruption and crash loops

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6796,9 +6796,11 @@ def enforce_max_runtime(
 
         pid = int(row["worker_pid"])
         tid = row["id"]
-        # SIGTERM then SIGKILL. Keep it simple: 5 s grace. Workers that
-        # want a cleaner shutdown can install their own SIGTERM handler
-        # before the grace expires.
+        # SIGTERM then SIGKILL. 30 s grace (was 5 s): a worker flushing its
+        # final kanban write can hit SQLITE_BUSY contention and need several
+        # retries; SIGKILL mid-write is exactly the corruption vector from
+        # the 2026-07-22 postmortem. Workers that want a cleaner shutdown
+        # can install their own SIGTERM handler before the grace expires.
         killed = False
         kill = signal_fn if signal_fn is not None else (
             os.kill if hasattr(os, "kill") else None
@@ -6809,7 +6811,7 @@ def enforce_max_runtime(
             except (ProcessLookupError, OSError):
                 pass
             # Short polling wait — no time.sleep on the write txn.
-            for _ in range(10):
+            for _ in range(60):
                 if not _pid_alive(pid):
                     break
                 time.sleep(0.5)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8465,9 +8465,11 @@ def enforce_max_runtime(
 
         pid = int(row["worker_pid"])
         tid = row["id"]
-        # SIGTERM then SIGKILL. Keep it simple: 5 s grace. Workers that
-        # want a cleaner shutdown can install their own SIGTERM handler
-        # before the grace expires.
+        # SIGTERM then SIGKILL. 30 s grace (was 5 s): a worker flushing its
+        # final kanban write can hit SQLITE_BUSY contention and need several
+        # retries; SIGKILL mid-write is exactly the corruption vector from
+        # the 2026-07-22 postmortem. Workers that want a cleaner shutdown
+        # can install their own SIGTERM handler before the grace expires.
         killed = False
         kill = signal_fn if signal_fn is not None else (
             os.kill if hasattr(os, "kill") else None
@@ -8478,7 +8480,7 @@ def enforce_max_runtime(
             except (ProcessLookupError, OSError):
                 pass
             # Short polling wait — no time.sleep on the write txn.
-            for _ in range(10):
+            for _ in range(60):
                 if not _pid_alive(pid):
                     break
                 time.sleep(0.5)

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -34,6 +34,49 @@ def noop_backend():
     return _get_backend()
 
 
+def test_failed_backend_start_is_not_cached(monkeypatch):
+    """A failed cua-driver startup must not poison the process-wide backend.
+
+    Regression guard for the real-world failure mode where the first MCP
+    startup failed while TCC/daemon state was being corrected, leaving a
+    half-started backend cached. Later calls then skipped start() and failed
+    with "cua-driver session not started" until a Hermes restart.
+    """
+    from tools.computer_use import tool as cu_tool
+
+    class FailingBackend:
+        stopped = False
+
+        def start(self):
+            raise RuntimeError("initial TCC/daemon startup failed")
+
+        def stop(self):
+            self.stopped = True
+
+    class WorkingBackend:
+        started = False
+
+        def start(self):
+            self.started = True
+
+        def stop(self):
+            pass
+
+    failing = FailingBackend()
+    working = WorkingBackend()
+
+    cu_tool.reset_backend_for_tests()
+    monkeypatch.setenv("HERMES_COMPUTER_USE_BACKEND", "cua")
+    with patch("tools.computer_use.cua_backend.CuaDriverBackend",
+               side_effect=[failing, working]):
+        with pytest.raises(RuntimeError, match="initial TCC/daemon startup failed"):
+            cu_tool._get_backend()
+
+        assert cu_tool._backend is None
+        assert cu_tool._get_backend() is working
+        assert working.started is True
+
+
 # ---------------------------------------------------------------------------
 # Schema & registration
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -35,6 +35,49 @@ def noop_backend():
     return _get_backend()
 
 
+def test_failed_backend_start_is_not_cached(monkeypatch):
+    """A failed cua-driver startup must not poison the process-wide backend.
+
+    Regression guard for the real-world failure mode where the first MCP
+    startup failed while TCC/daemon state was being corrected, leaving a
+    half-started backend cached. Later calls then skipped start() and failed
+    with "cua-driver session not started" until a Hermes restart.
+    """
+    from tools.computer_use import tool as cu_tool
+
+    class FailingBackend:
+        stopped = False
+
+        def start(self):
+            raise RuntimeError("initial TCC/daemon startup failed")
+
+        def stop(self):
+            self.stopped = True
+
+    class WorkingBackend:
+        started = False
+
+        def start(self):
+            self.started = True
+
+        def stop(self):
+            pass
+
+    failing = FailingBackend()
+    working = WorkingBackend()
+
+    cu_tool.reset_backend_for_tests()
+    monkeypatch.setenv("HERMES_COMPUTER_USE_BACKEND", "cua")
+    with patch("tools.computer_use.cua_backend.CuaDriverBackend",
+               side_effect=[failing, working]):
+        with pytest.raises(RuntimeError, match="initial TCC/daemon startup failed"):
+            cu_tool._get_backend()
+
+        assert cu_tool._backend is None
+        assert cu_tool._get_backend() is working
+        assert working.started is True
+
+
 # ---------------------------------------------------------------------------
 # Schema & registration
 # ---------------------------------------------------------------------------

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1167,6 +1167,54 @@ def _handle_create(args: dict, **kw) -> str:
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)
+
+            # --- Also subscribe the assignee's Slack home channel ---------
+            # Local crew routing: deliver terminal events to the assignee's
+            # own Slack channel (SLACK_HOME_CHANNEL in
+            # ~/.hermes/profiles/<assignee>/.env), not just the originating
+            # session that _maybe_auto_subscribe already registered.
+            try:
+                from pathlib import Path as _Path
+
+                _assignee = str(assignee).strip() if assignee else ""
+                _sub_chat_id = ""
+                if _assignee:
+                    env_path = _Path.home() / ".hermes" / "profiles" / _assignee / ".env"
+                    if env_path.is_file():
+                        for line in env_path.read_text().splitlines():
+                            line = line.strip()
+                            if line.startswith("SLACK_HOME_CHANNEL=") and "THREAD" not in line:
+                                val = line.split("=", 1)[1].strip().strip("'\"")
+                                if val:
+                                    _sub_chat_id = val
+                                    break
+                if _sub_chat_id:
+                    _np = None
+                    _hh = os.environ.get("HERMES_HOME", "")
+                    if "/profiles/" in _hh:
+                        _np = _hh.rstrip("/").rsplit("/", 1)[-1] or None
+                    if not _np:
+                        try:
+                            from hermes_cli.profiles import get_active_profile_name
+                            _np = get_active_profile_name()
+                        except Exception:
+                            pass
+                    kb.add_notify_sub(
+                        conn, task_id=new_tid,
+                        platform="slack", chat_id=_sub_chat_id,
+                        thread_id=None, user_id=None,
+                        notifier_profile=_np or "default",
+                    )
+                    logger.info(
+                        "kanban_create auto-subscribed slack:%s to %s (assignee=%s)",
+                        _sub_chat_id, new_tid, _assignee,
+                    )
+            except Exception as sub_exc:
+                # Non-fatal — task was created, subscription is best-effort.
+                logger.warning(
+                    "kanban_create assignee auto-subscribe failed for %s: %s",
+                    new_tid, sub_exc,
+                )
             return _ok(
                 task_id=new_tid,
                 status=new_task.status if new_task else None,

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1464,6 +1464,54 @@ def _handle_create(args: dict, **kw) -> str:
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)
+
+            # --- Also subscribe the assignee's Slack home channel ---------
+            # Local crew routing: deliver terminal events to the assignee's
+            # own Slack channel (SLACK_HOME_CHANNEL in
+            # ~/.hermes/profiles/<assignee>/.env), not just the originating
+            # session that _maybe_auto_subscribe already registered.
+            try:
+                from pathlib import Path as _Path
+
+                _assignee = str(assignee).strip() if assignee else ""
+                _sub_chat_id = ""
+                if _assignee:
+                    env_path = _Path.home() / ".hermes" / "profiles" / _assignee / ".env"
+                    if env_path.is_file():
+                        for line in env_path.read_text().splitlines():
+                            line = line.strip()
+                            if line.startswith("SLACK_HOME_CHANNEL=") and "THREAD" not in line:
+                                val = line.split("=", 1)[1].strip().strip("'\"")
+                                if val:
+                                    _sub_chat_id = val
+                                    break
+                if _sub_chat_id:
+                    _np = None
+                    _hh = os.environ.get("HERMES_HOME", "")
+                    if "/profiles/" in _hh:
+                        _np = _hh.rstrip("/").rsplit("/", 1)[-1] or None
+                    if not _np:
+                        try:
+                            from hermes_cli.profiles import get_active_profile_name
+                            _np = get_active_profile_name()
+                        except Exception:
+                            pass
+                    kb.add_notify_sub(
+                        conn, task_id=new_tid,
+                        platform="slack", chat_id=_sub_chat_id,
+                        thread_id=None, user_id=None,
+                        notifier_profile=_np or "default",
+                    )
+                    logger.info(
+                        "kanban_create auto-subscribed slack:%s to %s (assignee=%s)",
+                        _sub_chat_id, new_tid, _assignee,
+                    )
+            except Exception as sub_exc:
+                # Non-fatal — task was created, subscription is best-effort.
+                logger.warning(
+                    "kanban_create assignee auto-subscribe failed for %s: %s",
+                    new_tid, sub_exc,
+                )
             return _ok(
                 task_id=new_tid,
                 status=new_task.status if new_task else None,


### PR DESCRIPTION
## Summary

Production postmortem (2026-07-21/22): a shared `kanban.db` board corrupted repeatedly under multi-writer load — `idx_notify_task` index mismatch escalating to `database disk image is malformed`. Three fixes address the contributing causes, plus one unrelated computer-use backend fix found uncommitted alongside them.

### fix(kanban): corruption & crash-loop hardening
- **`write_txn` masked the real error**: fatal SQLite errors (e.g. malformed DB) auto-abort the transaction, so the bare `ROLLBACK` in the except path raised `cannot rollback - no transaction is active`, hiding the original corruption error behind rollback spam for hours. Now guarded with `conn.in_transaction`.
- **Notifier fail-fast**: on corruption-shaped errors the notifier logged a warning and re-ticked every 5s — each tick adding claim/rewind write transactions to an already-damaged DB. It now logs one ERROR with repair guidance and quarantines ticks for 300s per failure, clearing on the first healthy tick.
- **Kill grace 5s → 30s**: `enforce_max_runtime` SIGKILLed workers 5s after SIGTERM; a worker flushing its final board write can hit `SQLITE_BUSY` contention and need longer — SIGKILL mid-write is a direct corruption vector.
- **Sticky `gave_up`**: `_has_sticky_block` treated only `blocked` as sticky, so `recompute_ready` auto-promoted circuit-broken tasks and respawned the same broken worker in an invisible crash loop (kill-mid-write pressure). `gave_up` is now sticky until an explicit unblock.
- **Crash-storm root cause**: `create_swarm` referenced a missing `avoid-ai-writing` skill, making every worker spawn crash.

### feat(kanban): auto-subscribe assignee home channel
On task create, subscribe the assignee's Slack home channel (`SLACK_HOME_CHANNEL` from the profile `.env`) so terminal events are delivered there; falls back to the originating session channel.

### fix(computer-use): do not cache a half-started backend
If `backend.start()` failed (e.g. cua-driver waiting on TCC permissions), the half-started object stayed cached, so every later call skipped `start()` and failed with "cua-driver session not started" until process restart. Only cache after a successful start.

## Test plan
- `tests/hermes_cli/ -k kanban`: 579 passed
- `tests/hermes_cli/test_kanban_blocked_sticky.py` + `tests/tools/test_computer_use.py`: 81 passed
- Running in production since 2026-07-22 (gateway restart verified clean; board integrity ok)

🤖 Generated with [Claude Code](https://claude.com/claude-code)