### PR TITLE
fix(desktop): reject wrong-arch Windows Electron PE after update (#69179)

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
+++ b/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
@@ -210,13 +210,24 @@ pub async fn launch_hermes_desktop(
 /// Walks the well-known electron-builder unpacked-app paths under
 /// `install_root`. Mirrors the resolver in `cmd_gui` (apps/desktop/release/
 /// <os>-unpacked/<exe>).
+///
+/// On Windows, prefer the host-arch tree first (#69179). electron-builder
+/// writes x64 to `win-unpacked` and arm64 to `win-arm64-unpacked`; a stale
+/// wrong-arch sibling must not win just because it exists.
 pub(crate) fn resolve_hermes_desktop_exe(install_root: &std::path::Path) -> Option<PathBuf> {
     let release_dir = install_root.join("apps").join("desktop").join("release");
     let candidates: &[(&str, &str)] = if cfg!(target_os = "windows") {
-        &[
-            ("win-unpacked", "Hermes.exe"),
-            ("win-arm64-unpacked", "Hermes.exe"),
-        ]
+        if cfg!(target_arch = "aarch64") {
+            &[
+                ("win-arm64-unpacked", "Hermes.exe"),
+                ("win-unpacked", "Hermes.exe"),
+            ]
+        } else {
+            &[
+                ("win-unpacked", "Hermes.exe"),
+                ("win-arm64-unpacked", "Hermes.exe"),
+            ]
+        }
     } else if cfg!(target_os = "macos") {
         &[
             ("mac/Hermes.app/Contents/MacOS", "Hermes"),

--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -13,14 +13,23 @@
  * a stamp failure must never fail an otherwise-good build (worst case is the
  * stock icon, not a broken app), so we log and resolve rather than throw.
  *
+ * Also verifies the packed Hermes.exe PE Machine matches the pack target
+ * (#69179). A wrong-arch electronDist can otherwise produce a launchable-
+ * looking win-unpacked tree that Windows rejects with 「此应用无法在你的电脑上运行」.
+ *
  * electron-builder passes a context with:
  *   - electronPlatformName: 'win32' | 'darwin' | 'linux'
  *   - appOutDir:            the unpacked app directory for this target
+ *   - arch:                 Arch enum (0=ia32, 1=x64, 2=armv7l, 3=arm64, ...)
  *   - packager.appInfo.productFilename: the exe basename (e.g. 'Hermes')
  */
 
+import fs from 'node:fs'
 import path from 'node:path'
 
+import { Arch } from 'electron-builder'
+
+import { normalizeCpuArch, peArchMatches, readPeArch } from './pe-arch.mjs'
 import { stampExeIdentity } from './set-exe-identity.mjs'
 
 export default async function afterPack(context) {
@@ -31,6 +40,28 @@ export default async function afterPack(context) {
   const productName = context.packager?.appInfo?.productFilename || 'Hermes'
   const exe = path.join(context.appOutDir, `${productName}.exe`)
   const desktopRoot = path.resolve(import.meta.dirname, '..')
+
+  const archName =
+    context && typeof context.arch === 'number' ? Arch[context.arch] : undefined
+  const want = normalizeCpuArch(archName)
+  // Only gate when the packed exe is actually on disk. A missing path is
+  // electron-builder's problem (or a wrong productFilename); do not mis-report
+  // it as a PE arch mismatch.
+  if (want && fs.existsSync(exe) && !peArchMatches(exe, want)) {
+    const got = readPeArch(exe)
+    // Remove the bad exe so stamp/existence checks cannot treat it as ready
+    // and so the next rebuild cannot no-op on a poisoned tree.
+    try {
+      fs.rmSync(exe, { force: true })
+    } catch {
+      /* best-effort */
+    }
+    throw new Error(
+      `[after-pack] ${exe} PE arch is ${got ?? 'unreadable'} but target is ` +
+        `${want}. Refusing to ship a Windows desktop binary that would fail ` +
+        `with "This app can't run on your PC" (#69179).`
+    )
+  }
 
   try {
     await stampExeIdentity(exe, desktopRoot)

--- a/apps/desktop/scripts/pe-arch.mjs
+++ b/apps/desktop/scripts/pe-arch.mjs
@@ -1,0 +1,113 @@
+/**
+ * pe-arch.mjs — read a Windows PE file's COFF Machine field.
+ *
+ * Used to stop packaging / launching a Hermes.exe (or electron.exe) whose
+ * CPU architecture does not match the host. Windows surfaces that mismatch
+ * as the modal "This app can't run on your PC" / 「此应用无法在你的电脑上运行」
+ * (#69179) — there is no useful stderr, so we have to catch it before launch.
+ *
+ * PE layout (little-endian):
+ *   offset 0x00: "MZ"
+ *   offset 0x3C: DWORD e_lfanew → PE header
+ *   PE+0:        "PE\0\0"
+ *   PE+4:        WORD Machine
+ *
+ * Machine values we care about:
+ *   0x014c IMAGE_FILE_MACHINE_I386
+ *   0x8664 IMAGE_FILE_MACHINE_AMD64
+ *   0xAA64 IMAGE_FILE_MACHINE_ARM64
+ */
+
+import fs from 'node:fs'
+
+export const PE_MACHINE = Object.freeze({
+  ia32: 0x014c,
+  x64: 0x8664,
+  arm64: 0xaa64
+})
+
+const MACHINE_TO_ARCH = Object.freeze({
+  [PE_MACHINE.ia32]: 'ia32',
+  [PE_MACHINE.x64]: 'x64',
+  [PE_MACHINE.arm64]: 'arm64'
+})
+
+/**
+ * Map electron-builder / Node arch names onto the PE Machine vocabulary.
+ * Accepts Arch enum strings (`x64`, `arm64`, `ia32`) and Node's `process.arch`.
+ */
+export function normalizeCpuArch(arch) {
+  if (!arch || typeof arch !== 'string') return null
+  const a = arch.toLowerCase()
+  if (a === 'x64' || a === 'amd64' || a === 'x86_64') return 'x64'
+  if (a === 'arm64' || a === 'aarch64') return 'arm64'
+  if (a === 'ia32' || a === 'x86' || a === 'i386' || a === 'i686') return 'ia32'
+  return null
+}
+
+/**
+ * Read the COFF Machine of a PE file and return `'x64' | 'ia32' | 'arm64'`,
+ * or `null` when the file is missing / not a PE / uses an unknown Machine.
+ */
+export function readPeArch(filePath) {
+  let fd
+  try {
+    fd = fs.openSync(filePath, 'r')
+  } catch {
+    return null
+  }
+  try {
+    const header = Buffer.alloc(0x40)
+    if (fs.readSync(fd, header, 0, 0x40, 0) < 0x40) return null
+    if (header[0] !== 0x4d || header[1] !== 0x5a) return null
+
+    const peOffset = header.readUInt32LE(0x3c)
+    // Guard absurd e_lfanew values (corrupt / truncated files).
+    if (peOffset < 0x40 || peOffset > 1024 * 1024) return null
+
+    const pe = Buffer.alloc(6)
+    if (fs.readSync(fd, pe, 0, 6, peOffset) < 6) return null
+    if (pe[0] !== 0x50 || pe[1] !== 0x45 || pe[2] !== 0x00 || pe[3] !== 0x00) {
+      return null
+    }
+    const machine = pe.readUInt16LE(4)
+    return MACHINE_TO_ARCH[machine] ?? null
+  } finally {
+    try {
+      fs.closeSync(fd)
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/**
+ * True when `filePath` is a PE whose Machine matches `expectedArch`.
+ * Returns false when the PE is missing, unreadable, or mismatched.
+ * Non-Windows callers should not use this as a hard gate.
+ */
+export function peArchMatches(filePath, expectedArch) {
+  const want = normalizeCpuArch(expectedArch)
+  if (!want) return false
+  const got = readPeArch(filePath)
+  return got === want
+}
+
+/**
+ * Build a minimal (invalid-as-image, valid-as-header) PE buffer for tests.
+ */
+export function makeMinimalPeBuffer(arch) {
+  const normalized = normalizeCpuArch(arch)
+  const machine = normalized ? PE_MACHINE[normalized] : PE_MACHINE.x64
+  const peOffset = 0x40
+  const buf = Buffer.alloc(peOffset + 6, 0)
+  buf[0] = 0x4d
+  buf[1] = 0x5a
+  buf.writeUInt32LE(peOffset, 0x3c)
+  buf[peOffset] = 0x50
+  buf[peOffset + 1] = 0x45
+  buf[peOffset + 2] = 0x00
+  buf[peOffset + 3] = 0x00
+  buf.writeUInt16LE(machine, peOffset + 4)
+  return buf
+}

--- a/apps/desktop/scripts/pe-arch.test.mjs
+++ b/apps/desktop/scripts/pe-arch.test.mjs
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test } from 'vitest'
+
+import {
+  makeMinimalPeBuffer,
+  normalizeCpuArch,
+  peArchMatches,
+  readPeArch
+} from './pe-arch.mjs'
+import {
+  resolveBuilderTargetArch,
+  shouldReuseElectronDist
+} from './run-electron-builder-lib.mjs'
+
+test('normalizeCpuArch maps common aliases', () => {
+  assert.equal(normalizeCpuArch('AMD64'), 'x64')
+  assert.equal(normalizeCpuArch('x86_64'), 'x64')
+  assert.equal(normalizeCpuArch('aarch64'), 'arm64')
+  assert.equal(normalizeCpuArch('x86'), 'ia32')
+  assert.equal(normalizeCpuArch('nope'), null)
+})
+
+test('readPeArch returns COFF Machine for minimal PE fixtures', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-pe-arch-'))
+  try {
+    for (const arch of ['x64', 'arm64', 'ia32']) {
+      const file = path.join(dir, `${arch}.exe`)
+      fs.writeFileSync(file, makeMinimalPeBuffer(arch))
+      assert.equal(readPeArch(file), arch)
+      assert.equal(peArchMatches(file, arch), true)
+      assert.equal(peArchMatches(file, arch === 'x64' ? 'arm64' : 'x64'), false)
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('readPeArch returns null for non-PE and truncated files', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-pe-arch-bad-'))
+  try {
+    const empty = path.join(dir, 'empty.exe')
+    fs.writeFileSync(empty, '')
+    assert.equal(readPeArch(empty), null)
+
+    const text = path.join(dir, 'text.exe')
+    fs.writeFileSync(text, 'not a pe')
+    assert.equal(readPeArch(text), null)
+
+    assert.equal(readPeArch(path.join(dir, 'missing.exe')), null)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('resolveBuilderTargetArch prefers explicit flags over host', () => {
+  assert.equal(resolveBuilderTargetArch(['--dir', '--arm64'], 'x64'), 'arm64')
+  assert.equal(resolveBuilderTargetArch(['--arch=ia32'], 'x64'), 'ia32')
+  assert.equal(resolveBuilderTargetArch(['--arch', 'x64'], 'arm64'), 'x64')
+  assert.equal(resolveBuilderTargetArch(['--dir'], 'arm64'), 'arm64')
+})
+
+test('shouldReuseElectronDist refuses Windows arch-mismatched PE (#69179)', () => {
+  const decision = shouldReuseElectronDist({
+    platform: 'win32',
+    distDir: '/fake/dist',
+    binaryPath: '/fake/dist/electron.exe',
+    targetArch: 'x64',
+    hostArch: 'x64',
+    existsSync: () => true,
+    peArchReader: () => 'arm64'
+  })
+  assert.deepEqual(decision, {
+    reuse: false,
+    reason: 'arch-mismatch',
+    got: 'arm64',
+    want: 'x64'
+  })
+})
+
+test('shouldReuseElectronDist reuses matching Windows PE', () => {
+  const decision = shouldReuseElectronDist({
+    platform: 'win32',
+    distDir: '/fake/dist',
+    binaryPath: '/fake/dist/electron.exe',
+    targetArch: 'x64',
+    hostArch: 'x64',
+    existsSync: () => true,
+    peArchReader: () => 'x64'
+  })
+  assert.equal(decision.reuse, true)
+  assert.equal(decision.reason, 'arch-match')
+})
+
+test('shouldReuseElectronDist refuses unreadable Windows PE', () => {
+  const decision = shouldReuseElectronDist({
+    platform: 'win32',
+    distDir: '/fake/dist',
+    binaryPath: '/fake/dist/electron.exe',
+    targetArch: 'x64',
+    existsSync: () => true,
+    peArchReader: () => null
+  })
+  assert.equal(decision.reuse, false)
+  assert.equal(decision.reason, 'unreadable-pe')
+})
+
+test('shouldReuseElectronDist skips PE gate on non-Windows hosts', () => {
+  const decision = shouldReuseElectronDist({
+    platform: 'darwin',
+    distDir: '/fake/dist',
+    binaryPath: '/fake/dist/Electron',
+    targetArch: 'arm64',
+    existsSync: () => true,
+    peArchReader: () => {
+      throw new Error('should not read PE on darwin')
+    }
+  })
+  assert.equal(decision.reuse, true)
+  assert.equal(decision.reason, 'non-windows')
+})

--- a/apps/desktop/scripts/run-electron-builder-lib.mjs
+++ b/apps/desktop/scripts/run-electron-builder-lib.mjs
@@ -1,0 +1,61 @@
+// Pure helpers for run-electron-builder.mjs — kept import-safe for unit tests
+// (the CLI entry spawns electron-builder on load).
+
+import fs from "node:fs"
+
+import { normalizeCpuArch, readPeArch } from "./pe-arch.mjs"
+
+/**
+ * Best-effort target arch for this electron-builder invocation.
+ * Prefer an explicit `--x64` / `--arm64` / `--ia32` flag; otherwise host arch.
+ */
+export function resolveBuilderTargetArch(argv = [], hostArch = "x64") {
+  for (const arg of argv) {
+    if (arg === "--x64" || arg === "--arm64" || arg === "--ia32") {
+      return normalizeCpuArch(arg.slice(2))
+    }
+    if (arg.startsWith("--arch=")) {
+      return normalizeCpuArch(arg.slice("--arch=".length))
+    }
+  }
+  for (let i = 0; i < argv.length - 1; i++) {
+    if (argv[i] === "--arch") {
+      return normalizeCpuArch(argv[i + 1])
+    }
+  }
+  return normalizeCpuArch(hostArch)
+}
+
+/**
+ * Decide whether the local electron dist is safe to pass as electronDist.
+ */
+export function shouldReuseElectronDist({
+  platform = "win32",
+  distDir = null,
+  binaryPath = null,
+  targetArch = null,
+  hostArch = "x64",
+  peArchReader = readPeArch,
+  existsSync = fs.existsSync,
+} = {}) {
+  if (!distDir || !binaryPath || !existsSync(binaryPath)) {
+    return { reuse: false, reason: "missing" }
+  }
+  // PE Machine is a Windows concept. On other hosts, existence is enough
+  // (cross-OS reuse is a separate concern — see #66345).
+  if (platform !== "win32") {
+    return { reuse: true, reason: "non-windows" }
+  }
+  const want = normalizeCpuArch(targetArch) || normalizeCpuArch(hostArch)
+  if (!want) {
+    return { reuse: true, reason: "unknown-arch" }
+  }
+  const got = peArchReader(binaryPath)
+  if (!got) {
+    return { reuse: false, reason: "unreadable-pe", got, want }
+  }
+  if (got !== want) {
+    return { reuse: false, reason: "arch-mismatch", got, want }
+  }
+  return { reuse: true, reason: "arch-match", got, want }
+}

--- a/apps/desktop/scripts/run-electron-builder.mjs
+++ b/apps/desktop/scripts/run-electron-builder.mjs
@@ -3,11 +3,20 @@
 // npm workspace hoisting is non-deterministic — require.resolve finds electron
 // wherever it landed. Dist present → -c.electronDist=<abs>/dist; absent → let
 // electron-builder fetch via @electron/get (electronVersion + ELECTRON_MIRROR).
+//
+// #69179: also refuse a host-local dist whose PE Machine does not match the
+// build target. `npm_config_arch` (or a poisoned cache) can leave an arm64
+// electron.exe on an AMD64 host; packing that into win-unpacked yields the
+// Windows modal 「此应用无法在你的电脑上运行」 / "This app can't run on your PC".
 
-import fs from "node:fs"
 import path from "node:path"
 import { spawnSync } from "node:child_process"
 import { createRequire } from "node:module"
+
+import {
+  resolveBuilderTargetArch,
+  shouldReuseElectronDist,
+} from "./run-electron-builder-lib.mjs"
 
 const require = createRequire(import.meta.url)
 
@@ -38,8 +47,29 @@ function electronBuilderCli() {
 
 const dist = electronDistDir()
 const args = []
-if (dist && fs.existsSync(distBinary(dist))) {
+const targetArch = resolveBuilderTargetArch(process.argv.slice(2), process.arch)
+const binary = dist ? distBinary(dist) : null
+const decision = shouldReuseElectronDist({
+  platform: process.platform,
+  distDir: dist,
+  binaryPath: binary,
+  targetArch,
+  hostArch: process.arch,
+})
+
+if (decision.reuse) {
   args.push(`-c.electronDist=${dist}`)
+} else if (decision.reason === "arch-mismatch") {
+  console.warn(
+    `[run-electron-builder] refusing host electronDist (${decision.got}) for ` +
+      `target ${decision.want}; electron-builder will fetch a matching build ` +
+      `via @electron/get (#69179).`
+  )
+} else if (decision.reason === "unreadable-pe") {
+  console.warn(
+    `[run-electron-builder] host electronDist PE unreadable; electron-builder ` +
+      `will fetch via @electron/get (#69179).`
+  )
 } else {
   console.warn(
     "[run-electron-builder] no local electron dist; electron-builder will fetch " +

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5474,17 +5474,119 @@ def _write_desktop_build_stamp(project_root: Path, *, source_mode: bool) -> None
         logger.debug("Failed to write desktop build stamp: %s", exc)
 
 
+def _windows_host_cpu_arch() -> str:
+    """Return ``x64`` / ``arm64`` / ``ia32`` for this Windows process.
+
+    Uses the process/env view (``PROCESSOR_ARCHITECTURE`` /
+    ``PROCESSOR_ARCHITEW6432``, then ``platform.machine()``), not a CIM probe
+    of the physical CPU. That matches which Electron PE this interpreter can
+    actually exec: under WoA Prism an x64 Python correctly prefers the
+    ``win-unpacked`` (x64) tree even though the silicon is ARM64 (#69179).
+    """
+    import platform as _platform
+
+    machine = (_platform.machine() or "").lower()
+    # PROCESSOR_ARCHITEW6432 is set for WoW64 (32-bit process on 64-bit OS)
+    # and reports the outer OS arch; otherwise PROCESSOR_ARCHITECTURE is the
+    # arch of this process (including Prism x64-on-ARM64).
+    env_arch = (
+        os.environ.get("PROCESSOR_ARCHITEW6432")
+        or os.environ.get("PROCESSOR_ARCHITECTURE")
+        or ""
+    ).lower()
+    for candidate in (env_arch, machine):
+        if candidate in ("amd64", "x86_64", "x64"):
+            return "x64"
+        if candidate in ("arm64", "aarch64"):
+            return "arm64"
+        if candidate in ("x86", "i386", "i686"):
+            return "ia32"
+    return "x64"
+
+
+def _read_pe_machine_arch(exe: Path) -> Optional[str]:
+    """Return ``x64`` / ``arm64`` / ``ia32`` from a PE COFF Machine, else None."""
+    try:
+        with exe.open("rb") as fh:
+            header = fh.read(0x40)
+            if len(header) < 0x40 or header[0:2] != b"MZ":
+                return None
+            pe_offset = int.from_bytes(header[0x3C:0x40], "little")
+            if pe_offset < 0x40 or pe_offset > 1024 * 1024:
+                return None
+            fh.seek(pe_offset)
+            pe = fh.read(6)
+            if len(pe) < 6 or pe[0:4] != b"PE\0\0":
+                return None
+            machine = int.from_bytes(pe[4:6], "little")
+    except OSError:
+        return None
+    if machine == 0x8664:
+        return "x64"
+    if machine == 0xAA64:
+        return "arm64"
+    if machine == 0x014C:
+        return "ia32"
+    return None
+
+
+def _desktop_windows_exe_arch_ok(exe: Path, host_arch: Optional[str] = None) -> bool:
+    """True when *exe* is missing-PE (unknown) or matches the host arch.
+
+    Clear arch mismatches must not count as a launchable desktop app — Windows
+    reports them only as 「此应用无法在你的电脑上运行」 (#69179). Unreadable /
+    non-PE stubs (unit-test placeholders) stay accepted so existence checks
+    keep working.
+    """
+    want = host_arch or _windows_host_cpu_arch()
+    got = _read_pe_machine_arch(exe)
+    if got is None:
+        return True
+    return got == want
+
+
+def _desktop_any_unpacked_exe(desktop_dir: Path) -> bool:
+    """True when any electron-builder unpacked exe exists (any arch).
+
+    Used by ``hermes update`` to decide whether a desktop rebuild is in scope.
+    Unlike :func:`_desktop_packaged_executable`, this does NOT filter by host
+    PE arch — a wrong-arch Hermes.exe still means the user has a desktop
+    install that needs repair (#69179).
+    """
+    release_dir = desktop_dir / "release"
+    if not release_dir.is_dir():
+        return False
+    if sys.platform == "darwin":
+        return any(release_dir.glob("mac*/Hermes.app/Contents/MacOS/Hermes"))
+    if sys.platform == "win32":
+        for name in ("win-unpacked", "win-ia32-unpacked", "win-arm64-unpacked"):
+            if (release_dir / name / "Hermes.exe").exists():
+                return True
+        return False
+    for name in ("linux-unpacked", "linux-arm64-unpacked"):
+        if (release_dir / name / "hermes").exists() or (release_dir / name / "Hermes").exists():
+            return True
+    return False
+
+
 def _desktop_packaged_executable(desktop_dir: Path) -> Optional[Path]:
     """Return the current platform's unpacked Electron app executable."""
     release_dir = desktop_dir / "release"
     if sys.platform == "darwin":
         candidates = list(release_dir.glob("mac*/Hermes.app/Contents/MacOS/Hermes"))
     elif sys.platform == "win32":
-        candidates = [
-            release_dir / "win-unpacked" / "Hermes.exe",
-            release_dir / "win-ia32-unpacked" / "Hermes.exe",
-            release_dir / "win-arm64-unpacked" / "Hermes.exe",
-        ]
+        # Prefer the host-arch tree first. electron-builder names x64
+        # ``win-unpacked`` and arm64 ``win-arm64-unpacked``; picking by mtime
+        # alone can relaunch a stale wrong-arch Hermes.exe (#69179).
+        host_arch = _windows_host_cpu_arch()
+        by_arch = {
+            "x64": release_dir / "win-unpacked" / "Hermes.exe",
+            "ia32": release_dir / "win-ia32-unpacked" / "Hermes.exe",
+            "arm64": release_dir / "win-arm64-unpacked" / "Hermes.exe",
+        }
+        ordered = [by_arch[host_arch]]
+        ordered.extend(p for arch, p in by_arch.items() if arch != host_arch)
+        candidates = ordered
     else:
         candidates = [
             release_dir / "linux-unpacked" / "hermes",
@@ -5496,6 +5598,16 @@ def _desktop_packaged_executable(desktop_dir: Path) -> Optional[Path]:
     existing = [p for p in candidates if p.exists()]
     if not existing:
         return None
+    if sys.platform == "win32":
+        host_arch = _windows_host_cpu_arch()
+        compatible = [p for p in existing if _desktop_windows_exe_arch_ok(p, host_arch)]
+        if not compatible:
+            return None
+        # Prefer the host-arch path when present; otherwise newest compatible.
+        preferred = candidates[0]
+        if preferred in compatible:
+            return preferred
+        return max(compatible, key=lambda p: p.stat().st_mtime)
     return max(existing, key=lambda p: p.stat().st_mtime)
 
 
@@ -10643,7 +10755,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # never run ``hermes desktop`` shouldn't be forced into a full
         # Electron build by ``hermes update``.
         desktop_dir = PROJECT_ROOT / "apps" / "desktop"
-        has_desktop_app = _desktop_packaged_executable(desktop_dir) is not None or _desktop_dist_exists(desktop_dir)
+        has_desktop_app = (
+            _desktop_packaged_executable(desktop_dir) is not None
+            or _desktop_any_unpacked_exe(desktop_dir)
+            or _desktop_dist_exists(desktop_dir)
+        )
         if (desktop_dir / "package.json").exists() and _resolve_node_runtime_npm() and has_desktop_app:
             print("→ Checking if desktop app needs rebuilding...")
             _desktop_build_cmd = [sys.executable, "-m", "hermes_cli.main", "desktop", "--build-only"]

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3036,12 +3036,22 @@ function Install-Desktop {
     }
     Pop-Location
 
-    # 3. Sanity-check the produced binary. Probe both arches so this works
-    # on x64 and arm64 build machines.
-    $exeCandidates = @(
-        "$desktopDir\release\win-unpacked\Hermes.exe",
-        "$desktopDir\release\win-arm64-unpacked\Hermes.exe"
-    )
+    # 3. Sanity-check the produced binary. Prefer the host OS arch first so a
+    # stale wrong-arch sibling (win-unpacked vs win-arm64-unpacked) cannot win
+    # just by existing -- Windows would then show "This app can't run on your PC"
+    # (#69179).
+    $hostArch = Get-WindowsArch
+    if ($hostArch -eq 'arm64') {
+        $exeCandidates = @(
+            "$desktopDir\release\win-arm64-unpacked\Hermes.exe",
+            "$desktopDir\release\win-unpacked\Hermes.exe"
+        )
+    } else {
+        $exeCandidates = @(
+            "$desktopDir\release\win-unpacked\Hermes.exe",
+            "$desktopDir\release\win-arm64-unpacked\Hermes.exe"
+        )
+    }
     $found = $false
     $desktopExe = $null
     foreach ($cand in $exeCandidates) {

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -1102,3 +1102,87 @@ def test_desktop_launch_options_survives_config_error():
         flags, gpu = cli_main._desktop_launch_options()
     assert flags == []
     assert gpu == "auto"
+
+
+def _write_minimal_pe(path: Path, arch: str) -> None:
+    """Write a header-only PE whose COFF Machine matches *arch*."""
+    machines = {"x64": 0x8664, "arm64": 0xAA64, "ia32": 0x014C}
+    machine = machines[arch]
+    pe_offset = 0x40
+    buf = bytearray(pe_offset + 6)
+    buf[0:2] = b"MZ"
+    buf[0x3C:0x40] = pe_offset.to_bytes(4, "little")
+    buf[pe_offset : pe_offset + 4] = b"PE\0\0"
+    buf[pe_offset + 4 : pe_offset + 6] = machine.to_bytes(2, "little")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(bytes(buf))
+
+
+def test_read_pe_machine_arch_round_trip(tmp_path):
+    for arch in ("x64", "arm64", "ia32"):
+        exe = tmp_path / f"{arch}.exe"
+        _write_minimal_pe(exe, arch)
+        assert cli_main._read_pe_machine_arch(exe) == arch
+
+
+def test_desktop_packaged_executable_prefers_host_arch_on_windows(tmp_path, monkeypatch):
+    """x64 host must not relaunch a newer arm64 Hermes.exe (#69179)."""
+    root = _make_desktop_tree(tmp_path)
+    desktop = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main.sys, "platform", "win32")
+    monkeypatch.setattr(cli_main, "_windows_host_cpu_arch", lambda: "x64")
+
+    arm = desktop / "release" / "win-arm64-unpacked" / "Hermes.exe"
+    x64 = desktop / "release" / "win-unpacked" / "Hermes.exe"
+    _write_minimal_pe(arm, "arm64")
+    _write_minimal_pe(x64, "x64")
+    # Make the wrong-arch tree look "newer" so a pure mtime picker would pick it.
+    import os
+    import time
+
+    newer = time.time() + 60
+    os.utime(arm, (newer, newer))
+
+    assert cli_main._desktop_packaged_executable(desktop) == x64
+
+
+def test_desktop_packaged_executable_rejects_only_wrong_arch_pe(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    desktop = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main.sys, "platform", "win32")
+    monkeypatch.setattr(cli_main, "_windows_host_cpu_arch", lambda: "x64")
+
+    arm = desktop / "release" / "win-unpacked" / "Hermes.exe"
+    _write_minimal_pe(arm, "arm64")
+
+    assert cli_main._desktop_packaged_executable(desktop) is None
+    assert cli_main._desktop_any_unpacked_exe(desktop) is True
+    assert cli_main._desktop_build_needed(desktop, root, source_mode=False) is True
+
+
+def test_desktop_windows_exe_arch_ok_allows_unreadable_stub(tmp_path, monkeypatch):
+    """Empty/non-PE stubs stay accepted so unit fixtures keep working."""
+    exe = tmp_path / "Hermes.exe"
+    exe.write_text("", encoding="utf-8")
+    monkeypatch.setattr(cli_main, "_windows_host_cpu_arch", lambda: "x64")
+    assert cli_main._desktop_windows_exe_arch_ok(exe, "x64") is True
+
+
+def test_windows_host_cpu_arch_prefers_processor_env(monkeypatch):
+    """Process/env arch wins — Prism x64-on-ARM must resolve as x64 (#69179)."""
+    monkeypatch.setenv("PROCESSOR_ARCHITECTURE", "AMD64")
+    monkeypatch.delenv("PROCESSOR_ARCHITEW6432", raising=False)
+    monkeypatch.setattr(
+        "platform.machine",
+        lambda: "ARM64",
+        raising=False,
+    )
+    # Import inside helper uses `import platform as _platform`, so patch the
+    # module attribute the helper will read after import.
+    import platform as platform_mod
+
+    monkeypatch.setattr(platform_mod, "machine", lambda: "ARM64")
+    assert cli_main._windows_host_cpu_arch() == "x64"
+
+    monkeypatch.setenv("PROCESSOR_ARCHITECTURE", "ARM64")
+    assert cli_main._windows_host_cpu_arch() == "arm64"


### PR DESCRIPTION
## Summary
- After in-app Desktop update on Windows, a host `electronDist` whose COFF Machine did not match the pack target (e.g. `npm_config_arch=arm64` / poisoned cache on AMD64) could be packed into `win-unpacked/Hermes.exe`. Windows then only shows 「此应用无法在你的电脑上运行」 / "This app can't run on your PC" with no useful stderr ([#69179](https://github.com/NousResearch/hermes-agent/issues/69179)).
- Gate `run-electron-builder` electronDist reuse and `afterPack` on PE Machine vs target arch; delete a mismatched packed exe instead of shipping it.
- Prefer the host-arch unpacked tree in Python / bootstrap / `install.ps1` resolvers, and treat clear PE arch mismatches as missing so `hermes update` rebuilds repair them.

## Test plan
- [x] `cd apps/desktop && npx vitest run scripts/pe-arch.test.mjs`
- [x] `scripts/run_tests.sh tests/hermes_cli/test_gui_command.py -q`
- [ ] On Windows 10/11 AMD64: poison `node_modules/electron/dist/electron.exe` with an arm64 PE (or set `npm_config_arch=arm64` then reinstall electron), run `hermes desktop --force-build`, confirm builder refuses/refetches and does not leave a wrong-arch `Hermes.exe`
- [ ] Reproduce the reporter path: Desktop → Update Now → relaunch; confirm no 「此应用无法在你的电脑上运行」 dialog
- [ ] Confirm `git diff --name-only` for this PR is only the listed code + test files (no image assets)

## Infographic
![wrong-arch PE after Windows desktop update — before vs after](https://github.com/HexLab98/hermes-agent-fork/releases/download/pr-asset-69179-infographic/69179-windows-pe-arch-infographic.png)