### PR TITLE
fix(telegram): keep parse_mode consistent across multi-chunk replies

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4084,6 +4084,13 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
             used_thread_fallback = False
+            # Lock parse_mode across the whole multi-chunk reply. Per-chunk
+            # MarkdownV2→plain fallback left some parts formatted and others
+            # raw (same class of bug as Feishu #26841). Once any chunk fails
+            # MarkdownV2, every chunk of this reply is sent as plain text —
+            # deleting already-delivered Markdown chunks and restarting so the
+            # user never sees a mixed plain/rich split.
+            force_plain = False
             
             try:
                 from telegram.error import NetworkError as _NetErr
@@ -4100,7 +4107,9 @@ class TelegramAdapter(BasePlatformAdapter):
             except (ImportError, AttributeError):
                 _TimedOut = None  # type: ignore[assignment,misc]
 
-            for i, chunk in enumerate(chunks):
+            i = 0
+            while i < len(chunks):
+                chunk = chunks[i]
                 retried_thread_not_found = False
                 metadata_reply_to = self._metadata_reply_to_message_id(metadata)
                 private_dm_topic_send = self._is_private_dm_topic_send(chat_id, thread_id, metadata)
@@ -4144,23 +4153,66 @@ class TelegramAdapter(BasePlatformAdapter):
                 effective_thread_id = thread_kwargs.get("message_thread_id")
 
                 msg = None
+                restart_all_plain = False
                 for _send_attempt in range(3):
                     try:
-                        # Try Markdown first, fall back to plain text if it fails
+                        # Try Markdown first (unless this reply is locked to plain),
+                        # fall back to plain text if it fails — and keep that
+                        # decision for every remaining chunk of this send.
                         try:
-                            msg = await self._bot.send_message(
-                                chat_id=normalize_telegram_chat_id(chat_id),
-                                text=chunk,
-                                parse_mode=ParseMode.MARKDOWN_V2,
-                                reply_to_message_id=reply_to_id,
-                                **thread_kwargs,
-                                **self._link_preview_kwargs(),
-                                **self._notification_kwargs(metadata),
-                            )
+                            if force_plain:
+                                plain_chunk = _strip_mdv2(chunk)
+                                msg = await self._bot.send_message(
+                                    chat_id=normalize_telegram_chat_id(chat_id),
+                                    text=plain_chunk,
+                                    parse_mode=None,
+                                    reply_to_message_id=reply_to_id,
+                                    **thread_kwargs,
+                                    **self._link_preview_kwargs(),
+                                    **self._notification_kwargs(metadata),
+                                )
+                            else:
+                                msg = await self._bot.send_message(
+                                    chat_id=normalize_telegram_chat_id(chat_id),
+                                    text=chunk,
+                                    parse_mode=ParseMode.MARKDOWN_V2,
+                                    reply_to_message_id=reply_to_id,
+                                    **thread_kwargs,
+                                    **self._link_preview_kwargs(),
+                                    **self._notification_kwargs(metadata),
+                                )
                         except Exception as md_error:
                             # Markdown parsing failed, try plain text
