### PR TITLE
fix(state): compression child sessions inherit cwd and repo metadata

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2709,6 +2709,7 @@ class SessionDB:
         parent_session_id: str = None,
         cwd: str = None,
         profile_name: str = None,
+        git_repo_root: str = None,
     ) -> None:
         """Insert a session row, enriching NULL metadata on conflict.
 
@@ -2727,14 +2728,25 @@ class SessionDB:
         a persisted, now-inactive row belongs to the caller's chat/thread before
         switching to it (IDOR scoping — without them the ``sessions`` table has
         no chat/thread to compare).
+
+        When ``parent_session_id`` is set (compression fork, delegate/subagent
+        spawn, branch continuation) and this row's own ``cwd``/``git_repo_root``
+        are still NULL after the insert, they are backfilled from the parent
+        row. Callers of ``create_session`` for a child session historically
+        didn't propagate these fields themselves (e.g. the compression-fork
+        path), so a lineage could silently lose its working directory and drop
+        out of the project sidebar every time it forked (#64709). This only
+        fills NULLs — an explicit ``cwd``/``git_repo_root`` on the child is
+        never overwritten.
         """
         def _do(conn):
             conn.execute(
                 """INSERT INTO sessions (
                    id, source, user_id, session_key, chat_id, chat_type, thread_id,
-                   model, model_config, system_prompt, parent_session_id, cwd, profile_name, started_at
+                   model, model_config, system_prompt, parent_session_id, cwd,
+                   profile_name, git_repo_root, started_at
                 )
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(id) DO UPDATE SET
                        model = COALESCE(sessions.model, excluded.model),
                        model_config = COALESCE(sessions.model_config, excluded.model_config),
@@ -2745,7 +2757,8 @@ class SessionDB:
                        thread_id = COALESCE(sessions.thread_id, excluded.thread_id),
                        parent_session_id = COALESCE(sessions.parent_session_id, excluded.parent_session_id),
                        cwd = COALESCE(sessions.cwd, excluded.cwd),
-                       profile_name = COALESCE(sessions.profile_name, excluded.profile_name)""",
+                       profile_name = COALESCE(sessions.profile_name, excluded.profile_name),
+                       git_repo_root = COALESCE(sessions.git_repo_root, excluded.git_repo_root)""",
                 (
                     session_id,
                     source,
@@ -2760,9 +2773,22 @@ class SessionDB:
                     parent_session_id,
                     cwd,
                     profile_name,
+                    git_repo_root,
                     time.time(),
                 ),
             )
+            if parent_session_id:
+                conn.execute(
+                    """UPDATE sessions
+                       SET cwd = COALESCE(sessions.cwd,
+                                 (SELECT p.cwd FROM sessions p
+                                   WHERE p.id = sessions.parent_session_id)),
+                           git_repo_root = COALESCE(sessions.git_repo_root,
+                                           (SELECT p.git_repo_root FROM sessions p
+                                             WHERE p.id = sessions.parent_session_id))
+                     WHERE id = ? AND parent_session_id IS NOT NULL""",
+                    (session_id,),
+                )
         self._execute_write(_do)
 
     def create_session(self, session_id: str, source: str, **kwargs) -> str:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2730,14 +2730,19 @@ class SessionDB:
         no chat/thread to compare).
 
         When ``parent_session_id`` is set (compression fork, delegate/subagent
-        spawn, branch continuation) and this row's own ``cwd``/``git_repo_root``
-        are still NULL after the insert, they are backfilled from the parent
-        row. Callers of ``create_session`` for a child session historically
-        didn't propagate these fields themselves (e.g. the compression-fork
-        path), so a lineage could silently lose its working directory and drop
-        out of the project sidebar every time it forked (#64709). This only
-        fills NULLs — an explicit ``cwd``/``git_repo_root`` on the child is
-        never overwritten.
+        spawn, branch continuation) and this row's own ``cwd``/``git_repo_root``/
+        ``git_branch`` are still NULL after the insert, they are backfilled from
+        the parent row. Callers of ``create_session`` for a child session
+        historically didn't propagate these fields themselves (e.g. the
+        compression-fork path), so a lineage could silently lose its working
+        directory and drop out of the project sidebar every time it forked
+        (#64709). This only fills NULLs — an explicit ``cwd``/``git_repo_root``
+        on the child is never overwritten. For compression forks specifically
+        (parent ended with ``end_reason='compression'``), the gateway origin
+        columns (``user_id``/``session_key``/``chat_id``/``chat_type``/
+        ``thread_id``/``display_name``/``origin_json``) are inherited too, so a
+        crash before the gateway re-records the peer can't strand the child
+        without a recoverable routing mapping (#59527).
         """
         def _do(conn):
             conn.execute(
@@ -2785,8 +2790,53 @@ class SessionDB:
                                    WHERE p.id = sessions.parent_session_id)),
                            git_repo_root = COALESCE(sessions.git_repo_root,
                                            (SELECT p.git_repo_root FROM sessions p
-                                             WHERE p.id = sessions.parent_session_id))
+                                             WHERE p.id = sessions.parent_session_id)),
+                           git_branch = COALESCE(sessions.git_branch,
+                                        (SELECT p.git_branch FROM sessions p
+                                          WHERE p.id = sessions.parent_session_id))
                      WHERE id = ? AND parent_session_id IS NOT NULL""",
+                    (session_id,),
+                )
+                # Belt-and-suspenders for gateway routing metadata (#59527):
+                # the gateway re-records the peer on the child after rotation
+                # (d5b4879d4), but a hard crash between child creation and that
+                # write leaves the child row without origin columns, so
+                # ``find_latest_gateway_session_for_peer`` can't recover the
+                # mapping on restart. Inherit them from the parent at creation
+                # time — but ONLY for compression forks (parent already ended
+                # with end_reason='compression'). Delegate/subagent children
+                # are spawned while the parent is still live and must NOT
+                # inherit routing keys, or peer recovery could repoint gateway
+                # traffic into a subagent's session.
+                conn.execute(
+                    """UPDATE sessions
+                       SET user_id = COALESCE(sessions.user_id,
+                                     (SELECT p.user_id FROM sessions p
+                                       WHERE p.id = sessions.parent_session_id)),
+                           session_key = COALESCE(sessions.session_key,
+                                         (SELECT p.session_key FROM sessions p
+                                           WHERE p.id = sessions.parent_session_id)),
+                           chat_id = COALESCE(sessions.chat_id,
+                                     (SELECT p.chat_id FROM sessions p
+                                       WHERE p.id = sessions.parent_session_id)),
+                           chat_type = COALESCE(sessions.chat_type,
+                                       (SELECT p.chat_type FROM sessions p
+                                         WHERE p.id = sessions.parent_session_id)),
+                           thread_id = COALESCE(sessions.thread_id,
+                                       (SELECT p.thread_id FROM sessions p
+                                         WHERE p.id = sessions.parent_session_id)),
+                           display_name = COALESCE(sessions.display_name,
+                                          (SELECT p.display_name FROM sessions p
+                                            WHERE p.id = sessions.parent_session_id)),
+                           origin_json = COALESCE(sessions.origin_json,
+                                         (SELECT p.origin_json FROM sessions p
+                                           WHERE p.id = sessions.parent_session_id))
+                     WHERE id = ? AND parent_session_id IS NOT NULL
+                       AND EXISTS (
+                           SELECT 1 FROM sessions p
+                           WHERE p.id = sessions.parent_session_id
+                             AND p.end_reason = 'compression'
+                       )""",
                     (session_id,),
                 )
         self._execute_write(_do)

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -143,6 +143,46 @@ class TestOrphanRollbackOnCreateFailure:
         _ = real_create  # silence unused
 
 
+class TestWorkspaceMetadataFollowsRotation:
+    def test_child_row_inherits_cwd_repo_and_origin_on_rotation(self, tmp_path: Path):
+        """Behavioral #64709/#59527: drive the REAL compression rotation path
+        and assert the child session row carries the parent's workspace and
+        gateway-origin metadata, so the project sidebar entry and the peer
+        routing mapping both survive the compaction boundary."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_CWD_ROT"
+        db.create_session(
+            parent,
+            source="telegram",
+            user_id="u1",
+            session_key="telegram:u1:c1",
+            chat_id="c1",
+            chat_type="private",
+        )
+        db.update_session_cwd(
+            parent, "/work/repo", git_branch="main", git_repo_root="/work/repo"
+        )
+        agent = _build_agent_with_db(db, parent, platform="telegram")
+
+        agent._compress_context(_msgs(), "sys", approx_tokens=120_000)
+        child = agent.session_id
+        assert child != parent  # rotation happened
+
+        row = db.get_session(child)
+        assert row is not None
+        assert row["parent_session_id"] == parent
+        # Workspace metadata (#64709): sidebar grouping keys must survive.
+        assert row["cwd"] == "/work/repo"
+        assert row["git_repo_root"] == "/work/repo"
+        assert row["git_branch"] == "main"
+        # Gateway origin metadata (#59527): routing keys must survive even if
+        # the gateway never gets to re-record the peer (crash window).
+        assert row["session_key"] == "telegram:u1:c1"
+        assert row["chat_id"] == "c1"
+        assert row["chat_type"] == "private"
+        assert row["user_id"] == "u1"
+
+
 class TestPlatformForwardedAtBoundary:
     def test_on_session_start_receives_platform(self, tmp_path: Path):
         db = SessionDB(db_path=tmp_path / "state.db")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -139,6 +139,47 @@ class TestSessionLifecycle:
         assert session["cwd"] == "/work/repo"
         assert session["git_branch"] == "pets-feature"
 
