### PR TITLE
fix(agent): mask credential in authorization=Bearer assignments

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -117,8 +117,12 @@ _PREFIX_PATTERNS = [
 # Uppercase keys tolerate spaces around "=" (e.g. ``FOO_SECRET = bar``) because
 # an all-caps key is almost never prose/code.
 _SECRET_ENV_NAMES = r"(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH)"
+# Optional HTTP-auth scheme word (Bearer/Basic/Token/…) before the credential,
+# mirroring _AUTH_HEADER_RE, so ``AUTHORIZATION=Bearer <token>`` captures both
+# tokens — a bare \S+ would mask only "Bearer" and leak the credential.
+_ENV_ASSIGN_VALUE = r"((?:[A-Za-z][\w.+-]*[ \t]+)?\S+)"
 _ENV_ASSIGN_RE = re.compile(
-    rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(['\"]?)(\S+)\2",
+    rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(['\"]?){_ENV_ASSIGN_VALUE}\2",
 )
 
 # Lowercase / dotted / hyphenated config keys from config files
@@ -129,9 +133,11 @@ _ENV_ASSIGN_RE = re.compile(
 # These run only in a config-file context, NOT in prose, code, or URLs — three
 # carve-outs preserved from the original design (#4367 + the documented
 # web-URL passthrough below):
-#   1. The value is bounded by ``[^\s&]`` (stops at whitespace AND ``&``) so
-#      form-urlencoded bodies are handled pair-by-pair (by _redact_form_body),
-#      not greedily swallowed.
+#   1. The value is bounded by ``&`` / EOL. A single optional auth-scheme word
+#      (``Bearer `` / ``Basic `` / …) may precede the credential so
+#      ``authorization=Bearer <token>`` does not mask only the scheme word;
+#      further whitespace still terminates the match so form bodies stay
+#      pair-by-pair (_redact_form_body).
 #   2. _CFG_DOTTED_RE only matches when the key is NAMESPACED (contains a dot),
 #      which is unambiguously a config key — never a prose word.
 #   3. _CFG_ANCHORED_RE matches a bare secret-word key only at line start
@@ -139,7 +145,13 @@ _ENV_ASSIGN_RE = re.compile(
 #      mid-sentence is left alone.
 # The colon-form URL guard (skip when ``://`` present) lives at the call site.
 _SECRET_CFG_NAMES = r"(?:api[ _.\-]?key|token|secret|passwd|password|credential|auth)"
-_CFG_VALUE = r"(['\"]?)([^\s&]+?)\2(?=[\s&]|$)"
+_CFG_VALUE = r"(['\"]?)((?:[A-Za-z][\w.+-]*[ \t]+)?[^\s&]+?)\2(?=[\s&]|$)"
+# Split ``Scheme <credential>`` assignment values so masking preserves the
+# scheme word (same shape as _AUTH_HEADER_RE) instead of head/tail-masking
+# across ``Bearer <token>`` as one blob.
+_AUTH_SCHEME_VALUE_RE = re.compile(
+    r"^([A-Za-z][\w.+-]*)[ \t]+([^\s\"']+)$",
+)
 # Linear pre-gate for the _CFG_*_RE subs below: a text with no secret keyword
 # can never match either pattern, so the (potentially backtrack-heavy) subs
 # are skipped entirely for such text. See the call site in
@@ -207,7 +219,10 @@ _YAML_ASSIGN_RE = re.compile(
 # all-caps key is almost never prose, the same rationale as _ENV_ASSIGN_RE.
 _KEY_KEYWORD_RE = re.compile(
     r"(?:api|auth|access|refresh|session|secret)[ _.\-]?(?:key|token)"
-    r"|token|secret|passwd|password|credential|auth",
+    # ``authorization`` before bare ``auth`` so word-boundary validation
+    # accepts the full HTTP header/form key (``authorization=Bearer …``)
+    # instead of rejecting the embedded ``auth`` prefix mid-word.
+    r"|token|secret|passwd|password|credential|authorization|auth",
     re.IGNORECASE,
 )
 
@@ -471,6 +486,21 @@ def _mask_token(token: str) -> str:
     return mask_secret(token, head=6, tail=4, floor=18)
 
 
+def _mask_assignment_value(value: str) -> str:
+    """Mask a KEY=value credential, preserving an HTTP auth scheme word if present.
+
+    ``authorization=Bearer <token>`` must not treat ``Bearer`` as the whole
+    secret (CFG/ENV value classes historically stopped at the first
+    whitespace-free token). When the value is ``Scheme <credential>``, keep
+    the scheme for debuggability and mask only the credential — matching
+    ``_AUTH_HEADER_RE`` behavior for colon headers.
+    """
+    m = _AUTH_SCHEME_VALUE_RE.match(value)
+    if m:
+        return f"{m.group(1)} {_mask_token(m.group(2))}"
+    return _mask_token(value)
+
+
 def _redact_query_string(query: str) -> str:
     """Redact sensitive parameter values in a URL query string.
 
@@ -714,7 +744,7 @@ def redact_sensitive_text(
                 # embedded matching inside the helper.
                 if not _key_has_secret_keyword(name):
                     return m.group(0)
-                return f"{name}={quote}{_mask_token(value)}{quote}"
+                return f"{name}={quote}{_mask_assignment_value(value)}{quote}"
             text = _ENV_ASSIGN_RE.sub(_redact_env, text)
             # Lowercase/dotted config keys (issue #16413). Skip URLs entirely —
             # web-URL query params are intentionally passed through (see note

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -131,6 +131,48 @@ class TestAuthHeaders:
         text = "the authorization model is fully open"
         assert redact_sensitive_text(text) == text
 
+    def test_authorization_equals_bearer_masks_credential_not_scheme(self):
+        # CFG/ENV assignment path used to stop at the first whitespace-free
+        # token, so ``authorization=Bearer <token>`` masked only "Bearer"
+        # and left the real credential in logs.
+        text = "authorization=Bearer opaqueTokenValue12345&foo=bar"
+        result = redact_sensitive_text(text, force=True)
+        assert "opaqueTokenValue12345" not in result
+        assert "authorization=" in result.lower()
+        assert "Bearer" in result
+        assert "foo=bar" in result
+
+    def test_authorization_equals_bearer_single_pair(self):
+        text = "authorization=Bearer opaqueTokenValue12345"
+        result = redact_sensitive_text(text, force=True)
+        assert "opaqueTokenValue12345" not in result
+        assert "Bearer" in result
+
+    def test_uppercase_authorization_equals_bearer(self):
+        text = "AUTHORIZATION=Bearer OpaqueUpperTokenValue999"
+        result = redact_sensitive_text(text, force=True)
+        assert "OpaqueUpperTokenValue999" not in result
+        assert "Bearer" in result
+
+    def test_authorization_equals_bearer_quoted_preserves_quotes(self):
+        # Quote capture groups in CFG/ENV assignment regexes must keep the
+        # closing quote (same redaction-syntax contract as other quoted paths).
+        text = 'authorization="Bearer opaqueTokenValue12345"'
+        result = redact_sensitive_text(text, force=True)
+        assert "opaqueTokenValue12345" not in result
+        assert "Bearer" in result
+        assert result.count('"') == 2, result
+        assert result.startswith('authorization="')
+        assert result.endswith('"'), result
+
+    def test_uppercase_authorization_equals_bearer_quoted(self):
+        text = "AUTHORIZATION='Bearer OpaqueUpperTokenValue999'"
+        result = redact_sensitive_text(text, force=True)
+        assert "OpaqueUpperTokenValue999" not in result
+        assert "Bearer" in result
+        assert result.count("'") == 2, result
+        assert result.endswith("'"), result
+
     def test_token_flush_against_double_quote_preserves_quote(self):
         # Regression for #43083: a token sitting flush against a closing
         # double quote must NOT pull that quote into the mask. Greedy \S+


### PR DESCRIPTION
## What does this PR do?

`authorization=Bearer <token>` (and uppercase `AUTHORIZATION=...`) was only partially redacted: CFG/ENV assignment regexes stopped at the first whitespace-free token, so only the scheme word `Bearer` was masked and the real credential remained in logs/tool output.

This aligns the `KEY=Scheme <credential>` path with `_AUTH_HEADER_RE`: preserve the scheme word, mask only the credential. Related open PR #54618 covers form-body key wiring (`authorization` / `private_key` into `_SENSITIVE_QUERY_PARAMS`); it does not fix this CFG/ENV whitespace truncation.

## Related Issue

N/A - found via adversarial redaction review (RD-002). Related: #54618 (different gap).

## Type of Change

- [x] Security fix

## Changes Made

- `agent/redact.py`: allow optional HTTP auth scheme in `_ENV_ASSIGN_RE` / `_CFG_VALUE`; add `_mask_assignment_value` to preserve scheme and mask credential
- `tests/agent/test_redact.py`: regression tests for lowercase/uppercase `authorization=Bearer ...` (with and without trailing `&foo=bar`)

## How to Test

1. `scripts/run_tests.sh tests/agent/test_redact.py -q`
2. Manual:
   ```python
   from agent.redact import redact_sensitive_text
   print(redact_sensitive_text("authorization=Bearer opaqueTokenValue12345&foo=bar", force=True))
   # expect: opaqueTokenValue12345 absent; Bearer preserved; foo=bar preserved
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `scripts/run_tests.sh tests/agent/test_redact.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.x

### Documentation & Housekeeping

- [x] No documentation changes needed - N/A
- [x] No config key changes - N/A
- [x] No architecture/workflow doc updates - N/A
- [x] Cross-platform impact considered (pure regex, no OS paths) - N/A
- [x] No tool schema changes - N/A