### PR TITLE
fix(auth): resolve kimi-coding-cn pool base_url for sk-kimi- keys

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2986,7 +2986,10 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
             continue
         active_sources.add(source)
         base_url = env_url or pconfig.inference_base_url
-        if provider == "kimi-coding":
+        # sk-kimi- keys only work on api.kimi.com/coding — same redirect for
+        # both global (kimi-coding) and China-profile (kimi-coding-cn) pools.
+        # Without cn here, cn pool stays stuck on moonshot.cn → 401 forever.
+        if provider in {"kimi-coding", "kimi-coding-cn"}:
             base_url = _resolve_kimi_base_url(token, pconfig.inference_base_url, env_url)
         elif provider == "zai":
             base_url = _resolve_zai_base_url(token, pconfig.inference_base_url, env_url)


### PR DESCRIPTION
## Summary
- When credential pool entries use provider `kimi-coding-cn` with `sk-kimi-` keys, resolve the correct Coding API `base_url` so requests do not hit the wrong host.

## Test plan
- [ ] Pool entry with `kimi-coding-cn` + `sk-kimi-…` resolves `api.kimi.com/coding` (or configured CN endpoint)
- [ ] Existing `kimi-coding` path unchanged