### PR TITLE
Add Atlas Cloud model provider

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -190,6 +190,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://api.arcee.ai/api/v1",
         base_url_env_var="ARCEE_BASE_URL",
     ),
+    "atlascloud": HermesOverlay(
+        transport="openai_chat",
+        extra_env_vars=("ATLASCLOUD_API_KEY",),
+        base_url_override="https://api.atlascloud.ai/v1",
+        base_url_env_var="ATLASCLOUD_BASE_URL",
+    ),
     "gmi": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("GMI_API_KEY",),
@@ -350,6 +356,10 @@ ALIASES: Dict[str, str] = {
     "arcee-ai": "arcee",
     "arceeai": "arcee",
 
+    # atlascloud
+    "atlas": "atlascloud",
+    "atlas-cloud": "atlascloud",
+
     # gmi
     "gmi-cloud": "gmi",
     "gmicloud": "gmi",
@@ -391,6 +401,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "local": "Local endpoint",
     "bedrock": "AWS Bedrock",
     "ollama-cloud": "Ollama Cloud",
+    "atlascloud": "Atlas Cloud",
     "xai-oauth": "xAI Grok OAuth (SuperGrok / Premium+)",
 }
 

--- a/plugins/model-providers/atlascloud/__init__.py
+++ b/plugins/model-providers/atlascloud/__init__.py
@@ -1,0 +1,22 @@
+"""Atlas Cloud provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+atlascloud = ProviderProfile(
+    name="atlascloud",
+    aliases=("atlas", "atlas-cloud"),
+    display_name="Atlas Cloud",
+    description="Atlas Cloud - OpenAI-compatible unified model API",
+    signup_url="https://www.atlascloud.ai/console/api-keys",
+    env_vars=("ATLASCLOUD_API_KEY", "ATLASCLOUD_BASE_URL"),
+    base_url="https://api.atlascloud.ai/v1",
+    auth_type="api_key",
+    default_aux_model="qwen/qwen3.5-flash",
+    fallback_models=(
+        "qwen/qwen3.5-flash",
+        "deepseek-ai/deepseek-v4-pro",
+    ),
+)
+
+register_provider(atlascloud)

--- a/plugins/model-providers/atlascloud/plugin.yaml
+++ b/plugins/model-providers/atlascloud/plugin.yaml
@@ -1,0 +1,5 @@
+name: atlascloud-provider
+kind: model-provider
+version: 1.0.0
+description: Atlas Cloud OpenAI-compatible unified model API
+author: Nous Research

--- a/tests/providers/test_atlascloud_provider.py
+++ b/tests/providers/test_atlascloud_provider.py
@@ -1,0 +1,48 @@
+"""Tests for the Atlas Cloud model provider profile."""
+
+from __future__ import annotations
+
+
+def test_atlascloud_profile_metadata():
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("atlas")
+
+    assert profile is not None
+    assert profile.name == "atlascloud"
+    assert profile.display_name == "Atlas Cloud"
+    assert profile.base_url == "https://api.atlascloud.ai/v1"
+    assert profile.env_vars == ("ATLASCLOUD_API_KEY", "ATLASCLOUD_BASE_URL")
+    assert profile.default_aux_model == "qwen/qwen3.5-flash"
+    assert profile.fallback_models == (
+        "qwen/qwen3.5-flash",
+        "deepseek-ai/deepseek-v4-pro",
+    )
+
+
+def test_atlascloud_wires_auth_catalog_and_picker(monkeypatch):
+    monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+    monkeypatch.delenv("ATLASCLOUD_BASE_URL", raising=False)
+
+    from hermes_cli.auth import PROVIDER_REGISTRY
+    from hermes_cli.models import CANONICAL_PROVIDERS, provider_model_ids
+    from hermes_cli.providers import determine_api_mode, resolve_provider_full
+
+    auth_cfg = PROVIDER_REGISTRY["atlascloud"]
+    assert auth_cfg.api_key_env_vars == ("ATLASCLOUD_API_KEY",)
+    assert auth_cfg.base_url_env_var == "ATLASCLOUD_BASE_URL"
+    assert auth_cfg.inference_base_url == "https://api.atlascloud.ai/v1"
+    assert PROVIDER_REGISTRY["atlas"] is auth_cfg
+
+    assert "atlascloud" in {entry.slug for entry in CANONICAL_PROVIDERS}
+    assert provider_model_ids("atlascloud") == [
+        "qwen/qwen3.5-flash",
+        "deepseek-ai/deepseek-v4-pro",
+    ]
+
+    provider = resolve_provider_full("atlas-cloud")
+    assert provider is not None
+    assert provider.id == "atlascloud"
+    assert provider.base_url == "https://api.atlascloud.ai/v1"
+    assert provider.api_key_env_vars == ("ATLASCLOUD_API_KEY",)
+    assert determine_api_mode("atlascloud", provider.base_url) == "chat_completions"

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -69,6 +69,7 @@ def test_all_profiles_register():
     for required in (
         "openrouter", "anthropic", "custom", "bedrock", "openai-codex",
         "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan", "fireworks",
+        "atlascloud",
     ):
         assert required in names, f"Missing profile: {required}"
 


### PR DESCRIPTION
## Summary
- add an Atlas Cloud model-provider plugin profile with the OpenAI-compatible base URL
- wire Atlas Cloud into Hermes provider resolution with `atlas` / `atlas-cloud` aliases and `ATLASCLOUD_API_KEY` auth
- add focused provider tests for plugin discovery, auth/catalog registration, model fallbacks, and runtime resolution

## Details
- base URL: `https://api.atlascloud.ai/v1`
- API key env var: `ATLASCLOUD_API_KEY`
- optional base URL override: `ATLASCLOUD_BASE_URL`
- default/fallback models: `qwen/qwen3.5-flash`, `deepseek-ai/deepseek-v4-pro`

No README or promotional content changes are included.

## Validation
- `uv run --extra dev pytest tests/providers/test_plugin_discovery.py tests/providers/test_atlascloud_provider.py -q`
- `uv run --extra dev ruff check plugins/model-providers/atlascloud/__init__.py hermes_cli/providers.py tests/providers/test_plugin_discovery.py tests/providers/test_atlascloud_provider.py`
- `python3 -m py_compile plugins/model-providers/atlascloud/__init__.py hermes_cli/providers.py tests/providers/test_plugin_discovery.py tests/providers/test_atlascloud_provider.py`
- `git diff --check`
- Atlas Cloud live `/v1/models` catalog returned 119 models and confirmed `qwen/qwen3.5-flash` plus `deepseek-ai/deepseek-v4-pro`