### PR TITLE
fix(review): compress oversized snapshots in memory

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -794,17 +794,22 @@ def _run_review_in_thread(
             # conversation (the review fires every ~10 turns). Leave session
             # finalization to the real owner (CLI close / gateway reset / cron).
             review_agent._end_session_on_close = False
-            # Never let the review fork compress. It shares the parent's
-            # session_id, so if it won a compression race it would rotate the
-            # parent into a NEW child that the gateway never adopts (the fork
-            # is single-lifecycle and dies right after this run_conversation).
-            # The foreground turn would then start from the stale parent and
-            # compress it again, leaving the same parent with two sibling
-            # children (issue #38727). Review also needs full context to
-            # produce a good memory/skill summary — compressing would strip
-            # detail. Both compression triggers in conversation_loop.py gate on
-            # agent.compression_enabled, so this short-circuits both paths.
-            review_agent.compression_enabled = False
+            # Allow the review fork to compact an oversized snapshot before its
+            # first provider call.  Persistence is disabled above, so compaction
+            # remains in-memory and cannot rotate/archive the parent's session.
+            #
+            # AIAgent.__init__ already bound ContextCompressor to the parent's
+            # SessionDB/session_id before we nulled review_agent._session_db.
+            # Detach that hidden binding too: otherwise the review could still
+            # contend for the parent's compression lock or persist compression
+            # cooldown/streak state despite _persist_disabled=True.
+            _review_compressor = getattr(review_agent, "context_compressor", None)
+            _bind_review_compressor = getattr(
+                _review_compressor, "bind_session_state", None
+            )
+            if callable(_bind_review_compressor):
+                _bind_review_compressor(session_db=None, session_id="")
+            setattr(review_agent, "compression_enabled", True)
 
             from model_tools import get_tool_definitions
             from hermes_cli.plugins import (

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -894,17 +894,22 @@ def _run_review_in_thread(
             # conversation (the review fires every ~10 turns). Leave session
             # finalization to the real owner (CLI close / gateway reset / cron).
             review_agent._end_session_on_close = False
-            # Never let the review fork compress. It shares the parent's
-            # session_id, so if it won a compression race it would rotate the
-            # parent into a NEW child that the gateway never adopts (the fork
-            # is single-lifecycle and dies right after this run_conversation).
-            # The foreground turn would then start from the stale parent and
-            # compress it again, leaving the same parent with two sibling
-            # children (issue #38727). Review also needs full context to
-            # produce a good memory/skill summary — compressing would strip
-            # detail. Both compression triggers in conversation_loop.py gate on
-            # agent.compression_enabled, so this short-circuits both paths.
-            review_agent.compression_enabled = False
+            # Allow the review fork to compact an oversized snapshot before its
+            # first provider call.  Persistence is disabled above, so compaction
+            # remains in-memory and cannot rotate/archive the parent's session.
+            #
+            # AIAgent.__init__ already bound ContextCompressor to the parent's
+            # SessionDB/session_id before we nulled review_agent._session_db.
+            # Detach that hidden binding too: otherwise the review could still
+            # contend for the parent's compression lock or persist compression
+            # cooldown/streak state despite _persist_disabled=True.
+            _review_compressor = getattr(review_agent, "context_compressor", None)
+            _bind_review_compressor = getattr(
+                _review_compressor, "bind_session_state", None
+            )
+            if callable(_bind_review_compressor):
+                _bind_review_compressor(session_db=None, session_id="")
+            setattr(review_agent, "compression_enabled", True)
 
             # Register this fork on the PARENT's _active_children (the same
             # list interrupt() fans out to for subagent delegation) and

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -1188,74 +1188,122 @@ def test_real_lock_api_internal_errors_fail_closed_skips_compression(
 
 
 
-def test_review_fork_disables_compression_to_prevent_stale_parent_fork(tmp_path: Path) -> None:
-    """The background-review fork must set ``compression_enabled = False``
-    so it can never compress the parent it shares a session_id with
-    (issue #38727).
+def test_review_fork_compacts_only_its_detached_transcript(tmp_path: Path) -> None:
+    """An oversized review compacts in memory without mutating its parent.
 
-    The per-session compression lock only serialises a SAME-WINDOW concurrent
-    race. It does NOT stop a stale parent from being compressed again in a
-    LATER turn: if ``review_agent`` had won the race, its new child session is
-    never adopted by the gateway (the fork is single-lifecycle and dies right
-    after one ``run_conversation``), so the foreground path would start the
-    next turn from the stale parent and compress it AGAIN — leaving the same
-    parent with two sibling children.
-
-    The fix makes the review fork never trigger compression at all. Both
-    compression trigger sites in ``agent/conversation_loop.py`` gate on
-    ``agent.compression_enabled`` BEFORE calling ``_compress_context``:
-      • preflight (``if agent.compression_enabled and len(messages) > ...``)
-      • mid-loop  (``if agent.compression_enabled and _compressor.should_compress(...)``)
-    so a fork with the flag cleared never reaches the rotation path.
-
-    This test pins the contract at the source: ``_run_review_in_thread``
-    must set ``review_agent.compression_enabled = False`` on the fork it
-    builds. It calls the real worker synchronously with
-    ``AIAgent.run_conversation`` patched (so no LLM call happens) and
-    captures the constructed review agent to assert the flag.
+    Exercise the real background worker and ``run_conversation`` preflight
+    path. The review keeps the parent's session id for prompt-cache parity, but
+    its compressor and persistence are detached before threshold crossing.
     """
     import agent.background_review as br
-
-    captured = {}
-
-    def _fake_run_conversation(self, *_a, **_k):
-        captured["compression_enabled"] = self.compression_enabled
-        captured["session_id"] = self.session_id
-        return {"final_response": "", "messages": []}
-
-    parent_sid = "REVIEW_FORK_FLAG_TEST"
-
-    db = SessionDB(db_path=tmp_path / "state.db")
-    db.create_session(parent_sid, source="discord")
-    parent = _build_agent_with_db(db, parent_sid)
-
-    # The worker does a local ``from run_agent import AIAgent``; patching
-    # the class method covers that import path.
     from run_agent import AIAgent
 
-    with patch.object(AIAgent, "run_conversation", _fake_run_conversation):
-        br._run_review_in_thread(
-            parent,
-            [{"role": "user", "content": "hi"}],
-            "review this conversation",
-        )
+    parent_sid = "REVIEW_FORK_IN_MEMORY_COMPACTION"
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(parent_sid, source="discord")
+    db.append_message(parent_sid, role="user", content="durable parent turn")
+    durable_before = db.get_messages(parent_sid)
+    session_row_before = tuple(
+        db._conn.execute(
+            "SELECT id, parent_session_id, ended_at, end_reason FROM sessions WHERE id = ?",
+            (parent_sid,),
+        ).fetchone()
+    )
+    parent = _build_agent_with_db(db, parent_sid)
+    parent._cached_system_prompt = "stable parent prompt"
 
-    assert captured, (
-        "_run_review_in_thread never reached run_conversation — the spawn path "
-        "changed; update this test to capture the review AIAgent."
-    )
-    assert captured["session_id"] == parent_sid, (
-        "Review fork should inherit the parent's session_id (shared id is the "
-        "whole reason compression must be disabled)."
-    )
-    assert captured["compression_enabled"] is False, (
-        "FIX REGRESSION: background-review fork did NOT disable compression. "
-        "It shares the parent's session_id, so an enabled fork can rotate the "
-        "parent into an orphan child (issue #38727). The trigger gates in "
-        "conversation_loop.py only short-circuit when compression_enabled is "
-        "False — this flag MUST be cleared on the review fork."
-    )
-    db.close()
+    snapshot = [
+        {
+            "role": "user" if i % 2 == 0 else "assistant",
+            "content": f"review turn {i} " + "x" * 200,
+        }
+        for i in range(24)
+    ]
+    captured = {}
+    real_run_conversation = AIAgent.run_conversation
+
+    def _run_threshold_crossing_review(self, *args, **kwargs):
+        self.context_compressor.threshold_tokens = 1
+        self.context_compressor.protect_first_n = 1
+        self.context_compressor.protect_last_n = 1
+        self.context_compressor.compress = MagicMock(
+            return_value=[
+                {"role": "user", "content": "[CONTEXT COMPACTION] review summary"},
+                {"role": "assistant", "content": "summary acknowledged"},
+            ]
+        )
+        self._compression_feasibility_checked = True
+        response = type(
+            "Response",
+            (),
+            {
+                "choices": [
+                    type(
+                        "Choice",
+                        (),
+                        {
+                            "message": type(
+                                "Message",
+                                (),
+                                {
+                                    "content": "review complete",
+                                    "tool_calls": None,
+                                    "reasoning": None,
+                                },
+                            )(),
+                            "finish_reason": "stop",
+                        },
+                    )()
+                ],
+                "model": "test/model",
+                "usage": None,
+            },
+        )()
+        self.platform = "subagent"
+        self._interruptible_api_call = MagicMock(return_value=response)
+
+        result = real_run_conversation(self, *args, **kwargs)
+        outbound = self._interruptible_api_call.call_args.args[0]["messages"]
+        captured.update(
+            compression_calls=self.context_compressor.compress.call_count,
+            outbound=outbound,
+            review_session_id=self.session_id,
+            review_session_db=self._session_db,
+            compressor_session_db=self.context_compressor._session_db,
+            compressor_session_id=self.context_compressor._session_id,
+            result=result,
+        )
+        return result
+
+    try:
+        with patch.object(AIAgent, "run_conversation", _run_threshold_crossing_review):
+            br._run_review_in_thread(parent, snapshot, "review this conversation")
+
+        assert captured["compression_calls"] >= 1
+        outbound_contents = [
+            str(message.get("content", "")) for message in captured["outbound"]
+        ]
+        assert any(
+            "[CONTEXT COMPACTION] review summary" in text for text in outbound_contents
+        )
+        assert not any("review turn 12" in text for text in outbound_contents)
+        assert captured["review_session_id"] == parent_sid
+        assert captured["review_session_db"] is None
+        assert captured["compressor_session_db"] is None
+        assert captured["compressor_session_id"] == ""
+
+        assert parent.session_id == parent_sid
+        assert db.get_messages(parent_sid) == durable_before
+        session_row_after = tuple(
+            db._conn.execute(
+                "SELECT id, parent_session_id, ended_at, end_reason FROM sessions WHERE id = ?",
+                (parent_sid,),
+            ).fetchone()
+        )
+        assert session_row_after == session_row_before
+        assert _count_children(db, parent_sid) == 0
+    finally:
+        db.close()
 
 
 # ── Lease-refresher bounded-failure tolerance (salvage follow-up, #54465) ────

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -73,6 +73,11 @@ def _make_recorder_class(captured=None, record_on_run=()):
     after construction.
     """
 
+    class _Compressor:
+        def bind_session_state(self, *, session_db=None, session_id=""):
+            if captured is not None:
+                captured["compressor_binding"] = (session_db, session_id)
+
     class _Recorder:
         def __init__(self, *args, **kwargs):
             if captured is not None:
@@ -88,6 +93,8 @@ def _make_recorder_class(captured=None, record_on_run=()):
             self.suppress_status_output = None
             self.session_start = None
             self.session_id = None
+            self.context_compressor = _Compressor()
+            self.compression_enabled = None
 
         def run_conversation(self, *args, **kwargs):
             if captured is not None:
@@ -185,6 +192,28 @@ def test_review_fork_pins_session_start_and_session_id():
         "Review fork did not inherit parent's session_id — "
         "system-prompt rebuild paths would diverge."
     )
+
+
+def test_review_fork_enables_only_detached_in_memory_compression():
+    """Review compaction must not retain the parent SessionDB binding."""
+    import run_agent
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    captured = {}
+    _Recorder = _make_recorder_class(
+        captured, record_on_run=("compression_enabled",)
+    )
+
+    with patch.object(run_agent, "AIAgent", _Recorder), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert captured.get("compressor_binding") == (None, "")
+    assert captured.get("compression_enabled") is True
 
 
 def test_review_fork_inherits_parent_toolset_config():

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -86,6 +86,11 @@ def _make_recorder_class(captured=None, record_on_run=()):
     after construction.
     """
 
+    class _Compressor:
+        def bind_session_state(self, *, session_db=None, session_id=""):
+            if captured is not None:
+                captured["compressor_binding"] = (session_db, session_id)
+
     class _Recorder:
         def __init__(self, *args, **kwargs):
             if captured is not None:
@@ -102,6 +107,8 @@ def _make_recorder_class(captured=None, record_on_run=()):
             self.session_start = None
             self.session_id = None
             self.ephemeral_system_prompt = kwargs.get("ephemeral_system_prompt")
+            self.context_compressor = _Compressor()
+            self.compression_enabled = None
 
         def run_conversation(self, *args, **kwargs):
             if captured is not None:
@@ -271,6 +278,54 @@ def test_review_fork_pins_session_start_and_session_id():
     )
 
 
+def test_review_fork_enables_only_detached_in_memory_compression():
+    """Review compaction must not retain the parent SessionDB binding."""
+    import run_agent
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    captured = {}
+    _Recorder = _make_recorder_class(
+        captured, record_on_run=("compression_enabled",)
+    )
+
+    with patch.object(run_agent, "AIAgent", _Recorder), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert captured.get("compressor_binding") == (None, "")
+    assert captured.get("compression_enabled") is True
+
+
+def test_review_fork_inherits_parent_toolset_config():
+    """``tools[]`` byte-stability: fork must inherit parent's toolset config."""
+    import run_agent
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+
+    captured = {}
+    _Recorder = _make_recorder_class(captured)
+
+    with patch.object(run_agent, "AIAgent", _Recorder), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    init_kwargs = captured.get("init_kwargs", {})
+    assert init_kwargs.get("enabled_toolsets") == agent.enabled_toolsets, (
+        f"enabled_toolsets mismatch: {init_kwargs.get('enabled_toolsets')!r} "
+        f"vs expected {agent.enabled_toolsets!r}"
+    )
+    assert init_kwargs.get("disabled_toolsets") == agent.disabled_toolsets, (
+        f"disabled_toolsets mismatch: {init_kwargs.get('disabled_toolsets')!r} "
+        f"vs expected {agent.disabled_toolsets!r}"
+    )
 
 
 

--- a/tests/test_background_review_session_isolation.py
+++ b/tests/test_background_review_session_isolation.py
@@ -182,3 +182,70 @@ class TestPersistDisabledHardStop:
                 assert db.get_messages("s-review") == []
             finally:
                 db.close()
+
+
+class TestBackgroundReviewCompressionIsolation:
+    """Exercise the real AIAgent/ContextCompressor wiring, not a fork stub."""
+
+    def test_review_compressor_is_detached_from_parent_session_db(self):
+        import os
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        import run_agent
+        from hermes_state import SessionDB
+
+        captured = {}
+
+        class _InlineThread:
+            def __init__(self, *, target=None, daemon=None, name=None):
+                self._target = target
+
+            def start(self):
+                if self._target:
+                    self._target()
+
+        def _capture_review_state(review_agent, *args, **kwargs):
+            compressor = review_agent.context_compressor
+            captured.update(
+                compression_enabled=review_agent.compression_enabled,
+                agent_session_db=review_agent._session_db,
+                compressor_session_db=getattr(compressor, "_session_db", "missing"),
+                compressor_session_id=getattr(compressor, "_session_id", "missing"),
+            )
+            raise RuntimeError("stop after capturing review isolation state")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+                    parent = run_agent.AIAgent(
+                        api_key="test-key",
+                        base_url="https://openrouter.ai/api/v1",
+                        model="test/model",
+                        quiet_mode=True,
+                        session_db=db,
+                        session_id="parent-session",
+                        skip_context_files=True,
+                        skip_memory=True,
+                    )
+                setattr(parent, "_cached_system_prompt", "stable parent prompt")
+
+                with patch.object(
+                    run_agent.AIAgent, "run_conversation", _capture_review_state
+                ), patch("threading.Thread", _InlineThread):
+                    parent._spawn_background_review(
+                        messages_snapshot=[],
+                        review_memory=True,
+                        review_skills=False,
+                    )
+
+                assert captured == {
+                    "compression_enabled": True,
+                    "agent_session_db": None,
+                    "compressor_session_db": None,
+                    "compressor_session_id": "",
+                }
+            finally:
+                db.close()

--- a/tests/test_background_review_session_isolation.py
+++ b/tests/test_background_review_session_isolation.py
@@ -137,3 +137,70 @@ class TestPersistDisabledHardStop:
                 assert db.get_messages("s-review") == []
             finally:
                 db.close()
+
+
+class TestBackgroundReviewCompressionIsolation:
+    """Exercise the real AIAgent/ContextCompressor wiring, not a fork stub."""
+
+    def test_review_compressor_is_detached_from_parent_session_db(self):
+        import os
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        import run_agent
+        from hermes_state import SessionDB
+
+        captured = {}
+
+        class _InlineThread:
+            def __init__(self, *, target=None, daemon=None, name=None):
+                self._target = target
+
+            def start(self):
+                if self._target:
+                    self._target()
+
+        def _capture_review_state(review_agent, *args, **kwargs):
+            compressor = review_agent.context_compressor
+            captured.update(
+                compression_enabled=review_agent.compression_enabled,
+                agent_session_db=review_agent._session_db,
+                compressor_session_db=getattr(compressor, "_session_db", "missing"),
+                compressor_session_id=getattr(compressor, "_session_id", "missing"),
+            )
+            raise RuntimeError("stop after capturing review isolation state")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+                    parent = run_agent.AIAgent(
+                        api_key="test-key",
+                        base_url="https://openrouter.ai/api/v1",
+                        model="test/model",
+                        quiet_mode=True,
+                        session_db=db,
+                        session_id="parent-session",
+                        skip_context_files=True,
+                        skip_memory=True,
+                    )
+                setattr(parent, "_cached_system_prompt", "stable parent prompt")
+
+                with patch.object(
+                    run_agent.AIAgent, "run_conversation", _capture_review_state
+                ), patch("threading.Thread", _InlineThread):
+                    parent._spawn_background_review(
+                        messages_snapshot=[],
+                        review_memory=True,
+                        review_skills=False,
+                    )
+
+                assert captured == {
+                    "compression_enabled": True,
+                    "agent_session_db": None,
+                    "compressor_session_db": None,
+                    "compressor_session_id": "",
+                }
+            finally:
+                db.close()


### PR DESCRIPTION
## Problem

Background skill/memory reviews are launched after the primary turn and can inherit the parent's **entire active transcript**. On the same-model path this is intentional for prompt-cache parity, but the review fork currently forces `compression_enabled = False`.

That combination becomes expensive and fragile for valid long-running conversations, especially tool-heavy ones:

- the primary turn may already have made several large provider calls;
- the post-turn review replays the same large active context again;
- the extra request consumes provider quota and increases rate-limit/timeout risk after the user's answer has already been produced;
- users should not need to abandon a conversation merely to keep an auxiliary skill review affordable.

Compression was disabled because the review shares the parent's `session_id` for cache warmth. Re-enabling it naively is unsafe: `AIAgent.__init__` has already bound the fork's `ContextCompressor` to the parent `SessionDB` and session id. A review-side compaction could therefore contend for the parent's compression lock, persist cooldown/streak state, archive messages, or rotate the live conversation into an unadopted sibling session.

## Change

This PR enables compression for the background review **only after isolating it from persistent session state**:

1. keep the existing review protections:
   - `_persist_disabled = True`
   - `_session_db = None`
   - `_end_session_on_close = False`
2. explicitly rebind the review fork's `ContextCompressor` with:
   - `session_db=None`
   - `session_id=""`
3. set `compression_enabled = True`.

The review can now compact an oversized snapshot in memory before its provider call, while retaining the parent's cached system prompt and tool-definition parity. It cannot write compression state to, lock, archive, or rotate the live parent session.

## Why this matters

A long WebUI conversation and a large active provider context are different product concepts. Users should be able to keep one durable conversation while Hermes bounds auxiliary work internally. This patch removes an avoidable amplification path: post-turn learning no longer has to replay an over-threshold transcript uncompressed.

It is deliberately a narrow safety improvement rather than the full context architecture redesign.

## Validation

Targeted suite:

```text
27 passed in 1.53s
```

Executed with:

```bash
python -m pytest \
  tests/run_agent/test_background_review_cache_parity.py \
  tests/test_background_review_session_isolation.py \
  tests/run_agent/test_background_review_toolset_restriction.py \
  -o 'addopts=' -q
```

Additional gates:

- `python -m py_compile` on changed Python files
- `git diff --check`
- added-line security scan (no production findings; the only credential-shaped literal is the existing `test-key` fixture)

Coverage includes:

- a focused fork contract test asserting compression is enabled only after `bind_session_state(None, "")`;
- a real `AIAgent` + temporary `SessionDB` test proving both the review agent and its real `ContextCompressor` are detached from the parent DB/session when `run_conversation` begins;
- existing cache-parity, persistence-isolation, and tool-whitelist regressions.

## Scope and limitations

This does **not** yet:

- replace the review's full snapshot with a bounded incremental delta;
- impose an aggregate token budget on `_digest_history`;
- coalesce overlapping reviews;
- reduce the review's 16-iteration ceiling;
- isolate auxiliary review failures from primary-turn WebUI terminal status.

Those remain worthwhile follow-ups. This PR makes the existing compression mechanism safe and available immediately without changing review cadence, persistence semantics, or the primary conversation transcript.