-                            if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
-                                logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
+                            if (
+                                not force_plain
+                                and (
+                                    "parse" in str(md_error).lower()
+                                    or "markdown" in str(md_error).lower()
+                                )
+                            ):
+                                logger.warning(
+                                    "[%s] MarkdownV2 parse failed, falling back to plain text: %s",
+                                    self.name, md_error,
+                                )
+                                force_plain = True
+                                if message_ids:
+                                    # Earlier chunks already went out as MarkdownV2.
+                                    # Delete them and resend the whole reply as
+                                    # plain so formatting stays consistent.
+                                    logger.warning(
+                                        "[%s] Restarting multi-chunk Telegram send as plain text "
+                                        "after MarkdownV2 failure on chunk %d/%d",
+                                        self.name, i + 1, len(chunks),
+                                    )
+                                    for mid in list(message_ids):
+                                        try:
+                                            await self.delete_message(chat_id, mid)
+                                        except Exception:
+                                            pass
+                                    message_ids.clear()
+                                    restart_all_plain = True
+                                    i = 0
+                                    break
                                 plain_chunk = _strip_mdv2(chunk)
                                 msg = await self._bot.send_message(
                                     chat_id=normalize_telegram_chat_id(chat_id),
@@ -4292,7 +4344,10 @@ class TelegramAdapter(BasePlatformAdapter):
                                 await asyncio.sleep(wait)
                                 continue
                         raise
+                if restart_all_plain:
+                    continue
                 message_ids.append(str(msg.message_id))
+                i += 1
 
             # Re-trigger typing indicator after sending a message.
             # Telegram clears the typing state when a new message is delivered,
@@ -4638,6 +4693,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # Step 1 — edit the existing message with the first chunk.
         first_chunk = chunks[0]
+        first_chunk_plain = False
         try:
             if finalize:
                 # Use format_message + parse_mode for the final chunk;
@@ -4664,6 +4720,7 @@ class TelegramAdapter(BasePlatformAdapter):
                             message_id=int(message_id),
                             text=_strip_mdv2(first_chunk),
                         )
+                        first_chunk_plain = True
             else:
                 await self._bot.edit_message_text(
                     chat_id=normalize_telegram_chat_id(chat_id),
@@ -4688,11 +4745,13 @@ class TelegramAdapter(BasePlatformAdapter):
         # contiguous block.  We call self._bot.send_message directly so the
         # continuation skips ``self.send``'s own pre-chunking pass (chunks
         # are already correctly sized).  Best-effort MarkdownV2 with plain
-        # fallback, mirroring send().
+        # fallback, locking plain mode for every remaining chunk once any
+        # MarkdownV2 attempt fails (same consistency rule as send()).
         continuation_ids: list[str] = []
         delivered_chunks = [first_chunk]
         prev_id = message_id
         thread_id = self._metadata_thread_id(metadata)
+        force_plain = first_chunk_plain
         for chunk in chunks[1:]:
             sent_msg = None
             reply_to_id = int(prev_id) if prev_id else None
@@ -4702,7 +4761,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 metadata,
                 reply_to_message_id=reply_to_id,
             )
-            for use_markdown in (True, False) if finalize else (False,):
+            markdown_attempts = (False,) if (force_plain or not finalize) else (True, False)
+            for use_markdown in markdown_attempts:
                 try:
                     if use_markdown:
                         text = _separate_chunk_indicator_from_fence(
@@ -4723,6 +4783,8 @@ class TelegramAdapter(BasePlatformAdapter):
                         **self._link_preview_kwargs(),
                         **self._notification_kwargs(metadata),
                     )
+                    if not use_markdown and finalize:
+                        force_plain = True
                     break
                 except Exception as send_err:
                     if "reply message not found" in str(send_err).lower():
@@ -4744,6 +4806,8 @@ class TelegramAdapter(BasePlatformAdapter):
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
                             )
