### PR TITLE
fix(install): fallback search for uv.exe when astral installer uses non-standard location

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -120,6 +120,25 @@ def _ensure_uv_path() -> Optional[str]:
         ).stdout.strip()
         print(f"  ✓ Managed uv installed ({version})")
     else:
+        # #69216: The astral installer may have placed uv.exe in a
+        # fallback location. Try to find and copy it to the managed path.
+        fallback = _find_uv_fallback()
+        if fallback:
+            try:
+                import shutil
+                shutil.copy2(fallback, str(target))
+                result = resolve_uv()
+                if result:
+                    version = subprocess.run(
+                        [result, "--version"],
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    ).stdout.strip()
+                    print(f"  ✓ Managed uv installed from fallback ({version})")
+                    return result
+            except Exception as exc:
+                logger.warning("Fallback uv copy failed: %s", exc)
         print("  ✗ Managed uv install appeared to succeed but binary not found")
     return result
 
@@ -249,6 +268,32 @@ def _install_uv_windows(env: dict[str, str]) -> None:
         check=True,
         capture_output=True,
     )
+
+
+def _find_uv_fallback() -> Optional[str]:
+    """Search common fallback locations for uv.exe (#69216).
+
+    The astral installer may place the binary in a different directory
+    depending on version / configuration. Called after the primary
+    ``UV_INSTALL_DIR`` path check fails.
+    """
+    if platform.system() != "Windows":
+        return None
+
+    home = Path.home()
+    local_app_data = Path(os.environ.get("LOCALAPPDATA", str(home / "AppData" / "Local")))
+
+    fallback_dirs = [
+        home / ".local" / "bin",
+        local_app_data / "astral" / "bin",
+        local_app_data / "uv",
+    ]
+
+    for d in fallback_dirs:
+        candidate = d / "uv.exe"
+        if candidate.is_file():
+            return str(candidate)
+    return None
 
 def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> bool:
     True # dont remove me. ask ethernet

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -479,6 +479,30 @@ function Install-Uv {
             return $true
         }
 
+        # #69216: The astral installer may place uv.exe in a different
+        # location depending on version / configuration. Search common
+        # fallback locations and move the binary to the managed path.
+        $fallbackDirs = @(
+            (Join-Path $env:USERPROFILE ".local\bin"),
+            (Join-Path $env:LOCALAPPDATA "astral\bin"),
+            (Join-Path $env:LOCALAPPDATA "uv")
+        )
+        foreach $fbDir in $fallbackDirs) {
+            $fbUv = Join-Path $fbDir "uv.exe"
+            if (Test-Path $fbUv) {
+                Write-Info "uv.exe found at fallback location: $fbUv"
+                try {
+                    Copy-Item $fbUv $managedUv -Force
+                    $script:UvCmd = $managedUv
+                    $version = & $managedUv --version
+                    Write-Success "Managed uv installed from fallback ($version)"
+                    return $true
+                } catch {
+                    Write-Info "Could not copy from fallback: $_"
+                }
+            }
+        }
+
         Write-Err "uv installed but not found at $managedUv"
         Write-Info "Install manually: https://docs.astral.sh/uv/getting-started/installation/"
         return $false

