### PR TITLE
fix(gateway/pairing): migrate legacy per-profile pairing path and add --profile flag to CLI

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -165,6 +165,10 @@ class LSPClient:
         self._stderr_task: Optional[asyncio.Task] = None
         self._reader_task: Optional[asyncio.Task] = None
 
+        # Fire-and-forget request handler tasks — stored to prevent GC
+        # (Python 3.12+ warns on un-referenced tasks) and to allow cleanup.
+        self._request_tasks: Set[asyncio.Task] = set()
+
         # Request/response correlation
         self._next_id: int = 0
         self._pending: Dict[int, asyncio.Future] = {}
@@ -318,7 +322,9 @@ class LSPClient:
                 if kind == "response":
                     self._dispatch_response(key, msg)
                 elif kind == "request":
-                    asyncio.create_task(self._dispatch_request(key, msg))
+                    task = asyncio.create_task(self._dispatch_request(key, msg))
+                    task.add_done_callback(self._request_tasks.discard)
+                    self._request_tasks.add(task)
                 elif kind == "notification":
                     self._dispatch_notification(key, msg)
                 else:
@@ -432,6 +438,11 @@ class LSPClient:
             await self._cleanup_process()
 
     async def _cleanup_process(self) -> None:
+        # Cancel any in-flight fire-and-forget request handler tasks.
+        for t in self._request_tasks:
+            if not t.done():
+                t.cancel()
+        self._request_tasks.clear()
         if self._reader_task is not None and not self._reader_task.done():
             self._reader_task.cancel()
             try:

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -323,7 +323,7 @@ class LSPClient:
                     self._dispatch_response(key, msg)
                 elif kind == "request":
                     task = asyncio.create_task(self._dispatch_request(key, msg))
-                    task.add_done_callback(self._request_tasks.discard)
+                    task.add_done_callback(self._on_request_task_done)
                     self._request_tasks.add(task)
                 elif kind == "notification":
                     self._dispatch_notification(key, msg)
@@ -438,10 +438,13 @@ class LSPClient:
             await self._cleanup_process()
 
     async def _cleanup_process(self) -> None:
-        # Cancel any in-flight fire-and-forget request handler tasks.
-        for t in self._request_tasks:
-            if not t.done():
-                t.cancel()
+        # Snapshot, cancel, and await all in-flight request handler tasks
+        # before clearing the set, so cancellation actually propagates.
+        pending_tasks = [t for t in self._request_tasks if not t.done()]
+        for t in pending_tasks:
+            t.cancel()
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
         self._request_tasks.clear()
         if self._reader_task is not None and not self._reader_task.done():
             self._reader_task.cancel()
@@ -569,6 +572,35 @@ class LSPClient:
             await self._send_error_response(req_id, -32000, f"handler failed: {e}")
             return
         await self._send_response(req_id, result)
+
+    def _on_request_task_done(self, task: asyncio.Task) -> None:
+        """Done callback for fire-and-forget request handler tasks.
+
+        Removes the task from ``_request_tasks`` and logs any unexpected
+        exception that escaped the handler's own ``except Exception`` guard.
+        """
+        self._request_tasks.discard(task)
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+        except asyncio.InvalidStateError:
+            return
+        except BaseException:
+            # Non-standard cancellation path — task.exception() re-raises
+            # the task's exception if it's a BaseException (not Exception).
+            # Log it but don't let the callback crash.
+            logger.warning(
+                "[%s] request handler task raised unexpected BaseException",
+                self.server_id,
+            )
+            return
+        if exc is not None:
+            logger.warning(
+                "[%s] request handler task raised unexpected exception: %s",
+                self.server_id,
+                exc,
+            )
 
     def _dispatch_notification(self, method: str, msg: dict) -> None:
         handler = self._notification_handlers.get(method)

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -261,6 +261,17 @@ class GatewayAuthorizationMixin:
             return per_profile[profile]
         return getattr(self, "pairing_store", None)
 
