### PR TITLE
fix(desktop): bind coding status to git context

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/base-branch-picker.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/base-branch-picker.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesGitBaseBranch } from '@/global'
+import type * as ProjectsStore from '@/store/projects'
+import { listBaseBranches } from '@/store/projects'
+
+import { BaseBranchPicker } from './base-branch-picker'
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        projects: {
+          baseBranchNone: 'No base branches',
+          baseBranchPlaceholder: 'Find a base branch',
+          branchOff: () => ({ after: '', before: 'Branch off ' })
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/projects', async importOriginal => {
+  const actual = await importOriginal<typeof ProjectsStore>()
+
+  return { ...actual, listBaseBranches: vi.fn() }
+})
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      disconnect() {}
+      observe() {}
+      unobserve() {}
+    }
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('BaseBranchPicker', () => {
+  it('drops an old repository result and loads the new repository base', async () => {
+    let resolveBranchesA: (branches: HermesGitBaseBranch[]) => void = () => undefined
+
+    const branchesA = new Promise<HermesGitBaseBranch[]>(resolve => {
+      resolveBranchesA = resolve
+    })
+
+    const onValueChange = vi.fn()
+
+    vi.mocked(listBaseBranches).mockImplementation(repoPath =>
+      repoPath === '/repo-a'
+        ? branchesA
+        : Promise.resolve([{ isDefault: true, isRemote: false, name: 'main-b' }])
+    )
+
+    const view = render(<BaseBranchPicker onValueChange={onValueChange} repoPath="/repo-a" value="" />)
+    expect(listBaseBranches).toHaveBeenCalledWith('/repo-a')
+
+    view.rerender(<BaseBranchPicker onValueChange={onValueChange} repoPath="/repo-b" value="" />)
+    resolveBranchesA([{ isDefault: true, isRemote: false, name: 'main-a' }])
+
+    await waitFor(() => expect(listBaseBranches).toHaveBeenCalledWith('/repo-b'))
+    await waitFor(() => expect(onValueChange).toHaveBeenLastCalledWith('main-b'))
+    expect(onValueChange).not.toHaveBeenCalledWith('main-a')
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/base-branch-picker.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/base-branch-picker.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
@@ -32,6 +32,24 @@ export function BaseBranchPicker({
   const [branches, setBranches] = useState<HermesGitBaseBranch[]>([])
   const [loading, setLoading] = useState(false)
   const [open, setOpen] = useState(false)
+  const repoContextEpoch = useRef(0)
+  const repoPathRef = useRef(repoPath)
+
+  // A path change means a different Git authority. Reset before the new effect
+  // schedules its fetch so a late old response cannot fill the picker or choose
+  // its default branch for the new repository.
+  useLayoutEffect(() => {
+    if (repoPathRef.current === repoPath) {
+      return
+    }
+
+    repoPathRef.current = repoPath
+    repoContextEpoch.current += 1
+    setBranches([])
+    setLoading(false)
+    setOpen(false)
+  }, [repoPath])
+
 
   const currentBranch = repoStatus?.detached ? null : (repoStatus?.branch ?? null)
 
@@ -40,10 +58,16 @@ export function BaseBranchPicker({
       return
     }
 
+    const contextEpoch = repoContextEpoch.current
     setLoading(true)
 
     try {
       const list = await listBaseBranches(repoPath)
+
+      if (contextEpoch !== repoContextEpoch.current) {
+        return
+      }
+
       setBranches(list)
 
       // Default to the remote default (origin/HEAD). Fall back to the local
@@ -57,9 +81,13 @@ export function BaseBranchPicker({
         onValueChange(list[0]?.name ?? '')
       }
     } catch {
-      setBranches([])
+      if (contextEpoch === repoContextEpoch.current) {
+        setBranches([])
+      }
     } finally {
-      setLoading(false)
+      if (contextEpoch === repoContextEpoch.current) {
+        setLoading(false)
+      }
     }
   }, [repoPath, onValueChange])
 

--- a/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesGitBranch } from '@/global'
+import { listRepoBranches } from '@/store/projects'
+
+import { WorktreeDialog } from './worktree-dialog'
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      common: { cancel: 'Cancel' },
+      sidebar: {
+        projects: {
+          branchCreateWorktree: 'Create worktree',
+          branchOpenExisting: 'Open existing worktree',
+          branchPlaceholder: 'Branch name',
+          branchSwitchHome: 'Switch primary checkout',
+          branchesLoading: 'Loading branches',
+          convertBranchDesc: 'Choose an existing branch',
+          convertBranchInstead: 'Convert a branch instead',
+          convertBranchPlaceholder: 'Find a branch',
+          convertBranchTitle: 'Convert branch',
+          newWorktreeDesc: 'Create a worktree',
+          newWorktreeTitle: 'New worktree',
+          noBranches: 'No branches',
+          startWork: 'Start work',
+          startWorkFailed: 'Could not start worktree'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/projects', () => ({
+  listRepoBranches: vi.fn(),
+  startWorkInRepo: vi.fn(),
+  switchBranchInRepo: vi.fn()
+}))
+
+vi.mock('./base-branch-picker', () => ({
+  BaseBranchPicker: ({ value }: { value: string }) => <output data-testid="base-branch">{value}</output>
+}))
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      disconnect() {}
+      observe() {}
+      unobserve() {}
+    }
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('WorktreeDialog', () => {
+  it('drops a late branch list after reopening in a new repository context', async () => {
+    let resolveBranchesA: (branches: HermesGitBranch[]) => void = () => undefined
+    let resolveBranchesB: (branches: HermesGitBranch[]) => void = () => undefined
+
+    const branchesA = new Promise<HermesGitBranch[]>(resolve => {
+      resolveBranchesA = resolve
+    })
+
+    const branchesB = new Promise<HermesGitBranch[]>(resolve => {
+      resolveBranchesB = resolve
+    })
+
+    const onOpenChange = vi.fn()
+
+    vi.mocked(listRepoBranches).mockReturnValueOnce(branchesA).mockReturnValueOnce(branchesB)
+
+    const view = render(
+      <WorktreeDialog initialBase="main" onOpenChange={onOpenChange} onStarted={vi.fn()} open repoPath="/repo-a" />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Convert a branch instead' }))
+    expect(listRepoBranches).toHaveBeenCalledWith('/repo-a')
+
+    view.rerender(
+      <WorktreeDialog initialBase="main" onOpenChange={onOpenChange} onStarted={vi.fn()} open repoPath="/repo-b" />
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Convert a branch instead' }))
+    expect(listRepoBranches).toHaveBeenLastCalledWith('/repo-b')
+
+    resolveBranchesA([{ checkedOut: false, isDefault: false, name: 'feature/a', worktreePath: null }])
+
+    await waitFor(() => expect(screen.queryByText('feature/a')).toBeNull())
+
+    resolveBranchesB([{ checkedOut: false, isDefault: false, name: 'feature/b', worktreePath: null }])
+
+    await screen.findByText('feature/b')
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.tsx
@@ -1,5 +1,4 @@
-import { useStore } from '@nanostores/react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
@@ -12,23 +11,12 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { SanitizedInput } from '@/components/ui/sanitized-input'
 import type { HermesGitBranch } from '@/global'
 import { useI18n } from '@/i18n'
 import { gitRef } from '@/lib/sanitize'
 import { notifyError } from '@/store/notifications'
-import {
-  $projectTree,
-  $worktreeDialog,
-  closeWorktreeDialog,
-  listRepoBranches,
-  projectIdForCwd,
-  projectRootCwd,
-  requestStartWorkSession,
-  startWorkInRepo,
-  switchBranchInRepo
-} from '@/store/projects'
+import { listRepoBranches, startWorkInRepo, switchBranchInRepo } from '@/store/projects'
 
 import { BaseBranchPicker } from './base-branch-picker'
 
@@ -36,7 +24,6 @@ interface BranchActionCopy {
   branchCreateWorktree: string
   branchOpenExisting: string
   branchSwitchHome: string
-  branchTrackRemote: string
 }
 
 const branchActionLabel = (branch: HermesGitBranch, copy: BranchActionCopy) => {
@@ -44,118 +31,112 @@ const branchActionLabel = (branch: HermesGitBranch, copy: BranchActionCopy) => {
     return copy.branchOpenExisting
   }
 
-  if (branch.isRemote) {
-    return copy.branchTrackRemote
-  }
-
   return branch.isDefault ? copy.branchSwitchHome : copy.branchCreateWorktree
 }
 
+export interface WorktreeDialogProps {
+  /** Repo root path for git operations. */
+  repoPath: string
+  /** Called with the new/converted worktree path on success. */
+  onStarted: (path: string) => void
+  /** Controlled open state. */
+  open: boolean
+  /** Called when the user requests the dialog to close (cancel, Esc, backdrop). */
+  onOpenChange: (open: boolean) => void
+  /** Pre-select a base branch when opening (from "branch off from X" menus). */
+  initialBase?: string
+}
+
 /**
- * The "new worktree" dialog. It is mounted exactly once, in the sidebar beside
- * ProjectDialog, and the `$worktreeDialog` atom drives it. Every entry point
- * (⌘⇧B, the kebab of the coding rail, the + button of the sidebar) publishes
- * its intent to that atom. No entry point mounts its own copy. N composers on
- * screen gave N stacked dialogs for one keypress.
+ * Shared "new worktree" dialog — used by the sidebar's StartWorkButton and the
+ * composer's ⌘⇧B shortcut. Features:
+ * - Branch name input (sanitized as a git ref)
+ * - Base branch picker (filterable combobox — the sidebar's BaseBranchPicker)
+ * - Convert mode: check out an existing branch into a worktree
  *
- * Features:
- * - Project picker: change the repo before you name the branch
- * - Branch name input, made safe as a git ref
- * - Base branch picker: a combobox with a filter
- * - Convert mode: check an existing branch out into a worktree
+ * The caller owns the open state so both the sidebar button and the global
+ * hotkey can trigger the same dialog instance.
  */
-export function WorktreeDialog() {
+export function WorktreeDialog({ repoPath, onStarted, open, onOpenChange, initialBase }: WorktreeDialogProps) {
   const { t } = useI18n()
   const p = t.sidebar.projects
-  const state = useStore($worktreeDialog)
-  const open = state !== null
-  const projectTree = useStore($projectTree)
-
   const [name, setName] = useState('')
   const [pending, setPending] = useState(false)
   const [convertMode, setConvertMode] = useState(false)
   const [branches, setBranches] = useState<HermesGitBranch[]>([])
   const [branchesLoading, setBranchesLoading] = useState(false)
   const [selectedBase, setSelectedBase] = useState('')
-  // The repo that the dialog targets. It is seeded from the resolved intent.
-  // This component then owns it, so the project picker can change the target
-  // and the user does not reopen the dialog.
-  const [repoPath, setRepoPath] = useState('')
-  const [projectOpen, setProjectOpen] = useState(false)
+  const repoContextEpoch = useRef(0)
+  const repoPathRef = useRef(repoPath)
 
-  // Every project with a working root is a valid target. The list is deduped by
-  // path, because an auto project and a user project can share one folder.
-  const projectOptions = useMemo(() => {
-    const seen = new Set<string>()
+  // A repo path change swaps the dialog's Git authority. Close and reset before
+  // the new context can paint; callers may keep the component mounted while
+  // switching workspaces, so late branch/base requests from the old repository
+  // must not survive into the new one.
+  useLayoutEffect(() => {
+    if (repoPathRef.current === repoPath) {
+      return
+    }
 
-    return projectTree.flatMap(node => {
-      const path = projectRootCwd(node)
+    repoPathRef.current = repoPath
+    repoContextEpoch.current += 1
+    setName('')
+    setPending(false)
+    setConvertMode(false)
+    setBranches([])
+    setBranchesLoading(false)
+    setSelectedBase(initialBase ?? '')
 
-      if (!path || seen.has(path)) {
-        return []
+    if (open) {
+      onOpenChange(false)
+    }
+  }, [initialBase, onOpenChange, open, repoPath])
+
+  const onBaseValueChange = useCallback(
+    (value: string) => {
+      if (repoPathRef.current === repoPath) {
+        setSelectedBase(value)
       }
+    },
+    [repoPath]
+  )
 
-      seen.add(path)
-
-      return [{ id: node.id, label: node.label, path }]
-    })
-  }, [projectTree])
-
-  // The project that owns the target repo. `repoPath` is often a linked
-  // worktree, for example `<repo>/.worktrees/<branch>`, and no project row has
-  // that exact path. An equality test against the rows therefore matches
-  // nothing, and the label falls back to the last path segment, which is the
-  // name of the BRANCH. Ask which project owns the path instead, then fall back
-  // to a path match: two projects can share a folder, and the dedupe above
-  // keeps only the first, so the owner's own row can be the one it dropped.
-  const activeOption = useMemo(() => {
-    const owner = projectTree.length > 0 ? projectIdForCwd(repoPath) : null
-
-    return projectOptions.find(o => o.id === owner) ?? projectOptions.find(o => o.path === repoPath) ?? null
-  }, [projectOptions, projectTree, repoPath])
-
-  const activeProjectLabel = activeOption?.label ?? repoPath.split('/').pop() ?? repoPath
-
-  // Reset to a fresh state each time the dialog opens. Apply the resolved repo
-  // and the base branch that the caller selected, for example "branch off from
-  // main" in the dropdown menu of the coding row.
+  // Reset to a fresh state each time the dialog opens, applying any pre-selected
+  // base branch from the caller (e.g. "branch off from main" in the coding row's
+  // dropdown menu). When `initialBase` changes while open (shouldn't happen in
+  // practice), the effect re-syncs.
   useEffect(() => {
-    if (state) {
+    if (open) {
       setName('')
       setConvertMode(false)
-      setSelectedBase(state.base ?? '')
-      setRepoPath(state.repoPath)
-      setBranches([])
+      setSelectedBase(initialBase ?? '')
     }
-  }, [state])
-
-  const onOpenChange = (next: boolean) => {
-    if (!next && !pending) {
-      closeWorktreeDialog()
-    }
-  }
+  }, [open, initialBase])
 
   const loadBranches = useCallback(async () => {
     if (!repoPath) {
       return
     }
 
+    const contextEpoch = repoContextEpoch.current
     setBranchesLoading(true)
 
     try {
-      setBranches(await listRepoBranches(repoPath))
+      const list = await listRepoBranches(repoPath)
+
+      if (contextEpoch === repoContextEpoch.current) {
+        setBranches(list)
+      }
     } catch {
-      setBranches([])
+      if (contextEpoch === repoContextEpoch.current) {
+        setBranches([])
+      }
     } finally {
-      setBranchesLoading(false)
+      if (contextEpoch === repoContextEpoch.current) {
+        setBranchesLoading(false)
+      }
     }
   }, [repoPath])
-
-  // Give the new worktree to a fresh session, then close the dialog.
-  const started = (path: string) => {
-    requestStartWorkSession(path)
-    closeWorktreeDialog()
-  }
 
   const submit = async () => {
     const branch = name.trim()
@@ -164,19 +145,25 @@ export function WorktreeDialog() {
       return
     }
 
+    const contextEpoch = repoContextEpoch.current
     setPending(true)
 
     try {
       const result = await startWorkInRepo(repoPath, { base: selectedBase || undefined, branch, name: branch })
 
-      if (result) {
-        started(result.path)
+      if (result && contextEpoch === repoContextEpoch.current) {
+        onStarted(result.path)
+        onOpenChange(false)
         setName('')
       }
     } catch (err) {
-      notifyError(err, p.startWorkFailed)
+      if (contextEpoch === repoContextEpoch.current) {
+        notifyError(err, p.startWorkFailed)
+      }
     } finally {
-      setPending(false)
+      if (contextEpoch === repoContextEpoch.current) {
+        setPending(false)
+      }
     }
   }
 
@@ -185,6 +172,7 @@ export function WorktreeDialog() {
       return
     }
 
+    const contextEpoch = repoContextEpoch.current
     setPending(true)
 
     try {
@@ -199,13 +187,18 @@ export function WorktreeDialog() {
         result = await startWorkInRepo(repoPath, { existingBranch: branch.name })
       }
 
-      if (result) {
-        started(result.path)
+      if (result && contextEpoch === repoContextEpoch.current) {
+        onStarted(result.path)
+        onOpenChange(false)
       }
     } catch (err) {
-      notifyError(err, p.startWorkFailed)
+      if (contextEpoch === repoContextEpoch.current) {
+        notifyError(err, p.startWorkFailed)
+      }
     } finally {
-      setPending(false)
+      if (contextEpoch === repoContextEpoch.current) {
+        setPending(false)
+      }
     }
   }
 
@@ -215,64 +208,12 @@ export function WorktreeDialog() {
   }
 
   return (
-    <Dialog onOpenChange={onOpenChange} open={open}>
+    <Dialog onOpenChange={next => !pending && onOpenChange(next)} open={open}>
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>{convertMode ? p.convertBranchTitle : p.newWorktreeTitle}</DialogTitle>
           <DialogDescription>{convertMode ? p.convertBranchDesc : p.newWorktreeDesc}</DialogDescription>
         </DialogHeader>
-
-        {/* Project picker: change the repo that the worktree is cut from. Show
-            it only when there is another project to select. */}
-        {projectOptions.length > 1 && (
-          <Popover onOpenChange={setProjectOpen} open={projectOpen}>
-            <PopoverTrigger asChild>
-              <Button
-                className="group w-full flex justify-start items-center min-w-0 gap-1.5 hover:no-underline hover:text-muted-foreground"
-                disabled={pending}
-                size="inline"
-                variant="text"
-              >
-                <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="folder" size="0.8rem" />
-                <span className="shrink-0">{p.worktreeProjectLabel}</span>
-                <span className="truncate text-primary underline-offset-4 decoration-current/20 group-hover:underline">
-                  {activeProjectLabel}
-                </span>
-                <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="chevron-down" size="0.75rem" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent align="start" className="z-(--z-modal-popover) min-w-(--radix-popover-trigger-width) p-0">
-              <Command filter={(value, search) => (value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0)}>
-                <CommandInput autoFocus placeholder={p.worktreeProjectPlaceholder} />
-                <CommandList className="max-h-64">
-                  <CommandEmpty>{p.worktreeProjectNone}</CommandEmpty>
-                  <CommandGroup>
-                    {projectOptions.map(option => (
-                      <CommandItem
-                        key={option.path}
-                        onSelect={() => {
-                          setRepoPath(option.path)
-                          // The new repo has its own branches. Drop the old
-                          // list and the old base, so nothing stale stays.
-                          setBranches([])
-                          setSelectedBase('')
-                          setProjectOpen(false)
-                        }}
-                        value={`${option.label} ${option.path}`}
-                      >
-                        <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="repo" size="0.8rem" />
-                        <span className="truncate">{option.label}</span>
-                        {option === activeOption && (
-                          <Codicon className="ml-auto shrink-0 text-(--ui-accent)" name="check" size="0.8rem" />
-                        )}
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                </CommandList>
-              </Command>
-            </PopoverContent>
-          </Popover>
-        )}
 
         {convertMode ? (
           <Command
@@ -290,11 +231,7 @@ export function WorktreeDialog() {
                     onSelect={() => void convert(branch)}
                     value={branch.name}
                   >
-                    <Codicon
-                      className="shrink-0 text-(--ui-text-tertiary)"
-                      name={branch.isRemote ? 'repo' : 'git-branch'}
-                      size="0.8rem"
-                    />
+                    <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="git-branch" size="0.8rem" />
                     <span className="truncate">{branch.name}</span>
                     <span className="ml-auto shrink-0 text-[0.625rem] text-(--ui-text-tertiary)">
                       {branchActionLabel(branch, p)}
@@ -324,10 +261,7 @@ export function WorktreeDialog() {
             />
             <BaseBranchPicker
               disabled={pending}
-              // Remount on a repo change, so the picker loads the branches of
-              // the new repo and does not show those of the previous project.
-              key={repoPath}
-              onValueChange={setSelectedBase}
+              onValueChange={onBaseValueChange}
               repoPath={repoPath}
               value={selectedBase}
             />

--- a/apps/desktop/src/store/coding-status.test.ts
+++ b/apps/desktop/src/store/coding-status.test.ts
@@ -1,19 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { HermesRepoStatus } from '@/global'
+import type { HermesGitWorktree, HermesRepoStatus } from '@/global'
 
-import {
-  $repoStatus,
-  $repoStatusByCwd,
-  $repoStatusLoading,
-  _resetCodingStatusForTests,
-  refreshAllRepoStatuses,
-  refreshRepoStatus,
-  registerRepoStatusCwd,
-  repoChangeKindForPath,
-  repoStatusForCwd
-} from './coding-status'
-import { $currentCwd, $selectedStoredSessionId } from './session'
+import { $repoChangeByPath, $repoStatus, $repoStatusLoading, $repoWorktrees, refreshRepoStatus } from './coding-status'
+import { $connection, $currentCwd, $selectedStoredSessionId } from './session'
 
 const sampleStatus: HermesRepoStatus = {
   branch: 'feature/login',
@@ -31,16 +21,6 @@ const sampleStatus: HermesRepoStatus = {
   files: []
 }
 
-const otherStatus: HermesRepoStatus = {
-  ...sampleStatus,
-  branch: 'bb/other-worktree',
-  added: 3,
-  removed: 1,
-  changed: 1,
-  staged: 0,
-  unstaged: 1
-}
-
 function stubProbe(impl: (cwd: string) => Promise<HermesRepoStatus | null>) {
   ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = { git: { repoStatus: impl } }
 }
@@ -48,27 +28,25 @@ function stubProbe(impl: (cwd: string) => Promise<HermesRepoStatus | null>) {
 describe('refreshRepoStatus', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-    _resetCodingStatusForTests()
+    $connection.set(null)
+    $repoStatus.set(null)
+    $repoWorktrees.set([])
     $currentCwd.set('')
     $selectedStoredSessionId.set(null)
-    // Drain the cwd/session subscribe side-effects the sets above kick off.
-    vi.advanceTimersByTime(200)
     delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
-    _resetCodingStatusForTests()
   })
 
   afterEach(() => {
-    _resetCodingStatusForTests()
+    vi.unstubAllGlobals()
     vi.clearAllTimers()
     vi.useRealTimers()
+    $connection.set(null)
     delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
   })
 
-  it('populates the per-cwd cache and the primary computed for that cwd', async () => {
+  it('populates $repoStatus from the probe for an explicit cwd', async () => {
     stubProbe(async () => sampleStatus)
-    $currentCwd.set('/repo')
     await refreshRepoStatus('/repo')
-    expect(repoStatusForCwd('/repo').get()).toEqual(sampleStatus)
     expect($repoStatus.get()).toEqual(sampleStatus)
   })
 
@@ -78,89 +56,152 @@ describe('refreshRepoStatus', () => {
     $currentCwd.set('/active/repo')
     await refreshRepoStatus()
     expect(probe).toHaveBeenCalledWith('/active/repo')
-    expect($repoStatus.get()).toEqual(sampleStatus)
   })
 
-  it('leaves the cache alone (primary reads null) when there is no cwd', async () => {
+  it('clears status when there is no cwd', async () => {
     stubProbe(async () => sampleStatus)
-    $currentCwd.set('/repo')
-    await refreshRepoStatus('/repo')
-    expect($repoStatus.get()).toEqual(sampleStatus)
-
-    // Blank target is a no-op: other worktrees' cached truth must stay put.
+    $repoStatus.set(sampleStatus)
     await refreshRepoStatus('   ')
-    expect(repoStatusForCwd('/repo').get()).toEqual(sampleStatus)
-    $currentCwd.set('')
     expect($repoStatus.get()).toBeNull()
   })
 
-  it('clears every cached status when the probe is unavailable (remote backend)', async () => {
-    $currentCwd.set('/repo')
-    $repoStatusByCwd.set({ '/repo': sampleStatus, '/other': otherStatus })
+  it('clears status when the probe is unavailable (remote backend)', async () => {
+    $repoStatus.set(sampleStatus)
     await refreshRepoStatus('/repo')
-    expect($repoStatusByCwd.get()).toEqual({})
     expect($repoStatus.get()).toBeNull()
   })
 
-  it('clears only the failing cwd when the probe throws', async () => {
-    stubProbe(async cwd => {
-      if (cwd === '/bad') {
-        throw new Error('not a repo')
-      }
-
-      return sampleStatus
+  it('clears status when the probe throws', async () => {
+    stubProbe(async () => {
+      throw new Error('not a repo')
     })
-    $currentCwd.set('/bad')
-    $repoStatusByCwd.set({ '/bad': otherStatus, '/good': sampleStatus })
-    await refreshRepoStatus('/bad')
-    expect(repoStatusForCwd('/bad').get()).toBeNull()
-    expect(repoStatusForCwd('/good').get()).toEqual(sampleStatus)
+    $repoStatus.set(sampleStatus)
+    await refreshRepoStatus('/repo')
     expect($repoStatus.get()).toBeNull()
   })
 
-  it('never publishes an old worktree status onto the primary after the active cwd moves', async () => {
-    let resolveOld!: (status: HermesRepoStatus | null) => void
-    stubProbe(
-      () =>
-        new Promise(resolve => {
-          resolveOld = resolve
-        })
-    )
+  it('clears status, worktrees, and changed-path tints immediately when the cwd changes', () => {
+    const status = {
+      ...sampleStatus,
+      branch: 'feature/a',
+      files: [{ conflicted: false, path: 'src/a.ts', staged: false, unstaged: true, untracked: false }]
+    }
 
-    // Explicit probe (not the debounced cwd edge) so the hang is fully under
-    // our control — same race window the coding rail used to hit after a
-    // session switch mid-probe.
-    const inflight = refreshRepoStatus('/repo-a')
+    const worktrees: HermesGitWorktree[] = [
+      { branch: 'feature/a', detached: false, isMain: true, locked: false, path: '/repo-a' }
+    ]
+
     $currentCwd.set('/repo-a')
+    $repoStatus.set(status)
+    $repoWorktrees.set(worktrees)
+
+    expect($repoChangeByPath.get().get('/repo-a/src/a.ts')).toBe('modified')
+
+    $currentCwd.set('/repo-b')
+
+    expect($repoStatus.get()).toBeNull()
+    expect($repoWorktrees.get()).toEqual([])
+    expect($repoChangeByPath.get()).toEqual(new Map())
+  })
+
+  it('drops a status result that resolves after its cwd becomes inactive', async () => {
+    let resolveStatus: (status: HermesRepoStatus | null) => void = () => undefined
+
+    const status = new Promise<HermesRepoStatus | null>(resolve => {
+      resolveStatus = resolve
+    })
+
+    const worktreeList = vi.fn()
+
+    ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = {
+      git: { repoStatus: vi.fn(() => status), worktreeList }
+    }
+    $currentCwd.set('/repo-a')
+    const first = refreshRepoStatus('/repo-a')
+    $currentCwd.set('/repo-b')
+
+    resolveStatus({ ...sampleStatus, branch: 'feature/a' })
+    await first
+
+    expect($repoStatus.get()).toBeNull()
+    expect($repoWorktrees.get()).toEqual([])
+    expect(worktreeList).not.toHaveBeenCalled()
+  })
+
+  it('drops a worktree result that resolves after its cwd becomes inactive', async () => {
+    let resolveWorktrees: (worktrees: HermesGitWorktree[]) => void = () => undefined
+
+    const worktrees = new Promise<HermesGitWorktree[]>(resolve => {
+      resolveWorktrees = resolve
+    })
+
+    const worktreeList = vi.fn(() => worktrees)
+
+    ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = {
+      git: { repoStatus: vi.fn(async () => ({ ...sampleStatus, branch: 'feature/a' })), worktreeList }
+    }
+    $currentCwd.set('/repo-a')
+    const first = refreshRepoStatus('/repo-a')
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(worktreeList).toHaveBeenCalledWith('/repo-a')
+
+    $currentCwd.set('/repo-b')
+    resolveWorktrees([{ branch: 'feature/a', detached: false, isMain: true, locked: false, path: '/repo-a' }])
+    await first
     await Promise.resolve()
 
-    $currentCwd.set('/repo-b')
     expect($repoStatus.get()).toBeNull()
-
-    resolveOld(sampleStatus)
-    await inflight
-
-    // Primary follows the NEW cwd (empty). The old worktree may still cache the
-    // late result under its own key — that's what lets a tile rail paint
-    // instantly — but it must not leak onto the main rail via $repoStatus.
-    expect($repoStatus.get()).toBeNull()
-    expect(repoStatusForCwd('/repo-a').get()).toEqual(sampleStatus)
+    expect($repoWorktrees.get()).toEqual([])
   })
 
-  it('keeps independent statuses for two live worktrees', async () => {
-    stubProbe(async cwd => (cwd === '/repo-a' ? sampleStatus : otherStatus))
-    await refreshRepoStatus('/repo-a')
-    await refreshRepoStatus('/repo-b')
-    expect(repoStatusForCwd('/repo-a').get()).toEqual(sampleStatus)
-    expect(repoStatusForCwd('/repo-b').get()).toEqual(otherStatus)
+  it('clears immediately when backend identity changes at the same cwd', () => {
+    $currentCwd.set('/workspace')
+    $connection.set({ baseUrl: 'http://profile-a.test', mode: 'local', profile: 'profile-a' } as never)
+    $repoStatus.set({ ...sampleStatus, branch: 'feature/a' })
+    $repoWorktrees.set([{ branch: 'feature/a', detached: false, isMain: true, locked: false, path: '/workspace' }])
 
-    $currentCwd.set('/repo-a')
-    expect($repoStatus.get()).toEqual(sampleStatus)
-    $currentCwd.set('/repo-b')
-    expect($repoStatus.get()).toEqual(otherStatus)
+    $connection.set({ baseUrl: 'http://profile-b.test', mode: 'local', profile: 'profile-b' } as never)
+
+    expect($repoStatus.get()).toBeNull()
+    expect($repoWorktrees.get()).toEqual([])
   })
 
-  it('runs one probe at a time and coalesces overlap into one trailing refresh per drain', async () => {
+  it('retains a published row during a same-context refresh', async () => {
+    let resolveRefresh: (status: HermesRepoStatus | null) => void = () => undefined
+
+    const refresh = new Promise<HermesRepoStatus | null>(resolve => {
+      resolveRefresh = resolve
+    })
+
+    stubProbe(vi.fn(() => refresh))
+    $currentCwd.set('/repo')
+    $repoStatus.set({ ...sampleStatus, branch: 'feature/a' })
+
+    const next = refreshRepoStatus('/repo')
+
+    expect($repoStatus.get()).toMatchObject({ branch: 'feature/a' })
+
+    resolveRefresh({ ...sampleStatus, branch: 'feature/b' })
+    await next
+
+    expect($repoStatus.get()).toMatchObject({ branch: 'feature/b' })
+  })
+
+  it('clears immediately when the stored session changes at the same cwd', () => {
+    $currentCwd.set('/repo')
+    $selectedStoredSessionId.set('session-a')
+    $repoStatus.set({ ...sampleStatus, branch: 'feature/a' })
+    $repoWorktrees.set([{ branch: 'feature/a', detached: false, isMain: true, locked: false, path: '/repo' }])
+
+    $selectedStoredSessionId.set('session-b')
+
+    expect($repoStatus.get()).toBeNull()
+    expect($repoWorktrees.get()).toEqual([])
+  })
+
+  it('runs one probe at a time and coalesces overlap into one trailing refresh', async () => {
     const resolvers: Array<(status: HermesRepoStatus | null) => void> = []
     const calls: string[] = []
     let active = 0
@@ -179,10 +220,10 @@ describe('refreshRepoStatus', () => {
         })
     )
 
-    $currentCwd.set('/repo-c')
     const first = refreshRepoStatus('/repo-a')
     const second = refreshRepoStatus('/repo-b')
     const third = refreshRepoStatus('/repo-c')
+
 
     expect(calls).toEqual(['/repo-a'])
     expect(maxActive).toBe(1)
@@ -192,22 +233,33 @@ describe('refreshRepoStatus', () => {
     await Promise.resolve()
     await Promise.resolve()
 
+    expect(calls).toEqual(['/repo-a', '/repo-c'])
     expect(maxActive).toBe(1)
-    expect(calls.length).toBe(2)
+    expect($repoStatus.get()).toBeNull()
 
-    resolvers.shift()?.(otherStatus)
-    await Promise.resolve()
-    await Promise.resolve()
     resolvers.shift()?.(sampleStatus)
     await Promise.all([first, second, third])
 
     expect(maxActive).toBe(1)
-    expect(calls).toEqual(['/repo-a', '/repo-b', '/repo-c'])
-    expect(repoStatusForCwd('/repo-a').get()).toEqual(sampleStatus)
-    expect(repoStatusForCwd('/repo-b').get()).toEqual(otherStatus)
-    expect(repoStatusForCwd('/repo-c').get()).toEqual(sampleStatus)
     expect($repoStatus.get()).toEqual(sampleStatus)
     expect($repoStatusLoading.get()).toBe(false)
+  })
+
+  it('ignores an A debounce callback that runs after B takes ownership', async () => {
+    const probe = vi.fn(async cwd => ({ ...sampleStatus, branch: cwd === '/repo-b' ? 'feature/b' : 'feature/a' }))
+
+    stubProbe(probe)
+    vi.clearAllTimers()
+    vi.stubGlobal('clearTimeout', () => undefined)
+
+    $currentCwd.set('/repo-a')
+    $currentCwd.set('/repo-b')
+    vi.advanceTimersByTime(100)
+    await vi.runAllTicks()
+
+    expect(probe).toHaveBeenCalledOnce()
+    expect(probe).toHaveBeenCalledWith('/repo-b')
+    expect($repoStatus.get()).toMatchObject({ branch: 'feature/b' })
   })
 
   it('refreshes when the stored session id changes even if the cwd is unchanged', async () => {
@@ -231,57 +283,5 @@ describe('refreshRepoStatus', () => {
     await vi.runAllTicks()
 
     expect(probe).toHaveBeenCalledWith('/repo')
-  })
-
-  it('registerRepoStatusCwd keeps that worktree in unscoped refreshes', async () => {
-    const probe = vi.fn(async cwd => (cwd === '/tile' ? otherStatus : sampleStatus))
-    stubProbe(probe)
-
-    $currentCwd.set('/main')
-    const release = registerRepoStatusCwd('/tile')
-    // Drain the register kick + cwd edge so the assert only covers the
-    // unscoped fan-out.
-    vi.advanceTimersByTime(200)
-    await refreshAllRepoStatuses()
-    probe.mockClear()
-
-    // Unscoped fan-out: every registered worktree + primary, not main only.
-    await refreshAllRepoStatuses()
-
-    const probed = [...new Set(probe.mock.calls.map(call => call[0]))].sort()
-    expect(probed).toEqual(['/main', '/tile'])
-    expect(repoStatusForCwd('/tile').get()).toEqual(otherStatus)
-    expect(repoStatusForCwd('/main').get()).toEqual(sampleStatus)
-
-    release?.()
-  })
-})
-
-describe('repoChangeKindForPath', () => {
-  it('does not notify a row when only another path changes', () => {
-    $currentCwd.set('/repo')
-    $repoStatusByCwd.set({ '/repo': { ...sampleStatus, files: [] } })
-    const row = repoChangeKindForPath('/repo/a.ts')
-    const listener = vi.fn()
-    const unsubscribe = row.subscribe(listener)
-
-    $repoStatusByCwd.set({
-      '/repo': {
-        ...sampleStatus,
-        files: [{ path: 'b.ts', untracked: true } as HermesRepoStatus['files'][number]]
-      }
-    })
-    expect(listener).toHaveBeenCalledTimes(1)
-
-    $repoStatusByCwd.set({
-      '/repo': {
-        ...sampleStatus,
-        files: [{ path: 'a.ts', untracked: true } as HermesRepoStatus['files'][number]]
-      }
-    })
-    expect(listener).toHaveBeenCalledTimes(2)
-    expect(listener.mock.calls.at(-1)?.[0]).toBe('added')
-
-    unsubscribe()
   })
 })

--- a/apps/desktop/src/store/coding-status.ts
+++ b/apps/desktop/src/store/coding-status.ts
@@ -1,139 +1,68 @@
-import { atom, computed, type ReadableAtom } from 'nanostores'
+import { atom, computed } from 'nanostores'
 
 import type { HermesGitWorktree, HermesRepoStatus } from '@/global'
+import { desktopFsCacheKey } from '@/lib/desktop-fs'
 import { desktopGit } from '@/lib/desktop-git'
 
-import {
-  $projectScope,
-  $projectTree,
-  $worktreeDialog,
-  $worktreeRefreshToken,
-  ALL_PROJECTS,
-  projectRootCwd
-} from './projects'
-import {
-  $busy,
-  $currentCwd,
-  $selectedStoredSessionId,
-  $workspaceCwdOwner,
-  workspaceCwdBelongsToSelectedSession
-} from './session'
-import { $focusedRuntimeId, $sessionStates } from './session-states'
+import { $worktreeRefreshToken } from './projects'
+import { $busy, $connection, $currentCwd, $selectedStoredSessionId } from './session'
 import { $workspaceChangeTick } from './workspace-events'
 
-// Live working-tree status for every git surface on screen — the data backbone
-// of the composer coding rail. Keyed PER CWD: the main pane and each session
-// tile can sit in different worktrees, so a single global status would paint
-// the primary repo's branch/± onto every rail (the "tile shows main's diff"
-// bug). It's the same "cheaply re-read git truth at the right moments" model
-// as the sidebar worktree probe: a single bounded `git status --porcelain=v2`
-// per on-screen worktree per refresh, driven by structural edges (cwd change,
-// turn settle, window focus, worktree mutation), never per-token and never
-// touching the conversation/system-prompt cache.
+// Live working-tree status for the active session's cwd — the data backbone of
+// the composer coding rail. It's the same "cheaply re-read git truth at the
+// right moments" model as the sidebar worktree probe: a single bounded
+// `git status --porcelain=v2` per refresh, driven by structural edges (cwd
+// change, turn settle, window focus, worktree mutation), never per-token and
+// never touching the conversation/system-prompt cache.
 
-const REPO_STATUS_REFRESH_DEBOUNCE_MS = 100
+interface RepoStatusContext {
+  backendKey: string
+  cwd: string
+  storedSessionId: null | string
+}
 
-const normalizeCwd = (cwd?: null | string): null | string => cwd?.trim() || null
+let activeRepoStatusContext: null | RepoStatusContext = null
+let repoStatusContextEpoch = 0
 
-const EMPTY_WORKTREES: HermesGitWorktree[] = []
+function normalizeCwd(cwd?: null | string): null | string {
+  const trimmed = cwd?.trim()
 
-// Status + worktrees per normalized cwd. Entries outlive their surface (the
-// map stays bounded by the worktrees touched this run) so re-opening a tile
-// paints its last-known status instantly while the fresh probe runs.
-export const $repoStatusByCwd = atom<Record<string, HermesRepoStatus | null>>({})
-export const $repoWorktreesByCwd = atom<Record<string, HermesGitWorktree[]>>({})
+  if (!trimmed) {
+    return null
+  }
 
-// The PRIMARY (main pane) view — the active session's slice of the per-cwd
-// truth. Existing consumers (keybind gate, base-branch picker, file tree) keep
-// reading these; only surfaces that can live in ANOTHER worktree (tile rails)
-// need the per-cwd accessors below. During a conversation switch `$currentCwd`
-// can still name the previous conversation's path, so ownership hides only this
-// primary slice; the per-cwd cache stays available to any tile that genuinely
-// owns that worktree (#71254).
-export const $repoStatus: ReadableAtom<HermesRepoStatus | null> = computed(
-  [$repoStatusByCwd, $currentCwd, $selectedStoredSessionId, $workspaceCwdOwner],
-  (byCwd, cwd) => (workspaceCwdBelongsToSelectedSession() ? (byCwd[normalizeCwd(cwd) ?? ''] ?? null) : null)
-)
+  return trimmed.replace(/[/\\]+$/, '') || trimmed
+}
 
+function getRepoStatusContext(cwd?: null | string): null | RepoStatusContext {
+  const target = normalizeCwd(cwd)
+
+  if (!target) {
+    return null
+  }
+
+  return {
+    backendKey: desktopFsCacheKey(),
+    cwd: target,
+    storedSessionId: $selectedStoredSessionId.get()
+  }
+}
+
+function contextsMatch(left: null | RepoStatusContext, right: null | RepoStatusContext): boolean {
+  return (
+    left?.backendKey === right?.backendKey &&
+    left?.cwd === right?.cwd &&
+    left?.storedSessionId === right?.storedSessionId
+  )
+}
+
+export const $repoStatus = atom<HermesRepoStatus | null>(null)
 export const $repoStatusLoading = atom(false)
 
 // The repo's real worktrees (for the coding rail's "jump to a worktree" menu).
 // Refreshed on the same edges as the status probe; empty off a repo.
-export const $repoWorktrees: ReadableAtom<HermesGitWorktree[]> = computed(
-  [$repoWorktreesByCwd, $currentCwd, $selectedStoredSessionId, $workspaceCwdOwner],
-  (byCwd, cwd) =>
-    workspaceCwdBelongsToSelectedSession() ? (byCwd[normalizeCwd(cwd) ?? ''] ?? EMPTY_WORKTREES) : EMPTY_WORKTREES
-)
-
-// Reference-stable per-cwd slices, so any number of rails can each subscribe
-// to their own worktree's status without re-deriving atoms per render.
-const statusAtomByCwd = new Map<string, ReadableAtom<HermesRepoStatus | null>>()
-const worktreesAtomByCwd = new Map<string, ReadableAtom<HermesGitWorktree[]>>()
-const $noRepoStatus = atom<HermesRepoStatus | null>(null)
-const $noWorktrees = atom<HermesGitWorktree[]>(EMPTY_WORKTREES)
-
-/** Reactive status for one repo cwd (a tile's worktree). Stable per cwd. */
-export function repoStatusForCwd(cwd?: null | string): ReadableAtom<HermesRepoStatus | null> {
-  const key = normalizeCwd(cwd)
-
-  if (!key) {
-    return $noRepoStatus
-  }
-
-  let $slice = statusAtomByCwd.get(key)
-
-  if (!$slice) {
-    $slice = computed($repoStatusByCwd, byCwd => byCwd[key] ?? null)
-    statusAtomByCwd.set(key, $slice)
-  }
-
-  return $slice
-}
-
-/**
- * Is this path a git repo? This function reads the probe cache, and probes on
- * demand when the cache has no entry for the path. Use it to validate any repo
- * that was picked out of candidate FOLDERS: a path in a project row is not
- * evidence that git can branch from it. False on a remote backend, because
- * there is no local git truth to probe.
- */
-export async function isGitRepoPath(cwd: string): Promise<boolean> {
-  const key = normalizeCwd(cwd)
-
-  if (!key) {
-    return false
-  }
-
-  if (key in $repoStatusByCwd.get()) {
-    return $repoStatusByCwd.get()[key] !== null
-  }
-
-  if (!desktopGit()?.repoStatus) {
-    return false
-  }
-
-  await refreshRepoStatus(key)
-
-  return ($repoStatusByCwd.get()[key] ?? null) !== null
-}
-
-/** Reactive worktree list for one repo cwd. Stable per cwd. */
-export function repoWorktreesForCwd(cwd?: null | string): ReadableAtom<HermesGitWorktree[]> {
-  const key = normalizeCwd(cwd)
-
-  if (!key) {
-    return $noWorktrees
-  }
-
-  let $slice = worktreesAtomByCwd.get(key)
-
-  if (!$slice) {
-    $slice = computed($repoWorktreesByCwd, byCwd => byCwd[key] ?? EMPTY_WORKTREES)
-    worktreesAtomByCwd.set(key, $slice)
-  }
-
-  return $slice
-}
+export const $repoWorktrees = atom<HermesGitWorktree[]>([])
+const REPO_STATUS_REFRESH_DEBOUNCE_MS = 100
 
 export type RepoChangeKind = 'added' | 'conflicted' | 'modified'
 
@@ -143,9 +72,9 @@ export type RepoChangeKind = 'added' | 'conflicted' | 'modified'
 // appear — the file is gone from disk, so there's no tree row to tint.
 export const $repoChangeByPath = computed([$repoStatus, $currentCwd], (status, cwd) => {
   const map = new Map<string, RepoChangeKind>()
-  const root = (cwd || '').replace(/[/\\]+$/, '')
+  const root = normalizeCwd(cwd)
 
-  if (!status || !root) {
+  if (!status || !root || activeRepoStatusContext?.cwd !== root) {
     return map
   }
 
@@ -157,154 +86,98 @@ export const $repoChangeByPath = computed([$repoStatus, $currentCwd], (status, c
   return map
 })
 
-/**
- * Per-row Git decoration subscription. A visible file row reads one scalar, so
- * a fresh repo-status map only re-renders that row when its own kind changed.
- */
-export function repoChangeKindForPath(path: string): ReadableAtom<RepoChangeKind | undefined> {
-  return computed($repoChangeByPath, changes => changes.get(path))
-}
-
-// Cwds whose rails are on screen right now (refcounted — two tiles in one
-// worktree register it twice). Every refresh edge re-probes each registered
-// cwd plus the primary workspace, so a tile's rail moves when ITS agent
-// touches the tree — not only when main's does.
-const registeredCwds = new Map<string, number>()
-
-/** Keep `cwd` in the refresh set while its rail is mounted. Returns a release
- *  (undefined for a blank cwd), kicking off an immediate probe on register. */
-export function registerRepoStatusCwd(cwd?: null | string): (() => void) | undefined {
-  const key = normalizeCwd(cwd)
-
-  if (!key) {
-    return undefined
-  }
-
-  registeredCwds.set(key, (registeredCwds.get(key) ?? 0) + 1)
-  scheduleRepoStatusRefresh(key)
-
-  let released = false
-
-  return () => {
-    if (released) {
-      return
-    }
-
-    released = true
-    const count = registeredCwds.get(key) ?? 0
-
-    if (count <= 1) {
-      registeredCwds.delete(key)
-    } else {
-      registeredCwds.set(key, count - 1)
-    }
-  }
-}
-
-function setRepoStatusEntry(target: string, status: HermesRepoStatus | null): void {
-  const byCwd = $repoStatusByCwd.get()
-
-  // Skip the no-op null→null write so a repeated failed probe doesn't churn
-  // every rail's computed slice.
-  if (target in byCwd && byCwd[target] === status) {
-    return
-  }
-
-  $repoStatusByCwd.set({ ...byCwd, [target]: status })
-}
-
-function setRepoWorktreesEntry(target: string, worktrees: HermesGitWorktree[]): void {
-  const byCwd = $repoWorktreesByCwd.get()
-
-  if (target in byCwd && byCwd[target] === worktrees) {
-    return
-  }
-
-  $repoWorktreesByCwd.set({ ...byCwd, [target]: worktrees })
-}
-
-interface RepoStatusRefreshRequest {
-  probe: (cwd: string) => Promise<HermesRepoStatus | null>
-  seq: number
-  target: string
-}
-
-// Coalesce overlapping probes: many triggers can fire around a turn boundary
-// (busy flip + worktree token + focus), and several worktrees can need a
-// re-probe at once. Keep ONE probe in flight and at most one trailing request
-// per cwd so a slow `git status` cannot multiply into an unbounded subprocess
-// pile-up.
-const seqByCwd = new Map<string, number>()
-const pendingByCwd = new Map<string, RepoStatusRefreshRequest>()
-let repoStatusRefreshInFlight: Promise<void> | null = null
-let repoStatusRefreshTimer: ReturnType<typeof setTimeout> | null = null
-const scheduledCwds = new Set<string>()
-let scheduledAllTargets = false
-
-// A result only lands while it is still the newest request for ITS cwd. The
-// debounce below deliberately delays the next probe; without this live check,
-// an old probe can land during that gap and briefly make a session look like
-// it is on a stale branch.
-const isCurrentSeq = (target: string, seq: number): boolean => seqByCwd.get(target) === seq
-
-async function loadWorktrees(target: string, seq: number): Promise<void> {
+async function loadWorktrees(request: RepoStatusRefreshRequest): Promise<void> {
   const list = desktopGit()?.worktreeList
 
   if (!list) {
-    setRepoWorktreesEntry(target, EMPTY_WORKTREES)
+    if (isCurrentRepoStatusRequest(request)) {
+      $repoWorktrees.set([])
+    }
 
     return
   }
 
   try {
-    const worktrees = await list(target)
+    const worktrees = await list(request.context.cwd)
 
-    if (isCurrentSeq(target, seq)) {
-      setRepoWorktreesEntry(target, worktrees)
+    if (isCurrentRepoStatusRequest(request)) {
+      $repoWorktrees.set(worktrees)
     }
   } catch {
-    if (isCurrentSeq(target, seq)) {
-      setRepoWorktreesEntry(target, EMPTY_WORKTREES)
+    if (isCurrentRepoStatusRequest(request)) {
+      $repoWorktrees.set([])
     }
   }
 }
 
-/**
- * Re-probe the working tree for one cwd. Best-effort: a non-repo, a remote
- * backend, or a missing probe clears that cwd's entry so its rail hides
- * rather than showing stale data.
- */
-async function runRepoStatusRefresh({ probe, seq, target }: RepoStatusRefreshRequest): Promise<void> {
+interface RepoStatusRefreshRequest {
+  context: RepoStatusContext
+  epoch: number
+  probe: (cwd: string) => Promise<HermesRepoStatus | null>
+  seq: number
+}
+
+// Coalesce overlapping probes: many triggers can fire around a turn boundary
+// (busy flip + worktree token + focus), but only the latest active context
+// matters. Keep one probe in flight and retain at most one trailing request so
+// a slow Git status cannot multiply into an unbounded subprocess pile-up.
+let pendingRepoStatusRefresh: RepoStatusRefreshRequest | null = null
+let repoStatusRefreshInFlight: Promise<void> | null = null
+let repoStatusRefreshSeq = 0
+let repoStatusRefreshTimer: ReturnType<typeof setTimeout> | undefined
+
+function isActiveRepoStatusContext(context: RepoStatusContext, epoch: number): boolean {
+  return epoch === repoStatusContextEpoch && contextsMatch(activeRepoStatusContext, context)
+}
+
+function isCurrentRepoStatusRequest(request: RepoStatusRefreshRequest): boolean {
+  return request.seq === repoStatusRefreshSeq && isActiveRepoStatusContext(request.context, request.epoch)
+}
+
+function activateRepoStatusContext(context: null | RepoStatusContext): number {
+  if (contextsMatch(activeRepoStatusContext, context)) {
+    return repoStatusContextEpoch
+  }
+
+  activeRepoStatusContext = context
+  repoStatusContextEpoch += 1
+  pendingRepoStatusRefresh = null
+  $repoStatus.set(null)
+  $repoWorktrees.set([])
+
+  return repoStatusContextEpoch
+}
+
+async function runRepoStatusRefresh(request: RepoStatusRefreshRequest): Promise<void> {
   try {
-    const status = await probe(target)
+    const status = await request.probe(request.context.cwd)
 
-    // Drop the result if a newer refresh for this cwd started while we were
-    // probing — the newer probe owns the entry.
-    if (!isCurrentSeq(target, seq)) {
-      return
-    }
+    // A stale response may finish after the session, cwd, or filesystem backend
+    // changed. Only the latest request for the currently active context owns
+    // the shared coding rail atoms.
+    if (isCurrentRepoStatusRequest(request)) {
+      $repoStatus.set(status)
 
-    setRepoStatusEntry(target, status)
-
-    // Worktrees only matter inside a repo; clear them otherwise.
-    if (status) {
-      void loadWorktrees(target, seq)
-    } else {
-      setRepoWorktreesEntry(target, EMPTY_WORKTREES)
+      // Worktrees only matter inside a repo; clear them otherwise.
+      if (status) {
+        void loadWorktrees(request)
+      } else {
+        $repoWorktrees.set([])
+      }
     }
   } catch {
-    if (isCurrentSeq(target, seq)) {
-      setRepoStatusEntry(target, null)
-      setRepoWorktreesEntry(target, EMPTY_WORKTREES)
+    if (isCurrentRepoStatusRequest(request)) {
+      $repoStatus.set(null)
+      $repoWorktrees.set([])
     }
   }
 }
 
 async function drainRepoStatusRefreshes(): Promise<void> {
-  while (pendingByCwd.size > 0) {
-    const [target, request] = pendingByCwd.entries().next().value as [string, RepoStatusRefreshRequest]
+  while (pendingRepoStatusRefresh) {
+    const request = pendingRepoStatusRefresh
 
-    pendingByCwd.delete(target)
+    pendingRepoStatusRefresh = null
     await runRepoStatusRefresh(request)
   }
 
@@ -315,33 +188,27 @@ async function drainRepoStatusRefreshes(): Promise<void> {
   $repoStatusLoading.set(false)
 }
 
-export function refreshRepoStatus(cwd?: null | string): Promise<void> {
-  const target = normalizeCwd(cwd ?? $currentCwd.get())
+function enqueueRepoStatusRefresh(context: RepoStatusContext, epoch: number): Promise<void> {
+  if (!isActiveRepoStatusContext(context, epoch)) {
+    return Promise.resolve()
+  }
+
   const probe = desktopGit()?.repoStatus
+  const seq = (repoStatusRefreshSeq += 1)
 
   if (!probe) {
-    // Remote backend / no bridge: there is no local git truth at all — wipe
-    // every entry so no rail shows stale local status, and invalidate any
-    // in-flight probe results.
-    pendingByCwd.clear()
-    seqByCwd.clear()
-    $repoStatusByCwd.set({})
-    $repoWorktreesByCwd.set({})
-    $repoStatusLoading.set(false)
+    pendingRepoStatusRefresh = null
+    $repoStatus.set(null)
+    $repoWorktrees.set([])
+
+    if (!repoStatusRefreshInFlight) {
+      $repoStatusLoading.set(false)
+    }
 
     return repoStatusRefreshInFlight || Promise.resolve()
   }
 
-  if (!target) {
-    // No cwd (a detached fresh chat). The primary computed already reads null
-    // for a blank cwd, and other worktrees' entries stay valid.
-    return repoStatusRefreshInFlight || Promise.resolve()
-  }
-
-  const seq = (seqByCwd.get(target) ?? 0) + 1
-
-  seqByCwd.set(target, seq)
-  pendingByCwd.set(target, { probe, seq, target })
+  pendingRepoStatusRefresh = { context, epoch, probe, seq }
   $repoStatusLoading.set(true)
 
   if (!repoStatusRefreshInFlight) {
@@ -351,82 +218,65 @@ export function refreshRepoStatus(cwd?: null | string): Promise<void> {
   return repoStatusRefreshInFlight
 }
 
-/** Registered (on-screen) worktrees + the primary workspace. */
-function refreshTargets(): Set<string> {
-  const targets = new Set(registeredCwds.keys())
-  const primary = normalizeCwd($currentCwd.get())
+/**
+ * Re-probe the working tree for `cwd` (defaults to the active session's cwd).
+ * Best-effort: a non-repo, a remote backend, or a missing probe clears the
+ * status so the rail hides rather than showing stale data.
+ */
+export function refreshRepoStatus(cwd?: null | string): Promise<void> {
+  const context = getRepoStatusContext(cwd ?? $currentCwd.get())
+  const epoch = activateRepoStatusContext(context)
 
-  if (primary) {
-    targets.add(primary)
+  if (!context) {
+    pendingRepoStatusRefresh = null
+    $repoStatus.set(null)
+    $repoWorktrees.set([])
+
+    if (!repoStatusRefreshInFlight) {
+      $repoStatusLoading.set(false)
+    }
+
+    return repoStatusRefreshInFlight || Promise.resolve()
   }
 
-  return targets
+  return enqueueRepoStatusRefresh(context, epoch)
 }
 
-/** Re-probe every on-screen worktree (and the primary). Awaits the drain. */
-export async function refreshAllRepoStatuses(): Promise<void> {
-  const targets = refreshTargets()
+function scheduleRepoStatusRefresh(cwd?: null | string): void {
+  const context = getRepoStatusContext(cwd ?? $currentCwd.get())
 
-  if (targets.size === 0) {
+  // Context moves are a foreground ownership change, not a cosmetic refresh:
+  // clear synchronously so the Composer never paints the old backend/session's
+  // status during the debounce before Git can re-probe.
+  const epoch = activateRepoStatusContext(context)
+
+  clearTimeout(repoStatusRefreshTimer)
+
+  if (!context) {
+    repoStatusRefreshTimer = undefined
+
     return
   }
 
-  // Queue every target, then await the single in-flight drain once.
-  let last: Promise<void> = Promise.resolve()
-
-  for (const target of targets) {
-    last = refreshRepoStatus(target)
-  }
-
-  await last
-}
-
-// `cwd` scopes the refresh to one worktree; omit it to re-probe every
-// on-screen worktree (turn settle, window focus — the tree may have changed
-// under any of them).
-function scheduleRepoStatusRefresh(cwd?: null | string): void {
-  if (cwd === undefined) {
-    scheduledAllTargets = true
-  } else {
-    const key = normalizeCwd(cwd)
-
-    if (key) {
-      scheduledCwds.add(key)
-    }
-  }
-
-  if (repoStatusRefreshTimer) {
-    clearTimeout(repoStatusRefreshTimer)
-  }
-
   repoStatusRefreshTimer = setTimeout(() => {
-    repoStatusRefreshTimer = null
-    const targets = new Set(scheduledCwds)
+    repoStatusRefreshTimer = undefined
 
-    if (scheduledAllTargets) {
-      for (const target of refreshTargets()) {
-        targets.add(target)
-      }
-    }
-
-    scheduledCwds.clear()
-    scheduledAllTargets = false
-
-    for (const target of targets) {
-      void refreshRepoStatus(target)
-    }
+    // The timer represents the context that scheduled it. Do not turn an old
+    // cwd back into a current request after a newer context already took over.
+    void enqueueRepoStatusRefresh(context, epoch)
   }, REPO_STATUS_REFRESH_DEBOUNCE_MS)
 }
 
 // ── Triggers ─────────────────────────────────────────────────────────────────
 // Wired once at module load (mirrors projects.ts's module-scope subscriptions).
-// Each is a structural edge where a working tree may have changed under us.
+// Each is a structural edge where the working tree may have changed under us.
 
-// The active session's cwd changed (session switch / new chat) → the primary
-// computed re-keys instantly (a keyboard action in the switch-to-probe gap can
-// only ever see the NEW repo's last-known facts, never the previous
-// worktree's), then the debounced probe refreshes that repo's truth.
+// The active session's cwd changed (session switch / new chat) → re-probe.
 $currentCwd.subscribe(cwd => scheduleRepoStatusRefresh(cwd))
+
+// The same path can be served by another profile/backend. Match the filesystem
+// cache identity so a remote profile's status cannot leak through the shared rail.
+$connection.subscribe(() => scheduleRepoStatusRefresh())
 
 // Switching sessions can land on the same cwd but a different checked-out
 // branch (the agent ran `git checkout` in another session's terminal). The cwd
@@ -440,9 +290,7 @@ $selectedStoredSessionId.subscribe(() => scheduleRepoStatusRefresh())
 $worktreeRefreshToken.subscribe(() => scheduleRepoStatusRefresh())
 
 // A file-mutating tool finished (event-driven, not polled) → re-probe so the
-// rails' branch/+/- move exactly when an agent touches a tree. Unscoped on
-// purpose: the tool may belong to a background tile's session, so every
-// on-screen worktree re-probes, not just the primary.
+// rail's branch/+/- move exactly when the agent touches the tree.
 $workspaceChangeTick.subscribe(() => scheduleRepoStatusRefresh())
 
 // A turn settling is the backstop for changes no tool diff announced (e.g. a
@@ -457,69 +305,8 @@ $busy.subscribe(busy => {
   prevBusy = busy
 })
 
-// Window focus: external changes while we were away (an outside terminal).
+// External changes while the window was away (an outside terminal) — refresh on
+// refocus, the git-GUI standard.
 if (typeof window !== 'undefined') {
   window.addEventListener('focus', () => scheduleRepoStatusRefresh())
-}
-
-/** Test-only: drop in-flight / pending / registered state so cases don't leak. */
-export function _resetCodingStatusForTests(): void {
-  if (repoStatusRefreshTimer) {
-    clearTimeout(repoStatusRefreshTimer)
-    repoStatusRefreshTimer = null
-  }
-
-  scheduledCwds.clear()
-  scheduledAllTargets = false
-  pendingByCwd.clear()
-  seqByCwd.clear()
-  registeredCwds.clear()
-  repoStatusRefreshInFlight = null
-  $repoStatusByCwd.set({})
-  $repoWorktreesByCwd.set({})
-  $repoStatusLoading.set(false)
-}
-
-// ── New-worktree target resolution ───────────────────────────────────────────
-// This code lives here and not in projects.ts. To pick the target, it must read
-// both the project state and the git truth, and coding-status already depends
-// on projects. A dependency in the other direction is a cycle.
-
-// The repo that a new worktree is cut from: the cwd of the focused surface, or
-// the root of the project the user entered. Both are things the user points at.
-// There is no "use some other project's repo" step, because that branches
-// somewhere the user never selected.
-//
-// A project root is not always a repo, so existence alone is not proof. Each
-// candidate is validated against the probe cache. This function is the only
-// authority on the target, so the hotkey no longer tests `$repoStatus` first,
-// and ⌘⇧B now works from a detached session inside a project. '' means that no
-// repo is in reach. That is a no-op and not an error, because a worktree only
-// exists inside a repo.
-export async function resolveWorktreeRepoPath(): Promise<string> {
-  const runtimeId = $focusedRuntimeId.get()
-  const scope = $projectScope.get()
-
-  const candidates = [
-    runtimeId ? ($sessionStates.get()[runtimeId]?.cwd ?? '') : '',
-    scope === ALL_PROJECTS ? '' : projectRootCwd($projectTree.get().find(node => node.id === scope))
-  ]
-
-  for (const candidate of candidates) {
-    const path = candidate.trim()
-
-    if (path && (await isGitRepoPath(path))) {
-      return path
-    }
-  }
-
-  return ''
-}
-
-export async function openWorktreeDialog(options?: { base?: string; repoPath?: string }): Promise<void> {
-  const repoPath = options?.repoPath?.trim() || (await resolveWorktreeRepoPath())
-
-  if (repoPath) {
-    $worktreeDialog.set({ base: options?.base, repoPath })
-  }
 }


### PR DESCRIPTION
## Summary
- Bind Composer coding-status ownership to the active filesystem backend, normalized cwd, and stored session identity.
- Clear status, worktrees, and file-change tints synchronously on a context transition; fence delayed status/worktree responses and delayed debounce callbacks with a context epoch.
- Reset and fence branch/base picker async state when a worktree dialog changes repository context.

## Reproduction fixed
Before this change, rapidly switching from `/repo-a` to `/repo-b` could show `feature/a` for the 100 ms debounce interval:

```console
active_cwd=/repo-b
during_b_debounce=feature/a
after_b_probe=feature/b
```

The regression probe now returns:

```console
active_cwd=/repo-b
during_b_debounce=undefined
after_b_probe=feature/b
```

## Verification
- `npm run test:ui -- src/store/coding-status.test.ts src/app/chat/sidebar/projects/base-branch-picker.test.tsx src/app/chat/sidebar/projects/worktree-dialog.test.tsx` — 3 files / 16 tests passed
- Focused ESLint over all six changed source/test files — passed
- Independent review — ACCEPT
- `git diff --check` — passed

## Existing baseline failures
- Full `npm run lint` currently fails on `origin/main` as well, in `electron/main.ts` and `electron/native-oauth-login.ts`; this PR does not touch them.
- `npm run typecheck` reports 105 existing diagnostics in unrelated files from unavailable `@assistant-ui/*` modules; none name files changed by this PR.
