### PR TITLE
fix(terminal): add a repeated-identical-call circuit breaker for hardline blocks

### DIFF
--- a/tests/tools/test_terminal_repeat_breaker.py
+++ b/tests/tools/test_terminal_repeat_breaker.py
@@ -1,0 +1,227 @@
+"""Regression tests: repeated-identical-call circuit breaker for terminal_tool.
+
+Bug (#69256): tools/file_tools.py has a repeated-identical-call breaker for
+reads (:1381-1397) and searches (:1857-1895, ``_read_tracker``) that stops the
+model looping on a call whose result cannot change. tools/terminal_tool.py had
+no equivalent: when a command is hardline-blocked (``tools/approval.py``
+``detect_hardline_command`` / ``_hardline_block_result``, ``hardline: True`` --
+this covers both the catastrophic-pattern blocklist AND the malformed-payload
+guard, ``_MALFORMED_EXEC_DESCRIPTION``), the block is deterministic: an
+identical retry has a 0% chance of succeeding. Nothing stopped the model
+re-emitting the exact same blocked command until the turn cap, degrading the
+session to empty responses.
+
+Design (kept deliberately simple after two failed "consecutive"-streak cuts
+that a Sol xhigh review picked apart):
+
+- The breaker counts, per conversation, how many times each exact
+  (command, block message) pair has been hardline-blocked -- a plain
+  cumulative tally, NOT a consecutive streak. A streak needs a reset on every
+  other terminal outcome and the many early-return paths kept leaving stale
+  state; a cumulative tally is only ever touched on a hardline block, so
+  nothing can corrupt it (``test_cumulative_count_survives_intervening_call``).
+- ONE reason-neutral escalation for every hardline reason -- no attempt to
+  branch malformed-vs-catastrophic on a message substring (which
+  misclassifies executable commands that trip the malformed guard first) and
+  no advice that coaches around an unconditional safety block
+  (``test_escalation_is_reason_neutral``).
+- Keyed on the raw (command, block message); a call with neither task_id nor
+  session_id is left untracked; task/session keys are tagged so they can't
+  collide; tracker state is bounded on both axes.
+"""
+import json
+
+import pytest
+
+import tools.terminal_tool as tt
+from tools.terminal_tool import terminal_tool
+
+
+ESCALATION_MARKER = "is deterministic"
+# Phrases that would coach a bypass of an unconditional safety block -- the
+# escalation must contain NONE of these (Sol HIGH #2).
+BYPASS_COACHING = ["without pipes", "own terminal", "redirect output", "command substitution"]
+
+_HARDLINE_CATASTROPHIC = {
+    "approved": False,
+    "hardline": True,
+    "message": "BLOCKED (hardline): recursive delete of root filesystem. This command is on the unconditional blocklist and cannot be executed via the agent. If you genuinely need to run it, run it yourself in a terminal outside the agent.",
+}
+
+_HARDLINE_MALFORMED = {
+    "approved": False,
+    "hardline": True,
+    "message": "BLOCKED (hardline): command parser limit or malformed executable payload. This command is on the unconditional blocklist.",
+}
+
+_APPROVABLE_BLOCK = {
+    "approved": False,
+    "status": "blocked",
+    "description": "risky but not hardline",
+    "message": "BLOCKED: risky command. Use the approval prompt to allow it, or rephrase the command.",
+}
+
+_APPROVED = {"approved": True}
+
+
+def _make_env_config(**overrides):
+    config = {
+        "env_type": "local",
+        "timeout": 180,
+        "cwd": "/tmp",
+        "host_cwd": None,
+        "modal_mode": "auto",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+    }
+    config.update(overrides)
+    return config
+
+
+@pytest.fixture(autouse=True)
+def _patch_env(monkeypatch):
+    monkeypatch.setattr(
+        "tools.terminal_tool._get_env_config", lambda *a, **k: _make_env_config()
+    )
+    monkeypatch.setattr("tools.terminal_tool._start_cleanup_thread", lambda *a, **k: None)
+
+
+@pytest.fixture(autouse=True)
+def _clean_tracker():
+    """The repeat tracker is module-global; start each test from empty."""
+    tt._terminal_repeat_tracker.clear()
+    yield
+    tt._terminal_repeat_tracker.clear()
+
+
+def _run(monkeypatch, guard_result, command, **kwargs):
+    monkeypatch.setattr(
+        "tools.terminal_tool._check_all_guards", lambda *a, **k: guard_result
+    )
+    return json.loads(terminal_tool(command=command, **kwargs))
+
+
+class TestTerminalRepeatBreaker:
+    def test_third_identical_hardline_block_escalates(self, monkeypatch):
+        cmd = "rm -rf /"
+        r1 = _run(monkeypatch, _HARDLINE_CATASTROPHIC, cmd, task_id="t1")
+        r2 = _run(monkeypatch, _HARDLINE_CATASTROPHIC, cmd, task_id="t1")
+        r3 = _run(monkeypatch, _HARDLINE_CATASTROPHIC, cmd, task_id="t1")
+        assert ESCALATION_MARKER not in r1["error"], r1
+        assert ESCALATION_MARKER not in r2["error"], r2
+        assert ESCALATION_MARKER in r3["error"], r3
+        # The breaker augments the hardline message, never replaces it.
+        assert "recursive delete of root filesystem" in r3["error"], r3
+
+    def test_escalation_is_reason_neutral(self, monkeypatch):
+        """The single escalation must never coach a bypass -- for a catastrophic
+        block that would be dangerous, and the same text is used for the
+        malformed-payload block too (no substring classification)."""
+        for guard in (_HARDLINE_CATASTROPHIC, _HARDLINE_MALFORMED):
+            tt._terminal_repeat_tracker.clear()
+            cmd = "grep -P ; rm -rf /"
+            r = None
+            for _ in range(3):
+                r = _run(monkeypatch, guard, cmd, task_id="t-neutral")
+            assert ESCALATION_MARKER in r["error"], r
+            lowered = r["error"].lower()
+            for phrase in BYPASS_COACHING:
+                assert phrase not in lowered, (phrase, r["error"])
+            assert "different approach" in lowered, r
+
+    def test_cumulative_count_survives_intervening_call(self, monkeypatch):
+        """The key property of the cumulative (non-streak) design: an approved
+        command between two blocks does NOT reset the tally, and a
+        non-hardline block between them doesn't either. Third block of the
+        exact command still escalates."""
+        cmd = "rm -rf /"
+        r1 = _run(monkeypatch, _HARDLINE_CATASTROPHIC, cmd, task_id="t2")
+        # intervening approved command (proceeds toward execution)
+        _run(monkeypatch, _APPROVED, "echo hi", task_id="t2")
+        # intervening non-hardline block
+        _run(monkeypatch, _APPROVABLE_BLOCK, "sudo something", task_id="t2")
+        r2 = _run(monkeypatch, _HARDLINE_CATASTROPHIC, cmd, task_id="t2")
+        r3 = _run(monkeypatch, _HARDLINE_CATASTROPHIC, cmd, task_id="t2")
+        assert ESCALATION_MARKER not in r1["error"]
+        assert ESCALATION_MARKER not in r2["error"]
+        assert ESCALATION_MARKER in r3["error"], r3
+
+    def test_different_command_has_separate_count(self, monkeypatch):
+        """Each (command, block) pair is counted independently -- a second
+        blocked command doesn't inflate the first one's tally."""
+        a = "rm -rf /"
+        b = "mkfs /dev/sda"
+        _run(monkeypatch, _HARDLINE_CATASTROPHIC, a, task_id="t3")
+        rb = _run(monkeypatch, _HARDLINE_CATASTROPHIC, b, task_id="t3")
+        _run(monkeypatch, _HARDLINE_CATASTROPHIC, a, task_id="t3")
+        ra = _run(monkeypatch, _HARDLINE_CATASTROPHIC, a, task_id="t3")
+        assert ESCALATION_MARKER not in rb["error"], rb  # b only hit once
+        assert ESCALATION_MARKER in ra["error"], ra       # a hit three times
+
+    def test_non_hardline_block_never_escalates(self, monkeypatch):
+        cmd = "some risky command"
+        last = None
+        for _ in range(6):
+            last = _run(monkeypatch, _APPROVABLE_BLOCK, cmd, task_id="t4")
+        assert ESCALATION_MARKER not in last["error"], last
+
+    def test_no_task_or_session_id_skips_tracking(self, monkeypatch):
+        cmd = "rm -rf /"
+        last = None
+        for _ in range(5):
+            last = _run(monkeypatch, _HARDLINE_CATASTROPHIC, cmd)
+        assert ESCALATION_MARKER not in last["error"], last
+        assert not tt._terminal_repeat_tracker  # nothing tracked
+
+    def test_session_id_used_when_no_task_id(self, monkeypatch):
+        cmd = "rm -rf /"
+        r1 = _run(monkeypatch, _HARDLINE_CATASTROPHIC, cmd, session_id="s1")
+        r2 = _run(monkeypatch, _HARDLINE_CATASTROPHIC, cmd, session_id="s1")
+        r3 = _run(monkeypatch, _HARDLINE_CATASTROPHIC, cmd, session_id="s1")
+        assert ESCALATION_MARKER not in r1["error"]
+        assert ESCALATION_MARKER in r3["error"], r3
+
+    def test_task_and_session_keys_do_not_collide(self, monkeypatch):
+        """A task_id and another conversation's session_id with the same raw
+        string must not share a tally (tagged keys, Sol MEDIUM #3)."""
+        cmd = "rm -rf /"
+        _run(monkeypatch, _HARDLINE_CATASTROPHIC, cmd, task_id="X")
+        _run(monkeypatch, _HARDLINE_CATASTROPHIC, cmd, task_id="X")
+        # A different conversation whose session_id happens to equal "X":
+        r = _run(monkeypatch, _HARDLINE_CATASTROPHIC, cmd, session_id="X")
+        assert ESCALATION_MARKER not in r["error"], r  # its own count is 1
+
+    def test_escalated_response_still_denies_execution(self, monkeypatch):
+        cmd = "rm -rf /"
+        r = None
+        for _ in range(3):
+            r = _run(monkeypatch, _HARDLINE_CATASTROPHIC, cmd, task_id="t5")
+        assert ESCALATION_MARKER in r["error"], r
+        assert r["status"] == "blocked", r
+        assert r["exit_code"] == -1, r
+        assert r["output"] == "", r
+
+
+class TestTrackerBounds:
+    def test_task_keys_bounded_fifo(self):
+        tt._terminal_repeat_tracker.clear()
+        cap = tt._TERMINAL_REPEAT_TRACKER_MAX_TASKS
+        for i in range(cap + 10):
+            tt._track_hardline_repeat("t:%d" % i, "cmd", "msg")
+        assert len(tt._terminal_repeat_tracker) == cap
+        assert "t:0" not in tt._terminal_repeat_tracker
+        assert "t:%d" % (cap + 9) in tt._terminal_repeat_tracker
+
+    def test_per_task_keys_bounded_fifo(self):
+        tt._terminal_repeat_tracker.clear()
+        cap = tt._TERMINAL_REPEAT_MAX_KEYS_PER_TASK
+        for i in range(cap + 10):
+            tt._track_hardline_repeat("t:solo", "cmd-%d" % i, "msg")
+        assert len(tt._terminal_repeat_tracker["t:solo"]) == cap
+
+    def test_none_task_key_is_noop(self):
+        tt._terminal_repeat_tracker.clear()
+        assert tt._track_hardline_repeat(None, "cmd", "msg") == 0
+        assert not tt._terminal_repeat_tracker

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -286,6 +286,94 @@ def _check_all_guards(command: str, env_type: str,
                                   has_host_access=has_host_access)
 
 
