### PR TITLE
fix(api): preserve compaction summaries through Responses auto-truncation

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -200,28 +200,37 @@ def _auto_truncate_response_history(
     *,
     limit: int = RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT,
 ) -> List[Dict[str, Any]]:
-    """Keep recent Responses history without dropping the compaction handoff."""
+    """Keep recent Responses history without dropping the compaction handoff.
+
+    Compaction summaries are preserved wherever they sit in the history —
+    the gateway /compress path can leave them after a retained system head
+    (see ``context_compressor`` force-user-leading handling), so a
+    leading-block-only scan would silently drop them.
+    """
     if limit <= 0 or len(conversation_history) <= limit:
         return conversation_history
 
-    leading_summaries: List[Dict[str, Any]] = []
-    first_conversation_index = 0
-    for message in conversation_history:
-        if not _is_compressed_summary_message(message):
-            break
-        leading_summaries.append(message)
-        first_conversation_index += 1
-
-    if not leading_summaries:
+    summary_indices = [
+        index
+        for index, message in enumerate(conversation_history)
+        if _is_compressed_summary_message(message)
+    ]
+    if not summary_indices:
         return conversation_history[-limit:]
 
-    preserved = leading_summaries[:limit]
-    remaining = limit - len(preserved)
-    if remaining <= 0:
-        return preserved
+    kept_indices = set(summary_indices[:limit])
+    remaining = limit - len(kept_indices)
+    if remaining > 0:
+        summary_index_set = set(summary_indices)
+        for index in range(len(conversation_history) - 1, -1, -1):
+            if index in summary_index_set:
+                continue
+            kept_indices.add(index)
+            remaining -= 1
+            if remaining <= 0:
+                break
 
-    recent_tail = conversation_history[first_conversation_index:][-remaining:]
-    return preserved + recent_tail
+    return [conversation_history[index] for index in sorted(kept_indices)]
 
 
 def _normalize_chat_content(

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -127,6 +127,8 @@ MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversation
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT = 100
+_COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -164,6 +166,62 @@ def _coerce_request_bool(value: Any, default: bool = False) -> bool:
     if isinstance(value, (int, float)):
         return bool(value)
     return default
+
+
+def _message_text_prefix(content: Any) -> str:
+    if isinstance(content, str):
+        return content[:128]
+    if not isinstance(content, list):
+        return ""
+    parts: List[str] = []
+    for item in content[:4]:
+        if isinstance(item, str):
+            parts.append(item)
+        elif isinstance(item, dict):
+            text = item.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+        if sum(len(part) for part in parts) >= 128:
+            break
+    return "\n".join(parts)[:128]
+
+
+def _is_compressed_summary_message(message: Any) -> bool:
+    if not isinstance(message, dict):
+        return False
+    if message.get(_COMPRESSED_SUMMARY_METADATA_KEY):
+        return True
+    prefix = _message_text_prefix(message.get("content"))
+    return prefix.startswith("[CONTEXT COMPACTION") or prefix.startswith("[CONTEXT SUMMARY]:")
+
+
+def _auto_truncate_response_history(
+    conversation_history: List[Dict[str, Any]],
+    *,
+    limit: int = RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT,
+) -> List[Dict[str, Any]]:
+    """Keep recent Responses history without dropping the compaction handoff."""
+    if limit <= 0 or len(conversation_history) <= limit:
+        return conversation_history
+
+    leading_summaries: List[Dict[str, Any]] = []
+    first_conversation_index = 0
+    for message in conversation_history:
+        if not _is_compressed_summary_message(message):
+            break
+        leading_summaries.append(message)
+        first_conversation_index += 1
+
+    if not leading_summaries:
+        return conversation_history[-limit:]
+
+    preserved = leading_summaries[:limit]
+    remaining = limit - len(preserved)
+    if remaining <= 0:
+        return preserved
+
+    recent_tail = conversation_history[first_conversation_index:][-remaining:]
+    return preserved + recent_tail
 
 
 def _normalize_chat_content(
@@ -3898,8 +3956,8 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response(_openai_error("No user message found in input"), status=400)
 
         # Truncation support
-        if body.get("truncation") == "auto" and len(conversation_history) > 100:
-            conversation_history = conversation_history[-100:]
+        if body.get("truncation") == "auto":
+            conversation_history = _auto_truncate_response_history(conversation_history)
 
         # Reuse session from previous_response_id chain so the dashboard
         # groups the entire conversation under one session entry.

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3270,6 +3270,48 @@ class TestTruncation:
         call_kwargs = mock_run.call_args.kwargs
         # History should be truncated to 100
         assert len(call_kwargs["conversation_history"]) <= 100
+        assert call_kwargs["conversation_history"][0]["content"] == "msg 50"
+
+    @pytest.mark.asyncio
+    async def test_truncation_auto_preserves_leading_compaction_summary(self, adapter):
+        """truncation=auto must not discard the compacted-history handoff."""
+        mock_result = {"final_response": "OK", "messages": [], "api_calls": 1}
+
+        summary = {
+            "role": "user",
+            "content": "[CONTEXT COMPACTION — REFERENCE ONLY]\nEarlier work.",
+            "_compressed_summary": True,
+        }
+        long_history = [summary] + [
+            {"role": "user", "content": f"msg {i}"}
+            for i in range(149)
+        ]
+        adapter._response_store.put("resp_summary", {
+            "response": {"id": "resp_summary", "object": "response"},
+            "conversation_history": long_history,
+            "instructions": None,
+        })
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "follow up",
+                        "previous_response_id": "resp_summary",
+                        "truncation": "auto",
+                    },
+                )
+
+        assert resp.status == 200
+        history = mock_run.call_args.kwargs["conversation_history"]
+        assert len(history) == 100
+        assert history[0] == summary
+        assert history[1]["content"] == "msg 50"
+        assert history[-1]["content"] == "msg 148"
 
     @pytest.mark.asyncio
     async def test_no_truncation_keeps_full_history(self, adapter):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3314,6 +3314,53 @@ class TestTruncation:
         assert history[-1]["content"] == "msg 148"
 
     @pytest.mark.asyncio
