### PR TITLE
fix: register gateway service after profile import (#69163)

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2080,6 +2080,10 @@ def import_profile(archive_path: str, name: Optional[str] = None) -> Path:
 
         shutil.move(str(final_source), str(profile_dir))
 
+    # Register the imported profile's gateway service, matching what
+    # create_profile() does. On host (systemd/launchd) this is a no-op.
+    _maybe_register_gateway_service(canon)
+
     return profile_dir
 
 


### PR DESCRIPTION
import_profile() extracted the archive and moved it to the profiles
directory but never called _maybe_register_gateway_service(), unlike
create_profile() which does. This caused the gateway to show as
'stopped' in profile list but 'hermes -p <name> gateway start' to
fail with 'no such gateway'.

Fix: add _maybe_register_gateway_service(canon) at the end of
import_profile(), matching create_profile(). On host (systemd/launchd)
this is a no-op.