+# =============================================================================
+# Repeated hardline-block circuit breaker
+# =============================================================================
+# A *hardline* block (tools/approval.py: detect_hardline_command /
+# _hardline_block_result -- the catastrophic-pattern blocklist AND the
+# malformed-payload guard) is deterministic: an identical retry has a 0%
+# chance of succeeding. Without a circuit breaker a looping model can re-emit
+# the exact same blocked command until the turn cap, degrading the session to
+# empty responses. When the same command has been hardline-blocked enough
+# times for one conversation we append a short note telling the model to stop
+# retrying and change approach.
+#
+# Design (kept deliberately simple after two failed "consecutive"-streak
+# attempts, 2026-07 Sol review):
+#   * Count, per conversation, how many times each exact (command, block
+#     message) pair has been hardline-blocked -- a plain cumulative tally, not
+#     a consecutive streak. A streak needs a reset on every *other* terminal
+#     outcome, and the many early-return paths in terminal_tool() kept leaving
+#     stale streak state (Sol HIGH #1). A cumulative tally needs no reset at
+#     all: it is only ever touched on a hardline block, so there is no path
+#     that can corrupt it. Hitting the same unconditional block 3+ times in a
+#     conversation warrants the nudge regardless of what happened in between.
+#   * ONE reason-neutral escalation for every hardline reason. Trying to
+#     branch malformed-vs-catastrophic on a substring of the block message
+#     misclassifies executable commands that trip the malformed guard first
+#     (e.g. ``grep -P ; rm -rf /``), and coaching "run it without pipes / run
+#     it yourself" around a catastrophic block is unsafe (Sol HIGH #2). The
+#     base hardline message already tells the model it must run such commands
+#     itself; the escalation only adds "you have repeated this; it is
+#     deterministic; stop and change approach".
+_terminal_repeat_lock = threading.Lock()
+# task_key -> { (command, block_message): count }. Bounded on both axes.
+_terminal_repeat_tracker: "Dict[str, Dict[tuple, int]]" = {}
+
+# file_tools uses 4 for its search breaker; a hardline block is fully
+# deterministic, so 3 identical blocks is enough to be sure this is a loop.
+_TERMINAL_HARDLINE_REPEAT_THRESHOLD = 3
+
+# Bounded state for long-lived gateway processes (Sol MEDIUM #4): cap the
+# number of tracked conversations, and the distinct blocked commands per
+# conversation, evicting oldest-first (dicts preserve insertion order).
+_TERMINAL_REPEAT_TRACKER_MAX_TASKS = 512
+_TERMINAL_REPEAT_MAX_KEYS_PER_TASK = 64
+
+_TERMINAL_HARDLINE_ESCALATION = (
+    " You have hit this exact block {count} times in this conversation. It is "
+    "deterministic and will not succeed on retry -- stop repeating this "
+    "command and take a different approach to your goal."
+)
+
+
+def _repeat_conversation_key(task_id, session_id):
+    """Stable per-conversation key for the repeat tracker, or None to skip.
+
+    Tagged so a task_id can never collide with another conversation's
+    session_id (Sol MEDIUM #3). None when the caller has no stable identity
+    at all -- tracking is skipped rather than bucketed into a shared key that
+    would let unrelated calls cross-increment.
+    """
+    if task_id:
+        return "t:" + str(task_id)
+    if session_id:
+        return "s:" + str(session_id)
+    return None
+
+
+def _track_hardline_repeat(task_key, command: str, block_message: str) -> int:
+    """Increment and return the cumulative count of this exact hardline block
+    for ``task_key``. Keyed on the raw (command, block message) pair -- a
+    different command or a different hardline reason is a different key. No
+    reset path exists by design: the tally is only touched here, on a hardline
+    block, so nothing else can leave it stale.
+    """
+    if task_key is None:
+        return 0
+    repeat_key = (command, block_message)
+    with _terminal_repeat_lock:
+        if (task_key not in _terminal_repeat_tracker
+                and len(_terminal_repeat_tracker) >= _TERMINAL_REPEAT_TRACKER_MAX_TASKS):
+            del _terminal_repeat_tracker[next(iter(_terminal_repeat_tracker))]
+        task_counts = _terminal_repeat_tracker.setdefault(task_key, {})
+        if (repeat_key not in task_counts
+                and len(task_counts) >= _TERMINAL_REPEAT_MAX_KEYS_PER_TASK):
+            del task_counts[next(iter(task_counts))]
+        task_counts[repeat_key] = task_counts.get(repeat_key, 0) + 1
+        return task_counts[repeat_key]
+
+
 # Allowlist: characters that can legitimately appear in directory paths.
 # Covers alphanumeric, path separators, Windows drive/UNC separators, tilde,
 # dot, hyphen, underscore, space, plus, at, equals, and comma.  Everything
