### PR TITLE
fix(anthropic): guard leading-assistant transcripts after double compaction

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2412,6 +2412,12 @@ def _evict_old_screenshots(result: List[Dict[str, Any]]) -> None:
                 ]
 
 
+def _ensure_leading_user_turn(result: List[Dict[str, Any]], system: Any) -> None:
+    """Anthropic requires messages[0] to be user when system is extracted."""
+    if system is not None and result and result[0].get("role") != "user":
+        result.insert(0, {"role": "user", "content": [{"type": "text", "text": " "}]})
+
+
 def convert_messages_to_anthropic(
     messages: List[Dict],
     base_url: str | None = None,
@@ -2470,6 +2476,7 @@ def convert_messages_to_anthropic(
 
     _strip_orphaned_tool_blocks(result)
     result = _merge_consecutive_roles(result)
+    _ensure_leading_user_turn(result, system)
     _manage_thinking_signatures(result, base_url, model)
     _evict_old_screenshots(result)
 

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2412,9 +2412,21 @@ def _evict_old_screenshots(result: List[Dict[str, Any]]) -> None:
                 ]
 
 
-def _ensure_leading_user_turn(result: List[Dict[str, Any]], system: Any) -> None:
-    """Anthropic requires messages[0] to be user when system is extracted."""
-    if system is not None and result and result[0].get("role") != "user":
+def _ensure_leading_user_turn(result: List[Dict[str, Any]]) -> None:
+    """Anthropic requires messages[0] to have role=user.
+
+    After a second context compaction on the auto path the summary can be
+    emitted as role=assistant with nothing in front of it (the system prompt
+    lives outside messages[] or is extracted into the separate ``system``
+    param), so messages[0] ends up assistant and the Messages API rejects
+    the request with HTTP 400 — often masked by a misleading
+    "tool_use ids were found without tool_result blocks" error (#52160).
+
+    Mirror the Bedrock Converse adapter, which unconditionally prepends a
+    minimal user turn when the first message is not user
+    (convert_messages_to_converse).
+    """
+    if result and result[0].get("role") != "user":
         result.insert(0, {"role": "user", "content": [{"type": "text", "text": " "}]})
 
 
@@ -2476,7 +2488,7 @@ def convert_messages_to_anthropic(
 
     _strip_orphaned_tool_blocks(result)
     result = _merge_consecutive_roles(result)
-    _ensure_leading_user_turn(result, system)
+    _ensure_leading_user_turn(result)
     _manage_thinking_signatures(result, base_url, model)
     _evict_old_screenshots(result)
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1121,7 +1121,8 @@ class TestConvertMessages:
         ])
 
         _, result = convert_messages_to_anthropic(messages)
-        assistant_blocks = result[0]["content"]
+        assistant_msg = next(m for m in result if m["role"] == "assistant")
+        assistant_blocks = assistant_msg["content"]
 
         assert assistant_blocks[0]["type"] == "text"
         assert assistant_blocks[0]["text"] == "Hello from assistant"
@@ -1207,7 +1208,12 @@ class TestConvertMessages:
         ], native_anthropic=True)
 
         _, result = convert_messages_to_anthropic(messages)
-        user_msg = [m for m in result if m["role"] == "user"][0]
+        user_msg = next(
+            m for m in result
+            if m["role"] == "user"
+            and isinstance(m["content"], list)
+            and any(b.get("type") == "tool_result" for b in m["content"])
+        )
         tool_block = user_msg["content"][0]
 
         assert tool_block["type"] == "tool_result"
@@ -1355,6 +1361,69 @@ class TestConvertMessages:
         assert result[0]["role"] == "user"
         assert isinstance(result[0]["content"], list)
         assert result[0]["content"] == [{"type": "text", "text": "(empty message)"}]
