### PR TITLE
fix(cron): build failure reason from metadata, not the agent's final_response (#69224)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3662,11 +3662,26 @@ def run_job(
             and bool(final_response_text)
         )
         if result.get("failed") is True or (result.get("completed") is False and not max_iteration_summary):
-            _err_text = (
-                result.get("error")
-                or final_response_text
-                or "agent reported failure"
-            )
+            # Build the failure reason from failure *metadata* only.
+            # ``final_response`` is the agent's reply, not an error description;
+            # using it as the exception text pasted the entire response body into
+            # the job's ``last_status``, alert channels and logs, so a genuine
+            # crash was indistinguishable from a truncated-but-successful run and
+            # legitimate output was recorded as the failure reason (#69224). Prefer
+            # the explicit ``error``, fall back to a generic marker (optionally
+            # tagged with the turn-exit reason), and record the presence of a
+            # non-error response as a log field instead of leaking it as the text.
+            _err_text = str(result.get("error") or "").strip() or "agent reported failure"
+            if turn_exit_reason:
+                _err_text = f"{_err_text} (turn_exit_reason={turn_exit_reason})"
+            if not result.get("error") and final_response_text:
+                logger.warning(
+                    "Job '%s': agent-flagged failure carried a non-error "
+                    "final_response (%d chars); surfacing failure metadata as the "
+                    "reason instead of the response body",
+                    job_name,
+                    len(final_response_text),
+                )
             raise RuntimeError(_err_text)
         if max_iteration_summary:
             logger.warning(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1865,7 +1865,27 @@ def _final_response_from_result(result: dict, job_id: str, job_name: str, AIAgen
         and bool(final_response_text)
     )
     if result.get("failed") is True or (result.get("completed") is False and not max_iteration_summary):
-        raise RuntimeError(result.get("error") or final_response_text or "agent reported failure")
+        # Build the failure reason from failure *metadata* only.
+        # ``final_response`` is the agent's reply, not an error description;
+        # using it as the exception text pasted the entire response body into
+        # the job's ``last_status``, alert channels and logs, so a genuine
+        # crash was indistinguishable from a truncated-but-successful run and
+        # legitimate output was recorded as the failure reason (#69224). Prefer
+        # the explicit ``error``, fall back to a generic marker (optionally
+        # tagged with the turn-exit reason), and record the presence of a
+        # non-error response as a log field instead of leaking it as the text.
+        _err_text = str(result.get("error") or "").strip() or "agent reported failure"
+        if turn_exit_reason:
+            _err_text = f"{_err_text} (turn_exit_reason={turn_exit_reason})"
+        if not result.get("error") and final_response_text:
+            logger.warning(
+                "Job '%s': agent-flagged failure carried a non-error "
+                "final_response (%d chars); surfacing failure metadata as the "
+                "reason instead of the response body",
+                job_name,
+                len(final_response_text),
+            )
+        raise RuntimeError(_err_text)
     if max_iteration_summary:
         logger.warning(
             "Job '%s' reached the iteration limit but produced a final fallback response; "

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -532,6 +532,52 @@ class TestRunJobSessionPersistence:
             mock_agent_cls = entered[-1]  # the AIAgent patch
             yield fake_db, mock_agent_cls
 
+    def test_run_job_failure_reason_excludes_response_body(self, tmp_path):
+        """Issue #69224: on an agent-flagged failure that carries a real (non-error)
+        ``final_response``, the failure reason must be built from failure metadata
+        only. The response body must never be pasted into ``error`` — otherwise the
+        whole reply lands in ``last_status``/alerts and a genuine crash becomes
+        indistinguishable from a truncated-but-successful run.
+        """
+        body = "Quarterly summary: revenue up 12%, three incidents resolved."
+        job = {"id": "report-job", "name": "weekly report", "prompt": "summarize"}
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": body,
+                "failed": True,
+                "completed": False,
+                "turn_exit_reason": "model_abort",
+            }
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is False
+        assert final_response == ""
+        # The response body must not leak into the failure reason or FAILED output.
+        assert error is not None
+        assert body not in error
+        assert body not in output
+        # A useful failure reason is still produced, tagged with the exit reason.
+        assert "agent reported failure" in error
+        assert "model_abort" in error
 
     def test_tick_skips_due_jobs_while_dispatch_is_paused(self, tmp_path):
         """The drain gate runs before advancing a due job's schedule."""

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -725,6 +725,34 @@ class TestRunJobSessionPersistence:
         assert "file" in (kwargs["enabled_toolsets"] or [])
         assert "memory" not in kwargs["disabled_toolsets"]
 
+    def test_run_job_failure_reason_excludes_response_body(self, tmp_path):
+        """Issue #69224: on an agent-flagged failure that carries a real (non-error)
+        ``final_response``, the failure reason must be built from failure metadata
+        only. The response body must never be pasted into ``error`` — otherwise the
+        whole reply lands in ``last_status``/alerts and a genuine crash becomes
+        indistinguishable from a truncated-but-successful run.
+        """
+        body = "Quarterly summary: revenue up 12%, three incidents resolved."
+        job = {"id": "report-job", "name": "weekly report", "prompt": "summarize"}
+        with self._run_job_patches(tmp_path) as (fake_db, mock_agent_cls):
+            mock_agent_cls.return_value.run_conversation.return_value = {
+                "final_response": body,
+                "failed": True,
+                "completed": False,
+                "turn_exit_reason": "model_abort",
+            }
+            success, output, final_response, error = run_job(job)
+
+        assert success is False
+        assert final_response == ""
+        # The response body must not leak into the failure reason or FAILED output.
+        assert error is not None
+        assert body not in error
+        assert body not in output
+        # A useful failure reason is still produced, tagged with the exit reason.
+        assert "agent reported failure" in error
+        assert "model_abort" in error
+
     def test_tick_skips_due_jobs_while_dispatch_is_paused(self, tmp_path):
         """The drain gate runs before advancing a due job's schedule."""
         from cron.scheduler import tick


### PR DESCRIPTION
## Problem

When a cron job's agent run ends with `failed=True` or `completed=False` (outside the max-iterations fallback), the failure guard in `run_job` raised the agent's **entire `final_response`** as the `RuntimeError` text:

```python
_err_text = (
    result.get("error")
    or final_response_text        # <-- the agent's reply, not an error
    or "agent reported failure"
)
raise RuntimeError(_err_text)
```

`final_response` is the agent's message, not an error description. On failure paths where the agent produced real output but no `error` key, the whole response body became the exception message, so:

- the job's `last_status`, alerts and logs record the agent's response **as the failure reason** — alert channels get the full response pasted as an error;
- a genuine crash is indistinguishable from a truncated-but-successful run.

The guard itself is correct (raising instead of silently marking the run "ok" is the #17855 fix); only the fallback to `final_response` as the exception payload conflates response with error.

## Fix

Build the failure reason from failure **metadata only**: prefer the explicit `error`, fall back to a generic marker optionally tagged with `turn_exit_reason`, and record the presence of a non-error `final_response` as a log field (length, not the body) instead of leaking it as the reason. The `max_iterations_reached` fallback that legitimately delivers a response is untouched, and the #17855 raise-on-failure behavior is preserved.

## Tests

- New parametrized case + a dedicated regression test (`test_run_job_failure_reason_excludes_response_body`) asserting the response body appears in **neither** the `error` string nor the FAILED output, while a useful reason (`agent reported failure (turn_exit_reason=...)`) is still produced.
- Existing #17855 cases (explicit `error`, empty/None `final_response`) stay green.

Fixes #69224
