### PR TITLE
fix(telegram): drain general request pool on polling network error recovery

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2415,6 +2415,15 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         await self._drain_polling_connections()
 
+        # #69314: Also drain the general request pool. When the send path
+        # has hit pool timeouts (exhausting the general request pool with
+        # CLOSE_WAIT sockets), polling-only recovery leaves the general
+        # pool wedged. The adapter stays alive but can't send or bootstrap
+        # because all general connections are dead. Draining both pools
+        # on polling network error ensures full recovery.
+        if getattr(self, "_send_path_degraded", False):
+            await self._drain_general_connections_after_pool_timeout()
+
         if getattr(self, "_polling_teardown_started", False):
             return
 

--- a/tests/plugins/platforms/telegram/test_close_wait_recovery.py
+++ b/tests/plugins/platforms/telegram/test_close_wait_recovery.py
@@ -1,0 +1,43 @@
+"""#69314: Telegram polling recovery must drain the general request pool,
+not just the polling pool, when the send path is degraded."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+def test_polling_recovery_drains_general_pool():
+    """_handle_polling_network_error must call
+    _drain_general_connections_after_pool_timeout when send_path_degraded
+    is set (#69314)."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    src = inspect.getsource(TelegramAdapter._handle_polling_network_error)
+    assert "_drain_polling_connections" in src, \
+        "Must drain polling pool"
+    assert "_drain_general_connections_after_pool_timeout" in src, \
+        "Must also drain general pool when send path is degraded (#69314)"
+    assert "_send_path_degraded" in src, \
+        "Must check _send_path_degraded before draining general pool"
+
+
+def test_drain_general_pool_only_when_degraded():
+    """The general pool drain must be gated on _send_path_degraded,
+    not unconditional (avoid draining on pure polling-only errors)."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    src = inspect.getsource(TelegramAdapter._handle_polling_network_error)
+    # Find the drain call and verify it's guarded
+    assert 'if getattr(self, "_send_path_degraded", False)' in src, \
+        "General pool drain must be gated on _send_path_degraded"
+
+
+def test_send_path_degraded_set_on_network_error():
+    """_handle_polling_network_error must set _send_path_degraded."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    src = inspect.getsource(TelegramAdapter._handle_polling_network_error)
+    assert "_send_path_degraded = True" in src, \
+        "Must set _send_path_degraded = True on network error"


### PR DESCRIPTION
## Summary

When the Telegram gateway runs behind an HTTP proxy and experiences intermittent network faults, the send-path pool can timeout and drain the **general request pool** via `_drain_general_connections_after_pool_timeout()`. But polling recovery (`_handle_polling_network_error`) only drains the **polling pool** via `_drain_polling_connections()` — leaving the general pool wedged with hundreds of CLOSE_WAIT sockets. The adapter stays alive but can't send or bootstrap, stuck in `retrying` forever (#69314).

## Root cause

`_handle_polling_network_error` at line 2416 calls `_drain_polling_connections()` but does not call `_drain_general_connections_after_pool_timeout()`. When the send path is already degraded (pool timeouts exhausted the general pool), polling-only recovery leaves the general pool dead. The proxy is still healthy, but the gateway can't use it because all general connections are in CLOSE_WAIT.

## Fix

After draining the polling pool, also drain the general request pool when `_send_path_degraded` is set:

```python
await self._drain_polling_connections()

# #69314: Also drain the general request pool when the send path is degraded
if getattr(self, "_send_path_degraded", False):
    await self._drain_general_connections_after_pool_timeout()
```

This ensures full recovery: both pools are reset, and the adapter can resume both polling and sending through the proxy.

The drain is gated on `_send_path_degraded` to avoid unnecessary general pool resets on pure polling-only errors (where the general pool is still healthy).

## Test plan

- [x] `_handle_polling_network_error` calls `_drain_general_connections_after_pool_timeout`
- [x] The general pool drain is gated on `_send_path_degraded` (not unconditional)
- [x] `_send_path_degraded` is set to `True` on network error (already existed)

Related: #69314, #68983