### PR TITLE
fix(write-approval): mirror approved memory writes to external providers

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2991,6 +2991,45 @@ class GatewaySlashCommandsMixin:
             session_key, platform_key, args, persist_global=persist_global
         )
 
+    def _build_memory_manager_for_approvals(self):
+        """Construct a MemoryManager + configured provider for mirroring
+        approved memory writes to external providers (e.g. Open Brain).
+
+        Replicates the init path from agent/agent_init.py but without an
+        AIAgent instance — just enough to fire ``notify_memory_tool_write``
+        so external providers see approved writes. Returns None when no
+        external provider is configured or initialization fails.
+        """
+        try:
+            from gateway.run import _load_gateway_config, _hermes_home as _hh
+            from agent.memory_manager import MemoryManager
+            from plugins.memory import load_memory_provider
+
+            cfg = _load_gateway_config()
+            mem_config = cfg.get("memory", {}) or {}
+            provider_name = mem_config.get("provider", "").strip()
+            if not provider_name:
+                return None
+
+            mm = MemoryManager()
+            provider = load_memory_provider(provider_name)
+            if not provider or not provider.is_available():
+                return None
+            mm.add_provider(provider)
+            if not mm.providers:
+                return None
+
+            mm.initialize_all(
+                session_id="gateway-approvals",
+                platform="gateway",
+                hermes_home=str(_hh),
+                agent_context="gateway-approvals",
+            )
+            return mm
+        except Exception as e:
+            logger.debug("gateway memory-manager-for-approvals init failed: %s", e)
+            return None
+
     async def _handle_memory_command(self, event: MessageEvent) -> str:
         """Handle /memory — review pending memory writes + toggle the approval gate.
 
@@ -3025,8 +3064,19 @@ class GatewaySlashCommandsMixin:
         # load_on_disk_store() honors the user's configured char limits.
         store = load_on_disk_store()
 
+        # Build a MemoryManager so approved writes mirror to external providers
+        # (e.g. Open Brain), matching the non-gated tool path. Cached on the
+        # gateway instance so we don't re-initialize the provider on every
+        # /memory approve. Lazy: only built when an approve is actually issued.
+        mm = getattr(self, "_memory_manager_for_approvals", None)
+        if mm is None:
+            mm = self._build_memory_manager_for_approvals()
+            if mm is not None:
+                self._memory_manager_for_approvals = mm
+
         out = handle_pending_subcommand(
             wa.MEMORY, args, memory_store=store, set_mode_fn=_set_approval,
+            memory_manager=mm,
         )
         if out is None:
             out = ("Unknown /memory subcommand. Use: pending, approve <id>, "

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1605,6 +1605,7 @@ class CLICommandsMixin:
             wa.MEMORY, args,
             memory_store=store,
             set_mode_fn=lambda enabled: self._save_write_approval("memory", enabled),
+            memory_manager=getattr(self.agent, "_memory_manager", None) if getattr(self, "agent", None) else None,
         )
         if out is None:
             out = ("Unknown /memory subcommand. "

--- a/hermes_cli/write_approval_commands.py
+++ b/hermes_cli/write_approval_commands.py
@@ -16,7 +16,10 @@ platform the gateway truncates it and points the user at the dashboard / file.
 from __future__ import annotations
 
 import json
+import logging
 from typing import List, Optional
+
+logger = logging.getLogger(__name__)
 
 from tools import write_approval as wa
 
@@ -57,6 +60,7 @@ def handle_pending_subcommand(
     *,
     memory_store=None,
     set_mode_fn=None,
+    memory_manager=None,
 ) -> Optional[str]:
     """Dispatch a /memory or /skills subcommand.
 
