### PR TITLE
fix(desktop): preserve code block text selection

### DIFF
--- a/apps/desktop/src/components/chat/expandable-block.test.tsx
+++ b/apps/desktop/src/components/chat/expandable-block.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ExpandableBlock } from './expandable-block'
+
+class TestResizeObserver {
+  constructor(private readonly callback: ResizeObserverCallback) {}
+
+  observe(target: Element) {
+    Object.defineProperty(target, 'scrollHeight', { configurable: true, value: 200 })
+    this.callback([{ target } as ResizeObserverEntry], this as unknown as ResizeObserver)
+  }
+
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+
+describe('ExpandableBlock', () => {
+  afterEach(cleanup)
+
+  it('keeps the bottom fade click-through while limiting the toggle hit area', async () => {
+    render(
+      <ExpandableBlock>
+        <code>{['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight'].join('\n')}</code>
+      </ExpandableBlock>
+    )
+
+    const toggle = await screen.findByRole('button', { name: 'Expand' })
+    const fade = toggle.parentElement
+
+    expect(fade?.className).toContain('pointer-events-none')
+    expect(fade?.className).toContain('inset-x-0')
+    expect(toggle.className).toContain('pointer-events-auto')
+    expect(toggle.className).toContain('w-9')
+    expect(toggle.className).not.toContain('inset-x-0')
+
+    fireEvent.click(toggle)
+
+    expect(screen.getByRole('button', { name: 'Collapse' }).getAttribute('aria-expanded')).toBe('true')
+  })
+})

--- a/apps/desktop/src/components/chat/expandable-block.tsx
+++ b/apps/desktop/src/components/chat/expandable-block.tsx
@@ -35,15 +35,17 @@ export function ExpandableBlock({ children, className }: ExpandableBlockProps) {
         {children}
       </div>
       {overflowing && (
-        <button
-          aria-expanded={expanded}
-          aria-label={expanded ? 'Collapse' : 'Expand'}
-          className="absolute inset-x-0 bottom-0 flex h-7 cursor-pointer items-end justify-center bg-linear-to-t from-(--ui-chat-surface-background) to-transparent pb-1 text-muted-foreground/70 transition-colors hover:text-foreground"
-          onClick={() => setExpanded(v => !v)}
-          type="button"
-        >
-          <ChevronDown className={cn('size-3.5 transition-transform', expanded && 'rotate-180')} />
-        </button>
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 flex h-7 justify-center bg-linear-to-t from-(--ui-chat-surface-background) to-transparent">
+          <button
+            aria-expanded={expanded}
+            aria-label={expanded ? 'Collapse' : 'Expand'}
+            className="pointer-events-auto flex h-7 w-9 cursor-pointer items-end justify-center pb-1 text-muted-foreground/70 transition-colors hover:text-foreground"
+            onClick={() => setExpanded(v => !v)}
+            type="button"
+          >
+            <ChevronDown className={cn('size-3.5 transition-transform', expanded && 'rotate-180')} />
+          </button>
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- keep the bottom fade on expandable code blocks from intercepting text selection
- limit the expand/collapse hit area to the centered control while preserving its accessible state
- add focused regression coverage for the pointer-event contract and toggle behavior

## Root cause

`ExpandableBlock` used one full-width absolutely positioned button for both the visual fade and the expand control. That button covered the bottom line of the code block, so clicks and drag selection intended for the text were handled by the toggle instead.

## Validation

- `npm.cmd run test:ui --workspace apps/desktop -- src/components/chat/expandable-block.test.tsx`: 1 passed
- related Markdown/streaming tests: 48 passed across 3 files
- Desktop typecheck: passed
- ESLint and Prettier on touched files: passed
- Desktop production build: passed
- full Desktop UI suite: 1844 passed, 7 failed, 1 skipped
  - Skills (4) and Messaging (2) passed when rerun in isolation
  - Billing remained at 30 passed / 2 unrelated failures when rerun in isolation

Tested on Windows 11.

Fixes #69168