+                            if finalize:
+                                force_plain = True
                             break
                         except Exception as _retry_err:
                             logger.warning(
@@ -4753,7 +4817,8 @@ class TelegramAdapter(BasePlatformAdapter):
                             sent_msg = None
                             break
                     if use_markdown:
-                        # try plain text on next loop iteration
+                        # try plain text on next loop iteration; lock the rest
+                        force_plain = True
                         continue
                     logger.warning(
                         "[%s] Overflow continuation send failed: %s",

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -866,10 +866,91 @@ async def test_send_escapes_chunk_indicator_for_markdownv2(adapter):
     assert re.search(r" \\\([0-9]+/[0-9]+\\\)$", sent_texts[-1])
 
 
+@pytest.mark.asyncio
+async def test_send_restarts_all_chunks_as_plain_after_mid_reply_markdown_failure(adapter):
+    """Multi-chunk replies must not mix MarkdownV2 and plain chunks.
+
+    When chunk 1 succeeds as MarkdownV2 but a later chunk fails Telegram's
+    MarkdownV2 parse, the adapter must delete the already-sent Markdown
+    chunks and resend the whole reply as plain text — same consistency
+    rule as Feishu #26841.
+    """
+    from unittest.mock import patch
+
+    adapter._rich_messages_enabled = False
+    adapter._bot = MagicMock()
+    adapter.delete_message = AsyncMock(return_value=True)
+
+    first_chunk = "Intro prose with no special markers at all."
+    second_chunk = "Broken markdown leftover *unclosed bold"
+    sent = []
+
+    async def _fake_send_message(**kwargs):
+        parse_mode = kwargs.get("parse_mode")
+        text = kwargs["text"]
+        # First pass: accept MarkdownV2 for chunk 1, reject chunk 2.
+        # After restart, every send must be plain (parse_mode=None).
+        if parse_mode is not None and "unclosed" in text:
+            raise Exception("Can't parse entities: markdown parse error")
+        sent.append({"text": text, "parse_mode": parse_mode})
+        return SimpleNamespace(message_id=len(sent))
+
+    adapter._bot.send_message = AsyncMock(side_effect=_fake_send_message)
+    adapter._bot.send_chat_action = AsyncMock()
+
+    with patch.object(
+        adapter,
+        "truncate_message",
+        return_value=[first_chunk, second_chunk],
+    ), patch.object(adapter, "format_message", side_effect=lambda content: content):
+        result = await adapter.send("123", first_chunk + "\n" + second_chunk)
+
+    assert result.success is True
+    adapter.delete_message.assert_awaited()
+    # Final delivered messages are the restarted plain pair only.
+    assert all(entry["parse_mode"] is None for entry in sent[-2:])
+    assert len(sent) >= 3  # at least one MD attempt + two plain resends
+
+
+@pytest.mark.asyncio
+async def test_send_keeps_remaining_chunks_plain_when_first_chunk_markdown_fails(adapter):
+    """If chunk 1 already fails MarkdownV2, later chunks stay plain too."""
+    from unittest.mock import patch
+
+    adapter._rich_messages_enabled = False
+    adapter._bot = MagicMock()
+    adapter.delete_message = AsyncMock(return_value=True)
+
+    first_chunk = "Broken *markdown on purpose"
+    second_chunk = "Second chunk with **bold** markers"
+    sent = []
+
+    async def _fake_send_message(**kwargs):
+        parse_mode = kwargs.get("parse_mode")
+        if parse_mode is not None:
+            raise Exception("Can't parse entities in markdown")
+        sent.append({"text": kwargs["text"], "parse_mode": parse_mode})
+        return SimpleNamespace(message_id=len(sent))
+
+    adapter._bot.send_message = AsyncMock(side_effect=_fake_send_message)
+    adapter._bot.send_chat_action = AsyncMock()
+
+    with patch.object(
+        adapter,
+        "truncate_message",
+        return_value=[first_chunk, second_chunk],
+    ), patch.object(adapter, "format_message", side_effect=lambda content: content):
+        result = await adapter.send("123", first_chunk + "\n" + second_chunk)
+
+    assert result.success is True
+    assert len(sent) == 2
+    assert all(entry["parse_mode"] is None for entry in sent)
+    adapter.delete_message.assert_not_awaited()
+
+
 # =========================================================================
 # edit_message — streaming Markdown safety
 # =========================================================================
-
 
 class TestEditMessageStreamingSafety:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Long Telegram replies that exceed the 4096-character limit are split into chunks. Previously each chunk independently fell back from MarkdownV2 to plain text on parse failure, so one part could look formatted while another looked plain.
- After any MarkdownV2 failure, the adapter now locks the whole reply to plain text (deletes already-sent Markdown chunks and resends) so every part of the split looks the same.
- Overflow-split continuations follow the same rule.

## Test plan
- [x] `scripts/run_tests.sh tests/gateway/test_telegram_format.py tests/gateway/test_telegram_overflow_partial.py tests/gateway/test_telegram_reply_mode.py`
- [ ] On Telegram, send a long markdown reply that previously mixed plain/rich chunks and confirm every part uses the same formatting
- [ ] Confirm gateway logs show either a clean MarkdownV2 send or `Restarting multi-chunk Telegram send as plain text` when fallback triggers