### PR TITLE
fix(holographic): honor auto_extract=false strings and skip compaction summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3733,3 +3733,26 @@ This compaction should PRIORITISE preserving all information related to the focu
         self._last_compression_made_progress = True
 
         return compressed
+
+
+def is_compaction_summary_message(message: Any) -> bool:
+    """Return True when *message* is a context-compaction handoff summary.
+
+    Public API for consumers outside the compressor (memory providers,
+    frontends) that must not treat compaction summaries as real user or
+    assistant turns — e.g. fact extraction harvesting the compactor's own
+    output as user statements (#57682).
+
+    Prefers the in-process ``COMPRESSED_SUMMARY_METADATA_KEY`` marker and
+    falls back to the content heuristics in ``_is_context_summary_content``
+    (which cover the merged-into-tail and historical-prefix cases), because
+    the metadata key is stripped by the wire sanitizers and does not survive
+    all session-store round-trips.
+    """
+    if isinstance(message, dict):
+        if message.get(COMPRESSED_SUMMARY_METADATA_KEY):
+            return True
+        content = message.get("content")
+    else:
+        content = message
+    return ContextCompressor._is_context_summary_content(content)

--- a/contributors/emails/wernerhp@users.noreply.github.com
+++ b/contributors/emails/wernerhp@users.noreply.github.com
@@ -1,0 +1,1 @@
+wernerhp

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -374,7 +374,32 @@ class HolographicMemoryProvider(MemoryProvider):
     def _auto_extract_facts(self, messages: list) -> None:
         # Local import (pattern used in initialize()): the compressor module is
         # heavier than this plugin and is only needed when auto_extract is on.
