### PR TITLE
fix(desktop): don't override LC_CTYPE with invalid 'UTF-8' charset (#69265)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9552,7 +9552,6 @@ function terminalShellEnv() {
   delete env.COLORFGBG
 
   env.COLORTERM = 'truecolor'
-  env.LC_CTYPE = env.LC_CTYPE || 'UTF-8'
   env.TERM = 'xterm-256color'
   env.TERM_PROGRAM = 'Hermes'
   env.TERM_PROGRAM_VERSION = app.getVersion()


### PR DESCRIPTION
## Summary

Fix `bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8)` appearing on every shell invocation in the Hermes Desktop terminal on Linux/macOS.

## Root cause

`apps/desktop/electron/main.ts:9555` (in `terminalShellEnv()`) set:

```js
env.LC_CTYPE = env.LC_CTYPE || 'UTF-8'
```

`'UTF-8'` is a **charset**, not a locale name. On Linux, valid `LC_CTYPE` values are locale names like `de_DE.UTF-8`, `en_US.UTF-8`, `C.UTF-8`, or `C`. The bare string `'UTF-8'` is not recognised by `setlocale(3)`, so bash emits the warning every time the embedded PTY spawns.

## Fix

**Single-line deletion.** The system locale (`LANG`) already provides a sensible default when `LC_CTYPE` is unset, so the explicit override only caused harm.

```diff
   env.COLORTERM = 'truecolor'
-  env.LC_CTYPE = env.LC_CTYPE || 'UTF-8'
   env.TERM = 'xterm-256color'
```

## What this does NOT do

- **No** change to `LANG`, `LC_ALL`, `LC_MESSAGES`, or other locale env vars — they're handled by the host shell init and out of scope.
- **No** public API change. The Desktop terminal continues to spawn with the same colour/TERM/Hermes branding env.
- **No** Windows regression — `LANG` defaults also work on Windows; bash-on-Windows is unaffected because Windows PTY uses a different code path that already respects the user's system locale.

## Test plan

```bash
# 1. Verify TypeScript compile (no type errors from line removal)
cd apps/desktop && npx tsc --noEmit -p tsconfig.json
# exit 0 expected

# 2. Confirm the override is gone
grep -n "LC_CTYPE" apps/desktop/electron/main.ts
# (no output expected)

# 3. Confirm no other locale-related regressions in the same function
sed -n '9540,9570p' apps/desktop/electron/main.ts
# should show env.COLORTERM, env.TERM, env.TERM_PROGRAM unchanged
```

Manual verification on Linux after merging:

```bash
# Before fix:
$ /proc/<pid>/environ  # → LC_CTYPE=UTF-8
$ bash -c "echo hi"
bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
hi

# After fix:
$ /proc/<pid>/environ  # → no LC_CTYPE (LANG handles it)
$ bash -c "echo hi"
hi
```

Fixes #69265.

— written by Hermes Agent on behalf of @Enough1122