+    async def test_truncation_auto_preserves_non_leading_compaction_summary(self, adapter):
+        """A summary sitting after a retained system head must survive too.
+
+        The gateway /compress path can force a user-leading layout that
+        leaves the compaction summary after a kept system message, so the
+        preservation predicate must not assume the summary is at index 0.
+        """
+        mock_result = {"final_response": "OK", "messages": [], "api_calls": 1}
+
+        system_head = {"role": "system", "content": "You are a helpful agent."}
+        summary = {
+            "role": "user",
+            "content": "[CONTEXT COMPACTION — REFERENCE ONLY]\nEarlier work.",
+            "_compressed_summary": True,
+        }
+        long_history = [system_head, summary] + [
+            {"role": "user", "content": f"msg {i}"}
+            for i in range(148)
+        ]
+        adapter._response_store.put("resp_summary_mid", {
+            "response": {"id": "resp_summary_mid", "object": "response"},
+            "conversation_history": long_history,
+            "instructions": None,
+        })
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "follow up",
+                        "previous_response_id": "resp_summary_mid",
+                        "truncation": "auto",
+                    },
+                )
+
+        assert resp.status == 200
+        history = mock_run.call_args.kwargs["conversation_history"]
+        assert len(history) == 100
+        assert history[0] == summary
+        assert history[1]["content"] == "msg 49"
+        assert history[-1]["content"] == "msg 147"
+
+    @pytest.mark.asyncio
     async def test_no_truncation_keeps_full_history(self, adapter):
         """Without truncation=auto, long history is passed as-is."""
         mock_result = {"final_response": "OK", "messages": [], "api_calls": 1}


### PR DESCRIPTION
## Summary
`truncation: "auto"` on `/v1/responses` no longer discards the compaction summary when trimming long conversation history. The old code blindly sliced `conversation_history[-100:]`, dropping the `[CONTEXT COMPACTION — REFERENCE ONLY]` handoff message that carries all compressed prior context.

## Changes
- `gateway/platforms/api_server.py`: replaced the blind `[-100:]` slice with `_auto_truncate_response_history()` — preserves messages carrying the `_compressed_summary` metadata key or `[CONTEXT COMPACTION` / legacy `[CONTEXT SUMMARY]:` prefixes (string or list content), filling the remaining budget with the most recent other messages.
- Follow-up: summaries are preserved at **any** history position, not just a leading block — the gateway /compress path can force a user-leading layout that leaves the summary after a retained system head.
- `tests/gateway/test_api_server.py`: leading-summary preservation test (from the PR) + new non-leading-position test.

## Validation
| | Before | After |
|---|---|---|
| Summary at index 0, history > 100 | summary dropped by `[-100:]` slice | summary kept + 99 most recent messages |
| Summary after retained system head | dropped (even with the leading-block scan) | kept wherever it sits |

Targeted tests: `scripts/run_tests.sh tests/gateway/test_api_server*.py -k 'truncat or compact'` → 7 passed, 0 failed; full `TestTruncation` class → 4 passed.

## Credit
Salvaged from #55225 by @ooiuuii (first submitter, also reported #55224). The same bug was independently fixed in #55238 by @alaamohanad169-ship-it. Fixes #55224.

## Infographic
![responses-truncation-preserves-summaries](https://v3b.fal.media/files/b/0aa34464/Xi9hjEVbjspnpXjYAOYjt_xnBn6C9b.png)