@@ -2379,6 +2467,14 @@ def terminal_tool(
         # an approved command can't be SIGINT-killed by a bit that landed during
         # the approval-wait (see clear_current_thread_interrupt).
         _approved_run = bool(force)
+        # Tagged per-conversation key for the repeat-block circuit breaker
+        # below. Uses the RAW task_id/session_id (not effective_task_id, which
+        # collapses to "default" for almost every call via
+        # _resolve_container_task_id and would bucket unrelated conversations),
+        # tags them so a task_id can't collide with another conversation's
+        # session_id, and returns None (untracked) when neither is present
+        # rather than sharing a bucket (Sol review, MEDIUM #3).
+        _repeat_task_key = _repeat_conversation_key(task_id, session_id)
         if not force:
             approval = _check_all_guards(
                 command, env_type,
@@ -2405,10 +2501,23 @@ def terminal_tool(
                     f"Command denied: {desc}. "
                     "Use the approval prompt to allow it, or rephrase the command."
                 )
+                block_message = approval.get("message", fallback_msg)
+                if approval.get("hardline") is True:
+                    # Deterministic block: an identical retry has a 0% chance
+                    # of succeeding. Escalate once the model has looped on this
+                    # exact block enough times so it doesn't burn the whole
+                    # turn budget on repeated denials.
+                    repeat_count = _track_hardline_repeat(
+                        _repeat_task_key, command, block_message,
+                    )
+                    if repeat_count >= _TERMINAL_HARDLINE_REPEAT_THRESHOLD:
+                        block_message = block_message + _TERMINAL_HARDLINE_ESCALATION.format(
+                            count=repeat_count,
+                        )
                 return json.dumps({
                     "output": "",
                     "exit_code": -1,
-                    "error": approval.get("message", fallback_msg),
+                    "error": block_message,
                     "status": "blocked"
                 }, ensure_ascii=False)
             # Track whether approval was explicitly granted by the user


### PR DESCRIPTION
Fixes #69256.

A hardline block (`tools/approval.py` `detect_hardline_command` / `_hardline_block_result`, covering both the catastrophic-pattern blocklist and the malformed-payload guard) is deterministic: an identical retry has a 0% chance of succeeding. `tools/file_tools.py` already breaks read and search loops this way (`_read_tracker`, :1381 and :1857), but the terminal tool had no equivalent, so a looping model could re-emit the exact blocked command until the turn cap and degrade the session to empty responses.

## Fix

`tools/terminal_tool.py` now counts, per conversation, how many times each exact `(command, block message)` pair has been hardline-blocked. On the 3rd, it appends a short note to the existing hardline message. It never weakens the block (`status: "blocked"`, `exit_code: -1`, no execution) and never fires on `pending_approval` or approvable results, which can succeed on a later call.

Escalation text:

> You have hit this exact block N times in this conversation. It is deterministic and will not succeed on retry; stop repeating this command and take a different approach to your goal.

## Design

Two properties are worth calling out, because the obvious implementations get them wrong:

It counts cumulatively rather than tracking a consecutive streak. A streak has to be reset on every other terminal outcome, and `terminal_tool()` has many early-return paths (foreground-timeout cap, invalid input, environment failures); each one that forgets to reset leaves stale streak state that escalates an unrelated later repeat. A cumulative count is only ever touched on a hardline block, so no other path can corrupt it.

It uses one reason-neutral escalation for every hardline reason. Branching malformed-vs-catastrophic on a substring of the block message misclassifies executable commands that trip the malformed guard first (`grep -P ; rm -rf /` reads as malformed), and advice like "run it without pipes" or "run it yourself" coaches a bypass of an unconditional safety block. The base hardline message already covers the legitimate case, so the escalation only says the block is deterministic and to change approach.

The tally is keyed on the raw command; task and session keys are tagged (`t:` / `s:`) so they can't collide; a call with neither id is left untracked; and the state is bounded on both axes (512 conversations, 64 blocked commands each, FIFO eviction).

## Tests

`tests/tools/test_terminal_repeat_breaker.py` (12 tests): third identical block escalates; the escalation is reason-neutral for both a catastrophic and a malformed block and contains no bypass advice; the count survives an intervening approved or non-hardline call (the cumulative property); distinct commands count separately; non-hardline blocks never escalate; an id-less call is untracked; session id works as the key; tagged keys don't collide; the escalated response still denies execution; and both FIFO bounds hold. Each was confirmed to fail against the current tree before the fix.

## Known limitation

The bounds cap the number of tracked entries (512 × 64), not their bytes. A pathological run with tens of thousands of distinct, unusually large blocked commands could retain non-trivial memory; digesting the command into the key would hard-bound it. Left as-is because a real session hits a handful of distinct hardline blocks, not tens of thousands.
