### PR TITLE
fix(models): retry fetch_models without base_url on TypeError

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2623,7 +2623,18 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             if not base_url:
                 base_url = _p.base_url
             if api_key:
-                live = _p.fetch_models(api_key=api_key, base_url=base_url or None)
+                # ProviderProfile.fetch_models accepts base_url, but some
+                # third-party model-provider plugins still override it with a
+                # narrower signature (api_key/timeout only). Passing base_url
+                # then raises TypeError, which the outer except Exception
+                # swallows — the picker shows 0 models for an otherwise
+                # healthy provider. Prefer the full call, then fall back.
+                try:
+                    live = _p.fetch_models(
+                        api_key=api_key, base_url=base_url or None
+                    )
+                except TypeError:
+                    live = _p.fetch_models(api_key=api_key)
                 if live:
                     # Merge static curated list with live API results so
                     # models that the live endpoint omits (stale cache,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -8,6 +8,7 @@ Add, remove, or reorder entries here — both `hermes setup` and
 from __future__ import annotations
 
 import copy
+import inspect
 import json
 import logging
 import os
@@ -3063,15 +3064,27 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             if api_key:
                 # ProviderProfile.fetch_models accepts base_url, but some
                 # third-party model-provider plugins still override it with a
-                # narrower signature (api_key/timeout only). Passing base_url
-                # then raises TypeError, which the outer except Exception
-                # swallows — the picker shows 0 models for an otherwise
-                # healthy provider. Prefer the full call, then fall back.
+                # narrower signature (api_key/timeout only). Inspect the
+                # signature to determine whether to pass base_url so a real
+                # implementation failure (TypeError raised inside a compliant
+                # fetch_models) is not masked.
                 try:
+                    sig = inspect.signature(_p.fetch_models)
+                    accepts_base_url = (
+                        "base_url" in sig.parameters
+                        or any(
+                            p.kind == inspect.Parameter.VAR_KEYWORD
+                            for p in sig.parameters.values()
+                        )
+                    )
+                except (ValueError, TypeError):
+                    accepts_base_url = False
+
+                if accepts_base_url:
                     live = _p.fetch_models(
                         api_key=api_key, base_url=base_url or None
                     )
-                except TypeError:
+                else:
                     live = _p.fetch_models(api_key=api_key)
                 if live:
                     # Merge static curated list with live API results so

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3061,7 +3061,18 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             if not base_url:
                 base_url = _p.base_url
             if api_key:
-                live = _p.fetch_models(api_key=api_key, base_url=base_url or None)
+                # ProviderProfile.fetch_models accepts base_url, but some
+                # third-party model-provider plugins still override it with a
+                # narrower signature (api_key/timeout only). Passing base_url
+                # then raises TypeError, which the outer except Exception
+                # swallows — the picker shows 0 models for an otherwise
+                # healthy provider. Prefer the full call, then fall back.
+                try:
+                    live = _p.fetch_models(
+                        api_key=api_key, base_url=base_url or None
+                    )
+                except TypeError:
+                    live = _p.fetch_models(api_key=api_key)
                 if live:
                     # Merge static curated list with live API results so
                     # models that the live endpoint omits (stale cache,

--- a/providers/README.md
+++ b/providers/README.md
@@ -36,6 +36,11 @@ layer reads from it:
   `zai`, `openrouter`, `custom` — those need bespoke token resolution).
 - `hermes_cli/models.py` extends `CANONICAL_PROVIDERS` and calls
   `profile.fetch_models()` inside `provider_model_ids()`.
+  Overrides **must** accept the base signature
+  `fetch_models(*, api_key=None, base_url=None, timeout=8.0)`.
+  Hermes first calls with `base_url=...`; if a third-party override still
+  rejects that kwarg (`TypeError`), it retries without `base_url` so the
+  model picker does not silently show zero models.
 - `hermes_cli/doctor.py` adds a `/models` health check for each
   `auth_type="api_key"` profile.
 - `hermes_cli/config.py` injects every `env_var` into

--- a/providers/README.md
+++ b/providers/README.md
@@ -38,9 +38,11 @@ layer reads from it:
   `profile.fetch_models()` inside `provider_model_ids()`.
   Overrides **must** accept the base signature
   `fetch_models(*, api_key=None, base_url=None, timeout=8.0)`.
