### PR TITLE
feat: add isolated Hermes Worker Control Plane M2B-1

### DIFF
--- a/gateway/worker_control_plane/__init__.py
+++ b/gateway/worker_control_plane/__init__.py
@@ -1,0 +1,6 @@
+"""Isolated, test-only Worker Control Plane package."""
+
+from .app import create_worker_control_plane_app
+from .config import WorkerControlPlaneSettings
+
+__all__ = ["WorkerControlPlaneSettings", "create_worker_control_plane_app"]

--- a/gateway/worker_control_plane/app.py
+++ b/gateway/worker_control_plane/app.py
@@ -1,0 +1,163 @@
+"""Standalone aiohttp application factory; tests alone mount this app."""
+from __future__ import annotations
+
+import uuid
+from aiohttp import web
+
+from .config import WorkerControlPlaneSettings
+from .errors import WorkerControlPlaneError, error
+from .models import require_uuid, require_timestamp, require_worker_id
+from .service import WorkerControlPlaneService
+
+SERVICE_KEY: web.AppKey[WorkerControlPlaneService] = web.AppKey(
+    "worker_control_plane_service", WorkerControlPlaneService
+)
+
+REGISTER = {"protocol_version", "worker_id", "instance_id", "worker_name", "worker_version", "capabilities"}
+HEARTBEAT = {"worker_id", "instance_id", "registration_id", "status", "current_task_id", "worker_time"}
+POLL = {"worker_id", "instance_id", "registration_id", "capabilities", "max_tasks", "wait_seconds"}
+ACK = {"worker_id", "instance_id", "registration_id", "delivery_id", "accepted", "reason", "worker_time"}
+RESULT = {"worker_id", "instance_id", "registration_id", "delivery_id", "task_id", "task_type", "status", "stdout", "stderr", "exit_code", "started_at", "finished_at", "duration_ms", "result_idempotency_key", "payload_hash", "trace_id"}
+
+def _token(request: web.Request, scheme: str) -> str:
+    value = request.headers.get("Authorization", "")
+    prefix = scheme + " "
+    if not value.startswith(prefix) or not value[len(prefix):]:
+        raise error("invalid_credential")
+    return value[len(prefix):]
+
+def _key(request: web.Request) -> str:
+    key = request.headers.get("Idempotency-Key")
+    if not key or len(key) > 128 or any(ord(ch) < 33 or ord(ch) > 126 for ch in key):
+        raise error("malformed_request")
+    return key
+
+async def _json(request: web.Request, fields: set[str]) -> dict:
+    try:
+        body = await request.json()
+    except Exception:
+        raise error("malformed_request") from None
+    if not isinstance(body, dict) or set(body) != fields:
+        raise error("malformed_request")
+    return body
+
+def _identity(body: dict) -> None:
+    require_worker_id(body["worker_id"])
+    require_uuid(body["instance_id"], "instance_id")
+    require_uuid(body["registration_id"], "registration_id")
+
+def _register(body: dict) -> None:
+    if body["protocol_version"] != "1.0" or not isinstance(body["worker_name"], str) or not body["worker_name"] or not isinstance(body["worker_version"], str) or not body["worker_version"]:
+        raise error("unsupported_protocol")
+    require_worker_id(body["worker_id"])
+    require_uuid(body["instance_id"], "instance_id")
+    if body["capabilities"] != ["system.echo"]:
+        raise error("unsupported_capability")
+
+def _heartbeat(body: dict) -> None:
+    _identity(body)
+    if body["status"] not in {"idle", "busy"}:
+        raise error("malformed_request")
+    if body["current_task_id"] is not None:
+        require_uuid(body["current_task_id"], "current_task_id")
+    require_timestamp(body["worker_time"], "worker_time")
+
+def _poll(body: dict) -> None:
+    _identity(body)
+    if body["capabilities"] != ["system.echo"]:
+        raise error("unsupported_capability")
+    if type(body["max_tasks"]) is not int or type(body["wait_seconds"]) is not int:
+        raise error("malformed_request")
+    if body["max_tasks"] != 1 or body["wait_seconds"] != 0:
+        raise error("malformed_request")
+
+def _ack(body: dict) -> None:
+    _identity(body); require_uuid(body["delivery_id"], "delivery_id"); require_timestamp(body["worker_time"], "worker_time")
+    if not isinstance(body["accepted"], bool) or (body["reason"] is not None and body["reason"] not in {"temporary", "permanent"}):
+        raise error("malformed_request")
+    if body["accepted"] != (body["reason"] is None):
+        raise error("malformed_request")
+
+def _result(body: dict, route_task_id: str) -> None:
+    _identity(body); require_uuid(body["delivery_id"], "delivery_id"); require_uuid(body["task_id"], "task_id"); require_uuid(body["trace_id"], "trace_id")
+    if body["task_id"] != route_task_id or body["task_type"] != "system.echo" or body["status"] not in {"completed", "failed", "rejected", "cancelled", "expired"}:
+        raise error("invalid_result")
+    if not isinstance(body["stdout"], str) or not isinstance(body["stderr"], str) or type(body["exit_code"]) is not int or type(body["duration_ms"]) is not int or body["duration_ms"] < 0:
+        raise error("invalid_result")
+    if not isinstance(body["result_idempotency_key"], str) or not body["result_idempotency_key"] or len(body["result_idempotency_key"]) > 128:
+        raise error("invalid_result")
+    if not isinstance(body["payload_hash"], str) or len(body["payload_hash"]) != 64 or any(ch not in "0123456789abcdefABCDEF" for ch in body["payload_hash"]):
+        raise error("invalid_result")
+    require_timestamp(body["started_at"], "started_at"); require_timestamp(body["finished_at"], "finished_at")
+
+def _failure(exc: WorkerControlPlaneError) -> web.Response:
+    return web.json_response({"error": {"code": exc.code, "message": exc.message, "retryable": exc.retryable, "trace_id": str(uuid.uuid4())}}, status=exc.status)
+
+def create_worker_control_plane_app(settings: WorkerControlPlaneSettings, service: WorkerControlPlaneService | None = None) -> web.Application:
+    if not settings.enabled or not settings.test_mode:
+        raise ValueError("Worker Control Plane is test-only in M2B-1")
+    svc = service or WorkerControlPlaneService(settings)
+    app = web.Application(client_max_size=settings.max_body_bytes)
+    app[SERVICE_KEY] = svc
+
+    @web.middleware
+    async def errors(request: web.Request, handler):
+        try:
+            return await handler(request)
+        except WorkerControlPlaneError as exc:
+            return _failure(exc)
+        except web.HTTPRequestEntityTooLarge:
+            return _failure(error("payload_too_large"))
+        except (TypeError, ValueError, KeyError):
+            return _failure(error("malformed_request"))
+        except Exception:
+            return _failure(WorkerControlPlaneError("internal_error", 503, True, "Temporarily unavailable"))
+
+    app.middlewares.append(errors)
+    def audited(event: str):
+        def decorate(handler):
+            async def wrapped(request: web.Request):
+                try:
+                    return await handler(request)
+                except WorkerControlPlaneError as exc:
+                    svc.record_rejection(event, reason_code=exc.code)
+                    if exc.code == "invalid_credential":
+                        svc.record_rejection("credential_failed", reason_code=exc.code)
+                    if exc.code == "idempotency_conflict":
+                        svc.record_rejection("idempotency_conflict", reason_code=exc.code)
+                    raise
+                except (TypeError, ValueError, KeyError):
+                    exc = error("malformed_request")
+                    svc.record_rejection(event, reason_code=exc.code)
+                    raise exc
+            return wrapped
+        return decorate
+
+    @audited("registration_rejected")
+    async def register(request: web.Request):
+        body = await _json(request, REGISTER); _register(body)
+        status, response = svc.register_worker(body, _token(request, "Worker-Bootstrap"))
+        return web.json_response(response, status=status)
+    @audited("heartbeat_rejected")
+    async def heartbeat(request: web.Request):
+        body = await _json(request, HEARTBEAT); _heartbeat(body)
+        return web.json_response(svc.heartbeat(body, _token(request, "Bearer")))
+    @audited("poll_rejected")
+    async def poll(request: web.Request):
+        body = await _json(request, POLL); _poll(body)
+        response = svc.poll_one_task(body, _token(request, "Bearer"), _key(request))
+        return web.Response(status=204) if response is None else web.json_response(response)
+    @audited("ack_rejected")
+    async def ack(request: web.Request):
+        body = await _json(request, ACK); _ack(body)
+        return web.json_response(svc.ack_delivery(request.match_info["task_id"], body, _token(request, "Bearer"), _key(request)))
+    @audited("result_rejected")
+    async def result(request: web.Request):
+        body = await _json(request, RESULT); _result(body, request.match_info["task_id"])
+        return web.json_response(svc.submit_result(request.match_info["task_id"], body, _token(request, "Bearer"), _key(request)))
+    app.router.add_post("/worker/v1/register", register)
+    app.router.add_post("/worker/v1/heartbeat", heartbeat)
+    app.router.add_post("/worker/v1/tasks/poll", poll)
+    app.router.add_post("/worker/v1/tasks/{task_id}/ack", ack)
+    app.router.add_post("/worker/v1/tasks/{task_id}/result", result)
+    return app