+
+    def test_leading_assistant_after_compaction_gets_user_turn_prepended(self):
+        """The adapter backstops compactors that emit a leading assistant summary."""
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "assistant", "content": "[Context compaction summary] earlier work…"},
+            {"role": "user", "content": "continue"},
+        ]
+
+        system, result = convert_messages_to_anthropic(messages)
+
+        assert system == "You are helpful."
+        assert result[0]["role"] == "user"
+        assert result[0]["content"] == [{"type": "text", "text": " "}]
+        assert result[1]["role"] == "assistant"
+        assert any(
+            m["role"] == "assistant" and "Context compaction summary" in str(m["content"])
+            for m in result
+        )
+
+    def test_leading_user_message_is_not_modified(self):
+        """A normal transcript that already starts with user must be untouched."""
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+
+        _, result = convert_messages_to_anthropic(messages)
+
+        assert len(result) == 2
+        assert result[0]["role"] == "user"
+        assert result[0]["content"] == "hello"
+
+    def test_leading_assistant_with_tool_use_after_compaction_is_repaired(self):
+        """Repair the leading role without disturbing adjacent tool pairs."""
+        messages = [
+            {"role": "system", "content": "sys"},
+            {
+                "role": "assistant",
+                "content": "running it",
+                "tool_calls": [
+                    {"id": "toolu_1", "function": {"name": "terminal", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "toolu_1", "content": "ok"},
+            {"role": "user", "content": "next"},
+        ]
+
+        _, result = convert_messages_to_anthropic(messages)
+
+        assert result[0]["role"] == "user"
+        asst_idx = next(
+            i for i, m in enumerate(result)
+            if m["role"] == "assistant"
+            and any(b.get("type") == "tool_use" for b in m["content"] if isinstance(b, dict))
+        )
+        nxt = result[asst_idx + 1]
+        assert nxt["role"] == "user"
+        assert any(
+            isinstance(b, dict) and b.get("type") == "tool_result" and b.get("tool_use_id") == "toolu_1"
+            for b in nxt["content"]
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -945,7 +945,7 @@ class TestConvertMessages:
             {"role": "tool", "tool_call_id": "tc_1", "content": "search results"},
         ]
         _, result = convert_messages_to_anthropic(messages)
-        blocks = result[0]["content"]
+        blocks = next(m for m in result if m["role"] == "assistant")["content"]
         assert blocks[0] == {"type": "text", "text": "Let me search."}
         assert blocks[1]["type"] == "tool_use"
         assert blocks[1]["id"] == "tc_1"
@@ -963,8 +963,13 @@ class TestConvertMessages:
             {"role": "tool", "tool_call_id": "tc_1", "content": "result data"},
         ]
         _, result = convert_messages_to_anthropic(messages)
-        # tool result is in the second message (user role)
-        user_msg = [m for m in result if m["role"] == "user"][0]
+        # tool result is in the user message following the assistant turn
+        user_msg = next(
+            m for m in result
+            if m["role"] == "user"
+            and isinstance(m["content"], list)
+            and any(b.get("type") == "tool_result" for b in m["content"])
+        )
         assert user_msg["content"][0]["type"] == "tool_result"
         assert user_msg["content"][0]["tool_use_id"] == "tc_1"
 
@@ -983,7 +988,12 @@ class TestConvertMessages:
         ]
         _, result = convert_messages_to_anthropic(messages)
         # assistant + merged user (with 2 tool_results)
-        user_msgs = [m for m in result if m["role"] == "user"]
+        user_msgs = [
+            m for m in result
+            if m["role"] == "user"
+            and isinstance(m["content"], list)
+            and any(b.get("type") == "tool_result" for b in m["content"])
+        ]
         assert len(user_msgs) == 1
         assert len(user_msgs[0]["content"]) == 2
 
@@ -1041,7 +1051,12 @@ class TestConvertMessages:
             {"role": "tool", "tool_call_id": "tc_orphan", "content": "stale result"},
         ]
         _, result = convert_messages_to_anthropic(messages)
-        user_msg = [m for m in result if m["role"] == "user"][0]
+        user_msg = next(
+            m for m in result
+            if m["role"] == "user"
+            and isinstance(m["content"], list)
+            and any(b.get("type") == "tool_result" for b in m["content"])
+        )
         tool_results = [
             b for b in user_msg["content"] if b.get("type") == "tool_result"
         ]
@@ -1096,7 +1111,12 @@ class TestConvertMessages:
         _, result = convert_messages_to_anthropic(messages)
         asst = [m for m in result if m["role"] == "assistant"][0]
         assert any(b.get("type") == "tool_use" for b in asst["content"])
-        user = [m for m in result if m["role"] == "user"][0]
+        user = next(
+            m for m in result
+            if m["role"] == "user"
+            and isinstance(m["content"], list)
+            and any(b.get("type") == "tool_result" for b in m["content"])
+        )
         assert any(b.get("type") == "tool_result" for b in user["content"])
 
     def test_system_with_cache_control(self):
@@ -1380,6 +1400,27 @@ class TestConvertMessages:
             m["role"] == "assistant" and "Context compaction summary" in str(m["content"])
             for m in result
         )
