### PR TITLE
fix(agent): persist turn-completion explainer before session write

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -290,6 +290,69 @@ def finalize_turn(
             from agent.message_sanitization import close_interrupted_tool_sequence
             close_interrupted_tool_sequence(messages, final_response)
 
+        # Turn-completion explainer must run BEFORE the #43849 append /
+        # persist chokepoint. When inbound final_response is falsy
+        # ("" / None), the explainer synthesizes the user-visible
+        # "⚠️ No reply: …" text; if that happens after persist, the
+        # caller receives an explanation while the durable transcript
+        # still ends on a tool result — violating
+        # "delivered final_response ⇒ assistant row" and recreating
+        # #48879 tool→user risk on the next turn.
+        #
+        # When a turn ends abnormally after substantive work — empty
+        # content after retries, a partial/truncated stream, a
+        # still-pending tool result, or an iteration/budget limit — the
+        # user otherwise gets a blank or fragmentary response box with
+        # no consolidated reason why the agent stopped (#34452).
+        #
+        # Gate carefully so healthy turns stay quiet:
+        #   - ``text_response(...)`` exits never produce an explanation
+        #     (handled inside the formatter), so a terse ``Done.`` is silent.
+        #   - We only ACT when there is no genuinely usable reply this turn:
+        #     an empty response, the "(empty)" terminal sentinel, or a
+        #     suspiciously short partial fragment with no terminating
+        #     punctuation (e.g. "The").  A real short answer keeps its text.
+        if not interrupted:
+            try:
+                if agent._turn_completion_explainer_enabled():
+                    _stripped = (final_response or "").strip()
+                    _is_empty_terminal = _stripped == "" or _stripped == "(empty)"
+                    # A short fragment that is not a normal text_response exit
+                    # and lacks sentence-ending punctuation is treated as a
+                    # truncated partial (the "The" case from #34452).
+                    _is_partial_fragment = (
+                        not _is_empty_terminal
+                        and not preserved_verification_fallback
+                        and not str(_turn_exit_reason).startswith("text_response")
+                        and len(_stripped) <= 24
+                        and _stripped[-1:] not in {".", "!", "?", "。", "！", "？", "`", ")"}
+                    )
+                    _is_partial_stream_recovery = (
+                        str(_turn_exit_reason) == "partial_stream_recovery"
+                    )
+                    if (
+                        _is_empty_terminal
+                        or _is_partial_fragment
+                        or _is_partial_stream_recovery
+                    ):
+                        _explanation = agent._format_turn_completion_explanation(
+                            _turn_exit_reason
+                        )
+                        if _explanation:
+                            if _is_empty_terminal:
+                                # Replace the bare "(empty)"/blank sentinel with
+                                # the actionable explanation.
+                                final_response = _explanation
+                            else:
+                                # Keep the partial fragment, append the reason so
+                                # the user sees both what arrived and why it
+                                # stopped.
+                                final_response = (
+                                    _stripped + "\n\n" + _explanation
+                                )
+            except Exception as _exp_err:
+                logger.debug("turn-completion explainer failed: %s", _exp_err)
+
         # Some recovery/fallback paths return a real final_response without
         # adding a closing assistant message to the transcript (e.g. the
         # partial-stream and prior-turn-content recovery ``break`` sites in
@@ -480,63 +543,6 @@ def finalize_turn(
                     final_response = final_response.rstrip() + "\n\n" + footer
         except Exception as _ver_err:
             logger.debug("file-mutation verifier footer failed: %s", _ver_err)
-
-    # Turn-completion explainer.
-    # When a turn ends abnormally after substantive work — empty content
-    # after retries, a partial/truncated stream, a still-pending tool
-    # result, or an iteration/budget limit — the user otherwise gets a
-    # blank or fragmentary response box with no consolidated reason why
-    # the agent stopped (#34452).  Surface a single user-visible
-    # explanation derived from ``_turn_exit_reason``, mirroring the
-    # file-mutation verifier footer pattern above.
-    #
-    # Gate carefully so healthy turns stay quiet:
-    #   - ``text_response(...)`` exits never produce an explanation
-    #     (handled inside the formatter), so a terse ``Done.`` is silent.
-    #   - We only ACT when there is no genuinely usable reply this turn:
-    #     an empty response, the "(empty)" terminal sentinel, or a
-    #     suspiciously short partial fragment with no terminating
-    #     punctuation (e.g. "The").  A real short answer keeps its text.
-    if not interrupted:
-        try:
-            if agent._turn_completion_explainer_enabled():
-                _stripped = (final_response or "").strip()
-                _is_empty_terminal = _stripped == "" or _stripped == "(empty)"
-                # A short fragment that is not a normal text_response exit
-                # and lacks sentence-ending punctuation is treated as a
-                # truncated partial (the "The" case from #34452).
-                _is_partial_fragment = (
-                    not _is_empty_terminal
-                    and not preserved_verification_fallback
-                    and not str(_turn_exit_reason).startswith("text_response")
-                    and len(_stripped) <= 24
-                    and _stripped[-1:] not in {".", "!", "?", "。", "！", "？", "`", ")"}
-                )
-                _is_partial_stream_recovery = (
-                    str(_turn_exit_reason) == "partial_stream_recovery"
-                )
-                if (
-                    _is_empty_terminal
-                    or _is_partial_fragment
-                    or _is_partial_stream_recovery
-                ):
-                    _explanation = agent._format_turn_completion_explanation(
-                        _turn_exit_reason
-                    )
-                    if _explanation:
-                        if _is_empty_terminal:
-                            # Replace the bare "(empty)"/blank sentinel with
-                            # the actionable explanation.
-                            final_response = _explanation
-                        else:
-                            # Keep the partial fragment, append the reason so
-                            # the user sees both what arrived and why it
-                            # stopped.
-                            final_response = (
-                                _stripped + "\n\n" + _explanation
-                            )
-        except Exception as _exp_err:
-            logger.debug("turn-completion explainer failed: %s", _exp_err)
 
     _response_transformed = False
 

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -315,3 +315,166 @@ def test_final_response_fill_invalidates_flush_scan_cursor():
     )
 
     assert agent._db_flush_scan_prefix is None
+
+    persisted = agent.persisted_messages
+    assert persisted is not None
+    assert persisted[-1]["content"] == "Here is your answer."
+    assert persisted[-1]["tool_calls"]
+    assert "_db_persisted" not in persisted[-1], (
+        "marker must be popped so the next flush re-writes the filled content"
+    )
+
+
+def test_empty_terminal_sentinel_explainer_survives_sessiondb_reload(
+    tmp_path, monkeypatch
+):
+    """Production ``(empty)`` path must reload the same explainer from SessionDB.
+
+    Empty-response exhaustion appends ``_empty_terminal_sentinel`` and sets
+    ``final_response="(empty)"``. The finalizer strips that scaffold (and any
+    orphan tool tail) before the #43849 append/persist gate. FakeAgent leaves
+    ``_drop_trailing_empty_response_scaffolding`` as a no-op, so only a real
+    AIAgent + SessionDB round-trip proves the ``/resume`` transcript ends on
+    the delivered explanation rather than a tool/sentinel row.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("HERMES_TURN_COMPLETION_EXPLAINER", "1")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+
+    from hermes_state import SessionDB
+    from run_agent import AIAgent
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "sess-empty-terminal-explainer"
+    db.create_session(session_id=session_id, source="cli")
+
+    agent = object.__new__(AIAgent)
+    agent.max_iterations = 90
+    agent.iteration_budget = SimpleNamespace(remaining=10, used=1, max_total=90)
+    agent.quiet_mode = True
+    agent.model = "test-model"
+    agent.provider = "test-provider"
+    agent.base_url = ""
+    agent.session_id = session_id
+    agent.platform = "cli"
+    agent.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+    agent.session_input_tokens = 0
+    agent.session_output_tokens = 0
+    agent.session_cache_read_tokens = 0
+    agent.session_cache_write_tokens = 0
+    agent.session_reasoning_tokens = 0
+    agent.session_prompt_tokens = 0
+    agent.session_completion_tokens = 0
+    agent.session_total_tokens = 0
+    agent.session_estimated_cost_usd = 0
+    agent.session_cost_status = "unknown"
+    agent.session_cost_source = "test"
+    agent._tool_guardrail_halt_decision = None
+    agent._interrupt_message = None
+    agent._response_was_previewed = False
+    agent._skill_nudge_interval = 0
+    agent._iters_since_skill = 0
+    agent.valid_tool_names = []
+    agent._persist_user_message_idx = None
+    agent._persist_user_message_override = None
+    agent._persist_user_message_timestamp = None
+    agent._pending_cli_user_message = None
+    agent._persist_disabled = False
+    agent._session_db = db
+    agent._session_db_created = True
+    agent._session_messages = []
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._session_persist_lock = None
+    agent._session_json_enabled = False
+    agent._stream_callback = None
+    agent._turn_failed_file_mutations = {}
+    agent.request_overrides = {}
+
+    # Production methods under test — not FakeAgent no-ops.
+    agent._drop_trailing_empty_response_scaffolding = (
+        AIAgent._drop_trailing_empty_response_scaffolding.__get__(agent, AIAgent)
+    )
+    agent._persist_session = AIAgent._persist_session.__get__(agent, AIAgent)
+    agent._flush_messages_to_session_db = (
+        AIAgent._flush_messages_to_session_db.__get__(agent, AIAgent)
+    )
+    agent._flush_messages_to_session_db_unlocked = (
+        AIAgent._flush_messages_to_session_db_unlocked.__get__(agent, AIAgent)
+    )
+    agent._save_session_log = AIAgent._save_session_log.__get__(agent, AIAgent)
+    agent._apply_persist_user_message_override = (
+        AIAgent._apply_persist_user_message_override.__get__(agent, AIAgent)
+    )
+    agent._turn_completion_explainer_enabled = (
+        AIAgent._turn_completion_explainer_enabled.__get__(agent, AIAgent)
+    )
+    agent._format_turn_completion_explanation = (
+        AIAgent._format_turn_completion_explanation
+    )
+    agent._file_mutation_verifier_enabled = lambda: False
+    agent._handle_max_iterations = lambda *a, **k: (_ for _ in ()).throw(
+        AssertionError("not expected")
+    )
+    agent._emit_status = lambda *_a, **_k: None
+    agent._safe_print = lambda *_a, **_k: None
+    agent._save_trajectory = lambda *_a, **_k: None
+    agent._cleanup_task_resources = lambda *_a, **_k: None
+    agent._drain_pending_steer = lambda: None
+    agent.clear_interrupt = lambda: None
+    agent._sync_external_memory_for_turn = lambda **_k: None
+
+    # Shape left by conversation_loop empty-exhaustion before finalize_turn:
+    # tool work + the ``(empty)`` terminal sentinel, inbound final_response
+    # still the bare sentinel string.
+    messages = [
+        {"role": "user", "content": "run the task"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+        {
+            "role": "assistant",
+            "content": "(empty)",
+            "_empty_terminal_sentinel": True,
+        },
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response="(empty)",
+        api_call_count=4,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="run the task",
+        original_user_message="run the task",
+        _should_review_memory=False,
+        _turn_exit_reason="empty_response_exhausted",
+    )
+
+    delivered = result["final_response"]
+    assert delivered and "No reply" in delivered
+    assert delivered != "(empty)"
+    assert result["messages"][-1]["role"] == "assistant"
+    assert result["messages"][-1]["content"] == delivered
+    assert all(not m.get("_empty_terminal_sentinel") for m in result["messages"])
+
+    reloaded = db.get_messages_as_conversation(session_id)
+    assert reloaded, "expected durable rows in SessionDB"
+    assert reloaded[-1]["role"] == "assistant"
+    assert reloaded[-1]["content"] == delivered
+    assert all(row.get("role") != "tool" for row in reloaded)
+    assert all("(empty)" not in (row.get("content") or "") for row in reloaded)

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -35,6 +35,7 @@ class FakeAgent:
         self._persist_user_message_idx: int | None = None
         self._persist_user_message_override: Any = None
         self._persist_user_message_timestamp: float | None = None
+        self._turn_completion_explainer = False
 
     def _handle_max_iterations(self, messages, api_call_count):
         raise AssertionError("not expected")
@@ -69,7 +70,10 @@ class FakeAgent:
         return False
 
     def _turn_completion_explainer_enabled(self):
-        return False
+        return self._turn_completion_explainer
+
+    def _format_turn_completion_explanation(self, reason):
+        return f"⚠️ No reply: explained ({reason})"
 
     def _drain_pending_steer(self):
         return None
@@ -126,6 +130,94 @@ def test_final_response_closes_tool_tail_before_persistence(monkeypatch):
     assert result["messages"][-1] == {"role": "assistant", "content": "Done."}
     assert agent.persisted_messages is not None
     assert agent.persisted_messages[-1] == {"role": "assistant", "content": "Done."}
+
+
+def test_empty_final_response_explainer_closes_tool_tail_before_persist(monkeypatch):
+    """Explainer-synthesized replies must hit the #43849 persist chokepoint.
+
+    When inbound ``final_response`` is falsy (``""`` / ``None``), the append
+    gate used to skip, persist left a tool-tailed transcript, and only then
+    did the turn-completion explainer replace the delivered text — so the
+    caller saw an explanation while durable history still ended on ``tool``,
+    recreating #48879 ``tool → user`` risk on the next turn.
+    """
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    agent._turn_completion_explainer = True
+    messages = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response="",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="q",
+        original_user_message="q",
+        _should_review_memory=False,
+        _turn_exit_reason="empty_response_exhausted",
+    )
+
+    assert "No reply" in (result["final_response"] or "")
+    assert result["messages"][-1]["role"] == "assistant"
+    assert result["messages"][-1]["content"] == result["final_response"]
+    assert agent.persisted_messages is not None
+    assert agent.persisted_messages[-1]["role"] == "assistant"
+    assert agent.persisted_messages[-1]["content"] == result["final_response"]
+
+
+def test_none_final_response_explainer_closes_tool_tail_before_persist(monkeypatch):
+    """Same invariant as the empty-string case, with inbound ``None``."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    agent._turn_completion_explainer = True
+    messages = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response=None,
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="q",
+        original_user_message="q",
+        _should_review_memory=False,
+        _turn_exit_reason="empty_response_exhausted",
+    )
+
+    assert "No reply" in (result["final_response"] or "")
+    assert result["messages"][-1]["role"] == "assistant"
+    assert result["messages"][-1]["content"] == result["final_response"]
+    assert agent.persisted_messages is not None
+    assert agent.persisted_messages[-1]["content"] == result["final_response"]
 
 
 def test_final_response_fills_pure_tool_call_tail(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Move the turn-completion explainer ahead of the #43849 append / `_persist_session` chokepoint so a synthesized "No reply" explanation is written as a durable assistant row. This keeps delivered `final_response` aligned with session history when inbound `final_response` was empty.

### Bug Cause

In `agent/turn_finalizer.py`, the durable close gate is `if final_response and not interrupted`. An empty inbound `""` / `None` skipped the append, then `_persist_session` ran, and only afterward the explainer replaced the delivered text. Callers saw an explanation while the transcript still ended on `tool`, recreating #48879 `tool -> user` risk for strict providers.

### Reproduction Steps

1. End a turn with `final_response=""` (or `None`), messages ending on a tool result, and the turn-completion explainer enabled (default).
2. Compare the `finalize_turn` return value with the persisted messages.

Expected: the delivered explanation is also the durable assistant tail.
Before fix: `final_response` contains the explanation, but persisted history still ends on `tool`.

### Fix

Run the existing explainer block before the #43849 append / persist path so synthesized text flows through the same "delivered final_response => assistant row" invariant. Added regression tests for inbound `""` and `None` tool-tail cases.

Supersedes closed PR https://github.com/NousResearch/hermes-agent/pull/69415 (rewritten with an English-only description).

## Related Issue

No issue

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/turn_finalizer.py` — move turn-completion explainer before append/persist
- `tests/agent/test_turn_finalizer_final_response_persistence.py` — cover empty/None + explainer tool-tail close

## How to Test

1. Manual: run a turn that exhausts empty-response recovery after a tool result with the explainer on; confirm session/`/resume` history ends on the "No reply" assistant text, not a bare tool result.
2. Automated: `scripts/run_tests.sh tests/agent/test_turn_finalizer_final_response_persistence.py tests/agent/test_turn_finalizer_interrupt_alternation.py tests/run_agent/test_turn_completion_explainer.py tests/agent/test_turn_finalizer_cleanup_guard.py tests/agent/test_turn_finalizer_iteration_limit_exit.py -q` (47 passed locally)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure Python finalizer ordering)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