+    def test_child_session_inherits_cwd_and_git_repo_root_from_parent(self, db):
+        """A parent_session_id child born without cwd/git_repo_root (e.g. the
+        compression-fork path) must inherit both from its parent, so it
+        doesn't silently drop out of the project sidebar (#64709)."""
+        db.create_session(session_id="parent", source="cli")
+        db.update_session_cwd("parent", "/work/repo", git_repo_root="/work/repo")
+
+        db.create_session(session_id="child", source="cli", parent_session_id="parent")
+
+        child = db.get_session("child")
+        assert child["cwd"] == "/work/repo"
+        assert child["git_repo_root"] == "/work/repo"
+
+    def test_child_session_explicit_cwd_is_not_overwritten_by_parent(self, db):
+        """A child that explicitly sets its own cwd/git_repo_root keeps it —
+        parent inheritance only fills in NULLs, never clobbers."""
+        db.create_session(session_id="parent", source="cli")
+        db.update_session_cwd("parent", "/work/repo-a", git_repo_root="/work/repo-a")
+
+        db.create_session(
+            session_id="child", source="cli", parent_session_id="parent",
+            cwd="/work/repo-b", git_repo_root="/work/repo-b",
+        )
+
+        child = db.get_session("child")
+        assert child["cwd"] == "/work/repo-b"
+        assert child["git_repo_root"] == "/work/repo-b"
+
+    def test_multi_generation_lineage_inherits_cwd(self, db):
+        """cwd/git_repo_root propagate through a multi-hop compression chain
+        (root -> gen1 -> gen2), mirroring the multi-generation lineage from
+        the reported issue where a single conversation forked repeatedly."""
+        db.create_session(session_id="root", source="cli")
+        db.update_session_cwd("root", "/work/repo", git_repo_root="/work/repo")
+
+        db.create_session(session_id="gen1", source="cli", parent_session_id="root")
+        db.create_session(session_id="gen2", source="cli", parent_session_id="gen1")
+
+        assert db.get_session("gen1")["cwd"] == "/work/repo"
+        assert db.get_session("gen2")["cwd"] == "/work/repo"
+
     def test_update_session_cwd_empty_branch_does_not_clobber(self, db):
         """A failed branch probe (empty string) must not wipe a branch we
         already captured — only the cwd updates."""

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -180,6 +180,76 @@ class TestSessionLifecycle:
         assert db.get_session("gen1")["cwd"] == "/work/repo"
         assert db.get_session("gen2")["cwd"] == "/work/repo"
 