--- a/gateway/worker_control_plane/auth.py
+++ b/gateway/worker_control_plane/auth.py
@@ -1,0 +1,21 @@
+"""Test credentials: scrypt bootstrap and opaque access tokens."""
+from __future__ import annotations
+import hashlib, hmac, secrets
+
+SCRYPT = {"n": 2**14, "r": 8, "p": 1, "dklen": 32}
+def bootstrap_record(secret: str) -> tuple[str, str]:
+    salt = secrets.token_bytes(16)
+    digest = hashlib.scrypt(secret.encode(), salt=salt, **SCRYPT)
+    return salt.hex(), digest.hex()
+def verify_bootstrap(secret: str, salt_hex: str, digest_hex: str) -> bool:
+    candidate = hashlib.scrypt(secret.encode(), salt=bytes.fromhex(salt_hex), **SCRYPT)
+    return hmac.compare_digest(candidate.hex(), digest_hex)
+def new_access_token() -> tuple[str, str]:
+    token = secrets.token_urlsafe(32)
+    return token, hashlib.sha256(token.encode()).hexdigest()
+def token_hash(token: str) -> str: return hashlib.sha256(token.encode()).hexdigest()
+def verify_access_token(token: str, stored_digest: str) -> bool:
+    candidate = token_hash(token)
+    if not isinstance(stored_digest, str) or len(stored_digest) != len(candidate):
+        return False
+    return hmac.compare_digest(candidate, stored_digest)

