### PR TITLE
fix(runtime): toolless max-iteration summary + request contract preflight

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -31,6 +31,7 @@ from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
 from agent.errors import EmptyStreamError
+from agent.request_contract import validate_api_kwargs
 from agent.turn_context import substitute_api_content
 from agent.gemini_native_adapter import is_native_gemini_base_url
 from agent.model_metadata import is_local_endpoint
@@ -44,6 +45,12 @@ from tools.terminal_tool import is_persistent_env
 from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 
 logger = logging.getLogger(__name__)
+
+# Sentinel: ``build_api_kwargs(..., tools=...)`` uses agent.tools by default.
+# Pass ``tools=None`` (or ``[]``) for an explicit toolless request — never
+# mutate kwargs after the builder returns.
+_TOOLS_UNSET: Any = object()
+
 _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
 
 # When the fallback chain is fully exhausted on a non-rate-limit failure
@@ -566,6 +573,11 @@ def direct_api_call(agent, api_kwargs: dict):
     timeout (provider ``request_timeout_seconds`` / ``HERMES_API_TIMEOUT``) bounds
     a genuinely hung provider — the same bound interactive calls already rely on.
     """
+    validate_api_kwargs(
+        api_kwargs,
+        api_mode=getattr(agent, "api_mode", None),
+        where="direct_api_call",
+    )
     _check_stale_giveup(agent)
     agent._touch_activity("waiting for non-streaming API response")
     request_client_holder = {"client": None}
@@ -640,6 +652,12 @@ def interruptible_api_call(agent, api_kwargs: dict):
     the main retry loop can try again with backoff / credential rotation /
     provider fallback.
     """
+    # Fail-fast on illegal tools/tool_choice shapes before any provider I/O.
+    validate_api_kwargs(
+        api_kwargs,
+        api_mode=getattr(agent, "api_mode", None),
+        where="interruptible_api_call",
+    )
     # Cron and other non-interactive, nested-pool contexts must not spawn the
     # interrupt worker — it wedges before the socket opens on the 2nd+ call
     # (#62151). Run inline instead. See should_use_direct_api_call.
@@ -1120,9 +1138,30 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 
 
-def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = None) -> dict:
-    """Build the keyword arguments dict for the active API mode."""
-    if tools_for_api is None:
+def build_api_kwargs(
+    agent,
+    api_messages: list,
+    tools_for_api: list | None = None,
+    *,
+    tools: Any = _TOOLS_UNSET,
+) -> dict:
+    """Build the keyword arguments dict for the active API mode.
+
+    Args:
+        tools_for_api: positional override for the tools list; ``None``
+            (default) means use ``agent.tools``.
+        tools: keyword-only override that takes precedence over
+            ``tools_for_api`` when supplied.
+            * omitted (default) — fall back to ``tools_for_api`` / ``agent.tools``
+            * ``None`` or ``[]`` — explicit toolless request (summary path)
+            * non-empty list — use that list instead of ``agent.tools``
+
+    Never strip tools from the returned dict after the fact — that desyncs
+    ``tool_choice`` / ``parallel_tool_calls`` (Responses API 400).
+    """
+    if tools is not _TOOLS_UNSET:
+        tools_for_api = tools
+    elif tools_for_api is None:
         tools_for_api = agent.tools
 
     if agent.api_mode == "anthropic_messages":
@@ -2208,8 +2247,16 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             summary_extra_body["tags"] = _portal_tags()
 
         if agent.api_mode == "codex_responses":
-            codex_kwargs = agent._build_api_kwargs(api_messages)
-            codex_kwargs.pop("tools", None)
+            # Explicit toolless build — never pop tools from a tool-calling
+            # kwargs dict (that leaves tool_choice / parallel_tool_calls and
+            # 400s the Responses API). Complementary to #32777 / #61777 strip
+            # approach: build correctly instead of mutating after the fact.
+            codex_kwargs = agent._build_api_kwargs(api_messages, tools=None)
+            validate_api_kwargs(
+                codex_kwargs,
+                api_mode=agent.api_mode,
+                where="handle_max_iterations.codex_summary",
+            )
             summary_response = agent._run_codex_stream(codex_kwargs)
             _ct_sum = agent._get_transport()
             _cnr_sum = _ct_sum.normalize_response(summary_response)