-        from agent.context_compressor import is_compaction_summary_message
+        from agent.context_compressor import (
+            _MERGED_PRIOR_CONTEXT_HEADER,
+            _MERGED_SUMMARY_DELIMITER,
+            is_compaction_summary_message,
+        )
+
+        def _pre_delimiter_user_segment(msg: dict):
+            """Return the genuine user text preceding a merged-into-tail
+            compaction summary, or None when the whole message is a summary.
+
+            Merge-into-tail messages (agent/context_compressor.py ~3163-3190)
+            wrap real prior tail content BEFORE ``_MERGED_SUMMARY_DELIMITER``,
+            prefixed with ``_MERGED_PRIOR_CONTEXT_HEADER``, then append the
+            generated handoff summary AFTER the delimiter. Dropping the whole
+            row (as ``is_compaction_summary_message`` alone would suggest)
+            discards that genuine pre-delimiter content too (#57690 review).
+            Only the summary suffix must be excluded from harvesting.
+            """
+            content = msg.get("content", "")
+            if not isinstance(content, str) or _MERGED_SUMMARY_DELIMITER not in content:
+                return None
+            pre = content.split(_MERGED_SUMMARY_DELIMITER, 1)[0]
+            if pre.startswith(_MERGED_PRIOR_CONTEXT_HEADER):
+                pre = pre[len(_MERGED_PRIOR_CONTEXT_HEADER):]
+            pre = pre.strip()
+            return pre or None
 
         _PREF_PATTERNS = [
             re.compile(r'\bI\s+(?:prefer|like|love|use|want|need)\s+(.+)', re.IGNORECASE),
@@ -393,10 +418,17 @@ class HolographicMemoryProvider(MemoryProvider):
             # Compaction handoff summaries can be inserted as role="user"
             # messages; their prose reliably matches the decision patterns, so
             # without this guard the compactor's own output is stored as a
-            # durable "fact" on every rollover (#57682).
-            if is_compaction_summary_message(msg):
+            # durable "fact" on every rollover (#57682). A merge-into-tail
+            # summary also carries genuine pre-delimiter user content in the
+            # SAME row; harvest that segment instead of dropping the whole
+            # message (#57690 review).
+            pre_delimiter_segment = _pre_delimiter_user_segment(msg)
+            if pre_delimiter_segment is not None:
+                content = pre_delimiter_segment
+            elif is_compaction_summary_message(msg):
                 continue
-            content = msg.get("content", "")
+            else:
+                content = msg.get("content", "")
             if not isinstance(content, str) or len(content) < 10:
                 continue
 

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
+from utils import is_truthy_value
 from .store import MemoryStore
 from .retrieval import FactRetriever
 from hermes_cli.config import cfg_get
@@ -235,7 +236,10 @@ class HolographicMemoryProvider(MemoryProvider):
         return tool_error(f"Unknown tool: {tool_name}")
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
-        if not self._config.get("auto_extract", False):
+        # is_truthy_value: the config schema declares auto_extract as a string
+        # enum ("false"/"true"), and a plain truthiness check treats the string
+        # "false" as enabled (#57682).
+        if not is_truthy_value(self._config.get("auto_extract", False)):
             return
         if not self._store or not messages:
             return
@@ -368,6 +372,10 @@ class HolographicMemoryProvider(MemoryProvider):
     # -- Auto-extraction (on_session_end) ------------------------------------
 
     def _auto_extract_facts(self, messages: list) -> None:
+        # Local import (pattern used in initialize()): the compressor module is
+        # heavier than this plugin and is only needed when auto_extract is on.
+        from agent.context_compressor import is_compaction_summary_message
+
         _PREF_PATTERNS = [
             re.compile(r'\bI\s+(?:prefer|like|love|use|want|need)\s+(.+)', re.IGNORECASE),
             re.compile(r'\bmy\s+(?:favorite|preferred|default)\s+\w+\s+is\s+(.+)', re.IGNORECASE),
@@ -381,6 +389,12 @@ class HolographicMemoryProvider(MemoryProvider):
         extracted = 0
         for msg in messages:
             if msg.get("role") != "user":
+                continue
+            # Compaction handoff summaries can be inserted as role="user"
+            # messages; their prose reliably matches the decision patterns, so
+            # without this guard the compactor's own output is stored as a
+            # durable "fact" on every rollover (#57682).
+            if is_compaction_summary_message(msg):
                 continue
             content = msg.get("content", "")
             if not isinstance(content, str) or len(content) < 10:

--- a/tests/plugins/memory/test_holographic_auto_extract.py
+++ b/tests/plugins/memory/test_holographic_auto_extract.py
@@ -102,9 +102,10 @@ def test_metadata_marked_summary_not_harvested(tmp_path):
     provider.shutdown()
 
 
-def test_merged_into_tail_summary_not_harvested(tmp_path):
+def test_merged_into_tail_summary_suffix_not_harvested_prefix_content_ignored(tmp_path):
     """Merge-into-tail summaries embed the handoff prefix after the delimiter,
-    not at the start of the message."""
+    not at the start of the message. The wrapped pre-delimiter segment here has
+    no fact-pattern match, so nothing is harvested from either side."""
     provider = _make_provider(tmp_path, auto_extract=True)
     merged = _user(
         f"{_MERGED_PRIOR_CONTEXT_HEADER}\nplease fix the login bug\n"
@@ -112,6 +113,27 @@ def test_merged_into_tail_summary_not_harvested(tmp_path):
     )
     provider.on_session_end([merged])
     assert _fact_contents(provider) == []
+    provider.shutdown()
+
+
+def test_merged_into_tail_preserves_genuine_pre_delimiter_preference(tmp_path):
+    """#57690 review: teknium1 noted the ENTIRE merged row was being skipped,
+    discarding genuine pre-delimiter user content (context_compressor.py
+    ~3163-3190 retains real prior tail text before the summary). The fix must
+    extract and harvest that segment while still excluding the summary
+    suffix."""
+    provider = _make_provider(tmp_path, auto_extract=True)
+    merged = _user(
+        f"{_MERGED_PRIOR_CONTEXT_HEADER}\n"
+        "I prefer tabs over spaces for indentation\n"
+        f"{_MERGED_SUMMARY_DELIMITER}\n{SUMMARY_MSG}"
+    )
+    provider.on_session_end([merged])
+    facts = _fact_contents(provider)
+    assert len(facts) == 1
+    assert "tabs over spaces" in facts[0]
+    assert "kanban board" not in facts[0]
+    assert "PostgreSQL" not in facts[0]
     provider.shutdown()
 
 

--- a/tests/plugins/memory/test_holographic_auto_extract.py
+++ b/tests/plugins/memory/test_holographic_auto_extract.py
@@ -1,0 +1,148 @@
+"""Regression tests for #57682 — holographic auto_extract harvested
+context-compaction handoff summaries into fact_store, and ran even when
+configured off.
+
+Two compounding defects:
+
+1. Gate: the plugin's config schema declares ``auto_extract`` as a string enum
+   (``"false"``/``"true"``), and the ``on_session_end`` gate used plain
+   truthiness — ``not "false"`` is ``False`` — so extraction ran despite being
+   explicitly configured off.
+
+2. Eligibility: ``_auto_extract_facts`` scanned every ``role == "user"``
+   message. Compaction handoff summaries can be inserted as ``role="user"``
+   messages, and their prose reliably matches the decision patterns
+   (``we decided/agreed/chose``, ``the project uses/needs/requires``), so the
+   compactor's own output was stored as a durable ``project`` fact on every
+   session rollover that followed a compaction.
+"""
+
+import pytest
+
+from agent.context_compressor import (
+    COMPRESSED_SUMMARY_METADATA_KEY,
+    SUMMARY_PREFIX,
+    _MERGED_PRIOR_CONTEXT_HEADER,
+    _MERGED_SUMMARY_DELIMITER,
+    is_compaction_summary_message,
+)
+from plugins.memory.holographic import HolographicMemoryProvider
+
+
+def _make_provider(tmp_path, **config):
+    base = {"db_path": str(tmp_path / "memory_store.db"), "hrr_dim": 64}
+    base.update(config)
+    provider = HolographicMemoryProvider(config=base)
+    provider.initialize(session_id="test-session")
+    return provider
+
+
+def _fact_contents(provider):
+    return [f["content"] for f in provider._store.list_facts(limit=100)]
+
+
+def _user(content, **extra):
+    msg = {"role": "user", "content": content}
+    msg.update(extra)
+    return msg
+
+
+DECISION_MSG = "we decided to use PostgreSQL for the persistence layer"
+SUMMARY_MSG = (
+    f"{SUMMARY_PREFIX}\n## Historical Task Snapshot\n"
+    "The project uses a kanban board for all dispatch. "
+    "We agreed to route reviews through the fan-in consumer."
+)
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 — string-boolean gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("off_value", [False, "false", "False", "no", "off", "0", None, ""])
+def test_auto_extract_off_values_disable_extraction(tmp_path, off_value):
+    provider = _make_provider(tmp_path, auto_extract=off_value)
+    provider.on_session_end([_user(DECISION_MSG)])
+    assert _fact_contents(provider) == []
+    provider.shutdown()
+
+
+@pytest.mark.parametrize("on_value", [True, "true", "True", "1", "yes", "on"])
+def test_auto_extract_on_values_enable_extraction(tmp_path, on_value):
+    provider = _make_provider(tmp_path, auto_extract=on_value)
+    provider.on_session_end([_user(DECISION_MSG)])
+    facts = _fact_contents(provider)
+    assert len(facts) == 1
+    assert "PostgreSQL" in facts[0]
+    provider.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Defect 2 — compaction summaries harvested as facts
+# ---------------------------------------------------------------------------
+
+
+def test_compaction_summary_not_harvested(tmp_path):
+    """The exact failure mode from #57682: summary prose matches the decision
+    patterns but must not become a fact."""
+    provider = _make_provider(tmp_path, auto_extract=True)
+    provider.on_session_end([_user(SUMMARY_MSG)])
+    assert _fact_contents(provider) == []
+    provider.shutdown()
+
+
+def test_metadata_marked_summary_not_harvested(tmp_path):
+    """In-process summaries carry COMPRESSED_SUMMARY_METADATA_KEY even if a
+    future prefix rewrite changes the content sentinel."""
+    provider = _make_provider(tmp_path, auto_extract=True)
+    marked = _user(DECISION_MSG, **{COMPRESSED_SUMMARY_METADATA_KEY: True})
+    provider.on_session_end([marked])
+    assert _fact_contents(provider) == []
+    provider.shutdown()
+
+
+def test_merged_into_tail_summary_not_harvested(tmp_path):
+    """Merge-into-tail summaries embed the handoff prefix after the delimiter,
+    not at the start of the message."""
+    provider = _make_provider(tmp_path, auto_extract=True)
+    merged = _user(
+        f"{_MERGED_PRIOR_CONTEXT_HEADER}\nplease fix the login bug\n"
+        f"{_MERGED_SUMMARY_DELIMITER}\n{SUMMARY_MSG}"
+    )
+    provider.on_session_end([merged])
+    assert _fact_contents(provider) == []
+    provider.shutdown()
+
+
+def test_real_user_messages_still_extracted_alongside_summary(tmp_path):
+    """The guard must skip only the summary, not suppress extraction for the
+    genuine user turns around it."""
+    provider = _make_provider(tmp_path, auto_extract=True)
+    provider.on_session_end(
+        [
+            _user(SUMMARY_MSG),
+            _user("I prefer tabs over spaces for indentation"),
+        ]
+    )
+    facts = _fact_contents(provider)
+    assert len(facts) == 1
+    assert "tabs over spaces" in facts[0]
+    provider.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# is_compaction_summary_message — public helper contract
+# ---------------------------------------------------------------------------
+
+
+def test_helper_detects_prefix_metadata_and_merged_forms():
+    assert is_compaction_summary_message(_user(SUMMARY_MSG))
+    assert is_compaction_summary_message(
+        _user("anything", **{COMPRESSED_SUMMARY_METADATA_KEY: True})
+    )
+    assert is_compaction_summary_message(
+        _user(f"prior tail\n{_MERGED_SUMMARY_DELIMITER}\n{SUMMARY_MSG}")
+    )
+    assert not is_compaction_summary_message(_user(DECISION_MSG))
+    assert not is_compaction_summary_message(_user(""))


### PR DESCRIPTION
## Summary
Holographic memory now honors `auto_extract: "false"` (the schema's string default) and no longer harvests context-compaction handoff summaries into the fact store. Root cause: the `on_session_end` gate used plain truthiness on a string-enum config value (`not "false"` → False), and `_auto_extract_facts` pattern-scanned every `role=user` message with no summary filter — compaction prose reliably matches the decision patterns, so the compactor's own output was persisted as durable "project facts" on every rollover.

## Changes
- `plugins/memory/holographic/__init__.py`: gate `auto_extract` through `utils.is_truthy_value`; skip compaction summary messages in `_auto_extract_facts`, while still harvesting genuine pre-delimiter user content from merged-into-tail rows.
- `agent/context_compressor.py`: new public helper `is_compaction_summary_message()` — prefers the in-process `COMPRESSED_SUMMARY_METADATA_KEY` marker, falls back to `_is_context_summary_content()` (covers merged-into-tail and historical prefixes).
- `tests/plugins/memory/test_holographic_auto_extract.py`: 20 regression tests covering both defects, the merged-row pre-delimiter preservation, and the helper contract.

## Validation
| | Before | After |
|---|---|---|
| `auto_extract: "false"` (schema default string) | extraction runs anyway | extraction disabled |
| Compaction summary in session messages | harvested into fact_store as "project fact" | skipped; real user turns still extracted |
| Merged-into-tail row with genuine user text | n/a (whole row harvested incl. summary) | pre-delimiter user text harvested, summary suffix excluded |

Targeted tests: `tests/plugins/ -k holographic` → 46 passed, 0 failed (includes the new file's 20); `tests/agent/test_compressed_summary_metadata.py` + `test_compress_focus.py` → 9 passed.

## Credit
Salvaged from #57690 by @wernerhp — both commits cherry-picked onto current main with authorship preserved, including the review follow-up that preserves genuine pre-delimiter content in merged compaction rows.

Fixes #57682.

## Infographic
![holographic-auto-extract-fix](https://v3b.fal.media/files/b/0aa345db/jD_uBFBc9VHQSqKnYjCKp_JyKlrh7N.png)
