### PR TITLE
fix(desktop): make sidebar workspace session creation best-effort on branch switch

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
@@ -1,0 +1,106 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SidebarWorkspaceGroup } from './workspace-group'
+import type { SidebarSessionGroup } from './workspace-groups'
+
+const mockSwitchBranchInRepo = vi.fn()
+
+afterEach(cleanup)
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        newSessionIn: (label: string) => `New session in ${label}`,
+        noSessions: 'No sessions yet',
+        projects: {
+          menu: 'Project actions'
+        }
+      },
+      statusStack: {
+        coding: {
+          switchFailed: (branch: string) => `Could not switch to ${branch}`
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/projects', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store/projects')>()
+
+  return {
+    ...actual,
+    switchBranchInRepo: (...args: unknown[]) => mockSwitchBranchInRepo(...args)
+  }
+})
+
+vi.mock('@/store/profile', () => ({
+  newSessionInProfile: vi.fn()
+}))
+
+vi.mock('./model', () => ({
+  SIDEBAR_GROUP_PAGE: 10,
+  useWorkspaceNodeOpen: () => [true, vi.fn()]
+}))
+
+describe('SidebarWorkspaceGroup', () => {
+  it('calls onNewSession even if switchBranchInRepo fails (best-effort branch switch)', async () => {
+    mockSwitchBranchInRepo.mockRejectedValue(new Error('fatal: not a git repository'))
+    const onNewSession = vi.fn()
+
+    const group: SidebarSessionGroup = {
+      id: '/repo::branch::main',
+      isMain: true,
+      label: 'main',
+      path: '/repo',
+      sessions: []
+    }
+
+    render(
+      <SidebarWorkspaceGroup
+        group={group}
+        onNewSession={onNewSession}
+        renderRows={() => null}
+      />
+    )
+
+    const addButton = screen.getByRole('button', { name: 'New session in main' })
+    fireEvent.click(addButton)
+
+    await waitFor(() => {
+      expect(mockSwitchBranchInRepo).toHaveBeenCalledWith('/repo', 'main')
+      expect(onNewSession).toHaveBeenCalledWith('/repo')
+    })
+  })
+
+  it('calls onNewSession when switchBranchInRepo succeeds', async () => {
+    mockSwitchBranchInRepo.mockResolvedValue(undefined)
+    const onNewSession = vi.fn()
+
+    const group: SidebarSessionGroup = {
+      id: '/repo::branch::main',
+      isMain: true,
+      label: 'main',
+      path: '/repo',
+      sessions: []
+    }
+
+    render(
+      <SidebarWorkspaceGroup
+        group={group}
+        onNewSession={onNewSession}
+        renderRows={() => null}
+      />
+    )
+
+    const addButton = screen.getByRole('button', { name: 'New session in main' })
+    fireEvent.click(addButton)
+
+    await waitFor(() => {
+      expect(mockSwitchBranchInRepo).toHaveBeenCalledWith('/repo', 'main')
+      expect(onNewSession).toHaveBeenCalledWith('/repo')
+    })
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
@@ -80,14 +80,13 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
 
     // Main-checkout lanes are branch-labeled views over the same repo root path.
     // Clicking "+" on `main` should open on `main`, not whatever branch the root
-    // currently sits on (`test0`, etc.), so explicitly switch first.
+    // currently sits on (`test0`, etc.), so explicitly try to switch first.
     if (group.isMain && group.path && group.label) {
       try {
         await switchBranchInRepo(group.path, group.label)
-      } catch (err) {
-        notifyError(err, t.statusStack.coding.switchFailed(group.label))
-
-        return
+      } catch {
+        // Branch switch is best-effort (e.g. non-git directory, dirty tree, or
+        // label is not a valid branch); proceed to open the new session regardless.
       }
     }
 


### PR DESCRIPTION
### Description

When creating a new session via the desktop sidebar + button on a main checkout lane (`WorkspaceAddButton`), `handleNewSession` attempts to switch the working copy branch (`switchBranchInRepo`).

Previously, if `switchBranchInRepo` failed (for example on non-git project folders, dirty working copies, or custom lane labels), the caught exception displayed a error toast (`Could not switch to <branch>`) and executed an early return. This aborted the session creation (`onNewSession`), leaving the user unable to create a new session in that workspace.

### Solution

This change wraps the branch switch call in a best-effort try/catch block so that `onNewSession(group.path)` always executes whether the git branch switch succeeds or fails. Added unit tests for both success and error cases in `workspace-group.test.tsx`.