### PR TITLE
fix(vision): minimax-cn with /v1 base URL must use OpenAI image format

### DIFF
--- a/tests/agent/test_minimax_vision_endpoint.py
+++ b/tests/agent/test_minimax_vision_endpoint.py
@@ -1,0 +1,66 @@
+"""Predicate tests for MiniMax vision endpoint classification.
+
+Focused contract: when a MiniMax provider is paired with an explicit /v1
+base URL, image blocks must use OpenAI format (not Anthropic). Default
+/anthropic routes remain Anthropic-compat.
+
+This does not by itself change the minimax-cn plugin default base URL;
+that remains a separate concern from issue #69287's default-route path.
+"""
+
+from __future__ import annotations
+
+from agent.auxiliary_client import _is_anthropic_compat_endpoint
+
+
+class TestAnthropicCompatDetection:
+    def test_minimax_cn_default_url_is_anthropic_compat(self):
+        """minimax-cn with empty base URL is treated as Anthropic-compat default."""
+        assert _is_anthropic_compat_endpoint("minimax-cn", "") is True
+
+    def test_minimax_cn_with_anthropic_url_is_compat(self):
+        """minimax-cn with /anthropic URL is Anthropic-compat."""
+        assert (
+            _is_anthropic_compat_endpoint(
+                "minimax-cn", "https://api.minimaxi.com/anthropic"
+            )
+            is True
+        )
+
+    def test_minimax_cn_with_v1_url_is_not_anthropic_compat(self):
+        """minimax-cn with /v1 URL must NOT be treated as Anthropic-compat."""
+        assert (
+            _is_anthropic_compat_endpoint("minimax-cn", "https://api.minimaxi.com/v1")
+            is False
+        )
+
+    def test_minimax_with_v1_url_is_not_anthropic_compat(self):
+        """minimax (global) with /v1 URL must NOT be treated as Anthropic-compat."""
+        assert (
+            _is_anthropic_compat_endpoint("minimax", "https://api.minimax.io/v1")
+            is False
+        )
+
+    def test_minimax_oauth_with_v1_url_is_not_anthropic_compat(self):
+        """minimax-oauth with /v1 URL must NOT be treated as Anthropic-compat."""
+        assert (
+            _is_anthropic_compat_endpoint("minimax-oauth", "https://api.minimax.io/v1")
+            is False
+        )
+
+    def test_non_minimax_provider_with_anthropic_url_is_compat(self):
+        """Non-MiniMax providers with /anthropic URL are still compat."""
+        assert (
+            _is_anthropic_compat_endpoint("custom", "https://example.com/anthropic")
+            is True
+        )
+
+    def test_non_minimax_provider_without_anthropic_url_is_not_compat(self):
+        """Non-MiniMax providers without /anthropic URL are not compat."""
+        assert (
+            _is_anthropic_compat_endpoint("custom", "https://api.openai.com/v1")
+            is False
+        )
+
+    def test_empty_provider_and_url_is_not_compat(self):
+        assert _is_anthropic_compat_endpoint("", "") is False


### PR DESCRIPTION
## Summary

MiniMax-M3 vision silently hallucinated when using an explicit MiniMax `/v1` base URL because `_is_anthropic_compat_endpoint` returned `True` for all MiniMax providers regardless of the actual base URL — forcing Anthropic-format image blocks on Chat Completions endpoints.

## Root cause

`_ANTHROPIC_COMPAT_PROVIDERS` made the predicate provider-only. When a user overrides to `https://api.minimaxi.com/v1` (via `MINIMAX_CN_BASE_URL` or `auxiliary.vision.base_url`), vision still emitted Anthropic image blocks.

## Fix

`_is_anthropic_compat_endpoint` now checks the **base URL**, not just the provider name:
- URL contains `/anthropic` → Anthropic-compat
- Known MiniMax provider with **empty** base URL (default route) → Anthropic-compat
- MiniMax provider with explicit `/v1` URL → **not** Anthropic-compat (OpenAI image blocks)

## Scope note

This PR is the focused explicit-`/v1` fix. It does **not** change the minimax-cn plugin default base URL (`https://api.minimaxi.com/anthropic`). Full default-route closure for #69287 remains a separate follow-up if desired.

## Test plan

- [x] minimax-cn empty/default URL → Anthropic-compat
- [x] minimax-cn `/anthropic` → Anthropic-compat
- [x] minimax-cn `/v1` → not Anthropic-compat
- [x] minimax / minimax-oauth `/v1` → not Anthropic-compat
- [x] non-MiniMax `/anthropic` and `/v1` cases

Related: #69287