--- a/gateway/worker_control_plane/config.py
+++ b/gateway/worker_control_plane/config.py
@@ -1,0 +1,87 @@
+"""Constructor-injected test-only settings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+_PRODUCTION_DB_NAMES = {
+    "hermes.db",
+    "kanban.db",
+    "sessions.db",
+    "state.db",
+}
+
+
+def resolve_test_database_path(
+    approved_test_root: Path, db_path: Path
+) -> tuple[Path, Path]:
+    """Resolve and confine a test database path without creating anything."""
+    raw_root = Path(approved_test_root)
+    raw_db = Path(db_path)
+    if ".." in raw_root.parts or ".." in raw_db.parts:
+        raise ValueError("database traversal is not allowed")
+    try:
+        root = raw_root.resolve(strict=True)
+    except (OSError, RuntimeError):
+        raise ValueError("approved test root must already exist") from None
+    if not root.is_dir():
+        raise ValueError("approved test root must be a directory")
+    try:
+        parent = raw_db.parent.resolve(strict=False)
+        resolved_db = (parent / raw_db.name).resolve(strict=False)
+        relative = resolved_db.relative_to(root)
+    except (OSError, RuntimeError, ValueError):
+        raise ValueError("test database must be inside the approved test root") from None
+    if relative == Path("."):
+        raise ValueError("database path must name a file below the approved root")
+    if ".hermes" in resolved_db.parts or resolved_db.name.lower() in _PRODUCTION_DB_NAMES:
+        raise ValueError("production-like Hermes database paths are forbidden")
+    return root, resolved_db
+
+
+@dataclass(frozen=True)
+class WorkerControlPlaneSettings:
+    enabled: bool
+    test_mode: bool
+    db_path: Path
+    approved_test_root: Path
+    token_ttl_seconds: int = 300
+    heartbeat_seconds: int = 30
+    ack_deadline_seconds: int = 10
+    lease_seconds: int = 60
+    max_poll_wait_seconds: int = 0
+    max_body_bytes: int = 16 * 1024
+    max_stdout_bytes: int = 4096
+    max_stderr_bytes: int = 4096
+    max_attempts: int = 3
+
+    def __post_init__(self) -> None:
+        if not self.enabled or not self.test_mode:
+            raise ValueError("Worker Control Plane storage requires enabled test mode")
+        for name in (
+            "token_ttl_seconds", "heartbeat_seconds", "ack_deadline_seconds",
+            "lease_seconds", "max_body_bytes", "max_stdout_bytes",
+            "max_stderr_bytes", "max_attempts",
+        ):
+            if getattr(self, name) <= 0:
+                raise ValueError(f"{name} must be positive")
+        if self.max_poll_wait_seconds != 0:
+            raise ValueError("M2B-1 supports only zero-second polling")
+        root, db_path = resolve_test_database_path(
+            self.approved_test_root, self.db_path
+        )
+        object.__setattr__(self, "approved_test_root", root)
+        object.__setattr__(self, "db_path", db_path)
+
+    @classmethod
+    def for_test(
+        cls, db_path: Path, *, approved_test_root: Path
+    ) -> "WorkerControlPlaneSettings":
+        return cls(
+            enabled=True,
+            test_mode=True,
+            db_path=db_path,
+            approved_test_root=approved_test_root,
+        )

--- a/gateway/worker_control_plane/errors.py
+++ b/gateway/worker_control_plane/errors.py
@@ -1,0 +1,24 @@
+"""Domain errors exposed through a single safe envelope."""
+from __future__ import annotations
+from dataclasses import dataclass
+
+@dataclass
+class WorkerControlPlaneError(Exception):
+    code: str
+    status: int = 400
+    retryable: bool = False
+    message: str = "Request rejected"
+
+ERRORS = {
+ "invalid_credential": (401, "Authentication failed"), "worker_revoked": (403, "Worker is revoked"),
+ "worker_not_authorized": (403, "Worker is not authorized"), "task_not_found": (404, "Task not found"),
+ "duplicate_active_instance": (409, "An active instance already exists"), "state_conflict": (409, "State conflict"),
+ "idempotency_conflict": (409, "Idempotency key conflicts with the original request"),
+ "stale_delivery": (409, "Stale delivery"), "registration_expired": (410, "Registration expired"),
+ "lease_expired": (410, "Lease expired"), "payload_too_large": (413, "Payload too large"),
+ "unsupported_protocol": (422, "Unsupported protocol"), "unsupported_capability": (422, "Unsupported capability"),
+ "invalid_task_payload": (422, "Invalid task payload"), "invalid_result": (422, "Invalid result"),
+}
+def error(code: str, *, status: int | None = None, message: str | None = None) -> WorkerControlPlaneError:
+    default_status, default_message = ERRORS.get(code, (400, "Malformed request"))
+    return WorkerControlPlaneError(code, status or default_status, False, message or default_message)

--- a/gateway/worker_control_plane/models.py
+++ b/gateway/worker_control_plane/models.py
@@ -1,0 +1,38 @@
+"""Worker protocol validation and deterministic hashing."""
+from __future__ import annotations
+import hashlib, json, re
+from datetime import datetime, timezone
+from uuid import UUID
+
+WORKER_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{2,127}$")
+
+def canonical_json_hash(value: object) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, ensure_ascii=False, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+def validate_system_echo_payload(payload: object, max_bytes: int = 4096) -> dict[str, str]:
+    if not isinstance(payload, dict) or set(payload) != {"message"}:
+        raise ValueError("invalid_task_payload")
+    message = payload["message"]
+    if not isinstance(message, str) or not message or len(message.encode("utf-8")) > max_bytes:
+        raise ValueError("invalid_task_payload")
+    return {"message": message}
+
+def require_uuid(value: object, name: str) -> str:
+    if not isinstance(value, str): raise ValueError(f"invalid_{name}")
+    try: UUID(value)
+    except (ValueError, TypeError): raise ValueError(f"invalid_{name}") from None
+    return value
+
+def require_worker_id(value: object) -> str:
+    if not isinstance(value, str) or not WORKER_ID_RE.fullmatch(value): raise ValueError("invalid_worker_id")
+    return value
+
+def require_timestamp(value: object, name: str) -> str:
+    if not isinstance(value, str): raise ValueError(f"invalid_{name}")
+    try: datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError: raise ValueError(f"invalid_{name}") from None
+    return value
+
+def closed(data: object, fields: set[str]) -> dict:
+    if not isinstance(data, dict) or set(data) - fields: raise ValueError("malformed_request")
+    return data

--- a/gateway/worker_control_plane/service.py
+++ b/gateway/worker_control_plane/service.py
@@ -1,0 +1,187 @@
+"""Small transactional domain service for test-only system.echo."""
+from __future__ import annotations
+import json, uuid
+from datetime import datetime, timedelta, timezone
+from .auth import bootstrap_record, verify_bootstrap, new_access_token, verify_access_token
+from .config import WorkerControlPlaneSettings
+from .errors import error
+from .models import canonical_json_hash, validate_system_echo_payload
+from .storage import WorkerControlPlaneStore
+
+_NO_REPLAY = object()
+
+class WorkerAuthService:
+ def __init__(self, store, now): self.store,self.now=store,now
+ def bootstrap(self, worker_id, secret):
+  row=self.store.conn.execute("SELECT c.*,w.enabled FROM worker_credentials c JOIN workers w USING(worker_id) WHERE c.worker_id=? AND c.kind='bootstrap' AND c.revoked_at IS NULL",(worker_id,)).fetchone()
+  if not row or not row['enabled'] or not verify_bootstrap(secret,row['salt'],row['token_hash']): raise error('invalid_credential')
+  return row
+ def access(self, token):
+  rows=self.store.conn.execute("SELECT c.worker_id,c.credential_id,c.token_hash,c.expires_at,c.revoked_at,w.enabled,i.instance_id,i.registration_id,i.status FROM worker_credentials c JOIN workers w USING(worker_id) JOIN worker_instances i ON i.access_credential_id=c.credential_id WHERE c.kind='access'").fetchall()
+  row=next((candidate for candidate in rows if verify_access_token(token,candidate['token_hash'])),None)
+  if row is None: raise error('invalid_credential')
+  if not row['enabled'] or row['revoked_at']: raise error('worker_revoked')
+  if row['expires_at'] <= self.now(): raise error('invalid_credential')
+  if row['status'] != 'active': raise error('registration_expired')
+  return row
+
+class WorkerControlPlaneService:
+ def __init__(self, settings, *, now=None):
+  if not settings.enabled or not settings.test_mode: raise ValueError('test mode required')
+  self.settings=settings; self.store=WorkerControlPlaneStore(settings); self._now=now or datetime(2026,1,1,tzinfo=timezone.utc); self.auth=WorkerAuthService(self.store,self.now)
+ def now(self): return self._now.isoformat().replace('+00:00','Z')
+ def advance_for_test(self, seconds): self._now += timedelta(seconds=seconds)
+ def close(self): self.store.close()
+ def _audit(self,c,event,**fields):
+  safe={k:v for k,v in fields.items() if k in {'worker_id','instance_id','registration_id','task_id','delivery_id','trace_id','outcome','reason_code'}}
+  c.execute("INSERT INTO worker_audit_log(occurred_at,event_type,worker_id,instance_id,registration_id,task_id,delivery_id,trace_id,outcome,reason_code) VALUES(?,?,?,?,?,?,?,?,?,?)",(self.now(),event,safe.get('worker_id'),safe.get('instance_id'),safe.get('registration_id'),safe.get('task_id'),safe.get('delivery_id'),safe.get('trace_id'),safe.get('outcome','ok'),safe.get('reason_code')))
+ def record_rejection(self,event,**fields):
+  with self.store.transaction() as c: self._audit(c,event,outcome='rejected',**fields)
+ def seed_test_worker(self):
+  if not self.settings.test_mode: raise RuntimeError('test mode required')
+  secret=__import__('secrets').token_urlsafe(32); salt,digest=bootstrap_record(secret)
+  with self.store.transaction() as c:
+   c.execute("INSERT OR REPLACE INTO workers(worker_id,worker_name,allowed_capabilities,enabled) VALUES(?,?,?,1)",('server-a-worker','test worker','[\"system.echo\"]'))
+   c.execute("INSERT INTO worker_credentials VALUES(?,?,?,?,?,?,?,?)",(str(uuid.uuid4()),'server-a-worker','bootstrap',digest,salt,self.now(),None,None)); self._audit(c,'test_worker_seeded',worker_id='server-a-worker')
+  return secret
+ def revoke_test_worker(self):
+  with self.store.transaction() as c:
+   c.execute("UPDATE workers SET enabled=0,revoked_at=? WHERE worker_id='server-a-worker'",(self.now(),)); self._audit(c,'worker_revoked',worker_id='server-a-worker')
+ def create_test_echo_task(self,payload,key):
+  if not self.settings.test_mode: raise RuntimeError('test mode required')
+  payload=validate_system_echo_payload(payload,self.settings.max_stdout_bytes); task_id=str(uuid.uuid4()); trace=str(uuid.uuid4()); encoded=json.dumps(payload,ensure_ascii=False,sort_keys=True,separators=(',',':'))
+  with self.store.transaction() as c:
+   existing=c.execute("SELECT task_id,payload_hash FROM worker_tasks WHERE creation_idempotency_key=?",(key,)).fetchone()
+   h=canonical_json_hash(payload)
+   if existing:
+    if existing['payload_hash'] != h: raise error('state_conflict')
+    return existing['task_id']
+   c.execute("INSERT INTO worker_tasks VALUES(?,?,?,?,?,?,?,?,?,?,?,?)",(task_id,'system.echo',encoded,h,'queued',self.now(),self.now(),None,0,self.settings.max_attempts,key,trace)); self._audit(c,'test_task_created',task_id=task_id,trace_id=trace)
+  return task_id
+ def register_worker(self,d,secret):
+  if d.get('protocol_version')!='1.0': raise error('unsupported_protocol')
+  if d.get('worker_id')!='server-a-worker' or d.get('capabilities') != ['system.echo']: raise error('unsupported_capability' if d.get('worker_id')=='server-a-worker' else 'invalid_credential')
+  row=self.auth.bootstrap(d['worker_id'],secret); iid=d.get('instance_id')
+  try: uuid.UUID(iid)
+  except Exception: raise error('malformed_request')
+  with self.store.transaction() as c:
+   active=c.execute("SELECT * FROM worker_instances WHERE worker_id=? AND status='active'",(d['worker_id'],)).fetchone()
+   if active and active['instance_id'] != iid: self._audit(c,'registration_rejected',worker_id=d['worker_id'],outcome='rejected',reason_code='duplicate_active_instance'); raise error('duplicate_active_instance')
+   token,thash=new_access_token(); cid=str(uuid.uuid4()); expiry=(self._now+timedelta(seconds=self.settings.token_ttl_seconds)).isoformat().replace('+00:00','Z')
+   if active:
+    c.execute("UPDATE worker_credentials SET revoked_at=? WHERE credential_id=?",(self.now(),active['access_credential_id'])); rid=active['registration_id']; status=200; event='worker_reregistered'
+   else:
+    rid=str(uuid.uuid4()); status=201; event='worker_registered'
+   c.execute("INSERT INTO worker_credentials VALUES(?,?,?,?,?,?,?,?)",(cid,d['worker_id'],'access',thash,None,self.now(),expiry,None))
+   if active: c.execute("UPDATE worker_instances SET access_credential_id=?,last_seen_at=? WHERE registration_id=?",(cid,self.now(),rid))
+   else: c.execute("INSERT INTO worker_instances VALUES(?,?,?,?,?,?,?,?,?,?)",(rid,d['worker_id'],iid,'active',d.get('worker_version','0'),d['protocol_version'],self.now(),self.now(),cid,None))
+   self._audit(c,event,worker_id=d['worker_id'],instance_id=iid,registration_id=rid)
+  return status,{'registration_id':rid,'worker_id':d['worker_id'],'accepted_capabilities':['system.echo'],'access_token':token,'access_token_expires_at':expiry,'heartbeat_interval_seconds':self.settings.heartbeat_seconds,'ack_deadline_seconds':self.settings.ack_deadline_seconds,'lease_seconds':self.settings.lease_seconds,'server_time':self.now()}
+ def _context(self,token,d):
+  row=self.auth.access(token)
+  return self._assert_context(row,d)
+ def _assert_context(self,row,d):
+  if d.get('worker_id')!=row['worker_id'] or d.get('instance_id')!=row['instance_id']: raise error('worker_not_authorized')
+  rid=d.get('registration_id');
+  if rid is not None and rid!=row['registration_id']: raise error('state_conflict')
+  return row
+ def _dedup_replay(self,c,row,d,key,method,route,task_id=''):
+  existing=c.execute("SELECT * FROM worker_request_dedup WHERE worker_id=? AND idempotency_key=?",(row['worker_id'],key)).fetchone()
+  if not existing: return _NO_REPLAY
+  expected=(str(d.get('registration_id') or ''),method,route,task_id,canonical_json_hash(d))
+  actual=(existing['registration_id'],existing['method'],existing['route'],existing['task_id'],existing['request_body_hash'])
+  if actual!=expected: raise error('idempotency_conflict')
+  return json.loads(existing['response_json'])
+ def _dedup_store(self,c,row,d,key,method,route,task_id,response,status):
+  c.execute("INSERT INTO worker_request_dedup VALUES(?,?,?,?,?,?,?,?,?)",(row['worker_id'],str(d.get('registration_id') or ''),method,route,task_id,key,canonical_json_hash(d),status,json.dumps(response)))
+ def heartbeat(self,d,token):
+  row=self._context(token,d)
+  if d.get('status') not in ('idle','busy'): raise error('malformed_request')
+  with self.store.transaction() as c:
+   c.execute("UPDATE worker_instances SET last_seen_at=?,current_task_id=? WHERE registration_id=?",(self.now(),d.get('current_task_id'),row['registration_id'])); self._audit(c,'heartbeat_received',worker_id=row['worker_id'],instance_id=row['instance_id'],registration_id=row['registration_id'])
+  return {'accepted':True,'server_time':self.now(),'next_heartbeat_seconds':self.settings.heartbeat_seconds,'configuration_changed':False,'revoked':False}
+ def _reap(self,c):
+  # Security boundary: ACK is valid only while now < ack_deadline_at.
+  # Equality is expired, and acknowledged work expires at lease equality.
+  rows=c.execute("SELECT d.*,t.max_attempts FROM worker_deliveries d JOIN worker_tasks t USING(task_id) WHERE (d.state='leased' AND d.ack_deadline_at<=?) OR (d.state='acknowledged' AND d.lease_expires_at<=?)",(self.now(),self.now())).fetchall()
+  for r in rows:
+   attempt=r['attempt']; new='dead_letter' if attempt>=r['max_attempts'] else 'queued'
+   c.execute("UPDATE worker_deliveries SET state='expired' WHERE delivery_id=?",(r['delivery_id'],)); c.execute("UPDATE worker_tasks SET state=?,leased_until=NULL WHERE task_id=?",(new,r['task_id'])); self._audit(c,'lease_expired',task_id=r['task_id'],delivery_id=r['delivery_id']); self._audit(c,'task_dead_lettered' if new=='dead_letter' else 'task_redelivered',task_id=r['task_id'],delivery_id=r['delivery_id'])
+ def _dead_letter_exhausted_queued(self,c):
+  rows=c.execute("SELECT task_id FROM worker_tasks WHERE state='queued' AND attempt>=max_attempts").fetchall()
+  for row in rows:
+   c.execute("UPDATE worker_tasks SET state='dead_letter',leased_until=NULL WHERE task_id=?",(row['task_id'],)); self._audit(c,'task_dead_lettered',task_id=row['task_id'],reason_code='max_attempts')
+ def reap_expired_deliveries(self):
+  with self.store.transaction() as c: self._reap(c)
+ def poll_one_task(self,d,token,key):
+  row=self.auth.access(token)
+  with self.store.transaction() as c:
+   replay=self._dedup_replay(c,row,d,key,'POST','/worker/v1/tasks/poll')
+   if replay is not _NO_REPLAY:
+    self._audit(c,'poll_replayed',worker_id=row['worker_id']); return replay
+   self._assert_context(row,d)
+   if type(d.get('max_tasks')) is not int or type(d.get('wait_seconds')) is not int or d.get('max_tasks')!=1 or d.get('wait_seconds')!=0 or d.get('capabilities')!=['system.echo']: raise error('unsupported_capability')
+   self._reap(c); self._dead_letter_exhausted_queued(c)
+   active=c.execute("SELECT 1 FROM worker_deliveries WHERE registration_id=? AND state IN ('leased','acknowledged')",(row['registration_id'],)).fetchone()
+   if active: raise error('state_conflict')
+   task=c.execute("SELECT * FROM worker_tasks WHERE state='queued' ORDER BY available_at,created_at,rowid LIMIT 1").fetchone(); self._audit(c,'poll_received',worker_id=row['worker_id'])
+   if not task:
+    self._dedup_store(c,row,d,key,'POST','/worker/v1/tasks/poll','',None,204); self._audit(c,'poll_no_task',worker_id=row['worker_id']); return None
+   attempt=task['attempt']+1; did=str(uuid.uuid4()); ack=(self._now+timedelta(seconds=self.settings.ack_deadline_seconds)).isoformat().replace('+00:00','Z'); lease=(self._now+timedelta(seconds=self.settings.lease_seconds)).isoformat().replace('+00:00','Z')
+   c.execute("UPDATE worker_tasks SET state='leased',attempt=?,leased_until=? WHERE task_id=?",(attempt,lease,task['task_id'])); c.execute("INSERT INTO worker_deliveries VALUES(?,?,?,?,?,?,?,?,?,?,?)",(did,task['task_id'],row['worker_id'],row['registration_id'],attempt,'leased',self.now(),ack,lease,None,None)); env={'task':{'task_id':task['task_id'],'delivery_id':did,'task_type':'system.echo','payload':json.loads(task['payload_json']),'payload_hash':task['payload_hash'],'trace_id':task['trace_id'],'attempt':attempt,'max_attempts':task['max_attempts'],'ack_deadline_at':ack,'lease_expires_at':lease}}
+   self._dedup_store(c,row,d,key,'POST','/worker/v1/tasks/poll','',env,200); self._audit(c,'task_leased',worker_id=row['worker_id'],task_id=task['task_id'],delivery_id=did,trace_id=task['trace_id']); return env
+ def ack_delivery(self,task_id,d,token,key):
+  row=self.auth.access(token)
+  late=False; out=None
+  with self.store.transaction() as c:
+   replay=self._dedup_replay(c,row,d,key,'POST','/worker/v1/tasks/{task_id}/ack',task_id)
+   if replay is not _NO_REPLAY: return replay
+   self._assert_context(row,d); self._reap(c)
+   delivery=c.execute("SELECT d.*,t.attempt AS task_attempt,t.max_attempts AS task_max_attempts FROM worker_deliveries d JOIN worker_tasks t USING(task_id) WHERE d.delivery_id=? AND d.task_id=?",(d.get('delivery_id'),task_id)).fetchone()
+   if not delivery: raise error('stale_delivery')
+   if delivery['worker_id']!=row['worker_id'] or delivery['registration_id']!=row['registration_id']: raise error('worker_not_authorized')
+   if delivery['state']=='expired':
+    late=True
+   elif delivery['state']!='leased':
+    raise error('state_conflict')
+   else:
+    accepted=d.get('accepted'); reason=d.get('reason')
+    if accepted is True: ds,ts,event='acknowledged','running','task_acknowledged'
+    elif accepted is False and reason=='temporary' and delivery['task_attempt']>=delivery['task_max_attempts']: ds,ts,event='rejected','dead_letter','task_dead_lettered'
+    elif accepted is False and reason=='temporary': ds,ts,event='rejected','queued','task_rejected'
+    elif accepted is False and reason=='permanent': ds,ts,event='rejected','rejected','task_rejected'
+    else: raise error('malformed_request')
+    c.execute("UPDATE worker_deliveries SET state=?,acknowledged_at=? WHERE delivery_id=?",(ds,self.now() if accepted else None,delivery['delivery_id'])); c.execute("UPDATE worker_tasks SET state=?,leased_until=CASE WHEN ?='running' THEN leased_until ELSE NULL END WHERE task_id=?",(ts,ts,task_id)); out={'accepted':bool(accepted),'task_state':ts,'lease_expires_at':delivery['lease_expires_at'],'server_time':self.now()}; self._dedup_store(c,row,d,key,'POST','/worker/v1/tasks/{task_id}/ack',task_id,out,200); self._audit(c,event,worker_id=row['worker_id'],task_id=task_id,delivery_id=delivery['delivery_id'],reason_code=reason)
+  if late: raise error('lease_expired')
+  return out
+ def submit_result(self,task_id,d,token,key):
+  row=self.auth.access(token)
+  late=False; out=None
+  if d.get('task_id') != task_id or d.get('task_type')!='system.echo' or d.get('status') not in ('completed','failed','rejected','cancelled','expired'): raise error('invalid_result')
+  if not isinstance(d.get('stdout'),str) or not isinstance(d.get('stderr'),str) or len(d['stdout'].encode())>self.settings.max_stdout_bytes or len(d['stderr'].encode())>self.settings.max_stderr_bytes: raise error('payload_too_large')
+  with self.store.transaction() as c:
+   replay=self._dedup_replay(c,row,d,key,'POST','/worker/v1/tasks/{task_id}/result',task_id)
+   if replay is not _NO_REPLAY: return replay
+   self._assert_context(row,d); self._reap(c); delivery=c.execute("SELECT d.*,t.payload_hash,t.payload_json,t.trace_id,t.task_type,t.state AS task_state FROM worker_deliveries d JOIN worker_tasks t USING(task_id) WHERE d.delivery_id=? AND d.task_id=?",(d.get('delivery_id'),task_id)).fetchone()
+   if not delivery: raise error('stale_delivery')
+   if delivery['worker_id']!=row['worker_id'] or delivery['registration_id']!=row['registration_id']: raise error('worker_not_authorized')
+   if delivery['task_type']!=d.get('task_type'): raise error('invalid_result')
+   result_hash=canonical_json_hash(d); existing=c.execute("SELECT result_hash FROM worker_results WHERE task_id=? AND result_idempotency_key=?",(task_id,d.get('result_idempotency_key'))).fetchone()
+   if existing:
+    if existing['result_hash']!=result_hash: raise error('idempotency_conflict')
+    out={'accepted':True,'duplicate':True,'task_state':delivery['task_state'],'server_time':self.now()}; self._dedup_store(c,row,d,key,'POST','/worker/v1/tasks/{task_id}/result',task_id,out,200); return out
+   if delivery['state']=='expired':
+    late=True
+   elif delivery['state']!='acknowledged':
+    raise error('state_conflict')
+   else:
+    if d.get('payload_hash')!=delivery['payload_hash'] or d.get('trace_id')!=delivery['trace_id']: raise error('invalid_result')
+    message=json.loads(delivery['payload_json'])['message']
+    if d['status']=='completed' and (d['stdout']!=message or d['stderr']!='' or d.get('exit_code')!=0): raise error('invalid_result')
+    c.execute("INSERT INTO worker_results VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)",(str(uuid.uuid4()),task_id,delivery['delivery_id'],d['result_idempotency_key'],result_hash,d['status'],d['stdout'],d['stderr'],d.get('exit_code'),d['started_at'],d['finished_at'],d['duration_ms'],self.now()))
+    state='completed' if d['status']=='completed' else ('rejected' if d['status']=='rejected' else 'failed'); c.execute("UPDATE worker_deliveries SET state='completed',finished_at=? WHERE delivery_id=?",(self.now(),delivery['delivery_id'])); c.execute("UPDATE worker_tasks SET state=?,leased_until=NULL WHERE task_id=?",(state,task_id)); out={'accepted':True,'duplicate':False,'task_state':state,'server_time':self.now()}; self._dedup_store(c,row,d,key,'POST','/worker/v1/tasks/{task_id}/result',task_id,out,200); self._audit(c,'result_accepted',worker_id=row['worker_id'],task_id=task_id,delivery_id=delivery['delivery_id'],trace_id=delivery['trace_id'])
+  if late: raise error('lease_expired')
+  return out
+ def task_state(self,task_id): return self.store.conn.execute("SELECT state FROM worker_tasks WHERE task_id=?",(task_id,)).fetchone()['state']
+ def result_count(self,task_id): return self.store.conn.execute("SELECT count(*) FROM worker_results WHERE task_id=?",(task_id,)).fetchone()[0]
+ def audit_text(self): return '\n'.join(str(tuple(r)) for r in self.store.conn.execute("SELECT * FROM worker_audit_log"))

--- a/gateway/worker_control_plane/storage.py
+++ b/gateway/worker_control_plane/storage.py
@@ -1,0 +1,40 @@
+"""Dedicated SQLite persistence for the test-only control plane."""
+from __future__ import annotations
+import sqlite3
+from contextlib import contextmanager
+
+from .config import WorkerControlPlaneSettings, resolve_test_database_path
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS schema_migrations(version TEXT PRIMARY KEY, applied_at TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS workers(worker_id TEXT PRIMARY KEY, worker_name TEXT NOT NULL, allowed_capabilities TEXT NOT NULL, enabled INTEGER NOT NULL, revoked_at TEXT);
+CREATE TABLE IF NOT EXISTS worker_credentials(credential_id TEXT PRIMARY KEY, worker_id TEXT NOT NULL REFERENCES workers(worker_id), kind TEXT NOT NULL, token_hash TEXT NOT NULL UNIQUE, salt TEXT, issued_at TEXT NOT NULL, expires_at TEXT, revoked_at TEXT);
+CREATE TABLE IF NOT EXISTS worker_instances(registration_id TEXT PRIMARY KEY, worker_id TEXT NOT NULL REFERENCES workers(worker_id), instance_id TEXT NOT NULL, status TEXT NOT NULL, worker_version TEXT NOT NULL, protocol_version TEXT NOT NULL, registered_at TEXT NOT NULL, last_seen_at TEXT NOT NULL, access_credential_id TEXT NOT NULL REFERENCES worker_credentials(credential_id), current_task_id TEXT, UNIQUE(worker_id, instance_id));
+CREATE TABLE IF NOT EXISTS worker_tasks(task_id TEXT PRIMARY KEY, task_type TEXT NOT NULL CHECK(task_type='system.echo'), payload_json TEXT NOT NULL, payload_hash TEXT NOT NULL, state TEXT NOT NULL, created_at TEXT NOT NULL, available_at TEXT NOT NULL, leased_until TEXT, attempt INTEGER NOT NULL, max_attempts INTEGER NOT NULL, creation_idempotency_key TEXT NOT NULL UNIQUE, trace_id TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS worker_deliveries(delivery_id TEXT PRIMARY KEY, task_id TEXT NOT NULL REFERENCES worker_tasks(task_id), worker_id TEXT NOT NULL, registration_id TEXT NOT NULL REFERENCES worker_instances(registration_id), attempt INTEGER NOT NULL, state TEXT NOT NULL, leased_at TEXT NOT NULL, ack_deadline_at TEXT NOT NULL, lease_expires_at TEXT NOT NULL, acknowledged_at TEXT, finished_at TEXT, UNIQUE(task_id, attempt));
+CREATE TABLE IF NOT EXISTS worker_results(result_id TEXT PRIMARY KEY, task_id TEXT NOT NULL REFERENCES worker_tasks(task_id), delivery_id TEXT NOT NULL UNIQUE REFERENCES worker_deliveries(delivery_id), result_idempotency_key TEXT NOT NULL, result_hash TEXT NOT NULL, status TEXT NOT NULL, stdout TEXT NOT NULL, stderr TEXT NOT NULL, exit_code INTEGER, started_at TEXT NOT NULL, finished_at TEXT NOT NULL, duration_ms INTEGER NOT NULL, accepted_at TEXT NOT NULL, UNIQUE(task_id, result_idempotency_key));
+CREATE TABLE IF NOT EXISTS worker_request_dedup(worker_id TEXT NOT NULL, registration_id TEXT NOT NULL, method TEXT NOT NULL, route TEXT NOT NULL, task_id TEXT NOT NULL, idempotency_key TEXT NOT NULL, request_body_hash TEXT NOT NULL, response_status INTEGER NOT NULL, response_json TEXT NOT NULL, PRIMARY KEY(worker_id, idempotency_key));
+CREATE TABLE IF NOT EXISTS worker_audit_log(audit_id INTEGER PRIMARY KEY, occurred_at TEXT NOT NULL, event_type TEXT NOT NULL, worker_id TEXT, instance_id TEXT, registration_id TEXT, task_id TEXT, delivery_id TEXT, trace_id TEXT, outcome TEXT NOT NULL, reason_code TEXT, details_json TEXT);
+CREATE INDEX IF NOT EXISTS idx_tasks_queue ON worker_tasks(state,available_at,created_at);
+CREATE INDEX IF NOT EXISTS idx_deliveries_lease ON worker_deliveries(state,lease_expires_at);
+"""
+class WorkerControlPlaneStore:
+ def __init__(self, settings: WorkerControlPlaneSettings):
+  if not isinstance(settings, WorkerControlPlaneSettings):
+   raise TypeError("WorkerControlPlaneStore requires validated settings")
+  if not settings.enabled or not settings.test_mode:
+   raise ValueError("Worker Control Plane storage requires enabled test mode")
+  root,path=resolve_test_database_path(settings.approved_test_root,settings.db_path)
+  if root != settings.approved_test_root:
+   raise ValueError("approved test root changed after settings validation")
+  self.conn=sqlite3.connect(path, check_same_thread=False); self.conn.row_factory=sqlite3.Row
+  self.conn.execute("PRAGMA foreign_keys=ON"); self.conn.execute("PRAGMA synchronous=FULL"); self.conn.execute("PRAGMA secure_delete=ON"); self.conn.execute("PRAGMA cell_size_check=ON")
+  try: self.conn.execute("PRAGMA journal_mode=WAL")
+  except sqlite3.DatabaseError: self.conn.execute("PRAGMA journal_mode=DELETE")
+  self.conn.executescript(SCHEMA); self.conn.execute("INSERT OR IGNORE INTO schema_migrations VALUES('worker_control_plane_schema_v1',datetime('now'))"); self.conn.commit()
+ @contextmanager
+ def transaction(self):
+  try:
+   self.conn.execute("BEGIN IMMEDIATE"); yield self.conn; self.conn.commit()
+  except Exception: self.conn.rollback(); raise
+ def close(self): self.conn.close()

