### PR TITLE
fix(tools): normalize MSYS bash nul redirection to /dev/null on Windows

### DIFF
--- a/tests/tools/test_msys_nul_sanitizer.py
+++ b/tests/tools/test_msys_nul_sanitizer.py
@@ -1,0 +1,25 @@
+import pytest
+from tools.environments.local import _sanitize_msys_nul_redirection
+
+def test_sanitize_nul_stderr_redirection():
+    cmd = "uv pip list 2>nul || python -m pip list 2>nul || true"
+    expected = "uv pip list 2>/dev/null || python -m pip list 2>/dev/null || true"
+    assert _sanitize_msys_nul_redirection(cmd) == expected
+
+def test_sanitize_nul_stdout_redirection():
+    cmd = "taskkill /f /im hermes.exe >nul 2>&1"
+    expected = "taskkill /f /im hermes.exe >/dev/null 2>&1"
+    assert _sanitize_msys_nul_redirection(cmd) == expected
+
+def test_sanitize_nul_with_spaces():
+    cmd = "timeout /t 1 /nobreak > nul"
+    expected = "timeout /t 1 /nobreak > /dev/null"
+    assert _sanitize_msys_nul_redirection(cmd) == expected
+
+def test_preserve_normal_file_or_param():
+    cmd = "python script.py --param nul > log.txt"
+    assert _sanitize_msys_nul_redirection(cmd) == cmd
+
+def test_preserve_cat_command():
+    cmd = "cat nul_data.json"
+    assert _sanitize_msys_nul_redirection(cmd) == cmd

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -136,6 +136,24 @@ def _quote_bash_path(path: str) -> str:
     return shlex.quote(_bash_safe_path(path))
 
 
+def _sanitize_msys_nul_redirection(cmd: str) -> str:
+    """Normalize Windows CMD-style redirection to 'nul' / 'NUL' in Git Bash / MSYS.
+
+    In Git Bash / MSYS on Windows, writing '2>nul' or '> nul' opens a literal file
+    named './nul' in the process working directory instead of discarding output to
+    the null device. If the working directory lives inside a OneDrive folder, this
+    creates an unsyncable reserved Windows filename ('nul') and triggers OneDrive
+    sync error popups.
+
+    Rewrites redirection tokens '>nul', '2>nul', '> NUL', '2>NUL', '&>nul' to
+    '/dev/null' before handing off to bash.
+    """
+    if not _IS_WINDOWS or not cmd:
+        return cmd
+    pattern = r'([12&]?\s*>\s*)(?:nul|NUL)\b(?!\.)'
+    return re.sub(pattern, r'\1/dev/null', cmd)
+
+
 def _cwd_usable(path: str) -> bool:
     """True when *path* is a directory this process can actually chdir into.
 
@@ -1333,6 +1351,8 @@ class LocalEnvironment(BaseEnvironment):
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
+        if _IS_WINDOWS and cmd_string:
+            cmd_string = _sanitize_msys_nul_redirection(cmd_string)
         bash = _find_bash()
         # For login-shell invocations (used by init_session to build the
         # environment snapshot), prepend sources for the user's bashrc /

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -41,7 +41,12 @@ import time
 import uuid
 
 _IS_WINDOWS = platform.system() == "Windows"
-from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
+from tools.environments.local import (
+    _find_shell,
+    _resolve_safe_cwd,
+    _sanitize_subprocess_env,
+    _sanitize_msys_nul_redirection,
+)
 from hermes_cli._subprocess_compat import windows_hide_flags
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -705,6 +710,9 @@ class ProcessRegistry:
                      CLI tools (Codex, Claude Code, Python REPL). Falls back to
                      subprocess.Popen if ptyprocess is not installed.
         """
+        if _IS_WINDOWS and command:
+            command = _sanitize_msys_nul_redirection(command)
+
         session = ProcessSession(
             id=f"proc_{uuid.uuid4().hex[:12]}",
             command=command,


### PR DESCRIPTION
### Summary
On Windows, executing shell commands containing redirection operators like `2>nul` or `> nul` inside Git Bash / MSYS terminal causes Git Bash to create a literal file named `./nul` in the working directory, rather than sending output to the null device. When the working directory is in a synced location (such as OneDrive), this creates an unsyncable reserved Windows filename (`nul`) and triggers filesystem sync errors.

This PR adds `_sanitize_msys_nul_redirection` to automatically rewrite Windows CMD-style `>nul`, `2>nul`, and `> NUL` redirection tokens to `/dev/null` in MSYS/Git Bash execution before running local or background terminal commands on Windows.

### Verification
Added unit test suite `tests/tools/test_msys_nul_sanitizer.py` verifying that:
1. `uv pip list 2>nul` redirects to `/dev/null`
2. `taskkill /f /im process.exe >nul 2>&1` redirects to `/dev/null`
3. Non-redirection occurrences (such as `python script.py --param nul` or `cat nul_data.json`) remain untouched.