### PR TITLE
fix(memory): skip_memory no longer breaks the built-in memory tool

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1561,7 +1561,14 @@ def init_agent(
     agent._memory_nudge_interval = 10
     agent._turns_since_memory = 0
     agent._iters_since_skill = 0
-    if not skip_memory:
+    # A flush/background agent may pass skip_memory=True to avoid spinning up an
+    # external memory *provider*, but if the caller also explicitly enables the
+    # "memory" toolset it still needs the built-in file-backed store — otherwise
+    # the memory tool dispatches with store=None and every call fails (#65429).
+    # So the built-in store is created unless memory is globally disabled, while
+    # the external-provider block below stays gated on skip_memory.
+    _memory_toolset_requested = "memory" in (agent.enabled_toolsets or [])
+    if not skip_memory or _memory_toolset_requested:
         try:
             mem_config = _agent_cfg.get("memory", {})
             agent._memory_enabled = mem_config.get("memory_enabled", False)

--- a/contributors/emails/ella@cincin.mesh
+++ b/contributors/emails/ella@cincin.mesh
@@ -1,0 +1,1 @@
+dsitmilis

--- a/tests/agent/test_skip_memory_store_65429.py
+++ b/tests/agent/test_skip_memory_store_65429.py
@@ -63,3 +63,47 @@ def test_memory_toolset_without_skip_memory_creates_store(monkeypatch, tmp_path)
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hm"))
     agent = _make_agent(monkeypatch, enabled_toolsets=["memory"], skip_memory=False)
     assert agent._memory_store is not None
+
+
+def test_skip_memory_memory_tool_handler_works_and_provider_skipped(
+    monkeypatch, tmp_path
+):
+    """End-to-end behavioral check for #65429.
+
+    The memory tool handler must actually WORK (not return the
+    "Memory is not available" store=None error) on a skip_memory=True agent
+    with the memory toolset enabled, while the external memory provider
+    sync/prefetch stays skipped (no MemoryManager is created).
+    """
+    import json
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hm"))
+    agent = _make_agent(monkeypatch, enabled_toolsets=["memory"], skip_memory=True)
+
+    # Provider sync/prefetch must remain skipped: skip_memory still gates the
+    # external memory provider block.
+    assert agent._memory_manager is None, (
+        "skip_memory=True must still skip the external memory provider"
+    )
+
+    # Dispatch through the same entry point the tool executor uses
+    # (agent/tool_executor.py wires store=agent._memory_store).
+    from tools.memory_tool import memory_tool
+
+    raw = memory_tool(
+        action="add",
+        target="memory",
+        content="User prefers concise answers.",
+        store=agent._memory_store,
+    )
+    result = json.loads(raw)
+    assert result.get("success") is True, (
+        f"memory tool handler must work with skip_memory=True + memory "
+        f"toolset (#65429), got: {raw}"
+    )
+    assert "Memory is not available" not in raw
+
+    # The write must actually persist to the profile-scoped memories dir.
+    memory_md = tmp_path / "hm" / "memories" / "MEMORY.md"
+    assert memory_md.exists()
+    assert "User prefers concise answers." in memory_md.read_text()

--- a/tests/agent/test_skip_memory_store_65429.py
+++ b/tests/agent/test_skip_memory_store_65429.py
@@ -1,0 +1,65 @@
+"""Regression test for issue #65429.
+
+An agent built with ``skip_memory=True`` AND ``enabled_toolsets=["memory"]``
+used to get a memory tool wired to ``store=None`` (the built-in
+``MemoryStore`` was skipped along with the external provider), so every
+memory call failed silently and the main auto-capture path was dead.
+
+The fix creates the built-in store whenever memory is enabled in config OR the
+memory toolset is explicitly enabled, while the external-provider block stays
+gated on ``skip_memory``.
+"""
+
+import pytest
+
+from run_agent import AIAgent
+
+
+class _FakeOpenAI:
+    def __init__(self, **kw):
+        self.api_key = kw.get("api_key", "test")
+        self.base_url = kw.get("base_url", "http://test")
+
+    def close(self):
+        pass
+
+
+def _make_agent(monkeypatch, enabled_toolsets=None, skip_memory=True):
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: [])
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+    monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
+    return AIAgent(
+        api_key="test-key",
+        base_url="http://test",
+        provider="openrouter",
+        api_mode="chat_completions",
+        max_iterations=1,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=skip_memory,
+        enabled_toolsets=enabled_toolsets,
+    )
+
+
+def test_skip_memory_with_memory_toolset_creates_store(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hm"))
+    agent = _make_agent(monkeypatch, enabled_toolsets=["memory"], skip_memory=True)
+    assert agent._memory_store is not None, (
+        "memory toolset enabled despite skip_memory=True must still build "
+        "the built-in store (#65429)"
+    )
+
+
+def test_skip_memory_without_memory_toolset_has_no_store(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hm"))
+    agent = _make_agent(monkeypatch, enabled_toolsets=None, skip_memory=True)
+    assert agent._memory_store is None, (
+        "flush/background agent with skip_memory and no memory toolset must "
+        "have no built-in store"
+    )
+
+
+def test_memory_toolset_without_skip_memory_creates_store(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hm"))
+    agent = _make_agent(monkeypatch, enabled_toolsets=["memory"], skip_memory=False)
+    assert agent._memory_store is not None


### PR DESCRIPTION
## Summary
Agents built with `skip_memory=True` **and** `enabled_toolsets=["memory"]` (gateway hygiene/flush agents, slash-command compaction agents, cron) now get a working memory tool backed by the built-in file-backed `MemoryStore`, instead of a tool that permanently fails with `store=None`. Root cause: `agent/agent_init.py` gated the built-in store creation on `if not skip_memory:` even though `skip_memory` was only meant to skip the *external memory provider* — so every memory call on those agents returned "Memory is not available" and the main automatic memory-capture path was silently dead (issue #65429: 3 months, 301 sessions, zero bytes ever written).

## Changes
- `agent/agent_init.py`: create the built-in `MemoryStore` when memory is enabled in config OR the `memory` toolset is explicitly enabled; the external memory-provider block below stays gated on `skip_memory` (flush/cron agents still never spin up provider sync/prefetch).
- `tests/agent/test_skip_memory_store_65429.py`: regression tests — store created with `skip_memory=True + ["memory"]`, no store without the toolset, store with `skip_memory=False`; plus an end-to-end behavioral test that dispatches a real `memory_tool` add through the store the tool executor wires in, asserts the write persists to `memories/MEMORY.md`, and asserts `agent._memory_manager is None` (provider sync still skipped).
- `contributors/emails/ella@cincin.mesh`: contributor attribution mapping.

## Validation
| | Before | After |
|---|---|---|
| memory tool on `skip_memory=True` + memory toolset | every call fails: "Memory is not available" (`store=None`) | works; writes persist to `memories/MEMORY.md` |
| external memory provider under `skip_memory=True` | skipped | still skipped (`_memory_manager is None`) |
| flush/background agent without memory toolset | no store | no store (unchanged) |

Targeted tests: `tests/agent/test_skip_memory_store_65429.py` (4 passed), `tests/tools/test_memory_tool*.py` (89 passed), background-review + gateway shutdown memory tests (29 passed) — 0 failures.

## Credit
Salvaged from #65453 by @dsitmilis — both substantive commits cherry-picked with original authorship preserved.

Fixes #65429.

## Infographic
![skip-memory-memory-tool-fix](https://v3b.fal.media/files/b/0aa345f4/p-hX0buKCOdKj1potK4LU_VKUWdpbn.png)
