### PR TITLE
test(gateway): isolate systemd routing preflight

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -490,6 +490,14 @@ class TestGatewayServiceDetection:
 
 
 class TestGatewaySystemServiceRouting:
+    @pytest.fixture(autouse=True)
+    def _stub_user_systemd_preflight(self, monkeypatch):
+        # These tests exercise routing after systemd availability is established;
+        # the preflight contract has dedicated coverage below.
+        monkeypatch.setattr(
+            gateway_cli, "_preflight_user_systemd", lambda **kwargs: None
+        )
+
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):
         calls = []
 


### PR DESCRIPTION
## What does this PR do?

Keeps `TestGatewaySystemServiceRouting` independent of the host's user-D-Bus availability.

The routing tests mock systemctl behavior and intentionally exercise the path after systemd availability has been established, but their user-scope restart path still called the real `_preflight_user_systemd()`. On macOS and CI hosts without a reachable user D-Bus session, that made the routing tests fail for an environmental reason unrelated to the behavior under test.

This is the portion of the original #69218 follow-up that remains relevant on current `main`. The obsolete hard-exit test hunk was dropped during review because `test_run_gateway_refreshes_outdated_unit_on_boot` was removed in `39975613b`; focused hard-exit coverage remains in `tests/hermes_cli/test_gateway_run_hard_exit.py`.

Production behavior is unchanged.

## Related Issue

Related to #69218

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/hermes_cli/test_gateway_service.py`
  - Add a class-scoped autouse fixture that stubs `_preflight_user_systemd()` for `TestGatewaySystemServiceRouting`.
  - Leave the dedicated `TestPreflightUserSystemd` contract coverage unchanged.
  - Drop the obsolete boot-refresh hard-exit hunk identified during review.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway_run_hard_exit.py -q`.
2. Confirm all 70 gateway service tests and both focused hard-exit tests pass.
3. Run `uvx ruff check tests/hermes_cli/test_gateway_service.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched open and closed PRs/issues to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this test isolation
- [ ] I've run the full repository suite — not rerun for this review-only, test-scoped salvage
- [x] I've added behavior-focused coverage through the scoped fixture
- [x] I've tested on my platform: macOS 26.5.1, Python 3.13.5

### Documentation & Housekeeping

- [x] Relevant documentation update — N/A; test-only change
- [x] `cli-config.yaml.example` update — N/A; no config changes
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow changes
- [x] Cross-platform impact considered — the fixture removes a host user-D-Bus dependency from routing tests
- [x] Tool descriptions/schemas update — N/A; no tool changes

## Validation

On latest `main` (`71a86101a`):

- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway_run_hard_exit.py -q`: **72 passed** across 2 files.
- `uvx ruff check tests/hermes_cli/test_gateway_service.py`: passed.
- `git diff --check upstream/main...HEAD`: clean.
- Windows-footgun scan reports six pre-existing bare `Path.write_text()` sites elsewhere in the touched test file; none are introduced or modified by this fixture-only diff.

## Screenshots / Logs

Not applicable; test-only change.