### PR TITLE
test(cli): stop test_gateway_service hard-exit from truncating the suite (#69218)

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -239,8 +239,20 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr("gateway.run.start_gateway", fake_start_gateway)
 
+        # run_gateway()'s success path ends in _exit_after_graceful_shutdown()
+        # -> os._exit(0) (fd96e138b), which would hard-exit the whole pytest
+        # process here and silently truncate the rest of this file (#69218).
+        # Stub it the same way tests/hermes_cli/test_gateway_run_hard_exit.py
+        # does, and record that the boot path did reach the hard-exit backstop.
+        exit_codes: list[int] = []
+        monkeypatch.setattr(
+            "gateway.run._exit_after_graceful_shutdown",
+            lambda code: exit_codes.append(code),
+        )
+
         gateway_cli.run_gateway()
 
+        assert exit_codes == [0]
         assert unit_path.read_text(encoding="utf-8") == "new unit\n"
         assert ["systemctl", "--user", "daemon-reload"] in calls
 
@@ -1539,6 +1551,20 @@ class TestGatewayServiceDetection:
         assert gateway_cli._is_service_running() is False
 
 class TestGatewaySystemServiceRouting:
+    @pytest.fixture(autouse=True)
+    def _stub_user_systemd_preflight(self, monkeypatch):
+        """Isolate restart-routing logic from the user D-Bus preflight.
+
+        ``systemd_restart()`` calls ``_preflight_user_systemd()``, which raises
+        ``UserSystemdUnavailableError`` on any host without a reachable user
+        D-Bus session (macOS, CI runners with no lingering user session). These
+        routing tests mock systemctl/scope but assume the preflight passes — the
+        preflight's own behavior is covered separately by
+        ``TestPreflightUserSystemd``. Individual tests that mock the preflight
+        themselves still win (autouse applies first).
+        """
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda **kw: None)
+
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):
         calls = []
 


### PR DESCRIPTION
Fixes #69218

### Problem

Since `fd96e138b` (hard-exit CLI runner after graceful teardown), `run_gateway()`'s success path ends in `_exit_after_graceful_shutdown()` → `os._exit(0)`. The pre-existing test `TestSystemdServiceRefresh::test_run_gateway_refreshes_outdated_unit_on_boot` drives the real `run_gateway()` with `gateway.run.start_gateway` stubbed to return `True`, so that success path now **hard-exits the whole pytest process** eight tests into the file.

pytest exits `0`, prints no summary, writes no junitxml (`sessionfinish` never runs), and **every test after it in the file never executes** — ~180 tests on `main`. Nothing fails, so CI reads green. (Fixes #69218)

```
python -m pytest tests/hermes_cli/test_gateway_service.py -q --junitxml=/tmp/j.xml; echo $?
# before: exit 0, /tmp/j.xml never created, output stops after 8 dots
```

### Fix

1. **Stop the truncation.** `test_run_gateway_refreshes_outdated_unit_on_boot` now stubs `gateway.run._exit_after_graceful_shutdown` (the same seam `tests/hermes_cli/test_gateway_run_hard_exit.py` already uses) and asserts the boot path reached the hard-exit backstop with code `0`, instead of letting it `os._exit` the session.

2. **Make the un-hidden tests actually pass.** Restoring the suite surfaced 4 `TestGatewaySystemServiceRouting::test_systemd_restart_*` tests that had **never run on any platform** (they were added after the truncating commit). They drive `systemd_restart()`, which calls `_preflight_user_systemd()` and raises `UserSystemdUnavailableError` on any host without a reachable user D-Bus session (macOS, and CI runners with no lingering user session). The routing tests mock systemctl/scope but assumed the preflight passed — the earlier tests in the file already mock it, and the preflight's own behavior is covered separately by `TestPreflightUserSystemd`. Added a class-scoped autouse fixture that isolates the routing logic from the preflight (individual tests that mock it themselves still win).

### Verification

```
# whole file now runs to completion and is green
python -m pytest tests/hermes_cli/test_gateway_service.py -q --junitxml=/tmp/j.xml
# 189 passed; /tmp/j.xml written (tests=189, failures=0)
```

Before this PR the same command silently ran 8 tests and wrote no junitxml.

### Follow-up (not in this PR)

The reporter also suggested a conftest-level tripwire so a future `os._exit` inside a code path under test can't silently truncate a suite again. That's a broader, session-wide change with its own blast radius (xdist workers, teardown, other suites) and is best evaluated on its own — filing/keeping it separate keeps this PR to the focused regression fix.