@@ -2290,6 +2337,11 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                     base_url=getattr(agent, "_anthropic_base_url", None),
                 )
                 _ant_kw = _merge_nous_portal_messages_extra_body(agent, _ant_kw)
+                validate_api_kwargs(
+                    _ant_kw,
+                    api_mode=agent.api_mode,
+                    where="handle_max_iterations.anthropic_summary",
+                )
                 summary_response = _managed_summary_call(
                     _ant_kw,
                     agent._anthropic_messages_create,
@@ -2298,6 +2350,11 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 _summary_result = _tsum.normalize_response(summary_response, strip_tool_prefix=agent._is_anthropic_oauth)
                 final_response = (_summary_result.content or "").strip()
             else:
+                validate_api_kwargs(
+                    summary_kwargs,
+                    api_mode=agent.api_mode,
+                    where="handle_max_iterations.chat_summary",
+                )
                 summary_client = agent._ensure_primary_openai_client(
                     reason="iteration_limit_summary"
                 )
@@ -2320,8 +2377,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         else:
             # Retry summary generation
             if agent.api_mode == "codex_responses":
-                codex_kwargs = agent._build_api_kwargs(api_messages)
-                codex_kwargs.pop("tools", None)
+                codex_kwargs = agent._build_api_kwargs(api_messages, tools=None)
+                validate_api_kwargs(
+                    codex_kwargs,
+                    api_mode=agent.api_mode,
+                    where="handle_max_iterations.codex_summary_retry",
+                )
                 retry_response = agent._run_codex_stream(codex_kwargs)
                 _ct_retry = agent._get_transport()
                 _cnr_retry = _ct_retry.normalize_response(retry_response)
@@ -2339,6 +2400,11 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                     base_url=getattr(agent, "_anthropic_base_url", None),
                 )
                 _ant_kw2 = _merge_nous_portal_messages_extra_body(agent, _ant_kw2)
