### PR TITLE
fix(agent): scope parallel batches from V4A patch headers

### DIFF
--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -4,9 +4,10 @@ Pure module-level utilities extracted from ``run_agent.py``:
 
 * ``_is_destructive_command`` — terminal-command heuristic used to gate
   parallel batch dispatch.
-* ``_should_parallelize_tool_batch`` / ``_extract_parallel_scope_path`` /
-  ``_paths_overlap`` — the rules engine deciding when a multi-tool batch
-  can run concurrently.
+* ``_should_parallelize_tool_batch`` / ``_extract_parallel_scope_paths`` /
+  ``_extract_parallel_scope_path`` / ``_paths_overlap`` — the rules engine
+  deciding when a multi-tool batch can run concurrently (V4A patch scope
+  uses patch-body file headers, not a decoy ``path=``).
 * ``_is_multimodal_tool_result`` / ``_multimodal_text_summary`` /
   ``_append_subdir_hint_to_multimodal`` — envelope helpers for the
   ``{"_multimodal": True, "content": [...], "text_summary": ...}`` dict
@@ -117,9 +118,11 @@ def _plan_tool_batch_segments(tool_calls, *, execution_cwd: Optional[Path] = Non
     * ``_NEVER_PARALLEL_TOOLS`` (interactive tools) → barrier.
     * Unparseable / non-dict arguments → barrier.
     * Path-scoped tools (``read_file``/``write_file``/``patch``) join a
-      parallel run only when their target path does not overlap another
+      parallel run only when their target path(s) do not overlap another
       path already reserved in the same run; an overlap closes the run so
       the conflicting call starts a NEW run after the first completes.
+      For V4A ``patch(mode="patch")`` the reserved paths are the file
+      headers in the patch body, not a possibly-stale ``path=`` argument.
     * Anything not in ``_PARALLEL_SAFE_TOOLS`` and not an opted-in MCP
       tool → barrier.
 
@@ -173,15 +176,21 @@ def _plan_tool_batch_segments(tool_calls, *, execution_cwd: Optional[Path] = Non
             continue
 
         if tool_name in _PATH_SCOPED_TOOLS:
-            scoped_path = _extract_parallel_scope_path(tool_name, function_args, execution_cwd=execution_cwd)
-            if scoped_path is None:
+            scoped_paths = _extract_parallel_scope_paths(
+                tool_name, function_args, execution_cwd=execution_cwd
+            )
+            if not scoped_paths:
                 _add_sequential(tool_call)
                 continue
-            if any(_paths_overlap(scoped_path, existing) for existing in reserved_paths):
+            if any(
+                _paths_overlap(scoped_path, existing)
+                for scoped_path in scoped_paths
+                for existing in reserved_paths
+            ):
                 # Same-subtree conflict inside this run: close it so this
                 # call starts a fresh run AFTER the conflicting one lands.
                 _close_parallel()
-            reserved_paths.append(scoped_path)
+            reserved_paths.extend(scoped_paths)
             current.append(tool_call)
             continue
 
@@ -233,33 +242,70 @@ def _canonical_path(raw_path: str, execution_cwd: Optional[Path] = None) -> Path
     return Path(resolved)
 
 
-def _extract_parallel_scope_path(
+def _extract_parallel_scope_paths(
     tool_name: str,
     function_args: dict,
     execution_cwd: Optional[Path] = None,
-) -> Optional[Path]:
-    """Return the canonical file target for path-scoped tools.
+) -> List[Path]:
+    """Return every canonical path this call reserves for overlap checks.
 
     *execution_cwd* should be the working directory that the tool will
     actually use at runtime.  When omitted the process cwd is used,
     which may differ from the tool execution environment on some
     platforms (e.g. WSL, sandboxed sub-processes).
+
+    For ``patch`` in V4A ``mode=patch``, scope comes from patch-body
+    ``*** Update/Add/Delete/Move File:`` headers (not a possibly-decoy
+    ``path=``).  An empty result means the planner cannot determine the
+    scope and must treat the call as a sequential barrier.
     """
     if tool_name not in _PATH_SCOPED_TOOLS:
-        return None
+        return []
 
-    raw_path = function_args.get("path")
-    if not isinstance(raw_path, str) or not raw_path.strip():
-        return None
+    raw_paths: List[str] = []
+    if tool_name == "patch" and (function_args.get("mode") or "replace") == "patch":
+        raw_paths.extend(_extract_file_mutation_targets(tool_name, function_args))
+    else:
+        raw_path = function_args.get("path")
+        if isinstance(raw_path, str) and raw_path.strip():
+            raw_paths.append(raw_path)
 
-    return _canonical_path(raw_path, execution_cwd)
+    scoped: List[Path] = []
+    seen: set[str] = set()
+    for raw in raw_paths:
+        if not isinstance(raw, str) or not raw.strip():
+            continue
+        canonical = _canonical_path(raw, execution_cwd)
+        key = str(canonical)
+        if key in seen:
+            continue
+        seen.add(key)
+        scoped.append(canonical)
+    return scoped
+
+
+def _extract_parallel_scope_path(
+    tool_name: str,
+    function_args: dict,
+    execution_cwd: Optional[Path] = None,
+) -> Optional[Path]:
+    """Return the primary canonical file target for path-scoped tools.
+
+    Thin view over ``_extract_parallel_scope_paths`` kept for callers/tests
+    that only need a single representative path.  For multi-file V4A
+    patches this is the first header target.
+    """
+    scoped = _extract_parallel_scope_paths(
+        tool_name, function_args, execution_cwd=execution_cwd
+    )
+    return scoped[0] if scoped else None
 
 
 def _paths_overlap(left: Path, right: Path) -> bool:
     """Return True when two paths may refer to the same subtree.
 
     Both *left* and *right* must already be canonical (as returned by
-    ``_extract_parallel_scope_path`` / ``_canonical_path``) so that
+    ``_extract_parallel_scope_paths`` / ``_canonical_path``) so that
     symlink aliases and case differences are already normalised.
     """
     left_parts = left.parts
@@ -354,8 +400,10 @@ def _extract_file_mutation_targets(tool_name: str, args: Dict[str, Any]) -> List
         if not isinstance(body, str) or not body:
             return []
         paths: List[str] = []
+        # ``\s*`` (not ``\s+``) after ``***`` matches patch_parser / file_tools:
+        # they accept ``***Update File:`` with no space after the asterisks.
         for _m in re.finditer(
-            r'^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)$',
+            r'^\*\*\*\s*(?:Update|Add|Delete)\s+File:\s*(.+)$',
             body,
             re.MULTILINE,
         ):
@@ -363,7 +411,7 @@ def _extract_file_mutation_targets(tool_name: str, args: Dict[str, Any]) -> List
             if p:
                 paths.append(p)
         for _m in re.finditer(
-            r'^\*\*\*\s+Move\s+File:\s*(.+?)\s*->\s*(.+)$',
+            r'^\*\*\*\s*Move\s+File:\s*(.+?)\s*->\s*(.+)$',
             body,
             re.MULTILINE,
         ):
@@ -641,6 +689,7 @@ __all__ = [
     "_should_parallelize_tool_batch",
     "_canonical_path",
     "_extract_parallel_scope_path",
+    "_extract_parallel_scope_paths",
     "_paths_overlap",
     "_is_multimodal_tool_result",
     "_multimodal_text_summary",

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -89,6 +89,13 @@ class TestExtractFileMutationTargets:
         assert _extract_file_mutation_targets("patch", {"mode": "patch"}) == []
         assert _extract_file_mutation_targets("patch", {"mode": "patch", "patch": ""}) == []
 
+    def test_patch_v4a_accepts_no_space_after_asterisks(self):
+        """Match patch_parser / file_tools: ``***Update File:`` (no space)."""
+        body = "***Update File: nospace.py\n"
+        assert _extract_file_mutation_targets(
+            "patch", {"mode": "patch", "patch": body}
+        ) == ["nospace.py"]
+
 
 # ---------------------------------------------------------------------------
 # _extract_error_preview

--- a/tests/run_agent/test_tool_batch_segmentation.py
+++ b/tests/run_agent/test_tool_batch_segmentation.py
@@ -153,6 +153,98 @@ class TestPlanToolBatchSegments:
         # Order and completeness preserved.
         assert _flatten_ids(segments) == ["w1", "r1", "w2", "r2"]
 
+    def test_v4a_decoy_path_does_not_parallelize_with_real_target(self, tmp_path):
+        """mode=patch scopes via V4A headers, not a decoy path= argument.
+
+        A patch that claims path=dummy.txt but updates real.py must not share
+        a parallel segment with write_file/read_file on real.py.
+        """
+        patch_body = (
+            "*** Begin Patch\n"
+            "*** Update File: real.py\n"
+            "@@\n"
+            "-old\n"
+            "+new\n"
+            "*** End Patch\n"
+        )
+        patch_args = json.dumps({
+            "mode": "patch",
+            "path": "dummy.txt",
+            "patch": patch_body,
+        })
+        calls = [
+            _tc("patch", patch_args, call_id="p1"),
+            _tc("write_file", '{"path":"real.py","content":"x"}', call_id="w1"),
+        ]
+        segments = _plan_tool_batch_segments(calls, execution_cwd=tmp_path)
+        assert _flatten_ids(segments) == ["p1", "w1"]
+        # Overlap on real.py must prevent a single parallel segment.
+        assert not (
+            len(segments) == 1
+            and segments[0][0] == "parallel"
+            and [tc.id for tc in segments[0][1]] == ["p1", "w1"]
+        )
+        # Solo runs demote to sequential and may merge; either shape is safe.
+        if len(segments) == 1:
+            assert segments[0][0] == "sequential"
+        else:
+            assert [tc.id for tc in segments[0][1]] == ["p1"]
+            assert [tc.id for tc in segments[1][1]] == ["w1"]
+
+    def test_v4a_multi_file_reserves_all_header_targets(self, tmp_path):
+        """Multi-file V4A must reserve every Update/Add/Delete/Move target."""
+        patch_body = (
+            "*** Begin Patch\n"
+            "*** Update File: a.py\n"
+            "@@\n-a\n+b\n"
+            "*** Add File: b.py\n"
+            "+fresh\n"
+            "*** End Patch\n"
+        )
+        # Honest path= only names a.py — b.py still must be reserved.
+        patch_args = json.dumps({
+            "mode": "patch",
+            "path": "a.py",
+            "patch": patch_body,
+        })
+        calls = [
+            _tc("patch", patch_args, call_id="p1"),
+            _tc("read_file", '{"path":"b.py"}', call_id="r1"),
+        ]
+        segments = _plan_tool_batch_segments(calls, execution_cwd=tmp_path)
+        assert _flatten_ids(segments) == ["p1", "r1"]
+        assert not (
+            len(segments) == 1
+            and segments[0][0] == "parallel"
+            and [tc.id for tc in segments[0][1]] == ["p1", "r1"]
+        )
+        if len(segments) == 1:
+            assert segments[0][0] == "sequential"
+        else:
+            assert [tc.id for tc in segments[0][1]] == ["p1"]
+            assert [tc.id for tc in segments[1][1]] == ["r1"]
+
+    def test_v4a_without_path_arg_still_scopes_from_headers(self, tmp_path):
+        """mode=patch with no path= must still parallel-scope from V4A headers."""
+        patch_body = (
+            "*** Begin Patch\n"
+            "*** Update File: real.py\n"
+            "@@\n-old\n+new\n"
+            "*** End Patch\n"
+        )
+        patch_args = json.dumps({"mode": "patch", "patch": patch_body})
+        calls = [
+            _tc("patch", patch_args, call_id="p1"),
+            _tc("write_file", '{"path":"other.py","content":"x"}', call_id="w1"),
+            _tc("read_file", '{"path":"real.py"}', call_id="r1"),
+        ]
+        segments = _plan_tool_batch_segments(calls, execution_cwd=tmp_path)
+        # p1+w1 are disjoint → can share a parallel run; r1 overlaps real.py → new run.
+        assert _flatten_ids(segments) == ["p1", "w1", "r1"]
+        assert [tc.id for tc in segments[0][1]] == ["p1", "w1"]
+        assert segments[0][0] == "parallel"
+        assert [tc.id for tc in segments[1][1]] == ["r1"]
+
     def test_path_scoped_tool_without_path_is_a_barrier(self):
         calls = [
             _tc("read_file", "{}", call_id="nopath"),


### PR DESCRIPTION
## What does this PR do?

Fixes a race in the parallel tool-batch planner: `patch(mode="patch")` reserved scope only from `args["path"]`, ignoring V4A body headers (`*** Update/Add/Delete/Move File:`). A decoy or partial `path=` could place the patch in the same parallel segment as `read_file`/`write_file`/`patch` on the real targets, defeating the path-overlap barrier (CWE-362).

Also aligns the V4A header regex in `_extract_file_mutation_targets` with `file_tools`/`patch_parser` (`\s*` after `***`) so no-space headers like `***Update File:` are tracked.

## Bug cause

`_plan_tool_batch_segments` used `_extract_parallel_scope_path`, which only read `function_args["path"]`. For V4A patches the real targets live in the patch body; `_extract_file_mutation_targets` already parsed those headers for the mutation verifier but the planner never called it.

## How to reproduce

```python
import json
from pathlib import Path
from types import SimpleNamespace
from agent.tool_dispatch_helpers import _plan_tool_batch_segments

def tc(name, args, cid):
    return SimpleNamespace(id=cid, function=SimpleNamespace(name=name, arguments=json.dumps(args)))

tmp = Path(".").resolve()
calls = [
    tc("patch", {
        "mode": "patch",
        "path": "dummy.txt",
        "patch": "*** Begin Patch\n*** Update File: real.py\n@@\n-old\n+new\n*** End Patch\n",
    }, "p1"),
    tc("write_file", {"path": "real.py", "content": "x"}, "w1"),
]
print(_plan_tool_batch_segments(calls, execution_cwd=tmp))
# Before: single parallel segment [p1, w1]
# After: not concurrent on real.py (sequential / split)
```

## Fix

- Add `_extract_parallel_scope_paths`: for `mode=patch`, reserve all V4A header targets; otherwise keep `path=`.
- Planner `extend`s all reserved paths and closes the parallel run on any overlap.
- Empty V4A targets → sequential barrier.
- Regex `\s+` → `\s*` for Update/Add/Delete/Move headers.

## Related Issue

N/A (internal finding BUG-TDH-1 / BUG-TDH-2). Sibling of #41515 (checkpoint looks at `path=` for V4A) — different call site.

## Type of Change

- [x] Bug fix

## Changes Made

- `agent/tool_dispatch_helpers.py`: multi-path V4A scope for parallel planner; regex alignment
- `tests/run_agent/test_tool_batch_segmentation.py`: decoy path / multi-file / no-path V4A cases
- `tests/run_agent/test_file_mutation_verifier.py`: no-space header case

## How to Test

```bash
scripts/run_tests.sh tests/agent/test_tool_dispatch_helpers.py tests/run_agent/test_tool_batch_segmentation.py tests/run_agent/test_file_mutation_verifier.py -q
```

## Checklist

- [x] Tested on Linux
- [x] Tested on Windows
- [x] Added/updated tests
- [x] Docs updated (N/A — internal planner behavior)
- [x] CHANGELOG updated (N/A — bugfix PR)