--- a/tests/hermes_cli/test_uv_fallback.py
+++ b/tests/hermes_cli/test_uv_fallback.py
@@ -1,0 +1,76 @@
+"""#69216: uv.exe fallback search when astral installer places binary in
+a non-standard location."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def test_find_uv_fallback_returns_none_on_posix():
+    """On non-Windows, _find_uv_fallback must return None."""
+    with patch("platform.system", return_value="Linux"):
+        from hermes_cli.managed_uv import _find_uv_fallback
+        assert _find_uv_fallback() is None
+
+
+def test_find_uv_fallback_finds_userprofile_local_bin(tmp_path, monkeypatch):
+    """When uv.exe is in ~/.local/bin, the fallback finds it."""
+    fake_home = tmp_path / "fakehome"
+    fake_local = tmp_path / "fakeappdata"
+    uv_dir = fake_home / ".local" / "bin"
+    uv_dir.mkdir(parents=True)
+    (uv_dir / "uv.exe").write_bytes(b"fake uv binary")
+
+    monkeypatch.setenv("LOCALAPPDATA", str(fake_local))
+
+    with patch("platform.system", return_value="Windows"), \
+         patch("hermes_cli.managed_uv.Path.home", return_value=fake_home):
+        from hermes_cli.managed_uv import _find_uv_fallback
+        result = _find_uv_fallback()
+        assert result is not None
+        assert result.endswith("uv.exe")
+        assert ".local" in result
+
+
+def test_find_uv_fallback_finds_astral_bin(tmp_path, monkeypatch):
+    """When uv.exe is in $LOCALAPPDATA/astral/bin, the fallback finds it."""
+    fake_home = tmp_path / "fakehome"
+    fake_local = tmp_path / "fakeappdata"
+    astral_dir = fake_local / "astral" / "bin"
+    astral_dir.mkdir(parents=True)
+    (astral_dir / "uv.exe").write_bytes(b"fake uv binary")
+
+    monkeypatch.setenv("LOCALAPPDATA", str(fake_local))
+
+    # No uv in ~/.local/bin this time
+    with patch("platform.system", return_value="Windows"), \
+         patch("hermes_cli.managed_uv.Path.home", return_value=fake_home):
+        from hermes_cli.managed_uv import _find_uv_fallback
+        result = _find_uv_fallback()
+        assert result is not None
+        assert "astral" in result
+
+
+def test_find_uv_fallback_returns_none_when_not_found(tmp_path, monkeypatch):
+    """When uv.exe is nowhere, the fallback returns None."""
+    fake_home = tmp_path / "fakehome"
+    fake_local = tmp_path / "fakeappdata"
+    monkeypatch.setenv("LOCALAPPDATA", str(fake_local))
+
+    with patch("platform.system", return_value="Windows"), \
+         patch("hermes_cli.managed_uv.Path.home", return_value=fake_home):
+        from hermes_cli.managed_uv import _find_uv_fallback
+        assert _find_uv_fallback() is None
+
+
+def test_install_ps1_has_fallback_search():
+    """The install.ps1 script must include a fallback search path."""
+    src = Path("scripts/install.ps1").read_text(encoding="utf-8")
+    assert "fallback" in src.lower(), "install.ps1 must have fallback search"
+    assert ".local\\bin" in src, "install.ps1 must search ~/.local/bin"
+    assert "astral\\bin" in src, "install.ps1 must search $LOCALAPPDATA/astral/bin"


### PR DESCRIPTION
## Summary

On some Windows 11 configurations, the astral uv installer completes successfully but places `uv.exe` in a different location than `$HERMES_HOME\bin\` — the `UV_INSTALL_DIR` environment variable is not always honored. The installer reports success, but Hermes can't find the binary and aborts installation (#69216).

## Fix

Add a **fallback search** after the primary `UV_INSTALL_DIR` path check fails, in both the installer and the runtime:

### `scripts/install.ps1` (Install-Uv)
After the astral installer runs and `uv.exe` is not at `$HermesHome\bin\uv.exe`, search:
- `$USERPROFILE\.local\bin\uv.exe`
- `$LOCALAPPDATA\astral\bin\uv.exe`
- `$LOCALAPPDATA\uv\uv.exe`

If found, copy to the managed path and continue.

### `hermes_cli/managed_uv.py` (_find_uv_fallback + _ensure_uv_path)
Same fallback search for the runtime `ensure_uv()` path, so `hermes update` also recovers from a mislocated binary.

## Test plan

- [x] `_find_uv_fallback()` returns None on POSIX
- [x] Finds `uv.exe` in `$USERPROFILE/.local/bin`
- [x] Finds `uv.exe` in `$LOCALAPPDATA/astral/bin`
- [x] Returns None when not found anywhere
- [x] `install.ps1` source contains fallback search paths

Closes #69216