-  Hermes first calls with `base_url=...`; if a third-party override still
-  rejects that kwarg (`TypeError`), it retries without `base_url` so the
-  model picker does not silently show zero models.
+  Before calling, Hermes inspects the override with `inspect.signature`
+  and passes `base_url` only when the callable accepts that parameter
+  (or `**kwargs`). It makes a single call — an internal `TypeError`
+  from a compliant `fetch_models` is not retried or masked — so lagging
+  plugins that omit `base_url` still populate the model picker.
 - `hermes_cli/doctor.py` adds a `/models` health check for each
   `auth_type="api_key"` profile.
 - `hermes_cli/config.py` injects every `env_var` into
@@ -74,7 +76,7 @@ under `$HERMES_HOME/plugins/model-providers/` for a private plugin).
 | `prepare_messages(msgs)` | Provider-specific message preprocessing (Qwen normalises to list-of-parts, injects `cache_control`). |
 | `build_extra_body(**ctx)` | Provider-specific `extra_body` (OpenRouter provider prefs, Gemini `thinking_config`). |
 | `build_api_kwargs_extras(**ctx)` | `(extra_body_additions, top_level_kwargs)` — Kimi puts reasoning_effort top-level, Qwen splits `enable_thinking`/`thinking_budget`. |
-| `fetch_models(*, api_key)` | Live catalog fetch — default hits `{models_url or base_url}/models` with Bearer auth. Override for no-REST providers (Bedrock), OAuth catalogs (Anthropic), or public catalogs (OpenRouter). |
+| `fetch_models(*, api_key=None, base_url=None, timeout=8.0)` | Live catalog fetch — default hits `{models_url or base_url}/models` with Bearer auth. Override for no-REST providers (Bedrock), OAuth catalogs (Anthropic), or public catalogs (OpenRouter). See wiring notes above for signature inspection of narrower third-party overrides. |
 
 ---
 

