### PR TITLE
fix(tui): keep skill prompts scoped to their session

### DIFF
--- a/tests/tui_gateway/test_secret_capture_callback.py
+++ b/tests/tui_gateway/test_secret_capture_callback.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def server():
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_constants": MagicMock(
+                get_hermes_home=MagicMock(
+                    return_value=Path("/tmp/hermes_test_secret_callback")
+                )
+            ),
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+            "hermes_state": MagicMock(),
+        },
+    ):
+        import importlib
+
+        yield importlib.import_module("tui_gateway.server")
+
+
+def test_secret_capture_callback_stays_with_its_ui_session(server, monkeypatch):
+    import tools.skills_tool as skills
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    emitted = []
+    monkeypatch.setattr(
+        server,
+        "_block",
+        lambda event, sid, payload, timeout=300: emitted.append(
+            (event, sid, payload)
+        ) or "",
+    )
+
+    server._wire_callbacks("session-A")
+    server._wire_callbacks("session-B")
+
+    def capture_for(session_id):
+        tokens = set_session_vars(ui_session_id=session_id)
+        try:
+            return skills._capture_required_environment_variables(
+                "demo-skill", [{"name": "DEMO_TOKEN", "prompt": "Token"}]
+            )
+        finally:
+            clear_session_vars(tokens)
+
+    result = capture_for("session-A")
+    second_result = capture_for("session-B")
+
+    assert result["setup_skipped"] is True
+    assert second_result["setup_skipped"] is True
+    assert emitted == [
+        (
+            "secret.request",
+            "session-A",
+            {
+                "prompt": "Token",
+                "env_var": "DEMO_TOKEN",
+                "metadata": {"skill_name": "demo-skill"},
+            },
+        ),
+        (
+            "secret.request",
+            "session-B",
+            {
+                "prompt": "Token",
+                "env_var": "DEMO_TOKEN",
+                "metadata": {"skill_name": "demo-skill"},
+            },
+        ),
+    ]

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -68,6 +68,7 @@ Usage:
 
 import json
 import logging
+import threading
 import time
 
 from hermes_constants import get_hermes_home, display_hermes_home
@@ -174,6 +175,8 @@ _REMOTE_ENV_BACKENDS = frozenset(
     {"docker", "singularity", "modal", "ssh", "daytona"}
 )
 _secret_capture_callback = None
+_secret_capture_callbacks: dict[str, Any] = {}
+_secret_capture_callbacks_lock = threading.RLock()
 
 
 def _skill_lookup_path_error(name: str) -> Optional[str]:
@@ -241,9 +244,39 @@ _INJECTION_PATTERNS: list = [
 ]
 
 
-def set_secret_capture_callback(callback) -> None:
+def set_secret_capture_callback(callback, *, session_id: str | None = None) -> None:
     global _secret_capture_callback
+    if session_id:
+        with _secret_capture_callbacks_lock:
+            _secret_capture_callbacks[session_id] = callback
+        return
     _secret_capture_callback = callback
+
+
+def clear_secret_capture_callback(session_id: str) -> None:
+    with _secret_capture_callbacks_lock:
+        _secret_capture_callbacks.pop(session_id, None)
+
+
+def _get_secret_capture_callback():
+    """Return the callback bound to the current UI session, when available.
+
+    Keep the module attribute as a compatibility seam for existing callers and
+    tests that patch it directly. Gateway sessions use the session ID from the
+    current gateway context so wiring one session cannot replace another.
+    """
+    try:
+        from gateway.session_context import get_session_env
+
+        session_id = get_session_env("HERMES_UI_SESSION_ID", "")
+    except Exception:
+        session_id = ""
+    if session_id:
+        with _secret_capture_callbacks_lock:
+            callback = _secret_capture_callbacks.get(session_id)
+        if callback is not None:
+            return callback
+    return _secret_capture_callback
 
 
 def skill_matches_platform(frontmatter: Dict[str, Any]) -> bool:
@@ -427,7 +460,8 @@ def _capture_required_environment_variables(
             "gateway_setup_hint": _gateway_setup_hint(),
         }
 
