### PR TITLE
fix(slack): sanitize outbound Block Kit payloads — invalid_blocks / msg_too_long hardening

### DIFF
--- a/contributors/emails/cjwang@sowork.tw
+++ b/contributors/emails/cjwang@sowork.tw
@@ -1,0 +1,2 @@
+sowork-skills
+# PR #33224 salvage (slack: truncate edit_message to prevent msg_too_long)

--- a/contributors/emails/kamon@gao-ai.com
+++ b/contributors/emails/kamon@gao-ai.com
@@ -1,0 +1,2 @@
+kamonspecial
+# PR #59621 salvage (slack: empty rich_text content guards)

--- a/contributors/emails/nwadwa@gmail.com
+++ b/contributors/emails/nwadwa@gmail.com
@@ -1,0 +1,2 @@
+tw0316
+# PR #56618 salvage (slack: table column_settings + blocks rejection fallback)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4154,6 +4154,11 @@ class SlackAdapter(BasePlatformAdapter):
                 original_text = block.get("text", {}).get("text", "")
                 break
 
+        # Slack re-escapes HTML entities in the interaction payload
+        # (< → &lt;, > → &gt;, & → &amp;), which can inflate the text
+        # past the 3000-char section-block limit on chat.update.
+        original_text = original_text[:3000]
+
         updated_blocks = [
             {
                 "type": "section",
@@ -4320,6 +4325,11 @@ class SlackAdapter(BasePlatformAdapter):
             if block.get("type") == "section":
                 original_text = block.get("text", {}).get("text", "")
                 break
+
+        # Slack re-escapes HTML entities in the interaction payload
+        # (< → &lt;, > → &gt;, & → &amp;), which can inflate the text
+        # past the 3000-char section-block limit on chat.update.
+        original_text = original_text[:3000]
 
         updated_blocks = [
             {

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1458,9 +1458,23 @@ class SlackAdapter(BasePlatformAdapter):
                     if broadcast and i == 0:
                         kwargs["reply_broadcast"] = True
 
-                last_result = await self._get_client(
-                    chat_id, team_id=self._metadata_team_id(metadata)
-                ).chat_postMessage(**kwargs)
+                try:
+                    last_result = await self._get_client(
+                        chat_id, team_id=self._metadata_team_id(metadata)
+                    ).chat_postMessage(**kwargs)
+                except Exception as e:
+                    if kwargs.get("blocks") and self._is_block_payload_rejection(e):
+                        retry_kwargs = dict(kwargs)
+                        retry_kwargs.pop("blocks", None)
+                        logger.info(
+                            "[Slack] Block Kit payload rejected; retrying send without blocks: %s",
+                            e,
+                        )
+                        last_result = await self._get_client(
+                            chat_id, team_id=self._metadata_team_id(metadata)
+                        ).chat_postMessage(**retry_kwargs)
+                    else:
+                        raise
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
@@ -1556,9 +1570,26 @@ class SlackAdapter(BasePlatformAdapter):
                 blocks = self._maybe_blocks(content)
                 if blocks:
                     update_kwargs["blocks"] = blocks
-            await self._get_client(
-                chat_id, team_id=self._metadata_team_id(metadata)
-            ).chat_update(**update_kwargs)
+            try:
+                await self._get_client(
+                    chat_id, team_id=self._metadata_team_id(metadata)
+                ).chat_update(**update_kwargs)
+            except Exception as e:
+                if update_kwargs.get("blocks") and self._is_block_payload_rejection(e):
+                    retry_kwargs = dict(update_kwargs)
+                    # Explicitly clear any stale blocks when falling back to the
+                    # flat text update path; otherwise Slack can preserve the
+                    # prior block layout for an edited message.
+                    retry_kwargs["blocks"] = []
+                    logger.info(
+                        "[Slack] Block Kit payload rejected; retrying edit without blocks: %s",
+                        e,
+                    )
+                    await self._get_client(
+                        chat_id, team_id=self._metadata_team_id(metadata)
+                    ).chat_update(**retry_kwargs)
+                else:
+                    raise
             if finalize:
                 await self.stop_typing(chat_id, metadata=metadata)
             return SendResult(success=True, message_id=message_id)
@@ -2009,6 +2040,31 @@ class SlackAdapter(BasePlatformAdapter):
         return self._is_retryable_error(body)
 
     # ----- Markdown → mrkdwn conversion -----
+
+    @staticmethod
+    def _is_block_payload_rejection(error: BaseException) -> bool:
+        """Return True for Slack errors recoverable by removing ``blocks``.
+
+        Rich Block Kit output is a progressive enhancement over the plain
+        ``text`` fallback. If Slack rejects the structured payload as invalid
+        or too large, retrying the same content without blocks is safe and
+        prevents a formatting bug from dropping the whole response.
+        """
+        recoverable_codes = {
+            "invalid_blocks",
+            "msg_too_long",
+            "too_many_blocks",
+        }
+        response = getattr(error, "response", None)
+        response_get = getattr(response, "get", None)
+        if callable(response_get):
+            try:
+                if response_get("error") in recoverable_codes:
+                    return True
+            except Exception:
+                pass
+        message = str(error)
+        return any(code in message for code in recoverable_codes)
 
     def _rich_blocks_enabled(self) -> bool:
         """Whether to render outbound agent messages as Slack Block Kit blocks.

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -56,9 +56,9 @@ from gateway.platforms.base import (
 )
 
 try:  # sibling module; support both package and flat plugin-dir import
-    from .block_kit import render_blocks
+    from .block_kit import render_blocks, sanitize_blocks
 except ImportError:  # pragma: no cover - plugin loaded outside package context
-    from block_kit import render_blocks  # type: ignore
+    from block_kit import render_blocks, sanitize_blocks  # type: ignore
 
 
 logger = logging.getLogger(__name__)
@@ -2145,7 +2145,7 @@ class SlackAdapter(BasePlatformAdapter):
             return None
         try:
             blocks = render_blocks(content, mrkdwn_fn=self.format_message)
-            return self._append_feedback_block(blocks)
+            return sanitize_blocks(self._append_feedback_block(blocks))
         except Exception:  # pragma: no cover - renderer already guards itself
             logger.debug("[Slack] block render failed; using plain text", exc_info=True)
             return None
@@ -3941,7 +3941,7 @@ class SlackAdapter(BasePlatformAdapter):
             kwargs: Dict[str, Any] = {
                 "channel": chat_id,
                 "text": f"⚠️ Command approval required: {cmd_preview[:100]}",
-                "blocks": blocks,
+                "blocks": sanitize_blocks(blocks),
             }
             if thread_ts:
                 kwargs["thread_ts"] = thread_ts
@@ -4021,7 +4021,7 @@ class SlackAdapter(BasePlatformAdapter):
             kwargs: Dict[str, Any] = {
                 "channel": chat_id,
                 "text": f"{title or 'Confirm'}: {body[:100]}",
-                "blocks": blocks,
+                "blocks": sanitize_blocks(blocks),
             }
             if thread_ts:
                 kwargs["thread_ts"] = thread_ts
@@ -4191,7 +4191,7 @@ class SlackAdapter(BasePlatformAdapter):
                 channel=channel_id,
                 ts=msg_ts,
                 text=decision_text,
-                blocks=updated_blocks,
+                blocks=sanitize_blocks(updated_blocks),
             )
         except Exception as e:
             logger.warning("[Slack] Failed to update slash-confirm message: %s", e)
@@ -4363,7 +4363,7 @@ class SlackAdapter(BasePlatformAdapter):
                 channel=channel_id,
                 ts=msg_ts,
                 text=decision_text,
-                blocks=updated_blocks,
+                blocks=sanitize_blocks(updated_blocks),
             )
         except Exception as e:
             logger.warning("[Slack] Failed to update approval message: %s", e)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1562,6 +1562,12 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
         try:
             formatted = self.format_message(content)
+            # Slack's chat.update has the same ~40k char limit as postMessage.
+            # Unlike send() we can't split into multiple messages (we're
+            # editing an existing one), so truncate to fit — an oversized
+            # payload fails the whole edit with ``msg_too_long``.
+            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            formatted = chunks[0] if chunks else formatted
             update_kwargs: Dict[str, Any] = {
                 "channel": chat_id,
                 "ts": message_id,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1427,6 +1427,11 @@ class SlackAdapter(BasePlatformAdapter):
             # Convert standard markdown → Slack mrkdwn
             formatted = self.format_message(content)
 
+            # Guard against empty/whitespace-only messages — Slack API
+            # returns ``no_text`` for chat.postMessage with blank text.
+            if not formatted or not formatted.strip():
+                return SendResult(success=True)
+
             # Split long messages, preserving code block boundaries
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
@@ -5011,6 +5016,14 @@ async def _standalone_send(
                 "Failed to apply Slack mrkdwn formatting in _standalone_send",
                 exc_info=True,
             )
+
+    if not formatted or not formatted.strip():
+        logger.debug("[Slack] _standalone_send: skipping empty/whitespace message")
+        return {
+            "success": True,
+            "platform": "slack",
+            "skipped": "empty_text",
+        }
 
     try:
         import aiohttp

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -550,3 +550,118 @@ def _split_text(text: str, limit: int) -> List[str]:
     if remaining:
         out.append(remaining)
     return out
+
+
+# ----------------------------------------------------------------------------
+# Outbound payload boundary — last-resort clamp before the Slack API
+# ----------------------------------------------------------------------------
+
+
+def _clamp_text_obj(text_obj: Dict[str, Any], limit: int) -> Dict[str, Any]:
+    """Return ``text_obj`` with its ``text`` clamped to ``limit`` chars."""
+    txt = text_obj.get("text") or ""
+    if len(txt) <= limit:
+        return text_obj
+    clamped = dict(text_obj)
+    clamped["text"] = txt[: limit - 1].rstrip() + "…"
+    return clamped
+
+
+def sanitize_blocks(blocks: Optional[List[Block]]) -> Optional[List[Block]]:
+    """Clamp an outbound ``blocks`` payload to Slack's hard limits.
+
+    Defensive boundary applied wherever the adapter attaches ``blocks`` to
+    ``chat.postMessage`` / ``chat.update``.  One oversized or malformed block
+    fails the WHOLE call with ``invalid_blocks`` — approval cards then never
+    update and messages silently drop — so instead of trusting every builder,
+    the payload is normalized just before the API call:
+
+    * ``section`` / ``context`` text objects are truncated to the 3000-char
+      cap with an ellipsis (Slack HTML-escapes ``< > &`` on storage, so text
+      echoed back through interaction payloads can exceed the limit that the
+      send path originally budgeted for — see #53693 / #62054).
+    * ``header`` text is truncated to its 150-char cap.
+    * Empty blocks (no text / no elements / no rows) are dropped — Slack
+      rejects zero-length text objects and empty element lists.
+    * ``table.column_settings`` entries must all be objects; ``null`` entries
+      (emitted by older renderers, per the "use null to skip" misreading of
+      the schema) are replaced with ``{}`` and default trailing entries are
+      trimmed (#56615).
+    * The payload is capped at Slack's 50-block maximum.
+
+    Returns the sanitized list, or ``None`` when nothing valid remains — the
+    caller then sends the plain ``text`` fallback alone.  Never raises.
+    """
+    if not blocks:
+        return None
+    try:
+        out: List[Block] = []
+        for block in blocks:
+            if not isinstance(block, dict) or not block.get("type"):
+                continue
+            btype = block["type"]
+
+            if btype == "section":
+                text_obj = block.get("text")
+                has_body = bool(block.get("fields")) or bool(block.get("accessory"))
+                if isinstance(text_obj, dict):
+                    if not (text_obj.get("text") or "").strip() and not has_body:
+                        continue
+                    clamped = _clamp_text_obj(text_obj, MAX_SECTION_TEXT)
+                    if clamped is not text_obj:
+                        block = dict(block)
+                        block["text"] = clamped
+                elif not has_body:
+                    continue
+
+            elif btype == "header":
+                text_obj = block.get("text")
+                if not isinstance(text_obj, dict) or not (text_obj.get("text") or "").strip():
+                    continue
+                clamped = _clamp_text_obj(text_obj, MAX_HEADER_TEXT)
+                if clamped is not text_obj:
+                    block = dict(block)
+                    block["text"] = clamped
+
+            elif btype == "context":
+                elements = block.get("elements") or []
+                if not elements:
+                    continue
+                clamped_els = [
+                    _clamp_text_obj(el, MAX_SECTION_TEXT)
+                    if isinstance(el, dict) and el.get("type") in ("mrkdwn", "plain_text")
+                    else el
+                    for el in elements
+                ]
+                if any(c is not e for c, e in zip(clamped_els, elements)):
+                    block = dict(block)
+                    block["elements"] = clamped_els
+
+            elif btype in ("rich_text", "actions", "context_actions"):
+                if not block.get("elements"):
+                    continue
+
+            elif btype == "table":
+                if not block.get("rows"):
+                    continue
+                settings = block.get("column_settings")
+                if isinstance(settings, list) and any(
+                    not isinstance(cs, dict) for cs in settings
+                ):
+                    fixed = [cs if isinstance(cs, dict) else {} for cs in settings]
+                    while fixed and not fixed[-1]:
+                        fixed.pop()
+                    block = dict(block)
+                    if fixed:
+                        block["column_settings"] = fixed
+                    else:
+                        block.pop("column_settings", None)
+
+            out.append(block)
+
+        if not out:
+            return None
+        return out[:MAX_BLOCKS]
+    except Exception:
+        # A sanitizer bug must never take down the send path.
+        return None

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -146,9 +146,31 @@ def _inline_elements(text: str) -> List[Dict[str, Any]]:
 # ----------------------------------------------------------------------------
 
 
-def _header_block(text: str) -> Block:
+def _nonempty_elements(elements: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Make a rich_text child-element list safe for Slack.
+
+    Slack rejects any ``rich_text_section`` / ``rich_text_preformatted`` /
+    ``rich_text_quote`` whose ``elements`` list is empty or contains a ``text``
+    element of zero length (``invalid_blocks``: "missing element" / "must be
+    more than 0 characters"). Empty content is common — ragged table rows are
+    padded with ``""``, agents emit empty code fences around empty tool output,
+    blank quote lines and empty list items occur in the wild — so drop
+    zero-length text elements and, if nothing remains, substitute a single
+    space, which renders as blank yet stays schema-valid. Used by every
+    rich_text builder so empty content can never poison the whole payload.
+    """
+    els = [e for e in elements if not (e.get("type") == "text" and not e.get("text"))]
+    return els or [{"type": "text", "text": " "}]
+
+
+def _header_block(text: str) -> Optional[Block]:
     # header blocks are plain_text only, 150 char cap.
     clean = re.sub(r"[*_~`]", "", text).strip()
+    if not clean:
+        # Emphasis-/whitespace-only header (e.g. "# ***" or "#   ") reduces to
+        # empty; Slack rejects an empty plain_text with invalid_blocks. Skip it
+        # (caller drops None) rather than poison the whole payload.
+        return None
     if len(clean) > MAX_HEADER_TEXT:
         clean = clean[: MAX_HEADER_TEXT - 1] + "…"
     return {"type": "header", "text": {"type": "plain_text", "text": clean, "emoji": True}}
@@ -165,7 +187,7 @@ def _preformatted_block(text: str) -> Block:
         "elements": [
             {
                 "type": "rich_text_preformatted",
-                "elements": [{"type": "text", "text": text.rstrip("\n")}],
+                "elements": _nonempty_elements([{"type": "text", "text": text.rstrip("\n")}]),
             }
         ],
     }
@@ -179,7 +201,7 @@ def _quote_block(lines: List[str]) -> Block:
         section_children.extend(_inline_elements(ln))
     return {
         "type": "rich_text",
-        "elements": [{"type": "rich_text_quote", "elements": section_children}],
+        "elements": [{"type": "rich_text_quote", "elements": _nonempty_elements(section_children)}],
     }
 
 
@@ -207,7 +229,7 @@ def _list_block(items: List[Tuple[int, bool, str]]) -> Block:
             cur_key = key
         assert cur is not None
         cur["elements"].append(
-            {"type": "rich_text_section", "elements": _inline_elements(text)}
+            {"type": "rich_text_section", "elements": _nonempty_elements(_inline_elements(text))}
         )
     return {"type": "rich_text", "elements": elements}
 
@@ -252,11 +274,16 @@ def _split_row(row: str) -> List[str]:
 
 
 def _rich_text_cell(text: str) -> Dict[str, Any]:
-    """A ``rich_text`` table cell carrying inline-formatted content."""
+    """A ``rich_text`` table cell carrying inline-formatted content.
+
+    Empty cells are common (ragged rows are padded with ``""``); Slack rejects
+    a cell whose section is empty or carries a zero-length text element, so the
+    elements are routed through ``_nonempty_elements``.
+    """
     return {
         "type": "rich_text",
         "elements": [
-            {"type": "rich_text_section", "elements": _inline_elements(text)}
+            {"type": "rich_text_section", "elements": _nonempty_elements(_inline_elements(text))}
         ],
     }
 
@@ -409,7 +436,9 @@ def render_blocks(
             hm = _HEADER_RE.match(line)
             if hm:
                 flush_para()
-                blocks.append(_header_block(hm.group(2)))
+                header = _header_block(hm.group(2))
+                if header is not None:
+                    blocks.append(header)
                 i += 1
                 continue
 

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -227,7 +227,11 @@ def _list_block(items: List[Tuple[int, bool, str]]) -> Block:
             }
             elements.append(cur)
             cur_key = key
-        assert cur is not None
+        if cur is None:
+            # Defensive: should never happen (first iteration always enters
+            # the ``if key != cur_key`` block above), but guard explicitly
+            # so ``python -O`` doesn't silently drop the check.
+            continue
         cur["elements"].append(
             {"type": "rich_text_section", "elements": _nonempty_elements(_inline_elements(text))}
         )

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -285,18 +285,25 @@ def _table_block(rows: List[str], sep_line: str) -> Optional[Block]:
         return None
 
     aligns = _parse_alignment(sep_line)
-    column_settings: List[Optional[Dict[str, Any]]] = []
+    # Slack requires every provided ``column_settings`` entry to be an object.
+    # Missing trailing entries inherit defaults, so only emit settings through
+    # the last non-default alignment. Earlier default-left placeholders still
+    # need explicit valid objects to preserve positional alignment.
+    last_non_default = -1
     for c in range(min(ncols, MAX_TABLE_COLS)):
         align = aligns[c] if c < len(aligns) else "left"
-        # Only emit a setting when it differs from the default (left, no wrap);
-        # use null to skip a column, per the Slack schema.
-        column_settings.append({"align": align} if align != "left" else None)
+        if align != "left":
+            last_non_default = c
+    column_settings: List[Dict[str, Any]] = []
+    for c in range(last_non_default + 1):
+        align = aligns[c] if c < len(aligns) else "left"
+        column_settings.append({"align": align})
 
     block: Block = {
         "type": "table",
         "rows": [[_rich_text_cell(cell) for cell in row] for row in parsed],
     }
-    if any(cs is not None for cs in column_settings):
+    if column_settings:
         block["column_settings"] = column_settings
     return block
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4071,6 +4071,69 @@ class TestMessageSplitting:
         assert "<https://en.wikipedia.org/wiki/Foo_(bar)|Foo>" in kwargs["text"]
 
 
+class TestEmptyTextGuard:
+    """Guard against Slack ``no_text`` errors when content is empty/whitespace."""
+
+    @pytest.mark.asyncio
+    async def test_send_skips_empty_string(self, adapter):
+        """Empty content must not call chat_postMessage."""
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
+        result = await adapter.send("C123", "")
+        assert result.success is True
+        adapter._app.client.chat_postMessage.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_skips_whitespace_only(self, adapter):
+        """Whitespace-only content must not call chat_postMessage."""
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
+        result = await adapter.send("C123", "   \n\t  ")
+        assert result.success is True
+        adapter._app.client.chat_postMessage.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_skips_empty(self, monkeypatch):
+        """_standalone_send returns success without HTTP call on empty text."""
+        from plugins.platforms.slack.adapter import _standalone_send
+        from types import SimpleNamespace
+
+        pconfig = SimpleNamespace(token="xoxb-test", extra={})
+
+        # Patch aiohttp so the import succeeds, but it should never be used.
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(
+            "plugins.platforms.slack.adapter.aiohttp",
+            MagicMock(ClientSession=MagicMock(return_value=mock_session)),
+        )
+
+        result = await _standalone_send(pconfig, "C123", "")
+        assert result.get("success") is True
+        assert result.get("skipped") == "empty_text"
+        mock_session.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_skips_whitespace(self, monkeypatch):
+        """_standalone_send returns success without HTTP call on whitespace."""
+        from plugins.platforms.slack.adapter import _standalone_send
+        from types import SimpleNamespace
+
+        pconfig = SimpleNamespace(token="xoxb-test", extra={})
+
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(
+            "plugins.platforms.slack.adapter.aiohttp",
+            MagicMock(ClientSession=MagicMock(return_value=mock_session)),
+        )
+
+        result = await _standalone_send(pconfig, "C123", "   \n  ")
+        assert result.get("success") is True
+        assert result.get("skipped") == "empty_text"
+        mock_session.post.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # TestReplyBroadcast
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2912,6 +2912,15 @@ class TestEditMessage:
         kwargs = adapter._app.client.chat_update.call_args.kwargs
         assert kwargs["text"] == "AT&amp;T &lt; 5 &gt; 3"
 
+    @pytest.mark.asyncio
+    async def test_edit_message_truncates_oversized_content(self, adapter):
+        """Oversized edits are truncated instead of failing with msg_too_long."""
+        adapter._app.client.chat_update = AsyncMock(return_value={"ok": True})
+        result = await adapter.edit_message("C123", "1234.5678", "x" * 45000)
+        assert result.success
+        kwargs = adapter._app.client.chat_update.call_args.kwargs
+        assert len(kwargs["text"]) <= adapter.MAX_MESSAGE_LENGTH
+
 
 # ---------------------------------------------------------------------------
 # TestEditMessageStreamingPipeline

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -276,6 +276,37 @@ class TestSlackApprovalAction:
         assert "Denied by alice" in update_kwargs["text"]
 
     @pytest.mark.asyncio
+    async def test_truncates_inflated_original_text(self):
+        """Interaction payload re-escapes HTML entities; text must be capped."""
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._approval_resolved["1.2"] = False
+
+        # Simulate Slack re-escaping: original was ~2990 chars, but & → &amp;
+        # etc. inflates it past 3000.
+        inflated_text = "a" * 2990 + "&amp;" * 10  # 2990 + 50 = 3040 chars
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1.2", "blocks": [
+                {"type": "section", "text": {"type": "mrkdwn", "text": inflated_text}},
+            ]},
+            "channel": {"id": "C1"},
+            "user": {"name": "alice", "id": "U_ALICE"},
+        }
+        action = {"action_id": "hermes_approve_once", "value": "session-key"}
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1):
+            await adapter._handle_approval_action(ack, body, action)
+
+        update_kwargs = mock_client.chat_update.call_args[1]
+        section_text = update_kwargs["blocks"][0]["text"]["text"]
+        assert len(section_text) <= 3000
+
+    @pytest.mark.asyncio
     async def test_global_allowlist_blocks_unauthorized_click(self, monkeypatch):
         adapter = _make_adapter()
         adapter._approval_resolved["1234.5678"] = False
@@ -409,6 +440,40 @@ class TestSlackSlashConfirmAction:
         secondary_client.chat_update.assert_awaited_once()
         secondary_client.chat_postMessage.assert_awaited_once()
         adapter._team_clients["T1"].chat_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_truncates_inflated_original_text(self):
+        """Interaction payload re-escapes HTML entities; text must be capped."""
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._approval_resolved["2222.3333"] = False
+
+        # Simulate Slack re-escaping inflating text past 3000 chars.
+        inflated_text = "b" * 2990 + "&lt;" * 10  # 2990 + 40 = 3030 chars
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "2222.3333", "blocks": [
+                {"type": "section", "text": {"type": "mrkdwn", "text": inflated_text}},
+            ]},
+            "channel": {"id": "C1"},
+            "user": {"name": "owner", "id": "U_OWNER"},
+        }
+        action = {
+            "action_id": "hermes_confirm_once",
+            "value": "agent:main:slack:group:C1:1111|confirm-1",
+        }
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+        mock_client.chat_postMessage = AsyncMock()
+
+        with patch("tools.slash_confirm.resolve", new=AsyncMock(return_value="ok")):
+            await adapter._handle_slash_confirm_action(ack, body, action)
+
+        update_kwargs = mock_client.chat_update.call_args[1]
+        section_text = update_kwargs["blocks"][0]["text"]["text"]
+        assert len(section_text) <= 3000
 
 
 # ===========================================================================

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -251,3 +251,85 @@ class TestLimits:
         for junk in ["```unterminated\ncode", "| broken | table", "> ", "#" * 10]:
             # must not raise; either blocks or None
             render_blocks(junk)
