### PR TITLE
fix(config): clear model cache when deleting custom endpoint (#68943)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7450,6 +7450,13 @@ def delete_custom_endpoint(endpoint_id: str):
         cfg["providers"] = providers
         _detach_main_model_from_provider(cfg, provider_key)
         save_config(cfg)
+        # Bust the per-provider model-id disk cache so the model picker
+        # no longer lists models from the deleted provider (#68943).
+        try:
+            from hermes_cli.models import clear_provider_models_cache
+            clear_provider_models_cache(provider_key)
+        except Exception:
+            _log.debug("Failed to clear model cache for %s", provider_key, exc_info=True)
         response = _custom_endpoint_response(cfg)
         response["ok"] = True
         return response


### PR DESCRIPTION
## Summary

Fixes #68943 — deleted custom endpoint's models remain in the model picker.

## Problem

When a custom endpoint is deleted via `DELETE /api/providers/custom-endpoints/{id}`, the per-provider model-id disk cache (`provider_models_cache.json`) is not invalidated. The model picker continues listing models from the deleted provider until the user explicitly runs `/model --refresh`.

## Fix

Call `clear_provider_models_cache(provider_key)` after removing the endpoint from config, so the stale cache entry is dropped immediately.

Note: The `DELETE /api/env` path already handles this via `remove_provider_env_credential` (see comment at line 7566). This fix covers the custom-endpoint deletion path which was missing the same invalidation.