+    def test_child_session_inherits_git_branch_from_parent(self, db):
+        """git_branch travels with cwd/git_repo_root — the Desktop sidebar
+        shows the branch chip per session, so a compression child born
+        without it loses the chip even though the workspace didn't change."""
+        db.create_session(session_id="parent", source="cli")
+        db.update_session_cwd(
+            "parent", "/work/repo", git_branch="feature-x", git_repo_root="/work/repo"
+        )
+
+        db.create_session(session_id="child", source="cli", parent_session_id="parent")
+
+        child = db.get_session("child")
+        assert child["git_branch"] == "feature-x"
+
+    def test_compression_child_inherits_gateway_origin_columns(self, db):
+        """A compression fork's child inherits gateway routing metadata
+        (session_key/chat_id/...) from the ended parent, so a crash before
+        the gateway re-records the peer can't strand it (#59527)."""
+        db.create_session(
+            session_id="parent", source="telegram",
+            user_id="u1", session_key="telegram:u1:c1",
+            chat_id="c1", chat_type="private", thread_id="t1",
+        )
+        db.record_gateway_session_peer(
+            "parent", source="telegram", user_id="u1",
+            session_key="telegram:u1:c1", chat_id="c1", chat_type="private",
+            thread_id="t1", display_name="Chat One", origin_json='{"p":"telegram"}',
+        )
+        # Rotation path: parent is ended with 'compression' BEFORE the child
+        # row is created (agent/conversation_compression.py).
+        db.end_session("parent", "compression")
+
+        db.create_session(
+            session_id="child", source="telegram", parent_session_id="parent"
+        )
+
+        child = db.get_session("child")
+        assert child["user_id"] == "u1"
+        assert child["session_key"] == "telegram:u1:c1"
+        assert child["chat_id"] == "c1"
+        assert child["chat_type"] == "private"
+        assert child["thread_id"] == "t1"
+        assert child["display_name"] == "Chat One"
+        assert child["origin_json"] == '{"p":"telegram"}'
+
+    def test_live_parent_child_does_not_inherit_gateway_origin(self, db):
+        """Delegate/subagent children (parent still live) must NOT inherit
+        routing keys — peer recovery could otherwise repoint gateway traffic
+        into a subagent's session."""
+        db.create_session(
+            session_id="parent", source="telegram",
+            user_id="u1", session_key="telegram:u1:c1",
+            chat_id="c1", chat_type="private",
+        )
+
+        db.create_session(
+            session_id="sub", source="telegram", parent_session_id="parent"
+        )
+
+        sub = db.get_session("sub")
+        assert sub["session_key"] is None
+        assert sub["chat_id"] is None
+        assert sub["user_id"] is None
+        # Workspace metadata still inherits — that part is safe for any child.
+        db.update_session_cwd("parent", "/work/repo", git_repo_root="/work/repo")
+        db.create_session(
+            session_id="sub2", source="telegram", parent_session_id="parent"
+        )
+        assert db.get_session("sub2")["cwd"] == "/work/repo"
+
     def test_update_session_cwd_empty_branch_does_not_clobber(self, db):
         """A failed branch probe (empty string) must not wipe a branch we
         already captured — only the cwd updates."""