+
+    def test_double_compaction_no_system_in_messages_leads_with_user(self):
+        """Exact post-double-compaction shape on the auto path (#52160).
+
+        On the auto path the system prompt is NOT inside messages[] and after
+        the second compaction protect_head has decayed to 0, so the
+        assistant-role summary is messages[0]. The converted payload must
+        still lead with a user turn or Anthropic 400s.
+        """
+        messages = [
+            {"role": "assistant", "content": "[Context compaction summary] earlier work…"},
+            {"role": "user", "content": "continue"},
+        ]
+
+        system, result = convert_messages_to_anthropic(messages)
+
+        assert system is None
+        assert result[0]["role"] == "user"
+        assert result[0]["content"] == [{"type": "text", "text": " "}]
+        assert result[1]["role"] == "assistant"
+        assert "Context compaction summary" in str(result[1]["content"])
 
     def test_leading_user_message_is_not_modified(self):
         """A normal transcript that already starts with user must be untouched."""
@@ -2145,7 +2186,7 @@ class TestThinkingBlockSignatureManagement:
             },
         ]
         _, result = convert_messages_to_anthropic(messages)
-        blocks = result[0]["content"]
+        blocks = next(m for m in result if m["role"] == "assistant")["content"]
         thinking = [b for b in blocks if b.get("type") == "thinking"]
         assert len(thinking) == 1
         assert thinking[0]["signature"] == "sig_valid"
@@ -2163,7 +2204,7 @@ class TestThinkingBlockSignatureManagement:
             },
         ]
         _, result = convert_messages_to_anthropic(messages)
-        blocks = result[0]["content"]
+        blocks = next(m for m in result if m["role"] == "assistant")["content"]
 
         # No thinking blocks should remain
         assert not any(b.get("type") == "thinking" for b in blocks)
@@ -2183,7 +2224,7 @@ class TestThinkingBlockSignatureManagement:
             },
         ]
         _, result = convert_messages_to_anthropic(messages)
-        blocks = result[0]["content"]
+        blocks = next(m for m in result if m["role"] == "assistant")["content"]
         redacted = [b for b in blocks if b.get("type") == "redacted_thinking"]
         assert len(redacted) == 1
         assert redacted[0]["data"] == "opaque_signature_data"
@@ -2277,7 +2318,7 @@ class TestThinkingBlockSignatureManagement:
         _, result = convert_messages_to_anthropic(messages)
         # First assistant is non-last, so thinking is stripped completely.
         # The original content was empty and thinking was unsigned → placeholder
-        first_assistant = result[0]
+        first_assistant = next(m for m in result if m["role"] == "assistant")
         assert first_assistant["role"] == "assistant"
         assert len(first_assistant["content"]) >= 1
 


### PR DESCRIPTION
## Summary
The native Anthropic adapter now guarantees the converted payload leads with a user turn, so sessions survive a second context compaction instead of dying with HTTP 400. Root cause: after double compaction on the auto path, protect_head decays to 0 and the compaction summary (role=assistant) becomes messages[0]; Anthropic requires messages[0] to be role=user and rejects the request — often masked as a misleading `tool_use ids were found without tool_result blocks` error (#52160).

## Changes
- `agent/anthropic_adapter.py`: add `_ensure_leading_user_turn()` to the `convert_messages_to_anthropic` post-processing chain — when the first converted message is not role=user, prepend a minimal user text turn, exactly mirroring the existing Bedrock Converse adapter guard ("Converse requires the first message to be from the user"). Follow-up commit makes the guard unconditional (the #52276 version only fired when a system prompt was present inside messages[]; the live #52160 repro has the system prompt outside messages[], so system=None).
- `tests/agent/test_anthropic_adapter.py`: regression tests — leading-assistant-with-system, exact post-double-compaction shape (no system in messages, messages[0]=assistant summary → payload leads with user), leading-assistant with adjacent tool_use pair preserved, and a no-op negative control; existing fixtures that indexed `result[0]` on bare assistant-first transcripts now locate roles explicitly.

## Validation
| | Before | After |
|---|---|---|
| 2nd auto-compaction on Anthropic path | HTTP 400 `messages: first message must be user` / misleading tool_use error; session dead | Request accepted; conversation continues |
| Converted payload, messages[0]=assistant summary | leads with assistant | leads with synthesized user turn (mirrors Bedrock) |

Targeted tests: `tests/agent/test_anthropic_adapter.py` 182 passed, 0 failed; `tests/agent/ -k anthropic` 471 passed across 275 files, 0 failed.

## Credit
Salvaged from #52276 by @fesalfayed — commit cherry-picked with original authorship preserved. Complements the compressor-side fix #56197 (which only covers the system-in-messages gateway /compress path); this adapter-level guard is engine-agnostic and backstops any producer of a leading-assistant transcript.

Fixes #52160.

## Infographic
![leading-user-guard](https://v3b.fal.media/files/b/0aa3461c/XwzcizzBfAXWLzHB9Nv-o_DaSilrGd.png)
