### PR TITLE
fix(desktop): make clarify choice/question text fully selectable

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -100,6 +100,27 @@ describe('ClarifyTool settled view', () => {
     expect(document.querySelector('[data-clarify-answer]')?.textContent).toBe('staging')
   })
 
+  it('marks the shell selectable so choice/question text can be copied', () => {
+    // Body + button rules set user-select:none; data-selectable-text opts back in.
+    renderClarify(
+      <ClarifyTool
+        {...settledClarifyProps(
+          { question: 'Pick one long option?', choices: ['alpha with detail', 'beta'] },
+          {
+            question: 'Pick one long option?',
+            choices_offered: ['alpha with detail', 'beta'],
+            user_response: 'alpha with detail'
+          },
+          'clarify-selectable'
+        )}
+      />
+    )
+
+    const shell = document.querySelector('[data-slot="clarify-inline"]')
+    expect(shell).toBeTruthy()
+    expect(shell?.getAttribute('data-selectable-text')).toBe('true')
+  })
+
   it('labels an empty response as Skipped', () => {
     renderClarify(
       <ClarifyTool

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -88,12 +88,29 @@ const CLARIFY_SHELL_CLASS =
 
 const CLARIFY_ICON_CLASS = 'mt-px size-4 shrink-0 text-(--ui-text-tertiary)'
 
+/**
+ * Body defaults to user-select:none and `button` hard-sets none again, so long
+ * clarify options (tables / multi-line choices) cannot be copied. Mark the
+ * whole shell selectable — `[data-selectable-text] *` beats the button rule.
+ */
 function ClarifyShell({ children, className, ...props }: ComponentProps<'div'>) {
   return (
-    <div className={cn(CLARIFY_SHELL_CLASS, className)} data-slot="clarify-inline" {...props}>
+    <div
+      className={cn(CLARIFY_SHELL_CLASS, className)}
+      data-selectable-text="true"
+      data-slot="clarify-inline"
+      {...props}
+    >
       {children}
     </div>
   )
+}
+
+/** True when the user just finished a drag-select (mouseup still fires click). */
+function hasNonEmptyTextSelection(): boolean {
+  const selection = window.getSelection()
+
+  return Boolean(selection && !selection.isCollapsed && selection.toString().trim())
 }
 
 function ClarifyLine({
@@ -394,7 +411,14 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
                 data-choice
                 disabled={submitting}
                 key={`${index}-${choice}`}
-                onClick={() => selectChoice(choice)}
+                onClick={() => {
+                  // Drag-to-copy must not also pick the option.
+                  if (hasNonEmptyTextSelection()) {
+                    return
+                  }
+
+                  selectChoice(choice)
+                }}
                 type="button"
               >
                 <KeyBadge char={letterFor(index)} selected={selectedChoice === choice} />


### PR DESCRIPTION
## Summary
- Desktop sets `user-select: none` on `body` and again on `button`/`[role=button]`, so clarify **choice rows** (implemented as buttons) could not be drag-selected or copied — painful for long multi-line options.
- Mark the clarify shell with the existing `data-selectable-text="true"` opt-in so question, choices, and settled answer text are fully selectable (CSS `[data-selectable-text] *` already beats the button rule).
- Ignore option `click` when the user just finished a non-empty text selection, so drag-to-copy does not also pick the choice.

## Test plan
- [x] `cd apps/desktop && npx vitest run src/components/assistant-ui/clarify-tool.test.tsx` (6 passed)
- [ ] Manual: trigger a clarify with long choices → drag-select / copy option text
- [ ] Manual: plain click still selects the choice; Continue still submits
- [ ] Manual: settled Q&A block remains copyable