### PR TITLE
fix(kanban): guard closed-loop successor execution

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2115,18 +2115,24 @@ def _cmd_block(args: argparse.Namespace) -> int:
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
-            if reason:
-                kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
-            if not kb.block_task(
-                conn,
-                tid,
-                reason=reason,
-                kind=kind,
-                expected_run_id=_worker_run_id_for(tid),
-            ):
+            try:
+                blocked = kb.block_task(
+                    conn,
+                    tid,
+                    reason=reason,
+                    kind=kind,
+                    expected_run_id=_worker_run_id_for(tid),
+                )
+            except ValueError as exc:
+                failed.append(tid)
+                print(f"cannot block {tid}: {exc}", file=sys.stderr)
+                continue
+            if not blocked:
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
             else:
+                if reason:
+                    kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
                 # Report where the task actually landed — dependency blocks go
                 # to todo, and a tripped unblock-loop breaker routes to triage.
                 landed = kb.get_task(conn, tid)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5268,6 +5268,29 @@ def block_task(
         # here (rather than ``blocked``) is what keeps a cron from ever seeing
         # a dependency-wait as something to "unblock".
         if kind == "dependency":
+            child_row = conn.execute(
+                "SELECT child_id FROM task_links WHERE parent_id = ? LIMIT 1",
+                (task_id,),
+            ).fetchone()
+            if child_row is not None:
+                unsatisfied_parent = conn.execute(
+                    """
+                    SELECT l.parent_id
+                      FROM task_links l
+                      JOIN tasks p ON p.id = l.parent_id
+                     WHERE l.child_id = ?
+                       AND p.status != 'done'
+                     LIMIT 1
+                    """,
+                    (task_id,),
+                ).fetchone()
+                if unsatisfied_parent is None:
+                    raise ValueError(
+                        "dependency block is invalid after successor creation "
+                        "when no unsatisfied parent remains; complete parent "
+                        f"task {task_id} because successor "
+                        f"{child_row['child_id']} already exists"
+                    )
             cur = conn.execute(
                 """
                 UPDATE tasks

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -162,6 +162,47 @@ def test_dependency_then_parent_done_promotes(kanban_home: Path) -> None:
         assert kb.get_task(conn, child).status == "ready"
 
 
+def test_dependency_block_after_successor_creation_is_rejected(kanban_home: Path) -> None:
+    """Once a successor exists with no incoming wait, the parent should finish."""
+    with kb.connect_closing() as conn:
+        parent = _running_task(conn, title="implemented ACL change")
+        successor = kb.create_task(conn, title="QA successor", assignee="qa")
+        kb.link_tasks(conn, parent_id=parent, child_id=successor)
+
+        with pytest.raises(ValueError, match="dependency block is invalid after successor creation"):
+            kb.block_task(conn, parent, reason="QA successor exists", kind="dependency")
+
+        task = kb.get_task(conn, parent)
+        assert task is not None
+        assert task.status == "running"
+
+        kb.complete_task(conn, parent, result="done")
+        kb.recompute_ready(conn)
+        successor_task = kb.get_task(conn, successor)
+        assert successor_task is not None
+        assert successor_task.status == "ready"
+
+
+def test_dependency_block_with_successor_allowed_when_parent_unsatisfied(kanban_home: Path) -> None:
+    """A valid P->A->C graph may park A while A waits for unfinished P."""
+    with kb.connect_closing() as conn:
+        upstream = kb.create_task(conn, title="upstream prerequisite", assignee="worker")
+        active = _running_task(conn, title="active middle task")
+        successor = kb.create_task(conn, title="downstream successor", assignee="qa")
+        kb.link_tasks(conn, parent_id=upstream, child_id=active)
+        kb.link_tasks(conn, parent_id=active, child_id=successor)
+
+        assert kb.block_task(conn, active, reason="wait for upstream", kind="dependency")
+
+        active_task = kb.get_task(conn, active)
+        successor_task = kb.get_task(conn, successor)
+        assert active_task is not None
+        assert successor_task is not None
+        assert active_task.status == "todo"
+        assert active_task.block_kind == "dependency"
+        assert successor_task.status == "todo"
+
+
 # ---------------------------------------------------------------------------
 # Completion resets loop memory
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -159,6 +159,27 @@ def test_run_slash_block_unblock_cycle(kanban_home):
     assert "Unblocked" in kc.run_slash(f"unblock {tid}")
 
 
+def test_run_slash_dependency_block_rejection_does_not_comment(kanban_home):
+    parent_out = kc.run_slash("create 'parent' --assignee alice")
+    child_out = kc.run_slash("create 'child' --assignee qa")
+    import re
+    parent_match = re.search(r"(t_[a-f0-9]+)", parent_out)
+    child_match = re.search(r"(t_[a-f0-9]+)", child_out)
+    assert parent_match is not None
+    assert child_match is not None
+    parent = parent_match.group(1)
+    child = child_match.group(1)
+    kc.run_slash(f"claim {parent}")
+    kc.run_slash(f"link {parent} {child}")
+
+    out = kc.run_slash(f"block {parent} QA-successor-exists --kind dependency")
+
+    assert "dependency block is invalid after successor creation" in out
+    show = kc.run_slash(f"show {parent}")
+    assert "status:    running" in show
+    assert "BLOCKED:" not in show
+
+
 def test_run_slash_json_output(kanban_home):
     out = kc.run_slash("create 'jsontask' --assignee alice --json")
     payload = json.loads(out)


### PR DESCRIPTION
## Summary
- Fixes the kanban closed-loop successor guard for dependency blocking after a successor has already been created.
- Rejects a dependency block when the task has no unfinished incoming parent edge left to wait on, preventing a closed-loop task from being moved back to todo after successor handoff.
- Preserves the valid middle-task dependency wait case (`P -> A -> C`) and keeps CLI `BLOCKED:` comments gated behind a successful block.

## Exact scope
This clean current-main patch is intentionally limited to four files:
- `hermes_cli/kanban.py`
- `hermes_cli/kanban_db.py`
- `tests/hermes_cli/test_kanban_block_kinds.py`
- `tests/hermes_cli/test_kanban_cli.py`

It does not include the prior stale-branch contamination, #66632 duplicate content, task-label work, board-override work, or broader review/acceptance/evidence execution-dependency expansion.

## Verification
EVE exact-head QA PASS was completed for head `fce0263992ff2f407c25daaa1e72256c242611cd` against base `9b1028f2974f7b456285b23b28eac5336f71e13c`.

Evidence:
- PR metadata pinned at QA time: draft, mergeable, one commit, exact four-file diff listed above.
- Commit signature verified OK for `fce0263992ff2f407c25daaa1e72256c242611cd`.
- `git diff --check 9b1028f2974f7b456285b23b28eac5336f71e13c..HEAD` passed.
- Diff review PASS: dependency block after successor creation is rejected when no unfinished incoming parent remains; valid `P -> A -> C` middle-task dependency wait remains allowed; CLI catches `ValueError` and only writes `BLOCKED:` comments after successful block; no #66632 content or unrelated expansion found in the exact diff.
- Focused tests passed: `python -m pytest tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_cli.py -q`.
- Broader file-isolated suites passed on PR head: `tests/hermes_cli/test_kanban_db.py` (230 passed), `tests/hermes_cli/test_kanban_decompose.py` (9 passed), `tests/hermes_cli/test_kanban_lifecycle_hooks.py` (6 passed), and `tests/tools/test_kanban_tools.py` (114 passed).
- Combined broad glob remains pre-existing/order-dependent: PR head `16 failed, 860 passed, 1 skipped`; pinned base `16 failed, 857 passed, 1 skipped` with the same failure categories, while affected files pass file-isolated.

## Operational notes
- Current delivery guard: do not merge from this task.
- Ready-for-review state is requested only after confirming GitHub still reports head `fce0263992ff2f407c25daaa1e72256c242611cd`.
