### PR TITLE
fix(cron): isolate workdir from gateway sessions (#69396)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -40,6 +40,7 @@ from agent.model_metadata import (
     query_ollama_num_ctx,
 )
 from agent.process_bootstrap import _install_safe_stdio
+from agent.runtime_cwd import resolve_context_cwd
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.think_scrubber import StreamingThinkScrubber
 from agent.tool_guardrails import (
@@ -2402,8 +2403,9 @@ def init_agent(
         except Exception as _ce_err:
             _ra().logger.debug("Context engine on_session_start: %s", _ce_err)
 
+    _context_cwd = resolve_context_cwd()
     agent._subdirectory_hints = SubdirectoryHintTracker(
-        working_dir=os.getenv("TERMINAL_CWD") or None,
+        working_dir=str(_context_cwd) if _context_cwd else None,
     )
     agent._user_turn_count = 0
     # Copilot x-initiator flag: first API call of a user turn sends "user" (#3040).

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -6,8 +6,10 @@ gateway/cron startup). The local-CLI backend deliberately leaves it unset and
 relies on the launch dir. Reading it in one place keeps the system prompt, the
 tool surfaces, and context-file discovery agreeing on where the agent lives.
 
-Multi-session gateways can pin a logical cwd via the `_SESSION_CWD`
-contextvar; CLI/cron fall through to `TERMINAL_CWD`/launch cwd.
+Multi-session gateways and per-job cron ``workdir`` pin a logical cwd via
+the `_SESSION_CWD` contextvar so concurrent sessions never observe each
+other's override through process-global ``TERMINAL_CWD``. CLI surfaces with
+no pin fall through to `TERMINAL_CWD`/launch cwd.
 """
 
 import logging
@@ -97,4 +99,27 @@ def resolve_context_cwd() -> Path | None:
             logger.warning("TERMINAL_CWD does not exist: %s", raw)
         else:
             return p
+    return None
+
+
+def resolve_tool_cwd() -> str | None:
+    """ContextVar-first cwd string for tool backends, or ``None`` if unset.
+
+    Unlike :func:`resolve_agent_cwd`, this does **not** require the path to
+    exist on the local filesystem — Docker/SSH/Modal remotes often configure a
+    cwd that only exists inside the sandbox (e.g. ``/workspace``). Cron workdir
+    jobs pin via ``_SESSION_CWD`` so concurrent gateway sessions keep reading
+    the process-global ``TERMINAL_CWD`` without seeing the job's override
+    (#69396).
+
+    Returns the configured string **verbatim** (no ``expanduser``). SSH backends
+    must keep literal ``~`` / ``~/...`` so the *remote* shell expands them;
+    local callers that need host expansion do it themselves.
+    """
+    override = _session_cwd_override()
+    if override:
+        return override
+    raw = os.environ.get("TERMINAL_CWD", "").strip()
+    if raw:
+        return raw
     return None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -445,18 +445,12 @@ _sequential_pool: Optional[concurrent.futures.ThreadPoolExecutor] = None
 class _ReadWriteLock:
     """Writer-preferring readers-writer lock.
 
-    Guards the process-global ``os.environ["TERMINAL_CWD"]`` override that a
-    workdir cron job applies for the whole of its agent run.  Workdir jobs are
-    writers: they mutate the shared env and need exclusive access.  Workdir-less
-    jobs are readers: they only observe ``TERMINAL_CWD`` (indirectly, via the
-    terminal / file / code-exec tools), so any number of them may run
-    concurrently with each other, but none may run alongside a writer — that is
-    exactly what stops a workdir-less job from picking up another job's workdir
-    override and running its commands in the wrong directory.
-
-    Writer preference bounds the wait for a workdir job (dispatched on the
-    single-thread sequential pool) so a stream of workdir-less readers cannot
-    starve it.
+    Historically guarded a process-global ``os.environ["TERMINAL_CWD"]``
+    override that workdir cron jobs applied for their agent run (#56265).
+    Workdir jobs now pin cwd via the task-local ``_SESSION_CWD`` ContextVar
+    instead (#69396), so they no longer mutate that env — but the lock is
+    retained to serialize workdir jobs against the shared terminal environment
+    cache while the sequential pool runs them one at a time.
     """
 
     def __init__(self) -> None:
@@ -2110,13 +2104,18 @@ def _windows_cron_python_invocation(python_exe: str) -> tuple[str, dict[str, str
     return str(interpreter), env_overlay
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _run_job_script(
+    script_path: str, *, cwd: Optional[str] = None
+) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
     Scripts must reside within HERMES_HOME/scripts/.  Both relative and
     absolute paths are resolved and validated against this directory to
     prevent arbitrary script execution via path traversal or absolute
     path injection.
+
+    When *cwd* is set (a validated absolute job ``workdir``), the subprocess
+    runs there — without ``os.chdir`` on the scheduler process (#69396).
 
     Supported interpreters (chosen by file extension):
 
@@ -2206,12 +2205,13 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             }
         env = _sanitize_subprocess_env(os.environ.copy())
         env.update(env_overlay)
+        script_cwd = cwd if cwd and Path(cwd).is_dir() else str(path.parent)
         result = subprocess.run(
             argv,
             capture_output=True,
             text=True,
             timeout=script_timeout,
-            cwd=str(path.parent),
+            cwd=script_cwd,
             env=env,
             **popen_kwargs,
         )
@@ -2245,7 +2245,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
 
 def _run_job_script_with_claim_heartbeat(
-    job: dict, script_path: str
+    job: dict, script_path: str, *, cwd: Optional[str] = None
 ) -> tuple[bool, str]:
     """Run a cron script while keeping its owned one-shot claim fresh.
 
@@ -2267,7 +2267,7 @@ def _run_job_script_with_claim_heartbeat(
         and schedule.get("kind") == "once"
         and owner
     ):
-        return _run_job_script(script_path)
+        return _run_job_script(script_path, cwd=cwd)
 
     job_id = str(job.get("id") or "")
     stop = threading.Event()
@@ -2298,10 +2298,10 @@ def _run_job_script_with_claim_heartbeat(
             job_id,
             exc_info=True,
         )
-        return _run_job_script(script_path)
+        return _run_job_script(script_path, cwd=cwd)
 
     try:
-        return _run_job_script(script_path)
+        return _run_job_script(script_path, cwd=cwd)
     finally:
         stop.set()
         # Event.wait() wakes immediately.  Keep completion bounded if the
@@ -2362,7 +2362,10 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         if prerun_script is not None:
             success, script_output = prerun_script
         else:
-            success, script_output = _run_job_script(script_path)
+            success, script_output = _run_job_script(
+                script_path,
+                cwd=(job.get("workdir") or "").strip() or None,
+            )
         if success:
             if script_output:
                 prompt = (
@@ -2703,26 +2706,16 @@ def run_job(
             logger.error("Job '%s': %s", job_id, err)
             return False, "", "", err
 
-        # Apply workdir if configured — lets scripts use predictable relative
-        # paths. For no_agent jobs this is just the subprocess cwd (not an
-        # agent TERMINAL_CWD bridge).
+        # Apply workdir if configured — pass as subprocess cwd so relative
+        # paths work without os.chdir() on the gateway/scheduler process
+        # (which would leak into concurrent interactive sessions — #69396).
         _job_workdir = (job.get("workdir") or "").strip() or None
-        _prior_cwd = None
-        if _job_workdir and Path(_job_workdir).is_dir():
-            _prior_cwd = os.getcwd()
-            try:
-                os.chdir(_job_workdir)
-            except OSError:
-                _prior_cwd = None
+        if _job_workdir and not Path(_job_workdir).is_dir():
+            _job_workdir = None
 
-        try:
-            ok, output = _run_job_script_with_claim_heartbeat(job, script_path)
-        finally:
-            if _prior_cwd is not None:
-                try:
-                    os.chdir(_prior_cwd)
-                except OSError:
-                    pass
+        ok, output = _run_job_script_with_claim_heartbeat(
+            job, script_path, cwd=_job_workdir
+        )
 
         now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
 
@@ -2919,9 +2912,25 @@ def run_job(
     # scheduler process — every job this process runs is a cron job.
     os.environ["HERMES_CRON_SESSION"] = "1"
 
-    # Use ContextVars for per-job session/delivery state so parallel jobs
-    # don't clobber each other's targets (os.environ is process-global).
+    # Use ContextVars for per-job session/delivery/cwd state so parallel jobs
+    # and concurrent gateway sessions don't clobber each other (os.environ is
+    # process-global — see #69396).
     from gateway.session_context import set_session_vars, clear_session_vars, _VAR_MAP
+    from agent.runtime_cwd import set_session_cwd
+
+    # Per-job working directory (validated at create/update). Resolve BEFORE
+    # set_session_vars so we can pin it on the task-local ContextVar instead of
+    # mutating process-global TERMINAL_CWD — that env override used to leak into
+    # interactive gateway sessions created while the job was running (#69396).
+    _job_workdir = (job.get("workdir") or "").strip() or None
+    if _job_workdir and not Path(_job_workdir).is_dir():
+        # Directory was removed between create-time validation and now.  Log
+        # and drop back to old behaviour rather than crashing the job.
+        logger.warning(
+            "Job '%s': configured workdir %r no longer exists — running without it",
+            job_id, _job_workdir,
+        )
+        _job_workdir = None
 
     # Cron execution is an internal scheduler context, not a live inbound
     # gateway message. Do not seed HERMES_SESSION_* contextvars from the
@@ -2944,6 +2953,10 @@ def run_job(
     # Cron output delivery itself reads job["origin"] directly via
     # _resolve_origin(job) and the HERMES_CRON_AUTO_DELIVER_* vars set
     # below, so clearing HERMES_SESSION_* here does not affect delivery.
+    #
+    # cwd=_job_workdir pins project-context discovery + tool cwd resolution
+    # for THIS job's ContextVar only. Workdir-less jobs leave cwd empty so
+    # resolve_* falls through to the scheduler's TERMINAL_CWD (unchanged).
     _ctx_tokens = set_session_vars(
         platform="",
         chat_id="",
@@ -2962,6 +2975,7 @@ def run_job(
         # inline/synchronous path, so results return within the job's own turn.
         # See declare_stateless_channel(). Upstream: #53027, #63142.
         async_delivery=False,
+        cwd=_job_workdir or "",
     )
     _cron_delivery_vars = (
         "HERMES_CRON_AUTO_DELIVER_PLATFORM",
@@ -2971,38 +2985,10 @@ def run_job(
     for _var_name in _cron_delivery_vars:
         _VAR_MAP[_var_name].set("")
 
-    # Per-job working directory.  When set (and validated at create/update
-    # time), we point TERMINAL_CWD at it so:
-    #   - build_context_files_prompt() picks up AGENTS.md / CLAUDE.md /
-    #     .cursorrules from the job's project dir, AND
-    #   - the terminal, file, and code-exec tools run commands from there.
-    #
-    # os.environ["TERMINAL_CWD"] is process-global, so this override is
-    # serialized by _terminal_cwd_lock (acquired just below): a workdir job
-    # holds it as a writer for its whole run, excluding every other job, while
-    # workdir-less jobs hold it as readers and stay parallel with each other.
-    # The sequential pool only keeps workdir jobs from overlapping EACH OTHER;
-    # the lock is what additionally keeps a concurrently-firing workdir-less
-    # parallel-pool job from observing this override and running its shell /
-    # file / code-exec commands in the wrong directory.  For workdir-less jobs
-    # we leave TERMINAL_CWD untouched — preserves the original behaviour
-    # (skip_context_files=True, tools use whatever cwd the scheduler has).
-    _job_workdir = (job.get("workdir") or "").strip() or None
-    if _job_workdir and not Path(_job_workdir).is_dir():
-        # Directory was removed between create-time validation and now.  Log
-        # and drop back to old behaviour rather than crashing the job.
-        logger.warning(
-            "Job '%s': configured workdir %r no longer exists — running without it",
-            job_id, _job_workdir,
-        )
-        _job_workdir = None
-
-    # Snapshot the current env value BEFORE acquiring the lock so the finally
-    # below can always restore it, even if an exception fires before we set the
-    # override inside the try.  This read can't leak the lock (it precedes the
-    # acquire) and is a no-op for workdir-less jobs (they never mutate the env).
-    _prior_terminal_cwd = os.environ.get("TERMINAL_CWD", "_UNSET_")
-
+    # Readers-writer lock: workdir jobs no longer mutate TERMINAL_CWD, but the
+    # sequential pool still serializes them against each other (shared terminal
+    # environment cache / "default" task id). Workdir-less jobs still take a
+    # read lock so a future writer path can't race them if reintroduced.
     _holds_cwd_write = _job_workdir is not None
     if _holds_cwd_write:
         _terminal_cwd_lock.acquire_write()
@@ -3010,13 +2996,24 @@ def run_job(
         _terminal_cwd_lock.acquire_read()
 
     # Everything after the acquire MUST live inside this try, so the finally
-    # below always releases the lock even if the env override or any later
-    # statement raises.  A leaked writer would deadlock the whole scheduler
-    # (every future job blocks on acquire_*); a leaked reader blocks all
-    # future writers.  Acquire itself can't leak (it either blocks or returns).
+    # below always releases the lock even if any later statement raises.
     try:
+        # Seed the terminal/file/code-exec per-session cwd RECORD so tools that
+        # key off task_id (= cron session id) resolve the job workdir without
+        # reading process-global TERMINAL_CWD. Cleared in finally.
         if _job_workdir:
-            os.environ["TERMINAL_CWD"] = _job_workdir
+            try:
+                from tools.terminal_tool import record_session_cwd
+
+                record_session_cwd(_cron_session_id, _job_workdir)
+            except Exception:
+                logger.debug(
+                    "Job '%s': could not seed session cwd record for workdir",
+                    job_id,
+                    exc_info=True,
+                )
+            # Explicitly refuse to touch TERMINAL_CWD here (#69396).
+            set_session_cwd(_job_workdir)
             logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
 
         # Re-read .env and config.yaml fresh every run so provider/key
@@ -3037,6 +3034,9 @@ def run_job(
         )
         reset_secret_source_cache()
         load_hermes_dotenv(hermes_home=_get_hermes_home())
+        # load_hermes_dotenv must not clobber our ContextVar pin; re-assert.
+        if _job_workdir:
+            set_session_cwd(_job_workdir)
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
@@ -3608,21 +3608,22 @@ def run_job(
         return False, output, "", error_msg
 
     finally:
-        # Restore TERMINAL_CWD to whatever it was before this job ran.  We
-        # only ever mutate it when the job has a workdir; see the setup block
-        # at the top of run_job for the serialization guarantee.
-        if _job_workdir:
-            if _prior_terminal_cwd == "_UNSET_":
-                os.environ.pop("TERMINAL_CWD", None)
-            else:
-                os.environ["TERMINAL_CWD"] = _prior_terminal_cwd
-        # Release the cwd lock now that the env is restored, so a waiting
-        # workdir job (or queued reader) can proceed without seeing the override.
+        # Release the cwd lock. Workdir jobs no longer mutate TERMINAL_CWD
+        # (#69396); the lock still serializes them against the shared terminal
+        # environment cache while the sequential pool runs them one at a time.
         if _holds_cwd_write:
             _terminal_cwd_lock.release_write()
         else:
             _terminal_cwd_lock.release_read()
-        # Clean up ContextVar session/delivery state for this job.
+        # Drop the per-session cwd RECORD seeded for this cron run.
+        if _job_workdir:
+            try:
+                from tools.terminal_tool import clear_session_cwd as _clear_term_cwd
+
+                _clear_term_cwd(_cron_session_id)
+            except Exception:
+                pass
+        # Clean up ContextVar session/delivery/cwd state for this job.
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
@@ -3982,12 +3983,11 @@ def tick(
             body."""
             return run_one_job(job, adapters=adapters, loop=loop, verbose=verbose)
 
-        # Partition due jobs: those with a per-job workdir mutate
-        # os.environ["TERMINAL_CWD"] inside run_job, which is process-global, so
-        # they queue on the single-thread sequential pool to run one at a time.
-        # That alone only keeps workdir jobs from overlapping EACH OTHER;
-        # run_job's _terminal_cwd_lock is what additionally stops a concurrently
-        # firing workdir-less parallel-pool job from observing the override.
+        # Partition due jobs: those with a per-job workdir pin cwd via a
+        # task-local ContextVar (#69396) but still share the process-wide
+        # terminal environment cache, so they queue on the single-thread
+        # sequential pool to run one at a time. Workdir-less jobs stay on
+        # the parallel pool.
         sequential_jobs = [j for j in due_jobs if (j.get("workdir") or "").strip()]
         parallel_jobs = [j for j in due_jobs if not (j.get("workdir") or "").strip()]
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1919,6 +1919,13 @@ if not _configured_cwd or _configured_cwd in CWD_PLACEHOLDERS:
     else:
         os.environ["TERMINAL_CWD"] = _resolved_cwd
 
+# Snapshot the gateway's configured cwd AFTER placeholder resolution. Interactive
+# sessions pin this via set_session_vars(cwd=...) so a concurrent cron workdir
+# job can never redirect their project-context discovery through live
+# os.environ["TERMINAL_CWD"] (#69396). Cron itself no longer mutates that env,
+# but the pin remains as defense in depth.
+_GATEWAY_PINNED_CWD = os.environ.get("TERMINAL_CWD", "")
+
 from gateway.config import (
     ChannelOverride,
     Platform,
@@ -16691,6 +16698,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
             async_delivery=_async_delivery,
+            # Pin the startup-resolved messaging cwd so resolve_context_cwd()
+            # never falls through to a live TERMINAL_CWD that another task
+            # (cron workdir) might have mutated (#69396).
+            cwd=_GATEWAY_PINNED_CWD,
         )
 
     def _clear_session_env(self, tokens: list) -> None:

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -10,6 +10,7 @@ from agent.runtime_cwd import (
     clear_session_cwd,
     resolve_agent_cwd,
     resolve_context_cwd,
+    resolve_tool_cwd,
     set_session_cwd,
 )
 
@@ -105,8 +106,36 @@ class TestSessionCwdOverride:
         try:
             assert resolve_agent_cwd() == other
             assert resolve_context_cwd() == other
+            assert resolve_tool_cwd() == str(other)
         finally:
             rt._SESSION_CWD.reset(token)
+
+    def test_resolve_tool_cwd_allows_nonexistent_remote_path(self, monkeypatch):
+        """Container/SSH remotes may pin a cwd that only exists inside the sandbox."""
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        token = set_session_cwd("/workspace/only-in-container")
+        try:
+            assert resolve_tool_cwd() == "/workspace/only-in-container"
+            # resolve_agent_cwd requires is_dir(); falls through to getcwd.
+            assert resolve_agent_cwd() != Path("/workspace/only-in-container")
+        finally:
+            rt._SESSION_CWD.reset(token)
+
+    def test_resolve_tool_cwd_preserves_ssh_tilde(self, monkeypatch):
+        """Do not expanduser — SSH remotes need the literal tilde path (#69396 CI)."""
+        monkeypatch.setenv("TERMINAL_CWD", "~/project")
+        monkeypatch.setenv("HOME", "/opt/data")
+        assert resolve_tool_cwd() == "~/project"
+        token = set_session_cwd("~")
+        try:
+            assert resolve_tool_cwd() == "~"
+        finally:
+            rt._SESSION_CWD.reset(token)
+
+    def test_resolve_tool_cwd_none_when_unset(self, monkeypatch):
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        clear_session_cwd()
+        assert resolve_tool_cwd() is None
 
     def test_empty_session_cwd_falls_back_to_terminal_cwd(self, monkeypatch, tmp_path):
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -253,13 +253,14 @@ class TestTickWorkdirPartition:
 
 
 # ---------------------------------------------------------------------------
-# scheduler.run_job: TERMINAL_CWD + skip_context_files wiring
+# scheduler.run_job: session cwd ContextVar + skip_context_files wiring
 # ---------------------------------------------------------------------------
 
 class TestRunJobTerminalCwd:
     """
-    run_job sets TERMINAL_CWD + flips skip_context_files=False when workdir
-    is set, and restores the prior TERMINAL_CWD in finally — even on error.
+    run_job pins workdir on the task-local ContextVar + session cwd record
+    (NOT process-global TERMINAL_CWD — #69396), flips skip_context_files=False
+    when workdir is set, and clears the pin in finally — even on error.
     We stub AIAgent so no real API call happens.
     """
 
@@ -269,6 +270,7 @@ class TestRunJobTerminalCwd:
         import os
         import sys
         import cron.scheduler as sched
+        from agent.runtime_cwd import resolve_context_cwd
 
         class FakeAgent:
             def __init__(self, **kwargs):
@@ -277,11 +279,14 @@ class TestRunJobTerminalCwd:
                 observed["terminal_cwd_during_init"] = os.environ.get(
                     "TERMINAL_CWD", "_UNSET_"
                 )
+                observed["context_cwd_during_init"] = resolve_context_cwd()
+                observed["session_id"] = kwargs.get("session_id")
 
             def run_conversation(self, *_a, **_kw):
                 observed["terminal_cwd_during_run"] = os.environ.get(
                     "TERMINAL_CWD", "_UNSET_"
                 )
+                observed["context_cwd_during_run"] = resolve_context_cwd()
                 return {"final_response": "done", "messages": []}
 
             def get_activity_summary(self):
@@ -315,14 +320,19 @@ class TestRunJobTerminalCwd:
         # run_job calls load_dotenv(~/.hermes/.env, override=True), which will
         # happily clobber TERMINAL_CWD out from under us if the real user .env
         # has TERMINAL_CWD set (common on dev boxes).  Stub it out.
-        import dotenv
-        monkeypatch.setattr(dotenv, "load_dotenv", lambda *_a, **_kw: True)
+        monkeypatch.setattr(
+            "hermes_cli.env_loader.load_hermes_dotenv", lambda **_kw: None
+        )
+        monkeypatch.setattr(
+            "hermes_cli.env_loader.reset_secret_source_cache", lambda: None
+        )
 
     def test_workdir_sets_and_restores_terminal_cwd(
         self, tmp_path, monkeypatch
     ):
         import os
         import cron.scheduler as sched
+        from tools.terminal_tool import get_session_cwd
 
         # Make sure the test's TERMINAL_CWD starts at a known non-workdir value.
         # Use monkeypatch.setenv so it's restored on teardown regardless of
@@ -345,12 +355,15 @@ class TestRunJobTerminalCwd:
         # AIAgent was built with skip_context_files=False (feature ON).
         assert observed["skip_context_files"] is False
         assert observed["load_soul_identity"] is True
-        # TERMINAL_CWD was pointing at the job workdir while the agent ran.
-        assert observed["terminal_cwd_during_init"] == str(tmp_path.resolve())
-        assert observed["terminal_cwd_during_run"] == str(tmp_path.resolve())
-
-        # And it was restored to the original value in finally.
+        # ContextVar pointed at the job workdir while the agent ran.
+        assert observed["context_cwd_during_init"] == tmp_path.resolve()
+        assert observed["context_cwd_during_run"] == tmp_path.resolve()
+        # Process-global TERMINAL_CWD must NOT have been rewritten (#69396).
+        assert observed["terminal_cwd_during_init"] == "/original/cwd"
+        assert observed["terminal_cwd_during_run"] == "/original/cwd"
         assert os.environ["TERMINAL_CWD"] == "/original/cwd"
+        # Session cwd record is cleared in finally.
+        assert get_session_cwd(observed["session_id"]) is None
 
     def test_no_workdir_leaves_terminal_cwd_untouched(self, monkeypatch):
         """When workdir is absent, run_job must not touch TERMINAL_CWD at all —

--- a/tests/cron/test_cron_workdir_gateway_leak.py
+++ b/tests/cron/test_cron_workdir_gateway_leak.py
@@ -1,0 +1,244 @@
+"""Regression for #69396: cron workdir must not leak into gateway sessions.
+
+A workdir cron job used to mutate process-global ``os.environ["TERMINAL_CWD"]``
+for the duration of its agent run. Interactive gateway sessions created in that
+window inherited the job's directory via ``resolve_context_cwd()`` and loaded
+its ``AGENTS.md`` as ``# Project Context`` — then followed the cron task
+instead of the user's message.
+
+The fix pins cron workdir on the task-local ``_SESSION_CWD`` ContextVar (and a
+per-session cwd record) and leaves ``TERMINAL_CWD`` alone.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def gateway_and_cron_dirs(tmp_path):
+    gateway = tmp_path / "gateway-home"
+    cron = tmp_path / "cron-brief"
+    gateway.mkdir()
+    cron.mkdir()
+    (cron / "AGENTS.md").write_text(
+        "# Daily Brief\nProduce a SHORT home + server brief...\n",
+        encoding="utf-8",
+    )
+    (gateway / "AGENTS.md").write_text(
+        "# Gateway workspace\nAnswer the user's chat.\n",
+        encoding="utf-8",
+    )
+    return gateway, cron
+
+
+def test_run_job_workdir_does_not_mutate_terminal_cwd(gateway_and_cron_dirs, monkeypatch):
+    """While a workdir job runs, process-global TERMINAL_CWD stays at the
+    gateway/scheduler value — concurrent resolve_context_cwd() callers without
+    a session pin must not see the cron directory.
+    """
+    import cron.scheduler as sched
+    from agent.prompt_builder import build_context_files_prompt
+    from agent.runtime_cwd import resolve_context_cwd
+
+    gateway, cron = gateway_and_cron_dirs
+    monkeypatch.setenv("TERMINAL_CWD", str(gateway))
+
+    observed: dict = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            observed["skip_context_files"] = kwargs.get("skip_context_files")
+            observed["terminal_cwd_during_init"] = os.environ.get("TERMINAL_CWD")
+            observed["context_cwd_during_init"] = resolve_context_cwd()
+            # Simulate a concurrent gateway session that has no session cwd pin
+            # (the pre-fix path): it must still resolve to the gateway cwd.
+            observed["peer_context_cwd"] = None
+            observed["peer_prompt_has_cron_agents"] = None
+
+            def _peer_observe():
+                observed["peer_context_cwd"] = resolve_context_cwd()
+                prompt = build_context_files_prompt(
+                    cwd=str(observed["peer_context_cwd"])
+                    if observed["peer_context_cwd"]
+                    else None
+                )
+                observed["peer_prompt_has_cron_agents"] = (
+                    "Produce a SHORT home + server brief" in prompt
+                )
+                observed["peer_prompt_has_gateway_agents"] = (
+                    "Answer the user's chat" in prompt
+                )
+
+            # Run the peer observation on a fresh thread with a CLEARED
+            # ContextVar (no inherited cron pin) — matches a gateway handler
+            # that never called set_session_cwd(cron_workdir).
+            t = threading.Thread(target=_peer_observe)
+            t.start()
+            t.join(timeout=5)
+
+        def run_conversation(self, *_a, **_kw):
+            observed["terminal_cwd_during_run"] = os.environ.get("TERMINAL_CWD")
+            observed["context_cwd_during_run"] = resolve_context_cwd()
+            return {"final_response": "done", "messages": []}
+
+        def get_activity_summary(self):
+            return {"seconds_since_activity": 0.0}
+
+    import sys
+
+    fake_mod = type(sys)("run_agent")
+    fake_mod.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_mod)
+
+    from hermes_cli import runtime_provider as _rtp
+
+    monkeypatch.setattr(
+        _rtp,
+        "resolve_runtime_provider",
+        lambda **_kw: {
+            "provider": "test",
+            "api_key": "k",
+            "base_url": "http://test.local",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(sched, "_build_job_prompt", lambda job, prerun_script=None: "hi")
+    monkeypatch.setattr(sched, "_resolve_origin", lambda job: None)
+    monkeypatch.setattr(sched, "_resolve_delivery_target", lambda job: None)
+    monkeypatch.setattr(sched, "_resolve_cron_enabled_toolsets", lambda job, cfg: None)
+    monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0")
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.load_hermes_dotenv", lambda **_kw: None
+    )
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.reset_secret_source_cache", lambda: None
+    )
+
+    job = {
+        "id": "leak-job",
+        "name": "leak-job",
+        "workdir": str(cron),
+        "schedule_display": "manual",
+    }
+
+    success, *_ = sched.run_job(job)
+    assert success is True
+
+    # Cron agent sees the workdir via ContextVar.
+    assert observed["skip_context_files"] is False
+    assert observed["context_cwd_during_init"] == cron.resolve()
+    assert observed["context_cwd_during_run"] == cron.resolve()
+
+    # Process-global env never flipped to the cron workdir.
+    assert observed["terminal_cwd_during_init"] == str(gateway)
+    assert observed["terminal_cwd_during_run"] == str(gateway)
+    assert os.environ["TERMINAL_CWD"] == str(gateway)
+
+    # Concurrent unpinned peer kept the gateway cwd + AGENTS.md.
+    assert observed["peer_context_cwd"] == gateway.resolve()
+    assert observed["peer_prompt_has_cron_agents"] is False
+    assert observed["peer_prompt_has_gateway_agents"] is True
+
+
+def test_run_job_workdir_leaves_terminal_cwd_untouched_on_error(
+    gateway_and_cron_dirs, monkeypatch
+):
+    """Even when the workdir log raises, TERMINAL_CWD must be unchanged and
+    the writer lock must still be released (lock-leak regression from #56265).
+    """
+    import cron.scheduler as sched
+
+    gateway, cron = gateway_and_cron_dirs
+    monkeypatch.setenv("TERMINAL_CWD", str(gateway))
+
+    job = {
+        "id": "boom-job",
+        "name": "boom",
+        "prompt": "hi",
+        "workdir": str(cron),
+    }
+
+    real_info = sched.logger.info
+
+    def _raise_on_workdir_log(msg, *args, **kwargs):
+        if isinstance(msg, str) and "using workdir" in msg:
+            raise RuntimeError("boom")
+        return real_info(msg, *args, **kwargs)
+
+    with patch("cron.scheduler._hermes_home", gateway.parent), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+         patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+         patch.object(sched.logger, "info", side_effect=_raise_on_workdir_log), \
+         patch("hermes_state.SessionDB", return_value=MagicMock()):
+        success, *_ = sched.run_job(job)
+
+    assert success is False
+    assert os.environ["TERMINAL_CWD"] == str(gateway)
+
+    acquired = threading.Event()
+
+    def try_acquire():
+        sched._terminal_cwd_lock.acquire_write()
+        try:
+            acquired.set()
+        finally:
+            sched._terminal_cwd_lock.release_write()
+
+    t = threading.Thread(target=try_acquire, daemon=True)
+    t.start()
+    assert acquired.wait(timeout=5), "writer lock was leaked by run_job on exception"
+    t.join(timeout=5)
+
+
+def test_no_agent_workdir_does_not_chdir_process(tmp_path, monkeypatch):
+    """no_agent jobs must pass workdir as subprocess cwd, not os.chdir()."""
+    import cron.scheduler as sched
+
+    workdir = tmp_path / "brief"
+    workdir.mkdir()
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    script = scripts / "probe.py"
+    script.write_text(
+        "import os\nprint(os.getcwd())\n",
+        encoding="utf-8",
+    )
+
+    prior = os.getcwd()
+    monkeypatch.setattr(sched, "_get_hermes_home", lambda: tmp_path)
+
+    captured: dict = {}
+
+    def _capture_run(*args, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        captured["process_cwd"] = os.getcwd()
+
+        class _R:
+            returncode = 0
+            stdout = kwargs["cwd"] or ""
+            stderr = ""
+
+        return _R()
+
+    monkeypatch.setattr(sched.subprocess, "run", _capture_run)
+
+    job = {
+        "id": "na",
+        "name": "na",
+        "no_agent": True,
+        "script": "probe.py",
+        "workdir": str(workdir),
+        "schedule": {"kind": "cron", "expr": "0 0 * * *"},
+    }
+    ok, doc, final, err = sched.run_job(job)
+    assert ok is True, err
+    assert Path(captured["cwd"]).resolve() == workdir.resolve()
+    assert Path(captured["process_cwd"]).resolve() == Path(prior).resolve()
+    assert Path(os.getcwd()).resolve() == Path(prior).resolve()

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2925,7 +2925,7 @@ class TestRunJobWakeGate:
         import cron.scheduler as scheduler
 
         call_count = 0
-        def _script_stub(path):
+        def _script_stub(path, *, cwd=None):
             nonlocal call_count
             call_count += 1
             return (True, "regular output")

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -84,7 +84,7 @@ def test_long_running_script_refreshes_owned_claim_in_profile_store(
         heartbeat_seen.set()
         return updated
 
-    def _blocking_script(_script_path: str) -> tuple[bool, str]:
+    def _blocking_script(_script_path: str, *, cwd=None) -> tuple[bool, str]:
         assert heartbeat_seen.wait(timeout=2), (
             "claim was not refreshed while script blocked"
         )
@@ -146,7 +146,7 @@ def test_script_heartbeat_uses_captured_claim_owner(tmp_path, monkeypatch):
         heartbeat_seen.set()
         return updated
 
-    def _blocking_script(_script_path: str) -> tuple[bool, str]:
+    def _blocking_script(_script_path: str, *, cwd=None) -> tuple[bool, str]:
         assert heartbeat_seen.wait(timeout=2)
         return True, "done"
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1829,7 +1829,12 @@ def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
             session_cwd = None
         if session_cwd and os.path.isdir(session_cwd):
             return session_cwd
-    raw = os.environ.get("TERMINAL_CWD", "").strip()
+    try:
+        from agent.runtime_cwd import resolve_tool_cwd
+
+        raw = (resolve_tool_cwd() or "").strip()
+    except Exception:
+        raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         expanded = os.path.expanduser(raw)
         if os.path.isdir(expanded):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -744,13 +744,19 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
     guessing `/workspace/...` for local repo tasks.
     """
     candidates = [
-        os.getenv("TERMINAL_CWD"),
+        None,  # filled below from resolve_tool_cwd when available
         getattr(
             getattr(parent_agent, "_subdirectory_hints", None), "working_dir", None
         ),
         getattr(parent_agent, "terminal_cwd", None),
         getattr(parent_agent, "cwd", None),
     ]
+    try:
+        from agent.runtime_cwd import resolve_tool_cwd
+
+        candidates[0] = resolve_tool_cwd()
+    except Exception:
+        candidates[0] = os.getenv("TERMINAL_CWD")
     for candidate in candidates:
         if not candidate:
             continue

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -240,14 +240,19 @@ def _sentinel_free_abs_cwd(raw: str | None) -> str | None:
 
 
 def _configured_terminal_cwd() -> str | None:
-    """Return ``$TERMINAL_CWD`` only when it names a real directory anchor.
+    """Return the configured/session cwd only when it names a real directory anchor.
 
-    Sentinel values (see ``_TERMINAL_CWD_SENTINELS``) and relative paths are
-    rejected — a relative anchor is meaningless without knowing which cwd it is
-    relative to, which is exactly the ambiguity that misroutes worktree edits.
-    Only an absolute, sentinel-free value is honored.
+    Prefers the task-local ContextVar (cron workdir / gateway session pin) over
+    process-global ``$TERMINAL_CWD`` so concurrent sessions cannot steal each
+    other's workspace (#69396). Sentinel values (see ``_TERMINAL_CWD_SENTINELS``)
+    and relative paths are rejected.
     """
-    return _sentinel_free_abs_cwd(os.environ.get("TERMINAL_CWD"))
+    try:
+        from agent.runtime_cwd import resolve_tool_cwd
+
+        return _sentinel_free_abs_cwd(resolve_tool_cwd())
+    except Exception:
+        return _sentinel_free_abs_cwd(os.environ.get("TERMINAL_CWD"))
 
 
 def _registered_task_cwd_override(task_id: str = "default") -> str | None:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1391,16 +1391,17 @@ def _get_env_config() -> Dict[str, Any]:
     else:
         default_cwd = "/root"
 
-    # Read TERMINAL_CWD but sanity-check it for container backends.
-    # If Docker cwd passthrough is explicitly enabled, remap the host path to
-    # /workspace and track the original host path separately. Otherwise keep the
-    # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    # Read configured/session cwd. Prefer the task-local ContextVar
+    # (cron workdir / gateway session pin) over process-global TERMINAL_CWD
+    # so a concurrent cron job cannot redirect this environment (#69396).
+    from agent.runtime_cwd import resolve_tool_cwd
+
+    cwd = resolve_tool_cwd() or default_cwd
     if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
         cwd = os.path.expanduser(cwd)
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
+        docker_cwd_source = resolve_tool_cwd() or _safe_getcwd()
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
@@ -1411,7 +1412,7 @@ def _get_env_config() -> Dict[str, Any]:
     elif env_type in _CONTAINER_BACKENDS and cwd:
         # Host paths and relative paths that won't work inside containers
         if _is_unusable_container_cwd(cwd) and cwd != default_cwd:
-            logger.info("Ignoring TERMINAL_CWD=%r for %s backend "
+            logger.info("Ignoring tool cwd=%r for %s backend "
                         "(host/relative path won't work in sandbox). Using %r instead.",
                         cwd, env_type, default_cwd)
             cwd = default_cwd


### PR DESCRIPTION
## Summary
- Cron jobs with `workdir` no longer rewrite process-global `TERMINAL_CWD`. The job directory is pinned on the task-local `_SESSION_CWD` ContextVar (and a per-session cwd record) so concurrent Signal/Telegram/etc. sessions cannot inherit the cron `AGENTS.md` as `# Project Context` ([#69396](https://github.com/NousResearch/hermes-agent/issues/69396)).
- `no_agent` scripts receive an explicit subprocess `cwd=` instead of `os.chdir()` on the gateway process.
- Gateway message handlers pin the startup-resolved messaging cwd via `set_session_vars(cwd=...)` as defense in depth.
- Narrower alternative to draft [#66028](https://github.com/NousResearch/hermes-agent/pull/66028) (DIRTY / needs-decision): fixes the reported gateway-session leak without the full parallel-workdir rewrite.

## Test plan
- [x] `scripts/run_tests.sh tests/cron/test_cron_workdir_gateway_leak.py tests/cron/test_cron_workdir.py tests/cron/test_terminal_cwd_lock.py tests/agent/test_runtime_cwd.py -q`
- [x] Reproduce on current `main`: concurrent thread calling `resolve_context_cwd()` while a workdir job would previously see the cron dir; after the fix `TERMINAL_CWD` stays at the gateway value and the peer prompt keeps the gateway `AGENTS.md`.
- [ ] Manual: start gateway, fire a long cron job with `--workdir` pointing at a dir that has a distinctive `AGENTS.md`, send a new messaging message mid-run, confirm the new session system prompt has no cron `# Project Context`.

## Infographic
![cron workdir no longer leaks into gateway sessions](https://raw.githubusercontent.com/HexLab98/hermes-agent-fork/pr-asset-69396-infographic/69396-cron-workdir-gateway-leak-infographic.png)
