### PR TITLE
fix(telegram): require initial polling readiness

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -67,6 +67,10 @@ from hermes_cli.fallback_config import get_fallback_chain
 _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
+# Telegram cold polling now proves one real getUpdates round trip before connect
+# returns. Leave enough outer budget for initialize/deleteWebhook/start_polling
+# wall deadlines plus readiness; other platforms retain the 30s isolation bound.
+_TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT = 180.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
@@ -3812,7 +3816,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return max(0.0, timeout)
         return _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
 
-    def _platform_connect_timeout_secs(self) -> float:
+    def _platform_connect_timeout_secs(self, platform=None) -> float:
         """Return the per-platform connect timeout used during startup/retry."""
         raw = os.getenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "").strip()
         if raw:
@@ -3825,6 +3829,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             else:
                 return max(0.0, timeout)
+        if platform == Platform.TELEGRAM:
+            return _TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT
         return _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT
 
     async def _connect_adapter_with_timeout(
@@ -3838,7 +3844,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         (preserve the queue so messages sent during the outage are delivered
         rather than silently dropped — #46621).
         """
-        timeout = self._platform_connect_timeout_secs()
+        timeout = self._platform_connect_timeout_secs(platform)
         if timeout <= 0:
             return await adapter.connect(is_reconnect=is_reconnect)
         try:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -545,6 +545,10 @@ _UPDATER_STOP_TIMEOUT = 15.0
 # reconnect ladder from stalling indefinitely and allows the heartbeat loop to
 # trigger its own recovery path. Refs: NousResearch/hermes-agent#59614
 _UPDATER_START_TIMEOUT = 30.0
+# Initial connect is not healthy until the dedicated getUpdates request completes
+# one successful round trip. Unlike reconnect, initial bootstrap must fail closed
+# so GatewayRunner disposes the partial adapter and retries with a fresh PTB app.
+_INITIAL_POLLING_PROGRESS_TIMEOUT = 60.0
 # shutdown()/initialize() on the getUpdates httpx request close and rebuild the
 # connection pool. When a connection is wedged on a stale CLOSE-WAIT socket that
 # close can block forever, hanging _drain_polling_connections() and freezing the
@@ -2129,6 +2133,7 @@ class TelegramAdapter(BasePlatformAdapter):
         *,
         drop_pending_updates: bool,
         error_callback,
+        abandon_app_on_timeout: bool = False,
     ) -> None:
         """Start one generation and verify real getUpdates progress."""
         if getattr(self, "_polling_teardown_started", False):
@@ -2151,13 +2156,22 @@ class TelegramAdapter(BasePlatformAdapter):
 
         context_token = _POLLING_GENERATION_CONTEXT.set(generation)
         try:
-            await asyncio.wait_for(
+            # asyncio.wait_for can wait forever for cancellation to escape
+            # httpcore/AnyIO shielded scopes (#58236/#67498). Reuse the
+            # proven wall-deadline helper and abandon the partial updater;
+            # caller recovery will dispose/rebuild the whole adapter.
+            await _await_with_thread_deadline(
                 app.updater.start_polling(
                     allowed_updates=Update.ALL_TYPES,
                     drop_pending_updates=drop_pending_updates,
                     error_callback=_generation_error_callback,
                 ),
                 timeout=_UPDATER_START_TIMEOUT,
+                on_abandon=(
+                    (lambda app=app: _shutdown_abandoned_app(app))
+                    if abandon_app_on_timeout
+                    else None
+                ),
             )
         finally:
             _POLLING_GENERATION_CONTEXT.reset(context_token)
@@ -2264,12 +2278,14 @@ class TelegramAdapter(BasePlatformAdapter):
         self._background_tasks.add(self._polling_error_task)
         self._polling_error_task.add_done_callback(self._background_tasks.discard)
 
-    async def _delete_webhook_best_effort(self) -> bool:
-        """Clear any stale webhook, but never fail polling on a network error.
+    async def _delete_webhook_best_effort(
+        self, *, require_success: bool = False
+    ) -> bool:
+        """Clear stale webhook, optionally failing closed on initial connect.
 
-        Returns True when the webhook was cleared (or there was nothing to do)
-        and False when a transient network error was swallowed so bootstrap can
-        continue to polling; the reconnect ladder recovers from there.
+        Reconnect can recover a transient error in background. Cold startup uses
+        ``require_success`` so GatewayRunner disposes the partial adapter and
+        retries with a fresh PTB Application instead of publishing degraded state.
         """
         if not self._bot:
             return False
@@ -2277,10 +2293,19 @@ class TelegramAdapter(BasePlatformAdapter):
         if not callable(delete_webhook):
             return True
         try:
-            await delete_webhook(drop_pending_updates=False)
+            # Same shielded-cancellation class as initialize/start_polling:
+            # never let a wedged duplicate deleteWebhook pin initial connect.
+            await _await_with_thread_deadline(
+                delete_webhook(drop_pending_updates=False),
+                timeout=_UPDATER_START_TIMEOUT,
+            )
             return True
         except Exception as err:
             if self._looks_like_network_error(err):
+                if require_success:
+                    raise OSError(
+                        "Telegram deleteWebhook did not complete during initial connect"
+                    ) from err
                 logger.warning(
                     "[%s] deleteWebhook failed with a recoverable network error; "
                     "continuing to polling so getUpdates/retry can recover: %s",
@@ -2290,12 +2315,19 @@ class TelegramAdapter(BasePlatformAdapter):
                 return False
             raise
 
-    async def _start_polling_resilient(self, *, drop_pending_updates: bool, error_callback) -> bool:
-        """Start PTB polling; on a transient bootstrap failure, recover in background.
+    async def _start_polling_resilient(
+        self,
+        *,
+        drop_pending_updates: bool,
+        error_callback,
+        require_progress: bool = False,
+    ) -> bool:
+        """Start PTB polling and optionally require real getUpdates readiness.
 
-        Returns True when polling started, False when a transient conflict or
-        network error was scheduled for background recovery instead of raising
-        (keeping the gateway process alive).
+        Reconnects may recover in background. Initial connect sets
+        ``require_progress`` so a bootstrap failure or missing first successful
+        getUpdates response raises; GatewayRunner then disposes this partial
+        adapter and retries with a fresh PTB Application.
         """
         if getattr(self, "_polling_teardown_started", False):
             return False
@@ -2312,13 +2344,30 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._app,
                 drop_pending_updates=drop_pending_updates,
                 error_callback=error_callback,
+                abandon_app_on_timeout=require_progress,
             )
+            if require_progress:
+                try:
+                    await _await_with_thread_deadline(
+                        self._polling_progress_event.wait(),
+                        timeout=_INITIAL_POLLING_PROGRESS_TIMEOUT,
+                    )
+                except asyncio.TimeoutError as exc:
+                    raise OSError(
+                        "Telegram getUpdates made no progress during initial connect"
+                    ) from exc
+                if not self._polling_progress_event.is_set():
+                    raise OSError(
+                        "Telegram getUpdates did not become ready during initial connect"
+                    )
             return True
         except _PollingLifecycleAbort:
             return False
         except Exception as err:
             if getattr(self, "_polling_teardown_started", False):
                 return False
+            if require_progress:
+                raise
             if self._looks_like_polling_conflict(err):
                 logger.warning(
                     "[%s] Telegram polling bootstrap conflict; gateway stays alive "
@@ -3737,7 +3786,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 # updates. Best-effort: a transient Bot API network error here
                 # must not fail gateway startup — degrade to background polling
                 # recovery instead.
-                await self._delete_webhook_best_effort()
+                await self._delete_webhook_best_effort(
+                    require_success=not is_reconnect
+                )
 
                 loop = asyncio.get_running_loop()
 
@@ -3775,6 +3826,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     # sent while the bot was offline are delivered (#46621).
                     drop_pending_updates=not is_reconnect,
                     error_callback=_polling_error_callback,
+                    require_progress=not is_reconnect,
                 )
                 if not polling_started:
                     logger.warning(

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -138,6 +138,25 @@ class TestStartupPlatformIsolation:
         assert Platform.TELEGRAM not in runner.adapters
         assert runner._create_adapter.call_count == 2
 
+    def test_default_connect_timeout_allows_telegram_polling_readiness(
+        self, monkeypatch
+    ):
+        """Telegram gets a larger default; other platforms stay isolated at 30s."""
+        runner = _make_runner()
+        monkeypatch.delenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", raising=False)
+
+        assert runner._platform_connect_timeout_secs(Platform.TELEGRAM) == 180
+        assert runner._platform_connect_timeout_secs(Platform.FEISHU) == 30
+
+    def test_explicit_connect_timeout_still_applies_to_every_platform(
+        self, monkeypatch
+    ):
+        runner = _make_runner()
+        monkeypatch.setenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "90")
+
+        assert runner._platform_connect_timeout_secs(Platform.TELEGRAM) == 90
+        assert runner._platform_connect_timeout_secs(Platform.FEISHU) == 90
+
     @pytest.mark.asyncio
     async def test_connect_adapter_timeout_raises_retryable_exception(self, monkeypatch):
         """The timeout helper turns a hanging connect into a caught startup error."""

--- a/tests/gateway/test_telegram_polling_progress.py
+++ b/tests/gateway/test_telegram_polling_progress.py
@@ -138,13 +138,20 @@ async def test_polling_disconnect_webhook_reconnect_heals_webhook_send_path(monk
     adapter = _make_adapter()
     polling_app = _lifecycle_app()
     webhook_app = _lifecycle_app()
+
+    async def start_polling_with_progress(**_kwargs):
+        adapter._record_polling_progress(adapter._polling_generation)
+
+    polling_app.updater.start_polling = AsyncMock(
+        side_effect=start_polling_with_progress
+    )
     _configure_lifecycle_connect(monkeypatch, adapter, [polling_app, webhook_app])
     monkeypatch.delenv("TELEGRAM_WEBHOOK_URL", raising=False)
     monkeypatch.delenv("TELEGRAM_WEBHOOK_SECRET", raising=False)
 
     assert await adapter.connect() is True
     assert adapter._webhook_mode is False
-    assert adapter._send_path_degraded is True
+    assert adapter._send_path_degraded is False
     await adapter.disconnect()
 
     monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.test/telegram")

--- a/tests/gateway/test_telegram_start_polling_timeout.py
+++ b/tests/gateway/test_telegram_start_polling_timeout.py
@@ -8,9 +8,10 @@ httpx connection pool — it neither returns nor raises. Unbounded, that wedges:
 2. the heartbeat loop (sees the recovery task as alive-but-wedged and skips),
 3. the fatal-error escalation (never reached).
 
-The fix wraps every ``start_polling()`` await in ``asyncio.wait_for`` with
-``_UPDATER_START_TIMEOUT`` so a hung call raises and feeds the existing retry
-ladder. These tests patch the timeout down to keep the suite fast.
+The fix wraps every ``start_polling()`` await in the wall-deadline helper with
+``_UPDATER_START_TIMEOUT`` so a cancellation-shielded hung call still raises and
+feeds the existing retry ladder. These tests patch the timeout down to keep the
+suite fast.
 """
 import asyncio
 import sys
@@ -138,20 +139,34 @@ async def test_start_polling_success_path_unaffected(monkeypatch):
 
 
 def test_every_start_polling_call_site_is_time_bounded():
-    """Bug-class contract: every `updater.start_polling(` await in the adapter
-    must be wrapped in asyncio.wait_for. A new unbounded call site reintroduces
-    the #59614 wedge."""
+    """Every updater.start_polling call must use the wall-deadline helper."""
     import inspect
     import re
 
     src = inspect.getsource(tg_adapter)
-    # Find each start_polling( call and check an enclosing wait_for within the
-    # preceding 6 lines (the wrapper always sits directly above).
     lines = src.splitlines()
     unbounded = []
     for i, line in enumerate(lines):
         if re.search(r"updater\.start_polling\(", line) and "def " not in line:
-            window = "\n".join(lines[max(0, i - 6):i + 1])
-            if "wait_for" not in window:
+            window = "\n".join(lines[max(0, i - 8):i + 1])
+            if "_await_with_thread_deadline" not in window:
                 unbounded.append((i + 1, line.strip()))
     assert not unbounded, f"unbounded start_polling() call sites: {unbounded}"
+
+
+@pytest.mark.asyncio
+async def test_initial_connect_requires_get_updates_progress(monkeypatch):
+    """Cold connect must not claim success before real getUpdates I/O."""
+    monkeypatch.setattr(tg_adapter, "_INITIAL_POLLING_PROGRESS_TIMEOUT", 0.05)
+    a = _bare_adapter()
+    app = MagicMock()
+    app.updater = AsyncMock()
+    app.updater.start_polling = AsyncMock(return_value=None)
+    a._app = app
+
+    with pytest.raises(OSError, match="getUpdates made no progress"):
+        await a._start_polling_resilient(
+            drop_pending_updates=True,
+            error_callback=None,
+            require_progress=True,
+        )


### PR DESCRIPTION
## What does this PR do?

Prevents Telegram cold startup from reporting a connected adapter before polling has completed a real Bot API round trip.

`Application.initialize()` and `Application.start()` can both return successfully without proving that polling works. `Updater.start_polling()` can also return after creating its background task but before the first `getUpdates` request succeeds. In the failure reported by #67498, that left the gateway indefinitely at `Connecting to Telegram (attempt 1/8)…` with an idle event loop and no fresh adapter retry.

This change makes cold startup fail closed: it requires the first successful, generation-scoped `getUpdates` response before `_mark_connected()` can run. If `deleteWebhook`, `start_polling()`, or initial polling readiness misses its wall deadline, the partial PTB application is abandoned and GatewayRunner retries with a fresh adapter. Existing degraded/background recovery behavior remains unchanged for reconnects.

Telegram receives a 180-second default outer connect budget to contain its initialize, webhook cleanup, polling startup, and readiness deadlines. Other platforms retain the existing 30-second default, and the explicit environment override still wins.

## Related Issue

Fixes #67498

Compatible with #69213: that PR adds sanitized runtime-status evidence after `_mark_connected()`; this PR defines when Telegram has enough polling evidence to reach `_mark_connected()`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py`
  - Bound initial `deleteWebhook` and `Updater.start_polling()` with the existing wall-deadline helper instead of relying on coroutine cancellation to complete.
  - Add a cold-start-only readiness gate that waits for the first successful `getUpdates` response from the current polling generation.
  - Clean up abandoned partial PTB applications after startup timeouts.
  - Preserve background/degraded recovery semantics for reconnects.
- `gateway/run.py`
  - Use a 180-second default outer connect timeout for Telegram while retaining 30 seconds for every other platform.
  - Preserve `HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT` overrides for all platforms.
- `tests/gateway/`
  - Cover cancellation-resistant polling startup deadlines, initial progress requirements, generation-scoped progress, and per-platform timeout defaults/overrides.

## How to Test

1. Configure a valid Telegram bot in polling mode and start the gateway under a setup that reproduces #67498.
2. Confirm cold startup does not publish `connected` until a real `getUpdates` request succeeds; if it does not, confirm GatewayRunner retries with a fresh adapter instead of remaining on attempt 1 indefinitely.
3. Run the focused canonical suite:

```bash
scripts/run_tests.sh \
  tests/gateway/test_telegram_start_polling_timeout.py \
  tests/gateway/test_telegram_init_deadline.py \
  tests/gateway/test_telegram_polling_progress.py \
  tests/gateway/test_telegram_network_reconnect.py \
  tests/gateway/test_platform_reconnect.py
```

4. Run the cross-platform check:

```bash
python3 scripts/check-windows-footguns.py --diff origin/main
```

## Validation Results

- Focused canonical suite: **122 passed, 0 failed**.
- Windows-footgun diff check: **passed**.
- Live Ubuntu 24.04 x86_64 validation with Python 3.11.15, Hermes v0.19.0, PTB 22.6, and the LCM context plugin enabled:
  - Unmodified Hermes v0.19.0 control: **0/5** cold starts made polling progress within 90 seconds; each remained at attempt 1.
  - This branch: **5/5** cold starts connected successfully in **20–21 seconds**.
- The same control failure remained after upgrading the external LCM plugin from v0.18.0 to v0.19.0. LCM changes reproduction timing but is not treated as the root cause; the fix is confined to Telegram polling lifecycle/readiness.

The full repository suite was also started locally but is **not represented as passing**: local environment-sensitive failures occurred outside this PR's files, including disabled IPv6/dual-stack assumptions, install-method state, optional Holographic/NumPy CPU support, and Honcho cache tests. The focused canonical suite above is green; hosted CI remains authoritative for the complete matrix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched open and merged issues/PRs; #69213 is compatible but not a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — see the transparent full-suite environment note above
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu 24.04 x86_64 with Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation N/A — no user-facing command or configuration key was added
- [x] `cli-config.yaml.example` N/A — no configuration key was added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A — no architecture or contributor workflow changed
- [x] Cross-platform impact considered; `scripts/check-windows-footguns.py --diff origin/main` passes
- [x] Tool descriptions/schemas N/A — no tool API changed

## Screenshots / Logs

No UI changes. Representative live result from five consecutive service restarts:

```text
run 1: PASS connected=20s
run 2: PASS connected=20s
run 3: PASS connected=21s
run 4: PASS connected=21s
run 5: PASS connected=20s
DEFAULT TIMEOUT + LCM 0.19 RESULT: 5/5
```