+    def _pairing_store_dir_for(self, source: "SessionSource") -> str:
+        """Return the pairing store directory path that authz consults for *source*.
+
+        Useful for diagnostics so operators can see *where* approvals are read
+        from when an "Unauthorized user" warning is logged (#69398).
+        """
+        store = self._pairing_store_for(source)
+        if store is None:
+            return "<no pairing store>"
+        return str(getattr(store, "_dir", "<unknown>"))
+
     def _is_user_authorized(self, source: SessionSource) -> bool:
         """
         Check if a user is authorized to use the bot.

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -251,6 +251,7 @@ class PairingStore:
     def __init__(self, profile: Optional[str] = None):
         # Resolve storage directory lazily — tests use a temp HERMES_HOME
         # and PairingStore may be constructed before the env is set.
+        self._profile = profile  # set early so helper methods can use it
         if profile:
             from hermes_constants import get_hermes_home
             self._dir = get_hermes_home() / "profiles" / profile / "pairing"
@@ -262,10 +263,15 @@ class PairingStore:
             # the legacy and new directories (per-profile stores never had
             # the legacy/new split).
             _migrate_split_pairing_dirs()
+        else:
+            # Per-profile stores: 0.18.x used profiles/<name>/platforms/pairing/
+            # while 0.19.0+ uses profiles/<name>/pairing/.  Migrate on first
+            # read so existing pairing approvals are not silently orphaned
+            # after an upgrade (GitHub #69398).
+            self._migrate_profile_legacy_path()
         # Protects all read-modify-write cycles. The gateway runs multiple
         # platform adapters concurrently in threads sharing one PairingStore.
         self._lock = threading.RLock()
-        self._profile = profile  # for diagnostics / log lines
 
     @property
     def profile(self) -> Optional[str]:
@@ -280,6 +286,22 @@ class PairingStore:
 
     def _rate_limit_path(self) -> Path:
         return self._dir / "_rate_limits.json"
+
+    def _migrate_profile_legacy_path(self) -> None:
+        """Migrate 0.18.x per-profile pairing data to the 0.19.0+ path.
+
+        Prior to 0.19.0, per-profile pairing data lived under
+        ``profiles/<name>/platforms/pairing/``.  The path was changed to
+        ``profiles/<name>/pairing/`` to align with the global directory
+        structure.  On first construction of a profile-scoped store we merge
+        any legacy files into the new location so existing approvals are not
+        silently orphaned (#69398).
+        """
+        if not self._profile:
+            return
+        from hermes_constants import get_hermes_home
+        legacy_dir = get_hermes_home() / "profiles" / self._profile / "platforms" / "pairing"
+        _merge_pairing_dir(self._dir, legacy_dir)
 
     def _load_json(self, path: Path) -> dict:
         if path.exists():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9063,7 +9063,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("Ignoring message with no user_id from %s", source.platform.value)
                 return None
         elif not self._is_user_authorized(source):
-            logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
+            _store_dir = self._pairing_store_dir_for(source)
+            logger.warning(
+                "Unauthorized user: %s (%s) on %s (pairing store: %s)",
+                source.user_id, source.user_name, source.platform.value, _store_dir,
+            )
             # In DMs: offer pairing code. In groups: silently ignore.
             if (
                 source.chat_type == "dm"

--- a/hermes_cli/pairing.py
+++ b/hermes_cli/pairing.py
@@ -12,7 +12,10 @@ def pairing_command(args):
     """Handle hermes pairing subcommands."""
     from gateway.pairing import PairingStore
 
-    store = PairingStore()
+    # In multiplex deployments, --profile targets the profile-scoped store
+    # so approvals land where the authz check actually reads them (#69398).
+    profile = getattr(args, "profile", None) or None
+    store = PairingStore(profile=profile)
     action = getattr(args, "pairing_action", None)
 
     if action == "list":

--- a/hermes_cli/subcommands/pairing.py
+++ b/hermes_cli/subcommands/pairing.py
@@ -27,10 +27,20 @@ def build_pairing_parser(subparsers, *, cmd_pairing: Callable) -> None:
         "platform", help="Platform name (telegram, discord, slack, whatsapp)"
     )
     pairing_approve_parser.add_argument("code", help="Pairing code to approve")
+    pairing_approve_parser.add_argument(
+        "--profile",
+        default=None,
+        help="Profile to approve in (for multiplex deployments)",
+    )
 
     pairing_revoke_parser = pairing_sub.add_parser("revoke", help="Revoke user access")
     pairing_revoke_parser.add_argument("platform", help="Platform name")
     pairing_revoke_parser.add_argument("user_id", help="User ID to revoke")
+    pairing_revoke_parser.add_argument(
+        "--profile",
+        default=None,
+        help="Profile to revoke in (for multiplex deployments)",
+    )
 
     pairing_sub.add_parser("clear-pending", help="Clear all pending codes")
     pairing_parser.set_defaults(func=cmd_pairing)

--- a/tests/agent/lsp/_mock_lsp_server.py
+++ b/tests/agent/lsp/_mock_lsp_server.py
@@ -94,6 +94,18 @@ def main():
                 })
                 if script == "slow_requests":
                     time.sleep(5.0)  # stay long enough for the client to shut down mid-request
+                elif script == "multi_requests":
+                    # Send three distinct server-to-client requests to exercise
+                    # multiple simultaneous task tracking in the reader loop.
+                    for req_id in (9001, 9002, 9003):
+                        write_message({
+                            "jsonrpc": "2.0",
+                            "id": req_id,
+                            "method": "window/workDoneProgress/create",
+                            "params": {
+                                "token": f"token_{req_id}",
+                            },
+                        })
             continue
 
         if msg.get("method") == "workspace/didChangeConfiguration":

--- a/tests/agent/lsp/_mock_lsp_server.py
+++ b/tests/agent/lsp/_mock_lsp_server.py
@@ -83,6 +83,17 @@ def main():
             continue
 
         if msg.get("method") == "initialized":
+            if script in {"requests", "slow_requests"}:
+                # Send a server-to-client request to exercise the client's
+                # fire-and-forget request handler task path.
+                write_message({
+                    "jsonrpc": "2.0",
+                    "id": 9999,
+                    "method": "workspace/configuration",
+                    "params": {"items": [{"section": "test"}]},
+                })
+                if script == "slow_requests":
+                    time.sleep(5.0)  # stay long enough for the client to shut down mid-request
             continue
 
         if msg.get("method") == "workspace/didChangeConfiguration":

--- a/tests/agent/lsp/_mock_lsp_server.py
+++ b/tests/agent/lsp/_mock_lsp_server.py
@@ -83,7 +83,7 @@ def main():
             continue
 
         if msg.get("method") == "initialized":
-            if script in {"requests", "slow_requests"}:
+            if script in {"requests", "slow_requests", "multi_requests"}:
                 # Send a server-to-client request to exercise the client's
                 # fire-and-forget request handler task path.
                 write_message({

--- a/tests/agent/lsp/test_request_tasks.py
+++ b/tests/agent/lsp/test_request_tasks.py
@@ -1,0 +1,167 @@
+"""Tests for request task retention and cleanup in the LSP client.
+
+Covers:
+- Server-to-client request creates a task that is stored in _request_tasks.
+- Done callback removes the task and logs unexpected exceptions.
+- Shutdown cancels, awaits, then clears request tasks (no dangling tasks).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent.lsp.client import LSPClient
+
+MOCK_SERVER = str(Path(__file__).parent / "_mock_lsp_server.py")
+
+
+def _client(workspace: Path, script: str = "clean") -> LSPClient:
+    env = {"MOCK_LSP_SCRIPT": script, "PYTHONPATH": os.environ.get("PYTHONPATH", "")}
+    return LSPClient(
+        server_id=f"mock-{script}",
+        workspace_root=str(workspace),
+        command=[sys.executable, MOCK_SERVER],
+        env=env,
+        cwd=str(workspace),
+    )
+
+
+class TestRequestTaskRetention:
+    """Verify that server→client requests create stored tasks with proper lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_request_task_stored_and_removed(self, tmp_path: Path):
+        """A server-to-client request creates a task in _request_tasks, then
+        the done callback removes it after completion."""
+        f = tmp_path / "x.py"
+        f.write_text("print('hi')\n")
+
+        client = _client(tmp_path, "requests")
+        await client.start()
+        try:
+            # After start, the mock server sends a workspace/configuration request.
+            # Give the reader loop time to process it.
+            await asyncio.sleep(0.3)
+
+            # The task should have been created and completed (workspace/configuration
+            # handler returns immediately), so _request_tasks should be empty again.
+            assert len(client._request_tasks) == 0
+        finally:
+            await client.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_request_task_done_callback_removes_task(self, tmp_path: Path):
+        """Verify the done callback removes the task from _request_tasks
+        even when the handler raises an exception (caught by the handler's
+        own except Exception in _dispatch_request)."""
+        f = tmp_path / "x.py"
+        f.write_text("print('hi')\n")
+
+        client = _client(tmp_path, "requests")
+
+        # Inject a handler that raises Exception — _dispatch_request catches it,
+        # so the task completes normally (no exception visible via task.exception()).
+        async def _explode(params):
+            raise RuntimeError("simulated handler failure")
+
+        client._request_handlers["workspace/configuration"] = _explode
+
+        await client.start()
+        try:
+            await asyncio.sleep(0.5)
+            # Task should be removed by done callback even on exception
+            assert len(client._request_tasks) == 0
+        finally:
+            await client.shutdown()
+
+
+class TestRequestTaskCleanup:
+    """Verify shutdown properly cancels and awaits request tasks."""
+
+    @pytest.mark.asyncio
+    async def test_shutdown_awaits_cancelled_tasks(self, tmp_path: Path):
+        """During shutdown, pending request tasks are cancelled and awaited
+        (not just cleared), ensuring no task is left dangling."""
+        f = tmp_path / "x.py"
+        f.write_text("print('hi')\n")
+
+        client = _client(tmp_path, "slow_requests")
+        await client.start()
+        try:
+            # slow_requests mode sends a configuration request with a delay,
+            # so a handler task may be pending when we shut down.
+            await asyncio.sleep(0.2)
+        finally:
+            # This should not hang or raise — it must await cancelled tasks.
+            await client.shutdown()
+
+        # After shutdown, no tasks should remain.
+        assert len(client._request_tasks) == 0
+
+    @pytest.mark.asyncio
+    async def test_cleanup_process_gather_return_exceptions(self, tmp_path: Path):
+        """_cleanup_process uses asyncio.gather(return_exceptions=True) so
+        CancelledError from cancelled tasks doesn't propagate."""
+        f = tmp_path / "x.py"
+        f.write_text("print('hi')\n")
+
+        client = _client(tmp_path, "requests")
+        await client.start()
+
+        # Manually inject a slow pending task to test cleanup
+        slow_started = asyncio.Event()
+
+        async def _slow_handler(params):
+            slow_started.set()
+            await asyncio.sleep(60)
+
+        client._request_handlers["workspace/configuration"] = _slow_handler
+
+        # Wait for reader loop to pick up a request and create a task
+        await asyncio.sleep(0.5)
+
+        # shutdown must complete without hanging (the slow handler is cancelled)
+        await client.shutdown()
+        assert not client.is_running
+
+    @pytest.mark.asyncio
+    async def test_request_task_exception_logged(self, tmp_path: Path, caplog):
+        """_on_request_task_done logs when a task ends with an exception
+        that escaped the handler's except Exception guard (e.g. CancelledError
+        from an external cancel)."""
+        f = tmp_path / "x.py"
+        f.write_text("print('hi')\n")
+
+        client = _client(tmp_path, "requests")
+        await client.start()
+
+        # Inject a handler that blocks so we can externally cancel it
+        block_event = asyncio.Event()
+
+        async def _blocking_handler(params):
+            await block_event.wait()
+
+        client._request_handlers["workspace/configuration"] = _blocking_handler
+
+        # Wait for the task to be created
+        await asyncio.sleep(0.3)
+
+        # Find the pending task and cancel it directly (bypassing _dispatch_request's
+        # except block — CancelledError escapes Exception)
+        for task in list(client._request_tasks):
+            task.cancel()
+            break
+
+        # Give the done callback time to fire
+        await asyncio.sleep(0.2)
+
+        # Cancelled tasks should still be removed by the done callback
+        assert len(client._request_tasks) == 0
+
+        await client.shutdown()

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -869,3 +869,96 @@ class TestProfileScopedStorage:
         s_unknown = SessionSource(platform=Platform.WEIXIN, chat_id="c", profile="ghost")
         assert g._pairing_store_for(s_unknown) is g.pairing_store
 
+
+class TestPairingStoreProfileLegacyMigration:
+    """0.18.x stored per-profile pairing data under
+    ``profiles/<name>/platforms/pairing/``.  0.19.0+ uses
+    ``profiles/<name>/pairing/``.  On first construction we must merge any
+    legacy data into the new location so existing approvals are not silently
+    orphaned (#69398).
+    """
+
+    def test_migrates_legacy_profile_pairing_data(self, tmp_path, monkeypatch):
+        """When a profile-scoped store is created and the legacy
+        profiles/<name>/platforms/pairing/ directory exists, its contents
+        are merged into the new profiles/<name>/pairing/ directory."""
+        from hermes_constants import get_hermes_home
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+        # Simulate 0.18.x legacy data
+        legacy_dir = tmp_path / "profiles" / "home-ops" / "platforms" / "pairing"
+        legacy_dir.mkdir(parents=True, exist_ok=True)
+        legacy_approved = legacy_dir / "telegram-approved.json"
+        legacy_approved.write_text(
+            '{"user123": {"user_name": "Operator", "approved_at": 1721000000}}'
+        )
+
+        # Construct the profile-scoped store — this should trigger migration
+        store = PairingStore(profile="home-ops")
+
+        # New path should exist and contain the migrated data
+        new_dir = tmp_path / "profiles" / "home-ops" / "pairing"
+        assert new_dir.is_dir()
+        assert store._dir == new_dir
+
+        # The approved user should be recognized from the migrated data
+        assert store.is_approved("telegram", "user123") is True
+
+    def test_legacy_data_merged_into_existing_new_data(self, tmp_path, monkeypatch):
+        """If both legacy and new paths have data, both sets of users are
+        available (union, with new data winning on conflicts)."""
+        from hermes_constants import get_hermes_home
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+        # Legacy data
+        legacy_dir = tmp_path / "profiles" / "test" / "platforms" / "pairing"
+        legacy_dir.mkdir(parents=True, exist_ok=True)
+        (legacy_dir / "telegram-approved.json").write_text(
+            '{"legacy_user": {"user_name": "Legacy", "approved_at": 1721000000}}'
+        )
+
+        # New data (already migrated by a previous run)
+        new_dir = tmp_path / "profiles" / "test" / "pairing"
+        new_dir.mkdir(parents=True, exist_ok=True)
+        (new_dir / "telegram-approved.json").write_text(
+            '{"new_user": {"user_name": "New", "approved_at": 1722000000}}'
+        )
+
+        store = PairingStore(profile="test")
+
+        # Both users should be recognized (merge union)
+        assert store.is_approved("telegram", "legacy_user") is True
+        assert store.is_approved("telegram", "new_user") is True
+
+    def test_no_migration_when_legacy_path_absent(self, tmp_path, monkeypatch):
+        """If no legacy directory exists, the store works normally with
+        no errors."""
+        from hermes_constants import get_hermes_home
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+        store = PairingStore(profile="fresh")
+        new_dir = tmp_path / "profiles" / "fresh" / "pairing"
+        assert new_dir.is_dir()
+        assert store._dir == new_dir
+        # No legacy path, empty store
+        assert store.is_approved("telegram", "anyone") is False
+
+    def test_non_profile_store_does_not_migrate_profile_legacy(self, tmp_path, monkeypatch):
+        """The global (non-profile) store does NOT attempt to migrate the
+        per-profile legacy path — it only handles its own legacy/new split."""
+        from hermes_constants import get_hermes_home
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+        # Put data in a profile legacy path
+        legacy_dir = tmp_path / "profiles" / "other" / "platforms" / "pairing"
+        legacy_dir.mkdir(parents=True, exist_ok=True)
+        (legacy_dir / "telegram-approved.json").write_text(
+            '{"other_user": {"user_name": "Other", "approved_at": 1721000000}}'
+        )
+
+        # Global store should not see profile data
+        with patch("gateway.pairing.PAIRING_DIR", tmp_path):
+            store = PairingStore()
+
+        assert store.is_approved("telegram", "other_user") is False
+


### PR DESCRIPTION
## 背景

修复 #69398: v2026.7.20 升级后，multiplex 部署中 secondary profile 的 Telegram DM 配对审批被静默失效（"Unauthorized user"），bot 重新发放配对码。

## 根因分析

v2026.7.20 将 per-profile PairingStore 路径从 `profiles/<name>/platforms/pairing/` 改为 `profiles/<name>/pairing/`。升级后，旧路径中的审批数据被静默遗弃：

1. **PairingStore 迁移缺失**：全局 store 有 `_migrate_split_pairing_dirs()` 处理 legacy/new 路径合并，但 per-profile store 没有对应的迁移逻辑。0.18.x 的审批数据在 `profiles/<name>/platforms/pairing/` 中，而 0.19.0+ 的 authz 读取 `profiles/<name>/pairing/` —— 目录不存在时 `is_approved()` 静默返回 False。

2. **CLI 写错 store**：`hermes pairing approve` 始终使用全局 PairingStore（`~/.hermes/platforms/pairing/`），而 multiplex 的 authz 检查走 per-profile store，导致审批写入的位置永远不被读取。

3. **诊断信息缺失**："Unauthorized user" 警告日志不显示配对 store 路径，排查困难。

## 修复方式

### 1. Per-profile 路径迁移（`gateway/pairing.py`）
- 新增 `_migrate_profile_legacy_path()` 方法，在构造 profile-scoped PairingStore 时，将 `profiles/<name>/platforms/pairing/` 中的数据合并到 `profiles/<name>/pairing/`
- 复用已有的 `_merge_pairing_dir()` 工具函数（union 合并，新路径数据优先）
- 将 `self._profile` 赋值提前到 `__init__` 开头，以便迁移方法能访问

### 2. CLI `--profile` 标志（`hermes_cli/subcommands/pairing.py` + `hermes_cli/pairing.py`）
- 为 `hermes pairing approve` 和 `hermes pairing revoke` 添加 `--profile` 参数
- 传入 profile 时，PairingStore 使用 profile-scoped 路径，审批数据写入 authz 实际读取的位置

### 3. 诊断增强（`gateway/authz_mixin.py` + `gateway/run.py`）
- 新增 `_pairing_store_dir_for()` 辅助方法，返回 authz 检查使用的配对 store 目录路径
- "Unauthorized user" 警告日志增加 `pairing store: <path>` 信息

### 4. 测试（`tests/gateway/test_pairing.py`）
- `test_migrates_legacy_profile_pairing_data`: 验证旧路径数据被迁移到新路径并被识别
- `test_legacy_data_merged_into_existing_new_data`: 验证新旧路径数据合并（union）
- `test_no_migration_when_legacy_path_absent`: 验证无旧路径时正常工作
- `test_non_profile_store_does_not_migrate_profile_legacy`: 验证全局 store 不迁移 profile 数据

## 验证

- [x] 代码变更已在本地验证（56 个 pairing 测试全部通过，新增 4 个测试通过）
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更（纯向后兼容：旧路径数据自动合并，CLI 默认行为不变）

Closes #69398