### PR TITLE
fix(agent): do not re-persist empty failure sentinel after scaffolding drop

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -275,7 +275,15 @@ def finalize_turn(
         # Compare content (not just role) so a verification candidate that
         # matches the final response is not duplicated at budget
         # exhaustion. (#65919 §7)
-        if final_response and not interrupted:
+        #
+        # Skip the literal ``"(empty)"`` failure sentinel. The empty-response
+        # exhaustion path stamps a marked assistant("(empty)") that
+        # ``_drop_trailing_empty_response_scaffolding`` just removed so it
+        # would not poison SessionDB / resume. Re-appending an unmarked copy
+        # here because ``final_response`` is still ``"(empty)"`` undoes that
+        # contract and can re-enter empty-response loops on "continue".
+        _is_empty_failure_sentinel = final_response == "(empty)"
+        if final_response and not interrupted and not _is_empty_failure_sentinel:
             try:
                 _tail = messages[-1] if messages else None
             except Exception:

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -198,6 +198,62 @@ def test_final_response_closes_tool_tail_before_persistence(monkeypatch):
     assert agent.persisted_messages[-1] == {"role": "assistant", "content": "Done."}
 
 
+def test_empty_failure_sentinel_not_reappended_after_drop(monkeypatch):
+    """Marked ``(empty)`` terminal must stay out of durable history.
+
+    ``conversation_loop`` appends assistant("(empty)") with
+    ``_empty_terminal_sentinel`` then sets ``final_response="(empty)"``.
+    The finalizer drops the marked row before persist; the #43849 close
+    block must not re-append an unmarked copy just because final_response
+    is still truthy.
+    """
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+
+    def _drop_sentinel(messages):
+        while (
+            messages
+            and isinstance(messages[-1], dict)
+            and (
+                messages[-1].get("_empty_recovery_synthetic")
+                or messages[-1].get("_empty_terminal_sentinel")
+            )
+        ):
+            messages.pop()
+
+    agent._drop_trailing_empty_response_scaffolding = _drop_sentinel
+    messages = [
+        {"role": "user", "content": "do work"},
+        {
+            "role": "assistant",
+            "content": "(empty)",
+            "_empty_terminal_sentinel": True,
+        },
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response="(empty)",
+        api_call_count=3,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="do work",
+        original_user_message="do work",
+        _should_review_memory=False,
+        _turn_exit_reason="empty_response_exhausted",
+    )
+
+    persisted = agent.persisted_messages
+    assert persisted is not None
+    assert persisted == [{"role": "user", "content": "do work"}]
+    assert all(m.get("content") != "(empty)" for m in result["messages"])
+    assert all(not m.get("_empty_terminal_sentinel") for m in result["messages"])
+
+
 def test_final_response_fills_pure_tool_call_tail(monkeypatch):
     """A tail assistant row that is a *pure tool-call turn* carries no answer.
 

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -1,7 +1,8 @@
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 from typing import Any
 
 from agent.turn_finalizer import finalize_turn
+from run_agent import AIAgent
 
 
 class FakeAgent:
@@ -198,30 +199,33 @@ def test_final_response_closes_tool_tail_before_persistence(monkeypatch):
     assert agent.persisted_messages[-1] == {"role": "assistant", "content": "Done."}
 
 
-def test_empty_failure_sentinel_not_reappended_after_drop(monkeypatch):
-    """Marked ``(empty)`` terminal must stay out of durable history.
+def test_empty_failure_sentinel_absent_after_finalize_and_session_persist(monkeypatch):
+    """Marked terminal sentinel must stay out after real drop + session persist.
 
     ``conversation_loop`` appends assistant("(empty)") with
     ``_empty_terminal_sentinel`` then sets ``final_response="(empty)"``.
-    The finalizer drops the marked row before persist; the #43849 close
-    block must not re-append an unmarked copy just because final_response
-    is still truthy.
+    ``finalize_turn`` calls the production
+    ``AIAgent._drop_trailing_empty_response_scaffolding`` helper, then the
+    #43849 close block must not re-append an unmarked copy that
+    ``AIAgent._persist_session`` would keep in durable SessionDB / resume
+    history (unmarked ``(empty)`` survives persist by design).
     """
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
     agent = FakeAgent()
+    agent._session_persist_lock = None
+    agent._session_messages = []
+    agent.flushed_session_db_messages = []
+    agent._save_session_log = lambda _messages: None
+    agent._flush_messages_to_session_db = (
+        lambda messages, conversation_history=None: agent.flushed_session_db_messages.append(
+            [dict(message) for message in messages]
+        )
+    )
+    agent._drop_trailing_empty_response_scaffolding = MethodType(
+        AIAgent._drop_trailing_empty_response_scaffolding, agent
+    )
+    agent._persist_session = MethodType(AIAgent._persist_session, agent)
 
-    def _drop_sentinel(messages):
-        while (
-            messages
-            and isinstance(messages[-1], dict)
-            and (
-                messages[-1].get("_empty_recovery_synthetic")
-                or messages[-1].get("_empty_terminal_sentinel")
-            )
-        ):
-            messages.pop()
-
-    agent._drop_trailing_empty_response_scaffolding = _drop_sentinel
     messages = [
         {"role": "user", "content": "do work"},
         {
@@ -247,11 +251,12 @@ def test_empty_failure_sentinel_not_reappended_after_drop(monkeypatch):
         _turn_exit_reason="empty_response_exhausted",
     )
 
-    persisted = agent.persisted_messages
-    assert persisted is not None
-    assert persisted == [{"role": "user", "content": "do work"}]
-    assert all(m.get("content") != "(empty)" for m in result["messages"])
-    assert all(not m.get("_empty_terminal_sentinel") for m in result["messages"])
+    assert agent.flushed_session_db_messages, "expected real _persist_session flush"
+    durable = agent.flushed_session_db_messages[-1]
+    assert durable == [{"role": "user", "content": "do work"}]
+    assert all(message.get("content") != "(empty)" for message in durable)
+    assert all(message.get("content") != "(empty)" for message in result["messages"])
+    assert all(not message.get("_empty_terminal_sentinel") for message in result["messages"])
 
 
 def test_final_response_fills_pure_tool_call_tail(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

After empty-response retries/fallback are exhausted, `conversation_loop` sets `final_response=(empty)` and appends a marked `_empty_terminal_sentinel` assistant row. `finalize_turn` correctly drops that marked sentinel before persist so SessionDB / resume do not replay a fake answer.

The later #43849 close block treated any truthy `final_response` as a delivered answer and re-appended an *unmarked* `assistant((empty))`, undoing the drop contract and re-poisoning durable history. Continue/resume turns could then re-enter empty-response loops.

This skips the literal (empty)` failure sentinel in that close block so the intentional non-persistence of the sentinel is preserved. Real recovered responses still get closed into the transcript as before.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/turn_finalizer.py`: skip #43849 final-response persistence when `final_response == (empty)`
- `tests/agent/test_turn_finalizer_final_response_persistence.py`: regression covering drop-then-no-reappend of the marked empty terminal sentinel

## How to Test

1. `scripts/run_tests.sh tests/agent/test_turn_finalizer_final_response_persistence.py -q`
2. Confirm the new test `test_empty_failure_sentinel_not_reappended_after_drop` passes
3. Optional: run a turn that exits with `empty_response_exhausted`, then inspect SessionDB / `/resume` history — it must not end with durable unmarked `assistant((empty))`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/agent/test_turn_finalizer_final_response_persistence.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (Python-only finalizer gate)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
