### PR TITLE
fix(profiles): register gateway service after profile import (#69163)

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2080,6 +2080,13 @@ def import_profile(archive_path: str, name: Optional[str] = None) -> Path:
 
         shutil.move(str(final_source), str(profile_dir))
 
+    # Register the gateway service for the imported profile so that
+    # `hermes -p <name> gateway start` works immediately (#69163).
+    try:
+        _maybe_register_gateway_service(canon)
+    except Exception:
+        pass  # Best-effort: user can re-register manually later
+
     return profile_dir
 
 


### PR DESCRIPTION
## Summary

Fixes #69163 — imported profile's gateway not registered, causing 'no such gateway' error.

## Problem

After importing a profile from a tar.gz archive, the gateway service is not registered. This causes `hermes -p <name> gateway start` to fail with 'no such gateway' error even though the profile exists and shows in `hermes profile list`.

## Fix

Call `_maybe_register_gateway_service()` after successful import to register the gateway service, matching the behavior of profile create.

## Testing

- Verified the fix adds gateway registration after import
- No existing tests broken