### PR TITLE
fix(slack): Socket Mode health — fail-fast creds, session heal, staleness detection, clean shutdown, dedup TTL

### DIFF
--- a/contributors/emails/87degrees@87ui-Macmini.local
+++ b/contributors/emails/87degrees@87ui-Macmini.local
@@ -1,0 +1,2 @@
+87degrees
+# PR #52923 salvage (slack ping/pong staleness)

--- a/contributors/emails/mrabsaroka@gmail.com
+++ b/contributors/emails/mrabsaroka@gmail.com
@@ -1,0 +1,2 @@
+MrAbsaroka
+# PR #40064 salvage (slack dedup TTL)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1037,6 +1037,7 @@ class DiscordAdapter(BasePlatformAdapter):
         """Connect to Discord and start receiving events."""
         if not DISCORD_AVAILABLE:
             logger.error("[%s] discord.py not installed. Run: pip install discord.py", self.name)
+            self._set_fatal_error("missing_dependency", "discord.py not installed", retryable=False)
             return False
 
         # Load opus codec for voice channel support
@@ -1073,6 +1074,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         if not self.config.token:
             logger.error("[%s] No bot token configured", self.name)
+            self._set_fatal_error("missing_credentials", "No bot token configured", retryable=False)
             return False
 
         try:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -693,6 +693,16 @@ class SlackAdapter(BasePlatformAdapter):
         self._socket_watchdog_task: Optional[asyncio.Task] = None
         self._socket_reconnect_lock = asyncio.Lock()
         self._socket_watchdog_interval_s = 15.0
+        # Monotonic timestamp of the most recent Socket Mode handler (re)start,
+        # used to grant a grace window for the first ping/pong after connect.
+        self._socket_handler_started_monotonic: Optional[float] = None
+        # Reconnect when no ping/pong has arrived for this many multiples of the
+        # client's ping_interval. Slack pings roughly every ping_interval seconds
+        # even on an idle socket, so prolonged silence means a wedged transport.
+        self._socket_ping_stale_factor = 4
+        # Allow at least this long after (re)connect before treating a missing
+        # first ping/pong as evidence of a wedged transport.
+        self._socket_first_ping_grace_s = 60.0
 
     def _start_socket_mode_handler(self) -> None:
         """Start the Slack Socket Mode background task."""
@@ -706,6 +716,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         task = asyncio.create_task(self._handler.start_async())
         self._socket_mode_task = task
+        self._socket_handler_started_monotonic = time.monotonic()
         task.add_done_callback(self._on_socket_mode_task_done)
 
     async def _stop_socket_mode_handler(self) -> None:
@@ -766,6 +777,37 @@ class SlackAdapter(BasePlatformAdapter):
             )
             return None
 
+    def _socket_ping_pong_stale(self) -> bool:
+        """True when the Socket Mode transport shows no recent ping/pong.
+
+        slack_sdk's Socket Mode client records ``last_ping_pong_time`` whenever
+        Slack's periodic ping arrives (roughly every ``ping_interval`` seconds,
+        even on an otherwise idle connection). When the underlying aiohttp
+        session is closed, the client gets stuck retrying ("Session is closed")
+        while ``is_connected()`` can still report healthy — so ping/pong
+        staleness is the reliable signal that the socket is wedged and the
+        handler must be rebuilt. Guards against non-numeric attributes so a
+        mocked/partial client never triggers a spurious reconnect.
+        """
+        client = getattr(self._handler, "client", None)
+        if client is None:
+            return False
+        ping_interval = getattr(client, "ping_interval", None)
+        if not isinstance(ping_interval, (int, float)) or ping_interval <= 0:
+            return False
+        last = getattr(client, "last_ping_pong_time", None)
+        if last is None:
+            # No ping yet. Healthy right after (re)connect; only suspicious once
+            # the grace window elapses without ever seeing the first ping/pong.
+            started = self._socket_handler_started_monotonic
+            if started is None:
+                return False
+            grace = max(self._socket_first_ping_grace_s, ping_interval * 2)
+            return (time.monotonic() - started) > grace
+        if not isinstance(last, (int, float)):
+            return False
+        return (time.time() - last) > (ping_interval * self._socket_ping_stale_factor)
+
     async def _restart_socket_mode(self, reason: str) -> None:
         """Reconnect Socket Mode without rebuilding adapter state."""
         if not self._running:
@@ -810,6 +852,11 @@ class SlackAdapter(BasePlatformAdapter):
                 connected = await self._socket_transport_connected()
                 if connected is False:
                     await self._restart_socket_mode("transport disconnected")
+                elif self._socket_ping_pong_stale():
+                    # is_connected() can lie when the aiohttp session is closed
+                    # but the client keeps retrying; ping/pong staleness catches
+                    # that wedged-zombie case that the bool check above misses.
+                    await self._restart_socket_mode("ping/pong stale")
             except asyncio.CancelledError:
                 raise
             except Exception:  # pragma: no cover - defensive logging

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -420,6 +420,55 @@ def _apply_slack_proxy(client: Any, proxy_url: Optional[str]) -> None:
         client.proxy = proxy_url
 
 