### PR DESCRIPTION
## Summary
Compression-rotation child sessions now inherit `cwd`, `git_repo_root`, and `git_branch` from their parent row, so a project's sidebar entry (grouped by cwd) no longer disappears at every compaction boundary. Root cause: the rotation path's `create_session(..., parent_session_id=old_session_id)` passed no workspace metadata and `_insert_session_row` never backfilled it — the child row was born NULL (`git_repo_root` wasn't even in the INSERT column list).

## Changes
- `hermes_state.py` — `_insert_session_row`: adds `git_repo_root` to the INSERT/COALESCE-on-conflict column set; when `parent_session_id` is set, backfills still-NULL `cwd`/`git_repo_root`/`git_branch` from the immediate parent row inside the same write transaction (NULL-only — an explicit child value is never overwritten). Multi-generation chains resolve because each generation backfills from its already-resolved parent.
- `hermes_state.py` — belt-and-suspenders for #59527's crash window: compression forks (parent already ended with `end_reason='compression'`) also inherit the gateway origin columns (`user_id`/`session_key`/`chat_id`/`chat_type`/`thread_id`/`display_name`/`origin_json`) at DB-level creation. The gateway re-records the peer after rotation (d5b4879d4), but a hard crash between child creation and that write left the child unrecoverable by `find_latest_gateway_session_for_peer`. Scoped to compression forks only — delegate/subagent children (parent still live) do NOT inherit routing keys, so peer recovery can never repoint gateway traffic into a subagent's session.
- `tests/test_hermes_state.py` — inheritance, no-clobber, multi-generation, git_branch, origin-column, and live-parent-exclusion tests.
- `tests/agent/test_compression_rotation_state.py` — behavioral test driving the real `_compress_context` rotation path and asserting the child row carries workspace + origin metadata.

## Validation
| | Before | After |
|---|---|---|
| Child row after compression rotation | `cwd`/`git_repo_root`/`git_branch` NULL → project drops out of sidebar | inherits all three from parent row |
| Gateway crash between rotation and peer re-record | child has no routing columns → `/resume` mapping unrecoverable | compression child inherits origin columns |
| Delegate/subagent child (parent live) | — | still does NOT inherit routing keys |

Targeted tests: 555 passed, 0 failed (`tests/test_hermes_state.py`, `tests/agent/test_compression_rotation_state.py`, `tests/hermes_state/`, `tests/gateway/test_session_store_stale_prune.py`, `tests/gateway/test_session_hygiene.py`, `tests/gateway/test_compression_concurrent_sessions.py`, `tests/run_agent/test_compression_boundary_hook.py`, rotation-flush suites).

Fixes #64709.

## Credit
Salvaged from #64731 by @wesleysimplicio — cherry-picked with authorship preserved; conflicts against the schema-v23 `profile_name` column resolved to keep both. Follow-up commit adds `git_branch` + compression-scoped gateway-origin inheritance (residual from #59527).

## Infographic
![compression child sessions inherit cwd and repo metadata](https://v3b.fal.media/files/b/0aa3462b/kUn8ZoshL7anUzk5cU3Ob_EsVUEzIX.png)
