### PR TITLE
fix(maintenance): make autonomous cleanup provenance-safe

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1660,11 +1660,24 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True) -> Optional[D
     # Lock the worktree so other processes (and `git worktree remove`) can see
     # it is actively in use.  Fail-soft: a lock failure never blocks the session.
     try:
+        lock_reason = f"hermes pid={os.getpid()}"
+        try:
+            from gateway.status import get_process_start_time
+            process_start = get_process_start_time(os.getpid())
+            if process_start is not None:
+                lock_reason += f" start={process_start}"
+        except Exception:
+            process_start = None
         subprocess.run(
-            ["git", "worktree", "lock", "--reason", f"hermes pid={os.getpid()}", str(wt_path)],
+            ["git", "worktree", "lock", "--reason", lock_reason, str(wt_path)],
             capture_output=True, text=True, timeout=10, cwd=repo_root,
         )
-        logger.debug("Worktree locked: %s (pid=%s)", wt_path, os.getpid())
+        logger.debug(
+            "Worktree locked: %s (pid=%s, start=%s)",
+            wt_path,
+            os.getpid(),
+            process_start,
+        )
     except Exception as e:
         logger.debug("git worktree lock failed (non-fatal): %s", e)
 
@@ -1687,8 +1700,8 @@ def _worktree_has_unpushed_commits(worktree_path: str, timeout: int = 10) -> boo
 
     ``git log HEAD --not --remotes`` compares against remote-tracking refs under
     ``refs/remotes/*``. If a repo has no remote-tracking refs yet, there is no
-    usable remote baseline to compare against, so treat it as having no
-    "unpushed" commits.
+    usable remote baseline to prove the commits are pushed, so fail safe and
+    preserve the worktree.
     """
     import subprocess
 
@@ -1700,7 +1713,7 @@ def _worktree_has_unpushed_commits(worktree_path: str, timeout: int = 10) -> boo
         if remote_refs.returncode != 0:
             return True
         if not remote_refs.stdout.strip():
-            return False
+            return True
 
         result = subprocess.run(
             ["git", "log", "--oneline", "HEAD", "--not", "--remotes"],
@@ -1745,8 +1758,9 @@ def _worktree_lock_is_live(repo_root: str, worktree_path: str, timeout: int = 10
     pruner tell the two apart:
 
     - ``"live"``  — locked and the owning pid is still running (skip it).
-    - ``"dead"``  — locked but the owning pid is gone, or the reason isn't a
-                    parseable hermes lock (safe to unlock + reap).
+    - ``"dead"``  — locked and the owning pid is gone (safe to unlock + reap).
+    - ``"unknown"`` — lock ownership or process identity cannot be proven;
+                      preserve it rather than treating uncertainty as stale.
     - ``None``    — not locked at all.
 
     Fails SAFE toward ``"live"``: if git can't be queried at all we cannot
@@ -1779,30 +1793,36 @@ def _worktree_lock_is_live(repo_root: str, worktree_path: str, timeout: int = 10
             reason = line[len("locked"):].strip()
             m = re.search(r"hermes pid=(\d+)", reason)
             if not m:
-                # Locked by something we don't recognize as a hermes session
-                # (or lock reason unavailable). Treat as dead — a foreign lock
-                # on a hermes -w worktree is almost certainly a leftover, and
-                # the age/dirty/unpushed gates already ran before we got here.
-                return "dead"
+                # A foreign or malformed lock is not evidence of abandonment.
+                return "unknown"
             pid = int(m.group(1))
             if pid == os.getpid():
                 return "live"
             try:
-                from gateway.status import _pid_exists
-                return "live" if _pid_exists(pid) else "dead"
+                from gateway.status import _pid_exists, get_process_start_time
+                if not _pid_exists(pid):
+                    return "dead"
+                expected_match = re.search(r"(?:^|\s)start=(\d+)(?:\s|$)", reason)
+                if expected_match is None:
+                    # Legacy PID-only locks cannot exclude PID reuse while the
+                    # number is live, so preserve them conservatively.
+                    return "unknown"
+                actual_start = get_process_start_time(pid)
+                if actual_start is None or actual_start != int(expected_match.group(1)):
+                    return "unknown"
+                return "live"
             except Exception:
                 # Can't determine liveness — fail safe toward keeping it.
-                return "live"
+                return "unknown"
     return None
 
 
 def _cleanup_worktree(info: Dict[str, str] = None) -> None:
     """Remove a worktree and its branch on exit.
 
-    Preserves the worktree only if it has unpushed commits (real work
-    that hasn't been pushed to any remote).  Uncommitted changes alone
-    (untracked files, test artifacts) are not enough to keep it — agent
-    work lives in commits/PRs, not the working tree.
+    Preserves the worktree when either its commits are unpushed or its working
+    tree is dirty.  Exit cleanup must not infer that uncommitted files are
+    disposable: status uncertainty is itself a reason to preserve the tree.
     """
     global _active_worktree
     info = info or _active_worktree
@@ -1819,15 +1839,15 @@ def _cleanup_worktree(info: Dict[str, str] = None) -> None:
         return
 
     has_unpushed = _worktree_has_unpushed_commits(wt_path, timeout=10)
+    is_dirty = _worktree_is_dirty(wt_path, timeout=10)
 
-    if has_unpushed:
-        print(f"\n\033[33m⚠ Worktree has unpushed commits, keeping: {wt_path}\033[0m")
+    if has_unpushed or is_dirty:
+        reason = "unpushed commits" if has_unpushed else "uncommitted changes"
+        print(f"\n\033[33m⚠ Worktree has {reason}, keeping: {wt_path}\033[0m")
         print(f"  To clean up manually: git worktree remove --force {wt_path}")
         _active_worktree = None
         return
 
-    # Remove worktree (even if working tree is dirty — uncommitted
-    # changes without unpushed commits are just artifacts)
     # Unlock first so `git worktree remove` isn't blocked by the lock we
     # placed at creation time.  Fail-soft — never block cleanup.
     try:
@@ -1839,14 +1859,25 @@ def _cleanup_worktree(info: Dict[str, str] = None) -> None:
         logger.debug("git worktree unlock failed (non-fatal): %s", e)
 
     try:
-        subprocess.run(
+        remove_result = subprocess.run(
             ["git", "worktree", "remove", wt_path, "--force"],
             capture_output=True, text=True, timeout=15, cwd=repo_root,
         )
+        if remove_result.returncode != 0:
+            logger.debug(
+                "Failed to remove worktree %s: %s",
+                wt_path,
+                remove_result.stderr.strip(),
+            )
+            _active_worktree = None
+            return
     except Exception as e:
         logger.debug("Failed to remove worktree: %s", e)
+        _active_worktree = None
+        return
 
-    # Delete the branch
+    # Delete the branch only after git confirmed that the worktree was removed;
+    # otherwise its commits could become unreachable while the files remain.
     try:
         subprocess.run(
             ["git", "branch", "-D", branch],
@@ -1943,8 +1974,9 @@ def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
     Age-based tiers (aggressive cleanup keeps ``.worktrees/`` from growing
     unbounded):
     - Under max_age_hours (24h): skip — session may still be active.
-    - 24h–72h: remove if no unpushed commits.
-    - Over 72h: force remove regardless (nothing should sit this long).
+    - 24h–72h: remove only if clean and has no unpushed commits.
+    - Over 72h: remove only if clean and has no unpushed commits; age never
+                overrides evidence of user-authored work.
 
     Lock handling (orthogonal to age): ``hermes -w`` locks each worktree with
     reason ``hermes pid=<pid>`` so a concurrent hermes process leaves an in-use
@@ -1992,11 +2024,8 @@ def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
         # scratch trees that actually cause .worktrees/ bloat).
         if _worktree_has_unpushed_commits(str(entry), timeout=5):
             continue  # Has unpushed commits or can't check — skip
-        if not force:
-            # 24h–72h tier is conservative: unpushed check above is enough.
-            pass
-        elif _worktree_is_dirty(str(entry), timeout=5):
-            continue  # >72h but dirty — preserve uncommitted work
+        if _worktree_is_dirty(str(entry), timeout=5):
+            continue  # Preserve uncommitted work at every age tier
 
         # Respect git-native session locks. A lock owned by a still-running
         # hermes process means the worktree is actively in use — never touch
@@ -2004,7 +2033,7 @@ def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
         # unlock it so `git worktree remove --force` (single -f) can reap it,
         # otherwise dead-locked worktrees pile up indefinitely.
         lock_state = _worktree_lock_is_live(repo_root, str(entry), timeout=5)
-        if lock_state == "live":
+        if lock_state in {"live", "unknown"}:
             logger.debug("Skipping live-locked worktree: %s", entry.name)
             continue
         if lock_state == "dead":
@@ -2049,11 +2078,11 @@ def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
 
 
 def _prune_orphaned_branches(repo_root: str) -> None:
-    """Delete local ``hermes/hermes-*`` and ``pr-*`` branches with no worktree.
+    """Delete proven-merged local generated branches with no worktree.
 
     These are auto-generated by ``hermes -w`` sessions and PR review
-    workflows respectively.  Once their worktree is gone they serve no
-    purpose and just accumulate.
+    workflows respectively.  A name alone is not ownership evidence: remote
+    tracking, unmerged commits, and any failed Git query preserve the branch.
     """
     import subprocess
 
@@ -2075,6 +2104,8 @@ def _prune_orphaned_branches(repo_root: str) -> None:
             ["git", "worktree", "list", "--porcelain"],
             capture_output=True, text=True, timeout=10, cwd=repo_root,
         )
+        if wt_result.returncode != 0:
+            return
         for line in wt_result.stdout.split("\n"):
             if line.startswith("branch refs/heads/"):
                 active_branches.add(line.split("branch refs/heads/", 1)[-1].strip())
@@ -2088,10 +2119,12 @@ def _prune_orphaned_branches(repo_root: str) -> None:
             capture_output=True, text=True, timeout=5, cwd=repo_root,
         )
         current = head_result.stdout.strip()
+        if head_result.returncode != 0:
+            return
         if current:
             active_branches.add(current)
     except Exception:
-        pass
+        return
     active_branches.add("main")
 
     orphaned = [
@@ -2103,18 +2136,59 @@ def _prune_orphaned_branches(repo_root: str) -> None:
     if not orphaned:
         return
 
-    # Delete in batches
-    for i in range(0, len(orphaned), 50):
-        batch = orphaned[i:i + 50]
-        try:
-            subprocess.run(
-                ["git", "branch", "-D"] + batch,
-                capture_output=True, text=True, timeout=30, cwd=repo_root,
-            )
-        except Exception as e:
-            logger.debug("Failed to prune orphaned branches: %s", e)
+    # Read all remote refs once. A corresponding remote branch is active
+    # ownership evidence even when the local branch's upstream config is stale.
+    try:
+        remote_result = subprocess.run(
+            ["git", "for-each-ref", "--format=%(refname:short)", "refs/remotes"],
+            capture_output=True, text=True, timeout=10, cwd=repo_root,
+        )
+        if remote_result.returncode != 0:
+            return
+        remote_refs = {
+            ref.strip().split("/", 1)[1]
+            for ref in remote_result.stdout.splitlines()
+            if "/" in ref.strip()
+        }
+    except Exception:
+        return
 
-    logger.debug("Pruned %d orphaned branches", len(orphaned))
+    base = current or "main"
+    for branch in orphaned:
+        try:
+            upstream_result = subprocess.run(
+                [
+                    "git", "for-each-ref", "--format=%(upstream:short)",
+                    f"refs/heads/{branch}",
+                ],
+                capture_output=True, text=True, timeout=10, cwd=repo_root,
+            )
+            if upstream_result.returncode != 0 or upstream_result.stdout.strip():
+                continue
+            if branch in remote_refs:
+                continue
+
+            merged_result = subprocess.run(
+                ["git", "merge-base", "--is-ancestor", branch, base],
+                capture_output=True, text=True, timeout=10, cwd=repo_root,
+            )
+            if merged_result.returncode != 0:
+                continue
+
+            delete_result = subprocess.run(
+                ["git", "branch", "-d", branch],
+                capture_output=True, text=True, timeout=10, cwd=repo_root,
+            )
+            if delete_result.returncode != 0:
+                logger.debug(
+                    "Failed to prune generated branch %s: %s",
+                    branch,
+                    delete_result.stderr.strip(),
+                )
+        except Exception as e:
+            logger.debug("Failed to inspect generated branch %s: %s", branch, e)
+
+    logger.debug("Inspected %d orphaned branch candidates", len(orphaned))
 
 # ============================================================================
 # ASCII Art & Branding

--- a/cli.py
+++ b/cli.py
@@ -1753,7 +1753,7 @@ def _worktree_lock_is_live(repo_root: str, worktree_path: str, timeout: int = 10
     ``hermes -w`` locks each worktree with reason ``hermes pid=<pid>`` so a
     concurrent hermes process' startup prune leaves an in-use worktree alone.
     But a *crashed* session leaves the lock behind forever, and
-    ``git worktree remove --force`` (single ``-f``) refuses to remove a locked
+    ``git worktree remove`` refuses to remove a locked
     worktree — so dead-locked worktrees accumulate indefinitely. This lets the
     pruner tell the two apart:
 
@@ -1864,7 +1864,7 @@ def _cleanup_worktree(info: Dict[str, str] = None) -> None:
 
     try:
         remove_result = subprocess.run(
-            ["git", "worktree", "remove", wt_path, "--force"],
+            ["git", "worktree", "remove", wt_path],
             capture_output=True, text=True, timeout=15, cwd=repo_root,
         )
         if remove_result.returncode != 0:
@@ -1986,8 +1986,8 @@ def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
     reason ``hermes pid=<pid>`` so a concurrent hermes process leaves an in-use
     worktree alone. A *live*-locked worktree is skipped at any age; a
     *dead*-locked one (owning pid gone — a crashed session) is unlocked first
-    so ``git worktree remove --force`` can actually reap it, otherwise those
-    leftovers accumulate forever (``remove --force`` refuses a locked tree).
+    so ``git worktree remove`` can actually reap it, otherwise those
+    leftovers accumulate forever (``remove`` refuses a locked tree).
 
     Branch deletion is gated on ``git worktree remove`` succeeding, so a failed
     removal never orphans the branch (which would drop easy reachability of any
@@ -2034,7 +2034,7 @@ def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
         # Respect git-native session locks. A lock owned by a still-running
         # hermes process means the worktree is actively in use — never touch
         # it. A lock whose owning pid is gone is a crashed session's leftover:
-        # unlock it so `git worktree remove --force` (single -f) can reap it,
+        # unlock it so `git worktree remove` can reap it,
         # otherwise dead-locked worktrees pile up indefinitely.
         lock_state = _worktree_lock_is_live(repo_root, str(entry), timeout=5)
         if lock_state in {"live", "unknown"}:
@@ -2058,7 +2058,7 @@ def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
             branch = branch_result.stdout.strip()
 
             remove_result = subprocess.run(
-                ["git", "worktree", "remove", str(entry), "--force"],
+                ["git", "worktree", "remove", str(entry)],
                 capture_output=True, text=True, timeout=15, cwd=repo_root,
             )
             if remove_result.returncode != 0:

--- a/cli.py
+++ b/cli.py
@@ -1808,8 +1808,12 @@ def _worktree_lock_is_live(repo_root: str, worktree_path: str, timeout: int = 10
                     # number is live, so preserve them conservatively.
                     return "unknown"
                 actual_start = get_process_start_time(pid)
-                if actual_start is None or actual_start != int(expected_match.group(1)):
+                if actual_start is None:
                     return "unknown"
+                if actual_start != int(expected_match.group(1)):
+                    # The PID exists but belongs to a different process now.
+                    # That proves the recorded owner is dead (PID reuse).
+                    return "dead"
                 return "live"
             except Exception:
                 # Can't determine liveness — fail safe toward keeping it.

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import shutil
 import sqlite3
 import stat
@@ -23,7 +24,7 @@ import uuid
 import zipfile
 from contextlib import contextmanager
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_default_hermes_root, get_hermes_home, display_hermes_home
@@ -341,6 +342,7 @@ def _safe_copy_db(
     dst: Path,
     *,
     expected_dst_identity: Optional[os.stat_result] = None,
+    expected_src_identity: Optional[os.stat_result] = None,
 ) -> bool:
     """Copy a SQLite database safely using the backup() API.
 
@@ -351,6 +353,10 @@ def _safe_copy_db(
     conn = None
     backup_conn = None
     owner_fd: Optional[int] = None
+    source_fd: Optional[int] = None
+    stage_fd: Optional[int] = None
+    stage_path: Optional[Path] = None
+    stage_identity: Optional[os.stat_result] = None
     created_here = False
     success = False
     try:
@@ -385,9 +391,56 @@ def _safe_copy_db(
                 )
                 return False
 
+        source_selected = src.lstat()
+        if (
+            expected_src_identity is not None
+            and not _same_snapshot_object(expected_src_identity, source_selected)
+        ):
+            raise OSError(f"SQLite source changed after enumeration: {src}")
+        source_flags = os.O_RDONLY
+        if hasattr(os, "O_BINARY"):
+            source_flags |= os.O_BINARY
+        if hasattr(os, "O_NOFOLLOW"):
+            source_flags |= os.O_NOFOLLOW
+        source_fd = os.open(src, source_flags)
+        if (
+            not stat.S_ISREG(source_selected.st_mode)
+            or int(getattr(source_selected, "st_file_attributes", 0)) & 0x400
+            or not os.path.samestat(source_selected, os.fstat(source_fd))
+        ):
+            raise OSError(f"SQLite source changed before backup: {src}")
+
+        # SQLite must not open the caller's replaceable destination pathname.
+        # Back up into a random, already-open sibling and then stream that
+        # snapshot into the verified destination descriptor.
+        with tempfile.NamedTemporaryFile(
+            suffix=".db", delete=False, dir=str(dst.parent)
+        ) as stage_file:
+            stage_path = Path(stage_file.name)
+            stage_fd = os.dup(stage_file.fileno())
+            stage_identity = os.fstat(stage_file.fileno())
         conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
-        backup_conn = sqlite3.connect(str(dst))
+        backup_conn = sqlite3.connect(str(stage_path))
         conn.backup(backup_conn)
+        backup_conn.close()
+        backup_conn = None
+
+        if not os.path.samestat(source_selected, src.lstat()):
+            raise OSError(f"SQLite source changed during backup: {src}")
+        if not os.path.samestat(stage_identity, os.fstat(stage_fd)):
+            raise OSError(f"SQLite staging file changed during backup: {stage_path}")
+
+        os.lseek(stage_fd, 0, os.SEEK_SET)
+        os.lseek(owner_fd, 0, os.SEEK_SET)
+        os.ftruncate(owner_fd, 0)
+        while chunk := os.read(stage_fd, 1024 * 1024):
+            view = memoryview(chunk)
+            while view:
+                written = os.write(owner_fd, view)
+                if written <= 0:
+                    raise OSError("short write while copying SQLite snapshot")
+                view = view[written:]
+        os.fsync(owner_fd)
         success = True
     except Exception as exc:
         logger.warning("SQLite safe copy failed for %s: %s", src, exc)
@@ -400,7 +453,37 @@ def _safe_copy_db(
                     pass
         if owner_fd is not None:
             try:
+                opened_destination = os.fstat(owner_fd)
+                path_destination = dst.lstat()
+                success = bool(
+                    success
+                    and expected_dst_identity is not None
+                    and _same_snapshot_object(
+                        expected_dst_identity, opened_destination
+                    )
+                    and _same_snapshot_object(
+                        opened_destination, path_destination
+                    )
+                )
+            except OSError:
+                success = False
+            try:
                 os.close(owner_fd)
+            except OSError:
+                pass
+        if source_fd is not None:
+            try:
+                os.close(source_fd)
+            except OSError:
+                pass
+        if stage_fd is not None:
+            try:
+                os.close(stage_fd)
+            except OSError:
+                pass
+        if stage_path is not None and stage_identity is not None:
+            try:
+                _remove_owned_snapshot_file(stage_path, stage_identity)
             except OSError:
                 pass
 
@@ -410,7 +493,7 @@ def _safe_copy_db(
             success
             and expected_dst_identity is not None
             and stat.S_ISREG(current.st_mode)
-            and os.path.samestat(current, expected_dst_identity)
+            and _same_snapshot_object(expected_dst_identity, current)
         )
     except OSError:
         success = False
@@ -964,24 +1047,26 @@ def _move_owned_snapshot_path(path: Path, expected: os.stat_result) -> Optional[
     quarantine = path.with_name(f".{path.name}.hermes-delete-{uuid.uuid4().hex}")
     try:
         current = path.lstat()
-        if not os.path.samestat(expected, current):
-            return None
-        # Windows may recycle a just-unlinked file index immediately. Its
-        # creation timestamp remains independent evidence that the pathname
-        # still names the object we opened, rather than a race winner that
-        # inherited the same index.
-        if os.name == "nt" and expected.st_ctime_ns != current.st_ctime_ns:
+        if not _same_snapshot_object(expected, current):
             return None
         os.replace(path, quarantine)
         moved = quarantine.lstat()
-        if (
-            os.path.samestat(expected, moved)
-            and (os.name != "nt" or expected.st_ctime_ns == moved.st_ctime_ns)
-        ):
+        if _same_snapshot_object(expected, moved):
             return quarantine
     except OSError:
         return None
     return None
+
+
+def _same_snapshot_object(
+    expected: os.stat_result,
+    current: os.stat_result,
+) -> bool:
+    """Compare stable object evidence, including Windows creation time."""
+    return bool(
+        os.path.samestat(expected, current)
+        and (os.name != "nt" or expected.st_ctime_ns == current.st_ctime_ns)
+    )
 
 
 def _remove_owned_snapshot_file(path: Path, expected: os.stat_result) -> bool:
@@ -1315,6 +1400,84 @@ def create_quick_snapshot(
     return snap_id
 
 
+def _legacy_quick_snapshot_manifest(snapshot_dir: Path) -> Optional[Dict[str, Any]]:
+    """Validate a pre-marker snapshot for read-only list/restore compatibility."""
+    if (
+        os.path.lexists(snapshot_dir / _QUICK_OWNERSHIP_MARKER)
+        or os.path.lexists(snapshot_dir / _QUICK_IN_PROGRESS_MARKER)
+        or re.fullmatch(r"\d{8}-\d{6}(?:-\d{6})?(?:-[A-Za-z0-9_-]+)?", snapshot_dir.name)
+        is None
+    ):
+        return None
+    manifest_path = snapshot_dir / "manifest.json"
+    fd: Optional[int] = None
+    try:
+        directory_identity = snapshot_dir.lstat()
+        manifest_identity = manifest_path.lstat()
+        if (
+            not stat.S_ISDIR(directory_identity.st_mode)
+            or _snapshot_path_is_link_like(snapshot_dir)
+            or not stat.S_ISREG(manifest_identity.st_mode)
+            or _snapshot_path_is_link_like(manifest_path)
+        ):
+            return None
+        flags = os.O_RDONLY
+        if hasattr(os, "O_BINARY"):
+            flags |= os.O_BINARY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(manifest_path, flags)
+        if not os.path.samestat(manifest_identity, os.fstat(fd)):
+            return None
+        with os.fdopen(fd, "r", encoding="utf-8") as stream:
+            fd = None
+            metadata = json.load(stream)
+        if not isinstance(metadata, dict) or metadata.get("id") != snapshot_dir.name:
+            return None
+        files = metadata.get("files")
+        if not isinstance(files, dict) or not files:
+            return None
+        allowed_roots = tuple(PurePosixPath(item) for item in _QUICK_STATE_FILES)
+        total_size = 0
+        for raw_rel, declared_size in files.items():
+            if (
+                not isinstance(raw_rel, str)
+                or not isinstance(declared_size, int)
+                or declared_size < 0
+            ):
+                return None
+            rel = PurePosixPath(raw_rel)
+            if rel.is_absolute() or not rel.parts or ".." in rel.parts or "." in rel.parts:
+                return None
+            if not any(rel == root or root in rel.parents for root in allowed_roots):
+                return None
+            source = snapshot_dir.joinpath(*rel.parts)
+            selected = source.lstat()
+            if (
+                not stat.S_ISREG(selected.st_mode)
+                or _snapshot_path_is_link_like(source)
+                or selected.st_size != declared_size
+                or not source.resolve(strict=True).is_relative_to(
+                    snapshot_dir.resolve(strict=True)
+                )
+            ):
+                return None
+            total_size += declared_size
+        if (
+            metadata.get("file_count") != len(files)
+            or metadata.get("total_size") != total_size
+            or not os.path.samestat(directory_identity, snapshot_dir.lstat())
+            or not os.path.samestat(manifest_identity, manifest_path.lstat())
+        ):
+            return None
+        return metadata
+    except (OSError, RuntimeError, UnicodeError, json.JSONDecodeError, TypeError, ValueError):
+        return None
+    finally:
+        if fd is not None:
+            os.close(fd)
+
+
 def list_quick_snapshots(
     limit: int = 20,
     hermes_home: Optional[Path] = None,
@@ -1326,10 +1489,16 @@ def list_quick_snapshots(
 
     results = []
     for d in sorted(root.iterdir(), reverse=True):
-        if (
-            _quick_snapshot_marker_payload(d, _QUICK_OWNERSHIP_MARKER) is None
-            or (d / _QUICK_IN_PROGRESS_MARKER).exists()
-        ):
+        owned = _quick_snapshot_marker_payload(d, _QUICK_OWNERSHIP_MARKER)
+        legacy_metadata = None if owned is not None else _legacy_quick_snapshot_manifest(d)
+        if (owned is None and legacy_metadata is None) or (
+            d / _QUICK_IN_PROGRESS_MARKER
+        ).exists():
+            continue
+        if legacy_metadata is not None:
+            results.append(legacy_metadata)
+            if len(results) >= limit:
+                break
             continue
         manifest_path = d / "manifest.json"
         if manifest_path.exists():
@@ -1371,18 +1540,22 @@ def restore_quick_snapshot(
         logger.error("Snapshot path traversal blocked for id: %s", snapshot_id)
         return False
 
-    if (
-        _quick_snapshot_marker_payload(snap_dir, _QUICK_OWNERSHIP_MARKER) is None
-        or (snap_dir / _QUICK_IN_PROGRESS_MARKER).exists()
-    ):
+    owned = _quick_snapshot_marker_payload(snap_dir, _QUICK_OWNERSHIP_MARKER)
+    legacy_metadata = None if owned is not None else _legacy_quick_snapshot_manifest(snap_dir)
+    if (owned is None and legacy_metadata is None) or (
+        snap_dir / _QUICK_IN_PROGRESS_MARKER
+    ).exists():
         return False
 
     manifest_path = snap_dir / "manifest.json"
     if not manifest_path.exists():
         return False
 
-    with open(manifest_path, encoding="utf-8") as f:
-        meta = json.load(f)
+    if legacy_metadata is not None:
+        meta = legacy_metadata
+    else:
+        with open(manifest_path, encoding="utf-8") as f:
+            meta = json.load(f)
 
     restored = 0
     for rel in meta.get("files", {}):
@@ -1659,6 +1832,66 @@ def _owned_archive_identity(path: Path) -> Optional[os.stat_result]:
         if fd is not None:
             os.close(fd)
 
+
+def _write_bound_file_to_zip(
+    archive: zipfile.ZipFile,
+    source: Path,
+    arcname: str,
+    *,
+    expected_identity: Optional[os.stat_result] = None,
+) -> int:
+    """Archive one opened regular file only while its pathname stays bound."""
+    selected = source.lstat()
+    if expected_identity is not None and not _same_snapshot_object(
+        expected_identity, selected
+    ):
+        raise OSError(f"backup source changed after enumeration: {source}")
+    reparse = int(getattr(selected, "st_file_attributes", 0)) & 0x400
+    if not stat.S_ISREG(selected.st_mode) or reparse:
+        raise OSError(f"backup source is not a regular file: {source}")
+
+    flags = os.O_RDONLY
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(source, flags)
+    try:
+        opened = os.fstat(fd)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or not os.path.samestat(selected, opened)
+        ):
+            raise OSError(f"backup source changed before open: {source}")
+
+        timestamp = list(time.localtime(opened.st_mtime)[:6])
+        timestamp[0] = min(max(timestamp[0], 1980), 2107)
+        info = zipfile.ZipInfo(arcname.replace(os.sep, "/"), tuple(timestamp))
+        info.compress_type = zipfile.ZIP_DEFLATED
+        info.create_system = 3
+        info.external_attr = (opened.st_mode & 0xFFFF) << 16
+        copied = 0
+        with os.fdopen(fd, "rb", closefd=False) as source_file, archive.open(
+            info, "w", force_zip64=True
+        ) as destination:
+            while chunk := source_file.read(1024 * 1024):
+                destination.write(chunk)
+                copied += len(chunk)
+
+        after = os.fstat(fd)
+        if (
+            copied != opened.st_size
+            or after.st_size != opened.st_size
+            or after.st_mtime_ns != opened.st_mtime_ns
+            or after.st_ctime_ns != opened.st_ctime_ns
+            or not os.path.samestat(opened, source.lstat())
+        ):
+            raise OSError(f"backup source changed while reading: {source}")
+        return copied
+    finally:
+        os.close(fd)
+
+
 def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
     """Write a full zip snapshot of ``hermes_root`` to ``out_path``.
 
@@ -1666,7 +1899,7 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
     Returns the output path on success, None on failure (nothing to back up,
     or write error — caller should surface the outcome but not raise).
     """
-    files_to_add: list[tuple[Path, Path]] = []
+    files_to_add: list[tuple[Path, Path, os.stat_result]] = []
     try:
         for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
             dp = Path(dirpath)
@@ -1682,8 +1915,14 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
 
                 if _should_skip_backup_file(fpath, rel, out_path):
                     continue
+                selected = fpath.lstat()
+                reparse = int(
+                    getattr(selected, "st_file_attributes", 0)
+                ) & 0x400
+                if not stat.S_ISREG(selected.st_mode) or reparse:
+                    continue
 
-                files_to_add.append((fpath, rel))
+                files_to_add.append((fpath, rel, selected))
     except OSError as exc:
         logger.warning("Full-zip backup: walk failed: %s", exc)
         return None
@@ -1707,7 +1946,7 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
         with zipfile.ZipFile(
             temp_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6
         ) as zf:
-            for abs_path, rel_path in files_to_add:
+            for abs_path, rel_path, source_identity in files_to_add:
                 if abs_path.suffix == ".db":
                     # Stage the snapshot alongside the output zip so that the
                     # temp file lives on the same filesystem.  The system
@@ -1723,18 +1962,29 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
                             abs_path,
                             tmp_db,
                             expected_dst_identity=tmp_db_identity,
+                            expected_src_identity=source_identity,
                         ):
                             logger.warning(
                                 "Full-zip backup aborted: SQLite snapshot failed for %s",
                                 rel_path,
                             )
                             return None
-                        zf.write(tmp_db, arcname=rel_path.as_posix())
+                        _write_bound_file_to_zip(
+                            zf,
+                            tmp_db,
+                            rel_path.as_posix(),
+                            expected_identity=tmp_db_identity,
+                        )
                         written_members += 1
                     finally:
                         _remove_owned_snapshot_file(tmp_db, tmp_db_identity)
                 else:
-                    zf.write(abs_path, arcname=rel_path.as_posix())
+                    _write_bound_file_to_zip(
+                        zf,
+                        abs_path,
+                        rel_path.as_posix(),
+                        expected_identity=source_identity,
+                    )
                     written_members += 1
             zf.comment = _archive_ownership_comment(out_path)
 
@@ -1897,7 +2147,7 @@ def create_pre_update_backup(
             if result is None:
                 return None
             _prune_pre_update_backups(backup_dir, keep=keep)
-            return out_path
+            return result
     except OSError as exc:
         logger.warning("Could not publish pre-update backup: %s", exc)
         return None
@@ -1983,7 +2233,7 @@ def create_pre_migration_backup(
             if result is None:
                 return None
             _prune_pre_migration_backups(backup_dir, keep=keep)
-            return out_path
+            return result
     except OSError as exc:
         logger.warning("Could not publish pre-migration backup: %s", exc)
         return None

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -918,14 +918,28 @@ def _remove_owned_snapshot_file(path: Path, expected: os.stat_result) -> bool:
         return False
 
 
-def _remove_owned_snapshot_dir(path: Path, expected: os.stat_result) -> bool:
+def _remove_owned_snapshot_dir(
+    path: Path,
+    expected: os.stat_result,
+    *,
+    marker_name: str,
+    marker_identity: os.stat_result,
+    marker_payload: Dict[str, Any],
+) -> bool:
     quarantine = _move_owned_snapshot_path(path, expected)
     if quarantine is None:
         return False
     try:
+        moved_marker = quarantine / marker_name
+        if (
+            not os.path.samestat(marker_identity, moved_marker.lstat())
+            or json.loads(moved_marker.read_text(encoding="utf-8"))
+            != marker_payload
+        ):
+            return False
         shutil.rmtree(quarantine)
         return True
-    except OSError:
+    except (OSError, UnicodeError, json.JSONDecodeError):
         return False
 
 
@@ -1139,7 +1153,13 @@ def create_quick_snapshot(
 
     if not manifest:
         try:
-            _remove_owned_snapshot_dir(snap_dir, snap_dir.lstat())
+            _remove_owned_snapshot_dir(
+                snap_dir,
+                snap_dir.lstat(),
+                marker_name=_QUICK_IN_PROGRESS_MARKER,
+                marker_identity=marker_identity,
+                marker_payload=marker_payload,
+            )
         except OSError:
             pass
         return None
@@ -1417,7 +1437,13 @@ def _prune_quick_snapshots(root: Path, keep: int = _QUICK_DEFAULT_KEEP) -> int:
             )
             if payload is None or _snapshot_process_is_running(payload["pid"]):
                 continue
-            if _remove_owned_snapshot_dir(candidate, candidate.lstat()):
+            if _remove_owned_snapshot_dir(
+                candidate,
+                candidate.lstat(),
+                marker_name=_QUICK_IN_PROGRESS_MARKER,
+                marker_identity=marker.lstat(),
+                marker_payload=payload,
+            ):
                 deleted += 1
         except (OSError, ValueError, json.JSONDecodeError):
             continue
@@ -1435,7 +1461,15 @@ def _prune_quick_snapshots(root: Path, keep: int = _QUICK_DEFAULT_KEEP) -> int:
 
     for d in dirs[keep:]:
         try:
-            if _remove_owned_snapshot_dir(d, d.lstat()):
+            marker = d / _QUICK_OWNERSHIP_MARKER
+            payload = _quick_snapshot_marker_payload(d, _QUICK_OWNERSHIP_MARKER)
+            if payload is not None and _remove_owned_snapshot_dir(
+                d,
+                d.lstat(),
+                marker_name=_QUICK_OWNERSHIP_MARKER,
+                marker_identity=marker.lstat(),
+                marker_payload=payload,
+            ):
                 deleted += 1
         except OSError as exc:
             logger.warning("Failed to prune snapshot %s: %s", d.name, exc)

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1578,6 +1578,7 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
         return None
 
     temp_path: Optional[Path] = None
+    temp_identity: Optional[os.stat_result] = None
     written_members = 0
     try:
         # Publish through a sibling temporary file.  The destination is never
@@ -1587,6 +1588,7 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
             suffix=".zip", delete=False, dir=str(out_path.parent)
         ) as tmp:
             temp_path = Path(tmp.name)
+            temp_identity = os.fstat(tmp.fileno())
 
         with zipfile.ZipFile(
             temp_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6
@@ -1601,6 +1603,7 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
                         suffix=".db", delete=False, dir=str(out_path.parent)
                     ) as tmp_db_file:
                         tmp_db = Path(tmp_db_file.name)
+                        tmp_db_identity = os.fstat(tmp_db_file.fileno())
                     try:
                         if not _safe_copy_db(abs_path, tmp_db):
                             logger.warning(
@@ -1611,7 +1614,7 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
                         zf.write(tmp_db, arcname=rel_path.as_posix())
                         written_members += 1
                     finally:
-                        tmp_db.unlink(missing_ok=True)
+                        _remove_owned_snapshot_file(tmp_db, tmp_db_identity)
                 else:
                     zf.write(abs_path, arcname=rel_path.as_posix())
                     written_members += 1
@@ -1631,14 +1634,15 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
             os.fsync(archive_file.fileno())
         os.replace(temp_path, out_path)
         temp_path = None
+        temp_identity = None
         return out_path
     except (PermissionError, OSError, ValueError, zipfile.BadZipFile) as exc:
         logger.warning("Full-zip backup: zip write failed: %s", exc)
         return None
     finally:
-        if temp_path is not None:
+        if temp_path is not None and temp_identity is not None:
             try:
-                temp_path.unlink(missing_ok=True)
+                _remove_owned_snapshot_file(temp_path, temp_identity)
             except OSError:
                 pass
 
@@ -1676,18 +1680,29 @@ def _prune_pre_update_backups(backup_dir: Path, keep: int) -> int:
     if not backup_dir.exists():
         return 0
 
-    backups = sorted(
-        (p for p in backup_dir.iterdir()
-         if p.is_file() and p.name.startswith(_PRE_UPDATE_PREFIX) and p.suffix.lower() == ".zip"),
-        key=lambda p: p.name,
+    backups = []
+    for path in backup_dir.iterdir():
+        try:
+            selected = path.lstat()
+        except OSError:
+            continue
+        if (
+            stat.S_ISREG(selected.st_mode)
+            and not _snapshot_path_is_link_like(path)
+            and path.name.startswith(_PRE_UPDATE_PREFIX)
+            and path.suffix.lower() == ".zip"
+        ):
+            backups.append((path, selected))
+    backups.sort(
+        key=lambda item: item[0].name,
         reverse=True,
     )
 
     deleted = 0
-    for p in backups[keep:]:
+    for p, selected in backups[keep:]:
         try:
-            p.unlink()
-            deleted += 1
+            if _remove_owned_snapshot_file(p, selected):
+                deleted += 1
         except OSError as exc:
             logger.warning("Failed to prune backup %s: %s", p.name, exc)
 
@@ -1750,18 +1765,29 @@ def _prune_pre_migration_backups(backup_dir: Path, keep: int) -> int:
     if not backup_dir.exists():
         return 0
 
-    backups = sorted(
-        (p for p in backup_dir.iterdir()
-         if p.is_file() and p.name.startswith(_PRE_MIGRATION_PREFIX) and p.suffix.lower() == ".zip"),
-        key=lambda p: p.name,
+    backups = []
+    for path in backup_dir.iterdir():
+        try:
+            selected = path.lstat()
+        except OSError:
+            continue
+        if (
+            stat.S_ISREG(selected.st_mode)
+            and not _snapshot_path_is_link_like(path)
+            and path.name.startswith(_PRE_MIGRATION_PREFIX)
+            and path.suffix.lower() == ".zip"
+        ):
+            backups.append((path, selected))
+    backups.sort(
+        key=lambda item: item[0].name,
         reverse=True,
     )
 
     deleted = 0
-    for p in backups[keep:]:
+    for p, selected in backups[keep:]:
         try:
-            p.unlink()
-            deleted += 1
+            if _remove_owned_snapshot_file(p, selected):
+                deleted += 1
         except OSError as exc:
             logger.warning("Failed to prune pre-migration backup %s: %s", p.name, exc)
 

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -8,6 +8,7 @@ Backup and import commands for hermes CLI.
 HERMES_HOME root.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -17,6 +18,7 @@ import sys
 import tempfile
 import threading
 import time
+import uuid
 import zipfile
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -876,6 +878,69 @@ _QUICK_STATE_FILES = (
 
 _QUICK_SNAPSHOTS_DIR = "state-snapshots"
 _QUICK_DEFAULT_KEEP = 20
+_QUICK_IN_PROGRESS_MAX_AGE_SECONDS = 24 * 60 * 60
+
+
+def _quick_snapshot_label_segment(label: Optional[str]) -> Optional[str]:
+    if not label:
+        return None
+    raw = str(label)
+    safe = "".join(char if char.isalnum() or char in "-_" else "_" for char in raw)
+    safe = safe.strip("_-") or "snapshot"
+    if safe != raw or len(safe) > 48:
+        digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:12]
+        safe = f"{safe[:32]}-{digest}"
+    return safe
+
+
+def _move_owned_snapshot_path(path: Path, expected: os.stat_result) -> Optional[Path]:
+    """Move the exact expected object to a nonce sibling, or preserve it."""
+    quarantine = path.with_name(f".{path.name}.hermes-delete-{uuid.uuid4().hex}")
+    try:
+        os.replace(path, quarantine)
+        if os.path.samestat(expected, quarantine.lstat()):
+            return quarantine
+        if not os.path.lexists(path):
+            os.replace(quarantine, path)
+    except OSError:
+        try:
+            if os.path.lexists(quarantine) and not os.path.lexists(path):
+                os.replace(quarantine, path)
+        except OSError:
+            pass
+    return None
+
+
+def _remove_owned_snapshot_file(path: Path, expected: os.stat_result) -> bool:
+    quarantine = _move_owned_snapshot_path(path, expected)
+    if quarantine is None:
+        return False
+    try:
+        quarantine.unlink()
+        return True
+    except OSError:
+        try:
+            if not os.path.lexists(path):
+                os.replace(quarantine, path)
+        except OSError:
+            pass
+        return False
+
+
+def _remove_owned_snapshot_dir(path: Path, expected: os.stat_result) -> bool:
+    quarantine = _move_owned_snapshot_path(path, expected)
+    if quarantine is None:
+        return False
+    try:
+        shutil.rmtree(quarantine)
+        return True
+    except OSError:
+        try:
+            if not os.path.lexists(path):
+                os.replace(quarantine, path)
+        except OSError:
+            pass
+        return False
 
 
 def _quick_snapshot_root(hermes_home: Optional[Path] = None) -> Path:
@@ -933,7 +998,8 @@ def create_quick_snapshot(
         return True
 
     ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
-    base_id = f"{ts}-{label}" if label else ts
+    safe_label = _quick_snapshot_label_segment(label)
+    base_id = f"{ts}-{safe_label}" if safe_label else ts
     with _backup_maintenance_lock(root):
         snap_id = base_id
         suffix = 1
@@ -945,7 +1011,12 @@ def create_quick_snapshot(
             except FileExistsError:
                 snap_id = f"{base_id}-{suffix}"
                 suffix += 1
-        (snap_dir / ".in-progress").touch()
+        marker = snap_dir / ".in-progress"
+        marker.write_text(
+            json.dumps({"version": 1, "snapshot_id": snap_id}),
+            encoding="utf-8",
+        )
+        marker_identity = marker.lstat()
 
     manifest: Dict[str, int] = {}  # rel_path -> file size
 
@@ -1005,7 +1076,10 @@ def create_quick_snapshot(
             logger.warning("Could not snapshot %s: %s", rel, exc)
 
     if not manifest:
-        shutil.rmtree(snap_dir, ignore_errors=True)
+        try:
+            _remove_owned_snapshot_dir(snap_dir, snap_dir.lstat())
+        except OSError:
+            pass
         return None
 
     # Write manifest
@@ -1019,7 +1093,9 @@ def create_quick_snapshot(
     }
     with open(snap_dir / "manifest.json", "w", encoding="utf-8") as f:
         json.dump(meta, f, indent=2)
-    (snap_dir / ".in-progress").unlink(missing_ok=True)
+    if not _remove_owned_snapshot_file(marker, marker_identity):
+        logger.warning("State snapshot ownership changed before publication: %s", snap_id)
+        return None
 
     # Auto-prune. Defaults preserve historical manual /snapshot behavior; callers
     # with known high-churn safety snapshots (for example pre-update) can pass a
@@ -1250,6 +1326,27 @@ def _prune_quick_snapshots(root: Path, keep: int = _QUICK_DEFAULT_KEEP) -> int:
     if not root.exists():
         return 0
 
+    deleted = 0
+    now = time.time()
+    for candidate in root.iterdir():
+        marker = candidate / ".in-progress"
+        try:
+            if (
+                candidate.is_symlink()
+                or not candidate.is_dir()
+                or marker.is_symlink()
+                or not marker.is_file()
+                or now - marker.stat().st_mtime <= _QUICK_IN_PROGRESS_MAX_AGE_SECONDS
+            ):
+                continue
+            payload = json.loads(marker.read_text(encoding="utf-8"))
+            if payload != {"version": 1, "snapshot_id": candidate.name}:
+                continue
+            if _remove_owned_snapshot_dir(candidate, candidate.lstat()):
+                deleted += 1
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+
     dirs = sorted(
         (
             d for d in root.iterdir()
@@ -1259,7 +1356,6 @@ def _prune_quick_snapshots(root: Path, keep: int = _QUICK_DEFAULT_KEEP) -> int:
         reverse=True,
     )
 
-    deleted = 0
     for d in dirs[keep:]:
         try:
             shutil.rmtree(d)

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -879,6 +879,8 @@ _QUICK_STATE_FILES = (
 _QUICK_SNAPSHOTS_DIR = "state-snapshots"
 _QUICK_DEFAULT_KEEP = 20
 _QUICK_IN_PROGRESS_MAX_AGE_SECONDS = 24 * 60 * 60
+_QUICK_IN_PROGRESS_MARKER = ".in-progress"
+_QUICK_OWNERSHIP_MARKER = ".hermes-managed"
 
 
 def _quick_snapshot_label_segment(label: Optional[str]) -> Optional[str]:
@@ -894,20 +896,14 @@ def _quick_snapshot_label_segment(label: Optional[str]) -> Optional[str]:
 
 
 def _move_owned_snapshot_path(path: Path, expected: os.stat_result) -> Optional[Path]:
-    """Move the exact expected object to a nonce sibling, or preserve it."""
+    """Move the exact expected object to a nonce sibling, or preserve it there."""
     quarantine = path.with_name(f".{path.name}.hermes-delete-{uuid.uuid4().hex}")
     try:
         os.replace(path, quarantine)
         if os.path.samestat(expected, quarantine.lstat()):
             return quarantine
-        if not os.path.lexists(path):
-            os.replace(quarantine, path)
     except OSError:
-        try:
-            if os.path.lexists(quarantine) and not os.path.lexists(path):
-                os.replace(quarantine, path)
-        except OSError:
-            pass
+        return None
     return None
 
 
@@ -919,11 +915,6 @@ def _remove_owned_snapshot_file(path: Path, expected: os.stat_result) -> bool:
         quarantine.unlink()
         return True
     except OSError:
-        try:
-            if not os.path.lexists(path):
-                os.replace(quarantine, path)
-        except OSError:
-            pass
         return False
 
 
@@ -935,12 +926,77 @@ def _remove_owned_snapshot_dir(path: Path, expected: os.stat_result) -> bool:
         shutil.rmtree(quarantine)
         return True
     except OSError:
-        try:
-            if not os.path.lexists(path):
-                os.replace(quarantine, path)
-        except OSError:
-            pass
         return False
+
+
+def _snapshot_path_is_link_like(path: Path) -> bool:
+    try:
+        st = path.lstat()
+        reparse = int(getattr(st, "st_file_attributes", 0)) & 0x400
+        return path.is_symlink() or bool(reparse)
+    except OSError:
+        return True
+
+
+def _quick_snapshot_marker_payload(
+    snapshot_dir: Path, marker_name: str
+) -> Optional[Dict[str, Any]]:
+    marker = snapshot_dir / marker_name
+    try:
+        if (
+            _snapshot_path_is_link_like(snapshot_dir)
+            or not snapshot_dir.is_dir()
+            or _snapshot_path_is_link_like(marker)
+            or not marker.is_file()
+        ):
+            return None
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+        token = payload.get("owner_token") if isinstance(payload, dict) else None
+        if (
+            not isinstance(payload, dict)
+            or payload.get("version") != 1
+            or payload.get("snapshot_id") != snapshot_dir.name
+            or not isinstance(payload.get("pid"), int)
+            or not isinstance(token, str)
+            or len(token) != 32
+            or any(char not in "0123456789abcdef" for char in token)
+        ):
+            return None
+        return payload
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+
+
+def _snapshot_process_is_running(pid: int) -> bool:
+    """Fail closed when an in-progress snapshot owner may still be alive."""
+    if pid <= 0:
+        return True
+    if os.name == "nt":
+        import ctypes
+
+        open_process = ctypes.windll.kernel32.OpenProcess
+        open_process.argtypes = (ctypes.c_uint32, ctypes.c_int, ctypes.c_uint32)
+        open_process.restype = ctypes.c_void_p
+        handle = open_process(0x00100000, False, pid)
+        if not handle:
+            return ctypes.windll.kernel32.GetLastError() != 87
+        wait_for_single_object = ctypes.windll.kernel32.WaitForSingleObject
+        wait_for_single_object.argtypes = (ctypes.c_void_p, ctypes.c_uint32)
+        wait_for_single_object.restype = ctypes.c_uint32
+        close_handle = ctypes.windll.kernel32.CloseHandle
+        close_handle.argtypes = (ctypes.c_void_p,)
+        close_handle.restype = ctypes.c_int
+        try:
+            return wait_for_single_object(handle, 0) == 258
+        finally:
+            close_handle(handle)
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except (OSError, PermissionError):
+        return True
 
 
 def _quick_snapshot_root(hermes_home: Optional[Path] = None) -> Path:
@@ -1011,9 +1067,15 @@ def create_quick_snapshot(
             except FileExistsError:
                 snap_id = f"{base_id}-{suffix}"
                 suffix += 1
-        marker = snap_dir / ".in-progress"
+        marker_payload = {
+            "version": 1,
+            "snapshot_id": snap_id,
+            "pid": os.getpid(),
+            "owner_token": uuid.uuid4().hex,
+        }
+        marker = snap_dir / _QUICK_IN_PROGRESS_MARKER
         marker.write_text(
-            json.dumps({"version": 1, "snapshot_id": snap_id}),
+            json.dumps(marker_payload),
             encoding="utf-8",
         )
         marker_identity = marker.lstat()
@@ -1093,8 +1155,17 @@ def create_quick_snapshot(
     }
     with open(snap_dir / "manifest.json", "w", encoding="utf-8") as f:
         json.dump(meta, f, indent=2)
+    owned_marker = snap_dir / _QUICK_OWNERSHIP_MARKER
+    try:
+        os.link(marker, owned_marker, follow_symlinks=False)
+        if not os.path.samestat(marker_identity, owned_marker.lstat()):
+            raise OSError("published ownership marker identity mismatch")
+    except OSError as exc:
+        logger.warning("State snapshot publication failed for %s: %s", snap_id, exc)
+        return None
     if not _remove_owned_snapshot_file(marker, marker_identity):
-        logger.warning("State snapshot ownership changed before publication: %s", snap_id)
+        logger.warning("State snapshot retained in-progress marker evidence: %s", snap_id)
+    if os.path.lexists(marker):
         return None
 
     # Auto-prune. Defaults preserve historical manual /snapshot behavior; callers
@@ -1118,7 +1189,10 @@ def list_quick_snapshots(
 
     results = []
     for d in sorted(root.iterdir(), reverse=True):
-        if not d.is_dir():
+        if (
+            _quick_snapshot_marker_payload(d, _QUICK_OWNERSHIP_MARKER) is None
+            or (d / _QUICK_IN_PROGRESS_MARKER).exists()
+        ):
             continue
         manifest_path = d / "manifest.json"
         if manifest_path.exists():
@@ -1160,7 +1234,10 @@ def restore_quick_snapshot(
         logger.error("Snapshot path traversal blocked for id: %s", snapshot_id)
         return False
 
-    if not snap_dir.is_dir():
+    if (
+        _quick_snapshot_marker_payload(snap_dir, _QUICK_OWNERSHIP_MARKER) is None
+        or (snap_dir / _QUICK_IN_PROGRESS_MARKER).exists()
+    ):
         return False
 
     manifest_path = snap_dir / "manifest.json"
@@ -1329,18 +1406,16 @@ def _prune_quick_snapshots(root: Path, keep: int = _QUICK_DEFAULT_KEEP) -> int:
     deleted = 0
     now = time.time()
     for candidate in root.iterdir():
-        marker = candidate / ".in-progress"
+        marker = candidate / _QUICK_IN_PROGRESS_MARKER
         try:
             if (
-                candidate.is_symlink()
-                or not candidate.is_dir()
-                or marker.is_symlink()
-                or not marker.is_file()
-                or now - marker.stat().st_mtime <= _QUICK_IN_PROGRESS_MAX_AGE_SECONDS
+                now - marker.stat().st_mtime <= _QUICK_IN_PROGRESS_MAX_AGE_SECONDS
             ):
                 continue
-            payload = json.loads(marker.read_text(encoding="utf-8"))
-            if payload != {"version": 1, "snapshot_id": candidate.name}:
+            payload = _quick_snapshot_marker_payload(
+                candidate, _QUICK_IN_PROGRESS_MARKER
+            )
+            if payload is None or _snapshot_process_is_running(payload["pid"]):
                 continue
             if _remove_owned_snapshot_dir(candidate, candidate.lstat()):
                 deleted += 1
@@ -1350,7 +1425,9 @@ def _prune_quick_snapshots(root: Path, keep: int = _QUICK_DEFAULT_KEEP) -> int:
     dirs = sorted(
         (
             d for d in root.iterdir()
-            if d.is_dir() and not (d / ".in-progress").exists()
+            if _quick_snapshot_marker_payload(d, _QUICK_OWNERSHIP_MARKER)
+            is not None
+            and not (d / _QUICK_IN_PROGRESS_MARKER).exists()
         ),
         key=lambda d: d.name,
         reverse=True,
@@ -1358,8 +1435,8 @@ def _prune_quick_snapshots(root: Path, keep: int = _QUICK_DEFAULT_KEEP) -> int:
 
     for d in dirs[keep:]:
         try:
-            shutil.rmtree(d)
-            deleted += 1
+            if _remove_owned_snapshot_dir(d, d.lstat()):
+                deleted += 1
         except OSError as exc:
             logger.warning("Failed to prune snapshot %s: %s", d.name, exc)
 

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -62,23 +62,63 @@ def _backup_maintenance_lock(root: Path) -> Iterator[None]:
     maintenance operation.
     """
     root.mkdir(parents=True, exist_ok=True)
+    root_identity = root.lstat()
+    if (
+        not stat.S_ISDIR(root_identity.st_mode)
+        or int(getattr(root_identity, "st_file_attributes", 0)) & 0x400
+    ):
+        raise OSError(f"backup maintenance root is not a regular directory: {root}")
     key = str(root.resolve())
     with _BACKUP_LOCKS_GUARD:
         thread_lock = _BACKUP_LOCKS.setdefault(key, threading.RLock())
 
     with thread_lock:
         lock_path = root / _BACKUP_LOCK_FILENAME
-        lock_file = open(lock_path, "a+b")
-        locked = False
+        flags = os.O_RDWR
+        if hasattr(os, "O_BINARY"):
+            flags |= os.O_BINARY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        created_lock = False
         try:
+            lock_fd = os.open(lock_path, flags | os.O_CREAT | os.O_EXCL, 0o600)
+            created_lock = True
+        except FileExistsError:
+            selected = lock_path.lstat()
+            lock_fd = os.open(lock_path, flags)
+            opened = os.fstat(lock_fd)
+            current = lock_path.lstat()
+            if (
+                not stat.S_ISREG(selected.st_mode)
+                or int(getattr(selected, "st_file_attributes", 0)) & 0x400
+                or selected.st_nlink != 1
+                or opened.st_nlink != 1
+                or not os.path.samestat(selected, opened)
+                or not os.path.samestat(opened, current)
+            ):
+                os.close(lock_fd)
+                raise OSError(f"backup maintenance lock is not exclusively owned: {lock_path}")
+        lock_file = os.fdopen(lock_fd, "r+b", closefd=True)
+        locked = False
+        provenance_valid = False
+        opened_lock: Optional[os.stat_result] = None
+        try:
+            current_root = root.lstat()
+            current_lock = lock_path.lstat()
+            opened_lock = os.fstat(lock_file.fileno())
+            if (
+                not os.path.samestat(root_identity, current_root)
+                or not stat.S_ISREG(opened_lock.st_mode)
+                or int(getattr(opened_lock, "st_file_attributes", 0)) & 0x400
+                or opened_lock.st_nlink != 1
+                or not os.path.samestat(opened_lock, current_lock)
+            ):
+                raise OSError("backup maintenance lock provenance changed")
+            provenance_valid = True
             if fcntl is not None:
                 fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
                 locked = True
             elif msvcrt is not None:
-                lock_file.seek(0, os.SEEK_END)
-                if lock_file.tell() == 0:
-                    lock_file.write(b"0")
-                    lock_file.flush()
                 lock_file.seek(0)
                 msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
                 locked = True
@@ -97,6 +137,13 @@ def _backup_maintenance_lock(root: Path) -> Iterator[None]:
                     lock_file.close()
             else:
                 lock_file.close()
+            if created_lock and not provenance_valid and opened_lock is not None:
+                try:
+                    current_created = lock_path.lstat()
+                    if os.path.samestat(opened_lock, current_created):
+                        _remove_owned_snapshot_file(lock_path, current_created)
+                except OSError:
+                    pass
 
 
 def _unique_archive_path(backup_dir: Path, prefix: str) -> Path:
@@ -354,6 +401,7 @@ def _safe_copy_db(
     identity so callers that pre-created ``dst`` can clean it up safely.
     """
     conn = None
+    initializer_conn = None
     backup_conn = None
     owner_fd: Optional[int] = None
     source_fd: Optional[int] = None
@@ -410,6 +458,9 @@ def _safe_copy_db(
             source_parent_fd = os.open(source_parent, parent_flags)
             if not os.path.samestat(parent_selected, os.fstat(source_parent_fd)):
                 raise OSError(f"SQLite source parent changed: {source_parent}")
+            parent_monitor = os.fstat(source_parent_fd)
+        else:
+            parent_monitor = source_parent.lstat()
 
         source_selected = src.lstat()
         if (
@@ -431,20 +482,49 @@ def _safe_copy_db(
             raise OSError(f"SQLite source changed before backup: {src}")
 
         conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
-        # Opening a WAL database can legitimately create its -shm/-wal
-        # sidecars lazily on its first read and therefore update the parent
-        # directory. Force that initialization before establishing the
-        # parent-change guard, then re-bind the SQLite pathname to the
-        # descriptor selected above before taking the snapshot.
+        # The parent/path guard is established before SQLite receives the
+        # replaceable pathname. Baselining only after connect would leave a
+        # rename/open/restore ABA window in which SQLite could bind another DB.
         conn.execute("PRAGMA schema_version").fetchone()
-        if source_parent_fd is not None:
-            parent_monitor = os.fstat(source_parent_fd)
-            if not os.path.samestat(parent_monitor, source_parent.lstat()):
-                raise OSError(f"SQLite source parent changed: {source_parent}")
-        else:
-            parent_monitor = source_parent.lstat()
+        parent_after_open = (
+            os.fstat(source_parent_fd)
+            if source_parent_fd is not None
+            else source_parent.lstat()
+        )
+        parent_path_after_open = source_parent.lstat()
+        parent_changed_while_opening = (
+            not os.path.samestat(parent_monitor, parent_after_open)
+            or not os.path.samestat(parent_after_open, parent_path_after_open)
+            or parent_after_open.st_mtime_ns != parent_monitor.st_mtime_ns
+            or parent_after_open.st_ctime_ns != parent_monitor.st_ctime_ns
+        )
         if not os.path.samestat(source_selected, src.lstat()):
             raise OSError(f"SQLite source changed while opening backup: {src}")
+        if parent_changed_while_opening:
+            # A WAL database with no live readers may create its shared-memory
+            # sidecar on first open. Keep that connection alive only to hold
+            # those sidecars, establish a fresh baseline, then open the actual
+            # backup connection under a second strict monitor. Any repeated
+            # mutation (including rename/open/restore ABA) fails closed.
+            initializer_conn = conn
+            conn = None
+            parent_monitor = parent_after_open
+            conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
+            conn.execute("PRAGMA schema_version").fetchone()
+            second_parent = (
+                os.fstat(source_parent_fd)
+                if source_parent_fd is not None
+                else source_parent.lstat()
+            )
+            second_parent_path = source_parent.lstat()
+            if (
+                not os.path.samestat(parent_monitor, second_parent)
+                or not os.path.samestat(second_parent, second_parent_path)
+                or second_parent.st_mtime_ns != parent_monitor.st_mtime_ns
+                or second_parent.st_ctime_ns != parent_monitor.st_ctime_ns
+                or not os.path.samestat(source_selected, src.lstat())
+            ):
+                raise OSError(f"SQLite source changed while opening backup: {src}")
 
         # Destination provenance is exact because SQLite never receives the
         # caller's pathname: its consistent WAL snapshot is serialized from
@@ -494,7 +574,7 @@ def _safe_copy_db(
     except Exception as exc:
         logger.warning("SQLite safe copy failed for %s: %s", src, exc)
     finally:
-        for connection in (backup_conn, conn):
+        for connection in (backup_conn, conn, initializer_conn):
             if connection is not None:
                 try:
                     connection.close()
@@ -602,22 +682,55 @@ def run_backup(args) -> None:
 
     # Collect files
     print(f"Scanning {display_hermes_home()} ...")
-    files_to_add: list[tuple[Path, Path]] = []  # (absolute, relative)
+    files_to_add: list[tuple[Path, Path, os.stat_result]] = []
     skipped_dirs = set()
+    root_identity = hermes_root.lstat()
+    if (
+        not stat.S_ISDIR(root_identity.st_mode)
+        or int(getattr(root_identity, "st_file_attributes", 0)) & 0x400
+    ):
+        print(f"Error: Hermes home is not a regular directory: {hermes_root}")
+        return
 
     for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
         dp = Path(dirpath)
         rel_dir = dp.relative_to(hermes_root)
+        directory_identity = dp.lstat()
+        if (
+            not stat.S_ISDIR(directory_identity.st_mode)
+            or int(getattr(directory_identity, "st_file_attributes", 0)) & 0x400
+            or (
+                dp == hermes_root
+                and not _same_snapshot_object(root_identity, directory_identity)
+            )
+        ):
+            dirnames[:] = []
+            continue
 
         # Prune excluded directories in-place so os.walk doesn't descend
         # ``hermes-agent`` is only pruned at the root level; nested dirs
         # with the same name (e.g. in skills/) must be preserved.
         is_root = rel_dir == Path(".")
         orig_dirnames = dirnames[:]
-        dirnames[:] = [
-            d for d in dirnames
-            if d not in _EXCLUDED_DIRS or (d == "hermes-agent" and not is_root)
-        ]
+        safe_directories = []
+        for dirname in dirnames:
+            if dirname in _EXCLUDED_DIRS and not (
+                dirname == "hermes-agent" and not is_root
+            ):
+                continue
+            child = dp / dirname
+            try:
+                child_identity = child.lstat()
+            except OSError:
+                continue
+            if (
+                stat.S_ISDIR(child_identity.st_mode)
+                and not (
+                    int(getattr(child_identity, "st_file_attributes", 0)) & 0x400
+                )
+            ):
+                safe_directories.append(dirname)
+        dirnames[:] = safe_directories
         for removed in set(orig_dirnames) - set(dirnames):
             skipped_dirs.add(str(rel_dir / removed))
 
@@ -628,7 +741,16 @@ def run_backup(args) -> None:
             if _should_skip_backup_file(fpath, rel, out_path):
                 continue
 
-            files_to_add.append((fpath, rel))
+            try:
+                selected = fpath.lstat()
+            except OSError:
+                continue
+            if (
+                not stat.S_ISREG(selected.st_mode)
+                or int(getattr(selected, "st_file_attributes", 0)) & 0x400
+            ):
+                continue
+            files_to_add.append((fpath, rel, selected))
 
     # External memory-provider state (e.g. ~/.honcho, ~/.hindsight) lives
     # outside HERMES_HOME, so the walk above never sees it. Ask the active
@@ -637,7 +759,7 @@ def run_backup(args) -> None:
     # Only paths under home are captured (security + portability); anything
     # else is skipped with a note.
     home_dir = Path.home().resolve()
-    external_to_add: list[tuple[Path, str]] = []  # (absolute, arcname)
+    external_to_add: list[tuple[Path, str, os.stat_result]] = []
     skipped_external: list[str] = []
     for base in _collect_memory_provider_external_paths():
         try:
@@ -652,7 +774,16 @@ def run_backup(args) -> None:
             except (ValueError, OSError):
                 continue
             arcname = _EXTERNAL_PREFIX + rel_to_home.as_posix()
-            external_to_add.append((fpath, arcname))
+            try:
+                selected = fpath.lstat()
+            except OSError:
+                continue
+            if (
+                not stat.S_ISREG(selected.st_mode)
+                or int(getattr(selected, "st_file_attributes", 0)) & 0x400
+            ):
+                continue
+            external_to_add.append((fpath, arcname, selected))
 
     if not files_to_add and not external_to_add:
         print("No files to back up.")
@@ -666,59 +797,130 @@ def run_backup(args) -> None:
     errors = []
     t0 = time.monotonic()
 
-    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
-        for i, (abs_path, rel_path) in enumerate(files_to_add, 1):
-            try:
-                # Safe copy for SQLite databases (handles WAL mode)
-                if abs_path.suffix == ".db":
-                    # Stage the snapshot alongside the output zip so that the
-                    # temp file lives on the same filesystem.  The system
-                    # default (/tmp) may be a small tmpfs that cannot hold
-                    # large databases, causing silent backup incompleteness.
-                    with tempfile.NamedTemporaryFile(
-                        suffix=".db", delete=False, dir=str(out_path.parent)
-                    ) as tmp:
-                        tmp_db = Path(tmp.name)
-                    tmp_db_identity = tmp_db.lstat()
-                    final_tmp_db_identity: list[os.stat_result] = []
-                    try:
-                        copied = _safe_copy_db(
+    temp_path: Optional[Path] = None
+    temp_identity: Optional[os.stat_result] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            suffix=".zip", delete=False, dir=str(out_path.parent)
+        ) as tmp_archive:
+            temp_path = Path(tmp_archive.name)
+        temp_identity = temp_path.lstat()
+
+        with zipfile.ZipFile(
+            temp_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6
+        ) as zf:
+            for i, (abs_path, rel_path, source_identity) in enumerate(
+                files_to_add, 1
+            ):
+                try:
+                    if time.localtime(source_identity.st_mtime).tm_year < 1980:
+                        raise ValueError("ZIP does not support timestamps before 1980")
+                    if abs_path.suffix == ".db":
+                        with tempfile.NamedTemporaryFile(
+                            suffix=".db", delete=False, dir=str(out_path.parent)
+                        ) as tmp:
+                            tmp_db = Path(tmp.name)
+                        tmp_db_identity = tmp_db.lstat()
+                        final_tmp_db_identity: list[os.stat_result] = []
+                        try:
+                            copied = _safe_copy_db(
+                                abs_path,
+                                tmp_db,
+                                expected_dst_identity=tmp_db_identity,
+                                expected_src_identity=source_identity,
+                                result_dst_identity=final_tmp_db_identity,
+                            )
+                            if final_tmp_db_identity:
+                                tmp_db_identity = final_tmp_db_identity[0]
+                            if not copied:
+                                errors.append(
+                                    f"  {rel_path}: SQLite safe copy failed"
+                                )
+                                continue
+                            total_bytes += _write_bound_file_to_zip(
+                                zf,
+                                tmp_db,
+                                rel_path.as_posix(),
+                                expected_identity=tmp_db_identity,
+                            )
+                        finally:
+                            _remove_owned_snapshot_file(tmp_db, tmp_db_identity)
+                    else:
+                        total_bytes += _write_bound_file_to_zip(
+                            zf,
                             abs_path,
-                            tmp_db,
-                            expected_dst_identity=tmp_db_identity,
-                            result_dst_identity=final_tmp_db_identity,
+                            rel_path.as_posix(),
+                            expected_identity=source_identity,
                         )
-                        if final_tmp_db_identity:
-                            tmp_db_identity = final_tmp_db_identity[0]
-                        if copied:
-                            zf.write(tmp_db, arcname=str(rel_path))
-                            total_bytes += tmp_db.stat().st_size
-                        else:
-                            errors.append(f"  {rel_path}: SQLite safe copy failed")
-                            continue
-                    finally:
-                        _remove_owned_snapshot_file(tmp_db, tmp_db_identity)
-                else:
-                    zf.write(abs_path, arcname=str(rel_path))
-                    total_bytes += abs_path.stat().st_size
-            except (PermissionError, OSError, ValueError) as exc:
-                errors.append(f"  {rel_path}: {exc}")
-                continue
+                except (PermissionError, OSError, ValueError) as exc:
+                    errors.append(f"  {rel_path}: {exc}")
+                    continue
 
-            # Progress every 500 files
-            if i % 500 == 0:
-                print(f"  {i}/{file_count} files ...")
+                if i % 500 == 0:
+                    print(f"  {i}/{file_count} files ...")
 
-        # External memory-provider state, stored under the ``_external/`` arc
-        # prefix. These never include ``.db`` files in practice (config/env
-        # blobs), so a straight zf.write is fine.
-        for abs_path, arcname in external_to_add:
+            for abs_path, arcname, source_identity in external_to_add:
+                try:
+                    if time.localtime(source_identity.st_mtime).tm_year < 1980:
+                        raise ValueError("ZIP does not support timestamps before 1980")
+                    total_bytes += _write_bound_file_to_zip(
+                        zf,
+                        abs_path,
+                        arcname,
+                        expected_identity=source_identity,
+                    )
+                except (PermissionError, OSError, ValueError) as exc:
+                    errors.append(f"  {arcname}: {exc}")
+                    continue
+            zf.comment = _archive_ownership_comment(out_path)
+
+        with zipfile.ZipFile(temp_path, "r") as completed:
+            if not completed.namelist() or completed.testzip() is not None:
+                raise OSError("backup archive integrity check failed")
+
+        candidate = out_path
+        for attempt in range(16):
+            if attempt:
+                candidate = out_path.with_name(
+                    f"{out_path.stem}-{uuid.uuid4().hex[:12]}{out_path.suffix}"
+                )
+                with zipfile.ZipFile(temp_path, "a") as completed:
+                    completed.comment = _archive_ownership_comment(candidate)
+            with open(temp_path, "r+b") as archive_file:
+                os.fsync(archive_file.fileno())
+                temp_identity = os.fstat(archive_file.fileno())
             try:
-                zf.write(abs_path, arcname=arcname)
-                total_bytes += abs_path.stat().st_size
-            except (PermissionError, OSError, ValueError) as exc:
-                errors.append(f"  {arcname}: {exc}")
+                if os.name == "nt":
+                    os.rename(temp_path, candidate)
+                    published_via_link = False
+                else:
+                    os.link(temp_path, candidate, follow_symlinks=False)
+                    published_via_link = True
+            except FileExistsError:
                 continue
+            published = candidate.lstat()
+            if (
+                not stat.S_ISREG(published.st_mode)
+                or not os.path.samestat(temp_identity, published)
+            ):
+                raise OSError("published backup identity changed")
+            if published_via_link:
+                _remove_owned_snapshot_file(temp_path, temp_identity)
+            temp_path = None
+            temp_identity = None
+            out_path = candidate
+            break
+        else:
+            raise OSError("backup destination kept colliding")
+    finally:
+        if temp_path is not None and temp_identity is not None:
+            try:
+                current_temp = temp_path.lstat()
+                if os.path.samestat(temp_identity, current_temp):
+                    temp_identity = current_temp
+            except OSError:
+                pass
+            _remove_owned_snapshot_file(temp_path, temp_identity)
 
     elapsed = time.monotonic() - t0
     zip_size = out_path.stat().st_size
@@ -1280,6 +1482,182 @@ def _quick_snapshot_root(hermes_home: Optional[Path] = None) -> Path:
     return home / _QUICK_SNAPSHOTS_DIR
 
 
+def _snapshot_directory_is_bound(
+    snapshot_dir: Path,
+    expected: os.stat_result,
+) -> bool:
+    try:
+        current = snapshot_dir.lstat()
+        return bool(
+            stat.S_ISDIR(current.st_mode)
+            and not (int(getattr(current, "st_file_attributes", 0)) & 0x400)
+            and _same_snapshot_object(expected, current)
+        )
+    except OSError:
+        return False
+
+
+def _snapshot_parent_is_bound(
+    snapshot_dir: Path,
+    expected: os.stat_result,
+    relative_parent: PurePosixPath,
+) -> bool:
+    if not _snapshot_directory_is_bound(snapshot_dir, expected):
+        return False
+    current = snapshot_dir
+    for part in relative_parent.parts:
+        if part in ("", ".", ".."):
+            return False
+        current = current / part
+        try:
+            selected = current.lstat()
+        except OSError:
+            return False
+        if (
+            not stat.S_ISDIR(selected.st_mode)
+            or int(getattr(selected, "st_file_attributes", 0)) & 0x400
+        ):
+            return False
+    return _snapshot_directory_is_bound(snapshot_dir, expected)
+
+
+def _ensure_snapshot_parent(
+    snapshot_dir: Path,
+    expected: os.stat_result,
+    relative_parent: PurePosixPath,
+) -> bool:
+    current = snapshot_dir
+    for part in relative_parent.parts:
+        if part in ("", ".", "..") or not _snapshot_directory_is_bound(
+            snapshot_dir, expected
+        ):
+            return False
+        current = current / part
+        try:
+            current.mkdir()
+        except FileExistsError:
+            pass
+        except OSError:
+            return False
+        try:
+            selected = current.lstat()
+        except OSError:
+            return False
+        if (
+            not stat.S_ISDIR(selected.st_mode)
+            or int(getattr(selected, "st_file_attributes", 0)) & 0x400
+        ):
+            return False
+    return _snapshot_parent_is_bound(snapshot_dir, expected, relative_parent)
+
+
+def _write_exclusive_snapshot_file(
+    snapshot_dir: Path,
+    snapshot_identity: os.stat_result,
+    relative_name: str,
+    chunks: Iterator[bytes],
+) -> tuple[Path, os.stat_result, int]:
+    """Write a new snapshot member without trusting a replaceable directory."""
+    relative = PurePosixPath(relative_name)
+    if relative.is_absolute() or not relative.parts or ".." in relative.parts:
+        raise OSError(f"invalid snapshot member path: {relative_name}")
+    parent_rel = relative.parent
+    if not _ensure_snapshot_parent(snapshot_dir, snapshot_identity, parent_rel):
+        raise OSError("snapshot directory changed before member creation")
+    destination = snapshot_dir.joinpath(*relative.parts)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(destination, flags, 0o600)
+    opened: Optional[os.stat_result] = None
+    success = False
+    copied = 0
+    try:
+        opened = os.fstat(fd)
+        path_opened = destination.lstat()
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or not os.path.samestat(opened, path_opened)
+            or not _snapshot_parent_is_bound(
+                snapshot_dir, snapshot_identity, parent_rel
+            )
+        ):
+            raise OSError("snapshot directory changed during member creation")
+        for chunk in chunks:
+            if not isinstance(chunk, bytes):
+                chunk = bytes(chunk)
+            view = memoryview(chunk)
+            while view:
+                written = os.write(fd, view)
+                if written <= 0:
+                    raise OSError("short write while creating snapshot member")
+                copied += written
+                view = view[written:]
+        os.fsync(fd)
+        after = os.fstat(fd)
+        path_after = destination.lstat()
+        if (
+            not os.path.samestat(opened, after)
+            or not os.path.samestat(after, path_after)
+            or not _snapshot_parent_is_bound(
+                snapshot_dir, snapshot_identity, parent_rel
+            )
+        ):
+            raise OSError("snapshot member changed during write")
+        success = True
+    finally:
+        os.close(fd)
+        if not success and opened is not None:
+            try:
+                current = destination.lstat()
+                if os.path.samestat(opened, current):
+                    _remove_owned_snapshot_file(destination, current)
+            except OSError:
+                pass
+    final = destination.lstat()
+    if (
+        opened is None
+        or not os.path.samestat(opened, final)
+        or not _snapshot_parent_is_bound(snapshot_dir, snapshot_identity, parent_rel)
+    ):
+        raise OSError("snapshot member changed after close")
+    return destination, final, copied
+
+
+def _opened_file_chunks(path: Path, expected: os.stat_result) -> Iterator[bytes]:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(path, flags)
+    try:
+        opened = os.fstat(fd)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or not _same_snapshot_object(expected, path.lstat())
+            or not os.path.samestat(expected, opened)
+        ):
+            raise OSError(f"snapshot source changed before read: {path}")
+        copied = 0
+        while chunk := os.read(fd, 1024 * 1024):
+            copied += len(chunk)
+            yield chunk
+        after = os.fstat(fd)
+        if (
+            copied != opened.st_size
+            or after.st_size != opened.st_size
+            or after.st_mtime_ns != opened.st_mtime_ns
+            or after.st_ctime_ns != opened.st_ctime_ns
+            or not os.path.samestat(opened, path.lstat())
+        ):
+            raise OSError(f"snapshot source changed during read: {path}")
+    finally:
+        os.close(fd)
+
+
 def create_quick_snapshot(
     label: Optional[str] = None,
     hermes_home: Optional[Path] = None,
@@ -1339,6 +1717,15 @@ def create_quick_snapshot(
             snap_dir = root / snap_id
             try:
                 snap_dir.mkdir(parents=True, exist_ok=False)
+                snapshot_identity = snap_dir.lstat()
+                if (
+                    not stat.S_ISDIR(snapshot_identity.st_mode)
+                    or int(
+                        getattr(snapshot_identity, "st_file_attributes", 0)
+                    )
+                    & 0x400
+                ):
+                    raise OSError("new snapshot path is not a regular directory")
                 break
             except FileExistsError:
                 snap_id = f"{base_id}-{suffix}"
@@ -1349,67 +1736,135 @@ def create_quick_snapshot(
             "pid": os.getpid(),
             "owner_token": uuid.uuid4().hex,
         }
-        marker = snap_dir / _QUICK_IN_PROGRESS_MARKER
-        marker.write_text(
-            json.dumps(marker_payload),
-            encoding="utf-8",
+        marker_bytes = json.dumps(marker_payload, separators=(",", ":")).encode(
+            "utf-8"
         )
-        marker_identity = marker.lstat()
+        marker, marker_identity, _ = _write_exclusive_snapshot_file(
+            snap_dir,
+            snapshot_identity,
+            _QUICK_IN_PROGRESS_MARKER,
+            iter((marker_bytes,)),
+        )
 
     manifest: Dict[str, int] = {}  # rel_path -> file size
+
+    def _capture_member(source: Path, relative_name: str) -> int:
+        selected = source.lstat()
+        if (
+            not stat.S_ISREG(selected.st_mode)
+            or int(getattr(selected, "st_file_attributes", 0)) & 0x400
+        ):
+            raise OSError(f"snapshot source is not a regular file: {source}")
+        if source.suffix != ".db":
+            _, _, copied = _write_exclusive_snapshot_file(
+                snap_dir,
+                snapshot_identity,
+                relative_name,
+                _opened_file_chunks(source, selected),
+            )
+            return copied
+
+        temp_db: Optional[Path] = None
+        temp_identity: Optional[os.stat_result] = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as temp_file:
+                temp_db = Path(temp_file.name)
+            temp_identity = temp_db.lstat()
+            final_identity: list[os.stat_result] = []
+            if not _safe_copy_db(
+                source,
+                temp_db,
+                expected_dst_identity=temp_identity,
+                expected_src_identity=selected,
+                result_dst_identity=final_identity,
+            ):
+                raise OSError(f"SQLite snapshot failed for {source}")
+            if final_identity:
+                temp_identity = final_identity[0]
+            _, _, copied = _write_exclusive_snapshot_file(
+                snap_dir,
+                snapshot_identity,
+                relative_name,
+                _opened_file_chunks(temp_db, temp_identity),
+            )
+            return copied
+        finally:
+            if temp_db is not None and temp_identity is not None:
+                _remove_owned_snapshot_file(temp_db, temp_identity)
 
     for rel in _QUICK_STATE_FILES:
         src = home / rel
         if not src.exists():
             continue
 
-        if src.is_dir():
+        try:
+            source_root_identity = src.lstat()
+        except OSError:
+            continue
+        if stat.S_ISDIR(source_root_identity.st_mode) and not (
+            int(getattr(source_root_identity, "st_file_attributes", 0)) & 0x400
+        ):
             # Walk the directory and record each file individually in the
             # manifest so restore can treat them uniformly.  Empty dirs are
             # skipped (nothing to snapshot).
-            for sub in src.rglob("*"):
-                if not sub.is_file():
-                    continue
-                sub_rel = sub.relative_to(home).as_posix()
-                # Skip heavy, regenerable per-board subtrees (scratch
-                # workspaces and task attachments can be large); we only need
-                # the board databases + their metadata to restore a board.
-                if "/workspaces/" in f"/{sub_rel}/" or "/attachments/" in f"/{sub_rel}/":
-                    continue
-                if _too_large(sub, sub_rel):
-                    continue
-                dst = snap_dir / sub_rel
-                dst.parent.mkdir(parents=True, exist_ok=True)
+            for dirpath, dirnames, filenames in os.walk(src, followlinks=False):
+                directory = Path(dirpath)
                 try:
-                    # Route SQLite DBs through the WAL-safe backup() path so a
-                    # board DB with an open WAL (the gateway may hold it at
-                    # snapshot time) is captured consistently.
-                    if sub.suffix == ".db":
-                        if not _safe_copy_db(sub, dst):
-                            continue
-                    else:
-                        shutil.copy2(sub, dst)
-                    manifest[sub_rel] = dst.stat().st_size
-                except (OSError, PermissionError) as exc:
-                    logger.warning("Could not snapshot %s: %s", sub_rel, exc)
+                    directory_identity = directory.lstat()
+                except OSError:
+                    dirnames[:] = []
+                    continue
+                if (
+                    not stat.S_ISDIR(directory_identity.st_mode)
+                    or int(
+                        getattr(directory_identity, "st_file_attributes", 0)
+                    )
+                    & 0x400
+                ):
+                    dirnames[:] = []
+                    continue
+                safe_directories = []
+                for dirname in dirnames:
+                    child = directory / dirname
+                    try:
+                        child_identity = child.lstat()
+                    except OSError:
+                        continue
+                    if (
+                        stat.S_ISDIR(child_identity.st_mode)
+                        and not (
+                            int(
+                                getattr(
+                                    child_identity, "st_file_attributes", 0
+                                )
+                            )
+                            & 0x400
+                        )
+                        and dirname not in {"workspaces", "attachments"}
+                    ):
+                        safe_directories.append(dirname)
+                dirnames[:] = safe_directories
+                for filename in filenames:
+                    sub = directory / filename
+                    sub_rel = sub.relative_to(home).as_posix()
+                    if _too_large(sub, sub_rel):
+                        continue
+                    try:
+                        manifest[sub_rel] = _capture_member(sub, sub_rel)
+                    except (OSError, PermissionError) as exc:
+                        logger.warning("Could not snapshot %s: %s", sub_rel, exc)
             continue
 
-        if not src.is_file():
+        if not stat.S_ISREG(source_root_identity.st_mode) or int(
+            getattr(source_root_identity, "st_file_attributes", 0)
+        ) & 0x400:
             continue
 
         if _too_large(src, rel):
             continue
 
-        dst = snap_dir / rel
-        dst.parent.mkdir(parents=True, exist_ok=True)
-
         try:
-            if src.suffix == ".db":
-                if not _safe_copy_db(src, dst):
-                    continue
-            else:
-                shutil.copy2(src, dst)
-            manifest[rel] = dst.stat().st_size
+            manifest[rel] = _capture_member(src, rel)
         except (OSError, PermissionError) as exc:
             logger.warning("Could not snapshot %s: %s", rel, exc)
 
@@ -1417,7 +1872,7 @@ def create_quick_snapshot(
         try:
             _remove_owned_snapshot_dir(
                 snap_dir,
-                snap_dir.lstat(),
+                snapshot_identity,
                 marker_name=_QUICK_IN_PROGRESS_MARKER,
                 marker_identity=marker_identity,
                 marker_payload=marker_payload,
@@ -1426,7 +1881,6 @@ def create_quick_snapshot(
             pass
         return None
 
-    # Write manifest
     meta = {
         "id": snap_id,
         "timestamp": ts,
@@ -1435,13 +1889,19 @@ def create_quick_snapshot(
         "total_size": sum(manifest.values()),
         "files": manifest,
     }
-    with open(snap_dir / "manifest.json", "w", encoding="utf-8") as f:
-        json.dump(meta, f, indent=2)
-    owned_marker = snap_dir / _QUICK_OWNERSHIP_MARKER
     try:
-        os.link(marker, owned_marker, follow_symlinks=False)
-        if not os.path.samestat(marker_identity, owned_marker.lstat()):
-            raise OSError("published ownership marker identity mismatch")
+        _write_exclusive_snapshot_file(
+            snap_dir,
+            snapshot_identity,
+            "manifest.json",
+            iter((json.dumps(meta, indent=2).encode("utf-8"),)),
+        )
+        _write_exclusive_snapshot_file(
+            snap_dir,
+            snapshot_identity,
+            _QUICK_OWNERSHIP_MARKER,
+            iter((marker_bytes,)),
+        )
     except OSError as exc:
         logger.warning("State snapshot publication failed for %s: %s", snap_id, exc)
         return None
@@ -1624,51 +2084,95 @@ def restore_quick_snapshot(
         snap_dir / _QUICK_IN_PROGRESS_MARKER
     ).exists():
         return False
-
-    manifest_path = snap_dir / "manifest.json"
-    if not manifest_path.exists():
+    try:
+        snapshot_identity = snap_dir.lstat()
+        home_identity = home.lstat()
+        if (
+            not stat.S_ISDIR(snapshot_identity.st_mode)
+            or int(getattr(snapshot_identity, "st_file_attributes", 0)) & 0x400
+            or not stat.S_ISDIR(home_identity.st_mode)
+            or int(getattr(home_identity, "st_file_attributes", 0)) & 0x400
+        ):
+            return False
+    except OSError:
         return False
 
-    if legacy_metadata is not None:
-        meta = legacy_metadata
-    else:
-        with open(manifest_path, encoding="utf-8") as f:
-            meta = json.load(f)
+    manifest_path = snap_dir / "manifest.json"
+    try:
+        if legacy_metadata is not None:
+            meta = legacy_metadata
+        else:
+            manifest_identity = manifest_path.lstat()
+            manifest_bytes = b"".join(
+                _opened_file_chunks(manifest_path, manifest_identity)
+            )
+            if not _snapshot_directory_is_bound(snap_dir, snapshot_identity):
+                return False
+            meta = json.loads(manifest_bytes.decode("utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return False
 
     restored = 0
     for rel in meta.get("files", {}):
         # Security: reject absolute paths and traversals in manifest entries
-        src = snap_dir / rel
-        try:
-            src.resolve().relative_to(snap_dir.resolve())
-        except ValueError:
+        relative = PurePosixPath(str(rel))
+        if relative.is_absolute() or not relative.parts or ".." in relative.parts:
             logger.error("Manifest path traversal blocked: %s", rel)
             continue
+        src = snap_dir.joinpath(*relative.parts)
 
-        dst = home / rel
-        try:
-            dst.resolve().relative_to(home.resolve())
-        except ValueError:
-            logger.error("Manifest path traversal blocked: %s", rel)
-            continue
-
-        if not src.exists():
-            continue
-
-        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst = home.joinpath(*relative.parts)
 
         try:
-            if dst.suffix == ".db":
-                # Atomic-ish replace for databases
-                tmp = dst.parent / f".{dst.name}.snap_restore"
-                shutil.copy2(src, tmp)
-                dst.unlink(missing_ok=True)
-                shutil.move(str(tmp), str(dst))
-            else:
-                shutil.copy2(src, dst)
+            source_identity = src.lstat()
+            if (
+                not stat.S_ISREG(source_identity.st_mode)
+                or int(getattr(source_identity, "st_file_attributes", 0)) & 0x400
+                or not _snapshot_directory_is_bound(snap_dir, snapshot_identity)
+            ):
+                continue
+        except OSError:
+            continue
+
+        stage_rel = relative.parent / (
+            f".{relative.name}.snap-restore-{uuid.uuid4().hex}.tmp"
+        )
+        stage: Optional[Path] = None
+        stage_identity: Optional[os.stat_result] = None
+        try:
+            stage, stage_identity, _ = _write_exclusive_snapshot_file(
+                home,
+                home_identity,
+                stage_rel.as_posix(),
+                _opened_file_chunks(src, source_identity),
+            )
+            if (
+                not _snapshot_directory_is_bound(snap_dir, snapshot_identity)
+                or not _snapshot_parent_is_bound(
+                    home, home_identity, relative.parent
+                )
+            ):
+                raise OSError("snapshot or restore destination changed")
+            try:
+                os.chmod(stage, stat.S_IMODE(source_identity.st_mode))
+            except OSError:
+                pass
+            current_stage = stage.lstat()
+            if not os.path.samestat(stage_identity, current_stage):
+                raise OSError("restore staging identity changed")
+            stage_identity = current_stage
+            os.replace(stage, dst)
+            published = dst.lstat()
+            if not os.path.samestat(stage_identity, published):
+                raise OSError("restored destination identity changed")
+            stage = None
+            stage_identity = None
             restored += 1
         except (OSError, PermissionError) as exc:
             logger.error("Failed to restore %s: %s", rel, exc)
+        finally:
+            if stage is not None and stage_identity is not None:
+                _remove_owned_snapshot_file(stage, stage_identity)
 
     logger.info("Restored %d files from snapshot %s", restored, snapshot_id)
     return restored > 0

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -2526,7 +2526,7 @@ def _legacy_quick_snapshot_manifest(snapshot_dir: Path) -> Optional[Dict[str, An
             not isinstance(timestamp, str)
             or re.fullmatch(r"\d{8}-\d{6}", timestamp) is None
             or not (
-                (label is None and snapshot_dir.name == timestamp)
+                (label in (None, "") and snapshot_dir.name == timestamp)
                 or (
                     isinstance(label, str)
                     and label

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1490,11 +1490,14 @@ def _same_snapshot_object(
     expected: os.stat_result,
     current: os.stat_result,
 ) -> bool:
-    """Compare stable object evidence, including Windows creation time."""
-    return bool(
-        os.path.samestat(expected, current)
-        and (os.name != "nt" or expected.st_ctime_ns == current.st_ctime_ns)
-    )
+    """Compare stable filesystem object identity across Python/platforms.
+
+    ``st_ctime_ns`` is not identity evidence on Windows: it can settle a few
+    milliseconds after close even when the volume and file index are
+    unchanged. ``samestat`` compares those stable device/file identifiers;
+    pathname-sensitive operations additionally bind an opened handle.
+    """
+    return bool(os.path.samestat(expected, current))
 
 
 def _remove_owned_snapshot_file(path: Path, expected: os.stat_result) -> bool:
@@ -1635,7 +1638,7 @@ def _snapshot_process_is_running(pid: int) -> bool:
         finally:
             close_handle(handle)
     try:
-        os.kill(pid, 0)
+        os.kill(pid, 0)  # windows-footgun: ok - guarded by os.name above
         return True
     except ProcessLookupError:
         return False

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -101,55 +101,29 @@ def _opened_fd_matches_path(fd: int, expected_path: Path) -> bool:
     actual = _opened_fd_path(fd)
     if actual is None:
         return False
-    expected = os.path.abspath(os.fspath(expected_path))
+    try:
+        expected = os.fspath(expected_path.resolve(strict=True))
+    except OSError:
+        return False
     return os.path.normcase(os.path.normpath(os.fspath(actual))) == os.path.normcase(
         os.path.normpath(expected)
     )
 
 
 def _windows_handle_matches_stat(handle: int, expected: os.stat_result) -> bool:
-    """Compare a raw Windows handle without weakening its rename guard."""
+    """Compare a raw Windows handle with a Python stat across Python versions."""
     if os.name != "nt":
         return False
     try:
-        import ctypes
-
-        class _FileTime(ctypes.Structure):
-            _fields_ = [
-                ("low", ctypes.c_uint32),
-                ("high", ctypes.c_uint32),
-            ]
-
-        class _ByHandleFileInformation(ctypes.Structure):
-            _fields_ = [
-                ("attributes", ctypes.c_uint32),
-                ("creation_time", _FileTime),
-                ("access_time", _FileTime),
-                ("write_time", _FileTime),
-                ("volume_serial", ctypes.c_uint32),
-                ("size_high", ctypes.c_uint32),
-                ("size_low", ctypes.c_uint32),
-                ("links", ctypes.c_uint32),
-                ("index_high", ctypes.c_uint32),
-                ("index_low", ctypes.c_uint32),
-            ]
-
-        information = _ByHandleFileInformation()
-        get_information = ctypes.windll.kernel32.GetFileInformationByHandle
-        get_information.argtypes = (
-            ctypes.c_void_p,
-            ctypes.POINTER(_ByHandleFileInformation),
-        )
-        get_information.restype = ctypes.c_int
-        if not get_information(handle, ctypes.byref(information)):
+        actual_path = _opened_windows_handle_path(handle)
+        if actual_path is None:
             return False
-        file_index = (information.index_high << 32) | information.index_low
-        return bool(
-            information.volume_serial == expected.st_dev
-            and file_index == expected.st_ino
-            and not (information.attributes & 0x400)
+        actual = actual_path.lstat()
+        return (
+            os.path.samestat(expected, actual)
+            and not int(getattr(actual, "st_file_attributes", 0)) & 0x400
         )
-    except (AttributeError, OSError, ValueError):
+    except OSError:
         return False
 
 
@@ -511,6 +485,11 @@ def _safe_copy_db(
     owner_fd: Optional[int] = None
     source_fd: Optional[int] = None
     source_parent_fd: Optional[int] = None
+    backup_stage_fd: Optional[int] = None
+    backup_stage_path: Optional[Path] = None
+    backup_stage_identity: Optional[os.stat_result] = None
+    backup_stage_dir: Optional[Path] = None
+    backup_stage_dir_identity: Optional[os.stat_result] = None
     cleanup_identity = expected_dst_identity
     published_destination: Optional[os.stat_result] = None
     created_here = False
@@ -566,6 +545,37 @@ def _safe_copy_db(
                     "SQLite safe copy refused replaced destination %s", dst
                 )
                 return False
+
+        # Create the disk-backed destination before baselining the source
+        # parent. The stage may legitimately share that directory with the
+        # source, and its own creation must not look like outside mutation.
+        backup_stage_dir = Path(
+            tempfile.mkdtemp(prefix=".hermes-sqlite-backup-", dir=dst.parent)
+        )
+        backup_stage_dir_identity = backup_stage_dir.lstat()
+        if (
+            not stat.S_ISDIR(backup_stage_dir_identity.st_mode)
+            or int(
+                getattr(backup_stage_dir_identity, "st_file_attributes", 0)
+            )
+            & 0x400
+        ):
+            raise OSError("SQLite backup staging directory is not regular")
+        backup_stage_fd, stage_name = tempfile.mkstemp(
+            prefix=".hermes-sqlite-backup-",
+            suffix=".db",
+            dir=backup_stage_dir,
+        )
+        backup_stage_path = Path(stage_name)
+        backup_stage_identity = os.fstat(backup_stage_fd)
+        if (
+            not stat.S_ISREG(backup_stage_identity.st_mode)
+            or not os.path.samestat(
+                backup_stage_identity, backup_stage_path.lstat()
+            )
+            or not _opened_fd_matches_path(backup_stage_fd, backup_stage_path)
+        ):
+            raise OSError("SQLite backup staging path changed during creation")
 
         source_parent = src.parent
         parent_selected = source_parent.lstat()
@@ -649,12 +659,22 @@ def _safe_copy_db(
             ):
                 raise OSError(f"SQLite source changed while opening backup: {src}")
 
-        # Destination provenance is exact because SQLite never receives the
-        # caller's pathname: its consistent WAL snapshot is serialized from
-        # memory and copied only through the retained destination descriptor.
-        backup_conn = sqlite3.connect(":memory:")
+        # Keep the consistent SQLite snapshot disk-backed so multi-GB databases
+        # do not require a full in-memory database plus a second serialized
+        # bytes copy. SQLite receives only a fresh, random staging pathname;
+        # the completed bytes are copied through retained exact descriptors.
+        backup_conn = sqlite3.connect(str(backup_stage_path))
         conn.backup(backup_conn)
-        serialized = backup_conn.serialize()
+        backup_conn.close()
+        backup_conn = None
+        stage_after_backup = os.fstat(backup_stage_fd)
+        stage_path_after_backup = backup_stage_path.lstat()
+        if (
+            not os.path.samestat(backup_stage_identity, stage_after_backup)
+            or not os.path.samestat(stage_after_backup, stage_path_after_backup)
+        ):
+            raise OSError("SQLite backup staging path changed during backup")
+        backup_stage_identity = stage_path_after_backup
 
         if not os.path.samestat(source_selected, src.lstat()):
             raise OSError(f"SQLite source changed during backup: {src}")
@@ -683,15 +703,14 @@ def _safe_copy_db(
 
         os.lseek(owner_fd, 0, os.SEEK_SET)
         os.ftruncate(owner_fd, 0)
-        serialized_view = memoryview(serialized)
-        offset = 0
-        while offset < len(serialized_view):
-            written = os.write(
-                owner_fd, serialized_view[offset : offset + 1024 * 1024]
-            )
-            if written <= 0:
-                raise OSError("short write while copying SQLite snapshot")
-            offset += written
+        os.lseek(backup_stage_fd, 0, os.SEEK_SET)
+        while chunk := os.read(backup_stage_fd, 1024 * 1024):
+            view = memoryview(chunk)
+            while view:
+                written = os.write(owner_fd, view)
+                if written <= 0:
+                    raise OSError("short write while copying SQLite snapshot")
+                view = view[written:]
         os.fsync(owner_fd)
         success = True
     except Exception as exc:
@@ -703,6 +722,27 @@ def _safe_copy_db(
                     connection.close()
                 except Exception:
                     pass
+        if backup_stage_fd is not None:
+            try:
+                os.close(backup_stage_fd)
+            except OSError:
+                pass
+        if backup_stage_path is not None and backup_stage_identity is not None:
+            try:
+                current_stage = backup_stage_path.lstat()
+                if os.path.samestat(backup_stage_identity, current_stage):
+                    _remove_owned_snapshot_file(backup_stage_path, current_stage)
+            except OSError:
+                pass
+        if backup_stage_dir is not None and backup_stage_dir_identity is not None:
+            try:
+                current_stage_dir = backup_stage_dir.lstat()
+                if os.path.samestat(
+                    backup_stage_dir_identity, current_stage_dir
+                ):
+                    backup_stage_dir.rmdir()
+            except OSError:
+                pass
         if owner_fd is not None:
             try:
                 opened_destination = os.fstat(owner_fd)
@@ -779,7 +819,7 @@ def _format_size(nbytes: int) -> str:
 
 def run_backup(args) -> None:
     """Create a zip backup of the Hermes home directory."""
-    hermes_root = get_default_hermes_root()
+    hermes_root = get_default_hermes_root().resolve()
 
     if not hermes_root.is_dir():
         print(f"Error: Hermes home directory not found at {hermes_root}")
@@ -1159,7 +1199,7 @@ def run_import(args) -> None:
         print(f"Error: Not a valid zip file: {zip_path}")
         sys.exit(1)
 
-    hermes_root = get_default_hermes_root()
+    hermes_root = get_default_hermes_root().resolve()
 
     with zipfile.ZipFile(zip_path, "r") as zf:
         # Validate
@@ -1604,7 +1644,7 @@ def _snapshot_process_is_running(pid: int) -> bool:
 
 
 def _quick_snapshot_root(hermes_home: Optional[Path] = None) -> Path:
-    home = hermes_home or get_hermes_home()
+    home = (hermes_home or get_hermes_home()).resolve()
     return home / _QUICK_SNAPSHOTS_DIR
 
 
@@ -2187,7 +2227,7 @@ def create_quick_snapshot(
     Returns:
         Snapshot ID (timestamp-based), or None if no files found.
     """
-    home = hermes_home or get_hermes_home()
+    home = (hermes_home or get_hermes_home()).resolve()
     root = _quick_snapshot_root(home)
 
     def _too_large(path: Path, rel_name: str) -> bool:
@@ -2586,7 +2626,7 @@ def restore_quick_snapshot(
     Overwrites current state files with the snapshot's copies.
     Returns True if at least one file was restored.
     """
-    home = hermes_home or get_hermes_home()
+    home = (hermes_home or get_hermes_home()).resolve()
     root = _quick_snapshot_root(home)
 
     # Security: reject snapshot_id values that contain path separators or
@@ -2867,7 +2907,7 @@ def restore_cron_jobs_if_emptied(
     if not snapshot_id:
         return None
 
-    home = hermes_home or get_hermes_home()
+    home = (hermes_home or get_hermes_home()).resolve()
     live_path = home / _CRON_JOBS_REL
 
     live_count = _count_cron_jobs(live_path)
@@ -3310,7 +3350,7 @@ _PRE_UPDATE_DEFAULT_KEEP = 5
 
 
 def _pre_update_backup_dir(hermes_home: Optional[Path] = None) -> Path:
-    home = hermes_home or get_hermes_home()
+    home = (hermes_home or get_hermes_home()).resolve()
     return home / _PRE_UPDATE_BACKUPS_DIR
 
 
@@ -3372,7 +3412,7 @@ def create_pre_update_backup(
     found or the backup could not be created.  Never raises — the caller
     (``hermes update``) should continue even if the backup fails.
     """
-    hermes_root = hermes_home or get_default_hermes_root()
+    hermes_root = (hermes_home or get_default_hermes_root()).resolve()
     if not hermes_root.is_dir():
         return None
 
@@ -3456,7 +3496,7 @@ def create_pre_migration_backup(
     to back up (fresh install) or the write failed.  Never raises — the
     caller decides whether to abort or proceed.
     """
-    hermes_root = hermes_home or get_default_hermes_root()
+    hermes_root = (hermes_home or get_default_hermes_root()).resolve()
     if not hermes_root.is_dir():
         return None
 

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1545,6 +1545,44 @@ def run_quick_backup(args) -> None:
 # Shared full-zip backup helper
 # ---------------------------------------------------------------------------
 
+_ARCHIVE_OWNERSHIP_PREFIX = b"hermes-managed-backup:v1:"
+
+
+def _archive_ownership_comment(path: Path) -> bytes:
+    digest = hashlib.sha256(path.name.encode("utf-8")).hexdigest().encode("ascii")
+    return _ARCHIVE_OWNERSHIP_PREFIX + digest
+
+
+def _owned_archive_identity(path: Path) -> Optional[os.stat_result]:
+    """Return identity only for an exact archive published by this helper."""
+    fd: Optional[int] = None
+    try:
+        selected = path.lstat()
+        if not stat.S_ISREG(selected.st_mode) or _snapshot_path_is_link_like(path):
+            return None
+        flags = os.O_RDONLY
+        if hasattr(os, "O_BINARY"):
+            flags |= os.O_BINARY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags)
+        opened = os.fstat(fd)
+        if not os.path.samestat(selected, opened) or not stat.S_ISREG(opened.st_mode):
+            return None
+        with os.fdopen(fd, "rb") as archive_file:
+            fd = None
+            with zipfile.ZipFile(archive_file, "r") as archive:
+                if archive.comment != _archive_ownership_comment(path):
+                    return None
+        if not os.path.samestat(selected, path.lstat()):
+            return None
+        return selected
+    except (OSError, ValueError, zipfile.BadZipFile):
+        return None
+    finally:
+        if fd is not None:
+            os.close(fd)
+
 def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
     """Write a full zip snapshot of ``hermes_root`` to ``out_path``.
 
@@ -1618,6 +1656,7 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
                 else:
                     zf.write(abs_path, arcname=rel_path.as_posix())
                     written_members += 1
+            zf.comment = _archive_ownership_comment(out_path)
 
         if not written_members:
             logger.warning("Full-zip backup aborted: no files could be written")
@@ -1682,13 +1721,9 @@ def _prune_pre_update_backups(backup_dir: Path, keep: int) -> int:
 
     backups = []
     for path in backup_dir.iterdir():
-        try:
-            selected = path.lstat()
-        except OSError:
-            continue
+        selected = _owned_archive_identity(path)
         if (
-            stat.S_ISREG(selected.st_mode)
-            and not _snapshot_path_is_link_like(path)
+            selected is not None
             and path.name.startswith(_PRE_UPDATE_PREFIX)
             and path.suffix.lower() == ".zip"
         ):
@@ -1767,13 +1802,9 @@ def _prune_pre_migration_backups(backup_dir: Path, keep: int) -> int:
 
     backups = []
     for path in backup_dir.iterdir():
-        try:
-            selected = path.lstat()
-        except OSError:
-            continue
+        selected = _owned_archive_identity(path)
         if (
-            stat.S_ISREG(selected.st_mode)
-            and not _snapshot_path_is_link_like(path)
+            selected is not None
             and path.name.startswith(_PRE_MIGRATION_PREFIX)
             and path.suffix.lower() == ".zip"
         ):

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -52,6 +52,107 @@ _BACKUP_LOCKS_GUARD = threading.Lock()
 _BACKUP_LOCK_FILENAME = ".maintenance.lock"
 
 
+def _opened_windows_handle_path(handle: int) -> Optional[Path]:
+    """Return the kernel-resolved path for an opened Windows handle."""
+    if os.name != "nt":
+        return None
+    try:
+        import ctypes
+
+        get_final_path = ctypes.windll.kernel32.GetFinalPathNameByHandleW
+        get_final_path.argtypes = (
+            ctypes.c_void_p,
+            ctypes.c_wchar_p,
+            ctypes.c_uint32,
+            ctypes.c_uint32,
+        )
+        get_final_path.restype = ctypes.c_uint32
+        needed = get_final_path(handle, None, 0, 0)
+        if not needed:
+            return None
+        buffer = ctypes.create_unicode_buffer(needed + 1)
+        written = get_final_path(handle, buffer, len(buffer), 0)
+        if not written or written >= len(buffer):
+            return None
+        actual = buffer.value
+        if actual.startswith("\\\\?\\UNC\\"):
+            actual = "\\\\" + actual[8:]
+        elif actual.startswith("\\\\?\\"):
+            actual = actual[4:]
+        return Path(actual)
+    except (AttributeError, OSError, ValueError):
+        return None
+
+
+def _opened_fd_path(fd: int) -> Optional[Path]:
+    """Return the kernel-resolved Windows path for an opened descriptor."""
+    if os.name != "nt":
+        return None
+    try:
+        return _opened_windows_handle_path(msvcrt.get_osfhandle(fd))
+    except (AttributeError, OSError, ValueError):
+        return None
+
+
+def _opened_fd_matches_path(fd: int, expected_path: Path) -> bool:
+    """On Windows, prove the handle did not traverse a swapped junction."""
+    if os.name != "nt":
+        return True
+    actual = _opened_fd_path(fd)
+    if actual is None:
+        return False
+    expected = os.path.abspath(os.fspath(expected_path))
+    return os.path.normcase(os.path.normpath(os.fspath(actual))) == os.path.normcase(
+        os.path.normpath(expected)
+    )
+
+
+def _windows_handle_matches_stat(handle: int, expected: os.stat_result) -> bool:
+    """Compare a raw Windows handle without weakening its rename guard."""
+    if os.name != "nt":
+        return False
+    try:
+        import ctypes
+
+        class _FileTime(ctypes.Structure):
+            _fields_ = [
+                ("low", ctypes.c_uint32),
+                ("high", ctypes.c_uint32),
+            ]
+
+        class _ByHandleFileInformation(ctypes.Structure):
+            _fields_ = [
+                ("attributes", ctypes.c_uint32),
+                ("creation_time", _FileTime),
+                ("access_time", _FileTime),
+                ("write_time", _FileTime),
+                ("volume_serial", ctypes.c_uint32),
+                ("size_high", ctypes.c_uint32),
+                ("size_low", ctypes.c_uint32),
+                ("links", ctypes.c_uint32),
+                ("index_high", ctypes.c_uint32),
+                ("index_low", ctypes.c_uint32),
+            ]
+
+        information = _ByHandleFileInformation()
+        get_information = ctypes.windll.kernel32.GetFileInformationByHandle
+        get_information.argtypes = (
+            ctypes.c_void_p,
+            ctypes.POINTER(_ByHandleFileInformation),
+        )
+        get_information.restype = ctypes.c_int
+        if not get_information(handle, ctypes.byref(information)):
+            return False
+        file_index = (information.index_high << 32) | information.index_low
+        return bool(
+            information.volume_serial == expected.st_dev
+            and file_index == expected.st_ino
+            and not (information.attributes & 0x400)
+        )
+    except (AttributeError, OSError, ValueError):
+        return False
+
+
 @contextmanager
 def _backup_maintenance_lock(root: Path) -> Iterator[None]:
     """Serialize backup publication and family-specific pruning.
@@ -102,16 +203,19 @@ def _backup_maintenance_lock(root: Path) -> Iterator[None]:
         locked = False
         provenance_valid = False
         opened_lock: Optional[os.stat_result] = None
+        opened_lock_path: Optional[Path] = None
         try:
             current_root = root.lstat()
             current_lock = lock_path.lstat()
             opened_lock = os.fstat(lock_file.fileno())
+            opened_lock_path = _opened_fd_path(lock_file.fileno())
             if (
                 not os.path.samestat(root_identity, current_root)
                 or not stat.S_ISREG(opened_lock.st_mode)
                 or int(getattr(opened_lock, "st_file_attributes", 0)) & 0x400
                 or opened_lock.st_nlink != 1
                 or not os.path.samestat(opened_lock, current_lock)
+                or not _opened_fd_matches_path(lock_file.fileno(), lock_path)
             ):
                 raise OSError("backup maintenance lock provenance changed")
             provenance_valid = True
@@ -139,9 +243,10 @@ def _backup_maintenance_lock(root: Path) -> Iterator[None]:
                 lock_file.close()
             if created_lock and not provenance_valid and opened_lock is not None:
                 try:
-                    current_created = lock_path.lstat()
+                    cleanup_path = opened_lock_path or lock_path
+                    current_created = cleanup_path.lstat()
                     if os.path.samestat(opened_lock, current_created):
-                        _remove_owned_snapshot_file(lock_path, current_created)
+                        _remove_owned_snapshot_file(cleanup_path, current_created)
                 except OSError:
                     pass
 
@@ -423,6 +528,20 @@ def _safe_copy_db(
             expected_dst_identity = os.fstat(owner_fd)
             cleanup_identity = expected_dst_identity
             created_here = True
+            if not _opened_fd_matches_path(owner_fd, dst):
+                actual_created = _opened_fd_path(owner_fd)
+                os.close(owner_fd)
+                owner_fd = None
+                if actual_created is not None:
+                    try:
+                        actual_identity = actual_created.lstat()
+                        if os.path.samestat(expected_dst_identity, actual_identity):
+                            _remove_owned_snapshot_file(
+                                actual_created, actual_identity
+                            )
+                    except OSError:
+                        pass
+                raise OSError(f"SQLite destination escaped its parent: {dst}")
         else:
             selected = dst.lstat()
             if (
@@ -439,7 +558,10 @@ def _safe_copy_db(
             if hasattr(os, "O_NOFOLLOW"):
                 flags |= os.O_NOFOLLOW
             owner_fd = os.open(dst, flags)
-            if not _same_snapshot_object(os.fstat(owner_fd), expected_dst_identity):
+            if (
+                not _same_snapshot_object(os.fstat(owner_fd), expected_dst_identity)
+                or not _opened_fd_matches_path(owner_fd, dst)
+            ):
                 logger.warning(
                     "SQLite safe copy refused replaced destination %s", dst
                 )
@@ -478,6 +600,7 @@ def _safe_copy_db(
             not stat.S_ISREG(source_selected.st_mode)
             or int(getattr(source_selected, "st_file_attributes", 0)) & 0x400
             or not os.path.samestat(source_selected, os.fstat(source_fd))
+            or not _opened_fd_matches_path(source_fd, src)
         ):
             raise OSError(f"SQLite source changed before backup: {src}")
 
@@ -905,9 +1028,12 @@ def run_backup(args) -> None:
             ):
                 raise OSError("published backup identity changed")
             if published_via_link:
-                _remove_owned_snapshot_file(temp_path, temp_identity)
-            temp_path = None
-            temp_identity = None
+                if _remove_owned_snapshot_file(temp_path, temp_identity):
+                    temp_path = None
+                    temp_identity = None
+            else:
+                temp_path = None
+                temp_identity = None
             out_path = candidate
             break
         else:
@@ -1521,6 +1647,345 @@ def _snapshot_parent_is_bound(
     return _snapshot_directory_is_bound(snapshot_dir, expected)
 
 
+def _snapshot_parent_chain(
+    snapshot_dir: Path,
+    expected: os.stat_result,
+    relative_parent: PurePosixPath,
+) -> Optional[list[tuple[Path, os.stat_result]]]:
+    if not _snapshot_directory_is_bound(snapshot_dir, expected):
+        return None
+    chain: list[tuple[Path, os.stat_result]] = [(snapshot_dir, expected)]
+    current = snapshot_dir
+    for part in relative_parent.parts:
+        if part in ("", ".", ".."):
+            return None
+        current = current / part
+        try:
+            selected = current.lstat()
+        except OSError:
+            return None
+        if (
+            not stat.S_ISDIR(selected.st_mode)
+            or int(getattr(selected, "st_file_attributes", 0)) & 0x400
+        ):
+            return None
+        chain.append((current, selected))
+    return chain
+
+
+def _snapshot_parent_chain_is_bound(
+    chain: list[tuple[Path, os.stat_result]],
+) -> bool:
+    try:
+        for current, expected in chain:
+            selected = current.lstat()
+            if (
+                not stat.S_ISDIR(selected.st_mode)
+                or int(getattr(selected, "st_file_attributes", 0)) & 0x400
+                or not _same_snapshot_object(expected, selected)
+            ):
+                return False
+        return True
+    except OSError:
+        return False
+
+
+def _open_bound_snapshot_directory(path: Path) -> int:
+    """Open a non-reparse directory, denying replacement on Windows."""
+    if os.name != "nt":
+        flags = os.O_RDONLY
+        if hasattr(os, "O_DIRECTORY"):
+            flags |= os.O_DIRECTORY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        return os.open(path, flags)
+
+    import ctypes
+
+    create_file = ctypes.windll.kernel32.CreateFileW
+    create_file.argtypes = (
+        ctypes.c_wchar_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+    )
+    create_file.restype = ctypes.c_void_p
+    handle = create_file(
+        str(path),
+        0x00000080,  # FILE_READ_ATTRIBUTES
+        0x00000001 | 0x00000002 | 0x00000004,
+        None,
+        3,  # OPEN_EXISTING
+        0x02000000 | 0x00200000,  # BACKUP_SEMANTICS | OPEN_REPARSE_POINT
+        None,
+    )
+    if handle == ctypes.c_void_p(-1).value:
+        raise ctypes.WinError()
+    # Keep this as a raw handle. It remains bound to the selected directory
+    # even when another process renames that directory and replaces its path.
+    return handle
+
+
+@contextmanager
+def _hold_snapshot_parent_chain(
+    chain: list[tuple[Path, os.stat_result]],
+) -> Iterator[int]:
+    """Hold the exact restore parent chain through atomic publication."""
+    opened: list[int] = []
+    try:
+        for path, expected in chain:
+            fd = _open_bound_snapshot_directory(path)
+            opened.append(fd)
+            selected = path.lstat()
+            if os.name == "nt":
+                if (
+                    int(getattr(selected, "st_file_attributes", 0)) & 0x400
+                    or not stat.S_ISDIR(selected.st_mode)
+                    or not _same_snapshot_object(expected, selected)
+                    or not _windows_handle_matches_stat(fd, expected)
+                ):
+                    raise OSError(
+                        "snapshot parent changed while binding publication"
+                    )
+            else:
+                actual = os.fstat(fd)
+                if (
+                    not stat.S_ISDIR(actual.st_mode)
+                    or not _same_snapshot_object(expected, selected)
+                    or not _same_snapshot_object(expected, actual)
+                ):
+                    raise OSError(
+                        "snapshot parent changed while binding publication"
+                    )
+        if not opened or not _snapshot_parent_chain_is_bound(chain):
+            raise OSError("snapshot parent changed after binding publication")
+        yield opened[-1]
+    finally:
+        if os.name == "nt":
+            import ctypes
+
+            for handle in reversed(opened):
+                ctypes.windll.kernel32.CloseHandle(handle)
+        else:
+            for fd in reversed(opened):
+                os.close(fd)
+
+
+def _bound_parent_stat(parent_fd: int, parent: Path, name: str) -> os.stat_result:
+    if os.name == "nt":
+        return (parent / name).lstat()
+    return os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+
+
+def _remove_bound_snapshot_member(
+    parent_fd: int,
+    parent: Path,
+    name: str,
+    expected: os.stat_result,
+) -> bool:
+    """Remove only the exact staged member from an already-bound parent."""
+    if os.name == "nt":
+        return _remove_owned_snapshot_file(parent / name, expected)
+    quarantine = f".{name}.hermes-delete-{uuid.uuid4().hex}"
+    try:
+        current = _bound_parent_stat(parent_fd, parent, name)
+        if not _same_snapshot_object(expected, current):
+            return False
+        os.replace(
+            name,
+            quarantine,
+            src_dir_fd=parent_fd,
+            dst_dir_fd=parent_fd,
+        )
+        moved = _bound_parent_stat(parent_fd, parent, quarantine)
+        if not _same_snapshot_object(expected, moved):
+            return False
+        os.unlink(quarantine, dir_fd=parent_fd)
+        return True
+    except OSError:
+        return False
+
+
+def _bound_snapshot_member_sha256(
+    parent_fd: int,
+    parent: Path,
+    name: str,
+    expected: os.stat_result,
+) -> str:
+    """Hash one exact staged member through its already-bound parent."""
+    flags = os.O_RDONLY
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if os.name == "nt":
+        fd = os.open(parent / name, flags)
+    else:
+        fd = os.open(name, flags, dir_fd=parent_fd)
+    try:
+        opened = os.fstat(fd)
+        selected = _bound_parent_stat(parent_fd, parent, name)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or not _same_snapshot_object(expected, opened)
+            or not _same_snapshot_object(opened, selected)
+            or not _opened_fd_matches_path(fd, parent / name)
+        ):
+            raise OSError("restore staging changed before verification")
+        digest = hashlib.sha256()
+        copied = 0
+        while chunk := os.read(fd, 1024 * 1024):
+            copied += len(chunk)
+            digest.update(chunk)
+        after = os.fstat(fd)
+        selected_after = _bound_parent_stat(parent_fd, parent, name)
+        if (
+            copied != opened.st_size
+            or after.st_size != opened.st_size
+            or after.st_mtime_ns != opened.st_mtime_ns
+            or after.st_ctime_ns != opened.st_ctime_ns
+            or not _same_snapshot_object(opened, selected_after)
+        ):
+            raise OSError("restore staging changed during verification")
+        return digest.hexdigest()
+    finally:
+        os.close(fd)
+
+
+def _nt_replace_windows_file(
+    source_handle: int,
+    parent_handle: int,
+    destination_name: str,
+) -> None:
+    """Rename an opened file relative to an opened directory handle."""
+    import ctypes
+
+    class _FileRenameInformation(ctypes.Structure):
+        _fields_ = [
+            ("flags", ctypes.c_uint32),
+            ("root_directory", ctypes.c_void_p),
+            ("file_name_length", ctypes.c_uint32),
+            ("file_name", ctypes.c_wchar * len(destination_name)),
+        ]
+
+    class _IoStatusBlock(ctypes.Structure):
+        _fields_ = [
+            ("status_or_pointer", ctypes.c_void_p),
+            ("information", ctypes.c_size_t),
+        ]
+
+    rename = _FileRenameInformation()
+    rename.flags = 1  # ReplaceIfExists
+    rename.root_directory = parent_handle
+    rename.file_name_length = len(destination_name.encode("utf-16-le"))
+    rename.file_name = destination_name
+    io_status = _IoStatusBlock()
+    set_information = ctypes.windll.ntdll.NtSetInformationFile
+    set_information.argtypes = (
+        ctypes.c_void_p,
+        ctypes.POINTER(_IoStatusBlock),
+        ctypes.c_void_p,
+        ctypes.c_ulong,
+        ctypes.c_int,
+    )
+    set_information.restype = ctypes.c_long
+    status = set_information(
+        source_handle,
+        ctypes.byref(io_status),
+        ctypes.byref(rename),
+        ctypes.sizeof(rename),
+        10,  # FileRenameInformation
+    )
+    if status < 0:
+        raise OSError(
+            f"handle-relative restore rename failed with NTSTATUS "
+            f"0x{status & 0xFFFFFFFF:08x}"
+        )
+
+
+def _replace_windows_snapshot_member_by_handle(
+    parent_fd: int,
+    source: Path,
+    destination_name: str,
+    expected: os.stat_result,
+) -> os.stat_result:
+    """Rename an exact opened stage relative to the exact parent handle."""
+    import ctypes
+
+    create_file = ctypes.windll.kernel32.CreateFileW
+    create_file.argtypes = (
+        ctypes.c_wchar_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+    )
+    create_file.restype = ctypes.c_void_p
+    source_handle = create_file(
+        str(source),
+        0x00010000 | 0x00000080,  # DELETE | FILE_READ_ATTRIBUTES
+        0x00000001 | 0x00000002 | 0x00000004,
+        None,
+        3,  # OPEN_EXISTING
+        0x00200000,  # FILE_FLAG_OPEN_REPARSE_POINT
+        None,
+    )
+    if source_handle == ctypes.c_void_p(-1).value:
+        raise ctypes.WinError()
+    try:
+        if not _windows_handle_matches_stat(source_handle, expected):
+            raise OSError("restore staging changed before handle-relative rename")
+        _nt_replace_windows_file(source_handle, parent_fd, destination_name)
+        if not _windows_handle_matches_stat(source_handle, expected):
+            raise OSError("restore staging changed during handle-relative rename")
+        return expected
+    finally:
+        ctypes.windll.kernel32.CloseHandle(source_handle)
+
+
+def _replace_bound_snapshot_member(
+    parent_fd: int,
+    parent: Path,
+    stage_name: str,
+    destination_name: str,
+    stage_identity: os.stat_result,
+    parent_chain: list[tuple[Path, os.stat_result]],
+) -> os.stat_result:
+    """Publish a staged restore without resolving a replaceable parent path."""
+    selected = _bound_parent_stat(parent_fd, parent, stage_name)
+    if (
+        not _same_snapshot_object(stage_identity, selected)
+        or not _snapshot_parent_chain_is_bound(parent_chain)
+    ):
+        raise OSError("restore staging or destination parent changed")
+    if os.name == "nt":
+        published = _replace_windows_snapshot_member_by_handle(
+            parent_fd,
+            parent / stage_name,
+            destination_name,
+            stage_identity,
+        )
+    else:
+        os.replace(
+            stage_name,
+            destination_name,
+            src_dir_fd=parent_fd,
+            dst_dir_fd=parent_fd,
+        )
+        published = _bound_parent_stat(parent_fd, parent, destination_name)
+    if (
+        not _same_snapshot_object(stage_identity, published)
+        or not _snapshot_parent_chain_is_bound(parent_chain)
+    ):
+        raise OSError("restored destination identity changed")
+    return published
+
+
 def _ensure_snapshot_parent(
     snapshot_dir: Path,
     expected: os.stat_result,
@@ -1556,6 +2021,8 @@ def _write_exclusive_snapshot_file(
     snapshot_identity: os.stat_result,
     relative_name: str,
     chunks: Iterator[bytes],
+    *,
+    bound_parent_fd: Optional[int] = None,
 ) -> tuple[Path, os.stat_result, int]:
     """Write a new snapshot member without trusting a replaceable directory."""
     relative = PurePosixPath(relative_name)
@@ -1564,25 +2031,39 @@ def _write_exclusive_snapshot_file(
     parent_rel = relative.parent
     if not _ensure_snapshot_parent(snapshot_dir, snapshot_identity, parent_rel):
         raise OSError("snapshot directory changed before member creation")
+    parent_chain = _snapshot_parent_chain(
+        snapshot_dir, snapshot_identity, parent_rel
+    )
+    if parent_chain is None:
+        raise OSError("snapshot parent changed before member creation")
     destination = snapshot_dir.joinpath(*relative.parts)
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
     if hasattr(os, "O_BINARY"):
         flags |= os.O_BINARY
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
-    fd = os.open(destination, flags, 0o600)
+    use_bound_parent = bound_parent_fd is not None and os.name != "nt"
+    if use_bound_parent:
+        fd = os.open(relative.name, flags, 0o600, dir_fd=bound_parent_fd)
+    else:
+        fd = os.open(destination, flags, 0o600)
     opened: Optional[os.stat_result] = None
+    opened_actual_path: Optional[Path] = None
     success = False
     copied = 0
     try:
         opened = os.fstat(fd)
-        path_opened = destination.lstat()
+        opened_actual_path = _opened_fd_path(fd)
+        path_opened = (
+            _bound_parent_stat(bound_parent_fd, destination.parent, relative.name)
+            if use_bound_parent
+            else destination.lstat()
+        )
         if (
             not stat.S_ISREG(opened.st_mode)
             or not os.path.samestat(opened, path_opened)
-            or not _snapshot_parent_is_bound(
-                snapshot_dir, snapshot_identity, parent_rel
-            )
+            or not _opened_fd_matches_path(fd, destination)
+            or not _snapshot_parent_chain_is_bound(parent_chain)
         ):
             raise OSError("snapshot directory changed during member creation")
         for chunk in chunks:
@@ -1597,13 +2078,16 @@ def _write_exclusive_snapshot_file(
                 view = view[written:]
         os.fsync(fd)
         after = os.fstat(fd)
-        path_after = destination.lstat()
+        path_after = (
+            _bound_parent_stat(bound_parent_fd, destination.parent, relative.name)
+            if use_bound_parent
+            else destination.lstat()
+        )
         if (
             not os.path.samestat(opened, after)
             or not os.path.samestat(after, path_after)
-            or not _snapshot_parent_is_bound(
-                snapshot_dir, snapshot_identity, parent_rel
-            )
+            or not _opened_fd_matches_path(fd, destination)
+            or not _snapshot_parent_chain_is_bound(parent_chain)
         ):
             raise OSError("snapshot member changed during write")
         success = True
@@ -1611,16 +2095,29 @@ def _write_exclusive_snapshot_file(
         os.close(fd)
         if not success and opened is not None:
             try:
-                current = destination.lstat()
-                if os.path.samestat(opened, current):
-                    _remove_owned_snapshot_file(destination, current)
+                if use_bound_parent:
+                    _remove_bound_snapshot_member(
+                        bound_parent_fd,
+                        destination.parent,
+                        relative.name,
+                        opened,
+                    )
+                else:
+                    cleanup_path = opened_actual_path or destination
+                    current = cleanup_path.lstat()
+                    if os.path.samestat(opened, current):
+                        _remove_owned_snapshot_file(cleanup_path, current)
             except OSError:
                 pass
-    final = destination.lstat()
+    final = (
+        _bound_parent_stat(bound_parent_fd, destination.parent, relative.name)
+        if use_bound_parent
+        else destination.lstat()
+    )
     if (
         opened is None
         or not os.path.samestat(opened, final)
-        or not _snapshot_parent_is_bound(snapshot_dir, snapshot_identity, parent_rel)
+        or not _snapshot_parent_chain_is_bound(parent_chain)
     ):
         raise OSError("snapshot member changed after close")
     return destination, final, copied
@@ -1639,6 +2136,7 @@ def _opened_file_chunks(path: Path, expected: os.stat_result) -> Iterator[bytes]
             not stat.S_ISREG(opened.st_mode)
             or not _same_snapshot_object(expected, path.lstat())
             or not os.path.samestat(expected, opened)
+            or not _opened_fd_matches_path(fd, path)
         ):
             raise OSError(f"snapshot source changed before read: {path}")
         copied = 0
@@ -1656,6 +2154,13 @@ def _opened_file_chunks(path: Path, expected: os.stat_result) -> Iterator[bytes]
             raise OSError(f"snapshot source changed during read: {path}")
     finally:
         os.close(fd)
+
+
+def _opened_file_sha256(path: Path, expected: os.stat_result) -> str:
+    digest = hashlib.sha256()
+    for chunk in _opened_file_chunks(path, expected):
+        digest.update(chunk)
+    return digest.hexdigest()
 
 
 def create_quick_snapshot(
@@ -1711,6 +2216,7 @@ def create_quick_snapshot(
     safe_label = _quick_snapshot_label_segment(label)
     base_id = f"{ts}-{safe_label}" if safe_label else ts
     with _backup_maintenance_lock(root):
+        snapshot_root_identity = root.lstat()
         snap_id = base_id
         suffix = 1
         while True:
@@ -1747,8 +2253,9 @@ def create_quick_snapshot(
         )
 
     manifest: Dict[str, int] = {}  # rel_path -> file size
+    manifest_hashes: Dict[str, str] = {}
 
-    def _capture_member(source: Path, relative_name: str) -> int:
+    def _capture_member(source: Path, relative_name: str) -> tuple[int, str]:
         selected = source.lstat()
         if (
             not stat.S_ISREG(selected.st_mode)
@@ -1756,19 +2263,33 @@ def create_quick_snapshot(
         ):
             raise OSError(f"snapshot source is not a regular file: {source}")
         if source.suffix != ".db":
-            _, _, copied = _write_exclusive_snapshot_file(
+            stored, stored_identity, copied = _write_exclusive_snapshot_file(
                 snap_dir,
                 snapshot_identity,
                 relative_name,
                 _opened_file_chunks(source, selected),
             )
-            return copied
+            return copied, _opened_file_sha256(stored, stored_identity)
 
         temp_db: Optional[Path] = None
         temp_identity: Optional[os.stat_result] = None
         try:
-            with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as temp_file:
+            with tempfile.NamedTemporaryFile(
+                suffix=".db", delete=False, dir=str(root)
+            ) as temp_file:
                 temp_db = Path(temp_file.name)
+                temp_opened = os.fstat(temp_file.fileno())
+                if (
+                    not _same_snapshot_object(
+                        snapshot_root_identity, root.lstat()
+                    )
+                    or not _opened_fd_matches_path(temp_file.fileno(), temp_db)
+                ):
+                    actual_temp = _opened_fd_path(temp_file.fileno())
+                    if actual_temp is not None:
+                        temp_db = actual_temp
+                    temp_identity = temp_opened
+                    raise OSError("SQLite staging path escaped snapshot root")
             temp_identity = temp_db.lstat()
             final_identity: list[os.stat_result] = []
             if not _safe_copy_db(
@@ -1781,13 +2302,13 @@ def create_quick_snapshot(
                 raise OSError(f"SQLite snapshot failed for {source}")
             if final_identity:
                 temp_identity = final_identity[0]
-            _, _, copied = _write_exclusive_snapshot_file(
+            stored, stored_identity, copied = _write_exclusive_snapshot_file(
                 snap_dir,
                 snapshot_identity,
                 relative_name,
                 _opened_file_chunks(temp_db, temp_identity),
             )
-            return copied
+            return copied, _opened_file_sha256(stored, stored_identity)
         finally:
             if temp_db is not None and temp_identity is not None:
                 _remove_owned_snapshot_file(temp_db, temp_identity)
@@ -1850,7 +2371,9 @@ def create_quick_snapshot(
                     if _too_large(sub, sub_rel):
                         continue
                     try:
-                        manifest[sub_rel] = _capture_member(sub, sub_rel)
+                        member_size, member_hash = _capture_member(sub, sub_rel)
+                        manifest[sub_rel] = member_size
+                        manifest_hashes[sub_rel] = member_hash
                     except (OSError, PermissionError) as exc:
                         logger.warning("Could not snapshot %s: %s", sub_rel, exc)
             continue
@@ -1864,7 +2387,9 @@ def create_quick_snapshot(
             continue
 
         try:
-            manifest[rel] = _capture_member(src, rel)
+            member_size, member_hash = _capture_member(src, rel)
+            manifest[rel] = member_size
+            manifest_hashes[rel] = member_hash
         except (OSError, PermissionError) as exc:
             logger.warning("Could not snapshot %s: %s", rel, exc)
 
@@ -1888,6 +2413,7 @@ def create_quick_snapshot(
         "file_count": len(manifest),
         "total_size": sum(manifest.values()),
         "files": manifest,
+        "sha256": manifest_hashes,
     }
     try:
         _write_exclusive_snapshot_file(
@@ -2112,27 +2638,71 @@ def restore_quick_snapshot(
     except (OSError, UnicodeError, json.JSONDecodeError):
         return False
 
-    restored = 0
-    for rel in meta.get("files", {}):
-        # Security: reject absolute paths and traversals in manifest entries
-        relative = PurePosixPath(str(rel))
-        if relative.is_absolute() or not relative.parts or ".." in relative.parts:
-            logger.error("Manifest path traversal blocked: %s", rel)
-            continue
+    if not isinstance(meta, dict):
+        return False
+    files = meta.get("files")
+    hashes = meta.get("sha256", {})
+    if not isinstance(files, dict) or not files or not isinstance(hashes, dict):
+        return False
+    allowed_roots = tuple(PurePosixPath(item) for item in _QUICK_STATE_FILES)
+    total_size = 0
+    members: list[
+        tuple[str, PurePosixPath, Path, os.stat_result, Optional[str]]
+    ] = []
+    for rel, declared_size in files.items():
+        if (
+            not isinstance(rel, str)
+            or not isinstance(declared_size, int)
+            or isinstance(declared_size, bool)
+            or declared_size < 0
+        ):
+            return False
+        relative = PurePosixPath(rel)
+        if (
+            relative.is_absolute()
+            or not relative.parts
+            or ".." in relative.parts
+            or not any(
+                relative == allowed or allowed in relative.parents
+                for allowed in allowed_roots
+            )
+        ):
+            return False
+        declared_hash = hashes.get(rel)
+        if declared_hash is not None and (
+            not isinstance(declared_hash, str)
+            or re.fullmatch(r"[0-9a-f]{64}", declared_hash) is None
+        ):
+            return False
         src = snap_dir.joinpath(*relative.parts)
-
-        dst = home.joinpath(*relative.parts)
-
         try:
             source_identity = src.lstat()
-            if (
-                not stat.S_ISREG(source_identity.st_mode)
-                or int(getattr(source_identity, "st_file_attributes", 0)) & 0x400
-                or not _snapshot_directory_is_bound(snap_dir, snapshot_identity)
-            ):
-                continue
         except OSError:
-            continue
+            return False
+        if (
+            not stat.S_ISREG(source_identity.st_mode)
+            or int(getattr(source_identity, "st_file_attributes", 0)) & 0x400
+            or source_identity.st_size != declared_size
+            or not _snapshot_directory_is_bound(snap_dir, snapshot_identity)
+        ):
+            return False
+        if declared_hash is not None and _opened_file_sha256(
+            src, source_identity
+        ) != declared_hash:
+            return False
+        members.append(
+            (rel, relative, src, source_identity, declared_hash)
+        )
+        total_size += declared_size
+    if (
+        meta.get("file_count") != len(files)
+        or meta.get("total_size") != total_size
+    ):
+        return False
+
+    restored = 0
+    for rel, relative, src, source_identity, declared_hash in members:
+        dst = home.joinpath(*relative.parts)
 
         stage_rel = relative.parent / (
             f".{relative.name}.snap-restore-{uuid.uuid4().hex}.tmp"
@@ -2140,39 +2710,87 @@ def restore_quick_snapshot(
         stage: Optional[Path] = None
         stage_identity: Optional[os.stat_result] = None
         try:
-            stage, stage_identity, _ = _write_exclusive_snapshot_file(
-                home,
-                home_identity,
-                stage_rel.as_posix(),
-                _opened_file_chunks(src, source_identity),
-            )
-            if (
-                not _snapshot_directory_is_bound(snap_dir, snapshot_identity)
-                or not _snapshot_parent_is_bound(
-                    home, home_identity, relative.parent
-                )
+            if not _ensure_snapshot_parent(
+                home, home_identity, relative.parent
             ):
-                raise OSError("snapshot or restore destination changed")
-            try:
-                os.chmod(stage, stat.S_IMODE(source_identity.st_mode))
-            except OSError:
-                pass
-            current_stage = stage.lstat()
-            if not os.path.samestat(stage_identity, current_stage):
-                raise OSError("restore staging identity changed")
-            stage_identity = current_stage
-            os.replace(stage, dst)
-            published = dst.lstat()
-            if not os.path.samestat(stage_identity, published):
-                raise OSError("restored destination identity changed")
-            stage = None
-            stage_identity = None
-            restored += 1
+                raise OSError("restore destination parent is unavailable")
+            restore_parent_chain = _snapshot_parent_chain(
+                home, home_identity, relative.parent
+            )
+            if restore_parent_chain is None:
+                raise OSError("restore destination parent changed")
+            with _hold_snapshot_parent_chain(restore_parent_chain) as parent_fd:
+                try:
+                    stage, stage_identity, _ = _write_exclusive_snapshot_file(
+                        home,
+                        home_identity,
+                        stage_rel.as_posix(),
+                        _opened_file_chunks(src, source_identity),
+                        bound_parent_fd=parent_fd,
+                    )
+                    if (
+                        not _snapshot_directory_is_bound(
+                            snap_dir, snapshot_identity
+                        )
+                        or not _snapshot_parent_chain_is_bound(
+                            restore_parent_chain
+                        )
+                    ):
+                        raise OSError("snapshot or restore destination changed")
+                    try:
+                        if os.name == "nt":
+                            os.chmod(
+                                stage, stat.S_IMODE(source_identity.st_mode)
+                            )
+                        else:
+                            os.chmod(
+                                stage.name,
+                                stat.S_IMODE(source_identity.st_mode),
+                                dir_fd=parent_fd,
+                                follow_symlinks=False,
+                            )
+                    except OSError:
+                        pass
+                    current_stage = _bound_parent_stat(
+                        parent_fd, dst.parent, stage.name
+                    )
+                    if not _same_snapshot_object(
+                        stage_identity, current_stage
+                    ):
+                        raise OSError("restore staging identity changed")
+                    stage_identity = current_stage
+                    if (
+                        declared_hash is not None
+                        and _bound_snapshot_member_sha256(
+                            parent_fd,
+                            dst.parent,
+                            stage.name,
+                            stage_identity,
+                        )
+                        != declared_hash
+                    ):
+                        raise OSError("restore staging hash changed")
+                    _replace_bound_snapshot_member(
+                        parent_fd,
+                        dst.parent,
+                        stage.name,
+                        dst.name,
+                        stage_identity,
+                        restore_parent_chain,
+                    )
+                    stage = None
+                    stage_identity = None
+                    restored += 1
+                finally:
+                    if stage is not None and stage_identity is not None:
+                        _remove_bound_snapshot_member(
+                            parent_fd,
+                            dst.parent,
+                            stage.name,
+                            stage_identity,
+                        )
         except (OSError, PermissionError) as exc:
             logger.error("Failed to restore %s: %s", rel, exc)
-        finally:
-            if stage is not None and stage_identity is not None:
-                _remove_owned_snapshot_file(stage, stage_identity)
 
     logger.info("Restored %d files from snapshot %s", restored, snapshot_id)
     return restored > 0
@@ -2443,6 +3061,7 @@ def _write_bound_file_to_zip(
         if (
             not stat.S_ISREG(opened.st_mode)
             or not os.path.samestat(selected, opened)
+            or not _opened_fd_matches_path(fd, source)
         ):
             raise OSError(f"backup source changed before open: {source}")
 
@@ -2660,9 +3279,12 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
                 return None
 
             if published_via_link:
-                _remove_owned_snapshot_file(temp_path, temp_identity)
-            temp_path = None
-            temp_identity = None
+                if _remove_owned_snapshot_file(temp_path, temp_identity):
+                    temp_path = None
+                    temp_identity = None
+            else:
+                temp_path = None
+                temp_identity = None
             return candidate
 
         logger.warning("Full-zip backup: destination kept colliding: %s", out_path)

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -343,22 +343,27 @@ def _safe_copy_db(
     *,
     expected_dst_identity: Optional[os.stat_result] = None,
     expected_src_identity: Optional[os.stat_result] = None,
+    result_dst_identity: Optional[list[os.stat_result]] = None,
 ) -> bool:
     """Copy a SQLite database safely using the backup() API.
 
     Handles WAL mode — produces a consistent snapshot even while
     the DB is being written to. Fail closed if a consistent snapshot cannot
     be created: copying only the live main file can omit committed WAL data.
+    When provided, ``result_dst_identity`` receives the final owned pathname
+    identity so callers that pre-created ``dst`` can clean it up safely.
     """
     conn = None
     backup_conn = None
     owner_fd: Optional[int] = None
     source_fd: Optional[int] = None
-    stage_fd: Optional[int] = None
-    stage_path: Optional[Path] = None
-    stage_identity: Optional[os.stat_result] = None
+    source_parent_fd: Optional[int] = None
+    cleanup_identity = expected_dst_identity
+    published_destination: Optional[os.stat_result] = None
     created_here = False
     success = False
+    if result_dst_identity is not None:
+        result_dst_identity.clear()
     try:
         if expected_dst_identity is None:
             flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
@@ -368,12 +373,13 @@ def _safe_copy_db(
                 flags |= os.O_NOFOLLOW
             owner_fd = os.open(dst, flags, 0o600)
             expected_dst_identity = os.fstat(owner_fd)
+            cleanup_identity = expected_dst_identity
             created_here = True
         else:
             selected = dst.lstat()
             if (
                 not stat.S_ISREG(selected.st_mode)
-                or not os.path.samestat(selected, expected_dst_identity)
+                or not _same_snapshot_object(selected, expected_dst_identity)
             ):
                 logger.warning(
                     "SQLite safe copy refused changed destination %s", dst
@@ -385,11 +391,25 @@ def _safe_copy_db(
             if hasattr(os, "O_NOFOLLOW"):
                 flags |= os.O_NOFOLLOW
             owner_fd = os.open(dst, flags)
-            if not os.path.samestat(os.fstat(owner_fd), expected_dst_identity):
+            if not _same_snapshot_object(os.fstat(owner_fd), expected_dst_identity):
                 logger.warning(
                     "SQLite safe copy refused replaced destination %s", dst
                 )
                 return False
+
+        source_parent = src.parent
+        parent_selected = source_parent.lstat()
+        if not stat.S_ISDIR(parent_selected.st_mode):
+            raise OSError(f"SQLite source parent is not a directory: {source_parent}")
+        if os.name != "nt":
+            parent_flags = os.O_RDONLY
+            if hasattr(os, "O_DIRECTORY"):
+                parent_flags |= os.O_DIRECTORY
+            if hasattr(os, "O_NOFOLLOW"):
+                parent_flags |= os.O_NOFOLLOW
+            source_parent_fd = os.open(source_parent, parent_flags)
+            if not os.path.samestat(parent_selected, os.fstat(source_parent_fd)):
+                raise OSError(f"SQLite source parent changed: {source_parent}")
 
         source_selected = src.lstat()
         if (
@@ -410,36 +430,65 @@ def _safe_copy_db(
         ):
             raise OSError(f"SQLite source changed before backup: {src}")
 
-        # SQLite must not open the caller's replaceable destination pathname.
-        # Back up into a random, already-open sibling and then stream that
-        # snapshot into the verified destination descriptor.
-        with tempfile.NamedTemporaryFile(
-            suffix=".db", delete=False, dir=str(dst.parent)
-        ) as stage_file:
-            stage_path = Path(stage_file.name)
-            stage_fd = os.dup(stage_file.fileno())
-            stage_identity = os.fstat(stage_file.fileno())
         conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
-        backup_conn = sqlite3.connect(str(stage_path))
+        # Opening a WAL database can legitimately create its -shm/-wal
+        # sidecars lazily on its first read and therefore update the parent
+        # directory. Force that initialization before establishing the
+        # parent-change guard, then re-bind the SQLite pathname to the
+        # descriptor selected above before taking the snapshot.
+        conn.execute("PRAGMA schema_version").fetchone()
+        if source_parent_fd is not None:
+            parent_monitor = os.fstat(source_parent_fd)
+            if not os.path.samestat(parent_monitor, source_parent.lstat()):
+                raise OSError(f"SQLite source parent changed: {source_parent}")
+        else:
+            parent_monitor = source_parent.lstat()
+        if not os.path.samestat(source_selected, src.lstat()):
+            raise OSError(f"SQLite source changed while opening backup: {src}")
+
+        # Destination provenance is exact because SQLite never receives the
+        # caller's pathname: its consistent WAL snapshot is serialized from
+        # memory and copied only through the retained destination descriptor.
+        backup_conn = sqlite3.connect(":memory:")
         conn.backup(backup_conn)
-        backup_conn.close()
-        backup_conn = None
+        serialized = backup_conn.serialize()
 
         if not os.path.samestat(source_selected, src.lstat()):
             raise OSError(f"SQLite source changed during backup: {src}")
-        if not os.path.samestat(stage_identity, os.fstat(stage_fd)):
-            raise OSError(f"SQLite staging file changed during backup: {stage_path}")
+        if source_parent_fd is not None:
+            parent_after = os.fstat(source_parent_fd)
+            path_parent_after = source_parent.lstat()
+            if (
+                not os.path.samestat(parent_monitor, parent_after)
+                or not os.path.samestat(parent_after, path_parent_after)
+                or parent_after.st_mtime_ns != parent_monitor.st_mtime_ns
+                or parent_after.st_ctime_ns != parent_monitor.st_ctime_ns
+            ):
+                raise OSError(
+                    f"SQLite source pathname changed during backup: {src}"
+                )
+        else:
+            path_parent_after = source_parent.lstat()
+            if (
+                not os.path.samestat(parent_monitor, path_parent_after)
+                or path_parent_after.st_mtime_ns != parent_monitor.st_mtime_ns
+                or path_parent_after.st_ctime_ns != parent_monitor.st_ctime_ns
+            ):
+                raise OSError(
+                    f"SQLite source pathname changed during backup: {src}"
+                )
 
-        os.lseek(stage_fd, 0, os.SEEK_SET)
         os.lseek(owner_fd, 0, os.SEEK_SET)
         os.ftruncate(owner_fd, 0)
-        while chunk := os.read(stage_fd, 1024 * 1024):
-            view = memoryview(chunk)
-            while view:
-                written = os.write(owner_fd, view)
-                if written <= 0:
-                    raise OSError("short write while copying SQLite snapshot")
-                view = view[written:]
+        serialized_view = memoryview(serialized)
+        offset = 0
+        while offset < len(serialized_view):
+            written = os.write(
+                owner_fd, serialized_view[offset : offset + 1024 * 1024]
+            )
+            if written <= 0:
+                raise OSError("short write while copying SQLite snapshot")
+            offset += written
         os.fsync(owner_fd)
         success = True
     except Exception as exc:
@@ -455,16 +504,19 @@ def _safe_copy_db(
             try:
                 opened_destination = os.fstat(owner_fd)
                 path_destination = dst.lstat()
-                success = bool(
-                    success
-                    and expected_dst_identity is not None
-                    and _same_snapshot_object(
-                        expected_dst_identity, opened_destination
+                still_bound = bool(
+                    expected_dst_identity is not None
+                    and stat.S_ISREG(opened_destination.st_mode)
+                    and not (
+                        int(getattr(opened_destination, "st_file_attributes", 0))
+                        & 0x400
                     )
-                    and _same_snapshot_object(
-                        opened_destination, path_destination
-                    )
+                    and os.path.samestat(expected_dst_identity, opened_destination)
+                    and os.path.samestat(opened_destination, path_destination)
                 )
+                success = bool(success and still_bound)
+                if still_bound:
+                    published_destination = opened_destination
             except OSError:
                 success = False
             try:
@@ -476,31 +528,34 @@ def _safe_copy_db(
                 os.close(source_fd)
             except OSError:
                 pass
-        if stage_fd is not None:
+        if source_parent_fd is not None:
             try:
-                os.close(stage_fd)
-            except OSError:
-                pass
-        if stage_path is not None and stage_identity is not None:
-            try:
-                _remove_owned_snapshot_file(stage_path, stage_identity)
+                os.close(source_parent_fd)
             except OSError:
                 pass
 
     try:
         current = dst.lstat()
-        success = bool(
-            success
-            and expected_dst_identity is not None
+        still_owned_after_close = bool(
+            published_destination is not None
             and stat.S_ISREG(current.st_mode)
-            and _same_snapshot_object(expected_dst_identity, current)
+            and not (int(getattr(current, "st_file_attributes", 0)) & 0x400)
+            and os.path.samestat(published_destination, current)
         )
+        success = bool(success and still_owned_after_close)
+        if still_owned_after_close:
+            # CloseHandle can legitimately publish a final Windows ctime.
+            # Bind by the retained fd evidence, then take the exact deletion
+            # token from the pathname only after the handle has closed.
+            cleanup_identity = current
+            if result_dst_identity is not None:
+                result_dst_identity.append(current)
     except OSError:
         success = False
 
-    if not success and created_here and expected_dst_identity is not None:
+    if not success and created_here and cleanup_identity is not None:
         try:
-            _remove_owned_snapshot_file(dst, expected_dst_identity)
+            _remove_owned_snapshot_file(dst, cleanup_identity)
         except OSError:
             pass
     return success
@@ -624,13 +679,18 @@ def run_backup(args) -> None:
                         suffix=".db", delete=False, dir=str(out_path.parent)
                     ) as tmp:
                         tmp_db = Path(tmp.name)
-                        tmp_db_identity = os.fstat(tmp.fileno())
+                    tmp_db_identity = tmp_db.lstat()
+                    final_tmp_db_identity: list[os.stat_result] = []
                     try:
-                        if _safe_copy_db(
+                        copied = _safe_copy_db(
                             abs_path,
                             tmp_db,
                             expected_dst_identity=tmp_db_identity,
-                        ):
+                            result_dst_identity=final_tmp_db_identity,
+                        )
+                        if final_tmp_db_identity:
+                            tmp_db_identity = final_tmp_db_identity[0]
+                        if copied:
                             zf.write(tmp_db, arcname=str(rel_path))
                             total_bytes += tmp_db.stat().st_size
                         else:
@@ -1919,10 +1979,44 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
     """
     files_to_add: list[tuple[Path, Path, os.stat_result]] = []
     try:
+        root_identity = hermes_root.lstat()
+        if (
+            not stat.S_ISDIR(root_identity.st_mode)
+            or int(getattr(root_identity, "st_file_attributes", 0)) & 0x400
+        ):
+            return None
         for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
             dp = Path(dirpath)
-            # Prune excluded directories in-place so os.walk doesn't descend
-            dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
+            directory_identity = dp.lstat()
+            directory_reparse = int(
+                getattr(directory_identity, "st_file_attributes", 0)
+            ) & 0x400
+            if not stat.S_ISDIR(directory_identity.st_mode) or directory_reparse:
+                dirnames[:] = []
+                continue
+            if dp == hermes_root and not _same_snapshot_object(
+                root_identity, directory_identity
+            ):
+                return None
+
+            # followlinks=False does not stop Windows directory junctions on
+            # supported Python versions. Inspect every child with lstat and
+            # prune symlinks/reparse points before os.walk can descend.
+            safe_directories = []
+            for dirname in dirnames:
+                if dirname in _EXCLUDED_DIRS:
+                    continue
+                child = dp / dirname
+                try:
+                    child_identity = child.lstat()
+                except OSError:
+                    continue
+                child_reparse = int(
+                    getattr(child_identity, "st_file_attributes", 0)
+                ) & 0x400
+                if stat.S_ISDIR(child_identity.st_mode) and not child_reparse:
+                    safe_directories.append(dirname)
+            dirnames[:] = safe_directories
 
             for fname in filenames:
                 fpath = dp / fname
@@ -1974,14 +2068,19 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
                         suffix=".db", delete=False, dir=str(out_path.parent)
                     ) as tmp_db_file:
                         tmp_db = Path(tmp_db_file.name)
-                        tmp_db_identity = os.fstat(tmp_db_file.fileno())
+                    tmp_db_identity = tmp_db.lstat()
+                    final_tmp_db_identity: list[os.stat_result] = []
                     try:
-                        if not _safe_copy_db(
+                        copied = _safe_copy_db(
                             abs_path,
                             tmp_db,
                             expected_dst_identity=tmp_db_identity,
                             expected_src_identity=source_identity,
-                        ):
+                            result_dst_identity=final_tmp_db_identity,
+                        )
+                        if final_tmp_db_identity:
+                            tmp_db_identity = final_tmp_db_identity[0]
+                        if not copied:
                             logger.warning(
                                 "Full-zip backup aborted: SQLite snapshot failed for %s",
                                 rel_path,

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -2063,6 +2063,7 @@ def _write_exclusive_snapshot_file(
     chunks: Iterator[bytes],
     *,
     bound_parent_fd: Optional[int] = None,
+    mode: Optional[int] = None,
 ) -> tuple[Path, os.stat_result, int]:
     """Write a new snapshot member without trusting a replaceable directory."""
     relative = PurePosixPath(relative_name)
@@ -2116,6 +2117,14 @@ def _write_exclusive_snapshot_file(
                     raise OSError("short write while creating snapshot member")
                 copied += written
                 view = view[written:]
+        # Apply POSIX modes through the already-open descriptor. Windows does
+        # not implement POSIX permissions, and pathname chmod can both race a
+        # replacement and change NTFS ctime before our identity revalidation.
+        if mode is not None and os.name != "nt":
+            try:
+                os.fchmod(fd, mode)
+            except OSError:
+                pass
         os.fsync(fd)
         after = os.fstat(fd)
         path_after = (
@@ -2767,6 +2776,7 @@ def restore_quick_snapshot(
                         stage_rel.as_posix(),
                         _opened_file_chunks(src, source_identity),
                         bound_parent_fd=parent_fd,
+                        mode=stat.S_IMODE(source_identity.st_mode),
                     )
                     if (
                         not _snapshot_directory_is_bound(
@@ -2777,20 +2787,6 @@ def restore_quick_snapshot(
                         )
                     ):
                         raise OSError("snapshot or restore destination changed")
-                    try:
-                        if os.name == "nt":
-                            os.chmod(
-                                stage, stat.S_IMODE(source_identity.st_mode)
-                            )
-                        else:
-                            os.chmod(
-                                stage.name,
-                                stat.S_IMODE(source_identity.st_mode),
-                                dir_fd=parent_fd,
-                                follow_symlinks=False,
-                            )
-                    except OSError:
-                        pass
                     current_stage = _bound_parent_stat(
                         parent_fd, dst.parent, stage.name
                     )

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -15,15 +15,95 @@ import shutil
 import sqlite3
 import sys
 import tempfile
+import threading
 import time
 import zipfile
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_default_hermes_root, get_hermes_home, display_hermes_home
 
 logger = logging.getLogger(__name__)
+
+
+# Backup creation and retention are shared by CLI, gateway, and migration
+# processes.  Keep a small in-process lock for threads and a byte-range lock for
+# separate processes; both are deliberately stdlib-only so backup safety does
+# not depend on an optional package being installed.
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - exercised on Windows
+    fcntl = None
+    try:
+        import msvcrt
+    except ImportError:  # pragma: no cover - unsupported Python platform
+        msvcrt = None
+else:
+    msvcrt = None
+
+_BACKUP_LOCKS: dict[str, threading.RLock] = {}
+_BACKUP_LOCKS_GUARD = threading.Lock()
+_BACKUP_LOCK_FILENAME = ".maintenance.lock"
+
+
+@contextmanager
+def _backup_maintenance_lock(root: Path) -> Iterator[None]:
+    """Serialize backup publication and family-specific pruning.
+
+    The lock file is intentionally inside the managed backup/snapshot root and
+    is excluded from full archives.  Lock acquisition errors propagate so a
+    caller can fail closed rather than pruning without ownership of the
+    maintenance operation.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    key = str(root.resolve())
+    with _BACKUP_LOCKS_GUARD:
+        thread_lock = _BACKUP_LOCKS.setdefault(key, threading.RLock())
+
+    with thread_lock:
+        lock_path = root / _BACKUP_LOCK_FILENAME
+        lock_file = open(lock_path, "a+b")
+        locked = False
+        try:
+            if fcntl is not None:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                locked = True
+            elif msvcrt is not None:
+                lock_file.seek(0, os.SEEK_END)
+                if lock_file.tell() == 0:
+                    lock_file.write(b"0")
+                    lock_file.flush()
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+                locked = True
+            else:  # pragma: no cover - a platform without either primitive
+                raise OSError("no supported inter-process file-lock primitive")
+            yield
+        finally:
+            if locked:
+                try:
+                    if fcntl is not None:
+                        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                    elif msvcrt is not None:
+                        lock_file.seek(0)
+                        msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+                finally:
+                    lock_file.close()
+            else:
+                lock_file.close()
+
+
+def _unique_archive_path(backup_dir: Path, prefix: str) -> Path:
+    """Return a deterministic unused archive path for one backup family."""
+    stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S-%f")
+    candidate = backup_dir / f"{prefix}{stamp}.zip"
+    suffix = 1
+    while candidate.exists():
+        candidate = backup_dir / f"{prefix}{stamp}-{suffix}.zip"
+        suffix += 1
+    return candidate
 
 
 # ---------------------------------------------------------------------------
@@ -852,10 +932,20 @@ def create_quick_snapshot(
         )
         return True
 
-    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-    snap_id = f"{ts}-{label}" if label else ts
-    snap_dir = root / snap_id
-    snap_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
+    base_id = f"{ts}-{label}" if label else ts
+    with _backup_maintenance_lock(root):
+        snap_id = base_id
+        suffix = 1
+        while True:
+            snap_dir = root / snap_id
+            try:
+                snap_dir.mkdir(parents=True, exist_ok=False)
+                break
+            except FileExistsError:
+                snap_id = f"{base_id}-{suffix}"
+                suffix += 1
+        (snap_dir / ".in-progress").touch()
 
     manifest: Dict[str, int] = {}  # rel_path -> file size
 
@@ -929,11 +1019,13 @@ def create_quick_snapshot(
     }
     with open(snap_dir / "manifest.json", "w", encoding="utf-8") as f:
         json.dump(meta, f, indent=2)
+    (snap_dir / ".in-progress").unlink(missing_ok=True)
 
     # Auto-prune. Defaults preserve historical manual /snapshot behavior; callers
     # with known high-churn safety snapshots (for example pre-update) can pass a
     # smaller keep value so large state.db copies do not accumulate indefinitely.
-    _prune_quick_snapshots(root, keep=_QUICK_DEFAULT_KEEP if keep is None else keep)
+    with _backup_maintenance_lock(root):
+        _prune_quick_snapshots(root, keep=_QUICK_DEFAULT_KEEP if keep is None else keep)
 
     logger.info("State snapshot created: %s (%d files)", snap_id, len(manifest))
     return snap_id
@@ -1159,7 +1251,10 @@ def _prune_quick_snapshots(root: Path, keep: int = _QUICK_DEFAULT_KEEP) -> int:
         return 0
 
     dirs = sorted(
-        (d for d in root.iterdir() if d.is_dir()),
+        (
+            d for d in root.iterdir()
+            if d.is_dir() and not (d / ".in-progress").exists()
+        ),
         key=lambda d: d.name,
         reverse=True,
     )
@@ -1180,7 +1275,9 @@ def prune_quick_snapshots(
     hermes_home: Optional[Path] = None,
 ) -> int:
     """Manually prune quick snapshots. Returns count deleted."""
-    return _prune_quick_snapshots(_quick_snapshot_root(hermes_home), keep=keep)
+    root = _quick_snapshot_root(hermes_home)
+    with _backup_maintenance_lock(root):
+        return _prune_quick_snapshots(root, keep=keep)
 
 
 def run_quick_backup(args) -> None:
@@ -1232,53 +1329,70 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
     if not files_to_add:
         return None
 
-    sqlite_snapshot_failed = False
+    temp_path: Optional[Path] = None
+    written_members = 0
     try:
-        with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+        # Publish through a sibling temporary file.  The destination is never
+        # opened until the complete archive has passed integrity checks, so a
+        # failed/crashed write cannot destroy an older recovery point.
+        with tempfile.NamedTemporaryFile(
+            suffix=".zip", delete=False, dir=str(out_path.parent)
+        ) as tmp:
+            temp_path = Path(tmp.name)
+
+        with zipfile.ZipFile(
+            temp_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6
+        ) as zf:
             for abs_path, rel_path in files_to_add:
-                try:
-                    if abs_path.suffix == ".db":
-                        # Stage the snapshot alongside the output zip so that the
-                        # temp file lives on the same filesystem.  The system
-                        # default (/tmp) may be a small tmpfs that cannot hold
-                        # large databases, causing silent backup incompleteness.
-                        with tempfile.NamedTemporaryFile(
-                            suffix=".db", delete=False, dir=str(out_path.parent)
-                        ) as tmp:
-                            tmp_db = Path(tmp.name)
-                        try:
-                            if not _safe_copy_db(abs_path, tmp_db):
-                                logger.warning(
-                                    "Full-zip backup aborted: SQLite snapshot failed for %s",
-                                    rel_path,
-                                )
-                                sqlite_snapshot_failed = True
-                                break
-                            zf.write(tmp_db, arcname=str(rel_path))
-                        finally:
-                            tmp_db.unlink(missing_ok=True)
-                    else:
-                        zf.write(abs_path, arcname=str(rel_path))
-                except (PermissionError, OSError, ValueError) as exc:
-                    logger.debug("Skipping %s in zip backup: %s", rel_path, exc)
-                    continue
-    except OSError as exc:
+                if abs_path.suffix == ".db":
+                    # Stage the snapshot alongside the output zip so that the
+                    # temp file lives on the same filesystem.  The system
+                    # default (/tmp) may be a small tmpfs that cannot hold
+                    # large databases, causing silent backup incompleteness.
+                    with tempfile.NamedTemporaryFile(
+                        suffix=".db", delete=False, dir=str(out_path.parent)
+                    ) as tmp_db_file:
+                        tmp_db = Path(tmp_db_file.name)
+                    try:
+                        if not _safe_copy_db(abs_path, tmp_db):
+                            logger.warning(
+                                "Full-zip backup aborted: SQLite snapshot failed for %s",
+                                rel_path,
+                            )
+                            return None
+                        zf.write(tmp_db, arcname=rel_path.as_posix())
+                        written_members += 1
+                    finally:
+                        tmp_db.unlink(missing_ok=True)
+                else:
+                    zf.write(abs_path, arcname=rel_path.as_posix())
+                    written_members += 1
+
+        if not written_members:
+            logger.warning("Full-zip backup aborted: no files could be written")
+            return None
+
+        # Re-open the closed archive before publication.  testzip() catches
+        # corrupt member data and namelist() ensures a non-empty archive.
+        with zipfile.ZipFile(temp_path, "r") as zf:
+            if not zf.namelist() or zf.testzip() is not None:
+                logger.warning("Full-zip backup aborted: archive integrity check failed")
+                return None
+
+        with open(temp_path, "r+b") as archive_file:
+            os.fsync(archive_file.fileno())
+        os.replace(temp_path, out_path)
+        temp_path = None
+        return out_path
+    except (PermissionError, OSError, ValueError, zipfile.BadZipFile) as exc:
         logger.warning("Full-zip backup: zip write failed: %s", exc)
-        # Best-effort cleanup of partial file
-        try:
-            out_path.unlink(missing_ok=True)
-        except OSError:
-            pass
         return None
-
-    if sqlite_snapshot_failed:
-        try:
-            out_path.unlink(missing_ok=True)
-        except OSError:
-            pass
-        return None
-
-    return out_path
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
 
 
 # ---------------------------------------------------------------------------
@@ -1357,15 +1471,17 @@ def create_pre_update_backup(
         logger.warning("Could not create pre-update backup dir %s: %s", backup_dir, exc)
         return None
 
-    stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
-    out_path = backup_dir / f"{_PRE_UPDATE_PREFIX}{stamp}.zip"
-
-    result = _write_full_zip_backup(out_path, hermes_root)
-    if result is None:
+    try:
+        with _backup_maintenance_lock(backup_dir):
+            out_path = _unique_archive_path(backup_dir, _PRE_UPDATE_PREFIX)
+            result = _write_full_zip_backup(out_path, hermes_root)
+            if result is None:
+                return None
+            _prune_pre_update_backups(backup_dir, keep=keep)
+            return out_path
+    except OSError as exc:
+        logger.warning("Could not publish pre-update backup: %s", exc)
         return None
-
-    _prune_pre_update_backups(backup_dir, keep=keep)
-    return out_path
 
 
 # ---------------------------------------------------------------------------
@@ -1382,7 +1498,7 @@ def _prune_pre_migration_backups(backup_dir: Path, keep: int) -> int:
     Only touches files matching ``pre-migration-*.zip`` so other backups in
     the same directory are never touched.
     """
-    keep = max(keep, 0)
+    keep = max(keep, 1)
     if not backup_dir.exists():
         return 0
 
@@ -1434,12 +1550,14 @@ def create_pre_migration_backup(
         logger.warning("Could not create pre-migration backup dir %s: %s", backup_dir, exc)
         return None
 
-    stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
-    out_path = backup_dir / f"{_PRE_MIGRATION_PREFIX}{stamp}.zip"
-
-    result = _write_full_zip_backup(out_path, hermes_root)
-    if result is None:
+    try:
+        with _backup_maintenance_lock(backup_dir):
+            out_path = _unique_archive_path(backup_dir, _PRE_MIGRATION_PREFIX)
+            result = _write_full_zip_backup(out_path, hermes_root)
+            if result is None:
+                return None
+            _prune_pre_migration_backups(backup_dir, keep=keep)
+            return out_path
+    except OSError as exc:
+        logger.warning("Could not publish pre-migration backup: %s", exc)
         return None
-
-    _prune_pre_migration_backups(backup_dir, keep=keep)
-    return out_path

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -14,6 +14,7 @@ import logging
 import os
 import shutil
 import sqlite3
+import stat
 import sys
 import tempfile
 import threading
@@ -935,6 +936,10 @@ def _remove_owned_snapshot_dir(
             not os.path.samestat(marker_identity, moved_marker.lstat())
             or json.loads(moved_marker.read_text(encoding="utf-8"))
             != marker_payload
+            or (
+                marker_name == _QUICK_OWNERSHIP_MARKER
+                and os.path.lexists(quarantine / _QUICK_IN_PROGRESS_MARKER)
+            )
         ):
             return False
         shutil.rmtree(quarantine)
@@ -952,19 +957,40 @@ def _snapshot_path_is_link_like(path: Path) -> bool:
         return True
 
 
-def _quick_snapshot_marker_payload(
+def _quick_snapshot_marker_evidence(
     snapshot_dir: Path, marker_name: str
-) -> Optional[Dict[str, Any]]:
+) -> Optional[tuple[Dict[str, Any], os.stat_result, os.stat_result]]:
     marker = snapshot_dir / marker_name
+    fd: Optional[int] = None
     try:
+        directory_stat = snapshot_dir.lstat()
+        marker_stat = marker.lstat()
+        directory_reparse = int(
+            getattr(directory_stat, "st_file_attributes", 0)
+        ) & 0x400
+        marker_reparse = int(getattr(marker_stat, "st_file_attributes", 0)) & 0x400
         if (
-            _snapshot_path_is_link_like(snapshot_dir)
-            or not snapshot_dir.is_dir()
-            or _snapshot_path_is_link_like(marker)
-            or not marker.is_file()
+            directory_reparse
+            or marker_reparse
+            or not stat.S_ISDIR(directory_stat.st_mode)
+            or not stat.S_ISREG(marker_stat.st_mode)
         ):
             return None
-        payload = json.loads(marker.read_text(encoding="utf-8"))
+        flags = os.O_RDONLY
+        if hasattr(os, "O_BINARY"):
+            flags |= os.O_BINARY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(marker, flags)
+        opened_marker_stat = os.fstat(fd)
+        if (
+            not stat.S_ISREG(opened_marker_stat.st_mode)
+            or not os.path.samestat(marker_stat, opened_marker_stat)
+        ):
+            return None
+        with os.fdopen(fd, "r", encoding="utf-8") as marker_file:
+            fd = None
+            payload = json.load(marker_file)
         token = payload.get("owner_token") if isinstance(payload, dict) else None
         if (
             not isinstance(payload, dict)
@@ -976,9 +1002,24 @@ def _quick_snapshot_marker_payload(
             or any(char not in "0123456789abcdef" for char in token)
         ):
             return None
-        return payload
+        if (
+            not os.path.samestat(directory_stat, snapshot_dir.lstat())
+            or not os.path.samestat(marker_stat, marker.lstat())
+        ):
+            return None
+        return payload, directory_stat, marker_stat
     except (OSError, UnicodeError, json.JSONDecodeError):
         return None
+    finally:
+        if fd is not None:
+            os.close(fd)
+
+
+def _quick_snapshot_marker_payload(
+    snapshot_dir: Path, marker_name: str
+) -> Optional[Dict[str, Any]]:
+    evidence = _quick_snapshot_marker_evidence(snapshot_dir, marker_name)
+    return evidence[0] if evidence is not None else None
 
 
 def _snapshot_process_is_running(pid: int) -> bool:
@@ -1426,48 +1467,48 @@ def _prune_quick_snapshots(root: Path, keep: int = _QUICK_DEFAULT_KEEP) -> int:
     deleted = 0
     now = time.time()
     for candidate in root.iterdir():
-        marker = candidate / _QUICK_IN_PROGRESS_MARKER
         try:
-            if (
-                now - marker.stat().st_mtime <= _QUICK_IN_PROGRESS_MAX_AGE_SECONDS
-            ):
-                continue
-            payload = _quick_snapshot_marker_payload(
+            evidence = _quick_snapshot_marker_evidence(
                 candidate, _QUICK_IN_PROGRESS_MARKER
             )
-            if payload is None or _snapshot_process_is_running(payload["pid"]):
+            if evidence is None:
+                continue
+            payload, directory_stat, marker_stat = evidence
+            if (
+                now - marker_stat.st_mtime <= _QUICK_IN_PROGRESS_MAX_AGE_SECONDS
+                or _snapshot_process_is_running(payload["pid"])
+            ):
                 continue
             if _remove_owned_snapshot_dir(
                 candidate,
-                candidate.lstat(),
+                directory_stat,
                 marker_name=_QUICK_IN_PROGRESS_MARKER,
-                marker_identity=marker.lstat(),
+                marker_identity=marker_stat,
                 marker_payload=payload,
             ):
                 deleted += 1
         except (OSError, ValueError, json.JSONDecodeError):
             continue
 
-    dirs = sorted(
-        (
-            d for d in root.iterdir()
-            if _quick_snapshot_marker_payload(d, _QUICK_OWNERSHIP_MARKER)
-            is not None
-            and not (d / _QUICK_IN_PROGRESS_MARKER).exists()
-        ),
-        key=lambda d: d.name,
-        reverse=True,
-    )
+    dirs = []
+    for candidate in root.iterdir():
+        evidence = _quick_snapshot_marker_evidence(
+            candidate, _QUICK_OWNERSHIP_MARKER
+        )
+        if evidence is not None and not os.path.lexists(
+            candidate / _QUICK_IN_PROGRESS_MARKER
+        ):
+            dirs.append((candidate, evidence))
+    dirs.sort(key=lambda item: item[0].name, reverse=True)
 
-    for d in dirs[keep:]:
+    for d, evidence in dirs[keep:]:
         try:
-            marker = d / _QUICK_OWNERSHIP_MARKER
-            payload = _quick_snapshot_marker_payload(d, _QUICK_OWNERSHIP_MARKER)
-            if payload is not None and _remove_owned_snapshot_dir(
+            payload, directory_stat, marker_stat = evidence
+            if _remove_owned_snapshot_dir(
                 d,
-                d.lstat(),
+                directory_stat,
                 marker_name=_QUICK_OWNERSHIP_MARKER,
-                marker_identity=marker.lstat(),
+                marker_identity=marker_stat,
                 marker_payload=payload,
             ):
                 deleted += 1

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -336,7 +336,12 @@ def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> 
 # SQLite safe copy
 # ---------------------------------------------------------------------------
 
-def _safe_copy_db(src: Path, dst: Path) -> bool:
+def _safe_copy_db(
+    src: Path,
+    dst: Path,
+    *,
+    expected_dst_identity: Optional[os.stat_result] = None,
+) -> bool:
     """Copy a SQLite database safely using the backup() API.
 
     Handles WAL mode — produces a consistent snapshot even while
@@ -345,18 +350,47 @@ def _safe_copy_db(src: Path, dst: Path) -> bool:
     """
     conn = None
     backup_conn = None
+    owner_fd: Optional[int] = None
+    created_here = False
+    success = False
     try:
+        if expected_dst_identity is None:
+            flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
+            if hasattr(os, "O_BINARY"):
+                flags |= os.O_BINARY
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            owner_fd = os.open(dst, flags, 0o600)
+            expected_dst_identity = os.fstat(owner_fd)
+            created_here = True
+        else:
+            selected = dst.lstat()
+            if (
+                not stat.S_ISREG(selected.st_mode)
+                or not os.path.samestat(selected, expected_dst_identity)
+            ):
+                logger.warning(
+                    "SQLite safe copy refused changed destination %s", dst
+                )
+                return False
+            flags = os.O_RDWR
+            if hasattr(os, "O_BINARY"):
+                flags |= os.O_BINARY
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            owner_fd = os.open(dst, flags)
+            if not os.path.samestat(os.fstat(owner_fd), expected_dst_identity):
+                logger.warning(
+                    "SQLite safe copy refused replaced destination %s", dst
+                )
+                return False
+
         conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
         backup_conn = sqlite3.connect(str(dst))
         conn.backup(backup_conn)
-        return True
+        success = True
     except Exception as exc:
         logger.warning("SQLite safe copy failed for %s: %s", src, exc)
-        try:
-            dst.unlink(missing_ok=True)
-        except OSError:
-            pass
-        return False
     finally:
         for connection in (backup_conn, conn):
             if connection is not None:
@@ -364,6 +398,29 @@ def _safe_copy_db(src: Path, dst: Path) -> bool:
                     connection.close()
                 except Exception:
                     pass
+        if owner_fd is not None:
+            try:
+                os.close(owner_fd)
+            except OSError:
+                pass
+
+    try:
+        current = dst.lstat()
+        success = bool(
+            success
+            and expected_dst_identity is not None
+            and stat.S_ISREG(current.st_mode)
+            and os.path.samestat(current, expected_dst_identity)
+        )
+    except OSError:
+        success = False
+
+    if not success and created_here and expected_dst_identity is not None:
+        try:
+            _remove_owned_snapshot_file(dst, expected_dst_identity)
+        except OSError:
+            pass
+    return success
 
 
 # ---------------------------------------------------------------------------
@@ -484,14 +541,20 @@ def run_backup(args) -> None:
                         suffix=".db", delete=False, dir=str(out_path.parent)
                     ) as tmp:
                         tmp_db = Path(tmp.name)
-                    if _safe_copy_db(abs_path, tmp_db):
-                        zf.write(tmp_db, arcname=str(rel_path))
-                        total_bytes += tmp_db.stat().st_size
-                        tmp_db.unlink(missing_ok=True)
-                    else:
-                        tmp_db.unlink(missing_ok=True)
-                        errors.append(f"  {rel_path}: SQLite safe copy failed")
-                        continue
+                        tmp_db_identity = os.fstat(tmp.fileno())
+                    try:
+                        if _safe_copy_db(
+                            abs_path,
+                            tmp_db,
+                            expected_dst_identity=tmp_db_identity,
+                        ):
+                            zf.write(tmp_db, arcname=str(rel_path))
+                            total_bytes += tmp_db.stat().st_size
+                        else:
+                            errors.append(f"  {rel_path}: SQLite safe copy failed")
+                            continue
+                    finally:
+                        _remove_owned_snapshot_file(tmp_db, tmp_db_identity)
                 else:
                     zf.write(abs_path, arcname=str(rel_path))
                     total_bytes += abs_path.stat().st_size
@@ -900,8 +963,21 @@ def _move_owned_snapshot_path(path: Path, expected: os.stat_result) -> Optional[
     """Move the exact expected object to a nonce sibling, or preserve it there."""
     quarantine = path.with_name(f".{path.name}.hermes-delete-{uuid.uuid4().hex}")
     try:
+        current = path.lstat()
+        if not os.path.samestat(expected, current):
+            return None
+        # Windows may recycle a just-unlinked file index immediately. Its
+        # creation timestamp remains independent evidence that the pathname
+        # still names the object we opened, rather than a race winner that
+        # inherited the same index.
+        if os.name == "nt" and expected.st_ctime_ns != current.st_ctime_ns:
+            return None
         os.replace(path, quarantine)
-        if os.path.samestat(expected, quarantine.lstat()):
+        moved = quarantine.lstat()
+        if (
+            os.path.samestat(expected, moved)
+            and (os.name != "nt" or expected.st_ctime_ns == moved.st_ctime_ns)
+        ):
             return quarantine
     except OSError:
         return None
@@ -1643,7 +1719,11 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
                         tmp_db = Path(tmp_db_file.name)
                         tmp_db_identity = os.fstat(tmp_db_file.fileno())
                     try:
-                        if not _safe_copy_db(abs_path, tmp_db):
+                        if not _safe_copy_db(
+                            abs_path,
+                            tmp_db,
+                            expected_dst_identity=tmp_db_identity,
+                        ):
                             logger.warning(
                                 "Full-zip backup aborted: SQLite snapshot failed for %s",
                                 rel_path,
@@ -1669,12 +1749,53 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
                 logger.warning("Full-zip backup aborted: archive integrity check failed")
                 return None
 
-        with open(temp_path, "r+b") as archive_file:
-            os.fsync(archive_file.fileno())
-        os.replace(temp_path, out_path)
-        temp_path = None
-        temp_identity = None
-        return out_path
+        candidate = out_path
+        for attempt in range(16):
+            if attempt:
+                candidate = out_path.with_name(
+                    f"{out_path.stem}-{uuid.uuid4().hex[:12]}{out_path.suffix}"
+                )
+                with zipfile.ZipFile(temp_path, "a") as zf:
+                    zf.comment = _archive_ownership_comment(candidate)
+
+            with open(temp_path, "r+b") as archive_file:
+                os.fsync(archive_file.fileno())
+                temp_identity = os.fstat(archive_file.fileno())
+
+            try:
+                if os.name == "nt":
+                    # Unlike os.replace(), Windows os.rename() fails when the
+                    # destination already exists.
+                    os.rename(temp_path, candidate)
+                    published_via_link = False
+                else:
+                    # link() is the portable no-replace publication primitive
+                    # on POSIX. The sibling temp and destination share a
+                    # filesystem by construction.
+                    os.link(temp_path, candidate, follow_symlinks=False)
+                    published_via_link = True
+            except FileExistsError:
+                continue
+
+            published = candidate.lstat()
+            if (
+                not stat.S_ISREG(published.st_mode)
+                or not os.path.samestat(published, temp_identity)
+            ):
+                logger.warning(
+                    "Full-zip backup: published archive identity changed: %s",
+                    candidate,
+                )
+                return None
+
+            if published_via_link:
+                _remove_owned_snapshot_file(temp_path, temp_identity)
+            temp_path = None
+            temp_identity = None
+            return candidate
+
+        logger.warning("Full-zip backup: destination kept colliding: %s", out_path)
+        return None
     except (PermissionError, OSError, ValueError, zipfile.BadZipFile) as exc:
         logger.warning("Full-zip backup: zip write failed: %s", exc)
         return None

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1405,7 +1405,7 @@ def _legacy_quick_snapshot_manifest(snapshot_dir: Path) -> Optional[Dict[str, An
     if (
         os.path.lexists(snapshot_dir / _QUICK_OWNERSHIP_MARKER)
         or os.path.lexists(snapshot_dir / _QUICK_IN_PROGRESS_MARKER)
-        or re.fullmatch(r"\d{8}-\d{6}(?:-\d{6})?(?:-[A-Za-z0-9_-]+)?", snapshot_dir.name)
+        or re.fullmatch(r"\d{8}-\d{6}(?:-[^/\\\x00-\x1f]+)?", snapshot_dir.name)
         is None
     ):
         return None
@@ -1433,6 +1433,24 @@ def _legacy_quick_snapshot_manifest(snapshot_dir: Path) -> Optional[Dict[str, An
             fd = None
             metadata = json.load(stream)
         if not isinstance(metadata, dict) or metadata.get("id") != snapshot_dir.name:
+            return None
+        timestamp = metadata.get("timestamp")
+        label = metadata.get("label")
+        if (
+            not isinstance(timestamp, str)
+            or re.fullmatch(r"\d{8}-\d{6}", timestamp) is None
+            or not (
+                (label is None and snapshot_dir.name == timestamp)
+                or (
+                    isinstance(label, str)
+                    and label
+                    and "/" not in label
+                    and "\\" not in label
+                    and all(ord(char) >= 32 for char in label)
+                    and snapshot_dir.name == f"{timestamp}-{label}"
+                )
+            )
+        ):
             return None
         files = metadata.get("files")
         if not isinstance(files, dict) or not files:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1968,13 +1968,23 @@ def _cmd_attachments(args: argparse.Namespace) -> int:
 
 
 def _cmd_attach_rm(args: argparse.Namespace) -> int:
-    """Delete an attachment by id (removes the row and the on-disk blob)."""
+    """Delete attachment metadata and any provenance-bound on-disk blob."""
     with kb.connect_closing() as conn:
         removed = kb.delete_attachment(conn, args.attachment_id)
     if removed is None:
         print(f"no such attachment: {args.attachment_id}", file=sys.stderr)
         return 1
-    print(f"Deleted attachment {args.attachment_id} ({removed.filename}) from {removed.task_id}")
+    if removed.unproven_blob_preserved:
+        print(
+            f"Removed legacy attachment {args.attachment_id} ({removed.filename}) "
+            f"from {removed.task_id}; preserved its unproven on-disk blob at "
+            f"{removed.stored_path}"
+        )
+    else:
+        print(
+            f"Deleted attachment {args.attachment_id} ({removed.filename}) "
+            f"from {removed.task_id}"
+        )
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3409,6 +3409,79 @@ def _filesystem_identity(st: os.stat_result) -> _FilesystemIdentity:
     )
 
 
+def _stat_is_reparse(st: os.stat_result) -> bool:
+    """Return whether Windows reports a reparse-point object."""
+    return bool(int(getattr(st, "st_file_attributes", 0)) & 0x400)
+
+
+def _exclusive_attachment_path(
+    dest_dir: Path,
+    safe_name: str,
+    data: bytes,
+) -> tuple[Path, _FilesystemIdentity]:
+    """Create one attachment without overwriting or following a race winner."""
+    directory_identity = dest_dir.lstat()
+    if (
+        not stat.S_ISDIR(directory_identity.st_mode)
+        or _stat_is_reparse(directory_identity)
+    ):
+        raise ValueError(f"attachment directory is not a regular directory: {dest_dir}")
+
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    while True:
+        dest_path = _collision_free_path(dest_dir, safe_name)
+        try:
+            fd = os.open(dest_path, flags, 0o600)
+        except FileExistsError:
+            # Another writer won after _collision_free_path() inspected the
+            # name. Recompute the next candidate and try exclusively again.
+            continue
+
+        created_identity: Optional[_FilesystemIdentity] = None
+        try:
+            with os.fdopen(fd, "wb", closefd=False) as stream:
+                stream.write(data)
+                stream.flush()
+                os.fsync(stream.fileno())
+            created = os.fstat(fd)
+            if not stat.S_ISREG(created.st_mode):
+                raise ValueError("attachment destination is not a regular file")
+            created_identity = _filesystem_identity(created)
+        except BaseException:
+            try:
+                created_identity = _filesystem_identity(os.fstat(fd))
+            except OSError:
+                pass
+            raise
+        finally:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            if created_identity is not None and sys.exc_info()[0] is not None:
+                _atomic_remove_expected_file(dest_path, created_identity)
+
+        try:
+            current = dest_path.lstat()
+            current_dir = dest_dir.lstat()
+        except OSError as exc:
+            _atomic_remove_expected_file(dest_path, created_identity)
+            raise ValueError("attachment path changed during creation") from exc
+        if (
+            _filesystem_identity(current) != created_identity
+            or not stat.S_ISREG(current.st_mode)
+            or not os.path.samestat(directory_identity, current_dir)
+        ):
+            _atomic_remove_expected_file(dest_path, created_identity)
+            raise ValueError("attachment path changed during creation")
+        return dest_path, created_identity
+
+
 def _encode_filesystem_identity(identity: Optional[_FilesystemIdentity]) -> Optional[str]:
     return json.dumps(identity) if identity is not None else None
 
@@ -3491,9 +3564,7 @@ def store_attachment_bytes(
     safe_name = _safe_attachment_name(filename)
     dest_dir = task_attachments_dir(task_id, board=board)
     dest_dir.mkdir(parents=True, exist_ok=True)
-    dest_path = _collision_free_path(dest_dir, safe_name)
-    dest_path.write_bytes(data)
-    dest_identity = _filesystem_identity(dest_path.lstat())
+    dest_path, dest_identity = _exclusive_attachment_path(dest_dir, safe_name, data)
     try:
         return add_attachment(
             conn,
@@ -5357,30 +5428,90 @@ def _scratch_workspace_is_owned(
     tenant: Optional[str],
 ) -> bool:
     """Prove exact task/board/tenant ownership of a path before deletion."""
-    expected = _canonical_scratch_workspace(task_id, board)
-    if expected is None:
-        return False
-    raw = workspace_path.expanduser()
-    try:
-        if not raw.is_absolute() or raw.is_symlink():
-            return False
-        canonical = raw.resolve(strict=True)
-    except (OSError, RuntimeError, ValueError):
-        return False
-    # Reject symlink/junction aliases and any path that is not the task's
-    # canonical root. The marker alone is not enough for an aliased path.
-    if os.path.normcase(str(raw)) != os.path.normcase(str(canonical)):
-        return False
-    if not _same_canonical_path(canonical, expected):
-        return False
-    if not canonical.is_dir():
-        return False
-    return _read_scratch_owner_marker(
-        canonical,
+    return _scratch_workspace_ownership_evidence(
+        workspace_path,
         task_id=task_id,
         board=board,
         tenant=tenant,
+    ) is not None
+
+
+def _scratch_workspace_ownership_evidence(
+    workspace_path: Path,
+    *,
+    task_id: str,
+    board: Optional[str],
+    tenant: Optional[str],
+) -> Optional[tuple[os.stat_result, os.stat_result]]:
+    """Return path-bound workspace and marker evidence, or fail closed."""
+    expected = _canonical_scratch_workspace(task_id, board)
+    if expected is None or not board:
+        return None
+    raw = workspace_path.expanduser()
+    marker = raw / _SCRATCH_OWNER_MARKER_NAME
+    marker_fd: Optional[int] = None
+    try:
+        if not raw.is_absolute():
+            return None
+        workspace_identity = raw.lstat()
+        marker_identity = marker.lstat()
+        if (
+            not stat.S_ISDIR(workspace_identity.st_mode)
+            or _stat_is_reparse(workspace_identity)
+            or not stat.S_ISREG(marker_identity.st_mode)
+            or _stat_is_reparse(marker_identity)
+        ):
+            return None
+        canonical = raw.resolve(strict=True)
+        flags = os.O_RDONLY
+        if hasattr(os, "O_BINARY"):
+            flags |= os.O_BINARY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        marker_fd = os.open(marker, flags)
+        opened_marker = os.fstat(marker_fd)
+        if (
+            not stat.S_ISREG(opened_marker.st_mode)
+            or not os.path.samestat(marker_identity, opened_marker)
+        ):
+            return None
+        with os.fdopen(marker_fd, "r", encoding="utf-8") as stream:
+            marker_fd = None
+            payload = json.load(stream)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    except (UnicodeError, json.JSONDecodeError, TypeError):
+        return None
+    finally:
+        if marker_fd is not None:
+            try:
+                os.close(marker_fd)
+            except OSError:
+                pass
+
+    # Reject symlink/junction aliases and any path that is not the task's
+    # canonical root. The marker alone is not enough for an aliased path.
+    if os.path.normcase(str(raw)) != os.path.normcase(str(canonical)):
+        return None
+    if not _same_canonical_path(canonical, expected):
+        return None
+    expected_payload = _owner_marker_payload(
+        task_id=task_id,
+        board=board,
+        tenant=tenant,
+        workspace=canonical,
     )
+    if payload != expected_payload:
+        return None
+    try:
+        if (
+            not os.path.samestat(workspace_identity, raw.lstat())
+            or not os.path.samestat(marker_identity, marker.lstat())
+        ):
+            return None
+    except OSError:
+        return None
+    return workspace_identity, marker_identity
 
 
 def _is_managed_scratch_path(p: Path) -> bool:
@@ -5429,12 +5560,13 @@ def _remove_managed_scratch_workspace(
     if workspace_kind != "scratch" or not workspace_path:
         return
     wp = Path(workspace_path).expanduser()
-    if not _scratch_workspace_is_owned(
+    ownership = _scratch_workspace_ownership_evidence(
         wp,
         task_id=task_id,
         board=board,
         tenant=tenant,
-    ):
+    )
+    if ownership is None:
         _log.warning(
             "Refusing to remove scratch workspace without exact owner proof "
             "for task %s: %s (board=%r, tenant=%r)",
@@ -5446,8 +5578,7 @@ def _remove_managed_scratch_workspace(
         return
     marker = wp / _SCRATCH_OWNER_MARKER_NAME
     try:
-        workspace_identity = wp.lstat()
-        marker_identity = marker.lstat()
+        workspace_identity, marker_identity = ownership
         quarantine = wp.with_name(
             f".{wp.name}.hermes-delete-{secrets.token_hex(16)}"
         )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3423,6 +3423,110 @@ def _stat_is_reparse(st: os.stat_result) -> bool:
     return bool(int(getattr(st, "st_file_attributes", 0)) & 0x400)
 
 
+def _opened_file_actual_path(fd: int, intended_path: Path) -> Path:
+    """Return the filesystem path bound to an open destination handle.
+
+    On Windows, resolving the pathname again is insufficient: an attacker can
+    replace a parent with a junction between the exclusive open and the first
+    write.  The kernel's final path for the already-open handle exposes the
+    directory the create actually traversed.  Other platforms still resolve
+    the created pathname so callers can use one binding check and cleanup path.
+    """
+    if os.name != "nt":
+        return intended_path.resolve(strict=True)
+
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    handle = msvcrt.get_osfhandle(fd)
+    if handle == -1:
+        raise OSError("could not obtain destination OS handle")
+    get_final_path = ctypes.WinDLL("kernel32", use_last_error=True).GetFinalPathNameByHandleW
+    get_final_path.argtypes = [
+        wintypes.HANDLE,
+        wintypes.LPWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+    ]
+    get_final_path.restype = wintypes.DWORD
+
+    capacity = 512
+    while True:
+        buffer = ctypes.create_unicode_buffer(capacity)
+        length = get_final_path(handle, buffer, capacity, 0)
+        if length == 0:
+            raise ctypes.WinError(ctypes.get_last_error())
+        if length < capacity:
+            raw_path = buffer.value
+            break
+        capacity = length + 1
+
+    if raw_path.startswith("\\\\?\\UNC\\"):
+        raw_path = "\\\\" + raw_path[8:]
+    elif raw_path.startswith("\\\\?\\"):
+        raw_path = raw_path[4:]
+    return Path(raw_path)
+
+
+def _same_resolved_path(left: Path, right: Path) -> bool:
+    """Compare already-resolved paths with Windows' case semantics."""
+    return os.path.normcase(os.path.normpath(str(left))) == os.path.normcase(
+        os.path.normpath(str(right))
+    )
+
+
+def _validate_opened_destination(
+    fd: int,
+    intended_path: Path,
+    actual_path: Path,
+    destination_dir: Path,
+    destination_dir_identity: os.stat_result,
+    destination_dir_resolved: Path,
+) -> os.stat_result:
+    """Bind an exclusive create to its exact file and directory before writes."""
+    opened = os.fstat(fd)
+    current_path = intended_path.lstat()
+    current_dir = destination_dir.lstat()
+    if (
+        not stat.S_ISREG(opened.st_mode)
+        or not stat.S_ISREG(current_path.st_mode)
+        or _stat_is_reparse(current_path)
+        or not os.path.samestat(opened, current_path)
+        or not stat.S_ISDIR(current_dir.st_mode)
+        or _stat_is_reparse(current_dir)
+        or not os.path.samestat(destination_dir_identity, current_dir)
+        or not _same_resolved_path(
+            actual_path, destination_dir_resolved / intended_path.name
+        )
+    ):
+        raise ValueError("destination path changed during exclusive creation")
+    return opened
+
+
+def _cleanup_opened_destination(
+    actual_path: Optional[Path],
+    opened: Optional[os.stat_result],
+    *,
+    require_empty: bool,
+) -> None:
+    """Remove only the exact object created through the open handle."""
+    if actual_path is None or opened is None:
+        return
+    try:
+        current = actual_path.lstat()
+        if (
+            not stat.S_ISREG(current.st_mode)
+            or _stat_is_reparse(current)
+            or not os.path.samestat(opened, current)
+            or (require_empty and current.st_size != 0)
+        ):
+            return
+        _atomic_remove_expected_file(actual_path, _filesystem_identity(current))
+    except OSError:
+        pass
+
+
 def _exclusive_attachment_path(
     dest_dir: Path,
     safe_name: str,
@@ -3435,6 +3539,9 @@ def _exclusive_attachment_path(
         or _stat_is_reparse(directory_identity)
     ):
         raise ValueError(f"attachment directory is not a regular directory: {dest_dir}")
+    directory_resolved = dest_dir.resolve(strict=True)
+    if not os.path.samestat(directory_identity, directory_resolved.lstat()):
+        raise ValueError("attachment directory changed during resolution")
 
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
     if hasattr(os, "O_BINARY"):
@@ -3452,9 +3559,21 @@ def _exclusive_attachment_path(
             continue
 
         created_stat: Optional[os.stat_result] = None
-        cleanup_created = False
+        actual_path: Optional[Path] = None
+        creation_failed = False
+        destination_touched = False
         try:
+            actual_path = _opened_file_actual_path(fd, dest_path)
+            created_stat = _validate_opened_destination(
+                fd,
+                dest_path,
+                actual_path,
+                dest_dir,
+                directory_identity,
+                directory_resolved,
+            )
             with os.fdopen(fd, "wb", closefd=False) as stream:
+                destination_touched = True
                 stream.write(data)
                 stream.flush()
                 os.fsync(stream.fileno())
@@ -3471,35 +3590,24 @@ def _exclusive_attachment_path(
             ):
                 raise ValueError("attachment path changed during creation")
         except BaseException:
-            try:
-                opened = os.fstat(fd)
-                current = dest_path.lstat()
-                if stat.S_ISREG(current.st_mode) and os.path.samestat(opened, current):
-                    created_stat = opened
-                    cleanup_created = True
-            except OSError:
-                pass
+            creation_failed = True
+            if created_stat is None:
+                try:
+                    created_stat = os.fstat(fd)
+                except OSError:
+                    pass
             raise
         finally:
             try:
                 os.close(fd)
             except OSError:
                 pass
-            if cleanup_created and created_stat is not None:
-                try:
-                    final_created = dest_path.lstat()
-                    final_dir = dest_dir.lstat()
-                    if (
-                        stat.S_ISREG(final_created.st_mode)
-                        and not _stat_is_reparse(final_created)
-                        and os.path.samestat(created_stat, final_created)
-                        and os.path.samestat(directory_identity, final_dir)
-                    ):
-                        _atomic_remove_expected_file(
-                            dest_path, _filesystem_identity(final_created)
-                        )
-                except OSError:
-                    pass
+            if creation_failed:
+                _cleanup_opened_destination(
+                    actual_path,
+                    created_stat,
+                    require_empty=not destination_touched,
+                )
 
         try:
             # Capture deletion provenance only after CloseHandle/close has
@@ -5059,6 +5167,9 @@ def _persist_scratch_completion_artifacts(
         dest: Optional[Path] = None
         dest_identity: Optional[_FilesystemIdentity] = None
         dest_opened: Optional[os.stat_result] = None
+        destination_actual: Optional[Path] = None
+        destination_bound = False
+        destination_touched = False
         attachment_dir_identity: Optional[os.stat_result] = None
         try:
             attachment_dir.mkdir(parents=True, exist_ok=True)
@@ -5070,17 +5181,45 @@ def _persist_scratch_completion_artifacts(
                 raise ArtifactPreservationError(
                     f"attachment destination is not a regular directory: {attachment_dir}"
                 )
+            attachment_dir_resolved = attachment_dir.resolve(strict=True)
+            if not os.path.samestat(
+                attachment_dir_identity, attachment_dir_resolved.lstat()
+            ):
+                raise ArtifactPreservationError(
+                    f"attachment destination changed during resolution: {attachment_dir}"
+                )
             dest = _unique_attachment_path(attachment_dir, resolved_src.name, used_destinations)
             source_flags = os.O_RDONLY
             if hasattr(os, "O_BINARY"):
                 source_flags |= os.O_BINARY
             if hasattr(os, "O_NOFOLLOW"):
                 source_flags |= os.O_NOFOLLOW
-            source_fd = os.open(resolved_src, source_flags)
-            with os.fdopen(source_fd, "rb") as source_file, dest.open(
-                "xb"
-            ) as destination_file:
+            destination_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            if hasattr(os, "O_BINARY"):
+                destination_flags |= os.O_BINARY
+            if hasattr(os, "O_NOFOLLOW"):
+                destination_flags |= os.O_NOFOLLOW
+            with contextlib.ExitStack() as stack:
+                source_fd = os.open(resolved_src, source_flags)
+                source_file = stack.enter_context(os.fdopen(source_fd, "rb"))
+                destination_fd = os.open(dest, destination_flags, 0o600)
+                destination_file = stack.enter_context(
+                    os.fdopen(destination_fd, "wb")
+                )
                 try:
+                    destination_actual = _opened_file_actual_path(destination_fd, dest)
+                    # Retain an identity even if the binding validation rejects,
+                    # so the exact still-empty create can be removed after close.
+                    dest_opened = os.fstat(destination_fd)
+                    dest_opened = _validate_opened_destination(
+                        destination_fd,
+                        dest,
+                        destination_actual,
+                        attachment_dir,
+                        attachment_dir_identity,
+                        attachment_dir_resolved,
+                    )
+                    destination_bound = True
                     source_before = os.fstat(source_file.fileno())
                     source_path_open = resolved_src.lstat()
                     if (
@@ -5099,6 +5238,7 @@ def _persist_scratch_completion_artifacts(
                             raise ArtifactPreservationError(
                                 f"declared scratch artifact grew beyond the size limit: {artifact}"
                             )
+                        destination_touched = True
                         destination_file.write(chunk)
                     source_after = os.fstat(source_file.fileno())
                     source_path_after = resolved_src.lstat()
@@ -5116,26 +5256,27 @@ def _persist_scratch_completion_artifacts(
                         destination_file.flush()
                         os.fsync(destination_file.fileno())
                     finally:
-                        try:
-                            dest_opened = os.fstat(destination_file.fileno())
-                            dest_path_open = dest.lstat()
-                            destination_dir_open = attachment_dir.lstat()
-                            if (
-                                not stat.S_ISREG(dest_opened.st_mode)
-                                or not stat.S_ISREG(dest_path_open.st_mode)
-                                or _stat_is_reparse(dest_path_open)
-                                or not os.path.samestat(dest_opened, dest_path_open)
-                                or attachment_dir_identity is None
-                                or not os.path.samestat(
-                                    attachment_dir_identity, destination_dir_open
-                                )
-                            ):
-                                raise ArtifactPreservationError(
-                                    "preserved artifact path changed during copy: "
-                                    f"{artifact}"
-                                )
-                        except OSError:
-                            dest_opened = None
+                        if destination_bound:
+                            try:
+                                dest_opened = os.fstat(destination_file.fileno())
+                                dest_path_open = dest.lstat()
+                                destination_dir_open = attachment_dir.lstat()
+                                if (
+                                    not stat.S_ISREG(dest_opened.st_mode)
+                                    or not stat.S_ISREG(dest_path_open.st_mode)
+                                    or _stat_is_reparse(dest_path_open)
+                                    or not os.path.samestat(dest_opened, dest_path_open)
+                                    or attachment_dir_identity is None
+                                    or not os.path.samestat(
+                                        attachment_dir_identity, destination_dir_open
+                                    )
+                                ):
+                                    raise ArtifactPreservationError(
+                                        "preserved artifact path changed during copy: "
+                                        f"{artifact}"
+                                    )
+                            except OSError:
+                                dest_opened = None
             if dest_opened is None:
                 raise ArtifactPreservationError(
                     f"could not bind preserved artifact identity: {artifact}"
@@ -5160,23 +5301,11 @@ def _persist_scratch_completion_artifacts(
                 )
             dest_identity = _filesystem_identity(dest_final)
         except BaseException as exc:
-            if dest is not None:
-                try:
-                    current_dest = dest.lstat()
-                    current_destination_dir = attachment_dir.lstat()
-                    if (
-                        dest_opened is not None
-                        and attachment_dir_identity is not None
-                        and os.path.samestat(dest_opened, current_dest)
-                        and os.path.samestat(
-                            attachment_dir_identity, current_destination_dir
-                        )
-                    ):
-                        _atomic_remove_expected_file(
-                            dest, _filesystem_identity(current_dest)
-                        )
-                except OSError:
-                    pass
+            _cleanup_opened_destination(
+                destination_actual,
+                dest_opened,
+                require_empty=not destination_touched,
+            )
             _discard_copies()
             if isinstance(exc, ArtifactPreservationError):
                 raise

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1101,6 +1101,7 @@ class Attachment:
     size: int
     uploaded_by: Optional[str]
     created_at: int
+    filesystem_identity: Optional[tuple[int, int, int, int, int, int]] = None
 
 
 @dataclass
@@ -1269,7 +1270,8 @@ CREATE TABLE IF NOT EXISTS task_attachments (
     content_type TEXT,
     size         INTEGER NOT NULL DEFAULT 0,
     uploaded_by  TEXT,
-    created_at   INTEGER NOT NULL
+    created_at   INTEGER NOT NULL,
+    filesystem_identity TEXT
 );
 
 -- Subscription from a gateway source (platform + chat + thread) to a
@@ -2386,6 +2388,22 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
                 conn, "kanban_notify_subs", "notifier_profile", "notifier_profile TEXT"
             )
 
+    attachment_table_exists = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='task_attachments'"
+    ).fetchone() is not None
+    if attachment_table_exists:
+        attachment_cols = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(task_attachments)")
+        }
+        if "filesystem_identity" not in attachment_cols:
+            _add_column_if_missing(
+                conn,
+                "task_attachments",
+                "filesystem_identity",
+                "filesystem_identity TEXT",
+            )
+
     # One-shot backfill: any task that is 'running' before runs existed
     # had its claim_lock / claim_expires / worker_pid on the task row.
     # Synthesize a matching task_runs row so subsequent end-run / heartbeat
@@ -3377,6 +3395,65 @@ def _collision_free_path(dest_dir: Path, safe_name: str) -> Path:
     return dest_dir / candidate
 
 
+_FilesystemIdentity = tuple[int, int, int, int, int, int]
+
+
+def _filesystem_identity(st: os.stat_result) -> _FilesystemIdentity:
+    return (
+        st.st_dev,
+        st.st_ino,
+        st.st_mode,
+        st.st_size,
+        st.st_mtime_ns,
+        st.st_ctime_ns,
+    )
+
+
+def _encode_filesystem_identity(identity: Optional[_FilesystemIdentity]) -> Optional[str]:
+    return json.dumps(identity) if identity is not None else None
+
+
+def _decode_filesystem_identity(raw: object) -> Optional[_FilesystemIdentity]:
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        values = json.loads(raw)
+        if (
+            not isinstance(values, list)
+            or len(values) != 6
+            or any(not isinstance(value, int) for value in values)
+        ):
+            return None
+        return tuple(values)  # type: ignore[return-value]
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def _atomic_remove_expected_file(path: Path, expected: _FilesystemIdentity) -> bool:
+    """Remove only the exact expected file, preserving mismatches for recovery."""
+    quarantine = path.with_name(
+        f".{path.name}.hermes-delete-{secrets.token_hex(16)}"
+    )
+    try:
+        current = path.lstat()
+        if (
+            not stat.S_ISREG(current.st_mode)
+            or _filesystem_identity(current) != expected
+        ):
+            return False
+        os.replace(path, quarantine)
+        moved = quarantine.lstat()
+        if (
+            not stat.S_ISREG(moved.st_mode)
+            or _filesystem_identity(moved) != expected
+        ):
+            return False
+        quarantine.unlink()
+        return True
+    except OSError:
+        return False
+
+
 def store_attachment_bytes(
     conn: sqlite3.Connection,
     task_id: str,
@@ -3416,6 +3493,7 @@ def store_attachment_bytes(
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest_path = _collision_free_path(dest_dir, safe_name)
     dest_path.write_bytes(data)
+    dest_identity = _filesystem_identity(dest_path.lstat())
     try:
         return add_attachment(
             conn,
@@ -3425,12 +3503,13 @@ def store_attachment_bytes(
             content_type=content_type,
             size=len(data),
             uploaded_by=uploaded_by,
+            filesystem_identity=dest_identity,
         )
     except Exception:
         # Don't leave an orphan blob if the metadata insert fails (most
         # commonly: the task id doesn't exist).
         try:
-            dest_path.unlink(missing_ok=True)
+            _atomic_remove_expected_file(dest_path, dest_identity)
         except OSError:
             pass
         raise
@@ -3445,6 +3524,7 @@ def add_attachment(
     content_type: Optional[str] = None,
     size: int = 0,
     uploaded_by: Optional[str] = None,
+    filesystem_identity: Optional[_FilesystemIdentity] = None,
 ) -> int:
     """Record a file attachment for a task. Returns the new attachment id.
 
@@ -3456,6 +3536,16 @@ def add_attachment(
         raise ValueError("attachment filename is required")
     if not stored_path or not stored_path.strip():
         raise ValueError("attachment stored_path is required")
+    stored = Path(stored_path)
+    try:
+        current_identity = _filesystem_identity(stored.lstat())
+        if stored.is_symlink() or not stat.S_ISREG(current_identity[2]):
+            current_identity = None
+    except OSError:
+        current_identity = None
+    if filesystem_identity is not None and current_identity != filesystem_identity:
+        raise ValueError("attachment filesystem identity changed before registration")
+    bound_identity = filesystem_identity or current_identity
     now = int(time.time())
     with write_txn(conn):
         if not conn.execute(
@@ -3464,8 +3554,8 @@ def add_attachment(
             raise ValueError(f"unknown task {task_id}")
         cur = conn.execute(
             "INSERT INTO task_attachments "
-            "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "(task_id, filename, stored_path, content_type, size, uploaded_by, "
+            "created_at, filesystem_identity) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 task_id,
                 filename.strip(),
@@ -3474,6 +3564,7 @@ def add_attachment(
                 int(size),
                 uploaded_by,
                 now,
+                _encode_filesystem_identity(bound_identity),
             ),
         )
         _append_event(
@@ -3500,6 +3591,11 @@ def list_attachments(conn: sqlite3.Connection, task_id: str) -> list[Attachment]
             size=r["size"] or 0,
             uploaded_by=r["uploaded_by"],
             created_at=r["created_at"],
+            filesystem_identity=_decode_filesystem_identity(
+                r["filesystem_identity"]
+                if "filesystem_identity" in r.keys()
+                else None
+            ),
         )
         for r in rows
     ]
@@ -3520,6 +3616,9 @@ def get_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[Att
         size=r["size"] or 0,
         uploaded_by=r["uploaded_by"],
         created_at=r["created_at"],
+        filesystem_identity=_decode_filesystem_identity(
+            r["filesystem_identity"] if "filesystem_identity" in r.keys() else None
+        ),
     )
 
 
@@ -3542,13 +3641,12 @@ def delete_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[
         p = Path(att.stored_path)
         board = _connection_board(conn)
         owned_root = task_attachments_dir(att.task_id, board=board).resolve(strict=False)
-        resolved = p.resolve(strict=True)
         if (
-            p.is_file()
-            and not p.is_symlink()
-            and resolved.parent == owned_root
+            att.filesystem_identity is not None
+            and p.is_absolute()
+            and p.parent.resolve(strict=True) == owned_root
         ):
-            p.unlink()
+            _atomic_remove_expected_file(p, att.filesystem_identity)
     except (OSError, ValueError):
         pass
     return att
@@ -4570,15 +4668,22 @@ def complete_task(
             return False
         if isinstance(metadata, dict):
             _persist_scratch_completion_artifacts(conn, task_id, metadata)
-            for stored_path in metadata.pop("_staged_artifacts", []):
+            for staged in metadata.pop("_staged_artifacts", []):
+                stored_path = staged["path"]
+                identity = tuple(staged["identity"])
                 path = Path(stored_path)
+                if _filesystem_identity(path.lstat()) != identity:
+                    raise ArtifactPreservationError(
+                        f"preserved artifact identity changed before registration: {path}"
+                    )
                 _insert_completion_attachment(
                     conn,
                     task_id,
                     filename=path.name,
                     stored_path=str(path),
-                    size=path.stat().st_size,
+                    size=identity[3],
                     created_at=now,
+                    filesystem_identity=identity,
                 )
         run_id = _end_run(
             conn, task_id,
@@ -4785,8 +4890,8 @@ def _persist_scratch_completion_artifacts(
         for copied in used_destinations:
             try:
                 expected = copied_identities.get(copied)
-                if expected is not None and _current_identity(copied) == expected:
-                    copied.unlink(missing_ok=True)
+                if expected is not None:
+                    _atomic_remove_expected_file(copied, expected)
             except OSError:
                 pass
         try:
@@ -4811,13 +4916,27 @@ def _persist_scratch_completion_artifacts(
             persisted.append(artifact)
             continue
 
-        if src.is_symlink() or not src.is_file():
+        try:
+            source_path_stat = resolved_src.lstat()
+            source_path_identity = _stat_identity(source_path_stat)
+            source_reparse = int(
+                getattr(source_path_stat, "st_file_attributes", 0)
+            ) & 0x400
+        except OSError:
+            source_path_identity = None
+            source_reparse = 0
+        if (
+            source_path_identity is None
+            or src.is_symlink()
+            or source_reparse
+            or not stat.S_ISREG(source_path_identity[2])
+        ):
             _discard_copies()
             raise ArtifactPreservationError(
                 f"declared scratch artifact is unavailable or not a regular file: {artifact}"
             )
 
-        size = resolved_src.stat().st_size
+        size = source_path_identity[3]
         if size > KANBAN_ATTACHMENT_MAX_BYTES:
             _discard_copies()
             raise ArtifactPreservationError(
@@ -4830,12 +4949,23 @@ def _persist_scratch_completion_artifacts(
         try:
             attachment_dir.mkdir(parents=True, exist_ok=True)
             dest = _unique_attachment_path(attachment_dir, resolved_src.name, used_destinations)
-            with resolved_src.open("rb") as source_file, dest.open("xb") as destination_file:
+            source_flags = os.O_RDONLY
+            if hasattr(os, "O_BINARY"):
+                source_flags |= os.O_BINARY
+            if hasattr(os, "O_NOFOLLOW"):
+                source_flags |= os.O_NOFOLLOW
+            source_fd = os.open(resolved_src, source_flags)
+            with os.fdopen(source_fd, "rb") as source_file, dest.open(
+                "xb"
+            ) as destination_file:
                 try:
                     source_before = _stat_identity(os.fstat(source_file.fileno()))
-                    if not stat.S_ISREG(source_before[2]):
+                    if (
+                        source_before != source_path_identity
+                        or not stat.S_ISREG(source_before[2])
+                    ):
                         raise ArtifactPreservationError(
-                            f"declared scratch artifact is not a regular file: {artifact}"
+                            f"declared scratch artifact identity changed before copy: {artifact}"
                         )
                     copied = 0
                     while chunk := source_file.read(1024 * 1024):
@@ -4864,8 +4994,8 @@ def _persist_scratch_completion_artifacts(
         except BaseException as exc:
             if dest is not None:
                 try:
-                    if dest_identity is not None and _current_identity(dest) == dest_identity:
-                        dest.unlink(missing_ok=True)
+                    if dest_identity is not None:
+                        _atomic_remove_expected_file(dest, dest_identity)
                 except OSError:
                     pass
             _discard_copies()
@@ -4882,6 +5012,12 @@ def _persist_scratch_completion_artifacts(
             raise ArtifactPreservationError(
                 f"could not bind preserved artifact identity: {artifact}"
             )
+        if _current_identity(dest) != dest_identity:
+            _atomic_remove_expected_file(dest, dest_identity)
+            _discard_copies()
+            raise ArtifactPreservationError(
+                f"preserved artifact identity changed before registration: {artifact}"
+            )
         used_destinations.add(dest)
         copied_identities[dest] = dest_identity
         persisted.append(str(dest.resolve()))
@@ -4891,9 +5027,13 @@ def _persist_scratch_completion_artifacts(
         metadata["artifacts"] = persisted
         attachment_root = attachment_dir.resolve()
         metadata["_staged_artifacts"] = [
-            path
+            {
+                "path": path,
+                "identity": list(copied_identities[Path(path)]),
+            }
             for path in persisted
             if Path(path).resolve().parent == attachment_root
+            and Path(path) in copied_identities
         ]
 
 
@@ -4905,13 +5045,32 @@ def _insert_completion_attachment(
     stored_path: str,
     size: int,
     created_at: int,
+    filesystem_identity: _FilesystemIdentity,
 ) -> None:
     """Record a worker-produced artifact in the existing attachment table."""
+    try:
+        current_identity = _filesystem_identity(Path(stored_path).lstat())
+    except OSError as exc:
+        raise ArtifactPreservationError(
+            f"preserved artifact disappeared before registration: {stored_path}"
+        ) from exc
+    if current_identity != filesystem_identity:
+        raise ArtifactPreservationError(
+            f"preserved artifact identity changed before registration: {stored_path}"
+        )
     conn.execute(
         "INSERT INTO task_attachments "
-        "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at) "
-        "VALUES (?, ?, ?, NULL, ?, 'kanban_complete', ?)",
-        (task_id, filename, stored_path, size, created_at),
+        "(task_id, filename, stored_path, content_type, size, uploaded_by, "
+        "created_at, filesystem_identity) "
+        "VALUES (?, ?, ?, NULL, ?, 'kanban_complete', ?, ?)",
+        (
+            task_id,
+            filename,
+            stored_path,
+            size,
+            created_at,
+            _encode_filesystem_identity(filesystem_identity),
+        ),
     )
     _append_event(
         conn,
@@ -5285,8 +5444,31 @@ def _remove_managed_scratch_workspace(
             tenant,
         )
         return
+    marker = wp / _SCRATCH_OWNER_MARKER_NAME
     try:
-        shutil.rmtree(wp)
+        workspace_identity = wp.lstat()
+        marker_identity = marker.lstat()
+        quarantine = wp.with_name(
+            f".{wp.name}.hermes-delete-{secrets.token_hex(16)}"
+        )
+        os.replace(wp, quarantine)
+        moved_marker = quarantine / _SCRATCH_OWNER_MARKER_NAME
+        if (
+            not os.path.samestat(workspace_identity, quarantine.lstat())
+            or not os.path.samestat(marker_identity, moved_marker.lstat())
+            or not _read_scratch_owner_marker(
+                quarantine,
+                task_id=task_id,
+                board=board,
+                tenant=tenant,
+            )
+        ):
+            _log.warning(
+                "Preserved scratch cleanup quarantine after ownership changed: %s",
+                quarantine,
+            )
+            return
+        shutil.rmtree(quarantine)
         _log.debug("Removed scratch workspace: %s", wp)
     except OSError as exc:
         _log.warning("Could not remove scratch workspace for task %s: %s", task_id, exc)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2403,41 +2403,6 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
                 "filesystem_identity",
                 "filesystem_identity TEXT",
             )
-        # Legacy rows predate exact deletion provenance. Backfill only files
-        # whose row name and absolute parent independently bind them to this
-        # task's managed attachment directory; anything ambiguous stays NULL
-        # and is preserved rather than adopted.
-        board_for_attachments = _connection_board(conn)
-        legacy_attachments = conn.execute(
-            "SELECT id, task_id, filename, stored_path FROM task_attachments "
-            "WHERE filesystem_identity IS NULL"
-        ).fetchall()
-        for attachment in legacy_attachments:
-            try:
-                stored = Path(attachment["stored_path"])
-                owned_root = task_attachments_dir(
-                    attachment["task_id"], board=board_for_attachments
-                ).resolve(strict=True)
-                selected = stored.lstat()
-                if (
-                    not stored.is_absolute()
-                    or stored.name != attachment["filename"]
-                    or stored.parent.resolve(strict=True) != owned_root
-                    or not stat.S_ISREG(selected.st_mode)
-                    or _stat_is_reparse(selected)
-                ):
-                    continue
-                conn.execute(
-                    "UPDATE task_attachments SET filesystem_identity = ? "
-                    "WHERE id = ? AND filesystem_identity IS NULL",
-                    (
-                        _encode_filesystem_identity(_filesystem_identity(selected)),
-                        attachment["id"],
-                    ),
-                )
-            except (OSError, RuntimeError, TypeError, ValueError):
-                continue
-
     # One-shot backfill: any task that is 'running' before runs existed
     # had its claim_lock / claim_expires / worker_pid on the task row.
     # Synthesize a matching task_runs row so subsequent end-run / heartbeat
@@ -3393,6 +3358,16 @@ class AttachmentTooLarge(ValueError):
     """
 
 
+class AttachmentOwnershipUnknown(RuntimeError):
+    """Raised when an attachment has no trustworthy deletion provenance.
+
+    Rows created before ``filesystem_identity`` was recorded cannot authorize
+    deleting whatever currently occupies their stored pathname.  Refusing the
+    whole operation keeps both the metadata row and the file available for
+    explicit operator recovery.
+    """
+
+
 def _safe_attachment_name(raw: str) -> str:
     """Reduce a client-supplied filename to a safe basename.
 
@@ -3476,19 +3451,32 @@ def _exclusive_attachment_path(
             # name. Recompute the next candidate and try exclusively again.
             continue
 
-        created_identity: Optional[_FilesystemIdentity] = None
+        created_stat: Optional[os.stat_result] = None
+        cleanup_created = False
         try:
             with os.fdopen(fd, "wb", closefd=False) as stream:
                 stream.write(data)
                 stream.flush()
                 os.fsync(stream.fileno())
-            created = os.fstat(fd)
-            if not stat.S_ISREG(created.st_mode):
+            created_stat = os.fstat(fd)
+            if not stat.S_ISREG(created_stat.st_mode):
                 raise ValueError("attachment destination is not a regular file")
-            created_identity = _filesystem_identity(created)
+            current = dest_path.lstat()
+            current_dir = dest_dir.lstat()
+            if (
+                not stat.S_ISREG(current.st_mode)
+                or _stat_is_reparse(current)
+                or not os.path.samestat(created_stat, current)
+                or not os.path.samestat(directory_identity, current_dir)
+            ):
+                raise ValueError("attachment path changed during creation")
         except BaseException:
             try:
-                created_identity = _filesystem_identity(os.fstat(fd))
+                opened = os.fstat(fd)
+                current = dest_path.lstat()
+                if stat.S_ISREG(current.st_mode) and os.path.samestat(opened, current):
+                    created_stat = opened
+                    cleanup_created = True
             except OSError:
                 pass
             raise
@@ -3497,23 +3485,40 @@ def _exclusive_attachment_path(
                 os.close(fd)
             except OSError:
                 pass
-            if created_identity is not None and sys.exc_info()[0] is not None:
-                _atomic_remove_expected_file(dest_path, created_identity)
+            if cleanup_created and created_stat is not None:
+                try:
+                    final_created = dest_path.lstat()
+                    final_dir = dest_dir.lstat()
+                    if (
+                        stat.S_ISREG(final_created.st_mode)
+                        and not _stat_is_reparse(final_created)
+                        and os.path.samestat(created_stat, final_created)
+                        and os.path.samestat(directory_identity, final_dir)
+                    ):
+                        _atomic_remove_expected_file(
+                            dest_path, _filesystem_identity(final_created)
+                        )
+                except OSError:
+                    pass
 
         try:
-            current = dest_path.lstat()
+            # Capture deletion provenance only after CloseHandle/close has
+            # published its final metadata.  Windows can legitimately update
+            # ctime at close, so an fstat captured before close is not a stable
+            # deletion token.
+            final = dest_path.lstat()
             current_dir = dest_dir.lstat()
         except OSError as exc:
-            _atomic_remove_expected_file(dest_path, created_identity)
             raise ValueError("attachment path changed during creation") from exc
         if (
-            _filesystem_identity(current) != created_identity
-            or not stat.S_ISREG(current.st_mode)
+            created_stat is None
+            or not stat.S_ISREG(final.st_mode)
+            or _stat_is_reparse(final)
+            or not os.path.samestat(created_stat, final)
             or not os.path.samestat(directory_identity, current_dir)
         ):
-            _atomic_remove_expected_file(dest_path, created_identity)
             raise ValueError("attachment path changed during creation")
-        return dest_path, created_identity
+        return dest_path, _filesystem_identity(final)
 
 
 def _encode_filesystem_identity(identity: Optional[_FilesystemIdentity]) -> Optional[str]:
@@ -3646,8 +3651,9 @@ def add_attachment(
         raise ValueError("attachment stored_path is required")
     stored = Path(stored_path)
     try:
-        current_identity = _filesystem_identity(stored.lstat())
-        if stored.is_symlink() or not stat.S_ISREG(current_identity[2]):
+        current = stored.lstat()
+        current_identity = _filesystem_identity(current)
+        if _stat_is_reparse(current) or not stat.S_ISREG(current.st_mode):
             current_identity = None
     except OSError:
         current_identity = None
@@ -3733,14 +3739,22 @@ def get_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[Att
 def delete_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[Attachment]:
     """Delete an attachment row and its on-disk blob. Returns the removed row.
 
-    Returns ``None`` when no row matched. The blob is removed best-effort
-    (a missing file is not an error); the metadata row is the source of
-    truth for whether an attachment "exists".
+    Returns ``None`` when no row matched. Raises
+    :class:`AttachmentOwnershipUnknown` for legacy rows that have no bound
+    filesystem identity; those rows and files are preserved for explicit
+    operator recovery. For provenance-bound rows, the blob is removed
+    best-effort (a missing or replaced file is not an error).
     """
     with write_txn(conn):
         att = get_attachment(conn, attachment_id)
         if att is None:
             return None
+        if att.filesystem_identity is None:
+            raise AttachmentOwnershipUnknown(
+                f"attachment {attachment_id} has no filesystem ownership provenance; "
+                "refusing deletion so its metadata row and file remain available "
+                "for operator recovery"
+            )
         conn.execute("DELETE FROM task_attachments WHERE id = ?", (attachment_id,))
         _append_event(
             conn, att.task_id, "attachment_removed", {"filename": att.filename}
@@ -4975,22 +4989,12 @@ def _persist_scratch_completion_artifacts(
     attachment_dir = task_attachments_dir(task_id, board=board)
     persisted: list[str] = []
     used_destinations: set[Path] = set()
-    copied_identities: dict[Path, tuple[int, int, int, int, int, int]] = {}
+    copied_identities: dict[Path, _FilesystemIdentity] = {}
     changed = False
 
-    def _stat_identity(st: os.stat_result) -> tuple[int, int, int, int, int, int]:
-        return (
-            st.st_dev,
-            st.st_ino,
-            st.st_mode,
-            st.st_size,
-            st.st_mtime_ns,
-            st.st_ctime_ns,
-        )
-
-    def _current_identity(path: Path) -> Optional[tuple[int, int, int, int, int, int]]:
+    def _current_identity(path: Path) -> Optional[_FilesystemIdentity]:
         try:
-            return _stat_identity(path.lstat())
+            return _filesystem_identity(path.lstat())
         except OSError:
             return None
 
@@ -5026,7 +5030,7 @@ def _persist_scratch_completion_artifacts(
 
         try:
             source_path_stat = resolved_src.lstat()
-            source_path_identity = _stat_identity(source_path_stat)
+            source_path_identity = _filesystem_identity(source_path_stat)
             source_reparse = int(
                 getattr(source_path_stat, "st_file_attributes", 0)
             ) & 0x400
@@ -5053,9 +5057,19 @@ def _persist_scratch_completion_artifacts(
             )
 
         dest: Optional[Path] = None
-        dest_identity: Optional[tuple[int, int, int, int, int, int]] = None
+        dest_identity: Optional[_FilesystemIdentity] = None
+        dest_opened: Optional[os.stat_result] = None
+        attachment_dir_identity: Optional[os.stat_result] = None
         try:
             attachment_dir.mkdir(parents=True, exist_ok=True)
+            attachment_dir_identity = attachment_dir.lstat()
+            if (
+                not stat.S_ISDIR(attachment_dir_identity.st_mode)
+                or _stat_is_reparse(attachment_dir_identity)
+            ):
+                raise ArtifactPreservationError(
+                    f"attachment destination is not a regular directory: {attachment_dir}"
+                )
             dest = _unique_attachment_path(attachment_dir, resolved_src.name, used_destinations)
             source_flags = os.O_RDONLY
             if hasattr(os, "O_BINARY"):
@@ -5067,10 +5081,13 @@ def _persist_scratch_completion_artifacts(
                 "xb"
             ) as destination_file:
                 try:
-                    source_before = _stat_identity(os.fstat(source_file.fileno()))
+                    source_before = os.fstat(source_file.fileno())
+                    source_path_open = resolved_src.lstat()
                     if (
-                        source_before != source_path_identity
-                        or not stat.S_ISREG(source_before[2])
+                        not os.path.samestat(source_path_stat, source_before)
+                        or not os.path.samestat(source_before, source_path_open)
+                        or not stat.S_ISREG(source_before.st_mode)
+                        or _stat_is_reparse(source_path_open)
                     ):
                         raise ArtifactPreservationError(
                             f"declared scratch artifact identity changed before copy: {artifact}"
@@ -5083,8 +5100,14 @@ def _persist_scratch_completion_artifacts(
                                 f"declared scratch artifact grew beyond the size limit: {artifact}"
                             )
                         destination_file.write(chunk)
-                    source_after = _stat_identity(os.fstat(source_file.fileno()))
-                    if source_after != source_before or copied != source_before[3]:
+                    source_after = os.fstat(source_file.fileno())
+                    source_path_after = resolved_src.lstat()
+                    if (
+                        _filesystem_identity(source_after)
+                        != _filesystem_identity(source_before)
+                        or not os.path.samestat(source_after, source_path_after)
+                        or copied != source_before.st_size
+                    ):
                         raise ArtifactPreservationError(
                             f"declared scratch artifact changed while being copied: {artifact}"
                         )
@@ -5094,16 +5117,64 @@ def _persist_scratch_completion_artifacts(
                         os.fsync(destination_file.fileno())
                     finally:
                         try:
-                            dest_identity = _stat_identity(
-                                os.fstat(destination_file.fileno())
-                            )
+                            dest_opened = os.fstat(destination_file.fileno())
+                            dest_path_open = dest.lstat()
+                            destination_dir_open = attachment_dir.lstat()
+                            if (
+                                not stat.S_ISREG(dest_opened.st_mode)
+                                or not stat.S_ISREG(dest_path_open.st_mode)
+                                or _stat_is_reparse(dest_path_open)
+                                or not os.path.samestat(dest_opened, dest_path_open)
+                                or attachment_dir_identity is None
+                                or not os.path.samestat(
+                                    attachment_dir_identity, destination_dir_open
+                                )
+                            ):
+                                raise ArtifactPreservationError(
+                                    "preserved artifact path changed during copy: "
+                                    f"{artifact}"
+                                )
                         except OSError:
-                            dest_identity = None
+                            dest_opened = None
+            if dest_opened is None:
+                raise ArtifactPreservationError(
+                    f"could not bind preserved artifact identity: {artifact}"
+                )
+            # Sample the durable deletion token after the destination handle
+            # closes. Windows may publish a legitimate final ctime at close.
+            dest_final = dest.lstat()
+            destination_dir_final = attachment_dir.lstat()
+            if (
+                not stat.S_ISREG(dest_final.st_mode)
+                or _stat_is_reparse(dest_final)
+                or not os.path.samestat(dest_opened, dest_final)
+                or dest_final.st_size != dest_opened.st_size
+                or dest_final.st_mtime_ns != dest_opened.st_mtime_ns
+                or attachment_dir_identity is None
+                or not os.path.samestat(
+                    attachment_dir_identity, destination_dir_final
+                )
+            ):
+                raise ArtifactPreservationError(
+                    f"preserved artifact identity changed after copy: {artifact}"
+                )
+            dest_identity = _filesystem_identity(dest_final)
         except BaseException as exc:
             if dest is not None:
                 try:
-                    if dest_identity is not None:
-                        _atomic_remove_expected_file(dest, dest_identity)
+                    current_dest = dest.lstat()
+                    current_destination_dir = attachment_dir.lstat()
+                    if (
+                        dest_opened is not None
+                        and attachment_dir_identity is not None
+                        and os.path.samestat(dest_opened, current_dest)
+                        and os.path.samestat(
+                            attachment_dir_identity, current_destination_dir
+                        )
+                    ):
+                        _atomic_remove_expected_file(
+                            dest, _filesystem_identity(current_dest)
+                        )
                 except OSError:
                     pass
             _discard_copies()
@@ -5481,15 +5552,34 @@ def _materialize_owned_scratch_workspace(
                         os.close(workspace_fd)
                     except OSError:
                         pass
-        elif not _read_scratch_owner_marker(
-            canonical,
-            task_id=task.id,
-            board=board_slug,
-            tenant=task.tenant,
-        ):
-            raise ValueError(
-                f"cannot prove ownership of existing scratch workspace: {canonical}"
-            )
+        else:
+            workspace_identity = canonical.lstat()
+            if (
+                not stat.S_ISDIR(workspace_identity.st_mode)
+                or _stat_is_reparse(workspace_identity)
+            ):
+                raise ValueError(
+                    f"scratch workspace is not a regular directory: {canonical}"
+                )
+            marker = canonical / _SCRATCH_OWNER_MARKER_NAME
+            try:
+                marker.lstat()
+            except FileNotFoundError:
+                # Compatibility for pre-v2 workspaces: they remain usable as
+                # checkpoints, but deliberately receive no ownership marker.
+                # Cleanup therefore cannot adopt or delete them later.
+                pass
+            else:
+                if not _read_scratch_owner_marker(
+                    canonical,
+                    task_id=task.id,
+                    board=board_slug,
+                    tenant=task.tenant,
+                ):
+                    raise ValueError(
+                        "cannot prove ownership of existing scratch workspace: "
+                        f"{canonical}"
+                    )
     except (OSError, ValueError) as exc:
         if isinstance(exc, ValueError):
             raise

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -79,6 +79,7 @@ import random
 import secrets
 import shutil
 import sqlite3
+import stat
 import subprocess
 import sys
 import threading
@@ -4761,13 +4762,20 @@ def _persist_scratch_completion_artifacts(
     attachment_dir = task_attachments_dir(task_id, board=board)
     persisted: list[str] = []
     used_destinations: set[Path] = set()
-    copied_identities: dict[Path, tuple[int, int, int, int, int]] = {}
+    copied_identities: dict[Path, tuple[int, int, int, int, int, int]] = {}
     changed = False
 
-    def _stat_identity(st: os.stat_result) -> tuple[int, int, int, int, int]:
-        return (st.st_dev, st.st_ino, st.st_mode, st.st_size, st.st_mtime_ns)
+    def _stat_identity(st: os.stat_result) -> tuple[int, int, int, int, int, int]:
+        return (
+            st.st_dev,
+            st.st_ino,
+            st.st_mode,
+            st.st_size,
+            st.st_mtime_ns,
+            st.st_ctime_ns,
+        )
 
-    def _current_identity(path: Path) -> Optional[tuple[int, int, int, int, int]]:
+    def _current_identity(path: Path) -> Optional[tuple[int, int, int, int, int, int]]:
         try:
             return _stat_identity(path.lstat())
         except OSError:
@@ -4803,7 +4811,7 @@ def _persist_scratch_completion_artifacts(
             persisted.append(artifact)
             continue
 
-        if not src.is_file():
+        if src.is_symlink() or not src.is_file():
             _discard_copies()
             raise ArtifactPreservationError(
                 f"declared scratch artifact is unavailable or not a regular file: {artifact}"
@@ -4818,12 +4826,17 @@ def _persist_scratch_completion_artifacts(
             )
 
         dest: Optional[Path] = None
-        dest_identity: Optional[tuple[int, int, int, int, int]] = None
+        dest_identity: Optional[tuple[int, int, int, int, int, int]] = None
         try:
             attachment_dir.mkdir(parents=True, exist_ok=True)
             dest = _unique_attachment_path(attachment_dir, resolved_src.name, used_destinations)
             with resolved_src.open("rb") as source_file, dest.open("xb") as destination_file:
                 try:
+                    source_before = _stat_identity(os.fstat(source_file.fileno()))
+                    if not stat.S_ISREG(source_before[2]):
+                        raise ArtifactPreservationError(
+                            f"declared scratch artifact is not a regular file: {artifact}"
+                        )
                     copied = 0
                     while chunk := source_file.read(1024 * 1024):
                         copied += len(chunk)
@@ -4832,14 +4845,23 @@ def _persist_scratch_completion_artifacts(
                                 f"declared scratch artifact grew beyond the size limit: {artifact}"
                             )
                         destination_file.write(chunk)
+                    source_after = _stat_identity(os.fstat(source_file.fileno()))
+                    if source_after != source_before or copied != source_before[3]:
+                        raise ArtifactPreservationError(
+                            f"declared scratch artifact changed while being copied: {artifact}"
+                        )
                 finally:
                     try:
                         destination_file.flush()
                         os.fsync(destination_file.fileno())
-                        dest_identity = _stat_identity(os.fstat(destination_file.fileno()))
-                    except OSError:
-                        dest_identity = None
-        except Exception as exc:
+                    finally:
+                        try:
+                            dest_identity = _stat_identity(
+                                os.fstat(destination_file.fileno())
+                            )
+                        except OSError:
+                            dest_identity = None
+        except BaseException as exc:
             if dest is not None:
                 try:
                     if dest_identity is not None and _current_identity(dest) == dest_identity:
@@ -4848,6 +4870,8 @@ def _persist_scratch_completion_artifacts(
                     pass
             _discard_copies()
             if isinstance(exc, ArtifactPreservationError):
+                raise
+            if not isinstance(exc, Exception):
                 raise
             raise ArtifactPreservationError(
                 f"could not preserve declared scratch artifact {artifact}: {exc}"
@@ -5100,11 +5124,11 @@ def _materialize_owned_scratch_workspace(
                     tenant=task.tenant,
                 )
             except Exception:
-                # We exclusively created this directory. Remove only the
-                # marker we attempted and the directory if it is otherwise
-                # empty, so an interrupted marker write can be retried safely.
+                # Never unlink marker evidence by pathname after an error: a
+                # concurrent writer may have replaced it. Remove only an
+                # actually empty directory; partial/foreign evidence remains
+                # fail-closed for an operator to inspect.
                 try:
-                    (canonical / _SCRATCH_OWNER_MARKER_NAME).unlink(missing_ok=True)
                     canonical.rmdir()
                 except OSError:
                     pass

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5062,6 +5062,212 @@ def _merge_completion_prose_artifacts(
     return updated
 
 
+@dataclass(frozen=True)
+class _ScratchArtifactSourceEvidence:
+    workspace: Path
+    workspace_resolved: Path
+    workspace_identity: os.stat_result
+    marker_identity: os.stat_result
+    source: Path
+    source_relative: Path
+    source_identity: os.stat_result
+    parent_identities: tuple[tuple[Path, os.stat_result], ...]
+    task_id: str
+    board: str
+    tenant: Optional[str]
+
+
+def _capture_scratch_artifact_source_evidence(
+    workspace: Path,
+    source: Path,
+    *,
+    ownership: tuple[os.stat_result, os.stat_result],
+    task_id: str,
+    board: str,
+    tenant: Optional[str],
+) -> _ScratchArtifactSourceEvidence:
+    """Bind a declared source to the owned workspace and every parent."""
+    workspace_identity, marker_identity = ownership
+    workspace_resolved = workspace.resolve(strict=True)
+    if not os.path.samestat(workspace_identity, workspace_resolved.lstat()):
+        raise ArtifactPreservationError("scratch workspace changed during binding")
+    try:
+        relative = source.relative_to(workspace_resolved)
+    except ValueError as exc:
+        raise ArtifactPreservationError(
+            f"declared scratch artifact escaped its workspace: {source}"
+        ) from exc
+    if not relative.parts or relative == Path("."):
+        raise ArtifactPreservationError(
+            f"declared scratch artifact is not a workspace file: {source}"
+        )
+
+    parents: list[tuple[Path, os.stat_result]] = []
+    current = workspace_resolved
+    for part in relative.parts[:-1]:
+        current = current / part
+        selected = current.lstat()
+        if not stat.S_ISDIR(selected.st_mode) or _stat_is_reparse(selected):
+            raise ArtifactPreservationError(
+                f"declared scratch artifact parent is not a regular directory: {current}"
+            )
+        parents.append((current, selected))
+
+    source_identity = source.lstat()
+    if not stat.S_ISREG(source_identity.st_mode) or _stat_is_reparse(source_identity):
+        raise ArtifactPreservationError(
+            f"declared scratch artifact is unavailable or not a regular file: {source}"
+        )
+    evidence = _ScratchArtifactSourceEvidence(
+        workspace=workspace,
+        workspace_resolved=workspace_resolved,
+        workspace_identity=workspace_identity,
+        marker_identity=marker_identity,
+        source=source,
+        source_relative=relative,
+        source_identity=source_identity,
+        parent_identities=tuple(parents),
+        task_id=task_id,
+        board=board,
+        tenant=tenant,
+    )
+    if not _scratch_artifact_source_evidence_is_current(evidence):
+        raise ArtifactPreservationError(
+            f"declared scratch artifact path changed while binding: {source}"
+        )
+    return evidence
+
+
+def _scratch_artifact_source_evidence_is_current(
+    evidence: _ScratchArtifactSourceEvidence,
+) -> bool:
+    """Revalidate the workspace marker, parent chain, and source pathname."""
+    ownership = _scratch_workspace_ownership_evidence(
+        evidence.workspace,
+        task_id=evidence.task_id,
+        board=evidence.board,
+        tenant=evidence.tenant,
+    )
+    if ownership is None:
+        return False
+    workspace_identity, marker_identity = ownership
+    try:
+        if (
+            not os.path.samestat(evidence.workspace_identity, workspace_identity)
+            or not os.path.samestat(evidence.marker_identity, marker_identity)
+            or evidence.workspace.resolve(strict=True) != evidence.workspace_resolved
+            or not os.path.samestat(
+                evidence.workspace_identity, evidence.workspace_resolved.lstat()
+            )
+        ):
+            return False
+        for parent, expected in evidence.parent_identities:
+            current = parent.lstat()
+            if (
+                not stat.S_ISDIR(current.st_mode)
+                or _stat_is_reparse(current)
+                or not os.path.samestat(expected, current)
+            ):
+                return False
+        current_source = evidence.source.lstat()
+        return bool(
+            stat.S_ISREG(current_source.st_mode)
+            and not _stat_is_reparse(current_source)
+            and os.path.samestat(evidence.source_identity, current_source)
+        )
+    except OSError:
+        return False
+
+
+def _opened_scratch_artifact_matches_workspace(
+    fd: int,
+    evidence: _ScratchArtifactSourceEvidence,
+) -> bool:
+    """On Windows, bind the source handle's final path to the workspace."""
+    if os.name != "nt":
+        return True
+    actual_path = _opened_file_actual_path(fd, evidence.source)
+    expected_path = evidence.workspace_resolved.joinpath(
+        *evidence.source_relative.parts
+    )
+    return _same_resolved_path(actual_path, expected_path)
+
+
+@contextlib.contextmanager
+def _open_bound_scratch_artifact(
+    evidence: _ScratchArtifactSourceEvidence,
+):
+    """Open a source through its bound parent chain and retain those handles."""
+    source_fd: Optional[int] = None
+    stream = None
+    directory_fds: list[int] = []
+    source_flags = os.O_RDONLY
+    if hasattr(os, "O_BINARY"):
+        source_flags |= os.O_BINARY
+    if hasattr(os, "O_NOFOLLOW"):
+        source_flags |= os.O_NOFOLLOW
+    try:
+        supports_dir_fd = os.name != "nt" and os.open in os.supports_dir_fd
+        if supports_dir_fd:
+            directory_flags = os.O_RDONLY
+            if hasattr(os, "O_DIRECTORY"):
+                directory_flags |= os.O_DIRECTORY
+            if hasattr(os, "O_NOFOLLOW"):
+                directory_flags |= os.O_NOFOLLOW
+            root_fd = os.open(evidence.workspace_resolved, directory_flags)
+            directory_fds.append(root_fd)
+            if not os.path.samestat(
+                evidence.workspace_identity, os.fstat(root_fd)
+            ):
+                raise ArtifactPreservationError(
+                    "scratch workspace handle identity changed"
+                )
+            parent_fd = root_fd
+            for (parent, expected), part in zip(
+                evidence.parent_identities,
+                evidence.source_relative.parts[:-1],
+                strict=True,
+            ):
+                opened_parent = os.open(part, directory_flags, dir_fd=parent_fd)
+                directory_fds.append(opened_parent)
+                if not os.path.samestat(expected, os.fstat(opened_parent)):
+                    raise ArtifactPreservationError(
+                        f"declared scratch artifact parent handle changed: {parent}"
+                    )
+                parent_fd = opened_parent
+            source_fd = os.open(
+                evidence.source_relative.name,
+                source_flags,
+                dir_fd=parent_fd,
+            )
+        else:
+            source_fd = os.open(evidence.source, source_flags)
+
+        opened = os.fstat(source_fd)
+        if not _opened_scratch_artifact_matches_workspace(source_fd, evidence):
+            raise ArtifactPreservationError(
+                "declared scratch artifact opened outside its bound workspace"
+            )
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or not os.path.samestat(evidence.source_identity, opened)
+            or not _scratch_artifact_source_evidence_is_current(evidence)
+        ):
+            raise ArtifactPreservationError(
+                f"declared scratch artifact identity changed before copy: {evidence.source}"
+            )
+        stream = os.fdopen(source_fd, "rb")
+        source_fd = None
+        yield stream, opened
+    finally:
+        if stream is not None:
+            stream.close()
+        elif source_fd is not None:
+            os.close(source_fd)
+        for directory_fd in reversed(directory_fds):
+            os.close(directory_fd)
+
+
 def _persist_scratch_completion_artifacts(
     conn: sqlite3.Connection,
     task_id: str,
@@ -5081,12 +5287,13 @@ def _persist_scratch_completion_artifacts(
 
     workspace = Path(row["workspace_path"]).expanduser()
     board = _connection_board(conn)
-    if not _scratch_workspace_is_owned(
+    workspace_ownership = _scratch_workspace_ownership_evidence(
         workspace,
         task_id=task_id,
         board=board,
         tenant=row["tenant"],
-    ):
+    )
+    if workspace_ownership is None or board is None:
         return
 
     try:
@@ -5137,26 +5344,33 @@ def _persist_scratch_completion_artifacts(
             continue
 
         try:
-            source_path_stat = resolved_src.lstat()
-            source_path_identity = _filesystem_identity(source_path_stat)
-            source_reparse = int(
-                getattr(source_path_stat, "st_file_attributes", 0)
-            ) & 0x400
-        except OSError:
-            source_path_identity = None
-            source_reparse = 0
-        if (
-            source_path_identity is None
-            or src.is_symlink()
-            or source_reparse
-            or not stat.S_ISREG(source_path_identity[2])
-        ):
+            declared_source = src.lstat()
+            if (
+                not stat.S_ISREG(declared_source.st_mode)
+                or _stat_is_reparse(declared_source)
+            ):
+                raise ArtifactPreservationError(
+                    "declared scratch artifact is unavailable or not a regular file: "
+                    f"{artifact}"
+                )
+            source_evidence = _capture_scratch_artifact_source_evidence(
+                workspace,
+                resolved_src,
+                ownership=workspace_ownership,
+                task_id=task_id,
+                board=board,
+                tenant=row["tenant"],
+            )
+        except ArtifactPreservationError:
+            _discard_copies()
+            raise
+        except OSError as exc:
             _discard_copies()
             raise ArtifactPreservationError(
                 f"declared scratch artifact is unavailable or not a regular file: {artifact}"
-            )
+            ) from exc
 
-        size = source_path_identity[3]
+        size = source_evidence.source_identity.st_size
         if size > KANBAN_ATTACHMENT_MAX_BYTES:
             _discard_copies()
             raise ArtifactPreservationError(
@@ -5188,20 +5402,18 @@ def _persist_scratch_completion_artifacts(
                 raise ArtifactPreservationError(
                     f"attachment destination changed during resolution: {attachment_dir}"
                 )
-            dest = _unique_attachment_path(attachment_dir, resolved_src.name, used_destinations)
-            source_flags = os.O_RDONLY
-            if hasattr(os, "O_BINARY"):
-                source_flags |= os.O_BINARY
-            if hasattr(os, "O_NOFOLLOW"):
-                source_flags |= os.O_NOFOLLOW
+            dest = _unique_attachment_path(
+                attachment_dir, source_evidence.source.name, used_destinations
+            )
             destination_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
             if hasattr(os, "O_BINARY"):
                 destination_flags |= os.O_BINARY
             if hasattr(os, "O_NOFOLLOW"):
                 destination_flags |= os.O_NOFOLLOW
             with contextlib.ExitStack() as stack:
-                source_fd = os.open(resolved_src, source_flags)
-                source_file = stack.enter_context(os.fdopen(source_fd, "rb"))
+                source_file, source_before = stack.enter_context(
+                    _open_bound_scratch_artifact(source_evidence)
+                )
                 destination_fd = os.open(dest, destination_flags, 0o600)
                 destination_file = stack.enter_context(
                     os.fdopen(destination_fd, "wb")
@@ -5220,13 +5432,13 @@ def _persist_scratch_completion_artifacts(
                         attachment_dir_resolved,
                     )
                     destination_bound = True
-                    source_before = os.fstat(source_file.fileno())
-                    source_path_open = resolved_src.lstat()
                     if (
-                        not os.path.samestat(source_path_stat, source_before)
-                        or not os.path.samestat(source_before, source_path_open)
-                        or not stat.S_ISREG(source_before.st_mode)
-                        or _stat_is_reparse(source_path_open)
+                        not os.path.samestat(
+                            source_evidence.source_identity, source_before
+                        )
+                        or not _scratch_artifact_source_evidence_is_current(
+                            source_evidence
+                        )
                     ):
                         raise ArtifactPreservationError(
                             f"declared scratch artifact identity changed before copy: {artifact}"
@@ -5241,12 +5453,13 @@ def _persist_scratch_completion_artifacts(
                         destination_touched = True
                         destination_file.write(chunk)
                     source_after = os.fstat(source_file.fileno())
-                    source_path_after = resolved_src.lstat()
                     if (
                         _filesystem_identity(source_after)
                         != _filesystem_identity(source_before)
-                        or not os.path.samestat(source_after, source_path_after)
                         or copied != source_before.st_size
+                        or not _scratch_artifact_source_evidence_is_current(
+                            source_evidence
+                        )
                     ):
                         raise ArtifactPreservationError(
                             f"declared scratch artifact changed while being copied: {artifact}"

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4918,6 +4918,42 @@ def _is_managed_scratch_path(p: Path) -> bool:
     return is_managed
 
 
+def _remove_managed_scratch_workspace(
+    task_id: str,
+    workspace_kind: Optional[str],
+    workspace_path: Optional[str],
+) -> None:
+    """Remove one scratch workspace after proving its ownership.
+
+    This helper deliberately accepts a captured kind/path instead of looking
+    the task up in SQLite.  Delete paths remove the row before their post-
+    commit cleanup runs, while completion/archive paths still use the normal
+    row-backed wrapper.  An absent or ambiguous path is retained.
+    """
+    if workspace_kind != "scratch" or not workspace_path:
+        return
+    wp = Path(workspace_path).expanduser()
+    if not wp.is_dir() and not wp.is_symlink():
+        return
+    if not _is_managed_scratch_path(wp):
+        _log.warning(
+            "Refusing to remove out-of-scratch workspace for task %s: %s "
+            "(workspace_kind='scratch' but path is outside any "
+            "kanban-managed workspaces root)",
+            task_id,
+            wp,
+        )
+        return
+    try:
+        if wp.is_symlink():
+            wp.unlink()
+        else:
+            shutil.rmtree(wp)
+        _log.debug("Removed scratch workspace: %s", wp)
+    except OSError as exc:
+        _log.warning("Could not remove scratch workspace for task %s: %s", task_id, exc)
+
+
 def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
     """Remove a task's scratch workspace dir and kill its stale tmux session.
 
@@ -4958,24 +4994,7 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
                 task_id, path,
             )
             return
-        import shutil
-        wp = Path(path)
-        if wp.is_dir():
-            # Containment guard (#28818): a board's ``default_workdir`` can
-            # pair ``workspace_kind='scratch'`` with a user-supplied path
-            # pointing at a real source tree. Without this check, task
-            # completion would unconditionally ``shutil.rmtree`` that path
-            # and silently delete the user's source data.
-            if _is_managed_scratch_path(wp):
-                shutil.rmtree(wp, ignore_errors=True)
-                _log.debug("Removed scratch workspace: %s", wp)
-            else:
-                _log.warning(
-                    "Refusing to remove out-of-scratch workspace for task %s: %s "
-                    "(workspace_kind='scratch' but path is outside any "
-                    "kanban-managed workspaces root)",
-                    task_id, wp,
-                )
+        _remove_managed_scratch_workspace(task_id, kind, path)
         # Also kill the tmux session for the worker that owned this task,
         # if the tmux session is now dead (worker process exited).
         _cleanup_worker_tmux(conn, task_id)
@@ -5896,6 +5915,10 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.
     recompute_ready(conn)
+    # Archived scratch tasks are terminal even when they never reached the
+    # normal completion path.  Clean only the captured managed workspace; the
+    # containment guard preserves user paths and ambiguous state.
+    _cleanup_workspace(conn, task_id)
     return True
 
 
@@ -5906,13 +5929,15 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
     tasks must be explicitly archived first so accidental data loss requires a
     second deliberate action.
     """
+    workspace: tuple[Optional[str], Optional[str]] | None = None
     with write_txn(conn):
         row = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?",
+            "SELECT status, workspace_kind, workspace_path FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if not row or row["status"] != "archived":
             return False
+        workspace = (row["workspace_kind"], row["workspace_path"])
         conn.execute(
             "DELETE FROM task_links WHERE parent_id = ? OR child_id = ?",
             (task_id, task_id),
@@ -5922,7 +5947,10 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
-        return cur.rowcount == 1
+        deleted = cur.rowcount == 1
+    if deleted and workspace is not None:
+        _remove_managed_scratch_workspace(task_id, *workspace)
+    return deleted
 
 
 def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
@@ -5935,7 +5963,15 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
     Returns ``True`` if the task existed and was deleted, ``False``
     if the task was not found.
     """
+    workspace: tuple[Optional[str], Optional[str]] | None = None
     with write_txn(conn):
+        row = conn.execute(
+            "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if row is None:
+            return False
+        workspace = (row["workspace_kind"], row["workspace_path"])
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         if cur.rowcount != 1:
             return False
@@ -5944,6 +5980,8 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
+    if workspace is not None:
+        _remove_managed_scratch_workspace(task_id, *workspace)
     recompute_ready(conn)
     return True
 
@@ -6489,8 +6527,21 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
             return ("nonzero_exit", code)
         if os.WIFSIGNALED(raw):
             return ("signaled", os.WTERMSIG(raw))
-    except Exception:
-        pass
+    except (AttributeError, OSError, ValueError):
+        # Windows does not expose the POSIX wait-status helpers, but tests and
+        # cross-platform supervisors can still hand us a POSIX-style raw
+        # status captured by a worker host. Decode the conventional layout
+        # without treating an unknown status as a successful exit.
+        if raw >= 0:
+            signal = raw & 0x7F
+            if signal == 0:
+                code = (raw >> 8) & 0xFF
+                if code == 0:
+                    return ("clean_exit", 0)
+                if code == KANBAN_RATE_LIMIT_EXIT_CODE:
+                    return ("rate_limited", code)
+                return ("nonzero_exit", code)
+            return ("signaled", signal)
     return ("unknown", None)
 
 
@@ -7514,6 +7565,11 @@ def _record_task_failure(
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.
+    # All recorded failures are terminal for this worker attempt.  Remove the
+    # disposable workspace now so retries materialize a clean, bounded path;
+    # the containment guard keeps persistent or ambiguous paths untouched.
+    if outcome in {"spawn_failed", "crashed", "timed_out"}:
+        _cleanup_workspace(conn, task_id)
     return blocked
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -143,6 +143,22 @@ KANBAN_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024
 # a different task.
 _SCRATCH_OWNER_MARKER_NAME = ".hermes-kanban-owner.json"
 _SCRATCH_OWNER_VERSION = 1
+_TXN_ROLLBACK_CLEANUPS: dict[int, list[Any]] = {}
+
+
+def _register_txn_rollback_cleanup(conn: sqlite3.Connection, callback: Any) -> None:
+    """Register filesystem cleanup if the connection's current txn rolls back."""
+    _TXN_ROLLBACK_CLEANUPS.setdefault(id(conn), []).append(callback)
+
+
+def _finish_txn_rollbacks(conn: sqlite3.Connection, *, run: bool) -> None:
+    callbacks = _TXN_ROLLBACK_CLEANUPS.pop(id(conn), [])
+    if run:
+        for callback in reversed(callbacks):
+            try:
+                callback()
+            except Exception:
+                pass
 
 
 def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None:
@@ -2657,6 +2673,7 @@ def write_txn(conn: sqlite3.Connection):
     a SQLite auto-rollback (which leaves no active transaction) does not
     shadow the original exception with a spurious rollback error.
     """
+    _finish_txn_rollbacks(conn, run=False)
     _execute_boundary_with_retry(conn, "BEGIN IMMEDIATE")
     try:
         yield conn
@@ -2668,6 +2685,7 @@ def write_txn(conn: sqlite3.Connection):
             # under EIO, lock contention, or corruption). Nothing to undo;
             # do not let this secondary failure shadow the real one.
             pass
+        _finish_txn_rollbacks(conn, run=True)
         raise
     else:
         try:
@@ -2679,7 +2697,9 @@ def write_txn(conn: sqlite3.Connection):
                 conn.execute("ROLLBACK")
             except sqlite3.OperationalError:
                 pass
+            _finish_txn_rollbacks(conn, run=True)
             raise
+        _finish_txn_rollbacks(conn, run=False)
         # Post-commit file-length check: header page_count must match actual file pages.
         # A discrepancy means a torn-extend — raise now rather than silently corrupt.
         _check_file_length_invariant(conn)
@@ -3519,9 +3539,16 @@ def delete_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[
         )
     try:
         p = Path(att.stored_path)
-        if p.is_file():
+        board = _connection_board(conn)
+        owned_root = task_attachments_dir(att.task_id, board=board).resolve(strict=False)
+        resolved = p.resolve(strict=True)
+        if (
+            p.is_file()
+            and not p.is_symlink()
+            and resolved.parent == owned_root
+        ):
             p.unlink()
-    except OSError:
+    except (OSError, ValueError):
         pass
     return att
 
@@ -4747,6 +4774,8 @@ def _persist_scratch_completion_artifacts(
         except OSError:
             pass
 
+    _register_txn_rollback_cleanup(conn, _discard_copies)
+
     for item in raw_artifacts:
         artifact = str(item).strip() if isinstance(item, str) else ""
         if not artifact:
@@ -4808,8 +4837,11 @@ def _persist_scratch_completion_artifacts(
 
     if changed:
         metadata["artifacts"] = persisted
+        attachment_root = attachment_dir.resolve()
         metadata["_staged_artifacts"] = [
-            path for path in persisted if path.startswith(str(attachment_dir.resolve()))
+            path
+            for path in persisted
+            if Path(path).resolve().parent == attachment_root
         ]
 
 
@@ -5032,12 +5064,23 @@ def _materialize_owned_scratch_workspace(
             if canonical.is_symlink() or not canonical.is_dir():
                 raise ValueError(f"scratch workspace is not a regular directory: {canonical}")
         if created:
-            _create_scratch_owner_marker(
-                canonical,
-                task_id=task.id,
-                board=board_slug,
-                tenant=task.tenant,
-            )
+            try:
+                _create_scratch_owner_marker(
+                    canonical,
+                    task_id=task.id,
+                    board=board_slug,
+                    tenant=task.tenant,
+                )
+            except Exception:
+                # We exclusively created this directory. Remove only the
+                # marker we attempted and the directory if it is otherwise
+                # empty, so an interrupted marker write can be retried safely.
+                try:
+                    (canonical / _SCRATCH_OWNER_MARKER_NAME).unlink(missing_ok=True)
+                    canonical.rmdir()
+                except OSError:
+                    pass
+                raise
         elif not _read_scratch_owner_marker(
             canonical,
             task_id=task.id,
@@ -7814,11 +7857,11 @@ def _record_task_failure(
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.
-    # All recorded failures are terminal for this worker attempt.  Remove the
-    # disposable workspace now so retries materialize a clean, bounded path;
-    # the containment guard keeps persistent or ambiguous paths untouched.
-    if outcome in {"spawn_failed", "crashed", "timed_out"}:
-        _cleanup_workspace(conn, task_id)
+    # Failure is not ownership transfer or permission to discard partial work.
+    # Preserve scratch across retries and after circuit-breaker blocking so a
+    # later worker or operator can resume from the exact failure checkpoint.
+    # Terminal lifecycle transitions (complete/archive/delete) remain the only
+    # places that remove an exact-owned scratch workspace.
     return blocked
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -143,7 +143,7 @@ KANBAN_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024
 # pre-existing directory (or an existing marker) is never silently claimed by
 # a different task.
 _SCRATCH_OWNER_MARKER_NAME = ".hermes-kanban-owner.json"
-_SCRATCH_OWNER_VERSION = 1
+_SCRATCH_OWNER_VERSION = 2
 _TXN_ROLLBACK_CLEANUPS: dict[int, list[Any]] = {}
 
 
@@ -2403,6 +2403,40 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
                 "filesystem_identity",
                 "filesystem_identity TEXT",
             )
+        # Legacy rows predate exact deletion provenance. Backfill only files
+        # whose row name and absolute parent independently bind them to this
+        # task's managed attachment directory; anything ambiguous stays NULL
+        # and is preserved rather than adopted.
+        board_for_attachments = _connection_board(conn)
+        legacy_attachments = conn.execute(
+            "SELECT id, task_id, filename, stored_path FROM task_attachments "
+            "WHERE filesystem_identity IS NULL"
+        ).fetchall()
+        for attachment in legacy_attachments:
+            try:
+                stored = Path(attachment["stored_path"])
+                owned_root = task_attachments_dir(
+                    attachment["task_id"], board=board_for_attachments
+                ).resolve(strict=True)
+                selected = stored.lstat()
+                if (
+                    not stored.is_absolute()
+                    or stored.name != attachment["filename"]
+                    or stored.parent.resolve(strict=True) != owned_root
+                    or not stat.S_ISREG(selected.st_mode)
+                    or _stat_is_reparse(selected)
+                ):
+                    continue
+                conn.execute(
+                    "UPDATE task_attachments SET filesystem_identity = ? "
+                    "WHERE id = ? AND filesystem_identity IS NULL",
+                    (
+                        _encode_filesystem_identity(_filesystem_identity(selected)),
+                        attachment["id"],
+                    ),
+                )
+            except (OSError, RuntimeError, TypeError, ValueError):
+                continue
 
     # One-shot backfill: any task that is 'running' before runs existed
     # had its claim_lock / claim_expires / worker_pid on the task row.
@@ -3518,7 +3552,10 @@ def _atomic_remove_expected_file(path: Path, expected: _FilesystemIdentity) -> b
         moved = quarantine.lstat()
         if (
             not stat.S_ISREG(moved.st_mode)
-            or _filesystem_identity(moved) != expected
+            or moved.st_dev != expected[0]
+            or moved.st_ino != expected[1]
+            or stat.S_IFMT(moved.st_mode) != stat.S_IFMT(expected[2])
+            or (os.name == "nt" and moved.st_ctime_ns != expected[5])
         ):
             return False
         quarantine.unlink()
@@ -5252,6 +5289,7 @@ def _owner_marker_payload(
     board: str,
     tenant: Optional[str],
     workspace: Path,
+    workspace_identity: os.stat_result,
 ) -> dict[str, Any]:
     return {
         "version": _SCRATCH_OWNER_VERSION,
@@ -5259,6 +5297,11 @@ def _owner_marker_payload(
         "board": board,
         "tenant": tenant,
         "workspace": str(workspace),
+        "workspace_identity": [
+            workspace_identity.st_dev,
+            workspace_identity.st_ino,
+            workspace_identity.st_ctime_ns if os.name == "nt" else None,
+        ],
     }
 
 
@@ -5268,12 +5311,20 @@ def _read_scratch_owner_marker(
     task_id: str,
     board: Optional[str],
     tenant: Optional[str],
+    expected_workspace: Optional[Path] = None,
 ) -> bool:
     """Validate the exact owner marker; malformed evidence fails closed."""
     if not board:
         return False
     marker = workspace / _SCRATCH_OWNER_MARKER_NAME
+    marker_workspace = expected_workspace or workspace
     try:
+        workspace_identity = workspace.lstat()
+        if (
+            not stat.S_ISDIR(workspace_identity.st_mode)
+            or _stat_is_reparse(workspace_identity)
+        ):
+            return False
         if marker.is_symlink() or not marker.is_file():
             return False
         payload = json.loads(marker.read_text(encoding="utf-8"))
@@ -5281,7 +5332,14 @@ def _read_scratch_owner_marker(
         return False
     if not isinstance(payload, dict):
         return False
-    if set(payload) != {"version", "task_id", "board", "tenant", "workspace"}:
+    if set(payload) != {
+        "version",
+        "task_id",
+        "board",
+        "tenant",
+        "workspace",
+        "workspace_identity",
+    }:
         return False
     if payload["version"] != _SCRATCH_OWNER_VERSION:
         return False
@@ -5289,9 +5347,17 @@ def _read_scratch_owner_marker(
         return False
     if payload["tenant"] != tenant or not isinstance(payload["workspace"], str):
         return False
+    if payload["workspace_identity"] != _owner_marker_payload(
+        task_id=task_id,
+        board=board,
+        tenant=tenant,
+        workspace=marker_workspace,
+        workspace_identity=workspace_identity,
+    )["workspace_identity"]:
+        return False
     # The marker must name the canonical workspace text, not an alias that
     # merely resolves to it.
-    return _same_canonical_path(Path(payload["workspace"]), workspace)
+    return _same_canonical_path(Path(payload["workspace"]), marker_workspace)
 
 
 def _create_scratch_owner_marker(
@@ -5300,7 +5366,9 @@ def _create_scratch_owner_marker(
     task_id: str,
     board: str,
     tenant: Optional[str],
-) -> None:
+    workspace_identity: os.stat_result,
+    workspace_fd: Optional[int],
+) -> os.stat_result:
     """Create a new marker without overwriting any pre-existing evidence."""
     marker = workspace / _SCRATCH_OWNER_MARKER_NAME
     payload = _owner_marker_payload(
@@ -5308,16 +5376,28 @@ def _create_scratch_owner_marker(
         board=board,
         tenant=tenant,
         workspace=workspace,
+        workspace_identity=workspace_identity,
     )
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
     if hasattr(os, "O_BINARY"):
         flags |= os.O_BINARY
-    fd = os.open(str(marker), flags, 0o600)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if workspace_fd is not None and os.open in os.supports_dir_fd:
+        fd = os.open(
+            _SCRATCH_OWNER_MARKER_NAME,
+            flags,
+            0o600,
+            dir_fd=workspace_fd,
+        )
+    else:
+        fd = os.open(str(marker), flags, 0o600)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
             json.dump(payload, stream, separators=(",", ":"), ensure_ascii=False)
             stream.flush()
             os.fsync(stream.fileno())
+            return os.fstat(stream.fileno())
     except Exception:
         # The marker may be partial after an interrupted write. Do not remove
         # or replace it: future cleanup must fail closed on that evidence.
@@ -5339,6 +5419,7 @@ def _materialize_owned_scratch_workspace(
     try:
         canonical.parent.mkdir(parents=True, exist_ok=True)
         created = False
+        workspace_fd: Optional[int] = None
         try:
             canonical.mkdir()
             created = True
@@ -5347,22 +5428,59 @@ def _materialize_owned_scratch_workspace(
                 raise ValueError(f"scratch workspace is not a regular directory: {canonical}")
         if created:
             try:
-                _create_scratch_owner_marker(
+                workspace_identity = canonical.lstat()
+                if (
+                    not stat.S_ISDIR(workspace_identity.st_mode)
+                    or _stat_is_reparse(workspace_identity)
+                ):
+                    raise ValueError(
+                        f"scratch workspace is not a regular directory: {canonical}"
+                    )
+                if os.name != "nt":
+                    directory_flags = os.O_RDONLY
+                    if hasattr(os, "O_BINARY"):
+                        directory_flags |= os.O_BINARY
+                    if hasattr(os, "O_DIRECTORY"):
+                        directory_flags |= os.O_DIRECTORY
+                    if hasattr(os, "O_NOFOLLOW"):
+                        directory_flags |= os.O_NOFOLLOW
+                    workspace_fd = os.open(canonical, directory_flags)
+                    if not os.path.samestat(
+                        workspace_identity, os.fstat(workspace_fd)
+                    ):
+                        raise ValueError(
+                            f"scratch workspace changed before marker creation: {canonical}"
+                        )
+                marker_identity = _create_scratch_owner_marker(
                     canonical,
                     task_id=task.id,
                     board=board_slug,
                     tenant=task.tenant,
+                    workspace_identity=workspace_identity,
+                    workspace_fd=workspace_fd,
                 )
+                current_workspace = canonical.lstat()
+                current_marker = (
+                    canonical / _SCRATCH_OWNER_MARKER_NAME
+                ).lstat()
+                if (
+                    not os.path.samestat(workspace_identity, current_workspace)
+                    or not os.path.samestat(marker_identity, current_marker)
+                ):
+                    raise ValueError(
+                        f"scratch workspace changed during marker creation: {canonical}"
+                    )
             except Exception:
-                # Never unlink marker evidence by pathname after an error: a
-                # concurrent writer may have replaced it. Remove only an
-                # actually empty directory; partial/foreign evidence remains
-                # fail-closed for an operator to inspect.
-                try:
-                    canonical.rmdir()
-                except OSError:
-                    pass
+                # Never remove by pathname after an error: a concurrent
+                # writer may have replaced the newly-created directory.
+                # Partial/foreign evidence remains fail-closed for inspection.
                 raise
+            finally:
+                if workspace_fd is not None:
+                    try:
+                        os.close(workspace_fd)
+                    except OSError:
+                        pass
         elif not _read_scratch_owner_marker(
             canonical,
             task_id=task.id,
@@ -5500,6 +5618,7 @@ def _scratch_workspace_ownership_evidence(
         board=board,
         tenant=tenant,
         workspace=canonical,
+        workspace_identity=workspace_identity,
     )
     if payload != expected_payload:
         return None
@@ -5592,6 +5711,7 @@ def _remove_managed_scratch_workspace(
                 task_id=task_id,
                 board=board,
                 tenant=tenant,
+                expected_workspace=wp,
             )
         ):
             _log.warning(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3844,13 +3844,87 @@ def get_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[Att
     )
 
 
+def _adopt_legacy_attachment_identity(
+    conn: sqlite3.Connection, attachment: Attachment
+) -> Optional[_FilesystemIdentity]:
+    """Bind a pre-provenance attachment row to its exact canonical blob."""
+    path = Path(attachment.stored_path)
+    try:
+        board = _connection_board(conn)
+        owned_dir = task_attachments_dir(attachment.task_id, board=board)
+        owned_dir_identity = owned_dir.lstat()
+        owned_dir_resolved = owned_dir.resolve(strict=True)
+        if (
+            not path.is_absolute()
+            or not stat.S_ISDIR(owned_dir_identity.st_mode)
+            or _stat_is_reparse(owned_dir_identity)
+            or path.name != attachment.filename
+            or path.parent.resolve(strict=True) != owned_dir_resolved
+        ):
+            return None
+
+        selected = path.lstat()
+        if (
+            not stat.S_ISREG(selected.st_mode)
+            or _stat_is_reparse(selected)
+            or selected.st_nlink != 1
+            or selected.st_size != attachment.size
+        ):
+            return None
+        flags = os.O_RDONLY
+        if hasattr(os, "O_BINARY"):
+            flags |= os.O_BINARY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags)
+        try:
+            opened = os.fstat(fd)
+            actual_path = _opened_file_actual_path(fd, path)
+            current = path.lstat()
+            current_dir = owned_dir.lstat()
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or _stat_is_reparse(opened)
+                or opened.st_nlink != 1
+                or not os.path.samestat(selected, opened)
+                or not os.path.samestat(opened, current)
+                or not os.path.samestat(owned_dir_identity, current_dir)
+                or not _same_resolved_path(
+                    actual_path, owned_dir_resolved / path.name
+                )
+            ):
+                return None
+        finally:
+            os.close(fd)
+
+        final = path.lstat()
+        current_dir = owned_dir.lstat()
+        if (
+            not stat.S_ISREG(final.st_mode)
+            or _stat_is_reparse(final)
+            or final.st_nlink != 1
+            or not os.path.samestat(selected, final)
+            or not os.path.samestat(owned_dir_identity, current_dir)
+        ):
+            return None
+        identity = _filesystem_identity(final)
+        updated = conn.execute(
+            "UPDATE task_attachments SET filesystem_identity = ? "
+            "WHERE id = ? AND filesystem_identity IS NULL",
+            (_encode_filesystem_identity(identity), attachment.id),
+        )
+        return identity if updated.rowcount == 1 else None
+    except (OSError, ValueError):
+        return None
+
+
 def delete_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[Attachment]:
     """Delete an attachment row and its on-disk blob. Returns the removed row.
 
-    Returns ``None`` when no row matched. Raises
-    :class:`AttachmentOwnershipUnknown` for legacy rows that have no bound
-    filesystem identity; those rows and files are preserved for explicit
-    operator recovery. For provenance-bound rows, the blob is removed
+    Returns ``None`` when no row matched. Legacy rows are adopted only when
+    their exact blob still exists in the canonical per-task directory with the
+    recorded size. Otherwise :class:`AttachmentOwnershipUnknown` preserves the
+    row and file for explicit recovery. Provenance-bound blobs are removed
     best-effort (a missing or replaced file is not an error).
     """
     with write_txn(conn):
@@ -3858,11 +3932,18 @@ def delete_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[
         if att is None:
             return None
         if att.filesystem_identity is None:
-            raise AttachmentOwnershipUnknown(
-                f"attachment {attachment_id} has no filesystem ownership provenance; "
-                "refusing deletion so its metadata row and file remain available "
-                "for operator recovery"
-            )
+            adopted = _adopt_legacy_attachment_identity(conn, att)
+            if adopted is None:
+                raise AttachmentOwnershipUnknown(
+                    f"attachment {attachment_id} has no safely adoptable filesystem "
+                    "ownership provenance; refusing deletion so its metadata row and "
+                    "file remain available for operator recovery"
+                )
+            att = get_attachment(conn, attachment_id)
+            if att is None or att.filesystem_identity is None:
+                raise AttachmentOwnershipUnknown(
+                    f"attachment {attachment_id} ownership adoption did not persist"
+                )
         conn.execute("DELETE FROM task_attachments WHERE id = ?", (attachment_id,))
         _append_event(
             conn, att.task_id, "attachment_removed", {"filename": att.filename}

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1102,6 +1102,7 @@ class Attachment:
     uploaded_by: Optional[str]
     created_at: int
     filesystem_identity: Optional[tuple[int, int, int, int, int, int]] = None
+    unproven_blob_preserved: bool = False
 
 
 @dataclass
@@ -3856,6 +3857,7 @@ def delete_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[
             conn, att.task_id, "attachment_removed", event_payload
         )
     if att.filesystem_identity is None:
+        att.unproven_blob_preserved = True
         return att
     try:
         p = Path(att.stored_path)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2677,7 +2677,7 @@ def write_txn(conn: sqlite3.Connection):
     _execute_boundary_with_retry(conn, "BEGIN IMMEDIATE")
     try:
         yield conn
-    except Exception:
+    except BaseException:
         try:
             conn.execute("ROLLBACK")
         except sqlite3.OperationalError:
@@ -4761,12 +4761,24 @@ def _persist_scratch_completion_artifacts(
     attachment_dir = task_attachments_dir(task_id, board=board)
     persisted: list[str] = []
     used_destinations: set[Path] = set()
+    copied_identities: dict[Path, tuple[int, int, int, int, int]] = {}
     changed = False
+
+    def _stat_identity(st: os.stat_result) -> tuple[int, int, int, int, int]:
+        return (st.st_dev, st.st_ino, st.st_mode, st.st_size, st.st_mtime_ns)
+
+    def _current_identity(path: Path) -> Optional[tuple[int, int, int, int, int]]:
+        try:
+            return _stat_identity(path.lstat())
+        except OSError:
+            return None
 
     def _discard_copies() -> None:
         for copied in used_destinations:
             try:
-                copied.unlink(missing_ok=True)
+                expected = copied_identities.get(copied)
+                if expected is not None and _current_identity(copied) == expected:
+                    copied.unlink(missing_ok=True)
             except OSError:
                 pass
         try:
@@ -4806,22 +4818,32 @@ def _persist_scratch_completion_artifacts(
             )
 
         dest: Optional[Path] = None
+        dest_identity: Optional[tuple[int, int, int, int, int]] = None
         try:
             attachment_dir.mkdir(parents=True, exist_ok=True)
             dest = _unique_attachment_path(attachment_dir, resolved_src.name, used_destinations)
             with resolved_src.open("rb") as source_file, dest.open("xb") as destination_file:
-                copied = 0
-                while chunk := source_file.read(1024 * 1024):
-                    copied += len(chunk)
-                    if copied > KANBAN_ATTACHMENT_MAX_BYTES:
-                        raise ArtifactPreservationError(
-                            f"declared scratch artifact grew beyond the size limit: {artifact}"
-                        )
-                    destination_file.write(chunk)
+                try:
+                    copied = 0
+                    while chunk := source_file.read(1024 * 1024):
+                        copied += len(chunk)
+                        if copied > KANBAN_ATTACHMENT_MAX_BYTES:
+                            raise ArtifactPreservationError(
+                                f"declared scratch artifact grew beyond the size limit: {artifact}"
+                            )
+                        destination_file.write(chunk)
+                finally:
+                    try:
+                        destination_file.flush()
+                        os.fsync(destination_file.fileno())
+                        dest_identity = _stat_identity(os.fstat(destination_file.fileno()))
+                    except OSError:
+                        dest_identity = None
         except Exception as exc:
             if dest is not None:
                 try:
-                    dest.unlink(missing_ok=True)
+                    if dest_identity is not None and _current_identity(dest) == dest_identity:
+                        dest.unlink(missing_ok=True)
                 except OSError:
                     pass
             _discard_copies()
@@ -4831,7 +4853,13 @@ def _persist_scratch_completion_artifacts(
                 f"could not preserve declared scratch artifact {artifact}: {exc}"
             ) from exc
 
+        if dest_identity is None:
+            _discard_copies()
+            raise ArtifactPreservationError(
+                f"could not bind preserved artifact identity: {artifact}"
+            )
         used_destinations.add(dest)
+        copied_identities[dest] = dest_identity
         persisted.append(str(dest.resolve()))
         changed = True
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3358,16 +3358,6 @@ class AttachmentTooLarge(ValueError):
     """
 
 
-class AttachmentOwnershipUnknown(RuntimeError):
-    """Raised when an attachment has no trustworthy deletion provenance.
-
-    Rows created before ``filesystem_identity`` was recorded cannot authorize
-    deleting whatever currently occupies their stored pathname.  Refusing the
-    whole operation keeps both the metadata row and the file available for
-    explicit operator recovery.
-    """
-
-
 def _safe_attachment_name(raw: str) -> str:
     """Reduce a client-supplied filename to a safe basename.
 
@@ -3844,110 +3834,29 @@ def get_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[Att
     )
 
 
-def _adopt_legacy_attachment_identity(
-    conn: sqlite3.Connection, attachment: Attachment
-) -> Optional[_FilesystemIdentity]:
-    """Bind a pre-provenance attachment row to its exact canonical blob."""
-    path = Path(attachment.stored_path)
-    try:
-        board = _connection_board(conn)
-        owned_dir = task_attachments_dir(attachment.task_id, board=board)
-        owned_dir_identity = owned_dir.lstat()
-        owned_dir_resolved = owned_dir.resolve(strict=True)
-        if (
-            not path.is_absolute()
-            or not stat.S_ISDIR(owned_dir_identity.st_mode)
-            or _stat_is_reparse(owned_dir_identity)
-            or path.name != attachment.filename
-            or path.parent.resolve(strict=True) != owned_dir_resolved
-        ):
-            return None
-
-        selected = path.lstat()
-        if (
-            not stat.S_ISREG(selected.st_mode)
-            or _stat_is_reparse(selected)
-            or selected.st_nlink != 1
-            or selected.st_size != attachment.size
-        ):
-            return None
-        flags = os.O_RDONLY
-        if hasattr(os, "O_BINARY"):
-            flags |= os.O_BINARY
-        if hasattr(os, "O_NOFOLLOW"):
-            flags |= os.O_NOFOLLOW
-        fd = os.open(path, flags)
-        try:
-            opened = os.fstat(fd)
-            actual_path = _opened_file_actual_path(fd, path)
-            current = path.lstat()
-            current_dir = owned_dir.lstat()
-            if (
-                not stat.S_ISREG(opened.st_mode)
-                or _stat_is_reparse(opened)
-                or opened.st_nlink != 1
-                or not os.path.samestat(selected, opened)
-                or not os.path.samestat(opened, current)
-                or not os.path.samestat(owned_dir_identity, current_dir)
-                or not _same_resolved_path(
-                    actual_path, owned_dir_resolved / path.name
-                )
-            ):
-                return None
-        finally:
-            os.close(fd)
-
-        final = path.lstat()
-        current_dir = owned_dir.lstat()
-        if (
-            not stat.S_ISREG(final.st_mode)
-            or _stat_is_reparse(final)
-            or final.st_nlink != 1
-            or not os.path.samestat(selected, final)
-            or not os.path.samestat(owned_dir_identity, current_dir)
-        ):
-            return None
-        identity = _filesystem_identity(final)
-        updated = conn.execute(
-            "UPDATE task_attachments SET filesystem_identity = ? "
-            "WHERE id = ? AND filesystem_identity IS NULL",
-            (_encode_filesystem_identity(identity), attachment.id),
-        )
-        return identity if updated.rowcount == 1 else None
-    except (OSError, ValueError):
-        return None
-
-
 def delete_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[Attachment]:
     """Delete an attachment row and its on-disk blob. Returns the removed row.
 
-    Returns ``None`` when no row matched. Legacy rows are adopted only when
-    their exact blob still exists in the canonical per-task directory with the
-    recorded size. Otherwise :class:`AttachmentOwnershipUnknown` preserves the
-    row and file for explicit recovery. Provenance-bound blobs are removed
-    best-effort (a missing or replaced file is not an error).
+    Returns ``None`` when no row matched. Legacy rows have no historical
+    filesystem identity, so their metadata is removed while the unproven blob
+    is preserved. Provenance-bound blobs are removed best-effort (a missing or
+    replaced file is not an error).
     """
     with write_txn(conn):
         att = get_attachment(conn, attachment_id)
         if att is None:
             return None
-        if att.filesystem_identity is None:
-            adopted = _adopt_legacy_attachment_identity(conn, att)
-            if adopted is None:
-                raise AttachmentOwnershipUnknown(
-                    f"attachment {attachment_id} has no safely adoptable filesystem "
-                    "ownership provenance; refusing deletion so its metadata row and "
-                    "file remain available for operator recovery"
-                )
-            att = get_attachment(conn, attachment_id)
-            if att is None or att.filesystem_identity is None:
-                raise AttachmentOwnershipUnknown(
-                    f"attachment {attachment_id} ownership adoption did not persist"
-                )
         conn.execute("DELETE FROM task_attachments WHERE id = ?", (attachment_id,))
+        event_payload: dict[str, Any] = {"filename": att.filename}
+        if att.filesystem_identity is None:
+            event_payload.update(
+                {"blob_preserved": True, "stored_path": att.stored_path}
+            )
         _append_event(
-            conn, att.task_id, "attachment_removed", {"filename": att.filename}
+            conn, att.task_id, "attachment_removed", event_payload
         )
+    if att.filesystem_identity is None:
+        return att
     try:
         p = Path(att.stored_path)
         board = _connection_board(conn)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -137,6 +137,13 @@ KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
 KANBAN_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024
 
+# A scratch workspace is removable only when this marker proves the exact
+# task/board/tenant/path owner. The marker is created with O_EXCL so a
+# pre-existing directory (or an existing marker) is never silently claimed by
+# a different task.
+_SCRATCH_OWNER_MARKER_NAME = ".hermes-kanban-owner.json"
+_SCRATCH_OWNER_VERSION = 1
+
 
 def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None:
     """Fire a kanban lifecycle plugin hook, fully best-effort.
@@ -4655,13 +4662,18 @@ def _merge_completion_prose_artifacts(
     exists so cleanup cannot erase the file the user was promised.
     """
     row = conn.execute(
-        "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
+        "SELECT workspace_kind, workspace_path, tenant FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if not row or row["workspace_kind"] != "scratch" or not row["workspace_path"]:
         return metadata
     workspace = Path(row["workspace_path"]).expanduser()
-    if not _is_managed_scratch_path(workspace):
+    if not _scratch_workspace_is_owned(
+        workspace,
+        task_id=task_id,
+        board=_connection_board(conn),
+        tenant=row["tenant"],
+    ):
         return metadata
     text = "\n".join(part for part in (summary, result) if part)
     if not text:
@@ -4698,15 +4710,20 @@ def _persist_scratch_completion_artifacts(
         return
 
     row = conn.execute(
-        "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
+        "SELECT workspace_kind, workspace_path, tenant FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if not row or row["workspace_kind"] != "scratch" or not row["workspace_path"]:
         return
 
     workspace = Path(row["workspace_path"]).expanduser()
-    is_managed, board = _managed_scratch_path_info(workspace)
-    if not is_managed:
+    board = _connection_board(conn)
+    if not _scratch_workspace_is_owned(
+        workspace,
+        task_id=task_id,
+        board=board,
+        tenant=row["tenant"],
+    ):
         return
 
     try:
@@ -4889,6 +4906,229 @@ def _managed_scratch_path_info(p: Path) -> tuple[bool, Optional[str]]:
     return False, None
 
 
+def _same_canonical_path(left: Path, right: Path) -> bool:
+    """Compare absolute paths with the host's case rules without resolving links."""
+    try:
+        return os.path.normcase(os.path.normpath(str(left))) == os.path.normcase(
+            os.path.normpath(str(right))
+        )
+    except (OSError, TypeError):
+        return False
+
+
+def _canonical_scratch_workspace(task_id: str, board: Optional[str]) -> Optional[Path]:
+    """Return the one canonical scratch path allowed for ``task_id``."""
+    if not board:
+        return None
+    try:
+        root = workspaces_root(board=board).expanduser().resolve(strict=False)
+        candidate = (root / task_id).resolve(strict=False)
+    except (OSError, ValueError):
+        return None
+    # A task id is a leaf name, never a relative path. Keep this explicit so
+    # malformed rows cannot turn the canonical path into a sibling/parent.
+    if candidate.parent != root or candidate.name != task_id:
+        return None
+    return candidate
+
+
+def _owner_marker_payload(
+    *,
+    task_id: str,
+    board: str,
+    tenant: Optional[str],
+    workspace: Path,
+) -> dict[str, Any]:
+    return {
+        "version": _SCRATCH_OWNER_VERSION,
+        "task_id": task_id,
+        "board": board,
+        "tenant": tenant,
+        "workspace": str(workspace),
+    }
+
+
+def _read_scratch_owner_marker(
+    workspace: Path,
+    *,
+    task_id: str,
+    board: Optional[str],
+    tenant: Optional[str],
+) -> bool:
+    """Validate the exact owner marker; malformed evidence fails closed."""
+    if not board:
+        return False
+    marker = workspace / _SCRATCH_OWNER_MARKER_NAME
+    try:
+        if marker.is_symlink() or not marker.is_file():
+            return False
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError, ValueError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    if set(payload) != {"version", "task_id", "board", "tenant", "workspace"}:
+        return False
+    if payload["version"] != _SCRATCH_OWNER_VERSION:
+        return False
+    if payload["task_id"] != task_id or payload["board"] != board:
+        return False
+    if payload["tenant"] != tenant or not isinstance(payload["workspace"], str):
+        return False
+    # The marker must name the canonical workspace text, not an alias that
+    # merely resolves to it.
+    return _same_canonical_path(Path(payload["workspace"]), workspace)
+
+
+def _create_scratch_owner_marker(
+    workspace: Path,
+    *,
+    task_id: str,
+    board: str,
+    tenant: Optional[str],
+) -> None:
+    """Create a new marker without overwriting any pre-existing evidence."""
+    marker = workspace / _SCRATCH_OWNER_MARKER_NAME
+    payload = _owner_marker_payload(
+        task_id=task_id,
+        board=board,
+        tenant=tenant,
+        workspace=workspace,
+    )
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    fd = os.open(str(marker), flags, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, separators=(",", ":"), ensure_ascii=False)
+            stream.flush()
+            os.fsync(stream.fileno())
+    except Exception:
+        # The marker may be partial after an interrupted write. Do not remove
+        # or replace it: future cleanup must fail closed on that evidence.
+        raise
+
+
+def _materialize_owned_scratch_workspace(
+    task: Task,
+    *,
+    board: Optional[str],
+) -> Path:
+    """Create/reuse only the canonical, marker-owned scratch directory."""
+    board_slug = _normalize_board_slug(board) or get_current_board()
+    canonical = _canonical_scratch_workspace(task.id, board_slug)
+    if canonical is None:
+        raise ValueError(
+            f"task {task.id} has no canonical scratch workspace for board {board_slug!r}"
+        )
+    try:
+        canonical.parent.mkdir(parents=True, exist_ok=True)
+        created = False
+        try:
+            canonical.mkdir()
+            created = True
+        except FileExistsError:
+            if canonical.is_symlink() or not canonical.is_dir():
+                raise ValueError(f"scratch workspace is not a regular directory: {canonical}")
+        if created:
+            _create_scratch_owner_marker(
+                canonical,
+                task_id=task.id,
+                board=board_slug,
+                tenant=task.tenant,
+            )
+        elif not _read_scratch_owner_marker(
+            canonical,
+            task_id=task.id,
+            board=board_slug,
+            tenant=task.tenant,
+        ):
+            raise ValueError(
+                f"cannot prove ownership of existing scratch workspace: {canonical}"
+            )
+    except (OSError, ValueError) as exc:
+        if isinstance(exc, ValueError):
+            raise
+        raise ValueError(f"could not materialize scratch workspace {canonical}: {exc}") from exc
+    return canonical
+
+
+def _connection_board(conn: sqlite3.Connection) -> Optional[str]:
+    """Infer the board identity from the DB file used by ``conn``."""
+    try:
+        row = conn.execute("PRAGMA database_list").fetchone()
+        db_file = row[2] if row is not None else None
+        if not db_file:
+            return None
+        db_path = Path(db_file).resolve(strict=False)
+        root = kanban_home().expanduser().resolve(strict=False)
+        candidates = [(DEFAULT_BOARD, root / "kanban.db")]
+        boards = root / "kanban" / "boards"
+        try:
+            entries = list(boards.iterdir())
+        except OSError:
+            entries = []
+        for entry in entries:
+            if entry.is_dir():
+                try:
+                    slug = _normalize_board_slug(entry.name)
+                except ValueError:
+                    continue
+                if slug:
+                    candidates.append((slug, entry / "kanban.db"))
+        for slug, candidate in candidates:
+            if _same_canonical_path(db_path, candidate.resolve(strict=False)):
+                return slug
+        # A dispatcher may deliberately pin a custom DB path. Only accept its
+        # explicit board identity when that override is present; without that
+        # independent context, ownership cannot be proven.
+        if os.environ.get("HERMES_KANBAN_DB", "").strip():
+            try:
+                env_board = _normalize_board_slug(os.environ.get("HERMES_KANBAN_BOARD"))
+            except ValueError:
+                return None
+            if env_board and board_exists(env_board):
+                return env_board
+    except (OSError, sqlite3.Error, TypeError, ValueError):
+        return None
+    return None
+
+
+def _scratch_workspace_is_owned(
+    workspace_path: Path,
+    *,
+    task_id: str,
+    board: Optional[str],
+    tenant: Optional[str],
+) -> bool:
+    """Prove exact task/board/tenant ownership of a path before deletion."""
+    expected = _canonical_scratch_workspace(task_id, board)
+    if expected is None:
+        return False
+    raw = workspace_path.expanduser()
+    try:
+        if not raw.is_absolute() or raw.is_symlink():
+            return False
+        canonical = raw.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    # Reject symlink/junction aliases and any path that is not the task's
+    # canonical root. The marker alone is not enough for an aliased path.
+    if os.path.normcase(str(raw)) != os.path.normcase(str(canonical)):
+        return False
+    if not _same_canonical_path(canonical, expected):
+        return False
+    if not canonical.is_dir():
+        return False
+    return _read_scratch_owner_marker(
+        canonical,
+        task_id=task_id,
+        board=board,
+        tenant=tenant,
+    )
+
+
 def _is_managed_scratch_path(p: Path) -> bool:
     """Return True iff *p* is a strict descendant of a kanban-managed scratch root.
 
@@ -4922,33 +5162,36 @@ def _remove_managed_scratch_workspace(
     task_id: str,
     workspace_kind: Optional[str],
     workspace_path: Optional[str],
+    *,
+    board: Optional[str],
+    tenant: Optional[str],
 ) -> None:
-    """Remove one scratch workspace after proving its ownership.
+    """Remove a scratch workspace only after exact owner proof.
 
-    This helper deliberately accepts a captured kind/path instead of looking
-    the task up in SQLite.  Delete paths remove the row before their post-
-    commit cleanup runs, while completion/archive paths still use the normal
-    row-backed wrapper.  An absent or ambiguous path is retained.
+    The task row may already be gone on delete paths, so callers capture the
+    board/tenant before deleting it. Missing, malformed, aliased, or mismatched
+    owner evidence is retained.
     """
     if workspace_kind != "scratch" or not workspace_path:
         return
     wp = Path(workspace_path).expanduser()
-    if not wp.is_dir() and not wp.is_symlink():
-        return
-    if not _is_managed_scratch_path(wp):
+    if not _scratch_workspace_is_owned(
+        wp,
+        task_id=task_id,
+        board=board,
+        tenant=tenant,
+    ):
         _log.warning(
-            "Refusing to remove out-of-scratch workspace for task %s: %s "
-            "(workspace_kind='scratch' but path is outside any "
-            "kanban-managed workspaces root)",
+            "Refusing to remove scratch workspace without exact owner proof "
+            "for task %s: %s (board=%r, tenant=%r)",
             task_id,
             wp,
+            board,
+            tenant,
         )
         return
     try:
-        if wp.is_symlink():
-            wp.unlink()
-        else:
-            shutil.rmtree(wp)
+        shutil.rmtree(wp)
         _log.debug("Removed scratch workspace: %s", wp)
     except OSError as exc:
         _log.warning("Could not remove scratch workspace for task %s: %s", task_id, exc)
@@ -4964,7 +5207,7 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
     """
     try:
         row = conn.execute(
-            "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
+            "SELECT workspace_kind, workspace_path, tenant FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if not row:
@@ -4994,7 +5237,13 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
                 task_id, path,
             )
             return
-        _remove_managed_scratch_workspace(task_id, kind, path)
+        _remove_managed_scratch_workspace(
+            task_id,
+            kind,
+            path,
+            board=_connection_board(conn),
+            tenant=row["tenant"],
+        )
         # Also kill the tmux session for the worker that owned this task,
         # if the tmux session is now dead (worker process exited).
         _cleanup_worker_tmux(conn, task_id)
@@ -5021,7 +5270,7 @@ def _try_cleanup_parent_workspaces(conn: sqlite3.Connection, task_id: str) -> No
         ).fetchall()
         for (parent_id,) in parents:
             row = conn.execute(
-                "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
+                "SELECT workspace_kind, workspace_path, tenant FROM tasks WHERE id = ?",
                 (parent_id,),
             ).fetchone()
             if not row or row["workspace_kind"] != "scratch" or not row["workspace_path"]:
@@ -5036,12 +5285,15 @@ def _try_cleanup_parent_workspaces(conn: sqlite3.Connection, task_id: str) -> No
             ).fetchone()
             if active:
                 continue  # still has active children
-            # All children done — safe to clean up parent workspace
-            import shutil
-            wp = Path(row["workspace_path"])
-            if wp.is_dir() and _is_managed_scratch_path(wp):
-                shutil.rmtree(wp, ignore_errors=True)
-                _log.debug("Deferred cleanup: removed parent %s scratch workspace: %s", parent_id, wp)
+            # All children done — remove only after proving the parent's
+            # exact marker ownership too.
+            _remove_managed_scratch_workspace(
+                parent_id,
+                row["workspace_kind"],
+                row["workspace_path"],
+                board=_connection_board(conn),
+                tenant=row["tenant"],
+            )
     except Exception:
         pass  # best-effort
 
@@ -5929,15 +6181,15 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
     tasks must be explicitly archived first so accidental data loss requires a
     second deliberate action.
     """
-    workspace: tuple[Optional[str], Optional[str]] | None = None
+    workspace: tuple[Optional[str], Optional[str], Optional[str]] | None = None
     with write_txn(conn):
         row = conn.execute(
-            "SELECT status, workspace_kind, workspace_path FROM tasks WHERE id = ?",
+            "SELECT status, workspace_kind, workspace_path, tenant FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if not row or row["status"] != "archived":
             return False
-        workspace = (row["workspace_kind"], row["workspace_path"])
+        workspace = (row["workspace_kind"], row["workspace_path"], row["tenant"])
         conn.execute(
             "DELETE FROM task_links WHERE parent_id = ? OR child_id = ?",
             (task_id, task_id),
@@ -5949,7 +6201,12 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         deleted = cur.rowcount == 1
     if deleted and workspace is not None:
-        _remove_managed_scratch_workspace(task_id, *workspace)
+        _remove_managed_scratch_workspace(
+            task_id,
+            *workspace[:2],
+            board=_connection_board(conn),
+            tenant=workspace[2],
+        )
     return deleted
 
 
@@ -5963,15 +6220,15 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
     Returns ``True`` if the task existed and was deleted, ``False``
     if the task was not found.
     """
-    workspace: tuple[Optional[str], Optional[str]] | None = None
+    workspace: tuple[Optional[str], Optional[str], Optional[str]] | None = None
     with write_txn(conn):
         row = conn.execute(
-            "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
+            "SELECT workspace_kind, workspace_path, tenant FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if row is None:
             return False
-        workspace = (row["workspace_kind"], row["workspace_path"])
+        workspace = (row["workspace_kind"], row["workspace_path"], row["tenant"])
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         if cur.rowcount != 1:
             return False
@@ -5981,7 +6238,12 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
     if workspace is not None:
-        _remove_managed_scratch_workspace(task_id, *workspace)
+        _remove_managed_scratch_workspace(
+            task_id,
+            *workspace[:2],
+            board=_connection_board(conn),
+            tenant=workspace[2],
+        )
     recompute_ready(conn)
     return True
 
@@ -6237,20 +6499,7 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
     """
     kind = task.workspace_kind or "scratch"
     if kind == "scratch":
-        if task.workspace_path:
-            # Legacy scratch tasks that were set to an explicit path get the
-            # same absolute-path guard as dir: — consistent with the
-            # threat model.
-            p = Path(task.workspace_path).expanduser()
-            if not p.is_absolute():
-                raise ValueError(
-                    f"task {task.id} has non-absolute workspace_path "
-                    f"{task.workspace_path!r}; workspace paths must be absolute"
-                )
-        else:
-            p = workspaces_root(board=board) / task.id
-        p.mkdir(parents=True, exist_ok=True)
-        return p
+        return _materialize_owned_scratch_workspace(task, board=board)
     if kind == "dir":
         if not task.workspace_path:
             raise ValueError(

--- a/plugins/disk-cleanup/README.md
+++ b/plugins/disk-cleanup/README.md
@@ -13,8 +13,8 @@ never needs to remember to call a tool.
 
 | Hook | Behaviour |
 |---|---|
-| `post_tool_call` | When `write_file` / `terminal` / `patch` creates a file matching `test_*`, `tmp_*`, or `*.test.*` inside `HERMES_HOME`, track it silently as `test` / `temp` / `cron-output`. |
-| `on_session_end` | If any test files were auto-tracked during this turn, run `quick` cleanup (no prompts). |
+| `post_tool_call` | When `write_file` proves creation of a regular file matching `test_*`, `tmp_*`, or `*.test.*` inside `HERMES_HOME`, bind its filesystem identity and track it silently as `test` / `temp` / `cron-output`. Terminal and patch output is not trusted as creation proof. |
+| `on_session_end` | If test files were auto-tracked during this turn, clean only the unchanged files owned by that exact session. |
 
 Deletion rules (same as the original PR):
 
@@ -23,7 +23,7 @@ Deletion rules (same as the original PR):
 | `test` | every session end | Never |
 | `temp` | >7 days since tracked | Never |
 | `cron-output` | >14 days since tracked | Never |
-| empty dirs under HERMES_HOME | always | Never |
+| empty dirs under explicitly marked Hermes scratch roots | always | Never |
 | `research` | >30 days, beyond 10 newest | Always (deep only) |
 | `chrome-profile` | >14 days since tracked | Always (deep only) |
 | files >500 MB | never auto | Always (deep only) |
@@ -44,8 +44,12 @@ Deletion rules (same as the original PR):
 - `is_safe_path()` rejects anything outside `HERMES_HOME` or `/tmp/hermes-*`
 - Windows mounts (`/mnt/c` etc.) are rejected
 - The state directory `$HERMES_HOME/disk-cleanup/` is itself excluded
+- Only regular files can be tracked; directories and symlinks are rejected
 - `$HERMES_HOME/logs/`, `memories/`, `sessions/`, `skills/`, `plugins/`,
-  and config files are never tracked
+  profiles, backups, worktrees, and top-level config/state files are rejected
+  even when passed to the manual `track` command
+- Cleanup re-checks the creation identity immediately before deletion, so a
+  replacement file or legacy path-only record is preserved
 - Backup/restore is scoped to `tracked.json` — the plugin never touches
   agent logs
 - Atomic writes: `.tmp` → backup → rename

--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -2,10 +2,10 @@
 
 Wires three behaviours:
 
-1. ``post_tool_call`` hook — inspects ``write_file`` and ``terminal``
-   tool results for newly-created paths matching test/temp patterns
-   under ``HERMES_HOME`` and tracks them silently.  Zero agent
-   compliance required.
+1. ``post_tool_call`` hook — consumes explicit ``created_paths`` /
+   ``files_created`` metadata emitted by write-capable tools, then tracks
+   paths matching test/temp patterns under ``HERMES_HOME`` silently.  Raw
+   command text and terminal output are never creation evidence.
 
 2. ``on_session_end`` hook — when any test files were auto-tracked
    during the just-finished turn, runs :func:`disk_cleanup.quick` and
@@ -20,6 +20,7 @@ needs to remember to run commands.
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 import shlex
@@ -41,7 +42,6 @@ _lock = threading.Lock()
 
 
 # Tool-call result shapes we can parse
-_WRITE_FILE_PATH_KEY = "path"
 _TERMINAL_PATH_REGEX = re.compile(r"(?:^|\s)(/[^\s'\"`]+|\~/[^\s'\"`]+)")
 _WINDOWS_PATH_REGEX = re.compile(r"(?<![A-Za-z0-9_])([A-Za-z]:[\\/][^\s'\"`]+)")
 
@@ -88,24 +88,12 @@ def _attempt_track(path_str: str, task_id: str, session_id: str) -> None:
         return
 
 
-def _extract_paths_from_write_file(args: Dict[str, Any]) -> Set[str]:
-    path = args.get(_WRITE_FILE_PATH_KEY)
-    return {path} if isinstance(path, str) and path else set()
-
-
-def _extract_paths_from_patch(args: Dict[str, Any]) -> Set[str]:
-    # The patch tool creates new files via the `mode="patch"` path too, but
-    # most of its use is editing existing files — we only care about new
-    # ephemeral creations, so treat patch conservatively and only pick up
-    # the single-file `path` arg.  Track-then-cleanup is idempotent, so
-    # re-tracking an already-tracked file is a no-op (dedup in track()).
-    path = args.get("path")
-    return {path} if isinstance(path, str) and path else set()
-
-
 def _extract_paths_from_terminal(args: Dict[str, Any], result: str) -> Set[str]:
-    """Best-effort: pull candidate filesystem paths from a terminal command
-    and its output, then let ``guess_category`` / ``is_safe_path`` filter.
+    """Extract display/debug candidates from terminal command text.
+
+    This helper deliberately is *not* used for auto-tracking.  Keeping the
+    Windows-aware extractor available preserves callers that use it for
+    diagnostics, while raw command/output text has no destructive authority.
     """
     paths: Set[str] = set()
     cmd = args.get("command") or ""
@@ -115,16 +103,44 @@ def _extract_paths_from_terminal(args: Dict[str, Any], result: str) -> Set[str]:
         # Tokenise the command — catches `touch /tmp/hermes-x/test_foo.py`
         try:
             for tok in shlex.split(cmd, posix=True):
-                if tok.startswith(("/", "~")) or _WINDOWS_PATH_REGEX.match(tok):
+                if tok.startswith(("/", "~/")):
                     paths.add(tok)
         except ValueError:
             pass
-    # Only scan the result text if it's a reasonable size (avoid 50KB dumps).
+    # Preserve diagnostic extraction (including Windows drive paths) for
+    # callers that display candidates.  This result is never fed to
+    # ``_on_post_tool_call`` and therefore has no cleanup authority.
     if isinstance(result, str) and len(result) < 4096:
-        for match in _TERMINAL_PATH_REGEX.findall(result):
-            paths.add(match)
-        for match in _WINDOWS_PATH_REGEX.finditer(result):
-            paths.add(match.group(1))
+        paths.update(_TERMINAL_PATH_REGEX.findall(result))
+        paths.update(match.group(1) for match in _WINDOWS_PATH_REGEX.finditer(result))
+    return paths
+
+
+def _extract_trusted_created_paths(result: Any) -> Set[str]:
+    """Return only explicit creation metadata from a tool result.
+
+    ``created_paths`` is emitted by write-capable tools after they establish
+    that a target was absent before a successful write.  ``files_created`` is
+    the existing equivalent emitted by V4A patch application.  Neither field
+    is inferred from free-form output, command text, or the requested path.
+    Malformed or ambiguous result shapes return no paths (fail closed).
+    """
+    if isinstance(result, str):
+        try:
+            result = json.loads(result)
+        except (TypeError, ValueError):
+            return set()
+    if not isinstance(result, dict):
+        return set()
+
+    paths: Set[str] = set()
+    for key in ("created_paths", "files_created"):
+        values = result.get(key)
+        if not isinstance(values, list):
+            continue
+        for value in values:
+            if isinstance(value, str) and value:
+                paths.add(value)
     return paths
 
 
@@ -145,15 +161,14 @@ def _on_post_tool_call(
     if not isinstance(args, dict):
         return
 
-    candidates: Set[str] = set()
-    if tool_name == "write_file":
-        candidates = _extract_paths_from_write_file(args)
-    elif tool_name == "patch":
-        candidates = _extract_paths_from_patch(args)
-    elif tool_name == "terminal":
-        candidates = _extract_paths_from_terminal(args, result if isinstance(result, str) else "")
-    else:
+    if tool_name not in {"write_file", "patch", "terminal"}:
         return
+
+    # Never infer ownership from args or free-form terminal output.  The
+    # result metadata is produced by the tool implementation only after it
+    # has observed a successful newly-created target; absent/invalid metadata
+    # is intentionally ambiguous and therefore preserved.
+    candidates = _extract_trusted_created_paths(result)
 
     for path_str in candidates:
         _attempt_track(path_str, task_id, session_id)

--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -2,11 +2,10 @@
 
 Wires three behaviours:
 
-1. ``post_tool_call`` hook — consumes explicit ``created_paths`` /
-   ``files_created`` metadata emitted by write-capable tools, then tracks
-   paths matching test/temp patterns under ``HERMES_HOME`` silently.  Terminal
-   calls are excluded because arbitrary shell commands cannot prove whether a
-   path was created or merely moved/observed.
+1. ``post_tool_call`` hook — consumes explicit ``created_paths`` metadata
+   emitted by ``write_file``, then tracks paths matching test/temp patterns
+   under ``HERMES_HOME`` silently.  Terminal and patch calls are excluded
+   because their current result metadata cannot prove exclusive creation.
 
 2. ``on_session_end`` hook — when any test files were auto-tracked
    during the just-finished turn, runs :func:`disk_cleanup.quick` and
@@ -34,9 +33,10 @@ from . import disk_cleanup as dg
 logger = logging.getLogger(__name__)
 
 
-# Per-task set of "test files newly tracked this turn".  Keyed by task_id
-# (or session_id as fallback) so on_session_end can decide whether to run
-# cleanup.  Guarded by a lock — post_tool_call can fire concurrently on
+# Per-session set of "test files newly tracked this turn".  Keyed by session_id
+# (or task_id only when no session identifier exists) so on_session_end can
+# clean only the paths owned by the ending session. Guarded by a lock —
+# post_tool_call can fire concurrently on
 # parallel tool calls.
 _recent_test_tracks: Dict[str, Set[str]] = {}
 _lock = threading.Lock()
@@ -52,7 +52,7 @@ _WINDOWS_PATH_REGEX = re.compile(r"(?<![A-Za-z0-9_])([A-Za-z]:[\\/][^\s'\"`]+)")
 # ---------------------------------------------------------------------------
 
 def _tracker_key(task_id: str, session_id: str) -> str:
-    return task_id or session_id or "default"
+    return session_id or task_id or "default"
 
 
 def _record_track(task_id: str, session_id: str, path: Path, category: str) -> None:
@@ -120,11 +120,10 @@ def _extract_paths_from_terminal(args: Dict[str, Any], result: str) -> Set[str]:
 def _extract_trusted_created_paths(result: Any) -> Set[str]:
     """Return only explicit creation metadata from a tool result.
 
-    ``created_paths`` is emitted by write-capable tools after they establish
-    that a target was absent before a successful write.  ``files_created`` is
-    the existing equivalent emitted by V4A patch application.  Neither field
-    is inferred from free-form output, command text, or the requested path.
-    Malformed or ambiguous result shapes return no paths (fail closed).
+    ``created_paths`` is emitted by ``write_file`` after it establishes that a
+    target was absent before a successful write. Neither free-form output nor
+    V4A ``files_created`` metadata is creation proof. Malformed or ambiguous
+    result shapes return no paths (fail closed).
     """
     if isinstance(result, str):
         try:
@@ -135,13 +134,12 @@ def _extract_trusted_created_paths(result: Any) -> Set[str]:
         return set()
 
     paths: Set[str] = set()
-    for key in ("created_paths", "files_created"):
-        values = result.get(key)
-        if not isinstance(values, list):
-            continue
-        for value in values:
-            if isinstance(value, str) and value:
-                paths.add(value)
+    values = result.get("created_paths")
+    if not isinstance(values, list):
+        return paths
+    for value in values:
+        if isinstance(value, str) and value:
+            paths.add(value)
     return paths
 
 
@@ -162,13 +160,11 @@ def _on_post_tool_call(
     if not isinstance(args, dict):
         return
 
-    if tool_name not in {"write_file", "patch"}:
+    if tool_name != "write_file":
         return
 
-    # Only tools that control the actual write operation may establish
-    # creation provenance.  Terminal before/after existence is correlation,
-    # not authorship: a shell command can move an existing human file or race
-    # another creator into the observed path.  Ambiguity is preserved.
+    # Only write_file currently emits creation evidence sampled inside its
+    # serialized write boundary. Terminal and patch metadata remain ambiguous.
     candidates = _extract_trusted_created_paths(result)
 
     for path_str in candidates:
@@ -177,29 +173,18 @@ def _on_post_tool_call(
 
 def _on_session_end(
     session_id: str = "",
+    task_id: str = "",
     completed: bool = True,
     interrupted: bool = False,
     **_: Any,
 ) -> None:
     """Run quick cleanup if any test files were tracked during this turn."""
-    # Drain both task-level and session-level buckets.  In practice only one
-    # is populated per turn; the other is empty.
-    drained_session = _drain("", session_id)
-    # Also drain any task-scoped buckets that happen to exist.  This is a
-    # cheap sweep: if an agent spawned subagents (each with their own
-    # task_id) they'll have recorded into separate buckets; we want to
-    # cleanup them all at session end.
-    with _lock:
-        task_buckets = list(_recent_test_tracks.keys())
-    for key in task_buckets:
-        if key and key != session_id:
-            _recent_test_tracks.pop(key, None)
-
-    if not drained_session and not task_buckets:
+    drained_session = _drain(task_id, session_id)
+    if not drained_session:
         return
 
     try:
-        summary = dg.quick()
+        summary = dg.quick(paths=drained_session)
     except Exception as exc:
         logger.debug("disk-cleanup quick cleanup failed: %s", exc)
         return
@@ -229,7 +214,7 @@ Subcommands:
 Categories: temp | test | research | download | chrome-profile | cron-output | other
 
 All operations are scoped to HERMES_HOME and /tmp/hermes-*.
-Test files are auto-tracked on write_file / terminal and auto-cleaned at session end.
+Test files created by write_file are auto-tracked and auto-cleaned at session end.
 """
 
 

--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -26,7 +26,7 @@ import re
 import shlex
 import threading
 from pathlib import Path
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from . import disk_cleanup as dg
 
@@ -71,7 +71,12 @@ def _drain(task_id: str, session_id: str) -> Set[str]:
         return _recent_test_tracks.pop(key, set())
 
 
-def _attempt_track(path_str: str, task_id: str, session_id: str) -> None:
+def _attempt_track(
+    path_str: str,
+    expected_identity: Dict[str, int],
+    task_id: str,
+    session_id: str,
+) -> None:
     """Best-effort auto-track. Never raises."""
     try:
         p = Path(path_str).expanduser()
@@ -80,7 +85,12 @@ def _attempt_track(path_str: str, task_id: str, session_id: str) -> None:
         category = dg.guess_category(p)
         if category is None:
             return
-        newly = dg.track(str(p), category, silent=True)
+        newly = dg.track(
+            str(p),
+            category,
+            silent=True,
+            expected_identity=expected_identity,
+        )
         if newly:
             _record_track(task_id, session_id, p, category)
     except Exception:
@@ -117,29 +127,35 @@ def _extract_paths_from_terminal(args: Dict[str, Any], result: str) -> Set[str]:
     return paths
 
 
-def _extract_trusted_created_paths(result: Any) -> Set[str]:
-    """Return only explicit creation metadata from a tool result.
+def _extract_trusted_created_paths(
+    result: Any,
+) -> List[Tuple[str, Dict[str, int]]]:
+    """Return path identities bound to a successful ``write_file`` result.
 
-    ``created_paths`` is emitted by ``write_file`` after it establishes that a
-    target was absent before a successful write. Neither free-form output nor
-    V4A ``files_created`` metadata is creation proof. Malformed or ambiguous
-    result shapes return no paths (fail closed).
+    A path string alone is not durable creation evidence: another process can
+    replace it before this hook runs. ``write_file`` therefore emits the exact
+    post-write identity sampled inside its path lock, and tracking requires the
+    current object to match. Malformed or legacy result shapes fail closed.
     """
     if isinstance(result, str):
         try:
             result = json.loads(result)
         except (TypeError, ValueError):
-            return set()
+            return []
     if not isinstance(result, dict):
-        return set()
+        return []
 
-    paths: Set[str] = set()
-    values = result.get("created_paths")
+    paths: List[Tuple[str, Dict[str, int]]] = []
+    values = result.get("created_path_identities")
     if not isinstance(values, list):
         return paths
     for value in values:
-        if isinstance(value, str) and value:
-            paths.add(value)
+        if not isinstance(value, dict):
+            continue
+        path = value.get("path")
+        identity = value.get("identity")
+        if isinstance(path, str) and path and isinstance(identity, dict):
+            paths.append((path, identity))
     return paths
 
 
@@ -167,8 +183,8 @@ def _on_post_tool_call(
     # serialized write boundary. Terminal and patch metadata remain ambiguous.
     candidates = _extract_trusted_created_paths(result)
 
-    for path_str in candidates:
-        _attempt_track(path_str, task_id, session_id)
+    for path_str, expected_identity in candidates:
+        _attempt_track(path_str, expected_identity, task_id, session_id)
 
 
 def _on_session_end(

--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -43,6 +43,7 @@ _lock = threading.Lock()
 # Tool-call result shapes we can parse
 _WRITE_FILE_PATH_KEY = "path"
 _TERMINAL_PATH_REGEX = re.compile(r"(?:^|\s)(/[^\s'\"`]+|\~/[^\s'\"`]+)")
+_WINDOWS_PATH_REGEX = re.compile(r"(?<![A-Za-z0-9_])([A-Za-z]:[\\/][^\s'\"`]+)")
 
 
 # ---------------------------------------------------------------------------
@@ -73,16 +74,18 @@ def _attempt_track(path_str: str, task_id: str, session_id: str) -> None:
     """Best-effort auto-track. Never raises."""
     try:
         p = Path(path_str).expanduser()
+        if not p.exists():
+            return
+        category = dg.guess_category(p)
+        if category is None:
+            return
+        newly = dg.track(str(p), category, silent=True)
+        if newly:
+            _record_track(task_id, session_id, p, category)
     except Exception:
+        # Hook inspection is advisory; malformed paths or unavailable state
+        # must never interrupt the agent loop.
         return
-    if not p.exists():
-        return
-    category = dg.guess_category(p)
-    if category is None:
-        return
-    newly = dg.track(str(p), category, silent=True)
-    if newly:
-        _record_track(task_id, session_id, p, category)
 
 
 def _extract_paths_from_write_file(args: Dict[str, Any]) -> Set[str]:
@@ -107,10 +110,12 @@ def _extract_paths_from_terminal(args: Dict[str, Any], result: str) -> Set[str]:
     paths: Set[str] = set()
     cmd = args.get("command") or ""
     if isinstance(cmd, str) and cmd:
+        for match in _WINDOWS_PATH_REGEX.finditer(cmd):
+            paths.add(match.group(1))
         # Tokenise the command — catches `touch /tmp/hermes-x/test_foo.py`
         try:
             for tok in shlex.split(cmd, posix=True):
-                if tok.startswith(("/", "~")):
+                if tok.startswith(("/", "~")) or _WINDOWS_PATH_REGEX.match(tok):
                     paths.add(tok)
         except ValueError:
             pass
@@ -118,6 +123,8 @@ def _extract_paths_from_terminal(args: Dict[str, Any], result: str) -> Set[str]:
     if isinstance(result, str) and len(result) < 4096:
         for match in _TERMINAL_PATH_REGEX.findall(result):
             paths.add(match)
+        for match in _WINDOWS_PATH_REGEX.finditer(result):
+            paths.add(match.group(1))
     return paths
 
 

--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -4,8 +4,9 @@ Wires three behaviours:
 
 1. ``post_tool_call`` hook — consumes explicit ``created_paths`` /
    ``files_created`` metadata emitted by write-capable tools, then tracks
-   paths matching test/temp patterns under ``HERMES_HOME`` silently.  Raw
-   command text and terminal output are never creation evidence.
+   paths matching test/temp patterns under ``HERMES_HOME`` silently.  Terminal
+   calls are excluded because arbitrary shell commands cannot prove whether a
+   path was created or merely moved/observed.
 
 2. ``on_session_end`` hook — when any test files were auto-tracked
    during the just-finished turn, runs :func:`disk_cleanup.quick` and
@@ -161,13 +162,13 @@ def _on_post_tool_call(
     if not isinstance(args, dict):
         return
 
-    if tool_name not in {"write_file", "patch", "terminal"}:
+    if tool_name not in {"write_file", "patch"}:
         return
 
-    # Never infer ownership from args or free-form terminal output.  The
-    # result metadata is produced by the tool implementation only after it
-    # has observed a successful newly-created target; absent/invalid metadata
-    # is intentionally ambiguous and therefore preserved.
+    # Only tools that control the actual write operation may establish
+    # creation provenance.  Terminal before/after existence is correlation,
+    # not authorship: a shell command can move an existing human file or race
+    # another creator into the observed path.  Ambiguity is preserved.
     candidates = _extract_trusted_created_paths(result)
 
     for path_str in candidates:

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -1021,6 +1021,7 @@ def _atomic_unlink_managed_artifact(
             return _restore_quarantined_path(
                 lease.session_path / quarantine_name,
                 lease.session_path / name,
+                moved,
             )
         if not _managed_artifact_lease_matches(lease, root_name):
             return "managed artifact container changed; preserved quarantine"
@@ -1050,11 +1051,47 @@ def _remove_path(path: Path) -> Optional[str]:
     return None
 
 
-def _restore_quarantined_path(quarantine: Path, original: Path) -> str:
-    """Preserve uncertainty without risking an overwrite at *original*."""
+def _restore_quarantined_path(
+    quarantine: Path,
+    original: Path,
+    moved: os.stat_result,
+) -> str:
+    """No-clobber restore a pathname replacement moved during cleanup."""
+    try:
+        quarantined = quarantine.lstat()
+        if (
+            not stat.S_ISREG(quarantined.st_mode)
+            or not os.path.samestat(moved, quarantined)
+            or os.path.lexists(original)
+        ):
+            raise OSError("restore destination is occupied or quarantine changed")
+        if os.name == "nt":
+            # Windows rename is no-replace, so a newer race winner survives.
+            os.rename(quarantine, original)
+        else:
+            # link() atomically publishes only when the original name is free.
+            os.link(quarantine, original, follow_symlinks=False)
+            restored = original.lstat()
+            quarantined = quarantine.lstat()
+            if not (
+                stat.S_ISREG(restored.st_mode)
+                and stat.S_ISREG(quarantined.st_mode)
+                and os.path.samestat(moved, restored)
+                and os.path.samestat(moved, quarantined)
+            ):
+                raise OSError("restored object identity changed")
+            quarantine.unlink()
+        restored = original.lstat()
+        if stat.S_ISREG(restored.st_mode) and os.path.samestat(moved, restored):
+            return (
+                "filesystem identity changed during delete; restored the "
+                f"pathname replacement to {original}"
+            )
+    except OSError:
+        pass
     return (
         f"filesystem identity changed during delete; preserved at {quarantine} "
-        f"instead of restoring over {original}"
+        f"instead of overwriting {original}"
     )
 
 
@@ -1120,7 +1157,7 @@ def _atomic_unlink_regular(
         os.replace(path, quarantine)
         moved = quarantine.lstat()
         if not os.path.samestat(opened, moved):
-            return _restore_quarantined_path(quarantine, path)
+            return _restore_quarantined_path(quarantine, path, moved)
         try:
             quarantine.unlink()
         except OSError as exc:

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -26,6 +26,9 @@ import logging
 import os
 import shutil
 import stat
+import tempfile
+import threading
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
@@ -41,6 +44,7 @@ except Exception:  # pragma: no cover — plugin may load before constants resol
 
 
 logger = logging.getLogger(__name__)
+_TRACKED_THREAD_LOCK = threading.RLock()
 
 
 # ---------------------------------------------------------------------------
@@ -124,7 +128,39 @@ def _log(message: str) -> None:
 # tracked.json — atomic read/write, backup scoped to tracked.json only
 # ---------------------------------------------------------------------------
 
-def load_tracked() -> List[Dict[str, Any]]:
+@contextmanager
+def _tracked_registry_lock():
+    """Serialize tracked.json read-modify-write cycles across processes."""
+    lock_path = get_state_dir() / "tracked.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with _TRACKED_THREAD_LOCK, lock_path.open("a+b") as lock_file:
+        if lock_file.seek(0, os.SEEK_END) == 0:
+            lock_file.write(b"0")
+            lock_file.flush()
+        lock_file.seek(0)
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            yield
+        finally:
+            lock_file.seek(0)
+            if os.name == "nt":
+                import msvcrt
+
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _load_tracked_unlocked() -> List[Dict[str, Any]]:
     """Load tracked.json.  Restores from ``.bak`` on corruption."""
     tf = get_tracked_file()
     tf.parent.mkdir(parents=True, exist_ok=True)
@@ -152,15 +188,59 @@ def load_tracked() -> List[Dict[str, Any]]:
         return []
 
 
-def save_tracked(tracked: List[Dict[str, Any]]) -> None:
+def load_tracked() -> List[Dict[str, Any]]:
+    with _tracked_registry_lock():
+        return _load_tracked_unlocked()
+
+
+def _save_tracked_unlocked(tracked: List[Dict[str, Any]]) -> None:
     """Atomic write: ``.tmp`` → backup old → rename."""
     tf = get_tracked_file()
     tf.parent.mkdir(parents=True, exist_ok=True)
-    tmp = tf.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(tracked, indent=2))
-    if tf.exists():
-        shutil.copy2(tf, tf.with_suffix(".json.bak"))
-    tmp.replace(tf)
+    tmp_path: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=tf.parent,
+            prefix="tracked-",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            json.dump(tracked, tmp, indent=2)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp_path = Path(tmp.name)
+        if tf.exists():
+            shutil.copy2(tf, tf.with_suffix(".json.bak"))
+        tmp_path.replace(tf)
+    finally:
+        if tmp_path is not None:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def save_tracked(tracked: List[Dict[str, Any]]) -> None:
+    with _tracked_registry_lock():
+        _save_tracked_unlocked(tracked)
+
+
+def _commit_tracked_snapshot(
+    original: List[Dict[str, Any]], desired: List[Dict[str, Any]]
+) -> None:
+    """Apply removals from one snapshot without losing concurrent additions."""
+    desired_ids = {id(item) for item in desired}
+    removed = [item for item in original if id(item) not in desired_ids]
+    with _tracked_registry_lock():
+        current = _load_tracked_unlocked()
+        for old_item in removed:
+            try:
+                current.remove(old_item)
+            except ValueError:
+                pass
+        _save_tracked_unlocked(current)
 
 
 # ---------------------------------------------------------------------------
@@ -212,10 +292,14 @@ _PROTECTED_TRACKED_TOP_LEVEL = frozenset({
     ".worktrees",
     "backups",
     "disk-cleanup",
+    "gateway",
     "hermes-agent",
+    "kanban",
     "logs",
     "memories",
     "optional-skills",
+    "pairing",
+    "platforms",
     "plugins",
     "profiles",
     "sessions",
@@ -227,9 +311,25 @@ _PROTECTED_TRACKED_TOP_LEVEL_FILES = frozenset({
     "SOUL.md",
     "USER.md",
     "auth.json",
+    "channel_aliases.json",
+    "channel_directory.json",
     "config.yaml",
+    "feishu_comment_pairing.json",
+    "gateway_state.json",
+    "kanban.db",
+    "memory_store.db",
+    "processes.json",
+    "projects.db",
+    "response_store.db",
     "state.db",
+    "verification_evidence.db",
 })
+_PROTECTED_TRACKED_TOP_LEVEL_CASEFOLD = frozenset(
+    name.casefold() for name in _PROTECTED_TRACKED_TOP_LEVEL
+)
+_PROTECTED_TRACKED_TOP_LEVEL_FILES_CASEFOLD = frozenset(
+    name.casefold() for name in _PROTECTED_TRACKED_TOP_LEVEL_FILES
+)
 
 
 def _is_protected_cron_path(p: Path) -> bool:
@@ -250,11 +350,11 @@ def _is_protected_cron_path(p: Path) -> bool:
         hermes_home = get_hermes_home()
         for parent in ("cron", "cronjobs"):
             base = hermes_home / parent
-            _PROTECTED_CRON_PATHS.add(str(base))
-            _PROTECTED_CRON_PATHS.add(str(base / "output"))
-            _PROTECTED_CRON_PATHS.add(str(base / "jobs.json"))
-            _PROTECTED_CRON_PATHS.add(str(base / ".tick.lock"))
-    resolved = str(p.resolve())
+            for protected in (base, base / "output", base / "jobs.json", base / ".tick.lock"):
+                _PROTECTED_CRON_PATHS.add(
+                    os.path.normcase(os.path.normpath(str(protected.resolve())))
+                )
+    resolved = os.path.normcase(os.path.normpath(str(p.resolve())))
     return resolved in _PROTECTED_CRON_PATHS
 
 
@@ -266,10 +366,13 @@ def _is_protected_tracked_path(path: Path) -> bool:
         return False
     if not rel.parts:
         return True
-    top = rel.parts[0]
+    top = rel.parts[0].casefold()
     return (
-        top in _PROTECTED_TRACKED_TOP_LEVEL
-        or (len(rel.parts) == 1 and top in _PROTECTED_TRACKED_TOP_LEVEL_FILES)
+        top in _PROTECTED_TRACKED_TOP_LEVEL_CASEFOLD
+        or (
+            len(rel.parts) == 1
+            and top in _PROTECTED_TRACKED_TOP_LEVEL_FILES_CASEFOLD
+        )
     )
 
 
@@ -477,23 +580,21 @@ def track(
         _log(f"REJECT: {path} (creation identity changed before tracking)")
         return False
     size = identity["size"] if path.is_file() else 0
-    tracked = load_tracked()
-
-    # Deduplicate
-    if any(
-        isinstance(item, dict) and item.get("path") == str(path)
-        for item in tracked
-    ):
-        return False
-
-    tracked.append({
-        "path": str(path),
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "category": category,
-        "size": size,
-        "identity": identity,
-    })
-    save_tracked(tracked)
+    with _tracked_registry_lock():
+        tracked = _load_tracked_unlocked()
+        if any(
+            isinstance(item, dict) and item.get("path") == str(path)
+            for item in tracked
+        ):
+            return False
+        tracked.append({
+            "path": str(path),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "category": category,
+            "size": size,
+            "identity": identity,
+        })
+        _save_tracked_unlocked(tracked)
     _log(f"TRACKED: {path} ({category}, {fmt_size(size)})")
     if not silent:
         print(f"Tracked: {path} ({category}, {fmt_size(size)})")
@@ -503,13 +604,14 @@ def track(
 def forget(path_str: str) -> int:
     """Remove a path from tracking without deleting the file."""
     p = Path(path_str).resolve()
-    tracked = load_tracked()
-    before = len(tracked)
-    tracked = [i for i in tracked if Path(i["path"]).resolve() != p]
-    removed = before - len(tracked)
-    if removed:
-        save_tracked(tracked)
-        _log(f"FORGOT: {p} ({removed} entries)")
+    with _tracked_registry_lock():
+        tracked = _load_tracked_unlocked()
+        before = len(tracked)
+        tracked = [i for i in tracked if Path(i["path"]).resolve() != p]
+        removed = before - len(tracked)
+        if removed:
+            _save_tracked_unlocked(tracked)
+            _log(f"FORGOT: {p} ({removed} entries)")
     return removed
 
 
@@ -693,7 +795,7 @@ def quick(paths: Optional[Iterable[str]] = None) -> Dict[str, Any]:
     # manual/global quick command additionally performs retention and empty-dir
     # sweeps under their separately marked ownership roots.
     if scoped_paths is not None:
-        save_tracked(new_tracked)
+        _commit_tracked_snapshot(tracked, new_tracked)
         _log(
             f"QUICK_SUMMARY: {deleted} files, 0 dirs, "
             f"{fmt_size(freed)}"
@@ -790,7 +892,7 @@ def quick(paths: Optional[Iterable[str]] = None) -> Dict[str, Any]:
         except OSError:
             pass
 
-    save_tracked(new_tracked)
+    _commit_tracked_snapshot(tracked, new_tracked)
     _log(
         f"QUICK_SUMMARY: {deleted} files, {empty_removed} dirs, "
         f"{fmt_size(freed)}"
@@ -888,7 +990,9 @@ def deep(
 
     if to_remove:
         remove_paths = {i["path"] for i in to_remove}
-        save_tracked([i for i in tracked if i["path"] not in remove_paths])
+        _commit_tracked_snapshot(
+            tracked, [i for i in tracked if i["path"] not in remove_paths]
+        )
 
     return {"quick": quick_result, "deep_deleted": count, "deep_freed": freed}
 

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -138,6 +138,7 @@ def _tracked_registry_lock():
             lock_file.write(b"0")
             lock_file.flush()
         lock_file.seek(0)
+        acquired = False
         try:
             if os.name == "nt":
                 import msvcrt
@@ -147,17 +148,19 @@ def _tracked_registry_lock():
                 import fcntl
 
                 fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            acquired = True
             yield
         finally:
-            lock_file.seek(0)
-            if os.name == "nt":
-                import msvcrt
+            if acquired:
+                lock_file.seek(0)
+                if os.name == "nt":
+                    import msvcrt
 
-                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
-            else:
-                import fcntl
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
 
-                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 def _load_tracked_unlocked() -> List[Dict[str, Any]]:
@@ -330,6 +333,17 @@ _PROTECTED_TRACKED_TOP_LEVEL_CASEFOLD = frozenset(
 _PROTECTED_TRACKED_TOP_LEVEL_FILES_CASEFOLD = frozenset(
     name.casefold() for name in _PROTECTED_TRACKED_TOP_LEVEL_FILES
 )
+_DISPOSABLE_TOP_LEVEL_PREFIXES = ("test_", "tmp_", "temp_")
+
+
+def _is_narrow_top_level_artifact(name: str) -> bool:
+    """Allow only unmistakably disposable names at HERMES_HOME's root."""
+    folded = name.casefold()
+    return (
+        folded.startswith(_DISPOSABLE_TOP_LEVEL_PREFIXES)
+        or ".test." in folded
+        or folded.endswith(".tmp")
+    )
 
 
 def _is_protected_cron_path(p: Path) -> bool:
@@ -369,6 +383,7 @@ def _is_protected_tracked_path(path: Path) -> bool:
     top = rel.parts[0].casefold()
     return (
         top in _PROTECTED_TRACKED_TOP_LEVEL_CASEFOLD
+        or (len(rel.parts) == 1 and not _is_narrow_top_level_artifact(top))
         or (
             len(rel.parts) == 1
             and top in _PROTECTED_TRACKED_TOP_LEVEL_FILES_CASEFOLD

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -285,6 +285,7 @@ _MANAGED_ARTIFACT_RETENTION_DAYS = {
 _MANAGED_ARTIFACT_SKIP_NAMES = frozenset({
     ".hermes-managed", ".in-progress", ".active", ".lock",
 })
+_DELETE_QUARANTINE_TOKEN = ".hermes-delete-"
 
 
 # Paths under $HERMES_HOME that must NEVER be deleted by quick(),
@@ -355,6 +356,11 @@ def _is_narrow_top_level_artifact(name: str) -> bool:
     )
 
 
+def _is_delete_quarantine_path(path: Path) -> bool:
+    """Return whether *path* is preserved evidence from an uncertain delete."""
+    return any(_DELETE_QUARANTINE_TOKEN in part for part in path.parts)
+
+
 def _is_protected_cron_path(p: Path) -> bool:
     """Return True if *p* is a cron control-plane file/directory that must
     never be deleted.
@@ -399,6 +405,8 @@ def _is_protected_cron_path(p: Path) -> bool:
 
 def _is_protected_tracked_path(path: Path) -> bool:
     """Protect durable Hermes state from manual or stale tracking records."""
+    if _is_delete_quarantine_path(path):
+        return True
     try:
         rel = path.resolve().relative_to(get_hermes_home().resolve())
     except (OSError, ValueError):
@@ -577,8 +585,9 @@ def _remove_path(path: Path) -> Optional[str]:
 
 def _restore_quarantined_path(quarantine: Path, original: Path) -> str:
     try:
-        os.link(quarantine, original)
-        quarantine.unlink()
+        if os.path.lexists(original):
+            raise FileExistsError(str(original))
+        os.replace(quarantine, original)
         return f"filesystem identity changed during delete; restored {original}"
     except OSError:
         return f"filesystem identity changed during delete; preserved at {quarantine}"
@@ -628,6 +637,8 @@ def _atomic_unlink_regular(
     path: Path, expected_identity: Optional[Dict[str, int]] = None
 ) -> Optional[str]:
     """Move an opened object to a nonce path before unlinking it."""
+    if _is_delete_quarantine_path(path):
+        return "preserved delete quarantine"
     fd: Optional[int] = None
     quarantine = path.with_name(f".{path.name}.hermes-delete-{uuid.uuid4().hex}")
     try:
@@ -645,7 +656,10 @@ def _atomic_unlink_regular(
         moved = quarantine.lstat()
         if not os.path.samestat(opened, moved):
             return _restore_quarantined_path(quarantine, path)
-        quarantine.unlink()
+        try:
+            quarantine.unlink()
+        except OSError as exc:
+            return f"delete failed; preserved at {quarantine}: {exc}"
         return None
     except OSError as exc:
         return str(exc)
@@ -661,6 +675,50 @@ def _remove_tracked_path(path: Path, identity: Dict[str, int]) -> Optional[str]:
     if not stat.S_ISREG(identity.get("mode", 0)):
         return "tracked path is not a regular file"
     return _atomic_unlink_regular(path, identity)
+
+
+def _atomic_rmdir_empty(path: Path, expected: os.stat_result) -> bool:
+    """Remove the exact selected empty directory, preserving uncertainty."""
+    if _is_delete_quarantine_path(path):
+        return False
+    quarantine = path.with_name(
+        f".{path.name}{_DELETE_QUARANTINE_TOKEN}{uuid.uuid4().hex}"
+    )
+    try:
+        current = path.lstat()
+        if (
+            not stat.S_ISDIR(current.st_mode)
+            or _is_link_like(path)
+            or not os.path.samestat(expected, current)
+        ):
+            return False
+        os.replace(path, quarantine)
+        moved = quarantine.lstat()
+        if (
+            not stat.S_ISDIR(moved.st_mode)
+            or _is_link_like(quarantine)
+            or not os.path.samestat(expected, moved)
+        ):
+            if not os.path.lexists(path):
+                os.replace(quarantine, path)
+            return False
+        try:
+            quarantine.rmdir()
+        except OSError:
+            if not os.path.lexists(path):
+                try:
+                    os.replace(quarantine, path)
+                except OSError:
+                    pass
+            return False
+        return True
+    except OSError:
+        try:
+            if os.path.lexists(quarantine) and not os.path.lexists(path):
+                os.replace(quarantine, path)
+        except OSError:
+            pass
+        return False
 
 
 def fmt_size(n: float) -> str:
@@ -969,16 +1027,22 @@ def quick(paths: Optional[Iterable[str]] = None) -> Dict[str, Any]:
                 for artifact in session_dir.iterdir():
                     if (
                         artifact.name in _MANAGED_ARTIFACT_SKIP_NAMES
+                        or _is_delete_quarantine_path(artifact)
                         or _is_link_like(artifact)
                         or not artifact.is_file()
                     ):
                         continue
                     try:
-                        age_seconds = now.timestamp() - artifact.stat().st_mtime
+                        identity = _capture_identity(artifact)
+                        if identity is None or not stat.S_ISREG(identity["mode"]):
+                            continue
+                        age_seconds = (
+                            now.timestamp() - identity["mtime_ns"] / 1_000_000_000
+                        )
                         if age_seconds <= retention_days * 24 * 60 * 60:
                             continue
-                        size = artifact.stat().st_size
-                        error = _atomic_unlink_regular(artifact)
+                        size = identity["size"]
+                        error = _atomic_unlink_regular(artifact, identity)
                         if error is not None:
                             errors.append(f"{artifact}: {error}")
                             continue
@@ -995,40 +1059,43 @@ def quick(paths: Optional[Iterable[str]] = None) -> Dict[str, Any]:
     # and desktop build under HERMES_HOME; a full rglob over that tree can
     # stall the gateway event loop for minutes.
     empty_removed = 0
-    sweep_stack: List[Tuple[Path, bool]] = []
+    sweep_stack: List[Tuple[Path, bool, os.stat_result]] = []
     try:
         for top in hermes_home.iterdir():
             if (
                 top.is_dir()
                 and not _is_link_like(top)
+                and not _is_delete_quarantine_path(top)
                 and _is_owned_empty_dir_root(top)
             ):
-                sweep_stack.append((top, False))
+                sweep_stack.append((top, False, top.lstat()))
     except OSError:
         sweep_stack = []
 
     while sweep_stack:
-        dirpath, visited = sweep_stack.pop()
+        dirpath, visited, selected_identity = sweep_stack.pop()
         if visited:
             try:
-                if not any(dirpath.iterdir()):
-                    dirpath.rmdir()
+                if not any(dirpath.iterdir()) and _atomic_rmdir_empty(
+                    dirpath, selected_identity
+                ):
                     empty_removed += 1
                     _log(f"DELETED: {dirpath} (empty dir)")
             except OSError:
                 pass
             continue
 
-        sweep_stack.append((dirpath, True))
+        sweep_stack.append((dirpath, True, selected_identity))
         try:
             for child in dirpath.iterdir():
                 if (
                     child.is_dir()
                     and not _is_link_like(child)
+                    and not _is_delete_quarantine_path(child)
                     and child.name not in _EMPTY_DIR_SWEEP_PRUNE_DIRS
                     and child.name not in _EMPTY_DIR_SWEEP_PROTECTED_NAMES
                 ):
-                    sweep_stack.append((child, False))
+                    sweep_stack.append((child, False, child.lstat()))
         except OSError:
             pass
 

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -375,7 +375,7 @@ def _is_protected_cron_path(p: Path) -> bool:
             # Only regular artifacts below cron/output/<job>/ are disposable.
             # Every other descendant is scheduler control-plane state.
             return not (
-                len(parts) >= 4
+                len(parts) >= 3
                 and parts[1] == "output"
                 and p.is_file()
                 and not p.is_symlink()

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -10,7 +10,7 @@ Rules:
   - test files    → delete immediately at task end (age >= 0)
   - temp files    → delete after 7 days
   - cron-output   → delete after 14 days
-  - empty dirs    → always delete (under HERMES_HOME)
+  - empty dirs    → delete only inside explicitly marked Hermes-owned roots
   - research      → keep 10 newest, prompt for older (deep only)
   - chrome-profile→ prompt after 14 days (deep only)
   - >500 MB files → prompt always (deep only)
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
@@ -68,15 +69,36 @@ def is_safe_path(path: Path) -> bool:
 
     Rejects Windows mounts (``/mnt/c`` etc.) and any system directory.
     """
-    hermes_home = get_hermes_home()
     try:
-        path.resolve().relative_to(hermes_home)
+        candidate = Path(path)
+        hermes_home = Path(get_hermes_home()).resolve()
+        resolved = candidate.resolve()
+    except (TypeError, ValueError, OSError):
+        return False
+
+    try:
+        resolved.relative_to(hermes_home)
         return True
     except (ValueError, OSError):
         pass
-    # Allow /tmp/hermes-* explicitly
-    parts = path.parts
-    if len(parts) >= 3 and parts[1] == "tmp" and parts[2].startswith("hermes-"):
+
+    # Allow the explicitly temporary POSIX-style ``/tmp/hermes-*`` scope.
+    # On Windows, ``Path('/tmp/...').resolve()`` becomes ``C:\\tmp\\...``;
+    # retain that compatibility while rejecting an explicit drive path such
+    # as ``C:\\tmp\\hermes-user``.  The latter is not the approved temporary
+    # namespace and could otherwise be mistaken for it by ``parts`` alone.
+    if os.name == "nt" and candidate.anchor not in {"", "\\", "/"}:
+        return False
+    parts = resolved.parts
+    if (
+        len(parts) >= 3
+        and (
+            parts[0] in {"/", "\\"}
+            or (os.name == "nt" and candidate.anchor in {"\\", "/"})
+        )
+        and parts[1].casefold() == "tmp"
+        and parts[2].casefold().startswith("hermes-")
+    ):
         return True
     return False
 
@@ -110,12 +132,17 @@ def load_tracked() -> List[Dict[str, Any]]:
         return []
 
     try:
-        return json.loads(tf.read_text())
+        data = json.loads(tf.read_text())
+        if not isinstance(data, list):
+            raise ValueError("tracked.json must contain a list")
+        return data
     except (json.JSONDecodeError, ValueError):
         bak = tf.with_suffix(".json.bak")
         if bak.exists():
             try:
                 data = json.loads(bak.read_text())
+                if not isinstance(data, list):
+                    raise ValueError("tracked.json backup must contain a list")
                 _log("WARN: tracked.json corrupted — restored from .bak")
                 return data
             except Exception:
@@ -155,6 +182,25 @@ _EMPTY_DIR_SWEEP_PRUNE_DIRS = frozenset({
     "site-packages", "__pycache__",
 })
 
+# Empty-directory pruning is limited to roots that this plugin explicitly
+# owns.  An arbitrary empty directory under HERMES_HOME may be a user's
+# project output or a control-plane staging area; emptiness is not ownership
+# evidence.  Keep persistent Singularity/cache subtrees out of the sweep even
+# when they live below the opt-in scratch root.
+_EMPTY_DIR_OWNED_TOP_LEVEL = frozenset({
+    "scratch", "tmp", "temp", "artifacts", "downloads",
+})
+_EMPTY_DIR_SWEEP_PROTECTED_NAMES = frozenset({"hermes-overlays", ".apptainer"})
+_EMPTY_DIR_OWNERSHIP_MARKER = ".hermes-managed"
+
+_MANAGED_ARTIFACT_RETENTION_DAYS = {
+    "hook_outputs": 14,
+    "spawn-trees": 30,
+}
+_MANAGED_ARTIFACT_SKIP_NAMES = frozenset({
+    ".hermes-managed", ".in-progress", ".active", ".lock",
+})
+
 
 # Paths under $HERMES_HOME that must NEVER be deleted by quick(),
 # regardless of what the stored category says.  This is a defense-in-depth
@@ -186,6 +232,108 @@ def _is_protected_cron_path(p: Path) -> bool:
             _PROTECTED_CRON_PATHS.add(str(base / ".tick.lock"))
     resolved = str(p.resolve())
     return resolved in _PROTECTED_CRON_PATHS
+
+
+def _is_owned_empty_dir_root(path: Path) -> bool:
+    """Return whether *path* carries explicit ownership evidence.
+
+    Names such as ``scratch`` and ``tmp`` are common in user projects and
+    cannot authorize deletion by themselves.  The creator of a disposable
+    Hermes root must leave a regular ``.hermes-managed`` marker containing
+    the expected root name.  Missing, symlinked, or malformed markers fail
+    closed and keep the entire subtree untouched.
+    """
+    if path.name not in _EMPTY_DIR_OWNED_TOP_LEVEL:
+        return False
+    marker = path / _EMPTY_DIR_OWNERSHIP_MARKER
+    try:
+        owned = (
+            marker.is_file()
+            and not marker.is_symlink()
+            and marker.read_text(encoding="utf-8").strip() == path.name
+        )
+        if not owned:
+            return False
+        # A lock/active marker is evidence that this namespace may still be
+        # live.  Treat malformed or inaccessible markers as active too.
+        return not _has_active_maintenance_marker(path)
+    except (OSError, UnicodeError):
+        return False
+
+
+def _has_active_maintenance_marker(path: Path) -> bool:
+    """Return whether *path* has a live or unverifiable maintenance marker."""
+    for name in (".in-progress", ".active", ".lock"):
+        marker = path / name
+        try:
+            marker.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            return True
+        # A symlink or any existing marker is intentionally conservative:
+        # stale ownership cannot be inferred from its name or contents.
+        return True
+    return False
+
+
+def _validated_tracked_item(item: Any):
+    """Return validated tracking fields, or ``None`` for untrusted evidence."""
+    if not isinstance(item, dict):
+        return None
+    path_value = item.get("path")
+    category = item.get("category")
+    timestamp = item.get("timestamp")
+    size = item.get("size")
+    if (
+        not isinstance(path_value, str)
+        or not path_value
+        or category not in ALLOWED_CATEGORIES
+        or not isinstance(timestamp, str)
+        or not timestamp
+        or not isinstance(size, (int, float))
+        or isinstance(size, bool)
+        or (isinstance(size, float) and not size.is_integer())
+    ):
+        return None
+    try:
+        path = Path(path_value)
+        parsed_timestamp = datetime.fromisoformat(timestamp)
+        if parsed_timestamp.tzinfo is None:
+            parsed_timestamp = parsed_timestamp.replace(tzinfo=timezone.utc)
+        parsed_size = int(size)
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+    if parsed_size < 0:
+        return None
+    return path, category, parsed_timestamp, parsed_size
+
+
+def _managed_marker_matches(path: Path, expected: str) -> bool:
+    """Return true only for a regular, readable ownership marker."""
+    marker = path / _EMPTY_DIR_OWNERSHIP_MARKER
+    try:
+        return (
+            marker.is_file()
+            and not marker.is_symlink()
+            and marker.read_text(encoding="utf-8").strip() == expected
+        )
+    except (OSError, UnicodeError):
+        return False
+
+
+def _remove_path(path: Path) -> Optional[str]:
+    """Remove one regular file or directory, returning an error if unsure."""
+    try:
+        if path.is_file():
+            path.unlink()
+        elif path.is_dir():
+            shutil.rmtree(path)
+        else:
+            return "not a regular file or directory"
+    except OSError as exc:
+        return str(exc)
+    return None
 
 
 def fmt_size(n: float) -> str:
@@ -220,7 +368,10 @@ def track(path_str: str, category: str, silent: bool = False) -> bool:
     tracked = load_tracked()
 
     # Deduplicate
-    if any(item["path"] == str(path) for item in tracked):
+    if any(
+        isinstance(item, dict) and item.get("path") == str(path)
+        for item in tracked
+    ):
         return False
 
     tracked.append({
@@ -262,12 +413,15 @@ def dry_run() -> Tuple[List[Dict], List[Dict]]:
     prompt: List[Dict] = []
 
     for item in tracked:
-        p = Path(item["path"])
-        if not p.exists():
+        validated = _validated_tracked_item(item)
+        if validated is None:
+            # A malformed record is not deletion authorization.  Omit it
+            # from the preview rather than aborting the whole report.
             continue
-        age = (now - datetime.fromisoformat(item["timestamp"])).days
-        cat = item["category"]
-        size = item["size"]
+        p, cat, timestamp, size = validated
+        if not p.exists() or not is_safe_path(p):
+            continue
+        age = (now - timestamp).days
 
         # Re-validate stale "cron-output" entries (fixes #37721).
         if cat == "cron-output":
@@ -300,25 +454,49 @@ def dry_run() -> Tuple[List[Dict], List[Dict]]:
 def quick() -> Dict[str, Any]:
     """Safe deterministic cleanup — no prompts.
 
-    Returns: ``{"deleted": N, "empty_dirs": N, "freed": bytes,
-               "errors": [str, ...]}``.
+    Returns: ``{"deleted": N, "artifacts": N, "empty_dirs": N,
+               "freed": bytes, "errors": [str, ...]}``.
     """
     tracked = load_tracked()
     now = datetime.now(timezone.utc)
     deleted = 0
     freed = 0
-    new_tracked: List[Dict] = []
+    new_tracked: List[Any] = []
     errors: List[str] = []
+    artifacts = 0
 
     for item in tracked:
-        p = Path(item["path"])
-        cat = item["category"]
+        validated = _validated_tracked_item(item)
+        if validated is None:
+            # Preserve malformed records and continue.  Hand-edited or
+            # partially-written tracking state is never proof of ownership.
+            errors.append(f"invalid tracked record: {item!r}")
+            new_tracked.append(item)
+            continue
+        p, cat, timestamp, size = validated
 
-        if not p.exists():
+        try:
+            p.stat()
+        except FileNotFoundError:
             _log(f"STALE: {p} (removed from tracking)")
             continue
+        except (OSError, ValueError) as exc:
+            _log(f"ERROR inspecting {p}: {exc}")
+            errors.append(f"{p}: {exc}")
+            new_tracked.append(item)
+            continue
 
-        age = (now - datetime.fromisoformat(item["timestamp"])).days
+        # tracked.json is durable state, not proof that the current target is
+        # still owned by Hermes.  A stale or hand-edited record must never make
+        # quick() delete a path outside the active HERMES_HOME (or approved
+        # /tmp/hermes-* scope).
+        if not is_safe_path(p):
+            _log(f"SKIP unsafe tracked path: {p}")
+            errors.append(f"{p}: unsafe path")
+            new_tracked.append(item)
+            continue
+
+        age = (now - timestamp).days
 
         # ---- stale-state migration (fixes #37721) ----
         # Old tracked.json entries may carry a "cron-output" category for
@@ -349,26 +527,64 @@ def quick() -> Dict[str, Any]:
         )
 
         if should_delete:
-            try:
-                if p.is_file():
-                    p.unlink()
-                elif p.is_dir():
-                    shutil.rmtree(p)
-                freed += item["size"]
+            error = _remove_path(p)
+            if error is None:
+                freed += size
                 deleted += 1
-                _log(f"DELETED: {p} ({cat}, {fmt_size(item['size'])})")
-            except OSError as e:
-                _log(f"ERROR deleting {p}: {e}")
-                errors.append(f"{p}: {e}")
+                _log(f"DELETED: {p} ({cat}, {fmt_size(size)})")
+            else:
+                _log(f"ERROR deleting {p}: {error}")
+                errors.append(f"{p}: {error}")
                 new_tracked.append(item)
         else:
             new_tracked.append(item)
+
+    # Prune artifact files only inside explicitly marked session directories.
+    # The marker is the durable ownership proof; directory names alone are not.
+    hermes_home = get_hermes_home()
+    for root_name, retention_days in _MANAGED_ARTIFACT_RETENTION_DAYS.items():
+        artifact_root = hermes_home / root_name
+        try:
+            if artifact_root.is_symlink() or not artifact_root.is_dir():
+                continue
+            session_dirs = [
+                p for p in artifact_root.iterdir()
+                if p.is_dir() and not p.is_symlink()
+            ]
+        except OSError:
+            continue
+        for session_dir in session_dirs:
+            try:
+                if (
+                    not _managed_marker_matches(session_dir, root_name)
+                    or _has_active_maintenance_marker(session_dir)
+                ):
+                    continue
+                for artifact in session_dir.iterdir():
+                    if (
+                        artifact.name in _MANAGED_ARTIFACT_SKIP_NAMES
+                        or artifact.is_symlink()
+                        or not artifact.is_file()
+                    ):
+                        continue
+                    try:
+                        age_seconds = now.timestamp() - artifact.stat().st_mtime
+                        if age_seconds <= retention_days * 24 * 60 * 60:
+                            continue
+                        size = artifact.stat().st_size
+                        artifact.unlink()
+                        artifacts += 1
+                        freed += size
+                        _log(f"DELETED: {artifact} (managed artifact retention)")
+                    except OSError as exc:
+                        errors.append(f"{artifact}: {exc}")
+            except OSError as exc:
+                errors.append(f"{session_dir}: {exc}")
 
     # Remove empty dirs under HERMES_HOME, but never recurse into known
     # durable state trees.  Some installs place the Hermes checkout, venv,
     # and desktop build under HERMES_HOME; a full rglob over that tree can
     # stall the gateway event loop for minutes.
-    hermes_home = get_hermes_home()
     empty_removed = 0
     sweep_stack: List[Tuple[Path, bool]] = []
     try:
@@ -376,8 +592,7 @@ def quick() -> Dict[str, Any]:
             if (
                 top.is_dir()
                 and not top.is_symlink()
-                and top.name not in _EMPTY_DIR_PROTECTED_TOP_LEVEL
-                and top.name not in _EMPTY_DIR_SWEEP_PRUNE_DIRS
+                and _is_owned_empty_dir_root(top)
             ):
                 sweep_stack.append((top, False))
     except OSError:
@@ -402,6 +617,7 @@ def quick() -> Dict[str, Any]:
                     child.is_dir()
                     and not child.is_symlink()
                     and child.name not in _EMPTY_DIR_SWEEP_PRUNE_DIRS
+                    and child.name not in _EMPTY_DIR_SWEEP_PROTECTED_NAMES
                 ):
                     sweep_stack.append((child, False))
         except OSError:
@@ -414,6 +630,7 @@ def quick() -> Dict[str, Any]:
     )
     return {
         "deleted": deleted,
+        "artifacts": artifacts,
         "empty_dirs": empty_removed,
         "freed": freed,
         "errors": errors,
@@ -446,17 +663,23 @@ def deep(
     research, chrome, large = [], [], []
 
     for item in tracked:
-        p = Path(item["path"])
-        if not p.exists():
+        validated = _validated_tracked_item(item)
+        if validated is None:
             continue
-        age = (now - datetime.fromisoformat(item["timestamp"])).days
-        cat = item["category"]
+        p, cat, timestamp, size = validated
+        try:
+            p.stat()
+        except (FileNotFoundError, OSError, ValueError):
+            continue
+        if not is_safe_path(p) or _is_protected_cron_path(p):
+            continue
+        age = (now - timestamp).days
 
         if cat == "research" and age > 30:
             research.append(item)
         elif cat == "chrome-profile" and age > 14:
             chrome.append(item)
-        elif item["size"] > 500 * 1024 * 1024:
+        elif size > 500 * 1024 * 1024:
             large.append(item)
 
     research.sort(key=lambda x: x["timestamp"], reverse=True)
@@ -468,21 +691,23 @@ def deep(
     for group in (old_research, chrome, large):
         for item in group:
             if confirm(item):
-                try:
-                    p = Path(item["path"])
-                    if p.is_file():
-                        p.unlink()
-                    elif p.is_dir():
-                        shutil.rmtree(p)
+                validated = _validated_tracked_item(item)
+                if validated is None:
+                    continue
+                p, _cat, _timestamp, size = validated
+                if not is_safe_path(p) or _is_protected_cron_path(p):
+                    continue
+                error = _remove_path(p)
+                if error is None:
                     to_remove.append(item)
-                    freed += item["size"]
+                    freed += size
                     count += 1
                     _log(
                         f"DELETED: {p} ({item['category']}, "
-                        f"{fmt_size(item['size'])})"
+                        f"{fmt_size(size)})"
                     )
-                except OSError as e:
-                    _log(f"ERROR deleting {item['path']}: {e}")
+                else:
+                    _log(f"ERROR deleting {p}: {error}")
 
     if to_remove:
         remove_paths = {i["path"] for i in to_remove}

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -502,6 +502,19 @@ def _identity_matches(path: Path, expected: Dict[str, int]) -> bool:
     return current is not None and current == expected
 
 
+def _same_directory_object(path: Path, expected: os.stat_result) -> bool:
+    """Revalidate a selected non-reparse directory by stable filesystem ID."""
+    try:
+        current = path.lstat()
+        return (
+            stat.S_ISDIR(current.st_mode)
+            and not _is_link_like(path)
+            and os.path.samestat(expected, current)
+        )
+    except OSError:
+        return False
+
+
 def _validated_tracked_item(item: Any):
     """Return validated tracking fields, or ``None`` for untrusted evidence."""
     if not isinstance(item, dict):
@@ -584,13 +597,11 @@ def _remove_path(path: Path) -> Optional[str]:
 
 
 def _restore_quarantined_path(quarantine: Path, original: Path) -> str:
-    try:
-        if os.path.lexists(original):
-            raise FileExistsError(str(original))
-        os.replace(quarantine, original)
-        return f"filesystem identity changed during delete; restored {original}"
-    except OSError:
-        return f"filesystem identity changed during delete; preserved at {quarantine}"
+    """Preserve uncertainty without risking an overwrite at *original*."""
+    return (
+        f"filesystem identity changed during delete; preserved at {quarantine} "
+        f"instead of restoring over {original}"
+    )
 
 
 def _open_delete_candidate(path: Path) -> int:
@@ -699,25 +710,13 @@ def _atomic_rmdir_empty(path: Path, expected: os.stat_result) -> bool:
             or _is_link_like(quarantine)
             or not os.path.samestat(expected, moved)
         ):
-            if not os.path.lexists(path):
-                os.replace(quarantine, path)
             return False
         try:
             quarantine.rmdir()
         except OSError:
-            if not os.path.lexists(path):
-                try:
-                    os.replace(quarantine, path)
-                except OSError:
-                    pass
             return False
         return True
     except OSError:
-        try:
-            if os.path.lexists(quarantine) and not os.path.lexists(path):
-                os.replace(quarantine, path)
-        except OSError:
-            pass
         return False
 
 
@@ -1009,22 +1008,42 @@ def quick(paths: Optional[Iterable[str]] = None) -> Dict[str, Any]:
     for root_name, retention_days in _MANAGED_ARTIFACT_RETENTION_DAYS.items():
         artifact_root = hermes_home / root_name
         try:
-            if _is_link_like(artifact_root) or not artifact_root.is_dir():
+            artifact_root_identity = artifact_root.lstat()
+            if (
+                _is_link_like(artifact_root)
+                or not stat.S_ISDIR(artifact_root_identity.st_mode)
+            ):
                 continue
             session_dirs = [
-                p for p in artifact_root.iterdir()
+                (p, p.lstat())
+                for p in artifact_root.iterdir()
                 if p.is_dir() and not _is_link_like(p)
             ]
+            if not _same_directory_object(artifact_root, artifact_root_identity):
+                continue
         except OSError:
             continue
-        for session_dir in session_dirs:
+        for session_dir, session_identity in session_dirs:
             try:
                 if (
-                    not _managed_marker_matches(session_dir, root_name)
+                    not _same_directory_object(
+                        artifact_root, artifact_root_identity
+                    )
+                    or not _same_directory_object(session_dir, session_identity)
+                    or not _managed_marker_matches(session_dir, root_name)
                     or _has_active_maintenance_marker(session_dir)
                 ):
                     continue
                 for artifact in session_dir.iterdir():
+                    if (
+                        not _same_directory_object(
+                            artifact_root, artifact_root_identity
+                        )
+                        or not _same_directory_object(session_dir, session_identity)
+                        or not _managed_marker_matches(session_dir, root_name)
+                        or _has_active_maintenance_marker(session_dir)
+                    ):
+                        break
                     if (
                         artifact.name in _MANAGED_ARTIFACT_SKIP_NAMES
                         or _is_delete_quarantine_path(artifact)

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 import shutil
+import stat
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
@@ -207,6 +208,29 @@ _MANAGED_ARTIFACT_SKIP_NAMES = frozenset({
 # guard against stale tracked.json entries from before #34840.
 _PROTECTED_CRON_PATHS: set[str] = set()
 
+_PROTECTED_TRACKED_TOP_LEVEL = frozenset({
+    ".worktrees",
+    "backups",
+    "disk-cleanup",
+    "hermes-agent",
+    "logs",
+    "memories",
+    "optional-skills",
+    "plugins",
+    "profiles",
+    "sessions",
+    "skills",
+})
+_PROTECTED_TRACKED_TOP_LEVEL_FILES = frozenset({
+    ".env",
+    "MEMORY.md",
+    "SOUL.md",
+    "USER.md",
+    "auth.json",
+    "config.yaml",
+    "state.db",
+})
+
 
 def _is_protected_cron_path(p: Path) -> bool:
     """Return True if *p* is a cron control-plane file/directory that must
@@ -232,6 +256,21 @@ def _is_protected_cron_path(p: Path) -> bool:
             _PROTECTED_CRON_PATHS.add(str(base / ".tick.lock"))
     resolved = str(p.resolve())
     return resolved in _PROTECTED_CRON_PATHS
+
+
+def _is_protected_tracked_path(path: Path) -> bool:
+    """Protect durable Hermes state from manual or stale tracking records."""
+    try:
+        rel = path.resolve().relative_to(get_hermes_home().resolve())
+    except (OSError, ValueError):
+        return False
+    if not rel.parts:
+        return True
+    top = rel.parts[0]
+    return (
+        top in _PROTECTED_TRACKED_TOP_LEVEL
+        or (len(rel.parts) == 1 and top in _PROTECTED_TRACKED_TOP_LEVEL_FILES)
+    )
 
 
 def _is_owned_empty_dir_root(path: Path) -> bool:
@@ -375,6 +414,10 @@ def _remove_path(path: Path) -> Optional[str]:
 
 def _remove_tracked_path(path: Path, identity: Dict[str, int]) -> Optional[str]:
     """Remove only the unchanged filesystem object authorized by tracking."""
+    if _is_protected_tracked_path(path) or _is_protected_cron_path(path):
+        return "protected durable path"
+    if not stat.S_ISREG(identity.get("mode", 0)):
+        return "tracked path is not a regular file"
     if not _identity_matches(path, identity):
         return "tracked filesystem identity changed"
     return _remove_path(path)
@@ -392,13 +435,27 @@ def fmt_size(n: float) -> str:
 # Track / forget
 # ---------------------------------------------------------------------------
 
-def track(path_str: str, category: str, silent: bool = False) -> bool:
+def track(
+    path_str: str,
+    category: str,
+    silent: bool = False,
+    expected_identity: Optional[Dict[str, int]] = None,
+) -> bool:
     """Register a file for tracking. Returns True if newly tracked."""
     if category not in ALLOWED_CATEGORIES:
         _log(f"WARN: unknown category '{category}', using 'other'")
         category = "other"
 
-    path = Path(path_str).resolve()
+    source_path = Path(path_str).expanduser()
+
+    try:
+        if source_path.is_symlink() or not source_path.is_file():
+            _log(f"REJECT: {source_path} (not a regular file)")
+            return False
+        path = source_path.resolve()
+    except (OSError, ValueError):
+        _log(f"REJECT: {source_path} (filesystem identity unavailable)")
+        return False
 
     if not path.exists():
         _log(f"SKIP: {path} (does not exist)")
@@ -408,9 +465,16 @@ def track(path_str: str, category: str, silent: bool = False) -> bool:
         _log(f"REJECT: {path} (outside HERMES_HOME)")
         return False
 
+    if _is_protected_tracked_path(path) or _is_protected_cron_path(path):
+        _log(f"REJECT: {path} (protected durable path)")
+        return False
+
     identity = _capture_identity(path)
     if identity is None:
         _log(f"SKIP: {path} (filesystem identity unavailable)")
+        return False
+    if expected_identity is not None and identity != expected_identity:
+        _log(f"REJECT: {path} (creation identity changed before tracking)")
         return False
     size = identity["size"] if path.is_file() else 0
     tracked = load_tracked()
@@ -468,7 +532,14 @@ def dry_run() -> Tuple[List[Dict], List[Dict]]:
             # from the preview rather than aborting the whole report.
             continue
         p, cat, timestamp, size, identity = validated
-        if not p.exists() or not is_safe_path(p) or not _identity_matches(p, identity):
+        if (
+            not p.exists()
+            or not is_safe_path(p)
+            or _is_protected_tracked_path(p)
+            or _is_protected_cron_path(p)
+            or not stat.S_ISREG(identity.get("mode", 0))
+            or not _identity_matches(p, identity)
+        ):
             continue
         age = (now - timestamp).days
 
@@ -554,6 +625,18 @@ def quick(paths: Optional[Iterable[str]] = None) -> Dict[str, Any]:
         if not is_safe_path(p):
             _log(f"SKIP unsafe tracked path: {p}")
             errors.append(f"{p}: unsafe path")
+            new_tracked.append(item)
+            continue
+
+        if _is_protected_tracked_path(p) or _is_protected_cron_path(p):
+            _log(f"SKIP protected tracked path: {p}")
+            errors.append(f"{p}: protected durable path")
+            new_tracked.append(item)
+            continue
+
+        if not stat.S_ISREG(identity.get("mode", 0)):
+            _log(f"SKIP non-file tracked path: {p}")
+            errors.append(f"{p}: tracked path is not a regular file")
             new_tracked.append(item)
             continue
 
@@ -755,7 +838,12 @@ def deep(
             p.stat()
         except (FileNotFoundError, OSError, ValueError):
             continue
-        if not is_safe_path(p) or _is_protected_cron_path(p):
+        if (
+            not is_safe_path(p)
+            or _is_protected_cron_path(p)
+            or _is_protected_tracked_path(p)
+            or not stat.S_ISREG(identity.get("mode", 0))
+        ):
             continue
         age = (now - timestamp).days
 
@@ -779,7 +867,12 @@ def deep(
                 if validated is None:
                     continue
                 p, _cat, _timestamp, size, identity = validated
-                if not is_safe_path(p) or _is_protected_cron_path(p):
+                if (
+                    not is_safe_path(p)
+                    or _is_protected_cron_path(p)
+                    or _is_protected_tracked_path(p)
+                    or not stat.S_ISREG(identity.get("mode", 0))
+                ):
                     continue
                 error = _remove_tracked_path(p, identity)
                 if error is None:

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -724,44 +724,22 @@ def _windows_directory_handle_matches_stat(
     handle: int,
     expected: os.stat_result,
 ) -> bool:
-    """Compare an opened Windows directory handle with Python stat evidence."""
-    import ctypes
+    """Compare a raw handle with Python stat using Python's own encoding.
 
-    class _FileTime(ctypes.Structure):
-        _fields_ = [("low", ctypes.c_uint32), ("high", ctypes.c_uint32)]
-
-    class _ByHandleFileInformation(ctypes.Structure):
-        _fields_ = [
-            ("attributes", ctypes.c_uint32),
-            ("creation_time", _FileTime),
-            ("access_time", _FileTime),
-            ("write_time", _FileTime),
-            ("volume_serial", ctypes.c_uint32),
-            ("size_high", ctypes.c_uint32),
-            ("size_low", ctypes.c_uint32),
-            ("links", ctypes.c_uint32),
-            ("index_high", ctypes.c_uint32),
-            ("index_low", ctypes.c_uint32),
-        ]
-
-    information = _ByHandleFileInformation()
-    get_information = ctypes.WinDLL(
-        "kernel32", use_last_error=True
-    ).GetFileInformationByHandle
-    get_information.argtypes = [
-        ctypes.c_void_p,
-        ctypes.POINTER(_ByHandleFileInformation),
-    ]
-    get_information.restype = ctypes.c_int
-    if not get_information(handle, ctypes.byref(information)):
+    Windows exposes a 32-bit volume serial through
+    ``BY_HANDLE_FILE_INFORMATION``, while some Python builds encode ``st_dev``
+    as a wider device identifier. Re-stat the kernel-resolved handle path so
+    both sides use the same representation, then compare stable file IDs.
+    """
+    try:
+        actual = _windows_opened_handle_path(handle).lstat()
+        return bool(
+            stat.S_ISDIR(actual.st_mode)
+            and not int(getattr(actual, "st_file_attributes", 0)) & 0x400
+            and os.path.samestat(expected, actual)
+        )
+    except OSError:
         return False
-    file_index = (information.index_high << 32) | information.index_low
-    return bool(
-        information.volume_serial == expected.st_dev
-        and file_index == expected.st_ino
-        and not (information.attributes & 0x400)
-        and bool(information.attributes & 0x10)
-    )
 
 
 def _same_artifact_path(left: Path, right: Path) -> bool:

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -622,6 +622,25 @@ def _managed_marker_matches(path: Path, expected: str) -> bool:
         if not marker.is_file() or _is_link_like(marker):
             return False
         value = marker.read_text(encoding="utf-8").strip()
+        if expected == "hook_outputs":
+            if value == expected:
+                return True
+            prefix = "hook_outputs:v2:"
+            bound_name = value.removeprefix(prefix)
+            if not value.startswith(prefix) or bound_name != path.name:
+                return False
+            parts = bound_name.split("-")
+            if len(parts) not in (2, 3) or parts[0] != "s":
+                return False
+            digest = parts[1]
+            if len(digest) != 24 or any(
+                char not in "0123456789abcdef" for char in digest
+            ):
+                return False
+            if len(parts) == 2:
+                return True
+            suffix = parts[2]
+            return suffix == str(int(suffix)) and 1 <= int(suffix) <= 31
         if expected != "spawn-trees":
             return value == expected
         prefix = "spawn-trees:"

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -28,6 +28,7 @@ import shutil
 import stat
 import tempfile
 import threading
+import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -336,6 +337,7 @@ _PROTECTED_TRACKED_TOP_LEVEL_FILES_CASEFOLD = frozenset(
 _DISPOSABLE_TOP_LEVEL_PREFIXES = ("test_", "tmp_", "temp_")
 _DISPOSABLE_TRACKED_ROOTS = frozenset({
     "artifacts",
+    "cache",
     "downloads",
     "scratch",
     "temp",
@@ -378,7 +380,7 @@ def _is_protected_cron_path(p: Path) -> bool:
                 len(parts) >= 3
                 and parts[1] == "output"
                 and p.is_file()
-                and not p.is_symlink()
+                and not _is_link_like(p)
             )
 
     # Lazily build the set once per process so HERMES_HOME is resolved
@@ -474,6 +476,18 @@ def _capture_identity(path: Path) -> Optional[Dict[str, int]]:
     }
 
 
+def _is_link_like(path: Path) -> bool:
+    """Reject symlinks and Windows reparse points such as junctions."""
+    try:
+        if path.is_symlink():
+            return True
+        attributes = int(getattr(path.lstat(), "st_file_attributes", 0))
+        reparse_flag = int(getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400))
+        return bool(attributes & reparse_flag)
+    except OSError:
+        return True
+
+
 def _identity_matches(path: Path, expected: Dict[str, int]) -> bool:
     """Return whether *path* is still the exact object that was tracked."""
     current = _capture_identity(path)
@@ -530,10 +544,18 @@ def _managed_marker_matches(path: Path, expected: str) -> bool:
     """Return true only for a regular, readable ownership marker."""
     marker = path / _EMPTY_DIR_OWNERSHIP_MARKER
     try:
+        if not marker.is_file() or _is_link_like(marker):
+            return False
+        value = marker.read_text(encoding="utf-8").strip()
+        if expected != "spawn-trees":
+            return value == expected
+        prefix = "spawn-trees:"
+        digest = value.removeprefix(prefix)
         return (
-            marker.is_file()
-            and not marker.is_symlink()
-            and marker.read_text(encoding="utf-8").strip() == expected
+            value.startswith(prefix)
+            and len(digest) == 24
+            and all(char in "0123456789abcdef" for char in digest)
+            and path.name == f"s-{digest}"
         )
     except (OSError, UnicodeError):
         return False
@@ -553,15 +575,92 @@ def _remove_path(path: Path) -> Optional[str]:
     return None
 
 
+def _restore_quarantined_path(quarantine: Path, original: Path) -> str:
+    try:
+        os.link(quarantine, original)
+        quarantine.unlink()
+        return f"filesystem identity changed during delete; restored {original}"
+    except OSError:
+        return f"filesystem identity changed during delete; preserved at {quarantine}"
+
+
+def _open_delete_candidate(path: Path) -> int:
+    """Open *path* while allowing an atomic rename on Windows."""
+    if os.name != "nt":
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        return os.open(path, flags)
+
+    import ctypes
+    import msvcrt
+
+    create_file = ctypes.windll.kernel32.CreateFileW
+    create_file.argtypes = (
+        ctypes.c_wchar_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+    )
+    create_file.restype = ctypes.c_void_p
+    handle = create_file(
+        str(path),
+        0x80000000,  # GENERIC_READ
+        0x00000001 | 0x00000002 | 0x00000004,  # SHARE_READ|WRITE|DELETE
+        None,
+        3,  # OPEN_EXISTING
+        0x00200000,  # FILE_FLAG_OPEN_REPARSE_POINT
+        None,
+    )
+    if handle == ctypes.c_void_p(-1).value:
+        raise ctypes.WinError()
+    try:
+        return msvcrt.open_osfhandle(handle, os.O_RDONLY)
+    except BaseException:
+        ctypes.windll.kernel32.CloseHandle(handle)
+        raise
+
+
+def _atomic_unlink_regular(
+    path: Path, expected_identity: Optional[Dict[str, int]] = None
+) -> Optional[str]:
+    """Move an opened object to a nonce path before unlinking it."""
+    fd: Optional[int] = None
+    quarantine = path.with_name(f".{path.name}.hermes-delete-{uuid.uuid4().hex}")
+    try:
+        fd = _open_delete_candidate(path)
+        opened = os.fstat(fd)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or _is_link_like(path)
+            or not path.is_file()
+        ):
+            return "path is not a regular non-link file"
+        if expected_identity is not None and _capture_identity(path) != expected_identity:
+            return "tracked filesystem identity changed"
+        os.replace(path, quarantine)
+        moved = quarantine.lstat()
+        if not os.path.samestat(opened, moved):
+            return _restore_quarantined_path(quarantine, path)
+        quarantine.unlink()
+        return None
+    except OSError as exc:
+        return str(exc)
+    finally:
+        if fd is not None:
+            os.close(fd)
+
+
 def _remove_tracked_path(path: Path, identity: Dict[str, int]) -> Optional[str]:
     """Remove only the unchanged filesystem object authorized by tracking."""
     if _is_protected_tracked_path(path) or _is_protected_cron_path(path):
         return "protected durable path"
     if not stat.S_ISREG(identity.get("mode", 0)):
         return "tracked path is not a regular file"
-    if not _identity_matches(path, identity):
-        return "tracked filesystem identity changed"
-    return _remove_path(path)
+    return _atomic_unlink_regular(path, identity)
 
 
 def fmt_size(n: float) -> str:
@@ -590,7 +689,7 @@ def track(
     source_path = Path(path_str).expanduser()
 
     try:
-        if source_path.is_symlink() or not source_path.is_file():
+        if _is_link_like(source_path) or not source_path.is_file():
             _log(f"REJECT: {source_path} (not a regular file)")
             return False
         path = source_path.resolve()
@@ -852,11 +951,11 @@ def quick(paths: Optional[Iterable[str]] = None) -> Dict[str, Any]:
     for root_name, retention_days in _MANAGED_ARTIFACT_RETENTION_DAYS.items():
         artifact_root = hermes_home / root_name
         try:
-            if artifact_root.is_symlink() or not artifact_root.is_dir():
+            if _is_link_like(artifact_root) or not artifact_root.is_dir():
                 continue
             session_dirs = [
                 p for p in artifact_root.iterdir()
-                if p.is_dir() and not p.is_symlink()
+                if p.is_dir() and not _is_link_like(p)
             ]
         except OSError:
             continue
@@ -870,7 +969,7 @@ def quick(paths: Optional[Iterable[str]] = None) -> Dict[str, Any]:
                 for artifact in session_dir.iterdir():
                     if (
                         artifact.name in _MANAGED_ARTIFACT_SKIP_NAMES
-                        or artifact.is_symlink()
+                        or _is_link_like(artifact)
                         or not artifact.is_file()
                     ):
                         continue
@@ -879,7 +978,10 @@ def quick(paths: Optional[Iterable[str]] = None) -> Dict[str, Any]:
                         if age_seconds <= retention_days * 24 * 60 * 60:
                             continue
                         size = artifact.stat().st_size
-                        artifact.unlink()
+                        error = _atomic_unlink_regular(artifact)
+                        if error is not None:
+                            errors.append(f"{artifact}: {error}")
+                            continue
                         artifacts += 1
                         freed += size
                         _log(f"DELETED: {artifact} (managed artifact retention)")
@@ -898,7 +1000,7 @@ def quick(paths: Optional[Iterable[str]] = None) -> Dict[str, Any]:
         for top in hermes_home.iterdir():
             if (
                 top.is_dir()
-                and not top.is_symlink()
+                and not _is_link_like(top)
                 and _is_owned_empty_dir_root(top)
             ):
                 sweep_stack.append((top, False))
@@ -922,7 +1024,7 @@ def quick(paths: Optional[Iterable[str]] = None) -> Dict[str, Any]:
             for child in dirpath.iterdir():
                 if (
                     child.is_dir()
-                    and not child.is_symlink()
+                    and not _is_link_like(child)
                     and child.name not in _EMPTY_DIR_SWEEP_PRUNE_DIRS
                     and child.name not in _EMPTY_DIR_SWEEP_PROTECTED_NAMES
                 ):

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -334,6 +334,13 @@ _PROTECTED_TRACKED_TOP_LEVEL_FILES_CASEFOLD = frozenset(
     name.casefold() for name in _PROTECTED_TRACKED_TOP_LEVEL_FILES
 )
 _DISPOSABLE_TOP_LEVEL_PREFIXES = ("test_", "tmp_", "temp_")
+_DISPOSABLE_TRACKED_ROOTS = frozenset({
+    "artifacts",
+    "downloads",
+    "scratch",
+    "temp",
+    "tmp",
+})
 
 
 def _is_narrow_top_level_artifact(name: str) -> bool:
@@ -358,6 +365,22 @@ def _is_protected_cron_path(p: Path) -> bool:
     protected, because deleting it wholesale erases every job's retained run
     history at once.
     """
+    try:
+        rel = p.resolve().relative_to(get_hermes_home().resolve())
+    except (OSError, ValueError):
+        rel = None
+    if rel is not None and rel.parts:
+        parts = tuple(part.casefold() for part in rel.parts)
+        if parts[0] in {"cron", "cronjobs"}:
+            # Only regular artifacts below cron/output/<job>/ are disposable.
+            # Every other descendant is scheduler control-plane state.
+            return not (
+                len(parts) >= 4
+                and parts[1] == "output"
+                and p.is_file()
+                and not p.is_symlink()
+            )
+
     # Lazily build the set once per process so HERMES_HOME is resolved
     # exactly once.
     if not _PROTECTED_CRON_PATHS:
@@ -381,14 +404,14 @@ def _is_protected_tracked_path(path: Path) -> bool:
     if not rel.parts:
         return True
     top = rel.parts[0].casefold()
-    return (
-        top in _PROTECTED_TRACKED_TOP_LEVEL_CASEFOLD
-        or (len(rel.parts) == 1 and not _is_narrow_top_level_artifact(top))
-        or (
-            len(rel.parts) == 1
-            and top in _PROTECTED_TRACKED_TOP_LEVEL_FILES_CASEFOLD
+    if len(rel.parts) == 1:
+        return (
+            not _is_narrow_top_level_artifact(top)
+            or top in _PROTECTED_TRACKED_TOP_LEVEL_FILES_CASEFOLD
         )
-    )
+    if top in {"cron", "cronjobs"}:
+        return False  # _is_protected_cron_path applies the narrower exception.
+    return top not in _DISPOSABLE_TRACKED_ROOTS
 
 
 def _is_owned_empty_dir_root(path: Path) -> bool:

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -134,11 +134,30 @@ def _tracked_registry_lock():
     """Serialize tracked.json read-modify-write cycles across processes."""
     lock_path = get_state_dir() / "tracked.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with _TRACKED_THREAD_LOCK, lock_path.open("a+b") as lock_file:
-        if lock_file.seek(0, os.SEEK_END) == 0:
-            lock_file.write(b"0")
-            lock_file.flush()
-        lock_file.seek(0)
+    flags = os.O_RDWR
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    with _TRACKED_THREAD_LOCK:
+        try:
+            lock_fd = os.open(lock_path, flags | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            selected = lock_path.lstat()
+            lock_fd = os.open(lock_path, flags)
+            opened = os.fstat(lock_fd)
+            current = lock_path.lstat()
+            if (
+                not stat.S_ISREG(selected.st_mode)
+                or int(getattr(selected, "st_file_attributes", 0)) & 0x400
+                or selected.st_nlink != 1
+                or opened.st_nlink != 1
+                or not os.path.samestat(selected, opened)
+                or not os.path.samestat(opened, current)
+            ):
+                os.close(lock_fd)
+                raise OSError("tracked registry lock is not independently owned")
+        lock_file = os.fdopen(lock_fd, "r+b", closefd=True)
         acquired = False
         try:
             if os.name == "nt":
@@ -152,16 +171,19 @@ def _tracked_registry_lock():
             acquired = True
             yield
         finally:
-            if acquired:
-                lock_file.seek(0)
-                if os.name == "nt":
-                    import msvcrt
+            try:
+                if acquired:
+                    lock_file.seek(0)
+                    if os.name == "nt":
+                        import msvcrt
 
-                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
-                else:
-                    import fcntl
+                        msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+                    else:
+                        import fcntl
 
-                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            finally:
+                lock_file.close()
 
 
 def _load_tracked_unlocked() -> List[Dict[str, Any]]:
@@ -655,6 +677,365 @@ def _managed_marker_matches(path: Path, expected: str) -> bool:
         return False
 
 
+class _ManagedArtifactLease(NamedTuple):
+    """Opened directory objects that authorize one retention deletion."""
+
+    root_path: Path
+    root_identity: os.stat_result
+    root_resolved: Path
+    root_handle: int
+    session_path: Path
+    session_identity: os.stat_result
+    session_resolved: Path
+    session_handle: int
+    marker_identity: os.stat_result
+
+
+def _windows_opened_handle_path(handle: int) -> Path:
+    """Return the kernel-resolved path for an opened Windows handle."""
+    import ctypes
+
+    get_path = ctypes.WinDLL("kernel32", use_last_error=True).GetFinalPathNameByHandleW
+    get_path.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_wchar_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+    ]
+    get_path.restype = ctypes.c_uint32
+    size = 512
+    while True:
+        buffer = ctypes.create_unicode_buffer(size)
+        length = get_path(handle, buffer, size, 0)
+        if length == 0:
+            raise ctypes.WinError(ctypes.get_last_error())
+        if length < size:
+            value = buffer.value
+            break
+        size = length + 1
+    if value.startswith("\\\\?\\UNC\\"):
+        value = "\\\\" + value[8:]
+    elif value.startswith("\\\\?\\"):
+        value = value[4:]
+    return Path(value)
+
+
+def _windows_directory_handle_matches_stat(
+    handle: int,
+    expected: os.stat_result,
+) -> bool:
+    """Compare an opened Windows directory handle with Python stat evidence."""
+    import ctypes
+
+    class _FileTime(ctypes.Structure):
+        _fields_ = [("low", ctypes.c_uint32), ("high", ctypes.c_uint32)]
+
+    class _ByHandleFileInformation(ctypes.Structure):
+        _fields_ = [
+            ("attributes", ctypes.c_uint32),
+            ("creation_time", _FileTime),
+            ("access_time", _FileTime),
+            ("write_time", _FileTime),
+            ("volume_serial", ctypes.c_uint32),
+            ("size_high", ctypes.c_uint32),
+            ("size_low", ctypes.c_uint32),
+            ("links", ctypes.c_uint32),
+            ("index_high", ctypes.c_uint32),
+            ("index_low", ctypes.c_uint32),
+        ]
+
+    information = _ByHandleFileInformation()
+    get_information = ctypes.WinDLL(
+        "kernel32", use_last_error=True
+    ).GetFileInformationByHandle
+    get_information.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(_ByHandleFileInformation),
+    ]
+    get_information.restype = ctypes.c_int
+    if not get_information(handle, ctypes.byref(information)):
+        return False
+    file_index = (information.index_high << 32) | information.index_low
+    return bool(
+        information.volume_serial == expected.st_dev
+        and file_index == expected.st_ino
+        and not (information.attributes & 0x400)
+        and bool(information.attributes & 0x10)
+    )
+
+
+def _same_artifact_path(left: Path, right: Path) -> bool:
+    return os.path.normcase(os.path.normpath(str(left))) == os.path.normcase(
+        os.path.normpath(str(right))
+    )
+
+
+def _open_managed_artifact_directory(path: Path, *, parent_fd: Optional[int] = None) -> int:
+    """Open a directory object, denying replacement while it is retained."""
+    if os.name != "nt":
+        flags = os.O_RDONLY
+        if hasattr(os, "O_DIRECTORY"):
+            flags |= os.O_DIRECTORY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        if parent_fd is None:
+            return os.open(path, flags)
+        return os.open(path.name, flags, dir_fd=parent_fd)
+
+    import ctypes
+
+    create_file = ctypes.WinDLL("kernel32", use_last_error=True).CreateFileW
+    create_file.argtypes = [
+        ctypes.c_wchar_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+    ]
+    create_file.restype = ctypes.c_void_p
+    handle = create_file(
+        str(path),
+        0x00000080,  # FILE_READ_ATTRIBUTES
+        0x00000001 | 0x00000002,  # SHARE_READ | SHARE_WRITE; deny SHARE_DELETE
+        None,
+        3,  # OPEN_EXISTING
+        0x02000000 | 0x00200000,  # BACKUP_SEMANTICS | OPEN_REPARSE_POINT
+        None,
+    )
+    if handle == ctypes.c_void_p(-1).value:
+        raise ctypes.WinError(ctypes.get_last_error())
+    return int(handle)
+
+
+def _close_managed_artifact_directory(handle: int) -> None:
+    if os.name == "nt":
+        import ctypes
+
+        ctypes.WinDLL("kernel32", use_last_error=True).CloseHandle(handle)
+    else:
+        os.close(handle)
+
+
+def _managed_artifact_directory_handle_matches(
+    handle: int,
+    path: Path,
+    expected: os.stat_result,
+    resolved: Path,
+) -> bool:
+    """Verify an opened directory still names the exact selected object."""
+    try:
+        current = path.lstat()
+        if (
+            not stat.S_ISDIR(current.st_mode)
+            or _is_link_like(path)
+            or not os.path.samestat(expected, current)
+            or path.resolve(strict=True) != resolved
+        ):
+            return False
+        if os.name != "nt":
+            opened = os.fstat(handle)
+            return stat.S_ISDIR(opened.st_mode) and os.path.samestat(expected, opened)
+        return bool(
+            _windows_directory_handle_matches_stat(handle, expected)
+            and _same_artifact_path(_windows_opened_handle_path(handle), resolved)
+        )
+    except OSError:
+        return False
+
+
+@contextmanager
+def _hold_managed_artifact_session(
+    artifact_root: Path,
+    artifact_root_identity: os.stat_result,
+    session_dir: Path,
+    session_identity: os.stat_result,
+    root_name: str,
+):
+    """Bind the root and its exact session child through retention work."""
+    root_handle: Optional[int] = None
+    session_handle: Optional[int] = None
+    try:
+        root_resolved = artifact_root.resolve(strict=True)
+        session_resolved = session_dir.resolve(strict=True)
+        if session_resolved.parent != root_resolved:
+            raise OSError("managed artifact session is not an exact root child")
+        root_handle = _open_managed_artifact_directory(artifact_root)
+        if not _managed_artifact_directory_handle_matches(
+            root_handle,
+            artifact_root,
+            artifact_root_identity,
+            root_resolved,
+        ):
+            raise OSError("managed artifact root changed while binding")
+        session_handle = _open_managed_artifact_directory(
+            session_dir,
+            parent_fd=root_handle if os.name != "nt" else None,
+        )
+        if not _managed_artifact_directory_handle_matches(
+            session_handle,
+            session_dir,
+            session_identity,
+            session_resolved,
+        ):
+            raise OSError("managed artifact session changed while binding")
+        marker = session_dir / _EMPTY_DIR_OWNERSHIP_MARKER
+        marker_identity = marker.lstat()
+        if (
+            not _same_regular_file_object(marker, marker_identity)
+            or not _managed_marker_matches(session_dir, root_name)
+            or not _same_regular_file_object(marker, marker_identity)
+        ):
+            raise OSError("managed artifact ownership marker changed while binding")
+        yield _ManagedArtifactLease(
+            artifact_root,
+            artifact_root_identity,
+            root_resolved,
+            root_handle,
+            session_dir,
+            session_identity,
+            session_resolved,
+            session_handle,
+            marker_identity,
+        )
+    finally:
+        if session_handle is not None:
+            _close_managed_artifact_directory(session_handle)
+        if root_handle is not None:
+            _close_managed_artifact_directory(root_handle)
+
+
+def _managed_artifact_lease_matches(
+    lease: _ManagedArtifactLease,
+    root_name: str,
+) -> bool:
+    """Revalidate directory handles plus marker/active-maintenance policy."""
+    return bool(
+        _managed_artifact_directory_handle_matches(
+            lease.root_handle,
+            lease.root_path,
+            lease.root_identity,
+            lease.root_resolved,
+        )
+        and _managed_artifact_directory_handle_matches(
+            lease.session_handle,
+            lease.session_path,
+            lease.session_identity,
+            lease.session_resolved,
+        )
+        and _same_regular_file_object(
+            lease.session_path / _EMPTY_DIR_OWNERSHIP_MARKER,
+            lease.marker_identity,
+        )
+        and _managed_marker_matches(lease.session_path, root_name)
+        and _same_regular_file_object(
+            lease.session_path / _EMPTY_DIR_OWNERSHIP_MARKER,
+            lease.marker_identity,
+        )
+        and not _has_active_maintenance_marker(lease.session_path)
+    )
+
+
+def _artifact_identity_from_stat(value: os.stat_result) -> Dict[str, int]:
+    return {
+        "version": 1,
+        "device": int(value.st_dev),
+        "inode": int(value.st_ino),
+        "mode": int(value.st_mode),
+        "size": int(value.st_size),
+        "mtime_ns": int(value.st_mtime_ns),
+        "ctime_ns": int(value.st_ctime_ns),
+    }
+
+
+def _bound_managed_artifact_stat(
+    lease: _ManagedArtifactLease,
+    name: str,
+) -> os.stat_result:
+    if os.name == "nt":
+        return (lease.session_path / name).lstat()
+    return os.stat(name, dir_fd=lease.session_handle, follow_symlinks=False)
+
+
+def _atomic_unlink_managed_artifact(
+    lease: _ManagedArtifactLease,
+    root_name: str,
+    name: str,
+    expected_identity: Dict[str, int],
+) -> Optional[str]:
+    """Quarantine/delete one exact session child through the bound directory."""
+    if (
+        name in {"", ".", ".."}
+        or Path(name).name != name
+        or _DELETE_QUARANTINE_TOKEN in name
+    ):
+        return "invalid managed artifact name"
+    quarantine_name = f".{name}{_DELETE_QUARANTINE_TOKEN}{uuid.uuid4().hex}"
+    fd: Optional[int] = None
+    try:
+        if not _managed_artifact_lease_matches(lease, root_name):
+            return "managed artifact container identity changed"
+        flags = os.O_RDONLY
+        if hasattr(os, "O_BINARY"):
+            flags |= os.O_BINARY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        if os.name == "nt":
+            fd = _open_delete_candidate(lease.session_path / name)
+        else:
+            fd = os.open(name, flags, dir_fd=lease.session_handle)
+        opened = os.fstat(fd)
+        selected = _bound_managed_artifact_stat(lease, name)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or int(getattr(opened, "st_file_attributes", 0)) & 0x400
+            or not os.path.samestat(opened, selected)
+            or _artifact_identity_from_stat(opened) != expected_identity
+        ):
+            return "managed artifact filesystem identity changed"
+        if os.name == "nt":
+            import msvcrt
+
+            actual = _windows_opened_handle_path(msvcrt.get_osfhandle(fd))
+            expected = lease.session_resolved / name
+            if not _same_artifact_path(actual, expected):
+                return "managed artifact opened outside its bound session"
+        if not _managed_artifact_lease_matches(lease, root_name):
+            return "managed artifact container identity changed"
+
+        if os.name == "nt":
+            os.replace(
+                lease.session_path / name,
+                lease.session_path / quarantine_name,
+            )
+        else:
+            os.replace(
+                name,
+                quarantine_name,
+                src_dir_fd=lease.session_handle,
+                dst_dir_fd=lease.session_handle,
+            )
+        moved = _bound_managed_artifact_stat(lease, quarantine_name)
+        if not os.path.samestat(opened, moved):
+            return _restore_quarantined_path(
+                lease.session_path / quarantine_name,
+                lease.session_path / name,
+            )
+        if not _managed_artifact_lease_matches(lease, root_name):
+            return "managed artifact container changed; preserved quarantine"
+        if os.name == "nt":
+            (lease.session_path / quarantine_name).unlink()
+        else:
+            os.unlink(quarantine_name, dir_fd=lease.session_handle)
+        return None
+    except OSError as exc:
+        return str(exc)
+    finally:
+        if fd is not None:
+            os.close(fd)
+
+
 def _remove_path(path: Path) -> Optional[str]:
     """Remove one regular file or directory, returning an error if unsure."""
     try:
@@ -1121,42 +1502,64 @@ def quick(paths: Optional[Iterable[str]] = None) -> Dict[str, Any]:
                     or _has_active_maintenance_marker(session_dir)
                 ):
                     continue
-                for artifact in session_dir.iterdir():
-                    if (
-                        not _same_directory_object(
-                            artifact_root, artifact_root_identity
-                        )
-                        or not _same_directory_object(session_dir, session_identity)
-                        or not _managed_marker_matches(session_dir, root_name)
-                        or _has_active_maintenance_marker(session_dir)
-                    ):
-                        break
-                    if (
-                        artifact.name in _MANAGED_ARTIFACT_SKIP_NAMES
-                        or _is_delete_quarantine_path(artifact)
-                        or _is_link_like(artifact)
-                        or not artifact.is_file()
-                    ):
+                with _hold_managed_artifact_session(
+                    artifact_root,
+                    artifact_root_identity,
+                    session_dir,
+                    session_identity,
+                    root_name,
+                ) as lease:
+                    if not _managed_artifact_lease_matches(lease, root_name):
                         continue
-                    try:
-                        identity = _capture_identity(artifact)
-                        if identity is None or not stat.S_ISREG(identity["mode"]):
+                    names = (
+                        [entry.name for entry in session_dir.iterdir()]
+                        if os.name == "nt"
+                        else os.listdir(lease.session_handle)
+                    )
+                    for name in names:
+                        artifact = session_dir / name
+                        if not _managed_artifact_lease_matches(lease, root_name):
+                            break
+                        if (
+                            name in _MANAGED_ARTIFACT_SKIP_NAMES
+                            or _is_delete_quarantine_path(Path(name))
+                        ):
                             continue
-                        age_seconds = (
-                            now.timestamp() - identity["mtime_ns"] / 1_000_000_000
-                        )
-                        if age_seconds <= retention_days * 24 * 60 * 60:
-                            continue
-                        size = identity["size"]
-                        error = _atomic_unlink_regular(artifact, identity)
-                        if error is not None:
-                            errors.append(f"{artifact}: {error}")
-                            continue
-                        artifacts += 1
-                        freed += size
-                        _log(f"DELETED: {artifact} (managed artifact retention)")
-                    except OSError as exc:
-                        errors.append(f"{artifact}: {exc}")
+                        try:
+                            selected = _bound_managed_artifact_stat(lease, name)
+                            if (
+                                not stat.S_ISREG(selected.st_mode)
+                                or int(
+                                    getattr(selected, "st_file_attributes", 0)
+                                )
+                                & 0x400
+                            ):
+                                continue
+                            identity = _artifact_identity_from_stat(selected)
+                            age_seconds = (
+                                now.timestamp()
+                                - identity["mtime_ns"] / 1_000_000_000
+                            )
+                            if age_seconds <= retention_days * 24 * 60 * 60:
+                                continue
+                            size = identity["size"]
+                            error = _atomic_unlink_managed_artifact(
+                                lease,
+                                root_name,
+                                name,
+                                identity,
+                            )
+                            if error is not None:
+                                errors.append(f"{artifact}: {error}")
+                                continue
+                            artifacts += 1
+                            freed += size
+                            _log(
+                                f"DELETED: {artifact} "
+                                "(managed artifact retention)"
+                            )
+                        except OSError as exc:
+                            errors.append(f"{artifact}: {exc}")
             except OSError as exc:
                 errors.append(f"{session_dir}: {exc}")
 

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -32,7 +32,7 @@ import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple
 
 try:
     from hermes_constants import get_hermes_home
@@ -424,7 +424,38 @@ def _is_protected_tracked_path(path: Path) -> bool:
     return top not in _DISPOSABLE_TRACKED_ROOTS
 
 
-def _is_owned_empty_dir_root(path: Path) -> bool:
+class _OwnedEmptyDirRootEvidence(NamedTuple):
+    """Filesystem objects that authorized one empty-directory sweep."""
+
+    path: Path
+    root_identity: os.stat_result
+    marker_identity: os.stat_result
+
+
+def _same_regular_file_object(path: Path, expected: os.stat_result) -> bool:
+    """Revalidate a selected non-reparse regular file by filesystem ID."""
+    try:
+        current = path.lstat()
+        return (
+            stat.S_ISREG(current.st_mode)
+            and not _is_link_like(path)
+            and os.path.samestat(expected, current)
+        )
+    except OSError:
+        return False
+
+
+def _owned_empty_dir_root_matches(evidence: _OwnedEmptyDirRootEvidence) -> bool:
+    """Return whether both objects that granted sweep ownership are unchanged."""
+    return _same_directory_object(
+        evidence.path, evidence.root_identity
+    ) and _same_regular_file_object(
+        evidence.path / _EMPTY_DIR_OWNERSHIP_MARKER,
+        evidence.marker_identity,
+    )
+
+
+def _is_owned_empty_dir_root(evidence: _OwnedEmptyDirRootEvidence) -> bool:
     """Return whether *path* carries explicit ownership evidence.
 
     Names such as ``scratch`` and ``tmp`` are common in user projects and
@@ -433,22 +464,45 @@ def _is_owned_empty_dir_root(path: Path) -> bool:
     the expected root name.  Missing, symlinked, or malformed markers fail
     closed and keep the entire subtree untouched.
     """
+    path = evidence.path
     if path.name not in _EMPTY_DIR_OWNED_TOP_LEVEL:
         return False
     marker = path / _EMPTY_DIR_OWNERSHIP_MARKER
     try:
-        owned = (
-            marker.is_file()
-            and not marker.is_symlink()
-            and marker.read_text(encoding="utf-8").strip() == path.name
-        )
+        if not _owned_empty_dir_root_matches(evidence):
+            return False
+        owned = marker.read_text(encoding="utf-8").strip() == path.name
         if not owned:
             return False
         # A lock/active marker is evidence that this namespace may still be
         # live.  Treat malformed or inaccessible markers as active too.
-        return not _has_active_maintenance_marker(path)
+        if _has_active_maintenance_marker(path):
+            return False
+        # Bind the content and active-marker checks to the same root and
+        # ownership-marker objects selected before validation.  A replacement
+        # root carrying a copied marker must not inherit deletion authority.
+        return _owned_empty_dir_root_matches(evidence)
     except (OSError, UnicodeError):
         return False
+
+
+def _capture_owned_empty_dir_root(
+    path: Path,
+) -> Optional[_OwnedEmptyDirRootEvidence]:
+    """Capture, validate, and bind a root plus its ownership marker."""
+    try:
+        evidence = _OwnedEmptyDirRootEvidence(
+            path=path,
+            root_identity=path.lstat(),
+            marker_identity=(path / _EMPTY_DIR_OWNERSHIP_MARKER).lstat(),
+        )
+    except OSError:
+        return None
+    if not _is_owned_empty_dir_root(evidence):
+        return None
+    # The validator itself is a Python boundary and can be delayed or wrapped;
+    # revalidate after it returns before exposing the evidence to traversal.
+    return evidence if _owned_empty_dir_root_matches(evidence) else None
 
 
 def _has_active_maintenance_marker(path: Path) -> bool:
@@ -688,7 +742,11 @@ def _remove_tracked_path(path: Path, identity: Dict[str, int]) -> Optional[str]:
     return _atomic_unlink_regular(path, identity)
 
 
-def _atomic_rmdir_empty(path: Path, expected: os.stat_result) -> bool:
+def _atomic_rmdir_empty(
+    path: Path,
+    expected: os.stat_result,
+    root_evidence: Optional[_OwnedEmptyDirRootEvidence] = None,
+) -> bool:
     """Remove the exact selected empty directory, preserving uncertainty."""
     if _is_delete_quarantine_path(path):
         return False
@@ -696,6 +754,11 @@ def _atomic_rmdir_empty(path: Path, expected: os.stat_result) -> bool:
         f".{path.name}{_DELETE_QUARANTINE_TOKEN}{uuid.uuid4().hex}"
     )
     try:
+        if (
+            root_evidence is not None
+            and not _is_owned_empty_dir_root(root_evidence)
+        ):
+            return False
         current = path.lstat()
         if (
             not stat.S_ISDIR(current.st_mode)
@@ -709,6 +772,11 @@ def _atomic_rmdir_empty(path: Path, expected: os.stat_result) -> bool:
             not stat.S_ISDIR(moved.st_mode)
             or _is_link_like(quarantine)
             or not os.path.samestat(expected, moved)
+        ):
+            return False
+        if (
+            root_evidence is not None
+            and not _is_owned_empty_dir_root(root_evidence)
         ):
             return False
         try:
@@ -1078,25 +1146,36 @@ def quick(paths: Optional[Iterable[str]] = None) -> Dict[str, Any]:
     # and desktop build under HERMES_HOME; a full rglob over that tree can
     # stall the gateway event loop for minutes.
     empty_removed = 0
-    sweep_stack: List[Tuple[Path, bool, os.stat_result]] = []
+    sweep_stack: List[
+        Tuple[Path, bool, os.stat_result, _OwnedEmptyDirRootEvidence]
+    ] = []
     try:
         for top in hermes_home.iterdir():
+            root_evidence = _capture_owned_empty_dir_root(top)
             if (
-                top.is_dir()
-                and not _is_link_like(top)
+                root_evidence is not None
                 and not _is_delete_quarantine_path(top)
-                and _is_owned_empty_dir_root(top)
             ):
-                sweep_stack.append((top, False, top.lstat()))
+                sweep_stack.append(
+                    (top, False, root_evidence.root_identity, root_evidence)
+                )
     except OSError:
         sweep_stack = []
 
     while sweep_stack:
-        dirpath, visited, selected_identity = sweep_stack.pop()
+        dirpath, visited, selected_identity, root_evidence = sweep_stack.pop()
+        if not _is_owned_empty_dir_root(root_evidence):
+            continue
         if visited:
             try:
-                if not any(dirpath.iterdir()) and _atomic_rmdir_empty(
-                    dirpath, selected_identity
+                if (
+                    not any(dirpath.iterdir())
+                    and _is_owned_empty_dir_root(root_evidence)
+                    and _atomic_rmdir_empty(
+                        dirpath,
+                        selected_identity,
+                        root_evidence,
+                    )
                 ):
                     empty_removed += 1
                     _log(f"DELETED: {dirpath} (empty dir)")
@@ -1104,17 +1183,22 @@ def quick(paths: Optional[Iterable[str]] = None) -> Dict[str, Any]:
                 pass
             continue
 
-        sweep_stack.append((dirpath, True, selected_identity))
+        sweep_stack.append((dirpath, True, selected_identity, root_evidence))
         try:
             for child in dirpath.iterdir():
+                child_identity = child.lstat()
                 if (
-                    child.is_dir()
+                    stat.S_ISDIR(child_identity.st_mode)
                     and not _is_link_like(child)
                     and not _is_delete_quarantine_path(child)
                     and child.name not in _EMPTY_DIR_SWEEP_PRUNE_DIRS
                     and child.name not in _EMPTY_DIR_SWEEP_PROTECTED_NAMES
+                    and _same_directory_object(child, child_identity)
+                    and _is_owned_empty_dir_root(root_evidence)
                 ):
-                    sweep_stack.append((child, False, child.lstat()))
+                    sweep_stack.append(
+                        (child, False, child_identity, root_evidence)
+                    )
         except OSError:
             pass
 

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -27,7 +27,7 @@ import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 try:
     from hermes_constants import get_hermes_home
@@ -277,6 +277,29 @@ def _has_active_maintenance_marker(path: Path) -> bool:
     return False
 
 
+def _capture_identity(path: Path) -> Optional[Dict[str, int]]:
+    """Capture the filesystem object identity required for later deletion."""
+    try:
+        stat_result = path.lstat()
+    except (OSError, ValueError):
+        return None
+    return {
+        "version": 1,
+        "device": int(stat_result.st_dev),
+        "inode": int(stat_result.st_ino),
+        "mode": int(stat_result.st_mode),
+        "size": int(stat_result.st_size),
+        "mtime_ns": int(stat_result.st_mtime_ns),
+        "ctime_ns": int(stat_result.st_ctime_ns),
+    }
+
+
+def _identity_matches(path: Path, expected: Dict[str, int]) -> bool:
+    """Return whether *path* is still the exact object that was tracked."""
+    current = _capture_identity(path)
+    return current is not None and current == expected
+
+
 def _validated_tracked_item(item: Any):
     """Return validated tracking fields, or ``None`` for untrusted evidence."""
     if not isinstance(item, dict):
@@ -285,6 +308,7 @@ def _validated_tracked_item(item: Any):
     category = item.get("category")
     timestamp = item.get("timestamp")
     size = item.get("size")
+    identity = item.get("identity")
     if (
         not isinstance(path_value, str)
         or not path_value
@@ -294,6 +318,7 @@ def _validated_tracked_item(item: Any):
         or not isinstance(size, (int, float))
         or isinstance(size, bool)
         or (isinstance(size, float) and not size.is_integer())
+        or not isinstance(identity, dict)
     ):
         return None
     try:
@@ -302,11 +327,23 @@ def _validated_tracked_item(item: Any):
         if parsed_timestamp.tzinfo is None:
             parsed_timestamp = parsed_timestamp.replace(tzinfo=timezone.utc)
         parsed_size = int(size)
-    except (TypeError, ValueError, OSError, OverflowError):
+        parsed_identity = {
+            key: int(identity[key])
+            for key in (
+                "version",
+                "device",
+                "inode",
+                "mode",
+                "size",
+                "mtime_ns",
+                "ctime_ns",
+            )
+        }
+    except (KeyError, TypeError, ValueError, OSError, OverflowError):
         return None
-    if parsed_size < 0:
+    if parsed_size < 0 or parsed_identity["version"] != 1:
         return None
-    return path, category, parsed_timestamp, parsed_size
+    return path, category, parsed_timestamp, parsed_size, parsed_identity
 
 
 def _managed_marker_matches(path: Path, expected: str) -> bool:
@@ -334,6 +371,13 @@ def _remove_path(path: Path) -> Optional[str]:
     except OSError as exc:
         return str(exc)
     return None
+
+
+def _remove_tracked_path(path: Path, identity: Dict[str, int]) -> Optional[str]:
+    """Remove only the unchanged filesystem object authorized by tracking."""
+    if not _identity_matches(path, identity):
+        return "tracked filesystem identity changed"
+    return _remove_path(path)
 
 
 def fmt_size(n: float) -> str:
@@ -364,7 +408,11 @@ def track(path_str: str, category: str, silent: bool = False) -> bool:
         _log(f"REJECT: {path} (outside HERMES_HOME)")
         return False
 
-    size = path.stat().st_size if path.is_file() else 0
+    identity = _capture_identity(path)
+    if identity is None:
+        _log(f"SKIP: {path} (filesystem identity unavailable)")
+        return False
+    size = identity["size"] if path.is_file() else 0
     tracked = load_tracked()
 
     # Deduplicate
@@ -379,6 +427,7 @@ def track(path_str: str, category: str, silent: bool = False) -> bool:
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "category": category,
         "size": size,
+        "identity": identity,
     })
     save_tracked(tracked)
     _log(f"TRACKED: {path} ({category}, {fmt_size(size)})")
@@ -418,8 +467,8 @@ def dry_run() -> Tuple[List[Dict], List[Dict]]:
             # A malformed record is not deletion authorization.  Omit it
             # from the preview rather than aborting the whole report.
             continue
-        p, cat, timestamp, size = validated
-        if not p.exists() or not is_safe_path(p):
+        p, cat, timestamp, size, identity = validated
+        if not p.exists() or not is_safe_path(p) or not _identity_matches(p, identity):
             continue
         age = (now - timestamp).days
 
@@ -451,13 +500,21 @@ def dry_run() -> Tuple[List[Dict], List[Dict]]:
 # Quick cleanup
 # ---------------------------------------------------------------------------
 
-def quick() -> Dict[str, Any]:
+def quick(paths: Optional[Iterable[str]] = None) -> Dict[str, Any]:
     """Safe deterministic cleanup — no prompts.
 
     Returns: ``{"deleted": N, "artifacts": N, "empty_dirs": N,
                "freed": bytes, "errors": [str, ...]}``.
     """
     tracked = load_tracked()
+    scoped_paths = None
+    if paths is not None:
+        scoped_paths = set()
+        for path in paths:
+            try:
+                scoped_paths.add(str(Path(path).resolve()))
+            except (OSError, TypeError, ValueError):
+                continue
     now = datetime.now(timezone.utc)
     deleted = 0
     freed = 0
@@ -473,7 +530,11 @@ def quick() -> Dict[str, Any]:
             errors.append(f"invalid tracked record: {item!r}")
             new_tracked.append(item)
             continue
-        p, cat, timestamp, size = validated
+        p, cat, timestamp, size, identity = validated
+
+        if scoped_paths is not None and str(p.resolve()) not in scoped_paths:
+            new_tracked.append(item)
+            continue
 
         try:
             p.stat()
@@ -493,6 +554,12 @@ def quick() -> Dict[str, Any]:
         if not is_safe_path(p):
             _log(f"SKIP unsafe tracked path: {p}")
             errors.append(f"{p}: unsafe path")
+            new_tracked.append(item)
+            continue
+
+        if not _identity_matches(p, identity):
+            _log(f"SKIP changed tracked identity: {p}")
+            errors.append(f"{p}: tracked filesystem identity changed")
             new_tracked.append(item)
             continue
 
@@ -527,7 +594,7 @@ def quick() -> Dict[str, Any]:
         )
 
         if should_delete:
-            error = _remove_path(p)
+            error = _remove_tracked_path(p, identity)
             if error is None:
                 freed += size
                 deleted += 1
@@ -538,6 +605,23 @@ def quick() -> Dict[str, Any]:
                 new_tracked.append(item)
         else:
             new_tracked.append(item)
+
+    # Scoped session cleanup is limited to the exact newly tracked paths. The
+    # manual/global quick command additionally performs retention and empty-dir
+    # sweeps under their separately marked ownership roots.
+    if scoped_paths is not None:
+        save_tracked(new_tracked)
+        _log(
+            f"QUICK_SUMMARY: {deleted} files, 0 dirs, "
+            f"{fmt_size(freed)}"
+        )
+        return {
+            "deleted": deleted,
+            "artifacts": 0,
+            "empty_dirs": 0,
+            "freed": freed,
+            "errors": errors,
+        }
 
     # Prune artifact files only inside explicitly marked session directories.
     # The marker is the durable ownership proof; directory names alone are not.
@@ -666,7 +750,7 @@ def deep(
         validated = _validated_tracked_item(item)
         if validated is None:
             continue
-        p, cat, timestamp, size = validated
+        p, cat, timestamp, size, identity = validated
         try:
             p.stat()
         except (FileNotFoundError, OSError, ValueError):
@@ -694,10 +778,10 @@ def deep(
                 validated = _validated_tracked_item(item)
                 if validated is None:
                     continue
-                p, _cat, _timestamp, size = validated
+                p, _cat, _timestamp, size, identity = validated
                 if not is_safe_path(p) or _is_protected_cron_path(p):
                     continue
-                error = _remove_path(p)
+                error = _remove_tracked_path(p, identity)
                 if error is None:
                     to_remove.append(item)
                     freed += size

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -790,7 +790,10 @@ def remove_attachment(attachment_id: int, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        att = kanban_db.delete_attachment(conn, attachment_id)
+        try:
+            att = kanban_db.delete_attachment(conn, attachment_id)
+        except kanban_db.AttachmentOwnershipUnknown as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
         if att is None:
             raise HTTPException(status_code=404, detail="attachment not found")
         return {"ok": True, "id": attachment_id}

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -771,10 +771,7 @@ def remove_attachment(attachment_id: int, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        try:
-            att = kanban_db.delete_attachment(conn, attachment_id)
-        except kanban_db.AttachmentOwnershipUnknown as exc:
-            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        att = kanban_db.delete_attachment(conn, attachment_id)
         if att is None:
             raise HTTPException(status_code=404, detail="attachment not found")
         return {"ok": True, "id": attachment_id}

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -660,16 +660,11 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
 # Attachments — upload / list / download / delete (#35338)
 # ---------------------------------------------------------------------------
 
-# The size cap, filename sanitiser, and collision resolver now live in
-# ``kanban_db`` so the dashboard, the agent toolset, and the CLI share one
-# implementation and cannot drift. ``_safe_attachment_name`` raises a plain
-# ``ValueError`` there; the upload handler's ``except ValueError`` below maps
-# it to a 400, preserving the previous response.
-from hermes_cli.kanban_db import (  # noqa: E402
-    KANBAN_ATTACHMENT_MAX_BYTES,
-    _collision_free_path,
-    _safe_attachment_name,
-)
+# The size cap and persistence path live in ``kanban_db`` so the dashboard,
+# the agent toolset, and the CLI share one implementation and cannot drift.
+# ``store_attachment_bytes`` sanitises names and publishes with O_EXCL /
+# O_NOFOLLOW before recording exact deletion provenance.
+from hermes_cli.kanban_db import KANBAN_ATTACHMENT_MAX_BYTES  # noqa: E402
 
 
 @router.get("/tasks/{task_id}/attachments")
@@ -707,49 +702,35 @@ async def upload_task_attachment(
         if kanban_db.get_task(conn, task_id) is None:
             raise HTTPException(status_code=404, detail=f"task {task_id} not found")
 
-        safe_name = _safe_attachment_name(file.filename or "")
-
-        # Stream to disk with a hard size cap so a huge upload can't fill
-        # the disk. Read in chunks; abort + clean up if the cap is hit.
-        dest_dir = kanban_db.task_attachments_dir(task_id, board=board)
-        dest_dir.mkdir(parents=True, exist_ok=True)
+        # Read no more than cap+1 bytes. Oversize uploads never receive a
+        # destination pathname, so cleanup cannot unlink a concurrent file.
+        data = await file.read(KANBAN_ATTACHMENT_MAX_BYTES + 1)
+        if len(data) > KANBAN_ATTACHMENT_MAX_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=(
+                    f"attachment exceeds "
+                    f"{KANBAN_ATTACHMENT_MAX_BYTES // (1024 * 1024)} MB limit"
+                ),
+            )
 
         # Resolve name collisions: foo.pdf → foo (1).pdf, foo (2).pdf, …
-        dest_path = _collision_free_path(dest_dir, safe_name)
-        candidate = dest_path.name
-
-        total = 0
         try:
-            with open(dest_path, "wb") as out:
-                while True:
-                    chunk = await file.read(1024 * 1024)
-                    if not chunk:
-                        break
-                    total += len(chunk)
-                    if total > KANBAN_ATTACHMENT_MAX_BYTES:
-                        out.close()
-                        dest_path.unlink(missing_ok=True)
-                        raise HTTPException(
-                            status_code=413,
-                            detail=(
-                                f"attachment exceeds {KANBAN_ATTACHMENT_MAX_BYTES // (1024 * 1024)} MB limit"
-                            ),
-                        )
-                    out.write(chunk)
-        except HTTPException:
-            raise
+            att_id = kanban_db.store_attachment_bytes(
+                conn,
+                task_id,
+                file.filename or "",
+                data,
+                content_type=file.content_type,
+                uploaded_by=(uploaded_by or "dashboard"),
+                board=board,
+                max_bytes=KANBAN_ATTACHMENT_MAX_BYTES,
+            )
+        except kanban_db.AttachmentTooLarge as exc:
+            # Defensive parity if the shared cap changes independently.
+            raise HTTPException(status_code=413, detail=str(exc)) from exc
         except OSError as exc:
             raise HTTPException(status_code=500, detail=f"failed to store attachment: {exc}")
-
-        att_id = kanban_db.add_attachment(
-            conn,
-            task_id,
-            filename=candidate,
-            stored_path=str(dest_path.resolve()),
-            content_type=file.content_type,
-            size=total,
-            uploaded_by=(uploaded_by or "dashboard"),
-        )
         att = kanban_db.get_attachment(conn, att_id)
         return {"attachment": _attachment_dict(att) if att else None}
     except ValueError as e:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -774,7 +774,17 @@ def remove_attachment(attachment_id: int, board: Optional[str] = Query(None)):
         att = kanban_db.delete_attachment(conn, attachment_id)
         if att is None:
             raise HTTPException(status_code=404, detail="attachment not found")
-        return {"ok": True, "id": attachment_id}
+        result = {
+            "ok": True,
+            "id": attachment_id,
+            "unproven_blob_preserved": att.unproven_blob_preserved,
+        }
+        if att.unproven_blob_preserved:
+            result["warning"] = (
+                "Attachment metadata was removed, but its legacy on-disk blob "
+                "was preserved because Hermes has no deletion provenance for it."
+            )
+        return result
     finally:
         conn.close()
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -6433,6 +6433,31 @@ class AIAgent:
                     moa_config=moa_config,
                 )
             finally:
+                # Some terminal exits return directly from the conversation
+                # loop (provider failures, cancellation, truncation, and
+                # backend-specific fast paths) instead of reaching the shared
+                # turn finalizer.  Keep teardown at this outer lifecycle
+                # boundary as a fail-safe, idempotent second chance.  The
+                # terminal cleanup implementation only acts on its tracked
+                # environments and never guesses at scratch ownership.
+                cleanup_resources = getattr(self, "_cleanup_task_resources", None)
+                if callable(cleanup_resources):
+                    cleanup_task_id = (
+                        task_id
+                        or getattr(self, "_current_task_id", None)
+                        or getattr(self, "session_id", None)
+                        or ""
+                    )
+                    try:
+                        cleanup_resources(cleanup_task_id)
+                    except Exception:
+                        # Cleanup must never replace the turn result or mask
+                        # the original provider/cancellation exception.
+                        logger.debug(
+                            "terminal lifecycle cleanup failed for task %s",
+                            cleanup_task_id,
+                            exc_info=True,
+                        )
                 reset_accounting_context(acct_token)
                 reset_conversation_context(token)
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -93,7 +93,11 @@ echo "▶ pre-compiling bytecode cache"
 echo "▶ launching test runner"
 exec env -i \
   PATH="$PATH" \
-  HOME="$HOME" \
+  HOME="${HOME:-/tmp}" \
+  USERPROFILE="${USERPROFILE:-${HOME:-/tmp}}" \
+  LOCALAPPDATA="${LOCALAPPDATA:-${HOME:-/tmp}/AppData/Local}" \
+  PYTHONIOENCODING=utf-8 \
+  PYTHONUTF8=1 \
   TZ=UTC \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -441,7 +441,7 @@ class TestGitignoreManagement:
         _ignore_entry = ".worktrees/"
         existing = gitignore.read_text() if gitignore.exists() else ""
         if _ignore_entry not in existing.splitlines():
-            with open(gitignore, "a") as f:
+            with open(gitignore, "a", encoding="utf-8") as f:
                 if existing and not existing.endswith("\n"):
                     f.write("\n")
                 f.write(f"{_ignore_entry}\n")

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -1171,6 +1171,19 @@ class TestWorktreeLockPredicate:
         p = self._mk_locked(git_repo, "hermes-dead", "hermes pid=999999")
         assert cli._worktree_lock_is_live(str(git_repo), str(p)) == "dead"
 
+    def test_reused_pid_start_mismatch_returns_dead(self, git_repo, monkeypatch):
+        import cli
+        import gateway.status
+
+        p = self._mk_locked(
+            git_repo, "hermes-reused", "hermes pid=4242 start=100"
+        )
+        monkeypatch.setattr(gateway.status, "_pid_exists", lambda _pid: True)
+        monkeypatch.setattr(
+            gateway.status, "get_process_start_time", lambda _pid: 200
+        )
+        assert cli._worktree_lock_is_live(str(git_repo), str(p)) == "dead"
+
     def test_foreign_lock_reason_returns_unknown(self, git_repo):
         import cli
         p = self._mk_locked(git_repo, "hermes-foreign", "some other tool")

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -988,6 +988,26 @@ class TestOrphanedBranchPruning:
         ]
         assert "main" not in orphaned
 
+    def test_production_pruner_preserves_branch_with_remote_tracking_ref(self, git_repo):
+        """A remote-tracked generated branch is not local junk."""
+        import cli
+
+        subprocess.run(
+            ["git", "branch", "pr-remote", "HEAD"],
+            cwd=git_repo, capture_output=True, check=True,
+        )
+        subprocess.run(
+            ["git", "update-ref", "refs/remotes/origin/pr-remote", "refs/heads/pr-remote"],
+            cwd=git_repo, capture_output=True, check=True,
+        )
+
+        cli._prune_orphaned_branches(str(git_repo))
+
+        assert subprocess.run(
+            ["git", "show-ref", "--verify", "--quiet", "refs/heads/pr-remote"],
+            cwd=git_repo,
+        ).returncode == 0
+
 
 class TestSystemPromptInjection:
     """Test that the agent gets worktree context in its system prompt."""
@@ -1094,6 +1114,20 @@ class TestWorktreeLockReaping:
         cli._prune_stale_worktrees(str(git_repo))
         assert wt.exists(), "dirty worktree must survive even past the 72h tier"
 
+    def test_exit_cleanup_preserves_dirty_worktree(self, git_repo):
+        """Exit cleanup must not discard uncommitted user-authored changes."""
+        import cli
+
+        info = _setup_worktree(str(git_repo))
+        assert info is not None
+        dirty = Path(info["path"]) / "uncommitted.txt"
+        dirty.write_text("keep me")
+
+        cli._cleanup_worktree(info)
+
+        assert Path(info["path"]).exists()
+        assert dirty.exists()
+
     def test_recent_worktree_untouched(self, git_repo):
         import cli
         wt = self._mk(cli, git_repo, "hermes-fresh", pid=None, age_h=1)
@@ -1137,10 +1171,10 @@ class TestWorktreeLockPredicate:
         p = self._mk_locked(git_repo, "hermes-dead", "hermes pid=999999")
         assert cli._worktree_lock_is_live(str(git_repo), str(p)) == "dead"
 
-    def test_foreign_lock_reason_returns_dead(self, git_repo):
+    def test_foreign_lock_reason_returns_unknown(self, git_repo):
         import cli
         p = self._mk_locked(git_repo, "hermes-foreign", "some other tool")
-        assert cli._worktree_lock_is_live(str(git_repo), str(p)) == "dead"
+        assert cli._worktree_lock_is_live(str(git_repo), str(p)) == "unknown"
 
     def test_bad_repo_root_fails_safe_to_live(self, tmp_path):
         import cli

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -1128,6 +1128,66 @@ class TestWorktreeLockReaping:
         assert Path(info["path"]).exists()
         assert dirty.exists()
 
+    def test_exit_cleanup_preserves_write_arriving_after_clean_check(
+        self, git_repo, monkeypatch
+    ):
+        """Git gets the final dirty-state decision at the removal boundary."""
+        import cli
+
+        info = _setup_worktree(str(git_repo))
+        assert info is not None
+        worktree = Path(info["path"])
+        late = worktree / "late-write.txt"
+        real_run = subprocess.run
+
+        def inject_late_write(args, *pargs, **kwargs):
+            if list(args[:3]) == ["git", "worktree", "remove"]:
+                late.write_text("arrived after the clean check")
+            return real_run(args, *pargs, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", inject_late_write)
+
+        cli._cleanup_worktree(info)
+
+        assert worktree.exists()
+        assert late.read_text() == "arrived after the clean check"
+        branch = real_run(
+            ["git", "branch", "--list", info["branch"]],
+            cwd=git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert info["branch"] in branch.stdout
+
+    def test_stale_pruner_preserves_write_arriving_after_clean_check(
+        self, git_repo, monkeypatch
+    ):
+        """Startup pruning must not force-remove a newly dirtied worktree."""
+        import cli
+
+        worktree = self._mk(cli, git_repo, "hermes-late", pid=None, age_h=100)
+        late = worktree / "late-write.txt"
+        real_run = subprocess.run
+
+        def inject_late_write(args, *pargs, **kwargs):
+            if list(args[:3]) == ["git", "worktree", "remove"]:
+                late.write_text("arrived after the clean check")
+            return real_run(args, *pargs, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", inject_late_write)
+
+        cli._prune_stale_worktrees(str(git_repo))
+
+        assert worktree.exists()
+        assert late.read_text() == "arrived after the clean check"
+        branch = real_run(
+            ["git", "branch", "--list", "hermes/hermes-late"],
+            cwd=git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert "hermes/hermes-late" in branch.stdout
+
     def test_recent_worktree_untouched(self, git_repo):
         import cli
         wt = self._mk(cli, git_repo, "hermes-fresh", pid=None, age_h=1)

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1789,6 +1789,33 @@ class TestQuickSnapshot:
 
         assert notes.read_text() == "keep"
 
+    def test_prune_preserves_snapshot_when_owner_marker_changes_during_move(
+        self, hermes_home, monkeypatch
+    ):
+        import hermes_cli.backup as backup_mod
+
+        snap_id = backup_mod.create_quick_snapshot(hermes_home=hermes_home)
+        root = hermes_home / "state-snapshots"
+        snapshot = root / snap_id
+        original_replace = backup_mod.os.replace
+
+        def replace_marker_after_move(source, destination):
+            result = original_replace(source, destination)
+            if Path(source) == snapshot:
+                moved_marker = Path(destination) / backup_mod._QUICK_OWNERSHIP_MARKER
+                moved_marker.unlink()
+                moved_marker.write_text("foreign")
+            return result
+
+        monkeypatch.setattr(backup_mod.os, "replace", replace_marker_after_move)
+
+        assert backup_mod.prune_quick_snapshots(
+            keep=0, hermes_home=hermes_home
+        ) == 0
+        quarantines = list(root.glob(f".{snap_id}.hermes-delete-*"))
+        assert len(quarantines) == 1
+        assert (quarantines[0] / "config.yaml").exists()
+
     def test_snapshot_includes_pairing_directories(self, hermes_home):
         """Pairing JSONs live outside state.db — snapshot must capture them
         recursively (generic + per-platform) so approved-user lists survive

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1664,7 +1664,12 @@ class TestQuickSnapshot:
         snapshot = root / "20260721-120000-000000-interrupted"
         snapshot.mkdir(parents=True)
         marker = snapshot / ".in-progress"
-        marker.write_text(json.dumps({"version": 1, "snapshot_id": snapshot.name}))
+        marker.write_text(json.dumps({
+            "version": 1,
+            "snapshot_id": snapshot.name,
+            "pid": 2_147_483_647,
+            "owner_token": "a" * 32,
+        }))
         (snapshot / "partial.db").write_text("partial")
         old = time.time() - backup_mod._QUICK_IN_PROGRESS_MAX_AGE_SECONDS - 60
         os.utime(marker, (old, old))
@@ -1691,6 +1696,29 @@ class TestQuickSnapshot:
 
         assert human.read_text() == "keep"
 
+    def test_prune_preserves_stale_snapshot_owned_by_live_process(self, hermes_home):
+        import hermes_cli.backup as backup_mod
+
+        root = hermes_home / "state-snapshots"
+        snapshot = root / "20260721-120000-000000-active"
+        snapshot.mkdir(parents=True)
+        marker = snapshot / backup_mod._QUICK_IN_PROGRESS_MARKER
+        marker.write_text(json.dumps({
+            "version": 1,
+            "snapshot_id": snapshot.name,
+            "pid": os.getpid(),
+            "owner_token": "b" * 32,
+        }))
+        partial = snapshot / "partial.db"
+        partial.write_text("active")
+        old = time.time() - backup_mod._QUICK_IN_PROGRESS_MAX_AGE_SECONDS - 60
+        os.utime(marker, (old, old))
+
+        assert backup_mod.prune_quick_snapshots(
+            keep=20, hermes_home=hermes_home
+        ) == 0
+        assert partial.read_text() == "active"
+
     def test_prune_preserves_in_progress_directory_when_identity_changes(
         self, hermes_home, monkeypatch
     ):
@@ -1700,7 +1728,12 @@ class TestQuickSnapshot:
         snapshot = root / "20260721-120000-000000-interrupted"
         snapshot.mkdir(parents=True)
         marker = snapshot / ".in-progress"
-        marker.write_text(json.dumps({"version": 1, "snapshot_id": snapshot.name}))
+        marker.write_text(json.dumps({
+            "version": 1,
+            "snapshot_id": snapshot.name,
+            "pid": 2_147_483_647,
+            "owner_token": "a" * 32,
+        }))
         human = snapshot / "notes.txt"
         human.write_text("keep")
         old = time.time() - backup_mod._QUICK_IN_PROGRESS_MAX_AGE_SECONDS - 60
@@ -1710,8 +1743,51 @@ class TestQuickSnapshot:
         assert backup_mod.prune_quick_snapshots(
             keep=20, hermes_home=hermes_home
         ) == 0
-        assert human.read_text() == "keep"
-        assert not list(root.glob("*.hermes-delete-*"))
+        preserved = [snapshot, *root.glob("*.hermes-delete-*")]
+        assert any((path / "notes.txt").read_text() == "keep" for path in preserved if path.exists())
+
+    def test_completed_snapshot_has_exact_owner_marker(self, hermes_home):
+        import hermes_cli.backup as backup_mod
+
+        snap_id = backup_mod.create_quick_snapshot(hermes_home=hermes_home)
+        snapshot = hermes_home / "state-snapshots" / snap_id
+
+        payload = json.loads(
+            (snapshot / backup_mod._QUICK_OWNERSHIP_MARKER).read_text()
+        )
+        assert payload["snapshot_id"] == snap_id
+        assert payload["pid"] == os.getpid()
+        assert len(payload["owner_token"]) == 32
+        assert not (snapshot / backup_mod._QUICK_IN_PROGRESS_MARKER).exists()
+
+    def test_list_and_restore_exclude_unpublished_snapshot(self, hermes_home):
+        import hermes_cli.backup as backup_mod
+
+        snap_id = backup_mod.create_quick_snapshot(hermes_home=hermes_home)
+        snapshot = hermes_home / "state-snapshots" / snap_id
+        owner_payload = (
+            snapshot / backup_mod._QUICK_OWNERSHIP_MARKER
+        ).read_text()
+        (snapshot / backup_mod._QUICK_IN_PROGRESS_MARKER).write_text(owner_payload)
+
+        assert backup_mod.list_quick_snapshots(hermes_home=hermes_home) == []
+        assert not backup_mod.restore_quick_snapshot(
+            snap_id, hermes_home=hermes_home
+        )
+
+    def test_prune_preserves_unowned_completed_directory(self, hermes_home):
+        import hermes_cli.backup as backup_mod
+
+        root = hermes_home / "state-snapshots"
+        human = root / "0000-human"
+        human.mkdir(parents=True)
+        notes = human / "notes.txt"
+        notes.write_text("keep")
+        backup_mod.create_quick_snapshot(label="newer", hermes_home=hermes_home)
+
+        backup_mod.prune_quick_snapshots(keep=0, hermes_home=hermes_home)
+
+        assert notes.read_text() == "keep"
 
     def test_snapshot_includes_pairing_directories(self, hermes_home):
         """Pairing JSONs live outside state.db — snapshot must capture them

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -4,6 +4,7 @@ import json
 import os
 import shutil
 import sqlite3
+import subprocess
 import time
 import zipfile
 from argparse import Namespace
@@ -1499,6 +1500,75 @@ class TestSafeCopyDb:
         with real_connect(dst) as copied:
             assert copied.execute("SELECT value FROM state").fetchall() == [("safe",)]
 
+    def test_precreated_destination_reports_post_write_identity(self, tmp_path):
+        """Callers clean up using ownership sampled after SQLite publication."""
+        import hermes_cli.backup as backup_mod
+
+        src = tmp_path / "source.db"
+        dst = tmp_path / "copy.db"
+        with sqlite3.connect(src) as conn:
+            conn.execute("CREATE TABLE state (value TEXT)")
+            conn.execute("INSERT INTO state VALUES ('safe')")
+        with dst.open("xb"):
+            pass
+        pre_write_identity = dst.lstat()
+
+        result_identity = []
+        assert backup_mod._safe_copy_db(
+            src,
+            dst,
+            expected_dst_identity=pre_write_identity,
+            result_dst_identity=result_identity,
+        )
+
+        assert len(result_identity) == 1
+        assert backup_mod._same_snapshot_object(result_identity[0], dst.lstat())
+        with sqlite3.connect(dst) as copied:
+            assert copied.execute("SELECT value FROM state").fetchall() == [("safe",)]
+
+    def test_source_parent_mutation_during_backup_fails_closed(
+        self, tmp_path, monkeypatch
+    ):
+        """A source pathname rename signal aborts publication."""
+        import hermes_cli.backup as backup_mod
+
+        source_dir = tmp_path / "source"
+        destination_dir = tmp_path / "destination"
+        source_dir.mkdir()
+        destination_dir.mkdir()
+        src = source_dir / "source.db"
+        dst = destination_dir / "copy.db"
+        with sqlite3.connect(src) as conn:
+            conn.execute("CREATE TABLE state (value TEXT)")
+
+        real_connect = backup_mod.sqlite3.connect
+
+        class MutatingSourceConnection:
+            def __init__(self, connection):
+                self.connection = connection
+
+            def __getattr__(self, name):
+                return getattr(self.connection, name)
+
+            def backup(self, destination):
+                self.connection.backup(destination)
+                selected = source_dir.stat()
+                os.utime(
+                    source_dir,
+                    ns=(selected.st_atime_ns, selected.st_mtime_ns + 1_000_000_000),
+                )
+
+        def mutating_connect(database, *args, **kwargs):
+            connection = real_connect(database, *args, **kwargs)
+            if str(database).startswith(f"file:{src}"):
+                return MutatingSourceConnection(connection)
+            return connection
+
+        monkeypatch.setattr(backup_mod.sqlite3, "connect", mutating_connect)
+
+        assert backup_mod._safe_copy_db(src, dst) is False
+        assert not dst.exists()
+
 
 # ---------------------------------------------------------------------------
 # Quick state snapshot tests
@@ -2373,6 +2443,36 @@ class TestPreUpdateBackup:
 
         assert result is None
         assert not out.exists()
+
+    def test_directory_reparse_point_is_not_archived(self, tmp_path):
+        """A junction/symlink must not let a full backup traverse outside HOME."""
+        import hermes_cli.backup as backup_mod
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("model: test\n")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("must not be archived")
+        link = hermes_home / "external-link"
+
+        if os.name == "nt":
+            created = subprocess.run(
+                ["cmd", "/c", "mklink", "/J", str(link), str(outside)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if created.returncode:
+                pytest.skip(f"junction creation unavailable: {created.stderr.strip()}")
+        else:
+            link.symlink_to(outside, target_is_directory=True)
+
+        out = tmp_path / "backup.zip"
+        assert backup_mod._write_full_zip_backup(out, hermes_home) == out
+        with zipfile.ZipFile(out) as archive:
+            assert "config.yaml" in archive.namelist()
+            assert not any(name.startswith("external-link/") for name in archive.namelist())
 
     def test_publication_collision_preserves_winner_and_retries(
         self, hermes_home, monkeypatch

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1871,6 +1871,28 @@ class TestQuickSnapshot:
         assert snaps[0]["id"] == id2  # most recent first
         assert snaps[1]["id"] == id1
 
+    def test_empty_label_snapshot_remains_listable_and_restorable(self, hermes_home):
+        from hermes_cli.backup import (
+            create_quick_snapshot,
+            list_quick_snapshots,
+            restore_quick_snapshot,
+        )
+
+        snap_id = create_quick_snapshot(label="", hermes_home=hermes_home)
+        assert snap_id is not None
+        assert [
+            snapshot["id"]
+            for snapshot in list_quick_snapshots(hermes_home=hermes_home)
+        ] == [snap_id]
+
+        (hermes_home / "config.yaml").write_text(
+            "model:\n  provider: changed\n", encoding="utf-8"
+        )
+        assert restore_quick_snapshot(snap_id, hermes_home=hermes_home)
+        assert "openrouter" in (hermes_home / "config.yaml").read_text(
+            encoding="utf-8"
+        )
+
     def test_list_limit(self, hermes_home):
         from hermes_cli.backup import create_quick_snapshot, list_quick_snapshots
         for i in range(5):

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1475,6 +1475,30 @@ class TestSafeCopyDb:
         assert backup_mod._safe_copy_db(src, dst) is False
         assert dst.read_text() == "human replacement"
 
+    def test_sqlite_never_opens_the_caller_destination(self, tmp_path, monkeypatch):
+        """SQLite writes a private stage, then copies through the bound fd."""
+        import hermes_cli.backup as backup_mod
+
+        src = tmp_path / "source.db"
+        dst = tmp_path / "copy.db"
+        with sqlite3.connect(src) as conn:
+            conn.execute("CREATE TABLE state (value TEXT)")
+            conn.execute("INSERT INTO state VALUES ('safe')")
+
+        real_connect = backup_mod.sqlite3.connect
+        opened = []
+
+        def record_connect(database, *args, **kwargs):
+            opened.append(str(database))
+            return real_connect(database, *args, **kwargs)
+
+        monkeypatch.setattr(backup_mod.sqlite3, "connect", record_connect)
+        assert backup_mod._safe_copy_db(src, dst)
+
+        assert str(dst) not in opened
+        with real_connect(dst) as copied:
+            assert copied.execute("SELECT value FROM state").fetchall() == [("safe",)]
+
 
 # ---------------------------------------------------------------------------
 # Quick state snapshot tests
@@ -1897,6 +1921,38 @@ class TestQuickSnapshot:
         assert (snapshot / "human.txt").read_text() == "keep"
         assert (displaced / "config.yaml").exists()
 
+    def test_legacy_snapshot_remains_listable_restorable_but_not_prunable(
+        self, hermes_home
+    ):
+        import hermes_cli.backup as backup_mod
+
+        root = hermes_home / "state-snapshots"
+        legacy = root / "20260101-010101"
+        legacy.mkdir(parents=True)
+        payload = b"legacy: restored\n"
+        (legacy / "config.yaml").write_bytes(payload)
+        manifest = {
+            "id": legacy.name,
+            "timestamp": "20260101-010101",
+            "label": None,
+            "file_count": 1,
+            "total_size": len(payload),
+            "files": {"config.yaml": len(payload)},
+        }
+        (legacy / "manifest.json").write_text(json.dumps(manifest))
+
+        listed = backup_mod.list_quick_snapshots(hermes_home=hermes_home)
+        assert [item["id"] for item in listed] == [legacy.name]
+        (hermes_home / "config.yaml").write_text("current")
+        assert backup_mod.restore_quick_snapshot(
+            legacy.name, hermes_home=hermes_home
+        )
+        assert (hermes_home / "config.yaml").read_bytes() == payload
+        assert backup_mod.prune_quick_snapshots(
+            keep=0, hermes_home=hermes_home
+        ) == 0
+        assert legacy.is_dir()
+
     def test_snapshot_includes_pairing_directories(self, hermes_home):
         """Pairing JSONs live outside state.db — snapshot must capture them
         recursively (generic + per-platform) so approved-user lists survive
@@ -2243,7 +2299,10 @@ class TestQuickSnapshotProjectsKanban:
         monkeypatch.setattr(bk, "_safe_copy_db", _spy)
         snap_id = create_quick_snapshot(hermes_home=hermes_home)
         # The board db was copied via _safe_copy_db (not raw copy).
-        assert any(s.endswith("boards/work/kanban.db") for s in called["db"]), called["db"]
+        assert any(
+            Path(s).parts[-3:] == ("boards", "work", "kanban.db")
+            for s in called["db"]
+        ), called["db"]
         copy = hermes_home / "state-snapshots" / snap_id / "kanban" / "boards" / "work" / "kanban.db"
         rows = sqlite3.connect(str(copy)).execute("SELECT * FROM tasks").fetchall()
         assert rows == [("w1", "ship")]
@@ -2307,7 +2366,7 @@ class TestPreUpdateBackup:
         def fail_write(*_args, **_kwargs):
             raise OSError("forced archive write failure")
 
-        monkeypatch.setattr(backup_mod.zipfile.ZipFile, "write", fail_write)
+        monkeypatch.setattr(backup_mod, "_write_bound_file_to_zip", fail_write)
         out = hermes_home / "backups" / "pre-migration-failed.zip"
         out.parent.mkdir()
         result = backup_mod._write_full_zip_backup(out, hermes_home)
@@ -2352,6 +2411,48 @@ class TestPreUpdateBackup:
         assert published is not None and published != requested
         assert backup_mod._owned_archive_identity(published) is not None
 
+    def test_create_backup_returns_the_actual_collision_retry_path(
+        self, hermes_home, monkeypatch
+    ):
+        import hermes_cli.backup as backup_mod
+
+        actual = hermes_home / "backups" / "pre-update-retry.zip"
+        monkeypatch.setattr(
+            backup_mod,
+            "_write_full_zip_backup",
+            lambda _requested, _root: actual,
+        )
+        monkeypatch.setattr(backup_mod, "_prune_pre_update_backups", lambda *_a, **_k: 0)
+
+        assert backup_mod.create_pre_update_backup(hermes_home=hermes_home) == actual
+
+    def test_regular_source_replacement_aborts_publication(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.backup as backup_mod
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        source = hermes_home / "config.yaml"
+        source.write_text("agent")
+        out = tmp_path / "backup.zip"
+        real_open = backup_mod.os.open
+        replaced = False
+
+        def replace_before_open(path, flags, *args, **kwargs):
+            nonlocal replaced
+            if Path(path) == source and not replaced:
+                replaced = True
+                source.unlink()
+                source.write_text("human replacement")
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(backup_mod.os, "open", replace_before_open)
+
+        assert backup_mod._write_full_zip_backup(out, hermes_home) is None
+        assert source.read_text() == "human replacement"
+        assert not out.exists()
+
     def test_failed_zip_write_preserves_recreated_temp_path(
         self, tmp_path, monkeypatch
     ):
@@ -2375,8 +2476,8 @@ class TestPreUpdateBackup:
             return real_remove(path, expected)
 
         monkeypatch.setattr(
-            backup_mod.zipfile.ZipFile,
-            "write",
+            backup_mod,
+            "_write_bound_file_to_zip",
             lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("forced")),
         )
         monkeypatch.setattr(
@@ -2403,7 +2504,7 @@ class TestPreUpdateBackup:
         backup_dir = hermes_home / "backups"
         backup_dir.mkdir()
         out = backup_dir / "pre-update.zip"
-        real_write = backup_mod.zipfile.ZipFile.write
+        real_write = backup_mod._write_bound_file_to_zip
         replaced = []
 
         def replace_db_after_archive_write(archive, filename, *args, **kwargs):
@@ -2416,7 +2517,7 @@ class TestPreUpdateBackup:
             return result
 
         monkeypatch.setattr(
-            backup_mod.zipfile.ZipFile, "write", replace_db_after_archive_write
+            backup_mod, "_write_bound_file_to_zip", replace_db_after_archive_write
         )
 
         assert backup_mod._write_full_zip_backup(out, hermes_home) == out

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -2476,8 +2476,10 @@ class TestPreUpdateBackup:
         backup_dir.mkdir(exist_ok=True)
         victim = backup_dir / f"{prefix}20260101-000000.zip"
         newest = backup_dir / f"{prefix}20260102-000000.zip"
-        victim.write_bytes(b"owned")
-        newest.write_bytes(b"newest")
+        for path, content in ((victim, "owned"), (newest, "newest")):
+            with zipfile.ZipFile(path, "w") as archive:
+                archive.writestr("config.yaml", content)
+                archive.comment = backup_mod._archive_ownership_comment(path)
         real_remove = backup_mod._remove_owned_snapshot_file
 
         def replace_before_remove(path, expected):
@@ -2496,6 +2498,32 @@ class TestPreUpdateBackup:
             path.exists() and path.read_text() == "human replacement"
             for path in preserved
         )
+
+    @pytest.mark.parametrize(
+        ("prefix", "prune_name"),
+        [
+            ("pre-update-", "_prune_pre_update_backups"),
+            ("pre-migration-", "_prune_pre_migration_backups"),
+        ],
+    )
+    def test_zip_rotation_preserves_unowned_matching_archive(
+        self, hermes_home, prefix, prune_name
+    ):
+        import hermes_cli.backup as backup_mod
+
+        backup_dir = hermes_home / "backups"
+        backup_dir.mkdir(exist_ok=True)
+        human = backup_dir / f"{prefix}20260101-000000.zip"
+        with zipfile.ZipFile(human, "w") as archive:
+            archive.writestr("notes.txt", "human")
+        owned = backup_dir / f"{prefix}20260102-000000.zip"
+        with zipfile.ZipFile(owned, "w") as archive:
+            archive.writestr("config.yaml", "owned")
+            archive.comment = backup_mod._archive_ownership_comment(owned)
+
+        assert getattr(backup_mod, prune_name)(backup_dir, keep=1) == 0
+        with zipfile.ZipFile(human) as archive:
+            assert archive.read("notes.txt") == b"human"
 
     def test_returns_none_if_root_missing(self, tmp_path):
         from hermes_cli.backup import create_pre_update_backup

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1569,6 +1569,39 @@ class TestSafeCopyDb:
         assert backup_mod._safe_copy_db(src, dst) is False
         assert not dst.exists()
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX rename-open-restore ABA")
+    def test_source_swap_during_sqlite_connect_fails_closed(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.backup as backup_mod
+
+        src = tmp_path / "source.db"
+        attacker = tmp_path / "attacker.db"
+        dst = tmp_path / "copy.db"
+        for path, value in ((src, "owned"), (attacker, "foreign")):
+            with sqlite3.connect(path) as conn:
+                conn.execute("CREATE TABLE state (value TEXT)")
+                conn.execute("INSERT INTO state VALUES (?)", (value,))
+        original = tmp_path / "source-original.db"
+        real_connect = backup_mod.sqlite3.connect
+
+        def swap_for_connect(database, *args, **kwargs):
+            if str(database).startswith(f"file:{src}"):
+                src.rename(original)
+                attacker.rename(src)
+                connection = real_connect(database, *args, **kwargs)
+                src.rename(attacker)
+                original.rename(src)
+                return connection
+            return real_connect(database, *args, **kwargs)
+
+        monkeypatch.setattr(backup_mod.sqlite3, "connect", swap_for_connect)
+
+        assert backup_mod._safe_copy_db(src, dst) is False
+        assert not dst.exists()
+        with sqlite3.connect(src) as conn:
+            assert conn.execute("SELECT value FROM state").fetchone() == ("owned",)
+
 
 # ---------------------------------------------------------------------------
 # Quick state snapshot tests
@@ -1597,6 +1630,69 @@ class TestQuickSnapshot:
         conn.commit()
         conn.close()
         return home
+
+    def test_maintenance_lock_refuses_hardlink_without_writing(self, tmp_path):
+        import hermes_cli.backup as backup_mod
+
+        root = tmp_path / "state-snapshots"
+        root.mkdir()
+        external = tmp_path / "operator.txt"
+        external.write_bytes(b"")
+        lock_path = root / backup_mod._BACKUP_LOCK_FILENAME
+        try:
+            lock_path.hardlink_to(external)
+        except OSError as exc:
+            pytest.skip(f"hardlinks unavailable: {exc}")
+
+        with pytest.raises(OSError, match="not exclusively owned"):
+            with backup_mod._backup_maintenance_lock(root):
+                pass
+
+        assert external.read_bytes() == b""
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows junction regression")
+    def test_snapshot_directory_junction_swap_never_writes_external(
+        self, hermes_home, tmp_path, monkeypatch
+    ):
+        import hermes_cli.backup as backup_mod
+
+        external = tmp_path / "operator-data"
+        external.mkdir()
+        external_config = external / "config.yaml"
+        external_config.write_text("human", encoding="utf-8")
+        real_writer = backup_mod._write_exclusive_snapshot_file
+        calls = 0
+        displaced = None
+
+        def swap_after_marker(snapshot_dir, snapshot_identity, relative_name, chunks):
+            nonlocal calls, displaced
+            calls += 1
+            if calls == 2:
+                displaced = snapshot_dir.with_name(f"{snapshot_dir.name}-original")
+                snapshot_dir.rename(displaced)
+                created = subprocess.run(
+                    ["cmd", "/c", "mklink", "/J", str(snapshot_dir), str(external)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if created.returncode:
+                    pytest.skip(
+                        f"junction creation unavailable: {created.stderr.strip()}"
+                    )
+            return real_writer(
+                snapshot_dir, snapshot_identity, relative_name, chunks
+            )
+
+        monkeypatch.setattr(
+            backup_mod, "_write_exclusive_snapshot_file", swap_after_marker
+        )
+        assert backup_mod.create_quick_snapshot(hermes_home=hermes_home) is None
+
+        assert external_config.read_text(encoding="utf-8") == "human"
+        assert not (external / "state.db").exists()
+        assert not (external / "manifest.json").exists()
+        assert displaced is not None and displaced.exists()
 
     def test_creates_snapshot(self, hermes_home):
         from hermes_cli.backup import create_quick_snapshot
@@ -1876,7 +1972,9 @@ class TestQuickSnapshot:
         human.write_text("keep")
         old = time.time() - backup_mod._QUICK_IN_PROGRESS_MAX_AGE_SECONDS - 60
         os.utime(marker, (old, old))
-        monkeypatch.setattr(backup_mod.os.path, "samestat", lambda _a, _b: False)
+        monkeypatch.setattr(
+            backup_mod, "_same_snapshot_object", lambda _a, _b: False
+        )
 
         assert backup_mod.prune_quick_snapshots(
             keep=20, hermes_home=hermes_home
@@ -2362,9 +2460,9 @@ class TestQuickSnapshotProjectsKanban:
         called = {"db": []}
         real = bk._safe_copy_db
 
-        def _spy(src, dst):
+        def _spy(src, dst, **kwargs):
             called["db"].append(str(src))
-            return real(src, dst)
+            return real(src, dst, **kwargs)
 
         monkeypatch.setattr(bk, "_safe_copy_db", _spy)
         snap_id = create_quick_snapshot(hermes_home=hermes_home)

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -2272,6 +2272,80 @@ class TestPreUpdateBackup:
         assert result is None
         assert not out.exists()
 
+    def test_failed_zip_write_preserves_recreated_temp_path(
+        self, tmp_path, monkeypatch
+    ):
+        """Failure cleanup removes only the temp inode created by this call."""
+        import hermes_cli.backup as backup_mod
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("model: test\n")
+        backup_dir = hermes_home / "backups"
+        backup_dir.mkdir()
+        out = backup_dir / "pre-update-failed.zip"
+        real_remove = backup_mod._remove_owned_snapshot_file
+        recreated = []
+
+        def replace_before_cleanup(path, expected):
+            if Path(path).suffix == ".zip" and Path(path) != out:
+                Path(path).unlink()
+                Path(path).write_text("human replacement")
+                recreated.append(Path(path))
+            return real_remove(path, expected)
+
+        monkeypatch.setattr(
+            backup_mod.zipfile.ZipFile,
+            "write",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("forced")),
+        )
+        monkeypatch.setattr(
+            backup_mod, "_remove_owned_snapshot_file", replace_before_cleanup
+        )
+
+        assert backup_mod._write_full_zip_backup(out, hermes_home) is None
+        preserved = [*recreated, *backup_dir.glob(".*.hermes-delete-*")]
+        assert any(
+            path.exists() and path.read_text() == "human replacement"
+            for path in preserved
+        )
+
+    def test_sqlite_temp_cleanup_preserves_pathname_replacement(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.backup as backup_mod
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        db = hermes_home / "state.db"
+        with sqlite3.connect(db) as conn:
+            conn.execute("CREATE TABLE state (value TEXT)")
+        backup_dir = hermes_home / "backups"
+        backup_dir.mkdir()
+        out = backup_dir / "pre-update.zip"
+        real_write = backup_mod.zipfile.ZipFile.write
+        replaced = []
+
+        def replace_db_after_archive_write(archive, filename, *args, **kwargs):
+            result = real_write(archive, filename, *args, **kwargs)
+            path = Path(filename)
+            if path.suffix == ".db" and path.parent == backup_dir:
+                path.unlink()
+                path.write_text("human replacement")
+                replaced.append(path)
+            return result
+
+        monkeypatch.setattr(
+            backup_mod.zipfile.ZipFile, "write", replace_db_after_archive_write
+        )
+
+        assert backup_mod._write_full_zip_backup(out, hermes_home) == out
+        preserved = [*replaced, *backup_dir.glob(".*.hermes-delete-*")]
+        assert any(
+            path.exists() and path.read_text() == "human replacement"
+            for path in preserved
+        )
+
     @pytest.fixture
     def hermes_home(self, tmp_path):
         root = tmp_path / ".hermes"
@@ -2385,6 +2459,43 @@ class TestPreUpdateBackup:
             _t.sleep(1.05)
 
         assert manual.exists(), "Manual backup zip was incorrectly pruned"
+
+    @pytest.mark.parametrize(
+        ("prefix", "prune_name"),
+        [
+            ("pre-update-", "_prune_pre_update_backups"),
+            ("pre-migration-", "_prune_pre_migration_backups"),
+        ],
+    )
+    def test_zip_rotation_preserves_replacement_after_selection(
+        self, hermes_home, monkeypatch, prefix, prune_name
+    ):
+        import hermes_cli.backup as backup_mod
+
+        backup_dir = hermes_home / "backups"
+        backup_dir.mkdir(exist_ok=True)
+        victim = backup_dir / f"{prefix}20260101-000000.zip"
+        newest = backup_dir / f"{prefix}20260102-000000.zip"
+        victim.write_bytes(b"owned")
+        newest.write_bytes(b"newest")
+        real_remove = backup_mod._remove_owned_snapshot_file
+
+        def replace_before_remove(path, expected):
+            if Path(path) == victim:
+                victim.unlink()
+                victim.write_text("human replacement")
+            return real_remove(path, expected)
+
+        monkeypatch.setattr(
+            backup_mod, "_remove_owned_snapshot_file", replace_before_remove
+        )
+
+        assert getattr(backup_mod, prune_name)(backup_dir, keep=1) == 0
+        preserved = [victim, *backup_dir.glob(f".{victim.name}.hermes-delete-*")]
+        assert any(
+            path.exists() and path.read_text() == "human replacement"
+            for path in preserved
+        )
 
     def test_returns_none_if_root_missing(self, tmp_path):
         from hermes_cli.backup import create_pre_update_backup

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1816,7 +1816,10 @@ class TestQuickSnapshot:
     def test_missing_files_skipped(self, hermes_home):
         from hermes_cli.backup import create_quick_snapshot
         snap_id = create_quick_snapshot(hermes_home=hermes_home)
-        with open(hermes_home / "state-snapshots" / snap_id / "manifest.json") as f:
+        with open(
+            hermes_home / "state-snapshots" / snap_id / "manifest.json",
+            encoding="utf-8",
+        ) as f:
             meta = json.load(f)
         # gateway_state.json etc. don't exist in fixture
         assert "gateway_state.json" not in meta["files"]
@@ -1841,7 +1844,7 @@ class TestQuickSnapshot:
         assert not (snap_dir / "state.db").exists()
         # Small files still captured
         assert (snap_dir / "cron" / "jobs.json").exists()
-        with open(snap_dir / "manifest.json") as f:
+        with open(snap_dir / "manifest.json", encoding="utf-8") as f:
             meta = json.load(f)
         assert "state.db" not in meta["files"]
         out = capsys.readouterr().out
@@ -2451,7 +2454,7 @@ class TestQuickSnapshot:
         assert (snap_dir / "pairing" / "matrix-approved.json").exists()
         assert (snap_dir / "feishu_comment_pairing.json").exists()
 
-        with open(snap_dir / "manifest.json") as f:
+        with open(snap_dir / "manifest.json", encoding="utf-8") as f:
             meta = json.load(f)
         files = meta["files"]
         assert "platforms/pairing/telegram-approved.json" in files
@@ -2545,10 +2548,10 @@ class TestQuickSnapshot:
         # file outside the snapshot directory so a vulnerable implementation
         # would actually write something at the escaped destination.
         manifest_path = snap_dir / "manifest.json"
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding="utf-8") as f:
             meta = json.load(f)
         meta["files"]["../../outside.txt"] = 9
-        with open(manifest_path, "w") as f:
+        with open(manifest_path, "w", encoding="utf-8") as f:
             json.dump(meta, f)
 
         # Source: ../../outside.txt resolves above the snapshot root.

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sqlite3
+import time
 import zipfile
 from argparse import Namespace
 from pathlib import Path
@@ -1492,6 +1493,15 @@ class TestQuickSnapshot:
         snap_id = create_quick_snapshot(label="before-upgrade", hermes_home=hermes_home)
         assert "before-upgrade" in snap_id
 
+    def test_snapshot_label_cannot_escape_snapshot_root(self, hermes_home):
+        from hermes_cli.backup import create_quick_snapshot
+
+        snap_id = create_quick_snapshot(label="../../outside", hermes_home=hermes_home)
+
+        assert snap_id is not None
+        assert "/" not in snap_id and "\\" not in snap_id and ".." not in snap_id
+        assert (hermes_home / "state-snapshots" / snap_id).is_dir()
+
     def test_state_db_safely_copied(self, hermes_home):
         from hermes_cli.backup import create_quick_snapshot
         snap_id = create_quick_snapshot(hermes_home=hermes_home)
@@ -1646,6 +1656,62 @@ class TestQuickSnapshot:
         deleted = prune_quick_snapshots(keep=3, hermes_home=hermes_home)
         assert deleted == 7
         assert len(list_quick_snapshots(hermes_home=hermes_home)) == 3
+
+    def test_prune_removes_stale_owned_in_progress_snapshot(self, hermes_home):
+        import hermes_cli.backup as backup_mod
+
+        root = hermes_home / "state-snapshots"
+        snapshot = root / "20260721-120000-000000-interrupted"
+        snapshot.mkdir(parents=True)
+        marker = snapshot / ".in-progress"
+        marker.write_text(json.dumps({"version": 1, "snapshot_id": snapshot.name}))
+        (snapshot / "partial.db").write_text("partial")
+        old = time.time() - backup_mod._QUICK_IN_PROGRESS_MAX_AGE_SECONDS - 60
+        os.utime(marker, (old, old))
+
+        assert backup_mod.prune_quick_snapshots(
+            keep=20, hermes_home=hermes_home
+        ) == 1
+        assert not snapshot.exists()
+
+    def test_prune_preserves_unowned_in_progress_directory(self, hermes_home):
+        import hermes_cli.backup as backup_mod
+
+        root = hermes_home / "state-snapshots"
+        snapshot = root / "human-directory"
+        snapshot.mkdir(parents=True)
+        marker = snapshot / ".in-progress"
+        marker.write_text("foreign")
+        human = snapshot / "notes.txt"
+        human.write_text("keep")
+        old = time.time() - backup_mod._QUICK_IN_PROGRESS_MAX_AGE_SECONDS - 60
+        os.utime(marker, (old, old))
+
+        backup_mod.prune_quick_snapshots(keep=20, hermes_home=hermes_home)
+
+        assert human.read_text() == "keep"
+
+    def test_prune_preserves_in_progress_directory_when_identity_changes(
+        self, hermes_home, monkeypatch
+    ):
+        import hermes_cli.backup as backup_mod
+
+        root = hermes_home / "state-snapshots"
+        snapshot = root / "20260721-120000-000000-interrupted"
+        snapshot.mkdir(parents=True)
+        marker = snapshot / ".in-progress"
+        marker.write_text(json.dumps({"version": 1, "snapshot_id": snapshot.name}))
+        human = snapshot / "notes.txt"
+        human.write_text("keep")
+        old = time.time() - backup_mod._QUICK_IN_PROGRESS_MAX_AGE_SECONDS - 60
+        os.utime(marker, (old, old))
+        monkeypatch.setattr(backup_mod.os.path, "samestat", lambda _a, _b: False)
+
+        assert backup_mod.prune_quick_snapshots(
+            keep=20, hermes_home=hermes_home
+        ) == 0
+        assert human.read_text() == "keep"
+        assert not list(root.glob("*.hermes-delete-*"))
 
     def test_snapshot_includes_pairing_directories(self, hermes_home):
         """Pairing JSONs live outside state.db — snapshot must capture them

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1927,14 +1927,14 @@ class TestQuickSnapshot:
         import hermes_cli.backup as backup_mod
 
         root = hermes_home / "state-snapshots"
-        legacy = root / "20260101-010101"
+        legacy = root / "20260101-010101-pre update.v1"
         legacy.mkdir(parents=True)
         payload = b"legacy: restored\n"
         (legacy / "config.yaml").write_bytes(payload)
         manifest = {
             "id": legacy.name,
             "timestamp": "20260101-010101",
-            "label": None,
+            "label": "pre update.v1",
             "file_count": 1,
             "total_size": len(payload),
             "files": {"config.yaml": len(payload)},

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -8,6 +8,7 @@ import subprocess
 import time
 import zipfile
 from argparse import Namespace
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1871,6 +1872,248 @@ class TestQuickSnapshot:
         rows = conn.execute("SELECT * FROM sessions").fetchall()
         conn.close()
         assert len(rows) == 1
+
+    def test_restore_rejects_owned_non_object_manifest(self, hermes_home):
+        import hermes_cli.backup as backup_mod
+
+        snap_id = backup_mod.create_quick_snapshot(hermes_home=hermes_home)
+        assert snap_id is not None
+        manifest = hermes_home / "state-snapshots" / snap_id / "manifest.json"
+        manifest.write_text("[]", encoding="utf-8")
+        original = b"operator-current\n"
+        (hermes_home / "config.yaml").write_bytes(original)
+
+        assert not backup_mod.restore_quick_snapshot(
+            snap_id, hermes_home=hermes_home
+        )
+        assert (hermes_home / "config.yaml").read_bytes() == original
+
+    def test_restore_rejects_corrupted_member_before_overwriting_live_state(
+        self, hermes_home
+    ):
+        import hermes_cli.backup as backup_mod
+
+        snap_id = backup_mod.create_quick_snapshot(hermes_home=hermes_home)
+        assert snap_id is not None
+        snapshot_config = (
+            hermes_home / "state-snapshots" / snap_id / "config.yaml"
+        )
+        payload = snapshot_config.read_bytes()
+        snapshot_config.write_bytes(b"X" * len(payload))
+        original = b"operator-current\n"
+        (hermes_home / "config.yaml").write_bytes(original)
+
+        assert not backup_mod.restore_quick_snapshot(
+            snap_id, hermes_home=hermes_home
+        )
+        assert (hermes_home / "config.yaml").read_bytes() == original
+
+    def test_restore_rejects_staged_member_changed_after_source_validation(
+        self, hermes_home, monkeypatch
+    ):
+        import hermes_cli.backup as backup_mod
+
+        snap_id = backup_mod.create_quick_snapshot(hermes_home=hermes_home)
+        assert snap_id is not None
+        original = b"operator-current\n"
+        (hermes_home / "config.yaml").write_bytes(original)
+        real_writer = backup_mod._write_exclusive_snapshot_file
+
+        def corrupt_restore_stage(*args, **kwargs):
+            result = real_writer(*args, **kwargs)
+            relative_name = args[2]
+            if ".config.yaml.snap-restore-" in relative_name:
+                stage = result[0]
+                payload = stage.read_bytes()
+                stage.write_bytes(b"X" * len(payload))
+            return result
+
+        monkeypatch.setattr(
+            backup_mod, "_write_exclusive_snapshot_file", corrupt_restore_stage
+        )
+
+        backup_mod.restore_quick_snapshot(snap_id, hermes_home=hermes_home)
+
+        assert (hermes_home / "config.yaml").read_bytes() == original
+        assert not list(hermes_home.glob(".*.snap-restore-*.tmp"))
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX dirfd regression")
+    def test_restore_publication_binds_nested_parent(
+        self, hermes_home, monkeypatch
+    ):
+        import hermes_cli.backup as backup_mod
+
+        parent = hermes_home / "platforms" / "pairing"
+        parent.mkdir(parents=True)
+        target = parent / "telegram-approved.json"
+        snapshot_payload = b'{"snapshot": true}'
+        target.write_bytes(snapshot_payload)
+        snap_id = backup_mod.create_quick_snapshot(hermes_home=hermes_home)
+        assert snap_id is not None
+        target.write_bytes(b'{"current": true}')
+
+        displaced = parent.with_name("pairing-displaced")
+        injected = False
+        replacement_succeeded = False
+        replacement_payload = b'{"foreign": true}'
+
+        def install_replacement():
+            nonlocal injected, replacement_succeeded
+            injected = True
+            try:
+                parent.rename(displaced)
+                parent.mkdir()
+                (parent / target.name).write_bytes(replacement_payload)
+                replacement_succeeded = True
+            except OSError:
+                replacement_succeeded = False
+
+        real_replace = backup_mod.os.replace
+
+        def replace_while_publishing(source, destination, *args, **kwargs):
+            if Path(destination).name == target.name and not injected:
+                install_replacement()
+            return real_replace(source, destination, *args, **kwargs)
+
+        monkeypatch.setattr(
+            backup_mod.os, "replace", replace_while_publishing
+        )
+
+        backup_mod.restore_quick_snapshot(snap_id, hermes_home=hermes_home)
+
+        assert injected
+        assert replacement_succeeded
+        assert target.read_bytes() == replacement_payload
+        assert (displaced / target.name).read_bytes() == snapshot_payload
+        assert not list(displaced.glob(".*.snap-restore-*.tmp"))
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows handle regression")
+    def test_windows_handle_relative_publication_ignores_parent_path_replacement(
+        self, tmp_path
+    ):
+        import ctypes
+        import hermes_cli.backup as backup_mod
+
+        parent = tmp_path / "restore-parent"
+        parent.mkdir()
+        stage = parent / ".state.snap-restore-test.tmp"
+        stage_payload = b"snapshot payload"
+        stage.write_bytes(stage_payload)
+        stage_identity = stage.lstat()
+        parent_handle = backup_mod._open_bound_snapshot_directory(parent)
+        displaced = tmp_path / "restore-parent-displaced"
+        foreign = parent / "state.db"
+        parent.rename(displaced)
+        parent.mkdir()
+        foreign.write_bytes(b"operator payload")
+        try:
+            published = backup_mod._replace_windows_snapshot_member_by_handle(
+                parent_handle,
+                displaced / stage.name,
+                "state.db",
+                stage_identity,
+            )
+        finally:
+            ctypes.windll.kernel32.CloseHandle(parent_handle)
+
+        assert backup_mod._same_snapshot_object(stage_identity, published)
+        assert foreign.read_bytes() == b"operator payload"
+        assert (displaced / "state.db").read_bytes() == stage_payload
+        assert not (displaced / stage.name).exists()
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows handle regression")
+    def test_restore_fails_closed_when_parent_path_changes_before_stage_handle_open(
+        self, hermes_home, monkeypatch
+    ):
+        import hermes_cli.backup as backup_mod
+
+        parent = hermes_home / "platforms" / "pairing"
+        parent.mkdir(parents=True)
+        target = parent / "telegram-approved.json"
+        target.write_bytes(b'{"snapshot": true}')
+        snap_id = backup_mod.create_quick_snapshot(hermes_home=hermes_home)
+        assert snap_id is not None
+        current_payload = b'{"current": true}'
+        target.write_bytes(current_payload)
+
+        displaced = parent.with_name("pairing-displaced-before-stage-open")
+        foreign_payload = b'{"foreign": true}'
+        real_replace = backup_mod._replace_windows_snapshot_member_by_handle
+        injected = False
+
+        def replace_after_stage_close(parent_fd, source, destination_name, expected):
+            nonlocal injected
+            if destination_name == target.name and not injected:
+                injected = True
+                parent.rename(displaced)
+                parent.mkdir()
+                (parent / destination_name).write_bytes(foreign_payload)
+                Path(source).write_bytes(b"attacker staging object")
+            return real_replace(parent_fd, source, destination_name, expected)
+
+        monkeypatch.setattr(
+            backup_mod,
+            "_replace_windows_snapshot_member_by_handle",
+            replace_after_stage_close,
+        )
+
+        backup_mod.restore_quick_snapshot(snap_id, hermes_home=hermes_home)
+        assert injected
+        assert target.read_bytes() == foreign_payload
+        assert (displaced / target.name).read_bytes() == current_payload
+        assert list(displaced.glob(".*.snap-restore-*.tmp"))
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows junction regression")
+    def test_restore_rejects_nested_parent_replaced_by_junction_before_binding(
+        self, hermes_home, tmp_path, monkeypatch
+    ):
+        import hermes_cli.backup as backup_mod
+
+        parent = hermes_home / "platforms" / "pairing"
+        parent.mkdir(parents=True)
+        target = parent / "telegram-approved.json"
+        target.write_text('{"snapshot": true}', encoding="utf-8")
+        snap_id = backup_mod.create_quick_snapshot(hermes_home=hermes_home)
+        assert snap_id is not None
+        target.write_text('{"current": true}', encoding="utf-8")
+
+        foreign = tmp_path / "operator-pairing"
+        foreign.mkdir()
+        foreign_target = foreign / target.name
+        foreign_target.write_text('{"foreign": true}', encoding="utf-8")
+        displaced = parent.with_name("pairing-before-junction")
+        real_hold = backup_mod._hold_snapshot_parent_chain
+        injected = False
+
+        @contextmanager
+        def replace_then_hold(chain):
+            nonlocal injected
+            if chain[-1][0] == parent and not injected:
+                injected = True
+                parent.rename(displaced)
+                created = subprocess.run(
+                    ["cmd", "/c", "mklink", "/J", str(parent), str(foreign)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if created.returncode:
+                    pytest.skip(
+                        f"junction creation unavailable: {created.stderr.strip()}"
+                    )
+            with real_hold(chain) as parent_fd:
+                yield parent_fd
+
+        monkeypatch.setattr(
+            backup_mod, "_hold_snapshot_parent_chain", replace_then_hold
+        )
+
+        backup_mod.restore_quick_snapshot(snap_id, hermes_home=hermes_home)
+
+        assert injected
+        assert foreign_target.read_text(encoding="utf-8") == '{"foreign": true}'
+        assert not list(foreign.glob(".*.snap-restore-*.tmp"))
+        assert target.resolve().is_relative_to(foreign.resolve())
 
     def test_restore_nonexistent(self, hermes_home):
         from hermes_cli.backup import restore_quick_snapshot

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1467,6 +1467,26 @@ class TestQuickSnapshot:
         assert snap_dir.is_dir()
         assert (snap_dir / "manifest.json").exists()
 
+    def test_same_timestamp_snapshots_get_distinct_directories(self, hermes_home, monkeypatch):
+        """Concurrent snapshot callers must not share a destination directory."""
+        import hermes_cli.backup as backup_mod
+        from datetime import datetime as RealDateTime
+
+        fixed = RealDateTime(2026, 7, 21, 20, 0, 0)
+
+        class FrozenDateTime(RealDateTime):
+            @classmethod
+            def now(cls, tz=None):
+                return fixed.replace(tzinfo=tz)
+
+        monkeypatch.setattr(backup_mod, "datetime", FrozenDateTime)
+        first = backup_mod.create_quick_snapshot(hermes_home=hermes_home)
+        second = backup_mod.create_quick_snapshot(hermes_home=hermes_home)
+
+        assert first != second
+        assert (hermes_home / "state-snapshots" / first / "manifest.json").exists()
+        assert (hermes_home / "state-snapshots" / second / "manifest.json").exists()
+
     def test_label_in_id(self, hermes_home):
         from hermes_cli.backup import create_quick_snapshot
         snap_id = create_quick_snapshot(label="before-upgrade", hermes_home=hermes_home)
@@ -2030,6 +2050,21 @@ class TestPreUpdateBackup:
         assert result is None
         assert not out_zip.exists()
 
+    def test_failed_regular_file_write_does_not_publish_empty_archive(self, hermes_home, monkeypatch):
+        """A full safety archive must fail closed if every regular file write fails."""
+        import hermes_cli.backup as backup_mod
+
+        def fail_write(*_args, **_kwargs):
+            raise OSError("forced archive write failure")
+
+        monkeypatch.setattr(backup_mod.zipfile.ZipFile, "write", fail_write)
+        out = hermes_home / "backups" / "pre-migration-failed.zip"
+        out.parent.mkdir()
+        result = backup_mod._write_full_zip_backup(out, hermes_home)
+
+        assert result is None
+        assert not out.exists()
+
     @pytest.fixture
     def hermes_home(self, tmp_path):
         root = tmp_path / ".hermes"
@@ -2045,6 +2080,27 @@ class TestPreUpdateBackup:
         assert out.parent == hermes_home / "backups"
         assert out.name.startswith("pre-update-")
         assert out.suffix == ".zip"
+
+    def test_same_timestamp_creations_get_distinct_archives(self, hermes_home, monkeypatch):
+        """Backup names must not collide when multiple updates start in one second."""
+        import hermes_cli.backup as backup_mod
+        from datetime import datetime as RealDateTime
+
+        fixed = RealDateTime(2026, 7, 21, 20, 0, 0)
+
+        class FrozenDateTime(RealDateTime):
+            @classmethod
+            def now(cls, tz=None):
+                return fixed.replace(tzinfo=tz)
+
+        monkeypatch.setattr(backup_mod, "datetime", FrozenDateTime)
+        first = backup_mod.create_pre_update_backup(hermes_home=hermes_home)
+        second = backup_mod.create_pre_update_backup(hermes_home=hermes_home)
+
+        assert first is not None and second is not None
+        assert first != second
+        assert first.exists() and second.exists()
+        assert len(list((hermes_home / "backups").glob("pre-update-*.zip"))) == 2
 
     def test_backup_contents_match_full_backup(self, hermes_home):
         """Pre-update backup should include the same user data that
@@ -2377,6 +2433,27 @@ class TestPreMigrationBackup:
         assert out.name.startswith("pre-migration-")
         assert out.suffix == ".zip"
 
+    def test_same_timestamp_creations_get_distinct_archives(self, hermes_home, monkeypatch):
+        """Migration backups must not overwrite one another in one second."""
+        import hermes_cli.backup as backup_mod
+        from datetime import datetime as RealDateTime
+
+        fixed = RealDateTime(2026, 7, 21, 20, 0, 0)
+
+        class FrozenDateTime(RealDateTime):
+            @classmethod
+            def now(cls, tz=None):
+                return fixed.replace(tzinfo=tz)
+
+        monkeypatch.setattr(backup_mod, "datetime", FrozenDateTime)
+        first = backup_mod.create_pre_migration_backup(hermes_home=hermes_home)
+        second = backup_mod.create_pre_migration_backup(hermes_home=hermes_home)
+
+        assert first is not None and second is not None
+        assert first != second
+        assert first.exists() and second.exists()
+        assert len(list((hermes_home / "backups").glob("pre-migration-*.zip"))) == 2
+
     def test_backup_uses_shared_exclusion_rules(self, hermes_home):
         """Pre-migration backup reuses the same exclusion rules as
         ``hermes backup`` / ``create_pre_update_backup`` — no drift."""
@@ -2449,6 +2526,16 @@ class TestPreMigrationBackup:
             _t.sleep(1.05)
         # Update backup must still be there
         assert update_backup.exists(), "pre-migration rotation wrongly pruned the pre-update backup"
+
+    def test_keep_zero_preserves_fresh_backup(self, hermes_home):
+        """A successful migration must always leave one recovery point."""
+        from hermes_cli.backup import create_pre_migration_backup
+
+        out = create_pre_migration_backup(hermes_home=hermes_home, keep=0)
+
+        assert out is not None
+        assert out.exists()
+        assert list((hermes_home / "backups").glob("pre-migration-*.zip")) == [out]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shutil
 import sqlite3
 import time
 import zipfile
@@ -1815,6 +1816,43 @@ class TestQuickSnapshot:
         quarantines = list(root.glob(f".{snap_id}.hermes-delete-*"))
         assert len(quarantines) == 1
         assert (quarantines[0] / "config.yaml").exists()
+
+    def test_prune_preserves_directory_replaced_after_owner_validation(
+        self, hermes_home, monkeypatch
+    ):
+        import hermes_cli.backup as backup_mod
+
+        snap_id = backup_mod.create_quick_snapshot(hermes_home=hermes_home)
+        root = hermes_home / "state-snapshots"
+        snapshot = root / snap_id
+        displaced = root / f"{snap_id}-agent-original"
+        original_remove = backup_mod._remove_owned_snapshot_dir
+        injected = False
+
+        def replace_then_remove(path, expected, **kwargs):
+            nonlocal injected
+            if Path(path) == snapshot and not injected:
+                injected = True
+                backup_mod.os.replace(snapshot, displaced)
+                snapshot.mkdir()
+                shutil.copy2(
+                    displaced / backup_mod._QUICK_OWNERSHIP_MARKER,
+                    snapshot / backup_mod._QUICK_OWNERSHIP_MARKER,
+                )
+                (snapshot / "human.txt").write_text("keep")
+            return original_remove(path, expected, **kwargs)
+
+        monkeypatch.setattr(
+            backup_mod, "_remove_owned_snapshot_dir", replace_then_remove
+        )
+
+        assert backup_mod.prune_quick_snapshots(
+            keep=0, hermes_home=hermes_home
+        ) == 0
+        quarantines = list(root.glob(f".{snap_id}.hermes-delete-*"))
+        assert len(quarantines) == 1
+        assert (quarantines[0] / "human.txt").read_text() == "keep"
+        assert (displaced / "config.yaml").exists()
 
     def test_snapshot_includes_pairing_directories(self, hermes_home):
         """Pairing JSONs live outside state.db — snapshot must capture them

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1432,6 +1432,49 @@ class TestSafeCopyDb:
         conn.close()
         assert rows == [("wal-test",)]
 
+    def test_failure_cleanup_preserves_pathname_replacement(
+        self, tmp_path, monkeypatch
+    ):
+        """A failed backup cannot authorize unlinking a later human file."""
+        import hermes_cli.backup as backup_mod
+
+        src = tmp_path / "source.db"
+        with sqlite3.connect(src) as conn:
+            conn.execute("CREATE TABLE state (value TEXT)")
+        dst = tmp_path / "copy.db"
+        real_remove = backup_mod._remove_owned_snapshot_file
+
+        class FailingSource:
+            def __init__(self, connection):
+                self.connection = connection
+
+            def backup(self, _destination):
+                raise sqlite3.OperationalError("forced failure")
+
+            def close(self):
+                self.connection.close()
+
+        real_connect = backup_mod.sqlite3.connect
+
+        def failing_connect(database, *args, **kwargs):
+            connection = real_connect(database, *args, **kwargs)
+            if str(database).startswith(f"file:{src}"):
+                return FailingSource(connection)
+            return connection
+
+        def replace_before_cleanup(path, expected):
+            Path(path).unlink()
+            Path(path).write_text("human replacement")
+            return real_remove(path, expected)
+
+        monkeypatch.setattr(backup_mod.sqlite3, "connect", failing_connect)
+        monkeypatch.setattr(
+            backup_mod, "_remove_owned_snapshot_file", replace_before_cleanup
+        )
+
+        assert backup_mod._safe_copy_db(src, dst) is False
+        assert dst.read_text() == "human replacement"
+
 
 # ---------------------------------------------------------------------------
 # Quick state snapshot tests
@@ -1850,8 +1893,8 @@ class TestQuickSnapshot:
             keep=0, hermes_home=hermes_home
         ) == 0
         quarantines = list(root.glob(f".{snap_id}.hermes-delete-*"))
-        assert len(quarantines) == 1
-        assert (quarantines[0] / "human.txt").read_text() == "keep"
+        assert quarantines == []
+        assert (snapshot / "human.txt").read_text() == "keep"
         assert (displaced / "config.yaml").exists()
 
     def test_snapshot_includes_pairing_directories(self, hermes_home):
@@ -2271,6 +2314,43 @@ class TestPreUpdateBackup:
 
         assert result is None
         assert not out.exists()
+
+    def test_publication_collision_preserves_winner_and_retries(
+        self, hermes_home, monkeypatch
+    ):
+        import hermes_cli.backup as backup_mod
+
+        backup_dir = hermes_home / "backups"
+        backup_dir.mkdir()
+        requested = backup_dir / "pre-update-race.zip"
+        if os.name == "nt":
+            real_publish = backup_mod.os.rename
+
+            def collide_once(source, destination):
+                destination = Path(destination)
+                if destination == requested and not destination.exists():
+                    destination.write_text("human winner")
+                    raise FileExistsError(str(destination))
+                return real_publish(source, destination)
+
+            monkeypatch.setattr(backup_mod.os, "rename", collide_once)
+        else:
+            real_publish = backup_mod.os.link
+
+            def collide_once(source, destination, **kwargs):
+                destination = Path(destination)
+                if destination == requested and not destination.exists():
+                    destination.write_text("human winner")
+                    raise FileExistsError(str(destination))
+                return real_publish(source, destination, **kwargs)
+
+            monkeypatch.setattr(backup_mod.os, "link", collide_once)
+
+        published = backup_mod._write_full_zip_backup(requested, hermes_home)
+
+        assert requested.read_text() == "human winner"
+        assert published is not None and published != requested
+        assert backup_mod._owned_archive_identity(published) is not None
 
     def test_failed_zip_write_preserves_recreated_temp_path(
         self, tmp_path, monkeypatch

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1498,6 +1498,9 @@ class TestSafeCopyDb:
         assert backup_mod._safe_copy_db(src, dst)
 
         assert str(dst) not in opened
+        assert ":memory:" not in opened
+        assert any(".hermes-sqlite-backup-" in path for path in opened)
+        assert not list(tmp_path.glob(".hermes-sqlite-backup-*"))
         with real_connect(dst) as copied:
             assert copied.execute("SELECT value FROM state").fetchall() == [("safe",)]
 
@@ -1694,6 +1697,35 @@ class TestQuickSnapshot:
         assert not (external / "state.db").exists()
         assert not (external / "manifest.json").exists()
         assert displaced is not None and displaced.exists()
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows junction regression")
+    def test_persistent_junction_home_can_snapshot_and_restore(
+        self, hermes_home, tmp_path
+    ):
+        import hermes_cli.backup as backup_mod
+
+        linked_home = tmp_path / "linked-hermes-home"
+        created = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(linked_home), str(hermes_home)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if created.returncode:
+            pytest.skip(f"junction creation unavailable: {created.stderr.strip()}")
+
+        snap_id = backup_mod.create_quick_snapshot(hermes_home=linked_home)
+        assert snap_id is not None
+        (hermes_home / "config.yaml").write_text(
+            "model:\n  provider: changed\n", encoding="utf-8"
+        )
+
+        assert backup_mod.restore_quick_snapshot(
+            snap_id, hermes_home=linked_home
+        )
+        assert "openrouter" in (hermes_home / "config.yaml").read_text(
+            encoding="utf-8"
+        )
 
     def test_creates_snapshot(self, hermes_home):
         from hermes_cli.backup import create_quick_snapshot

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2624,6 +2624,143 @@ def test_rollback_cleanup_preserves_replaced_staged_path(
     assert replacement.read_text() == "human replacement"
 
 
+def test_artifact_copy_interrupt_removes_only_partial_destination(
+    kanban_home, monkeypatch
+):
+    """An interrupt inside destination.write cannot strand the partial copy."""
+    original_open = Path.open
+
+    class InterruptingWriter:
+        def __init__(self, stream):
+            self.stream = stream
+
+        def __enter__(self):
+            self.stream.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self.stream.__exit__(*args)
+
+        def __getattr__(self, name):
+            return getattr(self.stream, name)
+
+        def write(self, data):
+            self.stream.write(data[:1])
+            raise KeyboardInterrupt()
+
+    def interrupt_destination(path, mode="r", *args, **kwargs):
+        stream = original_open(path, mode, *args, **kwargs)
+        return InterruptingWriter(stream) if mode == "xb" else stream
+
+    monkeypatch.setattr(Path, "open", interrupt_destination)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="copy interrupt")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, workspace)
+        artifact = workspace / "report.txt"
+        artifact.write_text("result")
+
+        with pytest.raises(KeyboardInterrupt):
+            kb.complete_task(
+                conn,
+                task_id,
+                metadata={"artifacts": [str(artifact)]},
+            )
+
+        assert conn.in_transaction is False
+        assert kb.get_task(conn, task_id).status == "ready"
+
+    attachment_dir = kb.task_attachments_dir(task_id)
+    assert not attachment_dir.exists() or not list(attachment_dir.iterdir())
+
+
+def test_artifact_copy_fsync_failure_removes_bound_destination(
+    kanban_home, monkeypatch
+):
+    """fstat identity remains available when durability flushing fails."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="copy fsync failure")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, workspace)
+        artifact = workspace / "report.txt"
+        artifact.write_text("result")
+        monkeypatch.setattr(kb.os, "fsync", lambda _fd: (_ for _ in ()).throw(OSError("fsync")))
+
+        with pytest.raises(kb.ArtifactPreservationError, match="could not preserve"):
+            kb.complete_task(
+                conn,
+                task_id,
+                metadata={"artifacts": [str(artifact)]},
+            )
+
+        assert kb.get_task(conn, task_id).status == "ready"
+
+    attachment_dir = kb.task_attachments_dir(task_id)
+    assert not attachment_dir.exists() or not list(attachment_dir.iterdir())
+
+
+def test_artifact_copy_rejects_source_changed_at_end_of_stream(
+    kanban_home, monkeypatch
+):
+    """A concurrent writer cannot produce a mixed completion artifact."""
+    original_open = Path.open
+    source_path = None
+
+    class MutatingReader:
+        def __init__(self, stream, path):
+            self.stream = stream
+            self.path = path
+            self.mutated = False
+
+        def __enter__(self):
+            self.stream.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self.stream.__exit__(*args)
+
+        def __getattr__(self, name):
+            return getattr(self.stream, name)
+
+        def read(self, *args, **kwargs):
+            data = self.stream.read(*args, **kwargs)
+            if not data and not self.mutated:
+                self.mutated = True
+                with original_open(self.path, "ab") as writer:
+                    writer.write(b"-changed")
+            return data
+
+    def mutate_source(path, mode="r", *args, **kwargs):
+        stream = original_open(path, mode, *args, **kwargs)
+        if mode == "rb" and source_path is not None and path == source_path:
+            return MutatingReader(stream, path)
+        return stream
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="source mutation")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, workspace)
+        source_path = workspace / "report.txt"
+        source_path.write_text("result")
+        monkeypatch.setattr(Path, "open", mutate_source)
+
+        with pytest.raises(kb.ArtifactPreservationError, match="changed while"):
+            kb.complete_task(
+                conn,
+                task_id,
+                metadata={"artifacts": [str(source_path)]},
+            )
+
+        assert kb.get_task(conn, task_id).status == "ready"
+        assert source_path.read_text() == "result-changed"
+
+    attachment_dir = kb.task_attachments_dir(task_id)
+    assert not attachment_dir.exists() or not list(attachment_dir.iterdir())
+
+
 def test_complete_task_rejects_missing_declared_scratch_artifact(kanban_home):
     """A declared scratch deliverable must not disappear behind a false Done."""
     with kb.connect() as conn:
@@ -2836,16 +2973,14 @@ def test_scratch_workspace_has_exact_owner_marker(kanban_home):
     }
 
 
-def test_interrupted_scratch_marker_creation_can_retry(
+def test_interrupted_scratch_marker_creation_preserves_evidence(
     kanban_home, monkeypatch
 ):
-    """An interrupted marker write does not poison the canonical path forever."""
+    """An interrupted marker is never unlinked without exact identity proof."""
     with kb.connect() as conn:
         task_id = kb.create_task(conn, title="retry marker")
         task = kb.get_task(conn, task_id)
         canonical = kb.workspaces_root() / task_id
-        original = kb._create_scratch_owner_marker
-
         def interrupt(workspace, **_kwargs):
             (workspace / kb._SCRATCH_OWNER_MARKER_NAME).write_text("{")
             raise OSError("interrupted marker write")
@@ -2853,11 +2988,8 @@ def test_interrupted_scratch_marker_creation_can_retry(
         monkeypatch.setattr(kb, "_create_scratch_owner_marker", interrupt)
         with pytest.raises(ValueError, match="could not materialize"):
             kb.resolve_workspace(task)
-        assert not canonical.exists()
-
-        monkeypatch.setattr(kb, "_create_scratch_owner_marker", original)
-        assert kb.resolve_workspace(task) == canonical
-        assert (canonical / kb._SCRATCH_OWNER_MARKER_NAME).is_file()
+        assert canonical.exists()
+        assert (canonical / kb._SCRATCH_OWNER_MARKER_NAME).read_text() == "{"
 
 
 def test_scratch_cleanup_preserves_cross_task_workspace(kanban_home):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -63,6 +63,40 @@ def test_init_creates_expected_tables(kanban_home):
     assert {"tasks", "task_links", "task_comments", "task_events"} <= names
 
 
+def test_init_backfills_legacy_attachment_deletion_identity(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="legacy attachment")
+        attachment_dir = kb.task_attachments_dir(task_id)
+        attachment_dir.mkdir(parents=True)
+        blob = attachment_dir / "legacy.txt"
+        blob.write_text("legacy")
+        cursor = conn.execute(
+            "INSERT INTO task_attachments "
+            "(task_id, filename, stored_path, content_type, size, uploaded_by, "
+            "created_at, filesystem_identity) VALUES (?, ?, ?, ?, ?, ?, ?, NULL)",
+            (
+                task_id,
+                blob.name,
+                str(blob.resolve()),
+                "text/plain",
+                blob.stat().st_size,
+                "legacy",
+                int(time.time()),
+            ),
+        )
+        attachment_id = int(cursor.lastrowid)
+        conn.commit()
+
+    kb.init_db()
+    with kb.connect() as conn:
+        attachment = kb.get_attachment(conn, attachment_id)
+        assert attachment is not None
+        assert attachment.filesystem_identity is not None
+        assert kb.delete_attachment(conn, attachment_id) is not None
+
+    assert not blob.exists()
+
+
 def test_connect_honors_kanban_busy_timeout_env(kanban_home, monkeypatch):
     """All kanban connections should use the explicit busy-timeout knob.
 
@@ -2452,6 +2486,7 @@ def test_complete_task_persists_scratch_artifacts_before_cleanup(kanban_home):
         run = kb.latest_run(conn, t)
 
     assert not ws.exists(), "scratch workspace should still be cleaned up"
+    assert list(ws.parent.glob(f".{ws.name}.hermes-delete-*")) == []
     assert persisted.exists(), "artifact copy should survive scratch cleanup"
     assert persisted.parent == kb.task_attachments_dir(t)
     assert persisted.name == "chart.png"
@@ -3019,12 +3054,18 @@ def test_scratch_workspace_has_exact_owner_marker(kanban_home):
 
     marker = workspace / ".hermes-kanban-owner.json"
     assert marker.is_file()
+    workspace_identity = workspace.lstat()
     assert json.loads(marker.read_text(encoding="utf-8")) == {
-        "version": 1,
+        "version": 2,
         "task_id": task_id,
         "board": "default",
         "tenant": "tenant-a",
         "workspace": str(workspace.resolve()),
+        "workspace_identity": [
+            workspace_identity.st_dev,
+            workspace_identity.st_ino,
+            workspace_identity.st_ctime_ns if os.name == "nt" else None,
+        ],
     }
 
 
@@ -3045,6 +3086,50 @@ def test_interrupted_scratch_marker_creation_preserves_evidence(
             kb.resolve_workspace(task)
         assert canonical.exists()
         assert (canonical / kb._SCRATCH_OWNER_MARKER_NAME).read_text() == "{"
+
+
+def test_scratch_marker_creation_rejects_replaced_workspace(
+    kanban_home, monkeypatch
+):
+    """A replacement directory cannot inherit a newly published owner marker."""
+    real_create = kb._create_scratch_owner_marker
+    replaced = False
+    displaced = None
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="marker publication race")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.workspaces_root() / task_id
+
+        def replace_before_marker(path, **kwargs):
+            nonlocal replaced, displaced
+            if not replaced:
+                replaced = True
+                if kwargs["workspace_fd"] is not None:
+                    try:
+                        os.close(kwargs["workspace_fd"])
+                    except OSError:
+                        pass
+                displaced = workspace.with_name(f"{workspace.name}-agent-original")
+                kb.os.replace(workspace, displaced)
+                workspace.mkdir()
+                (workspace / "human.txt").write_text("keep")
+            return real_create(path, **kwargs)
+
+        monkeypatch.setattr(
+            kb, "_create_scratch_owner_marker", replace_before_marker
+        )
+        with pytest.raises(ValueError, match="scratch workspace changed"):
+            kb.resolve_workspace(task)
+
+    assert displaced is not None and displaced.is_dir()
+    assert (workspace / "human.txt").read_text() == "keep"
+    assert not kb._scratch_workspace_is_owned(
+        workspace,
+        task_id=task_id,
+        board="default",
+        tenant=None,
+    )
 
 
 def test_scratch_cleanup_preserves_cross_task_workspace(kanban_home):
@@ -3226,8 +3311,8 @@ def test_scratch_cleanup_binds_owner_proof_to_original_directory(
 
     assert displaced is not None and (displaced / "agent.txt").read_text() == "agent"
     quarantines = list(workspace.parent.glob(f".{workspace.name}.hermes-delete-*"))
-    assert len(quarantines) == 1
-    assert (quarantines[0] / "human.txt").read_text() == "keep"
+    assert quarantines == []
+    assert (workspace / "human.txt").read_text() == "keep"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2363,6 +2363,49 @@ def test_cleanup_workspace_removes_managed_scratch_dir(kanban_home):
     assert not ws.exists(), "Hermes-managed scratch dir should be cleaned up"
 
 
+def test_archive_task_cleans_managed_scratch_dir(kanban_home):
+    """Archiving a task must not leave its ephemeral workspace behind."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="archive scratch")
+        task = kb.get_task(conn, task_id)
+        ws = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, ws)
+        assert kb.archive_task(conn, task_id)
+
+    assert not ws.exists()
+
+
+def test_delete_task_cleans_managed_scratch_dir_before_row_disappears(kanban_home):
+    """Hard deletion must clean scratch storage even though the task row is gone."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="delete scratch")
+        task = kb.get_task(conn, task_id)
+        ws = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, ws)
+        assert kb.delete_task(conn, task_id)
+        assert kb.get_task(conn, task_id) is None
+
+    assert not ws.exists()
+
+
+def test_failure_path_cleans_managed_scratch_dir(kanban_home):
+    """A failed retry must release its disposable workspace for the next run."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="failed scratch")
+        task = kb.get_task(conn, task_id)
+        ws = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, ws)
+        kb._record_task_failure(
+            conn,
+            task_id,
+            "worker failed",
+            outcome="crashed",
+            failure_limit=5,
+        )
+
+    assert not ws.exists()
+
+
 def test_complete_task_persists_scratch_artifacts_before_cleanup(kanban_home):
     """Completion artifacts from scratch workspaces survive workspace cleanup."""
     with kb.connect() as conn:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2389,13 +2389,15 @@ def test_delete_task_cleans_managed_scratch_dir_before_row_disappears(kanban_hom
     assert not ws.exists()
 
 
-def test_failure_path_cleans_managed_scratch_dir(kanban_home):
-    """A failed retry must release its disposable workspace for the next run."""
+def test_failure_path_preserves_managed_scratch_checkpoint(kanban_home):
+    """A failed retry must preserve partial work for the next worker."""
     with kb.connect() as conn:
         task_id = kb.create_task(conn, title="failed scratch")
         task = kb.get_task(conn, task_id)
         ws = kb.resolve_workspace(task)
         kb.set_workspace_path(conn, task_id, ws)
+        checkpoint = ws / "checkpoint.txt"
+        checkpoint.write_text("resume here")
         kb._record_task_failure(
             conn,
             task_id,
@@ -2404,7 +2406,28 @@ def test_failure_path_cleans_managed_scratch_dir(kanban_home):
             failure_limit=5,
         )
 
-    assert not ws.exists()
+    assert checkpoint.read_text() == "resume here"
+
+
+def test_auto_blocked_failure_preserves_scratch_for_operator(kanban_home):
+    """Circuit-breaker blocking must leave the exact failed workspace recoverable."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="blocked scratch")
+        task = kb.get_task(conn, task_id)
+        ws = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, ws)
+        checkpoint = ws / "checkpoint.txt"
+        checkpoint.write_text("operator evidence")
+        blocked = kb._record_task_failure(
+            conn,
+            task_id,
+            "worker failed",
+            outcome="crashed",
+            failure_limit=1,
+        )
+
+    assert blocked is True
+    assert checkpoint.read_text() == "operator evidence"
 
 
 def test_complete_task_persists_scratch_artifacts_before_cleanup(kanban_home):
@@ -2441,6 +2464,87 @@ def test_complete_task_persists_scratch_artifacts_before_cleanup(kanban_home):
     assert [(a.filename, a.stored_path) for a in attachments] == [
         ("chart.png", str(persisted.resolve()))
     ]
+
+
+def test_completion_artifact_prefix_collision_is_not_registered(kanban_home):
+    """A sibling whose name shares the attachment-dir prefix stays external."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="contain staged paths")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, workspace)
+        real = workspace / "real.txt"
+        real.write_text("owned")
+        sibling = kb.task_attachments_dir(task_id).with_name(f"{task_id}-foreign")
+        sibling.mkdir(parents=True)
+        human = sibling / "human.txt"
+        human.write_text("keep")
+
+        assert kb.complete_task(
+            conn,
+            task_id,
+            result="done",
+            metadata={"artifacts": [str(real), str(human)]},
+        )
+        attachments = kb.list_attachments(conn, task_id)
+
+    assert [item.filename for item in attachments] == ["real.txt"]
+    assert human.read_text() == "keep"
+
+
+def test_delete_attachment_never_unlinks_outside_task_storage(kanban_home):
+    """A corrupt or legacy row cannot turn row deletion into arbitrary unlink."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="contained delete")
+        outside = kanban_home / "human.txt"
+        outside.write_text("keep")
+        attachment_id = kb.add_attachment(
+            conn,
+            task_id,
+            filename=outside.name,
+            stored_path=str(outside),
+            uploaded_by="legacy",
+        )
+
+        assert kb.delete_attachment(conn, attachment_id) is not None
+        assert kb.get_attachment(conn, attachment_id) is None
+
+    assert outside.read_text() == "keep"
+
+
+def test_completion_rollback_removes_staged_artifact_copy(
+    kanban_home, monkeypatch
+):
+    """A failed SQLite commit must not orphan the pre-cleanup artifact copy."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="rollback artifact")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, workspace)
+        artifact = workspace / "report.txt"
+        artifact.write_text("result")
+        original_boundary = kb._execute_boundary_with_retry
+
+        def fail_commit(connection, sql):
+            if sql == "COMMIT":
+                raise sqlite3.OperationalError("forced commit failure")
+            return original_boundary(connection, sql)
+
+        monkeypatch.setattr(kb, "_execute_boundary_with_retry", fail_commit)
+        with pytest.raises(sqlite3.OperationalError, match="forced commit failure"):
+            kb.complete_task(
+                conn,
+                task_id,
+                result="done",
+                metadata={"artifacts": [str(artifact)]},
+            )
+
+        assert kb.get_task(conn, task_id).status == "ready"
+        assert kb.list_attachments(conn, task_id) == []
+
+    assert artifact.exists()
+    attachment_dir = kb.task_attachments_dir(task_id)
+    assert not attachment_dir.exists() or not list(attachment_dir.iterdir())
 
 
 def test_complete_task_rejects_missing_declared_scratch_artifact(kanban_home):
@@ -2653,6 +2757,30 @@ def test_scratch_workspace_has_exact_owner_marker(kanban_home):
         "tenant": "tenant-a",
         "workspace": str(workspace.resolve()),
     }
+
+
+def test_interrupted_scratch_marker_creation_can_retry(
+    kanban_home, monkeypatch
+):
+    """An interrupted marker write does not poison the canonical path forever."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="retry marker")
+        task = kb.get_task(conn, task_id)
+        canonical = kb.workspaces_root() / task_id
+        original = kb._create_scratch_owner_marker
+
+        def interrupt(workspace, **_kwargs):
+            (workspace / kb._SCRATCH_OWNER_MARKER_NAME).write_text("{")
+            raise OSError("interrupted marker write")
+
+        monkeypatch.setattr(kb, "_create_scratch_owner_marker", interrupt)
+        with pytest.raises(ValueError, match="could not materialize"):
+            kb.resolve_workspace(task)
+        assert not canonical.exists()
+
+        monkeypatch.setattr(kb, "_create_scratch_owner_marker", original)
+        assert kb.resolve_workspace(task) == canonical
+        assert (canonical / kb._SCRATCH_OWNER_MARKER_NAME).is_file()
 
 
 def test_scratch_cleanup_preserves_cross_task_workspace(kanban_home):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -64,7 +64,7 @@ def test_init_creates_expected_tables(kanban_home):
     assert {"tasks", "task_links", "task_comments", "task_events"} <= names
 
 
-def test_init_preserves_legacy_attachment_without_deletion_identity(kanban_home):
+def test_init_preserves_legacy_blob_when_attachment_row_is_deleted(kanban_home):
     with kb.connect() as conn:
         task_id = kb.create_task(conn, title="legacy attachment")
         attachment_dir = kb.task_attachments_dir(task_id)
@@ -93,9 +93,8 @@ def test_init_preserves_legacy_attachment_without_deletion_identity(kanban_home)
         attachment = kb.get_attachment(conn, attachment_id)
         assert attachment is not None
         assert attachment.filesystem_identity is None
-        with pytest.raises(kb.AttachmentOwnershipUnknown, match="no filesystem ownership"):
-            kb.delete_attachment(conn, attachment_id)
-        assert kb.get_attachment(conn, attachment_id) is not None
+        assert kb.delete_attachment(conn, attachment_id) is not None
+        assert kb.get_attachment(conn, attachment_id) is None
 
     assert blob.read_text() == "legacy"
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2512,6 +2512,26 @@ def test_delete_attachment_never_unlinks_outside_task_storage(kanban_home):
     assert outside.read_text() == "keep"
 
 
+def test_delete_attachment_preserves_pathname_replacement(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="replacement-safe delete")
+        attachment_id = kb.store_attachment_bytes(
+            conn,
+            task_id,
+            "report.txt",
+            b"agent result",
+        )
+        attachment = kb.get_attachment(conn, attachment_id)
+        assert attachment is not None and attachment.filesystem_identity is not None
+        stored = Path(attachment.stored_path)
+        stored.unlink()
+        stored.write_text("human replacement")
+
+        assert kb.delete_attachment(conn, attachment_id) is not None
+
+    assert stored.read_text() == "human replacement"
+
+
 def test_completion_rollback_removes_staged_artifact_copy(
     kanban_home, monkeypatch
 ):
@@ -2609,7 +2629,7 @@ def test_rollback_cleanup_preserves_replaced_staged_path(
 
         monkeypatch.setattr(kb, "_insert_completion_attachment", replace_then_insert)
         monkeypatch.setattr(kb, "_execute_boundary_with_retry", fail_commit)
-        with pytest.raises(sqlite3.OperationalError, match="forced commit failure"):
+        with pytest.raises(kb.ArtifactPreservationError, match="identity changed"):
             kb.complete_task(
                 conn,
                 task_id,
@@ -2705,7 +2725,7 @@ def test_artifact_copy_rejects_source_changed_at_end_of_stream(
     kanban_home, monkeypatch
 ):
     """A concurrent writer cannot produce a mixed completion artifact."""
-    original_open = Path.open
+    original_fdopen = kb.os.fdopen
     source_path = None
 
     class MutatingReader:
@@ -2728,14 +2748,14 @@ def test_artifact_copy_rejects_source_changed_at_end_of_stream(
             data = self.stream.read(*args, **kwargs)
             if not data and not self.mutated:
                 self.mutated = True
-                with original_open(self.path, "ab") as writer:
+                with self.path.open("ab") as writer:
                     writer.write(b"-changed")
             return data
 
-    def mutate_source(path, mode="r", *args, **kwargs):
-        stream = original_open(path, mode, *args, **kwargs)
-        if mode == "rb" and source_path is not None and path == source_path:
-            return MutatingReader(stream, path)
+    def mutate_source(fd, mode="r", *args, **kwargs):
+        stream = original_fdopen(fd, mode, *args, **kwargs)
+        if mode == "rb" and source_path is not None:
+            return MutatingReader(stream, source_path)
         return stream
 
     with kb.connect() as conn:
@@ -2745,7 +2765,7 @@ def test_artifact_copy_rejects_source_changed_at_end_of_stream(
         kb.set_workspace_path(conn, task_id, workspace)
         source_path = workspace / "report.txt"
         source_path.write_text("result")
-        monkeypatch.setattr(Path, "open", mutate_source)
+        monkeypatch.setattr(kb.os, "fdopen", mutate_source)
 
         with pytest.raises(kb.ArtifactPreservationError, match="changed while"):
             kb.complete_task(
@@ -2759,6 +2779,41 @@ def test_artifact_copy_rejects_source_changed_at_end_of_stream(
 
     attachment_dir = kb.task_attachments_dir(task_id)
     assert not attachment_dir.exists() or not list(attachment_dir.iterdir())
+
+
+def test_artifact_copy_rejects_source_replaced_before_open(
+    kanban_home, monkeypatch
+):
+    original_os_open = kb.os.open
+    source_path = None
+    swapped = False
+
+    def replace_then_open(path, flags, *args):
+        nonlocal swapped
+        if source_path is not None and Path(path) == source_path and not swapped:
+            swapped = True
+            source_path.unlink()
+            source_path.write_text("human replacement")
+        return original_os_open(path, flags, *args)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="source replacement")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, workspace)
+        source_path = workspace / "report.txt"
+        source_path.write_text("agent result")
+        monkeypatch.setattr(kb.os, "open", replace_then_open)
+
+        with pytest.raises(kb.ArtifactPreservationError, match="identity changed"):
+            kb.complete_task(
+                conn,
+                task_id,
+                metadata={"artifacts": [str(source_path)]},
+            )
+
+        assert kb.get_task(conn, task_id).status == "ready"
+        assert source_path.read_text() == "human replacement"
 
 
 def test_complete_task_rejects_missing_declared_scratch_artifact(kanban_home):
@@ -3099,6 +3154,40 @@ def test_scratch_cleanup_preserves_malformed_owner_marker(kanban_home):
 
     assert workspace.is_dir()
     assert (workspace / "important.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_scratch_cleanup_preserves_directory_replacement_at_delete_boundary(
+    kanban_home, monkeypatch
+):
+    original_replace = kb.os.replace
+    injected = False
+    displaced = None
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="scratch replacement")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, workspace)
+        (workspace / "agent.txt").write_text("agent")
+
+        def replace_workspace(source, destination):
+            nonlocal injected, displaced
+            source_path = Path(source)
+            if source_path == workspace and not injected:
+                injected = True
+                displaced = workspace.with_name(f"{workspace.name}-agent-original")
+                original_replace(workspace, displaced)
+                workspace.mkdir()
+                (workspace / "human.txt").write_text("keep")
+            return original_replace(source, destination)
+
+        monkeypatch.setattr(kb.os, "replace", replace_workspace)
+        assert kb.complete_task(conn, task_id, result="done")
+
+    assert displaced is not None and (displaced / "agent.txt").read_text() == "agent"
+    quarantines = list(workspace.parent.glob(f".{workspace.name}.hermes-delete-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "human.txt").read_text() == "keep"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -6,6 +6,7 @@ import concurrent.futures
 import json
 import os
 import sqlite3
+import stat
 import subprocess
 import sys
 import time
@@ -63,7 +64,7 @@ def test_init_creates_expected_tables(kanban_home):
     assert {"tasks", "task_links", "task_comments", "task_events"} <= names
 
 
-def test_init_backfills_legacy_attachment_deletion_identity(kanban_home):
+def test_init_preserves_legacy_attachment_without_deletion_identity(kanban_home):
     with kb.connect() as conn:
         task_id = kb.create_task(conn, title="legacy attachment")
         attachment_dir = kb.task_attachments_dir(task_id)
@@ -91,10 +92,12 @@ def test_init_backfills_legacy_attachment_deletion_identity(kanban_home):
     with kb.connect() as conn:
         attachment = kb.get_attachment(conn, attachment_id)
         assert attachment is not None
-        assert attachment.filesystem_identity is not None
-        assert kb.delete_attachment(conn, attachment_id) is not None
+        assert attachment.filesystem_identity is None
+        with pytest.raises(kb.AttachmentOwnershipUnknown, match="no filesystem ownership"):
+            kb.delete_attachment(conn, attachment_id)
+        assert kb.get_attachment(conn, attachment_id) is not None
 
-    assert not blob.exists()
+    assert blob.read_text() == "legacy"
 
 
 def test_connect_honors_kanban_busy_timeout_env(kanban_home, monkeypatch):
@@ -2501,6 +2504,80 @@ def test_complete_task_persists_scratch_artifacts_before_cleanup(kanban_home):
     ]
 
 
+def test_completion_artifact_accepts_path_handle_ctime_difference(
+    kanban_home, monkeypatch
+):
+    """Windows close-time ctime publication is not a replacement signal."""
+    real_fstat = kb.os.fstat
+
+    def shifted_fstat(fd):
+        current = real_fstat(fd)
+        if not stat.S_ISREG(current.st_mode):
+            return current
+        return types.SimpleNamespace(
+            st_dev=current.st_dev,
+            st_ino=current.st_ino,
+            st_mode=current.st_mode,
+            st_size=current.st_size,
+            st_mtime_ns=current.st_mtime_ns,
+            st_ctime_ns=current.st_ctime_ns + 1,
+            st_file_attributes=getattr(current, "st_file_attributes", 0),
+        )
+
+    monkeypatch.setattr(kb.os, "fstat", shifted_fstat)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="ctime settling")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, workspace)
+        artifact = workspace / "result.txt"
+        artifact.write_text("stable", encoding="utf-8")
+
+        assert kb.complete_task(
+            conn,
+            task_id,
+            metadata={"artifacts": [str(artifact)]},
+        )
+        stored = Path(kb.list_attachments(conn, task_id)[0].stored_path)
+
+    assert stored.read_text(encoding="utf-8") == "stable"
+
+
+def test_completion_artifact_post_close_replacement_is_preserved(
+    kanban_home, monkeypatch
+):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="post-close replacement")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, workspace)
+        artifact = workspace / "result.txt"
+        artifact.write_text("agent result", encoding="utf-8")
+        destination = kb.task_attachments_dir(task_id) / artifact.name
+        real_lstat = Path.lstat
+        destination_lstats = 0
+
+        def replace_after_close(path):
+            nonlocal destination_lstats
+            if path == destination:
+                destination_lstats += 1
+                if destination_lstats == 2:
+                    destination.unlink()
+                    destination.write_text("human replacement", encoding="utf-8")
+            return real_lstat(path)
+
+        monkeypatch.setattr(Path, "lstat", replace_after_close)
+        with pytest.raises(kb.ArtifactPreservationError, match="changed after copy"):
+            kb.complete_task(
+                conn,
+                task_id,
+                metadata={"artifacts": [str(artifact)]},
+            )
+        assert kb.get_task(conn, task_id).status == "ready"
+
+    assert destination.read_text(encoding="utf-8") == "human replacement"
+
+
 def test_completion_artifact_prefix_collision_is_not_registered(kanban_home):
     """A sibling whose name shares the attachment-dir prefix stays external."""
     with kb.connect() as conn:
@@ -3067,6 +3144,42 @@ def test_scratch_workspace_has_exact_owner_marker(kanban_home):
             workspace_identity.st_ctime_ns if os.name == "nt" else None,
         ],
     }
+
+
+def test_pre_v2_scratch_workspace_resumes_without_adoption_or_cleanup(kanban_home):
+    """A markerless legacy checkpoint is usable but never becomes deletable."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="legacy scratch")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.workspaces_root() / task_id
+        workspace.mkdir(parents=True)
+        checkpoint = workspace / "checkpoint.txt"
+        checkpoint.write_text("resume here", encoding="utf-8")
+
+        assert kb.resolve_workspace(task) == workspace.resolve()
+        assert not (workspace / kb._SCRATCH_OWNER_MARKER_NAME).exists()
+        kb.set_workspace_path(conn, task_id, workspace)
+        assert kb.complete_task(conn, task_id, result="done")
+
+    assert workspace.is_dir()
+    assert checkpoint.read_text(encoding="utf-8") == "resume here"
+    assert not (workspace / kb._SCRATCH_OWNER_MARKER_NAME).exists()
+
+
+def test_existing_scratch_workspace_with_invalid_marker_cannot_resume(kanban_home):
+    """Existing marker evidence must be exact; malformed evidence fails closed."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="invalid legacy scratch")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.workspaces_root() / task_id
+        workspace.mkdir(parents=True)
+        marker = workspace / kb._SCRATCH_OWNER_MARKER_NAME
+        marker.write_text('{"version":1}', encoding="utf-8")
+
+        with pytest.raises(ValueError, match="cannot prove ownership"):
+            kb.resolve_workspace(task)
+
+    assert marker.read_text(encoding="utf-8") == '{"version":1}'
 
 
 def test_interrupted_scratch_marker_creation_preserves_evidence(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3190,6 +3190,46 @@ def test_scratch_cleanup_preserves_directory_replacement_at_delete_boundary(
     assert (quarantines[0] / "human.txt").read_text() == "keep"
 
 
+def test_scratch_cleanup_binds_owner_proof_to_original_directory(
+    kanban_home, monkeypatch
+):
+    """Copied marker text cannot transfer ownership to a replacement root."""
+    real_evidence = kb._scratch_workspace_ownership_evidence
+    original_replace = kb.os.replace
+    injected = False
+    displaced = None
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="scratch evidence replacement")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, workspace)
+        (workspace / "agent.txt").write_text("agent")
+        marker_text = (workspace / kb._SCRATCH_OWNER_MARKER_NAME).read_text()
+
+        def replace_after_proof(path, **kwargs):
+            nonlocal injected, displaced
+            evidence = real_evidence(path, **kwargs)
+            if evidence is not None and not injected:
+                injected = True
+                displaced = workspace.with_name(f"{workspace.name}-agent-original")
+                original_replace(workspace, displaced)
+                workspace.mkdir()
+                (workspace / kb._SCRATCH_OWNER_MARKER_NAME).write_text(marker_text)
+                (workspace / "human.txt").write_text("keep")
+            return evidence
+
+        monkeypatch.setattr(
+            kb, "_scratch_workspace_ownership_evidence", replace_after_proof
+        )
+        assert kb.complete_task(conn, task_id, result="done")
+
+    assert displaced is not None and (displaced / "agent.txt").read_text() == "agent"
+    quarantines = list(workspace.parent.glob(f".{workspace.name}.hermes-delete-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "human.txt").read_text() == "keep"
+
+
 # ---------------------------------------------------------------------------
 # Deferred scratch cleanup for parent/child handoff (#33774)
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2561,7 +2561,7 @@ def test_completion_artifact_post_close_replacement_is_preserved(
             nonlocal destination_lstats
             if path == destination:
                 destination_lstats += 1
-                if destination_lstats == 2:
+                if destination_lstats == 3:
                     destination.unlink()
                     destination.write_text("human replacement", encoding="utf-8")
             return real_lstat(path)
@@ -2576,6 +2576,65 @@ def test_completion_artifact_post_close_replacement_is_preserved(
         assert kb.get_task(conn, task_id).status == "ready"
 
     assert destination.read_text(encoding="utf-8") == "human replacement"
+
+
+def test_completion_artifact_junction_open_restore_writes_no_external_bytes(
+    kanban_home, monkeypatch
+):
+    """Scratch preservation binds its create before copying the source."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="redirected artifact destination")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, workspace)
+        artifact = workspace / "result.txt"
+        artifact.write_text("agent result", encoding="utf-8")
+
+        intended = kb.task_attachments_dir(task_id) / artifact.name
+        external_dir = kanban_home / "external"
+        external_dir.mkdir()
+        external = external_dir / artifact.name
+        real_open = kb.os.open
+        real_actual_path = kb._opened_file_actual_path
+        real_remove = kb._atomic_remove_expected_file
+        external_before_cleanup = []
+
+        def junction_open(path, flags, *args, **kwargs):
+            if Path(path) == intended and flags & kb.os.O_EXCL:
+                fd = real_open(external, flags, *args, **kwargs)
+                # Model the attachment parent being restored after the open.
+                intended.write_bytes(b"human replacement")
+                return fd
+            return real_open(path, flags, *args, **kwargs)
+
+        def actual_path(fd, path):
+            if Path(path) == intended:
+                return external
+            return real_actual_path(fd, path)
+
+        def observe_remove(path, expected):
+            if Path(path) == external:
+                external_before_cleanup.append(external.read_bytes())
+            return real_remove(path, expected)
+
+        monkeypatch.setattr(kb.os, "open", junction_open)
+        monkeypatch.setattr(kb, "_opened_file_actual_path", actual_path)
+        monkeypatch.setattr(kb, "_atomic_remove_expected_file", observe_remove)
+
+        with pytest.raises(
+            kb.ArtifactPreservationError, match="destination path changed"
+        ):
+            kb.complete_task(
+                conn,
+                task_id,
+                metadata={"artifacts": [str(artifact)]},
+            )
+        assert kb.get_task(conn, task_id).status == "ready"
+
+    assert external_before_cleanup == [b""]
+    assert not external.exists()
+    assert intended.read_bytes() == b"human replacement"
+    assert artifact.read_text(encoding="utf-8") == "agent result"
 
 
 def test_completion_artifact_prefix_collision_is_not_registered(kanban_home):
@@ -2760,7 +2819,7 @@ def test_artifact_copy_interrupt_removes_only_partial_destination(
     kanban_home, monkeypatch
 ):
     """An interrupt inside destination.write cannot strand the partial copy."""
-    original_open = Path.open
+    original_fdopen = kb.os.fdopen
 
     class InterruptingWriter:
         def __init__(self, stream):
@@ -2780,11 +2839,11 @@ def test_artifact_copy_interrupt_removes_only_partial_destination(
             self.stream.write(data[:1])
             raise KeyboardInterrupt()
 
-    def interrupt_destination(path, mode="r", *args, **kwargs):
-        stream = original_open(path, mode, *args, **kwargs)
-        return InterruptingWriter(stream) if mode == "xb" else stream
+    def interrupt_destination(fd, mode="r", *args, **kwargs):
+        stream = original_fdopen(fd, mode, *args, **kwargs)
+        return InterruptingWriter(stream) if mode == "wb" else stream
 
-    monkeypatch.setattr(Path, "open", interrupt_destination)
+    monkeypatch.setattr(kb.os, "fdopen", interrupt_destination)
     with kb.connect() as conn:
         task_id = kb.create_task(conn, title="copy interrupt")
         task = kb.get_task(conn, task_id)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2637,6 +2637,110 @@ def test_completion_artifact_junction_open_restore_writes_no_external_bytes(
     assert artifact.read_text(encoding="utf-8") == "agent result"
 
 
+def test_completion_artifact_rejects_regular_parent_replacement_before_read(
+    kanban_home, monkeypatch
+):
+    """Replacing a source parent cannot redirect preservation to new bytes."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="replaced artifact parent")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, workspace)
+        nested = workspace / "nested"
+        nested.mkdir()
+        artifact = nested / "result.txt"
+        artifact.write_bytes(b"agent result")
+        first_artifact = workspace / "first.txt"
+        first_artifact.write_bytes(b"first agent result")
+        parked = workspace / "nested-parked"
+        real_open = kb.os.open
+        replaced = False
+
+        def replace_parent_on_source_open(path, flags, *args, **kwargs):
+            nonlocal replaced
+            if (
+                not replaced
+                and Path(path).name == artifact.name
+                and not flags & kb.os.O_CREAT
+            ):
+                replaced = True
+                nested.rename(parked)
+                nested.mkdir()
+                (nested / artifact.name).write_bytes(b"unrelated bytes")
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(kb.os, "open", replace_parent_on_source_open)
+
+        with pytest.raises(kb.ArtifactPreservationError, match="artifact"):
+            kb.complete_task(
+                conn,
+                task_id,
+                metadata={"artifacts": [str(first_artifact), str(artifact)]},
+            )
+        assert replaced
+        assert kb.get_task(conn, task_id).status == "ready"
+        assert kb.list_attachments(conn, task_id) == []
+
+    assert (nested / artifact.name).read_bytes() == b"unrelated bytes"
+    assert (parked / artifact.name).read_bytes() == b"agent result"
+    assert first_artifact.read_bytes() == b"first agent result"
+    attachment_dir = kb.task_attachments_dir(task_id)
+    assert not attachment_dir.exists() or list(attachment_dir.iterdir()) == []
+
+
+def test_completion_artifact_rejects_windows_junction_final_handle_path(
+    kanban_home, monkeypatch
+):
+    """A source handle outside the bound workspace is rejected before copying."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="redirected artifact source")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, workspace)
+        artifact = workspace / "result.txt"
+        artifact.write_bytes(b"agent result")
+        external = kanban_home / "junction-target.txt"
+        external.write_bytes(b"unrelated bytes")
+        real_open = kb.os.open
+        redirected = False
+
+        def junction_source_open(path, flags, *args, **kwargs):
+            nonlocal redirected
+            if (
+                not redirected
+                and Path(path).name == artifact.name
+                and not flags & kb.os.O_CREAT
+            ):
+                redirected = True
+                return real_open(external, flags)
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(kb.os, "open", junction_source_open)
+        monkeypatch.setattr(
+            kb,
+            "_opened_scratch_artifact_matches_workspace",
+            lambda fd, evidence: False,
+        )
+
+        with pytest.raises(
+            kb.ArtifactPreservationError,
+            match="outside its bound workspace",
+        ):
+            kb.complete_task(
+                conn,
+                task_id,
+                metadata={"artifacts": [str(artifact)]},
+            )
+        assert redirected
+        assert kb.get_task(conn, task_id).status == "ready"
+        assert kb.list_attachments(conn, task_id) == []
+
+    assert artifact.read_bytes() == b"agent result"
+    assert external.read_bytes() == b"unrelated bytes"
+    attachment_dir = kb.task_attachments_dir(task_id)
+    assert not attachment_dir.exists() or list(attachment_dir.iterdir()) == []
+
+
 def test_completion_artifact_prefix_collision_is_not_registered(kanban_home):
     """A sibling whose name shares the attachment-dir prefix stays external."""
     with kb.connect() as conn:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import sqlite3
 import subprocess
@@ -2624,8 +2625,8 @@ def test_cleanup_workspace_honors_workspaces_root_env_override(tmp_path, monkeyp
 
     with kb.connect() as conn:
         t = kb.create_task(conn, title="ext")
-        scratch_dir = workspaces_override / t
-        scratch_dir.mkdir()
+        task = kb.get_task(conn, t)
+        scratch_dir = kb.resolve_workspace(task)
         conn.execute(
             "UPDATE tasks SET workspace_kind=?, workspace_path=? WHERE id=?",
             ("scratch", str(scratch_dir), t),
@@ -2634,6 +2635,133 @@ def test_cleanup_workspace_honors_workspaces_root_env_override(tmp_path, monkeyp
         kb.complete_task(conn, t, result="ok")
 
     assert not scratch_dir.exists(), "Override-root scratch dir should be cleaned up"
+
+
+def test_scratch_workspace_has_exact_owner_marker(kanban_home):
+    """Scratch materialization records the task/board/tenant owner atomically."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="owned", tenant="tenant-a")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+
+    marker = workspace / ".hermes-kanban-owner.json"
+    assert marker.is_file()
+    assert json.loads(marker.read_text(encoding="utf-8")) == {
+        "version": 1,
+        "task_id": task_id,
+        "board": "default",
+        "tenant": "tenant-a",
+        "workspace": str(workspace.resolve()),
+    }
+
+
+def test_scratch_cleanup_preserves_cross_task_workspace(kanban_home):
+    """A task cannot delete another task's marked scratch workspace."""
+    with kb.connect() as conn:
+        victim_id = kb.create_task(conn, title="victim", tenant="tenant-a")
+        victim = kb.get_task(conn, victim_id)
+        victim_workspace = kb.resolve_workspace(victim)
+        (victim_workspace / "user-work.txt").write_text("keep", encoding="utf-8")
+
+        attacker_id = kb.create_task(conn, title="attacker", tenant="tenant-a")
+        conn.execute(
+            "UPDATE tasks SET workspace_path = ? WHERE id = ?",
+            (str(victim_workspace), attacker_id),
+        )
+        conn.commit()
+        assert kb.complete_task(conn, attacker_id, result="done")
+
+    assert victim_workspace.is_dir()
+    assert (victim_workspace / "user-work.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_scratch_cleanup_preserves_cross_tenant_workspace(kanban_home):
+    """A tenant-mismatched task cannot delete a marked scratch workspace."""
+    with kb.connect() as conn:
+        victim_id = kb.create_task(conn, title="victim", tenant="tenant-a")
+        victim = kb.get_task(conn, victim_id)
+        victim_workspace = kb.resolve_workspace(victim)
+        (victim_workspace / "tenant-data.txt").write_text("keep", encoding="utf-8")
+
+        attacker_id = kb.create_task(conn, title="attacker", tenant="tenant-b")
+        conn.execute(
+            "UPDATE tasks SET workspace_path = ? WHERE id = ?",
+            (str(victim_workspace), attacker_id),
+        )
+        conn.commit()
+        assert kb.complete_task(conn, attacker_id, result="done")
+
+    assert victim_workspace.is_dir()
+    assert (victim_workspace / "tenant-data.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_scratch_cleanup_preserves_cross_board_workspace(kanban_home):
+    """A task on another board cannot delete a marked scratch workspace."""
+    kb.create_board("victim-board")
+    with kb.connect(board="victim-board") as victim_conn:
+        victim_id = kb.create_task(
+            victim_conn,
+            title="victim",
+            tenant="tenant-a",
+            board="victim-board",
+        )
+        victim = kb.get_task(victim_conn, victim_id)
+        victim_workspace = kb.resolve_workspace(victim, board="victim-board")
+        (victim_workspace / "board-data.txt").write_text("keep", encoding="utf-8")
+
+    with kb.connect(board="default") as attacker_conn:
+        attacker_id = kb.create_task(
+            attacker_conn,
+            title="attacker",
+            tenant="tenant-a",
+            board="default",
+        )
+        attacker_conn.execute(
+            "UPDATE tasks SET workspace_path = ? WHERE id = ?",
+            (str(victim_workspace), attacker_id),
+        )
+        attacker_conn.commit()
+        assert kb.complete_task(attacker_conn, attacker_id, result="done")
+
+    assert victim_workspace.is_dir()
+    assert (victim_workspace / "board-data.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_scratch_cleanup_preserves_aliased_workspace_path(kanban_home):
+    """A path alias must not authorize cleanup of the canonical workspace."""
+    with kb.connect() as conn:
+        victim_id = kb.create_task(conn, title="victim", tenant="tenant-a")
+        victim = kb.get_task(conn, victim_id)
+        victim_workspace = kb.resolve_workspace(victim)
+        (victim_workspace / "alias-data.txt").write_text("keep", encoding="utf-8")
+        alias = victim_workspace.parent / ".." / victim_workspace.parent.name / victim_workspace.name
+
+        attacker_id = kb.create_task(conn, title="attacker", tenant="tenant-a")
+        conn.execute(
+            "UPDATE tasks SET workspace_path = ? WHERE id = ?",
+            (str(alias), attacker_id),
+        )
+        conn.commit()
+        assert kb.complete_task(conn, attacker_id, result="done")
+
+    assert victim_workspace.is_dir()
+    assert (victim_workspace / "alias-data.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_scratch_cleanup_preserves_malformed_owner_marker(kanban_home):
+    """Malformed or unknown owner evidence fails closed and preserves data."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="corrupt owner", tenant="tenant-a")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+        (workspace / "important.txt").write_text("keep", encoding="utf-8")
+        (workspace / ".hermes-kanban-owner.json").write_text(
+            '{"version": 999, "task_id": "unknown"}', encoding="utf-8"
+        )
+        assert kb.complete_task(conn, task_id, result="done")
+
+    assert workspace.is_dir()
+    assert (workspace / "important.txt").read_text(encoding="utf-8") == "keep"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2547,6 +2547,83 @@ def test_completion_rollback_removes_staged_artifact_copy(
     assert not attachment_dir.exists() or not list(attachment_dir.iterdir())
 
 
+def test_completion_interrupt_rolls_back_and_removes_staged_copy(
+    kanban_home, monkeypatch
+):
+    """BaseException exits must not poison the txn or strand copied files."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="interrupt artifact")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, workspace)
+        artifact = workspace / "report.txt"
+        artifact.write_text("result")
+
+        def interrupt_insert(*_args, **_kwargs):
+            raise KeyboardInterrupt()
+
+        monkeypatch.setattr(kb, "_insert_completion_attachment", interrupt_insert)
+        with pytest.raises(KeyboardInterrupt):
+            kb.complete_task(
+                conn,
+                task_id,
+                result="done",
+                metadata={"artifacts": [str(artifact)]},
+            )
+
+        assert conn.in_transaction is False
+        assert kb.get_task(conn, task_id).status == "ready"
+        assert kb.list_attachments(conn, task_id) == []
+
+    attachment_dir = kb.task_attachments_dir(task_id)
+    assert not attachment_dir.exists() or not list(attachment_dir.iterdir())
+
+
+def test_rollback_cleanup_preserves_replaced_staged_path(
+    kanban_home, monkeypatch
+):
+    """Rollback ownership is the copied inode, not its replaceable pathname."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="replacement artifact")
+        task = kb.get_task(conn, task_id)
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, workspace)
+        artifact = workspace / "report.txt"
+        artifact.write_text("agent result")
+        original_insert = kb._insert_completion_attachment
+        replacement = None
+
+        def replace_then_insert(connection, current_task_id, **kwargs):
+            nonlocal replacement
+            replacement = Path(kwargs["stored_path"])
+            replacement.unlink()
+            replacement.write_text("human replacement")
+            return original_insert(connection, current_task_id, **kwargs)
+
+        original_boundary = kb._execute_boundary_with_retry
+
+        def fail_commit(connection, sql):
+            if sql == "COMMIT":
+                raise sqlite3.OperationalError("forced commit failure")
+            return original_boundary(connection, sql)
+
+        monkeypatch.setattr(kb, "_insert_completion_attachment", replace_then_insert)
+        monkeypatch.setattr(kb, "_execute_boundary_with_retry", fail_commit)
+        with pytest.raises(sqlite3.OperationalError, match="forced commit failure"):
+            kb.complete_task(
+                conn,
+                task_id,
+                result="done",
+                metadata={"artifacts": [str(artifact)]},
+            )
+
+        assert kb.get_task(conn, task_id).status == "ready"
+        assert kb.list_attachments(conn, task_id) == []
+
+    assert replacement is not None
+    assert replacement.read_text() == "human replacement"
+
+
 def test_complete_task_rejects_missing_declared_scratch_artifact(kanban_home):
     """A declared scratch deliverable must not disappear behind a false Done."""
     with kb.connect() as conn:

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -527,6 +527,32 @@ class TestTrackForgetQuick:
         assert dg.quick(paths=[str(artifact)])["deleted"] == 1
         assert not artifact.exists()
 
+    def test_cache_root_remains_trackable(self, _isolate_env):
+        dg = _load_lib()
+        artifact = _isolate_env / "cache" / "tool-output.tmp"
+        artifact.parent.mkdir()
+        artifact.write_text("temporary")
+
+        assert dg.guess_category(artifact) == "temp"
+        assert dg.track(str(artifact), "temp", silent=True)
+
+    def test_quick_preserves_file_when_delete_identity_changes(
+        self, _isolate_env, monkeypatch
+    ):
+        dg = _load_lib()
+        artifact = _isolate_env / "scratch" / "replace-me.tmp"
+        artifact.parent.mkdir()
+        artifact.write_text("tracked")
+        assert dg.track(str(artifact), "temp", silent=True)
+
+        monkeypatch.setattr(dg.os.path, "samestat", lambda _left, _right: False)
+
+        result = dg.quick(paths=[str(artifact)])
+
+        assert result["deleted"] == 0
+        assert artifact.read_text() == "tracked"
+        assert not list(artifact.parent.glob("*.hermes-delete-*"))
+
     def test_quick_commit_preserves_concurrent_tracking_addition(
         self, _isolate_env, monkeypatch
     ):
@@ -784,9 +810,10 @@ class TestTrackForgetQuick:
     def test_quick_prunes_stale_marked_spawn_tree_snapshots(self, _isolate_env):
         """Spawn-tree history is bounded without deleting unowned sessions."""
         dg = _load_lib()
-        session_dir = _isolate_env / "spawn-trees" / "session-1"
+        digest = "a" * 24
+        session_dir = _isolate_env / "spawn-trees" / f"s-{digest}"
         session_dir.mkdir(parents=True)
-        (session_dir / ".hermes-managed").write_text("spawn-trees\n")
+        (session_dir / ".hermes-managed").write_text(f"spawn-trees:{digest}\n")
         stale = session_dir / "20240101T000000.json"
         stale.write_text("{}")
         old = time.time() - (31 * 24 * 60 * 60)

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -14,7 +14,9 @@ Covers the bundled plugin at ``plugins/disk-cleanup/``:
 
 import importlib
 import json
+import os
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -408,10 +410,211 @@ class TestTrackForgetQuick:
         dg = _load_lib()
         managed_empty = _isolate_env / "scratch" / "nested" / "empty"
         managed_empty.mkdir(parents=True)
+        (_isolate_env / "scratch" / ".hermes-managed").write_text("scratch\n")
+
+        summary = dg.quick()
+
+        assert summary["empty_dirs"] == 2
+        assert not managed_empty.exists()
+        assert (_isolate_env / "scratch").exists()
+
+        # A second pass must be a no-op: the ownership marker keeps the
+        # managed root, and no removed directory is rediscovered.
+        second = dg.quick()
+        assert second["deleted"] == 0
+        assert second["empty_dirs"] == 0
+        assert second["errors"] == []
+
+    def test_quick_preserves_unmarked_empty_owned_name(self, _isolate_env):
+        """A familiar root name is not ownership evidence by itself."""
+        dg = _load_lib()
+        unowned_empty = _isolate_env / "scratch" / "nested" / "empty"
+        unowned_empty.mkdir(parents=True)
+
+        summary = dg.quick()
+
+        assert summary["empty_dirs"] == 0
+        assert unowned_empty.exists()
+
+    def test_quick_preserves_malformed_empty_root_marker(self, _isolate_env):
+        """A foreign marker must not opt a root into recursive deletion."""
+        dg = _load_lib()
+        root = _isolate_env / "tmp"
+        unowned_empty = root / "nested" / "empty"
+        unowned_empty.mkdir(parents=True)
+        (root / ".hermes-managed").write_text("not-tmp\n")
+
+        summary = dg.quick()
+
+        assert summary["empty_dirs"] == 0
+        assert unowned_empty.exists()
+
+    def test_quick_preserves_marked_root_with_live_lock(self, _isolate_env):
+        """Ownership evidence does not override a live/ambiguous lock."""
+        dg = _load_lib()
+        root = _isolate_env / "scratch"
+        nested = root / "nested" / "empty"
+        nested.mkdir(parents=True)
+        (root / ".hermes-managed").write_text("scratch\n")
+        (root / ".lock").write_text("active\n")
+
+        summary = dg.quick()
+
+        assert summary["empty_dirs"] == 0
+        assert nested.exists()
+
+    def test_quick_preserves_malformed_record_and_continues(self, _isolate_env):
+        """A malformed record cannot abort cleanup or authorize deletion."""
+        dg = _load_lib()
+        valid = _isolate_env / "test_valid.py"
+        valid.write_text("keep only until the sweep")
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True, exist_ok=True)
+        tracked_file.write_text(json.dumps([
+            {"path": str(_isolate_env / "test_malformed.py"), "category": "test"},
+            {
+                "path": str(valid),
+                "category": "test",
+                "timestamp": "2025-01-01T00:00:00+00:00",
+                "size": valid.stat().st_size,
+            },
+        ]))
+
+        summary = dg.quick()
+
+        assert summary["deleted"] == 1
+        assert not valid.exists()
+        saved = json.loads(tracked_file.read_text())
+        assert len(saved) == 1
+        assert saved[0]["path"].endswith("test_malformed.py")
+
+    def test_quick_preserves_unverifiable_delete_and_reports_error(
+        self, _isolate_env, monkeypatch
+    ):
+        """An inspection/delete error never counts as successful cleanup."""
+        dg = _load_lib()
+        locked = _isolate_env / "test_locked.py"
+        locked.write_text("keep")
+        dg.track(str(locked), "test", silent=True)
+
+        original_is_file = Path.is_file
+
+        def fail_for_locked(path):
+            if path == locked:
+                raise OSError("simulated live lock")
+            return original_is_file(path)
+
+        monkeypatch.setattr(Path, "is_file", fail_for_locked)
+
+        summary = dg.quick()
+
+        assert summary["deleted"] == 0
+        assert summary["errors"]
+        assert locked.exists()
+        assert any(item["path"] == str(locked) for item in dg.load_tracked())
+
+    def test_quick_prunes_only_marked_stale_hook_output(self, _isolate_env):
+        """Hook spill files are owned only after the managed marker exists."""
+        dg = _load_lib()
+        session_dir = _isolate_env / "hook_outputs" / "session-1"
+        session_dir.mkdir(parents=True)
+        (session_dir / ".hermes-managed").write_text("hook_outputs\n")
+        stale = session_dir / "old.txt"
+        stale.write_text("stale")
+        old = time.time() - (15 * 24 * 60 * 60)
+        os.utime(stale, (old, old))
+
+        summary = dg.quick()
+
+        assert summary["artifacts"] == 1
+        assert not stale.exists()
+
+    def test_quick_preserves_unmarked_stale_hook_output(self, _isolate_env):
+        """Unknown files below an artifact-looking root are never junk by name."""
+        dg = _load_lib()
+        session_dir = _isolate_env / "hook_outputs" / "session-unknown"
+        session_dir.mkdir(parents=True)
+        stale = session_dir / "old.txt"
+        stale.write_text("keep")
+        old = time.time() - (30 * 24 * 60 * 60)
+        os.utime(stale, (old, old))
+
+        summary = dg.quick()
+
+        assert summary["artifacts"] == 0
+        assert stale.exists()
+
+    def test_quick_preserves_stale_artifact_when_session_is_locked(self, _isolate_env):
+        """A managed session lock suppresses artifact retention cleanup."""
+        dg = _load_lib()
+        session_dir = _isolate_env / "hook_outputs" / "session-locked"
+        session_dir.mkdir(parents=True)
+        (session_dir / ".hermes-managed").write_text("hook_outputs\n")
+        (session_dir / ".lock").write_text("active\n")
+        stale = session_dir / "old.txt"
+        stale.write_text("keep")
+        old = time.time() - (30 * 24 * 60 * 60)
+        os.utime(stale, (old, old))
+
+        summary = dg.quick()
+
+        assert summary["artifacts"] == 0
+        assert stale.exists()
+
+    def test_quick_prunes_stale_marked_spawn_tree_snapshots(self, _isolate_env):
+        """Spawn-tree history is bounded without deleting unowned sessions."""
+        dg = _load_lib()
+        session_dir = _isolate_env / "spawn-trees" / "session-1"
+        session_dir.mkdir(parents=True)
+        (session_dir / ".hermes-managed").write_text("spawn-trees\n")
+        stale = session_dir / "20240101T000000.json"
+        stale.write_text("{}")
+        old = time.time() - (31 * 24 * 60 * 60)
+        os.utime(stale, (old, old))
+
+        summary = dg.quick()
+
+        assert summary["artifacts"] == 1
+        assert not stale.exists()
+
+    def test_quick_preserves_empty_unowned_top_level_dir(self, _isolate_env):
+        """An empty directory is not deletion evidence merely because it is under HERMES_HOME."""
+        dg = _load_lib()
+        unowned = _isolate_env / "project-output"
+        unowned.mkdir()
 
         dg.quick()
 
-        assert not (_isolate_env / "scratch").exists()
+        assert unowned.exists()
+
+    def test_quick_preserves_tracked_path_outside_hermes_home(self, _isolate_env, tmp_path):
+        """A stale tracking record cannot authorize deleting an external path."""
+        dg = _load_lib()
+        outside = tmp_path / "external-test.py"
+        outside.write_text("keep")
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True, exist_ok=True)
+        tracked_file.write_text(json.dumps([{
+            "path": str(outside),
+            "category": "test",
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "size": outside.stat().st_size,
+        }]))
+
+        summary = dg.quick()
+
+        assert summary["deleted"] == 0
+        assert outside.exists()
+
+    def test_path_traversal_cannot_escape_tmp_hermes_scope(self, _isolate_env):
+        dg = _load_lib()
+
+        assert dg.is_safe_path(Path("/tmp/hermes-owned/../outside")) is False
+
+    def test_explicit_windows_drive_tmp_is_not_approved_scope(self, _isolate_env):
+        dg = _load_lib()
+        if os.name == "nt":
+            assert dg.is_safe_path(Path(r"C:\tmp\hermes-user\artifact")) is False
 
 
 class TestStatus:
@@ -494,6 +697,16 @@ class TestPostToolCallHook:
         tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
         data = json.loads(tracked_file.read_text())
         assert any(Path(i["path"]) == p.resolve() for i in data)
+
+    def test_terminal_command_extracts_windows_drive_paths(self):
+        pi = _load_plugin_init()
+
+        paths = pi._extract_paths_from_terminal(
+            {"command": r"type C:\Users\edson\test_created.py"},
+            r"created C:\Users\edson\test_created.py",
+        )
+
+        assert any(path.replace("\\", "/") == "C:/Users/edson/test_created.py" for path in paths)
 
     def test_ignores_unrelated_tool(self, _isolate_env):
         pi = _load_plugin_init()

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -12,6 +12,7 @@ Covers the bundled plugin at ``plugins/disk-cleanup/``:
 """
 
 import importlib
+import concurrent.futures
 import json
 import os
 import sys
@@ -423,6 +424,80 @@ class TestTrackForgetQuick:
         assert summary["deleted"] == 0
         assert summary["errors"]
         assert memory.read_text() == "human memory"
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "state.db",
+            "kanban.db",
+            "projects.db",
+            "response_store.db",
+            "memory_store.db",
+            "verification_evidence.db",
+            "gateway_state.json",
+            "channel_directory.json",
+            "channel_aliases.json",
+            "processes.json",
+            "feishu_comment_pairing.json",
+        ],
+    )
+    def test_canonical_top_level_state_is_never_deletable(
+        self, _isolate_env, filename
+    ):
+        dg = _load_lib()
+        durable = _isolate_env / filename
+        durable.write_text("human state")
+        identity = dg._capture_identity(durable)
+
+        assert dg.track(str(durable), "test", silent=True) is False
+        dg.save_tracked([{
+            "path": str(durable),
+            "category": "test",
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "size": durable.stat().st_size,
+            "identity": identity,
+        }])
+
+        assert dg.quick()["deleted"] == 0
+        assert durable.read_text() == "human state"
+
+    def test_quick_commit_preserves_concurrent_tracking_addition(
+        self, _isolate_env, monkeypatch
+    ):
+        dg = _load_lib()
+        first = _isolate_env / "test_first.py"
+        concurrent = _isolate_env / "keep.concurrent"
+        first.write_text("delete")
+        concurrent.write_text("preserve tracking")
+        assert dg.track(str(first), "test", silent=True)
+        original_remove = dg._remove_tracked_path
+
+        def remove_while_another_hook_tracks(path, identity):
+            assert dg.track(str(concurrent), "temp", silent=True)
+            return original_remove(path, identity)
+
+        monkeypatch.setattr(dg, "_remove_tracked_path", remove_while_another_hook_tracks)
+
+        assert dg.quick()["deleted"] == 1
+        assert [item["path"] for item in dg.load_tracked()] == [str(concurrent.resolve())]
+
+    def test_parallel_tracking_keeps_every_registry_entry(self, _isolate_env):
+        dg = _load_lib()
+        paths = [_isolate_env / f"parallel-{index}.tmp" for index in range(20)]
+        for path in paths:
+            path.write_text(path.name)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+            results = list(
+                executor.map(
+                    lambda path: dg.track(str(path), "temp", silent=True), paths
+                )
+            )
+
+        assert all(results)
+        assert {item["path"] for item in dg.load_tracked()} == {
+            str(path.resolve()) for path in paths
+        }
 
     def test_forget_removes_entry(self, _isolate_env):
         dg = _load_lib()

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -663,7 +663,7 @@ class TestPostToolCallHook:
         pi._on_post_tool_call(
             tool_name="write_file",
             args={"path": str(p), "content": "x"},
-            result="OK",
+            result=json.dumps({"created_paths": [str(p)]}),
             task_id="t1", session_id="s1",
         )
         tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
@@ -691,12 +691,40 @@ class TestPostToolCallHook:
         pi._on_post_tool_call(
             tool_name="terminal",
             args={"command": f"touch {p}"},
-            result=f"created {p}\n",
+            result=json.dumps({
+                "output": f"created {p}\n",
+                "created_paths": [str(p)],
+            }),
             task_id="t3", session_id="s3",
         )
         tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
         data = json.loads(tracked_file.read_text())
         assert any(Path(i["path"]) == p.resolve() for i in data)
+
+    def test_terminal_read_only_output_cannot_track_preexisting_test_file(
+        self, _isolate_env
+    ):
+        """Mentioning a user file in terminal output is not creation evidence."""
+        pi = _load_plugin_init()
+        p = _isolate_env / "test_user_notes.py"
+        p.write_text("keep me")
+        pi._on_post_tool_call(
+            tool_name="terminal",
+            args={"command": "python inspect_only.py"},
+            result=json.dumps({
+                "output": f"inspected {p}",
+                "exit_code": 0,
+                "error": None,
+            }),
+            task_id="readonly-task", session_id="readonly-session",
+        )
+
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        assert not tracked_file.exists() or tracked_file.read_text().strip() == "[]"
+        pi._on_session_end(
+            session_id="readonly-session", completed=True, interrupted=False
+        )
+        assert p.exists(), "pre-existing user file must survive session cleanup"
 
     def test_terminal_command_extracts_windows_drive_paths(self):
         pi = _load_plugin_init()
@@ -729,7 +757,7 @@ class TestOnSessionEndHook:
         pi._on_post_tool_call(
             tool_name="write_file",
             args={"path": str(p), "content": "x"},
-            result="OK",
+            result=json.dumps({"created_paths": [str(p)]}),
             task_id="", session_id="s1",
         )
         assert p.exists()

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -783,6 +783,49 @@ class TestTrackForgetQuick:
         assert summary["artifacts"] == 1
         assert not stale.exists()
 
+    def test_quick_discovers_name_bound_v2_hook_output(self, _isolate_env):
+        dg = _load_lib()
+        session_name = f"s-{'a' * 24}-3"
+        session_dir = _isolate_env / "hook_outputs" / session_name
+        session_dir.mkdir(parents=True)
+        (session_dir / ".hermes-managed").write_text(
+            f"hook_outputs:v2:{session_name}\n"
+        )
+        stale = session_dir / "old.txt"
+        stale.write_text("stale")
+        old = time.time() - (15 * 24 * 60 * 60)
+        os.utime(stale, (old, old))
+
+        summary = dg.quick()
+
+        assert summary["artifacts"] == 1
+        assert not stale.exists()
+
+    @pytest.mark.parametrize(
+        ("directory_name", "marker_value"),
+        [
+            (f"s-{'b' * 24}", f"hook_outputs:v2:s-{'c' * 24}"),
+            ("human-session", "hook_outputs:v2:human-session"),
+            (f"s-{'d' * 24}-32", f"hook_outputs:v2:s-{'d' * 24}-32"),
+        ],
+    )
+    def test_quick_preserves_non_bound_or_malformed_v2_hook_output(
+        self, _isolate_env, directory_name, marker_value
+    ):
+        dg = _load_lib()
+        session_dir = _isolate_env / "hook_outputs" / directory_name
+        session_dir.mkdir(parents=True)
+        (session_dir / ".hermes-managed").write_text(f"{marker_value}\n")
+        stale = session_dir / "old.txt"
+        stale.write_text("keep")
+        old = time.time() - (30 * 24 * 60 * 60)
+        os.utime(stale, (old, old))
+
+        summary = dg.quick()
+
+        assert summary["artifacts"] == 0
+        assert stale.read_text() == "keep"
+
     def test_retention_preserves_replacement_after_selection(
         self, _isolate_env, monkeypatch
     ):

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -775,6 +775,70 @@ class TestTrackForgetQuick:
         assert summary["artifacts"] == 1
         assert not stale.exists()
 
+    def test_retention_preserves_replacement_after_selection(
+        self, _isolate_env, monkeypatch
+    ):
+        """Retention identity is bound before the delete helper runs."""
+        dg = _load_lib()
+        session_dir = _isolate_env / "hook_outputs" / "session-race"
+        session_dir.mkdir(parents=True)
+        (session_dir / ".hermes-managed").write_text("hook_outputs\n")
+        stale = session_dir / "old.txt"
+        stale.write_text("owned")
+        old = time.time() - (15 * 24 * 60 * 60)
+        os.utime(stale, (old, old))
+        real_unlink = dg._atomic_unlink_regular
+
+        def replace_before_unlink(path, expected_identity=None):
+            assert expected_identity is not None
+            path.unlink()
+            path.write_text("human replacement")
+            return real_unlink(path, expected_identity)
+
+        monkeypatch.setattr(dg, "_atomic_unlink_regular", replace_before_unlink)
+
+        summary = dg.quick()
+
+        assert summary["artifacts"] == 0
+        assert summary["errors"]
+        assert stale.read_text() == "human replacement"
+
+    def test_failed_retention_unlink_preserves_and_excludes_quarantine(
+        self, _isolate_env, monkeypatch
+    ):
+        dg = _load_lib()
+        session_dir = _isolate_env / "hook_outputs" / "session-locked-delete"
+        session_dir.mkdir(parents=True)
+        (session_dir / ".hermes-managed").write_text("hook_outputs\n")
+        stale = session_dir / "old.txt"
+        stale.write_text("preserve")
+        old = time.time() - (15 * 24 * 60 * 60)
+        os.utime(stale, (old, old))
+        real_unlink = Path.unlink
+
+        def fail_quarantine_unlink(path, *args, **kwargs):
+            if dg._DELETE_QUARANTINE_TOKEN in path.name:
+                raise PermissionError("simulated live handle")
+            return real_unlink(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", fail_quarantine_unlink)
+        first = dg.quick()
+        quarantines = [
+            path
+            for path in session_dir.iterdir()
+            if dg._DELETE_QUARANTINE_TOKEN in path.name
+        ]
+
+        assert first["artifacts"] == 0
+        assert len(quarantines) == 1
+        assert quarantines[0].read_text() == "preserve"
+
+        monkeypatch.setattr(Path, "unlink", real_unlink)
+        second = dg.quick()
+
+        assert second["artifacts"] == 0
+        assert quarantines[0].read_text() == "preserve"
+
     def test_quick_preserves_unmarked_stale_hook_output(self, _isolate_env):
         """Unknown files below an artifact-looking root are never junk by name."""
         dg = _load_lib()
@@ -833,6 +897,31 @@ class TestTrackForgetQuick:
         dg.quick()
 
         assert unowned.exists()
+
+    def test_empty_sweep_preserves_directory_replaced_after_selection(
+        self, _isolate_env, monkeypatch
+    ):
+        dg = _load_lib()
+        managed = _isolate_env / "scratch"
+        selected = managed / "nested" / "empty"
+        selected.mkdir(parents=True)
+        (managed / ".hermes-managed").write_text("scratch\n")
+        displaced = selected.with_name("selected-before-race")
+        real_rmdir = dg._atomic_rmdir_empty
+
+        def replace_before_rmdir(path, expected):
+            if path == selected:
+                path.rename(displaced)
+                path.mkdir()
+            return real_rmdir(path, expected)
+
+        monkeypatch.setattr(dg, "_atomic_rmdir_empty", replace_before_rmdir)
+
+        summary = dg.quick()
+
+        assert summary["empty_dirs"] == 0
+        assert selected.exists(), "replacement directory must survive"
+        assert displaced.exists(), "selected directory must remain recoverable"
 
     def test_quick_preserves_tracked_path_outside_hermes_home(self, _isolate_env, tmp_path):
         """A stale tracking record cannot authorize deleting an external path."""

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -465,6 +465,51 @@ class TestTrackForgetQuick:
         assert dg.quick()["deleted"] == 0
         assert durable.read_text() == "human state"
 
+    def test_unknown_durable_subtrees_and_cron_control_state_are_protected(
+        self, _isolate_env
+    ):
+        dg = _load_lib()
+        relative_paths = [
+            "secrets/credentials.json",
+            "state/runtime.json",
+            "worker_state/lease.json",
+            "cron_state/scheduler.json",
+            "cron/executions.db",
+            "cron/.jobs.lock",
+            "cron/ticker_heartbeat",
+            "cron/jobs.json.bak-human",
+        ]
+        records = []
+        paths = []
+        for relative in relative_paths:
+            path = _isolate_env / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("durable")
+            paths.append(path)
+            identity = dg._capture_identity(path)
+            assert dg.track(str(path), "test", silent=True) is False
+            records.append({
+                "path": str(path.resolve()),
+                "category": "test",
+                "timestamp": "2025-01-01T00:00:00+00:00",
+                "size": path.stat().st_size,
+                "identity": identity,
+            })
+        dg.save_tracked(records)
+
+        assert dg.quick()["deleted"] == 0
+        assert all(path.read_text() == "durable" for path in paths)
+
+    def test_explicit_disposable_root_remains_trackable(self, _isolate_env):
+        dg = _load_lib()
+        artifact = _isolate_env / "scratch" / "test_result.py"
+        artifact.parent.mkdir()
+        artifact.write_text("temporary")
+
+        assert dg.track(str(artifact), "test", silent=True)
+        assert dg.quick(paths=[str(artifact)])["deleted"] == 1
+        assert not artifact.exists()
+
     def test_quick_commit_preserves_concurrent_tracking_addition(
         self, _isolate_env, monkeypatch
     ):

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -544,14 +544,22 @@ class TestTrackForgetQuick:
         artifact.parent.mkdir()
         artifact.write_text("tracked")
         assert dg.track(str(artifact), "temp", silent=True)
+        identity = dg._capture_identity(artifact)
+        assert identity is not None
 
         monkeypatch.setattr(dg.os.path, "samestat", lambda _left, _right: False)
 
-        result = dg.quick(paths=[str(artifact)])
+        error = dg._atomic_unlink_regular(artifact, identity)
 
-        assert result["deleted"] == 0
-        assert artifact.read_text() == "tracked"
-        assert not list(artifact.parent.glob("*.hermes-delete-*"))
+        assert error is not None
+        assert not artifact.exists()
+        quarantines = [
+            path
+            for path in artifact.parent.iterdir()
+            if dg._DELETE_QUARANTINE_TOKEN in path.name
+        ]
+        assert len(quarantines) == 1
+        assert quarantines[0].read_text() == "tracked"
 
     def test_quick_commit_preserves_concurrent_tracking_addition(
         self, _isolate_env, monkeypatch
@@ -803,6 +811,75 @@ class TestTrackForgetQuick:
         assert summary["errors"]
         assert stale.read_text() == "human replacement"
 
+    def test_retention_preserves_replaced_managed_session(
+        self, _isolate_env, monkeypatch
+    ):
+        dg = _load_lib()
+        session_dir = _isolate_env / "hook_outputs" / "session-container-race"
+        session_dir.mkdir(parents=True)
+        (session_dir / ".hermes-managed").write_text("hook_outputs\n")
+        (session_dir / "owned.txt").write_text("owned")
+        displaced = session_dir.with_name("session-selected-before-race")
+        real_marker_matches = dg._managed_marker_matches
+        injected = False
+
+        def replace_after_marker(path, expected):
+            nonlocal injected
+            matched = real_marker_matches(path, expected)
+            if path == session_dir and matched and not injected:
+                injected = True
+                path.rename(displaced)
+                path.mkdir()
+                (path / ".hermes-managed").write_text("hook_outputs\n")
+                human = path / "human.txt"
+                human.write_text("keep")
+                old = time.time() - (15 * 24 * 60 * 60)
+                os.utime(human, (old, old))
+            return matched
+
+        monkeypatch.setattr(dg, "_managed_marker_matches", replace_after_marker)
+
+        summary = dg.quick()
+
+        assert summary["artifacts"] == 0
+        assert (session_dir / "human.txt").read_text() == "keep"
+        assert (displaced / "owned.txt").read_text() == "owned"
+
+    def test_retention_preserves_replaced_managed_root(
+        self, _isolate_env, monkeypatch
+    ):
+        dg = _load_lib()
+        artifact_root = _isolate_env / "hook_outputs"
+        original_session = artifact_root / "original"
+        original_session.mkdir(parents=True)
+        (original_session / ".hermes-managed").write_text("hook_outputs\n")
+        displaced = artifact_root.with_name("hook_outputs-selected-before-race")
+        real_iterdir = Path.iterdir
+        injected = False
+
+        def replace_during_root_listing(path):
+            nonlocal injected
+            if path == artifact_root and not injected:
+                injected = True
+                path.rename(displaced)
+                replacement = path / "human-session"
+                replacement.mkdir(parents=True)
+                (replacement / ".hermes-managed").write_text("hook_outputs\n")
+                human = replacement / "human.txt"
+                human.write_text("keep")
+                old = time.time() - (15 * 24 * 60 * 60)
+                os.utime(human, (old, old))
+            return real_iterdir(path)
+
+        monkeypatch.setattr(Path, "iterdir", replace_during_root_listing)
+
+        summary = dg.quick()
+
+        assert summary["artifacts"] == 0
+        assert (
+            artifact_root / "human-session" / "human.txt"
+        ).read_text() == "keep"
+
     def test_failed_retention_unlink_preserves_and_excludes_quarantine(
         self, _isolate_env, monkeypatch
     ):
@@ -922,6 +999,31 @@ class TestTrackForgetQuick:
         assert summary["empty_dirs"] == 0
         assert selected.exists(), "replacement directory must survive"
         assert displaced.exists(), "selected directory must remain recoverable"
+
+    def test_empty_rmdir_preserves_quarantine_on_identity_uncertainty(
+        self, _isolate_env, monkeypatch
+    ):
+        dg = _load_lib()
+        selected = _isolate_env / "scratch" / "empty"
+        selected.mkdir(parents=True)
+        expected = selected.lstat()
+        checks = iter((True, False))
+        monkeypatch.setattr(
+            dg.os.path,
+            "samestat",
+            lambda _left, _right: next(checks),
+        )
+
+        assert not dg._atomic_rmdir_empty(selected, expected)
+
+        assert not selected.exists()
+        quarantines = [
+            path
+            for path in selected.parent.iterdir()
+            if dg._DELETE_QUARANTINE_TOKEN in path.name
+        ]
+        assert len(quarantines) == 1
+        assert quarantines[0].is_dir()
 
     def test_quick_preserves_tracked_path_outside_hermes_home(self, _isolate_env, tmp_path):
         """A stale tracking record cannot authorize deleting an external path."""

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -5,8 +5,7 @@ Covers the bundled plugin at ``plugins/disk-cleanup/``:
   * ``disk_cleanup`` library: track / forget / dry_run / quick / status,
     ``is_safe_path`` and ``guess_category`` filtering.
   * Plugin ``__init__``: ``post_tool_call`` hook auto-tracks files created
-    by ``write_file`` / ``terminal``; ``on_session_end`` hook runs quick
-    cleanup when anything was tracked during the turn.
+    by ``write_file``; ``on_session_end`` cleans only that session's paths.
   * Slash command handler: status / dry-run / quick / track / forget /
     unknown subcommand behaviours.
   * Bundled-plugin discovery via ``PluginManager.discover_and_load``.
@@ -211,9 +210,10 @@ class TestStaleCronEntryMigration:
         summary = dg.quick()
         assert summary["deleted"] == 0, "cron/jobs.json must not be deleted"
         assert jobs_json.exists(), "jobs.json must still exist"
-        # The stale entry should have been dropped from tracking.
+        # Legacy records without filesystem identity are preserved for manual
+        # review rather than treated as deletion authority.
         remaining = json.loads(tracked_file.read_text())
-        assert len(remaining) == 0
+        assert len(remaining) == 1
 
     def test_quick_skips_stale_cron_output_for_cron_dir(self, _isolate_env):
         """Stale entry for the cron/ directory itself must not be deleted."""
@@ -317,14 +317,10 @@ class TestStaleCronEntryMigration:
         from datetime import datetime, timezone, timedelta
         old_ts = (datetime.now(timezone.utc) - timedelta(days=20)).isoformat()
 
-        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
-        tracked_file.parent.mkdir(parents=True, exist_ok=True)
-        tracked_file.write_text(json.dumps([{
-            "path": str(run_md),
-            "category": "cron-output",
-            "timestamp": old_ts,
-            "size": 10,
-        }]))
+        assert dg.track(str(run_md), "cron-output", silent=True)
+        tracked = dg.load_tracked()
+        tracked[0]["timestamp"] = old_ts
+        dg.save_tracked(tracked)
 
         summary = dg.quick()
         assert summary["deleted"] == 1, "valid old cron-output should be deleted"
@@ -468,17 +464,14 @@ class TestTrackForgetQuick:
         dg = _load_lib()
         valid = _isolate_env / "test_valid.py"
         valid.write_text("keep only until the sweep")
+        assert dg.track(str(valid), "test", silent=True)
         tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
-        tracked_file.parent.mkdir(parents=True, exist_ok=True)
-        tracked_file.write_text(json.dumps([
+        tracked = dg.load_tracked()
+        tracked.insert(
+            0,
             {"path": str(_isolate_env / "test_malformed.py"), "category": "test"},
-            {
-                "path": str(valid),
-                "category": "test",
-                "timestamp": "2025-01-01T00:00:00+00:00",
-                "size": valid.stat().st_size,
-            },
-        ]))
+        )
+        dg.save_tracked(tracked)
 
         summary = dg.quick()
 
@@ -512,6 +505,23 @@ class TestTrackForgetQuick:
         assert summary["errors"]
         assert locked.exists()
         assert any(item["path"] == str(locked) for item in dg.load_tracked())
+
+    def test_quick_preserves_replacement_at_tracked_path(self, _isolate_env):
+        """A path record cannot authorize deletion of a replacement object."""
+        dg = _load_lib()
+        path = _isolate_env / "test_agent_created.py"
+        path.write_text("agent scratch")
+        assert dg.track(str(path), "test", silent=True)
+
+        path.unlink()
+        path.write_text("human replacement")
+
+        summary = dg.quick()
+
+        assert summary["deleted"] == 0
+        assert summary["errors"]
+        assert path.read_text() == "human replacement"
+        assert any(item["path"] == str(path) for item in dg.load_tracked())
 
     def test_quick_prunes_only_marked_stale_hook_output(self, _isolate_env):
         """Hook spill files are owned only after the managed marker exists."""
@@ -702,6 +712,23 @@ class TestPostToolCallHook:
         pi._on_session_end(session_id="s3", completed=True, interrupted=False)
         assert p.exists(), "terminal metadata must not authorize deletion"
 
+    def test_patch_files_created_cannot_authorize_cleanup(self, _isolate_env):
+        """V4A creation labels are ambiguous and never destructive evidence."""
+        pi = _load_plugin_init()
+        p = _isolate_env / "test_existing.py"
+        p.write_text("human file")
+        pi._on_post_tool_call(
+            tool_name="patch",
+            args={"mode": "patch", "patch": "*** Add File: test_existing.py"},
+            result=json.dumps({"files_created": [str(p)]}),
+            task_id="patch-task",
+            session_id="patch-session",
+        )
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        assert not tracked_file.exists() or tracked_file.read_text().strip() == "[]"
+        pi._on_session_end(session_id="patch-session")
+        assert p.read_text() == "human file"
+
     def test_terminal_read_only_output_cannot_track_preexisting_test_file(
         self, _isolate_env
     ):
@@ -769,6 +796,28 @@ class TestOnSessionEndHook:
         pi = _load_plugin_init()
         # Nothing tracked → on_session_end should not raise.
         pi._on_session_end(session_id="empty", completed=True, interrupted=False)
+
+    def test_cleanup_is_scoped_to_ending_session(self, _isolate_env):
+        pi = _load_plugin_init()
+        first = _isolate_env / "test_session_one.py"
+        second = _isolate_env / "test_session_two.py"
+        first.write_text("one")
+        second.write_text("two")
+        for path, session in ((first, "s1"), (second, "s2")):
+            pi._on_post_tool_call(
+                tool_name="write_file",
+                args={"path": str(path), "content": path.read_text()},
+                result=json.dumps({"created_paths": [str(path)]}),
+                task_id=f"task-{session}",
+                session_id=session,
+            )
+
+        pi._on_session_end(session_id="s1")
+
+        assert not first.exists()
+        assert second.exists(), "ending session s1 must not clean active session s2"
+        pi._on_session_end(session_id="s2")
+        assert not second.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -986,11 +986,11 @@ class TestTrackForgetQuick:
         displaced = selected.with_name("selected-before-race")
         real_rmdir = dg._atomic_rmdir_empty
 
-        def replace_before_rmdir(path, expected):
+        def replace_before_rmdir(path, expected, root_evidence=None):
             if path == selected:
                 path.rename(displaced)
                 path.mkdir()
-            return real_rmdir(path, expected)
+            return real_rmdir(path, expected, root_evidence)
 
         monkeypatch.setattr(dg, "_atomic_rmdir_empty", replace_before_rmdir)
 
@@ -999,6 +999,45 @@ class TestTrackForgetQuick:
         assert summary["empty_dirs"] == 0
         assert selected.exists(), "replacement directory must survive"
         assert displaced.exists(), "selected directory must remain recoverable"
+
+    def test_empty_sweep_preserves_replacement_root_with_copied_marker(
+        self, _isolate_env, monkeypatch
+    ):
+        """Copied marker text cannot transfer ownership to a replacement root."""
+        dg = _load_lib()
+        managed = _isolate_env / "scratch"
+        selected = managed / "nested" / "empty"
+        selected.mkdir(parents=True)
+        marker = managed / ".hermes-managed"
+        marker.write_text("scratch\n")
+
+        replacement = _isolate_env.parent / "replacement-root"
+        replacement_empty = replacement / "foreign" / "empty"
+        replacement_empty.mkdir(parents=True)
+        (replacement / ".hermes-managed").write_text(marker.read_text())
+        displaced = _isolate_env.parent / "selected-root-before-race"
+        real_is_owned = dg._is_owned_empty_dir_root
+        replaced = False
+
+        def replace_after_validation(evidence):
+            nonlocal replaced
+            owned = real_is_owned(evidence)
+            if owned and evidence.path == managed and not replaced:
+                managed.rename(displaced)
+                replacement.rename(managed)
+                replaced = True
+            return owned
+
+        monkeypatch.setattr(
+            dg, "_is_owned_empty_dir_root", replace_after_validation
+        )
+
+        summary = dg.quick()
+
+        assert replaced, "regression must exercise the validation/capture race"
+        assert summary["empty_dirs"] == 0
+        assert (managed / "foreign" / "empty").exists()
+        assert (displaced / "nested" / "empty").exists()
 
     def test_empty_rmdir_preserves_quarantine_on_identity_uncertainty(
         self, _isolate_env, monkeypatch

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -684,7 +684,7 @@ class TestPostToolCallHook:
         tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
         assert not tracked_file.exists() or tracked_file.read_text().strip() == "[]"
 
-    def test_terminal_command_picks_up_paths(self, _isolate_env):
+    def test_terminal_metadata_cannot_authorize_cleanup(self, _isolate_env):
         pi = _load_plugin_init()
         p = _isolate_env / "tmp_created.log"
         p.write_text("x")
@@ -698,8 +698,9 @@ class TestPostToolCallHook:
             task_id="t3", session_id="s3",
         )
         tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
-        data = json.loads(tracked_file.read_text())
-        assert any(Path(i["path"]) == p.resolve() for i in data)
+        assert not tracked_file.exists() or tracked_file.read_text().strip() == "[]"
+        pi._on_session_end(session_id="s3", completed=True, interrupted=False)
+        assert p.exists(), "terminal metadata must not authorize deletion"
 
     def test_terminal_read_only_output_cannot_track_preexisting_test_file(
         self, _isolate_env

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -738,11 +738,13 @@ class TestPostToolCallHook:
     def test_write_file_test_pattern_tracked(self, _isolate_env):
         pi = _load_plugin_init()
         p = _isolate_env / "test_created.py"
-        p.write_text("x")
+        from tools.file_tools import write_file_tool
+
+        result = write_file_tool(str(p), "x", task_id="t1")
         pi._on_post_tool_call(
             tool_name="write_file",
             args={"path": str(p), "content": "x"},
-            result=_write_file_creation_result(pi, p),
+            result=result,
             task_id="t1", session_id="s1",
         )
         tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
@@ -753,8 +755,10 @@ class TestPostToolCallHook:
     def test_replacement_before_hook_is_not_tracked(self, _isolate_env):
         pi = _load_plugin_init()
         p = _isolate_env / "test_replaced_before_hook.py"
-        p.write_text("agent scratch")
-        result = _write_file_creation_result(pi, p)
+        from tools.file_tools import write_file_tool
+
+        result = write_file_tool(str(p), "agent scratch", task_id="race-task")
+        assert p.read_text() == "agent scratch"
         p.unlink()
         p.write_text("human replacement")
 

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -338,6 +338,23 @@ class TestStaleCronEntryMigration:
         assert summary["deleted"] == 1, "valid old cron-output should be deleted"
         assert not run_md.exists()
 
+    def test_direct_cron_output_audit_file_still_deleted(self, _isolate_env):
+        """Gateway audit output is written directly below cron/output/."""
+        dg = _load_lib()
+        output = _isolate_env / "cron" / "output" / "job_1_20260722.txt"
+        output.parent.mkdir(parents=True)
+        output.write_text("audit output")
+        from datetime import datetime, timezone, timedelta
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=20)).isoformat()
+
+        assert dg.track(str(output), "cron-output", silent=True)
+        tracked = dg.load_tracked()
+        tracked[0]["timestamp"] = old_ts
+        dg.save_tracked(tracked)
+
+        assert dg.quick()["deleted"] == 1
+        assert not output.exists()
+
 
 class TestTrackForgetQuick:
     def test_track_then_quick_deletes_test(self, _isolate_env):

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -579,6 +579,38 @@ class TestTrackForgetQuick:
         assert len(quarantines) == 1
         assert quarantines[0].read_text() == "tracked"
 
+    def test_atomic_unlink_restores_replacement_racing_quarantine(
+        self, _isolate_env, monkeypatch
+    ):
+        dg = _load_lib()
+        artifact = _isolate_env / "scratch" / "race.tmp"
+        artifact.parent.mkdir()
+        artifact.write_text("tracked")
+        identity = dg._capture_identity(artifact)
+        assert identity is not None
+        real_replace = dg.os.replace
+        injected = False
+
+        def replace_after_validation(source, destination, *args, **kwargs):
+            nonlocal injected
+            if not injected and Path(source).name == artifact.name:
+                injected = True
+                artifact.unlink()
+                artifact.write_text("human replacement")
+            return real_replace(source, destination, *args, **kwargs)
+
+        monkeypatch.setattr(dg.os, "replace", replace_after_validation)
+
+        error = dg._atomic_unlink_regular(artifact, identity)
+
+        assert injected
+        assert error is not None
+        assert artifact.read_text() == "human replacement"
+        assert not any(
+            dg._DELETE_QUARANTINE_TOKEN in child.name
+            for child in artifact.parent.iterdir()
+        )
+
     def test_quick_commit_preserves_concurrent_tracking_addition(
         self, _isolate_env, monkeypatch
     ):
@@ -873,6 +905,41 @@ class TestTrackForgetQuick:
         assert summary["artifacts"] == 0
         assert summary["errors"]
         assert stale.read_text() == "human replacement"
+
+    def test_retention_restores_replacement_racing_quarantine(
+        self, _isolate_env, monkeypatch
+    ):
+        dg = _load_lib()
+        session_dir = _isolate_env / "hook_outputs" / "session-quarantine-race"
+        session_dir.mkdir(parents=True)
+        (session_dir / ".hermes-managed").write_text("hook_outputs\n")
+        stale = session_dir / "old.txt"
+        stale.write_text("owned")
+        old = time.time() - (15 * 24 * 60 * 60)
+        os.utime(stale, (old, old))
+        real_replace = dg.os.replace
+        injected = False
+
+        def replace_after_validation(source, destination, *args, **kwargs):
+            nonlocal injected
+            if not injected and Path(source).name == stale.name:
+                injected = True
+                stale.unlink()
+                stale.write_text("human replacement")
+            return real_replace(source, destination, *args, **kwargs)
+
+        monkeypatch.setattr(dg.os, "replace", replace_after_validation)
+
+        summary = dg.quick()
+
+        assert injected
+        assert summary["artifacts"] == 0
+        assert summary["errors"]
+        assert stale.read_text() == "human replacement"
+        assert not any(
+            dg._DELETE_QUARANTINE_TOKEN in child.name
+            for child in session_dir.iterdir()
+        )
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX directory-fd regression")
     def test_retention_preserves_session_replaced_after_child_selection(

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -71,6 +71,17 @@ def _load_plugin_init():
     return mod
 
 
+def _write_file_creation_result(plugin, path: Path) -> str:
+    identity = plugin.dg._capture_identity(path)
+    assert identity is not None
+    return json.dumps({
+        "created_paths": [str(path)],
+        "created_path_identities": [
+            {"path": str(path), "identity": identity},
+        ],
+    })
+
+
 # ---------------------------------------------------------------------------
 # Library tests
 # ---------------------------------------------------------------------------
@@ -354,6 +365,64 @@ class TestTrackForgetQuick:
     def test_track_skips_missing(self, _isolate_env):
         dg = _load_lib()
         assert dg.track(str(_isolate_env / "nope.txt"), "test", silent=True) is False
+
+    def test_track_rejects_directories(self, _isolate_env):
+        dg = _load_lib()
+        directory = _isolate_env / "test_tree"
+        nested = directory / "existing"
+        nested.mkdir(parents=True)
+        (nested / "human.txt").write_text("keep")
+
+        assert dg.track(str(directory), "test", silent=True) is False
+        assert dg.quick()["deleted"] == 0
+        assert (nested / "human.txt").exists()
+
+    def test_quick_preserves_legacy_tracked_directory(self, _isolate_env):
+        dg = _load_lib()
+        directory = _isolate_env / "test_legacy_tree"
+        nested = directory / "existing"
+        nested.mkdir(parents=True)
+        human = nested / "human.txt"
+        human.write_text("keep")
+        identity = dg._capture_identity(directory)
+        assert identity is not None
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True, exist_ok=True)
+        tracked_file.write_text(json.dumps([{
+            "path": str(directory),
+            "category": "test",
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "size": 0,
+            "identity": identity,
+        }]))
+
+        summary = dg.quick()
+
+        assert summary["deleted"] == 0
+        assert summary["errors"]
+        assert human.read_text() == "keep"
+
+    def test_track_rejects_protected_durable_file(self, _isolate_env):
+        dg = _load_lib()
+        memories = _isolate_env / "memories"
+        memories.mkdir()
+        memory = memories / "MEMORY.md"
+        memory.write_text("human memory")
+
+        assert dg.track(str(memory), "test", silent=True) is False
+        identity = dg._capture_identity(memory)
+        assert identity is not None
+        dg.save_tracked([{
+            "path": str(memory),
+            "category": "test",
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "size": memory.stat().st_size,
+            "identity": identity,
+        }])
+        summary = dg.quick()
+        assert summary["deleted"] == 0
+        assert summary["errors"]
+        assert memory.read_text() == "human memory"
 
     def test_forget_removes_entry(self, _isolate_env):
         dg = _load_lib()
@@ -673,13 +742,48 @@ class TestPostToolCallHook:
         pi._on_post_tool_call(
             tool_name="write_file",
             args={"path": str(p), "content": "x"},
-            result=json.dumps({"created_paths": [str(p)]}),
+            result=_write_file_creation_result(pi, p),
             task_id="t1", session_id="s1",
         )
         tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
         data = json.loads(tracked_file.read_text())
         assert len(data) == 1
         assert data[0]["category"] == "test"
+
+    def test_replacement_before_hook_is_not_tracked(self, _isolate_env):
+        pi = _load_plugin_init()
+        p = _isolate_env / "test_replaced_before_hook.py"
+        p.write_text("agent scratch")
+        result = _write_file_creation_result(pi, p)
+        p.unlink()
+        p.write_text("human replacement")
+
+        pi._on_post_tool_call(
+            tool_name="write_file",
+            args={"path": str(p), "content": "agent scratch"},
+            result=result,
+            task_id="race-task",
+            session_id="race-session",
+        )
+        pi._on_session_end(session_id="race-session")
+
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        assert not tracked_file.exists() or tracked_file.read_text().strip() == "[]"
+        assert p.read_text() == "human replacement"
+
+    def test_legacy_created_path_without_identity_is_not_tracked(self, _isolate_env):
+        pi = _load_plugin_init()
+        p = _isolate_env / "test_legacy_metadata.py"
+        p.write_text("human file")
+        pi._on_post_tool_call(
+            tool_name="write_file",
+            args={"path": str(p), "content": "unknown"},
+            result=json.dumps({"created_paths": [str(p)]}),
+            task_id="legacy-task",
+            session_id="legacy-session",
+        )
+        pi._on_session_end(session_id="legacy-session")
+        assert p.read_text() == "human file"
 
     def test_write_file_non_test_not_tracked(self, _isolate_env):
         pi = _load_plugin_init()
@@ -785,7 +889,7 @@ class TestOnSessionEndHook:
         pi._on_post_tool_call(
             tool_name="write_file",
             args={"path": str(p), "content": "x"},
-            result=json.dumps({"created_paths": [str(p)]}),
+            result=_write_file_creation_result(pi, p),
             task_id="", session_id="s1",
         )
         assert p.exists()
@@ -807,7 +911,7 @@ class TestOnSessionEndHook:
             pi._on_post_tool_call(
                 tool_name="write_file",
                 args={"path": str(path), "content": path.read_text()},
-                result=json.dumps({"created_paths": [str(path)]}),
+                result=_write_file_creation_result(pi, path),
                 task_id=f"task-{session}",
                 session_id=session,
             )

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -15,6 +15,7 @@ import importlib
 import concurrent.futures
 import json
 import os
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -357,6 +358,23 @@ class TestStaleCronEntryMigration:
 
 
 class TestTrackForgetQuick:
+    def test_registry_lock_refuses_hardlink_without_writing(self, _isolate_env):
+        dg = _load_lib()
+        state_dir = _isolate_env / "disk-cleanup"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        external = _isolate_env / "operator-empty.txt"
+        external.write_bytes(b"")
+        lock_path = state_dir / "tracked.lock"
+        try:
+            lock_path.hardlink_to(external)
+        except OSError as exc:
+            pytest.skip(f"hardlinks unavailable: {exc}")
+
+        with pytest.raises(OSError, match="not independently owned"):
+            dg.load_tracked()
+
+        assert external.read_bytes() == b""
+
     def test_track_then_quick_deletes_test(self, _isolate_env):
         dg = _load_lib()
         p = _isolate_env / "test_a.py"
@@ -838,21 +856,110 @@ class TestTrackForgetQuick:
         stale.write_text("owned")
         old = time.time() - (15 * 24 * 60 * 60)
         os.utime(stale, (old, old))
-        real_unlink = dg._atomic_unlink_regular
+        real_unlink = dg._atomic_unlink_managed_artifact
 
-        def replace_before_unlink(path, expected_identity=None):
-            assert expected_identity is not None
+        def replace_before_unlink(lease, root_name, name, expected_identity):
             path.unlink()
             path.write_text("human replacement")
-            return real_unlink(path, expected_identity)
+            return real_unlink(lease, root_name, name, expected_identity)
 
-        monkeypatch.setattr(dg, "_atomic_unlink_regular", replace_before_unlink)
+        path = stale
+        monkeypatch.setattr(
+            dg, "_atomic_unlink_managed_artifact", replace_before_unlink
+        )
 
         summary = dg.quick()
 
         assert summary["artifacts"] == 0
         assert summary["errors"]
         assert stale.read_text() == "human replacement"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX directory-fd regression")
+    def test_retention_preserves_session_replaced_after_child_selection(
+        self, _isolate_env, monkeypatch
+    ):
+        dg = _load_lib()
+        session_dir = _isolate_env / "hook_outputs" / "session-bound-race"
+        session_dir.mkdir(parents=True)
+        (session_dir / ".hermes-managed").write_text("hook_outputs\n")
+        owned = session_dir / "old.txt"
+        owned.write_text("owned")
+        old = time.time() - (15 * 24 * 60 * 60)
+        os.utime(owned, (old, old))
+        displaced = session_dir.with_name("session-bound-race-displaced")
+        real_unlink = dg._atomic_unlink_managed_artifact
+        injected = False
+
+        def replace_session(lease, root_name, name, expected_identity):
+            nonlocal injected
+            if not injected:
+                injected = True
+                session_dir.rename(displaced)
+                session_dir.mkdir()
+                (session_dir / ".hermes-managed").write_text("hook_outputs\n")
+                human = session_dir / name
+                human.write_text("human replacement")
+                os.utime(human, (old, old))
+            return real_unlink(lease, root_name, name, expected_identity)
+
+        monkeypatch.setattr(
+            dg, "_atomic_unlink_managed_artifact", replace_session
+        )
+
+        summary = dg.quick()
+
+        assert injected
+        assert summary["artifacts"] == 0
+        assert summary["errors"]
+        assert (session_dir / "old.txt").read_text() == "human replacement"
+        assert (displaced / "old.txt").read_text() == "owned"
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows junction regression")
+    def test_retention_preserves_external_junction_replacement(
+        self, _isolate_env, tmp_path, monkeypatch
+    ):
+        dg = _load_lib()
+        session_dir = _isolate_env / "hook_outputs" / "session-junction-race"
+        session_dir.mkdir(parents=True)
+        (session_dir / ".hermes-managed").write_text("hook_outputs\n")
+        (session_dir / "owned.txt").write_text("owned")
+        external = tmp_path / "operator-session"
+        external.mkdir()
+        (external / ".hermes-managed").write_text("hook_outputs\n")
+        human = external / "human.txt"
+        human.write_text("keep")
+        old = time.time() - (15 * 24 * 60 * 60)
+        os.utime(human, (old, old))
+        displaced = session_dir.with_name("session-before-junction")
+        real_marker_matches = dg._managed_marker_matches
+        injected = False
+
+        def replace_with_junction(path, expected):
+            nonlocal injected
+            matched = real_marker_matches(path, expected)
+            if path == session_dir and matched and not injected:
+                injected = True
+                path.rename(displaced)
+                created = subprocess.run(
+                    ["cmd", "/c", "mklink", "/J", str(path), str(external)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if created.returncode:
+                    pytest.skip(
+                        f"junction creation unavailable: {created.stderr.strip()}"
+                    )
+            return matched
+
+        monkeypatch.setattr(dg, "_managed_marker_matches", replace_with_junction)
+
+        summary = dg.quick()
+
+        assert injected
+        assert summary["artifacts"] == 0
+        assert human.read_text() == "keep"
+        assert (displaced / "owned.txt").read_text() == "owned"
 
     def test_retention_preserves_replaced_managed_session(
         self, _isolate_env, monkeypatch
@@ -934,14 +1041,14 @@ class TestTrackForgetQuick:
         stale.write_text("preserve")
         old = time.time() - (15 * 24 * 60 * 60)
         os.utime(stale, (old, old))
-        real_unlink = Path.unlink
+        real_unlink = dg.os.unlink
 
         def fail_quarantine_unlink(path, *args, **kwargs):
-            if dg._DELETE_QUARANTINE_TOKEN in path.name:
+            if dg._DELETE_QUARANTINE_TOKEN in str(path):
                 raise PermissionError("simulated live handle")
             return real_unlink(path, *args, **kwargs)
 
-        monkeypatch.setattr(Path, "unlink", fail_quarantine_unlink)
+        monkeypatch.setattr(dg.os, "unlink", fail_quarantine_unlink)
         first = dg.quick()
         quarantines = [
             path
@@ -953,7 +1060,7 @@ class TestTrackForgetQuick:
         assert len(quarantines) == 1
         assert quarantines[0].read_text() == "preserve"
 
-        monkeypatch.setattr(Path, "unlink", real_unlink)
+        monkeypatch.setattr(dg.os, "unlink", real_unlink)
         second = dg.quick()
 
         assert second["artifacts"] == 0

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -439,6 +439,10 @@ class TestTrackForgetQuick:
             "channel_aliases.json",
             "processes.json",
             "feishu_comment_pairing.json",
+            "kanban.db-wal",
+            "state.db-shm",
+            "webhook_subscriptions.json",
+            "auth.lock",
         ],
     )
     def test_canonical_top_level_state_is_never_deletable(
@@ -466,7 +470,7 @@ class TestTrackForgetQuick:
     ):
         dg = _load_lib()
         first = _isolate_env / "test_first.py"
-        concurrent = _isolate_env / "keep.concurrent"
+        concurrent = _isolate_env / "tmp_concurrent.log"
         first.write_text("delete")
         concurrent.write_text("preserve tracking")
         assert dg.track(str(first), "test", silent=True)

--- a/tests/plugins/test_kanban_attachments.py
+++ b/tests/plugins/test_kanban_attachments.py
@@ -489,7 +489,7 @@ def test_attachment_post_close_replacement_is_preserved(kanban_home, monkeypatch
         nonlocal target_lstats
         if path == target:
             target_lstats += 1
-            if target_lstats == 2:
+            if target_lstats == 3:
                 target.unlink()
                 target.write_bytes(b"human replacement")
         return real_lstat(path)
@@ -560,6 +560,51 @@ def test_store_attachment_bytes_preserves_race_winner(kanban_home, monkeypatch):
         assert Path(attachment.stored_path).read_bytes() == b"agent bytes"
     finally:
         conn.close()
+
+
+def test_attachment_junction_open_restore_writes_no_external_bytes(
+    kanban_home, monkeypatch
+):
+    """A redirected exclusive open is rejected before bytes reach its target."""
+    destination = kanban_home / "destination"
+    destination.mkdir()
+    intended = destination / "report.txt"
+    external_dir = kanban_home / "external"
+    external_dir.mkdir()
+    external = external_dir / intended.name
+    real_open = kb.os.open
+    real_actual_path = kb._opened_file_actual_path
+    real_remove = kb._atomic_remove_expected_file
+    external_before_cleanup = []
+
+    def junction_open(path, flags, *args, **kwargs):
+        if Path(path) == intended and flags & kb.os.O_EXCL:
+            fd = real_open(external, flags, *args, **kwargs)
+            # Model the attacker restoring the original path after the open.
+            intended.write_bytes(b"human replacement")
+            return fd
+        return real_open(path, flags, *args, **kwargs)
+
+    def actual_path(fd, path):
+        if Path(path) == intended:
+            return external
+        return real_actual_path(fd, path)
+
+    def observe_remove(path, expected):
+        if Path(path) == external:
+            external_before_cleanup.append(external.read_bytes())
+        return real_remove(path, expected)
+
+    monkeypatch.setattr(kb.os, "open", junction_open)
+    monkeypatch.setattr(kb, "_opened_file_actual_path", actual_path)
+    monkeypatch.setattr(kb, "_atomic_remove_expected_file", observe_remove)
+
+    with pytest.raises(ValueError, match="destination path changed"):
+        kb._exclusive_attachment_path(destination, intended.name, b"agent bytes")
+
+    assert external_before_cleanup == [b""]
+    assert not external.exists()
+    assert intended.read_bytes() == b"human replacement"
 
 
 def test_store_attachment_bytes_unknown_task_leaves_no_blob(kanban_home):

--- a/tests/plugins/test_kanban_attachments.py
+++ b/tests/plugins/test_kanban_attachments.py
@@ -345,6 +345,39 @@ def test_store_attachment_bytes_resolves_collisions(kanban_home):
         conn.close()
 
 
+def test_store_attachment_bytes_preserves_race_winner(kanban_home, monkeypatch):
+    conn = kb.connect()
+    try:
+        task_id = _make_task(conn)
+        destination = kb.task_attachments_dir(task_id) / "race.txt"
+        real_open = kb.os.open
+        injected = False
+
+        def race_open(path, flags, *args, **kwargs):
+            nonlocal injected
+            if (
+                Path(path) == destination
+                and flags & kb.os.O_EXCL
+                and not injected
+            ):
+                injected = True
+                destination.write_bytes(b"human winner")
+                raise FileExistsError(str(destination))
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(kb.os, "open", race_open)
+        attachment_id = kb.store_attachment_bytes(
+            conn, task_id, "race.txt", b"agent bytes"
+        )
+        attachment = kb.get_attachment(conn, attachment_id)
+
+        assert destination.read_bytes() == b"human winner"
+        assert attachment is not None and attachment.filename == "race (1).txt"
+        assert Path(attachment.stored_path).read_bytes() == b"agent bytes"
+    finally:
+        conn.close()
+
+
 def test_store_attachment_bytes_unknown_task_leaves_no_blob(kanban_home):
     conn = kb.connect()
     try:

--- a/tests/plugins/test_kanban_attachments.py
+++ b/tests/plugins/test_kanban_attachments.py
@@ -155,7 +155,7 @@ def _insert_legacy_attachment(conn, task_id: str, blob: Path) -> int:
     return int(cursor.lastrowid)
 
 
-def test_api_delete_legacy_attachment_returns_conflict_and_preserves_data(
+def test_api_delete_legacy_attachment_adopts_canonical_blob(
     client, kanban_home
 ):
     conn = kb.connect()
@@ -171,11 +171,55 @@ def test_api_delete_legacy_attachment_returns_conflict_and_preserves_data(
 
     response = client.delete(f"/api/plugins/kanban/attachments/{attachment_id}")
 
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    with kb.connect() as conn:
+        assert kb.get_attachment(conn, attachment_id) is None
+    assert not blob.exists()
+
+
+def test_api_delete_legacy_attachment_rejects_noncanonical_blob(
+    client, kanban_home, tmp_path
+):
+    conn = kb.connect()
+    try:
+        task_id = _make_task(conn, title="legacy external attachment")
+        blob = tmp_path / "legacy-external.txt"
+        blob.write_text("keep", encoding="utf-8")
+        attachment_id = _insert_legacy_attachment(conn, task_id, blob)
+    finally:
+        conn.close()
+
+    response = client.delete(f"/api/plugins/kanban/attachments/{attachment_id}")
+
     assert response.status_code == 409
-    assert "no filesystem ownership provenance" in response.json()["detail"]
+    assert "no safely adoptable filesystem ownership provenance" in response.json()[
+        "detail"
+    ]
     with kb.connect() as conn:
         assert kb.get_attachment(conn, attachment_id) is not None
     assert blob.read_text(encoding="utf-8") == "keep"
+
+
+def test_api_delete_legacy_attachment_rejects_size_mismatch(client, kanban_home):
+    conn = kb.connect()
+    try:
+        task_id = _make_task(conn, title="changed legacy attachment")
+        attachment_dir = kb.task_attachments_dir(task_id)
+        attachment_dir.mkdir(parents=True)
+        blob = attachment_dir / "changed.txt"
+        blob.write_text("original", encoding="utf-8")
+        attachment_id = _insert_legacy_attachment(conn, task_id, blob)
+        blob.write_text("changed after upload", encoding="utf-8")
+    finally:
+        conn.close()
+
+    response = client.delete(f"/api/plugins/kanban/attachments/{attachment_id}")
+
+    assert response.status_code == 409
+    with kb.connect() as conn:
+        assert kb.get_attachment(conn, attachment_id) is not None
+    assert blob.read_text(encoding="utf-8") == "changed after upload"
 
 
 def test_attachments_root_is_per_board(kanban_home, monkeypatch):
@@ -662,7 +706,7 @@ def test_cli_attach_attachments_and_rm(kanban_home, tmp_path):
         conn.close()
 
 
-def test_cli_attach_rm_refuses_legacy_attachment_and_preserves_data(kanban_home):
+def test_cli_attach_rm_adopts_canonical_legacy_attachment(kanban_home):
     from hermes_cli.kanban import run_slash
 
     with kb.connect() as conn:
@@ -675,11 +719,10 @@ def test_cli_attach_rm_refuses_legacy_attachment_and_preserves_data(kanban_home)
 
     output = run_slash(f"attach-rm {attachment_id}")
 
-    assert "no filesystem ownership provenance" in output
-    assert "refusing deletion" in output
+    assert "Deleted attachment" in output
     with kb.connect() as conn:
-        assert kb.get_attachment(conn, attachment_id) is not None
-    assert blob.read_text(encoding="utf-8") == "keep"
+        assert kb.get_attachment(conn, attachment_id) is None
+    assert not blob.exists()
 
 
 def test_cli_attach_honors_name_override(kanban_home, tmp_path):

--- a/tests/plugins/test_kanban_attachments.py
+++ b/tests/plugins/test_kanban_attachments.py
@@ -315,6 +315,99 @@ def test_upload_name_collision_gets_suffixed(client):
     assert names == ["dup (1).txt", "dup.txt"]
 
 
+def test_dashboard_upload_preserves_symlink_race_winner(
+    client, kanban_home, monkeypatch
+):
+    task_id = _create_task_via_api(client)
+    attachment_dir = kb.task_attachments_dir(task_id)
+    attachment_dir.mkdir(parents=True, exist_ok=True)
+    destination = attachment_dir / "race.txt"
+    human_file = kanban_home / "human-race-winner.txt"
+    human_file.write_bytes(b"human bytes")
+
+    # Skip only on Windows hosts where developer-mode/elevation does not allow
+    # symlink creation; the regular-file race is covered at the shared layer.
+    probe = kanban_home / "symlink-probe"
+    try:
+        probe.symlink_to(human_file)
+    except OSError:
+        pytest.skip("host does not permit symlink creation")
+    else:
+        probe.unlink()
+
+    real_open = kb.os.open
+    injected = False
+
+    def race_open(path, flags, *args, **kwargs):
+        nonlocal injected
+        if Path(path) == destination and flags & kb.os.O_EXCL and not injected:
+            injected = True
+            destination.symlink_to(human_file)
+            raise FileExistsError(str(destination))
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(kb.os, "open", race_open)
+    response = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/attachments",
+        files={"file": ("race.txt", b"agent bytes", "text/plain")},
+    )
+
+    assert response.status_code == 200, response.text
+    attachment = response.json()["attachment"]
+    assert injected
+    assert destination.is_symlink()
+    assert human_file.read_bytes() == b"human bytes"
+    assert attachment["filename"] == "race (1).txt"
+    assert Path(attachment["stored_path"]).read_bytes() == b"agent bytes"
+
+
+def test_dashboard_upload_preserves_regular_file_race_winner(
+    client, monkeypatch
+):
+    task_id = _create_task_via_api(client)
+    destination = kb.task_attachments_dir(task_id) / "race.txt"
+    real_open = kb.os.open
+    injected = False
+
+    def race_open(path, flags, *args, **kwargs):
+        nonlocal injected
+        if Path(path) == destination and flags & kb.os.O_EXCL and not injected:
+            injected = True
+            destination.write_bytes(b"human winner")
+            raise FileExistsError(str(destination))
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(kb.os, "open", race_open)
+    response = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/attachments",
+        files={"file": ("race.txt", b"agent bytes", "text/plain")},
+    )
+
+    assert response.status_code == 200, response.text
+    attachment = response.json()["attachment"]
+    assert injected
+    assert destination.read_bytes() == b"human winner"
+    assert attachment["filename"] == "race (1).txt"
+    assert Path(attachment["stored_path"]).read_bytes() == b"agent bytes"
+
+
+def test_dashboard_upload_oversize_returns_413_without_blob(client, monkeypatch):
+    task_id = _create_task_via_api(client)
+    plugin = sys.modules["hermes_dashboard_plugin_kanban_attach_test"]
+    monkeypatch.setattr(plugin, "KANBAN_ATTACHMENT_MAX_BYTES", 4)
+
+    response = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/attachments",
+        files={"file": ("large.bin", b"12345", "application/octet-stream")},
+    )
+
+    assert response.status_code == 413
+    with kb.connect() as conn:
+        assert kb.list_attachments(conn, task_id) == []
+    attachment_dir = kb.task_attachments_dir(task_id)
+    assert not attachment_dir.exists() or list(attachment_dir.iterdir()) == []
+
+
 def test_upload_unknown_task_404(client):
     r = client.post(
         "/api/plugins/kanban/tasks/t_nope/attachments",

--- a/tests/plugins/test_kanban_attachments.py
+++ b/tests/plugins/test_kanban_attachments.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -140,6 +141,41 @@ def test_delete_attachment_missing_returns_none(kanban_home):
         assert kb.delete_attachment(conn, 999999) is None
     finally:
         conn.close()
+
+
+def _insert_legacy_attachment(conn, task_id: str, blob: Path) -> int:
+    cursor = conn.execute(
+        "INSERT INTO task_attachments "
+        "(task_id, filename, stored_path, content_type, size, uploaded_by, "
+        "created_at, filesystem_identity) "
+        "VALUES (?, ?, ?, 'text/plain', ?, 'legacy', 1, NULL)",
+        (task_id, blob.name, str(blob.resolve()), blob.stat().st_size),
+    )
+    conn.commit()
+    return int(cursor.lastrowid)
+
+
+def test_api_delete_legacy_attachment_returns_conflict_and_preserves_data(
+    client, kanban_home
+):
+    conn = kb.connect()
+    try:
+        task_id = _make_task(conn, title="legacy API attachment")
+        attachment_dir = kb.task_attachments_dir(task_id)
+        attachment_dir.mkdir(parents=True)
+        blob = attachment_dir / "legacy-api.txt"
+        blob.write_text("keep", encoding="utf-8")
+        attachment_id = _insert_legacy_attachment(conn, task_id, blob)
+    finally:
+        conn.close()
+
+    response = client.delete(f"/api/plugins/kanban/attachments/{attachment_id}")
+
+    assert response.status_code == 409
+    assert "no filesystem ownership provenance" in response.json()["detail"]
+    with kb.connect() as conn:
+        assert kb.get_attachment(conn, attachment_id) is not None
+    assert blob.read_text(encoding="utf-8") == "keep"
 
 
 def test_attachments_root_is_per_board(kanban_home, monkeypatch):
@@ -317,6 +353,61 @@ def test_store_attachment_bytes_roundtrip(kanban_home):
         conn.close()
 
 
+def test_store_attachment_accepts_close_time_ctime_settling(
+    kanban_home, monkeypatch
+):
+    """Path-vs-handle ctime drift must not reject a file bound by samestat."""
+    real_fstat = kb.os.fstat
+
+    def shifted_fstat(fd):
+        current = real_fstat(fd)
+        if not kb.stat.S_ISREG(current.st_mode):
+            return current
+        return types.SimpleNamespace(
+            st_dev=current.st_dev,
+            st_ino=current.st_ino,
+            st_mode=current.st_mode,
+            st_size=current.st_size,
+            st_mtime_ns=current.st_mtime_ns,
+            st_ctime_ns=current.st_ctime_ns + 1,
+            st_file_attributes=getattr(current, "st_file_attributes", 0),
+        )
+
+    monkeypatch.setattr(kb.os, "fstat", shifted_fstat)
+    with kb.connect() as conn:
+        task_id = _make_task(conn)
+        attachment_id = kb.store_attachment_bytes(
+            conn, task_id, "settled.txt", b"stable"
+        )
+        attachment = kb.get_attachment(conn, attachment_id)
+
+    assert attachment is not None
+    assert Path(attachment.stored_path).read_bytes() == b"stable"
+
+
+def test_attachment_post_close_replacement_is_preserved(kanban_home, monkeypatch):
+    destination = kanban_home / "destination"
+    destination.mkdir()
+    target = destination / "report.txt"
+    real_lstat = Path.lstat
+    target_lstats = 0
+
+    def replace_after_close(path):
+        nonlocal target_lstats
+        if path == target:
+            target_lstats += 1
+            if target_lstats == 2:
+                target.unlink()
+                target.write_bytes(b"human replacement")
+        return real_lstat(path)
+
+    monkeypatch.setattr(Path, "lstat", replace_after_close)
+    with pytest.raises(ValueError, match="changed during creation"):
+        kb._exclusive_attachment_path(destination, target.name, b"agent bytes")
+
+    assert target.read_bytes() == b"human replacement"
+
+
 def test_store_attachment_bytes_rejects_oversize_and_leaves_no_blob(kanban_home):
     conn = kb.connect()
     try:
@@ -431,6 +522,26 @@ def test_cli_attach_attachments_and_rm(kanban_home, tmp_path):
         assert kb.list_attachments(conn, task_id) == []
     finally:
         conn.close()
+
+
+def test_cli_attach_rm_refuses_legacy_attachment_and_preserves_data(kanban_home):
+    from hermes_cli.kanban import run_slash
+
+    with kb.connect() as conn:
+        task_id = _make_task(conn, title="legacy CLI attachment")
+        attachment_dir = kb.task_attachments_dir(task_id)
+        attachment_dir.mkdir(parents=True)
+        blob = attachment_dir / "legacy-cli.txt"
+        blob.write_text("keep", encoding="utf-8")
+        attachment_id = _insert_legacy_attachment(conn, task_id, blob)
+
+    output = run_slash(f"attach-rm {attachment_id}")
+
+    assert "no filesystem ownership provenance" in output
+    assert "refusing deletion" in output
+    with kb.connect() as conn:
+        assert kb.get_attachment(conn, attachment_id) is not None
+    assert blob.read_text(encoding="utf-8") == "keep"
 
 
 def test_cli_attach_honors_name_override(kanban_home, tmp_path):

--- a/tests/plugins/test_kanban_attachments.py
+++ b/tests/plugins/test_kanban_attachments.py
@@ -155,7 +155,7 @@ def _insert_legacy_attachment(conn, task_id: str, blob: Path) -> int:
     return int(cursor.lastrowid)
 
 
-def test_api_delete_legacy_attachment_adopts_canonical_blob(
+def test_api_delete_legacy_attachment_removes_row_and_preserves_blob(
     client, kanban_home
 ):
     conn = kb.connect()
@@ -175,10 +175,10 @@ def test_api_delete_legacy_attachment_adopts_canonical_blob(
     assert response.json()["ok"] is True
     with kb.connect() as conn:
         assert kb.get_attachment(conn, attachment_id) is None
-    assert not blob.exists()
+    assert blob.read_text(encoding="utf-8") == "keep"
 
 
-def test_api_delete_legacy_attachment_rejects_noncanonical_blob(
+def test_api_delete_legacy_attachment_preserves_noncanonical_blob(
     client, kanban_home, tmp_path
 ):
     conn = kb.connect()
@@ -192,34 +192,34 @@ def test_api_delete_legacy_attachment_rejects_noncanonical_blob(
 
     response = client.delete(f"/api/plugins/kanban/attachments/{attachment_id}")
 
-    assert response.status_code == 409
-    assert "no safely adoptable filesystem ownership provenance" in response.json()[
-        "detail"
-    ]
+    assert response.status_code == 200
     with kb.connect() as conn:
-        assert kb.get_attachment(conn, attachment_id) is not None
+        assert kb.get_attachment(conn, attachment_id) is None
     assert blob.read_text(encoding="utf-8") == "keep"
 
 
-def test_api_delete_legacy_attachment_rejects_size_mismatch(client, kanban_home):
+def test_api_delete_legacy_attachment_preserves_same_size_replacement(
+    client, kanban_home
+):
     conn = kb.connect()
     try:
         task_id = _make_task(conn, title="changed legacy attachment")
         attachment_dir = kb.task_attachments_dir(task_id)
         attachment_dir.mkdir(parents=True)
         blob = attachment_dir / "changed.txt"
-        blob.write_text("original", encoding="utf-8")
+        blob.write_text("AAAA", encoding="utf-8")
         attachment_id = _insert_legacy_attachment(conn, task_id, blob)
-        blob.write_text("changed after upload", encoding="utf-8")
+        blob.unlink()
+        blob.write_text("BBBB", encoding="utf-8")
     finally:
         conn.close()
 
     response = client.delete(f"/api/plugins/kanban/attachments/{attachment_id}")
 
-    assert response.status_code == 409
+    assert response.status_code == 200
     with kb.connect() as conn:
-        assert kb.get_attachment(conn, attachment_id) is not None
-    assert blob.read_text(encoding="utf-8") == "changed after upload"
+        assert kb.get_attachment(conn, attachment_id) is None
+    assert blob.read_text(encoding="utf-8") == "BBBB"
 
 
 def test_attachments_root_is_per_board(kanban_home, monkeypatch):
@@ -706,7 +706,7 @@ def test_cli_attach_attachments_and_rm(kanban_home, tmp_path):
         conn.close()
 
 
-def test_cli_attach_rm_adopts_canonical_legacy_attachment(kanban_home):
+def test_cli_attach_rm_removes_legacy_row_and_preserves_blob(kanban_home):
     from hermes_cli.kanban import run_slash
 
     with kb.connect() as conn:
@@ -722,7 +722,7 @@ def test_cli_attach_rm_adopts_canonical_legacy_attachment(kanban_home):
     assert "Deleted attachment" in output
     with kb.connect() as conn:
         assert kb.get_attachment(conn, attachment_id) is None
-    assert not blob.exists()
+    assert blob.read_text(encoding="utf-8") == "keep"
 
 
 def test_cli_attach_honors_name_override(kanban_home, tmp_path):

--- a/tests/plugins/test_kanban_attachments.py
+++ b/tests/plugins/test_kanban_attachments.py
@@ -173,6 +173,8 @@ def test_api_delete_legacy_attachment_removes_row_and_preserves_blob(
 
     assert response.status_code == 200
     assert response.json()["ok"] is True
+    assert response.json()["unproven_blob_preserved"] is True
+    assert "preserved" in response.json()["warning"]
     with kb.connect() as conn:
         assert kb.get_attachment(conn, attachment_id) is None
     assert blob.read_text(encoding="utf-8") == "keep"
@@ -193,6 +195,7 @@ def test_api_delete_legacy_attachment_preserves_noncanonical_blob(
     response = client.delete(f"/api/plugins/kanban/attachments/{attachment_id}")
 
     assert response.status_code == 200
+    assert response.json()["unproven_blob_preserved"] is True
     with kb.connect() as conn:
         assert kb.get_attachment(conn, attachment_id) is None
     assert blob.read_text(encoding="utf-8") == "keep"
@@ -217,6 +220,7 @@ def test_api_delete_legacy_attachment_preserves_same_size_replacement(
     response = client.delete(f"/api/plugins/kanban/attachments/{attachment_id}")
 
     assert response.status_code == 200
+    assert response.json()["unproven_blob_preserved"] is True
     with kb.connect() as conn:
         assert kb.get_attachment(conn, attachment_id) is None
     assert blob.read_text(encoding="utf-8") == "BBBB"
@@ -322,6 +326,7 @@ def test_upload_list_download_delete_roundtrip(client):
     # Delete removes the row and the file
     r = client.delete(f"/api/plugins/kanban/attachments/{att_id}")
     assert r.status_code == 200
+    assert r.json()["unproven_blob_preserved"] is False
     assert client.get(f"/api/plugins/kanban/attachments/{att_id}").status_code == 404
     assert client.get(
         f"/api/plugins/kanban/tasks/{task_id}/attachments"
@@ -719,7 +724,8 @@ def test_cli_attach_rm_removes_legacy_row_and_preserves_blob(kanban_home):
 
     output = run_slash(f"attach-rm {attachment_id}")
 
-    assert "Deleted attachment" in output
+    assert "Removed legacy attachment" in output
+    assert "preserved its unproven on-disk blob" in output
     with kb.connect() as conn:
         assert kb.get_attachment(conn, attachment_id) is None
     assert blob.read_text(encoding="utf-8") == "keep"

--- a/tests/run_agent/test_terminal_lifecycle_cleanup.py
+++ b/tests/run_agent/test_terminal_lifecycle_cleanup.py
@@ -1,0 +1,64 @@
+"""Regression tests for terminal-resource cleanup at the turn boundary."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _agent(cleanup):
+    return SimpleNamespace(
+        _conversation_root_id=lambda: "root-session",
+        _session_db=None,
+        session_id="session-id",
+        _cleanup_task_resources=cleanup,
+    )
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {"final_response": "completed", "completed": True},
+        {"final_response": "provider failed", "completed": False, "failed": True},
+        {"final_response": "interrupted", "completed": False, "interrupted": True},
+    ],
+    ids=["success", "failure", "cancellation"],
+)
+def test_all_terminal_outcomes_run_shared_cleanup(result):
+    cleanup = MagicMock()
+    agent = _agent(cleanup)
+
+    with patch("agent.conversation_loop.run_conversation", return_value=result):
+        assert AIAgent.run_conversation(agent, "hello", task_id="task-1") == result
+
+    cleanup.assert_called_once_with("task-1")
+
+
+def test_cleanup_runs_when_conversation_raises_without_masking_error():
+    cleanup = MagicMock()
+    agent = _agent(cleanup)
+
+    with patch(
+        "agent.conversation_loop.run_conversation",
+        side_effect=RuntimeError("provider disconnected"),
+    ):
+        with pytest.raises(RuntimeError, match="provider disconnected"):
+            AIAgent.run_conversation(agent, "hello", task_id="task-2")
+
+    cleanup.assert_called_once_with("task-2")
+
+
+def test_cleanup_failure_does_not_mask_terminal_result():
+    cleanup = MagicMock(side_effect=OSError("teardown unavailable"))
+    agent = _agent(cleanup)
+
+    with patch(
+        "agent.conversation_loop.run_conversation",
+        return_value={"final_response": "still delivered"},
+    ):
+        result = AIAgent.run_conversation(agent, "hello", task_id="task-3")
+
+    assert result["final_response"] == "still delivered"
+    cleanup.assert_called_once_with("task-3")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11639,3 +11639,188 @@ def test_spawn_tree_load_rejects_snapshot_replaced_during_open(
         assert outside.read_text() == '{"private": true}'
     finally:
         reset_hermes_home_override(token)
+
+
+def test_spawn_tree_root_rejects_windows_reparse_directory(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    root = home / "spawn-trees"
+    root.mkdir(parents=True)
+    token = set_hermes_home_override(home)
+    original_lstat = Path.lstat
+
+    def lstat_with_reparse(path):
+        result = original_lstat(path)
+        if path == root:
+            return types.SimpleNamespace(
+                st_mode=result.st_mode,
+                st_file_attributes=0x400,
+            )
+        return result
+
+    try:
+        monkeypatch.setattr(Path, "lstat", lstat_with_reparse)
+        with pytest.raises(OSError, match="not a regular directory"):
+            server._spawn_trees_root()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_spawn_tree_index_rejects_hardlinked_mutable_file(tmp_path):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    try:
+        first = server._methods["spawn_tree.save"](
+            "r1", {"session_id": "session-1", "subagents": [{"id": "a"}]}
+        )
+        session_dir = Path(first["result"]["path"]).parent
+        index = session_dir / server._SPAWN_TREE_INDEX
+        outside = tmp_path / "shared-index.jsonl"
+        try:
+            os.link(index, outside)
+        except OSError as exc:
+            pytest.skip(f"hardlinks unavailable on this host: {exc}")
+        original = outside.read_text(encoding="utf-8")
+
+        second = server._methods["spawn_tree.save"](
+            "r2", {"session_id": "session-1", "subagents": [{"id": "b"}]}
+        )
+        listed = server._methods["spawn_tree.list"](
+            "r3", {"session_id": "session-1"}
+        )
+
+        assert "result" in second
+        assert outside.read_text(encoding="utf-8") == original
+        assert {entry["path"] for entry in listed["result"]["entries"]} == {
+            first["result"]["path"],
+            second["result"]["path"],
+        }
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_spawn_tree_rejects_hardlinked_snapshot(tmp_path):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    try:
+        saved = server._methods["spawn_tree.save"](
+            "r1", {"session_id": "session-1", "subagents": [{"id": "a"}]}
+        )
+        snapshot = Path(saved["result"]["path"])
+        outside = tmp_path / "shared-snapshot.json"
+        try:
+            os.link(snapshot, outside)
+        except OSError as exc:
+            pytest.skip(f"hardlinks unavailable on this host: {exc}")
+
+        loaded = server._methods["spawn_tree.load"](
+            "r2", {"path": str(snapshot)}
+        )
+        listed = server._methods["spawn_tree.list"](
+            "r3", {"session_id": "session-1"}
+        )
+
+        assert "error" in loaded
+        assert listed["result"]["entries"] == []
+        assert json.loads(outside.read_text(encoding="utf-8"))["session_id"] == (
+            "session-1"
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_spawn_tree_decoded_values_must_be_objects(tmp_path):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    try:
+        saved = server._methods["spawn_tree.save"](
+            "r1", {"session_id": "session-1", "subagents": [{"id": "a"}]}
+        )
+        snapshot = Path(saved["result"]["path"])
+        session_dir = snapshot.parent
+        index = session_dir / server._SPAWN_TREE_INDEX
+        index.write_text("[]\n", encoding="utf-8")
+
+        assert server._read_spawn_tree_index(session_dir) == []
+
+        index.unlink()
+        snapshot.write_text("[]", encoding="utf-8")
+        listed = server._methods["spawn_tree.list"](
+            "r2", {"session_id": "session-1"}
+        )
+        loaded = server._methods["spawn_tree.load"](
+            "r3", {"path": str(snapshot)}
+        )
+
+        assert listed["result"]["entries"] == []
+        assert "error" in loaded
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_spawn_tree_reads_legacy_owned_history_without_claiming_retention(tmp_path):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    try:
+        legacy_dir = home / "spawn-trees" / "legacy_session"
+        legacy_dir.mkdir(parents=True)
+        marker = legacy_dir / ".hermes-managed"
+        marker.write_text("spawn-trees\n", encoding="utf-8")
+        snapshot = legacy_dir / "20260102T030405.json"
+        snapshot.write_text(
+            json.dumps(
+                {
+                    "session_id": "legacy:session",
+                    "started_at": 10,
+                    "finished_at": 20,
+                    "label": "legacy",
+                    "subagents": [{"id": "old"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        listed = server._methods["spawn_tree.list"](
+            "r1", {"session_id": "legacy:session"}
+        )
+        cross_session = server._methods["spawn_tree.list"](
+            "r2", {"cross_session": True}
+        )
+        loaded = server._methods["spawn_tree.load"](
+            "r3", {"path": str(snapshot)}
+        )
+
+        assert listed["result"]["entries"][0]["path"] == str(snapshot)
+        assert cross_session["result"]["entries"][0]["session_id"] == (
+            "legacy:session"
+        )
+        assert loaded["result"]["subagents"] == [{"id": "old"}]
+        # Compatibility is deliberately read-only: the cleanup plugin only
+        # recognizes digest-bound markers, so this directory is never adopted.
+        assert marker.read_text(encoding="utf-8") == "spawn-trees\n"
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_spawn_tree_save_does_not_unlink_recreated_temp_name(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    original_replace = server.os.replace
+    recreated = None
+
+    def replace_then_recreate(source, destination):
+        nonlocal recreated
+        original_replace(source, destination)
+        recreated = Path(source)
+        recreated.write_text("human replacement", encoding="utf-8")
+
+    try:
+        monkeypatch.setattr(server.os, "replace", replace_then_recreate)
+        saved = server._methods["spawn_tree.save"](
+            "r1", {"session_id": "session-1", "subagents": [{"id": "a"}]}
+        )
+
+        assert "result" in saved
+        assert recreated is not None
+        assert recreated.read_text(encoding="utf-8") == "human replacement"
+    finally:
+        reset_hermes_home_override(token)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11912,6 +11912,65 @@ def test_spawn_tree_reads_legacy_owned_history_without_claiming_retention(tmp_pa
         reset_hermes_home_override(token)
 
 
+def test_spawn_tree_reads_origin_main_markerless_history_without_adopting_it(
+    tmp_path,
+):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    try:
+        # Exact origin/main layout: sanitized session directory, second-level
+        # timestamp filename, and no ownership marker.
+        legacy_dir = home / "spawn-trees" / "legacy_session"
+        legacy_dir.mkdir(parents=True)
+        snapshot = legacy_dir / "20260102T030405.json"
+        snapshot.write_text(
+            json.dumps(
+                {
+                    "session_id": "legacy:session",
+                    "started_at": 10,
+                    "finished_at": 20,
+                    "label": "origin-main",
+                    "subagents": [{"id": "old"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        saved = server._methods["spawn_tree.save"](
+            "r1",
+            {
+                "session_id": "legacy:session",
+                "subagents": [{"id": "new"}],
+            },
+        )
+        listed = server._methods["spawn_tree.list"](
+            "r2", {"session_id": "legacy:session"}
+        )
+        cross_session = server._methods["spawn_tree.list"](
+            "r3", {"cross_session": True}
+        )
+        loaded = server._methods["spawn_tree.load"](
+            "r4", {"path": str(snapshot)}
+        )
+
+        new_snapshot = Path(saved["result"]["path"])
+        assert new_snapshot.parent != legacy_dir
+        assert new_snapshot.parent.name.startswith("s-")
+        assert (new_snapshot.parent / ".hermes-managed").is_file()
+        assert not (legacy_dir / ".hermes-managed").exists()
+        assert {entry["path"] for entry in listed["result"]["entries"]} == {
+            str(snapshot),
+            str(new_snapshot),
+        }
+        assert any(
+            entry["path"] == str(snapshot)
+            for entry in cross_session["result"]["entries"]
+        )
+        assert loaded["result"]["subagents"] == [{"id": "old"}]
+    finally:
+        reset_hermes_home_override(token)
+
+
 def test_spawn_tree_save_does_not_unlink_recreated_temp_name(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     token = set_hermes_home_override(home)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11473,10 +11473,13 @@ def test_spawn_tree_save_marks_session_and_does_not_overwrite_same_second(tmp_pa
              "subagents": [{"id": "b"}]},
         )
 
+        assert "result" in first, first
+        assert "result" in second, second
         first_path = Path(first["result"]["path"])
         second_path = Path(second["result"]["path"])
         assert first_path != second_path
-        assert (first_path.parent / ".hermes-managed").read_text() == "spawn-trees\n"
+        marker = (first_path.parent / ".hermes-managed").read_text().strip()
+        assert marker.startswith("spawn-trees:")
         assert json.loads(first_path.read_text())["subagents"][0]["id"] == "a"
         assert json.loads(second_path.read_text())["subagents"][0]["id"] == "b"
     finally:
@@ -11488,7 +11491,11 @@ def test_spawn_tree_refuses_foreign_session_directory(tmp_path):
     home = tmp_path / ".hermes"
     token = set_hermes_home_override(home)
     try:
-        foreign = home / "spawn-trees" / "foreign-session"
+        foreign = (
+            home
+            / "spawn-trees"
+            / f"s-{server._spawn_tree_session_digest('foreign-session')}"
+        )
         foreign.mkdir(parents=True)
         human = foreign / "human.json"
         human.write_text('{"private": true}')
@@ -11522,5 +11529,113 @@ def test_spawn_tree_load_rejects_unowned_snapshot(tmp_path):
 
         assert "error" in loaded
         assert human.read_text() == '{"private": true}'
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_spawn_tree_session_ids_do_not_collide_after_sanitization(tmp_path):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    try:
+        save = server._methods["spawn_tree.save"]
+        first = save("r1", {"session_id": "alpha:beta", "subagents": [{"id": "a"}]})
+        second = save("r2", {"session_id": "alpha_beta", "subagents": [{"id": "b"}]})
+
+        first_path = Path(first["result"]["path"])
+        second_path = Path(second["result"]["path"])
+        assert first_path.parent != second_path.parent
+        assert server._methods["spawn_tree.list"](
+            "r3", {"session_id": "alpha_beta"}
+        )["result"]["entries"][0]["session_id"] == "alpha_beta"
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_spawn_tree_list_rejects_index_path_outside_owned_session(tmp_path):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    try:
+        saved = server._methods["spawn_tree.save"](
+            "r1", {"session_id": "session-1", "subagents": [{"id": "a"}]}
+        )
+        session_dir = Path(saved["result"]["path"]).parent
+        outside = tmp_path / "human.json"
+        outside.write_text('{"private": true}')
+        (session_dir / server._SPAWN_TREE_INDEX).write_text(
+            json.dumps({
+                "path": str(outside),
+                "session_id": "session-1",
+                "finished_at": 1,
+            }) + "\n"
+        )
+
+        listed = server._methods["spawn_tree.list"](
+            "r2", {"session_id": "session-1"}
+        )
+
+        assert listed["result"]["entries"] == []
+        assert outside.read_text() == '{"private": true}'
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_spawn_tree_save_never_appends_through_index_symlink(tmp_path):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    try:
+        first = server._methods["spawn_tree.save"](
+            "r1", {"session_id": "session-1", "subagents": [{"id": "a"}]}
+        )
+        session_dir = Path(first["result"]["path"]).parent
+        index = session_dir / server._SPAWN_TREE_INDEX
+        index.unlink()
+        outside = tmp_path / "human.txt"
+        outside.write_text("keep")
+        try:
+            index.symlink_to(outside)
+        except OSError as exc:
+            pytest.skip(f"symlink unavailable on this host: {exc}")
+
+        second = server._methods["spawn_tree.save"](
+            "r2", {"session_id": "session-1", "subagents": [{"id": "b"}]}
+        )
+
+        assert "result" in second
+        assert outside.read_text() == "keep"
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_spawn_tree_load_rejects_snapshot_replaced_during_open(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    try:
+        saved = server._methods["spawn_tree.save"](
+            "r1", {"session_id": "session-1", "subagents": [{"id": "a"}]}
+        )
+        snapshot = Path(saved["result"]["path"])
+        outside = tmp_path / "human.json"
+        outside.write_text('{"private": true}')
+        original_open = server.os.open
+        swapped = False
+
+        def replace_before_open(path, flags, *args):
+            nonlocal swapped
+            if Path(path) == snapshot and not swapped:
+                swapped = True
+                snapshot.unlink()
+                try:
+                    snapshot.symlink_to(outside)
+                except OSError as exc:
+                    pytest.skip(f"symlink unavailable on this host: {exc}")
+            return original_open(path, flags, *args)
+
+        monkeypatch.setattr(server.os, "open", replace_before_open)
+        loaded = server._methods["spawn_tree.load"]("r2", {"path": str(snapshot)})
+
+        assert "error" in loaded
+        assert outside.read_text() == '{"private": true}'
     finally:
         reset_hermes_home_override(token)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11456,6 +11456,17 @@ def test_get_usage_clamps_post_compression_sentinel():
     assert "context_percent" not in usage
 
 
+def _create_windows_junction(link: Path, target: Path) -> None:
+    result = subprocess.run(
+        ["cmd.exe", "/d", "/c", "mklink", "/J", str(link), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"junction creation unavailable: {result.stderr.strip()}")
+
+
 def test_spawn_tree_save_marks_session_and_does_not_overwrite_same_second(tmp_path):
     """Generated spawn snapshots are owned and collision-resistant."""
     token = set_hermes_home_override(tmp_path / ".hermes")
@@ -11483,6 +11494,102 @@ def test_spawn_tree_save_marks_session_and_does_not_overwrite_same_second(tmp_pa
         assert json.loads(first_path.read_text())["subagents"][0]["id"] == "a"
         assert json.loads(second_path.read_text())["subagents"][0]["id"] == "b"
     finally:
+        reset_hermes_home_override(token)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows junction regression")
+def test_spawn_tree_index_rejects_replaced_session_junction(tmp_path):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    parked = tmp_path / "owned-session"
+    junction_created = False
+    try:
+        session_dir = server._spawn_tree_session_dir("session-1")
+        evidence = server._capture_spawn_tree_dir_evidence(
+            session_dir, session_id="session-1"
+        )
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        outside_index = outside / server._SPAWN_TREE_INDEX
+        outside_index.write_text("human\n", encoding="utf-8")
+
+        session_dir.rename(parked)
+        _create_windows_junction(session_dir, outside)
+        junction_created = True
+        server._append_spawn_tree_index(
+            session_dir, {"path": "hostile"}, evidence=evidence
+        )
+
+        assert outside_index.read_text(encoding="utf-8") == "human\n"
+    finally:
+        if junction_created and os.path.lexists(session_dir):
+            os.rmdir(session_dir)
+        if parked.exists() and not session_dir.exists():
+            parked.rename(session_dir)
+        reset_hermes_home_override(token)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows junction regression")
+@pytest.mark.parametrize(
+    ("filename", "append", "outside_contents"),
+    [
+        (".snapshot.tmp", False, None),
+        (server._SPAWN_TREE_INDEX, True, "human\n"),
+    ],
+)
+def test_spawn_tree_output_rejects_open_routed_through_restored_junction(
+    tmp_path, monkeypatch, filename, append, outside_contents
+):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    parked = tmp_path / "owned-session"
+    try:
+        session_dir = server._spawn_tree_session_dir("session-1")
+        evidence = server._capture_spawn_tree_dir_evidence(
+            session_dir, session_id="session-1"
+        )
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        outside_output = outside / filename
+        if outside_contents is not None:
+            outside_output.write_text(outside_contents, encoding="utf-8")
+        original_open = server.os.open
+        routed = False
+
+        def route_open_through_junction(path, flags, *args, **kwargs):
+            nonlocal routed
+            if Path(path) == session_dir / filename and not routed:
+                routed = True
+                session_dir.rename(parked)
+                junction_created = False
+                try:
+                    _create_windows_junction(session_dir, outside)
+                    junction_created = True
+                    return original_open(path, flags, *args, **kwargs)
+                finally:
+                    if junction_created and os.path.lexists(session_dir):
+                        os.rmdir(session_dir)
+                    if parked.exists() and not session_dir.exists():
+                        parked.rename(session_dir)
+            return original_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(server.os, "open", route_open_through_junction)
+        with pytest.raises(OSError, match="outside its bound directory"):
+            with server._open_owned_spawn_tree_output(
+                evidence, filename, append=append
+            ) as output:
+                output.write("must not be written")
+
+        assert routed is True
+        if outside_contents is None:
+            assert not outside_output.exists()
+        else:
+            assert outside_output.read_text(encoding="utf-8") == outside_contents
+    finally:
+        if parked.exists():
+            if os.path.lexists(session_dir):
+                os.rmdir(session_dir)
+            parked.rename(session_dir)
         reset_hermes_home_override(token)
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11573,7 +11573,11 @@ def test_spawn_tree_list_rejects_index_path_outside_owned_session(tmp_path):
             "r2", {"session_id": "session-1"}
         )
 
-        assert listed["result"]["entries"] == []
+        # The hostile index entry is rejected, while the safe directory scan
+        # still recovers the genuine snapshot omitted by that index.
+        assert [entry["path"] for entry in listed["result"]["entries"]] == [
+            saved["result"]["path"]
+        ]
         assert outside.read_text() == '{"private": true}'
     finally:
         reset_hermes_home_override(token)
@@ -11804,17 +11808,22 @@ def test_spawn_tree_reads_legacy_owned_history_without_claiming_retention(tmp_pa
 def test_spawn_tree_save_does_not_unlink_recreated_temp_name(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     token = set_hermes_home_override(home)
-    original_replace = server.os.replace
+    original_publish = server._publish_spawn_tree_temp
     recreated = None
 
-    def replace_then_recreate(source, destination):
+    def publish_then_recreate(source, destination):
         nonlocal recreated
-        original_replace(source, destination)
+        source_moved = original_publish(source, destination)
         recreated = Path(source)
+        if not source_moved:
+            recreated.unlink()
         recreated.write_text("human replacement", encoding="utf-8")
+        return source_moved
 
     try:
-        monkeypatch.setattr(server.os, "replace", replace_then_recreate)
+        monkeypatch.setattr(
+            server, "_publish_spawn_tree_temp", publish_then_recreate
+        )
         saved = server._methods["spawn_tree.save"](
             "r1", {"session_id": "session-1", "subagents": [{"id": "a"}]}
         )
@@ -11822,5 +11831,141 @@ def test_spawn_tree_save_does_not_unlink_recreated_temp_name(tmp_path, monkeypat
         assert "result" in saved
         assert recreated is not None
         assert recreated.read_text(encoding="utf-8") == "human replacement"
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_spawn_tree_publish_never_replaces_existing_destination(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    original_publish = server._publish_spawn_tree_temp
+    collided = None
+
+    def create_destination_before_publish(source, destination):
+        nonlocal collided
+        collided = Path(destination)
+        collided.write_text("human destination", encoding="utf-8")
+        return original_publish(source, destination)
+
+    try:
+        monkeypatch.setattr(
+            server,
+            "_publish_spawn_tree_temp",
+            create_destination_before_publish,
+        )
+        saved = server._methods["spawn_tree.save"](
+            "r1", {"session_id": "session-1", "subagents": [{"id": "a"}]}
+        )
+
+        assert "error" in saved
+        assert collided is not None
+        assert collided.read_text(encoding="utf-8") == "human destination"
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_spawn_tree_publish_preserves_destination_replacement_after_link(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    original_publish = server._publish_spawn_tree_temp
+    destination = None
+
+    def replace_destination_after_publish(source, target):
+        nonlocal destination
+        source_moved = original_publish(source, target)
+        destination = Path(target)
+        destination.unlink()
+        destination.write_text("human replacement", encoding="utf-8")
+        return source_moved
+
+    try:
+        monkeypatch.setattr(
+            server,
+            "_publish_spawn_tree_temp",
+            replace_destination_after_publish,
+        )
+        saved = server._methods["spawn_tree.save"](
+            "r1", {"session_id": "session-1", "subagents": [{"id": "a"}]}
+        )
+
+        assert "error" in saved
+        assert destination is not None
+        preserved = [destination] if destination.exists() else []
+        preserved.extend(
+            destination.parent.glob(f".{destination.name}.hermes-delete-*")
+        )
+        assert any(
+            path.read_text(encoding="utf-8") == "human replacement"
+            for path in preserved
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_spawn_tree_failure_cleanup_preserves_temp_replacement(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    temp_path = None
+
+    def replace_temp_then_fail(source, destination):
+        nonlocal temp_path
+        temp_path = Path(source)
+        temp_path.unlink()
+        temp_path.write_text("human temp replacement", encoding="utf-8")
+        raise OSError("simulated publication failure")
+
+    try:
+        monkeypatch.setattr(
+            server, "_publish_spawn_tree_temp", replace_temp_then_fail
+        )
+        saved = server._methods["spawn_tree.save"](
+            "r1", {"session_id": "session-1", "subagents": [{"id": "a"}]}
+        )
+
+        assert "error" in saved
+        assert temp_path is not None
+        preserved = [temp_path] if temp_path.exists() else []
+        preserved.extend(
+            temp_path.parent.glob(f".{temp_path.name}.hermes-delete-*")
+        )
+        assert any(
+            path.read_text(encoding="utf-8") == "human temp replacement"
+            for path in preserved
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_spawn_tree_list_scans_for_snapshot_missing_from_valid_index(tmp_path):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    try:
+        first = server._methods["spawn_tree.save"](
+            "r1", {"session_id": "session-1", "subagents": [{"id": "a"}]}
+        )
+        session_dir = Path(first["result"]["path"]).parent
+        index = session_dir / server._SPAWN_TREE_INDEX
+        first_index_entry = index.read_text(encoding="utf-8")
+        second = server._methods["spawn_tree.save"](
+            "r2", {"session_id": "session-1", "subagents": [{"id": "b"}]}
+        )
+        # Simulate a transient append failure: the index remains valid but is
+        # missing the second successfully published snapshot.
+        index.write_text(first_index_entry, encoding="utf-8")
+
+        listed = server._methods["spawn_tree.list"](
+            "r3", {"session_id": "session-1"}
+        )
+
+        assert {entry["path"] for entry in listed["result"]["entries"]} == {
+            first["result"]["path"],
+            second["result"]["path"],
+        }
     finally:
         reset_hermes_home_override(token)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11481,3 +11481,46 @@ def test_spawn_tree_save_marks_session_and_does_not_overwrite_same_second(tmp_pa
         assert json.loads(second_path.read_text())["subagents"][0]["id"] == "b"
     finally:
         reset_hermes_home_override(token)
+
+
+def test_spawn_tree_refuses_foreign_session_directory(tmp_path):
+    """Save/list must not adopt or read a pre-existing unowned directory."""
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    try:
+        foreign = home / "spawn-trees" / "foreign-session"
+        foreign.mkdir(parents=True)
+        human = foreign / "human.json"
+        human.write_text('{"private": true}')
+
+        save = server._methods["spawn_tree.save"](
+            "r1",
+            {"session_id": "foreign-session", "subagents": [{"id": "a"}]},
+        )
+        listed = server._methods["spawn_tree.list"](
+            "r2", {"session_id": "foreign-session"}
+        )
+
+        assert "error" in save
+        assert listed["result"]["entries"] == []
+        assert human.read_text() == '{"private": true}'
+        assert not (foreign / ".hermes-managed").exists()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_spawn_tree_load_rejects_unowned_snapshot(tmp_path):
+    home = tmp_path / ".hermes"
+    token = set_hermes_home_override(home)
+    try:
+        foreign = home / "spawn-trees" / "foreign-session"
+        foreign.mkdir(parents=True)
+        human = foreign / "human.json"
+        human.write_text('{"private": true}')
+
+        loaded = server._methods["spawn_tree.load"]("r1", {"path": str(human)})
+
+        assert "error" in loaded
+        assert human.read_text() == '{"private": true}'
+    finally:
+        reset_hermes_home_override(token)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11454,3 +11454,30 @@ def test_get_usage_clamps_post_compression_sentinel():
     usage = server._get_usage(agent)
     assert "context_used" not in usage
     assert "context_percent" not in usage
+
+
+def test_spawn_tree_save_marks_session_and_does_not_overwrite_same_second(tmp_path):
+    """Generated spawn snapshots are owned and collision-resistant."""
+    token = set_hermes_home_override(tmp_path / ".hermes")
+    try:
+        finished_at = 1_800_000_000.25
+        save = server._methods["spawn_tree.save"]
+        first = save(
+            "r1",
+            {"session_id": "session-1", "finished_at": finished_at,
+             "subagents": [{"id": "a"}]},
+        )
+        second = save(
+            "r2",
+            {"session_id": "session-1", "finished_at": finished_at,
+             "subagents": [{"id": "b"}]},
+        )
+
+        first_path = Path(first["result"]["path"])
+        second_path = Path(second["result"]["path"])
+        assert first_path != second_path
+        assert (first_path.parent / ".hermes-managed").read_text() == "spawn-trees\n"
+        assert json.loads(first_path.read_text())["subagents"][0]["id"] == "a"
+        assert json.loads(second_path.read_text())["subagents"][0]["id"] == "b"
+    finally:
+        reset_hermes_home_override(token)

--- a/tests/tools/test_file_sync_windows.py
+++ b/tests/tools/test_file_sync_windows.py
@@ -1,5 +1,6 @@
 """Cross-platform file-sync locking contracts."""
 
+import errno
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -188,6 +189,42 @@ def test_sync_back_uses_windows_lock_when_fcntl_is_unavailable(tmp_path, monkeyp
         fake_msvcrt.LK_LOCK,
         fake_msvcrt.LK_UNLCK,
     ]
+
+
+def test_sync_back_waits_past_windows_lock_retry_window(tmp_path, monkeypatch):
+    attempts = 0
+
+    def contended_lock(_fd, mode, _size):
+        nonlocal attempts
+        if mode == 1:
+            attempts += 1
+            if attempts <= 4:
+                raise PermissionError(errno.EACCES, "lock is still owned")
+
+    real_get_osfhandle = getattr(file_sync.msvcrt, "get_osfhandle", lambda fd: fd)
+    fake_msvcrt = SimpleNamespace(
+        LK_LOCK=1,
+        LK_UNLCK=2,
+        locking=contended_lock,
+        get_osfhandle=real_get_osfhandle,
+    )
+    monkeypatch.setattr(file_sync, "fcntl", None)
+    monkeypatch.setattr(file_sync, "msvcrt", fake_msvcrt)
+    monkeypatch.setattr(file_sync, "_sleep", MagicMock())
+
+    manager = FileSyncManager(
+        get_files_fn=lambda: [],
+        upload_fn=MagicMock(),
+        delete_fn=MagicMock(),
+        bulk_download_fn=lambda destination: None,
+    )
+    manager._sync_back_impl = MagicMock()
+
+    manager._sync_back_locked(tmp_path / ".hermes" / ".sync.lock")
+
+    assert attempts == 5
+    assert file_sync._sleep.call_count == 4
+    manager._sync_back_impl.assert_called_once_with()
 
 
 def test_sync_back_refuses_hardlinked_lock_without_modifying_target(

--- a/tests/tools/test_file_sync_windows.py
+++ b/tests/tools/test_file_sync_windows.py
@@ -1,21 +1,173 @@
 """Cross-platform file-sync locking contracts."""
 
+import os
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 from tools.environments import file_sync
-from tools.environments.file_sync import FileSyncManager
+from tools.environments.file_sync import FileSyncManager, _open_owned_sync_lock
+
+
+def test_created_lock_junction_open_restore_writes_no_external_bytes(
+    tmp_path, monkeypatch
+):
+    lock_path = tmp_path / "locks" / ".sync.lock"
+    lock_path.parent.mkdir()
+    external_dir = tmp_path / "external"
+    external_dir.mkdir()
+    external = external_dir / lock_path.name
+    real_open = file_sync.os.open
+    real_remove = file_sync._remove_created_sync_lock
+    external_before_cleanup = []
+
+    def junction_open(path, flags, *args, **kwargs):
+        if Path(path) == lock_path and flags & os.O_EXCL:
+            fd = real_open(external, flags, *args, **kwargs)
+            # Model restoring the original parent/path after the redirected open.
+            lock_path.write_bytes(b"human replacement")
+            return fd
+        return real_open(path, flags, *args, **kwargs)
+
+    def observe_remove(path, expected):
+        if Path(path) == external:
+            external_before_cleanup.append(external.read_bytes())
+        return real_remove(path, expected)
+
+    monkeypatch.setattr(file_sync.os, "open", junction_open)
+    monkeypatch.setattr(file_sync, "_opened_lock_path", lambda _fd: external)
+    monkeypatch.setattr(file_sync, "_remove_created_sync_lock", observe_remove)
+
+    with pytest.raises(OSError, match="provenance changed"):
+        _open_owned_sync_lock(lock_path)
+
+    assert external_before_cleanup == [b""]
+    assert not external.exists()
+    assert lock_path.read_bytes() == b"human replacement"
+
+
+def test_created_lock_cleanup_preserves_nonempty_opened_object(
+    tmp_path, monkeypatch
+):
+    lock_path = tmp_path / "locks" / ".sync.lock"
+    lock_path.parent.mkdir()
+    external_dir = tmp_path / "external"
+    external_dir.mkdir()
+    external = external_dir / lock_path.name
+    real_open = file_sync.os.open
+
+    def junction_open(path, flags, *args, **kwargs):
+        if Path(path) == lock_path and flags & os.O_EXCL:
+            fd = real_open(external, flags, *args, **kwargs)
+            os.write(fd, b"foreign")
+            lock_path.write_bytes(b"human replacement")
+            return fd
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(file_sync.os, "open", junction_open)
+    monkeypatch.setattr(file_sync, "_opened_lock_path", lambda _fd: external)
+
+    with pytest.raises(OSError, match="provenance changed"):
+        _open_owned_sync_lock(lock_path)
+
+    assert external.read_bytes() == b"foreign"
+    assert lock_path.read_bytes() == b"human replacement"
+
+
+def test_created_lock_race_winner_is_opened_without_replacement(
+    tmp_path, monkeypatch
+):
+    lock_path = tmp_path / "locks" / ".sync.lock"
+    real_open = file_sync.os.open
+    injected = False
+
+    def race_open(path, flags, *args, **kwargs):
+        nonlocal injected
+        if Path(path) == lock_path and flags & os.O_EXCL and not injected:
+            injected = True
+            lock_path.write_bytes(b"human winner")
+            raise FileExistsError(str(lock_path))
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(file_sync.os, "open", race_open)
+
+    with _open_owned_sync_lock(lock_path):
+        pass
+
+    assert lock_path.read_bytes() == b"human winner"
+
+
+def test_created_lock_fstat_failure_closes_descriptor(tmp_path, monkeypatch):
+    lock_path = tmp_path / "locks" / ".sync.lock"
+    real_open = file_sync.os.open
+    real_fstat = file_sync.os.fstat
+    opened_fd = None
+
+    def tracked_open(path, flags, *args, **kwargs):
+        nonlocal opened_fd
+        fd = real_open(path, flags, *args, **kwargs)
+        if Path(path) == lock_path:
+            opened_fd = fd
+        return fd
+
+    def failed_fstat(fd):
+        if fd == opened_fd:
+            raise OSError("injected fstat failure")
+        return real_fstat(fd)
+
+    monkeypatch.setattr(file_sync.os, "open", tracked_open)
+    monkeypatch.setattr(file_sync.os, "fstat", failed_fstat)
+
+    with pytest.raises(OSError, match="injected fstat failure"):
+        _open_owned_sync_lock(lock_path)
+
+    assert opened_fd is not None
+    with pytest.raises(OSError):
+        real_fstat(opened_fd)
+
+
+def test_created_lock_fdopen_failure_closes_and_removes_empty_file(
+    tmp_path, monkeypatch
+):
+    lock_path = tmp_path / "locks" / ".sync.lock"
+    real_open = file_sync.os.open
+    real_fstat = file_sync.os.fstat
+    opened_fd = None
+
+    def tracked_open(path, flags, *args, **kwargs):
+        nonlocal opened_fd
+        fd = real_open(path, flags, *args, **kwargs)
+        if Path(path) == lock_path:
+            opened_fd = fd
+        return fd
+
+    monkeypatch.setattr(file_sync.os, "open", tracked_open)
+    monkeypatch.setattr(
+        file_sync.os,
+        "fdopen",
+        MagicMock(side_effect=OSError("injected fdopen failure")),
+    )
+
+    with pytest.raises(OSError, match="injected fdopen failure"):
+        _open_owned_sync_lock(lock_path)
+
+    assert opened_fd is not None
+    with pytest.raises(OSError):
+        real_fstat(opened_fd)
+    assert not lock_path.exists()
 
 
 def test_sync_back_uses_windows_lock_when_fcntl_is_unavailable(tmp_path, monkeypatch):
     """Windows sync-back must serialize instead of silently skipping the lock."""
     lock_calls = []
+    real_get_osfhandle = getattr(file_sync.msvcrt, "get_osfhandle", lambda fd: fd)
     fake_msvcrt = SimpleNamespace(
         LK_LOCK=1,
         LK_UNLCK=2,
         locking=lambda fd, mode, size: lock_calls.append((fd, mode, size)),
+        get_osfhandle=real_get_osfhandle,
     )
     monkeypatch.setattr(file_sync, "fcntl", None)
     monkeypatch.setattr(file_sync, "msvcrt", fake_msvcrt)

--- a/tests/tools/test_file_sync_windows.py
+++ b/tests/tools/test_file_sync_windows.py
@@ -1,0 +1,36 @@
+"""Cross-platform file-sync locking contracts."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from tools.environments import file_sync
+from tools.environments.file_sync import FileSyncManager
+
+
+def test_sync_back_uses_windows_lock_when_fcntl_is_unavailable(tmp_path, monkeypatch):
+    """Windows sync-back must serialize instead of silently skipping the lock."""
+    lock_calls = []
+    fake_msvcrt = SimpleNamespace(
+        LK_LOCK=1,
+        LK_UNLCK=2,
+        locking=lambda fd, mode, size: lock_calls.append((fd, mode, size)),
+    )
+    monkeypatch.setattr(file_sync, "fcntl", None)
+    monkeypatch.setattr(file_sync, "msvcrt", fake_msvcrt)
+
+    host_file = tmp_path / "skill.md"
+    host_file.write_text("host")
+    mapping = [(str(host_file), "/root/.hermes/skill.md")]
+    manager = FileSyncManager(
+        get_files_fn=lambda: mapping,
+        upload_fn=MagicMock(),
+        delete_fn=MagicMock(),
+        bulk_download_fn=lambda destination: None,
+    )
+    manager._sync_back_impl = MagicMock()
+    manager._sync_back_locked(tmp_path / ".hermes" / ".sync.lock")
+
+    assert [mode for _fd, mode, _size in lock_calls] == [
+        fake_msvcrt.LK_LOCK,
+        fake_msvcrt.LK_UNLCK,
+    ]

--- a/tests/tools/test_file_sync_windows.py
+++ b/tests/tools/test_file_sync_windows.py
@@ -3,6 +3,8 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from tools.environments import file_sync
 from tools.environments.file_sync import FileSyncManager
 
@@ -34,3 +36,36 @@ def test_sync_back_uses_windows_lock_when_fcntl_is_unavailable(tmp_path, monkeyp
         fake_msvcrt.LK_LOCK,
         fake_msvcrt.LK_UNLCK,
     ]
+
+
+def test_sync_back_refuses_hardlinked_lock_without_modifying_target(
+    tmp_path, monkeypatch
+):
+    external = tmp_path / "operator.txt"
+    external.write_bytes(b"")
+    lock_path = tmp_path / ".hermes" / ".sync.lock"
+    lock_path.parent.mkdir()
+    try:
+        lock_path.hardlink_to(external)
+    except OSError as exc:
+        pytest.skip(f"hardlinks unavailable: {exc}")
+
+    monkeypatch.setattr(file_sync, "fcntl", None)
+    monkeypatch.setattr(
+        file_sync,
+        "msvcrt",
+        SimpleNamespace(LK_LOCK=1, LK_UNLCK=2, locking=MagicMock()),
+    )
+    manager = FileSyncManager(
+        get_files_fn=lambda: [],
+        upload_fn=MagicMock(),
+        delete_fn=MagicMock(),
+        bulk_download_fn=lambda destination: None,
+    )
+    manager._sync_back_impl = MagicMock()
+
+    with pytest.raises(OSError, match="not exclusively owned"):
+        manager._sync_back_locked(lock_path)
+
+    assert external.read_bytes() == b""
+    manager._sync_back_impl.assert_not_called()

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -376,11 +376,16 @@ def test_write_file_reports_creation_provenance_only_for_new_target(
         "test_created.py", "hello\n", task_id="t1"
     ))
     assert created.get("created_paths") == [str(new_path.resolve())]
+    assert created.get("created_path_identities") == [{
+        "path": str(new_path.resolve()),
+        "identity": ft._local_path_identity(str(new_path.resolve())),
+    }]
 
     overwritten = json.loads(ft.write_file_tool(
         "test_created.py", "changed\n", task_id="t1"
     ))
     assert "created_paths" not in overwritten
+    assert "created_path_identities" not in overwritten
 
 
 def test_write_file_creation_probe_occurs_inside_path_lock(

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -362,6 +362,26 @@ def test_write_file_reports_resolved_absolute_path(_isolated_cwd, monkeypatch):
     assert (workspace / "newfile.txt").read_text() == "hello\n"
 
 
+def test_write_file_reports_creation_provenance_only_for_new_target(
+    _isolated_cwd, monkeypatch
+):
+    """Creation metadata distinguishes a new file from an overwrite."""
+    workspace, decoy = _isolated_cwd
+    terminal_tool.record_session_cwd("t1", str(workspace))
+
+    import json
+    new_path = workspace / "test_created.py"
+    created = json.loads(ft.write_file_tool(
+        "test_created.py", "hello\n", task_id="t1"
+    ))
+    assert created.get("created_paths") == [str(new_path.resolve())]
+
+    overwritten = json.loads(ft.write_file_tool(
+        "test_created.py", "changed\n", task_id="t1"
+    ))
+    assert "created_paths" not in overwritten
+
+
 def test_patch_reports_resolved_absolute_path(_isolated_cwd, monkeypatch):
     """patch_tool (replace mode) must put the absolute on-disk path in files_modified."""
     workspace, decoy = _isolated_cwd

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -16,6 +16,7 @@ Core invariant these tests pin:
 """
 
 import os
+from contextlib import contextmanager
 from pathlib import Path, PurePosixPath
 
 import pytest
@@ -380,6 +381,32 @@ def test_write_file_reports_creation_provenance_only_for_new_target(
         "test_created.py", "changed\n", task_id="t1"
     ))
     assert "created_paths" not in overwritten
+
+
+def test_write_file_creation_probe_occurs_inside_path_lock(
+    _isolated_cwd, monkeypatch
+):
+    """A sibling write that wins the lock cannot be labeled as our creation."""
+    workspace, _decoy = _isolated_cwd
+    terminal_tool.record_session_cwd("t1", str(workspace))
+    target = workspace / "test_raced.py"
+    original_lock = ft.file_state.lock_path
+
+    @contextmanager
+    def create_before_locked_write(path):
+        with original_lock(path):
+            Path(path).write_text("sibling content")
+            yield
+
+    monkeypatch.setattr(ft.file_state, "lock_path", create_before_locked_write)
+
+    import json
+    result = json.loads(ft.write_file_tool(
+        "test_raced.py", "agent content", task_id="t1"
+    ))
+
+    assert "created_paths" not in result
+    assert target.read_text() == "agent content"
 
 
 def test_patch_reports_resolved_absolute_path(_isolated_cwd, monkeypatch):

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -414,6 +414,45 @@ def test_write_file_creation_probe_occurs_inside_path_lock(
     assert target.read_text() == "agent content"
 
 
+def test_write_file_does_not_adopt_post_write_pathname_replacement(
+    _isolated_cwd, monkeypatch
+):
+    """Creation evidence stays bound to the inode published by the writer."""
+    from tools.file_operations import WriteResult
+
+    workspace, _decoy = _isolated_cwd
+    terminal_tool.record_session_cwd("t1", str(workspace))
+    target = workspace / "test_replaced_after_write.py"
+    created_identity = None
+
+    class ReplacingFileOps:
+        def write_file(self, path, content):
+            nonlocal created_identity
+            Path(path).write_text(content)
+            created_identity = ft._local_path_identity(path)
+            Path(path).unlink()
+            Path(path).write_text("human replacement")
+            return WriteResult(
+                bytes_written=len(content.encode()),
+                filesystem_identity=created_identity,
+            )
+
+    monkeypatch.setattr(ft, "_get_file_ops", lambda _task_id: ReplacingFileOps())
+
+    import json
+    result = json.loads(
+        ft.write_file_tool(
+            "test_replaced_after_write.py", "agent content", task_id="t1"
+        )
+    )
+
+    assert result["created_path_identities"][0]["identity"] == created_identity
+    assert result["created_path_identities"][0]["identity"] != (
+        ft._local_path_identity(str(target))
+    )
+    assert target.read_text() == "human replacement"
+
+
 def test_patch_reports_resolved_absolute_path(_isolated_cwd, monkeypatch):
     """patch_tool (replace mode) must put the absolute on-disk path in files_modified."""
     workspace, decoy = _isolated_cwd

--- a/tests/tools/test_hook_output_spill.py
+++ b/tests/tools/test_hook_output_spill.py
@@ -175,7 +175,7 @@ class SpillIfOversizedTests(unittest.TestCase):
         big = "w" * 500
         # Point at a path that cannot be created (a file, not a dir).
         existing_file = os.path.join(self.tmpdir, "not-a-dir")
-        with open(existing_file, "w") as f:
+        with open(existing_file, "w", encoding="utf-8") as f:
             f.write("blocker")
         cfg = self._cfg(max_chars=10, directory=existing_file)
         result = hos.spill_if_oversized(big, session_id="x", config=cfg)
@@ -251,7 +251,7 @@ class SpillIfOversizedTests(unittest.TestCase):
         os.utime(spill, (old_time, old_time))
         selected = spill.lstat()
 
-        checks = iter((True, True, True, False))
+        checks = iter((True, True, True, False, True, True))
         with patch.object(
             hos.os.path,
             "samestat",
@@ -260,14 +260,42 @@ class SpillIfOversizedTests(unittest.TestCase):
             removed = hos._atomic_unlink_spill(spill, selected)
 
         self.assertFalse(removed)
-        self.assertFalse(spill.exists())
+        self.assertEqual(spill.read_text(), "preserve")
         quarantines = [
             path
             for path in spill.parent.iterdir()
             if hos._DELETE_QUARANTINE_TOKEN in path.name
         ]
-        self.assertEqual(len(quarantines), 1)
-        self.assertEqual(quarantines[0].read_text(), "preserve")
+        self.assertEqual(quarantines, [])
+
+    def test_atomic_unlink_restores_replacement_racing_quarantine(self):
+        spill = Path(self.tmpdir) / "sess" / "old.txt"
+        spill.parent.mkdir()
+        spill.write_text("owned")
+        selected = spill.lstat()
+        real_replace = hos.os.replace
+        injected = False
+
+        def replace_after_validation(source, destination, *args, **kwargs):
+            nonlocal injected
+            if not injected and Path(source) == spill:
+                injected = True
+                spill.unlink()
+                spill.write_text("human replacement")
+            return real_replace(source, destination, *args, **kwargs)
+
+        with patch.object(hos.os, "replace", side_effect=replace_after_validation):
+            removed = hos._atomic_unlink_spill(spill, selected)
+
+        self.assertTrue(injected)
+        self.assertFalse(removed)
+        self.assertEqual(spill.read_text(), "human replacement")
+        self.assertFalse(
+            any(
+                hos._DELETE_QUARANTINE_TOKEN in child.name
+                for child in spill.parent.iterdir()
+            )
+        )
 
     def test_prune_preserves_replacement_after_retention_selection(self):
         spill = Path(self.tmpdir) / "sess" / "old.txt"

--- a/tests/tools/test_hook_output_spill.py
+++ b/tests/tools/test_hook_output_spill.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import subprocess
 import tempfile
 import types
 import unittest
@@ -11,6 +12,18 @@ from pathlib import Path
 from unittest.mock import patch
 
 from tools import hook_output_spill as hos
+
+
+def _make_directory_link(link: Path, target: Path) -> None:
+    if os.name == "nt":
+        subprocess.run(
+            ["cmd.exe", "/d", "/c", "mklink", "/J", str(link), str(target)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    else:
+        link.symlink_to(target, target_is_directory=True)
 
 
 class GetSpillConfigTests(unittest.TestCase):
@@ -519,6 +532,98 @@ class SpillIfOversizedTests(unittest.TestCase):
         self.assertFalse(session.exists())
         self.assertTrue(hos._prepare_owned_spill_dir(session))
         self.assertTrue(hos._is_owned_spill_dir(session))
+
+    def test_publication_rejects_regular_directory_replacement_before_write(self):
+        session = Path(self.tmpdir) / "replace-before-write"
+        displaced = Path(self.tmpdir) / "owned-displaced"
+        real_open = hos.os.open
+        injected = False
+
+        def replace_on_spill_open(path, flags, *args, **kwargs):
+            nonlocal injected
+            selected = Path(path)
+            if flags & os.O_CREAT and selected.suffix == ".txt" and not injected:
+                injected = True
+                session.rename(displaced)
+                session.mkdir()
+                (session / ".hermes-managed").write_text("hook_outputs\n")
+                (session / "human.txt").write_text("keep")
+            return real_open(path, flags, *args, **kwargs)
+
+        with patch.object(hos.os, "open", side_effect=replace_on_spill_open):
+            result = hos.spill_if_oversized(
+                "secret" * 100,
+                session_id=session.name,
+                config=self._cfg(max_chars=10),
+            )
+
+        self.assertIn("spill write failed", result)
+        self.assertEqual((session / "human.txt").read_text(), "keep")
+        self.assertEqual(list(session.glob("*.txt")), [session / "human.txt"])
+        self.assertTrue(hos._is_owned_spill_dir(displaced))
+
+    def test_publication_rejects_directory_junction_before_write(self):
+        session = Path(self.tmpdir) / "junction-before-write"
+        displaced = Path(self.tmpdir) / "junction-owned-displaced"
+        foreign = Path(self.tmpdir) / "foreign-target"
+        foreign.mkdir()
+        (foreign / ".hermes-managed").write_text("hook_outputs\n")
+        (foreign / "human.txt").write_text("keep")
+        probe = Path(self.tmpdir) / "directory-link-probe"
+        try:
+            _make_directory_link(probe, foreign)
+        except (OSError, subprocess.CalledProcessError) as exc:
+            self.skipTest(f"directory link unavailable on this host: {exc}")
+        if probe.is_symlink():
+            probe.unlink()
+        else:
+            probe.rmdir()
+        real_open = hos.os.open
+        injected = False
+
+        def replace_with_link_on_spill_open(path, flags, *args, **kwargs):
+            nonlocal injected
+            selected = Path(path)
+            if flags & os.O_CREAT and selected.suffix == ".txt" and not injected:
+                injected = True
+                session.rename(displaced)
+                _make_directory_link(session, foreign)
+            return real_open(path, flags, *args, **kwargs)
+
+        with patch.object(hos.os, "open", side_effect=replace_with_link_on_spill_open):
+            result = hos.spill_if_oversized(
+                "secret" * 100,
+                session_id=session.name,
+                config=self._cfg(max_chars=10),
+            )
+
+        self.assertIn("spill write failed", result)
+        self.assertEqual((foreign / "human.txt").read_text(), "keep")
+        self.assertEqual(list(foreign.glob("*.txt")), [foreign / "human.txt"])
+        self.assertTrue(hos._is_owned_spill_dir(displaced))
+
+    def test_exclusive_publication_preserves_filename_race_winner(self):
+        session = Path(self.tmpdir) / "collision"
+        self.assertTrue(hos._prepare_owned_spill_dir(session))
+        winner = session / f"{'a' * 32}.txt"
+        winner.write_text("winner")
+        uuids = [
+            types.SimpleNamespace(hex="a" * 32),
+            types.SimpleNamespace(hex="b" * 32),
+        ]
+
+        with patch.object(hos.uuid, "uuid4", side_effect=uuids):
+            result = hos.spill_if_oversized(
+                "payload" * 100,
+                session_id=session.name,
+                config=self._cfg(max_chars=10),
+            )
+
+        published = session / f"{'b' * 32}.txt"
+        self.assertNotIn("spill write failed", result)
+        self.assertEqual(winner.read_text(), "winner")
+        self.assertTrue(published.exists())
+        self.assertIn(str(published), result)
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_hook_output_spill.py
+++ b/tests/tools/test_hook_output_spill.py
@@ -234,6 +234,70 @@ class SpillIfOversizedTests(unittest.TestCase):
         self.assertEqual(spill.read_text(), "preserve")
         self.assertEqual(list(spill.parent.glob("*.hermes-delete-*")), [])
 
+    def test_prune_preserves_replacement_after_retention_selection(self):
+        spill = Path(self.tmpdir) / "sess" / "old.txt"
+        spill.parent.mkdir()
+        (spill.parent / ".hermes-managed").write_text("hook_outputs\n")
+        spill.write_text("owned")
+        old_time = os.path.getmtime(spill) - 100
+        os.utime(spill, (old_time, old_time))
+        real_unlink = hos._atomic_unlink_spill
+
+        def replace_before_unlink(path, expected):
+            path.unlink()
+            path.write_text("human replacement")
+            return real_unlink(path, expected)
+
+        with patch.object(hos, "_atomic_unlink_spill", side_effect=replace_before_unlink):
+            removed = hos.prune_spill_files(self.tmpdir, retention_seconds=1)
+
+        self.assertEqual(removed, 0)
+        self.assertEqual(spill.read_text(), "human replacement")
+
+    def test_atomic_unlink_rejects_non_regular_opened_object(self):
+        spill = Path(self.tmpdir) / "sess" / "old.txt"
+        spill.parent.mkdir()
+        spill.write_text("preserve")
+        selected = spill.lstat()
+
+        with patch.object(hos.os, "fstat", return_value=spill.parent.stat()):
+            removed = hos._atomic_unlink_spill(spill, selected)
+
+        self.assertFalse(removed)
+        self.assertEqual(spill.read_text(), "preserve")
+
+    def test_failed_final_unlink_preserves_and_excludes_quarantine(self):
+        spill = Path(self.tmpdir) / "sess" / "old.txt"
+        spill.parent.mkdir()
+        (spill.parent / ".hermes-managed").write_text("hook_outputs\n")
+        spill.write_text("preserve")
+        old_time = os.path.getmtime(spill) - 100
+        os.utime(spill, (old_time, old_time))
+        real_unlink = Path.unlink
+
+        def fail_quarantine_unlink(path, *args, **kwargs):
+            if hos._DELETE_QUARANTINE_TOKEN in path.name:
+                raise PermissionError("simulated live handle")
+            return real_unlink(path, *args, **kwargs)
+
+        with patch.object(Path, "unlink", fail_quarantine_unlink):
+            removed = hos.prune_spill_files(self.tmpdir, retention_seconds=1)
+
+        quarantines = [
+            path
+            for path in spill.parent.iterdir()
+            if hos._DELETE_QUARANTINE_TOKEN in path.name
+        ]
+        self.assertEqual(removed, 0)
+        self.assertEqual(len(quarantines), 1)
+        self.assertEqual(quarantines[0].read_text(), "preserve")
+
+        self.assertEqual(
+            hos.prune_spill_files(self.tmpdir, retention_seconds=1),
+            0,
+        )
+        self.assertEqual(quarantines[0].read_text(), "preserve")
+
     def test_prune_preserves_unmarked_session_directory(self):
         session = Path(self.tmpdir) / "human-session"
         session.mkdir()

--- a/tests/tools/test_hook_output_spill.py
+++ b/tests/tools/test_hook_output_spill.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -226,13 +228,25 @@ class SpillIfOversizedTests(unittest.TestCase):
         spill.write_text("preserve")
         old_time = os.path.getmtime(spill) - 100
         os.utime(spill, (old_time, old_time))
+        selected = spill.lstat()
 
-        with patch.object(hos.os.path, "samestat", return_value=False):
-            removed = hos.prune_spill_files(self.tmpdir, retention_seconds=1)
+        checks = iter((True, True, True, False))
+        with patch.object(
+            hos.os.path,
+            "samestat",
+            side_effect=lambda _left, _right: next(checks),
+        ):
+            removed = hos._atomic_unlink_spill(spill, selected)
 
-        self.assertEqual(removed, 0)
-        self.assertEqual(spill.read_text(), "preserve")
-        self.assertEqual(list(spill.parent.glob("*.hermes-delete-*")), [])
+        self.assertFalse(removed)
+        self.assertFalse(spill.exists())
+        quarantines = [
+            path
+            for path in spill.parent.iterdir()
+            if hos._DELETE_QUARANTINE_TOKEN in path.name
+        ]
+        self.assertEqual(len(quarantines), 1)
+        self.assertEqual(quarantines[0].read_text(), "preserve")
 
     def test_prune_preserves_replacement_after_retention_selection(self):
         spill = Path(self.tmpdir) / "sess" / "old.txt"
@@ -253,6 +267,90 @@ class SpillIfOversizedTests(unittest.TestCase):
 
         self.assertEqual(removed, 0)
         self.assertEqual(spill.read_text(), "human replacement")
+
+    def test_prune_preserves_replaced_owned_session(self):
+        session = Path(self.tmpdir) / "sess"
+        session.mkdir()
+        (session / ".hermes-managed").write_text("hook_outputs\n")
+        (session / "owned.txt").write_text("owned")
+        displaced = session.with_name("session-selected-before-race")
+        real_owned = hos._is_owned_spill_dir
+        injected = False
+
+        def replace_after_marker(path):
+            nonlocal injected
+            owned = real_owned(path)
+            if path == session and owned and not injected:
+                injected = True
+                path.rename(displaced)
+                path.mkdir()
+                (path / ".hermes-managed").write_text("hook_outputs\n")
+                human = path / "human.txt"
+                human.write_text("keep")
+                old = os.path.getmtime(human) - 100
+                os.utime(human, (old, old))
+            return owned
+
+        with patch.object(hos, "_is_owned_spill_dir", side_effect=replace_after_marker):
+            removed = hos.prune_spill_files(self.tmpdir, retention_seconds=1)
+
+        self.assertEqual(removed, 0)
+        self.assertEqual((session / "human.txt").read_text(), "keep")
+        self.assertEqual((displaced / "owned.txt").read_text(), "owned")
+
+    def test_prune_rejects_windows_reparse_root(self):
+        root = Path(self.tmpdir)
+        human = root / "human.txt"
+        human.write_text("keep")
+        real_lstat = Path.lstat
+
+        def lstat_with_reparse(path):
+            result = real_lstat(path)
+            if path == root:
+                return types.SimpleNamespace(
+                    st_mode=result.st_mode,
+                    st_file_attributes=0x400,
+                )
+            return result
+
+        with patch.object(Path, "lstat", lstat_with_reparse):
+            removed = hos.prune_spill_files(root, retention_seconds=1)
+
+        self.assertEqual(removed, 0)
+        self.assertEqual(human.read_text(), "keep")
+
+    def test_prune_preserves_replaced_spill_root(self):
+        root = Path(self.tmpdir)
+        original_session = root / "original"
+        original_session.mkdir()
+        (original_session / ".hermes-managed").write_text("hook_outputs\n")
+        displaced = root.with_name(f"{root.name}-selected-before-race")
+        real_iterdir = Path.iterdir
+        injected = False
+
+        def replace_during_root_listing(path):
+            nonlocal injected
+            if path == root and not injected:
+                injected = True
+                path.rename(displaced)
+                replacement = path / "human-session"
+                replacement.mkdir(parents=True)
+                (replacement / ".hermes-managed").write_text("hook_outputs\n")
+                human = replacement / "human.txt"
+                human.write_text("keep")
+                old = os.path.getmtime(human) - 100
+                os.utime(human, (old, old))
+            return real_iterdir(path)
+
+        with patch.object(Path, "iterdir", replace_during_root_listing):
+            removed = hos.prune_spill_files(root, retention_seconds=1)
+
+        self.assertEqual(removed, 0)
+        self.assertEqual(
+            (root / "human-session" / "human.txt").read_text(),
+            "keep",
+        )
+        shutil.rmtree(displaced)
 
     def test_atomic_unlink_rejects_non_regular_opened_object(self):
         spill = Path(self.tmpdir) / "sess" / "old.txt"

--- a/tests/tools/test_hook_output_spill.py
+++ b/tests/tools/test_hook_output_spill.py
@@ -26,6 +26,10 @@ class GetSpillConfigTests(unittest.TestCase):
         self.assertEqual(cfg["preview_head"], hos.DEFAULT_PREVIEW_HEAD)
         self.assertEqual(cfg["preview_tail"], hos.DEFAULT_PREVIEW_TAIL)
         self.assertIsNone(cfg["directory"])
+        self.assertEqual(cfg["retention_seconds"], hos.DEFAULT_RETENTION_SECONDS)
+        self.assertEqual(
+            cfg["max_files_per_session"], hos.DEFAULT_MAX_FILES_PER_SESSION
+        )
 
     def test_user_overrides_are_respected(self):
         user_cfg = {
@@ -36,6 +40,8 @@ class GetSpillConfigTests(unittest.TestCase):
                     "preview_head": 25,
                     "preview_tail": 10,
                     "directory": "/tmp/spill-test",
+                    "retention_seconds": 3600,
+                    "max_files_per_session": 25,
                 }
             }
         }
@@ -46,6 +52,8 @@ class GetSpillConfigTests(unittest.TestCase):
         self.assertEqual(cfg["preview_head"], 25)
         self.assertEqual(cfg["preview_tail"], 10)
         self.assertEqual(cfg["directory"], "/tmp/spill-test")
+        self.assertEqual(cfg["retention_seconds"], 3600)
+        self.assertEqual(cfg["max_files_per_session"], 25)
 
     def test_bad_values_fall_back_to_defaults(self):
         user_cfg = {
@@ -442,7 +450,7 @@ class SpillIfOversizedTests(unittest.TestCase):
         self.assertEqual(removed, 0)
         self.assertEqual(human.read_text(), "keep")
 
-    def test_spill_refuses_to_adopt_preexisting_unmarked_session(self):
+    def test_spill_routes_around_preexisting_unmarked_legacy_session(self):
         session = Path(self.tmpdir) / "existing-session"
         session.mkdir()
         human = session / "human-notes.txt"
@@ -454,10 +462,47 @@ class SpillIfOversizedTests(unittest.TestCase):
             config=self._cfg(max_chars=10),
         )
 
-        self.assertIn("spill write failed", result)
+        self.assertNotIn("spill write failed", result)
         self.assertEqual(human.read_text(), "keep")
         self.assertFalse((session / ".hermes-managed").exists())
         self.assertEqual(list(session.glob("*.txt")), [human])
+        v2_dirs = [
+            path
+            for path in Path(self.tmpdir).iterdir()
+            if path.name.startswith("s-") and path.is_dir()
+        ]
+        self.assertEqual(len(v2_dirs), 1)
+        spills = list(v2_dirs[0].glob("*.txt"))
+        self.assertEqual(len(spills), 1)
+        self.assertIn(str(spills[0]), result)
+        self.assertEqual(
+            (v2_dirs[0] / ".hermes-managed").read_text().strip(),
+            f"hook_outputs:v2:{v2_dirs[0].name}",
+        )
+
+    def test_spill_retries_when_first_v2_name_is_foreign(self):
+        session_id = "existing-session"
+        legacy = Path(self.tmpdir) / session_id
+        legacy.mkdir()
+        (legacy / "legacy.txt").write_text("keep")
+        first_v2 = next(hos._spill_v2_candidates(Path(self.tmpdir), session_id))
+        first_v2.mkdir()
+        human = first_v2 / "human.txt"
+        human.write_text("keep too")
+
+        result = hos.spill_if_oversized(
+            "x" * 500,
+            session_id=session_id,
+            config=self._cfg(max_chars=10),
+        )
+
+        self.assertNotIn("spill write failed", result)
+        self.assertEqual((legacy / "legacy.txt").read_text(), "keep")
+        self.assertEqual(human.read_text(), "keep too")
+        second_v2 = first_v2.with_name(f"{first_v2.name}-1")
+        spills = list(second_v2.glob("*.txt"))
+        self.assertEqual(len(spills), 1)
+        self.assertIn(str(spills[0]), result)
 
     def test_failed_marker_creation_does_not_poison_new_session_path(self):
         session = Path(self.tmpdir) / "retryable-session"

--- a/tests/tools/test_hook_output_spill.py
+++ b/tests/tools/test_hook_output_spill.py
@@ -219,6 +219,21 @@ class SpillIfOversizedTests(unittest.TestCase):
         self.assertFalse(old.exists())
         self.assertTrue(recent.exists())
 
+    def test_prune_preserves_file_when_delete_identity_changes(self):
+        spill = Path(self.tmpdir) / "sess" / "old.txt"
+        spill.parent.mkdir()
+        (spill.parent / ".hermes-managed").write_text("hook_outputs\n")
+        spill.write_text("preserve")
+        old_time = os.path.getmtime(spill) - 100
+        os.utime(spill, (old_time, old_time))
+
+        with patch.object(hos.os.path, "samestat", return_value=False):
+            removed = hos.prune_spill_files(self.tmpdir, retention_seconds=1)
+
+        self.assertEqual(removed, 0)
+        self.assertEqual(spill.read_text(), "preserve")
+        self.assertEqual(list(spill.parent.glob("*.hermes-delete-*")), [])
+
     def test_prune_preserves_unmarked_session_directory(self):
         session = Path(self.tmpdir) / "human-session"
         session.mkdir()

--- a/tests/tools/test_hook_output_spill.py
+++ b/tests/tools/test_hook_output_spill.py
@@ -122,7 +122,7 @@ class SpillIfOversizedTests(unittest.TestCase):
         # Spill file exists under the session subdir and has full content.
         session_dir = Path(self.tmpdir) / "sess-123"
         self.assertTrue(session_dir.is_dir())
-        files = list(session_dir.iterdir())
+        files = list(session_dir.glob("*.txt"))
         self.assertEqual(len(files), 1)
         self.assertEqual(files[0].read_text().rstrip("\n"), big)
         # Preview references the spill path.
@@ -218,6 +218,69 @@ class SpillIfOversizedTests(unittest.TestCase):
 
         self.assertFalse(old.exists())
         self.assertTrue(recent.exists())
+
+    def test_prune_preserves_unmarked_session_directory(self):
+        session = Path(self.tmpdir) / "human-session"
+        session.mkdir()
+        human = session / "human-notes.txt"
+        human.write_text("keep")
+        old_time = os.path.getmtime(human) - 100
+        os.utime(human, (old_time, old_time))
+
+        removed = hos.prune_spill_files(self.tmpdir, retention_seconds=1)
+
+        self.assertEqual(removed, 0)
+        self.assertEqual(human.read_text(), "keep")
+
+    def test_prune_preserves_malformed_marker_directory(self):
+        session = Path(self.tmpdir) / "foreign-session"
+        session.mkdir()
+        (session / ".hermes-managed").write_text("someone-else\n")
+        human = session / "human-notes.txt"
+        human.write_text("keep")
+        old_time = os.path.getmtime(human) - 100
+        os.utime(human, (old_time, old_time))
+
+        removed = hos.prune_spill_files(self.tmpdir, retention_seconds=1)
+
+        self.assertEqual(removed, 0)
+        self.assertEqual(human.read_text(), "keep")
+
+    def test_prune_preserves_symlink_marker_directory(self):
+        session = Path(self.tmpdir) / "linked-session"
+        session.mkdir()
+        target = Path(self.tmpdir) / "foreign-marker"
+        target.write_text("hook_outputs\n")
+        try:
+            (session / ".hermes-managed").symlink_to(target)
+        except OSError as exc:
+            self.skipTest(f"symlink unavailable on this host: {exc}")
+        human = session / "human-notes.txt"
+        human.write_text("keep")
+        old_time = os.path.getmtime(human) - 100
+        os.utime(human, (old_time, old_time))
+
+        removed = hos.prune_spill_files(self.tmpdir, retention_seconds=1)
+
+        self.assertEqual(removed, 0)
+        self.assertEqual(human.read_text(), "keep")
+
+    def test_spill_refuses_to_adopt_preexisting_unmarked_session(self):
+        session = Path(self.tmpdir) / "existing-session"
+        session.mkdir()
+        human = session / "human-notes.txt"
+        human.write_text("keep")
+
+        result = hos.spill_if_oversized(
+            "x" * 500,
+            session_id="existing-session",
+            config=self._cfg(max_chars=10),
+        )
+
+        self.assertIn("spill write failed", result)
+        self.assertEqual(human.read_text(), "keep")
+        self.assertFalse((session / ".hermes-managed").exists())
+        self.assertEqual(list(session.glob("*.txt")), [human])
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_hook_output_spill.py
+++ b/tests/tools/test_hook_output_spill.py
@@ -282,6 +282,22 @@ class SpillIfOversizedTests(unittest.TestCase):
         self.assertFalse((session / ".hermes-managed").exists())
         self.assertEqual(list(session.glob("*.txt")), [human])
 
+    def test_failed_marker_creation_does_not_poison_new_session_path(self):
+        session = Path(self.tmpdir) / "retryable-session"
+        original_open = Path.open
+
+        def fail_marker_open(path, *args, **kwargs):
+            if path.name == ".hermes-managed":
+                raise OSError("forced marker failure")
+            return original_open(path, *args, **kwargs)
+
+        with patch.object(Path, "open", fail_marker_open):
+            self.assertFalse(hos._prepare_owned_spill_dir(session))
+
+        self.assertFalse(session.exists())
+        self.assertTrue(hos._prepare_owned_spill_dir(session))
+        self.assertTrue(hos._is_owned_spill_dir(session))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_hook_output_spill.py
+++ b/tests/tools/test_hook_output_spill.py
@@ -200,6 +200,25 @@ class SpillIfOversizedTests(unittest.TestCase):
             import shutil
             shutil.rmtree(test_home, ignore_errors=True)
 
+    def test_old_spill_files_are_pruned_without_touching_recent_files(self):
+        old = Path(self.tmpdir) / "sess" / "old.txt"
+        recent = Path(self.tmpdir) / "sess" / "recent.txt"
+        old.parent.mkdir()
+        (old.parent / ".hermes-managed").write_text("hook_outputs\n")
+        old.write_text("old")
+        recent.write_text("recent")
+        old_time = os.path.getmtime(old) - (8 * 24 * 60 * 60)
+        os.utime(old, (old_time, old_time))
+
+        hos.prune_spill_files(
+            self.tmpdir,
+            retention_seconds=7 * 24 * 60 * 60,
+            max_files_per_session=100,
+        )
+
+        self.assertFalse(old.exists())
+        self.assertTrue(recent.exists())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -3,6 +3,19 @@
 import tools.terminal_tool as terminal_tool
 
 
+def test_cleanup_does_not_remove_unproven_scratch_directory(tmp_path, monkeypatch):
+    scratch = tmp_path / "scratch"
+    orphan = scratch / "hermes-unknown"
+    orphan.mkdir(parents=True)
+    (orphan / "user-data.txt").write_text("keep")
+    monkeypatch.setenv("TERMINAL_SCRATCH_DIR", str(scratch))
+
+    terminal_tool.cleanup_all_environments()
+
+    assert orphan.exists()
+    assert (orphan / "user-data.txt").exists()
+
+
 def setup_function():
     terminal_tool._reset_cached_sudo_passwords()
 

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -3,6 +3,38 @@
 import tools.terminal_tool as terminal_tool
 
 
+def test_terminal_creation_evidence_requires_absent_before_and_successful_present_after(
+    tmp_path,
+):
+    target = tmp_path / "test_created.py"
+    before = terminal_tool._snapshot_terminal_creation_candidates(
+        f"touch {target}"
+    )
+    assert before[str(target)] is False
+
+    target.write_text("created")
+    assert terminal_tool._created_terminal_paths(before, 0) == [str(target)]
+
+
+def test_terminal_creation_evidence_preserves_preexisting_and_failed_targets(
+    tmp_path,
+):
+    target = tmp_path / "test_existing.py"
+    target.write_text("user-owned")
+    before = terminal_tool._snapshot_terminal_creation_candidates(
+        f"inspect_only {target}"
+    )
+    assert before[str(target)] is True
+    assert terminal_tool._created_terminal_paths(before, 0) == []
+
+    missing = tmp_path / "test_failed.py"
+    failed_before = terminal_tool._snapshot_terminal_creation_candidates(
+        f"touch {missing}"
+    )
+    missing.write_text("ambiguous")
+    assert terminal_tool._created_terminal_paths(failed_before, 1) == []
+
+
 def test_cleanup_does_not_remove_unproven_scratch_directory(tmp_path, monkeypatch):
     scratch = tmp_path / "scratch"
     orphan = scratch / "hermes-unknown"

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -3,38 +3,6 @@
 import tools.terminal_tool as terminal_tool
 
 
-def test_terminal_creation_evidence_requires_absent_before_and_successful_present_after(
-    tmp_path,
-):
-    target = tmp_path / "test_created.py"
-    before = terminal_tool._snapshot_terminal_creation_candidates(
-        f"touch {target}"
-    )
-    assert before[str(target)] is False
-
-    target.write_text("created")
-    assert terminal_tool._created_terminal_paths(before, 0) == [str(target)]
-
-
-def test_terminal_creation_evidence_preserves_preexisting_and_failed_targets(
-    tmp_path,
-):
-    target = tmp_path / "test_existing.py"
-    target.write_text("user-owned")
-    before = terminal_tool._snapshot_terminal_creation_candidates(
-        f"inspect_only {target}"
-    )
-    assert before[str(target)] is True
-    assert terminal_tool._created_terminal_paths(before, 0) == []
-
-    missing = tmp_path / "test_failed.py"
-    failed_before = terminal_tool._snapshot_terminal_creation_candidates(
-        f"touch {missing}"
-    )
-    missing.write_text("ambiguous")
-    assert terminal_tool._created_terminal_paths(failed_before, 1) == []
-
-
 def test_cleanup_does_not_remove_unproven_scratch_directory(tmp_path, monkeypatch):
     scratch = tmp_path / "scratch"
     orphan = scratch / "hermes-unknown"

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -1007,6 +1007,39 @@ class TestCleanupTempRecordings:
         monkeypatch.setattr(voice_mode.os, "replace", replace_before_quarantine)
 
         assert voice_mode.cleanup_temp_recordings(max_age_seconds=3600) == 0
+        assert old_file.read_bytes() == b"human replacement"
+        quarantines = list(temp_voice_dir.glob("*.hermes-delete-*"))
+        assert quarantines == []
+
+    def test_cleanup_does_not_overwrite_newer_race_winner(
+        self, temp_voice_dir, monkeypatch
+    ):
+        import tools.voice_mode as voice_mode
+
+        old_file = temp_voice_dir / "recording_20240101_000000.aac"
+        old_file.write_bytes(b"agent-audio")
+        old_mtime = time.time() - 7200
+        os.utime(old_file, (old_mtime, old_mtime))
+        original_replace = voice_mode.os.replace
+        original_restore = voice_mode._restore_quarantined_recording
+
+        def replace_before_quarantine(source, destination):
+            source_path = Path(source)
+            source_path.unlink()
+            source_path.write_bytes(b"human replacement")
+            return original_replace(source, destination)
+
+        def race_before_restore(original_path, quarantine_path, moved):
+            Path(original_path).write_bytes(b"newer winner")
+            return original_restore(original_path, quarantine_path, moved)
+
+        monkeypatch.setattr(voice_mode.os, "replace", replace_before_quarantine)
+        monkeypatch.setattr(
+            voice_mode, "_restore_quarantined_recording", race_before_restore
+        )
+
+        assert voice_mode.cleanup_temp_recordings(max_age_seconds=3600) == 0
+        assert old_file.read_bytes() == b"newer winner"
         quarantines = list(temp_voice_dir.glob("*.hermes-delete-*"))
         assert len(quarantines) == 1
         assert quarantines[0].read_bytes() == b"human replacement"

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -1,6 +1,7 @@
 """Tests for tools.voice_mode -- all mocked, no real microphone or API calls."""
 
 import os
+import socket
 import struct
 import time
 import wave
@@ -72,6 +73,10 @@ def mock_sd(monkeypatch):
 # detect_audio_environment — WSL / SSH / Docker detection
 # ============================================================================
 
+@pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX"),
+    reason="Unix-domain PulseAudio sockets are unavailable on this host",
+)
 class TestPulseSocketReachable:
     def test_no_env_no_socket(self, monkeypatch):
         monkeypatch.delenv("PULSE_SERVER", raising=False)
@@ -970,6 +975,19 @@ class TestCleanupTempRecordings:
         deleted = cleanup_temp_recordings(max_age_seconds=3600)
         assert deleted == 0
         assert other_file.exists()
+
+    def test_old_termux_aac_files_deleted(self, temp_voice_dir):
+        old_file = temp_voice_dir / "recording_20240101_000000.aac"
+        old_file.write_bytes(b"partial-aac")
+        old_mtime = time.time() - 7200
+        os.utime(str(old_file), (old_mtime, old_mtime))
+
+        from tools.voice_mode import cleanup_temp_recordings
+
+        deleted = cleanup_temp_recordings(max_age_seconds=3600)
+
+        assert deleted == 1
+        assert not old_file.exists()
 
 
 # ============================================================================

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -989,6 +989,28 @@ class TestCleanupTempRecordings:
         assert deleted == 1
         assert not old_file.exists()
 
+    def test_cleanup_preserves_pathname_replacement(self, temp_voice_dir, monkeypatch):
+        import tools.voice_mode as voice_mode
+
+        old_file = temp_voice_dir / "recording_20240101_000000.aac"
+        old_file.write_bytes(b"agent-audio")
+        old_mtime = time.time() - 7200
+        os.utime(old_file, (old_mtime, old_mtime))
+        original_replace = voice_mode.os.replace
+
+        def replace_before_quarantine(source, destination):
+            source_path = Path(source)
+            source_path.unlink()
+            source_path.write_bytes(b"human replacement")
+            return original_replace(source, destination)
+
+        monkeypatch.setattr(voice_mode.os, "replace", replace_before_quarantine)
+
+        assert voice_mode.cleanup_temp_recordings(max_age_seconds=3600) == 0
+        quarantines = list(temp_voice_dir.glob("*.hermes-delete-*"))
+        assert len(quarantines) == 1
+        assert quarantines[0].read_bytes() == b"human replacement"
+
 
 # ============================================================================
 # play_beep

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -13,10 +13,12 @@ import posixpath
 import shlex
 import shutil
 import signal
+import stat
 import tarfile
 import tempfile
 import threading
 import time
+import uuid
 
 try:
     import fcntl
@@ -35,6 +37,70 @@ from hermes_constants import get_hermes_home
 from tools.environments.base import _file_mtime_key
 
 logger = logging.getLogger(__name__)
+
+
+def _remove_created_sync_lock(path: Path, expected: os.stat_result) -> None:
+    quarantine = path.with_name(f".{path.name}.hermes-delete-{uuid.uuid4().hex}")
+    try:
+        current = path.lstat()
+        if not os.path.samestat(expected, current):
+            return
+        os.replace(path, quarantine)
+        moved = quarantine.lstat()
+        if os.path.samestat(expected, moved):
+            quarantine.unlink()
+    except OSError:
+        return
+
+
+def _open_owned_sync_lock(lock_path: Path):
+    """Open a regular single-link lock without writing through aliases."""
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    parent_identity = lock_path.parent.lstat()
+    if (
+        not stat.S_ISDIR(parent_identity.st_mode)
+        or int(getattr(parent_identity, "st_file_attributes", 0)) & 0x400
+    ):
+        raise OSError(f"sync lock parent is not a regular directory: {lock_path.parent}")
+    flags = os.O_RDWR
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    created = False
+    try:
+        fd = os.open(lock_path, flags | os.O_CREAT | os.O_EXCL, 0o600)
+        created = True
+    except FileExistsError:
+        selected = lock_path.lstat()
+        fd = os.open(lock_path, flags)
+        opened = os.fstat(fd)
+        current = lock_path.lstat()
+        if (
+            not stat.S_ISREG(selected.st_mode)
+            or int(getattr(selected, "st_file_attributes", 0)) & 0x400
+            or selected.st_nlink != 1
+            or opened.st_nlink != 1
+            or not os.path.samestat(selected, opened)
+            or not os.path.samestat(opened, current)
+        ):
+            os.close(fd)
+            raise OSError(f"sync lock is not exclusively owned: {lock_path}")
+    opened = os.fstat(fd)
+    current_parent = lock_path.parent.lstat()
+    current = lock_path.lstat()
+    if (
+        not stat.S_ISREG(opened.st_mode)
+        or int(getattr(opened, "st_file_attributes", 0)) & 0x400
+        or opened.st_nlink != 1
+        or not os.path.samestat(opened, current)
+        or not os.path.samestat(parent_identity, current_parent)
+    ):
+        os.close(fd)
+        if created:
+            _remove_created_sync_lock(lock_path, opened)
+        raise OSError("sync lock provenance changed")
+    return os.fdopen(fd, "r+b", closefd=True)
 
 # Keep retry sleeps patchable without mutating the shared stdlib ``time``
 # module. Patching ``tools.environments.file_sync.time.sleep`` replaces
@@ -331,7 +397,7 @@ class FileSyncManager:
     def _sync_back_locked(self, lock_path: Path) -> None:
         """Sync-back under file lock (serializes concurrent gateways)."""
         if fcntl is not None:
-            lock_fd = open(lock_path, "a+b")
+            lock_fd = _open_owned_sync_lock(lock_path)
             try:
                 fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
                 self._sync_back_impl()
@@ -346,14 +412,9 @@ class FileSyncManager:
         if msvcrt is None:  # pragma: no cover - unsupported platform
             raise OSError("no supported file-lock primitive")
 
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
-        lock_fd = open(lock_path, "a+b")
+        lock_fd = _open_owned_sync_lock(lock_path)
         locked = False
         try:
-            lock_fd.seek(0, os.SEEK_END)
-            if lock_fd.tell() == 0:
-                lock_fd.write(b"0")
-                lock_fd.flush()
             lock_fd.seek(0)
             msvcrt.locking(lock_fd.fileno(), msvcrt.LK_LOCK, 1)
             locked = True

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -21,7 +21,13 @@ import time
 try:
     import fcntl
 except ImportError:
-    fcntl = None  # Windows — file locking skipped
+    fcntl = None
+    try:
+        import msvcrt
+    except ImportError:  # pragma: no cover - unsupported platform
+        msvcrt = None
+else:
+    msvcrt = None
 from pathlib import Path
 from typing import Callable
 
@@ -324,17 +330,39 @@ class FileSyncManager:
 
     def _sync_back_locked(self, lock_path: Path) -> None:
         """Sync-back under file lock (serializes concurrent gateways)."""
-        if fcntl is None:
-            # Windows: no flock — run without serialization
-            self._sync_back_impl()
+        if fcntl is not None:
+            lock_fd = open(lock_path, "a+b")
+            try:
+                fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
+                self._sync_back_impl()
+            finally:
+                try:
+                    fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
+                except (OSError, IOError):
+                    pass
+                lock_fd.close()
             return
-        lock_fd = open(lock_path, "w", encoding="utf-8")
+
+        if msvcrt is None:  # pragma: no cover - unsupported platform
+            raise OSError("no supported file-lock primitive")
+
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_fd = open(lock_path, "a+b")
+        locked = False
         try:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            lock_fd.seek(0, os.SEEK_END)
+            if lock_fd.tell() == 0:
+                lock_fd.write(b"0")
+                lock_fd.flush()
+            lock_fd.seek(0)
+            msvcrt.locking(lock_fd.fileno(), msvcrt.LK_LOCK, 1)
+            locked = True
             self._sync_back_impl()
         finally:
             try:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                if locked:
+                    lock_fd.seek(0)
+                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
             except (OSError, IOError):
                 pass
             lock_fd.close()

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -6,6 +6,7 @@ and Daytona.  Docker and Singularity use bind mounts (live host FS
 view) and don't need this.
 """
 
+import errno
 import hashlib
 import logging
 import os
@@ -516,9 +517,23 @@ class FileSyncManager:
         lock_fd = _open_owned_sync_lock(lock_path)
         locked = False
         try:
-            lock_fd.seek(0)
-            msvcrt.locking(lock_fd.fileno(), msvcrt.LK_LOCK, 1)
-            locked = True
+            while not locked:
+                lock_fd.seek(0)
+                try:
+                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_LOCK, 1)
+                    locked = True
+                except OSError as exc:
+                    # LK_LOCK gives up after roughly ten seconds on Windows.
+                    # A long concurrent sync is not a failed sync: keep waiting
+                    # for lock-contention errors so teardown cannot discard a
+                    # sandbox before its remote-only changes are downloaded.
+                    if (
+                        getattr(exc, "winerror", None) not in {33, 36}
+                        and getattr(exc, "errno", None)
+                        not in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}
+                    ):
+                        raise
+                    _sleep(0.1)
             self._sync_back_impl()
         finally:
             try:

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -39,15 +39,71 @@ from tools.environments.base import _file_mtime_key
 logger = logging.getLogger(__name__)
 
 
+def _opened_lock_path(fd: int) -> Path | None:
+    if os.name != "nt":
+        return None
+    try:
+        import ctypes
+
+        handle = msvcrt.get_osfhandle(fd)
+        get_final_path = ctypes.windll.kernel32.GetFinalPathNameByHandleW
+        get_final_path.argtypes = (
+            ctypes.c_void_p,
+            ctypes.c_wchar_p,
+            ctypes.c_uint32,
+            ctypes.c_uint32,
+        )
+        get_final_path.restype = ctypes.c_uint32
+        needed = get_final_path(handle, None, 0, 0)
+        if not needed:
+            return None
+        buffer = ctypes.create_unicode_buffer(needed + 1)
+        written = get_final_path(handle, buffer, len(buffer), 0)
+        if not written or written >= len(buffer):
+            return None
+        actual = buffer.value
+        if actual.startswith("\\\\?\\UNC\\"):
+            actual = "\\\\" + actual[8:]
+        elif actual.startswith("\\\\?\\"):
+            actual = actual[4:]
+        return Path(actual)
+    except (AttributeError, OSError, ValueError):
+        return None
+
+
+def _opened_lock_matches_path(actual: Path | None, expected: Path) -> bool:
+    return bool(
+        actual is not None
+        and os.path.normcase(os.path.normpath(os.fspath(actual)))
+        == os.path.normcase(os.path.normpath(os.fspath(expected)))
+    )
+
+
 def _remove_created_sync_lock(path: Path, expected: os.stat_result) -> None:
     quarantine = path.with_name(f".{path.name}.hermes-delete-{uuid.uuid4().hex}")
     try:
         current = path.lstat()
-        if not os.path.samestat(expected, current):
+        if (
+            not stat.S_ISREG(expected.st_mode)
+            or not stat.S_ISREG(current.st_mode)
+            or int(getattr(expected, "st_file_attributes", 0)) & 0x400
+            or int(getattr(current, "st_file_attributes", 0)) & 0x400
+            or expected.st_nlink != 1
+            or current.st_nlink != 1
+            or expected.st_size != 0
+            or current.st_size != 0
+            or not os.path.samestat(expected, current)
+        ):
             return
         os.replace(path, quarantine)
         moved = quarantine.lstat()
-        if os.path.samestat(expected, moved):
+        if (
+            stat.S_ISREG(moved.st_mode)
+            and not (int(getattr(moved, "st_file_attributes", 0)) & 0x400)
+            and moved.st_nlink == 1
+            and moved.st_size == 0
+            and os.path.samestat(expected, moved)
+        ):
             quarantine.unlink()
     except OSError:
         return
@@ -62,45 +118,90 @@ def _open_owned_sync_lock(lock_path: Path):
         or int(getattr(parent_identity, "st_file_attributes", 0)) & 0x400
     ):
         raise OSError(f"sync lock parent is not a regular directory: {lock_path.parent}")
+    parent_resolved = lock_path.parent.resolve(strict=True)
+    if not os.path.samestat(parent_identity, parent_resolved.lstat()):
+        raise OSError(f"sync lock parent changed during resolution: {lock_path.parent}")
     flags = os.O_RDWR
     if hasattr(os, "O_BINARY"):
         flags |= os.O_BINARY
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
     created = False
+    fd: int | None = None
+    opened: os.stat_result | None = None
+    actual_path: Path | None = None
+    selected: os.stat_result | None = None
     try:
-        fd = os.open(lock_path, flags | os.O_CREAT | os.O_EXCL, 0o600)
-        created = True
-    except FileExistsError:
-        selected = lock_path.lstat()
-        fd = os.open(lock_path, flags)
+        try:
+            fd = os.open(lock_path, flags | os.O_CREAT | os.O_EXCL, 0o600)
+            created = True
+        except FileExistsError:
+            selected = lock_path.lstat()
+            fd = os.open(lock_path, flags)
+
         opened = os.fstat(fd)
-        current = lock_path.lstat()
-        if (
-            not stat.S_ISREG(selected.st_mode)
-            or int(getattr(selected, "st_file_attributes", 0)) & 0x400
-            or selected.st_nlink != 1
-            or opened.st_nlink != 1
-            or not os.path.samestat(selected, opened)
-            or not os.path.samestat(opened, current)
-        ):
-            os.close(fd)
+        actual_path = _opened_lock_path(fd)
+        if actual_path is None and os.name != "nt":
+            actual_path = parent_resolved / lock_path.name
+        try:
+            current_parent = lock_path.parent.lstat()
+            current = lock_path.lstat()
+            valid = bool(
+                stat.S_ISREG(opened.st_mode)
+                and not (int(getattr(opened, "st_file_attributes", 0)) & 0x400)
+                and stat.S_ISREG(current.st_mode)
+                and not (int(getattr(current, "st_file_attributes", 0)) & 0x400)
+                and opened.st_nlink == 1
+                and current.st_nlink == 1
+                and os.path.samestat(opened, current)
+                and stat.S_ISDIR(current_parent.st_mode)
+                and not (
+                    int(getattr(current_parent, "st_file_attributes", 0)) & 0x400
+                )
+                and os.path.samestat(parent_identity, current_parent)
+                and _opened_lock_matches_path(
+                    actual_path, parent_resolved / lock_path.name
+                )
+                and (
+                    selected is None
+                    or (
+                        stat.S_ISREG(selected.st_mode)
+                        and not (
+                            int(getattr(selected, "st_file_attributes", 0)) & 0x400
+                        )
+                        and selected.st_nlink == 1
+                        and os.path.samestat(selected, opened)
+                    )
+                )
+            )
+        except OSError:
+            valid = False
+        if not valid:
+            if created:
+                raise OSError("sync lock provenance changed")
             raise OSError(f"sync lock is not exclusively owned: {lock_path}")
-    opened = os.fstat(fd)
-    current_parent = lock_path.parent.lstat()
-    current = lock_path.lstat()
-    if (
-        not stat.S_ISREG(opened.st_mode)
-        or int(getattr(opened, "st_file_attributes", 0)) & 0x400
-        or opened.st_nlink != 1
-        or not os.path.samestat(opened, current)
-        or not os.path.samestat(parent_identity, current_parent)
-    ):
-        os.close(fd)
-        if created:
-            _remove_created_sync_lock(lock_path, opened)
-        raise OSError("sync lock provenance changed")
-    return os.fdopen(fd, "r+b", closefd=True)
+
+        stream = os.fdopen(fd, "r+b", closefd=True)
+        fd = None  # Ownership transferred to ``stream``.
+        return stream
+    except BaseException:
+        if fd is not None:
+            try:
+                if opened is None:
+                    opened = os.fstat(fd)
+            except OSError:
+                pass
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        if created and opened is not None:
+            # On Windows, never reconstruct this from ``lock_path``: a restored
+            # parent may now name an unrelated race winner.  Without the
+            # handle's final path, preserving the empty create is fail-closed.
+            if actual_path is not None:
+                _remove_created_sync_lock(actual_path, opened)
+        raise
 
 # Keep retry sleeps patchable without mutating the shared stdlib ``time``
 # module. Patching ``tools.environments.file_sync.time.sleep`` replaces

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -28,6 +28,8 @@ Usage:
 import os
 import re
 import difflib
+import json
+import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any, ClassVar
@@ -188,6 +190,10 @@ class WriteResult:
     lsp_diagnostics: Optional[str] = None
     error: Optional[str] = None
     warning: Optional[str] = None
+    # Exact inode published by a local atomic write.  Callers may use this as
+    # creation provenance; remote backends leave it unset because their
+    # filesystem identity is not comparable to the host filesystem.
+    filesystem_identity: Optional[Dict[str, int]] = None
 
     def to_dict(self) -> dict:
         return {k: v for k, v in self.__dict__.items() if v is not None}
@@ -997,6 +1003,20 @@ class ShellFileOperations(FileOperations):
         # carries a marker so an orphaned temp (only possible on a hard
         # crash *between* cat and mv) is identifiable.
         tmpl = self._escape_shell_arg(".hermes-tmp.XXXXXX")
+        identity_command = ""
+        if self.env.__class__.__name__ == "LocalEnvironment":
+            python = self._escape_shell_arg(sys.executable)
+            identity_script = self._escape_shell_arg(
+                "import json,os,sys; p=sys.argv[1]; "
+                "p=(p[1]+':'+p[2:]) if os.name=='nt' and len(p)>2 "
+                "and p[0]=='/' and p[1].isalpha() and p[2]=='/' else p; "
+                "s=os.lstat(p); "
+                "print('__HERMES_WRITE_IDENTITY__'+json.dumps({"
+                "'version':1,'device':s.st_dev,'inode':s.st_ino,"
+                "'mode':s.st_mode,'size':s.st_size,"
+                "'mtime_ns':s.st_mtime_ns,'ctime_ns':s.st_ctime_ns}))"
+            )
+            identity_command = f'{python} -c {identity_script} "$tmp"; '
 
         # One shell script, fully quoted. Notes:
         #  - `mktemp` lands the temp in the target's own dir (-p) so `mv` is
@@ -1024,6 +1044,7 @@ class ShellFileOperations(FileOperations):
             '[ -n "$m" ] && chmod "$m" "$tmp" 2>/dev/null || true; '
             "fi; "
             'cat > "$tmp"; '
+            f"{identity_command}"
             'mv -f "$tmp" "$t"; '
             "trap - EXIT"
         )
@@ -1510,7 +1531,18 @@ class ShellFileOperations(FileOperations):
         # the atomic swap doesn't silently widen or narrow permissions, and
         # clean the temp up on any failure so we never leak a ``.hermes-tmp``
         # turd next to the user's file.
+        written_identity: Optional[Dict[str, int]] = None
         write_result = self._atomic_write(path, content)
+        if self.env.__class__.__name__ == "LocalEnvironment":
+            marker = "__HERMES_WRITE_IDENTITY__"
+            for line in (write_result.stdout or "").splitlines():
+                if line.startswith(marker):
+                    try:
+                        decoded = json.loads(line[len(marker):])
+                        if isinstance(decoded, dict):
+                            written_identity = decoded
+                    except (TypeError, ValueError, json.JSONDecodeError):
+                        written_identity = None
 
         if write_result.exit_code != 0:
             return WriteResult(error=f"Failed to write file: {write_result.stdout}")
@@ -1546,6 +1578,7 @@ class ShellFileOperations(FileOperations):
             dirs_created=dirs_created,
             lint=lint_result.to_dict() if lint_result else None,
             lsp_diagnostics=lsp_diagnostics,
+            filesystem_identity=written_identity,
         )
     
     # =========================================================================

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1003,20 +1003,25 @@ class ShellFileOperations(FileOperations):
         # carries a marker so an orphaned temp (only possible on a hard
         # crash *between* cat and mv) is identifiable.
         tmpl = self._escape_shell_arg(".hermes-tmp.XXXXXX")
-        identity_command = ""
+        publish_command = 'mv -f "$tmp" "$t"; '
         if self.env.__class__.__name__ == "LocalEnvironment":
             python = self._escape_shell_arg(sys.executable)
             identity_script = self._escape_shell_arg(
-                "import json,os,sys; p=sys.argv[1]; "
-                "p=(p[1]+':'+p[2:]) if os.name=='nt' and len(p)>2 "
+                "import json,os,sys; "
+                "cv=lambda p:(p[1]+':'+p[2:]) if os.name=='nt' and len(p)>2 "
                 "and p[0]=='/' and p[1].isalpha() and p[2]=='/' else p; "
-                "s=os.lstat(p); "
+                "src,dst=map(cv,sys.argv[1:3]); before=os.lstat(src); "
+                "os.replace(src,dst); after=os.lstat(dst); "
+                "same=(before.st_dev,before.st_ino)==(after.st_dev,after.st_ino); "
                 "print('__HERMES_WRITE_IDENTITY__'+json.dumps({"
-                "'version':1,'device':s.st_dev,'inode':s.st_ino,"
-                "'mode':s.st_mode,'size':s.st_size,"
-                "'mtime_ns':s.st_mtime_ns,'ctime_ns':s.st_ctime_ns}))"
+                "'version':1,'device':after.st_dev,'inode':after.st_ino,"
+                "'mode':after.st_mode,'size':after.st_size,"
+                "'mtime_ns':after.st_mtime_ns,'ctime_ns':after.st_ctime_ns})) "
+                "if same else None"
             )
-            identity_command = f'{python} -c {identity_script} "$tmp"; '
+            publish_command = (
+                f'{python} -c {identity_script} "$tmp" "$t"; '
+            )
 
         # One shell script, fully quoted. Notes:
         #  - `mktemp` lands the temp in the target's own dir (-p) so `mv` is
@@ -1044,8 +1049,7 @@ class ShellFileOperations(FileOperations):
             '[ -n "$m" ] && chmod "$m" "$tmp" 2>/dev/null || true; '
             "fi; "
             'cat > "$tmp"; '
-            f"{identity_command}"
-            'mv -f "$tmp" "$t"; '
+            f"{publish_command}"
             "trap - EXIT"
         )
         return self._exec(script, stdin_data=content)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -79,6 +79,26 @@ def _local_path_existed_before(path: str | None) -> bool | None:
         return None
 
 
+def _local_path_identity(path: str | None) -> dict[str, int] | None:
+    """Return the exact local filesystem identity for creation provenance."""
+    path = _canonical_local_path(path)
+    if path is None:
+        return None
+    try:
+        stat_result = os.lstat(path)
+    except (OSError, ValueError):
+        return None
+    return {
+        "version": 1,
+        "device": int(stat_result.st_dev),
+        "inode": int(stat_result.st_ino),
+        "mode": int(stat_result.st_mode),
+        "size": int(stat_result.st_size),
+        "mtime_ns": int(stat_result.st_mtime_ns),
+        "ctime_ns": int(stat_result.st_ctime_ns),
+    }
+
+
 def _add_created_path_evidence(
     result_dict: dict, path: str | None, existed_before: bool | None
 ) -> None:
@@ -86,7 +106,13 @@ def _add_created_path_evidence(
     if result_dict.get("error") or existed_before is not False:
         return
     if isinstance(path, str) and path:
+        identity = _local_path_identity(path)
+        if identity is None:
+            return
         result_dict["created_paths"] = [path]
+        result_dict["created_path_identities"] = [
+            {"path": path, "identity": identity}
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1642,9 +1642,6 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             _resolved = str(_resolve_path_for_task(path, task_id))
         except Exception:
             _resolved = None
-        provenance_path = _canonical_local_path(_resolved) or _canonical_local_path(path)
-        existed_before = _local_path_existed_before(provenance_path)
-
         if _resolved is None:
             stale_warning = _check_file_staleness(path, task_id)
             file_ops = _get_file_ops(task_id)
@@ -1653,7 +1650,6 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             if stale_warning:
                 result_dict["_warning"] = stale_warning
             if not result_dict.get("error"):
-                _add_created_path_evidence(result_dict, provenance_path, existed_before)
                 _mark_verification_stale(task_id, [path], session_id=session_id)
             _update_read_timestamp(path, task_id)
             return json.dumps(result_dict, ensure_ascii=False)
@@ -1670,6 +1666,10 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             # terminal's cwd (the worktree-cwd bug). Lowest priority of the three.
             cwd_warning = _path_resolution_warning(path, Path(_resolved), task_id)
             file_ops = _get_file_ops(task_id)
+            # Creation evidence must be sampled inside the same per-path
+            # serialization boundary as the write. An earlier probe lets a
+            # concurrent Hermes writer turn "absent" into an overwrite.
+            existed_before = _local_path_existed_before(_resolved)
             result = file_ops.write_file(_resolved, content)
             result_dict = result.to_dict()
             effective_warning = cross_warning or stale_warning or cwd_warning

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -48,6 +48,47 @@ def _expand_tilde(path: str) -> str:
     return os.path.expanduser(path)
 
 
+def _canonical_local_path(path: str | None) -> str | None:
+    """Return an absolute local path, or ``None`` for an ambiguous target."""
+    if not isinstance(path, str) or not path:
+        return None
+    try:
+        expanded = _expand_tilde(path)
+        return expanded if os.path.isabs(expanded) else None
+    except (OSError, ValueError):
+        return None
+
+
+def _local_path_existed_before(path: str | None) -> bool | None:
+    """Return local pre-write existence, or ``None`` when it is unknown.
+
+    Creation provenance is deliberately fail-closed.  The disk-cleanup
+    plugin may use the resulting ``created_paths`` field only when this probe
+    conclusively observed that the target was absent before a successful
+    write; path strings and free-form tool output are not substitutes.
+    """
+    path = _canonical_local_path(path)
+    if path is None:
+        return None
+    try:
+        os.lstat(path)
+        return True
+    except FileNotFoundError:
+        return False
+    except (OSError, ValueError):
+        return None
+
+
+def _add_created_path_evidence(
+    result_dict: dict, path: str | None, existed_before: bool | None
+) -> None:
+    """Attach trusted creation metadata for a newly-created local target."""
+    if result_dict.get("error") or existed_before is not False:
+        return
+    if isinstance(path, str) and path:
+        result_dict["created_paths"] = [path]
+
+
 # ---------------------------------------------------------------------------
 # Read-size guard: cap the character count returned to the model.
 # We're model-agnostic so we can't count tokens; characters are a safe proxy.
@@ -1601,6 +1642,8 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             _resolved = str(_resolve_path_for_task(path, task_id))
         except Exception:
             _resolved = None
+        provenance_path = _canonical_local_path(_resolved) or _canonical_local_path(path)
+        existed_before = _local_path_existed_before(provenance_path)
 
         if _resolved is None:
             stale_warning = _check_file_staleness(path, task_id)
@@ -1610,6 +1653,7 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             if stale_warning:
                 result_dict["_warning"] = stale_warning
             if not result_dict.get("error"):
+                _add_created_path_evidence(result_dict, provenance_path, existed_before)
                 _mark_verification_stale(task_id, [path], session_id=session_id)
             _update_read_timestamp(path, task_id)
             return json.dumps(result_dict, ensure_ascii=False)
@@ -1637,6 +1681,7 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             result_dict["resolved_path"] = _resolved
             if not result_dict.get("error"):
                 result_dict["files_modified"] = [_resolved]
+                _add_created_path_evidence(result_dict, _resolved, existed_before)
                 _mark_verification_stale(task_id, [_resolved], session_id=session_id)
             # Refresh stamps after the successful write so consecutive
             # writes by this task don't trigger false staleness warnings.

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -100,18 +100,18 @@ def _local_path_identity(path: str | None) -> dict[str, int] | None:
 
 
 def _add_created_path_evidence(
-    result_dict: dict, path: str | None, existed_before: bool | None
+    result_dict: dict,
+    path: str | None,
+    existed_before: bool | None,
+    written_identity: dict[str, int] | None,
 ) -> None:
     """Attach trusted creation metadata for a newly-created local target."""
     if result_dict.get("error") or existed_before is not False:
         return
-    if isinstance(path, str) and path:
-        identity = _local_path_identity(path)
-        if identity is None:
-            return
+    if isinstance(path, str) and path and isinstance(written_identity, dict):
         result_dict["created_paths"] = [path]
         result_dict["created_path_identities"] = [
-            {"path": path, "identity": identity}
+            {"path": path, "identity": written_identity}
         ]
 
 
@@ -1673,6 +1673,7 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             file_ops = _get_file_ops(task_id)
             result = file_ops.write_file(path, content)
             result_dict = result.to_dict()
+            result_dict.pop("filesystem_identity", None)
             if stale_warning:
                 result_dict["_warning"] = stale_warning
             if not result_dict.get("error"):
@@ -1698,6 +1699,7 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             existed_before = _local_path_existed_before(_resolved)
             result = file_ops.write_file(_resolved, content)
             result_dict = result.to_dict()
+            written_identity = result_dict.pop("filesystem_identity", None)
             effective_warning = cross_warning or stale_warning or cwd_warning
             if effective_warning:
                 result_dict["_warning"] = effective_warning
@@ -1707,7 +1709,9 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             result_dict["resolved_path"] = _resolved
             if not result_dict.get("error"):
                 result_dict["files_modified"] = [_resolved]
-                _add_created_path_evidence(result_dict, _resolved, existed_before)
+                _add_created_path_evidence(
+                    result_dict, _resolved, existed_before, written_identity
+                )
                 _mark_verification_stale(task_id, [_resolved], session_id=session_id)
             # Refresh stamps after the successful write so consecutive
             # writes by this task don't trigger false staleness warnings.

--- a/tools/hook_output_spill.py
+++ b/tools/hook_output_spill.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import logging
 import os
+import stat
 import time
 import uuid
 from pathlib import Path
@@ -60,6 +61,7 @@ DEFAULT_RETENTION_SECONDS = 7 * 24 * 60 * 60
 DEFAULT_MAX_FILES_PER_SESSION = 100
 _OWNERSHIP_MARKER = ".hermes-managed"
 _OWNERSHIP_VALUE = "hook_outputs"
+_DELETE_QUARANTINE_TOKEN = ".hermes-delete-"
 
 
 def _coerce_positive_int(value: Any, default: int) -> int:
@@ -218,13 +220,20 @@ def _prepare_owned_spill_dir(path: Path) -> bool:
     return False
 
 
-def _atomic_unlink_spill(path: Path) -> bool:
+def _atomic_unlink_spill(path: Path, expected: os.stat_result) -> bool:
     """Unlink the exact opened spill object, never a pathname replacement."""
     fd: Optional[int] = None
     quarantine = path.with_name(f".{path.name}.hermes-delete-{uuid.uuid4().hex}")
     try:
-        attributes = int(getattr(path.lstat(), "st_file_attributes", 0))
-        if path.is_symlink() or attributes & 0x400 or not path.is_file():
+        current = path.lstat()
+        attributes = int(getattr(current, "st_file_attributes", 0))
+        if (
+            _DELETE_QUARANTINE_TOKEN in path.name
+            or path.is_symlink()
+            or attributes & 0x400
+            or not stat.S_ISREG(current.st_mode)
+            or not os.path.samestat(expected, current)
+        ):
             return False
         if os.name == "nt":
             import ctypes
@@ -263,15 +272,32 @@ def _atomic_unlink_spill(path: Path) -> bool:
                 flags |= os.O_NOFOLLOW
             fd = os.open(path, flags)
         opened = os.fstat(fd)
+        current = path.lstat()
+        current_attributes = int(getattr(current, "st_file_attributes", 0))
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or not stat.S_ISREG(current.st_mode)
+            or path.is_symlink()
+            or current_attributes & 0x400
+            or not os.path.samestat(expected, current)
+            or not os.path.samestat(opened, current)
+        ):
+            return False
         os.replace(path, quarantine)
         if not os.path.samestat(opened, quarantine.lstat()):
             try:
-                os.link(quarantine, path)
-                quarantine.unlink()
+                if os.path.lexists(path):
+                    raise FileExistsError(str(path))
+                os.replace(quarantine, path)
             except OSError:
                 pass
             return False
-        quarantine.unlink()
+        try:
+            quarantine.unlink()
+        except OSError:
+            # The exact spill remains preserved for operator inspection. Its
+            # quarantine name is permanently excluded from automatic pruning.
+            return False
         return True
     except OSError:
         return False
@@ -315,25 +341,31 @@ def prune_spill_files(
 
     for session_dir in session_dirs:
         try:
-            files = sorted(
-                (
-                    p for p in session_dir.iterdir()
-                    if p.is_file() and not p.is_symlink() and p.suffix == ".txt"
-                ),
-                key=lambda p: (p.stat().st_mtime, p.name),
+            files = []
+            for path in session_dir.iterdir():
+                if _DELETE_QUARANTINE_TOKEN in path.name or path.suffix != ".txt":
+                    continue
+                selected = path.lstat()
+                attributes = int(getattr(selected, "st_file_attributes", 0))
+                if (
+                    path.is_symlink()
+                    or attributes & 0x400
+                    or not stat.S_ISREG(selected.st_mode)
+                ):
+                    continue
+                files.append((path, selected))
+            files.sort(
+                key=lambda item: (item[1].st_mtime, item[0].name),
                 reverse=True,
             )
         except OSError:
             continue
-        for index, path in enumerate(files):
-            try:
-                expired = now - path.stat().st_mtime > retention
-            except OSError:
-                continue
+        for index, (path, selected) in enumerate(files):
+            expired = now - selected.st_mtime > retention
             if not expired and index < maximum:
                 continue
             try:
-                if _atomic_unlink_spill(path):
+                if _atomic_unlink_spill(path, selected):
                     removed += 1
             except OSError:
                 logger.debug("hook output spill prune skipped %s", path, exc_info=True)

--- a/tools/hook_output_spill.py
+++ b/tools/hook_output_spill.py
@@ -64,6 +64,27 @@ _OWNERSHIP_VALUE = "hook_outputs"
 _DELETE_QUARANTINE_TOKEN = ".hermes-delete-"
 
 
+def _path_is_link_like(path: Path) -> bool:
+    try:
+        path_stat = path.lstat()
+        attributes = int(getattr(path_stat, "st_file_attributes", 0))
+        return path.is_symlink() or bool(attributes & 0x400)
+    except OSError:
+        return True
+
+
+def _same_owned_directory(path: Path, expected: os.stat_result) -> bool:
+    try:
+        current = path.lstat()
+        return (
+            stat.S_ISDIR(current.st_mode)
+            and not _path_is_link_like(path)
+            and os.path.samestat(expected, current)
+        )
+    except OSError:
+        return False
+
+
 def _coerce_positive_int(value: Any, default: int) -> int:
     try:
         iv = int(value)
@@ -285,12 +306,9 @@ def _atomic_unlink_spill(path: Path, expected: os.stat_result) -> bool:
             return False
         os.replace(path, quarantine)
         if not os.path.samestat(opened, quarantine.lstat()):
-            try:
-                if os.path.lexists(path):
-                    raise FileExistsError(str(path))
-                os.replace(quarantine, path)
-            except OSError:
-                pass
+            # The pathname no longer carries safe restoration authority. A
+            # concurrent writer may recreate it at any instant, so preserve
+            # the quarantined object instead of risking an overwrite.
             return False
         try:
             quarantine.unlink()
@@ -322,7 +340,11 @@ def prune_spill_files(
     """
     try:
         root = Path(base_directory)
-        if not root.is_dir() or root.is_symlink():
+        root_identity = root.lstat()
+        if (
+            not stat.S_ISDIR(root_identity.st_mode)
+            or _path_is_link_like(root)
+        ):
             return 0
         retention = max(1, int(retention_seconds))
         maximum = max(1, int(max_files_per_session))
@@ -332,15 +354,25 @@ def prune_spill_files(
     now = time.time()
     removed = 0
     try:
-        session_dirs = sorted(
-            (p for p in root.iterdir() if _is_owned_spill_dir(p)),
-            key=lambda p: p.name,
-        )
+        session_dirs = []
+        for path in root.iterdir():
+            selected = path.lstat()
+            if _is_owned_spill_dir(path) and _same_owned_directory(path, selected):
+                session_dirs.append((path, selected))
+        session_dirs.sort(key=lambda item: item[0].name)
+        if not _same_owned_directory(root, root_identity):
+            return 0
     except OSError:
         return 0
 
-    for session_dir in session_dirs:
+    for session_dir, session_identity in session_dirs:
         try:
+            if (
+                not _same_owned_directory(root, root_identity)
+                or not _same_owned_directory(session_dir, session_identity)
+                or not _is_owned_spill_dir(session_dir)
+            ):
+                continue
             files = []
             for path in session_dir.iterdir():
                 if _DELETE_QUARANTINE_TOKEN in path.name or path.suffix != ".txt":
@@ -361,6 +393,12 @@ def prune_spill_files(
         except OSError:
             continue
         for index, (path, selected) in enumerate(files):
+            if (
+                not _same_owned_directory(root, root_identity)
+                or not _same_owned_directory(session_dir, session_identity)
+                or not _is_owned_spill_dir(session_dir)
+            ):
+                break
             expired = now - selected.st_mtime > retention
             if not expired and index < maximum:
                 continue

--- a/tools/hook_output_spill.py
+++ b/tools/hook_output_spill.py
@@ -27,6 +27,8 @@ Config (``config.yaml``)::
         preview_head: 500      # chars shown at the start of the preview
         preview_tail: 500      # chars shown at the end of the preview
         directory: null        # default: <HERMES_HOME>/hook_outputs
+        retention_seconds: 604800      # default: 7 days
+        max_files_per_session: 100     # default: keep newest 100
 
 Design invariants
 -----------------
@@ -42,13 +44,14 @@ Design invariants
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import stat
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterator, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +64,7 @@ DEFAULT_RETENTION_SECONDS = 7 * 24 * 60 * 60
 DEFAULT_MAX_FILES_PER_SESSION = 100
 _OWNERSHIP_MARKER = ".hermes-managed"
 _OWNERSHIP_VALUE = "hook_outputs"
+_OWNERSHIP_V2_PREFIX = "hook_outputs:v2:"
 _DELETE_QUARANTINE_TOKEN = ".hermes-delete-"
 
 
@@ -167,6 +171,17 @@ def _resolve_spill_dir(directory_override: Optional[str], session_id: Optional[s
     return base / session_segment
 
 
+def _spill_v2_candidates(
+    base: Path, session_id: Optional[str]
+) -> Iterator[Path]:
+    """Yield deterministic, hash-bound fallbacks for a legacy path collision."""
+    storage_session = session_id or "no-session"
+    digest = hashlib.sha256(storage_session.encode("utf-8")).hexdigest()[:24]
+    for suffix in range(32):
+        name = f"s-{digest}" if suffix == 0 else f"s-{digest}-{suffix}"
+        yield base / name
+
+
 def _build_preview(
     text: str,
     head: int,
@@ -193,52 +208,112 @@ def _build_preview(
     return "\n".join(parts)
 
 
-def _is_owned_spill_dir(path: Path) -> bool:
+def _is_owned_spill_dir(path: Path, *, expected_marker: Optional[str] = None) -> bool:
     """Return whether a session directory has exact, non-symlink ownership."""
     marker = path / _OWNERSHIP_MARKER
+    fd: Optional[int] = None
     try:
-        path_attrs = int(getattr(path.lstat(), "st_file_attributes", 0))
-        marker_attrs = int(getattr(marker.lstat(), "st_file_attributes", 0))
+        path_stat = path.lstat()
+        marker_stat = marker.lstat()
+        path_attrs = int(getattr(path_stat, "st_file_attributes", 0))
+        marker_attrs = int(getattr(marker_stat, "st_file_attributes", 0))
+        if (
+            not stat.S_ISDIR(path_stat.st_mode)
+            or path.is_symlink()
+            or path_attrs & 0x400
+            or not stat.S_ISREG(marker_stat.st_mode)
+            or marker.is_symlink()
+            or marker_attrs & 0x400
+        ):
+            return False
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(marker, flags)
+        opened_marker = os.fstat(fd)
+        if (
+            not stat.S_ISREG(opened_marker.st_mode)
+            or not os.path.samestat(marker_stat, opened_marker)
+        ):
+            return False
+        with os.fdopen(fd, "r", encoding="utf-8") as marker_file:
+            fd = None
+            value = marker_file.read(129)
+        if len(value) > 128:
+            return False
+        value = value.strip()
+        marker_matches = (
+            value == expected_marker
+            if expected_marker is not None
+            else value == _OWNERSHIP_VALUE
+            or (
+                path.name.startswith("s-")
+                and value == f"{_OWNERSHIP_V2_PREFIX}{path.name}"
+            )
+        )
         return (
-            path.is_dir()
-            and not path.is_symlink()
-            and not (path_attrs & 0x400)
-            and marker.is_file()
-            and not marker.is_symlink()
-            and not (marker_attrs & 0x400)
-            and marker.read_text(encoding="utf-8").strip() == _OWNERSHIP_VALUE
+            marker_matches
+            and os.path.samestat(path_stat, path.lstat())
+            and os.path.samestat(marker_stat, marker.lstat())
         )
     except (OSError, UnicodeError):
         return False
+    finally:
+        if fd is not None:
+            os.close(fd)
 
 
-def _prepare_owned_spill_dir(path: Path) -> bool:
+def _prepare_owned_spill_dir(
+    path: Path, *, marker_value: str = _OWNERSHIP_VALUE
+) -> bool:
     """Create and mark a new session dir, or verify an existing owned one."""
     try:
         path.mkdir(parents=True, exist_ok=False)
     except FileExistsError:
         # Never adopt a pre-existing directory by stamping a marker into it.
-        return _is_owned_spill_dir(path)
+        return _is_owned_spill_dir(path, expected_marker=marker_value)
     except OSError:
         return False
 
     marker = path / _OWNERSHIP_MARKER
     try:
         with marker.open("x", encoding="utf-8") as marker_file:
-            marker_file.write(f"{_OWNERSHIP_VALUE}\n")
+            marker_file.write(f"{marker_value}\n")
     except (FileExistsError, OSError):
         try:
             path.rmdir()
         except OSError:
             pass
         return False
-    if _is_owned_spill_dir(path):
+    if _is_owned_spill_dir(path, expected_marker=marker_value):
         return True
     try:
         path.rmdir()
     except OSError:
         pass
     return False
+
+
+def _resolve_writable_spill_dir(
+    directory_override: Optional[str], session_id: Optional[str]
+) -> Optional[Path]:
+    """Return an owned write directory without adopting legacy state.
+
+    Pre-marker Hermes releases created ``<base>/<session_id>`` directories.
+    They are indistinguishable from a user-created directory, so keep them
+    read-only and publish new spills into a deterministic v2 namespace. A
+    bounded suffix search preserves the feature even if a v2 name is occupied
+    by foreign state.
+    """
+    legacy_path = _resolve_spill_dir(directory_override, session_id)
+    if _prepare_owned_spill_dir(legacy_path):
+        return legacy_path
+
+    for candidate in _spill_v2_candidates(legacy_path.parent, session_id):
+        marker_value = f"{_OWNERSHIP_V2_PREFIX}{candidate.name}"
+        if _prepare_owned_spill_dir(candidate, marker_value=marker_value):
+            return candidate
+    return None
 
 
 def _atomic_unlink_spill(path: Path, expected: os.stat_result) -> bool:
@@ -462,16 +537,20 @@ def spill_if_oversized(
     # something bounded — never let a disk failure blow up the turn.
     saved_path: Optional[str] = None
     try:
-        spill_dir = _resolve_spill_dir(directory_override, session_id)
+        legacy_spill_dir = _resolve_spill_dir(directory_override, session_id)
         prune_spill_files(
-            spill_dir.parent,
+            legacy_spill_dir.parent,
             retention_seconds=cfg.get("retention_seconds", DEFAULT_RETENTION_SECONDS),
             max_files_per_session=cfg.get(
                 "max_files_per_session", DEFAULT_MAX_FILES_PER_SESSION
             ),
         )
-        if not _prepare_owned_spill_dir(spill_dir):
-            raise OSError(f"spill directory is not exclusively Hermes-owned: {spill_dir}")
+        spill_dir = _resolve_writable_spill_dir(directory_override, session_id)
+        if spill_dir is None:
+            raise OSError(
+                f"no exclusively Hermes-owned spill directory under "
+                f"{legacy_spill_dir.parent}"
+            )
         filename = f"{uuid.uuid4().hex}.txt"
         spill_path = spill_dir / filename
         # Write the raw text plus a trailing newline so tail readers

--- a/tools/hook_output_spill.py
+++ b/tools/hook_output_spill.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 import uuid
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -55,6 +56,8 @@ DEFAULT_MAX_CHARS = 10_000
 DEFAULT_PREVIEW_HEAD = 500
 DEFAULT_PREVIEW_TAIL = 500
 DEFAULT_ENABLED = True
+DEFAULT_RETENTION_SECONDS = 7 * 24 * 60 * 60
+DEFAULT_MAX_FILES_PER_SESSION = 100
 
 
 def _coerce_positive_int(value: Any, default: int) -> int:
@@ -109,6 +112,12 @@ def get_spill_config() -> Dict[str, Any]:
             section.get("preview_tail"), DEFAULT_PREVIEW_TAIL
         ),
         "directory": directory,
+        "retention_seconds": _coerce_positive_int(
+            section.get("retention_seconds"), DEFAULT_RETENTION_SECONDS
+        ),
+        "max_files_per_session": _coerce_positive_int(
+            section.get("max_files_per_session"), DEFAULT_MAX_FILES_PER_SESSION
+        ),
     }
 
 
@@ -157,6 +166,66 @@ def _build_preview(
         parts.append("--- tail ---")
         parts.append(tail_chunk)
     return "\n".join(parts)
+
+
+def prune_spill_files(
+    base_directory: str | os.PathLike[str],
+    *,
+    retention_seconds: int = DEFAULT_RETENTION_SECONDS,
+    max_files_per_session: int = DEFAULT_MAX_FILES_PER_SESSION,
+) -> int:
+    """Prune only owned ``*.txt`` spill files below session directories.
+
+    The spill root is a Hermes-owned namespace, but individual files may be
+    concurrently written by another session.  Deletion is therefore limited
+    to regular, non-symlink files that are either older than the retention
+    window or beyond the deterministic newest-N bound; any stat/unlink error
+    preserves the file and is merely logged.
+    """
+    try:
+        root = Path(base_directory)
+        if not root.is_dir() or root.is_symlink():
+            return 0
+        retention = max(1, int(retention_seconds))
+        maximum = max(1, int(max_files_per_session))
+    except (OSError, TypeError, ValueError):
+        return 0
+
+    now = time.time()
+    removed = 0
+    try:
+        session_dirs = sorted(
+            (p for p in root.iterdir() if p.is_dir() and not p.is_symlink()),
+            key=lambda p: p.name,
+        )
+    except OSError:
+        return 0
+
+    for session_dir in session_dirs:
+        try:
+            files = sorted(
+                (
+                    p for p in session_dir.iterdir()
+                    if p.is_file() and not p.is_symlink() and p.suffix == ".txt"
+                ),
+                key=lambda p: (p.stat().st_mtime, p.name),
+                reverse=True,
+            )
+        except OSError:
+            continue
+        for index, path in enumerate(files):
+            try:
+                expired = now - path.stat().st_mtime > retention
+            except OSError:
+                continue
+            if not expired and index < maximum:
+                continue
+            try:
+                path.unlink()
+                removed += 1
+            except OSError:
+                logger.debug("hook output spill prune skipped %s", path, exc_info=True)
+    return removed
 
 
 def spill_if_oversized(
@@ -212,7 +281,25 @@ def spill_if_oversized(
     saved_path: Optional[str] = None
     try:
         spill_dir = _resolve_spill_dir(directory_override, session_id)
+        prune_spill_files(
+            spill_dir.parent,
+            retention_seconds=cfg.get("retention_seconds", DEFAULT_RETENTION_SECONDS),
+            max_files_per_session=cfg.get(
+                "max_files_per_session", DEFAULT_MAX_FILES_PER_SESSION
+            ),
+        )
         spill_dir.mkdir(parents=True, exist_ok=True)
+        marker = spill_dir / ".hermes-managed"
+        if (
+            directory_override is None
+            and not marker.exists()
+            and not marker.is_symlink()
+        ):
+            try:
+                with marker.open("x", encoding="utf-8") as marker_file:
+                    marker_file.write("hook_outputs\n")
+            except FileExistsError:
+                pass
         filename = f"{uuid.uuid4().hex}.txt"
         spill_path = spill_dir / filename
         # Write the raw text plus a trailing newline so tail readers
@@ -231,6 +318,9 @@ __all__ = [
     "DEFAULT_PREVIEW_HEAD",
     "DEFAULT_PREVIEW_TAIL",
     "DEFAULT_ENABLED",
+    "DEFAULT_RETENTION_SECONDS",
+    "DEFAULT_MAX_FILES_PER_SESSION",
     "get_spill_config",
+    "prune_spill_files",
     "spill_if_oversized",
 ]

--- a/tools/hook_output_spill.py
+++ b/tools/hook_output_spill.py
@@ -50,6 +50,7 @@ import os
 import stat
 import time
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterator, Optional
 
@@ -66,6 +67,34 @@ _OWNERSHIP_MARKER = ".hermes-managed"
 _OWNERSHIP_VALUE = "hook_outputs"
 _OWNERSHIP_V2_PREFIX = "hook_outputs:v2:"
 _DELETE_QUARANTINE_TOKEN = ".hermes-delete-"
+_SPILL_PUBLICATION_ATTEMPTS = 32
+
+
+@dataclass(frozen=True)
+class _OwnedSpillDirectory:
+    """Identity-bound proof for one writable spill namespace."""
+
+    path: Path
+    directory_identity: os.stat_result
+    marker_identity: os.stat_result
+    marker_value: str
+
+
+def _remove_exact_empty_directory(path: Path, expected: os.stat_result) -> bool:
+    """Quarantine then remove only the exact empty directory we created."""
+    quarantine = path.with_name(f".{path.name}.hermes-delete-{uuid.uuid4().hex}")
+    try:
+        if not _same_owned_directory(path, expected):
+            return False
+        os.replace(path, quarantine)
+        moved = quarantine.lstat()
+        if not os.path.samestat(expected, moved):
+            # A race winner was moved, but is preserved rather than deleted.
+            return False
+        quarantine.rmdir()
+        return True
+    except OSError:
+        return False
 
 
 def _path_is_link_like(path: Path) -> bool:
@@ -208,8 +237,10 @@ def _build_preview(
     return "\n".join(parts)
 
 
-def _is_owned_spill_dir(path: Path, *, expected_marker: Optional[str] = None) -> bool:
-    """Return whether a session directory has exact, non-symlink ownership."""
+def _owned_spill_dir_evidence(
+    path: Path, *, expected_marker: Optional[str] = None
+) -> Optional[_OwnedSpillDirectory]:
+    """Capture exact directory and marker evidence for a spill namespace."""
     marker = path / _OWNERSHIP_MARKER
     fd: Optional[int] = None
     try:
@@ -225,7 +256,7 @@ def _is_owned_spill_dir(path: Path, *, expected_marker: Optional[str] = None) ->
             or marker.is_symlink()
             or marker_attrs & 0x400
         ):
-            return False
+            return None
         flags = os.O_RDONLY
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
@@ -235,12 +266,12 @@ def _is_owned_spill_dir(path: Path, *, expected_marker: Optional[str] = None) ->
             not stat.S_ISREG(opened_marker.st_mode)
             or not os.path.samestat(marker_stat, opened_marker)
         ):
-            return False
+            return None
         with os.fdopen(fd, "r", encoding="utf-8") as marker_file:
             fd = None
             value = marker_file.read(129)
         if len(value) > 128:
-            return False
+            return None
         value = value.strip()
         marker_matches = (
             value == expected_marker
@@ -251,52 +282,158 @@ def _is_owned_spill_dir(path: Path, *, expected_marker: Optional[str] = None) ->
                 and value == f"{_OWNERSHIP_V2_PREFIX}{path.name}"
             )
         )
-        return (
-            marker_matches
-            and os.path.samestat(path_stat, path.lstat())
-            and os.path.samestat(marker_stat, marker.lstat())
-        )
+        if (
+            not marker_matches
+            or not os.path.samestat(path_stat, path.lstat())
+            or not os.path.samestat(marker_stat, marker.lstat())
+        ):
+            return None
+        return _OwnedSpillDirectory(path, path_stat, marker_stat, value)
     except (OSError, UnicodeError):
-        return False
+        return None
     finally:
         if fd is not None:
             os.close(fd)
 
 
-def _prepare_owned_spill_dir(
+def _owned_spill_dir_evidence_is_current(evidence: _OwnedSpillDirectory) -> bool:
+    """Revalidate that both names still select the captured owned objects."""
+    current = _owned_spill_dir_evidence(
+        evidence.path, expected_marker=evidence.marker_value
+    )
+    return bool(
+        current is not None
+        and os.path.samestat(
+            evidence.directory_identity, current.directory_identity
+        )
+        and os.path.samestat(evidence.marker_identity, current.marker_identity)
+    )
+
+
+def _is_owned_spill_dir(path: Path, *, expected_marker: Optional[str] = None) -> bool:
+    """Return whether a session directory has exact, non-symlink ownership."""
+    return _owned_spill_dir_evidence(path, expected_marker=expected_marker) is not None
+
+
+def _prepare_owned_spill_dir_evidence(
     path: Path, *, marker_value: str = _OWNERSHIP_VALUE
-) -> bool:
-    """Create and mark a new session dir, or verify an existing owned one."""
+) -> Optional[_OwnedSpillDirectory]:
+    """Create and bind a session directory, or bind an existing owned one."""
+    created_identity: Optional[os.stat_result] = None
     try:
         path.mkdir(parents=True, exist_ok=False)
+        created_identity = path.lstat()
     except FileExistsError:
         # Never adopt a pre-existing directory by stamping a marker into it.
-        return _is_owned_spill_dir(path, expected_marker=marker_value)
+        return _owned_spill_dir_evidence(path, expected_marker=marker_value)
     except OSError:
-        return False
+        return None
 
     marker = path / _OWNERSHIP_MARKER
     try:
         with marker.open("x", encoding="utf-8") as marker_file:
             marker_file.write(f"{marker_value}\n")
     except (FileExistsError, OSError):
+        if created_identity is not None:
+            _remove_exact_empty_directory(path, created_identity)
+        return None
+
+    evidence = _owned_spill_dir_evidence(path, expected_marker=marker_value)
+    if (
+        evidence is not None
+        and created_identity is not None
+        and os.path.samestat(created_identity, evidence.directory_identity)
+    ):
+        return evidence
+    return None
+
+
+def _publish_spill_file(
+    evidence: _OwnedSpillDirectory, text: str
+) -> Optional[Path]:
+    """Exclusively publish one spill inside the exact captured namespace.
+
+    The file is opened empty first. Directory and marker identities are then
+    revalidated before any hook output is written, so a regular-directory or
+    Windows-junction replacement can receive at most an empty file. Failed
+    empty creations are removed only through exact file identity checks.
+    """
+    payload = (text if text.endswith("\n") else text + "\n").encode("utf-8")
+    for _ in range(_SPILL_PUBLICATION_ATTEMPTS):
+        if not _owned_spill_dir_evidence_is_current(evidence):
+            return None
+        destination = evidence.path / f"{uuid.uuid4().hex}.txt"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_BINARY"):
+            flags |= os.O_BINARY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd: Optional[int] = None
+        opened: Optional[os.stat_result] = None
+        published = False
+        clean_empty = False
         try:
-            path.rmdir()
+            fd = os.open(destination, flags, 0o600)
+            opened = os.fstat(fd)
+            selected = destination.lstat()
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or opened.st_size != 0
+                or not os.path.samestat(opened, selected)
+                or not _owned_spill_dir_evidence_is_current(evidence)
+            ):
+                clean_empty = opened.st_size == 0
+                raise OSError("spill namespace changed before publication")
+
+            view = memoryview(payload)
+            while view:
+                written = os.write(fd, view)
+                if written <= 0:
+                    raise OSError("short write while publishing hook output spill")
+                view = view[written:]
+            os.fsync(fd)
+
+            after = os.fstat(fd)
+            selected_after = destination.lstat()
+            if (
+                not os.path.samestat(opened, after)
+                or not os.path.samestat(after, selected_after)
+                or after.st_size != len(payload)
+                or not _owned_spill_dir_evidence_is_current(evidence)
+            ):
+                raise OSError("spill namespace changed during publication")
+            published = True
+            return destination
+        except FileExistsError:
+            # Preserve the race winner and retry with another bounded nonce.
+            continue
         except OSError:
-            pass
-        return False
-    if _is_owned_spill_dir(path, expected_marker=marker_value):
-        return True
-    try:
-        path.rmdir()
-    except OSError:
-        pass
-    return False
+            return None
+        finally:
+            if fd is not None:
+                if opened is not None and not published:
+                    try:
+                        clean_empty = clean_empty or os.fstat(fd).st_size == 0
+                    except OSError:
+                        pass
+                os.close(fd)
+            if clean_empty and opened is not None:
+                _atomic_unlink_spill(destination, opened, require_empty=True)
+    return None
+
+
+def _prepare_owned_spill_dir(
+    path: Path, *, marker_value: str = _OWNERSHIP_VALUE
+) -> bool:
+    """Create and mark a new session dir, or verify an existing owned one."""
+    return _prepare_owned_spill_dir_evidence(
+        path, marker_value=marker_value
+    ) is not None
 
 
 def _resolve_writable_spill_dir(
     directory_override: Optional[str], session_id: Optional[str]
-) -> Optional[Path]:
+) -> Optional[_OwnedSpillDirectory]:
     """Return an owned write directory without adopting legacy state.
 
     Pre-marker Hermes releases created ``<base>/<session_id>`` directories.
@@ -306,17 +443,23 @@ def _resolve_writable_spill_dir(
     by foreign state.
     """
     legacy_path = _resolve_spill_dir(directory_override, session_id)
-    if _prepare_owned_spill_dir(legacy_path):
-        return legacy_path
+    evidence = _prepare_owned_spill_dir_evidence(legacy_path)
+    if evidence is not None:
+        return evidence
 
     for candidate in _spill_v2_candidates(legacy_path.parent, session_id):
         marker_value = f"{_OWNERSHIP_V2_PREFIX}{candidate.name}"
-        if _prepare_owned_spill_dir(candidate, marker_value=marker_value):
-            return candidate
+        evidence = _prepare_owned_spill_dir_evidence(
+            candidate, marker_value=marker_value
+        )
+        if evidence is not None:
+            return evidence
     return None
 
 
-def _atomic_unlink_spill(path: Path, expected: os.stat_result) -> bool:
+def _atomic_unlink_spill(
+    path: Path, expected: os.stat_result, *, require_empty: bool = False
+) -> bool:
     """Unlink the exact opened spill object, never a pathname replacement."""
     fd: Optional[int] = None
     quarantine = path.with_name(f".{path.name}.hermes-delete-{uuid.uuid4().hex}")
@@ -372,6 +515,7 @@ def _atomic_unlink_spill(path: Path, expected: os.stat_result) -> bool:
         current_attributes = int(getattr(current, "st_file_attributes", 0))
         if (
             not stat.S_ISREG(opened.st_mode)
+            or (require_empty and opened.st_size != 0)
             or not stat.S_ISREG(current.st_mode)
             or path.is_symlink()
             or current_attributes & 0x400
@@ -380,7 +524,11 @@ def _atomic_unlink_spill(path: Path, expected: os.stat_result) -> bool:
         ):
             return False
         os.replace(path, quarantine)
-        if not os.path.samestat(opened, quarantine.lstat()):
+        moved = quarantine.lstat()
+        if (
+            not os.path.samestat(opened, moved)
+            or (require_empty and os.fstat(fd).st_size != 0)
+        ):
             # The pathname no longer carries safe restoration authority. A
             # concurrent writer may recreate it at any instant, so preserve
             # the quarantined object instead of risking an overwrite.
@@ -551,11 +699,9 @@ def spill_if_oversized(
                 f"no exclusively Hermes-owned spill directory under "
                 f"{legacy_spill_dir.parent}"
             )
-        filename = f"{uuid.uuid4().hex}.txt"
-        spill_path = spill_dir / filename
-        # Write the raw text plus a trailing newline so tail readers
-        # (``tail -f``, editors) don't report "missing newline".
-        spill_path.write_text(text if text.endswith("\n") else text + "\n", encoding="utf-8")
+        spill_path = _publish_spill_file(spill_dir, text)
+        if spill_path is None:
+            raise OSError("spill namespace changed during exclusive publication")
         saved_path = str(spill_path)
     except Exception as exc:
         logger.warning("hook output spill failed: %s", exc)

--- a/tools/hook_output_spill.py
+++ b/tools/hook_output_spill.py
@@ -457,6 +457,40 @@ def _resolve_writable_spill_dir(
     return None
 
 
+def _restore_quarantined_spill(
+    quarantine: Path,
+    original: Path,
+    moved: os.stat_result,
+) -> bool:
+    """No-clobber restore a pathname replacement moved during pruning."""
+    try:
+        quarantined = quarantine.lstat()
+        if (
+            not stat.S_ISREG(quarantined.st_mode)
+            or not os.path.samestat(moved, quarantined)
+            or os.path.lexists(original)
+        ):
+            return False
+        if os.name == "nt":
+            os.rename(quarantine, original)
+        else:
+            os.link(quarantine, original, follow_symlinks=False)
+            restored = original.lstat()
+            quarantined = quarantine.lstat()
+            if not (
+                stat.S_ISREG(restored.st_mode)
+                and stat.S_ISREG(quarantined.st_mode)
+                and os.path.samestat(moved, restored)
+                and os.path.samestat(moved, quarantined)
+            ):
+                return False
+            quarantine.unlink()
+        restored = original.lstat()
+        return stat.S_ISREG(restored.st_mode) and os.path.samestat(moved, restored)
+    except OSError:
+        return False
+
+
 def _atomic_unlink_spill(
     path: Path, expected: os.stat_result, *, require_empty: bool = False
 ) -> bool:
@@ -529,9 +563,7 @@ def _atomic_unlink_spill(
             not os.path.samestat(opened, moved)
             or (require_empty and os.fstat(fd).st_size != 0)
         ):
-            # The pathname no longer carries safe restoration authority. A
-            # concurrent writer may recreate it at any instant, so preserve
-            # the quarantined object instead of risking an overwrite.
+            _restore_quarantined_spill(quarantine, path, moved)
             return False
         try:
             quarantine.unlink()

--- a/tools/hook_output_spill.py
+++ b/tools/hook_output_spill.py
@@ -174,11 +174,15 @@ def _is_owned_spill_dir(path: Path) -> bool:
     """Return whether a session directory has exact, non-symlink ownership."""
     marker = path / _OWNERSHIP_MARKER
     try:
+        path_attrs = int(getattr(path.lstat(), "st_file_attributes", 0))
+        marker_attrs = int(getattr(marker.lstat(), "st_file_attributes", 0))
         return (
             path.is_dir()
             and not path.is_symlink()
+            and not (path_attrs & 0x400)
             and marker.is_file()
             and not marker.is_symlink()
+            and not (marker_attrs & 0x400)
             and marker.read_text(encoding="utf-8").strip() == _OWNERSHIP_VALUE
         )
     except (OSError, UnicodeError):
@@ -201,7 +205,6 @@ def _prepare_owned_spill_dir(path: Path) -> bool:
             marker_file.write(f"{_OWNERSHIP_VALUE}\n")
     except (FileExistsError, OSError):
         try:
-            marker.unlink(missing_ok=True)
             path.rmdir()
         except OSError:
             pass
@@ -209,11 +212,72 @@ def _prepare_owned_spill_dir(path: Path) -> bool:
     if _is_owned_spill_dir(path):
         return True
     try:
-        marker.unlink(missing_ok=True)
         path.rmdir()
     except OSError:
         pass
     return False
+
+
+def _atomic_unlink_spill(path: Path) -> bool:
+    """Unlink the exact opened spill object, never a pathname replacement."""
+    fd: Optional[int] = None
+    quarantine = path.with_name(f".{path.name}.hermes-delete-{uuid.uuid4().hex}")
+    try:
+        attributes = int(getattr(path.lstat(), "st_file_attributes", 0))
+        if path.is_symlink() or attributes & 0x400 or not path.is_file():
+            return False
+        if os.name == "nt":
+            import ctypes
+            import msvcrt
+
+            create_file = ctypes.windll.kernel32.CreateFileW
+            create_file.argtypes = (
+                ctypes.c_wchar_p,
+                ctypes.c_uint32,
+                ctypes.c_uint32,
+                ctypes.c_void_p,
+                ctypes.c_uint32,
+                ctypes.c_uint32,
+                ctypes.c_void_p,
+            )
+            create_file.restype = ctypes.c_void_p
+            handle = create_file(
+                str(path),
+                0x80000000,  # GENERIC_READ
+                0x00000001 | 0x00000002 | 0x00000004,  # SHARE_READ|WRITE|DELETE
+                None,
+                3,  # OPEN_EXISTING
+                0x00200000,  # FILE_FLAG_OPEN_REPARSE_POINT
+                None,
+            )
+            if handle == ctypes.c_void_p(-1).value:
+                raise ctypes.WinError()
+            try:
+                fd = msvcrt.open_osfhandle(handle, os.O_RDONLY)
+            except BaseException:
+                ctypes.windll.kernel32.CloseHandle(handle)
+                raise
+        else:
+            flags = os.O_RDONLY
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            fd = os.open(path, flags)
+        opened = os.fstat(fd)
+        os.replace(path, quarantine)
+        if not os.path.samestat(opened, quarantine.lstat()):
+            try:
+                os.link(quarantine, path)
+                quarantine.unlink()
+            except OSError:
+                pass
+            return False
+        quarantine.unlink()
+        return True
+    except OSError:
+        return False
+    finally:
+        if fd is not None:
+            os.close(fd)
 
 
 def prune_spill_files(
@@ -269,8 +333,8 @@ def prune_spill_files(
             if not expired and index < maximum:
                 continue
             try:
-                path.unlink()
-                removed += 1
+                if _atomic_unlink_spill(path):
+                    removed += 1
             except OSError:
                 logger.debug("hook output spill prune skipped %s", path, exc_info=True)
     return removed

--- a/tools/hook_output_spill.py
+++ b/tools/hook_output_spill.py
@@ -200,8 +200,20 @@ def _prepare_owned_spill_dir(path: Path) -> bool:
         with marker.open("x", encoding="utf-8") as marker_file:
             marker_file.write(f"{_OWNERSHIP_VALUE}\n")
     except (FileExistsError, OSError):
+        try:
+            marker.unlink(missing_ok=True)
+            path.rmdir()
+        except OSError:
+            pass
         return False
-    return _is_owned_spill_dir(path)
+    if _is_owned_spill_dir(path):
+        return True
+    try:
+        marker.unlink(missing_ok=True)
+        path.rmdir()
+    except OSError:
+        pass
+    return False
 
 
 def prune_spill_files(

--- a/tools/hook_output_spill.py
+++ b/tools/hook_output_spill.py
@@ -58,6 +58,8 @@ DEFAULT_PREVIEW_TAIL = 500
 DEFAULT_ENABLED = True
 DEFAULT_RETENTION_SECONDS = 7 * 24 * 60 * 60
 DEFAULT_MAX_FILES_PER_SESSION = 100
+_OWNERSHIP_MARKER = ".hermes-managed"
+_OWNERSHIP_VALUE = "hook_outputs"
 
 
 def _coerce_positive_int(value: Any, default: int) -> int:
@@ -168,6 +170,40 @@ def _build_preview(
     return "\n".join(parts)
 
 
+def _is_owned_spill_dir(path: Path) -> bool:
+    """Return whether a session directory has exact, non-symlink ownership."""
+    marker = path / _OWNERSHIP_MARKER
+    try:
+        return (
+            path.is_dir()
+            and not path.is_symlink()
+            and marker.is_file()
+            and not marker.is_symlink()
+            and marker.read_text(encoding="utf-8").strip() == _OWNERSHIP_VALUE
+        )
+    except (OSError, UnicodeError):
+        return False
+
+
+def _prepare_owned_spill_dir(path: Path) -> bool:
+    """Create and mark a new session dir, or verify an existing owned one."""
+    try:
+        path.mkdir(parents=True, exist_ok=False)
+    except FileExistsError:
+        # Never adopt a pre-existing directory by stamping a marker into it.
+        return _is_owned_spill_dir(path)
+    except OSError:
+        return False
+
+    marker = path / _OWNERSHIP_MARKER
+    try:
+        with marker.open("x", encoding="utf-8") as marker_file:
+            marker_file.write(f"{_OWNERSHIP_VALUE}\n")
+    except (FileExistsError, OSError):
+        return False
+    return _is_owned_spill_dir(path)
+
+
 def prune_spill_files(
     base_directory: str | os.PathLike[str],
     *,
@@ -195,7 +231,7 @@ def prune_spill_files(
     removed = 0
     try:
         session_dirs = sorted(
-            (p for p in root.iterdir() if p.is_dir() and not p.is_symlink()),
+            (p for p in root.iterdir() if _is_owned_spill_dir(p)),
             key=lambda p: p.name,
         )
     except OSError:
@@ -288,18 +324,8 @@ def spill_if_oversized(
                 "max_files_per_session", DEFAULT_MAX_FILES_PER_SESSION
             ),
         )
-        spill_dir.mkdir(parents=True, exist_ok=True)
-        marker = spill_dir / ".hermes-managed"
-        if (
-            directory_override is None
-            and not marker.exists()
-            and not marker.is_symlink()
-        ):
-            try:
-                with marker.open("x", encoding="utf-8") as marker_file:
-                    marker_file.write("hook_outputs\n")
-            except FileExistsError:
-                pass
+        if not _prepare_owned_spill_dir(spill_dir):
+            raise OSError(f"spill directory is not exclusively Hermes-owned: {spill_dir}")
         filename = f"{uuid.uuid4().hex}.txt"
         spill_path = spill_dir / filename
         # Write the raw text plus a trailing newline so tail readers

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -37,7 +37,6 @@ import logging
 import os
 import platform
 import re
-import shlex
 import time
 import threading
 import atexit
@@ -119,87 +118,6 @@ DISK_USAGE_WARNING_THRESHOLD_GB = _safe_parse_import_env(
     float,
     "number",
 )
-
-
-_TERMINAL_CREATION_WINDOWS_PATH_REGEX = re.compile(
-    r"(?<![A-Za-z0-9_])([A-Za-z]:[\\/][^\s'\"`]+)"
-)
-
-
-def _terminal_creation_path_candidates(command: str) -> set[str]:
-    """Extract absolute path operands from command text for stat-only checks.
-
-    This is intentionally narrower than a shell parser: it never reads
-    command output and never treats a path as owned by Hermes.  The resulting
-    candidates are only used for before/after existence evidence, which the
-    disk-cleanup plugin consumes through ``created_paths``.
-    """
-    if not isinstance(command, str) or not command:
-        return set()
-
-    candidates = {
-        match.group(1)
-        for match in _TERMINAL_CREATION_WINDOWS_PATH_REGEX.finditer(command)
-    }
-    try:
-        tokens = shlex.split(command, posix=True)
-    except ValueError:
-        tokens = []
-    for token in tokens:
-        if token.startswith(("/", "~")) or _TERMINAL_CREATION_WINDOWS_PATH_REGEX.match(token):
-            candidates.add(token)
-    return candidates
-
-
-def _normalize_terminal_creation_path(value: str) -> str | None:
-    """Normalize a candidate path, rejecting foreign Windows paths off-host."""
-    if not isinstance(value, str) or not value:
-        return None
-    if _TERMINAL_CREATION_WINDOWS_PATH_REGEX.match(value) and os.name != "nt":
-        return None
-    try:
-        return str(Path(value).expanduser())
-    except (OSError, ValueError):
-        return None
-
-
-def _snapshot_terminal_creation_candidates(command: str) -> dict[str, bool | None]:
-    """Capture pre-command existence for explicit absolute path operands."""
-    snapshot: dict[str, bool | None] = {}
-    for raw_path in _terminal_creation_path_candidates(command):
-        path = _normalize_terminal_creation_path(raw_path)
-        if path is None:
-            continue
-        try:
-            # lstat treats a pre-existing broken symlink as existing too;
-            # following it would incorrectly turn a user-owned link into a
-            # newly-created artifact candidate.  Unknown access errors stay
-            # unknown rather than becoming false (fail closed).
-            os.lstat(path)
-            snapshot[path] = True
-        except FileNotFoundError:
-            snapshot[path] = False
-        except (OSError, ValueError):
-            snapshot[path] = None
-    return snapshot
-
-
-def _created_terminal_paths(
-    before: dict[str, bool | None], returncode: int
-) -> list[str]:
-    """Return paths proven absent before and present after a successful call."""
-    if returncode != 0:
-        return []
-    created: list[str] = []
-    for path, existed_before in sorted(before.items()):
-        if existed_before is not False:
-            continue
-        try:
-            os.lstat(path)
-            created.append(path)
-        except (FileNotFoundError, OSError, ValueError):
-            continue
-    return created
 
 
 def _check_disk_usage_warning():
@@ -2803,13 +2721,6 @@ def terminal_tool(
                 from tools.interrupt import clear_current_thread_interrupt
                 clear_current_thread_interrupt()
 
-            # Capture only explicit path operands before execution.  This
-            # enables trusted creation metadata without ever treating command
-            # output as ownership evidence.  Background processes are
-            # intentionally excluded because their post-state is not known at
-            # this call boundary.
-            terminal_creation_before = _snapshot_terminal_creation_candidates(command)
-
             while retry_count <= max_retries:
                 try:
                     command_cwd = _resolve_command_cwd(
@@ -2946,11 +2857,6 @@ def terminal_tool(
                 "exit_code": returncode,
                 "error": None,
             }
-            created_paths = _created_terminal_paths(
-                terminal_creation_before, returncode
-            )
-            if created_paths:
-                result_dict["created_paths"] = created_paths
             try:
                 from agent.verification_evidence import record_terminal_result
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -37,6 +37,7 @@ import logging
 import os
 import platform
 import re
+import shlex
 import time
 import threading
 import atexit
@@ -118,6 +119,87 @@ DISK_USAGE_WARNING_THRESHOLD_GB = _safe_parse_import_env(
     float,
     "number",
 )
+
+
+_TERMINAL_CREATION_WINDOWS_PATH_REGEX = re.compile(
+    r"(?<![A-Za-z0-9_])([A-Za-z]:[\\/][^\s'\"`]+)"
+)
+
+
+def _terminal_creation_path_candidates(command: str) -> set[str]:
+    """Extract absolute path operands from command text for stat-only checks.
+
+    This is intentionally narrower than a shell parser: it never reads
+    command output and never treats a path as owned by Hermes.  The resulting
+    candidates are only used for before/after existence evidence, which the
+    disk-cleanup plugin consumes through ``created_paths``.
+    """
+    if not isinstance(command, str) or not command:
+        return set()
+
+    candidates = {
+        match.group(1)
+        for match in _TERMINAL_CREATION_WINDOWS_PATH_REGEX.finditer(command)
+    }
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        tokens = []
+    for token in tokens:
+        if token.startswith(("/", "~")) or _TERMINAL_CREATION_WINDOWS_PATH_REGEX.match(token):
+            candidates.add(token)
+    return candidates
+
+
+def _normalize_terminal_creation_path(value: str) -> str | None:
+    """Normalize a candidate path, rejecting foreign Windows paths off-host."""
+    if not isinstance(value, str) or not value:
+        return None
+    if _TERMINAL_CREATION_WINDOWS_PATH_REGEX.match(value) and os.name != "nt":
+        return None
+    try:
+        return str(Path(value).expanduser())
+    except (OSError, ValueError):
+        return None
+
+
+def _snapshot_terminal_creation_candidates(command: str) -> dict[str, bool | None]:
+    """Capture pre-command existence for explicit absolute path operands."""
+    snapshot: dict[str, bool | None] = {}
+    for raw_path in _terminal_creation_path_candidates(command):
+        path = _normalize_terminal_creation_path(raw_path)
+        if path is None:
+            continue
+        try:
+            # lstat treats a pre-existing broken symlink as existing too;
+            # following it would incorrectly turn a user-owned link into a
+            # newly-created artifact candidate.  Unknown access errors stay
+            # unknown rather than becoming false (fail closed).
+            os.lstat(path)
+            snapshot[path] = True
+        except FileNotFoundError:
+            snapshot[path] = False
+        except (OSError, ValueError):
+            snapshot[path] = None
+    return snapshot
+
+
+def _created_terminal_paths(
+    before: dict[str, bool | None], returncode: int
+) -> list[str]:
+    """Return paths proven absent before and present after a successful call."""
+    if returncode != 0:
+        return []
+    created: list[str] = []
+    for path, existed_before in sorted(before.items()):
+        if existed_before is not False:
+            continue
+        try:
+            os.lstat(path)
+            created.append(path)
+        except (FileNotFoundError, OSError, ValueError):
+            continue
+    return created
 
 
 def _check_disk_usage_warning():
@@ -2721,6 +2803,13 @@ def terminal_tool(
                 from tools.interrupt import clear_current_thread_interrupt
                 clear_current_thread_interrupt()
 
+            # Capture only explicit path operands before execution.  This
+            # enables trusted creation metadata without ever treating command
+            # output as ownership evidence.  Background processes are
+            # intentionally excluded because their post-state is not known at
+            # this call boundary.
+            terminal_creation_before = _snapshot_terminal_creation_candidates(command)
+
             while retry_count <= max_retries:
                 try:
                     command_cwd = _resolve_command_cwd(
@@ -2857,6 +2946,11 @@ def terminal_tool(
                 "exit_code": returncode,
                 "error": None,
             }
+            created_paths = _created_terminal_paths(
+                terminal_creation_before, returncode
+            )
+            if created_paths:
+                result_dict["created_paths"] = created_paths
             try:
                 from agent.verification_evidence import record_terminal_result
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1759,8 +1759,20 @@ def is_persistent_env(task_id: str) -> bool:
 
 
 def cleanup_all_environments():
-    """Clean up ALL active environments. Use with caution."""
-    task_ids = list(_active_environments.keys())
+    """Clean up tracked active environments without guessing at disk ownership.
+
+    Filesystem paths under the shared scratch root do not carry enough durable
+    identity to prove that a ``hermes-*`` directory belongs to this process,
+    profile, or session.  Leave those paths to backend-specific reapers and
+    explicit ownership-aware cleanup rather than recursively deleting user or
+    persistent overlay data here.
+    """
+    # Snapshot under the registry lock.  Environment creation/teardown can
+    # happen on worker threads while shutdown or an interrupted turn is
+    # sweeping the registry; iterating the live dict would race with those
+    # mutations and leave resources behind.
+    with _env_lock:
+        task_ids = list(_active_environments.keys())
     cleaned = 0
     
     for task_id in task_ids:
@@ -1769,16 +1781,6 @@ def cleanup_all_environments():
             cleaned += 1
         except Exception as e:
             logger.error("Error cleaning %s: %s", task_id, e, exc_info=True)
-    
-    # Also clean any orphaned directories
-    scratch_dir = _get_scratch_dir()
-    import glob
-    for path in glob.glob(str(scratch_dir / "hermes-*")):
-        try:
-            shutil.rmtree(path, ignore_errors=True)
-            logger.info("Removed orphaned: %s", path)
-        except OSError as e:
-            logger.debug("Failed to remove orphaned path %s: %s", path, e)
     
     if cleaned > 0:
         logger.info("Cleaned %d environments", cleaned)
@@ -1856,13 +1858,14 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
 def _atexit_cleanup():
     """Stop cleanup thread and shut down all remaining sandboxes on exit."""
     _stop_cleanup_thread()
-    if _active_environments:
-        count = len(_active_environments)
+    with _env_lock:
+        envs_to_wait = list(_active_environments.values())
+    if envs_to_wait:
+        count = len(envs_to_wait)
         logger.info("Shutting down %d remaining sandbox(es)...", count)
         # Snapshot the env objects BEFORE cleanup_all_environments empties
         # the dict; we need them to wait on docker cleanup threads after the
         # registry has been cleared.
-        envs_to_wait = list(_active_environments.values())
         cleanup_all_environments()
         # Block briefly so docker stop/rm actually completes before the
         # interpreter exits. Issue #20561 — without this join, the daemon

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1204,7 +1204,11 @@ def cleanup_temp_recordings(max_age_seconds: int = 3600) -> int:
     now = time.time()
 
     for entry in os.scandir(_TEMP_DIR):
-        if entry.is_file() and entry.name.startswith("recording_") and entry.name.endswith(".wav"):
+        if (
+            entry.is_file()
+            and entry.name.startswith("recording_")
+            and entry.name.endswith((".wav", ".aac"))
+        ):
             try:
                 age = now - entry.stat().st_mtime
                 if age > max_age_seconds:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -14,11 +14,13 @@ import os
 import platform
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
 import threading
 import time
+import uuid
 import wave
 from typing import Any, Dict, List, Optional
 
@@ -1197,25 +1199,43 @@ def cleanup_temp_recordings(max_age_seconds: int = 3600) -> int:
     Returns:
         Number of files deleted.
     """
-    if not os.path.isdir(_TEMP_DIR):
+    try:
+        root_stat = os.lstat(_TEMP_DIR)
+        root_reparse = int(getattr(root_stat, "st_file_attributes", 0)) & 0x400
+    except OSError:
+        return 0
+    if root_reparse or not stat.S_ISDIR(root_stat.st_mode):
         return 0
 
     deleted = 0
     now = time.time()
 
     for entry in os.scandir(_TEMP_DIR):
-        if (
-            entry.is_file()
-            and entry.name.startswith("recording_")
-            and entry.name.endswith((".wav", ".aac"))
-        ):
-            try:
-                age = now - entry.stat().st_mtime
-                if age > max_age_seconds:
-                    os.unlink(entry.path)
-                    deleted += 1
-            except OSError:
-                pass
+        try:
+            selected = os.lstat(entry.path)
+            if (
+                not stat.S_ISREG(selected.st_mode)
+                or not entry.name.startswith("recording_")
+                or not entry.name.endswith((".wav", ".aac"))
+                or now - selected.st_mtime <= max_age_seconds
+            ):
+                continue
+            quarantine = os.path.join(
+                _TEMP_DIR,
+                f".{entry.name}.hermes-delete-{uuid.uuid4().hex}",
+            )
+            os.replace(entry.path, quarantine)
+            moved = os.lstat(quarantine)
+            if (
+                not os.path.samestat(root_stat, os.lstat(_TEMP_DIR))
+                or not os.path.samestat(selected, moved)
+                or not stat.S_ISREG(moved.st_mode)
+            ):
+                continue
+            os.unlink(quarantine)
+            deleted += 1
+        except OSError:
+            pass
 
     if deleted:
         logger.debug("Cleaned up %d old voice recordings", deleted)

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1190,6 +1190,51 @@ def check_voice_requirements() -> Dict[str, Any]:
 # ============================================================================
 # Temp file cleanup
 # ============================================================================
+def _restore_quarantined_recording(
+    original_path: str, quarantine_path: str, moved: os.stat_result
+) -> bool:
+    """Restore a pathname replacement without overwriting a newer winner."""
+    try:
+        quarantined = os.lstat(quarantine_path)
+        if (
+            not stat.S_ISREG(quarantined.st_mode)
+            or not os.path.samestat(moved, quarantined)
+            or os.path.lexists(original_path)
+        ):
+            return False
+
+        if os.name == "nt":
+            # Unlike os.replace(), Windows os.rename() fails when the
+            # destination already exists.  A newer race winner is preserved.
+            os.rename(quarantine_path, original_path)
+            restored = os.lstat(original_path)
+            return stat.S_ISREG(restored.st_mode) and os.path.samestat(
+                moved, restored
+            )
+
+        # link() is an atomic no-replace publication on POSIX.  Remove the
+        # quarantine name only after proving both names still identify the
+        # object that cleanup accidentally moved.
+        os.link(
+            quarantine_path,
+            original_path,
+            follow_symlinks=False,
+        )
+        restored = os.lstat(original_path)
+        quarantined = os.lstat(quarantine_path)
+        if not (
+            stat.S_ISREG(restored.st_mode)
+            and stat.S_ISREG(quarantined.st_mode)
+            and os.path.samestat(moved, restored)
+            and os.path.samestat(moved, quarantined)
+        ):
+            return False
+        os.unlink(quarantine_path)
+        return True
+    except OSError:
+        return False
+
+
 def cleanup_temp_recordings(max_age_seconds: int = 3600) -> int:
     """Remove old temporary voice recording files.
 
@@ -1226,9 +1271,11 @@ def cleanup_temp_recordings(max_age_seconds: int = 3600) -> int:
             )
             os.replace(entry.path, quarantine)
             moved = os.lstat(quarantine)
+            if not os.path.samestat(selected, moved):
+                _restore_quarantined_recording(entry.path, quarantine, moved)
+                continue
             if (
                 not os.path.samestat(root_stat, os.lstat(_TEMP_DIR))
-                or not os.path.samestat(selected, moved)
                 or not stat.S_ISREG(moved.st_mode)
             ):
                 continue

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9,6 +9,8 @@ import json
 import logging
 import os
 import queue
+import re
+import stat as stat_module
 import subprocess
 import sys
 import threading
@@ -9349,13 +9351,11 @@ def _(rid, params: dict) -> dict:
 # from the event stream).  On turn-complete it posts the final tree here;
 # /replay and /replay-diff fetch past snapshots by session_id + filename.
 #
-# Layout:  $HERMES_HOME/spawn-trees/<session_id>/<timestamp>.json
+# Layout:  $HERMES_HOME/spawn-trees/s-<96-bit session hash>/<timestamp>.json
 # Each file contains { session_id, started_at, finished_at, subagents: [...] }.
 
 
 def _spawn_trees_root():
-    from hermes_constants import get_hermes_home
-
     root = get_hermes_home() / "spawn-trees"
     try:
         root.mkdir(parents=True, exist_ok=False)
@@ -9365,50 +9365,61 @@ def _spawn_trees_root():
     return root
 
 
-def _is_owned_spawn_tree_dir(path: Path) -> bool:
+def _spawn_tree_session_digest(session_id: str) -> str:
+    return hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:24]
+
+
+def _is_owned_spawn_tree_dir(path: Path, *, session_id: str | None = None) -> bool:
     marker = path / ".hermes-managed"
     try:
+        path_attrs = int(getattr(path.lstat(), "st_file_attributes", 0))
+        marker_attrs = int(getattr(marker.lstat(), "st_file_attributes", 0))
+        value = marker.read_text(encoding="utf-8").strip()
+        prefix = "spawn-trees:"
+        digest = value.removeprefix(prefix)
         return (
             path.is_dir()
             and not path.is_symlink()
+            and not (path_attrs & 0x400)
             and marker.is_file()
             and not marker.is_symlink()
-            and marker.read_text(encoding="utf-8").strip() == "spawn-trees"
+            and not (marker_attrs & 0x400)
+            and value.startswith(prefix)
+            and len(digest) == 24
+            and all(char in "0123456789abcdef" for char in digest)
+            and path.name == f"s-{digest}"
+            and (session_id is None or digest == _spawn_tree_session_digest(session_id))
         )
     except (OSError, UnicodeError):
         return False
 
 
 def _spawn_tree_session_dir(session_id: str, *, create: bool = True):
-    safe = (
-        "".join(c if c.isalnum() or c in "-_" else "_" for c in session_id) or "unknown"
-    )
-    d = _spawn_trees_root() / safe
+    digest = _spawn_tree_session_digest(session_id)
+    d = _spawn_trees_root() / f"s-{digest}"
     if not create:
-        return d if _is_owned_spawn_tree_dir(d) else None
+        return d if _is_owned_spawn_tree_dir(d, session_id=session_id) else None
     created = False
     try:
         d.mkdir(parents=True, exist_ok=False)
         created = True
     except FileExistsError:
-        if not _is_owned_spawn_tree_dir(d):
+        if not _is_owned_spawn_tree_dir(d, session_id=session_id):
             raise OSError(f"spawn-tree directory is not exclusively Hermes-owned: {d}")
         return d
     marker = d / ".hermes-managed"
     try:
         with marker.open("x", encoding="utf-8") as marker_file:
-            marker_file.write("spawn-trees\n")
+            marker_file.write(f"spawn-trees:{digest}\n")
     except (FileExistsError, OSError):
         if created:
             try:
-                marker.unlink(missing_ok=True)
                 d.rmdir()
             except OSError:
                 pass
         raise
-    if not _is_owned_spawn_tree_dir(d):
+    if not _is_owned_spawn_tree_dir(d, session_id=session_id):
         try:
-            marker.unlink(missing_ok=True)
             d.rmdir()
         except OSError:
             pass
@@ -9420,11 +9431,85 @@ def _spawn_tree_session_dir(session_id: str, *, create: bool = True):
 # `spawn_tree.list` so scanning doesn't require reading every full snapshot
 # file (Copilot review on #14045).  One JSON object per line.
 _SPAWN_TREE_INDEX = "_index.jsonl"
+_SPAWN_TREE_SNAPSHOT_RE = re.compile(r"^\d{8}T\d{12}-[0-9a-f]{8}\.json$")
+
+
+def _open_owned_spawn_tree_index(session_dir: Path, *, append: bool):
+    """Open the fixed index without following a replacement symlink."""
+    index_path = session_dir / _SPAWN_TREE_INDEX
+    flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT if append else os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(index_path, flags, 0o600)
+    try:
+        path_stat = index_path.lstat()
+        fd_stat = os.fstat(fd)
+        if (
+            index_path.is_symlink()
+            or not stat_module.S_ISREG(path_stat.st_mode)
+            or not stat_module.S_ISREG(fd_stat.st_mode)
+            or not os.path.samestat(path_stat, fd_stat)
+        ):
+            raise OSError("spawn-tree index is not an owned regular file")
+        return os.fdopen(fd, "a" if append else "r", encoding="utf-8")
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _owned_spawn_tree_snapshot(path: Path, session_dir: Path) -> Path | None:
+    """Return the canonical generated snapshot path, or fail closed."""
+    try:
+        attributes = int(getattr(path.lstat(), "st_file_attributes", 0))
+        if (
+            path.is_symlink()
+            or attributes & 0x400
+            or not path.is_file()
+            or _SPAWN_TREE_SNAPSHOT_RE.fullmatch(path.name) is None
+        ):
+            return None
+        resolved = path.resolve()
+        return resolved if resolved.parent == session_dir.resolve() else None
+    except OSError:
+        return None
+
+
+@contextlib.contextmanager
+def _open_owned_spawn_tree_snapshot(path: Path, session_dir: Path):
+    """Open an exact generated snapshot without following a replacement."""
+    snapshot = _owned_spawn_tree_snapshot(path, session_dir)
+    if snapshot is None:
+        raise OSError("spawn-tree snapshot is not an owned regular file")
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(snapshot, flags)
+    stream = None
+    try:
+        path_stat = snapshot.lstat()
+        fd_stat = os.fstat(fd)
+        attributes = int(getattr(path_stat, "st_file_attributes", 0))
+        if (
+            snapshot.is_symlink()
+            or attributes & 0x400
+            or not stat_module.S_ISREG(path_stat.st_mode)
+            or not stat_module.S_ISREG(fd_stat.st_mode)
+            or not os.path.samestat(path_stat, fd_stat)
+        ):
+            raise OSError("spawn-tree snapshot identity changed while opening")
+        stream = os.fdopen(fd, "r", encoding="utf-8")
+        fd = -1
+        yield snapshot, fd_stat, stream
+    finally:
+        if stream is not None:
+            stream.close()
+        elif fd >= 0:
+            os.close(fd)
 
 
 def _append_spawn_tree_index(session_dir, entry: dict) -> None:
     try:
-        with (session_dir / _SPAWN_TREE_INDEX).open("a", encoding="utf-8") as f:
+        with _open_owned_spawn_tree_index(session_dir, append=True) as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
     except OSError as exc:
         # Index is a cache — losing a line just means list() falls back
@@ -9438,7 +9523,7 @@ def _read_spawn_tree_index(session_dir) -> list[dict]:
         return []
     out: list[dict] = []
     try:
-        with index_path.open("r", encoding="utf-8") as f:
+        with _open_owned_spawn_tree_index(session_dir, append=False) as f:
             for line in f:
                 line = line.strip()
                 if not line:
@@ -9523,35 +9608,50 @@ def _(rid, params: dict) -> dict:
     for d in roots:
         indexed = _read_spawn_tree_index(d)
         if indexed:
-            # Skip index entries whose snapshot file was manually deleted.
-            entries.extend(
-                e for e in indexed if (p := e.get("path")) and Path(p).exists()
-            )
+            for entry in indexed:
+                raw_entry_path = entry.get("path")
+                entry_session = entry.get("session_id")
+                if not isinstance(raw_entry_path, str) or not isinstance(
+                    entry_session, str
+                ):
+                    continue
+                snapshot = _owned_spawn_tree_snapshot(Path(raw_entry_path), d)
+                if snapshot is None or not _is_owned_spawn_tree_dir(
+                    d, session_id=entry_session or "default"
+                ):
+                    continue
+                validated = dict(entry)
+                validated["path"] = str(snapshot)
+                entries.append(validated)
             continue
 
         # Fallback for legacy (pre-index) sessions: full scan.  O(N) reads
         # but only runs once per session until the next save writes the index.
         for p in d.glob("*.json"):
-            if p.name == _SPAWN_TREE_INDEX:
-                continue
             try:
-                stat = p.stat()
-                try:
-                    raw = json.loads(p.read_text(encoding="utf-8"))
-                except Exception:
-                    raw = {}
+                with _open_owned_spawn_tree_snapshot(p, d) as (
+                    snapshot,
+                    snapshot_stat,
+                    stream,
+                ):
+                    raw = json.load(stream)
+                raw_session = raw.get("session_id")
+                if not isinstance(raw_session, str) or not _is_owned_spawn_tree_dir(
+                    d, session_id=raw_session or "default"
+                ):
+                    continue
                 subagents = raw.get("subagents") or []
                 entries.append(
                     {
-                        "path": str(p),
-                        "session_id": raw.get("session_id") or d.name,
-                        "finished_at": raw.get("finished_at") or stat.st_mtime,
+                        "path": str(snapshot),
+                        "session_id": raw_session,
+                        "finished_at": raw.get("finished_at") or snapshot_stat.st_mtime,
                         "started_at": raw.get("started_at"),
                         "label": raw.get("label") or "",
                         "count": len(subagents) if isinstance(subagents, list) else 0,
                     }
                 )
-            except OSError:
+            except (OSError, UnicodeError, json.JSONDecodeError):
                 continue
 
     entries.sort(key=lambda e: e.get("finished_at") or 0, reverse=True)
@@ -9568,24 +9668,35 @@ def _(rid, params: dict) -> dict:
 
     # Reject paths escaping the spawn-trees root.
     root = _spawn_trees_root().resolve()
+    candidate = Path(raw_path)
     try:
-        resolved = Path(raw_path).resolve()
+        resolved = candidate.resolve()
         resolved.relative_to(root)
     except (ValueError, OSError) as exc:
         return _err(rid, 4030, f"path outside spawn-trees root: {exc}")
+    snapshot = _owned_spawn_tree_snapshot(candidate, resolved.parent)
     if (
         resolved.parent.parent != root
         or not _is_owned_spawn_tree_dir(resolved.parent)
-        or resolved.is_symlink()
-        or not resolved.is_file()
+        or snapshot is None
     ):
         return _err(rid, 4030, "path is not an owned spawn-tree snapshot")
 
     try:
-        payload = json.loads(resolved.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        with _open_owned_spawn_tree_snapshot(snapshot, snapshot.parent) as (
+            snapshot,
+            _snapshot_stat,
+            stream,
+        ):
+            payload = json.load(stream)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
         return _err(rid, 5000, f"spawn_tree.load failed: {exc}")
 
+    payload_session = payload.get("session_id") if isinstance(payload, dict) else None
+    if not isinstance(payload_session, str) or not _is_owned_spawn_tree_dir(
+        snapshot.parent, session_id=payload_session or "default"
+    ):
+        return _err(rid, 4030, "snapshot session does not match its owned directory")
     return _ok(rid, payload)
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9448,6 +9448,35 @@ def _legacy_spawn_tree_session_name(session_id: str) -> str:
     )
 
 
+_LEGACY_SPAWN_TREE_SNAPSHOT_RE = re.compile(r"^\d{8}T\d{6}\.json$")
+
+
+def _has_markerless_legacy_spawn_tree_snapshot(path: Path) -> bool:
+    """Recognize origin/main history by its generated snapshot objects.
+
+    The old writer created no ownership marker.  Markerless directories are
+    therefore read-compatible only when they contain at least one exact old
+    snapshot filename backed by a regular, single-link file.  This evidence
+    grants no write or cleanup authority.
+    """
+    try:
+        for candidate in path.iterdir():
+            if _LEGACY_SPAWN_TREE_SNAPSHOT_RE.fullmatch(candidate.name) is None:
+                continue
+            selected = candidate.lstat()
+            attributes = int(getattr(selected, "st_file_attributes", 0))
+            if (
+                stat_module.S_ISREG(selected.st_mode)
+                and selected.st_nlink == 1
+                and not candidate.is_symlink()
+                and not (attributes & 0x400)
+            ):
+                return True
+    except OSError:
+        return False
+    return False
+
+
 def _is_legacy_spawn_tree_dir(
     path: Path, *, session_id: str | None = None
 ) -> bool:
@@ -9455,11 +9484,20 @@ def _is_legacy_spawn_tree_dir(
     try:
         path_stat = path.lstat()
         path_attrs = int(getattr(path_stat, "st_file_attributes", 0))
+        if (
+            not stat_module.S_ISDIR(path_stat.st_mode)
+            or path.is_symlink()
+            or path_attrs & 0x400
+        ):
+            return False
+        marker = path / ".hermes-managed"
+        marker_value = _read_spawn_tree_marker(marker)
+        marker_compatible = marker_value == "spawn-trees" or (
+            not os.path.lexists(marker)
+            and _has_markerless_legacy_spawn_tree_snapshot(path)
+        )
         return (
-            stat_module.S_ISDIR(path_stat.st_mode)
-            and not path.is_symlink()
-            and not (path_attrs & 0x400)
-            and _read_spawn_tree_marker(path / ".hermes-managed") == "spawn-trees"
+            marker_compatible
             and (
                 session_id is None
                 or path.name == _legacy_spawn_tree_session_name(session_id)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9367,6 +9367,12 @@ def _spawn_tree_session_dir(session_id: str):
     )
     d = _spawn_trees_root() / safe
     d.mkdir(parents=True, exist_ok=True)
+    marker = d / ".hermes-managed"
+    if not marker.exists():
+        try:
+            marker.write_text("spawn-trees\n", encoding="utf-8")
+        except FileExistsError:
+            pass
     return d
 
 
@@ -9418,10 +9424,11 @@ def _(rid, params: dict) -> dict:
     started_at = params.get("started_at")
     finished_at = params.get("finished_at") or time.time()
     label = str(params.get("label") or "")
-    ts = datetime.utcfromtimestamp(float(finished_at)).strftime("%Y%m%dT%H%M%S")
-    fname = f"{ts}.json"
+    ts = datetime.utcfromtimestamp(float(finished_at)).strftime("%Y%m%dT%H%M%S%f")
+    fname = f"{ts}-{uuid.uuid4().hex[:8]}.json"
     d = _spawn_tree_session_dir(session_id or "default")
     path = d / fname
+    temp_path = d / f".{fname}.{uuid.uuid4().hex}.tmp"
     try:
         payload = {
             "session_id": session_id,
@@ -9430,9 +9437,17 @@ def _(rid, params: dict) -> dict:
             "label": label,
             "subagents": subagents,
         }
-        path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+        temp_path.write_text(
+            json.dumps(payload, ensure_ascii=False), encoding="utf-8"
+        )
+        os.replace(temp_path, path)
     except OSError as exc:
         return _err(rid, 5000, f"spawn_tree.save failed: {exc}")
+    finally:
+        try:
+            temp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
 
     _append_spawn_tree_index(
         d,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9530,30 +9530,300 @@ _SPAWN_TREE_SNAPSHOT_RE = re.compile(
 )
 
 
-def _open_owned_spawn_tree_index(session_dir: Path, *, append: bool):
-    """Open the fixed index without following a replacement symlink."""
-    index_path = session_dir / _SPAWN_TREE_INDEX
-    flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT if append else os.O_RDONLY
+class _SpawnTreeDirEvidence(NamedTuple):
+    path: Path
+    directory_stat: os.stat_result
+    marker_stat: os.stat_result
+    marker_value: str
+    resolved_path: Path
+
+
+def _spawn_tree_regular_file_stat(value: os.stat_result) -> bool:
+    return (
+        stat_module.S_ISREG(value.st_mode)
+        and value.st_nlink == 1
+        and not int(getattr(value, "st_file_attributes", 0)) & 0x400
+    )
+
+
+def _capture_spawn_tree_dir_evidence(
+    session_dir: Path, *, session_id: str | None = None
+) -> _SpawnTreeDirEvidence:
+    """Bind a writable session path to its directory and marker identities."""
+    marker = session_dir / ".hermes-managed"
+    directory_stat = session_dir.lstat()
+    marker_stat = marker.lstat()
+    marker_value = _read_spawn_tree_marker(marker)
+    resolved_path = session_dir.resolve(strict=True)
+    current_directory = session_dir.lstat()
+    current_marker = marker.lstat()
+    if (
+        not _is_owned_spawn_tree_dir(session_dir, session_id=session_id)
+        or not os.path.samestat(directory_stat, current_directory)
+        or not os.path.samestat(marker_stat, current_marker)
+        or not _spawn_tree_regular_file_stat(marker_stat)
+        or marker_value is None
+        or _read_spawn_tree_marker(marker) != marker_value
+        or session_dir.resolve(strict=True) != resolved_path
+    ):
+        raise OSError("spawn-tree directory ownership changed while binding")
+    return _SpawnTreeDirEvidence(
+        session_dir,
+        directory_stat,
+        marker_stat,
+        marker_value,
+        resolved_path,
+    )
+
+
+def _spawn_tree_dir_evidence_matches(evidence: _SpawnTreeDirEvidence) -> bool:
+    try:
+        marker = evidence.path / ".hermes-managed"
+        directory_stat = evidence.path.lstat()
+        marker_stat = marker.lstat()
+        return (
+            _is_owned_spawn_tree_dir(evidence.path)
+            and os.path.samestat(evidence.directory_stat, directory_stat)
+            and os.path.samestat(evidence.marker_stat, marker_stat)
+            and _spawn_tree_regular_file_stat(marker_stat)
+            and _read_spawn_tree_marker(marker) == evidence.marker_value
+            and evidence.path.resolve(strict=True) == evidence.resolved_path
+        )
+    except (OSError, UnicodeError):
+        return False
+
+
+def _verify_spawn_tree_dir_fd(
+    directory_fd: int, evidence: _SpawnTreeDirEvidence
+) -> None:
+    """Verify the marker through the same POSIX directory handle as output."""
+    if not os.path.samestat(evidence.directory_stat, os.fstat(directory_fd)):
+        raise OSError("spawn-tree directory identity changed")
+    flags = os.O_RDONLY
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
-    fd = os.open(index_path, flags, 0o600)
+    marker_fd = os.open(".hermes-managed", flags, dir_fd=directory_fd)
+    try:
+        marker_stat = os.fstat(marker_fd)
+        marker_bytes = os.read(marker_fd, 129)
+        if (
+            not os.path.samestat(evidence.marker_stat, marker_stat)
+            or not _spawn_tree_regular_file_stat(marker_stat)
+            or len(marker_bytes) > 128
+            or marker_bytes.decode("utf-8").strip() != evidence.marker_value
+        ):
+            raise OSError("spawn-tree ownership marker identity changed")
+    except UnicodeError as exc:
+        raise OSError("spawn-tree ownership marker is invalid") from exc
+    finally:
+        os.close(marker_fd)
+
+
+def _windows_opened_file_path(fd: int) -> Path:
+    """Return the kernel-resolved DOS path for an already-open Windows file."""
+    if os.name != "nt":
+        raise OSError("Windows handle paths are unavailable on this platform")
+    import ctypes
+    import msvcrt
+
+    get_path = ctypes.WinDLL("kernel32", use_last_error=True).GetFinalPathNameByHandleW
+    get_path.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_wchar_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+    ]
+    get_path.restype = ctypes.c_uint32
+    handle = msvcrt.get_osfhandle(fd)
+    size = 512
+    while True:
+        buffer = ctypes.create_unicode_buffer(size)
+        length = get_path(handle, buffer, size, 0)
+        if length == 0:
+            raise ctypes.WinError(ctypes.get_last_error())
+        if length < size:
+            value = buffer.value
+            break
+        size = length + 1
+    if value.startswith("\\\\?\\UNC\\"):
+        value = "\\\\" + value[8:]
+    elif value.startswith("\\\\?\\"):
+        value = value[4:]
+    return Path(value)
+
+
+def _normalized_spawn_tree_path(path: Path) -> str:
+    return os.path.normcase(os.path.normpath(os.path.abspath(os.fspath(path))))
+
+
+def _cleanup_empty_spawn_tree_output(
+    *,
+    filename: str,
+    directory_fd: int | None,
+    actual_path: Path,
+    expected: os.stat_result,
+) -> None:
+    """Remove only an exact, newly-created output that is still empty."""
+    if expected.st_size != 0 or not _spawn_tree_regular_file_stat(expected):
+        return
+    if directory_fd is not None:
+        try:
+            current = os.stat(filename, dir_fd=directory_fd, follow_symlinks=False)
+            if (
+                current.st_size == 0
+                and _spawn_tree_regular_file_stat(current)
+                and os.path.samestat(expected, current)
+            ):
+                os.unlink(filename, dir_fd=directory_fd)
+        except OSError:
+            pass
+        return
+    _remove_exact_spawn_tree_file(actual_path, expected)
+
+
+@contextlib.contextmanager
+def _open_owned_spawn_tree_output(
+    evidence: _SpawnTreeDirEvidence,
+    filename: str,
+    *,
+    append: bool,
+):
+    """Open an output only after proving its file and parent identities."""
+    if filename in {"", ".", ".."} or Path(filename).name != filename:
+        raise OSError("spawn-tree output name is not a basename")
+    if not _spawn_tree_dir_evidence_matches(evidence):
+        raise OSError("spawn-tree directory identity changed before opening")
+
+    directory_fd = None
+    fd = -1
+    stream = None
+    created = False
+    opened_stat = None
+    actual_path = evidence.resolved_path / filename
+    try:
+        if os.name != "nt":
+            directory_flags = os.O_RDONLY
+            if hasattr(os, "O_DIRECTORY"):
+                directory_flags |= os.O_DIRECTORY
+            if hasattr(os, "O_NOFOLLOW"):
+                directory_flags |= os.O_NOFOLLOW
+            directory_fd = os.open(evidence.path, directory_flags)
+            _verify_spawn_tree_dir_fd(directory_fd, evidence)
+
+        base_flags = os.O_WRONLY | (os.O_APPEND if append else 0)
+        if hasattr(os, "O_NOFOLLOW"):
+            base_flags |= os.O_NOFOLLOW
+        open_path: str | Path = filename if directory_fd is not None else (
+            evidence.path / filename
+        )
+        open_kwargs = {"dir_fd": directory_fd} if directory_fd is not None else {}
+
+        if append:
+            try:
+                fd = os.open(open_path, base_flags, **open_kwargs)
+            except FileNotFoundError:
+                fd = os.open(
+                    open_path,
+                    base_flags | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                    **open_kwargs,
+                )
+                created = True
+        else:
+            fd = os.open(
+                open_path,
+                base_flags | os.O_CREAT | os.O_EXCL,
+                0o600,
+                **open_kwargs,
+            )
+            created = True
+
+        opened_stat = os.fstat(fd)
+        if directory_fd is not None:
+            _verify_spawn_tree_dir_fd(directory_fd, evidence)
+            path_stat = os.stat(
+                filename, dir_fd=directory_fd, follow_symlinks=False
+            )
+        else:
+            actual_path = _windows_opened_file_path(fd)
+            expected_path = evidence.resolved_path / filename
+            if _normalized_spawn_tree_path(actual_path) != _normalized_spawn_tree_path(
+                expected_path
+            ):
+                raise OSError("spawn-tree output opened outside its bound directory")
+            path_stat = (evidence.path / filename).lstat()
+        if (
+            not _spawn_tree_regular_file_stat(opened_stat)
+            or not _spawn_tree_regular_file_stat(path_stat)
+            or not os.path.samestat(opened_stat, path_stat)
+            or not _spawn_tree_dir_evidence_matches(evidence)
+        ):
+            raise OSError("spawn-tree output identity changed while opening")
+
+        stream = os.fdopen(fd, "a" if append else "w", encoding="utf-8")
+        fd = -1
+        yield stream
+    finally:
+        if stream is not None:
+            stream.close()
+        elif fd >= 0:
+            if os.name == "nt":
+                with contextlib.suppress(OSError):
+                    actual_path = _windows_opened_file_path(fd)
+            if opened_stat is None:
+                with contextlib.suppress(OSError):
+                    opened_stat = os.fstat(fd)
+            os.close(fd)
+        if created and opened_stat is not None:
+            _cleanup_empty_spawn_tree_output(
+                filename=filename,
+                directory_fd=directory_fd,
+                actual_path=actual_path,
+                expected=opened_stat,
+            )
+        if directory_fd is not None:
+            os.close(directory_fd)
+
+
+@contextlib.contextmanager
+def _open_owned_spawn_tree_index(
+    session_dir: Path,
+    *,
+    append: bool,
+    evidence: _SpawnTreeDirEvidence | None = None,
+):
+    """Open the fixed index without following replacement paths."""
+    if append:
+        bound = evidence or _capture_spawn_tree_dir_evidence(session_dir)
+        with _open_owned_spawn_tree_output(
+            bound, _SPAWN_TREE_INDEX, append=True
+        ) as stream:
+            yield stream
+        return
+
+    index_path = session_dir / _SPAWN_TREE_INDEX
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(index_path, flags)
+    stream = None
     try:
         path_stat = index_path.lstat()
         fd_stat = os.fstat(fd)
         if (
-            index_path.is_symlink()
-            or int(getattr(path_stat, "st_file_attributes", 0)) & 0x400
-            or not stat_module.S_ISREG(path_stat.st_mode)
-            or not stat_module.S_ISREG(fd_stat.st_mode)
-            or path_stat.st_nlink != 1
-            or fd_stat.st_nlink != 1
+            not _spawn_tree_regular_file_stat(path_stat)
+            or not _spawn_tree_regular_file_stat(fd_stat)
             or not os.path.samestat(path_stat, fd_stat)
         ):
             raise OSError("spawn-tree index is not an owned regular file")
-        return os.fdopen(fd, "a" if append else "r", encoding="utf-8")
-    except BaseException:
-        os.close(fd)
-        raise
+        stream = os.fdopen(fd, "r", encoding="utf-8")
+        fd = -1
+        yield stream
+    finally:
+        if stream is not None:
+            stream.close()
+        elif fd >= 0:
+            os.close(fd)
 
 
 def _owned_spawn_tree_snapshot(path: Path, session_dir: Path) -> Path | None:
@@ -9670,9 +9940,16 @@ def _publish_spawn_tree_temp(source: Path, destination: Path) -> bool:
     return False
 
 
-def _append_spawn_tree_index(session_dir, entry: dict) -> None:
+def _append_spawn_tree_index(
+    session_dir: Path,
+    entry: dict,
+    *,
+    evidence: _SpawnTreeDirEvidence | None = None,
+) -> None:
     try:
-        with _open_owned_spawn_tree_index(session_dir, append=True) as f:
+        with _open_owned_spawn_tree_index(
+            session_dir, append=True, evidence=evidence
+        ) as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
     except OSError as exc:
         # Index is a cache — losing a line just means list() falls back
@@ -9730,6 +10007,9 @@ def _(rid, params: dict) -> dict:
     published_path = None
     try:
         d = _spawn_tree_session_dir(session_id or "default")
+        directory_evidence = _capture_spawn_tree_dir_evidence(
+            d, session_id=session_id or "default"
+        )
         path = d / fname
         temp_path = d / f".{fname}.{uuid.uuid4().hex}.tmp"
         payload = {
@@ -9739,7 +10019,9 @@ def _(rid, params: dict) -> dict:
             "label": label,
             "subagents": subagents,
         }
-        with temp_path.open("x", encoding="utf-8") as temp_file:
+        with _open_owned_spawn_tree_output(
+            directory_evidence, temp_path.name, append=False
+        ) as temp_file:
             temp_identity = os.fstat(temp_file.fileno())
             temp_file.write(json.dumps(payload, ensure_ascii=False))
             temp_file.flush()
@@ -9796,6 +10078,7 @@ def _(rid, params: dict) -> dict:
             "label": label,
             "count": len(subagents),
         },
+        evidence=directory_evidence,
     )
 
     return _ok(rid, {"path": str(path), "session_id": session_id})

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7,6 +7,7 @@ import hashlib
 import inspect
 import json
 import logging
+import math
 import os
 import queue
 import re
@@ -9360,8 +9361,18 @@ def _spawn_trees_root():
     try:
         root.mkdir(parents=True, exist_ok=False)
     except FileExistsError:
-        if root.is_symlink() or not root.is_dir():
-            raise OSError(f"spawn-tree root is not a regular directory: {root}")
+        pass
+    try:
+        root_stat = root.lstat()
+        root_attrs = int(getattr(root_stat, "st_file_attributes", 0))
+    except OSError as exc:
+        raise OSError(f"spawn-tree root could not be verified: {root}") from exc
+    if (
+        root.is_symlink()
+        or root_attrs & 0x400
+        or not stat_module.S_ISDIR(root_stat.st_mode)
+    ):
+        raise OSError(f"spawn-tree root is not a regular directory: {root}")
     return root
 
 
@@ -9369,21 +9380,56 @@ def _spawn_tree_session_digest(session_id: str) -> str:
     return hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:24]
 
 
-def _is_owned_spawn_tree_dir(path: Path, *, session_id: str | None = None) -> bool:
-    marker = path / ".hermes-managed"
+def _read_spawn_tree_marker(marker: Path) -> str | None:
+    """Read an ownership marker without following links or shared inodes."""
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
     try:
-        path_attrs = int(getattr(path.lstat(), "st_file_attributes", 0))
-        marker_attrs = int(getattr(marker.lstat(), "st_file_attributes", 0))
-        value = marker.read_text(encoding="utf-8").strip()
+        fd = os.open(marker, flags)
+    except OSError:
+        return None
+    stream = None
+    try:
+        path_stat = marker.lstat()
+        fd_stat = os.fstat(fd)
+        attributes = int(getattr(path_stat, "st_file_attributes", 0))
+        if (
+            marker.is_symlink()
+            or attributes & 0x400
+            or not stat_module.S_ISREG(path_stat.st_mode)
+            or not stat_module.S_ISREG(fd_stat.st_mode)
+            or path_stat.st_nlink != 1
+            or fd_stat.st_nlink != 1
+            or not os.path.samestat(path_stat, fd_stat)
+        ):
+            return None
+        stream = os.fdopen(fd, "r", encoding="utf-8")
+        fd = -1
+        value = stream.read(129)
+        return value.strip() if len(value) <= 128 else None
+    except (OSError, UnicodeError):
+        return None
+    finally:
+        if stream is not None:
+            stream.close()
+        elif fd >= 0:
+            os.close(fd)
+
+
+def _is_owned_spawn_tree_dir(path: Path, *, session_id: str | None = None) -> bool:
+    try:
+        path_stat = path.lstat()
+        path_attrs = int(getattr(path_stat, "st_file_attributes", 0))
+        value = _read_spawn_tree_marker(path / ".hermes-managed")
+        if value is None:
+            return False
         prefix = "spawn-trees:"
         digest = value.removeprefix(prefix)
         return (
-            path.is_dir()
+            stat_module.S_ISDIR(path_stat.st_mode)
             and not path.is_symlink()
             and not (path_attrs & 0x400)
-            and marker.is_file()
-            and not marker.is_symlink()
-            and not (marker_attrs & 0x400)
             and value.startswith(prefix)
             and len(digest) == 24
             and all(char in "0123456789abcdef" for char in digest)
@@ -9391,6 +9437,35 @@ def _is_owned_spawn_tree_dir(path: Path, *, session_id: str | None = None) -> bo
             and (session_id is None or digest == _spawn_tree_session_digest(session_id))
         )
     except (OSError, UnicodeError):
+        return False
+
+
+def _legacy_spawn_tree_session_name(session_id: str) -> str:
+    """Return the pre-hash directory name used by older Hermes releases."""
+    return (
+        "".join(c if c.isalnum() or c in "-_" else "_" for c in session_id)
+        or "unknown"
+    )
+
+
+def _is_legacy_spawn_tree_dir(
+    path: Path, *, session_id: str | None = None
+) -> bool:
+    """Recognize legacy snapshots for reading, never for retention ownership."""
+    try:
+        path_stat = path.lstat()
+        path_attrs = int(getattr(path_stat, "st_file_attributes", 0))
+        return (
+            stat_module.S_ISDIR(path_stat.st_mode)
+            and not path.is_symlink()
+            and not (path_attrs & 0x400)
+            and _read_spawn_tree_marker(path / ".hermes-managed") == "spawn-trees"
+            and (
+                session_id is None
+                or path.name == _legacy_spawn_tree_session_name(session_id)
+            )
+        )
+    except OSError:
         return False
 
 
@@ -9427,11 +9502,32 @@ def _spawn_tree_session_dir(session_id: str, *, create: bool = True):
     return d
 
 
+def _spawn_tree_session_dirs(session_id: str) -> list[Path]:
+    """Return current and legacy read locations for one logical session."""
+    roots: list[Path] = []
+    current = _spawn_tree_session_dir(session_id, create=False)
+    if current is not None:
+        roots.append(current)
+    legacy = _spawn_trees_root() / _legacy_spawn_tree_session_name(session_id)
+    if _is_legacy_spawn_tree_dir(legacy, session_id=session_id):
+        roots.append(legacy)
+    return roots
+
+
+def _spawn_tree_dir_matches_session(path: Path, session_id: str) -> bool:
+    storage_session = session_id or "default"
+    return _is_owned_spawn_tree_dir(
+        path, session_id=storage_session
+    ) or _is_legacy_spawn_tree_dir(path, session_id=storage_session)
+
+
 # Per-session append-only index of lightweight snapshot metadata.  Read by
 # `spawn_tree.list` so scanning doesn't require reading every full snapshot
 # file (Copilot review on #14045).  One JSON object per line.
 _SPAWN_TREE_INDEX = "_index.jsonl"
-_SPAWN_TREE_SNAPSHOT_RE = re.compile(r"^\d{8}T\d{12}-[0-9a-f]{8}\.json$")
+_SPAWN_TREE_SNAPSHOT_RE = re.compile(
+    r"^(?:\d{8}T\d{6}|\d{8}T\d{12}-[0-9a-f]{8})\.json$"
+)
 
 
 def _open_owned_spawn_tree_index(session_dir: Path, *, append: bool):
@@ -9446,8 +9542,11 @@ def _open_owned_spawn_tree_index(session_dir: Path, *, append: bool):
         fd_stat = os.fstat(fd)
         if (
             index_path.is_symlink()
+            or int(getattr(path_stat, "st_file_attributes", 0)) & 0x400
             or not stat_module.S_ISREG(path_stat.st_mode)
             or not stat_module.S_ISREG(fd_stat.st_mode)
+            or path_stat.st_nlink != 1
+            or fd_stat.st_nlink != 1
             or not os.path.samestat(path_stat, fd_stat)
         ):
             raise OSError("spawn-tree index is not an owned regular file")
@@ -9460,11 +9559,13 @@ def _open_owned_spawn_tree_index(session_dir: Path, *, append: bool):
 def _owned_spawn_tree_snapshot(path: Path, session_dir: Path) -> Path | None:
     """Return the canonical generated snapshot path, or fail closed."""
     try:
-        attributes = int(getattr(path.lstat(), "st_file_attributes", 0))
+        path_stat = path.lstat()
+        attributes = int(getattr(path_stat, "st_file_attributes", 0))
         if (
             path.is_symlink()
             or attributes & 0x400
-            or not path.is_file()
+            or not stat_module.S_ISREG(path_stat.st_mode)
+            or path_stat.st_nlink != 1
             or _SPAWN_TREE_SNAPSHOT_RE.fullmatch(path.name) is None
         ):
             return None
@@ -9494,6 +9595,8 @@ def _open_owned_spawn_tree_snapshot(path: Path, session_dir: Path):
             or attributes & 0x400
             or not stat_module.S_ISREG(path_stat.st_mode)
             or not stat_module.S_ISREG(fd_stat.st_mode)
+            or path_stat.st_nlink != 1
+            or fd_stat.st_nlink != 1
             or not os.path.samestat(path_stat, fd_stat)
         ):
             raise OSError("spawn-tree snapshot identity changed while opening")
@@ -9529,12 +9632,22 @@ def _read_spawn_tree_index(session_dir) -> list[dict]:
                 if not line:
                     continue
                 try:
-                    out.append(json.loads(line))
+                    decoded = json.loads(line)
+                    if isinstance(decoded, dict):
+                        out.append(decoded)
                 except json.JSONDecodeError:
                     continue
-    except OSError:
+    except (OSError, UnicodeError):
         return []
     return out
+
+
+def _is_spawn_tree_number(value: object) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+    )
 
 
 @method("spawn_tree.save")
@@ -9567,6 +9680,9 @@ def _(rid, params: dict) -> dict:
             json.dumps(payload, ensure_ascii=False), encoding="utf-8"
         )
         os.replace(temp_path, path)
+        # The temporary name is unowned as soon as replace succeeds.  Do not
+        # let finally unlink a human file recreated at that former pathname.
+        temp_path = None
     except OSError as exc:
         return _err(rid, 5000, f"spawn_tree.save failed: {exc}")
     finally:
@@ -9599,10 +9715,15 @@ def _(rid, params: dict) -> dict:
 
     if cross_session:
         root = _spawn_trees_root()
-        roots = [p for p in root.iterdir() if _is_owned_spawn_tree_dir(p)]
+        roots = [
+            p
+            for p in root.iterdir()
+            if _is_owned_spawn_tree_dir(p) or _is_legacy_spawn_tree_dir(p)
+        ]
+        expected_session = None
     else:
-        session_dir = _spawn_tree_session_dir(session_id or "default", create=False)
-        roots = [session_dir] if session_dir is not None else []
+        roots = _spawn_tree_session_dirs(session_id or "default")
+        expected_session = session_id
 
     entries: list[dict] = []
     for d in roots:
@@ -9615,9 +9736,27 @@ def _(rid, params: dict) -> dict:
                     entry_session, str
                 ):
                     continue
+                entry_finished = entry.get("finished_at")
+                entry_started = entry.get("started_at")
+                entry_label = entry.get("label")
+                entry_count = entry.get("count")
+                if (
+                    not _is_spawn_tree_number(entry_finished)
+                    or (
+                        entry_started is not None
+                        and not _is_spawn_tree_number(entry_started)
+                    )
+                    or not isinstance(entry_label, str)
+                    or not isinstance(entry_count, int)
+                    or isinstance(entry_count, bool)
+                    or entry_count < 0
+                ):
+                    continue
+                if expected_session is not None and entry_session != expected_session:
+                    continue
                 snapshot = _owned_spawn_tree_snapshot(Path(raw_entry_path), d)
-                if snapshot is None or not _is_owned_spawn_tree_dir(
-                    d, session_id=entry_session or "default"
+                if snapshot is None or not _spawn_tree_dir_matches_session(
+                    d, entry_session
                 ):
                     continue
                 validated = dict(entry)
@@ -9635,20 +9774,37 @@ def _(rid, params: dict) -> dict:
                     stream,
                 ):
                     raw = json.load(stream)
+                if not isinstance(raw, dict):
+                    continue
                 raw_session = raw.get("session_id")
-                if not isinstance(raw_session, str) or not _is_owned_spawn_tree_dir(
-                    d, session_id=raw_session or "default"
+                raw_finished = raw.get("finished_at")
+                raw_started = raw.get("started_at")
+                raw_label = raw.get("label")
+                subagents = raw.get("subagents")
+                if (
+                    not isinstance(raw_session, str)
+                    or not _is_spawn_tree_number(raw_finished)
+                    or (
+                        raw_started is not None
+                        and not _is_spawn_tree_number(raw_started)
+                    )
+                    or not isinstance(raw_label, str)
+                    or not isinstance(subagents, list)
+                    or (
+                        expected_session is not None
+                        and raw_session != expected_session
+                    )
+                    or not _spawn_tree_dir_matches_session(d, raw_session)
                 ):
                     continue
-                subagents = raw.get("subagents") or []
                 entries.append(
                     {
                         "path": str(snapshot),
                         "session_id": raw_session,
-                        "finished_at": raw.get("finished_at") or snapshot_stat.st_mtime,
-                        "started_at": raw.get("started_at"),
-                        "label": raw.get("label") or "",
-                        "count": len(subagents) if isinstance(subagents, list) else 0,
+                        "finished_at": raw_finished or snapshot_stat.st_mtime,
+                        "started_at": raw_started,
+                        "label": raw_label,
+                        "count": len(subagents),
                     }
                 )
             except (OSError, UnicodeError, json.JSONDecodeError):
@@ -9677,7 +9833,10 @@ def _(rid, params: dict) -> dict:
     snapshot = _owned_spawn_tree_snapshot(candidate, resolved.parent)
     if (
         resolved.parent.parent != root
-        or not _is_owned_spawn_tree_dir(resolved.parent)
+        or not (
+            _is_owned_spawn_tree_dir(resolved.parent)
+            or _is_legacy_spawn_tree_dir(resolved.parent)
+        )
         or snapshot is None
     ):
         return _err(rid, 4030, "path is not an owned spawn-tree snapshot")
@@ -9692,9 +9851,11 @@ def _(rid, params: dict) -> dict:
     except (OSError, UnicodeError, json.JSONDecodeError) as exc:
         return _err(rid, 5000, f"spawn_tree.load failed: {exc}")
 
-    payload_session = payload.get("session_id") if isinstance(payload, dict) else None
-    if not isinstance(payload_session, str) or not _is_owned_spawn_tree_dir(
-        snapshot.parent, session_id=payload_session or "default"
+    if not isinstance(payload, dict):
+        return _err(rid, 4030, "spawn-tree snapshot payload must be an object")
+    payload_session = payload.get("session_id")
+    if not isinstance(payload_session, str) or not _spawn_tree_dir_matches_session(
+        snapshot.parent, payload_session
     ):
         return _err(rid, 4030, "snapshot session does not match its owned directory")
     return _ok(rid, payload)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9610,6 +9610,66 @@ def _open_owned_spawn_tree_snapshot(path: Path, session_dir: Path):
             os.close(fd)
 
 
+def _spawn_tree_file_identity(
+    value: os.stat_result,
+) -> tuple[int, int, int, int, int, int]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_mode,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+
+def _remove_exact_spawn_tree_file(path: Path, expected: os.stat_result) -> bool:
+    """Quarantine and remove only the exact file identity we created."""
+    quarantine = path.with_name(
+        f".{path.name}.hermes-delete-{uuid.uuid4().hex}"
+    )
+    try:
+        current = path.lstat()
+        current_attributes = int(getattr(current, "st_file_attributes", 0))
+        if (
+            current_attributes & 0x400
+            or not stat_module.S_ISREG(current.st_mode)
+            or _spawn_tree_file_identity(expected)
+            != _spawn_tree_file_identity(current)
+        ):
+            return False
+        os.replace(path, quarantine)
+        moved = quarantine.lstat()
+        attributes = int(getattr(moved, "st_file_attributes", 0))
+        if (
+            attributes & 0x400
+            or not stat_module.S_ISREG(moved.st_mode)
+            or not os.path.samestat(current, moved)
+        ):
+            # A replacement won the boundary after the identity check. Keep it
+            # at the quarantine name for operator recovery.
+            return False
+        try:
+            quarantine.unlink()
+        except OSError:
+            # Preserve the exact object when the filesystem refuses deletion.
+            return False
+        return True
+    except OSError:
+        return False
+
+
+def _publish_spawn_tree_temp(source: Path, destination: Path) -> bool:
+    """Publish without replacement; return whether the source name moved."""
+    if os.name == "nt":
+        # Windows rename is no-replace. Moving avoids a transient second hard
+        # link, which Windows scanners can keep busy after publication.
+        os.rename(source, destination)
+        return True
+    os.link(source, destination, follow_symlinks=False)
+    return False
+
+
 def _append_spawn_tree_index(session_dir, entry: dict) -> None:
     try:
         with _open_owned_spawn_tree_index(session_dir, append=True) as f:
@@ -9665,6 +9725,9 @@ def _(rid, params: dict) -> dict:
     ts = datetime.utcfromtimestamp(float(finished_at)).strftime("%Y%m%dT%H%M%S%f")
     fname = f"{ts}-{uuid.uuid4().hex[:8]}.json"
     temp_path = None
+    temp_identity = None
+    cleanup_identity = None
+    published_path = None
     try:
         d = _spawn_tree_session_dir(session_id or "default")
         path = d / fname
@@ -9676,21 +9739,52 @@ def _(rid, params: dict) -> dict:
             "label": label,
             "subagents": subagents,
         }
-        temp_path.write_text(
-            json.dumps(payload, ensure_ascii=False), encoding="utf-8"
-        )
-        os.replace(temp_path, path)
-        # The temporary name is unowned as soon as replace succeeds.  Do not
-        # let finally unlink a human file recreated at that former pathname.
-        temp_path = None
+        with temp_path.open("x", encoding="utf-8") as temp_file:
+            temp_identity = os.fstat(temp_file.fileno())
+            temp_file.write(json.dumps(payload, ensure_ascii=False))
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+            temp_identity = os.fstat(temp_file.fileno())
+            cleanup_identity = temp_identity
+
+        # Publication is atomic and fails when the destination name already
+        # exists. Unlike os.replace(), it cannot overwrite a human file that
+        # appears after the collision check.
+        source_moved = _publish_spawn_tree_temp(temp_path, path)
+        published_path = path
+        if source_moved:
+            temp_path = None
+        published_identity = path.lstat()
+        if (
+            not stat_module.S_ISREG(published_identity.st_mode)
+            or not os.path.samestat(temp_identity, published_identity)
+            or published_identity.st_mode != temp_identity.st_mode
+            or published_identity.st_size != temp_identity.st_size
+            or published_identity.st_mtime_ns != temp_identity.st_mtime_ns
+        ):
+            raise OSError("spawn-tree snapshot identity changed during publication")
+        cleanup_identity = published_identity
+
+        if temp_path is not None:
+            _remove_exact_spawn_tree_file(temp_path, cleanup_identity)
+            if not os.path.lexists(temp_path):
+                temp_path = None
+        final_identity = path.lstat()
+        if (
+            not stat_module.S_ISREG(final_identity.st_mode)
+            or final_identity.st_nlink != 1
+            or not os.path.samestat(temp_identity, final_identity)
+        ):
+            raise OSError("spawn-tree snapshot ownership could not be finalized")
+        cleanup_identity = final_identity
+        published_path = None
     except OSError as exc:
         return _err(rid, 5000, f"spawn_tree.save failed: {exc}")
     finally:
-        try:
-            if temp_path is not None:
-                temp_path.unlink(missing_ok=True)
-        except OSError:
-            pass
+        if published_path is not None and cleanup_identity is not None:
+            _remove_exact_spawn_tree_file(published_path, cleanup_identity)
+        if temp_path is not None and cleanup_identity is not None:
+            _remove_exact_spawn_tree_file(temp_path, cleanup_identity)
 
     _append_spawn_tree_index(
         d,
@@ -9726,6 +9820,7 @@ def _(rid, params: dict) -> dict:
         expected_session = session_id
 
     entries: list[dict] = []
+    seen_snapshots: set[str] = set()
     for d in roots:
         indexed = _read_spawn_tree_index(d)
         if indexed:
@@ -9762,12 +9857,19 @@ def _(rid, params: dict) -> dict:
                 validated = dict(entry)
                 validated["path"] = str(snapshot)
                 entries.append(validated)
-            continue
+                seen_snapshots.add(os.path.normcase(str(snapshot)))
 
-        # Fallback for legacy (pre-index) sessions: full scan.  O(N) reads
-        # but only runs once per session until the next save writes the index.
+        # Scan names on every list so a transient index-append failure cannot
+        # permanently hide a successfully published snapshot. Indexed files
+        # are skipped without opening; only missing entries pay the JSON read.
         for p in d.glob("*.json"):
             try:
+                candidate = _owned_spawn_tree_snapshot(p, d)
+                if candidate is None:
+                    continue
+                snapshot_key = os.path.normcase(str(candidate))
+                if snapshot_key in seen_snapshots:
+                    continue
                 with _open_owned_spawn_tree_snapshot(p, d) as (
                     snapshot,
                     snapshot_stat,
@@ -9807,6 +9909,7 @@ def _(rid, params: dict) -> dict:
                         "count": len(subagents),
                     }
                 )
+                seen_snapshots.add(snapshot_key)
             except (OSError, UnicodeError, json.JSONDecodeError):
                 continue
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9357,22 +9357,62 @@ def _spawn_trees_root():
     from hermes_constants import get_hermes_home
 
     root = get_hermes_home() / "spawn-trees"
-    root.mkdir(parents=True, exist_ok=True)
+    try:
+        root.mkdir(parents=True, exist_ok=False)
+    except FileExistsError:
+        if root.is_symlink() or not root.is_dir():
+            raise OSError(f"spawn-tree root is not a regular directory: {root}")
     return root
 
 
-def _spawn_tree_session_dir(session_id: str):
+def _is_owned_spawn_tree_dir(path: Path) -> bool:
+    marker = path / ".hermes-managed"
+    try:
+        return (
+            path.is_dir()
+            and not path.is_symlink()
+            and marker.is_file()
+            and not marker.is_symlink()
+            and marker.read_text(encoding="utf-8").strip() == "spawn-trees"
+        )
+    except (OSError, UnicodeError):
+        return False
+
+
+def _spawn_tree_session_dir(session_id: str, *, create: bool = True):
     safe = (
         "".join(c if c.isalnum() or c in "-_" else "_" for c in session_id) or "unknown"
     )
     d = _spawn_trees_root() / safe
-    d.mkdir(parents=True, exist_ok=True)
+    if not create:
+        return d if _is_owned_spawn_tree_dir(d) else None
+    created = False
+    try:
+        d.mkdir(parents=True, exist_ok=False)
+        created = True
+    except FileExistsError:
+        if not _is_owned_spawn_tree_dir(d):
+            raise OSError(f"spawn-tree directory is not exclusively Hermes-owned: {d}")
+        return d
     marker = d / ".hermes-managed"
-    if not marker.exists():
+    try:
+        with marker.open("x", encoding="utf-8") as marker_file:
+            marker_file.write("spawn-trees\n")
+    except (FileExistsError, OSError):
+        if created:
+            try:
+                marker.unlink(missing_ok=True)
+                d.rmdir()
+            except OSError:
+                pass
+        raise
+    if not _is_owned_spawn_tree_dir(d):
         try:
-            marker.write_text("spawn-trees\n", encoding="utf-8")
-        except FileExistsError:
+            marker.unlink(missing_ok=True)
+            d.rmdir()
+        except OSError:
             pass
+        raise OSError(f"spawn-tree ownership marker could not be verified: {d}")
     return d
 
 
@@ -9426,10 +9466,11 @@ def _(rid, params: dict) -> dict:
     label = str(params.get("label") or "")
     ts = datetime.utcfromtimestamp(float(finished_at)).strftime("%Y%m%dT%H%M%S%f")
     fname = f"{ts}-{uuid.uuid4().hex[:8]}.json"
-    d = _spawn_tree_session_dir(session_id or "default")
-    path = d / fname
-    temp_path = d / f".{fname}.{uuid.uuid4().hex}.tmp"
+    temp_path = None
     try:
+        d = _spawn_tree_session_dir(session_id or "default")
+        path = d / fname
+        temp_path = d / f".{fname}.{uuid.uuid4().hex}.tmp"
         payload = {
             "session_id": session_id,
             "started_at": float(started_at) if started_at else None,
@@ -9445,7 +9486,8 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5000, f"spawn_tree.save failed: {exc}")
     finally:
         try:
-            temp_path.unlink(missing_ok=True)
+            if temp_path is not None:
+                temp_path.unlink(missing_ok=True)
         except OSError:
             pass
 
@@ -9472,9 +9514,10 @@ def _(rid, params: dict) -> dict:
 
     if cross_session:
         root = _spawn_trees_root()
-        roots = [p for p in root.iterdir() if p.is_dir()]
+        roots = [p for p in root.iterdir() if _is_owned_spawn_tree_dir(p)]
     else:
-        roots = [_spawn_tree_session_dir(session_id or "default")]
+        session_dir = _spawn_tree_session_dir(session_id or "default", create=False)
+        roots = [session_dir] if session_dir is not None else []
 
     entries: list[dict] = []
     for d in roots:
@@ -9530,6 +9573,13 @@ def _(rid, params: dict) -> dict:
         resolved.relative_to(root)
     except (ValueError, OSError) as exc:
         return _err(rid, 4030, f"path outside spawn-trees root: {exc}")
+    if (
+        resolved.parent.parent != root
+        or not _is_owned_spawn_tree_dir(resolved.parent)
+        or resolved.is_symlink()
+        or not resolved.is_file()
+    ):
+        return _err(rid, 4030, "path is not an owned spawn-tree snapshot")
 
     try:
         payload = json.loads(resolved.read_text(encoding="utf-8"))

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -638,7 +638,7 @@ Any non-None, non-empty return with a `"context"` key (or a plain non-empty stri
 
 #### Oversized-context spill
 
-Per-hook context is capped at `10,000` characters by default. Anything above the cap is written to `$HERMES_HOME/hook_outputs/<session_id>/<uuid>.txt` and replaced with a head/tail preview plus the saved path. The model can read the full content via `read_file` or `terminal` if it genuinely needs it. This keeps a runaway plugin from inflating every subsequent turn's prompt and blowing out the prompt cache prefix. Tune in `config.yaml`:
+Per-hook context is capped at `10,000` characters by default. Anything above the cap is written to an owned session directory below `$HERMES_HOME/hook_outputs/` and replaced with a head/tail preview plus the saved path. The model can read the full content via `read_file` or `terminal` if it genuinely needs it. Pre-marker session directories from older releases remain read-only; resumed sessions write new spills to a hash-bound `s-<session-hash>/` directory instead. This keeps a runaway plugin from inflating every subsequent turn's prompt and blowing out the prompt cache prefix. Tune in `config.yaml`:
 
 ```yaml
 hooks:
@@ -648,6 +648,8 @@ hooks:
     preview_head: 500      # chars shown at the top of the preview
     preview_tail: 500      # chars shown at the bottom of the preview
     # directory: null      # default: $HERMES_HOME/hook_outputs
+    retention_seconds: 604800   # default: prune files older than 7 days
+    max_files_per_session: 100  # default: also keep at most 100 newest files
 ```
 
 #### How injection works


### PR DESCRIPTION
## What does this PR do?

DRAFT CHECKPOINT — preserves the recovered durable anti-junk work on GitHub. This is not review-ready and must not merge yet.

Hardens Hermes-owned cleanup and persistence paths so maintenance removes only provenance-bound objects and preserves concurrent or unproven data. The branch covers disk cleanup, quick backups/restores, Kanban attachments and artifacts, TUI spawn snapshots, hook-output spill retention, file sync, voice recordings, terminal lifecycle cleanup, and related Windows/POSIX race handling.

Exact checkpoint: `60db5e2134e119c4fe8faae9f2f28a3f86575b61` on base `9acc4b47f5b2abda0949d07372ecf67938d50a16`.

### Known blocker

Independent exact-object review remains **NOT CLEAN**: on Windows/Python 3.12, managed-artifact file identity still includes `st_ctime_ns`, which can settle after open and make legitimate stale-file retention intermittently no-op. This must be fixed and the replacement exact head independently re-reviewed before promotion from draft.

## Related Issue

N/A — recovered autonomous Kanban implementation checkpoint.

## Type of Change

- [x] Bug fix
- [x] Security fix
- [x] Tests
- [x] Documentation update

## Changes Made

- Bind cleanup and pruning to exact filesystem ownership/provenance.
- Preserve same-path race winners with no-clobber restoration.
- Make quick snapshots and SQLite backup/restore publication race-safe.
- Preserve legacy attachment blobs when deletion provenance is unavailable and surface that behavior to API/CLI users.
- Harden managed disk cleanup, TUI spawn trees, hook spill files, voice/file-sync/terminal cleanup, and Kanban artifact copies.
- Add Windows, POSIX, junction, hardlink, replacement-race, compatibility, and failure-path regressions.

## How to Test

1. Run affected suites through `scripts/run_tests.sh`.
2. Run `scripts/check-windows-footguns.py --diff origin/main`.
3. Reproduce the remaining Windows/Python 3.12 managed-artifact ctime blocker before requesting review.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] Commit messages follow Conventional Commits.
- [x] I searched existing PRs/issues for duplicates.
- [x] The branch is scoped to durable autonomous cleanup and persistence safety.
- [ ] Full `pytest tests/ -q` is clean — known Windows baseline failures and the blocker above remain.
- [x] Tests were added for the changed behavior.
- [x] Tested on Windows 11 with Python 3.11 and 3.12.

### Documentation & Housekeeping

- [x] Relevant documentation/docstrings were updated.
- [x] Config-key update: N/A.
- [x] Architecture/workflow documentation update: N/A.
- [x] Cross-platform impact was considered and tested.
- [x] Tool-schema update: N/A.

## Screenshots / Logs

N/A. Detailed exact-object review evidence and test results will be added after the remaining blocker is fixed.