+# SocketModeClient's own background tasks. Looked up with getattr so a rename
+# inside the SDK degrades to a no-op instead of raising during shutdown.
+_SOCKET_CLIENT_TASK_ATTRS = (
+    "current_session_monitor",
+    "message_processor",
+    "message_receiver",
+)
+
+# Cap on how long teardown waits for cancelled tasks. A task wedged in a network
+# call must not be able to hold up shutdown indefinitely.
+_SOCKET_TASK_CANCEL_TIMEOUT_S = 3.0
+
+
+async def _cancel_socket_tasks(tasks: Any) -> None:
+    """Cancel Socket Mode tasks and wait, with a bound, for them to finish.
+
+    Cancellation is only a request until the task is awaited, so a caller that
+    cancels without awaiting can still race the work it meant to stop.
+    """
+    pending = set()
+    for task in tasks:
+        if task is None or not callable(getattr(task, "cancel", None)):
+            continue
+        if callable(getattr(task, "done", None)) and task.done():
+            continue
+        task.cancel()
+        pending.add(task)
+
+    if not pending:
+        return
+
+    done, still_running = await asyncio.wait(
+        pending, timeout=_SOCKET_TASK_CANCEL_TIMEOUT_S
+    )
+    for task in done:
+        if task.cancelled():
+            continue
+        if task.exception() is not None:  # pragma: no cover - defensive logging
+            logger.debug(
+                "[Slack] Socket Mode task failed while stopping", exc_info=True
+            )
+    if still_running:  # pragma: no cover - defensive logging
+        logger.warning(
+            "[Slack] %d Socket Mode task(s) did not stop within %.1fs",
+            len(still_running),
+            _SOCKET_TASK_CANCEL_TIMEOUT_S,
+        )
+
+
 _SLACK_PROXY_HOSTS = (
     "slack.com",
     "files.slack.com",
@@ -660,11 +709,31 @@ class SlackAdapter(BasePlatformAdapter):
         task.add_done_callback(self._on_socket_mode_task_done)
 
     async def _stop_socket_mode_handler(self) -> None:
-        """Stop Socket Mode handler and task."""
+        """Stop Socket Mode handler and task.
+
+        Order matters. ``close_async()`` closes the SocketModeClient's shared
+        aiohttp session, and ``SocketModeClient.connect()`` is a ``while True``
+        retry loop that never checks the client's ``closed`` flag, so anything
+        inside it when the session goes away retries forever against a session
+        that can never work again ("Session is closed").
+
+        Everything that can reach ``connect()`` therefore has to be stopped
+        first. ``monitor_current_session()`` and ``receive_messages()`` each get
+        there on their own, and ``connect()`` rebinds the client's task
+        attributes on success, so the set of live tasks changes across the
+        awaits inside ``close()``. Cancelling from a snapshot taken partway
+        through that would race a moving target. See
+        slackapi/python-slack-sdk#1913.
+        """
         handler = self._handler
         task = self._socket_mode_task
         self._handler = None
         self._socket_mode_task = None
+
+        client = getattr(handler, "client", None)
+        await _cancel_socket_tasks(
+            [task] + [getattr(client, attr, None) for attr in _SOCKET_CLIENT_TASK_ATTRS]
+        )
 
         if handler is not None:
             try:
@@ -674,17 +743,6 @@ class SlackAdapter(BasePlatformAdapter):
                     "[Slack] Error while closing Socket Mode handler: %s",
                     e,
                     exc_info=True,
-                )
-
-        if task is not None and not task.done():
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-            except Exception:  # pragma: no cover - defensive logging
-                logger.debug(
-                    "[Slack] Socket Mode task failed while stopping", exc_info=True
                 )
 
     async def _socket_transport_connected(self) -> Optional[bool]:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1115,6 +1115,7 @@ class SlackAdapter(BasePlatformAdapter):
             logger.error(
                 "[Slack] slack-bolt not installed. Run: pip install slack-bolt",
             )
+            self._set_fatal_error("missing_dependency", "slack-bolt not installed", retryable=False)
             return False
 
         raw_token = self.config.token

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1131,10 +1131,34 @@ class SlackAdapter(BasePlatformAdapter):
             app_token = os.getenv("SLACK_APP_TOKEN")
 
         if not raw_token:
-            logger.error("[Slack] SLACK_BOT_TOKEN not set")
+            logger.error(
+                "[Slack] SLACK_BOT_TOKEN not set — this is a permanent config "
+                "error; set SLACK_BOT_TOKEN via `hermes gateway setup` "
+                "or in the active profile's ~/.hermes/.env file, then restart "
+                "the gateway.",
+            )
+            self._set_fatal_error(
+                "missing_slack_bot_token",
+                "SLACK_BOT_TOKEN not configured. Use `hermes gateway setup` "
+                "or add it to your active profile's ~/.hermes/.env file, "
+                "then restart the gateway.",
+                retryable=False,
+            )
             return False
         if not app_token:
-            logger.error("[Slack] SLACK_APP_TOKEN not set")
+            logger.error(
+                "[Slack] SLACK_APP_TOKEN not set — this is a permanent config "
+                "error; set SLACK_APP_TOKEN via `hermes gateway setup` "
+                "or in the active profile's ~/.hermes/.env file, then restart "
+                "the gateway.",
+            )
+            self._set_fatal_error(
+                "missing_slack_app_token",
+                "SLACK_APP_TOKEN not configured. Use `hermes gateway setup` "
+                "or add it to your active profile's ~/.hermes/.env file, "
+                "then restart the gateway.",
+                retryable=False,
+            )
             return False
 
         proxy_url = _resolve_slack_proxy_url()

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -498,6 +498,30 @@ def _resolve_slack_proxy_url() -> Optional[str]:
     return proxy_url
 
 
