### PR TITLE
fix(gateway): follow async delegation completions across compression

### DIFF
--- a/contributors/emails/zkgit.substance129@passmail.com
+++ b/contributors/emails/zkgit.substance129@passmail.com
@@ -1,0 +1,1 @@
+richkapp

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17201,6 +17201,59 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return (evt_type, producer_id, started_at)
         return None
 
+    async def _classify_completion_target(self, parent_session_id: str) -> str:
+        """Classify an async-completion delivery target before adapter acceptance.
+
+        Returns one of:
+
+        - ``"deliver"`` — the spawning session is live, or ended by a
+          compression rotation with a verified live continuation. The inner
+          #55578 resolver (:meth:`_resolve_async_delegation_session`) still
+          owns the actual route retarget; this pre-flight only proves the
+          completion is deliverable so the durable ack stays honest.
+        - ``"terminal"`` — the spawning session is gone for good (unknown, or
+          ended at an explicit user boundary such as /new). Delivery can never
+          succeed; the durable row should be terminally dropped rather than
+          falsely acknowledged as delivered or replayed forever as pending.
+        - ``"retry"`` — transient uncertainty (session DB unavailable, lookup
+          error, or a compression rotation caught mid-flight before its
+          continuation exists). The claim should be released so a later
+          consumer can retry; the attempt cap bounds the churn.
+        """
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None:
+            return "retry"
+        try:
+            parent = await session_db.get_session(parent_session_id)
+        except Exception:
+            logger.debug(
+                "Async-completion pre-flight parent lookup failed for %s",
+                parent_session_id, exc_info=True,
+            )
+            return "retry"
+        if parent is None:
+            return "terminal"
+        if not parent.get("ended_at"):
+            return "deliver"
+        if parent.get("end_reason") != "compression":
+            return "terminal"
+        try:
+            tip_session_id = await session_db.get_compression_tip(parent_session_id)
+            if not tip_session_id or tip_session_id == parent_session_id:
+                # Rotation caught mid-flight: parent is compression-ended but
+                # its continuation isn't visible yet. Retry, don't drop.
+                return "retry"
+            tip = await session_db.get_session(tip_session_id)
+        except Exception:
+            logger.debug(
+                "Async-completion pre-flight tip lookup failed for %s",
+                parent_session_id, exc_info=True,
+            )
+            return "retry"
+        if tip is None or tip.get("ended_at"):
+            return "retry"
+        return "deliver"
+
     async def _deliver_completion_notification(
         self, synth_text: str, evt: dict,
     ) -> Optional[bool]:
@@ -17231,6 +17284,49 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "Could not claim durable async completion %s: %s",
                         durable_delegation_id, exc,
                     )
+                    return False
+            parent_session_id = str(evt.get("parent_session_id") or "").strip()
+            if parent_session_id:
+                # Pre-flight (#65838-class): adapter acceptance is NOT proof of
+                # delivery — the inner #55578 resolver can still fail closed
+                # inside the message pipeline AFTER the adapter accepted, which
+                # would falsely acknowledge the durable row as delivered.
+                # Verify the target here, before acceptance, and give drops an
+                # honest durable disposition.
+                verdict = await self._classify_completion_target(parent_session_id)
+                if verdict == "terminal":
+                    logger.warning(
+                        "Async delegation %s targets permanently-gone session %s; "
+                        "terminally dropping delivery (result remains in the "
+                        "delegation records).",
+                        durable_delegation_id or "<legacy>", parent_session_id,
+                    )
+                    if durable_claim_id:
+                        try:
+                            from tools.async_delegation import drop_completion_delivery
+
+                            drop_completion_delivery(
+                                durable_delegation_id, durable_claim_id,
+                            )
+                        except Exception:
+                            logger.debug(
+                                "Could not drop durable completion claim",
+                                exc_info=True,
+                            )
+                    return None
+                if verdict == "retry":
+                    if durable_claim_id:
+                        try:
+                            from tools.async_delegation import release_completion_delivery
+
+                            release_completion_delivery(
+                                durable_delegation_id, durable_claim_id,
+                            )
+                        except Exception:
+                            logger.debug(
+                                "Could not release durable completion claim",
+                                exc_info=True,
+                            )
                     return False
         if identity is not None:
             with self._completion_delivery_lock:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -44,7 +44,7 @@ from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
-from typing import Awaitable, Callable, Dict, Optional, Any, List, Union
+from typing import Awaitable, Callable, Dict, Optional, Any, List, Union, cast
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
 # /usage; we still import it at module top in the gateway because test
