### PR TITLE
fix: strip unclosed think/reasoning blocks from truncated LLM output (#69074)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -793,6 +793,13 @@ def strip_think_blocks(agent, content: str) -> str:
     content = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL | re.IGNORECASE)
     content = re.sub(r'<thinking>.*?</thinking>', '', content, flags=re.DOTALL | re.IGNORECASE)
     content = re.sub(r'<reasoning>.*?</reasoning>', '', content, flags=re.DOTALL | re.IGNORECASE)
+
+
+    # Catch-all: strip unclosed think/reasoning blocks from
+    # token-truncated output that has no closing tag.
+    content = re.sub(r'<thinking>.*', '', content, flags=re.DOTALL)
+    content = re.sub(r'<reasoning>.*', '', content, flags=re.DOTALL)
+    content = re.sub(r'<think>.*', '', content, flags=re.DOTALL)
     content = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', content, flags=re.DOTALL | re.IGNORECASE)
     content = re.sub(r'<thought>.*?</thought>', '', content, flags=re.DOTALL | re.IGNORECASE)
     # 1b. Tool-call XML blocks (openclaw/openclaw#67318). Handle the


### PR DESCRIPTION
Fixes #69074

## Problem

`strip_think_blocks()` in `agent/agent_runtime_helpers.py` strips closed `<think>`, `<thinking>`, and `<reasoning>` tag pairs. When LLM output is truncated by `max_tokens`, the closing tag is missing and the raw reasoning chain is stored as permanent episodic memory via `sleep_consolidation`.

18 entries found in episodic memory with `source: sleep_consolidation` containing raw `<think>` content.

## Fix

Add a catch-all pass after the existing closed-pair handling that strips unclosed blocks from token-truncated output:

```python
content = re.sub(r'<thinking>.*', '', content, flags=re.DOTALL)
content = re.sub(r'<reasoning>.*', '', content, flags=re.DOTALL)
content = re.sub(r'<think>.*', '', content, flags=re.DOTALL)
```

These are non-greedy-unnecessary (no closing tag to anchor to) and run after the existing closed-pair regexes, so only orphaned open tags are affected.

## Verification

- `py_compile` passes
- Closed pairs continue to be handled by the existing regexes (no behavior change for non-truncated output)