+def _slack_dedup_ttl_seconds() -> float:
+    """Dedup window for redelivered Socket Mode events (#4777).
+
+    Slack buffers un-acked Socket Mode events and replays them when the
+    websocket reconnects. The replay can arrive several minutes after the
+    original — well past the 300s default TTL — which would otherwise be
+    treated as a new message and produce a duplicate bot reply. Memory is
+    bounded by ``MessageDeduplicator(max_size=...)`` (LRU pruning), not by
+    the TTL, so the window can safely span the worst-case reconnect gap.
+    Override with ``SLACK_DEDUP_TTL_SECONDS``.
+    """
+    raw = os.getenv("SLACK_DEDUP_TTL_SECONDS", "")
+    if raw:
+        try:
+            value = float(raw)
+            if value > 0:
+                return value
+        except ValueError:
+            logger.warning(
+                "[Slack] Invalid SLACK_DEDUP_TTL_SECONDS=%r; using default", raw
+            )
+    return 3600.0  # 1 hour — covers Slack reconnect redelivery windows
+
+
 # Map Slack audio mimetypes to the file extension that matches the actual
 # container bytes.  Critically, Slack's in-app "record a clip" voice messages
 # arrive as MP4/AAC containers (``audio/mp4``, filename ``audio_message*.mp4``),
@@ -643,8 +667,12 @@ class SlackAdapter(BasePlatformAdapter):
         self._team_bot_user_ids: Dict[str, str] = {}  # team_id → bot_user_id
         self._channel_team: Dict[str, str] = {}  # channel_id → team_id
         # Dedup cache: prevents duplicate bot responses when Socket Mode
-        # reconnects redeliver events.
-        self._dedup = MessageDeduplicator()
+        # reconnects redeliver events (#4777). The TTL must outlast Slack's
+        # worst-case reconnect-redelivery gap, not just a few seconds — the
+        # 300s default let replays that landed >5 min later slip through and
+        # produce a second reply. max_size bounds memory, so the long window
+        # is safe.
+        self._dedup = MessageDeduplicator(ttl_seconds=_slack_dedup_ttl_seconds())
         # Track pending approval message_ts → resolved flag to prevent
         # double-clicks on approval buttons.
         self._approval_resolved: Dict[str, bool] = {}

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -10,6 +10,7 @@ Uses slack-bolt (Python) with Socket Mode for:
 
 import asyncio
 import contextvars
+import inspect
 import json
 import logging
 import os
@@ -704,6 +705,31 @@ class SlackAdapter(BasePlatformAdapter):
         # first ping/pong as evidence of a wedged transport.
         self._socket_first_ping_grace_s = 60.0
 
+    async def _close_workspace_clients(self) -> None:
+        """Close any Slack SDK clients that may own aiohttp sessions."""
+        clients: List[Any] = []
+        if self._app is not None:
+            primary_client = getattr(self._app, "client", None)
+            if primary_client is not None:
+                clients.append(primary_client)
+        clients.extend(self._team_clients.values())
+
+        seen_ids: set[int] = set()
+        for client in clients:
+            ident = id(client)
+            if ident in seen_ids:
+                continue
+            seen_ids.add(ident)
+
+            for method_name in ("close", "aclose"):
+                closer = getattr(client, method_name, None)
+                if not callable(closer):
+                    continue
+                result = closer()
+                if inspect.isawaitable(result):
+                    await result
+                break
+
     def _start_socket_mode_handler(self) -> None:
         """Start the Slack Socket Mode background task."""
         if not self._app or not self._app_token:
@@ -1334,6 +1360,7 @@ class SlackAdapter(BasePlatformAdapter):
             # receive every Slack event and dispatch it twice, producing double
             # responses — the same bug that affected DiscordAdapter (#18187).
             await self._stop_socket_mode_handler()
+            await self._close_workspace_clients()
             self._app = None
             self._app_token = app_token
             self._proxy_url = proxy_url
@@ -1651,9 +1678,14 @@ class SlackAdapter(BasePlatformAdapter):
                 )
 
         await self._stop_socket_mode_handler()
+        await self._close_workspace_clients()
         self._app = None
         self._app_token = None
         self._proxy_url = None
+        self._bot_user_id = None
+        self._team_clients = {}
+        self._team_bot_user_ids = {}
+        self._channel_team = {}
 
         self._release_platform_lock()
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3434,10 +3434,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[%s] python-telegram-bot not installed. Run: pip install python-telegram-bot",
                 self.name,
             )
+            self._set_fatal_error("missing_dependency", "python-telegram-bot not installed", retryable=False)
             return False
         
         if not self.config.token:
             logger.error("[%s] No bot token configured", self.name)
+            self._set_fatal_error("missing_credentials", "No bot token configured", retryable=False)
             return False
         
         try:

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -1076,3 +1076,37 @@ async def test_safe_sync_detects_contexts_drift():
     fake_http.edit_global_command.assert_not_awaited()
     fake_http.delete_global_command.assert_awaited_once_with(999, 77)
     fake_http.upsert_global_command.assert_awaited_once_with(999, desired)
+
+
+# ============================================================================
+# #31049: unconfigured platform skips reconnection (non-retryable fatal error)
+# ============================================================================
+
+class TestDiscordUnconfiguredNonRetryable:
+    """Verify that missing dependency/token sets a non-retryable fatal error
+    so the gateway does not queue the platform for background reconnection."""
+
+    @pytest.mark.asyncio
+    async def test_no_discord_lib_sets_non_retryable_fatal(self, monkeypatch):
+        """connect() with discord.py unavailable → non-retryable fatal error."""
+        _ensure_discord_mock()
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="fake"))
+        # Simulate discord.py not installed
+        monkeypatch.setattr(discord_platform, "DISCORD_AVAILABLE", False)
+        result = await adapter.connect()
+        assert result is False
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert adapter.fatal_error_code == "missing_dependency"
+
+    @pytest.mark.asyncio
+    async def test_no_bot_token_sets_non_retryable_fatal(self, monkeypatch):
+        """connect() with empty token → non-retryable fatal error."""
+        _ensure_discord_mock()
+        monkeypatch.setattr(discord_platform, "DISCORD_AVAILABLE", True)
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token=""))
+        result = await adapter.connect()
+        assert result is False
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert adapter.fatal_error_code == "missing_credentials"

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -12,6 +12,7 @@ import asyncio
 import contextlib
 import os
 import sys