+
+
+class TestEmptyContentGuards:
+    """Empty content must never produce a Slack-rejected (invalid_blocks) payload.
+
+    Slack rejects a rich_text_section / rich_text_preformatted /
+    rich_text_quote whose ``elements`` is empty or contains a zero-length
+    ``text`` element, and a ``header`` whose plain_text is empty. Each guard
+    below corresponds to a real chat.postMessage rejection observed in
+    production ("missing element" / "must be more than 0 characters").
+    """
+
+    @staticmethod
+    def _assert_schema_valid(blocks):
+        def walk(o):
+            if isinstance(o, dict):
+                if o.get("type") in (
+                    "rich_text_section", "rich_text_preformatted", "rich_text_quote"
+                ):
+                    assert o.get("elements"), f"empty {o['type']} elements"
+                if o.get("type") == "text":
+                    assert len(o.get("text", "")) > 0, "zero-length text element"
+                if o.get("type") == "header":
+                    assert o["text"]["text"], "empty plain_text header"
+                for v in o.values():
+                    walk(v)
+            elif isinstance(o, list):
+                for v in o:
+                    walk(v)
+
+        walk(blocks)
+
+    def test_ragged_and_empty_table_cells_are_schema_valid(self):
+        # Blank middle cell + ragged short row (padded with "") must not emit
+        # an empty section or a 0-char text element.
+        md = (
+            "| x | y | z |\n"
+            "| --- | --- | --- |\n"
+            "| 1 |  | 3 |\n"   # blank middle cell
+            "| 4 |"           # ragged row -> padded with empty cells
+        )
+        blocks = render_blocks(md)
+        assert blocks[0]["type"] == "table"
+        self._assert_schema_valid(blocks)
+
+    def test_empty_code_fence_quote_and_list_item_are_schema_valid(self):
+        # Empty fenced code block (common around empty tool output), blank
+        # quote line, and empty list item must all stay schema-valid.
+        md = "```\n```\n\n> \n\n- \n- real item"
+        blocks = render_blocks(md)
+        assert blocks is not None
+        self._assert_schema_valid(blocks)
+
+    def test_multiline_quote_preserves_newline_separators(self):
+        # _quote_block separates lines with length-1 "\n" text elements; the
+        # guard must KEEP them so a multi-line blockquote stays multi-line.
+        blocks = render_blocks("> alpha\n> bravo")
+        quote = None
+        for b in blocks:
+            for el in b.get("elements", []):
+                if isinstance(el, dict) and el.get("type") == "rich_text_quote":
+                    quote = el
+        assert quote is not None, "no rich_text_quote produced"
+        texts = [e.get("text") for e in quote["elements"] if e.get("type") == "text"]
+        assert "\n" in texts, "newline separator dropped from multi-line quote"
+        assert any("alpha" in (t or "") for t in texts)
+        assert any("bravo" in (t or "") for t in texts)
+
+    def test_emphasis_only_header_is_dropped_not_empty(self):
+        # "# ***" reduces to "" after marker-strip; an empty plain_text header
+        # is rejected by Slack, so the header is skipped entirely.
+        blocks = render_blocks("# ***\n\nreal body")
+        assert not any(b.get("type") == "header" for b in blocks)
+        self._assert_schema_valid(blocks)
+
+    def test_normal_content_unaffected(self):
+        # Guard must not alter well-formed content.
+        md = "# Title\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n\n> quoted\n\n- item"
+        blocks = render_blocks(md)
+        assert any(b.get("type") == "header" for b in blocks)
+        assert any(b.get("type") == "table" for b in blocks)
+        self._assert_schema_valid(blocks)

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -5,6 +5,7 @@ from plugins.platforms.slack.block_kit import (
     MAX_HEADER_TEXT,
     MAX_SECTION_TEXT,
     render_blocks,
+    sanitize_blocks,
 )
 
 
