### PR TITLE
feat(desktop): show cache hit% and session $ on statusbar context chip

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2409,6 +2409,9 @@ def init_agent(
     agent.session_estimated_cost_usd = 0.0
     agent.session_cost_status = "unknown"
     agent.session_cost_source = "none"
+    # Per-call cache counters for status-bar hit% (session_* are cumulative).
+    agent.last_cache_read_tokens = 0
+    agent.last_cache_write_tokens = 0
     
     # ── Ollama num_ctx injection ──
     # Ollama defaults to 2048 context regardless of the model's capabilities.

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -137,6 +137,8 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
     agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
     agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
     agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
+    agent.last_cache_read_tokens = int(canonical_usage.cache_read_tokens or 0)
+    agent.last_cache_write_tokens = int(canonical_usage.cache_write_tokens or 0)
 
     cost_result = estimate_usage_cost(
         agent.model,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2358,6 +2358,8 @@ def run_conversation(
                     agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
                     agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
                     agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
+                    agent.last_cache_read_tokens = int(canonical_usage.cache_read_tokens or 0)
+                    agent.last_cache_write_tokens = int(canonical_usage.cache_write_tokens or 0)
 
                     # Log API call details for debugging/observability
                     _cache_pct = ""

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -11,7 +11,13 @@ import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { useI18n } from '@/i18n'
 import { Activity, AlertCircle, Clock, Command, FolderOpen, Hash, Loader2, Terminal } from '@/lib/icons'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
-import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
+import {
+  contextBarLabel,
+  formatCacheFresh,
+  formatStatusCost,
+  LiveDuration,
+  usageContextLabel
+} from '@/lib/statusbar'
 import { cn } from '@/lib/utils'
 import { copyFilePath, revealFile } from '@/store/file-actions'
 import { revealFileInTree } from '@/store/layout'
@@ -144,6 +150,17 @@ export function useStatusbarItems({
 
   const contextUsage = useMemo(() => usageContextLabel(currentUsage), [currentUsage])
   const contextBar = useMemo(() => contextBarLabel(currentUsage), [currentUsage])
+  // Cache hit% + session $ ride the context chip detail when backend supplies them.
+  const cacheLabel = useMemo(() => formatCacheFresh(currentUsage, true), [currentUsage])
+  // Upstream types currentUsage as a union with a zero-usage literal that lacks
+  // cost_usd / cost_status; narrow with `in` before reading optional fields.
+  const costUsd = 'cost_usd' in currentUsage ? currentUsage.cost_usd : undefined
+  const costStatus =
+    'cost_status' in currentUsage ? currentUsage.cost_status : undefined
+  const costLabel = useMemo(
+    () => formatStatusCost(costUsd, costStatus),
+    [costUsd, costStatus]
+  )
   const approvalModeItem = useApprovalModeStatusbarItem(activeGatewayProfile, requestGateway)
 
   const gatewayMenuContent = useMemo(
@@ -448,10 +465,13 @@ export function useStatusbarItems({
         variant: 'text'
       },
       {
-        detail: contextBar || undefined,
-        hidden: !contextUsage,
+        // Prefer bar+%; cache/cost ride on detail when backend provides them.
+        detail:
+          [contextBar || undefined, cacheLabel || undefined, costLabel || undefined].filter(Boolean).join(' · ') ||
+          undefined,
+        hidden: !contextUsage && !cacheLabel && !costLabel,
         id: 'context-usage',
-        label: contextUsage,
+        label: contextUsage || copy.contextUsage || 'ctx',
         menuAlign: 'end',
         menuClassName: 'w-auto border-(--ui-stroke-secondary) p-0',
         menuContent: (
@@ -490,11 +510,13 @@ export function useStatusbarItems({
       approvalModeItem,
       backendVersionItem,
       busy,
+      cacheLabel,
       chatOpen,
       clientVersionItem,
       contextBar,
       contextUsage,
       copy,
+      costLabel,
       currentUsage,
       requestGateway,
       sessionStartedAt,

--- a/apps/desktop/src/lib/statusbar-cache-cost.test.ts
+++ b/apps/desktop/src/lib/statusbar-cache-cost.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Fact-Forcing Gate (pre-create):
+ * 1. Importers: vitest only — `npx vitest run src/lib/statusbar-cache-cost.test.ts`
+ *    under apps/desktop. Production code imports `./statusbar`, not this file.
+ * 2. External API: none (test module). Exercises pure helpers
+ *    `formatCacheFresh` / `formatStatusCost` from `./statusbar`.
+ * 3. Data schema: none — synthetic UsageStats fixtures only
+ *    (cache_read, last_prompt, cost_usd numbers).
+ * 4. User instruction (verbatim): "底栏 cache与费用，需要保留，出稳定方案"
+ */
+import { describe, expect, it } from 'vitest'
+
+import { formatCacheFresh, formatStatusCost } from './statusbar'
+
+import type { UsageStats } from '@/types/hermes'
+
+const baseUsage = (patch: Partial<UsageStats> = {}): UsageStats => ({
+  calls: 1,
+  input: 0,
+  output: 0,
+  total: 0,
+  ...patch
+})
+
+describe('statusbar cache + cost helpers', () => {
+  describe('formatCacheFresh', () => {
+    it('returns empty when there is no cache_read (no fabricated hits)', () => {
+      expect(formatCacheFresh(baseUsage({ context_used: 10_000, last_prompt: 10_000 }))).toBe('')
+    })
+
+    it('uses last_prompt as hit denominator', () => {
+      const full = formatCacheFresh(
+        baseUsage({
+          cache_read: 71_168,
+          last_prompt: 71_614,
+          context_used: 71_614
+        })
+      )
+      expect(full).toContain('cache R=')
+      expect(full).toContain('99%')
+      expect(full).toContain('fresh=')
+
+      const compact = formatCacheFresh(
+        baseUsage({
+          cache_read: 71_168,
+          last_prompt: 71_614,
+          context_used: 71_614
+        }),
+        true
+      )
+      expect(compact).toMatch(/^R=/)
+      expect(compact).toContain('99%')
+      expect(compact).not.toContain('fresh=')
+    })
+  })
+
+  describe('formatStatusCost', () => {
+    it('hides non-positive costs', () => {
+      expect(formatStatusCost(undefined)).toBe('')
+      expect(formatStatusCost(0)).toBe('')
+      expect(formatStatusCost(-1)).toBe('')
+    })
+
+    it('formats sub-cent and larger sessions', () => {
+      expect(formatStatusCost(0.004)).toBe('<$0.01')
+      expect(formatStatusCost(1.2)).toBe('$1.20')
+      expect(formatStatusCost(127.093)).toBe('$127.093')
+    })
+
+    it('marks estimated costs with a tilde', () => {
+      expect(formatStatusCost(1.2, 'estimated')).toBe('~$1.20')
+      expect(formatStatusCost(0.004, 'estimated')).toBe('~<$0.01')
+    })
+  })
+})

--- a/apps/desktop/src/lib/statusbar.tsx
+++ b/apps/desktop/src/lib/statusbar.tsx
@@ -58,6 +58,82 @@ export function contextBarLabel(usage: UsageStats): string {
   return `[${contextBar(usage.context_percent)}] ${pct}%`
 }
 
+const fmtK = (n: number): string => {
+  if (!Number.isFinite(n) || n < 0) {
+    return '0'
+  }
+
+  if (n < 1000) {
+    return String(Math.round(n))
+  }
+
+  if (n < 10_000) {
+    return `${(n / 1000).toFixed(1).replace(/\.0$/, '')}k`
+  }
+
+  if (n < 1_000_000) {
+    return `${Math.round(n / 1000)}k`
+  }
+
+  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`
+}
+
+/**
+ * Claude-style cache segment. Returns '' when cache_read is missing/zero so
+ * providers without cache hits never fabricate a percentage.
+ * Full: `cache R=134k(96%) fresh=5k` · compact: `R=134k(96%)`
+ */
+export function formatCacheFresh(usage: UsageStats, compact = false): string {
+  const cacheRead = Math.max(0, Number(usage.cache_read ?? 0) || 0)
+
+  if (cacheRead <= 0) {
+    return ''
+  }
+
+  const lastPrompt = Math.max(0, Number(usage.last_prompt ?? 0) || 0)
+  const ctxUsed = Math.max(0, Number(usage.context_used ?? 0) || 0)
+  const denom = lastPrompt > 0 ? lastPrompt : ctxUsed > 0 ? ctxUsed : cacheRead
+  const hit = Math.max(0, Math.min(100, Math.round((cacheRead / denom) * 100)))
+  const freshBase = lastPrompt > 0 ? lastPrompt : ctxUsed
+  const fresh = freshBase > 0 ? Math.max(0, freshBase - cacheRead) : 0
+
+  if (compact) {
+    return `R=${fmtK(cacheRead)}(${hit}%)`
+  }
+
+  const pieces = [`cache R=${fmtK(cacheRead)}(${hit}%)`]
+
+  if (freshBase > 0) {
+    pieces.push(`fresh=${fmtK(fresh)}`)
+  }
+
+  return pieces.join(' ')
+}
+
+/**
+ * Claude-like dollar amount; empty when cost is missing or non-positive.
+ * Prefix with ~ when backend marks the figure as estimated (not provider invoice).
+ */
+export function formatStatusCost(usd?: number, status?: string): string {
+  if (usd == null || !Number.isFinite(usd) || usd <= 0) {
+    return ''
+  }
+
+  let body: string
+  if (usd < 0.01) {
+    body = '<$0.01'
+  } else if (usd < 10) {
+    body = `$${usd.toFixed(2)}`
+  } else {
+    body = `$${Number(usd.toFixed(3))}`
+  }
+
+  if (status === 'estimated') {
+    return body.startsWith('<') ? `~${body}` : `~${body}`
+  }
+  return body
+}
+
 export function LiveDuration({ since }: { since: number | null | undefined }) {
   const [now, setNow] = useState(() => Date.now())
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -485,7 +485,20 @@ export interface UsageStats {
   context_max?: number
   context_percent?: number
   context_used?: number
+  /** Session estimated cost (USD). Absent or 0 when pricing is unavailable. */
   cost_usd?: number
+  /** Pricing provenance when the backend reports it (e.g. estimated / n/a). */
+  cost_status?: string
+  /**
+   * Last API call cache-read tokens (prefer over session sum for Claude-style
+   * hit%). Only present when the provider reports cache usage.
+   */
+  cache_read?: number
+  cache_write?: number
+  /** Last API prompt tokens — denominator for cache hit% when available. */
+  last_prompt?: number
+  /** Cumulative session cache-read (fallback when last-call fields missing). */
+  session_cache_read?: number
   input: number
   output: number
   total: number

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3722,8 +3722,28 @@ def _get_usage(agent) -> dict:
         "completion": g("session_completion_tokens"),
         "total": g("session_total_tokens"),
         "calls": g("session_api_calls"),
+        # Desktop status-bar: cache hit + session cost (Claude-style). Prefer
+        # last-call counters when present; fall back to session sums so restored
+        # agents still show something useful.
+        "cache_read": int(getattr(agent, "last_cache_read_tokens", 0) or 0),
+        "cache_write": int(getattr(agent, "last_cache_write_tokens", 0) or 0),
+        "session_cache_read": int(getattr(agent, "session_cache_read_tokens", 0) or 0),
+        "cost_usd": float(getattr(agent, "session_estimated_cost_usd", 0.0) or 0.0),
+        "cost_status": getattr(agent, "session_cost_status", None) or "unknown",
     }
+    if not usage["cache_read"]:
+        usage["cache_read"] = int(getattr(agent, "session_cache_read_tokens", 0) or 0)
+    if not usage["cache_write"]:
+        usage["cache_write"] = int(getattr(agent, "session_cache_write_tokens", 0) or 0)
+    # last_prompt lives on the compressor on main; expose for cache hit%.
     comp = getattr(agent, "context_compressor", None)
+    if comp:
+        _lp = int(getattr(comp, "last_prompt_tokens", 0) or 0)
+        if _lp < 0:
+            _lp = 0
+        usage["last_prompt"] = _lp
+    else:
+        usage["last_prompt"] = int(getattr(agent, "last_prompt_tokens", 0) or 0)
     if comp:
         # context_used is the *current-window* occupancy. Do NOT fall back to
         # usage["total"] (cumulative lifetime session_total_tokens): for an


### PR DESCRIPTION
## Summary
- Gateway usage payload exposes `cost_usd` + `cost_status` from `estimate_usage_cost`.
- Desktop context chip detail shows **cache hit%** and **session $** (prefix `~` when `cost_status=estimated`).
- Vitest coverage in `statusbar-cache-cost.test.ts`.

## Depends on
Works best with pricing PR for xAI/Kimi/Z.AI so non-OpenAI sessions are non-zero. UI still handles missing cost gracefully (empty string).

## Test plan
- [ ] `cd apps/desktop && npm test -- --run src/lib/statusbar-cache-cost.test.ts`
- [ ] Manual: enable `display.show_cost: true`, run a turn, confirm context chip shows `$` / `~$`