### PR TITLE
fix(computer-use): change foreground capability block to soft warning + attempt (#69170)

### DIFF
--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1885,14 +1885,11 @@ class CuaDriverBackend(ComputerUseBackend):
         if not self._session.supports_capability(
             "input.delivery_mode", tool=action
         ):
-            return ActionResult(
-                ok=False, action=action, code="foreground_unsupported",
-                delivery_mode="foreground",
-                message=(
-                    "This cua-driver build does not support foreground "
-                    "delivery (no `input.delivery_mode` capability). Update "
-                    "cua-driver to escalate to the foreground rung."
-                ),
+            logger.warning(
+                "cua-driver does not advertise `input.delivery_mode` capability "
+                "for %s, but attempting foreground delivery anyway. "
+                "Update cua-driver to register this capability.",
+                action,
             )
         args["delivery_mode"] = "foreground"
         if bring_to_front:


### PR DESCRIPTION
Closes #69170

**Problem:** When `delivery_mode: "foreground"` is requested, Hermes checks cua-driver's capability advertisement for `input.delivery_mode`. If missing, it returns a hard `foreground_unsupported` error immediately — even though cua-driver's tool schema *does* accept the `foreground` parameter. Only the capability registration is missing.

**Fix:** Change the capability check from a hard block (`ActionResult(ok=False)`) to a `logger.warning()` + attempt. If the capability is not declared, we log a warning and still set `delivery_mode="foreground"`, letting the actual call determine success or failure.

**Before:** capability missing → immediate error
**After:** capability missing → warning logged → attempt call → success or real error