### PR TITLE
feat(compression): opt-in idle-triggered compaction

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1869,6 +1869,12 @@ def init_agent(
             codex_app_server_auto_compaction,
         )
         codex_app_server_auto_compaction = "native"
+    # Opt-in idle compaction: compact a session up front when it resumes after
+    # this many seconds of inactivity (0 = disabled). Time-based, so it
+    # complements the size-based threshold above. Consumed by build_turn_context().
+    compression_idle_compact_after_seconds = max(
+        0, int(_compression_cfg.get("idle_compact_after_seconds", 0))
+    )
 
     # Read optional explicit context_length override for the auxiliary
     # compression model. Custom endpoints often cannot report this via
@@ -2295,6 +2301,9 @@ def init_agent(
     agent.compression_in_place = compression_in_place
     agent.codex_app_server_auto_compaction = codex_app_server_auto_compaction
     agent.max_compression_attempts = compression_max_attempts
+    agent.compression_idle_compact_after_seconds = (
+        compression_idle_compact_after_seconds
+    )
 
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -662,13 +662,28 @@ def build_turn_context(
                     f"💤 Resumed after {int(_idle_gap)}s idle — compacting "
                     f"~{_idle_tokens:,} tokens before continuing."
                 )
+                _idle_input = messages
                 messages, active_system_prompt = agent._compress_context(
                     messages, system_message, approx_tokens=_idle_tokens,
                     task_id=effective_task_id,
                 )
-                conversation_history = conversation_history_after_compression(
-                    agent, messages
-                )
+                # ``_compress_context`` returns the INPUT list object when it
+                # skips (per-session lock held by another path, failure
+                # cooldown, anti-thrash breaker, codex-native routing). Only
+                # re-baseline + re-anchor after a real compaction — a skip
+                # must leave the turn's flush baseline and user-message index
+                # untouched.
+                if messages is not _idle_input:
+                    conversation_history = conversation_history_after_compression(
+                        agent, messages
+                    )
+                    # Compaction rebuilt the list, so the index of this turn's
+                    # just-appended user message is stale — re-anchor it the
+                    # same way the preflight path does below.
+                    current_turn_user_idx = reanchor_current_turn_user_idx(
+                        messages, user_message
+                    )
+                    agent._persist_user_message_idx = current_turn_user_idx
 
     # ── Preflight context compression ──
     # Gate the (expensive) full token estimate behind a cheap pre-check.

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, Optional
@@ -253,6 +254,40 @@ def _should_run_preflight_estimate(
     if len(messages) > protect_first_n + protect_last_n + 1:
         return True
     return estimate_messages_tokens_rough(messages) >= threshold_tokens
+
+
+def _should_idle_compact(
+    *,
+    enabled: bool,
+    idle_after_seconds: int,
+    idle_gap_seconds: float,
+    tokens: int,
+    floor_tokens: int,
+    cooldown_active: bool,
+) -> bool:
+    """Decide whether an idle-triggered compaction should run this turn.
+
+    Idle compaction is opt-in (``idle_after_seconds <= 0`` disables it). It
+    fires when a session resumes after a wall-clock gap of at least
+    ``idle_after_seconds`` since its last activity, so a long-lived thread
+    that is paused and later resumed compacts its accumulated history up
+    front instead of re-reading it on every subsequent turn.
+
+    It is orthogonal to the token-threshold trigger: it does NOT require the
+    context to exceed ``threshold_tokens``. It still skips work when the
+    context is at or below ``floor_tokens`` (the size compaction would reduce
+    *to*), so a small idle thread never pays for a summarisation that saves
+    nothing, and it defers to an active compression-failure cooldown.
+
+    Pure predicate so the policy is unit-testable without a live agent.
+    """
+    if not enabled or idle_after_seconds <= 0:
+        return False
+    if idle_gap_seconds < idle_after_seconds:
+        return False
+    if cooldown_active:
+        return False
+    return tokens > floor_tokens
 
 
 @dataclass
@@ -578,6 +613,62 @@ def build_turn_context(
         # fresh staged input.
         if not isinstance(pending_cli_message, dict) or pending_cli_message.get("_db_persisted"):
             agent._pending_cli_user_message = None
+
+    # ── Idle-triggered compaction (opt-in; ``idle_compact_after_seconds``) ──
+    # When a session resumes after a long idle gap, compact the accumulated
+    # history up front so the rest of the conversation does not keep re-reading
+    # a large stale context on every turn. This fires on elapsed wall-clock time
+    # rather than size, so it complements (does not replace) the token-threshold
+    # preflight below. ``_last_activity_ts`` is the last time this turn loop did
+    # work; nothing has touched it yet this turn, so it measures the gap since
+    # the previous turn finished. The cheap gap pre-check gates the (more
+    # expensive) token estimate, mirroring ``_should_run_preflight_estimate``.
+    _idle_after = getattr(agent, "compression_idle_compact_after_seconds", 0)
+    if agent.compression_enabled and _idle_after > 0 and messages:
+        _idle_gap = time.time() - getattr(agent, "_last_activity_ts", time.time())
+        if _idle_gap >= _idle_after:
+            _compressor = agent.context_compressor
+            _idle_tokens = estimate_request_tokens_rough(
+                messages,
+                system_prompt=active_system_prompt or "",
+                tools=agent.tools or None,
+            )
+            # Post-compression target size: don't summarise a thread already
+            # below what compaction would reduce it to.
+            _idle_floor = int(
+                _compressor.threshold_tokens * _compressor.summary_target_ratio
+            )
+            _idle_cooldown = getattr(
+                _compressor, "get_active_compression_failure_cooldown", lambda: None
+            )()
+            if _should_idle_compact(
+                enabled=agent.compression_enabled,
+                idle_after_seconds=_idle_after,
+                idle_gap_seconds=_idle_gap,
+                tokens=_idle_tokens,
+                floor_tokens=_idle_floor,
+                cooldown_active=bool(_idle_cooldown),
+            ):
+                logger.info(
+                    "Idle compaction: %ss idle >= %ss, ~%s tokens > %s floor "
+                    "(session %s)",
+                    int(_idle_gap),
+                    _idle_after,
+                    f"{_idle_tokens:,}",
+                    f"{_idle_floor:,}",
+                    agent.session_id or "none",
+                )
+                agent._emit_status(
+                    f"💤 Resumed after {int(_idle_gap)}s idle — compacting "
+                    f"~{_idle_tokens:,} tokens before continuing."
+                )
+                messages, active_system_prompt = agent._compress_context(
+                    messages, system_message, approx_tokens=_idle_tokens,
+                    task_id=effective_task_id,
+                )
+                conversation_history = conversation_history_after_compression(
+                    agent, messages
+                )
 
     # ── Preflight context compression ──
     # Gate the (expensive) full token estimate behind a cheap pre-check.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -474,6 +474,16 @@ compression:
   # head messages, matching the pre-feature behaviour.
   protect_first_n: 3
 
+  # Idle compaction (default: 0 = disabled). When > 0, a session that resumes
+  # after at least this many seconds of inactivity compacts its accumulated
+  # history up front, before the first reply, so a long-lived thread you come
+  # back to later doesn't re-read its full stale context on every turn.
+  # Time-based, so it complements (does not replace) the size-based `threshold`
+  # above. It is skipped when the context is already small (at or below the
+  # post-compression target = threshold × target_ratio), so it never wastes a
+  # summarization on a short idle thread. Example: 1800 = compact after 30 min idle.
+  idle_compact_after_seconds: 0
+
   # To pin a specific model/provider for compression summaries, use the
   # auxiliary section below (auxiliary.compression.provider / model).
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -80,6 +80,7 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|no\s+auxiliary\s+llm\s+provider\s+configured"
     r"|auto-lowered\s+compression\s+threshold"
     r"|compacting\s+context\s+[—-]\s+summarizing\s+earlier\s+conversation"
+    r"|resumed\s+after\s+\d+s\s+idle\s+[—-]\s+compacting"
     r"|preflight\s+compression"
     r"|session\s+compressed\s+\d+\s+times"
     r"|rate\s+limited\.\s+waiting\s+\d"

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1549,6 +1549,21 @@ DEFAULT_CONFIG = {
                                       # models) still applies on top of overrides
                                       # (raise-only: an override above the floor
                                       # wins; one below it is raised to the floor).
+        "idle_compact_after_seconds": 0,  # Opt-in idle compaction (0 = disabled).
+                                      # When > 0, a session that resumes after at
+                                      # least this many seconds of inactivity
+                                      # compacts its accumulated history up front,
+                                      # before the first reply — so a long-lived
+                                      # thread resumed hours later doesn't re-read
+                                      # its full stale context on every turn.
+                                      # Time-based; complements (does not replace)
+                                      # the size-based `threshold` above. Skipped
+                                      # when the context is already at/below the
+                                      # post-compression target (threshold ×
+                                      # target_ratio) and it honors the same
+                                      # failure-cooldown / anti-thrash / per-session
+                                      # lock guards as every automatic compaction.
+                                      # Example: 1800 = compact after 30 min idle.
     },
 
     # Kanban subsystem (orchestrator workers + dispatcher-driven child tasks).

--- a/tests/agent/test_idle_compaction.py
+++ b/tests/agent/test_idle_compaction.py
@@ -1,0 +1,55 @@
+"""Tests for the opt-in idle-triggered compaction policy.
+
+Covers ``agent.turn_context._should_idle_compact`` — the pure predicate that
+decides whether a session resuming after an idle gap should compact up front.
+The predicate is intentionally side-effect-free so the policy can be verified
+without constructing a live agent or DB.
+"""
+
+from agent.turn_context import _should_idle_compact
+
+
+def _decide(**overrides):
+    """Call the predicate with sensible defaults (idle + large context => fire)."""
+    kwargs = dict(
+        enabled=True,
+        idle_after_seconds=1800,
+        idle_gap_seconds=3600.0,
+        tokens=100_000,
+        floor_tokens=40_000,
+        cooldown_active=False,
+    )
+    kwargs.update(overrides)
+    return _should_idle_compact(**kwargs)
+
+
+class TestShouldIdleCompact:
+    def test_fires_when_idle_long_enough_and_context_large(self):
+        assert _decide() is True
+
+    def test_disabled_when_idle_after_zero(self):
+        # 0 is the documented "off" value — must never fire regardless of gap.
+        assert _decide(idle_after_seconds=0, idle_gap_seconds=10_000.0) is False
+
+    def test_disabled_when_idle_after_negative(self):
+        assert _decide(idle_after_seconds=-1) is False
+
+    def test_disabled_when_compression_off(self):
+        assert _decide(enabled=False) is False
+
+    def test_skips_when_gap_below_threshold(self):
+        assert _decide(idle_gap_seconds=600.0) is False
+
+    def test_gap_exactly_at_threshold_fires(self):
+        assert _decide(idle_after_seconds=1800, idle_gap_seconds=1800.0) is True
+
+    def test_skips_when_context_at_or_below_floor(self):
+        # At/below the post-compression target there is nothing worth saving.
+        assert _decide(tokens=40_000, floor_tokens=40_000) is False
+        assert _decide(tokens=39_999, floor_tokens=40_000) is False
+
+    def test_fires_just_above_floor(self):
+        assert _decide(tokens=40_001, floor_tokens=40_000) is True
+
+    def test_defers_to_active_compression_cooldown(self):
+        assert _decide(cooldown_active=True) is False

--- a/tests/agent/test_idle_compaction_lock_and_guards.py
+++ b/tests/agent/test_idle_compaction_lock_and_guards.py
@@ -1,0 +1,241 @@
+"""Idle-triggered compaction: interaction with the compression guards.
+
+The idle trigger (``agent/turn_context.py``, opt-in via
+``compression.idle_compact_after_seconds``) does not compress anything
+itself — it routes through ``agent._compress_context`` (the forwarder to
+``agent.conversation_compression.compress_context``), which owns ALL of the
+automatic-compaction guards:
+
+- the per-session compression lock (added after the idle-compaction PR was
+  written — an idle-triggered compress racing a turn-triggered one on the
+  same session_id must be serialized, not forked),
+- the persisted summary-failure cooldown,
+- the anti-thrash / fallback-streak breaker.
+
+These tests pin that composition end-to-end with a real ``AIAgent`` wired to
+a real ``SessionDB``: when a guard says no, the idle path must be a strict
+no-op for the turn (no compressor call, no session rotation, no flush
+re-baseline, no user-message re-anchor).
+"""
+
+from __future__ import annotations
+
+import time
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from hermes_state import SessionDB
+
+from agent.turn_context import build_turn_context
+
+from tests.agent.test_compression_concurrent_fork import _build_agent_with_db
+
+
+def _prep_idle_agent(db: SessionDB, session_id: str, *, idle_after: int = 60,
+                     idle_gap: float = 3600.0):
+    """Real AIAgent (mock compressor) primed so the idle trigger is eligible."""
+    agent = _build_agent_with_db(db, session_id)
+    agent.compression_enabled = True
+    agent.compression_idle_compact_after_seconds = idle_after
+    agent._last_activity_ts = time.time() - idle_gap
+    # The idle block reads these from the compressor; give the MagicMock real
+    # numbers so the floor computation and the preflight gate behave.
+    agent.context_compressor.threshold_tokens = 100_000
+    agent.context_compressor.summary_target_ratio = 0.20
+    agent.context_compressor.protect_first_n = 2
+    agent.context_compressor.protect_last_n = 2
+    # No active failure cooldown unless a test installs one.
+    agent.context_compressor.get_active_compression_failure_cooldown = (
+        lambda *a, **k: None
+    )
+    agent._cached_system_prompt = "SYSTEM"
+    return agent
+
+
+def _run_prologue(agent, history, user_message="hello again"):
+    """Invoke ``build_turn_context`` the way ``conversation_loop`` does.
+
+    The token-threshold preflight gate is pinned False so these tests
+    exercise the IDLE trigger in isolation (the preflight path has its own
+    coverage in ``test_turn_context.py``).
+    """
+    with patch("agent.auxiliary_client.set_runtime_main", lambda *a, **k: None), \
+         patch("agent.turn_context._should_run_preflight_estimate",
+               return_value=False), \
+         patch("agent.turn_context.estimate_request_tokens_rough",
+               return_value=999_999):
+        return build_turn_context(
+            agent=agent,
+            user_message=user_message,
+            system_message=None,
+            conversation_history=history,
+            task_id=None,
+            stream_callback=None,
+            persist_user_message=None,
+            restore_or_build_system_prompt=lambda *a, **k: None,
+            install_safe_stdio=lambda: None,
+            sanitize_surrogates=lambda s: s,
+            summarize_user_message_for_log=lambda s: str(s),
+            set_session_context=lambda _sid: None,
+            set_current_write_origin=lambda _o: None,
+            ra=lambda: types.SimpleNamespace(_set_interrupt=lambda *a, **k: None),
+        )
+
+
+def _history(n: int = 20) -> list:
+    return [{"role": "user", "content": f"m{i}"} for i in range(n)]
+
+
+def test_idle_compaction_runs_through_guarded_path_and_releases_lock(
+    tmp_path: Path,
+) -> None:
+    """Happy path: the idle trigger reaches the real ``compress_context``.
+
+    It must acquire + release the per-session lock, invoke the compressor
+    exactly once, and (rotation mode) rotate the session — proving the trigger
+    is wired through the guarded entrypoint rather than calling the compressor
+    directly.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "IDLE_HAPPY"
+    db.create_session(sid, source="cli")
+    agent = _prep_idle_agent(db, sid)
+
+    ctx = _run_prologue(agent, _history())
+
+    agent.context_compressor.compress.assert_called_once()
+    # Rotation mode (in_place=False in the shared fixture) creates a child.
+    assert agent.session_id != sid
+    # The lock keyed on the OLD session id must not leak.
+    assert db.get_compression_lock_holder(sid) is None
+    # The turn continues on the compacted transcript, with the user-message
+    # anchor pointing at a live user row in the rebuilt list.
+    assert 0 <= ctx.current_turn_user_idx < len(ctx.messages)
+    assert ctx.messages[ctx.current_turn_user_idx].get("role") == "user"
+
+
+def test_idle_compaction_defers_to_held_compression_lock(tmp_path: Path) -> None:
+    """An idle-triggered compress racing another path must sit the round out.
+
+    The per-session lock landed after the idle-compaction PR: when another
+    path (turn-triggered preflight, background-review fork) already holds the
+    lock, ``compress_context`` returns the input list unchanged. The idle
+    block must treat that skip as a strict no-op: no compressor call, no
+    rotation, no flush re-baseline, anchor untouched.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "IDLE_LOCKED"
+    db.create_session(sid, source="cli")
+    assert db.try_acquire_compression_lock(sid, "external_holder") is True
+
+    agent = _prep_idle_agent(db, sid)
+    history = _history()
+
+    ctx = _run_prologue(agent, history)
+
+    # Skipped: the compressor never ran and the session did not rotate.
+    agent.context_compressor.compress.assert_not_called()
+    assert agent.session_id == sid
+    # The external holder still owns the lock (we must not have stolen or
+    # released someone else's lease).
+    assert db.get_compression_lock_holder(sid) == "external_holder"
+    # Turn state untouched: full history + this turn's user message, anchor on
+    # the just-appended message, flush baseline not re-baselined to None-then-
+    # doubled semantics.
+    assert len(ctx.messages) == len(history) + 1
+    assert ctx.current_turn_user_idx == len(ctx.messages) - 1
+    assert ctx.messages[ctx.current_turn_user_idx]["content"] == "hello again"
+
+
+def test_idle_compaction_respects_anti_thrash_breaker(tmp_path: Path) -> None:
+    """A tripped ineffective-compression breaker must block the idle trigger.
+
+    The breaker lives in ``ContextCompressor._automatic_compression_blocked``
+    and is consulted by ``compress_context`` for every non-forced entrypoint.
+    The idle path is an automatic entrypoint, so two prior ineffective
+    compactions must silence it too.
+    """
+    from agent.context_compressor import ContextCompressor
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "IDLE_THRASH"
+    db.create_session(sid, source="cli")
+    agent = _prep_idle_agent(db, sid)
+
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=100_000
+    ):
+        compressor = ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=2,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+    compressor.bind_session_state(db, sid)
+    compressor._ineffective_compression_count = 2  # breaker tripped
+    compressor.compress = MagicMock()
+    agent.context_compressor = compressor
+
+    ctx = _run_prologue(agent, _history())
+
+    compressor.compress.assert_not_called()
+    assert agent.session_id == sid
+    assert len(ctx.messages) == len(_history()) + 1
+
+
+def test_idle_compaction_respects_persisted_failure_cooldown(
+    tmp_path: Path,
+) -> None:
+    """An active summary-failure cooldown must gate the idle trigger up front.
+
+    The idle predicate itself consults
+    ``get_active_compression_failure_cooldown`` — with a persisted cooldown in
+    state.db the trigger must not even reach ``_compress_context``.
+    """
+    from agent.context_compressor import ContextCompressor
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "IDLE_COOLDOWN"
+    db.create_session(sid, source="cli")
+    db.record_compression_failure_cooldown(sid, 4_000_000_000.0, "timeout")
+
+    agent = _prep_idle_agent(db, sid)
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=100_000
+    ):
+        compressor = ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=2,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+    compressor.bind_session_state(db, sid)
+    compressor.compress = MagicMock()
+    agent.context_compressor = compressor
+    agent._compress_context = MagicMock()
+
+    ctx = _run_prologue(agent, _history())
+
+    agent._compress_context.assert_not_called()
+    compressor.compress.assert_not_called()
+    assert agent.session_id == sid
+    assert len(ctx.messages) == len(_history()) + 1
+
+
+def test_idle_compaction_disabled_by_default(tmp_path: Path) -> None:
+    """With the default config (0) a huge idle gap must never trigger."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "IDLE_OFF"
+    db.create_session(sid, source="cli")
+    agent = _prep_idle_agent(db, sid, idle_after=0, idle_gap=10_000_000.0)
+    agent._compress_context = MagicMock()
+
+    ctx = _run_prologue(agent, _history())
+
+    agent._compress_context.assert_not_called()
+    agent.context_compressor.compress.assert_not_called()
+    assert agent.session_id == sid
+    assert len(ctx.messages) == len(_history()) + 1

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -31,6 +31,7 @@ CHAT_PLATFORMS = [
 NOISY_STATUS_MESSAGES = [
     "🗜️ Preflight compression check before sending...",
     "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
+    "💤 Resumed after 3600s idle — compacting ~120,000 tokens before continuing.",
     "⚠️  Session compressed 12 times — accuracy may degrade. Consider /new to start fresh.",
     "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
     "⏱️ Rate limited. Waiting 30.0s (attempt 2/3)...",

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -108,6 +108,7 @@ auxiliary:
 | `target_ratio` | `0.20` | 0.10-0.80 | Controls tail protection token budget: `threshold_tokens × target_ratio` |
 | `protect_last_n` | `20` | ≥1 | Minimum number of recent messages always preserved |
 | `protect_first_n` | `3` | (hardcoded) | System prompt + first exchange always preserved |
+| `idle_compact_after_seconds` | `0` | ≥0 seconds | Opt-in: compact up front when a session resumes after this many seconds idle (0 = disabled). Skips when context ≤ threshold × target_ratio; honors cooldown/anti-thrash/lock guards |
 | `codex_gpt55_autoraise` | `true` | bool | Raise the trigger to 85% for gpt-5.5 on the ChatGPT Codex OAuth route (see below). Set `false` to keep the global `threshold` |
 | `codex_gpt55_autoraise_notice` | `true` | bool | Show the one-time Codex gpt-5.5 autoraise notice. Set `false` to keep the 85% autoraise but suppress the banner |
 | `codex_app_server_auto` | `native` | `native`, `hermes`, `off` | Thread-compaction mode for Codex app-server sessions (see below) |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -748,6 +748,7 @@ compression:
   target_ratio: 0.20                                # Fraction of threshold to preserve as recent tail
   protect_last_n: 20                                # Min recent messages to keep uncompressed
   protect_first_n: 3                                # Non-system head messages pinned across compactions (0 = pin nothing)
+  idle_compact_after_seconds: 0                     # Opt-in idle compaction (0 = disabled) — see below
   hygiene_hard_message_limit: 5000                  # Gateway safety valve — see below
 
 # The summarization model/provider is configured under auxiliary:
@@ -767,6 +768,8 @@ Older configs with `compression.summary_model`, `compression.summary_provider`, 
 `protect_first_n` controls how many **non-system** head messages are pinned across every compaction. Default `3` — the opening user/assistant exchange survives every summarizer pass so the original goal stays visible. On long-running rolling-compaction sessions where the opening turn is no longer relevant, set `protect_first_n: 0` to pin nothing but the system prompt + summary + tail. The system prompt itself is always preserved regardless of this setting.
 
 `threshold_tokens` sets an optional **absolute token cap** for the compression trigger. When set, compression fires at the lower of the ratio-based `threshold` and this absolute count — so compression never fires later than the user's preferred token number regardless of which model is active. This solves the problem where switching between models with different context windows (e.g. 1M → 400K) shifts the absolute trigger point. The cap is clamped to the model's context length, so setting it higher than the model supports is safe — the ratio-based threshold is used instead. Default `null` (disabled — ratio-based threshold only). The cap survives model switches and fallback activations.
+
+`idle_compact_after_seconds` is an **opt-in, time-based** trigger that complements the size-based `threshold`. Default `0` (disabled). When set above 0, a session that resumes after at least that many seconds of inactivity compacts its accumulated history up front, before the first reply — so a long-lived thread (e.g. a Telegram conversation you come back to hours later) doesn't re-read its full stale context on every subsequent turn. It never fires when the context is already at or below the post-compression target (`threshold × target_ratio`), and it honors the same failure-cooldown, anti-thrash, and per-session lock guards as every automatic compaction. Example: `idle_compact_after_seconds: 1800` compacts after 30 minutes idle.
 
 :::tip Gateway hot-reload of compression and context length
 As of recent releases, editing `model.context_length` or any `compression.*` key in `config.yaml` on a running gateway takes effect on the next message — no gateway restart, no `/reset`, no session rotation required. The cached-agent signature includes these keys, so the gateway transparently rebuilds the agent when it sees a change. API keys and tool/skill config still require the usual reload paths.


### PR DESCRIPTION
## Summary
Opt-in, time-based context compaction: a session that resumes after `compression.idle_compact_after_seconds` of inactivity compacts its accumulated history up front, before the first reply — so a long-lived gateway thread resumed hours later stops re-reading its full stale context on every turn (#27579). Disabled by default (`0`), so existing behavior is unchanged.

## Changes
- `agent/turn_context.py`: idle trigger in `build_turn_context` — cheap wall-clock gap pre-check (`_last_activity_ts`) gates the token estimate; pure predicate `_should_idle_compact` (skips at/below the post-compression target `threshold × target_ratio`, defers to the failure cooldown); routes through the guarded `agent._compress_context` path.
- Follow-up hardening (post-PR main churn): a skipped `_compress_context` (per-session **compression lock** held by another path, cooldown, anti-thrash breaker, codex-native routing) is now a strict no-op — flush baseline and `current_turn_user_idx` are only rewritten after a REAL compaction, and the user-message anchor is re-anchored the same way the preflight path does.
- `agent/agent_init.py` + `hermes_cli/config.py` (DEFAULT_CONFIG) + `cli-config.yaml.example`: `compression.idle_compact_after_seconds` (default `0`).
- `gateway/run.py`: the new `💤 Resumed after Ns idle — compacting…` status added to `_TELEGRAM_NOISY_STATUS_RE` (routine compaction stays silent on chat surfaces), pinned in `tests/gateway/test_telegram_noise_filter.py`.
- `tests/agent/test_idle_compaction.py`: the PR's 10 predicate tests.
- `tests/agent/test_idle_compaction_lock_and_guards.py`: NEW — real `AIAgent` + `SessionDB` end-to-end coverage: idle-vs-turn-triggered compress race is serialized by the per-session lock (loser is a clean no-op, external holder's lease untouched), lock released after an idle compaction, persisted failure cooldown and anti-thrash breaker both silence the trigger, default-off never fires.
- docs: `website/docs/user-guide/configuration.md` + `developer-guide/context-compression-and-caching.md`.

## Validation
| | Before | After |
|---|---|---|
| Resumed long-lived thread | Re-reads full stale context every turn until the size threshold trips | Compacts once, up front, on resume (opt-in) |
| Idle compress racing a turn-triggered one | (lock landed after the PR — un-covered) | Serialized by the per-session lock; loser sits out cleanly, no session fork |

Targeted tests: `tests/agent/test_idle_compaction.py` (10), `tests/agent/test_idle_compaction_lock_and_guards.py` (5) (mock-compressor happy path also verifies session rotation + lock release), plus `tests/agent/test_turn_context.py`, `tests/gateway/test_telegram_noise_filter.py`, `tests/agent/test_compression_concurrent_fork.py` — 292 passed, 0 failed. Full `-k 'idle'` sweep across `tests/`: 101 passed, 0 failed.

## Credit
Salvaged from #55800 by @iso2kx. Implements #27579.

## Infographic
![idle-compaction](https://v3b.fal.media/files/b/0aa346ef/RVHMzzCAg9dEE-ZmxCqVf_KDl8pyA6.png)