@@ -69,6 +73,11 @@ def handle_pending_subcommand(
         set_mode_fn: optional callable ``(enabled: bool) -> None`` that
             persists the new write_approval boolean to config (gateway provides
             this; CLI uses its own ``save_config_value`` and passes a closure).
+        memory_manager: optional live MemoryManager — when provided, approved
+            memory writes are mirrored to external providers (e.g. Open Brain)
+            via ``notify_memory_tool_write``, mirroring the non-gated path.
+            Without this, approved writes land in MEMORY/USER.md but external
+            providers never see them (issue: write-approval breaks the mirror).
 
     Returns a text string to show the user. Returns None when the args are not
     a write-approval subcommand (caller falls through to its other handling,
@@ -85,7 +94,7 @@ def handle_pending_subcommand(
         return _fmt_pending_list(subsystem)
 
     if sub in {"approve", "apply"}:
-        return _approve(subsystem, rest, memory_store)
+        return _approve(subsystem, rest, memory_store, memory_manager=memory_manager)
 
     if sub in {"reject", "deny", "drop"}:
         return _reject(subsystem, rest)
@@ -105,7 +114,7 @@ def _resolve_one(subsystem: str, rest: List[str]):
     return rest[0], None
 
 
-def _approve(subsystem: str, rest: List[str], memory_store) -> str:
+def _approve(subsystem: str, rest: List[str], memory_store, *, memory_manager=None) -> str:
     target, err = _resolve_one(subsystem, rest)
     if err or target is None:
         return err or f"Usage: /{subsystem} approve <id>"
@@ -124,7 +133,7 @@ def _approve(subsystem: str, rest: List[str], memory_store) -> str:
 
     applied, failed = 0, []
     for rec in targets:
-        ok, msg = _apply_one(subsystem, rec, memory_store)
+        ok, msg = _apply_one(subsystem, rec, memory_store, memory_manager=memory_manager)
         if ok:
             wa.discard_pending(subsystem, rec["id"])
             applied += 1
@@ -138,7 +147,7 @@ def _approve(subsystem: str, rest: List[str], memory_store) -> str:
     return "\n".join(out)
 
 
-def _apply_one(subsystem: str, rec, memory_store):
+def _apply_one(subsystem: str, rec, memory_store, *, memory_manager=None):
     payload = rec.get("payload", {})
     try:
         if subsystem == wa.MEMORY:
@@ -146,6 +155,19 @@ def _apply_one(subsystem: str, rec, memory_store):
                 return False, "memory store unavailable"
             from tools.memory_tool import apply_memory_pending
             result = apply_memory_pending(payload, memory_store)
+            # Mirror approved memory writes to external providers (e.g. Open
+            # Brain), exactly as the non-gated tool path does. Without this,
+            # write-approval silently breaks the external mirror: MEMORY.md
+            # is updated but on_memory_write never fires.
+            if result.get("success") and memory_manager is not None:
+                try:
+                    memory_manager.notify_memory_tool_write(
+                        json.dumps(result),
+                        payload,
+                        build_metadata=lambda: {},
+                    )
+                except Exception as e:
+                    logger.debug("mirror of approved write to external provider failed: %s", e)
             return bool(result.get("success")), result.get("error", "")
         else:
             from tools.skill_manager_tool import apply_skill_pending

--- a/tests/hermes_cli/test_write_approval_memory_mirror.py
+++ b/tests/hermes_cli/test_write_approval_memory_mirror.py
@@ -1,0 +1,85 @@
+"""Behavior tests: approved memory writes must mirror to external providers.
+
+Bug: with memory write-approval enabled, writes staged for approval landed in
+MEMORY.md/USER.md when approved via /memory approve — but the external-provider
+mirror (``MemoryManager.notify_memory_tool_write``) never fired, so providers
+like Open Brain silently missed every approved write. The fix threads a
+MemoryManager through the approval path. These tests pin that contract:
+approving with a manager mirrors, approving without one still applies locally.
+"""
+
+import json
+
+from tools import write_approval as wa
+from tools.memory_tool import apply_memory_pending, load_on_disk_store
+from hermes_cli.write_approval_commands import _apply_one, _approve
+
+
+class _FakeManager:
+    """Stands in for MemoryManager; records notify_memory_tool_write calls."""
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    def notify_memory_tool_write(self, result_json, args, build_metadata=None):
+        self.calls.append({"result": json.loads(result_json), "args": dict(args)})
+
+
+def _stage_add(content: str) -> str:
+    rec = wa.stage_write(
+        wa.MEMORY,
+        {"action": "add", "target": "memory", "content": content},
+        summary="test staged add",
+        origin="test",
+    )
+    return rec["id"]
+
+
+def test_apply_one_mirrors_when_manager_present():
+    store = load_on_disk_store()
+    pid = _stage_add("mirror-contract test fact alpha")
+    rec = wa.get_pending(wa.MEMORY, pid)
+    manager = _FakeManager()
+
+    ok, _ = _apply_one(wa.MEMORY, rec, store, memory_manager=manager)
+
+    assert ok
+    assert len(manager.calls) == 1
+    assert manager.calls[0]["result"]["success"] is True
+    assert manager.calls[0]["args"]["content"] == "mirror-contract test fact alpha"
+
+
+def test_apply_one_without_manager_still_applies():
+    store = load_on_disk_store()
+    pid = _stage_add("no-manager test fact beta")
+    rec = wa.get_pending(wa.MEMORY, pid)
+
+    ok, _ = _apply_one(wa.MEMORY, rec, store)
+
+    assert ok
+
+
+def test_mirror_failure_does_not_fail_the_approve():
+    store = load_on_disk_store()
+    pid = _stage_add("fragile-mirror test fact gamma")
+    rec = wa.get_pending(wa.MEMORY, pid)
+
+    class _ExplodingManager:
+        def notify_memory_tool_write(self, *a, **k):
+            raise RuntimeError("provider down")
+
+    ok, _ = _apply_one(wa.MEMORY, rec, store, memory_manager=_ExplodingManager())
+
+    assert ok  # local write must survive a provider-side mirror failure
+
+
+def test_approve_full_path_mirrors_and_clears_pending():
+    store = load_on_disk_store()
+    pid = _stage_add("full-path test fact delta")
+    manager = _FakeManager()
+
+    out = _approve(wa.MEMORY, [pid], store, memory_manager=manager)
+
+    assert len(manager.calls) == 1
+    assert wa.get_pending(wa.MEMORY, pid) is None
+    assert "delta" in out or "Applied" in out or "approved" in out.lower()


### PR DESCRIPTION
## Bug

With `memory.write_approval` enabled, every memory write is staged for approval. When the user approves one (`/memory approve <id>`, CLI or gateway), the write lands in MEMORY.md/USER.md — but `MemoryManager.notify_memory_tool_write` never fires, so **external memory providers (Open Brain, Mem0, Honcho, etc.) silently miss every approved write**. The non-gated tool path mirrors correctly; the approval path didn't. Result: built-in memory and the external provider drift apart with no error anywhere.

Observed in production: ~100 approved writes over two weeks landed locally while the external provider saw none of them.

## Fix

Thread a `MemoryManager` through the approval path:

- `hermes_cli/write_approval_commands.py` — `handle_pending_subcommand`/`_approve`/`_apply_one` accept an optional `memory_manager`; on successful apply, approved writes are mirrored via `notify_memory_tool_write`, same as the non-gated path. A mirror failure is logged at debug and never fails the local write.
- `hermes_cli/cli_commands_mixin.py` — CLI passes the live agent's `_memory_manager`.
- `gateway/slash_commands.py` — gateway lazily builds a minimal MemoryManager (provider load + `initialize_all`, no AIAgent), cached on the instance; returns None gracefully when no external provider is configured.

No behavior change when no external provider is configured or when the manager is absent — the parameter is optional end-to-end.

## Tests

New `tests/hermes_cli/test_write_approval_memory_mirror.py` (4 tests, all passing via `scripts/run_tests.sh`):

- approve with manager → exactly one mirror call with the applied payload
- approve without manager → local write still applies (no regression)
- provider-side mirror exception → local write still succeeds (fail-open)
- full `_approve` path → mirrors and clears the pending record

Existing `tests/agent/test_memory_write_bridge.py` (10 tests) still passes.