### PR TITLE
feat: runtime footer token display, profile indicator, compression context inheritance

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -392,11 +392,28 @@ def check_compression_model_feasibility(agent: Any) -> None:
         _raw_aux_key = getattr(client, "api_key", "")
         aux_api_key = "" if (callable(_raw_aux_key) and not isinstance(_raw_aux_key, str)) else str(_raw_aux_key or "")
 
+        aux_config_context = getattr(agent, "_aux_compression_context_length_config", None)
+        # When auxiliary.compression is left on auto (provider auto / no model),
+        # it intentionally inherits the live main chat model.  In that case the
+        # compression model's context window is already known: it is the active
+        # context compressor's main-model window.  Reuse it instead of probing
+        # the endpoint again.  Custom OpenAI-compatible proxies often report a
+        # conservative /models default (commonly 256K) even when the active model
+        # was explicitly configured with a larger context_length; probing here
+        # would incorrectly auto-lower the compression threshold and make users
+        # hand-edit auxiliary.compression on every model switch.
+        if (
+            (_aux_cfg_provider in {"", "auto", None})
+            and aux_config_context is None
+            and str(aux_model or "") == str(getattr(agent, "model", "") or "")
+        ):
+            aux_config_context = getattr(agent.context_compressor, "context_length", None)
+
         aux_context = get_model_context_length(
             aux_model,
             base_url=aux_base_url,
             api_key=aux_api_key,
-            config_context_length=getattr(agent, "_aux_compression_context_length_config", None),
+            config_context_length=aux_config_context,
             # Each model must be resolved with its own provider so that
             # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
             # are invoked for the correct client, not inherited from the main model.

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -322,6 +322,13 @@ export function useStatusbarItems({
     () => [
       ...(connectionItem ? [connectionItem] : []),
       {
+        detail: activeGatewayProfile ?? 'default',
+        icon: <Codicon name="account" size="0.75rem" />,
+        id: 'active-profile',
+        title: `Profile: ${activeGatewayProfile ?? 'default'}`,
+        variant: 'text'
+      },
+      {
         className: `w-7 justify-center px-0${commandCenterOpen ? ' bg-accent/55 text-foreground' : ''}`,
         icon: <Command className="size-3.5" />,
         id: 'command-center',
@@ -414,6 +421,7 @@ export function useStatusbarItems({
       }
     ],
     [
+      activeGatewayProfile,
       agentsOpen,
       commandCenterOpen,
       connectionItem,

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -32,6 +32,15 @@ _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
 _SEP = " · "
 
 
+def _format_token_count(n: int) -> str:
+    """Human-readable token count: 85.6K, 1.0M, 325."""
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}K"
+    return str(n)
+
+
 def _home_relative_cwd(cwd: str) -> str:
     """Return *cwd* with ``$HOME`` collapsed to ``~``.  Empty string if unset."""
     if not cwd:
@@ -110,7 +119,14 @@ def format_runtime_footer(
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
-                parts.append(f"{pct}%")
+                parts.append(f"上下文 {pct}%")
+        elif field == "token_usage":
+            if context_tokens >= 0 and context_length and context_length > 0:
+                parts.append(f"token {_format_token_count(context_tokens)} / {_format_token_count(context_length)}")
+        elif field == "remaining_pct":
+            if context_length and context_length > 0 and context_tokens >= 0:
+                remaining = max(0, 100 - round((context_tokens / context_length) * 100))
+                parts.append(f"{remaining}%")
         elif field == "cwd":
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3979,22 +3979,33 @@ def generate_launchd_plist() -> str:
         )
     )
 
-    # Build ProgramArguments array, including --profile when using a named profile
-    prog_args = [
-        f"<string>{python_path}</string>",
-        "<string>-m</string>",
-        "<string>hermes_cli.main</string>",
-    ]
-    if profile_arg:
-        for part in profile_arg.split():
-            prog_args.append(f"<string>{part}</string>")
-    prog_args.extend(
-        [
-            "<string>gateway</string>",
-            "<string>run</string>",
-            "<string>--replace</string>",
+    # Build ProgramArguments array. Prefer the stable readable wrapper when it
+    # exists so macOS Background Items shows `hermes-gateway[-profile]` instead
+    # of a generic `python` entry. Fall back to the raw Python invocation for
+    # installs that have not created the wrapper yet.
+    from hermes_constants import get_default_hermes_root
+
+    suffix = _profile_suffix()
+    wrapper_name = f"hermes-gateway-{suffix}" if suffix else "hermes-gateway"
+    wrapper_path = get_default_hermes_root() / "bin" / wrapper_name
+    if wrapper_path.exists():
+        prog_args = [f"<string>{wrapper_path}</string>"]
+    else:
+        prog_args = [
+            f"<string>{python_path}</string>",
+            "<string>-m</string>",
+            "<string>hermes_cli.main</string>",
         ]
-    )
+        if profile_arg:
+            for part in profile_arg.split():
+                prog_args.append(f"<string>{part}</string>")
+        prog_args.extend(
+            [
+                "<string>gateway</string>",
+                "<string>run</string>",
+                "<string>--replace</string>",
+            ]
+        )
     prog_args_xml = "\n        ".join(prog_args)
 
     return f"""<?xml version="1.0" encoding="UTF-8"?>

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -932,7 +932,12 @@ class EmailAdapter(BasePlatformAdapter):
         # Thread context for reply
         ctx = self._thread_context.get(to_addr, {})
         subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
+        
+        # If body starts with "Cronjob Response: " or "Cronjob Response：", use the task name as subject
+        cron_match = re.match(r'^Cronjob Response[：:]\s*(.+?)\n', body)
+        if cron_match:
+            subject = cron_match.group(1).strip()
+        elif not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
@@ -1046,7 +1051,12 @@ class EmailAdapter(BasePlatformAdapter):
 
         ctx = self._thread_context.get(to_addr, {})
         subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
+
+        # If body starts with "Cronjob Response: ", use the task name as subject
+        cron_match = re.match(r'^Cronjob Response:\s*(.+?)\n', body)
+        if cron_match:
+            subject = cron_match.group(1).strip()
+        elif not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
@@ -1126,7 +1136,12 @@ class EmailAdapter(BasePlatformAdapter):
 
         ctx = self._thread_context.get(to_addr, {})
         subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
+
+        # If body starts with "Cronjob Response: ", use the task name as subject
+        cron_match = re.match(r'^Cronjob Response:\s*(.+?)\n', body)
+        if cron_match:
+            subject = cron_match.group(1).strip()
+        elif not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
@@ -1219,7 +1234,12 @@ async def _standalone_send(
         msg = MIMEText(message, "plain", "utf-8")
         msg["From"] = address
         msg["To"] = chat_id
-        msg["Subject"] = "Hermes Agent"
+        # Use cron job name as subject when the message starts with "Cronjob Response:"
+        subject = "Hermes Agent"
+        cron_match = re.match(r'^Cronjob Response[：:]\s*(.+?)\n', message)
+        if cron_match:
+            subject = cron_match.group(1).strip()
+        msg["Subject"] = subject
         msg["Date"] = formatdate(localtime=True)
 
         server = smtplib.SMTP(smtp_host, smtp_port)

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -207,6 +207,39 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
     )
 
 
+@patch("agent.model_metadata.get_model_context_length", return_value=1_000_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_auto_compression_inherits_main_context_length(mock_get_client, mock_ctx_len):
+    """provider:auto + empty model should inherit the live main model context.
+
+    This prevents custom endpoints from being re-probed as a smaller /models
+    default (for example 256K) after the main model was explicitly configured
+    with a larger context window.
+    """
+    agent = _make_agent(main_context=1_000_000, threshold_percent=0.75)
+    agent.model = "gpt-5.5"
+    agent.provider = "custom"
+    agent.base_url = "http://localhost:8317/v1"
+    agent.api_key = "sk-main"
+    agent._aux_compression_context_length_config = None
+    mock_client = MagicMock()
+    mock_client.base_url = "http://localhost:8317/v1"
+    mock_client.api_key = "sk-main"
+    mock_get_client.return_value = (mock_client, "gpt-5.5")
+
+    agent._emit_status = lambda msg: None
+    agent._check_compression_model_feasibility()
+
+    mock_ctx_len.assert_called_once_with(
+        "gpt-5.5",
+        base_url="http://localhost:8317/v1",
+        api_key="sk-main",
+        config_context_length=1_000_000,
+        provider="custom",
+        custom_providers=[],
+    )
+
+
 @patch("agent.model_metadata.get_model_context_length", return_value=128_000)
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_ctx_len):


### PR DESCRIPTION
## Summary

Five small improvements bundled together:

### 1. Runtime footer: token usage display (`gateway/runtime_footer.py`)
- Add `token_usage` and `remaining_pct` fields with human-readable formatting (85.6K / 1.0M)
- Label `context_pct` as "上下文" for clarity

### 2. Desktop statusbar: active profile indicator (`use-statusbar-items.tsx`)
- Show the active gateway profile name in the status bar so users know which profile they are in

### 3. Compression: inherit main model context on auto (`conversation_compression.py`)
- When `auxiliary.compression` is on auto (provider auto, no explicit model), inherit the live main model `context_length` instead of re-probing the endpoint
- Custom OpenAI-compatible proxies often report a conservative `/models` default (e.g. 256K) even when the model was explicitly configured with a larger context, causing the compression threshold to be incorrectly lowered

### 4. Email adapter: cron job name as subject (`email/adapter.py`)
- When the message body starts with "Cronjob Response:", use the task name as the email subject instead of a generic "Re: ..." or "Hermes Agent"

### 5. Launchd plist: use wrapper script (`hermes_cli/gateway.py`)
- Prefer the `hermes-gateway` wrapper script in the launchd plist when it exists, so macOS Background Items shows a readable name instead of generic `python`

## Tests
- `test_auto_compression_inherits_main_context_length` — verifies that auto provider inherits the main model context_length
- All 18 tests in `test_compression_feasibility.py` pass