+                validate_api_kwargs(
+                    _ant_kw2,
+                    api_mode=agent.api_mode,
+                    where="handle_max_iterations.anthropic_summary_retry",
+                )
                 retry_response = _managed_summary_call(
                     _ant_kw2,
                     agent._anthropic_messages_create,
@@ -2360,6 +2426,11 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 if summary_extra_body:
                     summary_kwargs["extra_body"] = summary_extra_body
 
+                validate_api_kwargs(
+                    summary_kwargs,
+                    api_mode=agent.api_mode,
+                    where="handle_max_iterations.chat_summary_retry",
+                )
                 summary_client = agent._ensure_primary_openai_client(
                     reason="iteration_limit_summary_retry"
                 )
@@ -2493,6 +2564,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     Falls back to _interruptible_api_call on provider errors indicating
     streaming is not supported.
     """
+    validate_api_kwargs(
+        api_kwargs,
+        api_mode=getattr(agent, "api_mode", None),
+        where="interruptible_streaming_api_call",
+    )
     if agent._interrupt_requested:
         raise InterruptedError("Agent interrupted before streaming API call")
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1237,6 +1237,14 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     payload shape — we never let the SDK reconstruct a typed object from
     the terminal event's ``output`` field.
     """
+    from agent.request_contract import validate_api_kwargs
+
+    validate_api_kwargs(
+        api_kwargs,
+        api_mode=getattr(agent, "api_mode", None) or "codex_responses",
+        where="run_codex_stream",
+    )
+
     import httpx as _httpx
 
     from agent import relay_llm

--- a/agent/errors.py
+++ b/agent/errors.py
@@ -11,3 +11,17 @@ class EmptyStreamError(RuntimeError):
 
 class MoAPresetNotFoundError(ValueError):
     """Raised when a persisted MoA preset no longer exists in config."""
+
+
+class RuntimeContractViolation(Exception):
+    """The runtime assembled a provider request that violates an internal invariant.
+
+    This is **not** a model failure and **not** a provider outage.  It means
+    Hermes itself built an illegal payload (e.g. ``tool_choice`` without
+    ``tools``).  Callers must fail fast **before** the HTTP request is sent.
+    """
+
+    def __init__(self, message: str, *, field: str | None = None, context: dict | None = None):
+        super().__init__(message)
+        self.field = field
+        self.context = context or {}

--- a/agent/request_contract.py
+++ b/agent/request_contract.py
@@ -1,0 +1,90 @@
+"""Outbound API request contract checks.
+
+Centralizes the tools ↔ tool_choice invariant so the main conversation loop
+and the max-iterations summary path share one preflight gate.  Violations
+raise :class:`agent.errors.RuntimeContractViolation` and must never reach a
+provider.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from agent.errors import RuntimeContractViolation
+
+# Fields that only make sense when tools are present on the wire.
+_TOOL_DEPENDENT_FIELDS = (
+    "tool_choice",
+    "parallel_tool_calls",
+)
+
+
+def _tools_are_present(api_kwargs: Mapping[str, Any]) -> bool:
+    """Return True when the payload exposes a non-empty tools collection."""
+    if "tools" not in api_kwargs:
+        return False
+    tools = api_kwargs.get("tools")
+    if tools is None:
+        return False
+    if isinstance(tools, (list, tuple, set)):
+        return len(tools) > 0
+    # Non-sequence tool payloads (rare provider shapes) count as present.
+    return True
+
+
+def validate_api_kwargs(
+    api_kwargs: Optional[Mapping[str, Any]],
+    *,
+    api_mode: Optional[str] = None,
+    where: str = "api_request",
+) -> None:
+    """Assert outbound kwargs satisfy tools/tool_choice invariants.
+
+    Rules:
+    - ``tools=None`` must not appear as an explicit key (omit the key instead).
+    - ``tool_choice`` / ``parallel_tool_calls`` require a non-empty ``tools`` list.
+    - Empty ``tools=[]`` is treated as absent (must not carry tool-dependent fields).
+
+    Raises:
+        RuntimeContractViolation: on any invariant breach.
+    """
+    if not isinstance(api_kwargs, Mapping):
+        raise RuntimeContractViolation(
+            f"{where}: api_kwargs must be a mapping, got {type(api_kwargs).__name__}",
+            field="api_kwargs",
+            context={"api_mode": api_mode},
+        )
+
+    if "tools" in api_kwargs and api_kwargs.get("tools") is None:
+        raise RuntimeContractViolation(
+            f"{where}: tools=None is illegal — omit the key entirely "
+            f"(api_mode={api_mode!r})",
+            field="tools",
+            context={"api_mode": api_mode, "keys": sorted(api_kwargs.keys())},
+        )
+
+    tools_present = _tools_are_present(api_kwargs)
+
+    for field in _TOOL_DEPENDENT_FIELDS:
+        if field not in api_kwargs:
+            continue
+        value = api_kwargs.get(field)
+        if value is None:
+            # Explicit null is also illegal — omit the key.
+            raise RuntimeContractViolation(
+                f"{where}: {field}=None is illegal without tools — omit the key "
+                f"(api_mode={api_mode!r})",
+                field=field,
+                context={"api_mode": api_mode, "tools_present": tools_present},
+            )
+        if not tools_present:
+            raise RuntimeContractViolation(
+                f"{where}: {field}={value!r} requires a non-empty tools list "
+                f"(api_mode={api_mode!r})",
+                field=field,
+                context={
+                    "api_mode": api_mode,
+                    "tools_present": tools_present,
+                    "keys": sorted(api_kwargs.keys()),
+                },
+            )

--- a/run_agent.py
+++ b/run_agent.py
@@ -5557,6 +5557,12 @@ class AIAgent:
         # Defensive: strip Responses-only kwargs that can leak in under an
         # api_mode-flip race (the Anthropic SDK raises a non-retryable
         # TypeError on them). See #31673.
+        from agent.request_contract import validate_api_kwargs
+        validate_api_kwargs(
+            api_kwargs,
+            api_mode=getattr(self, "api_mode", None),
+            where="_anthropic_messages_create",
+        )
         from agent.anthropic_adapter import create_anthropic_message
         return create_anthropic_message(
             client or self._anthropic_client,
@@ -6569,10 +6575,13 @@ class AIAgent:
                     content[-1]["cache_control"] = {"type": "ephemeral"}
                 break
 
-    def _build_api_kwargs(self, api_messages: list, tools_for_api: Optional[list] = None) -> dict:
-        """Forwarder — see ``agent.chat_completion_helpers.build_api_kwargs``."""
+    def _build_api_kwargs(self, api_messages: list, tools_for_api: Optional[list] = None, **kwargs) -> dict:
+        """Forwarder — see ``agent.chat_completion_helpers.build_api_kwargs``.
+
+        Accepts ``tools=None`` for an explicit toolless request (summary path).
+        """
         from agent.chat_completion_helpers import build_api_kwargs
-        return build_api_kwargs(self, api_messages, tools_for_api=tools_for_api)
+        return build_api_kwargs(self, api_messages, tools_for_api=tools_for_api, **kwargs)
 
     def _supports_reasoning_extra_body(self) -> bool:
         """Return True when reasoning extra_body is safe to send for this route/model.

--- a/tests/run_agent/test_request_contract.py
+++ b/tests/run_agent/test_request_contract.py
@@ -1,0 +1,308 @@
+"""Outbound request-contract preflight + max-iterations summary tools invariant.
+
+Pins the fix for the codex_responses summary path that used to:
+
+    kwargs = build_api_kwargs(...)   # tools + tool_choice=\"auto\"
+    kwargs.pop(\"tools\", None)       # leaves tool_choice → Responses API 400
+
+Also covers the shared preflight gate used by the main loop and summary path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.errors import RuntimeContractViolation
+from agent.request_contract import validate_api_kwargs
+
+
+# ---------------------------------------------------------------------------
+# validate_api_kwargs unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateApiKwargs:
+    def test_ok_with_tools_and_tool_choice(self):
+        validate_api_kwargs(
+            {"model": "m", "tools": [{"type": "function"}], "tool_choice": "auto"},
+            api_mode="codex_responses",
+        )
+
+    def test_ok_toolless(self):
+        validate_api_kwargs({"model": "m", "input": []}, api_mode="codex_responses")
+
+    def test_rejects_tool_choice_without_tools(self):
+        with pytest.raises(RuntimeContractViolation) as ei:
+            validate_api_kwargs(
+                {"model": "m", "tool_choice": "auto"},
+                api_mode="codex_responses",
+                where="unit",
+            )
+        assert ei.value.field == "tool_choice"
+        assert "requires a non-empty tools list" in str(ei.value)
+
+    def test_rejects_parallel_without_tools(self):
+        with pytest.raises(RuntimeContractViolation) as ei:
+            validate_api_kwargs(
+                {"model": "m", "parallel_tool_calls": True},
+                api_mode="codex_responses",
+            )
+        assert ei.value.field == "parallel_tool_calls"
+
+    def test_rejects_tools_none_key(self):
+        with pytest.raises(RuntimeContractViolation) as ei:
+            validate_api_kwargs({"tools": None, "model": "m"}, api_mode="codex_responses")
+        assert ei.value.field == "tools"
+
+    def test_rejects_tool_choice_with_empty_tools(self):
+        with pytest.raises(RuntimeContractViolation):
+            validate_api_kwargs(
+                {"tools": [], "tool_choice": "auto"},
+                api_mode="chat_completions",
+            )
+
+    def test_ok_chat_with_tools(self):
+        validate_api_kwargs(
+            {
+                "model": "gpt",
+                "messages": [],
+                "tools": [{"type": "function", "function": {"name": "t"}}],
+            },
+            api_mode="chat_completions",
+        )
+
+
+# ---------------------------------------------------------------------------
+# build_api_kwargs tools= override
+# ---------------------------------------------------------------------------
+
+
+class TestBuildApiKwargsToolsOverride:
+    def test_codex_tools_none_omits_tool_fields(self, agent):
+        from agent.chat_completion_helpers import build_api_kwargs
+
+        agent.api_mode = "codex_responses"
+        agent.provider = "openai-codex"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+        agent._base_url_lower = agent.base_url.lower()
+        agent._base_url_hostname = "chatgpt.com"
+        agent.model = "gpt-5.5"
+        # Agent still has tools registered (main-loop state).
+        assert agent.tools
+
+        kwargs = build_api_kwargs(
+            agent,
+            [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "hi"},
+            ],
+            tools=None,
+        )
+        assert "tools" not in kwargs
+        assert "tool_choice" not in kwargs
+        assert "parallel_tool_calls" not in kwargs
+        # Preflight must accept the toolless build.
+        validate_api_kwargs(kwargs, api_mode="codex_responses")
+
+    def test_codex_default_includes_tools_when_registered(self, agent):
+        from agent.chat_completion_helpers import build_api_kwargs
+
+        agent.api_mode = "codex_responses"
+        agent.provider = "openai-codex"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+        agent._base_url_lower = agent.base_url.lower()
+        agent._base_url_hostname = "chatgpt.com"
+        agent.model = "gpt-5.5"
+
+        kwargs = build_api_kwargs(
+            agent,
+            [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "hi"},
+            ],
+        )
+        assert "tools" in kwargs and kwargs["tools"]
+        assert kwargs.get("tool_choice") == "auto"
+        validate_api_kwargs(kwargs, api_mode="codex_responses")
+
+    def test_chat_tools_none_omits_tools(self, agent):
+        from agent.chat_completion_helpers import build_api_kwargs
+
+        agent.api_mode = "chat_completions"
+        kwargs = build_api_kwargs(
+            agent,
+            [{"role": "user", "content": "hi"}],
+            tools=None,
+        )
+        assert "tools" not in kwargs
+        assert "tool_choice" not in kwargs
+        validate_api_kwargs(kwargs, api_mode="chat_completions")
+
+
+# ---------------------------------------------------------------------------
+# handle_max_iterations summary paths
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+@pytest.fixture()
+def agent():
+    """Minimal AIAgent with mocked client (mirrors tests/run_agent fixture)."""
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        return a
+
+
+class TestMaxIterationsSummaryContract:
+    def test_codex_summary_no_tool_choice_when_agent_has_tools(self, agent):
+        """Regression: summary must not send tool_choice without tools."""
+        agent.api_mode = "codex_responses"
+        agent.provider = "openai-codex"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+        agent._base_url_lower = agent.base_url.lower()
+        agent._base_url_hostname = "chatgpt.com"
+        agent.model = "gpt-5.5"
+        agent._cached_system_prompt = "You are helpful."
+        assert agent.tools  # tools still registered on the agent
+        captured = {}
+
+        def fake_run_codex_stream(kwargs):
+            captured.update(kwargs)
+            # Preflight would already have run inside run_codex_stream; assert
+            # shape here too for the handle_max_iterations construction path.
+            validate_api_kwargs(kwargs, api_mode="codex_responses")
+            return SimpleNamespace(
+                status="completed",
+                output=[
+                    SimpleNamespace(
+                        type="message",
+                        status="completed",
+                        content=[SimpleNamespace(type="output_text", text="Summary done.")],
+                    )
+                ],
+            )
+
+        with patch.object(agent, "_run_codex_stream", side_effect=fake_run_codex_stream):
+            result = agent._handle_max_iterations(
+                [{"role": "user", "content": "do stuff"}], 20
+            )
+
+        assert "Summary" in result or result == "Summary done."
+        assert "tools" not in captured
+        assert "tool_choice" not in captured
+        assert "parallel_tool_calls" not in captured
+
+    def test_chat_summary_still_works(self, agent):
+        agent.api_mode = "chat_completions"
+        agent._cached_system_prompt = "You are helpful."
+        agent.client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="Chat summary.", tool_calls=None),
+                    finish_reason="stop",
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+        # normalize_response path — mock transport if needed
+        with patch.object(
+            agent,
+            "_ensure_primary_openai_client",
+            return_value=agent.client,
+        ):
+            # Use a simple normalize that returns content
+            mock_transport = MagicMock()
+            mock_transport.normalize_response.return_value = SimpleNamespace(
+                content="Chat summary."
+            )
+            with patch.object(agent, "_get_transport", return_value=mock_transport):
+                result = agent._handle_max_iterations(
+                    [{"role": "user", "content": "do stuff"}], 20
+                )
+        assert "Chat summary" in result or result == "Chat summary."
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert "tools" not in kwargs
+        assert "tool_choice" not in kwargs
+
+    def test_anthropic_summary_tools_none(self, agent):
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "anthropic"
+        agent._is_anthropic_oauth = False
+        agent._cached_system_prompt = "You are helpful."
+        agent.max_tokens = 1024
+        agent.reasoning_config = None
+
+        mock_transport = MagicMock()
+        mock_transport.build_kwargs.return_value = {
+            "model": "claude-test",
+            "messages": [{"role": "user", "content": "x"}],
+            "max_tokens": 1024,
+        }
+        mock_transport.normalize_response.return_value = SimpleNamespace(
+            content="Anthropic summary."
+        )
+
+        with (
+            patch.object(agent, "_get_transport", return_value=mock_transport),
+            patch.object(
+                agent,
+                "_anthropic_messages_create",
+                return_value=SimpleNamespace(content=[]),
+            ) as create_mock,
+        ):
+            result = agent._handle_max_iterations(
+                [{"role": "user", "content": "do stuff"}], 20
+            )
+
+        assert "Anthropic summary" in result
+        # build_kwargs must have been called with tools=None
+        assert mock_transport.build_kwargs.call_args.kwargs.get("tools") is None
+        create_mock.assert_called()
+        sent = create_mock.call_args.args[0]
+        assert "tools" not in sent
+        assert "tool_choice" not in sent
+
+
+# ---------------------------------------------------------------------------
+# Preflight on main send path
+# ---------------------------------------------------------------------------
+
+
+class TestInterruptibleApiCallPreflight:
+    def test_rejects_illegal_kwargs_before_provider(self, agent):
+        from agent.chat_completion_helpers import interruptible_api_call
+        from agent.errors import RuntimeContractViolation
+
+        agent.api_mode = "codex_responses"
+        bad = {"model": "gpt-5.5", "tool_choice": "auto"}  # no tools
+        with pytest.raises(RuntimeContractViolation):
+            interruptible_api_call(agent, bad)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2505,6 +2505,10 @@ class TestHandleMaxIterations:
             and item.get("call_id") == "call_orphan"
             for item in input_items
         )
+        # Summary is toolless: must not leave tool_choice after tools strip.
+        assert "tools" not in captured
+        assert "tool_choice" not in captured
+        assert "parallel_tool_calls" not in captured
 
     def test_api_sanitizer_matches_responses_call_id_when_id_differs(self, agent):
         messages = [


### PR DESCRIPTION
## What

Fix the max-iteration summary path for `codex_responses` so Hermes never sends `tool_choice` / `parallel_tool_calls` without `tools`.

Also add a shared outbound request-contract preflight so illegal payloads fail **before** the provider call.

## Why

When `handle_max_iterations` builds Responses kwargs and then does `pop(\"tools\")`, it leaves `tool_choice=\"auto\"` (set by `CodexTransport` whenever tools are present). xAI/OpenAI Responses returns HTTP 400:

```
A tool_choice was set on the request but no tools were specified.
```

`xai-oauth` / Grok uses `api_mode=codex_responses`, so long tool loops hit this on wrap-up. Observed as:

```
I reached the maximum iterations (N) but couldn't summarize. Error: ... 400 ...
```

This is a **runtime contract** failure, not a model failure.

## How (architecture, not just strip)

Related strip-only PRs: #32777, #61777 — complementary, not duplicates.

This PR:

1. **`build_api_kwargs(..., tools=None)`** — explicit toolless build (single writer)
2. **Removes the `pop(\"tools\")` pattern** from first-try and retry summary paths
3. **`validate_api_kwargs` preflight** shared by main loop + summary (`interruptible_api_call`, streaming, `run_codex_stream`, anthropic create, summary)
4. **`RuntimeContractViolation`** — illegal Hermes-built payload (fail-fast, never HTTP)

Invariant:

```
tool_choice / parallel_tool_calls  ⇒  non-empty tools
tools absent/empty                 ⇒  omit tool-dependent fields
```

## Changes

| File | Change |
|------|--------|
| `agent/request_contract.py` | new preflight |
| `agent/errors.py` | `RuntimeContractViolation` |
| `agent/chat_completion_helpers.py` | tools override + toolless summary + validate |
| `agent/codex_runtime.py` | preflight on stream send |
| `run_agent.py` | forwarder `**kwargs`; anthropic preflight |
| `tests/run_agent/test_request_contract.py` | new coverage |
| `tests/run_agent/test_run_agent.py` | assert toolless codex summary |

## Verification

```bash
python -m pytest tests/run_agent/test_request_contract.py   tests/run_agent/test_run_agent.py::TestHandleMaxIterations -q
# 28 passed
```

## Scope

- No prompt / planner / provider profile / merge changes
- No behavior change to tool-calling main loop when tools are present