@@ -1912,6 +1912,7 @@ from gateway.config import (
 )
 from gateway.session import (
     AsyncSessionStore,
+    SessionEntry,
     SessionStore,
     SessionSource,
     SessionContext,
@@ -10065,6 +10066,156 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         await adapter.send(source.chat_id, content, metadata=metadata)
 
+    async def _resolve_async_delegation_session(
+        self,
+        session_entry: SessionEntry,
+        pinned_session_id: str,
+    ) -> Optional[SessionEntry]:
+        """Resolve an async completion to its verified owning gateway session.
+
+        A compression rotation ends the physical parent row while continuing
+        the same logical conversation in a child.  Follow that lineage, but
+        never let a late completion override an unrelated /new or restored
+        route.  Unknown ownership remains fail-closed; the result is still
+        available in the delegation records.
+        """
+        session_db = cast(Any, self._session_db)
+        if session_db is None:
+            logger.warning(
+                "Async-delegation completion has no session database; "
+                "dropping injection (#55578 fail-closed)."
+            )
+            return None
+
+        pinned_row = None
+        try:
+            pinned_row = await session_db.get_session(pinned_session_id)
+        except Exception:
+            logger.debug(
+                "Async-delegation parent lookup failed for %s",
+                pinned_session_id,
+                exc_info=True,
+            )
+
+        if pinned_row is None:
+            logger.warning(
+                "Async-delegation completion has unknown spawning session %s; "
+                "dropping injection (#55578 fail-closed).",
+                pinned_session_id,
+            )
+            return None
+
+        target_session_id = pinned_session_id
+        follows_compression = False
+        if pinned_row.get("ended_at"):
+            if pinned_row.get("end_reason") != "compression":
+                logger.warning(
+                    "Async-delegation completion pinned to ended session %s "
+                    "(end_reason=%r); dropping injection instead of resurrecting it "
+                    "(#55578 fail-closed).",
+                    pinned_session_id,
+                    pinned_row.get("end_reason"),
+                )
+                return None
+
+            follows_compression = True
+            try:
+                target_session_id = await session_db.get_compression_tip(
+                    pinned_session_id
+                )
+            except Exception:
+                logger.debug(
+                    "Async-delegation compression-tip lookup failed for %s",
+                    pinned_session_id,
+                    exc_info=True,
+                )
+                target_session_id = None
+
+            if not target_session_id or target_session_id == pinned_session_id:
+                logger.warning(
+                    "Async-delegation completion pinned to compressed session %s "
+                    "without a continuation; dropping injection.",
+                    pinned_session_id,
+                )
+                return None
+
+            try:
+                tip_row = await session_db.get_session(target_session_id)
+            except Exception:
+                tip_row = None
+            if tip_row is None or tip_row.get("ended_at"):
+                logger.warning(
+                    "Async-delegation compression continuation %s is %s; "
+                    "dropping injection.",
+                    target_session_id,
+                    "unknown" if tip_row is None else "ended",
+                )
+                return None
+
+            route_owns_lineage = session_entry.session_id in {
+                pinned_session_id,
+                target_session_id,
+            }
+            if not route_owns_lineage:
+                # A long-running delegation may survive multiple compression
+                # rotations.  Accept an intermediate stale route only when its
+                # own verified compression tip is the same live target.
+                try:
+                    route_row = await session_db.get_session(session_entry.session_id)
+                    route_tip = (
+                        await session_db.get_compression_tip(session_entry.session_id)
+                        if route_row is not None
+                        and route_row.get("ended_at")
+                        and route_row.get("end_reason") == "compression"
+                        else None
+                    )
+                except Exception:
+                    route_tip = None
+                route_owns_lineage = route_tip == target_session_id
+
+            if not route_owns_lineage:
+                logger.warning(
+                    "Async-delegation completion for compression lineage %s -> %s "
+                    "does not own current route %s; dropping injection.",
+                    pinned_session_id,
+                    target_session_id,
+                    session_entry.session_id,
+                )
+                return None
+
+        if target_session_id == session_entry.session_id:
+            return session_entry
+
+        prior_session_id = session_entry.session_id
+        if follows_compression:
+            switched = await self.async_session_store.advance_compression_session(
+                session_entry.session_key,
+                prior_session_id,
+                target_session_id,
+            )
+        else:
+            switched = await self.async_session_store.switch_session(
+                session_entry.session_key,
+                target_session_id,
+            )
+        if switched is None:
+            logger.warning(
+                "Async-delegation completion could not bind routing key %s to "
+                "owning session %s; dropping injection.",
+                session_entry.session_key,
+                target_session_id,
+            )
+            return None
+
+        logger.info(
+            "Pinned async-delegation completion to owning session %s "
+            "(was %s) for routing key %s (#57498)",
+            target_session_id,
+            prior_session_id,
+            session_entry.session_key,
+        )
+        return switched
+
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
         Handle an incoming message from any platform.
@@ -12123,43 +12274,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         pinned_session_id = str(
             (getattr(event, "metadata", None) or {}).get("gateway_session_id") or ""
         ).strip()
-        if pinned_session_id and pinned_session_id != session_entry.session_id:
-            # Fail closed (#55578): the spawning session may have ENDED since
-            # dispatch (user /new-reset, compression rotation whose parent was
-            # closed). switch_session() re-opens ended sessions, so pinning
-            # blindly would RESURRECT a conversation the user explicitly
-            # ended and inject into it — the same illicit-revival class as
-            # the ws_orphan_reap loop (#60609). A completion whose spawning
-            # session is dead is dropped from injection; the subagent's
-            # output remains in the delegation records.
-            pinned_row = None
-            try:
-                if self._session_db is not None:
-                    # AsyncSessionDB already offloads to a thread.
-                    pinned_row = await self._session_db.get_session(pinned_session_id)
-            except Exception:
-                pinned_row = None
-            if pinned_row is None or pinned_row.get("ended_at"):
-                logger.warning(
-                    "Async-delegation completion pinned to session %s, which is "
-                    "%s — dropping injection instead of resurrecting it "
-                    "(#55578 fail-closed; result remains in the delegation "
-                    "records).",
-                    pinned_session_id,
-                    "unknown" if pinned_row is None else "ended",
-                )
+        if pinned_session_id:
+            resolved_entry = await self._resolve_async_delegation_session(
+                session_entry,
+                pinned_session_id,
+            )
+            if resolved_entry is None:
                 return
-            prior_session_id = session_entry.session_id
-            switched = await self.async_session_store.switch_session(session_key, pinned_session_id)
-            if switched is not None:
-                session_entry = switched
-                logger.info(
-                    "Pinned async-delegation completion to spawning session %s "
-                    "(was %s) for routing key %s (#57498)",
-                    pinned_session_id,
-                    prior_session_id,
-                    session_key,
-                )
+            session_entry = resolved_entry
         self._cache_session_source(session_key, source)
         if await asyncio.to_thread(self._is_telegram_topic_lane, source):
             try:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2401,6 +2401,42 @@ class SessionStore:
 
         return new_entry
 
+    def advance_compression_session(
+        self,
+        session_key: str,
+        expected_session_id: str,
+        target_session_id: str,
+    ) -> Optional[SessionEntry]:
+        """CAS-advance one route along an already-verified compression lineage.
+
+        Unlike ``switch_session``, this does not end or reopen SQLite rows. The
+        compression transaction already owns that lifecycle; this method only
+        repairs the persisted gateway key→session mapping. Returning ``None``
+        means the route moved after the caller's snapshot (for example /new),
+        so the caller must fail closed instead of overwriting the newer route.
+        """
+        if not session_key or not expected_session_id or not target_session_id:
+            return None
+
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return None
+            if entry.session_id == target_session_id:
+                return entry
+            if entry.session_id != expected_session_id:
+                return None
+            if not self._heal_compression_tip_locked(
+                entry,
+                expected_session_id,
+                target_session_id,
+            ):
+                return None
+            entry.updated_at = _now()
+            self._save()
+            return entry
+
     def switch_session(self, session_key: str, target_session_id: str) -> Optional[SessionEntry]:
         """Switch a session key to point at an existing session ID.
 

--- a/tests/gateway/test_async_delegation_session_binding.py
+++ b/tests/gateway/test_async_delegation_session_binding.py
@@ -8,7 +8,6 @@ Three invariants on the messaging-gateway surface, mirroring the TUI rules:
 3. /new interrupts the old conversation's in-flight async delegations.
 """
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -62,61 +61,349 @@ class TestInterruptForSessionByParentId:
 
 
 class TestGatewayPinningFailsClosed:
-    """The gateway injection path must never resurrect an ended session."""
+    """The gateway must follow only verified compression continuations."""
 
-    def _make_runner(self, pinned_row):
+    @staticmethod
+    def _entry(session_id):
+        from datetime import datetime
+
+        from gateway.config import Platform
+        from gateway.session import SessionEntry
+
+        return SessionEntry(
+            session_key="agent:main:telegram:group:-100:4",
+            session_id=session_id,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            platform=Platform.TELEGRAM,
+            chat_type="group",
+        )
+
+    def _make_runner(
+        self,
+        rows,
+        *,
+        compression_tip=None,
+        compression_error=None,
+        switched_entry=None,
+    ):
         from gateway.run import GatewayRunner
+        from gateway.session import AsyncSessionStore
 
         runner = object.__new__(GatewayRunner)
         db = MagicMock()
-        db.get_session = AsyncMock(return_value=pinned_row)
+        db.get_session = AsyncMock(side_effect=lambda session_id: rows.get(session_id))
+        db.get_compression_tip = AsyncMock(
+            return_value=compression_tip,
+            side_effect=compression_error,
+        )
         runner._session_db = db
-
-        entry = MagicMock()
-        entry.session_key = "agent:main:telegram:dm:1"
-        entry.session_id = "sess_current"
         runner.session_store = MagicMock()
-        runner.session_store.get_or_create_session.return_value = entry
-        runner.session_store.switch_session.return_value = entry
-        return runner, entry
+        runner.session_store.switch_session = MagicMock(return_value=switched_entry)
+        runner.session_store.advance_compression_session = MagicMock(
+            return_value=switched_entry
+        )
+        runner._async_session_store = AsyncSessionStore(runner.session_store)
+        return runner
 
-    def _run_pinning_prefix(self, runner, pinned_session_id):
-        """Execute the pinning guard logic exactly as _handle_message does."""
+    @staticmethod
+    def _assert_no_route_change(runner):
+        getattr(runner.session_store, "switch_session").assert_not_called()
+        getattr(
+            runner.session_store, "advance_compression_session"
+        ).assert_not_called()
 
-        async def _go():
-            event = MagicMock()
-            event.metadata = {"gateway_session_id": pinned_session_id}
-            session_entry = runner.session_store.get_or_create_session(MagicMock())
-            pinned = str((getattr(event, "metadata", None) or {}).get("gateway_session_id") or "").strip()
-            if pinned and pinned != session_entry.session_id:
-                pinned_row = None
-                try:
-                    if runner._session_db is not None:
-                        pinned_row = await runner._session_db.get_session(pinned)
-                except Exception:
-                    pinned_row = None
-                if pinned_row is None or pinned_row.get("ended_at"):
-                    return "dropped"
-                switched = runner.session_store.switch_session(session_entry.session_key, pinned)
-                if switched is not None:
-                    return "pinned"
-            return "default"
+    @pytest.mark.asyncio
+    async def test_live_spawning_session_stays_pinned(self):
+        current = self._entry("sess_live")
+        runner = self._make_runner(
+            {"sess_live": {"id": "sess_live", "ended_at": None}}
+        )
 
-        return asyncio.run(_go())
+        resolved = await runner._resolve_async_delegation_session(
+            current, "sess_live"
+        )
 
-    def test_live_spawning_session_pins(self):
-        runner, _ = self._make_runner({"id": "sess_old", "ended_at": None})
-        assert self._run_pinning_prefix(runner, "sess_old") == "pinned"
+        assert resolved is current
+        self._assert_no_route_change(runner)
 
-    def test_ended_spawning_session_drops(self):
-        runner, _ = self._make_runner({"id": "sess_old", "ended_at": "2026-07-08T00:00:00"})
-        assert self._run_pinning_prefix(runner, "sess_old") == "dropped"
-        runner.session_store.switch_session.assert_not_called()
+    @pytest.mark.asyncio
+    async def test_live_spawning_session_rebinds_from_different_route(self):
+        current = self._entry("sess_current")
+        pinned = self._entry("sess_live")
+        runner = self._make_runner(
+            {"sess_live": {"id": "sess_live", "ended_at": None}},
+            switched_entry=pinned,
+        )
 
-    def test_unknown_spawning_session_drops(self):
-        runner, _ = self._make_runner(None)
-        assert self._run_pinning_prefix(runner, "sess_gone") == "dropped"
-        runner.session_store.switch_session.assert_not_called()
+        resolved = await runner._resolve_async_delegation_session(
+            current, "sess_live"
+        )
+
+        assert resolved is pinned
+        getattr(runner.session_store, "switch_session").assert_called_once_with(
+            current.session_key, "sess_live"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_compression_ended_parent_drops(self):
+        current = self._entry("sess_old")
+        runner = self._make_runner(
+            {
+                "sess_old": {
+                    "id": "sess_old",
+                    "ended_at": "2026-07-08T00:00:00",
+                    "end_reason": "session_reset",
+                }
+            }
+        )
+
+        resolved = await runner._resolve_async_delegation_session(
+            current, "sess_old"
+        )
+
+        assert resolved is None
+        self._assert_no_route_change(runner)
+
+    @pytest.mark.asyncio
+    async def test_compression_parent_advances_stale_route_to_live_tip(self):
+        current = self._entry("sess_parent")
+        tip = self._entry("sess_tip")
+        runner = self._make_runner(
+            {
+                "sess_parent": {
+                    "id": "sess_parent",
+                    "ended_at": "2026-07-08T00:00:00",
+                    "end_reason": "compression",
+                },
+                "sess_tip": {
+                    "id": "sess_tip",
+                    "ended_at": None,
+                    "parent_session_id": "sess_parent",
+                },
+            },
+            compression_tip="sess_tip",
+            switched_entry=tip,
+        )
+
+        resolved = await runner._resolve_async_delegation_session(
+            current, "sess_parent"
+        )
+
+        assert resolved is tip
+        getattr(
+            runner.session_store, "advance_compression_session"
+        ).assert_called_once_with(current.session_key, "sess_parent", "sess_tip")
+
+    @pytest.mark.asyncio
+    async def test_compression_cas_losing_to_new_drops(self):
+        current = self._entry("sess_parent")
+        runner = self._make_runner(
+            {
+                "sess_parent": {
+                    "id": "sess_parent",
+                    "ended_at": "2026-07-08T00:00:00",
+                    "end_reason": "compression",
+                },
+                "sess_tip": {
+                    "id": "sess_tip",
+                    "ended_at": None,
+                    "parent_session_id": "sess_parent",
+                },
+            },
+            compression_tip="sess_tip",
+            switched_entry=None,
+        )
+
+        resolved = await runner._resolve_async_delegation_session(
+            current, "sess_parent"
+        )
+
+        assert resolved is None
+        getattr(
+            runner.session_store, "advance_compression_session"
+        ).assert_called_once_with(current.session_key, "sess_parent", "sess_tip")
+
+    @pytest.mark.asyncio
+    async def test_intermediate_compression_route_advances_to_same_live_tip(self):
+        current = self._entry("sess_middle")
+        tip = self._entry("sess_tip")
+        runner = self._make_runner(
+            {
+                "sess_parent": {
+                    "id": "sess_parent",
+                    "ended_at": "2026-07-08T00:00:00",
+                    "end_reason": "compression",
+                },
+                "sess_middle": {
+                    "id": "sess_middle",
+                    "ended_at": "2026-07-08T00:01:00",
+                    "end_reason": "compression",
+                    "parent_session_id": "sess_parent",
+                },
+                "sess_tip": {
+                    "id": "sess_tip",
+                    "ended_at": None,
+                    "parent_session_id": "sess_middle",
+                },
+            },
+            compression_tip="sess_tip",
+            switched_entry=tip,
+        )
+
+        resolved = await runner._resolve_async_delegation_session(
+            current, "sess_parent"
+        )
+
+        assert resolved is tip
+        getattr(
+            runner.session_store, "advance_compression_session"
+        ).assert_called_once_with(current.session_key, "sess_middle", "sess_tip")
+
+    @pytest.mark.asyncio
+    async def test_compression_parent_follows_real_sessiondb_lineage(self, tmp_path):
+        from gateway.run import GatewayRunner
+        from gateway.session import AsyncSessionStore
+        from hermes_state import AsyncSessionDB, SessionDB
+
+        session_db = SessionDB(db_path=tmp_path / "state.db")
+        session_db.create_session("sess_parent", source="telegram")
+        session_db.end_session("sess_parent", end_reason="compression")
+        session_db.create_session(
+            "sess_tip",
+            source="telegram",
+            parent_session_id="sess_parent",
+        )
+
+        current = self._entry("sess_parent")
+        tip = self._entry("sess_tip")
+        runner = object.__new__(GatewayRunner)
+        runner._session_db = AsyncSessionDB(session_db)
+        runner.session_store = MagicMock()
+        runner.session_store.switch_session = MagicMock(return_value=tip)
+        runner.session_store.advance_compression_session = MagicMock(return_value=tip)
+        runner._async_session_store = AsyncSessionStore(runner.session_store)
+
+        resolved = await runner._resolve_async_delegation_session(
+            current, "sess_parent"
+        )
+
+        assert resolved is tip
+        getattr(
+            runner.session_store, "advance_compression_session"
+        ).assert_called_once_with(current.session_key, "sess_parent", "sess_tip")
+
+    @pytest.mark.asyncio
+    async def test_ended_compression_tip_drops(self):
+        current = self._entry("sess_parent")
+        runner = self._make_runner(
+            {
+                "sess_parent": {
+                    "id": "sess_parent",
+                    "ended_at": "2026-07-08T00:00:00",
+                    "end_reason": "compression",
+                },
+                "sess_tip": {
+                    "id": "sess_tip",
+                    "ended_at": "2026-07-08T00:01:00",
+                    "end_reason": "session_reset",
+                    "parent_session_id": "sess_parent",
+                },
+            },
+            compression_tip="sess_tip",
+        )
+
+        resolved = await runner._resolve_async_delegation_session(
+            current, "sess_parent"
+        )
+
+        assert resolved is None
+        self._assert_no_route_change(runner)
+
+    @pytest.mark.asyncio
+    async def test_compression_lookup_failure_drops(self):
+        current = self._entry("sess_parent")
+        runner = self._make_runner(
+            {
+                "sess_parent": {
+                    "id": "sess_parent",
+                    "ended_at": "2026-07-08T00:00:00",
+                    "end_reason": "compression",
+                }
+            },
+            compression_error=RuntimeError("db unavailable"),
+        )
+
+        resolved = await runner._resolve_async_delegation_session(
+            current, "sess_parent"
+        )
+
+        assert resolved is None
+        self._assert_no_route_change(runner)
+
+    @pytest.mark.asyncio
+    async def test_compression_parent_accepts_already_current_tip(self):
+        current = self._entry("sess_tip")
+        runner = self._make_runner(
+            {
+                "sess_parent": {
+                    "id": "sess_parent",
+                    "ended_at": "2026-07-08T00:00:00",
+                    "end_reason": "compression",
+                },
+                "sess_tip": {
+                    "id": "sess_tip",
+                    "ended_at": None,
+                    "parent_session_id": "sess_parent",
+                },
+            },
+            compression_tip="sess_tip",
+        )
+
+        resolved = await runner._resolve_async_delegation_session(
+            current, "sess_parent"
+        )
+
+        assert resolved is current
+        self._assert_no_route_change(runner)
+
+    @pytest.mark.asyncio
+    async def test_compression_parent_does_not_override_new_route(self):
+        current = self._entry("sess_after_new")
+        runner = self._make_runner(
+            {
+                "sess_parent": {
+                    "id": "sess_parent",
+                    "ended_at": "2026-07-08T00:00:00",
+                    "end_reason": "compression",
+                },
+                "sess_tip": {
+                    "id": "sess_tip",
+                    "ended_at": None,
+                    "parent_session_id": "sess_parent",
+                },
+            },
+            compression_tip="sess_tip",
+        )
+
+        resolved = await runner._resolve_async_delegation_session(
+            current, "sess_parent"
+        )
+
+        assert resolved is None
+        self._assert_no_route_change(runner)
+
+    @pytest.mark.asyncio
+    async def test_unknown_spawning_session_drops(self):
+        current = self._entry("sess_current")
+        runner = self._make_runner({})
+
+        resolved = await runner._resolve_async_delegation_session(
+            current, "sess_gone"
+        )
+
+        assert resolved is None
+        self._assert_no_route_change(runner)
 
 
 class TestResetHandlerInterruptsDelegations:

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -186,6 +186,164 @@ def test_failed_async_injection_is_retried_and_only_success_is_acked(
     assert acknowledgements == ["deleg_duplicate"]
 
 
+def _persist_pending_completion(event):
+    from tools import async_delegation
+
+    async_delegation._persist_dispatch({
+        "delegation_id": event["delegation_id"],
+        "session_key": event["session_key"],
+        "origin_ui_session_id": "",
+        "parent_session_id": event.get("parent_session_id"),
+        "dispatched_at": event["dispatched_at"],
+    })
+    async_delegation._persist_completion(event, {
+        "status": "completed",
+        "summary": event["summary"],
+    })
+
+
+def test_compression_parent_delivery_targets_tip_and_is_acked(
+    monkeypatch, isolated_registry,
+):
+    """A compression-rotated parent with a live tip is deliverable + acked."""
+    from tools import async_delegation
+
+    event = _async_event("deleg_compression")
+    event["parent_session_id"] = "sess_parent"
+    _persist_pending_completion(event)
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    runner._session_db = SimpleNamespace(
+        get_session=AsyncMock(side_effect=lambda session_id: {
+            "sess_parent": {
+                "id": "sess_parent",
+                "ended_at": "2026-07-16T12:00:00",
+                "end_reason": "compression",
+            },
+            "sess_tip": {"id": "sess_tip", "ended_at": None, "end_reason": None},
+        }.get(session_id)),
+        get_compression_tip=AsyncMock(return_value="sess_tip"),
+    )
+
+    assert asyncio.run(
+        runner._deliver_completion_notification("completion", event)
+    ) is True
+
+    adapter.handle_message.assert_awaited_once()
+    durable = async_delegation.get_durable_delegation(event["delegation_id"])
+    assert durable is not None
+    assert durable["delivery_state"] == "delivered"
+
+
+def test_explicit_reset_drop_is_terminal_not_falsely_delivered(
+    monkeypatch, isolated_registry,
+):
+    """An explicit /new boundary drop gets a terminal 'dropped' disposition.
+
+    Not 'delivered' (the ack must stay honest — nothing was injected) and not
+    'pending' (restart recovery would replay a completion that is fail-closed
+    dropped again on every boot).
+    """
+    from tools import async_delegation
+
+    event = _async_event("deleg_explicit_new")
+    event["parent_session_id"] = "sess_reset"
+    _persist_pending_completion(event)
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    runner._session_db = SimpleNamespace(
+        get_session=AsyncMock(return_value={
+            "id": "sess_reset",
+            "ended_at": "2026-07-16T12:00:00",
+            "end_reason": "session_reset",
+        }),
+        get_compression_tip=AsyncMock(),
+    )
+
+    assert asyncio.run(
+        runner._deliver_completion_notification("completion", event)
+    ) is None
+
+    adapter.handle_message.assert_not_awaited()
+    durable = async_delegation.get_durable_delegation(event["delegation_id"])
+    assert durable is not None
+    assert durable["delivery_state"] == "dropped"
+    restored = queue.Queue()
+    assert async_delegation.restore_undelivered_completions(restored) == 0
+
+
+def test_midflight_compression_rotation_stays_pending_for_retry(
+    monkeypatch, isolated_registry,
+):
+    """A rotation without a visible continuation yet is retryable, not dropped."""
+    from tools import async_delegation
+
+    event = _async_event("deleg_midflight")
+    event["parent_session_id"] = "sess_rotating"
+    _persist_pending_completion(event)
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    runner._session_db = SimpleNamespace(
+        get_session=AsyncMock(return_value={
+            "id": "sess_rotating",
+            "ended_at": "2026-07-16T12:00:00",
+            "end_reason": "compression",
+        }),
+        get_compression_tip=AsyncMock(return_value=None),
+    )
+
+    assert asyncio.run(
+        runner._deliver_completion_notification("completion", event)
+    ) is False
+
+    adapter.handle_message.assert_not_awaited()
+    durable = async_delegation.get_durable_delegation(event["delegation_id"])
+    assert durable is not None
+    assert durable["delivery_state"] == "pending"
+    restored = queue.Queue()
+    assert async_delegation.restore_undelivered_completions(restored) == 1
+    assert restored.get_nowait()["delegation_id"] == event["delegation_id"]
+
+
+def test_retry_attempts_are_capped_to_a_terminal_drop(
+    monkeypatch, isolated_registry,
+):
+    """Endless claim/release churn converges to a terminal 'dropped' state."""
+    from tools import async_delegation
+
+    event = _async_event("deleg_attempt_cap")
+    event["parent_session_id"] = "sess_rotating"
+    _persist_pending_completion(event)
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    runner._session_db = SimpleNamespace(
+        get_session=AsyncMock(return_value={
+            "id": "sess_rotating",
+            "ended_at": "2026-07-16T12:00:00",
+            "end_reason": "compression",
+        }),
+        get_compression_tip=AsyncMock(return_value=None),
+    )
+
+    async def _churn():
+        for _ in range(async_delegation._MAX_DELIVERY_ATTEMPTS + 2):
+            await runner._deliver_completion_notification("completion", event)
+
+    asyncio.run(_churn())
+
+    adapter.handle_message.assert_not_awaited()
+    durable = async_delegation.get_durable_delegation(event["delegation_id"])
+    assert durable is not None
+    assert durable["delivery_state"] == "dropped"
+    assert durable["delivery_attempts"] <= async_delegation._MAX_DELIVERY_ATTEMPTS
+    restored = queue.Queue()
+    assert async_delegation.restore_undelivered_completions(restored) == 0
+
+
 def test_distinct_process_incarnations_are_not_deduplicated():
     """Producer spawn time distinguishes a reused process session ID."""
     adapter = SimpleNamespace(handle_message=AsyncMock())

--- a/tests/gateway/test_session_store_runtime_stale_guard.py
+++ b/tests/gateway/test_session_store_runtime_stale_guard.py
@@ -267,3 +267,63 @@ class TestRuntimeStaleGuard:
         db.reopen_session.assert_not_called()
         # A brand-new session row was created.
         db.create_session.assert_called_once()
+
+
+class TestAdvanceCompressionSession:
+    def test_cas_advances_route_without_reopening_rows(self, tmp_path):
+        db = _db_returning({})
+        store = _make_store_with_db(tmp_path, db)
+        source = _source()
+        key = store._generate_session_key(source)
+        original = _make_entry(key, "sid_parent")
+        store._entries[key] = original
+
+        result = store.advance_compression_session(
+            key,
+            "sid_parent",
+            "sid_tip",
+        )
+
+        assert result is not None
+        assert result is original
+        assert result.session_id == "sid_tip"
+        assert store.peek_session_id(key) == "sid_tip"
+        db.end_session.assert_not_called()
+        db.reopen_session.assert_not_called()
+
+    def test_cas_is_idempotent_when_another_caller_already_advanced(self, tmp_path):
+        db = _db_returning({})
+        store = _make_store_with_db(tmp_path, db)
+        source = _source()
+        key = store._generate_session_key(source)
+        current = _make_entry(key, "sid_tip")
+        store._entries[key] = current
+
+        result = store.advance_compression_session(
+            key,
+            "sid_parent",
+            "sid_tip",
+        )
+
+        assert result is current
+        assert store.peek_session_id(key) == "sid_tip"
+        db.end_session.assert_not_called()
+        db.reopen_session.assert_not_called()
+
+    def test_cas_refuses_to_overwrite_route_changed_by_new(self, tmp_path):
+        db = _db_returning({})
+        store = _make_store_with_db(tmp_path, db)
+        source = _source()
+        key = store._generate_session_key(source)
+        store._entries[key] = _make_entry(key, "sid_after_new")
+
+        result = store.advance_compression_session(
+            key,
+            "sid_parent",
+            "sid_tip",
+        )
+
+        assert result is None
+        assert store.peek_session_id(key) == "sid_after_new"
+        db.end_session.assert_not_called()
+        db.reopen_session.assert_not_called()

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -77,6 +77,11 @@ _DEFAULT_MAX_ASYNC_CHILDREN = 3
 _MAX_RETAINED_COMPLETED = 50
 _DURABLE_RETENTION_SECONDS = 7 * 24 * 60 * 60
 _MAX_DURABLE_PENDING = 1000
+# A pending completion whose delivery keeps failing is retried across claim
+# cycles (and across restarts via restore_undelivered_completions). Cap the
+# attempts so an unroutable row converges to a terminal 'dropped' state
+# instead of replaying on every restart forever.
+_MAX_DELIVERY_ATTEMPTS = 8
 _DB_LOCK = threading.Lock()
 
 
@@ -334,14 +339,59 @@ def claim_event_delivery(evt: Dict[str, Any], consumer: str) -> Optional[str]:
 
 
 def release_completion_delivery(delegation_id: str, claim_id: str) -> bool:
-    """Release a failed delivery claim so another consumer may retry."""
+    """Release a failed delivery claim so another consumer may retry.
+
+    Attempts are counted at claim time, so a row that keeps being claimed and
+    released has burned real delivery attempts. Once the budget is exhausted
+    the row converges to a terminal ``dropped`` state instead of returning to
+    ``pending`` — otherwise an undeliverable completion replays on every
+    gateway restart forever (restore_undelivered_completions only restores
+    pending rows).
+    """
+    now = time.time()
     with _DB_LOCK, _connect() as conn:
+        capped = conn.execute(
+            """UPDATE async_delegations SET delivery_state='dropped',
+                      delivery_claim=NULL, delivery_claimed_at=NULL, updated_at=?
+               WHERE delegation_id=? AND delivery_state='pending'
+                 AND delivery_claim=? AND delivery_attempts>=?""",
+            (now, delegation_id, claim_id, _MAX_DELIVERY_ATTEMPTS),
+        )
+        if capped.rowcount == 1:
+            logger.warning(
+                "Async delegation %s exhausted its %d delivery attempts; "
+                "marking terminally dropped (result remains queryable).",
+                delegation_id, _MAX_DELIVERY_ATTEMPTS,
+            )
+            return True
         cur = conn.execute(
             """UPDATE async_delegations SET delivery_claim=NULL,
                       delivery_claimed_at=NULL, updated_at=?
                WHERE delegation_id=? AND delivery_state='pending'
                  AND delivery_claim=?""",
-            (time.time(), delegation_id, claim_id),
+            (now, delegation_id, claim_id),
+        )
+        return cur.rowcount == 1
+
+
+def drop_completion_delivery(delegation_id: str, claim_id: str) -> bool:
+    """Terminally drop a claimed completion that can never be delivered.
+
+    Used when the delivery target is permanently gone — the spawning session
+    ended at an explicit user boundary (/new, reset) rather than a compression
+    rotation. Marking the row ``dropped`` (not ``delivered``) keeps the ack
+    honest, and (not ``pending``) keeps restart recovery from replaying a
+    completion that will be fail-closed dropped again every time.
+    """
+    now = time.time()
+    with _DB_LOCK, _connect() as conn:
+        cur = conn.execute(
+            """UPDATE async_delegations SET delivery_state='dropped',
+                      updated_at=?, delivery_claim=NULL,
+                      delivery_claimed_at=NULL
+               WHERE delegation_id=? AND delivery_state='pending'
+                 AND delivery_claim=?""",
+            (now, delegation_id, claim_id),
         )
         return cur.rowcount == 1
 


### PR DESCRIPTION
## Summary
Async delegation completions now reach the user after a context-compression rotation instead of being silently dropped, and undeliverable completions get an honest durable disposition instead of being falsely marked delivered. Root cause: the #55578 fail-closed pinning guard treated a compression-ended parent session like an explicitly-ended one (dropping the completion without consulting `end_reason`/`get_compression_tip`), while `_deliver_completion_notification` acknowledged the durable row as delivered on mere adapter acceptance — so drops inside the pipeline were unrecoverable.

## Changes
- `gateway/run.py`: new `_resolve_async_delegation_session()` — resolves a pinned parent to its verified live compression tip (live → keep pin; compression-ended → follow `SessionDB.get_compression_tip` to a verified live continuation; anything else fails closed), with a lineage-ownership check so a late completion can never override an unrelated `/new` or restored route; also covers the pinned==current stale-route bypass.
- `gateway/session.py`: new `SessionStore.advance_compression_session()` — CAS route-advance along an already-verified compression lineage; deliberately NOT `switch_session`, whose end/reopen side effects are wrong for a compression heal.
- `gateway/run.py`: pre-flight `_classify_completion_target()` in `_deliver_completion_notification` — deliver / terminal / retry verdict before adapter acceptance, so the durable ack stays honest.
- `tools/async_delegation.py`: new `drop_completion_delivery()` terminal disposition for permanently-gone targets (explicit `/new`-reset boundaries); `release_completion_delivery()` now converges to a terminal `dropped` state after `_MAX_DELIVERY_ATTEMPTS` (8) so an undeliverable row can't replay on every gateway restart forever.
- Tests: 9 resolver scenarios + a real-SessionDB lineage test (`test_async_delegation_session_binding.py`), 3 CAS route-advance tests (`test_session_store_runtime_stale_guard.py`), 4 ack-semantics tests incl. attempt-cap churn (`test_completion_delivery.py`).

## Validation
| | Before | After |
|---|---|---|
| Delegation completes after compression rotation | Completion silently dropped (parent has `ended_at`) | Delivered to the verified live continuation session |
| Fail-closed drop of a claimed durable completion | Falsely marked `delivered` on adapter acceptance | Terminal `dropped` (explicit reset) or `pending` retry with attempt cap |
| Undeliverable completion across restarts | Replayed and re-dropped on every boot | Converges to terminal `dropped` after 8 attempts |

Targeted tests: `tests/gateway/ -k 'delegation or completion or compression'` → 160 passed, 0 failed; async-delegation consumer suites (12 files) → 921 passed, 0 failed.

## Credit
Salvaged from #64530 by @richkapp (first submitter). Ack-semantics hardening adapted from #65838 by @henrynguyeninfo1. Root-cause diagnosis credit: @allenkaplan (#65779, #65780). Also fixes the same bug reported in #65820 by @heyparth1. Fixes #65779.

## Infographic
![delegation-completions-across-compression](https://v3b.fal.media/files/b/0aa3451f/Mm2SSoDCkofWhezZchKky_ZcZJL3ft.png)