@@ -333,3 +334,98 @@ class TestEmptyContentGuards:
         assert any(b.get("type") == "header" for b in blocks)
         assert any(b.get("type") == "table" for b in blocks)
         self._assert_schema_valid(blocks)
+
+
+class TestSanitizeBlocks:
+    """Outbound boundary clamp: one bad block must never fail the whole call.
+
+    Regression coverage for the invalid_blocks / msg_too_long bug class
+    (#56615 null column_settings, #62054 / #53693 >3000-char sections on
+    approval chat.update after HTML-escaping inflation).
+    """
+
+    def test_none_and_empty_return_none(self):
+        assert sanitize_blocks(None) is None
+        assert sanitize_blocks([]) is None
+
+    def test_valid_payload_passes_through(self):
+        blocks = render_blocks("# Title\n\nbody text\n\n- item")
+        assert sanitize_blocks(blocks) == blocks
+
+    def test_oversized_section_text_is_clamped(self):
+        blocks = [
+            {"type": "section", "text": {"type": "mrkdwn", "text": "x" * 3500}},
+        ]
+        out = sanitize_blocks(blocks)
+        assert len(out[0]["text"]["text"]) <= MAX_SECTION_TEXT
+        assert out[0]["text"]["text"].endswith("…")
+
+    def test_html_escape_inflated_approval_update_is_clamped(self):
+        # #53693 / #62054: send path budgeted the RAW text to <=3000, but the
+        # interaction payload echoes it back HTML-escaped (& -> &amp;) so the
+        # chat.update section exceeds the cap.
+        inflated = "a" * 2990 + "&amp;" * 10  # 3040 chars
+        blocks = [
+            {"type": "section", "text": {"type": "mrkdwn", "text": inflated}},
+            {"type": "context", "elements": [{"type": "mrkdwn", "text": "✅ ok"}]},
+        ]
+        out = sanitize_blocks(blocks)
+        assert len(out[0]["text"]["text"]) <= MAX_SECTION_TEXT
+        # context block untouched
+        assert out[1] == blocks[1]
+
+    def test_null_column_settings_entries_are_fixed(self):
+        # #56615: Slack rejects null entries in table column_settings.
+        table = {
+            "type": "table",
+            "rows": [[{"type": "rich_text", "elements": []}]],
+            "column_settings": [None, {"align": "center"}, None],
+        }
+        out = sanitize_blocks([table])
+        cs = out[0]["column_settings"]
+        assert cs == [{}, {"align": "center"}]
+        assert all(isinstance(c, dict) for c in cs)
+
+    def test_all_null_column_settings_are_dropped(self):
+        table = {
+            "type": "table",
+            "rows": [[{"type": "rich_text", "elements": []}]],
+            "column_settings": [None, None],
+        }
+        out = sanitize_blocks([table])
+        assert "column_settings" not in out[0]
+
+    def test_empty_blocks_are_dropped(self):
+        blocks = [
+            {"type": "section", "text": {"type": "mrkdwn", "text": "   "}},
+            {"type": "rich_text", "elements": []},
+            {"type": "actions", "elements": []},
+            {"type": "context", "elements": []},
+            {"type": "header", "text": {"type": "plain_text", "text": ""}},
+            {"type": "table", "rows": []},
+            {"type": "section", "text": {"type": "mrkdwn", "text": "keep me"}},
+        ]
+        out = sanitize_blocks(blocks)
+        assert out == [blocks[-1]]
+
+    def test_all_invalid_returns_none_for_plain_text_fallback(self):
+        blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": ""}}]
+        assert sanitize_blocks(blocks) is None
+
+    def test_oversized_header_is_clamped(self):
+        blocks = [
+            {"type": "header", "text": {"type": "plain_text", "text": "h" * 200}},
+        ]
+        out = sanitize_blocks(blocks)
+        assert len(out[0]["text"]["text"]) <= MAX_HEADER_TEXT
+
+    def test_payload_capped_at_50_blocks(self):
+        blocks = [
+            {"type": "section", "text": {"type": "mrkdwn", "text": f"b{i}"}}
+            for i in range(60)
+        ]
+        out = sanitize_blocks(blocks)
+        assert len(out) == MAX_BLOCKS
+
+    def test_never_raises_on_garbage(self):
+        assert sanitize_blocks([{"no_type": True}, "not-a-dict", 42]) is None

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -159,10 +159,33 @@ class TestTables:
         )
         blocks = render_blocks(md)
         cs = blocks[0]["column_settings"]
