### PR TITLE
fix: propagate caption-fallback warning and add voice/audio retry in Telegram caption parse path

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -437,6 +437,114 @@ class TestSendTelegramMediaDelivery:
         bot.send_audio.assert_not_awaited()
         bot.send_message.assert_not_awaited()
 
+    def test_sends_audio_for_mp3(self, tmp_path, monkeypatch):
+        audio_path = tmp_path / "clip.mp3"
+        audio_path.write_bytes(b"ID3" + b"\x00" * 32)
+
+        bot = MagicMock()
+        bot.send_message = AsyncMock()
+        bot.send_photo = AsyncMock()
+        bot.send_video = AsyncMock()
+        bot.send_voice = AsyncMock()
+        bot.send_audio = AsyncMock(return_value=SimpleNamespace(message_id=8))
+        bot.send_document = AsyncMock()
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_telegram(
+                "token",
+                "12345",
+                "",
+                media_files=[(str(audio_path), False)],
+            )
+        )
+
+        assert result["success"] is True
+        bot.send_audio.assert_awaited_once()
+        bot.send_voice.assert_not_awaited()
+
+    def test_audio_caption_parse_retry_uses_send_audio(self, tmp_path, monkeypatch):
+        """When an .mp3 with a caption fails to parse, the retry must still
+        use send_audio — not fall back to send_document (issue #69252)."""
+        audio_path = tmp_path / "clip.mp3"
+        audio_path.write_bytes(b"ID3" + b"\x00" * 32)
+
+        bot = MagicMock()
+        bot.send_message = AsyncMock()
+        bot.send_photo = AsyncMock()
+        bot.send_video = AsyncMock()
+        bot.send_voice = AsyncMock()
+        bot.send_document = AsyncMock()
+        # First send_audio raises a caption-parse error; retry succeeds.
+        bot.send_audio = AsyncMock(
+            side_effect=[
+                Exception("can't parse entities in caption: unexpected end of string"),
+                SimpleNamespace(message_id=9),
+            ]
+        )
+        _install_telegram_mock(monkeypatch, bot)
+
+        # .mp3 is not in _CAPTIONABLE_EXTS, so _media_caption_split returns
+        # (None, text) and parse_mode is never set on media_kwargs.  Patch
+        # it to return a caption so the caption-parse retry path is reached.
+        monkeypatch.setattr(
+            "tools.send_message_tool._media_caption_split",
+            lambda text, media_files, max_caption_len: ("Some caption text", ""),
+        )
+
+        result = asyncio.run(
+            _send_telegram(
+                "token",
+                "12345",
+                "Some caption text",
+                media_files=[(str(audio_path), False)],
+            )
+        )
+
+        assert result["success"] is True
+        # send_audio called twice: first attempt (parse error) + retry.
+        assert bot.send_audio.await_count == 2
+        # send_document must never be called for an .mp3.
+        bot.send_document.assert_not_awaited()
+
+    def test_caption_fallback_error_surfaces_in_warnings(self, tmp_path, monkeypatch):
+        """When the caption-fallback send for a missing media file fails,
+        the sanitized error must appear in the result warnings (issue #69252)."""
+        # Reference a media file that does not exist so the caption-fallback
+        # path is triggered.  The caption text is short enough to be attached
+        # as a media caption, so _tg_caption is set and formatted is emptied.
+        missing_path = str(tmp_path / "nonexistent.png")
+
+        bot = MagicMock()
+        bot.send_message = AsyncMock()
+        bot.send_photo = AsyncMock()
+        bot.send_video = AsyncMock()
+        bot.send_voice = AsyncMock()
+        bot.send_audio = AsyncMock()
+        bot.send_document = AsyncMock()
+        _install_telegram_mock(monkeypatch, bot)
+
+        # Patch the retry helper to raise so the fallback send fails.
+        monkeypatch.setattr(
+            "tools.send_message_tool._send_telegram_message_with_retry",
+            AsyncMock(side_effect=Exception("connection refused")),
+        )
+
+        result = asyncio.run(
+            _send_telegram(
+                "token",
+                "12345",
+                "Caption for missing file",
+                media_files=[(missing_path, False)],
+            )
+        )
+
+        # The warning list should contain the sanitized fallback error.
+        warnings = result.get("warnings", [])
+        assert any("connection refused" in w for w in warnings), (
+            f"expected fallback error in warnings, got {warnings}"
+        )
+
     def test_missing_media_returns_error_without_leaking_raw_tag(self, monkeypatch):
         bot = MagicMock()
         bot.send_message = AsyncMock()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1361,6 +1361,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                             "Telegram caption-fallback send failed for missing media: %s",
                             _sanitize_error_text(_cap_err),
                         )
+                        warnings.append(_sanitize_error_text(_cap_err))
                 continue
 
             ext = os.path.splitext(media_path)[1].lower()
@@ -1460,6 +1461,14 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                             elif ext in _VIDEO_EXTS:
                                 last_msg = await bot.send_video(
                                     chat_id=int_chat_id, video=f, **media_kwargs
+                                )
+                            elif ext in _VOICE_EXTS and is_voice:
+                                last_msg = await bot.send_voice(
+                                    chat_id=int_chat_id, voice=f, **media_kwargs
+                                )
+                            elif ext in _TELEGRAM_SEND_AUDIO_EXTS:
+                                last_msg = await bot.send_audio(
+                                    chat_id=int_chat_id, audio=f, **media_kwargs
                                 )
                             else:
                                 last_msg = await bot.send_document(

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1361,7 +1361,10 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                             "Telegram caption-fallback send failed for missing media: %s",
                             _sanitize_error_text(_cap_err),
                         )
-                        warnings.append(_sanitize_error_text(_cap_err))
+                        warnings.append(
+                            "Telegram caption-fallback send failed for missing media: "
+                            f"{_sanitize_error_text(_cap_err)}"
+                        )
                 continue
 
             ext = os.path.splitext(media_path)[1].lower()


### PR DESCRIPTION
## Problem

Two error-handling gaps in the Telegram caption parse retry path:

1. **Caption-fallback failure is invisible to the agent.** When the caption-fallback send fails (the file is gone and the caption text is sent alone), the error is logged via `logger.warning` but never appended to the `warnings` list — the agent never knows it happened.

2. **Voice/audio files silently downgraded on caption parse error.** The caption parse retry block was missing the `_VOICE_EXTS` and `_TELEGRAM_SEND_AUDIO_EXTS` type checks that exist in the primary `try` block and the thread-not-found retry block. If an audio or voice file encounters a caption parse error, it falls through to `send_document` instead of `send_voice`/`send_audio`.

## Fix

Two changes in `tools/send_message_tool.py`:

1. **Caption-fallback warning propagation:** Added `warnings.append(_sanitize_error_text(_cap_err))` alongside the existing `logger.warning` call in the caption-fallback exception handler.

2. **Voice/audio handling in caption parse retry:** Added the missing `elif ext in _VOICE_EXTS and is_voice:` and `elif ext in _TELEGRAM_SEND_AUDIO_EXTS:` branches to the caption parse retry block, matching the structure of the primary and thread-not-found retry blocks.

Split from #69169 (closed as duplicate of #67565 for the send_document basename changes).