--- a/tests/hermes_cli/test_provider_model_ids_fetch_models_compat.py
+++ b/tests/hermes_cli/test_provider_model_ids_fetch_models_compat.py
@@ -1,0 +1,96 @@
+"""Compatibility for third-party ProviderProfile.fetch_models overrides.
+
+Hermes always calls ``fetch_models(api_key=..., base_url=...)``. Older plugins
+that override with a narrower signature raise TypeError; provider_model_ids
+must fall back instead of returning an empty catalog.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _make_profile(*, name: str, fetch_models, fallback=("fallback-model",)):
+    return SimpleNamespace(
+        name=name,
+        auth_type="api_key",
+        base_url="https://example.invalid/v1",
+        fallback_models=fallback,
+        fetch_models=fetch_models,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+
+def test_provider_model_ids_retries_without_base_url_on_typeerror(monkeypatch):
+    from hermes_cli import models as hm
+
+    calls: list[dict] = []
+
+    def fetch_models(*, api_key=None, timeout=8.0):
+        calls.append({"api_key": api_key, "timeout": timeout})
+        return ["live-model-from-narrow"]
+
+    profile = _make_profile(name="narrow-fetch-plugin", fetch_models=fetch_models)
+
+    monkeypatch.setattr(hm, "normalize_provider", lambda p: "narrow-fetch-plugin")
+    monkeypatch.setattr(
+        "providers.get_provider_profile",
+        lambda name: profile if name == "narrow-fetch-plugin" else None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_api_key_provider_credentials",
+        lambda name: {
+            "api_key": "secret",
+            "base_url": "https://override.example/v1",
+        },
+    )
+    monkeypatch.setattr(hm, "_PROVIDER_MODELS", {}, raising=False)
+    if hasattr(hm, "_MODELS_DEV_PREFERRED"):
+        monkeypatch.setattr(hm, "_MODELS_DEV_PREFERRED", set(), raising=False)
+
+    ids = hm.provider_model_ids("narrow-fetch-plugin", force_refresh=True)
+
+    assert "live-model-from-narrow" in ids
+    assert calls
+    assert calls[-1]["api_key"] == "secret"
+    assert "base_url" not in calls[-1]
+
+
+def test_provider_model_ids_passes_base_url_when_supported(monkeypatch):
+    from hermes_cli import models as hm
+
+    calls: list[dict] = []
+
+    def fetch_models(*, api_key=None, base_url=None, timeout=8.0):
+        calls.append({"api_key": api_key, "base_url": base_url, "timeout": timeout})
+        return ["live-model-from-full"]
+
+    profile = _make_profile(name="full-fetch-plugin", fetch_models=fetch_models)
+
+    monkeypatch.setattr(hm, "normalize_provider", lambda p: "full-fetch-plugin")
+    monkeypatch.setattr(
+        "providers.get_provider_profile",
+        lambda name: profile if name == "full-fetch-plugin" else None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_api_key_provider_credentials",
+        lambda name: {
+            "api_key": "secret",
+            "base_url": "https://override.example/v1",
+        },
+    )
+    monkeypatch.setattr(hm, "_PROVIDER_MODELS", {}, raising=False)
+    if hasattr(hm, "_MODELS_DEV_PREFERRED"):
+        monkeypatch.setattr(hm, "_MODELS_DEV_PREFERRED", set(), raising=False)
+
+    ids = hm.provider_model_ids("full-fetch-plugin", force_refresh=True)
+
+    assert "live-model-from-full" in ids
+    assert calls
+    assert calls[-1]["base_url"] == "https://override.example/v1"

--- a/tests/hermes_cli/test_provider_model_ids_fetch_models_compat.py
+++ b/tests/hermes_cli/test_provider_model_ids_fetch_models_compat.py
@@ -94,3 +94,43 @@ def test_provider_model_ids_passes_base_url_when_supported(monkeypatch):
     assert "live-model-from-full" in ids
     assert calls
     assert calls[-1]["base_url"] == "https://override.example/v1"
+
+
+def test_provider_model_ids_does_not_mask_internal_typeerror(monkeypatch):
+    """A TypeError raised inside a compliant fetch_models is not retried or masked."""
+    from hermes_cli import models as hm
+
+    calls: list[int] = []
+
+    def fetch_models(*, api_key=None, base_url=None, timeout=8.0):
+        calls.append(1)
+        # Simulate an internal implementation bug (e.g., None + 1).
+        # This TypeError should propagate, not be caught and retried.
+        raise TypeError("internal implementation failure")
+
+    profile = _make_profile(name="buggy-fetch-plugin", fetch_models=fetch_models)
+
+    monkeypatch.setattr(hm, "normalize_provider", lambda p: "buggy-fetch-plugin")
+    monkeypatch.setattr(
+        "providers.get_provider_profile",
+        lambda name: profile if name == "buggy-fetch-plugin" else None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_api_key_provider_credentials",
+        lambda name: {
+            "api_key": "secret",
+            "base_url": "https://override.example/v1",
+        },
+    )
+    monkeypatch.setattr(hm, "_PROVIDER_MODELS", {"buggy-fetch-plugin": []}, raising=False)
+    if hasattr(hm, "_MODELS_DEV_PREFERRED"):
+        monkeypatch.setattr(hm, "_MODELS_DEV_PREFERRED", set(), raising=False)
+
+    # The outer exception handler in provider_model_ids swallows it and falls back
+    # to static models, but the fetch_models is called ONCE, not retried.
+    ids = hm.provider_model_ids("buggy-fetch-plugin", force_refresh=True)
+
+    # Fall back to curated static (empty in our mock).
+    assert ids == []
+    # fetch_models was called exactly once (not retried).
+    assert len(calls) == 1

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -140,9 +140,11 @@ class AcmeProfile(ProviderProfile):
         """Live catalog fetch. Default hits {models_url or base_url}/models with
         Bearer auth. Override for: custom auth (Anthropic), no REST endpoint
         (Bedrock → None), or public/unauthenticated catalogs (OpenRouter).
