### PR TITLE
fix(gateway/signal): reconnect stale SSE before daemon probe

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -501,22 +501,21 @@ class SignalAdapter(BasePlatformAdapter):
 
             elapsed = time.time() - self._last_sse_activity
             if elapsed > HEALTH_CHECK_STALE_THRESHOLD:
-                logger.warning("Signal: SSE idle for %.0fs, checking daemon health", elapsed)
+                # Stale SSE means the receive path is dead regardless of daemon
+                # process health — reconnect first, and never let the daemon
+                # probe below refresh the activity clock (#40199).
+                logger.warning("Signal: SSE idle for %.0fs, forcing reconnect", elapsed)
+                self._force_reconnect()
                 try:
                     resp = await self.client.get(
                         f"{self.http_url}/api/v1/check", timeout=10.0
                     )
                     if resp.status_code == 200:
-                        # Daemon is alive but SSE is idle — update activity to
-                        # avoid repeated warnings (connection may just be quiet)
-                        self._last_sse_activity = time.time()
-                        logger.debug("Signal: daemon healthy, SSE idle")
+                        logger.debug("Signal: daemon reachable, reconnect triggered by stale SSE")
                     else:
-                        logger.warning("Signal: health check failed (%d), forcing reconnect", resp.status_code)
-                        self._force_reconnect()
+                        logger.warning("Signal: daemon health check also failed (%d)", resp.status_code)
                 except Exception as e:
-                    logger.warning("Signal: health check error: %s, forcing reconnect", e)
-                    self._force_reconnect()
+                    logger.warning("Signal: daemon health check error: %s", e)
 
     def _force_reconnect(self) -> None:
         """Force SSE reconnection by closing the current response."""

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -103,6 +103,74 @@ class TestSignalConnectCleanup:
         assert adapter._platform_lock_identity is None
 
 
+class TestSignalHealthMonitor:
+    """A stale SSE stream means the
+    receive path is dead regardless of daemon process health, so
+    ``_health_monitor()`` must force a reconnect before running its
+    diagnostic probe, and that probe must never refresh
+    ``_last_sse_activity`` (#40199 blind spot)."""
+
+    @pytest.mark.asyncio
+    async def test_health_monitor_reconnects_before_probe_on_stale_sse(self, monkeypatch):
+        """Stale SSE must force a reconnect regardless of what the diagnostic
+        probe (still healthy at 200) returns, and in that order."""
+        import time as time_module
+
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter.client = AsyncMock()
+        adapter.client.get = AsyncMock(return_value=MagicMock(status_code=200))
+        adapter._running = True
+        adapter._last_sse_activity = time_module.time() - 200  # stale, past threshold
+
+        call_order = []
+        adapter.client.get.side_effect = lambda *a, **k: (
+            call_order.append("probe"), MagicMock(status_code=200)
+        )[1]
+
+        sleep_calls = {"n": 0}
+
+        async def fake_sleep(_):
+            sleep_calls["n"] += 1
+            if sleep_calls["n"] >= 2:
+                adapter._running = False
+
+        def record_reconnect():
+            call_order.append("reconnect")
+
+        with patch("gateway.platforms.signal.asyncio.sleep", fake_sleep), \
+             patch.object(adapter, "_force_reconnect", side_effect=record_reconnect) as mock_reconnect:
+            stale_activity = adapter._last_sse_activity
+            await adapter._health_monitor()
+
+        mock_reconnect.assert_called_once()
+        assert call_order == ["reconnect", "probe"]
+        # A healthy probe after a forced reconnect must not mask staleness.
+        assert adapter._last_sse_activity == stale_activity
+
+    @pytest.mark.asyncio
+    async def test_health_monitor_forces_reconnect_on_unhealthy_status(self, monkeypatch):
+        import time as time_module
+
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter.client = AsyncMock()
+        adapter.client.get = AsyncMock(return_value=MagicMock(status_code=500))
+        adapter._running = True
+        adapter._last_sse_activity = time_module.time() - 200
+
+        sleep_calls = {"n": 0}
+
+        async def fake_sleep(_):
+            sleep_calls["n"] += 1
+            if sleep_calls["n"] >= 2:
+                adapter._running = False
+
+        with patch("gateway.platforms.signal.asyncio.sleep", fake_sleep), \
+             patch.object(adapter, "_force_reconnect") as mock_reconnect:
+            await adapter._health_monitor()
+
+        mock_reconnect.assert_called_once()
+
+
 class TestSignalHelpers:
     def test_redact_phone_long(self):
         from gateway.platforms.helpers import redact_phone


### PR DESCRIPTION
## Problem

Signal receive can silently stall when the SSE stream goes stale while the native `signal-cli --http` daemon still answers health checks. The daemon process being reachable does not prove the receive path is alive.

## Fix

- Keep the existing native signal-cli health contract unchanged: `/api/v1/check`, HTTP 200.
- When `_health_monitor()` sees stale SSE activity, force reconnect first.
- Run the daemon probe only afterward for diagnostic logging.
- Do not refresh `_last_sse_activity` from a healthy daemon probe, so process health cannot mask a dead SSE stream.

## Review update

Addressed @teknium1 / hermes-sweeper feedback by dropping the endpoint constant/helper refactor and retitling this PR around the actual stale-SSE liveness fix.

## Tests

- `scripts/run_tests.sh tests/gateway/test_signal.py::TestSignalHealthMonitor tests/gateway/test_signal.py::TestSignalConnectCleanup -q` -> 3 passed
- `.venv/bin/python -m ruff check gateway/platforms/signal.py tests/gateway/test_signal.py`
- `git diff --check`