### PR TITLE
fix(compression): CJK-aware token estimates and stop re-copying stale head summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -31,6 +31,7 @@ from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
     get_model_context_length,
     estimate_messages_tokens_rough,
+    estimate_tokens_rough,
 )
 from agent.redact import redact_sensitive_text
 from agent.turn_context import drop_stale_api_content
@@ -436,11 +437,15 @@ def _estimate_msg_budget_tokens(msg: dict) -> int:
     compaction re-fires continuously (#55572).  Accounting-only: replay
     fields are never mutated or pruned here.
     """
-    content_len = _content_length_for_budget(msg.get("content") or "")
-    tokens = content_len // _CHARS_PER_TOKEN + 10  # +10 for role/key overhead
+    content = msg.get("content") or ""
+    if isinstance(content, str):
+        tokens = estimate_tokens_rough(content) + 10  # +10 for role/key overhead
+    else:
+        content_len = _content_length_for_budget(content)
+        tokens = content_len // _CHARS_PER_TOKEN + 10
     for tc in msg.get("tool_calls") or []:
         if isinstance(tc, dict):
-            tokens += len(str(tc)) // _CHARS_PER_TOKEN
+            tokens += estimate_tokens_rough(str(tc))
     for key in _REPLAY_BUDGET_KEYS:
         tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
     return tokens
@@ -3548,6 +3553,19 @@ This compaction should PRIORITISE preserving all information related to the focu
         # Phase 4: Assemble compressed message list
         compressed = []
         for i in range(compress_start):
+            # If an earlier compaction handoff is in the protected head
+            # (common after resume / in-place compaction), do not carry it
+            # forward verbatim. It has already been rehydrated into
+            # _previous_summary above and _generate_summary() will emit the
+            # updated replacement below. Keeping both makes repeated
+            # compactions accumulate old summaries and prevents the live prompt
+            # from actually shrinking.
+            if (
+                summary_idx is not None
+                and i == summary_idx
+                and self._is_context_summary_content(messages[i].get("content"))
+            ):
+                continue
             msg = _fresh_compaction_message_copy(messages[i])
             if i == 0 and msg.get("role") == "system":
                 existing = msg.get("content")
@@ -3574,7 +3592,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             )
 
         _merge_summary_into_tail = False
-        last_head_role = messages[compress_start - 1].get("role", "user") if compress_start > 0 else "user"
+        last_head_role = compressed[-1].get("role", "user") if compressed else "user"
         first_tail_role = messages[compress_end].get("role", "user") if compress_end < n_messages else "user"
         # When the only protected head message is the system prompt, the
         # summary becomes the first *visible* message in the API request

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2666,16 +2666,39 @@ async def get_model_context_length_async(
     )
 
 
+def _is_cjk_token_dense_char(ch: str) -> bool:
+    code = ord(ch)
+    return (
+        0x1100 <= code <= 0x11FF  # Hangul Jamo
+        or 0x2E80 <= code <= 0x9FFF  # CJK radicals/ideographs
+        or 0xA960 <= code <= 0xA97F  # Hangul Jamo Extended-A
+        or 0xAC00 <= code <= 0xD7AF  # Hangul Syllables
+        or 0xF900 <= code <= 0xFAFF  # CJK compatibility ideographs
+        or 0xFF00 <= code <= 0xFFEF  # Fullwidth forms / halfwidth kana
+    )
+
+
 def estimate_tokens_rough(text: str) -> int:
-    """Rough token estimate (~4 chars/token) for pre-flight checks.
+    """Rough token estimate for pre-flight checks.
 
     Uses ceiling division so short texts (1-3 chars) never estimate as
     0 tokens, which would cause the compressor and pre-flight checks to
     systematically undercount when many short tool results are present.
+    CJK/Hangul/Kana text is much denser than English under common LLM
+    tokenizers, so count those codepoints as roughly one token each instead
+    of applying the English-centric ~4 chars/token rule.
     """
     if not text:
         return 0
-    return (len(text) + 3) // 4
+    text = str(text)
+    dense = 0
+    sparse = 0
+    for ch in text:
+        if _is_cjk_token_dense_char(ch):
+            dense += 1
+        else:
+            sparse += 1
+    return dense + ((sparse + 3) // 4)
 
 
 def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
@@ -2687,12 +2710,12 @@ def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
     estimated at ~250K tokens and trigger premature context compression.
     """
     _IMAGE_TOKEN_COST = 1500
-    total_chars = 0
+    text_tokens = 0
     image_tokens = 0
     for msg in messages:
-        total_chars += _estimate_message_chars(msg)
+        text_tokens += _estimate_message_tokens_without_images(msg)
         image_tokens += _count_image_tokens(msg, _IMAGE_TOKEN_COST)
-    return ((total_chars + 3) // 4) + image_tokens
+    return text_tokens + image_tokens
 
 
 def _count_image_tokens(msg: Dict[str, Any], cost_per_image: int) -> int:
@@ -2754,6 +2777,35 @@ def _estimate_message_chars(msg: Dict[str, Any]) -> int:
     return len(str(shadow))
 
 
+def _estimate_message_tokens_without_images(msg: Dict[str, Any]) -> int:
+    """Token estimate for a message shadow with image payloads stripped."""
+    if not isinstance(msg, dict):
+        return estimate_tokens_rough(str(msg))
+    shadow: Dict[str, Any] = {}
+    for k, v in msg.items():
+        if k == "_anthropic_content_blocks":
+            continue
+        if k == "content":
+            if isinstance(v, list):
+                cleaned = []
+                for part in v:
+                    if isinstance(part, dict):
+                        if part.get("type") in {"image", "image_url", "input_image"}:
+                            cleaned.append({"type": part.get("type"), "image": "[stripped]"})
+                        else:
+                            cleaned.append(part)
+                    else:
+                        cleaned.append(part)
+                shadow[k] = cleaned
+            elif isinstance(v, dict) and v.get("_multimodal"):
+                shadow[k] = v.get("text_summary", "")
+            else:
+                shadow[k] = v
+        else:
+            shadow[k] = v
+    return estimate_tokens_rough(str(shadow))
+
+
 def estimate_request_tokens_rough(
     messages: List[Dict[str, Any]],
     *,
@@ -2770,7 +2822,7 @@ def estimate_request_tokens_rough(
     """
     total = 0
     if system_prompt:
-        total += (len(system_prompt) + 3) // 4
+        total += estimate_tokens_rough(system_prompt)
     if messages:
         total += estimate_messages_tokens_rough(messages)
     if tools:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2678,6 +2678,20 @@ def _is_cjk_token_dense_char(ch: str) -> bool:
     )
 
 
+# Same codepoint ranges as _is_cjk_token_dense_char, as a compiled character
+# class so dense-char counting runs in C (``len(text) - len(re.sub(...))``)
+# instead of a per-char Python loop.  MUST stay in sync with
+# _is_cjk_token_dense_char.
+_CJK_DENSE_RE = re.compile(
+    "[\u1100-\u11ff"  # Hangul Jamo
+    "\u2e80-\u9fff"  # CJK radicals/ideographs
+    "\ua960-\ua97f"  # Hangul Jamo Extended-A
+    "\uac00-\ud7af"  # Hangul Syllables
+    "\uf900-\ufaff"  # CJK compatibility ideographs
+    "\uff00-\uffef]"  # Fullwidth forms / halfwidth kana
+)
+
+
 def estimate_tokens_rough(text: str) -> int:
     """Rough token estimate for pre-flight checks.
 
@@ -2687,17 +2701,25 @@ def estimate_tokens_rough(text: str) -> int:
     CJK/Hangul/Kana text is much denser than English under common LLM
     tokenizers, so count those codepoints as roughly one token each instead
     of applying the English-centric ~4 chars/token rule.
+
+    Perf: this runs on every message in every preflight/compaction walk,
+    including MB-scale tool outputs, so the common all-ASCII case must stay
+    O(1).  ``str.isascii()`` is a flag check on CPython's compact unicode
+    representation (no scan), and the CJK counting itself is a single
+    C-level ``re.findall`` rather than a per-character Python loop.
     """
     if not text:
         return 0
     text = str(text)
-    dense = 0
-    sparse = 0
-    for ch in text:
-        if _is_cjk_token_dense_char(ch):
-            dense += 1
-        else:
-            sparse += 1
+    if text.isascii():
+        # O(1) fast path — ASCII text cannot contain token-dense CJK chars.
+        return (len(text) + 3) // 4
+    dense = len(text) - len(_CJK_DENSE_RE.sub("", text))
+    if not dense:
+        # Non-ASCII but no CJK (accents, Cyrillic, emoji, ...): keep the
+        # classic ~4 chars/token rule.
+        return (len(text) + 3) // 4
+    sparse = len(text) - dense
     return dense + ((sparse + 3) // 4)
 
 

--- a/contributors/emails/miniadmin@skshim-mini.local
+++ b/contributors/emails/miniadmin@skshim-mini.local
@@ -1,0 +1,1 @@
+plainOldCode

--- a/tests/agent/test_cjk_token_estimation.py
+++ b/tests/agent/test_cjk_token_estimation.py
@@ -1,0 +1,50 @@
+from unittest.mock import patch
+
+from agent.context_compressor import ContextCompressor, _estimate_msg_budget_tokens
+from agent.model_metadata import estimate_messages_tokens_rough, estimate_tokens_rough
+
+
+def test_cjk_text_is_not_estimated_as_four_chars_per_token():
+    assert estimate_tokens_rough("a" * 400) == 100
+    assert estimate_tokens_rough("가" * 400) >= 400
+
+
+def test_message_estimate_counts_korean_content_as_token_dense():
+    messages = [{"role": "user", "content": "압축 테스트 " + ("가" * 1000)}]
+
+    assert estimate_messages_tokens_rough(messages) >= 1000
+
+
+def test_compressor_tail_budget_uses_cjk_aware_message_estimate():
+    korean_msg = {"role": "assistant", "content": "가" * 2000}
+    english_msg = {"role": "assistant", "content": "a" * 2000}
+
+    assert _estimate_msg_budget_tokens(korean_msg) > _estimate_msg_budget_tokens(english_msg)
+
+
+def test_cjk_tail_does_not_expand_to_english_char_budget():
+    with patch("agent.context_compressor.get_model_context_length", return_value=65536):
+        compressor = ContextCompressor(
+            "test/model",
+            protect_first_n=3,
+            protect_last_n=20,
+            summary_target_ratio=0.2,
+            quiet_mode=True,
+        )
+
+    messages = [
+        {"role": "user", "content": "head 1"},
+        {"role": "assistant", "content": "head 2"},
+        {"role": "user", "content": "head 3"},
+    ]
+    for idx in range(40):
+        role = "assistant" if idx % 2 else "user"
+        messages.append({"role": role, "content": "가" * 1200})
+
+    compress_start = compressor._align_boundary_forward(
+        messages,
+        compressor._protect_head_size(messages),
+    )
+    compress_end = compressor._find_tail_cut_by_tokens(messages, compress_start)
+
+    assert len(messages) - compress_end < 31

--- a/tests/agent/test_cjk_token_estimation.py
+++ b/tests/agent/test_cjk_token_estimation.py
@@ -1,7 +1,11 @@
 from unittest.mock import patch
 
 from agent.context_compressor import ContextCompressor, _estimate_msg_budget_tokens
-from agent.model_metadata import estimate_messages_tokens_rough, estimate_tokens_rough
+from agent.model_metadata import (
+    _is_cjk_token_dense_char,
+    estimate_messages_tokens_rough,
+    estimate_tokens_rough,
+)
 
 
 def test_cjk_text_is_not_estimated_as_four_chars_per_token():
@@ -48,3 +52,43 @@ def test_cjk_tail_does_not_expand_to_english_char_budget():
     compress_end = compressor._find_tail_cut_by_tokens(messages, compress_start)
 
     assert len(messages) - compress_end < 31
+
+
+def _reference_per_char_estimate(text: str) -> int:
+    """The pre-perf-gate per-character reference implementation."""
+    dense = 0
+    sparse = 0
+    for ch in text:
+        if _is_cjk_token_dense_char(ch):
+            dense += 1
+        else:
+            sparse += 1
+    return dense + ((sparse + 3) // 4)
+
+
+def test_perf_gated_estimator_matches_per_char_reference():
+    samples = [
+        "",
+        "ab",
+        "a" * 400,
+        "가" * 400,
+        "압축 테스트 " + ("가" * 1000),
+        "café résumé naïve",  # non-ASCII, no CJK
+        "hello 안녕 world",
+        "ｱｲｳｴｵ ﾃｽﾄ",  # halfwidth kana (fullwidth-forms block)
+        "漢字とかな交じり文です。",
+        "русский текст",  # Cyrillic — non-ASCII, non-CJK
+    ]
+    for text in samples:
+        assert estimate_tokens_rough(text) == _reference_per_char_estimate(text), repr(text)
+
+
+def test_ascii_fast_path_keeps_classic_four_chars_per_token():
+    # Pure ASCII must be bit-identical to the historical (len+3)//4 rule.
+    for text in ("x", "xyz", "a" * 1000, "tool output\n" * 500):
+        assert estimate_tokens_rough(text) == (len(text) + 3) // 4
+
+
+def test_non_ascii_non_cjk_keeps_classic_rule():
+    text = "café résumé " * 40
+    assert estimate_tokens_rough(text) == (len(text) + 3) // 4

--- a/tests/agent/test_compressor_tool_call_budget.py
+++ b/tests/agent/test_compressor_tool_call_budget.py
@@ -70,8 +70,10 @@ class TestToolCallEnvelopeEstimate:
 
     def test_non_dict_tool_calls_do_not_crash(self):
         msg = {"role": "assistant", "content": "hi", "tool_calls": ["weird", None]}
-        # Non-dict entries are ignored (as before) without raising.
-        assert _estimate_msg_budget_tokens(msg) == len("hi") // _CHARS_PER_TOKEN + 10
+        # Non-dict entries are ignored (as before) without raising. String
+        # content now goes through estimate_tokens_rough (ceiling division),
+        # so 2 chars estimate as 1 token instead of flooring to 0.
+        assert _estimate_msg_budget_tokens(msg) == (len("hi") + 3) // _CHARS_PER_TOKEN + 10
 
 
 @pytest.fixture()

--- a/tests/agent/test_context_compressor_summary_continuity.py
+++ b/tests/agent/test_context_compressor_summary_continuity.py
@@ -89,3 +89,23 @@ def test_handoff_in_protected_head_populates_previous_summary_before_update():
     assert compressor._previous_summary == old_summary
     assert seen_turns
     assert all(old_summary not in str(msg.get("content", "")) for msg in seen_turns)
+
+
+def test_handoff_in_protected_head_is_replaced_not_duplicated():
+    """Re-compaction must replace a protected old handoff with the updated one."""
+    compressor = _compressor()
+    old_summary = "OLD-PROTECTED-HANDOFF unique old summary body"
+
+    with patch("agent.context_compressor.call_llm", return_value=_response("UPDATED summary body")):
+        compressed = compressor.compress(_messages_with_handoff(old_summary))
+
+    summary_messages = [
+        msg
+        for msg in compressed
+        if isinstance(msg, dict)
+        and str(msg.get("content") or "").startswith(SUMMARY_PREFIX)
+    ]
+    assert len(summary_messages) == 1
+    assert "UPDATED summary body" in summary_messages[0]["content"]
+    assert old_summary not in summary_messages[0]["content"]
+    assert old_summary not in "\n".join(str(msg.get("content") or "") for msg in compressed)

--- a/tests/agent/test_context_compressor_summary_continuity.py
+++ b/tests/agent/test_context_compressor_summary_continuity.py
@@ -99,13 +99,16 @@ def test_handoff_in_protected_head_is_replaced_not_duplicated():
     with patch("agent.context_compressor.call_llm", return_value=_response("UPDATED summary body")):
         compressed = compressor.compress(_messages_with_handoff(old_summary))
 
+    # The summary may be emitted standalone or merged into the first tail
+    # message (alternation corner case), so detect it the same way the
+    # compressor does rather than via a startswith(SUMMARY_PREFIX) check.
     summary_messages = [
         msg
         for msg in compressed
         if isinstance(msg, dict)
-        and str(msg.get("content") or "").startswith(SUMMARY_PREFIX)
+        and ContextCompressor._is_context_summary_content(msg.get("content"))
     ]
     assert len(summary_messages) == 1
-    assert "UPDATED summary body" in summary_messages[0]["content"]
-    assert old_summary not in summary_messages[0]["content"]
+    assert "UPDATED summary body" in str(summary_messages[0]["content"])
+    assert old_summary not in str(summary_messages[0]["content"])
     assert old_summary not in "\n".join(str(msg.get("content") or "") for msg in compressed)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -58,9 +58,9 @@ class TestEstimateTokensRough:
         assert long > short
 
     def test_unicode_multibyte(self):
-        """Unicode chars are still 1 Python char each — 4 chars/token holds."""
+        """CJK chars are token-dense: counted ~1 token each, not 4 chars/token."""
         text = "你好世界"  # 4 CJK characters
-        assert estimate_tokens_rough(text) == 1
+        assert estimate_tokens_rough(text) == 4
 
 
 class TestEstimateMessagesTokensRough:


### PR DESCRIPTION
## Summary
Context compression now budgets CJK/Hangul/Kana text at its real token density and stops re-copying a stale handoff summary into the protected head on every re-compaction. Root causes: `estimate_tokens_rough` applied the English-centric `(len+3)//4` rule to CJK text (undercounting ~4x, inflating the protected tail), and the Phase-4 head-copy loop carried an old protected-head handoff forward verbatim while also inserting its updated replacement, so summaries accumulated across compactions and the live prompt never actually shrank.

## Changes
- `agent/model_metadata.py`: `estimate_tokens_rough` counts CJK-dense codepoints (Hangul Jamo/Syllables, CJK ideographs, fullwidth forms/halfwidth kana) as ~1 token each; `estimate_messages_tokens_rough` / `estimate_request_tokens_rough` route through it via a new image-stripping token shadow.
- `agent/model_metadata.py` (salvage addition): **perf gate** — `str.isascii()` O(1) fast path keeps pure-ASCII text bit-identical to the classic `(len+3)//4` rule, and the CJK count runs as a single compiled-regex C pass instead of the PR's per-character Python loop.
- `agent/context_compressor.py`: Phase-4 head assembly skips the old handoff at `summary_idx` (`_is_context_summary_content` guarded) so re-compaction replaces it instead of duplicating it; `last_head_role` now reads from the assembled head. `_estimate_msg_budget_tokens` uses the CJK-aware estimator for string content and tool-call envelopes while preserving the #55572 `_REPLAY_BUDGET_KEYS` replay-field accounting.
- Tests: new `tests/agent/test_cjk_token_estimation.py` (+ salvage parity/fast-path tests against the per-char reference), continuity regression test for the stale-head-summary fix, and two stale expectations updated to the new intended behavior.

Dropped from the original PR: the `compression.hygiene_threshold` gateway knob (scope creep — split out).

### Perf evidence (timeit, 1MB strings)
| Case | (len+3)//4 baseline | PR per-char loop | This PR (gated) |
|---|---|---|---|
| 1MB ASCII | 0.17 µs | ~3.0 s (~2.8×10⁷x) | 0.23 µs (**1.3x**) |
| 1MB Hangul | — | ~2.1 s | ~352 ms |
| 1MB mixed EN/KO | — | — | ~127 ms |

## Validation
| | Before | After |
|---|---|---|
| `estimate_tokens_rough("가"*400)` | 100 | 400 |
| Re-compaction with protected-head handoff | old + new summaries both kept, prompt grows | exactly one (updated) summary survives |
| 1MB ASCII tool-output estimate | 0.17 µs | 0.23 µs (no hot-path regression) |

Targeted tests: `bash scripts/run_tests.sh tests/agent/ -q -k 'estimate or cjk or continuity or head'` → 163 passed, 0 failed; full runs of the 4 touched test files → 144 passed, 0 failed.

## Credit
Salvaged from #52517 by @plainOldCode (gateway hygiene knob split out; estimator perf-gated during salvage).

## Infographic
![cjk-compression-mission-patch](https://v3b.fal.media/files/b/0aa344bb/01yzUX-R2nPSDQ_b0rcqM_c1XqpqRW.png)
