### PR TITLE
feat: per-job profile override for cron scheduler (multiplex support)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1087,6 +1087,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    profile: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1131,6 +1132,11 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        profile: Optional profile name for multiplex mode. When set, the job
+                runs under that profile's HERMES_HOME — loading the correct
+                SOUL.md, config.yaml, .env credentials, skills, and memory
+                instead of the default profile's. No-op for single-profile
+                gateways.
 
     Returns:
         The created job dict
@@ -1163,6 +1169,8 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    normalized_profile = str(profile).strip() if isinstance(profile, str) else None
+    normalized_profile = normalized_profile or None
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1252,6 +1260,7 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "profile": normalized_profile,
     }
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3750,6 +3750,49 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # becomes running only immediately before the actual run.
         mark_execution_running(execution_id)
 
+        # ── Per-job profile override (multiplex support) ──────────────
+        # Under gateway.multiplex_profiles, the cron ticker runs inside the
+        # default profile's gateway process. Without a per-job override, every
+        # job loads the default profile's SOUL.md, config.yaml, .env secrets,
+        # skills, and Hindsight bank — even if the job logically belongs to a
+        # different agent profile.
+        #
+        # When a job carries a ``profile`` field (e.g. ``"profile": "antu"``),
+        # we install the same ``set_hermes_home_override`` + ``set_secret_scope``
+        # pair the multiplexer uses for inbound message routing
+        # (gateway/run.py::_profile_runtime_scope). This makes SOUL.md, config,
+        # credentials, skills, and memory resolve to the job's own profile for
+        # the duration of this run.
+        #
+        # Jobs without ``profile`` are unaffected (single-profile gateways, or
+        # default-profile jobs under multiplex) — ``_get_hermes_home()`` still
+        # resolves to the process-wide HERMES_HOME as before.
+        _job_profile = (job.get("profile") or "").strip()
+        _home_override_token = None
+        if _job_profile:
+            from pathlib import Path as _Path
+            from hermes_constants import set_hermes_home_override as _set_override
+            _profile_home = _Path(_get_hermes_home().anchor) / "root" / ".hermes" / "profiles" / _job_profile
+            # Fallback: derive from the default profile root
+            if not _profile_home.is_dir():
+                _default_root = _get_hermes_home()
+                while _default_root.name != ".hermes" and _default_root.parent != _default_root:
+                    _default_root = _default_root.parent
+                if _default_root.name == ".hermes":
+                    _profile_home = _default_root / "profiles" / _job_profile
+            if _profile_home.is_dir():
+                _home_override_token = _set_override(str(_profile_home))
+                logger.info(
+                    "Job '%s': running under profile '%s' (%s)",
+                    job.get("name", job["id"]), _job_profile, _profile_home,
+                )
+            else:
+                logger.warning(
+                    "Job '%s': profile '%s' home not found at %s — "
+                    "falling back to default profile",
+                    job.get("name", job["id"]), _job_profile, _profile_home,
+                )
+
         # Run the job under the profile's secret scope. get_secret() fails
         # closed outside a scope once profile isolation is in play (multiple
         # gateway profiles / room→profile multiplexing), and cron fires from
@@ -3789,6 +3832,9 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             raise
         finally:
             reset_secret_scope(_scope_token)
+            if _home_override_token is not None:
+                from hermes_constants import reset_hermes_home_override as _reset_override
+                _reset_override(_home_override_token)
 
         # Everything from here through delivery runs with the agent still live
         # (deferred teardown). Wrap it ALL in a try/finally so that if any step

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -598,6 +598,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("profile"):
+        result["profile"] = job["profile"]
     return result
 
 
@@ -677,6 +679,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    profile: Optional[str] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -750,6 +753,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                profile=_normalize_optional_job_value(profile),
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -927,6 +931,9 @@ def cronjob(
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
                 updates["workdir"] = _normalize_optional_job_value(workdir) or None
+            if profile is not None:
+                # Empty string clears the field; otherwise set the profile name.
+                updates["profile"] = _normalize_optional_job_value(profile) or None
             if no_agent is not None:
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
@@ -1085,6 +1092,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "profile": {
+                "type": "string",
+                "description": "Optional profile name for gateway.multiplex_profiles mode. When set (e.g. 'antu'), the job runs under that profile's HERMES_HOME — loading the correct SOUL.md identity, config.yaml, .env credentials, skills, and memory bank instead of the default profile's. No-op for single-profile gateways. On update, pass an empty string to clear."
+            },
         },
         "required": ["action"]
     }
@@ -1140,6 +1151,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        profile=args.get("profile"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
## Summary

Under `gateway.multiplex_profiles`, the cron ticker runs inside the default profile's gateway process. Every job — regardless of which agent profile it logically belongs to — loads the default profile's SOUL.md, config.yaml, .env credentials, skills, and memory bank. This means agent-driven cron jobs lose their identity, credentials, and memory context.

This PR adds an optional `profile` field to cron jobs. When set, the scheduler installs the same `set_hermes_home_override` + `set_secret_scope` pair the multiplexer already uses for inbound message routing (`gateway/run.py::_profile_runtime_scope`).

## Problem

When running a multiplexed gateway (one process serving multiple profiles):

1. **Agent identity lost** — a job belonging to profile "antu" loads the default profile's generic SOUL.md instead of Antu's identity
2. **Credentials wrong** — jobs read the default profile's `.env` instead of their own profile's API keys, OAuth tokens, etc.
3. **Skills misconfigured** — profile-specific `skills.external_dirs` in config.yaml are ignored
4. **Memory isolated** — Hindsight memory bank resolves to the default profile (empty), not the job's profile
5. **no_agent scripts** — scripts resolve against the default profile's `scripts/` directory, not the job's own profile

## Solution

Add a `profile` field to the cron job schema:

```json
{
  "id": "abc123",
  "name": "Ops Morning Briefing",
  "profile": "antu",
  "schedule": {"kind": "cron", "expr": "0 7 * * *"},
  "prompt": "Produce the morning ops brief..."
}
```

When `profile` is set, `run_one_job()` in `cron/scheduler.py`:
1. Resolves the profile's HERMES_HOME (`~/.hermes/profiles/<profile>`)
2. Calls `set_hermes_home_override(profile_home)` — redirects SOUL.md, config.yaml, skills, memory
3. Calls `set_secret_scope()` (already present) — now reads the correct profile's `.env`
4. Resets both in the `finally` block

## Changes

| File | Change |
|---|---|
| `cron/scheduler.py` | `run_one_job()` — install `set_hermes_home_override` before secret scope, reset in finally |
| `cron/jobs.py` | `create_job()` — accept and persist `profile` field |
| `tools/cronjob_tools.py` | Expose `profile` in tool schema, create handler, update handler, and `_format_job` output |

## Backward Compatibility

- Jobs without `profile` are completely unaffected (single-profile gateways, default-profile jobs under multiplex)
- The `profile` field is optional at both the JSON and API level
- Existing `jobs.json` files work as-is (missing field = default behavior)

## Testing

- Syntax-checked all 3 modified files
- Running in production on a 9-profile multiplexer
- `_profile_runtime_scope` is the same mechanism the multiplexer uses for every inbound message (battle-tested)