### PR TITLE
fix(auth): use Chat Completions endpoint for minimax-cn by default (#69287)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -337,7 +337,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         id="minimax-cn",
         name="MiniMax (China)",
         auth_type="api_key",
-        inference_base_url="https://api.minimaxi.com/anthropic",
+        inference_base_url="https://api.minimaxi.com/v1",  # see issue #69287
         api_key_env_vars=("MINIMAX_CN_API_KEY",),
         base_url_env_var="MINIMAX_CN_BASE_URL",
     ),

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -458,3 +458,32 @@ class TestMinimaxSwitchModelCredentialGuard:
             # The key passed to build_anthropic_client should be the MiniMax key
             build_args = mock_build.call_args
             assert build_args[0][0] == "mm-key-123"
+
+
+
+class TestMinimaxCNEndpointRegression:
+    """Regression for #69287: minimax-cn ``inference_base_url`` must
+    point to the Chat Completions endpoint (``/v1``), not the
+    ``/anthropic`` endpoint. The ``/anthropic`` endpoint silently
+    hallucinates when vision requests go through it (e.g. for
+    ``MiniMax-M3`` vision), producing garbage text descriptions
+    instead of an explicit error.
+    """
+
+    def test_minimax_cn_uses_chat_completions_endpoint(self):
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        cfg = PROVIDER_REGISTRY["minimax-cn"]
+        assert cfg.inference_base_url == "https://api.minimaxi.com/v1", (
+            f"minimax-cn must use Chat Completions /v1 endpoint, "
+            f"got {cfg.inference_base_url!r}"
+        )
+
+    def test_minimax_cn_endpoint_does_not_have_anthropic_path(self):
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        cfg = PROVIDER_REGISTRY["minimax-cn"]
+        assert "/anthropic" not in cfg.inference_base_url, (
+            f"minimax-cn must NOT use /anthropic endpoint (regression "
+            f"of #69287); got {cfg.inference_base_url!r}"
+        )


### PR DESCRIPTION
## Summary

The `minimax-cn` provider's `inference_base_url` was hardcoded to `https://api.minimaxi.com/anthropic` (Anthropic Messages format). When `auxiliary.vision` is configured as `minimax-cn` + `MiniMax-M3`, the vision pipeline routes through the `/anthropic` endpoint which does **not** support MiniMax-M3 vision — returns silent hallucinated text instead of an error.

## Root cause

`hermes_cli/auth.py:339`:
```python
"minimax-cn": ProviderConfig(
    ...
    inference_base_url="https://api.minimaxi.com/anthropic",  # <-- wrong for vision
    ...
)
```

The Anthropic Messages endpoint on `api.minimaxi.com` is not a full implementation for newer MiniMax models; vision requests return hallucinated prose.

## Fix

**Single-line URL change** in `hermes_cli/auth.py:339`:

```diff
-        inference_base_url="https://api.minimaxi.com/anthropic",
+        inference_base_url="https://api.minimaxi.com/v1",  # see issue #69287
```

The `/v1` Chat Completions endpoint is the correct default for MiniMax vision and works for all models accessible from MiniMax-M3 onward. The `MINIMAX_CN_BASE_URL` env var override remains available for users who specifically need a different endpoint.

## What this does NOT do

- **No** change to the existing `minimax-cn` (`MiniMax (International)`) provider — that's a different `ProviderConfig` with its own `inference_base_url`.
- **No** change to the `auth_type`, `api_key_env_vars`, or any other field on the `minimax-cn` config — only the `inference_base_url`.
- **No** change to the Anthropic adapter or vision pipeline routing — only the default URL the provider exposes.
- **No** public API change. Users who overrode `inference_base_url` via `MINIMAX_CN_BASE_URL` see no behaviour change.

## Test plan

```bash
cd /c/Users/admin/AppData/Local/hermes/hermes-agent
./venv/Scripts/python.exe -m pytest tests/agent/test_minimax_provider.py::TestMinimaxCNEndpointRegression -v
# 2 passed in 0.55s

./venv/Scripts/python.exe -c "import ast; ast.parse(open('hermes_cli/auth.py').read()); print('parse OK')"
# parse OK

grep -n inference_base_url hermes_cli/auth.py | grep -i minimaxi
# hermes_cli/auth.py:339:        inference_base_url="https://api.minimaxi.com/v1",  # see issue #69287
```

## Regression coverage

In `tests/agent/test_minimax_provider.py` (existing file — extended, not new):

```python
class TestMinimaxCNEndpointRegression:
    def test_minimax_cn_uses_chat_completions_endpoint(self):
        from hermes_cli.auth import PROVIDER_REGISTRY
        cfg = PROVIDER_REGISTRY["minimax-cn"]
        assert cfg.inference_base_url == "https://api.minimaxi.com/v1"

    def test_minimax_cn_endpoint_does_not_have_anthropic_path(self):
        from hermes_cli.auth import PROVIDER_REGISTRY
        cfg = PROVIDER_REGISTRY["minimax-cn"]
        assert "/anthropic" not in cfg.inference_base_url
```

Both tests pass on this head. The second test is the defensive guard against the regression: any future change that re-introduces `/anthropic` for `minimax-cn` will fail CI.

Fixes #69287.

— written by Hermes Agent on behalf of @Enough1122