### PR TITLE
fix(secrets): report Bitwarden override_existing default as True in CLI status/preview

### DIFF
--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -338,7 +338,7 @@ def cmd_status(args: argparse.Namespace) -> int:
         "Server URL",
         server_url or "[dim]default (US Cloud, https://vault.bitwarden.com)[/dim]",
     )
-    table.add_row("Override existing", _yn(bool(bw_cfg.get("override_existing", False))))
+    table.add_row("Override existing", _yn(bool(bw_cfg.get("override_existing", True))))
     table.add_row("Cache TTL (s)",   str(bw_cfg.get("cache_ttl_seconds", 300)))
     table.add_row("Auto-install",    _yn(bool(bw_cfg.get("auto_install", True))))
 
@@ -486,7 +486,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
         console.print("[yellow]No secrets in project.[/yellow]")
         return 0
 
-    override = bool(bw_cfg.get("override_existing", False)) or args.apply
+    override = bool(bw_cfg.get("override_existing", True)) or args.apply
     table = Table(show_header=True, header_style="bold")
     table.add_column("Name", style="cyan")
     table.add_column("Action")

--- a/tests/hermes_cli/test_bitwarden_status.py
+++ b/tests/hermes_cli/test_bitwarden_status.py
@@ -108,3 +108,45 @@ def test_status_marks_validation_as_not_checked_without_bws_binary(monkeypatch, 
     assert "Token validation" in out
     assert "not checked" in out
     assert "bws not installed" in out
+
+
+def _override_existing_row(out: str) -> str:
+    for line in out.splitlines():
+        if "Override existing" in line:
+            return line
+    raise AssertionError(f"'Override existing' row not found in status output:\n{out}")
+
+
+def test_status_reports_override_existing_default_true_when_key_absent(monkeypatch, capsys):
+    """A config block that omits ``override_existing`` must display the same
+    default the runtime uses (``True``), not ``False``.
+
+    ``BitwardenSource.override_existing({})`` — the path the startup
+    orchestrator actually calls — resolves an absent key to ``True`` (see
+    ``agent/secret_sources/bitwarden.py`` and DEFAULT_CONFIG). The status
+    readout previously defaulted to ``False``, so it told users
+    "Override existing  no" while Bitwarden really did override at startup.
+    """
+    from agent.secret_sources.bitwarden import BitwardenSource
+    from hermes_cli import secrets_cli
+
+    # Sanity-anchor to the authoritative runtime resolver.
+    assert BitwardenSource().override_existing({}) is True
+
+    config = _bitwarden_config()
+    # Drop the explicit key so the CLI must fall back to its default.
+    config["secrets"]["bitwarden"].pop("override_existing")
+
+    monkeypatch.setattr(secrets_cli, "load_config", lambda: config)
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.token-present")
+    monkeypatch.setattr(
+        secrets_cli.bw,
+        "find_bws",
+        lambda install_if_missing=False: None,
+    )
+
+    assert secrets_cli.cmd_status(Namespace()) == 0
+
+    row = _override_existing_row(capsys.readouterr().out)
+    assert "yes" in row
+    assert "no" not in row


### PR DESCRIPTION
## What does this PR do?

The `hermes secrets bitwarden status` readout and the `hermes secrets bitwarden sync` dry-run preview default `secrets.bitwarden.override_existing` to **`False`** when the key is absent from config. The authoritative runtime default is **`True`**, so when a user's config omits the key the CLI flatly misreports what Hermes actually does at startup.

This matches the Bitwarden CLI to its already-correct **1Password sibling**: `hermes_cli/onepassword_secrets_cli.py` defaults every `override_existing` read-site to `True` (lines 184/219/396/431). The Bitwarden CLI had drifted to `False` in two display/preview sites.

**Source of truth for the `True` default:**
- `agent/secret_sources/bitwarden.py` — `BitwardenSource.override_existing(cfg)` returns `cfg.get("override_existing", True)` ("Default True (matches DEFAULT_CONFIG)"). This is the path the startup orchestrator calls via the secret-source registry.
- `hermes_cli/config.py` — `DEFAULT_CONFIG` ships `override_existing: True`.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/secrets_cli.py` (`cmd_status`) — default the "Override existing" row to `True` so status matches the runtime resolver.
- `hermes_cli/secrets_cli.py` (`cmd_sync`) — default the sync dry-run `override` computation to `True` so the preview labels keys correctly.
- `tests/hermes_cli/test_bitwarden_status.py` — regression test: with a `secrets.bitwarden` block that omits `override_existing`, status must display `yes`, anchored to `BitwardenSource().override_existing({}) is True`.

## How to Test

1. Write a config with a `secrets.bitwarden` block that omits `override_existing` (e.g. a hand-edited or migrated config).
2. Run `hermes secrets bitwarden status`.
   - Before: `Override existing   no` (contradicts real startup behavior).
   - After: `Override existing   yes` (matches `BitwardenSource.override_existing`).
3. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_bitwarden_status.py -v` — 4 passed.
4. Regression direction verified: reverting the production default to `False` fails the new test (`assert 'yes' in 'Override existing    no'`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new keys; aligns display default with existing DEFAULT_CONFIG)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python display default; platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A