### PR TITLE
feat(memory): add reusable OpenViking Quick Local setup

### DIFF
--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -2,34 +2,49 @@
 
 Context database by Volcengine (ByteDance) with filesystem-style knowledge hierarchy, tiered retrieval, and automatic memory extraction.
 
-## Requirements
-
-- OpenViking installed with the `openviking-server` command available
-- OpenViking server config initialized and validated (`openviking-server init`,
-  then `openviking-server doctor`)
-- OpenViking server running and reachable from Hermes
-
 ## Setup
-
-Prepare OpenViking first:
-
-```bash
-openviking-server init
-openviking-server doctor
-openviking-server
-```
-
-Then configure Hermes:
 
 ```bash
 hermes memory setup    # select "openviking"
 ```
 
-The setup can link to an existing `~/.openviking/ovcli.conf`, copy its current
-connection values into Hermes, or create a minimal `ovcli.conf` when one does
-not exist.
+Setup offers three paths:
 
-Or manually:
+1. **OpenViking Service (VolcEngine Cloud)** — a managed cloud service that
+   requires an API key and preserves identity validation.
+2. **Quick local setup** — configures a local server, installs OpenViking when
+   needed, ensures Ollama and `qwen3-embedding:0.6b` are available, creates a
+   Hermes-scoped local workspace, and reuses Hermes' effective static API-key LLM
+   configuration. Generated files live under the active Hermes home in
+   `openviking/`.
+3. **Connect to an existing server** — uses the user's own local or remote
+   endpoint by linking a detected `ovcli.conf` profile or accepting another
+   server URL. That server remains managed separately.
+
+The quick-local server starts automatically when Hermes needs it. On a clean
+Hermes shutdown, tracked workflows and queued semantic/vector work can finish
+briefly in the background; the plugin then stops only the exact child process
+started by that provider instance. Configuration and stored data are preserved,
+and Ollama is left running because other applications may share it. If work
+completion or process ownership cannot be verified, the server is left running
+rather than risk interrupting work. Existing local and remote servers are never
+controlled at runtime. If an existing local endpoint is down during setup,
+Hermes can start it once only when a separate OpenViking `ov.conf` already
+exists; otherwise setup offers the local-server setup path or another endpoint.
+
+Hermes OAuth, cloud-native, and external-process credentials are not copied to
+OpenViking because they may expire or require Hermes-specific refresh logic.
+Use a static API-key LLM for quick local setup, or configure and connect an
+OpenViking server separately.
+
+Setup links one OpenViking-owned profile and records only that profile path in
+the active Hermes profile. New service/custom connections are stored as
+`ovcli.conf.<name>` profiles; Quick Local uses its Hermes-scoped `ovcli.conf`.
+Editing the linked profile therefore updates the next Hermes run without
+duplicating credentials into Hermes configuration.
+
+For compatibility, a manually configured Hermes profile can still use
+environment variables:
 
 ```bash
 hermes config set memory.provider openviking
@@ -40,11 +55,11 @@ default profile that is `~/.hermes/.env`; for a named profile use
 `~/.hermes/profiles/<profile>/.env`.
 
 ```text
-OPENVIKING_ENDPOINT=http://127.0.0.1:1933
+OPENVIKING_URL=http://127.0.0.1:1933
 # OPENVIKING_API_KEY=...
 # OPENVIKING_ACCOUNT=default
 # OPENVIKING_USER=default
-# OPENVIKING_AGENT=hermes
+# OPENVIKING_ACTOR_PEER_ID=hermes
 ```
 
 ## Config
@@ -54,20 +69,24 @@ OpenViking's server config is separate from Hermes:
 - `ov.conf` configures OpenViking storage, embedding/VLM models, auth, and
   server behavior. OpenViking reads it from `--config`,
   `OPENVIKING_CONFIG_FILE`, or `~/.openviking/ov.conf`.
-- `ovcli.conf` stores client/CLI connection values such as `url`, `api_key`,
-  `account`, and `user`. It is read from `OPENVIKING_CLI_CONFIG_FILE` or
-  `~/.openviking/ovcli.conf`.
+- `ovcli.conf` and named `ovcli.conf.<name>` profiles store client connection
+  values such as `url`, `api_key`, `account`, `user`, and `actor_peer_id`.
+  Hermes setup links one exact profile; `OPENVIKING_CLI_CONFIG_FILE` is used
+  only when no explicit profile path is linked.
 
-Hermes-side provider config is read from environment variables in the active
-profile's `.env`:
+Hermes can link an OpenViking CLI profile or read connection values from
+environment variables in the active profile's `.env`:
 
 | Env Var | Default | Description |
 |---------|---------|-------------|
-| `OPENVIKING_ENDPOINT` | `http://127.0.0.1:1933` | Server URL |
+| `OPENVIKING_URL` | `http://127.0.0.1:1933` | Server URL |
 | `OPENVIKING_API_KEY` | (none) | User/admin API key for authenticated servers |
 | `OPENVIKING_ACCOUNT` | `default` | Tenant account for local/trusted mode |
 | `OPENVIKING_USER` | `default` | Tenant user for local/trusted mode |
-| `OPENVIKING_AGENT` | `hermes` | Hermes peer ID in OpenViking, used for peer-scoped memories |
+| `OPENVIKING_ACTOR_PEER_ID` | `hermes` | Agent ID in OpenViking, used for peer-scoped memories |
+
+`OPENVIKING_ENDPOINT` and `OPENVIKING_AGENT` remain supported as legacy
+fallbacks. Canonical variables take precedence when both forms are present.
 
 When `OPENVIKING_API_KEY` is set, Hermes lets OpenViking derive account/user
 identity from the key. In local or trusted deployments without an API key,
@@ -88,9 +107,10 @@ Hermes sends `OPENVIKING_ACCOUNT` and `OPENVIKING_USER` as identity headers.
 
 `viking_remember` writes directly to OpenViking with `POST /api/v1/content/write`
 and `mode=create`. It creates peer-scoped memory files under
-`viking://user/peers/${OPENVIKING_AGENT}/memories/...`; OpenViking may return a
-canonical user-scoped form such as
-`viking://user/default/peers/${OPENVIKING_AGENT}/memories/...` in API-key mode.
+`viking://user/peers/${OPENVIKING_ACTOR_PEER_ID}/memories/...`; OpenViking may
+return a canonical user-scoped form such as
+`viking://user/default/peers/${OPENVIKING_ACTOR_PEER_ID}/memories/...` in
+API-key mode.
 Explicit remembers do not depend on session commit extraction.
 
 Hermes built-in `memory` tool additions are mirrored to OpenViking after the

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -7,13 +7,16 @@ automatic memory extraction, and session management.
 Original PR #3369 by Mibayy, rewritten to use the full OpenViking session
 lifecycle instead of read-only search endpoints.
 
