### PR TITLE
feat(nous): send top-level session_id for provider sticky routing

### DIFF
--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -14,6 +14,15 @@ class NousProfile(ProviderProfile):
         self, *, session_id: str | None = None, **context
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"tags": nous_portal_tags(session_id=session_id)}
+        if session_id:
+            # Top-level session_id → provider sticky routing key. Pins every
+            # turn of a session to the same upstream endpoint so explicit
+            # Anthropic cache_control breakpoints stay warm instead of
+            # cold-writing a fresh cache on each reroute (Anthropic/Vertex/
+            # Bedrock caches are instance-local). Mirrors the OpenRouter
+            # profile; without it the portal falls back to hashing the opening
+            # messages, which breaks pinning whenever those shift.
+            body["session_id"] = session_id
         provider_preferences = context.get("provider_preferences")
         if provider_preferences:
             body["provider"] = provider_preferences

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -431,6 +431,18 @@ class TestNousProfile:
         body = p.build_extra_body(session_id="sess-99")
         assert conversation_tag("sess-99") in body["tags"]
 
+    def test_extra_body_session_id(self):
+        """Top-level session_id is the provider sticky-routing key — keeps
+        Anthropic cache_control breakpoints pinned to one upstream endpoint."""
+        p = get_provider_profile("nous")
+        body = p.build_extra_body(session_id="sess-99")
+        assert body["session_id"] == "sess-99"
+
+    def test_extra_body_no_session_id(self):
+        p = get_provider_profile("nous")
+        body = p.build_extra_body()
+        assert "session_id" not in body
+
     def test_auth_type(self):
         p = get_provider_profile("nous")
         assert p.auth_type == "oauth_device_code"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4046,9 +4046,11 @@ class TestHandleMaxIterations:
         kwargs = agent.client.chat.completions.create.call_args.kwargs
         from agent.portal_tags import nous_portal_tags
 
-        assert kwargs["extra_body"] == {
-            "tags": nous_portal_tags(session_id=agent.session_id)
-        }
+        expected = {"tags": nous_portal_tags(session_id=agent.session_id)}
+        if agent.session_id:
+            # Top-level sticky-routing key ships whenever a session exists.
+            expected["session_id"] = agent.session_id
+        assert kwargs["extra_body"] == expected
 
     def test_summary_drops_invalid_provider_sort(self, agent):
         agent.base_url = "https://openrouter.ai/api/v1"


### PR DESCRIPTION
## Summary
Nous Portal Claude traffic now carries a top-level `session_id`, giving the portal a sticky-routing key so multi-turn sessions pin to one upstream endpoint and Anthropic `cache_control` breakpoints stay warm.

Root cause: the Nous profile only embedded the session id inside portal `tags` — with no top-level routing key, sessions fall back to opening-message hashing, which breaks pinning whenever the opening messages shift. Each reroute between upstream endpoints (provider caches are instance-local) cold-writes a fresh prompt cache, dragging the effective cache-hit rate down.

## Changes
- `plugins/model-providers/nous/__init__.py`: `build_extra_body()` emits `session_id` when the agent has one (mirrors the OpenRouter profile).
- `tests/providers/test_provider_profiles.py`: session_id present when set / absent when unset.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/providers/` (profiles + transport parity) | 82/82 pass |
| E2E via real `ChatCompletionsTransport.build_kwargs()` | `extra_body.session_id` on wire when set; absent when unset |

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa34355/JKnAB-3g8fu9c5nVRsF_Z_quq5hLDj.png)