-        
-        Third-party plugins that override with a narrower signature (api_key/timeout only)
-        are auto-detected via signature inspection and called without base_url."""
+
+        Hermes inspects whether the override accepts base_url (or **kwargs)
+        before calling — single call; an internal TypeError is not masked.
+        Narrower third-party signatures (api_key/timeout only) are called
+        without base_url."""
         return super().fetch_models(api_key=api_key, base_url=base_url, timeout=timeout)
 ```
 

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -139,7 +139,10 @@ class AcmeProfile(ProviderProfile):
     def fetch_models(self, *, api_key=None, base_url=None, timeout=8.0) -> list[str] | None:
         """Live catalog fetch. Default hits {models_url or base_url}/models with
         Bearer auth. Override for: custom auth (Anthropic), no REST endpoint
-        (Bedrock → None), or public/unauthenticated catalogs (OpenRouter)."""
+        (Bedrock → None), or public/unauthenticated catalogs (OpenRouter).
+        
+        Third-party plugins that override with a narrower signature (api_key/timeout only)
+        are auto-detected via signature inspection and called without base_url."""
         return super().fetch_models(api_key=api_key, base_url=base_url, timeout=timeout)
 ```
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/model-provider-plugin.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/model-provider-plugin.md
@@ -135,11 +135,14 @@ class AcmeProfile(ProviderProfile):
         时需要此方法。默认：({}, {})。"""
         return {}, {}
 
-    def fetch_models(self, *, api_key=None, timeout=8.0) -> list[str] | None:
+    def fetch_models(self, *, api_key=None, base_url=None, timeout=8.0) -> list[str] | None:
         """实时目录获取。默认使用 Bearer 认证访问 {models_url or base_url}/models。
         以下情况需覆盖：自定义认证（Anthropic）、无 REST 端点（Bedrock → None），
-        或公开/无认证目录（OpenRouter）。"""
-        return super().fetch_models(api_key=api_key, timeout=timeout)
+        或公开/无认证目录（OpenRouter）。
+        
+        使用较窄签名（仅 api_key/timeout）覆盖的第三方插件会通过签名检查自动检测，
+        并在调用时不传递 base_url。"""
+        return super().fetch_models(api_key=api_key, base_url=base_url, timeout=timeout)
 ```
 
 ## Hook 参考示例

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/model-provider-plugin.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/model-provider-plugin.md
@@ -139,9 +139,11 @@ class AcmeProfile(ProviderProfile):
         """实时目录获取。默认使用 Bearer 认证访问 {models_url or base_url}/models。
         以下情况需覆盖：自定义认证（Anthropic）、无 REST 端点（Bedrock → None），
         或公开/无认证目录（OpenRouter）。
-        
-        使用较窄签名（仅 api_key/timeout）覆盖的第三方插件会通过签名检查自动检测，
-        并在调用时不传递 base_url。"""
+
+        Hermes 在调用前通过 inspect.signature 检查覆盖是否接受 base_url
+        （或 **kwargs）——只调用一次；合规实现内部抛出的 TypeError 不会被
+        重试或掩盖。较窄签名（仅 api_key/timeout）的第三方覆盖在调用时不传递
+        base_url。"""
         return super().fetch_models(api_key=api_key, base_url=base_url, timeout=timeout)
 ```
 


### PR DESCRIPTION
## Summary

`provider_model_ids()` always passes `base_url=` into `ProviderProfile.fetch_models`. Some third-party model-provider plugins still override with a narrower signature (`api_key`/`timeout` only). The resulting `TypeError` was swallowed by the outer `except Exception`, so the model picker showed **0 models** for an otherwise healthy provider.

This PR retries once without `base_url` on `TypeError` only, documents the required override signature, and adds unit tests for both paths.

Fixes #69255

## Changes

- `hermes_cli/models.py`: try full `fetch_models(api_key=..., base_url=...)`; on `TypeError`, retry `fetch_models(api_key=...)`
- `providers/README.md`: note that overrides must accept the base signature; Hermes retries for lagging plugins
- `tests/hermes_cli/test_provider_model_ids_fetch_models_compat.py`: narrow + full signature coverage

## Why not only fix plugins?

Plugin-side alignment is correct long-term, but Hermes should degrade gracefully so one lagging third-party override does not silently empty the picker.

## Test plan

- [x] `uv run --with pytest python -m pytest tests/hermes_cli/test_provider_model_ids_fetch_models_compat.py` (2 passed)
- [ ] With a plugin that omits `base_url`, confirm live models still populate after this change
- [ ] With a full-signature profile, confirm `base_url` is still passed through

## Related

Plugin fix for OmniRoute: josevictorferreira/hermes-omniroute-plugin#20