### PR TITLE
fix: bump fast-uri lockfile entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10950,9 +10950,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9993,9 +9993,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Bumps transitive fast-uri lockfile entries from 3.1.2 to 3.1.4 in the root and website lockfiles to clear GHSA-v2hh-gcrm-f6hx and GHSA-4c8g-83qw-93j6.

Verification run locally:
- npm install --ignore-scripts (root)
- npm install --ignore-scripts (website)
- npm audit --workspace apps/desktop: fast-uri absent from remaining advisories
- npm audit in website: fast-uri absent from remaining advisories
- git diff --check

Note: this PR intentionally does not address unrelated pre-existing npm audit findings on upstream/main.