+import time
 from unittest.mock import AsyncMock, MagicMock, patch, call
 
 import pytest
@@ -799,6 +800,85 @@ class TestSlackSocketWatchdog:
                 assert (
                     new_handlers <= 2
                 ), f"reconnect lock failed: {new_handlers} new handlers"
+            finally:
+                await adapter.disconnect()
+
+    # -- ping/pong staleness: heals the wedged transport that is_connected() misses --
+
+    def _adapter_with_fake_client(self, **client_attrs):
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+        client = MagicMock()
+        for key, value in client_attrs.items():
+            setattr(client, key, value)
+        adapter._handler = MagicMock(client=client)
+        return adapter
+
+    def test_ping_pong_stale_when_last_ping_old(self):
+        adapter = self._adapter_with_fake_client(
+            ping_interval=30, last_ping_pong_time=time.time() - 1000
+        )
+        assert adapter._socket_ping_pong_stale() is True
+
+    def test_ping_pong_fresh_when_last_ping_recent(self):
+        adapter = self._adapter_with_fake_client(
+            ping_interval=30, last_ping_pong_time=time.time() - 5
+        )
+        assert adapter._socket_ping_pong_stale() is False
+
+    def test_ping_pong_none_within_grace_not_stale(self):
+        adapter = self._adapter_with_fake_client(
+            ping_interval=30, last_ping_pong_time=None
+        )
+        adapter._socket_handler_started_monotonic = time.monotonic()
+        assert adapter._socket_ping_pong_stale() is False
+
+    def test_ping_pong_none_beyond_grace_is_stale(self):
+        adapter = self._adapter_with_fake_client(
+            ping_interval=30, last_ping_pong_time=None
+        )
+        adapter._socket_first_ping_grace_s = 0.0
+        adapter._socket_handler_started_monotonic = time.monotonic() - 200
+        assert adapter._socket_ping_pong_stale() is True
+
+    def test_ping_pong_no_handler_not_stale(self):
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+        adapter._handler = None
+        assert adapter._socket_ping_pong_stale() is False
+
+    def test_ping_pong_nonnumeric_attrs_not_stale(self):
+        # A mocked/partial client (MagicMock attrs) must never trigger reconnect.
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+        adapter._handler = MagicMock()
+        assert adapter._socket_ping_pong_stale() is False
+
+    @pytest.mark.asyncio
+    async def test_watchdog_reconnects_when_ping_pong_stale_despite_is_connected_true(self):
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+        adapter._socket_watchdog_interval_s = 0.01
+        factory, instances = self._make_fake_handler_factory()
+
+        with contextlib.ExitStack() as stack:
+            for p in self._patch_stack(factory):
+                stack.enter_context(p)
+
+            try:
+                assert await adapter.connect() is True
+                assert len(instances) == 1
+
+                # Transport lies: is_connected() stays True while ping/pong has
+                # gone stale (the wedged "Session is closed" zombie).
+                instances[0].client.is_connected = lambda: True
+                instances[0].client.ping_interval = 30
+                instances[0].client.last_ping_pong_time = time.time() - 1000
+
+                for _ in range(40):
+                    if len(instances) >= 2:
+                        break
+                    await asyncio.sleep(0.01)
+
+                assert len(instances) >= 2, "watchdog did not heal wedged (lying) transport"
+                assert instances[0].closed is True
+                assert adapter._handler is instances[-1]
             finally:
                 await adapter.disconnect()
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -5192,3 +5192,64 @@ class TestThreadContextAppMessages:
             )
 
         assert "hello" in content  # the real message survives; empty bot msg dropped
+
+
+# ---------------------------------------------------------------------------
+# Missing-credential handling — fatal-error contract
+# ---------------------------------------------------------------------------
+
+
+class TestMissingCredentials:
+    """Missing SLACK_BOT_TOKEN or SLACK_APP_TOKEN must set a non-retryable fatal error."""
+
+    @pytest.mark.asyncio
+    async def test_missing_bot_token_sets_fatal_error(self):
+        """When SLACK_BOT_TOKEN is absent from both config and env, connect()
+        must set fatal_error with code 'missing_slack_bot_token' and retryable=False."""
+        config = PlatformConfig(enabled=True, token=None)  # no bot token
+        adapter = SlackAdapter(config)
+
+        fatal_errors = []
+
+        def capture_fatal(code, message, *, retryable):
+            fatal_errors.append({"code": code, "message": message, "retryable": retryable})
+
+        with (
+            patch.object(adapter, "_set_fatal_error", side_effect=capture_fatal),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            result = await adapter.connect()
+
+        assert result is False
+        assert len(fatal_errors) == 1
+        assert fatal_errors[0]["code"] == "missing_slack_bot_token"
+        assert fatal_errors[0]["retryable"] is False
+        assert "SLACK_BOT_TOKEN" in fatal_errors[0]["message"]
+        assert "hermes gateway setup" in fatal_errors[0]["message"].lower() or ".env" in fatal_errors[0]["message"]
+
+    @pytest.mark.asyncio
+    async def test_missing_app_token_sets_fatal_error(self):
+        """When SLACK_APP_TOKEN is absent but SLACK_BOT_TOKEN is present,
+        connect() must set fatal_error with code 'missing_slack_app_token'
+        and retryable=False."""
+        config = PlatformConfig(enabled=True, token="xoxb-fake")
+        adapter = SlackAdapter(config)
+
+        fatal_errors = []
+
+        def capture_fatal(code, message, *, retryable):
+            fatal_errors.append({"code": code, "message": message, "retryable": retryable})
+
+        with (
+            patch.object(adapter, "_set_fatal_error", side_effect=capture_fatal),
+            patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-fake"}, clear=True),
+        ):
+            result = await adapter.connect()
+
+        assert result is False
+        assert len(fatal_errors) == 1
+        assert fatal_errors[0]["code"] == "missing_slack_app_token"
+        assert fatal_errors[0]["retryable"] is False
+        assert "SLACK_APP_TOKEN" in fatal_errors[0]["message"]
+        assert "hermes gateway setup" in fatal_errors[0]["message"].lower() or ".env" in fatal_errors[0]["message"]
+

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -468,6 +468,7 @@ class TestSlackConnectCleanup:
         )
 
         second_handler = MagicMock()
