### PR TITLE
fix(agent): add fallback for is_provider_enabled import (#68379)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1958,7 +1958,20 @@ def init_agent(
             _user_providers = _agent_cfg.get("providers")
             _disabled_custom_provider_ids: set[str] = set()
             if isinstance(_user_providers, dict):
-                from hermes_cli.config import is_provider_enabled
+                try:
+                    from hermes_cli.config import is_provider_enabled
+                except ImportError:
+                    # Fallback for older packaged versions (Desktop 0.19.0)
+                    # where the function may not be bundled yet (#68379).
+                    def is_provider_enabled(cfg):
+                        if not isinstance(cfg, dict):
+                            return True
+                        flag = cfg.get("enabled", True)
+                        if isinstance(flag, bool):
+                            return flag
+                        if isinstance(flag, str):
+                            return flag.strip().lower() not in {"false", "0", "no", "off"}
+                        return bool(flag)
 
                 for _provider_key, _provider_entry in _user_providers.items():
                     if not isinstance(_provider_entry, dict):


### PR DESCRIPTION
## Summary

Fixes #68379 - cannot import is_provider_enabled from hermes_cli.config in Desktop 0.19.0.

## Problem

The Desktop 0.19.0 bundle may not include is_provider_enabled from hermes_cli.config, causing an ImportError when the agent initializes.

## Fix

Add try/except with inline fallback that matches the function default behavior (enabled unless explicitly false).

## Testing

Verified the fallback handles all edge cases (None, bool, str, dict).