### PR TITLE
fix(mcp): swallow RuntimeError when cancelling parked tasks on closed loop

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2294,8 +2294,8 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
                     try:
+                        t.cancel()
                         await t
                     except (asyncio.CancelledError, Exception):
                         pass
@@ -2338,8 +2338,8 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
                     try:
+                        t.cancel()
                         await t
                     except (asyncio.CancelledError, Exception):
                         pass


### PR DESCRIPTION
When /exit shuts down the CLI while an MCP server task is parked in _wait_for_reconnect_or_shutdown (or the keepalive loop), t.cancel() calls loop.call_soon() on an already-closed event loop and raises RuntimeError: Event loop is closed. The exception is ignored but prints an ugly traceback on every quit.

Move t.cancel() inside the existing try/except so the RuntimeError is caught along with CancelledError. Apply the same pattern to both locations that cancel shutdown_task/reconnect_task.

Fixes #60197