+        second_handler.close_async = AsyncMock(return_value=None)
         # _start_socket_mode_handler awaits the result of start_async via
         # asyncio.create_task — so the stub must return a real coroutine, not a
         # bare MagicMock.
@@ -489,6 +490,62 @@ class TestSlackConnectCleanup:
         assert result is True
         first_handler.close_async.assert_awaited_once_with()
         assert adapter._handler is second_handler
+
+        with patch("gateway.status.release_scoped_lock"):
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_closes_workspace_clients_and_clears_runtime_state(self):
+        """Regression for #51465: shutdown must close Slack WebClients.
+
+        ``hermes gateway run --replace`` takes the old process through the
+        normal adapter.disconnect() path. If Slack leaves AsyncWebClient
+        instances open there, aiohttp logs ``Unclosed client session`` while
+        the old gateway exits after SIGTERM.
+        """
+        config = PlatformConfig(enabled=True, token="xoxb-fake")
+        adapter = SlackAdapter(config)
+
+        socket_task = asyncio.create_task(_pending_for_fake_task())
+        handler = MagicMock()
+        handler.close_async = AsyncMock(return_value=None)
+
+        primary_client = MagicMock()
+        primary_client.close = AsyncMock(return_value=None)
+        team_client = MagicMock()
+        team_client.close = AsyncMock(return_value=None)
+
+        adapter._running = True
+        adapter._handler = handler
+        adapter._socket_mode_task = socket_task
+        adapter._app = MagicMock()
+        adapter._app.client = primary_client
+        adapter._team_clients = {"T_FAKE": team_client}
+        adapter._team_bot_user_ids = {"T_FAKE": "U_BOT"}
+        adapter._channel_team = {"C_FAKE": "T_FAKE"}
+        adapter._platform_lock_scope = "slack-app-token"
+        adapter._platform_lock_identity = "xapp-fake"
+        adapter._app_token = "xapp-fake"
+        adapter._proxy_url = "http://proxy.example.com:3128"
+        adapter._bot_user_id = "U_BOT"
+
+        with patch("gateway.status.release_scoped_lock") as mock_release:
+            await adapter.disconnect()
+
+        handler.close_async.assert_awaited_once_with()
+        primary_client.close.assert_awaited_once_with()
+        team_client.close.assert_awaited_once_with()
+        assert socket_task.cancelled()
+        assert adapter._app is None
+        assert adapter._handler is None
+        assert adapter._socket_mode_task is None
+        assert adapter._team_clients == {}
+        assert adapter._team_bot_user_ids == {}
+        assert adapter._channel_team == {}
+        assert adapter._bot_user_id is None
+        assert adapter._app_token is None
+        assert adapter._proxy_url is None
+        mock_release.assert_called_once_with("slack-app-token", "xapp-fake")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack_dedup_ttl.py
+++ b/tests/gateway/test_slack_dedup_ttl.py
@@ -1,0 +1,92 @@
+"""
+Tests for Slack Socket Mode dedup TTL (#4777).
+
+Slack replays un-acked Socket Mode events when the websocket reconnects.
+The replay can land several minutes after the original; the dedup window
+must outlast that gap so the redelivered event is suppressed instead of
+producing a second bot reply. Regression for the 300s-default bug where
+replays >5 min later slipped through.
+
+Follows the slack-bolt mocking pattern from test_slack_mention.py.
+"""
+
+import os
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return
+
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        ("slack_bolt.adapter.socket_mode.async_handler", slack_bolt.adapter.socket_mode.async_handler),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_slack_mock()
+
+import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
+
+_slack_mod.SLACK_AVAILABLE = True
+
+from gateway.platforms.helpers import MessageDeduplicator  # noqa: E402
+from plugins.platforms.slack.adapter import _slack_dedup_ttl_seconds  # noqa: E402
+
+
+def test_default_ttl_outlasts_slack_reconnect_redelivery_window():
+    # The whole point of the fix: the window must be much longer than the
+    # ~6 min reconnect-redelivery gap that caused the duplicate reply.
+    with patch.dict(os.environ, {}, clear=True):
+        assert _slack_dedup_ttl_seconds() >= 1800.0
+
+
+def test_env_override_is_respected():
+    with patch.dict(os.environ, {"SLACK_DEDUP_TTL_SECONDS": "120"}, clear=True):
+        assert _slack_dedup_ttl_seconds() == 120.0
+
+
+def test_invalid_env_falls_back_to_default():
+    with patch.dict(os.environ, {"SLACK_DEDUP_TTL_SECONDS": "not-a-number"}, clear=True):
+        assert _slack_dedup_ttl_seconds() >= 1800.0
+    with patch.dict(os.environ, {"SLACK_DEDUP_TTL_SECONDS": "0"}, clear=True):
+        assert _slack_dedup_ttl_seconds() >= 1800.0
+
+
+def test_redelivery_six_minutes_later_is_suppressed():
+    """A replay 6 min after first processing must be treated as duplicate."""
+    dedup = MessageDeduplicator(ttl_seconds=_slack_dedup_ttl_seconds())
+    event_ts = "1733382960.001500"
+
+    # First delivery — recorded now.
+    assert dedup.is_duplicate(event_ts) is False
+    # Simulate the entry being stamped 6 minutes ago (reconnect redelivery gap).
+    dedup._seen[event_ts] = time.time() - 360
+    # Redelivery of the SAME event must still be caught.
+    assert dedup.is_duplicate(event_ts) is True
+
+
+def test_old_default_300s_would_have_missed_it():
+    """Pins the regression: the prior 300s window let the replay through."""
+    dedup = MessageDeduplicator(ttl_seconds=300)
+    event_ts = "1733382960.001500"
+    assert dedup.is_duplicate(event_ts) is False
+    dedup._seen[event_ts] = time.time() - 360  # 6 min ago, past 300s TTL
+    # Demonstrates the bug: replay treated as new → second reply.
+    assert dedup.is_duplicate(event_ts) is False

