### PR TITLE
feat(desktop): keep the current session visible in the sidebar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -93,6 +93,7 @@ import {
   $sessions,
   $sessionsLoading,
   $sessionsTotal,
+  resolveCurrentSession,
   sessionPinId,
   setCurrentCwd
 } from '@/store/session'
@@ -523,6 +524,15 @@ export function ChatSidebar({
   const agentSessions = useMemo(
     () => (agentOrderManual ? orderByIds(unpinnedAgentSessions, s => s.id, agentOrderIds) : unpinnedAgentSessions),
     [unpinnedAgentSessions, agentOrderIds, agentOrderManual]
+  )
+
+  // Surface the focused chat in its own "Current" section above the long,
+  // virtualized history scroller — whether it is a recent, pinned, or project
+  // session — without mutating any persisted order. Selection is
+  // compression-aware and position-independent (see resolveCurrentSession).
+  const current = useMemo(
+    () => resolveCurrentSession(visibleSessions, activeSidebarSessionId, pinnedSessionIds),
+    [visibleSessions, activeSidebarSessionId, pinnedSessionIds]
   )
 
   // Recents are local-only: messaging-platform sessions are fetched as their
@@ -1202,6 +1212,28 @@ export function ChatSidebar({
               value={searchQuery}
             />
           </div>
+        )}
+
+        {!trimmedQuery && current && (
+          <SidebarSessionsSection
+            activeSessionId={activeSidebarSessionId}
+            collapsible={false}
+            contentClassName="flex flex-col gap-px rounded-lg pb-1"
+            emptyState={null}
+            label={s.current}
+            onArchiveSession={onArchiveSession}
+            onBranchSession={onBranchSession}
+            onDeleteSession={onDeleteSession}
+            onResumeSession={onResumeSession}
+            onToggle={() => undefined}
+            onTogglePin={current.pinned ? unpinSession : pinSession}
+            open
+            pinned={current.pinned}
+            rootClassName="shrink-0 px-2 pb-1"
+            sessions={[current.session]}
+            showProfileTags={showAllProfiles}
+            workingSessionIdSet={workingSessionIdSet}
+          />
         )}
 
         {showSessionSections && (

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1641,6 +1641,7 @@ export const en: Translations = {
     clearSearch: 'Clear search',
     noMatch: query => `No sessions match “${query}”.`,
     results: 'Results',
+    current: 'Current',
     pinned: 'Pinned',
     sessions: 'Sessions',
     cronJobs: 'Cron jobs',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1580,6 +1580,7 @@ export const ja = defineLocale({
     clearSearch: '検索をクリア',
     noMatch: query => `"${query}" に一致するセッションがありません。`,
     results: '結果',
+    current: '現在',
     pinned: 'ピン留め',
     sessions: 'セッション',
     cronJobs: 'Cronジョブ',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1361,6 +1361,7 @@ export interface Translations {
     clearSearch: string
     noMatch: (query: string) => string
     results: string
+    current: string
     pinned: string
     sessions: string
     cronJobs: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1529,6 +1529,7 @@ export const zhHant = defineLocale({
     clearSearch: '清除搜尋',
     noMatch: query => `沒有工作階段符合「${query}」。`,
     results: '結果',
+    current: '目前',
     pinned: '已釘選',
     sessions: '工作階段',
     cronJobs: '排程任務',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1832,6 +1832,7 @@ export const zh: Translations = {
     clearSearch: '清除搜索',
     noMatch: query => `没有会话匹配"${query}"。`,
     results: '结果',
+    current: '当前',
     pinned: '已置顶',
     sessions: '会话',
     cronJobs: '定时任务',

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -13,6 +13,7 @@ import {
   applyConfiguredDefaultProjectDir,
   mergeSessionPage,
   resolveComposerSessionKey,
+  resolveCurrentSession,
   sessionPinId,
   setCurrentCwd,
   setSelectedStoredSessionId,
@@ -98,6 +99,46 @@ describe('resolveComposerSessionKey', () => {
 
   it('falls back to the live id when the tip row is not loaded yet', () => {
     expect(resolveComposerSessionKey('tip-new', [])).toBe('tip-new')
+  })
+})
+
+describe('resolveCurrentSession', () => {
+  it('surfaces an ordinary focused session regardless of its list position', () => {
+    // The focused row sits below newer sessions in a recency-sorted list; the
+    // Current section must still find it without touching that order.
+    const sessions = [session({ id: 'newest' }), session({ id: 'focused' }), session({ id: 'oldest' })]
+
+    const result = resolveCurrentSession(sessions, 'focused', [])
+
+    expect(result?.session).toBe(sessions[1])
+    expect(result?.pinned).toBe(false)
+  })
+
+  it('marks a pinned/project session as pinned via its durable pin id', () => {
+    // A pinned lineage pins on the root, so pinned-ness must resolve off the pin
+    // id — not the live id — exactly like the Pinned section.
+    const sessions = [session({ id: 'tip', _lineage_root_id: 'root' })]
+
+    const result = resolveCurrentSession(sessions, 'tip', ['root'])
+
+    expect(result?.session).toBe(sessions[0])
+    expect(result?.pinned).toBe(true)
+  })
+
+  it('follows a compressed lineage: focus keyed on the root finds the tip row', () => {
+    const sessions = [session({ id: 'other' }), session({ id: 'tip', _lineage_root_id: 'root' })]
+
+    const result = resolveCurrentSession(sessions, 'root', [])
+
+    expect(result?.session).toBe(sessions[1])
+    expect(result?.pinned).toBe(false)
+  })
+
+  it('returns null when nothing is focused or the focus is out of scope', () => {
+    const sessions = [session({ id: 'a' })]
+
+    expect(resolveCurrentSession(sessions, null, [])).toBeNull()
+    expect(resolveCurrentSession(sessions, 'not-loaded', [])).toBeNull()
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -165,6 +165,37 @@ export function resolveComposerSessionKey(
   return row ? sessionPinId(row) : selectedSessionId
 }
 
+/**
+ * Resolve the focused session — and whether it is pinned — for the sidebar's
+ * dedicated "Current" section.
+ *
+ * Selection is compression-aware ({@link sessionMatchesStoredId} matches the
+ * live id OR the lineage root) so a focused conversation stays surfaced across
+ * auto-compression tip rotation, and it is independent of the session's
+ * position in the (possibly long, virtualized) list. Pinned-ness keys off the
+ * durable pin id ({@link sessionPinId}), so it holds for a pinned lineage the
+ * same way the Pinned section does. Returns null when nothing is focused or the
+ * focused session is not in `sessions` (e.g. it belongs to another profile
+ * scope). Purely derived — never mutates persisted order.
+ */
+export function resolveCurrentSession(
+  sessions: readonly SessionInfo[],
+  activeSessionId: null | string,
+  pinnedSessionIds: readonly string[]
+): { pinned: boolean; session: SessionInfo } | null {
+  if (!activeSessionId) {
+    return null
+  }
+
+  const session = sessions.find(entry => sessionMatchesStoredId(entry, activeSessionId))
+
+  if (!session) {
+    return null
+  }
+
+  return { pinned: pinnedSessionIds.includes(sessionPinId(session)), session }
+}
+
 /** Merge a fresh server session page into the in-memory list, keeping any
  *  row the server omitted that we still want visible — both still-"working"
  *  sessions and pinned sessions.


### PR DESCRIPTION
## Summary
- add a dedicated **Current** sidebar section for the focused chat
- resolve focused sessions across compression lineage and durable pin IDs
- preserve pinned, project, recent, and manual ordering
- add localized labels for English, Japanese, Simplified Chinese, and Traditional Chinese

## Verification
- [x] focused sidebar/session tests (40/40)
- [x] full Desktop UI suite (1,850 passed, 1 skipped)
- [x] Desktop typecheck
- [x] changed-file ESLint
- [x] production build and unpacked macOS package
- [x] independent fresh-context review: PASS, no security or logic blockers

## Notes
The focused row remains in its native Pinned/Project/Recents location as well as the dedicated Current section. No persisted ordering is changed.