### PR TITLE
fix(codex): preserve commentary across interleaved output items

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1025,14 +1025,76 @@ def _consume_codex_event_stream(
     collected_text_deltas: List[str] = []
     has_tool_calls = False
     first_delta_fired = False
-    active_message_phase: str | None = None
-    commentary_text_deltas: List[str] = []
+    active_message_state: Dict[str, Any] | None = None
+    message_states: List[Dict[str, Any]] = []
+    message_states_by_alias: Dict[tuple[str, Any], Dict[str, Any]] = {}
     terminal_status: str = "completed"
     terminal_usage: Any = None
     terminal_response_id: str = None
     terminal_incomplete_details: Any = None
     terminal_error: Any = None
     saw_terminal = False
+
+    def _message_aliases(event: Any, item: Any = None) -> List[tuple[str, Any]]:
+        aliases: List[tuple[str, Any]] = []
+        item_id = _event_field(event, "item_id", None)
+        if item_id is None and item is not None:
+            item_id = _item_field(item, "id", None)
+        if item_id is not None:
+            aliases.append(("item_id", item_id))
+        output_index = _event_field(event, "output_index", None)
+        if output_index is not None:
+            aliases.append(("output_index", output_index))
+        return aliases
+
+    def _message_state(
+        event: Any,
+        *,
+        item: Any = None,
+        phase: str | None = None,
+        create: bool = False,
+    ) -> Dict[str, Any] | None:
+        aliases = _message_aliases(event, item)
+        state = next(
+            (message_states_by_alias[alias] for alias in aliases if alias in message_states_by_alias),
+            None,
+        )
+        if state is None and not aliases:
+            state = active_message_state
+        if state is None and create:
+            state = {"phase": phase, "deltas": [], "aliases": set()}
+            message_states.append(state)
+        if state is not None:
+            if phase:
+                state["phase"] = phase
+            for alias in aliases:
+                state["aliases"].add(alias)
+                message_states_by_alias[alias] = state
+        return state
+
+    def _completed_message_text(item: Any) -> str:
+        content_parts = _item_field(item, "content", [])
+        if not isinstance(content_parts, list):
+            return ""
+        return "".join(
+            str(_item_field(part, "text", "") or "")
+            for part in content_parts
+            if _item_field(part, "type", "") == "output_text"
+        ).strip()
+
+    def _flush_commentary_state(state: Dict[str, Any] | None, item: Any = None) -> None:
+        if state is None or state.get("phase") != "commentary":
+            return
+        text = "".join(state.get("deltas") or []).strip()
+        if not text and item is not None:
+            text = _completed_message_text(item)
+        if text and on_commentary_message is not None:
+            try:
+                on_commentary_message(text)
+            except Exception:
+                logger.debug("Codex stream on_commentary_message raised", exc_info=True)
+        state["deltas"] = []
+        state["phase"] = "delivered"
 
     for event in event_iter:
         if on_event is not None:
@@ -1070,19 +1132,30 @@ def _consume_codex_event_stream(
             item_type = _item_field(item, "type", "")
             if item_type == "message":
                 phase = _item_field(item, "phase", None)
-                active_message_phase = phase.strip().lower() if isinstance(phase, str) else None
-                if active_message_phase == "commentary":
-                    commentary_text_deltas = []
+                phase = phase.strip().lower() if isinstance(phase, str) else None
+                if not _message_aliases(event, item):
+                    _flush_commentary_state(active_message_state)
+                active_message_state = _message_state(
+                    event, item=item, phase=phase, create=True
+                )
             else:
-                active_message_phase = None
+                if not _message_aliases(event, item):
+                    _flush_commentary_state(active_message_state)
+                    if not (
+                        active_message_state is not None
+                        and active_message_state.get("phase") == "analysis"
+                    ):
+                        active_message_state = None
             if "function_call" in str(item_type):
                 has_tool_calls = True
             continue
 
         if "output_text.delta" in event_type or event_type == "response.output_text.delta":
             delta_text = _event_field(event, "delta", "")
-            if delta_text and active_message_phase == "commentary":
-                commentary_text_deltas.append(delta_text)
+            state = _message_state(event)
+            phase = state.get("phase") if state is not None else None
+            if delta_text and state is not None and phase == "commentary":
+                state["deltas"].append(delta_text)
                 # Preserve CLI/backward compatibility when no first-class
                 # commentary consumer is installed.
                 if on_commentary_message is None and on_reasoning_delta is not None:
@@ -1090,7 +1163,7 @@ def _consume_codex_event_stream(
                         on_reasoning_delta(delta_text)
                     except Exception:
                         logger.debug("Codex stream on_reasoning_delta raised", exc_info=True)
-            elif delta_text and active_message_phase == "analysis":
+            elif delta_text and phase == "analysis":
                 if on_reasoning_delta is not None:
                     try:
                         on_reasoning_delta(delta_text)
@@ -1132,25 +1205,11 @@ def _consume_codex_event_stream(
                 collected_output_items.append(done_item)
                 done_phase = _item_field(done_item, "phase", None)
                 done_phase = done_phase.strip().lower() if isinstance(done_phase, str) else None
-                if done_phase == "commentary" and on_commentary_message is not None:
-                    commentary_text = "".join(commentary_text_deltas).strip()
-                    if not commentary_text:
-                        content_parts = _item_field(done_item, "content", [])
-                        if isinstance(content_parts, list):
-                            commentary_text = "".join(
-                                str(_item_field(part, "text", "") or "")
-                                for part in content_parts
-                                if _item_field(part, "type", "") == "output_text"
-                            ).strip()
-                    if commentary_text:
-                        try:
-                            on_commentary_message(commentary_text)
-                        except Exception:
-                            logger.debug(
-                                "Codex stream on_commentary_message raised",
-                                exc_info=True,
-                            )
-                    commentary_text_deltas = []
+                state = _message_state(
+                    event, item=done_item, phase=done_phase, create=done_phase == "commentary"
+                )
+                if done_phase == "commentary":
+                    _flush_commentary_state(state, done_item)
             continue
 
         if event_type in _TERMINAL_EVENT_TYPES:
@@ -1347,6 +1406,37 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
             return bool(agent._interrupt_requested)
 
         try:
+            # Compatibility: some mocks/providers return a concrete response
+            # instead of an iterable. Relay now stores it on
+            # ``event_stream.final_response`` (completed_response_predicate);
+            # preserve completed commentary delivery before passing the
+            # provider response through unchanged.
+            concrete_response = getattr(event_stream, "final_response", None)
+            if (
+                concrete_response is not None
+                and hasattr(concrete_response, "output")
+                and not hasattr(concrete_response, "__iter__")
+            ):
+                if (
+                    getattr(agent, "interim_assistant_callback", None) is not None
+                    and getattr(agent, "show_commentary", True)
+                ):
+                    for item in getattr(concrete_response, "output", None) or []:
+                        phase = _item_field(item, "phase", None)
+                        if not isinstance(phase, str) or phase.strip().lower() != "commentary":
+                            continue
+                        content = _item_field(item, "content", [])
+                        if not isinstance(content, list):
+                            continue
+                        text = "".join(
+                            str(_item_field(part, "text", "") or "")
+                            for part in content
+                            if _item_field(part, "type", "") == "output_text"
+                        ).strip()
+                        if text:
+                            _on_commentary_message(text)
+                return concrete_response
+
             try:
                 final = _consume_codex_event_stream(
                     event_stream,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1152,8 +1152,20 @@ def _consume_codex_event_stream(
 
         if "output_text.delta" in event_type or event_type == "response.output_text.delta":
             delta_text = _event_field(event, "delta", "")
+            aliases = _message_aliases(event)
             state = _message_state(event)
             phase = state.get("phase") if state is not None else None
+            # An aliased delta that cannot be tied to a registered message item
+            # must never fall through to visible final text. Providers can mix
+            # item_id/output_index shapes; without a proven association the safe
+            # destination is the private reasoning rail.
+            if delta_text and state is None and aliases:
+                if on_reasoning_delta is not None:
+                    try:
+                        on_reasoning_delta(delta_text)
+                    except Exception:
+                        logger.debug("Codex stream on_reasoning_delta raised", exc_info=True)
+                continue
             if delta_text and state is not None and phase == "commentary":
                 state["deltas"].append(delta_text)
                 # Preserve CLI/backward compatibility when no first-class

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1159,7 +1159,12 @@ def _consume_codex_event_stream(
             # must never fall through to visible final text. Providers can mix
             # item_id/output_index shapes; without a proven association the safe
             # destination is the private reasoning rail.
-            if delta_text and state is None and aliases:
+            if (
+                delta_text
+                and state is None
+                and aliases
+                and active_message_state is not None
+            ):
                 if on_reasoning_delta is not None:
                     try:
                         on_reasoning_delta(delta_text)

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1741,3 +1741,223 @@ def test_duplicate_detection_uses_commentary_when_hidden_reasoning_changes(monke
 
 
 
+# Regression coverage for interleaved/finalized Codex commentary items.
+def test_consume_codex_stream_tracks_interleaved_message_items(monkeypatch):
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    commentary_item = SimpleNamespace(
+        type="message",
+        id="msg_commentary",
+        phase="commentary",
+        content=[
+            SimpleNamespace(type="output_text", text="I’ll inspect the logs now.")
+        ],
+    )
+    final_item = SimpleNamespace(
+        type="message",
+        id="msg_final",
+        phase="final_answer",
+        content=[SimpleNamespace(type="output_text", text="Final answer.")],
+    )
+    interim_commentary = []
+    visible_text = []
+    reasoning_text = []
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream([
+            SimpleNamespace(
+                type="response.output_item.added",
+                output_index=0,
+                item=SimpleNamespace(
+                    type="message", id="msg_commentary", phase="commentary"
+                ),
+            ),
+            SimpleNamespace(
+                type="response.output_text.delta",
+                item_id="msg_commentary",
+                output_index=0,
+                delta="I’ll inspect ",
+            ),
+            SimpleNamespace(
+                type="response.output_item.added",
+                output_index=1,
+                item=SimpleNamespace(
+                    type="message", id="msg_final", phase="final_answer"
+                ),
+            ),
+            SimpleNamespace(
+                type="response.output_text.delta",
+                item_id="msg_final",
+                output_index=1,
+                delta="Final answer.",
+            ),
+            SimpleNamespace(
+                type="response.output_text.delta",
+                item_id="msg_commentary",
+                output_index=0,
+                delta="the logs now.",
+            ),
+            SimpleNamespace(
+                type="response.reasoning_summary_text.delta",
+                delta="Validated the event routing.",
+            ),
+            SimpleNamespace(
+                type="response.output_item.done",
+                output_index=0,
+                item=commentary_item,
+            ),
+            SimpleNamespace(
+                type="response.output_item.done", output_index=1, item=final_item
+            ),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed"),
+            ),
+        ]),
+        model="gpt-5-codex",
+        on_text_delta=visible_text.append,
+        on_reasoning_delta=reasoning_text.append,
+        on_commentary_message=interim_commentary.append,
+    )
+
+    assert interim_commentary == ["I’ll inspect the logs now."]
+    assert visible_text == ["Final answer."]
+    assert reasoning_text == ["Validated the event routing."]
+    assert response.output_text == "Final answer."
+
+def test_consume_codex_stream_waits_for_commentary_after_interleaved_function_call(
+    monkeypatch,
+):
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    commentary_item = SimpleNamespace(
+        type="message",
+        id="msg_commentary",
+        phase="commentary",
+        content=[SimpleNamespace(type="output_text", text="First second")],
+    )
+    function_item = SimpleNamespace(
+        type="function_call",
+        id="call_1",
+        name="terminal",
+        arguments="{}",
+    )
+    commentary = []
+
+    _consume_codex_event_stream(
+        _FakeCreateStream([
+            SimpleNamespace(
+                type="response.output_item.added",
+                output_index=0,
+                item=SimpleNamespace(
+                    type="message", id="msg_commentary", phase="commentary"
+                ),
+            ),
+            SimpleNamespace(
+                type="response.output_text.delta",
+                item_id="msg_commentary",
+                output_index=0,
+                delta="First ",
+            ),
+            SimpleNamespace(
+                type="response.output_item.added",
+                output_index=1,
+                item=SimpleNamespace(type="function_call", id="call_1"),
+            ),
+            SimpleNamespace(
+                type="response.output_text.delta",
+                item_id="msg_commentary",
+                output_index=0,
+                delta="second",
+            ),
+            SimpleNamespace(
+                type="response.output_item.done",
+                output_index=0,
+                item=commentary_item,
+            ),
+            SimpleNamespace(
+                type="response.output_item.done",
+                output_index=1,
+                item=function_item,
+            ),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed"),
+            ),
+        ]),
+        model="gpt-5-codex",
+        on_commentary_message=commentary.append,
+    )
+
+    assert commentary == ["First second"]
+
+def test_consume_codex_stream_fails_closed_for_unidentified_interleaved_delta(
+    monkeypatch,
+):
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    commentary = []
+    reasoning = []
+    visible = []
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream([
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="message", phase="commentary"),
+            ),
+            SimpleNamespace(type="response.output_text.delta", delta="Public preface."),
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="message", phase="analysis"),
+            ),
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="function_call"),
+            ),
+            SimpleNamespace(type="response.output_text.delta", delta="PRIVATE"),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed"),
+            ),
+        ]),
+        model="gpt-5-codex",
+        on_text_delta=visible.append,
+        on_reasoning_delta=reasoning.append,
+        on_commentary_message=commentary.append,
+    )
+
+    assert commentary == ["Public preface."]
+    assert reasoning == ["PRIVATE"]
+    assert visible == []
+    assert response.output_text == ""
+
+def test_run_codex_stream_surfaces_commentary_from_concrete_response(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    interim_commentary = []
+    agent.interim_assistant_callback = (
+        lambda text, *, already_streamed=False: interim_commentary.append(text)
+    )
+    response = SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="message",
+                id="msg_commentary",
+                phase="commentary",
+                content=[
+                    SimpleNamespace(type="output_text", text="I’ll inspect the logs.")
+                ],
+            )
+        ],
+        output_text="",
+        status="completed",
+    )
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kwargs: response)
+    )
+
+    returned = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert returned is response
+    assert interim_commentary == ["I’ll inspect the logs."]
+>>>>>>> 1d8a4ce0c (fix(codex): preserve interleaved commentary items)

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1960,4 +1960,63 @@ def test_run_codex_stream_surfaces_commentary_from_concrete_response(monkeypatch
 
     assert returned is response
     assert interim_commentary == ["I’ll inspect the logs."]
->>>>>>> 1d8a4ce0c (fix(codex): preserve interleaved commentary items)
+
+
+@pytest.mark.parametrize(
+    ("added_event", "delta_event"),
+    [
+        (
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="message", id="analysis-1", phase="analysis"),
+            ),
+            SimpleNamespace(
+                type="response.output_text.delta",
+                output_index=0,
+                delta="PRIVATE-A",
+            ),
+        ),
+        (
+            SimpleNamespace(
+                type="response.output_item.added",
+                output_index=0,
+                item=SimpleNamespace(type="message", phase="analysis"),
+            ),
+            SimpleNamespace(
+                type="response.output_text.delta",
+                item_id="analysis-1",
+                delta="PRIVATE-B",
+            ),
+        ),
+    ],
+)
+def test_consume_codex_stream_keeps_unmatched_aliased_deltas_private(
+    added_event, delta_event
+):
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    visible = []
+    reasoning = []
+    commentary = []
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream(
+            [
+                added_event,
+                delta_event,
+                SimpleNamespace(
+                    type="response.completed",
+                    response=SimpleNamespace(status="completed"),
+                ),
+            ]
+        ),
+        model="gpt-5-codex",
+        on_text_delta=visible.append,
+        on_reasoning_delta=reasoning.append,
+        on_commentary_message=commentary.append,
+    )
+
+    assert visible == []
+    assert commentary == []
+    assert reasoning == [delta_event.delta]
+    assert response.output_text == ""


### PR DESCRIPTION
## Summary

- preserve commentary buffers when Codex Responses output items interleave
- keep unmatched aliased deltas private while a private item is active
- preserve standalone unphased final output streams instead of dropping visible text

## Context

PR #59831 was superseded by #66115, which landed the core commentary-to-interim routing and `display.show_commentary` control. This is a narrow follow-up for residual stream-shape cases reproduced against current `main`; it does not reintroduce the superseded implementation.

## Tests

- `HERMES_PYTHON=/usr/local/lib/hermes-agent/venv/bin/python ./scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py -q` — 112 passed
- `python -m py_compile agent/codex_runtime.py`
- `git diff origin/main..HEAD --check`