--- a/tests/gateway/test_slack_socket_reconnect_heal.py
+++ b/tests/gateway/test_slack_socket_reconnect_heal.py
@@ -1,0 +1,381 @@
+"""
+Tests for Slack Socket Mode teardown (issue #46990).
+
+slack_sdk's SocketModeClient.connect() is an unconditional retry loop that
+swallows connection errors and never checks the client's ``closed`` flag. If a
+task is still inside that loop when the client's shared aiohttp session is
+closed, it keeps retrying forever and logs
+``Failed to connect (error: Session is closed); Retrying...`` against a session
+that can never work again.
+
+These tests pin the ordering and cleanup that keep old-client background work
+from outliving a teardown.
+"""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Mock the slack-bolt package if it's not installed
+# ---------------------------------------------------------------------------
+
+
+def _ensure_slack_mock():
+    """Install mock slack modules so SlackAdapter can be imported."""
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return  # Real library installed
+
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        (
+            "slack_bolt.adapter.socket_mode.async_handler",
+            slack_bolt.adapter.socket_mode.async_handler,
+        ),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        sys.modules.setdefault(name, mod)
+
+    sys.modules.setdefault("aiohttp", MagicMock())
+
+
+_ensure_slack_mock()
+
+import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
+
+_slack_mod.SLACK_AVAILABLE = True
+
+from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+from gateway.config import PlatformConfig  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Minimal stand-ins for the slack_sdk objects involved in teardown
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession:
+    """Stands in for the ``aiohttp.ClientSession`` SocketModeClient holds."""
+
+    def __init__(self, client=None) -> None:
+        self.closed = False
+        self.reachable = False
+        self.ws_connect_after_close = 0
+        self._client = client
+        self.live_tasks_at_close: list = []
+
+    async def ws_connect(self):
+        if self.closed:
+            # This is the exact failure recorded in #46990.
+            self.ws_connect_after_close += 1
+            raise RuntimeError("Session is closed")
+        if not self.reachable:
+            raise ConnectionError("connection refused")
+        return object()
+
+    async def close(self) -> None:
+        # Record which client tasks were still alive at the instant the shared
+        # session went away. Anything listed here could be inside connect().
+        if self._client is not None:
+            self.live_tasks_at_close = self._client.live_task_names()
+        self.closed = True
+        # Closing a real session performs I/O and yields control back to the
+        # loop, which is what gives a surviving retry task a chance to run.
+        await asyncio.sleep(0.01)
+
+
+class _FakeSocketModeClient:
+    """Mirrors the parts of SocketModeClient that matter during teardown."""
+
+    _TASK_ATTRS = ("message_processor", "current_session_monitor", "message_receiver")
+
+    def __init__(self) -> None:
+        self.aiohttp_client_session = _FakeSession(self)
+        self.closed = False
+        self.close_should_raise = False
+        self.message_processor = None
+        self.current_session_monitor = None
+        self.message_receiver = None
+
+    def live_task_names(self) -> list:
+        return [
+            attr
+            for attr in self._TASK_ATTRS
+            if getattr(self, attr) is not None and not getattr(self, attr).done()
+        ]
+
+    async def connect_to_new_endpoint(self) -> None:
+        # monitor_current_session() (on staleness) and receive_messages() (on a
+        # CLOSE frame) both reach connect() through here, independently.
+        await self.connect()
+
+    async def monitor_current_session(self) -> None:
+        while not self.closed:
+            await asyncio.sleep(0.001)
+            await self.connect_to_new_endpoint()
+
+    async def connect(self) -> None:
+        # Mirrors SocketModeClient.connect(): ``while True`` with a broad
+        # ``except Exception``, so neither the closed flag nor a closed session
+        # ends the loop.
+        while True:
+            try:
+                await self.aiohttp_client_session.ws_connect()
+                return
+            except Exception:
+                await asyncio.sleep(0.001)
+
+    async def close(self) -> None:
+        self.closed = True
+        if self.close_should_raise:
+            # SocketModeClient.close() calls disconnect() before it cancels its
+            # background tasks. A broken session makes disconnect() raise, so
+            # the SDK never reaches those cancel() calls at all.
+            raise RuntimeError("Session is closed")
+        for task in (
+            self.message_processor,
+            self.current_session_monitor,
+            self.message_receiver,
+        ):
+            if task is not None:
+                # The SDK requests cancellation but never awaits it.
+                task.cancel()
+        await self.aiohttp_client_session.close()
+
+
+class _FakeHandler:
+    """Stands in for AsyncSocketModeHandler."""
+
+    def __init__(self) -> None:
+        self.client = _FakeSocketModeClient()
+
+    async def start_async(self) -> None:
+        await self.client.connect()
+        await asyncio.sleep(float("inf"))
+
+    async def close_async(self) -> None:
+        await self.client.close()
+
+
+async def _spin() -> None:
+    while True:
+        await asyncio.sleep(0.001)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def adapter():
+    config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+    a = SlackAdapter(config)
+    a._app = MagicMock()
+    a._app_token = "xapp-fake"
+    a._proxy_url = None
+    a._running = True
+    a.handle_message = AsyncMock()
+    return a
+
+
+def _attach(adapter, handler):
+    """Wire a handler into the adapter the way _start_socket_mode_handler does."""
+    adapter._handler = handler
+    task = asyncio.create_task(handler.start_async())
+    adapter._socket_mode_task = task
+    return task
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSocketModeTeardown:
+    @pytest.mark.asyncio
+    async def test_socket_task_stops_before_session_is_closed(self, adapter):
+        """The socket task must be stopped before close_async() kills the session.
+
+        The task is parked in the SDK's connect() retry loop, which is the state
+        #46990 describes. If teardown closes the shared session first, that loop
+        wakes up and retries against a session that is already gone.
+        """
+        handler = _FakeHandler()
+        task = _attach(adapter, handler)
+        # Let the task settle into the retry loop.
+        await asyncio.sleep(0.01)
+
+        await adapter._stop_socket_mode_handler()
+        # Give anything that survived a chance to make itself known.
+        await asyncio.sleep(0.03)
+
+        session = handler.client.aiohttp_client_session
+        assert session.ws_connect_after_close == 0, (
+            "the old socket task retried against a closed session "
+            f"{session.ws_connect_after_close} time(s) after close_async()"
+        )
+        assert task.done(), "the old socket task outlived teardown"
+
+    @pytest.mark.asyncio
+    async def test_sdk_background_tasks_do_not_outlive_teardown(self, adapter):
+        """Old-client background tasks must be cancelled even if close_async() fails.
+
+        SocketModeClient.close() cancels message_processor,
+        current_session_monitor and message_receiver only after disconnect()
+        returns, so a raising disconnect() leaves all three running. The adapter
+        logs and moves on, so it has to clean them up itself.
+        """
+        handler = _FakeHandler()
+        client = handler.client
+        client.close_should_raise = True
+        client.message_processor = asyncio.create_task(_spin())
+        client.current_session_monitor = asyncio.create_task(_spin())
+        client.message_receiver = asyncio.create_task(_spin())
+
+        _attach(adapter, handler)
+        await asyncio.sleep(0.01)
+
+        await adapter._stop_socket_mode_handler()
+        await asyncio.sleep(0.03)
+
+        for name in (
+            "message_processor",
+            "current_session_monitor",
+            "message_receiver",
+        ):
+            assert getattr(client, name).done(), f"{name} outlived teardown"
+
+    @pytest.mark.asyncio
+    async def test_client_tasks_are_dead_before_the_session_closes(self, adapter):
+        """Nothing may still be inside connect() when the shared session closes.
+
+        monitor_current_session() and receive_messages() each reach
+        connect_to_new_endpoint() on their own, and connect() rebinds
+        current_session_monitor and message_receiver to fresh tasks on success.
+        The live task set therefore changes across the awaits inside
+        SocketModeClient.close(), so cancelling from a snapshot taken partway
+        through races a moving target. Everything has to be stopped before the
+        session is closed. See slackapi/python-slack-sdk#1913.
+        """
+        handler = _FakeHandler()
+        client = handler.client
+        client.message_processor = asyncio.create_task(_spin())
+        client.current_session_monitor = asyncio.create_task(
+            client.monitor_current_session()
+        )
+        client.message_receiver = asyncio.create_task(client.monitor_current_session())
+
+        _attach(adapter, handler)
+        # Let both reconnect loops settle inside connect().
+        await asyncio.sleep(0.01)
+
+        await adapter._stop_socket_mode_handler()
+        await asyncio.sleep(0.03)
+
+        session = client.aiohttp_client_session
+        assert session.live_tasks_at_close == [], (
+            "client tasks were still running when the shared session was closed: "
+            f"{session.live_tasks_at_close}"
+        )
+        assert session.ws_connect_after_close == 0, (
+            "a client task retried against a closed session "
+            f"{session.ws_connect_after_close} time(s)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_clears_adapter_state(self, adapter):
+        """Teardown always drops its references, even when close_async() raises."""
+        handler = _FakeHandler()
+        handler.client.close_should_raise = True
+        _attach(adapter, handler)
+        await asyncio.sleep(0.01)
+
+        await adapter._stop_socket_mode_handler()
+
+        assert adapter._handler is None
+        assert adapter._socket_mode_task is None
+
+
+class TestSocketModeRestart:
+    @pytest.mark.asyncio
+    async def test_restart_stops_old_handler_before_starting_new_one(self, adapter):
+        """A reconnect must fully retire the old handler before replacing it."""
+        old = _FakeHandler()
+        old_task = _attach(adapter, old)
+        await asyncio.sleep(0.01)
+
+        started: list[str] = []
+
+        def _fake_start() -> None:
+            started.append("started")
+            assert old_task.done(), (
+                "the replacement handler was created while the old socket task "
+                "was still running"
+            )
+
+        with patch.object(adapter, "_start_socket_mode_handler", _fake_start):
+            await adapter._restart_socket_mode("transport disconnected")
+
+        await asyncio.sleep(0.03)
+
+        assert started == ["started"]
+        assert old.client.aiohttp_client_session.ws_connect_after_close == 0
+
+    @pytest.mark.asyncio
+    async def test_watchdog_restarts_when_socket_task_stops(self, adapter):
+        """The existing watchdog triggers still fire after the teardown change."""
+        done_task = MagicMock()
+        done_task.done.return_value = True
+        adapter._socket_mode_task = done_task
+
+        reasons: list[str] = []
+
+        async def _fake_restart(reason: str) -> None:
+            reasons.append(reason)
+            adapter._running = False
+
+        adapter._restart_socket_mode = _fake_restart
+        adapter._socket_transport_connected = AsyncMock(return_value=None)
+        adapter._socket_watchdog_interval_s = 0.01
+
+        await adapter._socket_watchdog_loop()
+
+        assert reasons == ["socket task stopped"]
+
+    @pytest.mark.asyncio
+    async def test_watchdog_restarts_when_transport_disconnected(self, adapter):
+        """A transport that reports itself down still triggers a reconnect."""
+        live_task = MagicMock()
+        live_task.done.return_value = False
+        adapter._socket_mode_task = live_task
+        adapter._handler = MagicMock()
+
+        reasons: list[str] = []
+
+        async def _fake_restart(reason: str) -> None:
+            reasons.append(reason)
+            adapter._running = False
+
+        adapter._restart_socket_mode = _fake_restart
+        adapter._socket_transport_connected = AsyncMock(return_value=False)
+        adapter._socket_watchdog_interval_s = 0.01
+
+        await adapter._socket_watchdog_loop()
+
+        assert reasons == ["transport disconnected"]

--- a/tests/gateway/test_telegram_connect.py
+++ b/tests/gateway/test_telegram_connect.py
@@ -1,0 +1,66 @@
+"""Tests for Telegram connect() non-retryable fatal error on missing credentials.
+
+When Telegram has no bot token or no python-telegram-bot installed, connect()
+must set a non-retryable fatal error so the gateway does not queue it for
+background reconnection (#31049).
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+
+    telegram_mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    telegram_mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    telegram_mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+    sys.modules.setdefault("telegram.error", telegram_mod.error)
+
+
+_ensure_telegram_mock()
+
+import plugins.platforms.telegram.adapter as telegram_mod  # noqa: E402
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+class TestTelegramUnconfiguredNonRetryable:
+    """Verify that missing dependency/token sets a non-retryable fatal error."""
+
+    @pytest.mark.asyncio
+    async def test_no_telegram_lib_sets_non_retryable_fatal(self, monkeypatch):
+        """connect() with python-telegram-bot unavailable → non-retryable fatal error."""
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake"))
+        monkeypatch.setattr(telegram_mod, "TELEGRAM_AVAILABLE", False)
+        result = await adapter.connect()
+        assert result is False
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert adapter.fatal_error_code == "missing_dependency"
+
+    @pytest.mark.asyncio
+    async def test_no_bot_token_sets_non_retryable_fatal(self, monkeypatch):
+        """connect() with empty token → non-retryable fatal error."""
+        monkeypatch.setattr(telegram_mod, "TELEGRAM_AVAILABLE", True)
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token=""))
+        result = await adapter.connect()
+        assert result is False
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert adapter.fatal_error_code == "missing_credentials"


### PR DESCRIPTION
## Summary
Slack Socket Mode connections now fail fast on missing credentials, heal closed-session and wedged-socket states, shut down cleanly, and dedup reconnect redelivery — ending the reconnect-loop / zombie-connection bug class.

Fixes #66696, #46990, #14326, #51465, #31049, #4777.

## Changes
- Missing SLACK_APP_TOKEN/bot token → non-retryable fatal error with actionable guidance (#66720), layered on the cross-platform class fix marking unconfigured platforms non-retryable across Slack/Telegram/Discord (#31057, reapplied to plugin paths).
- "Session is closed" hot loop: quiesce socket tasks (message_processor, session_monitor, receiver) with a 3s bound before `close_async()` (#66645).
- Wedged-zombie sockets: ping/pong staleness check in the existing watchdog — `is_connected()` can lie (#52923).
- Clean shutdown: `_close_workspace_clients()` on disconnect + pre-reconnect; no more "Unclosed client session" on `--replace` (#51670).
- Reconnect redelivery: dedup TTL 300s→3600s with `SLACK_DEDUP_TTL_SECONDS` override (#40064, reapplied).
- Widening audit: both `aiohttp.ClientSession` sites already use `async with`; no further leak sites.

## Credits
Salvaged with authorship preserved: #66720 (@x7peeps), #31057 (@dskwe), #66645 (@NimbleCoAI), #52923 (@87degrees), #51670 (@LeonSGP43), #40064 (@MrAbsaroka).
Supersedes #62196 (same quiesce fix + unrelated CI changes), #58658 (teardown flag can strand the disconnect midway).
Deferred: #51623/#47003 websockets backend swap (architectural, watchdog probes are aiohttp-shaped — needs its own PR), #44714/#44178 mention backfill (replays old messages into the agent pipeline — risk; staleness detection addresses the root cause). #3944 recommend close as stale.

## Validation
| Check | Result |
|---|---|
| `test_slack_socket_reconnect_heal.py` (new, 381 ln) | credential fail-fast, quiesce, staleness heal, clean close |
| `test_slack_dedup_ttl.py` (new) | TTL covers redelivery window |
| `scripts/run_tests.sh tests/gateway/ -q -k slack` + discord/telegram connect suites | all green (re-verified post-rebase) |

## Infographic

![slack-socket-mode-health](https://v3b.fal.media/files/b/0aa3453b/QiQqBHH9KG8fwHndh0UEg_RTAZdJTI.png)
