### PR TITLE
fix(cli): move Termux fast-path call after PROJECT_ROOT is bound (#69365)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -385,9 +385,6 @@ def _try_termux_ultrafast_version() -> bool:
     return True
 
 
-if _try_termux_ultrafast_version():
-    raise SystemExit(0)
-
 import argparse
 import hashlib
 import json
@@ -462,6 +459,13 @@ def _require_tty(command_name: str) -> None:
 # Add project root to path
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
+
+
+# Termux ultrafast version path — must run AFTER PROJECT_ROOT is bound
+# (#69365).  On Termux, _try_termux_ultrafast_version() prints version
+# info and exits; if it returns False, normal startup continues.
+if _try_termux_ultrafast_version():
+    raise SystemExit(0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`hermes --version` (and `-V`) on **Termux** raises `NameError: name 'PROJECT_ROOT' is not defined` and crashes with a traceback.

## Root cause

The Termux "ultrafast version" path runs at module import time (line 388: `if _try_termux_ultrafast_version():`). That calls `_print_fast_version_info()` which references `PROJECT_ROOT`. But `PROJECT_ROOT` is only defined later at line 462 (`PROJECT_ROOT = Path(__file__).parent.parent.resolve()`). On Termux, the fast-path fires before `PROJECT_ROOT` is bound.

Off-Termux: `_is_termux_startup_environment_fast()` returns `False`, the fast-path is skipped, normal startup runs, `PROJECT_ROOT` is defined first. CI/dev machines never hit the bug.

## Fix

Move the `if _try_termux_ultrafast_version():` call from line 388 (import time) to after the `PROJECT_ROOT = ...` assignment at line 462. The ordering is now correct regardless of which function accesses `PROJECT_ROOT`.

## Test plan

```bash
cd /c/Users/admin/AppData/Local/hermes/hermes-agent
./venv/Scripts/python.exe -c "import ast; ast.parse(open('hermes_cli/main.py').read()); print('parse OK')"
# parse OK
```

## What this does NOT do

- **No** change to the Termux fast-path logic itself — only the ordering of when it runs
- **No** behavior change on non-Termux platforms (the fast-path is skipped there anyway)
- **No** public API change

Fixes #69365.

— written by Hermes Agent on behalf of @Enough1122