-    if _secret_capture_callback is None:
+    secret_capture_callback = _get_secret_capture_callback()
+    if secret_capture_callback is None:
         return {
             "missing_names": missing_names,
             "setup_skipped": False,
@@ -445,7 +479,7 @@ def _capture_required_environment_variables(
             metadata["required_for"] = entry["required_for"]
 
         try:
-            callback_result = _secret_capture_callback(
+            callback_result = secret_capture_callback(
                 entry["name"],
                 entry["prompt"],
                 metadata,

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -68,7 +68,6 @@ Usage:
 
 import json
 import logging
-import threading
 import time
 
 from hermes_constants import get_hermes_home, display_hermes_home
@@ -175,8 +174,6 @@ _REMOTE_ENV_BACKENDS = frozenset(
     {"docker", "singularity", "modal", "ssh", "daytona"}
 )
 _secret_capture_callback = None
-_secret_capture_callbacks: dict[str, Any] = {}
-_secret_capture_callbacks_lock = threading.RLock()
 
 
 def _skill_lookup_path_error(name: str) -> Optional[str]:
@@ -244,39 +241,9 @@ _INJECTION_PATTERNS: list = [
 ]
 
 
-def set_secret_capture_callback(callback, *, session_id: str | None = None) -> None:
+def set_secret_capture_callback(callback) -> None:
     global _secret_capture_callback
-    if session_id:
-        with _secret_capture_callbacks_lock:
-            _secret_capture_callbacks[session_id] = callback
-        return
     _secret_capture_callback = callback
-
-
-def clear_secret_capture_callback(session_id: str) -> None:
-    with _secret_capture_callbacks_lock:
-        _secret_capture_callbacks.pop(session_id, None)
-
-
-def _get_secret_capture_callback():
-    """Return the callback bound to the current UI session, when available.
-
-    Keep the module attribute as a compatibility seam for existing callers and
-    tests that patch it directly. Gateway sessions use the session ID from the
-    current gateway context so wiring one session cannot replace another.
-    """
-    try:
-        from gateway.session_context import get_session_env
-
-        session_id = get_session_env("HERMES_UI_SESSION_ID", "")
-    except Exception:
-        session_id = ""
-    if session_id:
-        with _secret_capture_callbacks_lock:
-            callback = _secret_capture_callbacks.get(session_id)
-        if callback is not None:
-            return callback
-    return _secret_capture_callback
 
 
 def skill_matches_platform(frontmatter: Dict[str, Any]) -> bool:
@@ -460,8 +427,7 @@ def _capture_required_environment_variables(
             "gateway_setup_hint": _gateway_setup_hint(),
         }
 
-    secret_capture_callback = _get_secret_capture_callback()
-    if secret_capture_callback is None:
+    if _secret_capture_callback is None:
         return {
             "missing_names": missing_names,
             "setup_skipped": False,
@@ -479,7 +445,7 @@ def _capture_required_environment_variables(
             metadata["required_for"] = entry["required_for"]
 
         try:
-            callback_result = secret_capture_callback(
+            callback_result = _secret_capture_callback(
                 entry["name"],
                 entry["prompt"],
                 metadata,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4464,7 +4464,10 @@ def _wire_callbacks(sid: str):
         pl = {"prompt": prompt, "env_var": env_var}
         if metadata:
             pl["metadata"] = metadata
-        val = _block("secret.request", sid, pl)
+        from gateway.session_context import get_session_env
+
+        target_sid = get_session_env("HERMES_UI_SESSION_ID") or sid
+        val = _block("secret.request", target_sid, pl)
         if not val:
             return {
                 "success": True,


### PR DESCRIPTION
Fixes NousResearch#68261

Skill credential prompts in the TUI/Desktop gateway were routed through a process-global callback. When multiple sessions were active, wiring a newer session replaced the callback used by older sessions.

This change stores gateway callbacks by UI session ID and resolves the callback from the current session context. Closing a session also removes its callback registration.

The existing CLI callback behavior remains unchanged.

Added regression coverage for two active UI sessions and verified that each credential request is delivered to its owning session.

Validation:
159 tests passed