### PR TITLE
fix: retry fetch_models without base_url on TypeError (#69255)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2623,7 +2623,10 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             if not base_url:
                 base_url = _p.base_url
             if api_key:
-                live = _p.fetch_models(api_key=api_key, base_url=base_url or None)
+                try:
+                    live = _p.fetch_models(api_key=api_key, base_url=base_url or None)
+                except TypeError:
+                    live = _p.fetch_models(api_key=api_key)
                 if live:
                     # Merge static curated list with live API results so
                     # models that the live endpoint omits (stale cache,


### PR DESCRIPTION
Fixes #69255

## Problem

`provider_model_ids()` always passes `base_url=` to `fetch_models()`. Third-party model-provider plugins that override `fetch_models` with a narrower signature (e.g. only `api_key` / `timeout`) raise `TypeError`, which is caught by the outer `except Exception` and treated as a failed live fetch — the model picker shows 0 models for an otherwise healthy provider.

## Fix

Wrap the call in `try/except TypeError` and retry without `base_url` for backward compatibility:

```python
try:
    live = _p.fetch_models(api_key=api_key, base_url=base_url or None)
except TypeError:
    live = _p.fetch_models(api_key=api_key)
```

This is a 4-line change in `hermes_cli/models.py`. Plugins with the full signature continue to work as before; plugins with a narrower signature get a graceful fallback.

## Why not only fix the plugins?

Plugin fix is the correct long-term fix, but Hermes should degrade gracefully: a signature mismatch should not silently empty the picker for every third-party provider that lags the base API.

## Verification

- Syntax check: `py_compile` passes
- The fix is a pure fallback — no behavior change for plugins that already accept `base_url`