--- a/tests/gateway/test_worker_control_plane.py
+++ b/tests/gateway/test_worker_control_plane.py
@@ -1,0 +1,723 @@
+"""Behavioral tests for the isolated, test-only Worker Control Plane."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import os
+import uuid
+
+import pytest
+import pytest_asyncio
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.worker_control_plane.app import create_worker_control_plane_app
+from gateway.worker_control_plane.config import WorkerControlPlaneSettings
+from gateway.worker_control_plane.service import WorkerControlPlaneService
+from tests.gateway.worker_control_plane_helpers import MockWorkerClient
+
+
+@pytest_asyncio.fixture
+async def control_plane(tmp_path):
+    settings = WorkerControlPlaneSettings.for_test(
+        tmp_path / "worker-control-plane.db", approved_test_root=tmp_path
+    )
+    service = WorkerControlPlaneService(settings)
+    secret = service.seed_test_worker()
+    app = create_worker_control_plane_app(settings, service)
+    server = TestServer(app)
+    client = TestClient(server)
+    await client.start_server()
+    try:
+        yield service, client, secret
+    finally:
+        await client.close()
+        service.close()
+
+
+def _register_direct_test_worker(service):
+    secret = service.seed_test_worker()
+    instance_id = str(uuid.uuid4())
+    status, response = service.register_worker(
+        {
+            "protocol_version": "1.0",
+            "worker_id": "server-a-worker",
+            "instance_id": instance_id,
+            "worker_name": "test worker",
+            "worker_version": "0.1.0",
+            "capabilities": ["system.echo"],
+        },
+        secret,
+    )
+    assert status == 201
+    identity = {
+        "worker_id": "server-a-worker",
+        "instance_id": instance_id,
+        "registration_id": response["registration_id"],
+    }
+    return identity, response["access_token"]
+
+
+def _direct_poll(service, identity, token, key):
+    return service.poll_one_task(
+        identity
+        | {
+            "capabilities": ["system.echo"],
+            "max_tasks": 1,
+            "wait_seconds": 0,
+        },
+        token,
+        key,
+    )
+
+
+def _direct_temporary_nack(service, identity, token, task, key):
+    return service.ack_delivery(
+        task["task_id"],
+        identity
+        | {
+            "delivery_id": task["delivery_id"],
+            "accepted": False,
+            "reason": "temporary",
+            "worker_time": "2026-01-01T00:00:00Z",
+        },
+        token,
+        key,
+    )
+
+
+@pytest.mark.asyncio
+async def test_full_echo_lifecycle_and_idempotent_result(control_plane):
+    service, client, secret = control_plane
+    worker = MockWorkerClient(client, secret)
+    assert (await worker.register())[0] == 201
+    task_id = service.create_test_echo_task({"message": "你好 🌍"}, "create-1")
+    assert (await worker.heartbeat())[0] == 200
+    status, envelope = await worker.poll()
+    assert status == 200
+    task = envelope["task"]
+    assert task["task_id"] == task_id
+    assert (await worker.ack(task))[0] == 200
+    status, body = await worker.result(task)
+    assert status == 200 and body["task_state"] == "completed"
+    status, replay = await worker.result(task)
+    assert status == 200 and replay == body
+    assert service.task_state(task_id) == "completed"
+    assert service.result_count(task_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_registration_auth_capability_and_instance_guards(control_plane):
+    _, client, secret = control_plane
+    bad = MockWorkerClient(client, "not-the-secret")
+    assert (await bad.register())[0] == 401
+    unknown = MockWorkerClient(client, secret, worker_id="unknown-worker")
+    assert (await unknown.register())[0] == 401
+    worker = MockWorkerClient(client, secret)
+    assert (await worker.register(capabilities=["codex.task"]))[0] == 422
+    assert (await worker.register(protocol_version="2.0"))[0] == 422
+    assert (await worker.register())[0] == 201
+    assert (await worker.register())[0] == 200
+    second = MockWorkerClient(client, secret)
+    assert (await second.register())[0] == 409
+
+
+@pytest.mark.asyncio
+async def test_poll_ack_result_validation_and_fifo(control_plane):
+    service, client, secret = control_plane
+    worker = MockWorkerClient(client, secret)
+    await worker.register()
+    assert (await worker.poll())[0] == 204
+    first = service.create_test_echo_task({"message": "first"}, "fifo-1")
+    service.create_test_echo_task({"message": "second"}, "fifo-2")
+    status, envelope = await worker.poll("same-poll")
+    assert status == 200 and envelope["task"]["task_id"] == first
+    status2, replay = await worker.poll("same-poll")
+    assert status2 == 200 and replay["task"]["delivery_id"] == envelope["task"]["delivery_id"]
+    task = envelope["task"]
+    assert (await worker.ack(task))[0] == 200
+    wrong_hash = dict(task)
+    wrong_hash["payload_hash"] = "0" * 64
+    assert (await worker.result(wrong_hash))[0] == 422
+    assert (await worker.result(task, stdout="not echo", result_key="bad-result", request_key="bad-request"))[0] == 422
+    assert (await worker.result(task))[0] == 200
+
+
+@pytest.mark.asyncio
+async def test_negative_ack_expiry_redelivery_and_dead_letter(control_plane):
+    service, client, secret = control_plane
+    worker = MockWorkerClient(client, secret)
+    await worker.register()
+    task_id = service.create_test_echo_task({"message": "retry"}, "retry-1")
+    _, env = await worker.poll("p1")
+    task = env["task"]
+    assert (await worker.ack(task, accepted=False, reason="temporary", key="a1"))[0] == 200
+    _, env = await worker.poll("p2")
+    task = env["task"]
+    service.advance_for_test(120)
+    service.reap_expired_deliveries()
+    assert service.task_state(task_id) == "queued"
+    for index in range(3):
+        _, env = await worker.poll(f"expire-{index}")
+        if env is None:
+            break
+        service.advance_for_test(120)
+        service.reap_expired_deliveries()
+    assert service.task_state(task_id) == "dead_letter"
+
+
+@pytest.mark.asyncio
+async def test_wrong_registration_revocation_and_size_limits_are_safe(control_plane):
+    service, client, secret = control_plane
+    worker = MockWorkerClient(client, secret)
+    await worker.register()
+    task_id = service.create_test_echo_task({"message": "x"}, "size-1")
+    _, env = await worker.poll()
+    task = env["task"]
+    original = worker.registration_id
+    worker.registration_id = str(uuid.uuid4())
+    assert (await worker.heartbeat())[0] == 409
+    worker.registration_id = original
+    assert (await worker.ack(task))[0] == 200
+    assert (await worker.result(task, stdout="x" * 5000))[0] == 413
+    service.revoke_test_worker()
+    assert (await worker.heartbeat())[0] == 403
+    audit = service.audit_text()
+    assert secret not in audit and (worker.access_token or "") not in audit
+    assert service.task_state(task_id) == "running"
+
+
+def test_closed_echo_schema_and_no_production_dependencies(tmp_path):
+    from gateway.worker_control_plane.models import validate_system_echo_payload
+    from gateway.worker_control_plane import app, auth, service, storage
+
+    assert validate_system_echo_payload({"message": "x"}) == {"message": "x"}
+    for invalid in ({}, {"message": ""}, {"message": ["x"]}, {"message": "x", "command": "id"}):
+        with pytest.raises(ValueError):
+            validate_system_echo_payload(invalid)
+    settings = WorkerControlPlaneSettings.for_test(
+        tmp_path / "x.db", approved_test_root=tmp_path
+    )
+    with pytest.raises(ValueError):
+        create_worker_control_plane_app(
+            WorkerControlPlaneSettings(
+                False, True, tmp_path / "x2.db", approved_test_root=tmp_path
+            )
+        )
+    source = "\n".join(inspect.getsource(module) for module in (app, auth, service, storage))
+    for forbidden in ("subprocess", "os.system", "kanban.db", "SessionDB", "state.db", "C:\\\\HermesServerWorker", "/v1/runs"):
+        assert forbidden not in source
+
+
+@pytest.mark.asyncio
+async def test_closed_schema_ack_deadline_and_idempotency_conflicts(control_plane):
+    service, client, secret = control_plane
+    worker = MockWorkerClient(client, secret)
+    assert (await worker.register())[0] == 201
+    body = worker.base() | {"capabilities": ["system.echo"], "max_tasks": 1, "wait_seconds": 0, "extra": True}
+    response = await client.post("/worker/v1/tasks/poll", headers=worker.headers("closed"), json=body)
+    assert response.status == 400
+    task_id = service.create_test_echo_task({"message": "deadline"}, "deadline-create")
+    _, envelope = await worker.poll("deadline-poll")
+    task = envelope["task"]
+    service.advance_for_test(11)
+    assert (await worker.ack(task, key="deadline-ack"))[0] == 410
+    assert service.task_state(task_id) == "queued"
+    _, envelope = await worker.poll("redelivery-poll")
+    task = envelope["task"]
+    assert (await worker.ack(task, key="same-key"))[0] == 200
+    conflicting = worker.base() | {"delivery_id": task["delivery_id"], "accepted": False, "reason": "temporary", "worker_time": "2026-01-01T00:00:00Z"}
+    response = await client.post(f"/worker/v1/tasks/{task_id}/ack", headers=worker.headers("same-key"), json=conflicting)
+    assert response.status == 409
+    wrong_body = worker.base() | {"task_id": str(uuid.uuid4()), "delivery_id": task["delivery_id"], "task_type": "system.echo", "status": "completed", "stdout": "deadline", "stderr": "", "exit_code": 0, "started_at": "2026-01-01T00:00:00Z", "finished_at": "2026-01-01T00:00:00Z", "duration_ms": 0, "result_idempotency_key": "wrong-task", "payload_hash": task["payload_hash"], "trace_id": task["trace_id"]}
+    response = await client.post(f"/worker/v1/tasks/{task_id}/result", headers=worker.headers("wrong-task-request"), json=wrong_body)
+    assert response.status == 422
+
+
+def test_test_settings_reject_non_temporary_database_path():
+    with pytest.raises(ValueError):
+        WorkerControlPlaneSettings.for_test(
+            __import__("pathlib").Path("/home/boonl/not-test-worker.db"),
+            approved_test_root=__import__("pathlib").Path("/tmp"),
+        )
+
+
+def test_sqlite_path_is_confined_to_explicit_approved_root(tmp_path):
+    approved = tmp_path / "approved"
+    approved.mkdir()
+    valid = approved / "worker-control-plane.db"
+    settings = WorkerControlPlaneSettings.for_test(valid, approved_test_root=approved)
+    assert settings.db_path == valid.resolve()
+    assert settings.approved_test_root == approved.resolve()
+
+    outside = tmp_path / "outside.db"
+    with pytest.raises(ValueError):
+        WorkerControlPlaneSettings.for_test(outside, approved_test_root=approved)
+    assert not outside.exists()
+
+    traversal = approved / "nested" / ".." / "escape.db"
+    with pytest.raises(ValueError):
+        WorkerControlPlaneSettings.for_test(traversal, approved_test_root=approved)
+    assert not traversal.resolve().exists()
+
+
+def test_sqlite_path_rejects_symlink_escape_and_production_like_names(tmp_path):
+    approved = tmp_path / "approved"
+    approved.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = approved / "link"
+    try:
+        os.symlink(outside, link, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable")
+    escaped = link / "worker-control-plane.db"
+    with pytest.raises(ValueError):
+        WorkerControlPlaneSettings.for_test(escaped, approved_test_root=approved)
+    assert not (outside / "worker-control-plane.db").exists()
+
+    production = approved / ".hermes" / "state.db"
+    with pytest.raises(ValueError):
+        WorkerControlPlaneSettings.for_test(production, approved_test_root=approved)
+    assert not production.exists()
+    assert not production.parent.exists()
+
+
+def test_store_revalidates_path_after_delayed_symlink_escape(tmp_path):
+    from gateway.worker_control_plane.storage import WorkerControlPlaneStore
+
+    approved = tmp_path / "approved"
+    approved.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    child = approved / "child"
+    outside_db = outside / "worker-control-plane.db"
+    settings = WorkerControlPlaneSettings.for_test(
+        child / "worker-control-plane.db", approved_test_root=approved
+    )
+
+    try:
+        os.symlink(outside, child, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable")
+
+    with pytest.raises(ValueError):
+        WorkerControlPlaneStore(settings)
+    assert not outside_db.exists()
+
+
+def test_store_connect_time_revalidation_accepts_unchanged_path(tmp_path):
+    from gateway.worker_control_plane.storage import WorkerControlPlaneStore
+
+    approved = tmp_path / "approved"
+    approved.mkdir()
+    child = approved / "child"
+    db_path = child / "worker-control-plane.db"
+    settings = WorkerControlPlaneSettings.for_test(
+        db_path, approved_test_root=approved
+    )
+    child.mkdir()
+
+    store = WorkerControlPlaneStore(settings)
+    try:
+        assert db_path.exists()
+    finally:
+        store.close()
+
+
+def test_store_and_service_require_test_mode(tmp_path):
+    from gateway.worker_control_plane.storage import WorkerControlPlaneStore
+
+    with pytest.raises(ValueError):
+        settings = WorkerControlPlaneSettings(
+            enabled=True,
+            test_mode=False,
+            db_path=tmp_path / "disabled.db",
+            approved_test_root=tmp_path,
+        )
+        WorkerControlPlaneService(settings)
+    assert not (tmp_path / "disabled.db").exists()
+
+    with pytest.raises((TypeError, ValueError)):
+        WorkerControlPlaneStore(tmp_path / "direct.db")
+    assert not (tmp_path / "direct.db").exists()
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_binds_endpoint_and_empty_poll(control_plane):
+    service, client, secret = control_plane
+    worker = MockWorkerClient(client, secret)
+    assert (await worker.register())[0] == 201
+
+    assert (await worker.poll("empty-replay"))[0] == 204
+    service.create_test_echo_task({"message": "later"}, "empty-later")
+    assert (await worker.poll("empty-replay"))[0] == 204
+
+    _, envelope = await worker.poll("lease-later")
+    task = envelope["task"]
+    status, body = await worker.ack(task, key="empty-replay")
+    assert status == 409
+    assert body["error"]["code"] == "idempotency_conflict"
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_binds_body_registration_and_task(control_plane):
+    service, client, secret = control_plane
+    worker = MockWorkerClient(client, secret)
+    assert (await worker.register())[0] == 201
+    assert (await worker.poll("identity-key"))[0] == 204
+
+    changed_registration = worker.base() | {
+        "registration_id": str(uuid.uuid4()),
+        "capabilities": ["system.echo"],
+        "max_tasks": 1,
+        "wait_seconds": 0,
+    }
+    response = await client.post(
+        "/worker/v1/tasks/poll",
+        headers=worker.headers("identity-key"),
+        json=changed_registration,
+    )
+    body = await response.json()
+    assert response.status == 409
+    assert body["error"]["code"] == "idempotency_conflict"
+
+    first = service.create_test_echo_task({"message": "first"}, "task-key-first")
+    _, first_envelope = await worker.poll("first-lease")
+    assert first_envelope["task"]["task_id"] == first
+    assert (await worker.ack(first_envelope["task"], accepted=False, reason="permanent", key="task-bound"))[0] == 200
+
+    second = service.create_test_echo_task({"message": "second"}, "task-key-second")
+    _, second_envelope = await worker.poll("second-lease")
+    assert second_envelope["task"]["task_id"] == second
+    status, body = await worker.ack(second_envelope["task"], accepted=False, reason="permanent", key="task-bound")
+    assert status == 409
+    assert body["error"]["code"] == "idempotency_conflict"
+
+
+@pytest.mark.asyncio
+async def test_result_http_idempotency_replays_and_conflicts_before_mutation(control_plane):
+    service, client, secret = control_plane
+    worker = MockWorkerClient(client, secret)
+    assert (await worker.register())[0] == 201
+    service.create_test_echo_task({"message": "one"}, "result-one")
+    _, envelope = await worker.poll("result-poll-one")
+    task = envelope["task"]
+    assert (await worker.ack(task, key="result-ack-one"))[0] == 200
+
+    status, accepted = await worker.result(task, result_key="body-result-one", request_key="http-result-key")
+    assert status == 200 and accepted["duplicate"] is False
+    status, replay = await worker.result(task, result_key="body-result-one", request_key="http-result-key")
+    assert status == 200 and replay == accepted
+
+    changed = worker.base() | {
+        "task_id": task["task_id"],
+        "delivery_id": task["delivery_id"],
+        "task_type": "system.echo",
+        "status": "failed",
+        "stdout": "changed",
+        "stderr": "",
+        "exit_code": 1,
+        "started_at": "2026-01-01T00:00:00Z",
+        "finished_at": "2026-01-01T00:00:00Z",
+        "duration_ms": 1,
+        "result_idempotency_key": "body-result-changed",
+        "payload_hash": task["payload_hash"],
+        "trace_id": task["trace_id"],
+    }
+    response = await client.post(
+        f'/worker/v1/tasks/{task["task_id"]}/result',
+        headers=worker.headers("http-result-key"),
+        json=changed,
+    )
+    body = await response.json()
+    assert response.status == 409
+    assert body["error"]["code"] == "idempotency_conflict"
+
+    service.create_test_echo_task({"message": "two"}, "result-two")
+    _, envelope = await worker.poll("result-poll-two")
+    second = envelope["task"]
+    assert (await worker.ack(second, key="result-ack-two"))[0] == 200
+    status, body = await worker.result(second, result_key="body-result-two", request_key="http-result-key")
+    assert status == 409
+    assert body["error"]["code"] == "idempotency_conflict"
+    assert service.task_state(second["task_id"]) == "running"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("field", "value"), (("max_tasks", True), ("wait_seconds", False)))
+async def test_poll_rejects_boolean_integer_fields(control_plane, field, value):
+    _, client, secret = control_plane
+    worker = MockWorkerClient(client, secret)
+    assert (await worker.register())[0] == 201
+    body = worker.base() | {"capabilities": ["system.echo"], "max_tasks": 1, "wait_seconds": 0}
+    body[field] = value
+    response = await client.post("/worker/v1/tasks/poll", headers=worker.headers(f"bool-{field}"), json=body)
+    assert response.status == 400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("current_task_id", ("not-a-uuid", {"task_id": str(uuid.uuid4()), "extra": True}))
+async def test_heartbeat_rejects_invalid_or_nested_current_task_id(control_plane, current_task_id):
+    _, client, secret = control_plane
+    worker = MockWorkerClient(client, secret)
+    assert (await worker.register())[0] == 201
+    status, _ = await worker.heartbeat(current_task_id=current_task_id)
+    assert status == 400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("field", "value"), (("exit_code", True), ("duration_ms", False)))
+async def test_result_rejects_boolean_integer_fields(control_plane, field, value):
+    service, client, secret = control_plane
+    worker = MockWorkerClient(client, secret)
+    assert (await worker.register())[0] == 201
+    service.create_test_echo_task({"message": "types"}, f"types-{field}")
+    _, envelope = await worker.poll(f"types-poll-{field}")
+    task = envelope["task"]
+    assert (await worker.ack(task, key=f"types-ack-{field}"))[0] == 200
+    body = worker.base() | {
+        "task_id": task["task_id"],
+        "delivery_id": task["delivery_id"],
+        "task_type": "system.echo",
+        "status": "failed",
+        "stdout": "",
+        "stderr": "",
+        "exit_code": 1,
+        "started_at": "2026-01-01T00:00:00Z",
+        "finished_at": "2026-01-01T00:00:00Z",
+        "duration_ms": 1,
+        "result_idempotency_key": f"types-result-{field}",
+        "payload_hash": task["payload_hash"],
+        "trace_id": task["trace_id"],
+    }
+    body[field] = value
+    response = await client.post(
+        f'/worker/v1/tasks/{task["task_id"]}/result',
+        headers=worker.headers(f"types-http-{field}"),
+        json=body,
+    )
+    assert response.status == 422
+
+
+@pytest.mark.asyncio
+async def test_missing_null_and_unknown_fields_are_deterministic(control_plane):
+    _, client, secret = control_plane
+    worker = MockWorkerClient(client, secret)
+    assert (await worker.register())[0] == 201
+    base = worker.base() | {"status": "idle", "current_task_id": None, "worker_time": "2026-01-01T00:00:00Z"}
+    missing = dict(base)
+    missing.pop("status")
+    extra = base | {"extra": {"nested": True}}
+    wrong_null = base | {"status": None}
+    for body in (missing, extra, wrong_null):
+        response = await client.post("/worker/v1/heartbeat", headers=worker.headers(), json=body)
+        assert response.status == 400
+
+
+@pytest.mark.asyncio
+async def test_temporary_nack_cannot_exceed_retry_limit(control_plane):
+    service, _, secret = control_plane
+    worker = MockWorkerClient(control_plane[1], secret)
+    assert (await worker.register())[0] == 201
+    task_id = service.create_test_echo_task({"message": "bounded"}, "bounded-retry")
+    for attempt in range(1, service.settings.max_attempts + 1):
+        status, envelope = await worker.poll(f"bounded-poll-{attempt}")
+        assert status == 200
+        status, body = await worker.ack(
+            envelope["task"],
+            accepted=False,
+            reason="temporary",
+            key=f"bounded-ack-{attempt}",
+        )
+        assert status == 200
+        expected = "queued" if attempt < service.settings.max_attempts else "dead_letter"
+        assert body["task_state"] == expected
+        assert service.task_state(task_id) == expected
+    assert (await worker.poll("bounded-after"))[0] == 204
+    assert service.store.conn.execute(
+        "SELECT max(attempt) FROM worker_deliveries WHERE task_id=?", (task_id,)
+    ).fetchone()[0] == service.settings.max_attempts
+    assert "task_dead_lettered" in service.audit_text()
+
+
+def test_temporary_nack_uses_persisted_limit_after_config_increase(tmp_path):
+    db_path = tmp_path / "persisted-increase.db"
+    initial_settings = WorkerControlPlaneSettings(
+        enabled=True,
+        test_mode=True,
+        db_path=db_path,
+        approved_test_root=tmp_path,
+        max_attempts=2,
+    )
+    service = WorkerControlPlaneService(initial_settings)
+    try:
+        identity, token = _register_direct_test_worker(service)
+        task_id = service.create_test_echo_task(
+            {"message": "persisted increase"}, "persisted-increase-task"
+        )
+        first = _direct_poll(service, identity, token, "persisted-increase-poll-1")["task"]
+        assert _direct_temporary_nack(
+            service, identity, token, first, "persisted-increase-ack-1"
+        )["task_state"] == "queued"
+        second = _direct_poll(service, identity, token, "persisted-increase-poll-2")["task"]
+        assert second["attempt"] == 2
+    finally:
+        service.close()
+
+    reopened_settings = WorkerControlPlaneSettings(
+        enabled=True,
+        test_mode=True,
+        db_path=db_path,
+        approved_test_root=tmp_path,
+        max_attempts=5,
+    )
+    reopened = WorkerControlPlaneService(reopened_settings)
+    try:
+        response = _direct_temporary_nack(
+            reopened, identity, token, second, "persisted-increase-ack-2"
+        )
+        assert response["task_state"] == "dead_letter"
+        assert reopened.task_state(task_id) == "dead_letter"
+        assert "task_dead_lettered" in reopened.audit_text()
+        assert _direct_poll(
+            reopened, identity, token, "persisted-increase-after"
+        ) is None
+    finally:
+        reopened.close()
+
+
+def test_temporary_nack_uses_persisted_limit_after_config_decrease(tmp_path):
+    db_path = tmp_path / "persisted-decrease.db"
+    initial_settings = WorkerControlPlaneSettings(
+        enabled=True,
+        test_mode=True,
+        db_path=db_path,
+        approved_test_root=tmp_path,
+        max_attempts=5,
+    )
+    service = WorkerControlPlaneService(initial_settings)
+    try:
+        identity, token = _register_direct_test_worker(service)
+        task_id = service.create_test_echo_task(
+            {"message": "persisted decrease"}, "persisted-decrease-task"
+        )
+        first = _direct_poll(service, identity, token, "persisted-decrease-poll-1")["task"]
+        assert _direct_temporary_nack(
+            service, identity, token, first, "persisted-decrease-ack-1"
+        )["task_state"] == "queued"
+        second = _direct_poll(service, identity, token, "persisted-decrease-poll-2")["task"]
+        assert second["attempt"] == 2
+    finally:
+        service.close()
+
+    reopened_settings = WorkerControlPlaneSettings(
+        enabled=True,
+        test_mode=True,
+        db_path=db_path,
+        approved_test_root=tmp_path,
+        max_attempts=2,
+    )
+    reopened = WorkerControlPlaneService(reopened_settings)
+    try:
+        response = _direct_temporary_nack(
+            reopened, identity, token, second, "persisted-decrease-ack-2"
+        )
+        assert response["task_state"] == "queued"
+        assert reopened.task_state(task_id) == "queued"
+    finally:
+        reopened.close()
+
+
+def test_access_token_verifier_uses_constant_time_digest_comparison(monkeypatch):
+    from gateway.worker_control_plane import auth
+
+    calls = []
+    original = auth.hmac.compare_digest
+
+    def tracked(left, right):
+        calls.append((left, right))
+        return original(left, right)
+
+    monkeypatch.setattr(auth.hmac, "compare_digest", tracked)
+    digest = auth.token_hash("opaque-access-token")
+    assert auth.verify_access_token("opaque-access-token", digest) is True
+    assert auth.verify_access_token("wrong-access-token", digest) is False
+    assert len(calls) == 2
+    assert all(len(left) == len(right) == 64 for left, right in calls)
+
+
+@pytest.mark.asyncio
+async def test_rejection_audits_persist_without_sensitive_values(control_plane):
+    service, client, secret = control_plane
+    bad = MockWorkerClient(client, "wrong-bootstrap-secret")
+    assert (await bad.register())[0] == 401
+
+    worker = MockWorkerClient(client, secret)
+    assert (await worker.register())[0] == 201
+    original_registration = worker.registration_id
+    worker.registration_id = str(uuid.uuid4())
+    assert (await worker.heartbeat())[0] == 409
+    worker.registration_id = original_registration
+
+    assert (await worker.poll("audit-conflict"))[0] == 204
+    changed = worker.base() | {
+        "registration_id": str(uuid.uuid4()),
+        "capabilities": ["system.echo"],
+        "max_tasks": 1,
+        "wait_seconds": 0,
+    }
+    response = await client.post(
+        "/worker/v1/tasks/poll",
+        headers=worker.headers("audit-conflict"),
+        json=changed,
+    )
+    assert response.status == 409
+
+    task_id = service.create_test_echo_task({"message": "audit"}, "audit-task")
+    _, envelope = await worker.poll("audit-lease")
+    task = envelope["task"]
+    service.advance_for_test(service.settings.ack_deadline_seconds)
+    assert (await worker.ack(task, key="audit-late-ack"))[0] == 410
+
+    _, envelope = await worker.poll("audit-redelivery")
+    task = envelope["task"]
+    assert (await worker.ack(task, key="audit-ack"))[0] == 200
+    wrong_hash = dict(task)
+    wrong_hash["payload_hash"] = "0" * 64
+    assert (await worker.result(wrong_hash, request_key="audit-result"))[0] == 422
+    service.revoke_test_worker()
+
+    audit = service.audit_text()
+    required = {
+        "worker_revoked",
+        "credential_failed",
+        "registration_rejected",
+        "idempotency_conflict",
+        "heartbeat_rejected",
+        "poll_rejected",
+        "ack_rejected",
+        "result_rejected",
+    }
+    assert all(event in audit for event in required)
+    credential_rows = service.store.conn.execute(
+        "SELECT token_hash,salt FROM worker_credentials"
+    ).fetchall()
+    forbidden = [secret, worker.access_token, "wrong-bootstrap-secret"]
+    forbidden.extend(value for row in credential_rows for value in row if value)
+    assert all(value not in audit for value in forbidden)
+    assert "audit" not in audit
+    assert service.task_state(task_id) == "running"
+
+
+@pytest.mark.asyncio
+async def test_ack_is_rejected_exactly_at_deadline(control_plane):
+    service, _, secret = control_plane
+    worker = MockWorkerClient(control_plane[1], secret)
+    assert (await worker.register())[0] == 201
+    task_id = service.create_test_echo_task({"message": "boundary"}, "ack-boundary")
+    _, envelope = await worker.poll("ack-boundary-poll")
+    service.advance_for_test(service.settings.ack_deadline_seconds)
+    status, _ = await worker.ack(envelope["task"], key="ack-boundary-key")
+    assert status == 410
+    assert service.task_state(task_id) == "queued"

--- a/tests/gateway/worker_control_plane_helpers.py
+++ b/tests/gateway/worker_control_plane_helpers.py
@@ -1,0 +1,66 @@
+"""Test-only in-process client for the isolated Worker Control Plane."""
+
+from __future__ import annotations
+
+import uuid
+
+
+class MockWorkerClient:
+    def __init__(self, client, bootstrap_secret: str, *, worker_id: str = "server-a-worker"):
+        self.client = client
+        self.bootstrap_secret = bootstrap_secret
+        self.worker_id = worker_id
+        self.instance_id = str(uuid.uuid4())
+        self.registration_id = None
+        self.access_token = None
+
+    async def register(self, *, capabilities=None, protocol_version="1.0"):
+        response = await self.client.post(
+            "/worker/v1/register",
+            headers={"Authorization": f"Worker-Bootstrap {self.bootstrap_secret}"},
+            json={"protocol_version": protocol_version, "worker_id": self.worker_id,
+                  "instance_id": self.instance_id, "worker_name": "test worker",
+                  "worker_version": "0.1.0", "capabilities": capabilities or ["system.echo"]},
+        )
+        body = await response.json()
+        if response.status in (200, 201):
+            self.registration_id = body["registration_id"]
+            self.access_token = body["access_token"]
+        return response.status, body
+
+    def headers(self, key=None):
+        data = {"Authorization": f"Bearer {self.access_token}"}
+        if key:
+            data["Idempotency-Key"] = key
+        return data
+
+    def base(self):
+        return {"worker_id": self.worker_id, "instance_id": self.instance_id,
+                "registration_id": self.registration_id}
+
+    async def heartbeat(self, status="idle", current_task_id=None):
+        data = self.base() | {"status": status, "current_task_id": current_task_id,
+                              "worker_time": "2026-01-01T00:00:00Z"}
+        response = await self.client.post("/worker/v1/heartbeat", headers=self.headers(), json=data)
+        return response.status, await response.json()
+
+    async def poll(self, key="poll-1"):
+        data = self.base() | {"capabilities": ["system.echo"], "max_tasks": 1, "wait_seconds": 0}
+        response = await self.client.post("/worker/v1/tasks/poll", headers=self.headers(key), json=data)
+        return response.status, (await response.json() if response.status != 204 else None)
+
+    async def ack(self, task, accepted=True, reason=None, key="ack-1"):
+        data = self.base() | {"delivery_id": task["delivery_id"], "accepted": accepted,
+                              "reason": reason, "worker_time": "2026-01-01T00:00:00Z"}
+        response = await self.client.post(f'/worker/v1/tasks/{task["task_id"]}/ack', headers=self.headers(key), json=data)
+        return response.status, await response.json()
+
+    async def result(self, task, *, stdout=None, result_key="result-1", request_key="request-result-1"):
+        message = task["payload"]["message"] if stdout is None else stdout
+        data = self.base() | {"task_id": task["task_id"], "delivery_id": task["delivery_id"],
+            "task_type": "system.echo", "status": "completed", "stdout": message, "stderr": "",
+            "exit_code": 0, "started_at": "2026-01-01T00:00:00Z", "finished_at": "2026-01-01T00:00:00Z",
+            "duration_ms": 0, "result_idempotency_key": result_key, "payload_hash": task["payload_hash"],
+            "trace_id": task["trace_id"]}
+        response = await self.client.post(f'/worker/v1/tasks/{task["task_id"]}/result', headers=self.headers(request_key), json=data)
+        return response.status, await response.json()


### PR DESCRIPTION
## Summary

- Adds an isolated, standalone, test-only aiohttp Worker Control Plane app factory.
- Supports `system.echo` only.
- Uses dedicated temporary SQLite storage confined to an approved test root.

## Security boundaries

- No production route or listener is mounted.
- No real Server Worker connection is created.
- No INPRO integration or Codex/LLM executor is invoked.
- Final independent security review result: **SAFE (100/100)**.

## Validation

- Targeted Worker Control Plane tests: **29 passed**.
- Gateway regression tests: **6002 passed**.

## Scope

M2B-2 is explicitly excluded from this pull request.