-Config via environment variables (profile-scoped via each profile's .env)
-or a linked OpenViking CLI config:
-  OPENVIKING_ENDPOINT  — Server URL (default: http://127.0.0.1:1933)
-  OPENVIKING_API_KEY   — API key (required for authenticated servers)
-  OPENVIKING_ACCOUNT   — Tenant account for local/trusted mode (default: default)
-  OPENVIKING_USER      — Tenant user for local/trusted mode (default: default)
-  OPENVIKING_AGENT     — Hermes peer ID in OpenViking (default: hermes)
+Config normally uses a linked OpenViking CLI profile. Environment variables
+can still override individual runtime values:
+  OPENVIKING_URL            — Server URL (default: http://127.0.0.1:1933)
+  OPENVIKING_API_KEY        — API key (required for authenticated servers)
+  OPENVIKING_ACCOUNT        — Tenant account for local/trusted mode (default: default)
+  OPENVIKING_USER           — Tenant user for local/trusted mode (default: default)
+  OPENVIKING_ACTOR_PEER_ID  — Agent ID in OpenViking (default: hermes)
+
+Legacy OPENVIKING_ENDPOINT and OPENVIKING_AGENT remain runtime fallbacks.
+Setup writes only provider-owned profiles and canonical names.
 
 Capabilities:
   - Automatic memory extraction on session commit (6 categories)
@@ -41,6 +44,7 @@ import time
 import uuid
 import zipfile
 from dataclasses import dataclass, replace
+from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set
 from urllib.parse import quote, unquote, urlparse
@@ -52,6 +56,8 @@ from agent.skill_commands import extract_user_instruction_from_skill_message
 from tools.registry import tool_error
 from utils import atomic_json_write, env_var_enabled
 
+from . import local_server, quick_local
+
 try:
     import fcntl
 except ImportError:  # pragma: no cover - Windows
@@ -62,17 +68,20 @@ logger = logging.getLogger(__name__)
 _DEFAULT_ENDPOINT = "http://127.0.0.1:1933"
 _OPENVIKING_SERVICE_ENDPOINT = "https://api.vikingdb.cn-beijing.volces.com/openviking"
 _DEFAULT_AGENT = "hermes"
-_AGENT_PROMPT_LABEL = "Hermes peer ID in OpenViking"
+_AGENT_PROMPT_LABEL = "Agent ID"
 _OVCLI_CONFIG_ENV = "OPENVIKING_CLI_CONFIG_FILE"
 _OVCLI_DEFAULT_RELATIVE_PATH = ".openviking/ovcli.conf"
 _OVCLI_SAVED_PREFIX = "ovcli.conf."
 _OPENVIKING_ENV_KEYS = (
-    "OPENVIKING_ENDPOINT",
+    "OPENVIKING_URL",
     "OPENVIKING_API_KEY",
     "OPENVIKING_ACCOUNT",
     "OPENVIKING_USER",
-    "OPENVIKING_AGENT",
+    "OPENVIKING_ACTOR_PEER_ID",
 )
+_OPENVIKING_LEGACY_ENV_KEYS = ("OPENVIKING_ENDPOINT", "OPENVIKING_AGENT")
+_OPENVIKING_ENV_KEYS_TO_REMOVE = _OPENVIKING_ENV_KEYS + _OPENVIKING_LEGACY_ENV_KEYS
+_OPENVIKING_ENV_KEYS_FOR_STATUS = _OPENVIKING_ENV_KEYS + _OPENVIKING_LEGACY_ENV_KEYS
 _TIMEOUT = 30.0
 _SESSION_DRAIN_TIMEOUT = 10.0
 _DEFERRED_COMMIT_TIMEOUT = (_TIMEOUT * 2) + 5.0
@@ -125,19 +134,21 @@ _GENERATED_MEMORY_SUMMARY_FILENAMES = {
     ".overview.md",
 }
 _LOCAL_OPENVIKING_HOSTS = {"localhost", "127.0.0.1", "::1"}
-_LOCAL_OPENVIKING_AUTOSTART_TIMEOUT = 60.0
+_LOCAL_OPENVIKING_AUTOSTART_TIMEOUT = local_server.AUTOSTART_TIMEOUT_SECONDS
 # After a refresh attempt fails for a given (unchanged) config, skip re-probing
 # for this long. Keeps "unavailable endpoints reconnect on a later access"
 # true while preventing every provider access from paying a 3s health probe
 # (and emitting a warning) under _client_refresh_lock while a server is down.
 _FAILED_CONFIG_RETRY_COOLDOWN_SECONDS = 30.0
-_OPENVIKING_SERVER_LOG_RELATIVE_PATH = Path("logs") / "openviking-server.log"
-_OPENVIKING_RESPONDED_FAILURE_PREFIX = "OpenViking server responded"
+_MANAGED_LOCAL_DEPLOYMENT = quick_local.DEPLOYMENT
+_MANAGED_LOCAL_EMBEDDING_MODEL = quick_local.EMBEDDING_MODEL
 _PENDING_SESSIONS_RELATIVE_DIR = Path("openviking") / "pending_sessions"
 _RUN_LOCKS_RELATIVE_DIR = Path("openviking") / "runs"
 _LEGACY_RECOVERY_LOCK_FILENAME = "legacy-recovery.lock"
 _LOCK_BUSY_ERRNOS = {errno.EWOULDBLOCK, errno.EACCES, errno.EAGAIN}
 _SETUP_CANCELLED = object()
+_ROUTE_TO_QUICK_LOCAL = object()
+_ENTER_EXISTING_ENDPOINT = object()
 
 
 @dataclass(frozen=True)
@@ -148,6 +159,31 @@ class _OvcliProfile:
     data: dict
     values: dict
     is_active: bool = False
+
+
+class _OpenVikingReachabilityState(str, Enum):
+    HEALTHY = "healthy"
+    UNREACHABLE = "unreachable"
+    UNHEALTHY = "unhealthy"
+    RESPONDED_ERROR = "responded_error"
+
+
+@dataclass(frozen=True)
+class _OpenVikingReachability:
+    state: _OpenVikingReachabilityState
+    message: str = ""
+
+    @property
+    def reachable(self) -> bool:
+        return self.state is _OpenVikingReachabilityState.HEALTHY
+
+    @property
+    def allows_local_autostart(self) -> bool:
+        return self.state is _OpenVikingReachabilityState.UNREACHABLE
+
+
+_ManagedLocalPaths = quick_local.QuickLocalPaths
+_LocalServerStartResult = local_server.LocalServerStartResult
 
 
 class _OpenVikingHTTPError(RuntimeError):
@@ -221,7 +257,7 @@ _last_active_provider: Optional["OpenVikingMemoryProvider"] = None
 
 
 def _atexit_commit_sessions():
-    """Fire on_session_end for the last active provider on process exit."""
+    """Finalize and shut down the last active provider on process exit."""
     global _last_active_provider
     provider = _last_active_provider
     if provider is None:
@@ -231,7 +267,13 @@ def _atexit_commit_sessions():
         provider.on_session_end([])
     except Exception:
         pass  # best-effort at shutdown time
+    try:
+        provider.shutdown()
+    except Exception:
+        pass  # best-effort at shutdown time
     finally:
+        # shutdown normally releases this lock; keep the atexit fallback
+        # idempotent in case shutdown itself fails before reaching cleanup.
         try:
             provider._release_run_lock()
         except Exception:
@@ -267,7 +309,12 @@ class _VikingClient:
         # after OpenViking explicitly asks for asserted tenant identity.
         self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "default")
         self._user = user or os.environ.get("OPENVIKING_USER", "default")
-        self._agent = agent if agent is not None else os.environ.get("OPENVIKING_AGENT", _DEFAULT_AGENT)
+        self._agent = (
+            agent
+            if agent is not None
+            else os.environ.get("OPENVIKING_ACTOR_PEER_ID")
+            or os.environ.get("OPENVIKING_AGENT", _DEFAULT_AGENT)
+        )
         self._httpx = _get_httpx()
         if self._httpx is None:
             raise ImportError("httpx is required for OpenViking: pip install httpx")
@@ -724,11 +771,11 @@ def _default_ovcli_config_path() -> Path:
 
 
 def _resolve_ovcli_config_path(config_path: str = "") -> Path:
+    if config_path:
+        return Path(config_path).expanduser()
     env_path = os.environ.get(_OVCLI_CONFIG_ENV, "").strip()
     if env_path:
         return Path(env_path).expanduser()
-    if config_path:
-        return Path(config_path).expanduser()
     return _default_ovcli_config_path()
 
 
@@ -747,19 +794,31 @@ def _load_ovcli_config(path: Optional[Path] = None) -> dict:
     return data
 
 
+def _load_required_ovcli_config(path: Path) -> dict:
+    if not path.exists() or not path.is_file():
+        raise ValueError(f"OpenViking profile file was not found: {path}")
+    return _load_ovcli_config(path)
+
+
 def _connection_values_from_ovcli(data: dict) -> dict:
     api_key = _clean_config_value(data.get("api_key")) or _clean_config_value(data.get("root_api_key"))
     root_api_key = _clean_config_value(data.get("root_api_key"))
     send_identity = not api_key or api_key == root_api_key
     account = _clean_config_value(data.get("account") or data.get("account_id"))
     user = _clean_config_value(data.get("user") or data.get("user_id"))
+    actor_peer_id = _clean_config_value(data.get("actor_peer_id"))
+    legacy_agent_id = _clean_config_value(data.get("agent_id"))
+    if actor_peer_id and legacy_agent_id:
+        raise ValueError("actor_peer_id cannot be used with agent_id.")
     return {
         "endpoint": _normalize_openviking_url(data.get("url")),
         "api_key": api_key,
         "root_api_key": root_api_key,
         "account": account if send_identity else "",
         "user": user if send_identity else "",
-        "agent": _clean_config_value(data.get("actor_peer_id") or data.get("agent_id")),
+        "agent": _validated_openviking_actor_peer_id(
+            actor_peer_id or legacy_agent_id
+        ),
     }
 
 
@@ -769,6 +828,10 @@ def _is_valid_ovcli_profile_name(name: str) -> bool:
     if "/" in name or "\\" in name:
         return False
     return all(ch.isascii() and (ch.isalnum() or ch in {"-", "_"}) for ch in name)
+
+
+def _is_valid_new_ovcli_profile_name(name: str) -> bool:
+    return _is_valid_ovcli_profile_name(name) and name != "active"
 
 
 def _validate_openviking_identity_value(value: str, *, field: str) -> tuple[bool, str, str]:
@@ -788,7 +851,20 @@ def _validate_openviking_identity_value(value: str, *, field: str) -> tuple[bool
     return True, "", trimmed
 
 
-def _normalize_openviking_url(url: str) -> str:
+def _validated_openviking_actor_peer_id(
+    value: Any,
+    *,
+    default: str = "",
+) -> str:
+    actor_peer_id = _clean_config_value(value)
+    if not actor_peer_id:
+        return default
+    if "/" in actor_peer_id or "\\" in actor_peer_id:
+        raise ValueError("Agent ID cannot contain path separators.")
+    return actor_peer_id
+
+
+def _normalize_openviking_url(url: Any) -> str:
     trimmed = _clean_config_value(url).rstrip("/")
     if not trimmed:
         return _DEFAULT_ENDPOINT
@@ -808,8 +884,11 @@ def _normalize_openviking_url(url: str) -> str:
 
 
 def _load_profile(path: Path, *, source: str, name: str) -> Optional[_OvcliProfile]:
+    if not path.exists() or not path.is_file():
+        return None
     try:
         data = _load_ovcli_config(path)
+        values = _connection_values_from_ovcli(data)
     except Exception as e:
         logger.debug("Skipping invalid OpenViking CLI config %s: %s", path, e)
         return None
@@ -818,7 +897,7 @@ def _load_profile(path: Path, *, source: str, name: str) -> Optional[_OvcliProfi
         name=name,
         path=path,
         data=data,
-        values=_connection_values_from_ovcli(data),
+        values=values,
     )
 
 
@@ -922,37 +1001,35 @@ def _resolve_connection_settings(provider_config: Optional[dict] = None) -> dict
     ovcli_values: dict = {}
     if provider_config.get("use_ovcli_config"):
         ovcli_path = _resolve_ovcli_config_path(str(provider_config.get("ovcli_config_path") or ""))
-        ovcli_values = _connection_values_from_ovcli(_load_ovcli_config(ovcli_path))
+        ovcli_values = _connection_values_from_ovcli(
+            _load_required_ovcli_config(ovcli_path)
+        )
 
-    endpoint_env = _env_value("OPENVIKING_ENDPOINT")
+    endpoint_env = _env_value("OPENVIKING_URL")
+    legacy_endpoint_env = _env_value("OPENVIKING_ENDPOINT")
     api_key_env = _env_value("OPENVIKING_API_KEY")
     account_env = _env_value("OPENVIKING_ACCOUNT")
     user_env = _env_value("OPENVIKING_USER")
-    agent_env = _env_value("OPENVIKING_AGENT")
+    agent_env = _env_value("OPENVIKING_ACTOR_PEER_ID")
+    legacy_agent_env = _env_value("OPENVIKING_AGENT")
 
     return {
-        "endpoint": _first_nonempty(endpoint_env, ovcli_values.get("endpoint"), default=_DEFAULT_ENDPOINT),
+        "endpoint": _first_nonempty(
+            endpoint_env,
+            legacy_endpoint_env,
+            ovcli_values.get("endpoint"),
+            default=_DEFAULT_ENDPOINT,
+        ),
         "api_key": api_key_env if api_key_env is not None else ovcli_values.get("api_key", ""),
         "account": account_env if account_env is not None else ovcli_values.get("account", ""),
         "user": user_env if user_env is not None else ovcli_values.get("user", ""),
-        "agent": _first_nonempty(agent_env, ovcli_values.get("agent"), default=_DEFAULT_AGENT),
+        "agent": _first_nonempty(
+            agent_env,
+            legacy_agent_env,
+            ovcli_values.get("agent"),
+            default=_DEFAULT_AGENT,
+        ),
     }
-
-
-def _env_writes_from_connection_values(values: dict) -> dict:
-    writes = {}
-    mapping = {
-        "OPENVIKING_ENDPOINT": "endpoint",
-        "OPENVIKING_API_KEY": "api_key",
-        "OPENVIKING_ACCOUNT": "account",
-        "OPENVIKING_USER": "user",
-        "OPENVIKING_AGENT": "agent",
-    }
-    for env_key, value_key in mapping.items():
-        value = _clean_config_value(values.get(value_key))
-        if value:
-            writes[env_key] = value
-    return writes
 
 
 def _restrict_secret_file_permissions(path: Path) -> None:
@@ -1020,11 +1097,10 @@ def _write_env_vars(env_path: Path, env_writes: dict, remove_keys: tuple[str, ..
 
 
 def _remember_ovcli_path(provider_config: dict, ovcli_path: Path) -> None:
-    default_path = _default_ovcli_config_path().expanduser()
-    if os.environ.get(_OVCLI_CONFIG_ENV, "").strip() or ovcli_path.expanduser() != default_path:
-        provider_config["ovcli_config_path"] = str(ovcli_path)
-    else:
-        provider_config.pop("ovcli_config_path", None)
+    # Persist the exact selected profile even when it is the conventional
+    # default. A later process-wide OPENVIKING_CLI_CONFIG_FILE must not silently
+    # retarget an already configured Hermes profile.
+    provider_config["ovcli_config_path"] = str(ovcli_path.expanduser())
 
 
 def _ovcli_data_from_connection_values(values: dict) -> dict:
@@ -1033,7 +1109,10 @@ def _ovcli_data_from_connection_values(values: dict) -> dict:
     root_api_key = _clean_config_value(values.get("root_api_key"))
     account = _clean_config_value(values.get("account"))
     user = _clean_config_value(values.get("user"))
-    agent = _clean_config_value(values.get("agent")) or _DEFAULT_AGENT
+    agent = _validated_openviking_actor_peer_id(
+        values.get("agent"),
+        default=_DEFAULT_AGENT,
+    )
     if api_key:
         data["api_key"] = api_key
     if root_api_key:
@@ -1055,23 +1134,67 @@ def _write_ovcli_config(path: Path, values: dict) -> None:
     atomic_json_write(path, _ovcli_data_from_connection_values(values), mode=0o600)
 
 
-def _validate_openviking_reachability(endpoint: str) -> tuple[bool, str]:
+def _is_openviking_transport_error(error: Exception) -> bool:
+    """Return whether a health failure proves that no server response arrived."""
+
+    httpx = _get_httpx()
+    connection_error_types = []
+    if httpx is not None:
+        for name in ("ConnectError", "ConnectTimeout"):
+            error_type = getattr(httpx, name, None)
+            if isinstance(error_type, type):
+                connection_error_types.append(error_type)
+    if connection_error_types and isinstance(error, tuple(connection_error_types)):
+        return True
+    if isinstance(error, ConnectionRefusedError):
+        return True
+    return isinstance(error, OSError) and error.errno in {
+        errno.ECONNREFUSED,
+        errno.EHOSTUNREACH,
+        errno.ENETUNREACH,
+    }
+
+
+def _probe_openviking_reachability(endpoint: str) -> _OpenVikingReachability:
     endpoint = _normalize_openviking_url(endpoint)
     try:
         client = _VikingClient(endpoint)
         if hasattr(client, "health_payload"):
             payload = client.health_payload()
             if payload.get("healthy") is False:
-                return False, "OpenViking server responded but reported unhealthy status."
+                return _OpenVikingReachability(
+                    _OpenVikingReachabilityState.UNHEALTHY,
+                    "OpenViking server responded but reported unhealthy status.",
+                )
             if payload:
-                return True, ""
+                return _OpenVikingReachability(_OpenVikingReachabilityState.HEALTHY)
         elif client.health():
-            return True, ""
+            return _OpenVikingReachability(_OpenVikingReachabilityState.HEALTHY)
     except Exception as e:
         if _status_code_from_error(e) is not None:
-            return False, f"OpenViking server responded with {_format_openviking_exception(e)}."
-        return False, f"OpenViking server is not reachable at {endpoint}: {_format_openviking_exception(e)}"
-    return False, f"OpenViking server is not reachable at {endpoint}."
+            return _OpenVikingReachability(
+                _OpenVikingReachabilityState.RESPONDED_ERROR,
+                f"OpenViking server responded with {_format_openviking_exception(e)}.",
+            )
+        if _is_openviking_transport_error(e):
+            return _OpenVikingReachability(
+                _OpenVikingReachabilityState.UNREACHABLE,
+                f"OpenViking server is not reachable at {endpoint}: "
+                f"{_format_openviking_exception(e)}",
+            )
+        return _OpenVikingReachability(
+            _OpenVikingReachabilityState.RESPONDED_ERROR,
+            f"OpenViking health validation failed: {_format_openviking_exception(e)}",
+        )
+    return _OpenVikingReachability(
+        _OpenVikingReachabilityState.RESPONDED_ERROR,
+        "OpenViking server returned an invalid health response.",
+    )
+
+
+def _validate_openviking_reachability(endpoint: str) -> tuple[bool, str]:
+    result = _probe_openviking_reachability(endpoint)
+    return result.reachable, result.message
 
 
 def _validate_openviking_auth(values: dict) -> tuple[bool, str]:
@@ -1146,6 +1269,13 @@ def _validate_openviking_setup_values(
     api_key = _clean_config_value(values.get("api_key"))
     if require_api_key and not api_key:
         return False, "Remote OpenViking configs require an API key.", None
+    try:
+        actor_peer_id = _validated_openviking_actor_peer_id(
+            values.get("agent"),
+            default=_DEFAULT_AGENT,
+        )
+    except ValueError as exc:
+        return False, str(exc), None
 
     try:
         client = _VikingClient(
@@ -1153,7 +1283,7 @@ def _validate_openviking_setup_values(
             api_key,
             account=_clean_config_value(values.get("account")),
             user=_clean_config_value(values.get("user")),
-            agent=_clean_config_value(values.get("agent")) or _DEFAULT_AGENT,
+            agent=actor_peer_id,
         )
         health = client.health_payload()
         if health.get("healthy") is False:
@@ -1197,70 +1327,152 @@ def _print_validation_progress(message: str) -> None:
     print(f"  {message}", flush=True)
 
 
-def _local_openviking_bind(endpoint: str) -> tuple[str, int]:
-    normalized = _normalize_openviking_url(endpoint)
-    parsed = urlparse(normalized)
-    host = parsed.hostname or "127.0.0.1"
-    port = parsed.port or 1933
-    return host, port
-
-
-def _openviking_server_log_path() -> Path:
+def _current_hermes_home() -> Path:
     try:
         from hermes_constants import get_hermes_home
-        home = get_hermes_home()
+
+        return get_hermes_home()
     except Exception:
-        home = Path(os.environ.get("HERMES_HOME", "")).expanduser() if os.environ.get("HERMES_HOME") else Path.home() / ".hermes"
-    return home / _OPENVIKING_SERVER_LOG_RELATIVE_PATH
+        configured_home = os.environ.get("HERMES_HOME", "").strip()
+        return (
+            Path(configured_home).expanduser()
+            if configured_home
+            else Path.home() / ".hermes"
+        )
 
 
-def _start_local_openviking_server(endpoint: str) -> tuple[bool, str]:
-    server_cmd = shutil.which("openviking-server")
-    if not server_cmd:
-        return False, "openviking-server was not found on PATH. Start it manually, then retry."
+def _default_openviking_server_config_path() -> Path:
+    return local_server.resolve_server_config_path()
+
+
+def _managed_local_config_path(provider_config: dict) -> Optional[Path]:
+    return quick_local.managed_server_config_path(provider_config)
+
+
+def _clear_managed_local_settings(provider_config: dict) -> None:
+    quick_local.clear_managed_settings(provider_config)
+
+
+def _start_local_openviking_server(
+    endpoint: str,
+    *,
+    config_path: Optional[Path] = None,
+) -> _LocalServerStartResult:
+    return local_server.start_local_server(
+        endpoint,
+        hermes_home=_current_hermes_home(),
+        config_path=config_path,
+    )
+
+
+def _stop_owned_local_openviking_process(
+    process: subprocess.Popen,
+    *,
+    timeout_seconds: float = local_server.PROCESS_STOP_TIMEOUT_SECONDS,
+) -> bool:
+    return local_server.stop_owned_process(
+        process,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _activate_managed_local_connection(
+    *,
+    paths: _ManagedLocalPaths,
+    config: dict,
+    provider_config: dict,
+    env_path: Path,
+) -> None:
+    _link_ovcli_profile(
+        config=config,
+        provider_config=provider_config,
+        env_path=env_path,
+        ovcli_path=paths.ovcli_config,
+    )
+    provider_config["deployment"] = _MANAGED_LOCAL_DEPLOYMENT
+    provider_config["server_config_path"] = str(paths.config)
+    _set_openviking_provider(config, provider_config)
+
+
+def _run_managed_local_setup(
+    *,
+    select,
+    cancelled,
+    config: dict,
+    provider_config: dict,
+    env_path: Path,
+) -> bool | object:
+    hermes_home = env_path.parent
+    setup = quick_local.QuickLocalSetup(
+        health_check=_validate_openviking_reachability,
+        progress=lambda event: print(f"  {event.message}", flush=True),
+    )
     try:
-        host, port = _local_openviking_bind(endpoint)
-    except ValueError as e:
-        return False, f"Could not parse local OpenViking URL: {e}"
-    log_path = _openviking_server_log_path()
+        preflight = setup.preflight(hermes_home)
+    except quick_local.QuickLocalSetupError as exc:
+        print(f"  Quick local setup could not start: {exc}")
+        return False
+
+    allow_ollama_install = False
+    if (
+        preflight.reusable_endpoint is None
+        and preflight.ollama_install_required
+    ):
+        choice = select(
+            "  Ollama is required",
+            [
+                ("Install Ollama", "install the local model runtime"),
+                ("Cancel setup", "install Ollama manually and retry later"),
+            ],
+            default=0,
+            cancel_returns=cancelled,
+        )
+        if choice != 0:
+            return _SETUP_CANCELLED
+        allow_ollama_install = True
+
     try:
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-        with log_path.open("ab") as log_file:
-            subprocess.Popen(
-                [server_cmd, "--host", host, "--port", str(port)],
-                stdout=log_file,
-                stderr=log_file,
-                stdin=subprocess.DEVNULL,
-                start_new_session=True,
-            )
-    except Exception as e:
-        return False, f"Could not start openviking-server: {e}"
-    return True, f"Started openviking-server on {host}:{port} in the background. Logs: {log_path}"
+        result = setup.provision(
+            hermes_home=hermes_home,
+            hermes_config=config,
+            allow_ollama_install=allow_ollama_install,
+            preflight=preflight,
+        )
+    except quick_local.QuickLocalSetupCancelled:
+        return _SETUP_CANCELLED
+    except quick_local.QuickLocalSetupError as exc:
+        print(f"  Quick local setup could not complete: {exc}")
+        return False
+
+    _activate_managed_local_connection(
+        paths=result.paths,
+        config=config,
+        provider_config=provider_config,
+        env_path=env_path,
+    )
+    ready_message = (
+        "Existing quick local server is reachable; reusing it."
+        if result.reused
+        else f"Quick local server configured with {_MANAGED_LOCAL_EMBEDDING_MODEL}."
+    )
+    _print_openviking_ready(ready_message, result.paths.config)
+    return True
 
 
 def _wait_for_openviking_health(
     endpoint: str,
     *,
     timeout_seconds: float = 15.0,
+    cancel_event: Optional[threading.Event] = None,
     should_stop=None,
 ) -> bool:
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
-        # Bail out promptly if the provider is being torn down, so the daemon
-        # thread running this waiter can be join()ed at shutdown instead of
-        # lingering up to ``timeout_seconds`` (a worker still alive at
-        # interpreter exit aborts CPython with SIGABRT at Py_FinalizeEx).
-        if should_stop is not None and should_stop():
-            return False
-        ok, _message = _validate_openviking_reachability(endpoint)
-        if ok:
-            return True
-        time.sleep(0.5)
-    return False
-
-
-def _reachability_failure_allows_local_autostart(message: str) -> bool:
-    return not (message or "").startswith(_OPENVIKING_RESPONDED_FAILURE_PREFIX)
+    return local_server.wait_for_health(
+        endpoint,
+        _validate_openviking_reachability,
+        timeout_seconds=timeout_seconds,
+        cancel_event=cancel_event,
+        should_stop=should_stop,
+    )
 
 
 def _handle_unreachable_endpoint(
@@ -1273,20 +1485,63 @@ def _handle_unreachable_endpoint(
 ):
     if _is_local_openviking_url(endpoint) and allow_local_autostart:
         print(f"  {message}")
+        server_config = _default_openviking_server_config_path()
+        server_command = local_server.server_command()
+        can_start = server_command is not None and server_config.is_file()
+        if can_start:
+            options = [
+                (
+                    "Start existing local server",
+                    "start it once for validation; it remains self-managed",
+                ),
+                ("Use quick local setup", "create a separate local server with automatic startup"),
+                ("Choose another endpoint", "enter a different local or remote server URL"),
+                ("Cancel setup", "no changes saved"),
+            ]
+        elif server_command is None:
+            print(
+                "  OpenViking is not installed. Install the OpenViking server "
+                "command, configure it, and retry; or use quick local setup."
+            )
+            options = [
+                ("Use quick local setup", "install and configure OpenViking automatically"),
+                (
+                    "Retry after installing it",
+                    "install and start OpenViking, then check again",
+                ),
+                ("Choose another endpoint", "enter a different local or remote server URL"),
+                ("Cancel setup", "no changes saved"),
+            ]
+        else:
+            print(
+                "  No OpenViking server config was found at "
+                f"{server_config}. Run `openviking-server init`, then start "
+                "the server and retry; or use quick local setup."
+            )
+            options = [
+                ("Use quick local setup", "create and configure a local OpenViking server"),
+                (
+                    "Retry after initializing it",
+                    "run openviking-server init, start the server, then check again",
+                ),
+                ("Choose another endpoint", "enter a different local or remote server URL"),
+                ("Cancel setup", "no changes saved"),
+            ]
         choice = select(
             "  Local OpenViking server is down",
-            [
-                ("Start local OpenViking", "run openviking-server and retry"),
-                ("Retry URL", "enter the server URL again"),
-                ("Cancel setup", "no changes saved"),
-            ],
+            options,
             default=0,
             cancel_returns=cancelled,
         )
-        if choice == 0:
-            started, start_message = _start_local_openviking_server(endpoint)
-            print(f"  {start_message}")
-            if not started:
+        if choice == cancelled or choice == 3:
+            return _SETUP_CANCELLED
+        if can_start and choice == 0:
+            start_result = _start_local_openviking_server(
+                endpoint,
+                config_path=server_config,
+            )
+            print(f"  {start_result.message}")
+            if not start_result.started:
                 return False
             print("  Waiting for OpenViking server to become reachable...", flush=True)
             if _wait_for_openviking_health(
@@ -1294,12 +1549,28 @@ def _handle_unreachable_endpoint(
                 timeout_seconds=_LOCAL_OPENVIKING_AUTOSTART_TIMEOUT,
             ):
                 print("  OpenViking server is reachable.")
+                print(
+                    "  This self-managed server will remain running when Hermes exits."
+                )
                 return True
+            # The user asked Hermes to start this process solely so setup could
+            # validate it. If validation fails, retain exact Popen ownership
+            # long enough to avoid leaving a broken child or database lock
+            # behind. A healthy custom server becomes self-managed above and
+            # is deliberately left running.
+            _stop_owned_local_openviking_process(start_result.process)
             print("  OpenViking server did not become reachable.")
             return False
-        if choice == 1:
+        if (can_start and choice == 1) or (not can_start and choice == 0):
+            return _ROUTE_TO_QUICK_LOCAL
+        if not can_start and choice == 1:
+            reachable, retry_message = _validate_openviking_reachability(endpoint)
+            if reachable:
+                print("  OpenViking server is reachable.")
+                return True
+            print(f"  {retry_message}")
             return False
-        return _SETUP_CANCELLED
+        return False
 
     return _retry_or_cancel_manual_setup(
         select,
@@ -1349,25 +1620,39 @@ def _classify_runtime_openviking_health(client: _VikingClient, endpoint: str) ->
             return "healthy", ""
         if client.health():
             return "healthy", ""
-    except _OpenVikingHTTPError as e:
+        # Legacy/test clients expose only a boolean and cannot distinguish a
+        # connection failure from a structured unhealthy response.
+        return "unreachable", ""
+    except Exception as e:
+        if _status_code_from_error(e) is not None:
+            return (
+                "responded",
+                f"OpenViking server at {endpoint} responded with "
+                f"{_format_openviking_exception(e)}.",
+            )
+        if _is_openviking_transport_error(e):
+            return "unreachable", ""
         return (
             "responded",
-            f"OpenViking server at {endpoint} responded with {_format_openviking_exception(e)}.",
+            f"OpenViking health validation at {endpoint} failed: "
+            f"{_format_openviking_exception(e)}.",
         )
-    except Exception:
-        return "unreachable", ""
-    return "unreachable", ""
+    return (
+        "responded",
+        f"OpenViking server at {endpoint} returned an invalid health response.",
+    )
 
 
 def _prompt_profile_name(prompt, select, cancelled) -> str | object:
     while True:
         name = _clean_config_value(prompt("OpenViking profile name"))
-        if _is_valid_ovcli_profile_name(name):
+        if _is_valid_new_ovcli_profile_name(name):
             return name
         retry = _retry_or_cancel_manual_setup(
             select,
             "  Invalid OpenViking profile name",
-            "Profile names can only contain letters, numbers, '-' and '_'.",
+            "Profile names can only contain letters, numbers, '-' and '_'; "
+            "'active' is reserved.",
             cancelled,
         )
         if retry is _SETUP_CANCELLED:
@@ -1408,19 +1693,21 @@ def _prompt_manual_connection_values(prompt, select, cancelled, *, service: bool
         while True:
             endpoint = _normalize_openviking_url(prompt("OpenViking server URL", default=_DEFAULT_ENDPOINT))
             _print_validation_progress("Checking OpenViking server...")
-            reachable, message = _validate_openviking_reachability(endpoint)
-            if reachable:
+            reachability = _probe_openviking_reachability(endpoint)
+            if reachability.reachable:
                 print("  OpenViking server is reachable.")
                 break
             retry = _handle_unreachable_endpoint(
                 endpoint,
-                message,
+                reachability.message,
                 select,
                 cancelled,
-                allow_local_autostart=_reachability_failure_allows_local_autostart(message),
+                allow_local_autostart=reachability.allows_local_autostart,
             )
             if retry is True:
                 break
+            if retry is _ROUTE_TO_QUICK_LOCAL:
+                return _ROUTE_TO_QUICK_LOCAL
             if retry is _SETUP_CANCELLED:
                 return _SETUP_CANCELLED
 
@@ -1636,31 +1923,15 @@ def _link_ovcli_profile(
     env_path: Path,
     ovcli_path: Path,
 ) -> None:
+    _clear_managed_local_settings(provider_config)
     for key in ("endpoint", "api_key", "root_api_key", "account", "user", "agent", "api_key_type"):
         provider_config.pop(key, None)
     provider_config["use_ovcli_config"] = True
     _remember_ovcli_path(provider_config, ovcli_path)
     _set_openviking_provider(config, provider_config)
-    _write_env_vars(env_path, {}, remove_keys=_OPENVIKING_ENV_KEYS)
-    for key in _OPENVIKING_ENV_KEYS:
+    _write_env_vars(env_path, {}, remove_keys=_OPENVIKING_ENV_KEYS_TO_REMOVE)
+    for key in _OPENVIKING_ENV_KEYS_TO_REMOVE:
         os.environ.pop(key, None)
-
-
-def _save_hermes_only_config(
-    *,
-    config: dict,
-    provider_config: dict,
-    env_path: Path,
-    values: dict,
-) -> None:
-    provider_config["use_ovcli_config"] = False
-    provider_config.pop("ovcli_config_path", None)
-    _set_openviking_provider(config, provider_config)
-    _write_env_vars(
-        env_path,
-        _env_writes_from_connection_values(values),
-        remove_keys=_OPENVIKING_ENV_KEYS,
-    )
 
 
 def _profile_display_name(profile: _OvcliProfile) -> str:
@@ -1697,21 +1968,49 @@ def _run_existing_profile_setup(
     config: dict,
     provider_config: dict,
     env_path: Path,
+    allow_manual_endpoint: bool = False,
 ) -> bool | object:
     while True:
+        options = [
+            (_profile_display_name(profile), _profile_description(profile))
+            for profile in profiles
+        ]
+        if allow_manual_endpoint:
+            options.append(
+                ("Use another endpoint", "enter a local or remote OpenViking server URL")
+            )
         choice = select(
             "  OpenViking profile",
-            [(_profile_display_name(profile), _profile_description(profile)) for profile in profiles],
+            options,
             default=0,
             cancel_returns=cancelled,
         )
         if choice == cancelled:
             return _SETUP_CANCELLED
+        if allow_manual_endpoint and choice == len(profiles):
+            return _ENTER_EXISTING_ENDPOINT
         if choice < 0 or choice >= len(profiles):
             return _SETUP_CANCELLED
 
         profile = profiles[choice]
         _print_validation_progress("Validating OpenViking profile...")
+        endpoint = profile.values.get("endpoint", "")
+        if _is_local_openviking_url(endpoint):
+            reachability = _probe_openviking_reachability(endpoint)
+            if reachability.allows_local_autostart:
+                recovery = _handle_unreachable_endpoint(
+                    endpoint,
+                    reachability.message,
+                    select,
+                    cancelled,
+                )
+                if recovery is _ROUTE_TO_QUICK_LOCAL:
+                    return _ROUTE_TO_QUICK_LOCAL
+                if recovery is _SETUP_CANCELLED:
+                    return _SETUP_CANCELLED
+                if recovery is not True:
+                    continue
+
         ok, message, _role = _validate_profile_for_setup(profile)
         if ok:
             _link_ovcli_profile(
@@ -1753,7 +2052,7 @@ def _run_existing_profile_setup(
         return _SETUP_CANCELLED
 
 
-def _mirror_manual_config_to_openviking_store(
+def _save_manual_connection_profile(
     *,
     prompt,
     select,
@@ -1782,12 +2081,23 @@ def _run_create_profile_setup(
     config: dict,
     provider_config: dict,
     env_path: Path,
+    profiles: Optional[list[_OvcliProfile]] = None,
 ) -> bool | object:
     source_choice = select(
         "  OpenViking connection",
         [
-            ("OpenViking Service (VolcEngine Cloud)", "use the managed OpenViking endpoint"),
-            ("Custom", "use a local, VPS, or self-hosted OpenViking server"),
+            (
+                "OpenViking Service (VolcEngine Cloud)",
+                "Managed cloud service; API key required",
+            ),
+            (
+                "Quick local setup",
+                "Set up OpenViking and Ollama on this device",
+            ),
+            (
+                "Connect to an existing server",
+                "Use a self-managed custom server (Remote/Local)",
+            ),
         ],
         default=0,
         cancel_returns=cancelled,
@@ -1795,49 +2105,72 @@ def _run_create_profile_setup(
     if source_choice == cancelled:
         return _SETUP_CANCELLED
 
-    values = _prompt_manual_connection_values(prompt, select, cancelled, service=(source_choice == 0))
+    if source_choice == 1:
+        return _run_managed_local_setup(
+            select=select,
+            cancelled=cancelled,
+            config=config,
+            provider_config=provider_config,
+            env_path=env_path,
+        )
+
+    if source_choice == 2 and profiles:
+        profile_result = _run_existing_profile_setup(
+            profiles=profiles,
+            select=select,
+            cancelled=cancelled,
+            config=config,
+            provider_config=provider_config,
+            env_path=env_path,
+            allow_manual_endpoint=True,
+        )
+        if profile_result is _ROUTE_TO_QUICK_LOCAL:
+            return _run_managed_local_setup(
+                select=select,
+                cancelled=cancelled,
+                config=config,
+                provider_config=provider_config,
+                env_path=env_path,
+            )
+        if profile_result is not _ENTER_EXISTING_ENDPOINT:
+            return profile_result
+
+    values = _prompt_manual_connection_values(
+        prompt,
+        select,
+        cancelled,
+        service=(source_choice == 0),
+    )
+    if values is _ROUTE_TO_QUICK_LOCAL:
+        return _run_managed_local_setup(
+            select=select,
+            cancelled=cancelled,
+            config=config,
+            provider_config=provider_config,
+            env_path=env_path,
+        )
     if values is _SETUP_CANCELLED:
         return _SETUP_CANCELLED
     if values is None:
         return False
 
-    save_choice = select(
-        "  Save OpenViking config",
-        [
-            ("Keep in Hermes only", "write values only to Hermes .env"),
-            ("Mirror to OpenViking store", "write ~/.openviking/ovcli.conf.<name> and link it"),
-        ],
-        default=1,
-        cancel_returns=cancelled,
+    ovcli_path = _save_manual_connection_profile(
+        prompt=prompt,
+        select=select,
+        cancelled=cancelled,
+        values=values,
     )
-    if save_choice == cancelled:
+    if ovcli_path is _SETUP_CANCELLED:
         return _SETUP_CANCELLED
-
-    if save_choice == 1:
-        ovcli_path = _mirror_manual_config_to_openviking_store(
-            prompt=prompt,
-            select=select,
-            cancelled=cancelled,
-            values=values,
-        )
-        if ovcli_path is _SETUP_CANCELLED:
-            return _SETUP_CANCELLED
-        _link_ovcli_profile(
-            config=config,
-            provider_config=provider_config,
-            env_path=env_path,
-            ovcli_path=ovcli_path,
-        )
-        _print_openviking_ready("Created and linked OpenViking profile.", ovcli_path)
-        return True
-
-    _save_hermes_only_config(
+    if not isinstance(ovcli_path, Path):
+        raise TypeError("OpenViking profile setup returned an invalid path.")
+    _link_ovcli_profile(
         config=config,
         provider_config=provider_config,
         env_path=env_path,
-        values=values,
+        ovcli_path=ovcli_path,
     )
-    _print_openviking_ready("Connection saved to Hermes .env.")
+    _print_openviking_ready("Created and linked OpenViking profile.", ovcli_path)
     return True
 
 
@@ -1849,15 +2182,25 @@ class OpenVikingMemoryProvider(MemoryProvider):
     """Full bidirectional memory via OpenViking context database."""
 
     def backup_paths(self) -> List[str]:
-        """OpenViking's ovcli config lives at ~/.openviking/ovcli.conf by
-        default (or OPENVIKING_CLI_CONFIG_FILE). Capture the resolved file so
-        endpoint/api-key survive a backup/import cycle."""
+        """Capture only the OpenViking profile used by this provider."""
         try:
-            cfg = _resolve_ovcli_config_path()
             # The home-scoped guard in the backup walk drops anything outside
             # the user's home; an env override pointing elsewhere is skipped
             # there rather than here.
-            return [str(cfg)]
+            provider_config = _load_hermes_openviking_config()
+            if provider_config.get("use_ovcli_config"):
+                profile = _resolve_ovcli_config_path(
+                    str(provider_config.get("ovcli_config_path") or ""),
+                )
+            else:
+                profile = _resolve_ovcli_config_path()
+            if not profile.exists():
+                return []
+            try:
+                profile.resolve().relative_to(_current_hermes_home().resolve())
+                return []
+            except ValueError:
+                return [str(profile)]
         except Exception:
             return []
 
@@ -1868,6 +2211,15 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._account = ""
         self._user = ""
         self._agent = ""
+        self._managed_local_server_config: Optional[Path] = None
+        # Only this concrete Popen handle proves that this provider instance
+        # owns the quick-local server. Deployment metadata alone never grants
+        # permission to stop a process.
+        self._owned_local_server_process: Optional[subprocess.Popen] = None
+        # A just-spawned child has not accepted Hermes work yet and can be
+        # stopped directly during cancellation. Once attached, shutdown must
+        # use the work-aware reaper.
+        self._owned_local_server_ready = False
         self._session_id = ""
         self._turn_count = 0
         self._hermes_home = ""
@@ -1913,6 +2265,11 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._runtime_start_lock = threading.Lock()
         self._runtime_start_thread: Optional[threading.Thread] = None
         self._runtime_start_pending = False
+        self._pending_task_ids: Set[str] = set()
+        self._pending_task_lock = threading.Lock()
+        self._task_tracking_uncertain = False
+        self._runtime_status_callback = None
+        self._runtime_warning_callback = None
         self._memory_write_lock = threading.Lock()
         self._memory_write_threads: Set[threading.Thread] = set()
         self._profile_prefetched_sessions: Set[str] = set()
@@ -1926,7 +2283,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
     def is_available(self) -> bool:
         """Check if OpenViking endpoint is configured. No network calls."""
-        if os.environ.get("OPENVIKING_ENDPOINT"):
+        if os.environ.get("OPENVIKING_URL") or os.environ.get(
+            "OPENVIKING_ENDPOINT"
+        ):
             return True
         provider_config = _load_hermes_openviking_config()
         if not provider_config.get("use_ovcli_config"):
@@ -1940,11 +2299,11 @@ class OpenVikingMemoryProvider(MemoryProvider):
     def get_config_schema(self):
         return [
             {
-                "key": "endpoint",
+                "key": "url",
                 "description": "OpenViking server URL",
                 "required": True,
                 "default": _DEFAULT_ENDPOINT,
-                "env_var": "OPENVIKING_ENDPOINT",
+                "env_var": "OPENVIKING_URL",
             },
             {
                 "key": "api_key",
@@ -1963,13 +2322,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 "env_var": "OPENVIKING_USER",
             },
             {
-                "key": "agent",
+                "key": "actor_peer_id",
                 "description": (
-                    "Hermes peer ID in OpenViking, sent as the actor peer and "
-                    "used for peer-scoped memories"
+                    "Agent ID sent as OpenViking's actor peer and used for "
+                    "peer-scoped memories"
                 ),
                 "default": "hermes",
-                "env_var": "OPENVIKING_AGENT",
+                "env_var": "OPENVIKING_ACTOR_PEER_ID",
             },
             {
                 "key": "recall_limit",
@@ -2043,14 +2402,22 @@ class OpenVikingMemoryProvider(MemoryProvider):
             display = {
                 "use_ovcli_config": True,
                 "ovcli_config_path": str(ovcli_path),
-                "endpoint": settings.get("endpoint") or _DEFAULT_ENDPOINT,
-                "agent": settings.get("agent") or _DEFAULT_AGENT,
+                "url": settings.get("endpoint") or _DEFAULT_ENDPOINT,
+                "actor_peer_id": settings.get("agent") or _DEFAULT_AGENT,
             }
+            managed_config = _managed_local_config_path(provider_config)
+            if managed_config is not None:
+                display["deployment"] = _MANAGED_LOCAL_DEPLOYMENT
+                display["server_config_path"] = str(managed_config)
             if settings.get("account"):
                 display["account"] = settings["account"]
             if settings.get("user"):
                 display["user"] = settings["user"]
-            env_overrides = [key for key in _OPENVIKING_ENV_KEYS if _env_value(key) is not None]
+            env_overrides = [
+                key
+                for key in _OPENVIKING_ENV_KEYS_FOR_STATUS
+                if _env_value(key) is not None
+            ]
             if env_overrides:
                 display["env_overrides"] = ", ".join(env_overrides)
             return display
@@ -2077,40 +2444,6 @@ class OpenVikingMemoryProvider(MemoryProvider):
         print("\n  OpenViking memory setup\n")
 
         profiles = _discover_ovcli_profiles()
-        if profiles:
-            setup_options = [
-                ("Use existing OpenViking profile", "choose from detected ovcli.conf profiles"),
-                ("Create new OpenViking profile", "enter a new URL/API key"),
-            ]
-            choice = _curses_select(
-                "  OpenViking config source",
-                setup_options,
-                default=0,
-                cancel_returns=_CANCELLED,
-            )
-            if choice == _CANCELLED:
-                _print_cancelled_setup()
-                return
-
-            if choice == 0:
-                result = _run_existing_profile_setup(
-                    profiles=profiles,
-                    select=_curses_select,
-                    cancelled=_CANCELLED,
-                    config=config,
-                    provider_config=provider_config,
-                    env_path=env_path,
-                )
-                if result is _SETUP_CANCELLED:
-                    _print_cancelled_setup()
-                    return
-                if result:
-                    save_config(config)
-                return
-
-        else:
-            print("  No existing OpenViking CLI profiles found. Creating a new config.")
-
         result = _run_create_profile_setup(
             prompt=_prompt,
             select=_curses_select,
@@ -2118,6 +2451,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             config=config,
             provider_config=provider_config,
             env_path=env_path,
+            profiles=profiles,
         )
         if result is _SETUP_CANCELLED:
             _print_cancelled_setup()
@@ -2161,6 +2495,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             timeout_seconds=_LOCAL_OPENVIKING_AUTOSTART_TIMEOUT,
             should_stop=lambda: self._shutting_down or self._endpoint != endpoint,
         ):
+            self._stop_owned_server_after_start_failure()
             if self._shutting_down or self._endpoint != endpoint:
                 return
             _emit_runtime_warning(
@@ -2171,50 +2506,67 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         warning_message = ""
         status_message = ""
+        cancelled = False
         with self._client_refresh_lock:
             if self._shutting_down or self._endpoint != endpoint:
-                return
-            try:
-                client = _VikingClient(
-                    endpoint,
-                    self._api_key,
-                    account=self._account,
-                    user=self._user,
-                    agent=self._agent,
-                )
-                healthy = client.health()
-                if self._shutting_down or self._endpoint != endpoint:
-                    return
-                if not healthy:
+                cancelled = True
+            else:
+                try:
+                    client = _VikingClient(
+                        endpoint,
+                        self._api_key,
+                        account=self._account,
+                        user=self._user,
+                        agent=self._agent,
+                    )
+                    healthy = client.health()
+                    if self._shutting_down or self._endpoint != endpoint:
+                        cancelled = True
+                    elif not healthy:
+                        warning_message = (
+                            f"OpenViking server at {endpoint} is still not reachable after "
+                            "auto-start; OpenViking memory disabled for this Hermes run."
+                        )
+                    else:
+                        self._client = client
+                        self._conn_snapshot = (
+                            endpoint,
+                            self._api_key,
+                            self._account,
+                            self._user,
+                            self._agent,
+                        )
+                        self._failed_refresh = None
+                        with self._runtime_start_lock:
+                            if self._owned_local_server_process is not None:
+                                self._owned_local_server_ready = True
+                        status_message = (
+                            f"Local OpenViking server at {endpoint} is reachable; "
+                            "OpenViking memory is active for later turns."
+                        )
+                except ImportError:
                     warning_message = (
-                        f"OpenViking server at {endpoint} is still not reachable after auto-start; "
-                        "OpenViking memory disabled for this Hermes run."
+                        "httpx is not installed; OpenViking memory is disabled for this "
+                        "Hermes run."
                     )
-                else:
-                    self._client = client
-                    self._conn_snapshot = (
-                        endpoint, self._api_key, self._account, self._user, self._agent,
+                except Exception as exc:
+                    warning_message = (
+                        f"OpenViking server at {endpoint} could not be attached after "
+                        f"auto-start: {exc}. OpenViking memory disabled for this Hermes run."
                     )
-                    self._failed_refresh = None
-                    status_message = (
-                        f"Local OpenViking server at {endpoint} is reachable; "
-                        "OpenViking memory is active for later turns."
-                    )
-            except ImportError:
-                logger.warning("httpx not installed — OpenViking plugin disabled")
-                return
-            except Exception as e:
-                warning_message = (
-                    f"OpenViking server at {endpoint} could not be attached after auto-start: {e}. "
-                    "OpenViking memory disabled for this Hermes run."
-                )
+
+        if cancelled:
+            self._stop_owned_server_after_start_failure()
+            return
 
         if warning_message:
+            self._stop_owned_server_after_start_failure()
             _emit_runtime_warning(
                 warning_message,
                 warning_callback,
             )
             return
+
         if status_message:
             # Client attached: recover orphaned sessions outside the refresh
             # lock (network I/O), then announce.
@@ -2238,8 +2590,29 @@ class OpenVikingMemoryProvider(MemoryProvider):
             self._client = None
             return
 
+        if self._managed_local_server_config is None:
+            _emit_runtime_warning(
+                f"Local OpenViking server at {endpoint} is not reachable; "
+                "OpenViking memory disabled for this Hermes run. Start the separately "
+                "managed server, then begin a new Hermes session.",
+                warning_callback,
+            )
+            self._client = None
+            return
+        if not self._managed_local_server_config.is_file():
+            _emit_runtime_warning(
+                f"Local OpenViking server at {endpoint} is not reachable, and its local "
+                f"setup config is missing at {self._managed_local_server_config}. Run "
+                "OpenViking memory setup again. OpenViking memory disabled for this "
+                "Hermes run.",
+                warning_callback,
+            )
+            self._client = None
+            return
+
         warning_message = ""
         status_message = ""
+        process_to_stop: Optional[subprocess.Popen] = None
         should_start_waiter = False
         with self._runtime_start_lock:
             if (
@@ -2251,52 +2624,73 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 return
 
             self._runtime_start_pending = True
-            started, start_message = _start_local_openviking_server(endpoint)
-            if not started:
+            start_result = local_server.start_local_server(
+                endpoint,
+                hermes_home=Path(self._hermes_home),
+                config_path=self._managed_local_server_config,
+            )
+            started_process = start_result.process
+            if started_process is None:
                 self._runtime_start_pending = False
                 warning_message = (
-                    f"Local OpenViking server at {endpoint} is not reachable. {start_message} "
-                    "OpenViking memory disabled for this Hermes run."
+                    f"Local OpenViking server at {endpoint} is not reachable. "
+                    f"{start_result.message} OpenViking memory disabled for this Hermes run."
                 )
                 self._client = None
+            elif self._shutting_down:
+                self._runtime_start_pending = False
+                process_to_stop = started_process
             else:
+                self._owned_local_server_process = started_process
+                self._owned_local_server_ready = False
                 self._client = None
                 status_message = (
-                    f"{start_message} OpenViking memory is starting in the background and will attach when ready."
+                    f"{start_result.message} OpenViking memory is starting in the "
+                    "background and will attach when ready."
                 )
                 should_start_waiter = True
 
-        if warning_message:
-            _emit_runtime_warning(
-                warning_message,
-                warning_callback,
-            )
+        if process_to_stop is not None:
+            _stop_owned_local_openviking_process(process_to_stop)
             return
+        if warning_message:
+            _emit_runtime_warning(warning_message, warning_callback)
         if status_message:
             _emit_runtime_status(status_message, status_callback)
         if should_start_waiter:
             with self._runtime_start_lock:
                 self._runtime_start_pending = False
                 if self._shutting_down:
-                    return
-                self._start_runtime_openviking_waiter(
-                    endpoint=endpoint,
-                    status_callback=status_callback,
-                    warning_callback=warning_callback,
-                )
+                    process_to_stop = self._owned_local_server_process
+                    self._owned_local_server_process = None
+                    self._owned_local_server_ready = False
+                else:
+                    self._start_runtime_openviking_waiter(
+                        endpoint=endpoint,
+                        status_callback=status_callback,
+                        warning_callback=warning_callback,
+                    )
+            if process_to_stop is not None:
+                _stop_owned_local_openviking_process(process_to_stop)
+
+    def _take_owned_local_server_process(self) -> Optional[subprocess.Popen]:
+        """Atomically relinquish this provider's one owned child process."""
+        with self._runtime_start_lock:
+            process = self._owned_local_server_process
+            self._owned_local_server_process = None
+            self._owned_local_server_ready = False
+        return process
+
+    def _stop_owned_server_after_start_failure(self) -> None:
+        """Clean up a quick-local child that never became usable."""
+        process = self._take_owned_local_server_process()
+        if process is not None:
+            _stop_owned_local_openviking_process(process)
 
     def initialize(self, session_id: str, **kwargs) -> None:
-        settings = _resolve_connection_settings(_load_hermes_openviking_config())
-        self._endpoint = settings["endpoint"]
-        self._api_key = settings["api_key"]
-        self._account = settings["account"]
-        self._user = settings["user"]
-        self._agent = settings["agent"]
-        # Baseline established — subsequent accesses may refresh from env
-        # (#21130). Set here (not at the end of initialize) so an exception in
-        # the connection attempt below — swallowed by MemoryManager's guard —
-        # can't leave the provider silently stuck in never-refresh mode.
-        self._env_refresh_enabled = True
+        global _last_active_provider
+
+        provider_config = _load_hermes_openviking_config()
         self._session_id = session_id
         self._turn_count = 0
         hermes_home = str(kwargs.get("hermes_home") or "").strip()
@@ -2307,7 +2701,6 @@ class OpenVikingMemoryProvider(MemoryProvider):
             except Exception:
                 hermes_home = str(Path.home() / ".hermes")
         self._hermes_home = hermes_home
-        self._acquire_run_lock()
         self._profile_prefetched_sessions.clear()
         warning_callback = (
             kwargs.get("warning_callback")
@@ -2319,6 +2712,34 @@ class OpenVikingMemoryProvider(MemoryProvider):
             if kwargs.get("platform") == "cli"
             else None
         )
+        self._runtime_status_callback = status_callback
+        self._runtime_warning_callback = warning_callback
+        # Baseline established — subsequent accesses may refresh from env
+        # (#21130). Set here (not at the end of initialize) so an exception in
+        # the connection attempt below — swallowed by MemoryManager's guard —
+        # cannot leave the provider silently stuck in never-refresh mode.
+        self._env_refresh_enabled = True
+        try:
+            settings = _resolve_connection_settings(provider_config)
+        except Exception as exc:
+            _emit_runtime_warning(
+                f"{_format_openviking_exception(exc)} OpenViking memory disabled "
+                "for this Hermes run.",
+                warning_callback,
+            )
+            self._client = None
+            _last_active_provider = self
+            return
+
+        self._endpoint = settings["endpoint"]
+        self._api_key = settings["api_key"]
+        self._account = settings["account"]
+        self._user = settings["user"]
+        self._agent = settings["agent"]
+        self._managed_local_server_config = _managed_local_config_path(
+            provider_config
+        )
+        self._acquire_run_lock()
 
         try:
             self._client = _VikingClient(
@@ -2348,7 +2769,6 @@ class OpenVikingMemoryProvider(MemoryProvider):
             self._recover_pending_sessions()
 
         # Register as the last active provider for atexit safety net
-        global _last_active_provider
         _last_active_provider = self
 
     def _ensure_client(self) -> Optional["_VikingClient"]:
@@ -2378,12 +2798,14 @@ class OpenVikingMemoryProvider(MemoryProvider):
             self._client = None
             return None
 
-        settings = _resolve_connection_settings(_load_hermes_openviking_config())
+        provider_config = _load_hermes_openviking_config()
+        settings = _resolve_connection_settings(provider_config)
         endpoint = settings["endpoint"]
         api_key = settings["api_key"]
         account = settings["account"]
         user = settings["user"]
         agent = settings["agent"]
+        managed_local_server_config = _managed_local_config_path(provider_config)
         settings_key = (endpoint, api_key, account, user, agent)
 
         config_unchanged = (
@@ -2392,6 +2814,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
             and account == getattr(self, "_account", None)
             and user == getattr(self, "_user", None)
             and agent == getattr(self, "_agent", None)
+            and managed_local_server_config
+            == getattr(self, "_managed_local_server_config", None)
         )
         if config_unchanged and self._client is not None:
             return self._client
@@ -2420,6 +2844,17 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._account = account
         self._user = user
         self._agent = agent
+        self._managed_local_server_config = managed_local_server_config
+
+        # If live reload changes the connection identity while this provider
+        # owns a Quick Local child, previously tracked task IDs and the current
+        # client can no longer be proven to describe that same server. Preserve
+        # the child rather than handing it to a reaper with mismatched details.
+        with self._runtime_start_lock:
+            owns_local_server = self._owned_local_server_process is not None
+        if owns_local_server:
+            with self._pending_task_lock:
+                self._task_tracking_uncertain = True
 
         try:
             client = _VikingClient(
@@ -3009,10 +3444,25 @@ class OpenVikingMemoryProvider(MemoryProvider):
         clear_missing: bool = False,
     ) -> bool:
         try:
-            self._client.post(
+            response = self._client.post(
                 f"/api/v1/sessions/{sid}/commit",
                 {"keep_recent_count": 0},
             )
+            result = self._unwrap_result(response)
+            task_id = ""
+            if isinstance(result, dict):
+                task_id = str(result.get("task_id") or "").strip()
+            with self._pending_task_lock:
+                if task_id:
+                    self._pending_task_ids.add(task_id)
+                elif not (
+                    isinstance(result, dict)
+                    and str(result.get("status") or "").strip().lower() == "skipped"
+                ):
+                    # The commit may have been accepted, but without its task
+                    # ID we cannot prove that extraction finished before
+                    # stopping an owned quick-local server.
+                    self._task_tracking_uncertain = True
             self._mark_session_committed(sid)
             self._clear_pending_session(sid)
             logger.info("OpenViking session %s committed %s (%d turns)", sid, context, turn_count)
@@ -3022,8 +3472,66 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 self._clear_pending_session(sid)
                 logger.debug("OpenViking pending session %s no longer exists; dropped marker", sid)
                 return False
+            with self._pending_task_lock:
+                # A transport failure can occur after the server accepted the
+                # request. Preserve the server rather than risk interrupting
+                # an unobservable extraction task.
+                self._task_tracking_uncertain = True
             logger.warning("OpenViking session commit failed for %s: %s", sid, e)
             return False
+
+    def _defer_owned_server_shutdown_for_background_tasks(
+        self,
+        process: subprocess.Popen,
+    ) -> bool:
+        """Hand managed work and an exact owned child to the detached reaper.
+
+        ``False`` means task completion or helper startup cannot be proven;
+        callers must leave the OpenViking process running in that case.
+        """
+        with self._pending_task_lock:
+            if self._task_tracking_uncertain:
+                _emit_runtime_warning(
+                    "OpenViking background task completion cannot be verified; "
+                    "leaving the local server running.",
+                    self._runtime_warning_callback,
+                )
+                return False
+            pending = set(self._pending_task_ids)
+
+        if self._client is None:
+            _emit_runtime_warning(
+                "OpenViking background completion cannot be verified because no "
+                "client is available; leaving the local server running.",
+                self._runtime_warning_callback,
+            )
+            return False
+
+        if not local_server.defer_owned_shutdown(
+            process,
+            hermes_home=Path(self._hermes_home),
+            endpoint=self._endpoint,
+            headers=self._client._headers(),
+            task_ids=pending,
+        ):
+            _emit_runtime_warning(
+                "OpenViking background shutdown could not be handed off safely; "
+                "leaving the local server running.",
+                self._runtime_warning_callback,
+            )
+            return False
+
+        work_description = (
+            f"{len(pending)} background task(s) and queued work"
+            if pending
+            else "queued work"
+        )
+        _emit_runtime_status(
+            f"OpenViking is finishing {work_description}; its local server will "
+            "stop automatically.",
+            self._runtime_status_callback,
+        )
+        return True
 
     def _finalize_session_async(self, sid: str, turn_count: int, *, context: str) -> None:
         """Drain the old session's writers and commit it on a daemon thread.
@@ -3045,16 +3553,12 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         def _finalize() -> None:
             try:
-                if self._shutting_down:
-                    return
                 if not self._drain_writers(sid, timeout=_DEFERRED_COMMIT_TIMEOUT):
                     logger.warning(
                         "OpenViking writer for %s still alive after drain — "
                         "leaving session uncommitted",
                         sid,
                     )
-                    return
-                if self._shutting_down:
                     return
                 if self._session_needs_commit(sid, turn_count):
                     self._commit_session(sid, turn_count, context=context)
@@ -4228,6 +4732,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
                     "mode": "create",
                 })
             except Exception as e:
+                with self._pending_task_lock:
+                    self._task_tracking_uncertain = True
                 logger.debug("OpenViking memory mirror failed: %s", e)
             finally:
                 with self._memory_write_lock:
@@ -4276,10 +4782,12 @@ class OpenVikingMemoryProvider(MemoryProvider):
             return tool_error(str(e))
 
     def shutdown(self) -> None:
-        # Stop deferred finalizers from issuing new commits against a
-        # torn-down client, then drain everything still in flight.
+        # Reject new writer/finalizer work, then drain everything already in
+        # flight before deciding whether the owned child can be stopped.
         self._shutting_down = True
-        # Wait for every in-flight writer across all tracked sessions.
+        # Wait for every in-flight writer/finalizer within one shared budget.
+        # If anything remains alive, an owned server must stay up because work
+        # may still reach it after this method returns.
         with self._inflight_lock:
             all_workers = [
                 t for workers in self._inflight_writers.values() for t in workers
@@ -4293,18 +4801,43 @@ class OpenVikingMemoryProvider(MemoryProvider):
         # at interpreter exit (SIGABRT at Py_FinalizeEx). Setting _shutting_down
         # above makes its health-wait loop bail out promptly so the join lands.
         with self._runtime_start_lock:
-            runtime_start_thread = self._runtime_start_thread
-        for t in all_workers:
-            if t.is_alive():
-                t.join(timeout=5.0)
-        for t in deferred_workers:
-            if t.is_alive():
-                t.join(timeout=5.0)
-        for t in memory_write_workers:
-            if t.is_alive():
-                t.join(timeout=5.0)
-        if runtime_start_thread is not None and runtime_start_thread.is_alive():
-            runtime_start_thread.join(timeout=5.0)
+            runtime_start_worker = self._runtime_start_thread
+
+        workers = all_workers + deferred_workers + memory_write_workers
+        if (
+            runtime_start_worker is not None
+            and runtime_start_worker is not threading.current_thread()
+        ):
+            workers.append(runtime_start_worker)
+        deadline = time.monotonic() + 5.0
+        for thread in workers:
+            if not thread.is_alive():
+                continue
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            thread.join(timeout=remaining)
+        workers_drained = all(not thread.is_alive() for thread in workers)
+
+        with self._runtime_start_lock:
+            owned_server_ready = self._owned_local_server_ready
+        owned_process = self._take_owned_local_server_process()
+        if owned_process is not None:
+            try:
+                already_exited = owned_process.poll() is not None
+            except Exception:
+                already_exited = False
+            if not already_exited:
+                if not owned_server_ready:
+                    _stop_owned_local_openviking_process(owned_process)
+                elif not workers_drained:
+                    _emit_runtime_warning(
+                        "OpenViking background work is still active; leaving the local server "
+                        "running.",
+                        self._runtime_warning_callback,
+                    )
+                else:
+                    self._defer_owned_server_shutdown_for_background_tasks(owned_process)
         # Clear atexit reference so it doesn't double-commit.
         global _last_active_provider
         if _last_active_provider is self:
@@ -4590,6 +5123,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 "message": f"Memory stored ({written}b) and queued for vector indexing.",
             })
         except Exception as e:
+            with self._pending_task_lock:
+                self._task_tracking_uncertain = True
             logger.error("OpenViking content/write failed: %s", e)
             return tool_error(f"Failed to store memory: {e}")
 
@@ -4670,8 +5205,24 @@ class OpenVikingMemoryProvider(MemoryProvider):
             else:
                 payload["path"] = url
 
-            resp = self._client.post("/api/v1/resources", payload)
+            try:
+                resp = self._client.post("/api/v1/resources", payload)
+            except Exception:
+                if not payload.get("wait"):
+                    with self._pending_task_lock:
+                        self._task_tracking_uncertain = True
+                raise
             result = resp.get("result", {})
+            if not payload.get("wait"):
+                task_id = str(result.get("task_id") or "").strip()
+                with self._pending_task_lock:
+                    if task_id:
+                        self._pending_task_ids.add(task_id)
+                    else:
+                        # Non-wait resource ingestion is asynchronous by API
+                        # contract. Without a task ID, an owned server cannot
+                        # be stopped safely at teardown.
+                        self._task_tracking_uncertain = True
         finally:
             if cleanup_path:
                 cleanup_path.unlink(missing_ok=True)

--- a/plugins/memory/openviking/local_server.py
+++ b/plugins/memory/openviking/local_server.py
@@ -1,0 +1,322 @@
+"""Local OpenViking server process management.
+
+This module deliberately owns only process mechanics. Provisioning belongs to
+``quick_local.py`` and connection/profile semantics remain with the provider.
+Keeping the original ``Popen`` handle is the sole ownership proof: configured
+endpoints and deployment markers never authorize Hermes to stop a process.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Optional
+from urllib.parse import urlparse
+
+from hermes_cli._subprocess_compat import (
+    windows_detach_flags,
+    windows_detach_flags_without_breakaway,
+)
+
+__all__ = [
+    "AUTOSTART_TIMEOUT_SECONDS",
+    "DEFAULT_PORT",
+    "LocalServerStartResult",
+    "PROCESS_STOP_TIMEOUT_SECONDS",
+    "defer_owned_shutdown",
+    "endpoint_bind",
+    "resolve_server_config_path",
+    "server_command",
+    "start_local_server",
+    "stop_owned_process",
+    "wait_for_health",
+]
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PORT = 1933
+AUTOSTART_TIMEOUT_SECONDS = 60.0
+PROCESS_STOP_TIMEOUT_SECONDS = 10.0
+TASK_WAIT_TIMEOUT_SECONDS = 300.0
+TASK_POLL_INTERVAL_SECONDS = 0.5
+
+_SERVER_LOG_RELATIVE_PATH = Path("logs") / "openviking-server.log"
+_REAPER_LOG_RELATIVE_PATH = Path("logs") / "openviking-reaper.log"
+
+
+@dataclass(frozen=True)
+class LocalServerStartResult:
+    """Result of starting one local OpenViking child process."""
+
+    process: Optional[subprocess.Popen]
+    message: str
+
+    @property
+    def started(self) -> bool:
+        return self.process is not None
+
+
+def resolve_server_config_path(
+    *,
+    env: Optional[dict[str, str]] = None,
+    home: Optional[Path] = None,
+) -> Path:
+    """Resolve the separately managed OpenViking server configuration."""
+
+    env_values = os.environ if env is None else env
+    configured = env_values.get("OPENVIKING_CONFIG_FILE", "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return (Path.home() if home is None else home) / ".openviking" / "ov.conf"
+
+
+def server_command() -> Optional[str]:
+    """Return the installed OpenViking server executable, if available."""
+
+    discovered = shutil.which("openviking-server")
+    if discovered:
+        return discovered
+    executable_name = "openviking-server.exe" if is_windows() else "openviking-server"
+    alongside_python = Path(sys.executable).parent / executable_name
+    if alongside_python.is_file():
+        return str(alongside_python)
+    return None
+
+
+def endpoint_bind(endpoint: str) -> tuple[str, int]:
+    """Return the host/port a local server should bind for an endpoint."""
+
+    parsed = urlparse(endpoint if "://" in endpoint else f"http://{endpoint}")
+    return parsed.hostname or "127.0.0.1", parsed.port or DEFAULT_PORT
+
+
+def start_detached_process(
+    command: list[str],
+    *,
+    stdin,
+    **kwargs,
+) -> subprocess.Popen:
+    """Start a child using Hermes' established cross-platform conventions."""
+
+    if not is_windows():
+        return subprocess.Popen(
+            command,
+            stdin=stdin,
+            start_new_session=True,
+            **kwargs,
+        )
+
+    try:
+        return subprocess.Popen(
+            command,
+            stdin=stdin,
+            creationflags=windows_detach_flags(),
+            **kwargs,
+        )
+    except OSError:
+        # Some Windows parents are already inside a job object that rejects
+        # CREATE_BREAKAWAY_FROM_JOB. Match the gateway's proven fallback.
+        return subprocess.Popen(
+            command,
+            stdin=stdin,
+            creationflags=windows_detach_flags_without_breakaway(),
+            **kwargs,
+        )
+
+
+def start_local_server(
+    endpoint: str,
+    *,
+    hermes_home: Path,
+    config_path: Optional[Path] = None,
+) -> LocalServerStartResult:
+    """Start OpenViking for a local endpoint and return exact ownership."""
+
+    executable = server_command()
+    if not executable:
+        return LocalServerStartResult(
+            None,
+            "openviking-server was not found. Install OpenViking, then retry.",
+        )
+
+    try:
+        host, port = endpoint_bind(endpoint)
+    except ValueError as exc:
+        return LocalServerStartResult(
+            None,
+            f"Could not parse local OpenViking URL: {exc}",
+        )
+
+    log_path = hermes_home / _SERVER_LOG_RELATIVE_PATH
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        command = [executable]
+        if config_path is not None:
+            command.extend(["--config", str(config_path)])
+        command.extend(["--host", host, "--port", str(port)])
+        with log_path.open("ab") as log_file:
+            process = start_detached_process(
+                command,
+                stdout=log_file,
+                stderr=log_file,
+                stdin=subprocess.DEVNULL,
+            )
+    except Exception as exc:
+        return LocalServerStartResult(
+            None,
+            f"Could not start openviking-server: {exc}",
+        )
+
+    return LocalServerStartResult(
+        process,
+        f"Started openviking-server on {host}:{port} in the background. Logs: {log_path}",
+    )
+
+
+def wait_for_health(
+    endpoint: str,
+    health_check: Callable[[str], tuple[bool, str]],
+    *,
+    timeout_seconds: float = AUTOSTART_TIMEOUT_SECONDS,
+    cancel_event=None,
+    should_stop=None,
+    monotonic=None,
+    sleep=None,
+) -> bool:
+    """Poll a caller-supplied health check until success, timeout, or cancel."""
+
+    if monotonic is None or sleep is None:
+        import time
+
+        monotonic = monotonic or time.monotonic
+        sleep = sleep or time.sleep
+
+    deadline = monotonic() + timeout_seconds
+    while monotonic() < deadline:
+        if (
+            (cancel_event is not None and cancel_event.is_set())
+            or (should_stop is not None and should_stop())
+        ):
+            return False
+        healthy, _message = health_check(endpoint)
+        if healthy:
+            return True
+        sleep(0.5)
+    return False
+
+
+def stop_owned_process(
+    process: subprocess.Popen,
+    *,
+    timeout_seconds: float = PROCESS_STOP_TIMEOUT_SECONDS,
+) -> bool:
+    """Stop exactly one child process owned through its ``Popen`` handle."""
+
+    try:
+        if process.poll() is not None:
+            return True
+        process.terminate()
+        process.wait(timeout=timeout_seconds)
+        return True
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "Owned OpenViking server did not stop within %.1f seconds; force-stopping it",
+            timeout_seconds,
+        )
+    except Exception as exc:
+        logger.warning("Could not stop owned OpenViking server cleanly: %s", exc)
+        return False
+
+    try:
+        process.kill()
+        process.wait(timeout=timeout_seconds)
+        return True
+    except subprocess.TimeoutExpired:
+        logger.error(
+            "Owned OpenViking server still did not exit after force-stop within %.1f seconds",
+            timeout_seconds,
+        )
+        return False
+    except Exception as exc:
+        logger.error("Could not force-stop owned OpenViking server: %s", exc)
+        return False
+
+
+def defer_owned_shutdown(
+    process: subprocess.Popen,
+    *,
+    hermes_home: Path,
+    endpoint: str,
+    headers: dict[str, str],
+    task_ids: set[str],
+) -> bool:
+    """Hand exact ownership to the detached, work-aware shutdown helper."""
+
+    reaper: Optional[subprocess.Popen] = None
+    try:
+        import psutil
+
+        create_time = psutil.Process(process.pid).create_time()
+        log_path = hermes_home / _REAPER_LOG_RELATIVE_PATH
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        popen_kwargs: dict[str, Any] = {
+            "stdin": subprocess.PIPE,
+            "stdout": None,
+            "stderr": None,
+            "close_fds": True,
+        }
+        reaper_command = [sys.executable, str(Path(__file__).with_name("reaper.py"))]
+        if is_windows():
+            from hermes_cli.gateway_windows import _resolve_detached_python
+
+            pythonw, _venv_dir, extra_pythonpath = _resolve_detached_python(
+                sys.executable
+            )
+            reaper_command[0] = pythonw
+            if extra_pythonpath:
+                env = dict(os.environ)
+                pythonpath_entries = list(extra_pythonpath)
+                if env.get("PYTHONPATH"):
+                    pythonpath_entries.append(env["PYTHONPATH"])
+                env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+                popen_kwargs["env"] = env
+
+        payload = {
+            "endpoint": endpoint,
+            "pid": process.pid,
+            "create_time": create_time,
+            "task_ids": sorted(task_ids),
+            "headers": headers,
+            "wait_timeout": TASK_WAIT_TIMEOUT_SECONDS,
+            "poll_interval": TASK_POLL_INTERVAL_SECONDS,
+            "stop_timeout": PROCESS_STOP_TIMEOUT_SECONDS,
+        }
+        with log_path.open("ab") as log_file:
+            popen_kwargs["stdout"] = log_file
+            popen_kwargs["stderr"] = log_file
+            reaper = start_detached_process(reaper_command, **popen_kwargs)
+            if reaper.stdin is None:
+                raise RuntimeError("shutdown helper stdin was not created")
+            reaper.stdin.write(json.dumps(payload).encode("utf-8"))
+            reaper.stdin.close()
+        return True
+    except Exception as exc:
+        if reaper is not None:
+            try:
+                if reaper.stdin is not None and not reaper.stdin.closed:
+                    reaper.stdin.close()
+                reaper.terminate()
+            except Exception:
+                pass
+        logger.warning("Could not defer managed OpenViking shutdown: %s", exc)
+        return False
+
+
+def is_windows() -> bool:
+    return os.name == "nt"

--- a/plugins/memory/openviking/quick_local.py
+++ b/plugins/memory/openviking/quick_local.py
@@ -1,0 +1,817 @@
+"""Reusable, interface-neutral OpenViking Quick Local provisioning.
+
+The CLI and future graphical surfaces supply decisions and render progress.
+This module owns the deterministic work: dependency preflight, installation,
+configuration, validation, and the private ovcli profile written for one
+Hermes home.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional
+from urllib.parse import urlparse
+from urllib.request import ProxyHandler, Request, build_opener
+
+from utils import atomic_json_write
+
+from . import local_server
+
+__all__ = [
+    "DEFAULT_ACTOR_PEER_ID",
+    "DEPLOYMENT",
+    "EMBEDDING_DIMENSION",
+    "EMBEDDING_MODEL",
+    "OllamaInstallRequired",
+    "QuickLocalPaths",
+    "QuickLocalPreflight",
+    "QuickLocalProgress",
+    "QuickLocalSetup",
+    "QuickLocalSetupCancelled",
+    "QuickLocalSetupError",
+    "QuickLocalSetupResult",
+    "QuickLocalStage",
+    "build_server_config",
+    "clear_managed_settings",
+    "find_available_port",
+    "find_reusable_endpoint",
+    "managed_paths",
+    "managed_server_config_path",
+    "repair_server_address",
+    "resolve_hermes_vlm_config",
+]
+
+DEPLOYMENT = "quick_local"
+EMBEDDING_MODEL = "qwen3-embedding:0.6b"
+EMBEDDING_DIMENSION = 1024
+DEFAULT_ACTOR_PEER_ID = "hermes"
+
+_ROOT_DIRNAME = "openviking"
+_SERVER_CONFIG_FILENAME = "ov.conf"
+_OVCLI_CONFIG_FILENAME = "ovcli.conf"
+_WORKSPACE_DIRNAME = "data"
+_FIRST_SERVER_PORT = 1933
+_SERVER_PORT_ATTEMPTS = 20
+_MODEL_DOWNLOAD_SIZE = "approximately 639 MB"
+_VALIDATION_DRAIN_TIMEOUT_SECONDS = 60.0
+_VALIDATION_REQUEST_SETTLE_SECONDS = 0.5
+
+
+class QuickLocalStage(str, Enum):
+    PREFLIGHT = "preflight"
+    INSTALL_OPENVIKING = "install_openviking"
+    INSTALL_OLLAMA = "install_ollama"
+    START_OLLAMA = "start_ollama"
+    DOWNLOAD_MODEL = "download_model"
+    WRITE_CONFIG = "write_config"
+    START_VALIDATION = "start_validation"
+    WAIT_FOR_HEALTH = "wait_for_health"
+    DRAIN_VALIDATION = "drain_validation"
+    COMPLETE = "complete"
+
+
+@dataclass(frozen=True)
+class QuickLocalProgress:
+    stage: QuickLocalStage
+    message: str
+
+
+@dataclass(frozen=True)
+class QuickLocalPaths:
+    root: Path
+    server_config: Path
+    ovcli_config: Path
+    workspace: Path
+
+    @property
+    def config(self) -> Path:
+        """Backward-compatible name used by existing provider call sites."""
+
+        return self.server_config
+
+
+@dataclass(frozen=True)
+class QuickLocalPreflight:
+    paths: QuickLocalPaths
+    reusable_endpoint: Optional[str]
+    ollama_install_required: bool
+
+
+@dataclass(frozen=True)
+class QuickLocalSetupResult:
+    paths: QuickLocalPaths
+    endpoint: str
+    reused: bool
+
+
+class QuickLocalSetupError(RuntimeError):
+    """Quick Local could not complete without leaving partial activation."""
+
+
+class QuickLocalSetupCancelled(QuickLocalSetupError):
+    """The caller cancelled Quick Local provisioning."""
+
+
+class OllamaInstallRequired(QuickLocalSetupError):
+    """Provisioning requires explicit permission to install Ollama."""
+
+
+ProgressReporter = Callable[[QuickLocalProgress], None]
+HealthCheck = Callable[[str], tuple[bool, str]]
+
+
+def managed_paths(hermes_home: Path) -> QuickLocalPaths:
+    root = hermes_home / _ROOT_DIRNAME
+    return QuickLocalPaths(
+        root=root,
+        server_config=root / _SERVER_CONFIG_FILENAME,
+        ovcli_config=root / _OVCLI_CONFIG_FILENAME,
+        workspace=root / _WORKSPACE_DIRNAME,
+    )
+
+
+def managed_server_config_path(provider_config: Mapping[str, Any]) -> Optional[Path]:
+    if provider_config.get("deployment") != DEPLOYMENT:
+        return None
+    raw_path = _clean_value(provider_config.get("server_config_path"))
+    return Path(raw_path).expanduser() if raw_path else None
+
+
+def clear_managed_settings(provider_config: dict[str, Any]) -> None:
+    provider_config.pop("deployment", None)
+    provider_config.pop("server_config_path", None)
+
+
+def build_server_config(
+    paths: QuickLocalPaths,
+    vlm: Mapping[str, Any],
+    *,
+    port: int = _FIRST_SERVER_PORT,
+) -> dict[str, Any]:
+    return {
+        "server": {"host": "127.0.0.1", "port": port},
+        "storage": {"workspace": str(paths.workspace)},
+        "embedding": {
+            "dense": {
+                "provider": "ollama",
+                "model": EMBEDDING_MODEL,
+                "api_base": "http://localhost:11434/v1",
+                "dimension": EMBEDDING_DIMENSION,
+                "input": "text",
+            }
+        },
+        "vlm": dict(vlm),
+    }
+
+
+def resolve_hermes_vlm_config(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Translate Hermes' effective static LLM into OpenViking VLM config."""
+
+    model_config = config.get("model", {}) if isinstance(config, Mapping) else {}
+    if isinstance(model_config, str):
+        model_config = {"default": model_config}
+    if not isinstance(model_config, Mapping):
+        model_config = {}
+    model = _clean_value(
+        model_config.get("default")
+        or model_config.get("model")
+        or model_config.get("name")
+    )
+    requested_provider = _clean_value(model_config.get("provider")) or None
+    if not model:
+        raise QuickLocalSetupError("Hermes has no default LLM model configured.")
+
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    runtime = resolve_runtime_provider(
+        requested=requested_provider,
+        target_model=model,
+    )
+    runtime_model = _clean_value(runtime.get("model")) or model
+    provider = _clean_value(runtime.get("provider")).lower()
+    api_mode = _clean_value(runtime.get("api_mode")).lower()
+    source = _clean_value(runtime.get("source")).lower()
+    api_key = _clean_value(runtime.get("api_key"))
+    api_base = _clean_value(runtime.get("base_url"))
+
+    ephemeral_auth = (
+        "oauth" in source
+        or provider
+        in {
+            "bedrock",
+            "copilot-acp",
+            "minimax-oauth",
+            "nous",
+            "openai-codex",
+            "qwen-oauth",
+            "vertex",
+            "xai-oauth",
+        }
+        or api_key.startswith("sk-ant-oat")
+        or api_key == "aws-sdk"
+    )
+    if ephemeral_auth:
+        raise QuickLocalSetupError(
+            "Hermes is using refreshed OAuth, cloud-native, or external-process "
+            "credentials that cannot be copied safely into OpenViking. Configure "
+            "a static API-key LLM for Hermes, or connect to an OpenViking server "
+            "configured separately."
+        )
+    if api_mode not in {"chat_completions", "anthropic_messages"}:
+        raise QuickLocalSetupError(
+            f"Hermes' {api_mode or 'unknown'} LLM transport is not supported by "
+            "quick local setup. Use an OpenAI-compatible or Anthropic-compatible "
+            "API-key provider, or connect to an OpenViking server configured "
+            "separately."
+        )
+    if not api_base:
+        raise QuickLocalSetupError(
+            "Hermes' LLM provider did not resolve an API base URL."
+        )
+    if not api_key:
+        raise QuickLocalSetupError(
+            "Hermes' LLM provider did not resolve usable credentials."
+        )
+
+    vlm: dict[str, Any]
+    if api_mode == "anthropic_messages":
+        if not runtime_model.startswith("anthropic/"):
+            runtime_model = f"anthropic/{runtime_model}"
+        vlm = {
+            "provider": "litellm",
+            "model": runtime_model,
+            "api_key": api_key,
+            "api_base": api_base,
+        }
+    else:
+        vlm = {
+            "provider": "openai",
+            "model": runtime_model,
+            "api_key": api_key,
+            "api_base": api_base,
+        }
+
+    extra_headers = runtime.get("extra_headers")
+    if isinstance(extra_headers, dict) and extra_headers:
+        vlm["extra_headers"] = dict(extra_headers)
+    request_overrides = runtime.get("request_overrides")
+    if isinstance(request_overrides, dict):
+        extra_body = request_overrides.get("extra_body")
+        if isinstance(extra_body, dict) and extra_body:
+            vlm["extra_request_body"] = dict(extra_body)
+    vlm.update({"temperature": 0.0, "max_retries": 2})
+    return vlm
+
+
+class QuickLocalSetup:
+    """Provision one Hermes-home-scoped Quick Local deployment."""
+
+    def __init__(
+        self,
+        *,
+        health_check: HealthCheck,
+        progress: Optional[ProgressReporter] = None,
+    ) -> None:
+        self._health_check = health_check
+        self._progress = progress or (lambda _event: None)
+
+    def preflight(self, hermes_home: Path) -> QuickLocalPreflight:
+        """Inspect reusable state without mutating the selected Hermes home."""
+
+        try:
+            paths = managed_paths(hermes_home)
+            self._emit(
+                QuickLocalStage.PREFLIGHT,
+                "Checking local OpenViking setup...",
+            )
+            reusable_endpoint = find_reusable_endpoint(
+                paths,
+                self._health_check,
+            )
+            return QuickLocalPreflight(
+                paths=paths,
+                reusable_endpoint=reusable_endpoint,
+                ollama_install_required=(
+                    reusable_endpoint is None and not _ollama_command_available()
+                ),
+            )
+        except QuickLocalSetupError:
+            raise
+        except Exception as exc:
+            raise QuickLocalSetupError(f"Quick Local preflight failed: {exc}") from exc
+
+    def provision(
+        self,
+        *,
+        hermes_home: Path,
+        hermes_config: Mapping[str, Any],
+        allow_ollama_install: bool,
+        cancel_event: Optional[threading.Event] = None,
+        preflight: Optional[QuickLocalPreflight] = None,
+    ) -> QuickLocalSetupResult:
+        """Provision Quick Local and expose only stable domain errors."""
+
+        try:
+            return self._provision(
+                hermes_home=hermes_home,
+                hermes_config=hermes_config,
+                allow_ollama_install=allow_ollama_install,
+                cancel_event=cancel_event,
+                preflight=preflight,
+            )
+        except QuickLocalSetupError:
+            raise
+        except Exception as exc:
+            raise QuickLocalSetupError(f"Quick Local setup failed: {exc}") from exc
+
+    def _provision(
+        self,
+        *,
+        hermes_home: Path,
+        hermes_config: Mapping[str, Any],
+        allow_ollama_install: bool,
+        cancel_event: Optional[threading.Event],
+        preflight: Optional[QuickLocalPreflight],
+    ) -> QuickLocalSetupResult:
+        self._check_cancelled(cancel_event)
+        preflight = preflight or self.preflight(hermes_home)
+        expected_paths = managed_paths(hermes_home)
+        if preflight.paths != expected_paths:
+            raise QuickLocalSetupError(
+                "Quick Local preflight belongs to a different Hermes home."
+            )
+        reusable_endpoint = find_reusable_endpoint(
+            preflight.paths,
+            self._health_check,
+        )
+        if reusable_endpoint is not None:
+            repair_server_address(
+                preflight.paths,
+                reusable_endpoint,
+            )
+            self._emit(
+                QuickLocalStage.COMPLETE,
+                "Existing quick local server is reachable; reusing it.",
+            )
+            return QuickLocalSetupResult(
+                paths=preflight.paths,
+                endpoint=reusable_endpoint,
+                reused=True,
+            )
+
+        self._check_cancelled(cancel_event)
+        vlm = resolve_hermes_vlm_config(hermes_config)
+        preflight.paths.workspace.mkdir(parents=True, exist_ok=True)
+        self._ensure_openviking_installed(cancel_event)
+        self._ensure_ollama(
+            allow_install=allow_ollama_install,
+            cancel_event=cancel_event,
+        )
+
+        self._check_cancelled(cancel_event)
+        port = find_available_port()
+        if port is None:
+            last_port = _FIRST_SERVER_PORT + _SERVER_PORT_ATTEMPTS - 1
+            raise QuickLocalSetupError(
+                "No available local port was found for OpenViking "
+                f"(checked {_FIRST_SERVER_PORT}-{last_port})."
+            )
+
+        server_config = build_server_config(preflight.paths, vlm, port=port)
+        atomic_json_write(preflight.paths.server_config, server_config, mode=0o600)
+        endpoint = f"http://127.0.0.1:{port}"
+        self._emit(
+            QuickLocalStage.WRITE_CONFIG,
+            f"Wrote Quick Local configuration to {preflight.paths.server_config}.",
+        )
+
+        self._validate_generated_config(
+            paths=preflight.paths,
+            endpoint=endpoint,
+            server_config=server_config,
+            cancel_event=cancel_event,
+        )
+        _write_managed_ovcli_profile(preflight.paths.ovcli_config, endpoint)
+        self._emit(
+            QuickLocalStage.COMPLETE,
+            f"Quick local server configured with {EMBEDDING_MODEL}.",
+        )
+        return QuickLocalSetupResult(
+            paths=preflight.paths,
+            endpoint=endpoint,
+            reused=False,
+        )
+
+    def _ensure_openviking_installed(
+        self,
+        cancel_event: Optional[threading.Event],
+    ) -> None:
+        if local_server.server_command():
+            return
+        self._check_cancelled(cancel_event)
+        self._emit(
+            QuickLocalStage.INSTALL_OPENVIKING,
+            "Installing OpenViking...",
+        )
+        try:
+            from hermes_cli.tools_config import _pip_install
+
+            previous_native_tls = os.environ.get("UV_NATIVE_TLS")
+            os.environ["UV_NATIVE_TLS"] = "true"
+            try:
+                result = _pip_install(
+                    ["openviking"],
+                    timeout=600,
+                    capture_output=False,
+                )
+            finally:
+                if previous_native_tls is None:
+                    os.environ.pop("UV_NATIVE_TLS", None)
+                else:
+                    os.environ["UV_NATIVE_TLS"] = previous_native_tls
+        except Exception as exc:
+            raise QuickLocalSetupError(f"Could not install OpenViking: {exc}") from exc
+        self._check_cancelled(cancel_event)
+        if result.returncode != 0 or not local_server.server_command():
+            raise QuickLocalSetupError(
+                "Could not install OpenViking. Review the installer output above."
+            )
+
+    def _ensure_ollama(
+        self,
+        *,
+        allow_install: bool,
+        cancel_event: Optional[threading.Event],
+    ) -> None:
+        self._check_cancelled(cancel_event)
+        try:
+            ollama = importlib.import_module("openviking_cli.utils.ollama")
+        except Exception as exc:
+            raise QuickLocalSetupError(
+                f"OpenViking's Ollama support could not be loaded: {exc}"
+            ) from exc
+
+        _add_windows_ollama_to_path()
+        if not ollama.is_ollama_installed():
+            if not allow_install:
+                raise OllamaInstallRequired("Ollama is required for Quick Local setup.")
+            self._emit(QuickLocalStage.INSTALL_OLLAMA, "Installing Ollama...")
+            if not _install_ollama(ollama):
+                raise QuickLocalSetupError(
+                    "Ollama installation failed. Install it manually, then retry."
+                )
+            if not ollama.is_ollama_installed():
+                raise QuickLocalSetupError(
+                    "Ollama installation completed, but the ollama command is not "
+                    "available. Restart the terminal, then retry."
+                )
+
+        self._check_cancelled(cancel_event)
+        if not ollama.check_ollama_running():
+            self._emit(QuickLocalStage.START_OLLAMA, "Starting Ollama...")
+            start_result = ollama.start_ollama()
+            if not start_result.success:
+                detail = start_result.stderr_output.strip() or start_result.message
+                raise QuickLocalSetupError(f"Ollama could not be started: {detail}")
+
+        self._check_cancelled(cancel_event)
+        if not ollama.is_model_available(
+            EMBEDDING_MODEL,
+            ollama.get_ollama_models(),
+        ):
+            self._emit(
+                QuickLocalStage.DOWNLOAD_MODEL,
+                f"Downloading {EMBEDDING_MODEL} ({_MODEL_DOWNLOAD_SIZE})...",
+            )
+            if not ollama.ollama_pull_model(EMBEDDING_MODEL):
+                raise QuickLocalSetupError(f"Could not download {EMBEDDING_MODEL}.")
+        self._check_cancelled(cancel_event)
+
+    def _validate_generated_config(
+        self,
+        *,
+        paths: QuickLocalPaths,
+        endpoint: str,
+        server_config: dict[str, Any],
+        cancel_event: Optional[threading.Event],
+    ) -> None:
+        with tempfile.TemporaryDirectory(
+            prefix="setup-validation-",
+            dir=paths.root,
+        ) as validation_root:
+            validation_root_path = Path(validation_root)
+            validation_config = json.loads(json.dumps(server_config))
+            validation_config["storage"]["workspace"] = str(
+                validation_root_path / _WORKSPACE_DIRNAME
+            )
+            validation_config_path = validation_root_path / _SERVER_CONFIG_FILENAME
+            atomic_json_write(
+                validation_config_path,
+                validation_config,
+                mode=0o600,
+            )
+
+            self._check_cancelled(cancel_event)
+            self._emit(
+                QuickLocalStage.START_VALIDATION,
+                "Starting a temporary OpenViking validation server...",
+            )
+            start_result = local_server.start_local_server(
+                endpoint,
+                hermes_home=paths.root.parent,
+                config_path=validation_config_path,
+            )
+            if start_result.process is None:
+                raise QuickLocalSetupError(start_result.message)
+
+            validation_succeeded = False
+            validation_drained = False
+            stop_succeeded = False
+            try:
+                self._emit(
+                    QuickLocalStage.WAIT_FOR_HEALTH,
+                    "Waiting for OpenViking server to become reachable...",
+                )
+                validation_succeeded = local_server.wait_for_health(
+                    endpoint,
+                    self._health_check,
+                    timeout_seconds=local_server.AUTOSTART_TIMEOUT_SECONDS,
+                    cancel_event=cancel_event,
+                )
+                if validation_succeeded:
+                    self._check_cancelled(cancel_event)
+                    self._emit(
+                        QuickLocalStage.DRAIN_VALIDATION,
+                        "Finishing temporary OpenViking validation work...",
+                    )
+                    _wait_for_processing(
+                        endpoint,
+                        timeout_seconds=_VALIDATION_DRAIN_TIMEOUT_SECONDS,
+                    )
+                    # OpenViking can finish sending the response just before
+                    # its ASGI middleware exits. Avoid delivering SIGTERM
+                    # during that narrow teardown window.
+                    if cancel_event is None:
+                        time.sleep(_VALIDATION_REQUEST_SETTLE_SECONDS)
+                    elif cancel_event.wait(_VALIDATION_REQUEST_SETTLE_SECONDS):
+                        raise QuickLocalSetupCancelled(
+                            "Quick Local setup was cancelled."
+                        )
+                    validation_drained = True
+            finally:
+                stop_succeeded = local_server.stop_owned_process(start_result.process)
+
+            self._check_cancelled(cancel_event)
+            if not stop_succeeded:
+                raise QuickLocalSetupError(
+                    "The temporary OpenViking validation server could not be "
+                    "stopped; check the server log before retrying setup."
+                )
+            if not validation_succeeded:
+                raise QuickLocalSetupError(
+                    "OpenViking server did not become reachable. Check the "
+                    "server log and retry."
+                )
+            if not validation_drained:
+                raise QuickLocalSetupError(
+                    "OpenViking validation work did not finish before shutdown."
+                )
+
+    def _emit(self, stage: QuickLocalStage, message: str) -> None:
+        self._progress(QuickLocalProgress(stage=stage, message=message))
+
+    @staticmethod
+    def _check_cancelled(
+        cancel_event: Optional[threading.Event],
+    ) -> None:
+        if cancel_event is not None and cancel_event.is_set():
+            raise QuickLocalSetupCancelled("Quick Local setup was cancelled.")
+
+
+def find_available_port(
+    *,
+    first_port: int = _FIRST_SERVER_PORT,
+    attempts: int = _SERVER_PORT_ATTEMPTS,
+) -> Optional[int]:
+    for port in range(first_port, first_port + attempts):
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as candidate:
+                candidate.bind(("127.0.0.1", port))
+            return port
+        except OSError:
+            continue
+    return None
+
+
+def find_reusable_endpoint(
+    paths: QuickLocalPaths,
+    health_check: HealthCheck,
+) -> Optional[str]:
+    """Return a healthy endpoint proven to use this managed workspace."""
+
+    if not paths.server_config.is_file() or not paths.ovcli_config.is_file():
+        return None
+
+    try:
+        server_config = json.loads(paths.server_config.read_text(encoding="utf-8"))
+        storage = (
+            server_config.get("storage", {}) if isinstance(server_config, dict) else {}
+        )
+        if not isinstance(storage, dict) or not _paths_equivalent(
+            storage.get("workspace"),
+            paths.workspace,
+        ):
+            return None
+
+        profile = json.loads(paths.ovcli_config.read_text(encoding="utf-8"))
+        endpoint = _normalize_local_endpoint(
+            profile.get("url") if isinstance(profile, dict) else ""
+        )
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return None
+
+    if endpoint is None:
+        return None
+    healthy, _message = health_check(endpoint)
+    return endpoint if healthy else None
+
+
+def repair_server_address(paths: QuickLocalPaths, endpoint: str) -> None:
+    """Keep persisted startup config aligned with a reusable server."""
+
+    server_config = json.loads(paths.server_config.read_text(encoding="utf-8"))
+    host, port = local_server.endpoint_bind(endpoint)
+    server_config["server"] = {"host": host, "port": port}
+    atomic_json_write(paths.server_config, server_config, mode=0o600)
+
+
+def _write_managed_ovcli_profile(path: Path, endpoint: str) -> None:
+    atomic_json_write(
+        path,
+        {
+            "url": endpoint,
+            "actor_peer_id": DEFAULT_ACTOR_PEER_ID,
+        },
+        mode=0o600,
+    )
+
+
+def _wait_for_processing(
+    endpoint: str,
+    *,
+    timeout_seconds: float,
+) -> None:
+    """Drain bootstrap work before stopping a temporary validation server."""
+
+    request = Request(
+        f"{endpoint.rstrip('/')}/api/v1/system/wait",
+        data=json.dumps({"timeout": timeout_seconds}).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    response = build_opener(ProxyHandler({})).open(
+        request,
+        timeout=timeout_seconds + 1.0,
+    )
+    with response:
+        payload = json.loads(response.read())
+    result = payload.get("result") if isinstance(payload, dict) else None
+    if (
+        not isinstance(payload, dict)
+        or payload.get("status") != "ok"
+        or not isinstance(result, dict)
+    ):
+        raise QuickLocalSetupError(
+            "OpenViking validation queue returned an invalid response."
+        )
+
+    failed_queues: list[tuple[str, int]] = []
+    for queue_name, queue_status in result.items():
+        if not isinstance(queue_status, dict):
+            raise QuickLocalSetupError(
+                "OpenViking validation queue returned an invalid response."
+            )
+        error_count = queue_status.get("error_count", 0)
+        errors = queue_status.get("errors", [])
+        if (
+            not isinstance(error_count, int)
+            or isinstance(error_count, bool)
+            or error_count < 0
+            or not isinstance(errors, list)
+        ):
+            raise QuickLocalSetupError(
+                "OpenViking validation queue returned an invalid response."
+            )
+        if error_count or errors:
+            failed_queues.append((str(queue_name), max(error_count, len(errors))))
+
+    if failed_queues:
+        summary = ", ".join(
+            f"{queue_name}: {error_count}" for queue_name, error_count in failed_queues
+        )
+        raise QuickLocalSetupError(
+            "OpenViking validation reported processing errors "
+            f"({summary}). Check the OpenViking server log and Hermes LLM "
+            "configuration, then retry."
+        )
+
+
+def _ollama_command_available() -> bool:
+    _add_windows_ollama_to_path()
+    return shutil.which("ollama") is not None
+
+
+def _add_windows_ollama_to_path() -> None:
+    if not _is_windows():
+        return
+    local_app_data = os.environ.get("LOCALAPPDATA", "").strip()
+    if not local_app_data:
+        return
+    install_dir = Path(local_app_data) / "Programs" / "Ollama"
+    if not (install_dir / "ollama.exe").is_file():
+        return
+    entries = os.environ.get("PATH", "").split(os.pathsep)
+    normalized = {os.path.normcase(entry) for entry in entries if entry}
+    if os.path.normcase(str(install_dir)) not in normalized:
+        os.environ["PATH"] = os.pathsep.join([
+            str(install_dir),
+            *(entry for entry in entries if entry),
+        ])
+
+
+def _install_ollama(ollama) -> bool:
+    if not _is_windows():
+        return bool(ollama.install_ollama())
+
+    powershell = next(
+        (
+            executable
+            for name in (
+                "powershell.exe",
+                "powershell",
+                "pwsh.exe",
+                "pwsh",
+            )
+            if (executable := shutil.which(name))
+        ),
+        None,
+    )
+    if not powershell:
+        return False
+    result = subprocess.run(
+        [
+            powershell,
+            "-NoLogo",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            "Invoke-RestMethod https://ollama.com/install.ps1 | Invoke-Expression",
+        ],
+        check=False,
+    )
+    _add_windows_ollama_to_path()
+    return result.returncode == 0
+
+
+def _normalize_local_endpoint(value: Any) -> Optional[str]:
+    endpoint = _clean_value(value).rstrip("/")
+    if not endpoint:
+        return None
+    if "://" not in endpoint:
+        endpoint = f"http://{endpoint}"
+    parsed = urlparse(endpoint)
+    if parsed.scheme.lower() != "http":
+        return None
+    if (parsed.hostname or "").lower() not in {"localhost", "127.0.0.1", "::1"}:
+        return None
+    host = f"[{parsed.hostname}]" if parsed.hostname == "::1" else parsed.hostname
+    return f"http://{host}:{parsed.port or local_server.DEFAULT_PORT}"
+
+
+def _paths_equivalent(left: Any, right: Path) -> bool:
+    if not isinstance(left, (str, os.PathLike)):
+        return False
+    try:
+        return Path(left).expanduser().resolve() == right.expanduser().resolve()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return False
+
+
+def _clean_value(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"

--- a/plugins/memory/openviking/reaper.py
+++ b/plugins/memory/openviking/reaper.py
@@ -1,0 +1,278 @@
+"""Finish a managed OpenViking shutdown after the Hermes CLI exits.
+
+The interactive CLI has a short, process-wide exit watchdog. OpenViking
+session commits and queued indexing can legitimately take longer, so the
+provider hands its exact child process and tracked task IDs to this small
+detached helper. The helper waits for every tracked task, drains OpenViking's
+remaining processing queues, and only then stops that exact process.
+
+The JSON payload is read from stdin so credentials never appear in the process
+list. This module is intentionally standalone and uses only stdlib plus
+``psutil``, which is a Hermes core dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import sys
+import time
+from typing import Any
+from urllib.parse import quote, urlparse
+from urllib.request import ProxyHandler, Request, build_opener
+
+import psutil
+
+
+logger = logging.getLogger(__name__)
+
+_LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1"}
+_TERMINAL_TASK_STATUSES = {"completed", "failed"}
+_ACTIVE_TASK_STATUSES = {"pending", "running"}
+
+
+def _validated_payload(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ValueError("shutdown payload must be a JSON object")
+
+    endpoint = str(raw.get("endpoint") or "").rstrip("/")
+    parsed_endpoint = urlparse(endpoint)
+    if (
+        parsed_endpoint.scheme.lower() != "http"
+        or (parsed_endpoint.hostname or "").lower() not in _LOCAL_HOSTS
+    ):
+        raise ValueError("shutdown endpoint must be local HTTP")
+
+    pid = int(raw.get("pid") or 0)
+    create_time = float(raw.get("create_time") or 0)
+    if pid <= 1 or pid == os.getpid() or create_time <= 0:
+        raise ValueError("shutdown process identity is invalid")
+
+    task_ids = raw.get("task_ids")
+    if not isinstance(task_ids, list):
+        raise ValueError("tracked task IDs must be a list")
+    normalized_task_ids = []
+    for task_id in task_ids:
+        value = str(task_id or "").strip()
+        if not value or len(value) > 256:
+            raise ValueError("tracked task ID is invalid")
+        normalized_task_ids.append(value)
+
+    headers = raw.get("headers") or {}
+    if not isinstance(headers, dict) or not all(
+        isinstance(key, str) and isinstance(value, str)
+        for key, value in headers.items()
+    ):
+        raise ValueError("request headers are invalid")
+
+    wait_timeout = float(raw.get("wait_timeout") or 0)
+    poll_interval = float(raw.get("poll_interval") or 0)
+    stop_timeout = float(raw.get("stop_timeout") or 0)
+    if wait_timeout <= 0 or poll_interval <= 0 or stop_timeout <= 0:
+        raise ValueError("shutdown timeouts must be positive")
+
+    return {
+        "endpoint": endpoint,
+        "pid": pid,
+        "create_time": create_time,
+        "task_ids": normalized_task_ids,
+        "headers": headers,
+        "wait_timeout": wait_timeout,
+        "poll_interval": poll_interval,
+        "stop_timeout": stop_timeout,
+    }
+
+
+def _task_status(endpoint: str, task_id: str, headers: dict[str, str]) -> str:
+    request = Request(
+        f"{endpoint}/api/v1/tasks/{quote(task_id, safe='')}",
+        headers=headers,
+        method="GET",
+    )
+    # Do not inherit proxy settings for a loopback-only control request.
+    response = build_opener(ProxyHandler({})).open(request, timeout=5.0)
+    with response:
+        payload = json.loads(response.read())
+    result = payload.get("result") if isinstance(payload, dict) else None
+    if not isinstance(result, dict):
+        raise ValueError(f"task {task_id} returned an invalid response")
+    status = str(result.get("status") or "").strip().lower()
+    if status not in _TERMINAL_TASK_STATUSES | _ACTIVE_TASK_STATUSES:
+        raise ValueError(f"task {task_id} returned unknown status {status!r}")
+    return status
+
+
+def _wait_for_processing(
+    endpoint: str,
+    headers: dict[str, str],
+    timeout: float,
+) -> None:
+    """Wait for all queued OpenViking semantic and embedding work."""
+    request = Request(
+        f"{endpoint}/api/v1/system/wait",
+        data=json.dumps({"timeout": timeout}).encode("utf-8"),
+        headers={**headers, "Content-Type": "application/json"},
+        method="POST",
+    )
+    # Give the HTTP exchange a small allowance beyond OpenViking's own bounded
+    # wait. Do not inherit proxy settings for a loopback-only control request.
+    response = build_opener(ProxyHandler({})).open(request, timeout=timeout + 1.0)
+    with response:
+        payload = json.loads(response.read())
+    result = payload.get("result") if isinstance(payload, dict) else None
+    if (
+        not isinstance(payload, dict)
+        or payload.get("status") != "ok"
+        or not isinstance(result, dict)
+    ):
+        raise ValueError("system wait returned an invalid response")
+
+    for queue_name, queue_status in result.items():
+        if not isinstance(queue_status, dict):
+            raise ValueError("system wait returned an invalid queue response")
+        error_count = queue_status.get("error_count", 0)
+        errors = queue_status.get("errors", [])
+        if (
+            not isinstance(error_count, int)
+            or isinstance(error_count, bool)
+            or error_count < 0
+            or not isinstance(errors, list)
+        ):
+            raise ValueError("system wait returned an invalid queue response")
+        if error_count or errors:
+            raise RuntimeError(
+                f"OpenViking queue {queue_name!r} reported processing errors"
+            )
+
+
+def _same_process(pid: int, expected_create_time: float) -> psutil.Process | None:
+    try:
+        process = psutil.Process(pid)
+        if abs(process.create_time() - expected_create_time) > 0.01:
+            return None
+        # A detached helper is not the OpenViking process's parent and cannot
+        # reap it. On POSIX, a server that has already exited can therefore
+        # remain visible as a zombie until Hermes itself exits. Treat that as
+        # stopped instead of reporting a false timeout or attempting SIGKILL.
+        if process.status() == psutil.STATUS_ZOMBIE:
+            return None
+        return process
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+        return None
+
+
+def _stop_exact_process(pid: int, create_time: float, timeout: float) -> bool:
+    process = _same_process(pid, create_time)
+    if process is None:
+        return True
+    try:
+        process.send_signal(signal.SIGTERM)
+        process.wait(timeout=timeout)
+        return True
+    except psutil.TimeoutExpired:
+        logger.warning(
+            "Managed OpenViking PID %d did not stop within %.1f seconds; force-stopping it",
+            pid,
+            timeout,
+        )
+    except (psutil.NoSuchProcess, psutil.ZombieProcess):
+        return True
+    except (psutil.AccessDenied, OSError) as exc:
+        logger.error("Could not stop managed OpenViking PID %d: %s", pid, exc)
+        return False
+
+    # Revalidate the creation time immediately before the destructive fallback.
+    process = _same_process(pid, create_time)
+    if process is None:
+        return True
+    try:
+        process.kill()
+        process.wait(timeout=timeout)
+        return True
+    except (psutil.NoSuchProcess, psutil.ZombieProcess):
+        return True
+    except (psutil.AccessDenied, psutil.TimeoutExpired, OSError) as exc:
+        logger.error("Could not force-stop managed OpenViking PID %d: %s", pid, exc)
+        return False
+
+
+def run(payload: dict[str, Any]) -> int:
+    config = _validated_payload(payload)
+    pending = set(config["task_ids"])
+    deadline = time.monotonic() + config["wait_timeout"]
+
+    while pending:
+        if _same_process(config["pid"], config["create_time"]) is None:
+            return 0
+        try:
+            for task_id in tuple(pending):
+                status = _task_status(config["endpoint"], task_id, config["headers"])
+                if status in _TERMINAL_TASK_STATUSES:
+                    pending.discard(task_id)
+        except Exception as exc:
+            logger.error(
+                "Could not verify managed OpenViking background work; leaving PID %d running: %s",
+                config["pid"],
+                exc,
+            )
+            return 2
+
+        if not pending:
+            break
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            logger.error(
+                "Managed OpenViking tasks did not finish within %.1f seconds; leaving PID %d running",
+                config["wait_timeout"],
+                config["pid"],
+            )
+            return 3
+        time.sleep(min(config["poll_interval"], remaining))
+
+    if _same_process(config["pid"], config["create_time"]) is None:
+        return 0
+
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        logger.error(
+            "Managed OpenViking work did not finish within %.1f seconds; leaving PID %d running",
+            config["wait_timeout"],
+            config["pid"],
+        )
+        return 3
+    try:
+        _wait_for_processing(config["endpoint"], config["headers"], remaining)
+    except Exception as exc:
+        logger.error(
+            "Could not verify managed OpenViking queue drain; leaving PID %d running: %s",
+            config["pid"],
+            exc,
+        )
+        return 2
+
+    return (
+        0
+        if _stop_exact_process(
+            config["pid"], config["create_time"], config["stop_timeout"]
+        )
+        else 4
+    )
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    try:
+        payload = json.load(sys.stdin)
+        return run(payload)
+    except Exception:
+        logger.exception("Managed OpenViking shutdown handoff failed")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -1697,7 +1697,7 @@ class TestEnsureClientReloadsEnv:
         assert results == {"first": None, "second": None}
         assert all(client is not stale_client for client in results.values())
 
-    def test_handle_tool_call_after_reload_to_local_endpoint_starts_runtime_recovery(
+    def test_handle_tool_call_after_reload_to_self_managed_local_does_not_start_it(
         self,
         tmp_path,
         monkeypatch,
@@ -1756,9 +1756,9 @@ class TestEnsureClientReloadsEnv:
         start_calls = []
         waiter_calls = []
         monkeypatch.setattr(
-            openviking_plugin,
-            "_start_local_openviking_server",
-            lambda endpoint: start_calls.append(endpoint) or (True, "started"),
+            openviking_plugin.local_server,
+            "start_local_server",
+            lambda endpoint, **kwargs: start_calls.append(endpoint),
         )
         monkeypatch.setattr(
             provider,
@@ -1774,10 +1774,12 @@ class TestEnsureClientReloadsEnv:
 
         assert "not connected" in out["error"]
         assert provider._client is None
-        assert start_calls == ["http://127.0.0.1:31933"]
-        assert len(waiter_calls) == 1
+        assert start_calls == []
+        assert waiter_calls == []
 
-    def test_repeated_access_while_local_runtime_starts_does_not_spawn_again(self, monkeypatch):
+    def test_repeated_access_while_managed_local_runtime_starts_does_not_spawn_again(
+        self, tmp_path, monkeypatch
+    ):
         class _AliveThread:
             def is_alive(self):
                 return True
@@ -1792,14 +1794,29 @@ class TestEnsureClientReloadsEnv:
         monkeypatch.setattr(openviking_plugin, "_VikingClient", _StubClient)
         monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://127.0.0.1:31933")
         monkeypatch.setenv("OPENVIKING_API_KEY", "")
-
-        start_calls = []
-        provider = OpenVikingMemoryProvider()
-        provider._env_refresh_enabled = True
+        server_config = tmp_path / "ov.conf"
+        server_config.write_text("{}", encoding="utf-8")
         monkeypatch.setattr(
             openviking_plugin,
-            "_start_local_openviking_server",
-            lambda endpoint: start_calls.append(endpoint) or (True, "started"),
+            "_load_hermes_openviking_config",
+            lambda: {
+                "deployment": openviking_plugin._MANAGED_LOCAL_DEPLOYMENT,
+                "server_config_path": str(server_config),
+            },
+        )
+
+        start_calls = []
+        process = object()
+        provider = OpenVikingMemoryProvider()
+        provider._hermes_home = str(tmp_path / "hermes")
+        provider._env_refresh_enabled = True
+        monkeypatch.setattr(
+            openviking_plugin.local_server,
+            "start_local_server",
+            lambda endpoint, **kwargs: (
+                start_calls.append((endpoint, kwargs))
+                or openviking_plugin._LocalServerStartResult(process, "started")
+            ),
         )
         monkeypatch.setattr(
             provider,
@@ -1811,29 +1828,49 @@ class TestEnsureClientReloadsEnv:
         assert provider._ensure_client() is None
         assert provider._ensure_client() is None
 
-        assert start_calls == ["http://127.0.0.1:31933"]
+        assert start_calls == [
+            (
+                "http://127.0.0.1:31933",
+                {
+                    "hermes_home": tmp_path / "hermes",
+                    "config_path": server_config,
+                },
+            )
+        ]
 
-    def test_concurrent_local_runtime_recovery_starts_once(self, monkeypatch):
+    def test_concurrent_managed_local_runtime_recovery_starts_once(
+        self, tmp_path, monkeypatch
+    ):
         class _AliveThread:
             def is_alive(self):
                 return True
 
         provider = OpenVikingMemoryProvider()
         provider._endpoint = "http://127.0.0.1:31933"
+        provider._hermes_home = str(tmp_path / "hermes")
+        server_config = tmp_path / "ov.conf"
+        server_config.write_text("{}", encoding="utf-8")
+        provider._managed_local_server_config = server_config
         start_calls = []
         start_lock = threading.Lock()
         first_start_entered = threading.Event()
         release_start = threading.Event()
         second_started = threading.Event()
 
-        def start_local(endpoint):
+        process = object()
+
+        def start_local(endpoint, **kwargs):
             with start_lock:
-                start_calls.append(endpoint)
+                start_calls.append((endpoint, kwargs))
             first_start_entered.set()
             release_start.wait(timeout=2)
-            return True, "started"
+            return openviking_plugin._LocalServerStartResult(process, "started")
 
-        monkeypatch.setattr(openviking_plugin, "_start_local_openviking_server", start_local)
+        monkeypatch.setattr(
+            openviking_plugin.local_server,
+            "start_local_server",
+            start_local,
+        )
         monkeypatch.setattr(
             provider,
             "_start_runtime_openviking_waiter",
@@ -1870,7 +1907,15 @@ class TestEnsureClientReloadsEnv:
             assert not thread.is_alive()
 
         assert errors == []
-        assert start_calls == ["http://127.0.0.1:31933"]
+        assert start_calls == [
+            (
+                "http://127.0.0.1:31933",
+                {
+                    "hermes_home": tmp_path / "hermes",
+                    "config_path": server_config,
+                },
+            )
+        ]
 
     def test_handle_tool_call_uses_ensure_client(self, monkeypatch):
         provider = OpenVikingMemoryProvider()

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1,15 +1,19 @@
+import io
 import json
 import os
 import stat
+import subprocess
 import threading
 import time
 import zipfile
+from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
 import plugins.memory.openviking as openviking_module
+from plugins.memory.openviking import local_server, quick_local
 from plugins.memory.openviking import (
     OpenVikingMemoryProvider,
     _DEFERRED_COMMIT_TIMEOUT,
@@ -18,7 +22,12 @@ from plugins.memory.openviking import (
 
 
 def _clear_openviking_tenant_env(monkeypatch):
-    for name in ("OPENVIKING_ACCOUNT", "OPENVIKING_USER", "OPENVIKING_AGENT"):
+    for name in (
+        "OPENVIKING_ACCOUNT",
+        "OPENVIKING_USER",
+        "OPENVIKING_ACTOR_PEER_ID",
+        "OPENVIKING_AGENT",
+    ):
         monkeypatch.delenv(name, raising=False)
 
 
@@ -30,15 +39,43 @@ def _isolate_openviking_home(tmp_path, monkeypatch):
 
 def _clear_openviking_env(monkeypatch):
     for key in (
+        "OPENVIKING_URL",
         "OPENVIKING_ENDPOINT",
         "OPENVIKING_API_KEY",
         "OPENVIKING_ACCOUNT",
         "OPENVIKING_USER",
+        "OPENVIKING_ACTOR_PEER_ID",
         "OPENVIKING_AGENT",
         "OPENVIKING_CLI_CONFIG_FILE",
         "OPENVIKING_PROFILE_TOKEN_BUDGET",
     ):
         monkeypatch.delenv(key, raising=False)
+
+
+def _started_server(process=None, message="started"):
+    if process is None:
+        process = MagicMock()
+        process.poll.return_value = None
+    return openviking_module._LocalServerStartResult(process, message)
+
+
+def _failed_server(message="openviking-server was not found on PATH."):
+    return openviking_module._LocalServerStartResult(None, message)
+
+
+def _reachability(state=None, message=""):
+    return openviking_module._OpenVikingReachability(
+        state or openviking_module._OpenVikingReachabilityState.HEALTHY,
+        message,
+    )
+
+
+def _set_reachability(monkeypatch, state=None, message=""):
+    monkeypatch.setattr(
+        openviking_module,
+        "_probe_openviking_reachability",
+        lambda endpoint: _reachability(state, message),
+    )
 
 
 def _prompt_from_values(values: dict[str, str], *, forbidden: set[str] | None = None):
@@ -59,6 +96,7 @@ def _allow_setup_validation(monkeypatch, *, root_access: bool = False):
         lambda endpoint: (True, ""),
         raising=False,
     )
+    _set_reachability(monkeypatch)
     monkeypatch.setattr(
         openviking_module,
         "_validate_openviking_auth",
@@ -114,6 +152,69 @@ def test_openviking_provider_config_loader_uses_readonly_config(monkeypatch):
         "api_key": "test-key",
     }
     assert config is not backing_config["memory"]["openviking"]
+
+
+def test_backup_paths_include_linked_profile_without_collecting_unrelated_profiles(
+    tmp_path, monkeypatch
+):
+    linked = tmp_path / "ovcli.conf.hermes"
+    default = tmp_path / "ovcli.conf"
+    unrelated = tmp_path / "ovcli.conf.other"
+    for path in (linked, default, unrelated):
+        path.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setenv("OPENVIKING_CLI_CONFIG_FILE", str(default))
+    monkeypatch.setattr(
+        openviking_module,
+        "_load_hermes_openviking_config",
+        lambda: {
+            "use_ovcli_config": True,
+            "ovcli_config_path": str(linked),
+        },
+    )
+
+    paths = OpenVikingMemoryProvider().backup_paths()
+
+    assert paths == [str(linked)]
+    assert str(default) not in paths
+    assert str(unrelated) not in paths
+
+
+def test_backup_paths_preserve_legacy_resolved_profile(tmp_path, monkeypatch):
+    profile = tmp_path / "ovcli.conf"
+    profile.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("OPENVIKING_CLI_CONFIG_FILE", str(profile))
+    monkeypatch.setattr(
+        openviking_module,
+        "_load_hermes_openviking_config",
+        lambda: {"use_ovcli_config": False},
+    )
+
+    assert OpenVikingMemoryProvider().backup_paths() == [str(profile)]
+
+
+def test_backup_paths_skip_quick_local_profile_already_inside_hermes_home(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes"
+    profile = hermes_home / "openviking" / "ovcli.conf"
+    profile.parent.mkdir(parents=True)
+    profile.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        openviking_module,
+        "_current_hermes_home",
+        lambda: hermes_home,
+    )
+    monkeypatch.setattr(
+        openviking_module,
+        "_load_hermes_openviking_config",
+        lambda: {
+            "use_ovcli_config": True,
+            "ovcli_config_path": str(profile),
+        },
+    )
+
+    assert OpenVikingMemoryProvider().backup_paths() == []
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")
@@ -276,7 +377,51 @@ def test_openviking_env_overrides_linked_ovcli_config(tmp_path, monkeypatch):
     }
 
 
-def test_openviking_cli_config_env_overrides_saved_profile_path(tmp_path, monkeypatch):
+def test_canonical_openviking_env_names_override_legacy_names(tmp_path, monkeypatch):
+    _clear_openviking_env(monkeypatch)
+    ovcli_path = tmp_path / "ovcli.conf"
+    ovcli_path.write_text(
+        json.dumps({
+            "url": "http://profile.local",
+            "actor_peer_id": "profile-agent",
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENVIKING_URL", "http://canonical.local")
+    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://legacy.local")
+    monkeypatch.setenv("OPENVIKING_ACTOR_PEER_ID", "canonical-agent")
+    monkeypatch.setenv("OPENVIKING_AGENT", "legacy-agent")
+
+    settings = openviking_module._resolve_connection_settings({
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(ovcli_path),
+    })
+
+    assert settings["endpoint"] == "http://canonical.local"
+    assert settings["agent"] == "canonical-agent"
+
+
+def test_missing_linked_profile_does_not_fall_back_to_localhost(tmp_path, monkeypatch):
+    _clear_openviking_env(monkeypatch)
+    missing_profile = tmp_path / "missing-ovcli.conf"
+
+    with pytest.raises(ValueError, match="profile file was not found"):
+        openviking_module._resolve_connection_settings({
+            "use_ovcli_config": True,
+            "ovcli_config_path": str(missing_profile),
+        })
+
+
+def test_ovcli_profile_rejects_conflicting_actor_id_fields():
+    with pytest.raises(ValueError, match="actor_peer_id cannot be used with agent_id"):
+        openviking_module._connection_values_from_ovcli({
+            "url": "http://127.0.0.1:1933",
+            "actor_peer_id": "canonical",
+            "agent_id": "legacy",
+        })
+
+
+def test_linked_profile_path_overrides_process_wide_ovcli_config(tmp_path, monkeypatch):
     _clear_openviking_env(monkeypatch)
     saved_path = tmp_path / "ovcli.conf.saved"
     env_path = tmp_path / "ovcli.conf.env"
@@ -295,8 +440,30 @@ def test_openviking_cli_config_env_overrides_saved_profile_path(tmp_path, monkey
         "ovcli_config_path": str(saved_path),
     })
 
-    assert settings["endpoint"] == "http://env-profile.local"
-    assert settings["api_key"] == "env-profile-key"
+    assert settings["endpoint"] == "http://saved.local"
+    assert settings["api_key"] == "saved-key"
+
+
+def test_linking_default_profile_persists_exact_path(tmp_path, monkeypatch):
+    default_path = tmp_path / ".openviking" / "ovcli.conf"
+    env_path = tmp_path / "other-ovcli.conf"
+    default_path.parent.mkdir()
+    default_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        openviking_module,
+        "_default_ovcli_config_path",
+        lambda: default_path,
+    )
+    monkeypatch.delenv("OPENVIKING_CLI_CONFIG_FILE", raising=False)
+    provider_config = {}
+
+    openviking_module._remember_ovcli_path(provider_config, default_path)
+    monkeypatch.setenv("OPENVIKING_CLI_CONFIG_FILE", str(env_path))
+
+    assert provider_config == {"ovcli_config_path": str(default_path)}
+    assert openviking_module._resolve_ovcli_config_path(
+        provider_config["ovcli_config_path"]
+    ) == default_path
 
 
 def test_connection_values_omit_stale_identity_for_user_key_with_root_key():
@@ -348,7 +515,14 @@ def test_discover_ovcli_profiles_lists_saved_profiles_without_active_label(tmp_p
 
 def test_link_ovcli_profile_removes_stale_inline_config(tmp_path):
     env_path = tmp_path / ".env"
-    env_path.write_text("OPENVIKING_ENDPOINT=http://old.local\nOTHER_KEY=keep\n", encoding="utf-8")
+    env_path.write_text(
+        "OPENVIKING_URL=http://canonical.local\n"
+        "OPENVIKING_ENDPOINT=http://legacy.local\n"
+        "OPENVIKING_ACTOR_PEER_ID=canonical-agent\n"
+        "OPENVIKING_AGENT=legacy-agent\n"
+        "OTHER_KEY=keep\n",
+        encoding="utf-8",
+    )
     config = {"memory": {}}
     provider_config = {
         "use_ovcli_config": False,
@@ -372,8 +546,9 @@ def test_link_ovcli_profile_removes_stale_inline_config(tmp_path):
         "use_ovcli_config": True,
         "ovcli_config_path": str(ovcli_path),
     }
-    assert "OPENVIKING_ENDPOINT" not in env_path.read_text(encoding="utf-8")
-    assert "OTHER_KEY=keep" in env_path.read_text(encoding="utf-8")
+    env_text = env_path.read_text(encoding="utf-8")
+    assert "OPENVIKING_" not in env_text
+    assert "OTHER_KEY=keep" in env_text
 
 
 def test_post_setup_existing_profile_picker_validates_and_links_saved_profile(tmp_path, monkeypatch):
@@ -408,7 +583,7 @@ def test_post_setup_existing_profile_picker_validates_and_links_saved_profile(tm
         validate_values,
         raising=False,
     )
-    choices = iter([0, 0])
+    choices = iter([2, 0])
     monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(choices))
     config = {"memory": {}}
 
@@ -432,7 +607,7 @@ def test_post_setup_existing_profile_picker_validates_and_links_saved_profile(tm
     assert "OTHER_KEY=keep" in env_text
 
 
-def test_post_setup_create_remote_user_profile_can_mirror_to_openviking_store(tmp_path, monkeypatch):
+def test_post_setup_create_remote_user_profile_in_openviking_store(tmp_path, monkeypatch):
     _clear_openviking_env(monkeypatch)
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir()
@@ -442,7 +617,7 @@ def test_post_setup_create_remote_user_profile_can_mirror_to_openviking_store(tm
 
     from hermes_cli import memory_setup
 
-    choices = iter([1, 0, 1])
+    choices = iter([2, 0])
     monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(choices))
     monkeypatch.setattr(
         memory_setup,
@@ -450,7 +625,7 @@ def test_post_setup_create_remote_user_profile_can_mirror_to_openviking_store(tm
         _prompt_from_values({
             "OpenViking server URL": "https://openviking.example",
             "OpenViking user API key": "user-secret",
-            "Hermes peer ID in OpenViking": "hermes",
+            "Agent ID": "hermes",
             "OpenViking profile name": "VPS",
         }),
     )
@@ -475,7 +650,7 @@ def test_post_setup_create_remote_user_profile_can_mirror_to_openviking_store(tm
         assert "OPENVIKING_" not in env_path.read_text(encoding="utf-8")
 
 
-def test_post_setup_create_remote_user_can_keep_hermes_only(tmp_path, monkeypatch):
+def test_post_setup_create_remote_user_always_links_openviking_profile(tmp_path, monkeypatch):
     _clear_openviking_env(monkeypatch)
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir()
@@ -484,7 +659,7 @@ def test_post_setup_create_remote_user_can_keep_hermes_only(tmp_path, monkeypatc
 
     from hermes_cli import memory_setup
 
-    choices = iter([1, 0, 0])
+    choices = iter([2, 0])
     monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(choices))
     monkeypatch.setattr(
         memory_setup,
@@ -492,7 +667,8 @@ def test_post_setup_create_remote_user_can_keep_hermes_only(tmp_path, monkeypatc
         _prompt_from_values({
             "OpenViking server URL": "https://openviking.example",
             "OpenViking user API key": "user-secret",
-            "Hermes peer ID in OpenViking": "agent",
+            "Agent ID": "agent",
+            "OpenViking profile name": "remote",
         }),
     )
     config = {"memory": {}}
@@ -500,12 +676,19 @@ def test_post_setup_create_remote_user_can_keep_hermes_only(tmp_path, monkeypatc
     OpenVikingMemoryProvider().post_setup(str(hermes_home), config)
 
     assert config["memory"]["provider"] == "openviking"
-    assert config["memory"]["openviking"] == {"use_ovcli_config": False}
-    env_text = (hermes_home / ".env").read_text(encoding="utf-8")
-    assert "OPENVIKING_ENDPOINT=https://openviking.example" in env_text
-    assert "OPENVIKING_API_KEY=user-secret" in env_text
-    assert "OPENVIKING_AGENT=agent" in env_text
-    assert not (tmp_path / "home" / ".openviking").exists()
+    profile_path = tmp_path / "home" / ".openviking" / "ovcli.conf.remote"
+    assert json.loads(profile_path.read_text(encoding="utf-8")) == {
+        "url": "https://openviking.example",
+        "api_key": "user-secret",
+        "actor_peer_id": "agent",
+    }
+    assert config["memory"]["openviking"] == {
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(profile_path),
+    }
+    env_path = hermes_home / ".env"
+    if env_path.exists():
+        assert "OPENVIKING_" not in env_path.read_text(encoding="utf-8")
 
 
 def test_post_setup_create_openviking_service_validates_after_api_key(tmp_path, monkeypatch):
@@ -536,7 +719,8 @@ def test_post_setup_create_openviking_service_validates_after_api_key(tmp_path, 
         _prompt_from_values(
             {
                 "OpenViking API key": "service-secret",
-                "Hermes peer ID in OpenViking": "agent",
+                "Agent ID": "agent",
+                "OpenViking profile name": "service",
             },
             forbidden={"OpenViking server URL", "OpenViking user API key", "OpenViking root API key"},
         ),
@@ -557,10 +741,16 @@ def test_post_setup_create_openviking_service_validates_after_api_key(tmp_path, 
         },
         True,
     )]
-    env_text = (hermes_home / ".env").read_text(encoding="utf-8")
-    assert "OPENVIKING_ENDPOINT=https://api.vikingdb.cn-beijing.volces.com/openviking" in env_text
-    assert "OPENVIKING_API_KEY=service-secret" in env_text
-    assert "OPENVIKING_AGENT=agent" in env_text
+    profile_path = tmp_path / "home" / ".openviking" / "ovcli.conf.service"
+    assert json.loads(profile_path.read_text(encoding="utf-8")) == {
+        "url": "https://api.vikingdb.cn-beijing.volces.com/openviking",
+        "api_key": "service-secret",
+        "actor_peer_id": "agent",
+    }
+    assert config["memory"]["openviking"] == {
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(profile_path),
+    }
 
 
 def test_post_setup_remote_blank_api_key_cancels_without_saving(tmp_path, monkeypatch):
@@ -568,14 +758,14 @@ def test_post_setup_remote_blank_api_key_cancels_without_saving(tmp_path, monkey
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-    monkeypatch.setattr(openviking_module, "_validate_openviking_reachability", lambda endpoint: (True, ""))
+    _set_reachability(monkeypatch)
 
     from hermes_cli import config as hermes_config
     from hermes_cli import memory_setup
 
     save_config = MagicMock()
     monkeypatch.setattr(hermes_config, "save_config", save_config)
-    choices = iter([1, 0, 1])
+    choices = iter([2, 0, 1])
     monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(choices))
     monkeypatch.setattr(
         memory_setup,
@@ -606,9 +796,9 @@ def test_post_setup_user_key_path_can_route_detected_root_key_to_root_setup(tmp_
         assert values["api_key"] == "root-secret"
         return True, "", "root"
 
-    monkeypatch.setattr(openviking_module, "_validate_openviking_reachability", lambda endpoint: (True, ""))
+    _set_reachability(monkeypatch)
     monkeypatch.setattr(openviking_module, "_validate_openviking_setup_values", validate_values)
-    choices = iter([1, 0, 0, 0])
+    choices = iter([2, 0, 0])
     monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(choices))
     prompt_events = []
 
@@ -621,7 +811,8 @@ def test_post_setup_user_key_path_can_route_detected_root_key_to_root_setup(tmp_
             "OpenViking user API key": "root-secret",
             "OpenViking account": "acct",
             "OpenViking user": "alice",
-            "Hermes peer ID in OpenViking": "agent",
+            "Agent ID": "agent",
+            "OpenViking profile name": "root-profile",
         }
         return values.get(label, default or "")
 
@@ -630,12 +821,16 @@ def test_post_setup_user_key_path_can_route_detected_root_key_to_root_setup(tmp_
 
     OpenVikingMemoryProvider().post_setup(str(hermes_home), config)
 
-    assert prompt_events.count("Hermes peer ID in OpenViking") == 1
-    env_text = (hermes_home / ".env").read_text(encoding="utf-8")
-    assert "OPENVIKING_API_KEY=root-secret" in env_text
-    assert "OPENVIKING_ACCOUNT=acct" in env_text
-    assert "OPENVIKING_USER=alice" in env_text
-    assert "OPENVIKING_AGENT=agent" in env_text
+    assert prompt_events.count("Agent ID") == 1
+    profile_path = tmp_path / "home" / ".openviking" / "ovcli.conf.root-profile"
+    assert json.loads(profile_path.read_text(encoding="utf-8")) == {
+        "url": "https://openviking.example",
+        "api_key": "root-secret",
+        "root_api_key": "root-secret",
+        "account": "acct",
+        "user": "alice",
+        "actor_peer_id": "agent",
+    }
 
 
 def test_post_setup_root_key_path_can_route_detected_user_key_to_user_setup(tmp_path, monkeypatch):
@@ -650,9 +845,9 @@ def test_post_setup_root_key_path_can_route_detected_user_key_to_user_setup(tmp_
         assert values["api_key"] == "user-secret"
         return True, "", "user"
 
-    monkeypatch.setattr(openviking_module, "_validate_openviking_reachability", lambda endpoint: (True, ""))
+    _set_reachability(monkeypatch)
     monkeypatch.setattr(openviking_module, "_validate_openviking_setup_values", validate_values)
-    choices = iter([1, 1, 0, 0])
+    choices = iter([2, 1, 0, 0])
     monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(choices))
     monkeypatch.setattr(
         memory_setup,
@@ -661,7 +856,8 @@ def test_post_setup_root_key_path_can_route_detected_user_key_to_user_setup(tmp_
             {
                 "OpenViking server URL": "https://openviking.example",
                 "OpenViking root API key": "user-secret",
-                "Hermes peer ID in OpenViking": "agent",
+                "Agent ID": "agent",
+                "OpenViking profile name": "user-profile",
             },
             forbidden={"OpenViking user API key", "OpenViking account", "OpenViking user"},
         ),
@@ -670,17 +866,18 @@ def test_post_setup_root_key_path_can_route_detected_user_key_to_user_setup(tmp_
 
     OpenVikingMemoryProvider().post_setup(str(hermes_home), config)
 
-    env_text = (hermes_home / ".env").read_text(encoding="utf-8")
-    assert "OPENVIKING_API_KEY=user-secret" in env_text
-    assert "OPENVIKING_AGENT=agent" in env_text
-    assert "OPENVIKING_ACCOUNT" not in env_text
-    assert "OPENVIKING_USER" not in env_text
+    profile_path = tmp_path / "home" / ".openviking" / "ovcli.conf.user-profile"
+    assert json.loads(profile_path.read_text(encoding="utf-8")) == {
+        "url": "https://openviking.example",
+        "api_key": "user-secret",
+        "actor_peer_id": "agent",
+    }
 
 
 def test_manual_root_key_flow_prints_validation_progress(monkeypatch, capsys):
     _clear_openviking_env(monkeypatch)
 
-    monkeypatch.setattr(openviking_module, "_validate_openviking_reachability", lambda endpoint: (True, ""))
+    _set_reachability(monkeypatch)
 
     validate_calls = []
 
@@ -697,7 +894,7 @@ def test_manual_root_key_flow_prints_validation_progress(monkeypatch, capsys):
             "OpenViking root API key": "root-secret",
             "OpenViking account": "acct",
             "OpenViking user": "alice",
-            "Hermes peer ID in OpenViking": "agent",
+            "Agent ID": "agent",
         }),
         lambda *args, **kwargs: next(choices),
         -1,
@@ -711,23 +908,1062 @@ def test_manual_root_key_flow_prints_validation_progress(monkeypatch, capsys):
     assert "Validating OpenViking API access..." in output
 
 
+def test_setup_has_one_clear_three_way_connection_choice(tmp_path):
+    seen = []
+
+    def select(title, options, **kwargs):
+        seen.append((title, options, kwargs))
+        return -1
+
+    result = openviking_module._run_create_profile_setup(
+        prompt=MagicMock(),
+        select=select,
+        cancelled=-1,
+        config={"memory": {}},
+        provider_config={},
+        env_path=tmp_path / ".env",
+    )
+
+    assert result is openviking_module._SETUP_CANCELLED
+    assert [label for label, _description in seen[0][1]] == [
+        "OpenViking Service (VolcEngine Cloud)",
+        "Quick local setup",
+        "Connect to an existing server",
+    ]
+    assert [description for _label, description in seen[0][1]] == [
+        "Managed cloud service; API key required",
+        "Set up OpenViking and Ollama on this device",
+        "Use a self-managed custom server (Remote/Local)",
+    ]
+    assert "for me" not in str(seen[0][1]).lower()
+
+
+def test_resolve_hermes_vlm_config_reuses_effective_openai_compatible_runtime(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "https://llm.example/v1",
+            "api_key": "secret",
+            "source": "custom_provider:test",
+            "extra_headers": {"X-Tenant": "tenant"},
+            "request_overrides": {"extra_body": {"thinking": {"type": "disabled"}}},
+        },
+    )
+
+    vlm = quick_local.resolve_hermes_vlm_config({
+        "model": {"provider": "custom", "default": "model-1"},
+    })
+
+    assert vlm == {
+        "provider": "openai",
+        "model": "model-1",
+        "api_key": "secret",
+        "api_base": "https://llm.example/v1",
+        "extra_headers": {"X-Tenant": "tenant"},
+        "extra_request_body": {"thinking": {"type": "disabled"}},
+        "temperature": 0.0,
+        "max_retries": 2,
+    }
+
+
+def test_resolve_hermes_vlm_config_reuses_anthropic_compatible_runtime(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://api.anthropic.com",
+            "api_key": "secret",
+            "source": "environment",
+            "model": "claude-sonnet-4-20250514",
+            "extra_headers": {"anthropic-version": "2023-06-01"},
+        },
+    )
+
+    vlm = quick_local.resolve_hermes_vlm_config({
+        "model": {
+            "provider": "anthropic",
+            "default": "claude-sonnet-4-20250514",
+        },
+    })
+
+    assert vlm == {
+        "provider": "litellm",
+        "model": "anthropic/claude-sonnet-4-20250514",
+        "api_key": "secret",
+        "api_base": "https://api.anthropic.com",
+        "extra_headers": {"anthropic-version": "2023-06-01"},
+        "temperature": 0.0,
+        "max_retries": 2,
+    }
+
+
+def test_resolve_hermes_vlm_config_rejects_ephemeral_auth(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "short-lived",
+            "source": "hermes-auth-store",
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="cannot be copied safely"):
+        quick_local.resolve_hermes_vlm_config({
+            "model": {"provider": "openai-codex", "default": "gpt-5"},
+        })
+
+
+def test_quick_local_ollama_installs_starts_and_pulls_model(monkeypatch):
+    events = []
+    installed = iter([False, True])
+    fake_ollama = SimpleNamespace(
+        is_ollama_installed=lambda: next(installed),
+        install_ollama=lambda: events.append("install") or True,
+        check_ollama_running=lambda: False,
+        start_ollama=lambda: events.append("start") or SimpleNamespace(
+            success=True,
+            stderr_output="",
+            message="started",
+        ),
+        get_ollama_models=lambda: [],
+        is_model_available=lambda model, available: False,
+        ollama_pull_model=lambda model: events.append(("pull", model)) or True,
+    )
+    monkeypatch.setattr(
+        quick_local.importlib,
+        "import_module",
+        lambda name: fake_ollama,
+    )
+
+    setup = quick_local.QuickLocalSetup(
+        health_check=lambda _endpoint: (True, ""),
+    )
+    setup._ensure_ollama(allow_install=True, cancel_event=None)
+
+    assert events == [
+        "install",
+        "start",
+        ("pull", "qwen3-embedding:0.6b"),
+    ]
+
+
+def test_quick_local_ollama_cancel_does_not_install(monkeypatch):
+    install = MagicMock(side_effect=AssertionError("cancelled setup must not install Ollama"))
+    fake_ollama = SimpleNamespace(
+        is_ollama_installed=lambda: False,
+        install_ollama=install,
+    )
+    monkeypatch.setattr(
+        quick_local.importlib,
+        "import_module",
+        lambda name: fake_ollama,
+    )
+
+    setup = quick_local.QuickLocalSetup(
+        health_check=lambda _endpoint: (True, ""),
+    )
+    with pytest.raises(quick_local.OllamaInstallRequired):
+        setup._ensure_ollama(allow_install=False, cancel_event=None)
+
+    install.assert_not_called()
+
+
+def test_quick_local_ollama_uses_official_windows_installer(monkeypatch):
+    fake_ollama = SimpleNamespace(
+        is_ollama_installed=MagicMock(side_effect=[False, True]),
+        check_ollama_running=lambda: True,
+        get_ollama_models=lambda: ["qwen3-embedding:0.6b"],
+        is_model_available=lambda model, available: model in available,
+    )
+    run = MagicMock(return_value=SimpleNamespace(returncode=0))
+    monkeypatch.setattr(quick_local, "_is_windows", lambda: True)
+    monkeypatch.setattr(
+        quick_local.shutil,
+        "which",
+        lambda name: "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+        if name == "powershell.exe"
+        else None,
+    )
+    monkeypatch.setattr(quick_local.subprocess, "run", run)
+
+    monkeypatch.setattr(
+        quick_local.importlib,
+        "import_module",
+        lambda _name: fake_ollama,
+    )
+    setup = quick_local.QuickLocalSetup(
+        health_check=lambda _endpoint: (True, ""),
+    )
+    setup._ensure_ollama(allow_install=True, cancel_event=None)
+
+    run.assert_called_once_with(
+        [
+            "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+            "-NoLogo",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            "Invoke-RestMethod https://ollama.com/install.ps1 | Invoke-Expression",
+        ],
+        check=False,
+    )
+
+
+def test_quick_local_installs_openviking_only_when_server_is_missing(monkeypatch):
+    locations = iter([None, "/bin/openviking-server"])
+    pip_install = MagicMock(return_value=SimpleNamespace(returncode=0, stderr=""))
+    monkeypatch.setattr(
+        local_server,
+        "server_command",
+        lambda: next(locations),
+    )
+    monkeypatch.setattr("hermes_cli.tools_config._pip_install", pip_install)
+
+    setup = quick_local.QuickLocalSetup(
+        health_check=lambda _endpoint: (True, ""),
+    )
+    setup._ensure_openviking_installed(cancel_event=None)
+
+    pip_install.assert_called_once_with(
+        ["openviking"],
+        timeout=600,
+        capture_output=False,
+    )
+    assert "UV_NATIVE_TLS" not in os.environ
+
+
+def test_quick_local_cancellation_prevents_preflight_and_filesystem_changes(
+    tmp_path,
+):
+    hermes_home = tmp_path / "hermes"
+    health_check = MagicMock(
+        side_effect=AssertionError("cancelled setup must not run preflight")
+    )
+    setup = quick_local.QuickLocalSetup(health_check=health_check)
+    cancelled = threading.Event()
+    cancelled.set()
+
+    with pytest.raises(quick_local.QuickLocalSetupCancelled):
+        setup.provision(
+            hermes_home=hermes_home,
+            hermes_config={},
+            allow_ollama_install=False,
+            cancel_event=cancelled,
+        )
+
+    health_check.assert_not_called()
+    assert not quick_local.managed_paths(hermes_home).root.exists()
+
+
+def test_quick_local_preflight_wraps_unexpected_health_failure(tmp_path):
+    paths = quick_local.managed_paths(tmp_path)
+    paths.workspace.mkdir(parents=True)
+    openviking_module.atomic_json_write(
+        paths.server_config,
+        {"storage": {"workspace": str(paths.workspace)}},
+        mode=0o600,
+    )
+    openviking_module.atomic_json_write(
+        paths.ovcli_config,
+        {"url": "http://127.0.0.1:1933"},
+        mode=0o600,
+    )
+    setup = quick_local.QuickLocalSetup(
+        health_check=MagicMock(side_effect=LookupError("health unavailable")),
+    )
+
+    with pytest.raises(
+        quick_local.QuickLocalSetupError,
+        match="Quick Local preflight failed: health unavailable",
+    ) as exc_info:
+        setup.preflight(tmp_path)
+
+    assert isinstance(exc_info.value.__cause__, LookupError)
+
+
+def test_quick_local_wraps_unexpected_failures_in_domain_error(
+    tmp_path,
+    monkeypatch,
+):
+    hermes_home = tmp_path / "hermes"
+    setup = quick_local.QuickLocalSetup(
+        health_check=lambda _endpoint: (False, "")
+    )
+    preflight = quick_local.QuickLocalPreflight(
+        paths=quick_local.managed_paths(hermes_home),
+        reusable_endpoint=None,
+        ollama_install_required=False,
+    )
+    monkeypatch.setattr(
+        quick_local,
+        "resolve_hermes_vlm_config",
+        MagicMock(side_effect=LookupError("provider resolution failed")),
+    )
+
+    with pytest.raises(
+        quick_local.QuickLocalSetupError,
+        match="Quick Local setup failed: provider resolution failed",
+    ) as exc_info:
+        setup.provision(
+            hermes_home=hermes_home,
+            hermes_config={},
+            allow_ollama_install=False,
+            preflight=preflight,
+        )
+
+    assert isinstance(exc_info.value.__cause__, LookupError)
+
+
+def test_quick_local_validation_drain_uses_bounded_system_wait(monkeypatch):
+    captured = {}
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return b'{"status":"ok","result":{"Embedding":{"processed":10}}}'
+
+    class Opener:
+        def open(self, request, timeout):
+            captured["request"] = request
+            captured["timeout"] = timeout
+            return Response()
+
+    monkeypatch.setattr(quick_local, "build_opener", lambda *_args: Opener())
+
+    quick_local._wait_for_processing(
+        "http://127.0.0.1:1933",
+        timeout_seconds=12.5,
+    )
+
+    request = captured["request"]
+    assert request.full_url == "http://127.0.0.1:1933/api/v1/system/wait"
+    assert request.method == "POST"
+    assert json.loads(request.data) == {"timeout": 12.5}
+    assert captured["timeout"] == 13.5
+
+
+def test_quick_local_validation_rejects_drained_queue_errors(monkeypatch):
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return (
+                b'{"status":"ok","result":{"Embedding":'
+                b'{"processed":0,"error_count":1,'
+                b'"errors":[{"message":"secret provider detail"}]}}}'
+            )
+
+    class Opener:
+        def open(self, _request, timeout):
+            return Response()
+
+    monkeypatch.setattr(quick_local, "build_opener", lambda *_args: Opener())
+
+    with pytest.raises(
+        quick_local.QuickLocalSetupError,
+        match=r"processing errors \(Embedding: 1\)",
+    ) as exc_info:
+        quick_local._wait_for_processing(
+            "http://127.0.0.1:1933",
+            timeout_seconds=12.5,
+        )
+
+    assert "secret provider detail" not in str(exc_info.value)
+
+
+def test_quick_local_reports_structured_progress_when_reusing_server(tmp_path):
+    paths = quick_local.managed_paths(tmp_path)
+    paths.workspace.mkdir(parents=True)
+    openviking_module.atomic_json_write(
+        paths.server_config,
+        {"storage": {"workspace": str(paths.workspace)}},
+        mode=0o600,
+    )
+    openviking_module.atomic_json_write(
+        paths.ovcli_config,
+        {
+            "url": "http://127.0.0.1:1933",
+            "actor_peer_id": "hermes",
+        },
+        mode=0o600,
+    )
+    progress = []
+    setup = quick_local.QuickLocalSetup(
+        health_check=lambda endpoint: (endpoint.endswith(":1933"), ""),
+        progress=progress.append,
+    )
+
+    preflight = setup.preflight(tmp_path)
+    result = setup.provision(
+        hermes_home=tmp_path,
+        hermes_config={},
+        allow_ollama_install=False,
+        preflight=preflight,
+    )
+
+    assert result.reused is True
+    assert [event.stage for event in progress] == [
+        quick_local.QuickLocalStage.PREFLIGHT,
+        quick_local.QuickLocalStage.COMPLETE,
+    ]
+
+
+def test_quick_local_rechecks_reusable_server_after_preflight(
+    tmp_path,
+    monkeypatch,
+):
+    paths = quick_local.managed_paths(tmp_path)
+    paths.workspace.mkdir(parents=True)
+    openviking_module.atomic_json_write(
+        paths.server_config,
+        {"storage": {"workspace": str(paths.workspace)}},
+        mode=0o600,
+    )
+    openviking_module.atomic_json_write(
+        paths.ovcli_config,
+        {"url": "http://127.0.0.1:1933"},
+        mode=0o600,
+    )
+    health_results = iter([(False, "not ready"), (True, "")])
+    setup = quick_local.QuickLocalSetup(
+        health_check=lambda _endpoint: next(health_results),
+    )
+    monkeypatch.setattr(quick_local, "_ollama_command_available", lambda: True)
+    resolve_vlm = MagicMock(
+        side_effect=AssertionError(
+            "a server that became healthy must be reused before provisioning"
+        )
+    )
+    monkeypatch.setattr(quick_local, "resolve_hermes_vlm_config", resolve_vlm)
+
+    preflight = setup.preflight(tmp_path)
+    assert preflight.reusable_endpoint is None
+
+    result = setup.provision(
+        hermes_home=tmp_path,
+        hermes_config={},
+        allow_ollama_install=False,
+        preflight=preflight,
+    )
+
+    assert result.reused is True
+    assert result.endpoint == "http://127.0.0.1:1933"
+    resolve_vlm.assert_not_called()
+
+
+def test_quick_local_does_not_trust_stale_reusable_preflight(
+    tmp_path,
+    monkeypatch,
+):
+    paths = quick_local.managed_paths(tmp_path)
+    paths.workspace.mkdir(parents=True)
+    openviking_module.atomic_json_write(
+        paths.server_config,
+        {"storage": {"workspace": str(paths.workspace)}},
+        mode=0o600,
+    )
+    openviking_module.atomic_json_write(
+        paths.ovcli_config,
+        {"url": "http://127.0.0.1:1933"},
+        mode=0o600,
+    )
+    health_results = iter([(True, ""), (False, "stopped")])
+    setup = quick_local.QuickLocalSetup(
+        health_check=lambda _endpoint: next(health_results),
+    )
+    resolve_vlm = MagicMock(
+        side_effect=quick_local.QuickLocalSetupError(
+            "continued into provisioning"
+        )
+    )
+    monkeypatch.setattr(quick_local, "resolve_hermes_vlm_config", resolve_vlm)
+
+    preflight = setup.preflight(tmp_path)
+    assert preflight.reusable_endpoint == "http://127.0.0.1:1933"
+
+    with pytest.raises(
+        quick_local.QuickLocalSetupError,
+        match="continued into provisioning",
+    ):
+        setup.provision(
+            hermes_home=tmp_path,
+            hermes_config={},
+            allow_ollama_install=False,
+            preflight=preflight,
+        )
+
+    resolve_vlm.assert_called_once_with({})
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")
+def test_quick_local_setup_writes_owned_config_and_marker(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    provider_config = {}
+    config = {"memory": {}, "model": {"default": "model-1"}}
+    start_calls = []
+    validation_configs = []
+    validation_process = MagicMock()
+    validation_process.poll.return_value = None
+    shutdown_events = []
+
+    monkeypatch.setattr(
+        quick_local,
+        "resolve_hermes_vlm_config",
+        lambda config: {
+            "provider": "openai",
+            "model": "model-1",
+            "api_key": "llm-secret",
+            "api_base": "https://llm.example/v1",
+        },
+    )
+    monkeypatch.setattr(local_server, "server_command", lambda: "/bin/openviking-server")
+    monkeypatch.setattr(quick_local, "_ollama_command_available", lambda: True)
+    monkeypatch.setattr(
+        quick_local.QuickLocalSetup,
+        "_ensure_ollama",
+        lambda self, **kwargs: None,
+    )
+    monkeypatch.setattr(quick_local, "find_available_port", lambda: 1933)
+    monkeypatch.setattr(
+        local_server,
+        "start_local_server",
+        lambda endpoint, **kwargs: (
+            start_calls.append((endpoint, kwargs["config_path"]))
+            or validation_configs.append(
+                json.loads(kwargs["config_path"].read_text(encoding="utf-8"))
+            )
+            or _started_server(validation_process)
+        ),
+    )
+    monkeypatch.setattr(local_server, "wait_for_health", lambda *args, **kwargs: True)
+    drain_processing = MagicMock(
+        side_effect=lambda *args, **kwargs: shutdown_events.append("drain")
+    )
+    monkeypatch.setattr(quick_local, "_wait_for_processing", drain_processing)
+    stop_process = MagicMock(
+        side_effect=lambda process: shutdown_events.append("stop") or True
+    )
+    monkeypatch.setattr(local_server, "stop_owned_process", stop_process)
+
+    result = openviking_module._run_managed_local_setup(
+        select=MagicMock(),
+        cancelled=-1,
+        config=config,
+        provider_config=provider_config,
+        env_path=hermes_home / ".env",
+    )
+
+    paths = quick_local.managed_paths(hermes_home)
+    assert result is True
+    assert stat.S_IMODE(paths.config.stat().st_mode) == 0o600
+    server_config = json.loads(paths.config.read_text(encoding="utf-8"))
+    assert server_config["server"] == {"host": "127.0.0.1", "port": 1933}
+    assert server_config["storage"]["workspace"] == str(paths.workspace)
+    assert server_config["embedding"]["dense"] == {
+        "provider": "ollama",
+        "model": "qwen3-embedding:0.6b",
+        "api_base": "http://localhost:11434/v1",
+        "dimension": 1024,
+        "input": "text",
+    }
+    assert server_config["vlm"]["api_key"] == "llm-secret"
+    assert json.loads(paths.ovcli_config.read_text(encoding="utf-8")) == {
+        "url": "http://127.0.0.1:1933",
+        "actor_peer_id": "hermes",
+    }
+    assert provider_config == {
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(paths.ovcli_config),
+        "deployment": openviking_module._MANAGED_LOCAL_DEPLOYMENT,
+        "server_config_path": str(paths.config),
+    }
+    assert len(start_calls) == 1
+    validation_endpoint, validation_config_path = start_calls[0]
+    assert validation_endpoint == "http://127.0.0.1:1933"
+    assert validation_config_path != paths.config
+    assert validation_config_path.parent.parent == paths.root
+    assert not validation_config_path.exists()
+    assert validation_configs[0]["storage"]["workspace"] != str(paths.workspace)
+    assert Path(validation_configs[0]["storage"]["workspace"]).parent == (
+        validation_config_path.parent
+    )
+    drain_processing.assert_called_once_with(
+        "http://127.0.0.1:1933",
+        timeout_seconds=60.0,
+    )
+    stop_process.assert_called_once_with(validation_process)
+    assert shutdown_events == ["drain", "stop"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")
+def test_quick_local_setup_reuses_healthy_managed_server(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    paths = quick_local.managed_paths(hermes_home)
+    paths.workspace.mkdir(parents=True)
+    # Reproduce an interrupted setup: the persisted profile still identifies
+    # the healthy server on 1933, but ov.conf was overwritten with a free port.
+    openviking_module.atomic_json_write(
+        paths.config,
+        {
+            "server": {"host": "127.0.0.1", "port": 1934},
+            "storage": {"workspace": str(paths.workspace)},
+            "vlm": {"provider": "openai", "model": "already-running-model"},
+        },
+        mode=0o600,
+    )
+    openviking_module._write_ovcli_config(
+        paths.ovcli_config,
+        {"endpoint": "http://127.0.0.1:1933", "agent": "hermes"},
+    )
+    provider_config = {
+        "deployment": openviking_module._MANAGED_LOCAL_DEPLOYMENT,
+        "server_config_path": str(paths.config),
+    }
+    config = {"memory": {}, "model": {"default": "model-1"}}
+
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_openviking_reachability",
+        lambda endpoint: (endpoint == "http://127.0.0.1:1933", ""),
+    )
+
+    def must_not_run(*args, **kwargs):
+        pytest.fail("healthy managed server should be reused before provisioning")
+
+    monkeypatch.setattr(quick_local, "resolve_hermes_vlm_config", must_not_run)
+    monkeypatch.setattr(quick_local, "_ollama_command_available", must_not_run)
+    monkeypatch.setattr(local_server, "server_command", must_not_run)
+    monkeypatch.setattr(local_server, "start_local_server", must_not_run)
+
+    result = openviking_module._run_managed_local_setup(
+        select=MagicMock(),
+        cancelled=-1,
+        config=config,
+        provider_config=provider_config,
+        env_path=hermes_home / ".env",
+    )
+
+    assert result is True
+    repaired_config = json.loads(paths.config.read_text(encoding="utf-8"))
+    assert repaired_config["server"] == {"host": "127.0.0.1", "port": 1933}
+    assert repaired_config["storage"]["workspace"] == str(paths.workspace)
+    assert repaired_config["vlm"] == {
+        "provider": "openai",
+        "model": "already-running-model",
+    }
+    assert stat.S_IMODE(paths.config.stat().st_mode) == 0o600
+    assert json.loads(paths.ovcli_config.read_text(encoding="utf-8"))["url"] == (
+        "http://127.0.0.1:1933"
+    )
+    assert provider_config["deployment"] == openviking_module._MANAGED_LOCAL_DEPLOYMENT
+    assert provider_config["server_config_path"] == str(paths.config)
+
+
+def test_quick_local_does_not_reuse_unowned_profile(tmp_path, monkeypatch):
+    paths = quick_local.managed_paths(tmp_path)
+    paths.root.mkdir(parents=True)
+    openviking_module.atomic_json_write(
+        paths.config,
+        {"storage": {"workspace": str(tmp_path / "someone-elses-data")}},
+        mode=0o600,
+    )
+    openviking_module._write_ovcli_config(
+        paths.ovcli_config,
+        {"endpoint": "http://127.0.0.1:1933", "agent": "hermes"},
+    )
+    reachability = MagicMock(return_value=(True, ""))
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_openviking_reachability",
+        reachability,
+    )
+
+    endpoint = quick_local.find_reusable_endpoint(paths, reachability)
+
+    assert endpoint is None
+    reachability.assert_not_called()
+
+
+def test_quick_local_config_uses_selected_available_port(tmp_path):
+    paths = quick_local.managed_paths(tmp_path)
+
+    server_config = quick_local.build_server_config(
+        paths,
+        {"provider": "openai"},
+        port=1941,
+    )
+
+    assert server_config["server"] == {"host": "127.0.0.1", "port": 1941}
+
+
+def test_quick_local_setup_stops_validation_server_when_health_check_fails(
+    tmp_path,
+    monkeypatch,
+):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    process = MagicMock()
+    process.poll.return_value = None
+    monkeypatch.setattr(
+        quick_local,
+        "resolve_hermes_vlm_config",
+        lambda config: {"provider": "openai"},
+    )
+    monkeypatch.setattr(local_server, "server_command", lambda: "/bin/openviking-server")
+    monkeypatch.setattr(quick_local, "_ollama_command_available", lambda: True)
+    monkeypatch.setattr(
+        quick_local.QuickLocalSetup,
+        "_ensure_ollama",
+        lambda self, **kwargs: None,
+    )
+    monkeypatch.setattr(quick_local, "find_available_port", lambda: 1933)
+    monkeypatch.setattr(
+        local_server,
+        "start_local_server",
+        lambda *args, **kwargs: _started_server(process),
+    )
+    monkeypatch.setattr(
+        local_server,
+        "wait_for_health",
+        lambda *args, **kwargs: False,
+    )
+    stop_process = MagicMock(return_value=True)
+    monkeypatch.setattr(local_server, "stop_owned_process", stop_process)
+
+    result = openviking_module._run_managed_local_setup(
+        select=MagicMock(),
+        cancelled=-1,
+        config={"memory": {}, "model": {"default": "model-1"}},
+        provider_config={},
+        env_path=hermes_home / ".env",
+    )
+
+    assert result is False
+    stop_process.assert_called_once_with(process)
+
+
+def test_quick_local_setup_stops_validation_server_when_queue_drain_fails(
+    tmp_path,
+    monkeypatch,
+):
+    paths = quick_local.managed_paths(tmp_path)
+    paths.root.mkdir(parents=True)
+    process = MagicMock()
+    monkeypatch.setattr(
+        local_server,
+        "start_local_server",
+        lambda *_args, **_kwargs: _started_server(process),
+    )
+    monkeypatch.setattr(
+        local_server,
+        "wait_for_health",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        quick_local,
+        "_wait_for_processing",
+        MagicMock(
+            side_effect=quick_local.QuickLocalSetupError(
+                "validation processing failed"
+            )
+        ),
+    )
+    stop_process = MagicMock(return_value=True)
+    monkeypatch.setattr(local_server, "stop_owned_process", stop_process)
+    setup = quick_local.QuickLocalSetup(
+        health_check=lambda _endpoint: (True, ""),
+    )
+
+    with pytest.raises(
+        quick_local.QuickLocalSetupError,
+        match="validation processing failed",
+    ):
+        setup._validate_generated_config(
+            paths=paths,
+            endpoint="http://127.0.0.1:1933",
+            server_config=quick_local.build_server_config(
+                paths,
+                {"provider": "openai"},
+            ),
+            cancel_event=None,
+        )
+
+    stop_process.assert_called_once_with(process)
+
+
+def test_linking_existing_profile_clears_quick_local_ownership(tmp_path, monkeypatch):
+    _clear_openviking_env(monkeypatch)
+    ovcli_path = tmp_path / "ovcli.conf.remote"
+    openviking_module._write_ovcli_config(
+        ovcli_path,
+        {"endpoint": "https://openviking.example", "api_key": "secret"},
+    )
+    provider_config = {
+        "deployment": openviking_module._MANAGED_LOCAL_DEPLOYMENT,
+        "server_config_path": "/old/ov.conf",
+    }
+    config = {"memory": {}}
+
+    openviking_module._link_ovcli_profile(
+        config=config,
+        provider_config=provider_config,
+        env_path=tmp_path / ".env",
+        ovcli_path=ovcli_path,
+    )
+
+    assert "deployment" not in provider_config
+    assert "server_config_path" not in provider_config
+    assert provider_config["use_ovcli_config"] is True
+
+
+def test_missing_existing_local_config_routes_to_quick_local(tmp_path, monkeypatch):
+    missing = tmp_path / "missing-ov.conf"
+    monkeypatch.setattr(
+        openviking_module,
+        "_default_openviking_server_config_path",
+        lambda: missing,
+    )
+    monkeypatch.setattr(local_server, "server_command", lambda: "/bin/openviking-server")
+    monkeypatch.setattr(
+        openviking_module,
+        "_start_local_openviking_server",
+        MagicMock(side_effect=AssertionError("a config-less existing server must not be started")),
+    )
+
+    result = openviking_module._handle_unreachable_endpoint(
+        "http://127.0.0.1:1933",
+        "OpenViking server is not reachable.",
+        lambda *args, **kwargs: 0,
+        -1,
+    )
+
+    assert result is openviking_module._ROUTE_TO_QUICK_LOCAL
+
+
+def test_detected_local_profile_connection_refused_routes_to_quick_local(
+    tmp_path, monkeypatch
+):
+    missing = tmp_path / "missing-ov.conf"
+    profile_path = tmp_path / "ovcli.conf.local"
+    profile = openviking_module._OvcliProfile(
+        source="saved",
+        name="local",
+        path=profile_path,
+        data={"url": "http://127.0.0.1:1933"},
+        values={"endpoint": "http://127.0.0.1:1933"},
+    )
+    _set_reachability(
+        monkeypatch,
+        openviking_module._OpenVikingReachabilityState.UNREACHABLE,
+        "OpenViking validation failed: [Errno 61] Connection refused",
+    )
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_profile_for_setup",
+        MagicMock(
+            side_effect=AssertionError(
+                "an unreachable local profile must enter recovery before validation"
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        openviking_module,
+        "_default_openviking_server_config_path",
+        lambda: missing,
+    )
+    monkeypatch.setattr(local_server, "server_command", lambda: "/bin/openviking-server")
+    choices = iter([0, 0])
+
+    result = openviking_module._run_existing_profile_setup(
+        profiles=[profile],
+        select=lambda *args, **kwargs: next(choices),
+        cancelled=-1,
+        config={"memory": {}},
+        provider_config={},
+        env_path=tmp_path / ".env",
+        allow_manual_endpoint=True,
+    )
+
+    assert result is openviking_module._ROUTE_TO_QUICK_LOCAL
+
+
+@pytest.mark.parametrize(
+    ("reachability_state", "validation_message"),
+    [
+        (
+            openviking_module._OpenVikingReachabilityState.UNHEALTHY,
+            "OpenViking server responded but reported unhealthy status.",
+        ),
+        (
+            openviking_module._OpenVikingReachabilityState.RESPONDED_ERROR,
+            "OpenViking health validation failed: malformed response",
+        ),
+        (
+            openviking_module._OpenVikingReachabilityState.HEALTHY,
+            "OpenViking authentication validation failed: forbidden",
+        ),
+    ],
+)
+def test_local_profile_server_and_auth_failures_do_not_trigger_autostart(
+    tmp_path,
+    monkeypatch,
+    reachability_state,
+    validation_message,
+):
+    profile = openviking_module._OvcliProfile(
+        source="saved",
+        name="local",
+        path=tmp_path / "ovcli.conf.local",
+        data={"url": "http://127.0.0.1:1933"},
+        values={"endpoint": "http://127.0.0.1:1933"},
+    )
+    _set_reachability(monkeypatch, reachability_state, validation_message)
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_profile_for_setup",
+        lambda profile: (False, validation_message, None),
+    )
+    monkeypatch.setattr(
+        openviking_module,
+        "_handle_unreachable_endpoint",
+        MagicMock(
+            side_effect=AssertionError(
+                "a responding server or auth failure must not trigger local autostart"
+            )
+        ),
+    )
+    choices = iter([0, 2])
+
+    result = openviking_module._run_existing_profile_setup(
+        profiles=[profile],
+        select=lambda *args, **kwargs: next(choices),
+        cancelled=-1,
+        config={"memory": {}},
+        provider_config={},
+        env_path=tmp_path / ".env",
+        allow_manual_endpoint=True,
+    )
+
+    assert result is openviking_module._SETUP_CANCELLED
+
+
 def test_start_local_openviking_server_uses_endpoint_host_and_port(monkeypatch):
     popen_calls = []
+    process = object()
 
     def fake_popen(args, **kwargs):
         popen_calls.append((args, kwargs))
-        return object()
+        return process
 
-    monkeypatch.setattr(openviking_module.shutil, "which", lambda name: "/usr/local/bin/openviking-server")
-    monkeypatch.setattr(openviking_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(local_server.shutil, "which", lambda name: "/usr/local/bin/openviking-server")
+    monkeypatch.setattr(local_server.subprocess, "Popen", fake_popen)
 
-    started, message = openviking_module._start_local_openviking_server("http://127.0.0.1:1934")
+    result = openviking_module._start_local_openviking_server("http://127.0.0.1:1934")
 
-    assert started is True
-    assert "127.0.0.1:1934" in message
+    assert result.started is True
+    assert result.process is process
+    assert "127.0.0.1:1934" in result.message
     args, kwargs = popen_calls[0]
     assert args == ["/usr/local/bin/openviking-server", "--host", "127.0.0.1", "--port", "1934"]
     assert kwargs["start_new_session"] is True
+
+
+def test_start_local_openviking_server_uses_explicit_owned_config(tmp_path, monkeypatch):
+    popen_calls = []
+    config_path = tmp_path / "ov.conf"
+    monkeypatch.setattr(local_server.shutil, "which", lambda name: "/bin/openviking-server")
+    monkeypatch.setattr(
+        local_server.subprocess,
+        "Popen",
+        lambda args, **kwargs: popen_calls.append((args, kwargs)) or object(),
+    )
+
+    result = openviking_module._start_local_openviking_server(
+        "http://localhost:1940",
+        config_path=config_path,
+    )
+
+    assert result.started is True
+    assert popen_calls[0][0] == [
+        "/bin/openviking-server",
+        "--config",
+        str(config_path),
+        "--host",
+        "localhost",
+        "--port",
+        "1940",
+    ]
+
+
+def test_start_local_openviking_server_uses_shared_windows_detach_flags(monkeypatch):
+    popen = MagicMock(return_value=object())
+    expected_flags = 0x10
+    monkeypatch.setattr(local_server, "is_windows", lambda: True)
+    monkeypatch.setattr(
+        local_server,
+        "server_command",
+        lambda: "C:/Hermes/openviking-server.exe",
+    )
+    monkeypatch.setattr(
+        local_server,
+        "windows_detach_flags",
+        lambda: expected_flags,
+    )
+    monkeypatch.setattr(local_server.subprocess, "Popen", popen)
+
+    result = openviking_module._start_local_openviking_server(
+        "http://127.0.0.1:1934"
+    )
+
+    assert result.started is True
+    kwargs = popen.call_args.kwargs
+    assert kwargs["creationflags"] == expected_flags
+    assert "start_new_session" not in kwargs
+
+
+def test_windows_detached_process_retries_without_breakaway(monkeypatch):
+    process = object()
+    popen = MagicMock(side_effect=[OSError("breakaway denied"), process])
+    preferred_flags = 0x10
+    fallback_flags = 0x20
+    monkeypatch.setattr(local_server, "is_windows", lambda: True)
+    monkeypatch.setattr(
+        local_server,
+        "windows_detach_flags",
+        lambda: preferred_flags,
+    )
+    monkeypatch.setattr(
+        local_server,
+        "windows_detach_flags_without_breakaway",
+        lambda: fallback_flags,
+    )
+    monkeypatch.setattr(local_server.subprocess, "Popen", popen)
+
+    result = local_server.start_detached_process(
+        ["C:/Hermes/openviking-server.exe"],
+        stdin=subprocess.DEVNULL,
+    )
+
+    assert result is process
+    assert popen.call_count == 2
+    assert popen.call_args_list[0].kwargs["creationflags"] == preferred_flags
+    assert popen.call_args_list[1].kwargs["creationflags"] == fallback_flags
 
 
 def test_start_local_openviking_server_writes_output_to_log(tmp_path, monkeypatch):
@@ -745,14 +1981,89 @@ def test_start_local_openviking_server_writes_output_to_log(tmp_path, monkeypatc
         assert not kwargs["stdout"].closed
         return FakeProcess()
 
-    monkeypatch.setattr(openviking_module.shutil, "which", lambda name: "/usr/local/bin/openviking-server")
-    monkeypatch.setattr(openviking_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(local_server.shutil, "which", lambda name: "/usr/local/bin/openviking-server")
+    monkeypatch.setattr(local_server.subprocess, "Popen", fake_popen)
 
-    started, message = openviking_module._start_local_openviking_server("http://127.0.0.1:1934")
+    result = openviking_module._start_local_openviking_server("http://127.0.0.1:1934")
 
-    assert started is True
-    assert str(hermes_home / "logs" / "openviking-server.log") in message
+    assert result.started is True
+    assert str(hermes_home / "logs" / "openviking-server.log") in result.message
     assert popen_calls
+
+
+def test_local_server_health_wait_honors_setup_cancellation():
+    cancel_event = threading.Event()
+    cancel_event.set()
+
+    healthy = local_server.wait_for_health(
+        "http://127.0.0.1:1933",
+        MagicMock(side_effect=AssertionError("cancelled wait must not probe health")),
+        cancel_event=cancel_event,
+        monotonic=iter([0.0, 0.1]).__next__,
+        sleep=MagicMock(),
+    )
+
+    assert healthy is False
+
+
+def test_local_server_health_wait_honors_runtime_shutdown_predicate():
+    should_stop = MagicMock(return_value=True)
+
+    healthy = local_server.wait_for_health(
+        "http://127.0.0.1:1933",
+        MagicMock(side_effect=AssertionError("stopped wait must not probe health")),
+        should_stop=should_stop,
+        monotonic=iter([0.0, 0.1]).__next__,
+        sleep=MagicMock(),
+    )
+
+    assert healthy is False
+    should_stop.assert_called_once_with()
+
+
+def test_stop_owned_local_openviking_process_force_kills_after_graceful_timeout(caplog):
+    process = MagicMock()
+    process.poll.return_value = None
+    process.wait.side_effect = [
+        local_server.subprocess.TimeoutExpired(
+            cmd="openviking-server",
+            timeout=0.01,
+        ),
+        0,
+    ]
+
+    with caplog.at_level("WARNING", logger=local_server.__name__):
+        stopped = openviking_module._stop_owned_local_openviking_process(
+            process,
+            timeout_seconds=0.01,
+        )
+
+    assert stopped is True
+    process.terminate.assert_called_once_with()
+    process.kill.assert_called_once_with()
+    assert process.wait.call_args_list == [call(timeout=0.01), call(timeout=0.01)]
+    assert "force-stopping it" in caplog.text
+
+
+def test_stop_owned_local_openviking_process_reports_force_kill_timeout(caplog):
+    process = MagicMock()
+    process.poll.return_value = None
+    process.wait.side_effect = local_server.subprocess.TimeoutExpired(
+        cmd="openviking-server",
+        timeout=0.01,
+    )
+
+    with caplog.at_level("WARNING", logger=local_server.__name__):
+        stopped = openviking_module._stop_owned_local_openviking_process(
+            process,
+            timeout_seconds=0.01,
+        )
+
+    assert stopped is False
+    process.terminate.assert_called_once_with()
+    process.kill.assert_called_once_with()
+    assert process.wait.call_count == 2
+    assert "still did not exit after force-stop" in caplog.text
 
 
 def test_https_local_endpoint_is_not_runtime_autostart_eligible(monkeypatch):
@@ -817,43 +2128,130 @@ def test_runtime_does_not_autostart_when_local_server_reports_unhealthy(monkeypa
     ]
 
 
-def test_handle_unreachable_endpoint_does_not_wait_when_autostart_command_missing(monkeypatch, capsys):
+@pytest.mark.parametrize(
+    "error",
+    [
+        RuntimeError("malformed health response"),
+        openviking_module._get_httpx().ReadTimeout("read timed out"),
+    ],
+)
+def test_runtime_does_not_autostart_after_non_transport_health_failure(
+    tmp_path, monkeypatch, error
+):
+    _clear_openviking_env(monkeypatch)
+    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://localhost:1934")
+    server_config = tmp_path / "ov.conf"
+    server_config.write_text("{}", encoding="utf-8")
     monkeypatch.setattr(
         openviking_module,
-        "_start_local_openviking_server",
-        lambda endpoint: (False, "openviking-server was not found on PATH."),
+        "_load_hermes_openviking_config",
+        lambda: {
+            "deployment": openviking_module._MANAGED_LOCAL_DEPLOYMENT,
+            "server_config_path": str(server_config),
+        },
+    )
+
+    class FakeVikingClient:
+        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+            assert endpoint == "http://localhost:1934"
+
+        def health_payload(self):
+            raise error
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", FakeVikingClient)
+    start_server = MagicMock(
+        side_effect=AssertionError(
+            "a server response failure must not start another local process"
+        )
+    )
+    monkeypatch.setattr(local_server, "start_local_server", start_server)
+
+    warnings = []
+    provider = OpenVikingMemoryProvider()
+    provider.initialize("session-1", platform="cli", warning_callback=warnings.append)
+
+    assert provider._client is None
+    start_server.assert_not_called()
+    assert len(warnings) == 1
+    assert "health validation" in warnings[0]
+
+
+def test_handle_unreachable_endpoint_explains_missing_server_command(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    server_config = tmp_path / "ov.conf"
+    server_config.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        openviking_module,
+        "_default_openviking_server_config_path",
+        lambda: server_config,
+    )
+    monkeypatch.setattr(
+        local_server,
+        "server_command",
+        lambda: None,
     )
     monkeypatch.setattr(
         openviking_module,
-        "_wait_for_openviking_health",
-        MagicMock(side_effect=AssertionError("should not wait when server did not start")),
+        "_start_local_openviking_server",
+        MagicMock(side_effect=AssertionError("missing command must not be started")),
+    )
+    monkeypatch.setattr(
+        openviking_module,
+        "_validate_openviking_reachability",
+        lambda endpoint: (False, "OpenViking server is not reachable."),
     )
 
     result = openviking_module._handle_unreachable_endpoint(
         "http://127.0.0.1:1934",
         "OpenViking server is not reachable.",
-        lambda *args, **kwargs: 0,
+        lambda *args, **kwargs: 1,
         -1,
     )
 
     assert result is False
     output = capsys.readouterr().out
-    assert "openviking-server was not found on PATH." in output
-    assert "did not become reachable" not in output
+    assert "OpenViking is not installed" in output
+    assert "Install the OpenViking server command" in output
 
 
-def test_handle_unreachable_endpoint_waits_long_enough_after_autostart(monkeypatch, capsys):
+def test_handle_unreachable_endpoint_waits_long_enough_after_autostart(tmp_path, monkeypatch, capsys):
     wait_calls = []
+    server_config = tmp_path / "ov.conf"
+    server_config.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        openviking_module,
+        "_default_openviking_server_config_path",
+        lambda: server_config,
+    )
+    monkeypatch.setattr(local_server, "server_command", lambda: "/bin/openviking-server")
 
+    start_server = MagicMock(
+        return_value=_started_server(
+            message="Started openviking-server on 127.0.0.1:1934 in the background."
+        )
+    )
     monkeypatch.setattr(
         openviking_module,
         "_start_local_openviking_server",
-        lambda endpoint: (True, "Started openviking-server on 127.0.0.1:1934 in the background."),
+        start_server,
     )
     monkeypatch.setattr(
         openviking_module,
         "_wait_for_openviking_health",
         lambda endpoint, *, timeout_seconds=0: wait_calls.append((endpoint, timeout_seconds)) or True,
+    )
+    stop_process = MagicMock(
+        side_effect=AssertionError(
+            "a healthy self-managed custom server must remain running"
+        )
+    )
+    monkeypatch.setattr(
+        openviking_module,
+        "_stop_owned_local_openviking_process",
+        stop_process,
     )
 
     result = openviking_module._handle_unreachable_endpoint(
@@ -864,9 +2262,62 @@ def test_handle_unreachable_endpoint_waits_long_enough_after_autostart(monkeypat
     )
 
     assert result is True
+    start_server.assert_called_once_with(
+        "http://127.0.0.1:1934",
+        config_path=server_config,
+    )
     assert wait_calls == [("http://127.0.0.1:1934", 60.0)]
+    stop_process.assert_not_called()
     output = capsys.readouterr().out
     assert "Waiting for OpenViking server to become reachable..." in output
+    assert "self-managed server will remain running" in output
+
+
+def test_handle_unreachable_endpoint_stops_failed_validation_process(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    server_config = tmp_path / "ov.conf"
+    server_config.write_text("{}", encoding="utf-8")
+    process = MagicMock()
+    monkeypatch.setattr(
+        openviking_module,
+        "_default_openviking_server_config_path",
+        lambda: server_config,
+    )
+    monkeypatch.setattr(
+        local_server,
+        "server_command",
+        lambda: "/bin/openviking-server",
+    )
+    monkeypatch.setattr(
+        openviking_module,
+        "_start_local_openviking_server",
+        lambda *args, **kwargs: _started_server(process=process),
+    )
+    monkeypatch.setattr(
+        openviking_module,
+        "_wait_for_openviking_health",
+        lambda *args, **kwargs: False,
+    )
+    stop_process = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        openviking_module,
+        "_stop_owned_local_openviking_process",
+        stop_process,
+    )
+
+    result = openviking_module._handle_unreachable_endpoint(
+        "http://127.0.0.1:1934",
+        "OpenViking server is not reachable.",
+        lambda *args, **kwargs: 0,
+        -1,
+    )
+
+    assert result is False
+    stop_process.assert_called_once_with(process)
+    assert "did not become reachable" in capsys.readouterr().out
 
 
 def test_manual_setup_does_not_offer_autostart_when_local_server_is_unhealthy(monkeypatch):
@@ -909,12 +2360,24 @@ def test_manual_setup_does_not_offer_autostart_when_local_server_is_unhealthy(mo
     )]
 
 
-def test_initialize_autostarts_local_openviking_in_background_when_runtime_health_fails(monkeypatch):
+def test_initialize_autostarts_managed_local_openviking_in_background_when_runtime_health_fails(tmp_path, monkeypatch):
     _clear_openviking_env(monkeypatch)
     monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://127.0.0.1:1934")
+    server_config = tmp_path / "ov.conf"
+    server_config.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        openviking_module,
+        "_load_hermes_openviking_config",
+        lambda: {
+            "deployment": openviking_module._MANAGED_LOCAL_DEPLOYMENT,
+            "server_config_path": str(server_config),
+        },
+    )
     health_calls = []
     start_calls = []
     waiter_calls = []
+    owned_process = MagicMock()
+    owned_process.poll.return_value = None
 
     class FakeVikingClient:
         def __init__(self, endpoint, api_key="", account="", user="", agent=""):
@@ -926,9 +2389,12 @@ def test_initialize_autostarts_local_openviking_in_background_when_runtime_healt
 
     monkeypatch.setattr(openviking_module, "_VikingClient", FakeVikingClient)
     monkeypatch.setattr(
-        openviking_module,
-        "_start_local_openviking_server",
-        lambda endpoint: start_calls.append(endpoint) or (True, "started"),
+        local_server,
+        "start_local_server",
+        lambda endpoint, **kwargs: (
+            start_calls.append((endpoint, kwargs))
+            or _started_server(owned_process)
+        ),
     )
     monkeypatch.setattr(
         openviking_module,
@@ -948,15 +2414,34 @@ def test_initialize_autostarts_local_openviking_in_background_when_runtime_healt
 
     assert provider._client is None
     assert health_calls == ["health"]
-    assert start_calls == ["http://127.0.0.1:1934"]
+    assert len(start_calls) == 1
+    start_endpoint, start_kwargs = start_calls[0]
+    assert start_endpoint == "http://127.0.0.1:1934"
+    assert start_kwargs == {
+        "hermes_home": Path(provider._hermes_home),
+        "config_path": server_config,
+    }
     assert len(waiter_calls) == 1
     assert waiter_calls[0]["status_callback"] == statuses.append
+    assert provider._owned_local_server_process is owned_process
     assert any("starting in the background" in message for message in statuses)
 
 
-def test_initialize_emits_starting_status_before_runtime_waiter_can_attach(monkeypatch):
+def test_initialize_emits_starting_status_before_runtime_waiter_can_attach(
+    tmp_path, monkeypatch
+):
     _clear_openviking_env(monkeypatch)
     monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://127.0.0.1:1934")
+    server_config = tmp_path / "ov.conf"
+    server_config.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        openviking_module,
+        "_load_hermes_openviking_config",
+        lambda: {
+            "deployment": openviking_module._MANAGED_LOCAL_DEPLOYMENT,
+            "server_config_path": str(server_config),
+        },
+    )
 
     class FakeVikingClient:
         def __init__(self, endpoint, api_key="", account="", user="", agent=""):
@@ -966,10 +2451,12 @@ def test_initialize_emits_starting_status_before_runtime_waiter_can_attach(monke
             return False
 
     monkeypatch.setattr(openviking_module, "_VikingClient", FakeVikingClient)
+    process = MagicMock()
+    process.poll.return_value = None
     monkeypatch.setattr(
-        openviking_module,
-        "_start_local_openviking_server",
-        lambda endpoint: (True, "started"),
+        local_server,
+        "start_local_server",
+        lambda endpoint, **kwargs: _started_server(process),
     )
 
     provider = OpenVikingMemoryProvider()
@@ -986,6 +2473,38 @@ def test_initialize_emits_starting_status_before_runtime_waiter_can_attach(monke
 
     assert "starting in the background" in statuses[0]
     assert "memory is active" in statuses[1]
+
+
+def test_runtime_start_status_callback_shutdown_stops_unattached_child(
+    tmp_path, monkeypatch
+):
+    server_config = tmp_path / "ov.conf"
+    server_config.write_text("{}", encoding="utf-8")
+    process = MagicMock()
+    process.poll.return_value = None
+    provider = OpenVikingMemoryProvider()
+    provider._endpoint = "http://127.0.0.1:1934"
+    provider._hermes_home = str(tmp_path / "hermes")
+    provider._managed_local_server_config = server_config
+    monkeypatch.setattr(
+        local_server,
+        "start_local_server",
+        lambda endpoint, **kwargs: _started_server(process),
+    )
+    handoff = MagicMock(
+        side_effect=AssertionError(
+            "an unattached child has accepted no work and must stop directly"
+        )
+    )
+    monkeypatch.setattr(local_server, "defer_owned_shutdown", handoff)
+
+    provider._handle_runtime_openviking_unreachable(
+        status_callback=lambda _message: provider.shutdown(),
+    )
+
+    process.terminate.assert_called_once_with()
+    handoff.assert_not_called()
+    assert provider._owned_local_server_process is None
 
 
 def test_runtime_openviking_waiter_attaches_client_after_health_recovers(monkeypatch):
@@ -1108,6 +2627,27 @@ def test_runtime_openviking_waiter_warns_when_background_start_times_out(monkeyp
     ]
 
 
+def test_runtime_openviking_waiter_shutdown_stops_child_without_late_warning(monkeypatch):
+    process = MagicMock()
+    process.poll.return_value = None
+    provider = OpenVikingMemoryProvider()
+    provider._endpoint = "http://127.0.0.1:1934"
+    provider._owned_local_server_process = process
+    provider._shutting_down = True
+    warnings = []
+    monkeypatch.setattr(
+        openviking_module,
+        "_wait_for_openviking_health",
+        lambda endpoint, **kwargs: False,
+    )
+
+    provider._finish_runtime_openviking_start(warning_callback=warnings.append)
+
+    assert warnings == []
+    process.terminate.assert_called_once_with()
+    assert provider._owned_local_server_process is None
+
+
 def test_initialize_does_not_autostart_remote_openviking(monkeypatch, caplog):
     _clear_openviking_env(monkeypatch)
     monkeypatch.setenv("OPENVIKING_ENDPOINT", "https://openviking.example")
@@ -1139,7 +2679,7 @@ def test_initialize_does_not_autostart_remote_openviking(monkeypatch, caplog):
     assert "Remote OpenViking server at https://openviking.example is not reachable" in caplog.text
 
 
-def test_initialize_warns_clearly_when_local_runtime_autostart_fails(monkeypatch, caplog):
+def test_initialize_does_not_autostart_separately_managed_local_server(monkeypatch, caplog):
     _clear_openviking_env(monkeypatch)
     monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://localhost:1934")
 
@@ -1154,7 +2694,7 @@ def test_initialize_warns_clearly_when_local_runtime_autostart_fails(monkeypatch
     monkeypatch.setattr(
         openviking_module,
         "_start_local_openviking_server",
-        lambda endpoint: (False, "openviking-server was not found on PATH."),
+        lambda endpoint: _failed_server(),
     )
     monkeypatch.setattr(
         openviking_module,
@@ -1168,10 +2708,10 @@ def test_initialize_warns_clearly_when_local_runtime_autostart_fails(monkeypatch
 
     assert provider._client is None
     assert "Local OpenViking server at http://localhost:1934 is not reachable" in caplog.text
-    assert "openviking-server was not found on PATH" in caplog.text
+    assert "Start the separately managed server" in caplog.text
 
 
-def test_initialize_emits_cli_warning_when_local_runtime_autostart_fails(monkeypatch):
+def test_initialize_emits_cli_warning_for_separately_managed_local_server(monkeypatch):
     _clear_openviking_env(monkeypatch)
     monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://localhost:1934")
 
@@ -1187,7 +2727,7 @@ def test_initialize_emits_cli_warning_when_local_runtime_autostart_fails(monkeyp
     monkeypatch.setattr(
         openviking_module,
         "_start_local_openviking_server",
-        lambda endpoint: (False, "openviking-server was not found on PATH."),
+        lambda endpoint: _failed_server(),
     )
 
     provider = OpenVikingMemoryProvider()
@@ -1195,9 +2735,9 @@ def test_initialize_emits_cli_warning_when_local_runtime_autostart_fails(monkeyp
 
     assert provider._client is None
     assert warnings == [
-        "Local OpenViking server at http://localhost:1934 is not reachable. "
-        "openviking-server was not found on PATH. "
-        "OpenViking memory disabled for this Hermes run."
+        "Local OpenViking server at http://localhost:1934 is not reachable; "
+        "OpenViking memory disabled for this Hermes run. Start the separately "
+        "managed server, then begin a new Hermes session."
     ]
 
 
@@ -1216,7 +2756,7 @@ def test_initialize_does_not_emit_cli_warning_when_callback_absent(monkeypatch):
     monkeypatch.setattr(
         openviking_module,
         "_start_local_openviking_server",
-        lambda endpoint: (False, "openviking-server was not found on PATH."),
+        lambda endpoint: _failed_server(),
     )
 
     provider = OpenVikingMemoryProvider()
@@ -1230,39 +2770,67 @@ def test_post_setup_local_server_down_can_offer_autostart(tmp_path, monkeypatch)
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    server_config = tmp_path / "ov.conf"
+    server_config.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        openviking_module,
+        "_default_openviking_server_config_path",
+        lambda: server_config,
+    )
+    monkeypatch.setattr(local_server, "server_command", lambda: "/bin/openviking-server")
     monkeypatch.setattr(openviking_module, "_validate_openviking_setup_values", lambda values, *, require_api_key=False: (True, "", None))
 
     from hermes_cli import memory_setup
 
     reachability_calls = []
 
-    def validate_reachability(endpoint):
+    def probe_reachability(endpoint):
         reachability_calls.append(endpoint)
-        return False, "OpenViking server is not reachable." if len(reachability_calls) == 1 else ""
+        return _reachability(
+            openviking_module._OpenVikingReachabilityState.UNREACHABLE,
+            "OpenViking server is not reachable.",
+        )
 
     started = []
-    monkeypatch.setattr(openviking_module, "_validate_openviking_reachability", validate_reachability)
-    monkeypatch.setattr(openviking_module, "_start_local_openviking_server", lambda endpoint: (started.append(endpoint) or True, "started"))
+    monkeypatch.setattr(
+        openviking_module,
+        "_probe_openviking_reachability",
+        probe_reachability,
+    )
+    monkeypatch.setattr(
+        openviking_module,
+        "_start_local_openviking_server",
+        lambda endpoint, **kwargs: started.append((endpoint, kwargs)) or _started_server(),
+    )
     monkeypatch.setattr(openviking_module, "_wait_for_openviking_health", lambda endpoint, **kwargs: True)
-    choices = iter([1, 0, 0, 0])
+    choices = iter([2, 0, 0])
     monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(choices))
     monkeypatch.setattr(
         memory_setup,
         "_prompt",
         _prompt_from_values({
             "OpenViking server URL": "localhost",
-            "Hermes peer ID in OpenViking": "agent",
+            "Agent ID": "agent",
+            "OpenViking profile name": "local",
         }),
     )
     config = {"memory": {}}
 
     OpenVikingMemoryProvider().post_setup(str(hermes_home), config)
 
-    assert started == ["http://localhost:1933"]
+    assert started == [
+        ("http://localhost:1933", {"config_path": server_config})
+    ]
     assert reachability_calls == ["http://localhost:1933"]
-    env_text = (hermes_home / ".env").read_text(encoding="utf-8")
-    assert "OPENVIKING_ENDPOINT=http://localhost:1933" in env_text
-    assert "OPENVIKING_API_KEY" not in env_text
+    profile_path = tmp_path / "home" / ".openviking" / "ovcli.conf.local"
+    assert json.loads(profile_path.read_text(encoding="utf-8")) == {
+        "url": "http://localhost:1933",
+        "actor_peer_id": "agent",
+    }
+    assert config["memory"]["openviking"] == {
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(profile_path),
+    }
 
 
 def test_post_setup_invalid_env_profile_can_create_new_config(tmp_path, monkeypatch):
@@ -1278,7 +2846,7 @@ def test_post_setup_invalid_env_profile_can_create_new_config(tmp_path, monkeypa
 
     from hermes_cli import memory_setup
 
-    choices = iter([1, 0, 0])
+    choices = iter([2, 0])
     monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(choices))
     monkeypatch.setattr(
         memory_setup,
@@ -1286,7 +2854,8 @@ def test_post_setup_invalid_env_profile_can_create_new_config(tmp_path, monkeypa
         _prompt_from_values({
             "OpenViking server URL": "https://openviking.example",
             "OpenViking user API key": "user-secret",
-            "Hermes peer ID in OpenViking": "agent",
+            "Agent ID": "agent",
+            "OpenViking profile name": "recovered",
         }),
     )
     config = {"memory": {}}
@@ -1294,7 +2863,12 @@ def test_post_setup_invalid_env_profile_can_create_new_config(tmp_path, monkeypa
     OpenVikingMemoryProvider().post_setup(str(hermes_home), config)
 
     assert ovcli_path.read_text(encoding="utf-8") == "{"
-    assert config["memory"]["openviking"] == {"use_ovcli_config": False}
+    recovered_path = tmp_path / "home" / ".openviking" / "ovcli.conf.recovered"
+    assert recovered_path.exists()
+    assert config["memory"]["openviking"] == {
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(recovered_path),
+    }
 
 
 def test_tool_search_sorts_by_raw_score_across_buckets():
@@ -1647,7 +3221,10 @@ def test_tool_add_resource_sends_remote_url_as_path():
     provider._client = MagicMock()
     provider._client.post.return_value = {
         "status": "ok",
-        "result": {"root_uri": "viking://resources/remote"},
+        "result": {
+            "root_uri": "viking://resources/remote",
+            "task_id": "resource-task-1",
+        },
     }
 
     provider._tool_add_resource({"url": "https://example.com/doc.md"})
@@ -1656,6 +3233,24 @@ def test_tool_add_resource_sends_remote_url_as_path():
     provider._client.post.assert_called_once_with("/api/v1/resources", {
         "path": "https://example.com/doc.md",
     })
+    assert provider._pending_task_ids == {"resource-task-1"}
+
+
+def test_tool_add_resource_wait_true_does_not_register_background_task():
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.post.return_value = {
+        "status": "ok",
+        "result": {"root_uri": "viking://resources/remote"},
+    }
+
+    provider._tool_add_resource({
+        "url": "https://example.com/doc.md",
+        "wait": True,
+    })
+
+    assert provider._pending_task_ids == set()
+    assert provider._task_tracking_uncertain is False
 
 
 @pytest.mark.parametrize("url", [
@@ -2209,6 +3804,86 @@ def test_validate_openviking_reachability_uses_health_only(monkeypatch):
     assert events == ["health"]
 
 
+@pytest.mark.parametrize(
+    "error",
+    [
+        ConnectionRefusedError(61, "Connection refused"),
+        openviking_module._get_httpx().ConnectTimeout("connect timed out"),
+    ],
+)
+def test_probe_openviking_reachability_classifies_transport_errors(
+    monkeypatch, error
+):
+    class FakeVikingClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def health_payload(self):
+            raise error
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", FakeVikingClient)
+
+    result = openviking_module._probe_openviking_reachability(
+        "http://127.0.0.1:1933"
+    )
+
+    assert (
+        result.state
+        is openviking_module._OpenVikingReachabilityState.UNREACHABLE
+    )
+    assert result.allows_local_autostart is True
+
+
+@pytest.mark.parametrize(
+    ("health_result", "error", "expected_state"),
+    [
+        (
+            {"healthy": False},
+            None,
+            openviking_module._OpenVikingReachabilityState.UNHEALTHY,
+        ),
+        (
+            None,
+            openviking_module._OpenVikingHTTPError("service unavailable", 503),
+            openviking_module._OpenVikingReachabilityState.RESPONDED_ERROR,
+        ),
+        (
+            None,
+            RuntimeError("malformed health response"),
+            openviking_module._OpenVikingReachabilityState.RESPONDED_ERROR,
+        ),
+        (
+            None,
+            openviking_module._get_httpx().ReadTimeout("read timed out"),
+            openviking_module._OpenVikingReachabilityState.RESPONDED_ERROR,
+        ),
+    ],
+)
+def test_probe_openviking_reachability_does_not_autostart_for_server_failures(
+    monkeypatch,
+    health_result,
+    error,
+    expected_state,
+):
+    class FakeVikingClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def health_payload(self):
+            if error is not None:
+                raise error
+            return health_result
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", FakeVikingClient)
+
+    result = openviking_module._probe_openviking_reachability(
+        "http://127.0.0.1:1933"
+    )
+
+    assert result.state is expected_state
+    assert result.allows_local_autostart is False
+
+
 def test_validate_openviking_auth_uses_status_without_health(monkeypatch):
     events = []
 
@@ -2414,6 +4089,9 @@ def test_validate_openviking_identity_value_matches_cli_rules(value, field, ok):
 def _make_provider_with_session(session_id: str, turn_count: int):
     provider = OpenVikingMemoryProvider()
     provider._client = MagicMock()
+    provider._client.post.return_value = {
+        "result": {"task_id": f"commit-{session_id}"},
+    }
     provider._session_id = session_id
     provider._turn_count = turn_count
     return provider
@@ -3730,6 +5408,278 @@ def test_shutdown_waits_for_memory_write_worker(monkeypatch):
     assert not returned_before_worker_finished
     assert worker_finished.is_set()
     assert provider._memory_write_threads == set()
+
+
+def test_shutdown_hands_commit_task_and_owned_server_to_reaper(monkeypatch):
+    provider = _make_provider_with_session("sid-1", turn_count=1)
+    statuses = []
+    provider._runtime_status_callback = statuses.append
+    process = MagicMock()
+    process.poll.return_value = None
+    provider._owned_local_server_process = process
+    provider._owned_local_server_ready = True
+    handoff = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        local_server,
+        "defer_owned_shutdown",
+        handoff,
+    )
+
+    provider.on_session_end([])
+    provider.shutdown()
+
+    handoff.assert_called_once_with(
+        process,
+        hermes_home=Path(provider._hermes_home),
+        endpoint=provider._endpoint,
+        headers=provider._client._headers(),
+        task_ids={"commit-sid-1"},
+    )
+    process.terminate.assert_not_called()
+    assert provider._owned_local_server_process is None
+    assert any("finishing 1 background task" in status for status in statuses)
+    assert any("stop automatically" in status for status in statuses)
+
+
+def test_reaper_handoff_sends_credentials_over_stdin_not_argv(monkeypatch, tmp_path):
+    class CapturingStdin(io.BytesIO):
+        def close(self):
+            self.was_closed = True
+
+    reaper_stdin = CapturingStdin()
+    reaper_process = SimpleNamespace(stdin=reaper_stdin)
+    popen = MagicMock(return_value=reaper_process)
+    server_process = SimpleNamespace(pid=4321)
+    process_identity = SimpleNamespace(create_time=lambda: 123.5)
+    monkeypatch.setattr("psutil.Process", MagicMock(return_value=process_identity))
+    monkeypatch.setattr(local_server.subprocess, "Popen", popen)
+
+    assert local_server.defer_owned_shutdown(
+        server_process,
+        hermes_home=tmp_path,
+        endpoint="http://127.0.0.1:1933",
+        headers={"Authorization": "Bearer top-secret"},
+        task_ids={"task-2", "task-1"},
+    )
+
+    argv = popen.call_args.args[0]
+    assert argv == [
+        local_server.sys.executable,
+        str(Path(local_server.__file__).with_name("reaper.py")),
+    ]
+    assert "top-secret" not in " ".join(argv)
+    payload = json.loads(reaper_stdin.getvalue())
+    assert payload["headers"] == {"Authorization": "Bearer top-secret"}
+    assert payload["task_ids"] == ["task-1", "task-2"]
+    assert payload["pid"] == 4321
+    assert payload["create_time"] == 123.5
+    assert reaper_stdin.was_closed is True
+
+
+def test_reaper_handoff_cleans_up_helper_if_payload_write_fails(monkeypatch, tmp_path):
+    reaper_stdin = MagicMock()
+    reaper_stdin.closed = False
+    reaper_stdin.write.side_effect = OSError("broken pipe")
+    reaper_process = SimpleNamespace(stdin=reaper_stdin, terminate=MagicMock())
+    monkeypatch.setattr(
+        "psutil.Process",
+        MagicMock(return_value=SimpleNamespace(create_time=lambda: 123.5)),
+    )
+    monkeypatch.setattr(
+        local_server.subprocess,
+        "Popen",
+        MagicMock(return_value=reaper_process),
+    )
+
+    assert not local_server.defer_owned_shutdown(
+        SimpleNamespace(pid=4321),
+        hermes_home=tmp_path,
+        endpoint="http://127.0.0.1:1933",
+        headers={},
+        task_ids={"task-1"},
+    )
+
+    reaper_stdin.close.assert_called_once_with()
+    reaper_process.terminate.assert_called_once_with()
+
+
+def test_shutdown_leaves_server_running_when_reaper_handoff_fails(monkeypatch, caplog):
+    provider = _make_provider_with_session("sid-1", turn_count=1)
+    process = MagicMock()
+    process.poll.return_value = None
+    provider._owned_local_server_process = process
+    provider._owned_local_server_ready = True
+    monkeypatch.setattr(
+        local_server,
+        "defer_owned_shutdown",
+        MagicMock(return_value=False),
+    )
+
+    provider.on_session_end([])
+    with caplog.at_level("WARNING", logger=openviking_module.__name__):
+        provider.shutdown()
+
+    process.terminate.assert_not_called()
+    assert "could not be handed off safely" in caplog.text
+
+
+def test_shutdown_leaves_owned_server_running_when_commit_status_is_uncertain(caplog):
+    provider = _make_provider_with_session("sid-1", turn_count=1)
+    process = MagicMock()
+    process.poll.return_value = None
+    provider._owned_local_server_process = process
+    provider._owned_local_server_ready = True
+    provider._client.get.side_effect = RuntimeError("connection dropped")
+
+    provider.on_session_end([])
+    with caplog.at_level("WARNING", logger=openviking_module.__name__):
+        provider.shutdown()
+
+    process.terminate.assert_not_called()
+    assert "leaving the local server running" in caplog.text
+
+
+def test_shutdown_leaves_owned_server_running_when_commit_response_has_no_task_id(caplog):
+    provider = _make_provider_with_session("sid-1", turn_count=1)
+    provider._client.post.return_value = {"result": {}}
+    process = MagicMock()
+    process.poll.return_value = None
+    provider._owned_local_server_process = process
+    provider._owned_local_server_ready = True
+
+    provider.on_session_end([])
+    with caplog.at_level("WARNING", logger=openviking_module.__name__):
+        provider.shutdown()
+
+    provider._client.get.assert_not_called()
+    process.terminate.assert_not_called()
+    assert "cannot be verified" in caplog.text
+
+
+def test_shutdown_drains_queues_when_commit_is_explicitly_skipped(monkeypatch):
+    provider = _make_provider_with_session("sid-1", turn_count=1)
+    provider._client.post.return_value = {
+        "result": {
+            "session_id": "sid-1",
+            "status": "skipped",
+            "task_id": None,
+            "reason": "no_messages",
+        }
+    }
+    process = MagicMock()
+    process.poll.return_value = None
+    provider._owned_local_server_process = process
+    provider._owned_local_server_ready = True
+    handoff = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        local_server,
+        "defer_owned_shutdown",
+        handoff,
+    )
+
+    provider.on_session_end([])
+    provider.shutdown()
+
+    provider._client.get.assert_not_called()
+    handoff.assert_called_once_with(
+        process,
+        hermes_home=Path(provider._hermes_home),
+        endpoint=provider._endpoint,
+        headers=provider._client._headers(),
+        task_ids=set(),
+    )
+    process.terminate.assert_not_called()
+
+
+@pytest.mark.parametrize("deployment", [None, "custom", "quick_local"])
+def test_shutdown_never_stops_server_without_owned_process_handle(deployment, monkeypatch):
+    provider = OpenVikingMemoryProvider()
+    provider._managed_local_server_config = (
+        MagicMock() if deployment == "quick_local" else None
+    )
+    stop = MagicMock(side_effect=AssertionError("unowned server must not be stopped"))
+    monkeypatch.setattr(
+        openviking_module,
+        "_stop_owned_local_openviking_process",
+        stop,
+    )
+
+    provider.shutdown()
+
+    stop.assert_not_called()
+
+
+def test_shutdown_leaves_owned_server_running_if_background_writer_did_not_drain(caplog):
+    provider = OpenVikingMemoryProvider()
+    process = MagicMock()
+    process.poll.return_value = None
+    provider._owned_local_server_process = process
+    provider._owned_local_server_ready = True
+    provider._inflight_writers["sid-1"] = {_HungThread()}
+
+    with caplog.at_level("WARNING", logger=openviking_module.__name__):
+        provider.shutdown()
+
+    process.terminate.assert_not_called()
+    assert "background work is still active" in caplog.text
+
+
+def test_shutdown_joins_cancelled_runtime_start_before_releasing_ownership(monkeypatch):
+    provider = OpenVikingMemoryProvider()
+    provider._endpoint = "http://127.0.0.1:1933"
+    process = MagicMock()
+    process.poll.return_value = None
+    provider._owned_local_server_process = process
+    entered_wait = threading.Event()
+
+    def wait_for_health(_endpoint, *, should_stop, **_kwargs):
+        entered_wait.set()
+        deadline = time.monotonic() + 2.0
+        while not should_stop() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert should_stop()
+        return False
+
+    monkeypatch.setattr(
+        openviking_module,
+        "_wait_for_openviking_health",
+        wait_for_health,
+    )
+    handoff = MagicMock()
+    monkeypatch.setattr(
+        local_server,
+        "defer_owned_shutdown",
+        handoff,
+    )
+    runtime_thread = threading.Thread(
+        target=provider._finish_runtime_openviking_start,
+        daemon=True,
+    )
+    provider._runtime_start_thread = runtime_thread
+    runtime_thread.start()
+    assert entered_wait.wait(timeout=2.0)
+
+    provider.shutdown()
+
+    runtime_thread.join(timeout=2.0)
+    assert not runtime_thread.is_alive()
+    process.terminate.assert_called_once_with()
+    handoff.assert_not_called()
+    assert provider._owned_local_server_process is None
+
+
+def test_atexit_safety_net_finalizes_before_provider_shutdown(monkeypatch):
+    provider = MagicMock()
+    monkeypatch.setattr(openviking_module, "_last_active_provider", provider)
+
+    openviking_module._atexit_commit_sessions()
+
+    assert provider.method_calls == [
+        call.on_session_end([]),
+        call.shutdown(),
+        call._release_run_lock(),
+    ]
+    assert openviking_module._last_active_provider is None
 
 
 @pytest.mark.parametrize(

--- a/tests/plugins/memory/test_openviking_reaper.py
+++ b/tests/plugins/memory/test_openviking_reaper.py
@@ -1,0 +1,336 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import psutil
+import pytest
+
+from plugins.memory.openviking import local_server, reaper
+
+
+def _payload(**overrides):
+    payload = {
+        "endpoint": "http://127.0.0.1:1933",
+        "pid": 1234,
+        "create_time": 100.0,
+        "task_ids": ["task-1"],
+        "headers": {"X-OpenViking-Actor-Peer": "hermes"},
+        "wait_timeout": 300.0,
+        "poll_interval": 0.5,
+        "stop_timeout": 10.0,
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://example.com",
+        "https://127.0.0.1:1933",
+        "ftp://localhost/resource",
+        "http://192.168.1.10:1933",
+        "not-a-url",
+    ],
+)
+def test_payload_rejects_non_loopback_or_non_http_endpoint(endpoint):
+    with pytest.raises(ValueError, match="endpoint must be local HTTP"):
+        reaper._validated_payload(_payload(endpoint=endpoint))
+
+
+def test_reaper_handoff_uses_windowless_python_and_shared_windows_detach_flags(
+    monkeypatch,
+    tmp_path,
+):
+    reaper_stdin = MagicMock()
+    reaper_process = SimpleNamespace(stdin=reaper_stdin)
+    popen = MagicMock(return_value=reaper_process)
+    expected_flags = 0x10
+    monkeypatch.setattr(
+        local_server,
+        "is_windows",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "psutil.Process",
+        MagicMock(return_value=SimpleNamespace(create_time=lambda: 123.5)),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.gateway_windows._resolve_detached_python",
+        lambda executable: ("C:/Python/pythonw.exe", Path("C:/venv"), []),
+    )
+    monkeypatch.setattr(
+        local_server,
+        "windows_detach_flags",
+        lambda: expected_flags,
+    )
+    monkeypatch.setattr(local_server.subprocess, "Popen", popen)
+
+    assert local_server.defer_owned_shutdown(
+        SimpleNamespace(pid=4321),
+        hermes_home=tmp_path,
+        endpoint="http://127.0.0.1:1933",
+        headers={},
+        task_ids=set(),
+    )
+
+    argv = popen.call_args.args[0]
+    assert argv[0] == "C:/Python/pythonw.exe"
+    assert argv[1].endswith("plugins/memory/openviking/reaper.py")
+    assert popen.call_args.kwargs["creationflags"] == expected_flags
+    assert "start_new_session" not in popen.call_args.kwargs
+
+
+def test_run_waits_for_terminal_task_then_drains_queues_before_stopping(monkeypatch):
+    statuses = iter(["pending", "running", "completed"])
+    events = []
+    stop = MagicMock(return_value=True)
+    monkeypatch.setattr(reaper, "_same_process", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(
+        reaper,
+        "_task_status",
+        lambda *_args: events.append("task") or next(statuses),
+    )
+    monkeypatch.setattr(
+        reaper,
+        "_wait_for_processing",
+        lambda *_args: events.append("queues"),
+    )
+    monkeypatch.setattr(
+        reaper,
+        "_stop_exact_process",
+        lambda *args: events.append("stop") or stop(*args),
+    )
+    monkeypatch.setattr(reaper.time, "sleep", lambda _seconds: None)
+
+    assert reaper.run(_payload()) == 0
+    assert stop.call_args.args == (1234, 100.0, 10.0)
+    assert events == ["task", "task", "task", "queues", "stop"]
+
+
+def test_run_drains_queues_without_task_ids_before_stopping(monkeypatch):
+    wait_for_processing = MagicMock()
+    stop = MagicMock(return_value=True)
+    monkeypatch.setattr(reaper, "_same_process", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(reaper, "_task_status", MagicMock())
+    monkeypatch.setattr(reaper, "_wait_for_processing", wait_for_processing)
+    monkeypatch.setattr(reaper, "_stop_exact_process", stop)
+
+    assert reaper.run(_payload(task_ids=[])) == 0
+
+    reaper._task_status.assert_not_called()
+    wait_for_processing.assert_called_once()
+    stop.assert_called_once_with(1234, 100.0, 10.0)
+
+
+def test_run_leaves_server_when_queue_drain_cannot_be_verified(monkeypatch, caplog):
+    stop = MagicMock()
+    monkeypatch.setattr(reaper, "_same_process", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(
+        reaper,
+        "_wait_for_processing",
+        MagicMock(side_effect=RuntimeError("queue wait failed")),
+    )
+    monkeypatch.setattr(reaper, "_stop_exact_process", stop)
+
+    with caplog.at_level("ERROR", logger=reaper.__name__):
+        assert reaper.run(_payload(task_ids=[])) == 2
+
+    stop.assert_not_called()
+    assert "Could not verify managed OpenViking queue drain" in caplog.text
+    assert "leaving PID 1234 running" in caplog.text
+
+
+def test_wait_for_processing_posts_bounded_system_wait(monkeypatch):
+    captured = {}
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return b'{"status":"ok","result":{"Embedding":{"processed":1}}}'
+
+    class Opener:
+        def open(self, request, timeout):
+            captured["request"] = request
+            captured["timeout"] = timeout
+            return Response()
+
+    monkeypatch.setattr(reaper, "build_opener", lambda *_args: Opener())
+
+    reaper._wait_for_processing(
+        "http://127.0.0.1:1933",
+        {"Authorization": "Bearer secret"},
+        12.5,
+    )
+
+    request = captured["request"]
+    assert request.full_url == "http://127.0.0.1:1933/api/v1/system/wait"
+    assert request.method == "POST"
+    assert json.loads(request.data) == {"timeout": 12.5}
+    assert request.get_header("Authorization") == "Bearer secret"
+    assert captured["timeout"] == 13.5
+
+
+def test_wait_for_processing_rejects_queue_errors(monkeypatch):
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return (
+                b'{"status":"ok","result":{"Embedding":'
+                b'{"processed":0,"error_count":1,"errors":["failed"]}}}'
+            )
+
+    opener = MagicMock()
+    opener.open.return_value = Response()
+    monkeypatch.setattr(reaper, "build_opener", lambda *_args: opener)
+
+    with pytest.raises(RuntimeError, match="reported processing errors"):
+        reaper._wait_for_processing(
+            "http://127.0.0.1:1933",
+            {},
+            12.5,
+        )
+
+
+def test_task_status_encodes_id_and_validates_status(monkeypatch):
+    captured = {}
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return b'{"status":"ok","result":{"status":"running"}}'
+
+    class Opener:
+        def open(self, request, timeout):
+            captured["request"] = request
+            captured["timeout"] = timeout
+            return Response()
+
+    monkeypatch.setattr(reaper, "build_opener", lambda *_args: Opener())
+
+    assert (
+        reaper._task_status(
+            "http://127.0.0.1:1933",
+            "task/with spaces",
+            {"Authorization": "Bearer secret"},
+        )
+        == "running"
+    )
+
+    request = captured["request"]
+    assert request.full_url.endswith("/api/v1/tasks/task%2Fwith%20spaces")
+    assert request.get_header("Authorization") == "Bearer secret"
+    assert captured["timeout"] == 5.0
+
+
+def test_task_status_rejects_unknown_status(monkeypatch):
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return b'{"status":"ok","result":{"status":"mystery"}}'
+
+    opener = MagicMock()
+    opener.open.return_value = Response()
+    monkeypatch.setattr(reaper, "build_opener", lambda *_args: opener)
+
+    with pytest.raises(ValueError, match="unknown status"):
+        reaper._task_status("http://127.0.0.1:1933", "task-1", {})
+
+
+def test_run_leaves_server_when_task_status_cannot_be_verified(monkeypatch, caplog):
+    stop = MagicMock()
+    monkeypatch.setattr(reaper, "_same_process", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(
+        reaper,
+        "_task_status",
+        MagicMock(side_effect=RuntimeError("connection failed")),
+    )
+    monkeypatch.setattr(reaper, "_stop_exact_process", stop)
+
+    with caplog.at_level("ERROR", logger=reaper.__name__):
+        assert reaper.run(_payload()) == 2
+
+    stop.assert_not_called()
+    assert "leaving PID 1234 running" in caplog.text
+
+
+def test_run_is_bounded_when_task_remains_pending(monkeypatch, caplog):
+    stop = MagicMock()
+    monotonic = iter([10.0, 11.0])
+    monkeypatch.setattr(reaper, "_same_process", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(reaper, "_task_status", MagicMock(return_value="pending"))
+    monkeypatch.setattr(reaper, "_stop_exact_process", stop)
+    monkeypatch.setattr(reaper.time, "monotonic", lambda: next(monotonic))
+
+    with caplog.at_level("ERROR", logger=reaper.__name__):
+        assert reaper.run(_payload(wait_timeout=0.5)) == 3
+
+    stop.assert_not_called()
+    assert "did not finish within 0.5 seconds" in caplog.text
+
+
+def test_run_does_nothing_if_owned_process_already_exited(monkeypatch):
+    stop = MagicMock()
+    monkeypatch.setattr(reaper, "_same_process", MagicMock(return_value=None))
+    monkeypatch.setattr(reaper, "_task_status", MagicMock())
+    monkeypatch.setattr(reaper, "_stop_exact_process", stop)
+
+    assert reaper.run(_payload()) == 0
+    stop.assert_not_called()
+
+
+def test_same_process_treats_zombie_as_exited(monkeypatch):
+    process = SimpleNamespace(
+        create_time=lambda: 100.0,
+        status=lambda: psutil.STATUS_ZOMBIE,
+    )
+    monkeypatch.setattr(reaper.psutil, "Process", lambda _pid: process)
+
+    assert reaper._same_process(1234, 100.0) is None
+
+
+def test_stop_exact_process_revalidates_identity_before_force_kill(monkeypatch):
+    process = MagicMock()
+    process.wait.side_effect = [psutil.TimeoutExpired(10, pid=1234), None]
+    same_process = MagicMock(side_effect=[process, process])
+    monkeypatch.setattr(reaper, "_same_process", same_process)
+
+    assert reaper._stop_exact_process(1234, 100.0, 10.0) is True
+
+    process.send_signal.assert_called_once()
+    process.kill.assert_called_once_with()
+    assert same_process.call_count == 2
+
+
+def test_stop_exact_process_never_force_kills_reused_pid(monkeypatch):
+    process = MagicMock()
+    process.wait.side_effect = psutil.TimeoutExpired(10, pid=1234)
+    monkeypatch.setattr(
+        reaper,
+        "_same_process",
+        MagicMock(side_effect=[process, None]),
+    )
+
+    assert reaper._stop_exact_process(1234, 100.0, 10.0) is True
+    process.kill.assert_not_called()

--- a/tests/plugins/memory/test_openviking_shutdown.py
+++ b/tests/plugins/memory/test_openviking_shutdown.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import threading
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import plugins.memory.openviking as openviking_module
 from plugins.memory.openviking import OpenVikingMemoryProvider
@@ -70,18 +70,29 @@ def test_shutdown_waits_for_runtime_start_thread():
     assert not t.is_alive()
 
 
-def test_shutdown_during_pending_runtime_start_does_not_launch_waiter(monkeypatch):
+def test_shutdown_during_pending_managed_runtime_start_does_not_launch_waiter(
+    tmp_path, monkeypatch
+):
     """A waiter reserved before shutdown must not start after shutdown returns."""
     provider = OpenVikingMemoryProvider()
     provider._endpoint = "http://127.0.0.1:1934"
+    provider._hermes_home = str(tmp_path / "hermes")
+    server_config = tmp_path / "ov.conf"
+    server_config.write_text("{}", encoding="utf-8")
+    provider._managed_local_server_config = server_config
     status_entered = threading.Event()
     release_status = threading.Event()
     waiter_calls = []
+    process = MagicMock()
+    process.poll.return_value = None
 
     monkeypatch.setattr(
-        openviking_module,
-        "_start_local_openviking_server",
-        lambda endpoint: (True, "started"),
+        openviking_module.local_server,
+        "start_local_server",
+        lambda endpoint, **kwargs: openviking_module._LocalServerStartResult(
+            process,
+            "started",
+        ),
     )
     monkeypatch.setattr(
         provider,
@@ -108,6 +119,7 @@ def test_shutdown_during_pending_runtime_start_does_not_launch_waiter(monkeypatc
     assert not starter.is_alive()
     assert provider._runtime_start_pending is False
     assert waiter_calls == []
+    process.terminate.assert_called_once_with()
 
 
 def test_shutdown_during_final_health_probe_does_not_publish_client(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Adds a reusable, interface-neutral Quick Local adapter to the OpenViking memory plugin, with the existing CLI setup flow acting as a prompt-based caller. Managed OpenViking Service and self-managed custom server paths remain available.

Quick Local installs and configures OpenViking and Ollama with `qwen3-embedding:0.6b`, stores its configuration and workspace under the active Hermes home, and reuses Hermes' effective static API-key LLM configuration. Provisioning exposes structured preflight, progress, cancellation, validation, and result contracts so another Hermes surface can call the same plugin-owned logic without duplicating installation or server-management behavior.

At runtime, Hermes lazily starts only Quick Local deployments. The provider retains the exact `Popen` handle as ownership proof. On shutdown, a detached helper waits for tracked OpenViking tasks, drains remaining processing queues, revalidates the PID and creation time, and stops only that owned child. Self-managed local servers, remote servers, and shared Ollama processes are never stopped by Hermes.

## Related Issue

Related: #37332 documents manual local configuration; this PR adds guided provisioning and a managed runtime lifecycle.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added three explicit setup paths:
  - OpenViking Service (VolcEngine Cloud)
  - Quick local setup
  - Connect to a self-managed custom server
- Extracted Quick Local dependency checks, installation, Ollama/model preparation, configuration generation, validation, progress, and cancellation into a reusable plugin adapter.
- Added profile-first configuration using exact OpenViking-owned `ovcli.conf` paths and canonical `OPENVIKING_URL` / `OPENVIKING_ACTOR_PEER_ID` names, while retaining legacy environment fallbacks.
- Preserved existing API-key role and identity validation for managed and custom endpoints.
- Reused supported static Hermes LLM credentials without copying OAuth, cloud-native, or external-process authentication state.
- Added structured reachability classification so only a true connection failure may offer local startup; unhealthy, malformed, timed-out, and HTTP-error responses do not start another server.
- Added lazy Quick Local runtime startup and exact-process ownership without changing self-managed local or remote server behavior.
- Added task-aware background shutdown for session commits, direct content writes, and resource ingestion. If completion or ownership cannot be verified, OpenViking is left running.
- Added cross-platform process handling, including the official Windows Ollama installer and Windows detached-process fallback.
- Expanded setup, profile, backup, lifecycle, race, shutdown, Windows, and failure-path coverage.

## How to Test

Focused post-rebase gate:

```bash
scripts/run_tests.sh -j 4 -q \
  tests/plugins/memory/test_openviking_provider.py \
  tests/plugins/memory/test_openviking_reaper.py \
  tests/plugins/memory/test_openviking_shutdown.py \
  tests/openviking_plugin/test_openviking.py \
  tests/cron/test_scheduler_provider.py \
  tests/cron/test_scheduler.py
```

Result: **597 passed**.

Static and portability checks:

```bash
./.venv/bin/python -m py_compile \
  plugins/memory/openviking/__init__.py \
  plugins/memory/openviking/local_server.py \
  plugins/memory/openviking/quick_local.py \
  plugins/memory/openviking/reaper.py

./.venv/bin/ruff check \
  plugins/memory/openviking/__init__.py \
  plugins/memory/openviking/local_server.py \
  plugins/memory/openviking/quick_local.py \
  plugins/memory/openviking/reaper.py \
  tests/plugins/memory/test_openviking_provider.py \
  tests/plugins/memory/test_openviking_reaper.py \
  tests/plugins/memory/test_openviking_shutdown.py \
  tests/openviking_plugin/test_openviking.py

./.venv/bin/python scripts/check-windows-footguns.py
git diff --check upstream/main...HEAD
```

Real isolated macOS service tests covered:

- Fresh Quick Local provisioning and temporary validation-server cleanup.
- Lazy managed runtime startup and client attachment.
- A final `viking_remember` immediately followed by shutdown.
- Queue-aware shutdown of the exact owned OpenViking child.
- Confirmation that Ollama remains healthy after Hermes-managed shutdown.
- Healthy self-managed custom-local startup remaining online.
- Failed custom-local validation cleaning up only the exact process started for validation.

A broad `scripts/run_tests.sh -j 24 -q` run completed with **46,460 passed** and **29 failed** across 18 unchanged test files. The one stale OpenViking lifecycle expectation found by that run was updated and is green in the focused gate above. The remaining failures are outside this diff and reflect macOS path/platform assumptions, missing Linux services/tools, or high-parallelism timing/resource failures.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (the repository wrapper result and unchanged environment/platform failures are documented above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Apple Silicon, Python 3.13.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; plugin setup persists provider-owned configuration through the existing provider config
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; tool schemas are unchanged

## Screenshots / Logs

Not applicable; this is a terminal setup and provider lifecycle workflow.
