### PR TITLE
fix(desktop): resolve out-of-order message tailing on reconnect and resume

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -13,6 +13,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { type CSSProperties, lazy, type ReactNode, Suspense, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
+import { preserveLocalPendingTurnMessages } from '@/app/session/hooks/use-session-actions/utils'
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { BootFailureOverlay } from '@/components/boot-failure-overlay'
 import { DesktopInstallOverlay } from '@/components/desktop-install-overlay'
@@ -276,7 +277,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
           const messages = toChatMessages(latest.messages)
           updateSessionState(
             runtimeSessionId,
-            state => ({ ...state, messages: preserveLocalAssistantErrors(messages, state.messages) }),
+            state => {
+              const withPendingTurn = preserveLocalPendingTurnMessages(messages, state.messages)
+
+              return { ...state, messages: preserveLocalAssistantErrors(withPendingTurn, state.messages) }
+            },
             storedSessionId
           )
 
@@ -332,7 +337,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
       updateSessionState(
         runtimeSessionId,
-        state => ({ ...state, messages: preserveLocalAssistantErrors(messages, state.messages) }),
+        state => {
+          const withPendingTurn = preserveLocalPendingTurnMessages(messages, state.messages)
+
+          return { ...state, messages: preserveLocalAssistantErrors(withPendingTurn, state.messages) }
+        },
         storedSessionId
       )
     } catch {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -789,7 +789,7 @@ export function useSessionActions({
 
         let localSnapshot = resumedSameSelectedSession
           ? preserveLocalPendingTurnMessages($messages.get(), resumeStartMessages)
-          : $messages.get()
+          : []
 
         let prefetchApplied = false
         let prefetchedMessageCount = 0
@@ -826,7 +826,7 @@ export function useSessionActions({
             if (isCurrentResume()) {
               const previousMessages = resumedSameSelectedSession
                 ? preserveLocalPendingTurnMessages($messages.get(), resumeStartMessages)
-                : $messages.get()
+                : []
 
               localSnapshot = reconcileAuthoritativeMessages(storedMessages.messages, previousMessages)
               prefetchApplied = true
@@ -871,7 +871,7 @@ export function useSessionActions({
             : (() => {
                 const previousMessages = resumedSameSelectedSession
                   ? preserveLocalPendingTurnMessages(currentMessages, resumeStartMessages)
-                  : currentMessages
+                  : []
 
                 const resumedMessages = reconcileAuthoritativeMessages(resumed.messages, previousMessages, resumed)
 
@@ -884,7 +884,7 @@ export function useSessionActions({
         const messagesForView =
           preferredMessages === currentMessages
             ? currentMessages
-            : preserveLocalAssistantErrors(preferredMessages, currentMessages)
+            : preserveLocalAssistantErrors(preferredMessages, resumedSameSelectedSession ? currentMessages : [])
 
         if (sessionShouldHaveTranscript(stored) && messagesForView.length === 0) {
           setActiveSessionId(null)
@@ -938,7 +938,7 @@ export function useSessionActions({
 
           const previousMessages = resumedSameSelectedSession
             ? preserveLocalPendingTurnMessages($messages.get(), resumeStartMessages)
-            : $messages.get()
+            : []
 
           setMessages(reconcileAuthoritativeMessages(fallback.messages, previousMessages))
         } catch (e) {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -327,6 +327,37 @@ describe('preserveLocalPendingTurnMessages', () => {
 
     expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
   })
+
+  it('drops local optimistic user messages when server text includes image attachment notices', () => {
+    const previous = [
+      msg('1-user', 'user', 'First, the voice SUCKS.'),
+      msg('2-assistant', 'assistant', 'HOW TO USE THEM'),
+      msg('user-optimistic-1', 'user', 'Nothing happens.'),
+      msg('user-optimistic-2', 'user', 'Nothing happens when I click Create')
+    ]
+
+    const next = [
+      msg('1-user-stored', 'user', 'First, the voice SUCKS.\n[Image attached at: C:\\path\\shot.png]'),
+      msg('2-assistant-stored', 'assistant', 'HOW TO USE THEM'),
+      msg('3-user-stored', 'user', 'Nothing happens.\n[Image attached at: C:\\path\\shot2.png]'),
+      msg('4-user-stored', 'user', 'Nothing happens when I click Create')
+    ]
+
+    expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
+  })
+
+  it('drops local optimistic user messages if content matches anywhere in nextMessages even if ordinals shifted', () => {
+    const previous = [
+      msg('user-optimistic-1', 'user', 'First, the voice SUCKS.')
+    ]
+
+    const next = [
+      msg('0-sys', 'system', 'System prompt'),
+      msg('1-user-stored', 'user', 'First, the voice SUCKS.\n[Image attached at: C:\\path\\shot.png]')
+    ]
+
+    expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
+  })
 })
 
 describe('appendLiveSessionProjection', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -175,6 +175,34 @@ export function chatMessageArraysEquivalent(a: ChatMessage[], b: ChatMessage[]):
   return a.length === b.length && a.every((message, index) => chatMessagesEquivalent(message, b[index]))
 }
 
+export function stripAttachmentNotices(text: string): string {
+  const withoutEmbedded = textWithoutEmbeddedImages(text)
+
+  return withoutEmbedded
+    .replace(/\n?\[Image attached(?: at)?:[\s\S]*?\]/gi, '')
+    .replace(/\n?\[IMAGE:[\s\S]*?\]/gi, '')
+    .replace(/\n?@image:[^\s]+/gi, '')
+    .replace(/\n?@file:[^\s]+/gi, '')
+    .trim()
+}
+
+export function userTextMatches(textA: string, textB: string): boolean {
+  const cleanA = stripAttachmentNotices(textA)
+  const cleanB = stripAttachmentNotices(textB)
+
+  if (cleanA === cleanB) {
+    return true
+  }
+
+  if (cleanA && cleanB) {
+    if (cleanA.startsWith(cleanB) || cleanB.startsWith(cleanA)) {
+      return true
+    }
+  }
+
+  return false
+}
+
 export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMessages: ChatMessage[]): ChatMessage[] {
   if (!previousMessages.length) {
     return nextMessages
@@ -206,7 +234,11 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
     const previousVisibleText = textWithoutEmbeddedImages(previousText)
     let preserved = message
 
-    if (nextText === previousVisibleText || nextText === previousText.trim()) {
+    if (
+      nextText === previousVisibleText ||
+      nextText === previousText.trim() ||
+      userTextMatches(nextText, previousText)
+    ) {
       preserved = preserveReasoningParts(preserved, previous)
     }
 
@@ -245,11 +277,16 @@ export function preserveLocalPendingTurnMessages(
 
   const nextByRoleOrdinal = new Map<string, ChatMessage>()
   const nextRoleCounts = new Map<ChatMessage['role'], number>()
+  const nextUserMessages: ChatMessage[] = []
 
   for (const message of nextMessages) {
     const ordinal = nextRoleCounts.get(message.role) ?? 0
     nextRoleCounts.set(message.role, ordinal + 1)
     nextByRoleOrdinal.set(`${message.role}:${ordinal}`, message)
+
+    if (message.role === 'user') {
+      nextUserMessages.push(message)
+    }
   }
 
   const nextIds = new Set(nextMessages.map(message => message.id))
@@ -269,14 +306,23 @@ export function preserveLocalPendingTurnMessages(
       continue
     }
 
-    const authoritative = nextByRoleOrdinal.get(`${message.role}:${ordinal}`)
+    if (isPendingAssistant) {
+      const authoritative = nextByRoleOrdinal.get(`assistant:${ordinal}`)
 
-    if (authoritative) {
-      if (isPendingAssistant) {
+      if (authoritative) {
+        continue
+      }
+    }
+
+    if (isOptimisticUser) {
+      const localText = chatMessageText(message)
+      const authoritative = nextByRoleOrdinal.get(`user:${ordinal}`)
+
+      if (authoritative && userTextMatches(chatMessageText(authoritative), localText)) {
         continue
       }
 
-      if (chatMessageText(authoritative).trim() === chatMessageText(message).trim()) {
+      if (nextUserMessages.some(nextMsg => userTextMatches(chatMessageText(nextMsg), localText))) {
         continue
       }
     }

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -927,50 +927,97 @@ export function preserveLocalAssistantErrors(
   })
 
   const existingIds = new Set(mergedNextMessages.map(message => message.id))
-  const preserveIds = new Set<string>()
-  const normalize = (value: string) => value.replace(/\s+/g, ' ').trim()
-  const tailUserInNext = [...mergedNextMessages].reverse().find(message => message.role === 'user' && !message.hidden)
-  const tailUserText = tailUserInNext ? normalize(chatMessageText(tailUserInNext)) : ''
-  const tailUserRefs = tailUserInNext ? (tailUserInNext.attachmentRefs ?? []).join('\n') : ''
+  
+  const stripAttachments = (text: string) => text
+    .replace(/\n?\[Image attached(?: at)?:[\s\S]*?\]/gi, '')
+    .replace(/\n?\[IMAGE:[\s\S]*?\]/gi, '')
+    .replace(/\n?@image:[^\s]+/gi, '')
+    .replace(/\n?@file:[^\s]+/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim()
 
-  const matchesTailUserInNext = (candidate: ChatMessage) =>
-    Boolean(tailUserInNext) &&
-    normalize(chatMessageText(candidate)) === tailUserText &&
-    (candidate.attachmentRefs ?? []).join('\n') === tailUserRefs
+  const normalize = (value: string) => stripAttachments(value)
 
+  // Find all local assistant errors that need to be preserved
+  const errorsToPreserve: ChatMessage[] = []
+  
   for (let index = 0; index < currentMessages.length; index += 1) {
     const message = currentMessages[index]
-
-    if (message.role !== 'assistant' || !message.error || message.hidden || existingIds.has(message.id)) {
-      continue
-    }
-
-    preserveIds.add(message.id)
-
-    for (let probe = index - 1; probe >= 0; probe -= 1) {
-      const candidate = currentMessages[probe]
-
-      if (candidate.hidden) {
-        continue
+    if (message.role === 'assistant' && message.error && !message.hidden && !existingIds.has(message.id)) {
+      // Find the preceding user message in currentMessages to know where this error belongs
+      let precedingUser: ChatMessage | null = null
+      for (let probe = index - 1; probe >= 0; probe -= 1) {
+        if (!currentMessages[probe].hidden && currentMessages[probe].role === 'user') {
+          precedingUser = currentMessages[probe]
+          break
+        }
       }
-
-      if (candidate.role === 'user' && !existingIds.has(candidate.id) && !matchesTailUserInNext(candidate)) {
-        preserveIds.add(candidate.id)
-      }
-
-      break
+      
+      errorsToPreserve.push({
+        ...message,
+        pending: false,
+        // Attach a hint about which user message it followed
+        _localPrecedingUserText: precedingUser ? normalize(chatMessageText(precedingUser)) : '',
+        _localPrecedingUserRefs: precedingUser ? (precedingUser.attachmentRefs ?? []).join('\n') : ''
+      } as any)
     }
   }
 
-  if (preserveIds.size === 0) {
+  if (errorsToPreserve.length === 0) {
     return mergedNextMessages
   }
 
-  const preserved = currentMessages
-    .filter(message => preserveIds.has(message.id))
-    .map(message => ({ ...message, pending: false }))
+  const result: ChatMessage[] = []
+  const consumedErrors = new Set<string>()
 
-  return [...mergedNextMessages, ...preserved]
+  // Rebuild the array, inserting errors immediately after the matching user message
+  for (const message of mergedNextMessages) {
+    result.push(message)
+
+    if (message.role === 'user' && !message.hidden) {
+      const text = normalize(chatMessageText(message))
+      const refs = (message.attachmentRefs ?? []).join('\n')
+
+      // Find any unconsumed errors that belonged to this user message
+      for (const err of errorsToPreserve) {
+        if (!consumedErrors.has(err.id) && (err as any)._localPrecedingUserText === text && (err as any)._localPrecedingUserRefs === refs) {
+          const cleanErr = { ...err }
+          delete (cleanErr as any)._localPrecedingUserText
+          delete (cleanErr as any)._localPrecedingUserRefs
+          result.push(cleanErr)
+          consumedErrors.add(err.id)
+        }
+      }
+    }
+  }
+
+  // Append any errors that couldn't be matched (along with their user message if it's missing)
+  for (const err of errorsToPreserve) {
+    if (!consumedErrors.has(err.id)) {
+      const text = (err as any)._localPrecedingUserText
+      const refs = (err as any)._localPrecedingUserRefs
+      
+      // If the user message itself is missing from the DB (optimistic and dropped),
+      // we must also restore the user message so the error isn't orphaned.
+      const originalUser = currentMessages.find(m => 
+        m.role === 'user' && 
+        normalize(chatMessageText(m)) === text && 
+        (m.attachmentRefs ?? []).join('\n') === refs
+      )
+      
+      if (originalUser && !existingIds.has(originalUser.id)) {
+        result.push(originalUser)
+        existingIds.add(originalUser.id)
+      }
+      
+      const cleanErr = { ...err }
+      delete (cleanErr as any)._localPrecedingUserText
+      delete (cleanErr as any)._localPrecedingUserRefs
+      result.push(cleanErr)
+    }
+  }
+
+  return result
 }
 
 export function branchGroupForUser(userMessage: ChatMessage): string {


### PR DESCRIPTION
### Summary
Fixes an issue in the desktop app where reconnecting or switching sessions caused optimistic local user messages (particularly those containing image or file attachments) to fail matching against authoritative server messages, appending them to the bottom of the conversation history out of order.

### Root Cause
1. `preserveLocalPendingTurnMessages` compared local user message text against authoritative server text using exact string equality. Server messages often include appended attachment notices (such as `[Image attached at: ...]`), causing exact string checks against optimistic local prompts to return `false`.
2. Unmatched local user messages were appended unconditionally to `nextMessages` via `[...nextMessages, ...preserved]`, rendering older user prompts below assistant responses at the bottom of the chat list.
3. Matching relied solely on position/role ordinal index (`user:N`), which could mismatch if system/tool message counts shifted upon reload.

### Solution
- Added `stripAttachmentNotices` and `userTextMatches` to strip attachment headers/footers (`[Image attached at: ...]`, `@image:...`, `@file:...`, data URLs) before comparing prompt text.
- Added a full-transcript lookup across `nextMessages` so optimistic user messages are recognized as committed even if role ordinals shift.
- Added unit tests covering reconnect reconciliation with attached images and shifted message ordinals.