### PR TITLE
kanban: add explicit `delete` verb for archived tasks

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -649,6 +649,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Permanently delete already-archived task ids from the board",
     )
 
+    p_delete = sub.add_parser(
+        "delete",
+        help="Permanently delete already-archived tasks",
+    )
+    p_delete.add_argument(
+        "task_ids",
+        nargs="+",
+        help="Already-archived task ids to permanently delete",
+    )
+
     # --- tail ---
     p_tail = sub.add_parser("tail", help="Follow a task's event stream")
     p_tail.add_argument("task_id")
@@ -1007,6 +1017,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "unblock":  _cmd_unblock,
             "promote":  _cmd_promote,
             "archive":  _cmd_archive,
+            "delete":   _cmd_delete,
             "tail":     _cmd_tail,
             "dispatch": _cmd_dispatch,
             "daemon":   _cmd_daemon,
@@ -2264,6 +2275,19 @@ def _cmd_archive(args: argparse.Namespace) -> int:
                 print(f"cannot archive {tid}", file=sys.stderr)
             else:
                 print(f"Archived {tid}")
+    return 0 if not failed else 1
+
+
+def _cmd_delete(args: argparse.Namespace) -> int:
+    """Permanently delete archived tasks via the explicit CLI verb."""
+    failed: list[str] = []
+    with kb.connect_closing() as conn:
+        for tid in args.task_ids:
+            if not kb.delete_archived_task(conn, tid):
+                failed.append(tid)
+                print(f"cannot delete {tid} (must already be archived)", file=sys.stderr)
+            else:
+                print(f"Deleted {tid}")
     return 0 if not failed else 1
 
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -788,6 +788,24 @@ def test_cli_archive_rm_deletes_archived_tasks(kanban_home):
         conn.close()
 
 
+def test_cli_delete_removes_archived_task(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="gone")
+        assert kb.archive_task(conn, tid)
+    finally:
+        conn.close()
+
+    out = run_slash(f"delete {tid}")
+
+    assert f"Deleted {tid}" in out
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid) is None
+    finally:
+        conn.close()
+
+
 def test_cli_archive_rm_rejects_live_tasks(kanban_home):
     conn = kb.connect()
     try:


### PR DESCRIPTION
## Summary

Adds `hermes kanban delete <task_ids...>` as a first-class subcommand that permanently deletes already-archived tasks via the existing `delete_archived_task` helper.

Previously, permanent deletion was only reachable through the `archive` flow's rm path, and there was no direct `delete` verb — users (and agents shelling out to the CLI) reaching for `hermes kanban delete` got an argparse error. This surfaces the existing, safety-checked deletion path (archived tasks only) under the verb people actually try first.

- `delete` refuses live tasks: each id must already be archived, mirroring the `archive` rm semantics.
- Prints `Deleted <id>` per task; exits non-zero if any id could not be deleted.

## Testing

- `pytest tests/hermes_cli/test_kanban_core_functionality.py -k "delete or archive_rm"` — 4 passed on current `main` (86fb04638).
- Manual smoke test: create → archive → `hermes kanban delete` on a real board removes the task; `show` returns `no such task`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)