### PR TITLE
fix(file_tools): normalize path separator before device-path blocklist compare (#69373)

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -990,3 +990,33 @@ class TestWriteInvalidatesDedup(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+
+class TestWindowsBlocklistSeparatorNormalize:
+    """Regression for #69373: Windows ``os.path.normpath`` preserves backslashes
+    (``\\dev\\zero``) which never match the POSIX strings in
+    ``_BLOCKED_DEVICE_PATHS``. The fix normalises to forward slashes before
+    the blocklist compare so the check is cross-platform.
+    """
+
+    def test_normalize_for_blocklist_uses_forward_slashes(self):
+        from tools.file_tools import _normalize_for_blocklist
+        result = _normalize_for_blocklist("/dev/zero")
+        assert result == "/dev/zero", f"expected /dev/zero, got {result!r}"
+
+    def test_windows_normpath_matches_posix_blocklist(self):
+        from tools.file_tools import _is_blocked_device_path
+        assert _is_blocked_device_path("/dev/zero") is True
+
+    def test_windows_normpath_matches_proc_blocklist(self):
+        from tools.file_tools import _is_blocked_device_path
+        assert _is_blocked_device_path("/proc/self/environ") is True
+        assert _is_blocked_device_path("/proc/1/fd/0") is True
+
+    def test_windows_realpath_recheck_normalizes(self):
+        from tools.file_tools import _is_blocked_device_path
+        if os.path.exists("/dev/zero"):
+            from os.path import realpath
+            resolved = realpath("/dev/zero")
+            assert _is_blocked_device_path(resolved) is True

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -132,6 +132,22 @@ def _truncate_to_char_budget(content: str, max_chars: int) -> tuple[str, int, bo
 # range (limit <= 200), we include a hint encouraging targeted reads.
 _LARGE_FILE_HINT_BYTES = 512_000  # 512 KB
 
+
+def _normalize_for_blocklist(path: str) -> str:
+    """Normalize to POSIX form for device-path blocklist comparison.
+
+    On Windows, ``os.path.normpath`` preserves backslashes, so ``/dev/zero``
+    becomes ``\\dev\\zero`` — which never matches the POSIX strings in
+    ``_BLOCKED_DEVICE_PATHS`` (nor the ``startswith("/proc/")`` checks).
+    That made the entire device/fd/proc read-guard a silent no-op on
+    Windows, including the ``/proc/*/environ`` secret-leak family added
+    for #4427, and let ``read_file(/dev/zero)`` hang via Git Bash's MSYS
+    ``/dev/zero`` emulation.  Convert to forward slashes after normpath so
+    the comparison is cross-platform (#69373).
+    """
+    return os.path.normpath(path).replace(os.sep, "/")
+
+
 # ---------------------------------------------------------------------------
 # Device path blocklist — reading these hangs the process (infinite output
 # or blocking on input).  Checked by path only (no I/O).
@@ -441,7 +457,7 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
 
 def _is_blocked_device_path(path: str) -> bool:
     """Return True for concrete device/fd paths that can hang reads."""
-    normalized = os.path.normpath(_expand_tilde(path))
+    normalized = _normalize_for_blocklist(_expand_tilde(path))
     if normalized in _BLOCKED_DEVICE_PATHS:
         return True
     # /proc/self/fd/0-2 and /proc/<pid>/fd/0-2 are Linux aliases for stdio


### PR DESCRIPTION
## Summary

`_is_blocked_device_path()` normalizes with `os.path.normpath` and compares against POSIX strings. On Windows, `normpath("/dev/zero")` returns `"\dev\zero"` (backslashes) which never matches the POSIX `"/dev/zero"`. The same applies to the `startswith("/proc/")` checks. The entire device/fd/proc read-guard was a silent no-op on Windows, and `read_file("/dev/zero")` genuinely hung via Git Bash's MSYS `/dev/zero` emulation.

## Fix

Add `_normalize_for_blocklist()` helper that converts to forward slashes after `os.path.normpath`, then use it in `_is_blocked_device_path()`. The fix is cross-platform (same code path on all platforms, no platform-specific branches).

## Files touched

- `tools/file_tools.py` — add `_normalize_for_blocklist()` helper + one-line change in `_is_blocked_device_path()`
- `tests/tools/test_file_read_guards.py` — add `TestWindowsBlocklistSeparatorNormalize` with 4 regression tests

## Test plan

```bash
cd /c/Users/admin/AppData/Local/hermes/hermes-agent
./venv/Scripts/python.exe -m pytest tests/tools/test_file_read_guards.py::TestWindowsBlocklistSeparatorNormalize -v
# 4 passed in 0.79s
```

## What this does NOT do

- **No** change to the blocklist contents — only the comparison path
- **No** platform-specific branches — the fix is one-line normalization that works identically on all platforms
- **No** public API change

Fixes #69373. Refs #4427.

— written by Hermes Agent on behalf of @Enough1122