-        # left is default -> null; center/right emitted
-        assert cs[0] is None
+        # Every provided entry must be a valid Slack column-settings object.
+        # Left placeholders are explicit only when needed to preserve position.
+        assert cs[0] == {"align": "left"}
         assert cs[1] == {"align": "center"}
         assert cs[2] == {"align": "right"}
+
+    def test_default_trailing_column_settings_are_omitted(self):
+        md = (
+            "| L | R | L2 |\n"
+            "|---|---:|---|\n"
+            "| 1 | 2 | 3 |"
+        )
+        blocks = render_blocks(md)
+        assert blocks is not None
+        cs = blocks[0]["column_settings"]
+        assert cs == [{"align": "left"}, {"align": "right"}]
+        assert all(isinstance(item, dict) for item in cs)
+
+    def test_all_default_table_omits_column_settings(self):
+        md = (
+            "| A | B |\n"
+            "|---|---|\n"
+            "| 1 | 2 |"
+        )
+        blocks = render_blocks(md)
+        assert blocks is not None
+        assert "column_settings" not in blocks[0]
 
     def test_inline_formatting_inside_cells(self):
         md = (

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -7,7 +7,7 @@ Verifies the opt-in behaviour contract:
   * multi-chunk (>39k) messages fall back to plain text
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
@@ -29,6 +29,17 @@ def _make_adapter(extra=None):
 
 
 RICH_MD = "# Title\n\n- a\n  - nested\n\n---\n\nbody text"
+RICH_TABLE_MD = (
+    "| Item | Status | Note |\n"
+    "|---|---:|---|\n"
+    "| Hermes | ok | table |"
+)
+
+
+class SlackRejectedBlocks(Exception):
+    def __init__(self, error="invalid_blocks"):
+        super().__init__(f"Slack API rejected blocks: {error}")
+        self.response = {"error": error}
 
 
 class TestSendMessageBlocks:
@@ -98,6 +109,29 @@ class TestSendMessageBlocks:
 
         assert "blocks" not in client.chat_postMessage.await_args.kwargs
 
+    @pytest.mark.asyncio
+    async def test_block_rejection_retries_send_without_blocks_using_workspace_client(self):
+        adapter, client = _make_adapter({"rich_blocks": True})
+        client.chat_postMessage = AsyncMock(
+            side_effect=[SlackRejectedBlocks("invalid_blocks"), {"ts": "111.333"}]
+        )
+
+        result = await adapter.send(
+            "C1", RICH_TABLE_MD, metadata={"team_id": "T_SECONDARY"}
+        )
+
+        assert result.success is True
+        assert adapter._get_client.call_args_list == [
+            call("C1", team_id="T_SECONDARY"),
+            call("C1", team_id="T_SECONDARY"),
+        ]
+        assert client.chat_postMessage.await_count == 2
+        first = client.chat_postMessage.await_args_list[0].kwargs
+        second = client.chat_postMessage.await_args_list[1].kwargs
+        assert "blocks" in first and first["blocks"]
+        assert "blocks" not in second
+        assert second["text"]
+
 
 class TestEditMessageBlocks:
     @pytest.mark.asyncio
@@ -128,3 +162,30 @@ class TestEditMessageBlocks:
         adapter, client = _make_adapter()  # rich_blocks off
         await adapter.edit_message("C1", "111.222", RICH_MD, finalize=True)
         assert "blocks" not in client.chat_update.await_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_block_rejection_retries_edit_without_blocks_using_workspace_client(self):
+        adapter, client = _make_adapter({"rich_blocks": True})
+        client.chat_update = AsyncMock(
+            side_effect=[SlackRejectedBlocks("invalid_blocks"), {"ts": "111.222"}]
+        )
+
+        result = await adapter.edit_message(
+            "C1",
+            "111.222",
+            RICH_TABLE_MD,
+            finalize=True,
+            metadata={"team_id": "T_SECONDARY"},
+        )
+
+        assert result.success is True
+        assert adapter._get_client.call_args_list == [
+            call("C1", team_id="T_SECONDARY"),
+            call("C1", team_id="T_SECONDARY"),
+        ]
+        assert client.chat_update.await_count == 2
+        first = client.chat_update.await_args_list[0].kwargs
+        second = client.chat_update.await_args_list[1].kwargs
+        assert "blocks" in first and first["blocks"]
+        assert second["blocks"] == []
+        assert second["text"]


### PR DESCRIPTION
## Summary
One defensive boundary — `block_kit.sanitize_blocks()` — now guards every Slack `blocks=` call site, ending the invalid_blocks / msg_too_long bug class where approval cards never updated and messages silently failed.

Fixes #56615, #62054, #53693.

## Changes
- `sanitize_blocks()` applied at every send/update boundary (`_maybe_blocks` → send/edit, `send_exec_approval`, `send_slash_confirm`, both button-handler `chat.update`s): clamps section/context text to 3000 chars, headers to 150, drops empty blocks, repairs null `column_settings`, caps at 50 blocks, falls back to plain text instead of raising.
- Cherry-picked contributor fixes: column_settings hardening + retry-without-blocks (#56618), approval/confirm `original_text` truncation (#53701), empty rich_text guards (#59621, #64071), empty-text send guard (#52672), oversized edit truncation (#33224, reapplied to plugin path).

## Credits
Salvaged with authorship preserved: #56618 (@tw0316, also filed #56615), #53701 + #52672 (@liuhao1024), #59621 (@kamonspecial), #64071 (@AlexFucuson9), #33224 (@sowork-skills).
Supersedes #57128, #65355 (later column_settings dupes), #61697, #30253, #9462.

## Validation
| Sub-bug | Test |
|---|---|
| null column_settings rejected | `test_null_column_settings_entries_are_fixed` |
| HTML-escape-inflated approval update >3000 | `test_html_escape_inflated_approval_update_is_clamped` |
| empty rich_text / empty blocks | `TestEmptyContentGuards`, `test_empty_blocks_are_dropped` |
| oversized edit → msg_too_long | `test_edit_message_truncates_oversized_content` |
| invalid_blocks retry + plain-text fallback | `test_invalid_blocks_retries_once_without_blocks` |
| gateway slack suites | 525 passed, 0 failed (re-verified post-rebase) |

## Infographic

![slack-block-limits-hardening](https://v3b.fal.media/files/b/0aa3451b/F329QMZpS2Hyb6IMrjZ3R_r21OVYho.png)
