### PR TITLE
feat(gateway): interactive /profile picker (parity with /model)

### DIFF
--- a/contributors/emails/hermes@local
+++ b/contributors/emails/hermes@local
@@ -1,0 +1,2 @@
+rarf
+# Profile picker commits authored as Hermes Local on PR #69441

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -7045,7 +7045,29 @@ class BasePlatformAdapter(ABC):
         profile = None
         profile_route_rejected = False
         runner = getattr(self, "gateway_runner", None)
-        if runner is not None:
+        multiplexed = bool(
+            getattr(getattr(runner, "config", None), "multiplex_profiles", False)
+        )
+
+        # 1) Runtime per-source override (set via `/profile set <name>`). This
+        #    wins over profile_routes so a chat can pin its own profile live
+        #    without restarting the gateway. Hierarchical: thread > chat.
+        if multiplexed:
+            try:
+                from gateway.profile_overrides import resolve_override
+
+                _ov = resolve_override(
+                    self.platform.value if hasattr(self.platform, "value") else str(self.platform),
+                    str(chat_id),
+                    str(thread_id) if thread_id else None,
+                )
+                if _ov:
+                    profile = _ov
+            except Exception:
+                logger.debug("profile override lookup failed", exc_info=True)
+
+        # 2) Configured profile_routes (only consulted when no live override).
+        if profile is None and runner is not None:
             from gateway.profile_routing import ProfileRouteRejected
 
             try:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6587,7 +6587,29 @@ class BasePlatformAdapter(ABC):
         # Resolve profile from configured routes (None when no match / no routes)
         profile = None
         runner = getattr(self, "gateway_runner", None)
-        if runner is not None:
+        multiplexed = bool(
+            getattr(getattr(runner, "config", None), "multiplex_profiles", False)
+        )
+
+        # 1) Runtime per-source override (set via `/profile set <name>`). This
+        #    wins over profile_routes so a chat can pin its own profile live
+        #    without restarting the gateway. Hierarchical: thread > chat.
+        if multiplexed:
+            try:
+                from gateway.profile_overrides import resolve_override
+
+                _ov = resolve_override(
+                    self.platform.value if hasattr(self.platform, "value") else str(self.platform),
+                    str(chat_id),
+                    str(thread_id) if thread_id else None,
+                )
+                if _ov:
+                    profile = _ov
+            except Exception:
+                logger.debug("profile override lookup failed", exc_info=True)
+
+        # 2) Configured profile_routes (only consulted when no live override).
+        if profile is None and runner is not None:
             try:
                 profile = runner._profile_name_for_source(
                     SessionSource(

--- a/gateway/profile_model.py
+++ b/gateway/profile_model.py
@@ -1,0 +1,81 @@
+"""Helper to read a profile's configured model."""
+import os
+from pathlib import Path
+from typing import Optional
+
+try:
+    from hermes_cli.config import load_config_readonly as _load_config_readonly
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+except ImportError:
+    _load_config_readonly = None
+    set_hermes_home_override = None
+    reset_hermes_home_override = None
+
+
+def _resolve_profile_dir(profile_name: str) -> Path:
+    """
+    Resolve the profile directory, checking both standard locations.
+    
+    Standard: ~/.hermes/profiles/<name> or ~/.hermes (for default)
+    Windows AppData: %LOCALAPPDATA%\Hermes\profiles\<name> or %LOCALAPPDATA%\Hermes
+    """
+    # Check standard location first
+    if profile_name == "default":
+        std_dir = Path.home() / ".hermes"
+        appdata_dir = Path(os.environ.get("LOCALAPPDATA", "")) / "Hermes"
+    else:
+        std_dir = Path.home() / ".hermes" / "profiles" / profile_name
+        appdata_dir = Path(os.environ.get("LOCALAPPDATA", "")) / "Hermes" / "profiles" / profile_name
+    
+    # Prefer the one that exists and has config.yaml
+    for d in [std_dir, appdata_dir]:
+        if d.exists() and (d / "config.yaml").exists():
+            return d
+    
+    # Fallback to standard
+    return std_dir
+
+
+def get_profile_active_model(profile_name: str) -> Optional[str]:
+    """
+    Get the active model string for a given profile.
+    
+    Reads the profile's config.yaml and returns the model in format
+    "provider/model" or just "model" depending on configuration.
+    Returns None if not found or on error.
+    """
+    if not _load_config_readonly or not set_hermes_home_override:
+        return None
+    
+    profile_dir = _resolve_profile_dir(profile_name)
+    
+    token = set_hermes_home_override(str(profile_dir))
+    try:
+        cfg = _load_config_readonly()
+        model_cfg = cfg.get("model", {})
+        
+        # Check for explicit provider/model structure
+        provider = model_cfg.get("provider")
+        model = model_cfg.get("default")
+        
+        if provider and model:
+            return f"{provider}/{model}"
+        elif model:
+            return model
+        else:
+            return None
+    except Exception:
+        return None
+    finally:
+        if reset_hermes_home_override:
+            reset_hermes_home_override(token)
+
+
+def get_profile_model_info(profile_name: str) -> str:
+    """
+    Get a formatted model info string for display.
+    
+    Returns string like "nous/tencent/hy3:free" or "unknown".
+    """
+    model = get_profile_active_model(profile_name)
+    return model if model else "unknown"

--- a/gateway/profile_overrides.py
+++ b/gateway/profile_overrides.py
@@ -1,0 +1,155 @@
+"""Persistent per-source profile overrides for the gateway.
+
+Lets a chat (and optionally a thread) pin itself to a named profile at
+runtime via a slash command (``/profile set <name>``), without restarting
+the gateway.
+
+The override map is keyed by the same scope identifiers the multiplexing
+router uses (``platform``, ``chat_id``, ``thread_id``), so it composes
+cleanly with :mod:`gateway.profile_routing` — an explicit override always
+wins over a ``profile_routes`` rule. The lookup is hierarchical: a
+thread override beats a chat override beats no override.
+
+State lives in ``<hermes_root>/profile_overrides.json`` (atomic writes).
+This file is shared across profiles by design — it is the runtime switch
+table, not profile-local state.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional
+
+from hermes_constants import get_default_hermes_root
+from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
+
+_OVERRIDES_FILE = "profile_overrides.json"
+_WRITE_LOCK = threading.RLock()
+
+
+def _overrides_path() -> Path:
+    return get_default_hermes_root() / _OVERRIDES_FILE
+
+
+def _read_map() -> dict:
+    path = _overrides_path()
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        logger.warning("Failed to read profile overrides, starting empty", exc_info=True)
+        return {}
+
+
+def _write_map(data: dict) -> None:
+    path = _overrides_path()
+    atomic_json_write(path, data, sort_keys=True)
+
+
+@contextmanager
+def _locked_update() -> Iterator[None]:
+    """Serialize profile-override read-modify-write updates.
+
+    The in-process lock protects concurrent picker callbacks. The sibling lock
+    file extends that protection across gateway processes, while
+    :func:`atomic_json_write` uses a unique temporary file for each writer so a
+    concurrent replace can never collide on a shared ``.json.tmp`` pathname.
+    """
+    path = _overrides_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+
+    with _WRITE_LOCK:
+        with lock_path.open("a+b") as lock_fh:
+            if os.name == "nt":
+                import msvcrt
+
+                # msvcrt.locking locks from the current file position and
+                # requires a byte to exist at that position.
+                lock_fh.seek(0, os.SEEK_END)
+                if lock_fh.tell() == 0:
+                    lock_fh.write(b"\0")
+                    lock_fh.flush()
+                lock_fh.seek(0)
+                msvcrt.locking(lock_fh.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                if os.name == "nt":
+                    import msvcrt
+
+                    lock_fh.seek(0)
+                    msvcrt.locking(lock_fh.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+
+
+def _key_for(platform: str, chat_id: str, thread_id: Optional[str]) -> str:
+    """Build the override key for a (platform, chat, thread) scope."""
+    pid = str(platform)
+    cid = str(chat_id)
+    tid = str(thread_id) if thread_id else ""
+    if tid:
+        return f"{pid}:{cid}:{tid}"
+    return f"{pid}:{cid}"
+
+
+def set_override(platform: str, chat_id: str, profile: str, thread_id: Optional[str] = None) -> None:
+    """Pin ``platform:chat_id[:thread_id]`` to ``profile``.
+
+    ``profile`` is stored normalized (lowercase; ``default`` special-cased)
+    by the caller; we don't import profiles here to keep this module
+    dependency-light.
+    """
+    with _locked_update():
+        data = _read_map()
+        data[_key_for(platform, chat_id, thread_id)] = profile
+        _write_map(data)
+
+
+def clear_override(platform: str, chat_id: str, thread_id: Optional[str] = None) -> bool:
+    """Remove an override. Returns True if something was removed."""
+    with _locked_update():
+        data = _read_map()
+        key = _key_for(platform, chat_id, thread_id)
+        if key in data:
+            del data[key]
+            _write_map(data)
+            return True
+        return False
+
+
+def resolve_override(
+    platform: str, chat_id: str, thread_id: Optional[str] = None
+) -> Optional[str]:
+    """Return the pinned profile for this scope, or None.
+
+    Thread-specific override wins over chat-level override.
+    """
+    data = _read_map()
+    if thread_id:
+        hit = data.get(_key_for(platform, chat_id, thread_id))
+        if hit:
+            return hit
+    return data.get(_key_for(platform, chat_id, None))
+
+
+def list_overrides() -> dict:
+    """Return the full override map (read-only copy)."""
+    return dict(_read_map())

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -471,9 +471,19 @@ class GatewaySlashCommandsMixin:
                 logger.exception("Failed to persist profile override")
                 return f"❌ Could not save profile pin: {exc}"
             scope = "thread" if thread_id else "chat"
+            # Immediately reset the session so the new profile takes effect now
+            try:
+                session_key = self._session_key_for_source(source)
+                self._invalidate_session_run_generation(session_key, reason="profile_switch")
+                self._release_running_agent_state(session_key)
+                self._evict_cached_agent(session_key)
+                self._clear_conversation_scope(session_key, reason="profile_switch")
+                await self.async_session_store.reset_session(session_key)
+            except Exception:
+                logger.debug("Session reset after profile switch failed", exc_info=True)
             return (
                 f"✅ This {scope} now serves profile **{canon}** "
-                "(live — no restart needed). Next message runs under it.\n"
+                "(live — session reset, next message runs under it).\n"
                 "To revert: `/profile clear`"
             )
 
@@ -547,9 +557,19 @@ class GatewaySlashCommandsMixin:
                         logger.exception("Failed to persist profile override")
                         return f"❌ Could not save profile pin: {exc}"
                     scope = "thread" if thread_id else "chat"
+                    # Immediately reset the session so the new profile takes effect now
+                    try:
+                        session_key = self._session_key_for_source(source)
+                        self._invalidate_session_run_generation(session_key, reason="profile_switch")
+                        self._release_running_agent_state(session_key)
+                        self._evict_cached_agent(session_key)
+                        self._clear_conversation_scope(session_key, reason="profile_switch")
+                        await self.async_session_store.reset_session(session_key)
+                    except Exception:
+                        logger.debug("Session reset after profile switch failed", exc_info=True)
                     return (
                         f"✅ This {scope} now serves profile **{canon}** "
-                        "(live — no restart needed). Next message runs under it.\n"
+                        "(live — session reset, next message runs under it).\n"
                         "To revert: `/profile clear`"
                     )
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -350,33 +350,144 @@ class GatewaySlashCommandsMixin:
             return EphemeralReply(f"{header}\n\n{session_info}{_tip_line}")
         return EphemeralReply(f"{header}{_tip_line}")
 
-    async def _handle_profile_command(self, event: MessageEvent) -> str:
-        """Handle /profile — show the profile serving this source and its home.
+    def _profile_mutation_allowed(self, source: Optional[SessionSource]) -> bool:
+        """Return whether ``source`` may persist a profile pin.
 
-        On a multiplexed gateway the process-level active profile is always
-        the multiplexer's own (usually ``default``), so reporting it would
-        answer "default" in every chat regardless of which profile actually
-        serves the room/channel (``source.profile`` — stamped by the
-        ``/p/<profile>/`` URL prefix, a per-credential adapter, or a room→
-        profile map). When ``multiplex_profiles`` is on, report the stamped
-        profile and, like the scoped /reset banner (#59003), resolve the
-        displayed home under that profile's runtime scope. When multiplexing
-        is off (the default) the stamp is ignored — mirroring the gating in
-        ``_run_agent`` and ``_reset_notice_session_info`` — and the command
-        reports the active profile and default home, byte-identical to before.
+        ``/profile`` itself can be allowed to non-admin users for status, but
+        selecting or clearing a persistent runtime route is an admin-only
+        mutation whenever the platform policy has an admin list configured.
         """
+        if source is None:
+            return False
+        try:
+            from gateway.slash_access import policy_for_source
+
+            policy = policy_for_source(self.config, source)
+            # Preserve the compatibility contract: without an admin list the
+            # policy is unrestricted. Once admins are configured, a user
+            # command allowlist must not grant this persistent mutation.
+            return bool(policy.is_admin(getattr(source, "user_id", None)))
+        except Exception:
+            logger.warning("Failed to resolve /profile mutation authorization", exc_info=True)
+            return False
+
+    async def _handle_profile_command(self, event: MessageEvent) -> Optional[str]:
+        """Handle /profile — show or change the profile serving this source.
+
+        Subcommands:
+          /profile            → status, or an interactive picker when enabled
+          /profile set NAME   → pin this chat/thread to profile NAME
+          /profile clear      → drop this chat/thread's pin
+          /profile list       → list profiles on this machine
+
+        Persistent mutations require ``gateway.multiplex_profiles`` and the
+        source's admin policy. The read-only status command remains available
+        to users who are allowed to run ``/profile``.
+        """
+        import asyncio
+        import shlex
+
+        from hermes_cli.profiles import (
+            get_active_profile_name,
+            list_profiles,
+            normalize_profile_name,
+            profile_exists,
+            validate_profile_name,
+        )
         from hermes_constants import display_hermes_home
         from hermes_cli.slash_exec import CommandContext, execute_command
+
+        raw_args = (event.get_command_args() or "").strip()
+        argv = shlex.split(raw_args) if raw_args else []
+        sub = argv[0].lower() if argv else ""
+        # ``/profile set`` with no name opens the interactive picker.
+        if sub == "set" and len(argv) < 2:
+            sub = ""
 
         multiplexed = getattr(
             getattr(self, "config", None), "multiplex_profiles", False
         )
         source = getattr(event, "source", None)
+        platform = source.platform.value if source and source.platform else ""
+        chat_id = getattr(source, "chat_id", "") or ""
+        thread_id = getattr(source, "thread_id", None)
 
+        if sub == "list":
+            try:
+                infos = list_profiles()
+            except Exception:
+                infos = []
+            if not infos:
+                return "No profiles found."
+            active = get_active_profile_name() or "default"
+            rows = []
+            for info in infos:
+                name = getattr(info, "name", None) or getattr(info, "id", "?")
+                mark = " ●" if name == active else ""
+                rows.append(f"• {name}{mark}")
+            rows.extend(["", "(● = sticky default)"])
+            return "\n".join(rows)
+
+        if sub in ("set", "clear"):
+            if not multiplexed:
+                return (
+                    "⚠️ Switching profiles live requires "
+                    "`gateway.multiplex_profiles: true`.\n"
+                    "Set it with `hermes config set gateway.multiplex_profiles true` "
+                    "and restart the gateway, then run `/profile set NAME` again."
+                )
+            if not self._profile_mutation_allowed(source):
+                return "Only gateway admins can change the persistent profile pin."
+            if sub == "clear":
+                try:
+                    from gateway.profile_overrides import clear_override
+
+                    removed = clear_override(platform, chat_id, thread_id)
+                except Exception:
+                    removed = False
+                if removed:
+                    scope = "thread" if thread_id else "chat"
+                    return f"✅ Profile pin cleared for this {scope}. Falling back to routes/default."
+                return "Nothing to clear — this chat has no profile pin."
+
+            if len(argv) < 2:
+                return "Usage: `/profile set NAME`"
+            requested = argv[1]
+            try:
+                canon = normalize_profile_name(requested)
+                validate_profile_name(canon)
+            except ValueError as exc:
+                return f"❌ Invalid profile name: {exc}"
+            if not profile_exists(canon):
+                return (
+                    f"❌ Profile '{canon}' does not exist. "
+                    f"Create it first: `hermes profile create {canon}`"
+                )
+            try:
+                from gateway.profile_overrides import set_override
+
+                set_override(platform, chat_id, canon, thread_id)
+            except Exception as exc:
+                logger.exception("Failed to persist profile override")
+                return f"❌ Could not save profile pin: {exc}"
+            scope = "thread" if thread_id else "chat"
+            return (
+                f"✅ This {scope} now serves profile **{canon}** "
+                "(live — no restart needed). Next message runs under it.\n"
+                "To revert: `/profile clear`"
+            )
+
+        pinned = None
         profile_name = ""
         display = ""
         if multiplexed:
-            profile_name = (getattr(source, "profile", "") or "").strip()
+            try:
+                from gateway.profile_overrides import resolve_override
+
+                pinned = resolve_override(platform, chat_id, thread_id)
+            except Exception:
+                pinned = None
+            profile_name = pinned or (getattr(source, "profile", "") or "").strip()
             try:
                 from gateway.run import _profile_runtime_scope
 
@@ -386,8 +497,62 @@ class GatewaySlashCommandsMixin:
             except Exception:
                 display = display_hermes_home()
 
-        # Shared executor resolves process-level fallbacks; the multiplexed
-        # per-source overrides (when any) ride in via options.
+        profile_name = profile_name or get_active_profile_name()
+
+        # Plain /profile is read-only, so the picker callback is the actual
+        # mutation boundary and rechecks admin authority at callback time.
+        if not sub and multiplexed:
+            try:
+                infos = list_profiles()
+            except Exception:
+                infos = []
+            if infos:
+                choices = []
+                for info in infos:
+                    name = getattr(info, "name", None) or getattr(info, "id", "?")
+                    choices.append(
+                        {"value": name, "label": name, "is_current": name == profile_name}
+                    )
+
+                async def _on_profile_selected(_chat_id: str, value: str) -> str:
+                    if not self._profile_mutation_allowed(source):
+                        return "Only gateway admins can change the persistent profile pin."
+                    canon = normalize_profile_name(value)
+                    try:
+                        validate_profile_name(canon)
+                    except ValueError as exc:
+                        return f"❌ Invalid profile name: {exc}"
+                    if not profile_exists(canon):
+                        return (
+                            f"❌ Profile '{canon}' does not exist. "
+                            f"Create it first: `hermes profile create {canon}`"
+                        )
+                    try:
+                        from gateway.profile_overrides import set_override
+
+                        await asyncio.to_thread(
+                            set_override, platform, chat_id, canon, thread_id
+                        )
+                    except Exception as exc:
+                        logger.exception("Failed to persist profile override")
+                        return f"❌ Could not save profile pin: {exc}"
+                    scope = "thread" if thread_id else "chat"
+                    return (
+                        f"✅ This {scope} now serves profile **{canon}** "
+                        "(live — no restart needed). Next message runs under it.\n"
+                        "To revert: `/profile clear`"
+                    )
+
+                picker_sent = await self._try_send_choice_picker(
+                    event,
+                    self._session_key_for_source(source),
+                    title=t("gateway.profile.picker_title", current=profile_name),
+                    choices=choices,
+                    on_choice_selected=_on_profile_selected,
+                )
+                if picker_sent:
+                    return None
+
         reply = execute_command(
             "profile",
             CommandContext(
@@ -395,12 +560,20 @@ class GatewaySlashCommandsMixin:
                 options={"profile_name": profile_name, "home_display": display},
             ),
         )
-
         lines = [
             t("gateway.profile.header", profile=reply.data["profile"]),
             t("gateway.profile.home", home=reply.data["home"]),
         ]
-
+        if pinned:
+            lines.append(f"pinned: {pinned} (live override)")
+        if not sub and not multiplexed:
+            lines.extend(
+                [
+                    "",
+                    "⚠️ Live profile switching requires `gateway.multiplex_profiles: true`.",
+                    "Set it with `hermes config set gateway.multiplex_profiles true` and restart the gateway.",
+                ]
+            )
         return "\n".join(lines)
 
     async def _handle_whoami_command(self, event: MessageEvent) -> str:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -513,18 +513,18 @@ class GatewaySlashCommandsMixin:
                     choices.append(
                         {"value": name, "label": name, "is_current": name == profile_name}
                     )
-                    # Escape hatch — selecting Cancel leaves the current profile
-                    # untouched (parity with the /model cost-confirm cancel).
-                    choices.append(
-                        {"value": "cancel", "label": "❌ Cancel", "is_current": False}
-                    )
+                # Escape hatch — selecting Cancel leaves the current profile
+                # untouched (parity with the /model cost-confirm cancel).
+                choices.append(
+                    {"value": "cancel", "label": "❌ Cancel", "is_current": False}
+                )
 
-                    async def _on_profile_selected(_chat_id: str, value: str) -> str:
-                        if value == "cancel":
-                            return (
-                                f"🟡 Profile switch cancelled. Current profile unchanged "
-                                f"({profile_name or 'unknown'})."
-                            )
+                async def _on_profile_selected(_chat_id: str, value: str) -> str:
+                    if value == "cancel":
+                        return (
+                            f"🟡 Profile switch cancelled. Current profile unchanged "
+                            f"({profile_name or 'unknown'})."
+                        )
                     if not self._profile_mutation_allowed(source):
                         return "Only gateway admins can change the persistent profile pin."
                     canon = normalize_profile_name(value)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -513,8 +513,18 @@ class GatewaySlashCommandsMixin:
                     choices.append(
                         {"value": name, "label": name, "is_current": name == profile_name}
                     )
+                    # Escape hatch — selecting Cancel leaves the current profile
+                    # untouched (parity with the /model cost-confirm cancel).
+                    choices.append(
+                        {"value": "cancel", "label": "❌ Cancel", "is_current": False}
+                    )
 
-                async def _on_profile_selected(_chat_id: str, value: str) -> str:
+                    async def _on_profile_selected(_chat_id: str, value: str) -> str:
+                        if value == "cancel":
+                            return (
+                                f"🟡 Profile switch cancelled. Current profile unchanged "
+                                f"({profile_name or 'unknown'})."
+                            )
                     if not self._profile_mutation_allowed(source):
                         return "Only gateway admins can change the persistent profile pin."
                     canon = normalize_profile_name(value)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -34,6 +34,7 @@ from agent.i18n import t
 from agent.turn_context import extract_api_content_sidecar
 from gateway.config import HomeChannel, Platform, PlatformConfig, persist_home_channel
 from gateway.platforms.base import EphemeralReply, MessageEvent, MessageType
+from gateway.profile_model import get_profile_model_info
 from gateway.session import (
     AsyncSessionStore,
     SessionSource,
@@ -483,6 +484,7 @@ class GatewaySlashCommandsMixin:
                 logger.debug("Session reset after profile switch failed", exc_info=True)
             return (
                 f"✅ This {scope} now serves profile **{canon}** "
+                f"(model: **{get_profile_model_info(canon)}**) "
                 "(live — session reset, next message runs under it).\n"
                 "To revert: `/profile clear`"
             )
@@ -569,6 +571,7 @@ class GatewaySlashCommandsMixin:
                         logger.debug("Session reset after profile switch failed", exc_info=True)
                     return (
                         f"✅ This {scope} now serves profile **{canon}** "
+                        f"(model: **{get_profile_model_info(canon)}**) "
                         "(live — session reset, next message runs under it).\n"
                         "To revert: `/profile clear`"
                     )

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -446,9 +446,19 @@ class GatewaySlashCommandsMixin:
                 logger.exception("Failed to persist profile override")
                 return f"❌ Could not save profile pin: {exc}"
             scope = "thread" if thread_id else "chat"
+            # Immediately reset the session so the new profile takes effect now
+            try:
+                session_key = self._session_key_for_source(source)
+                self._invalidate_session_run_generation(session_key, reason="profile_switch")
+                self._release_running_agent_state(session_key)
+                self._evict_cached_agent(session_key)
+                self._clear_conversation_scope(session_key, reason="profile_switch")
+                await self.async_session_store.reset_session(session_key)
+            except Exception:
+                logger.debug("Session reset after profile switch failed", exc_info=True)
             return (
                 f"✅ This {scope} now serves profile **{canon}** "
-                "(live — no restart needed). Next message runs under it.\n"
+                "(live — session reset, next message runs under it).\n"
                 "To revert: `/profile clear`"
             )
 
@@ -522,9 +532,19 @@ class GatewaySlashCommandsMixin:
                         logger.exception("Failed to persist profile override")
                         return f"❌ Could not save profile pin: {exc}"
                     scope = "thread" if thread_id else "chat"
+                    # Immediately reset the session so the new profile takes effect now
+                    try:
+                        session_key = self._session_key_for_source(source)
+                        self._invalidate_session_run_generation(session_key, reason="profile_switch")
+                        self._release_running_agent_state(session_key)
+                        self._evict_cached_agent(session_key)
+                        self._clear_conversation_scope(session_key, reason="profile_switch")
+                        await self.async_session_store.reset_session(session_key)
+                    except Exception:
+                        logger.debug("Session reset after profile switch failed", exc_info=True)
                     return (
                         f"✅ This {scope} now serves profile **{canon}** "
-                        "(live — no restart needed). Next message runs under it.\n"
+                        "(live — session reset, next message runs under it).\n"
                         "To revert: `/profile clear`"
                     )
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -34,6 +34,7 @@ from agent.i18n import t
 from agent.turn_context import extract_api_content_sidecar
 from gateway.config import HomeChannel, Platform, PlatformConfig, persist_home_channel
 from gateway.platforms.base import EphemeralReply, MessageEvent, MessageType
+from gateway.profile_model import get_profile_model_info
 from gateway.session import (
     AsyncSessionStore,
     SessionSource,
@@ -458,6 +459,7 @@ class GatewaySlashCommandsMixin:
                 logger.debug("Session reset after profile switch failed", exc_info=True)
             return (
                 f"✅ This {scope} now serves profile **{canon}** "
+                f"(model: **{get_profile_model_info(canon)}**) "
                 "(live — session reset, next message runs under it).\n"
                 "To revert: `/profile clear`"
             )
@@ -544,6 +546,7 @@ class GatewaySlashCommandsMixin:
                         logger.debug("Session reset after profile switch failed", exc_info=True)
                     return (
                         f"✅ This {scope} now serves profile **{canon}** "
+                        f"(model: **{get_profile_model_info(canon)}**) "
                         "(live — session reset, next message runs under it).\n"
                         "To revert: `/profile clear`"
                     )

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -488,8 +488,18 @@ class GatewaySlashCommandsMixin:
                     choices.append(
                         {"value": name, "label": name, "is_current": name == profile_name}
                     )
+                    # Escape hatch — selecting Cancel leaves the current profile
+                    # untouched (parity with the /model cost-confirm cancel).
+                    choices.append(
+                        {"value": "cancel", "label": "❌ Cancel", "is_current": False}
+                    )
 
-                async def _on_profile_selected(_chat_id: str, value: str) -> str:
+                    async def _on_profile_selected(_chat_id: str, value: str) -> str:
+                        if value == "cancel":
+                            return (
+                                f"🟡 Profile switch cancelled. Current profile unchanged "
+                                f"({profile_name or 'unknown'})."
+                            )
                     if not self._profile_mutation_allowed(source):
                         return "Only gateway admins can change the persistent profile pin."
                     canon = normalize_profile_name(value)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -488,18 +488,18 @@ class GatewaySlashCommandsMixin:
                     choices.append(
                         {"value": name, "label": name, "is_current": name == profile_name}
                     )
-                    # Escape hatch — selecting Cancel leaves the current profile
-                    # untouched (parity with the /model cost-confirm cancel).
-                    choices.append(
-                        {"value": "cancel", "label": "❌ Cancel", "is_current": False}
-                    )
+                # Escape hatch — selecting Cancel leaves the current profile
+                # untouched (parity with the /model cost-confirm cancel).
+                choices.append(
+                    {"value": "cancel", "label": "❌ Cancel", "is_current": False}
+                )
 
-                    async def _on_profile_selected(_chat_id: str, value: str) -> str:
-                        if value == "cancel":
-                            return (
-                                f"🟡 Profile switch cancelled. Current profile unchanged "
-                                f"({profile_name or 'unknown'})."
-                            )
+                async def _on_profile_selected(_chat_id: str, value: str) -> str:
+                    if value == "cancel":
+                        return (
+                            f"🟡 Profile switch cancelled. Current profile unchanged "
+                            f"({profile_name or 'unknown'})."
+                        )
                     if not self._profile_mutation_allowed(source):
                         return "Only gateway admins can change the persistent profile pin."
                     canon = normalize_profile_name(value)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -325,33 +325,144 @@ class GatewaySlashCommandsMixin:
             return EphemeralReply(f"{header}\n\n{session_info}{_tip_line}")
         return EphemeralReply(f"{header}{_tip_line}")
 
-    async def _handle_profile_command(self, event: MessageEvent) -> str:
-        """Handle /profile — show the profile serving this source and its home.
+    def _profile_mutation_allowed(self, source: Optional[SessionSource]) -> bool:
+        """Return whether ``source`` may persist a profile pin.
 
-        On a multiplexed gateway the process-level active profile is always
-        the multiplexer's own (usually ``default``), so reporting it would
-        answer "default" in every chat regardless of which profile actually
-        serves the room/channel (``source.profile`` — stamped by the
-        ``/p/<profile>/`` URL prefix, a per-credential adapter, or a room→
-        profile map). When ``multiplex_profiles`` is on, report the stamped
-        profile and, like the scoped /reset banner (#59003), resolve the
-        displayed home under that profile's runtime scope. When multiplexing
-        is off (the default) the stamp is ignored — mirroring the gating in
-        ``_run_agent`` and ``_reset_notice_session_info`` — and the command
-        reports the active profile and default home, byte-identical to before.
+        ``/profile`` itself can be allowed to non-admin users for status, but
+        selecting or clearing a persistent runtime route is an admin-only
+        mutation whenever the platform policy has an admin list configured.
         """
+        if source is None:
+            return False
+        try:
+            from gateway.slash_access import policy_for_source
+
+            policy = policy_for_source(self.config, source)
+            # Preserve the compatibility contract: without an admin list the
+            # policy is unrestricted. Once admins are configured, a user
+            # command allowlist must not grant this persistent mutation.
+            return bool(policy.is_admin(getattr(source, "user_id", None)))
+        except Exception:
+            logger.warning("Failed to resolve /profile mutation authorization", exc_info=True)
+            return False
+
+    async def _handle_profile_command(self, event: MessageEvent) -> Optional[str]:
+        """Handle /profile — show or change the profile serving this source.
+
+        Subcommands:
+          /profile            → status, or an interactive picker when enabled
+          /profile set NAME   → pin this chat/thread to profile NAME
+          /profile clear      → drop this chat/thread's pin
+          /profile list       → list profiles on this machine
+
+        Persistent mutations require ``gateway.multiplex_profiles`` and the
+        source's admin policy. The read-only status command remains available
+        to users who are allowed to run ``/profile``.
+        """
+        import asyncio
+        import shlex
+
+        from hermes_cli.profiles import (
+            get_active_profile_name,
+            list_profiles,
+            normalize_profile_name,
+            profile_exists,
+            validate_profile_name,
+        )
         from hermes_constants import display_hermes_home
         from hermes_cli.slash_exec import CommandContext, execute_command
+
+        raw_args = (event.get_command_args() or "").strip()
+        argv = shlex.split(raw_args) if raw_args else []
+        sub = argv[0].lower() if argv else ""
+        # ``/profile set`` with no name opens the interactive picker.
+        if sub == "set" and len(argv) < 2:
+            sub = ""
 
         multiplexed = getattr(
             getattr(self, "config", None), "multiplex_profiles", False
         )
         source = getattr(event, "source", None)
+        platform = source.platform.value if source and source.platform else ""
+        chat_id = getattr(source, "chat_id", "") or ""
+        thread_id = getattr(source, "thread_id", None)
 
+        if sub == "list":
+            try:
+                infos = list_profiles()
+            except Exception:
+                infos = []
+            if not infos:
+                return "No profiles found."
+            active = get_active_profile_name() or "default"
+            rows = []
+            for info in infos:
+                name = getattr(info, "name", None) or getattr(info, "id", "?")
+                mark = " ●" if name == active else ""
+                rows.append(f"• {name}{mark}")
+            rows.extend(["", "(● = sticky default)"])
+            return "\n".join(rows)
+
+        if sub in ("set", "clear"):
+            if not multiplexed:
+                return (
+                    "⚠️ Switching profiles live requires "
+                    "`gateway.multiplex_profiles: true`.\n"
+                    "Set it with `hermes config set gateway.multiplex_profiles true` "
+                    "and restart the gateway, then run `/profile set NAME` again."
+                )
+            if not self._profile_mutation_allowed(source):
+                return "Only gateway admins can change the persistent profile pin."
+            if sub == "clear":
+                try:
+                    from gateway.profile_overrides import clear_override
+
+                    removed = clear_override(platform, chat_id, thread_id)
+                except Exception:
+                    removed = False
+                if removed:
+                    scope = "thread" if thread_id else "chat"
+                    return f"✅ Profile pin cleared for this {scope}. Falling back to routes/default."
+                return "Nothing to clear — this chat has no profile pin."
+
+            if len(argv) < 2:
+                return "Usage: `/profile set NAME`"
+            requested = argv[1]
+            try:
+                canon = normalize_profile_name(requested)
+                validate_profile_name(canon)
+            except ValueError as exc:
+                return f"❌ Invalid profile name: {exc}"
+            if not profile_exists(canon):
+                return (
+                    f"❌ Profile '{canon}' does not exist. "
+                    f"Create it first: `hermes profile create {canon}`"
+                )
+            try:
+                from gateway.profile_overrides import set_override
+
+                set_override(platform, chat_id, canon, thread_id)
+            except Exception as exc:
+                logger.exception("Failed to persist profile override")
+                return f"❌ Could not save profile pin: {exc}"
+            scope = "thread" if thread_id else "chat"
+            return (
+                f"✅ This {scope} now serves profile **{canon}** "
+                "(live — no restart needed). Next message runs under it.\n"
+                "To revert: `/profile clear`"
+            )
+
+        pinned = None
         profile_name = ""
         display = ""
         if multiplexed:
-            profile_name = (getattr(source, "profile", "") or "").strip()
+            try:
+                from gateway.profile_overrides import resolve_override
+
+                pinned = resolve_override(platform, chat_id, thread_id)
+            except Exception:
+                pinned = None
+            profile_name = pinned or (getattr(source, "profile", "") or "").strip()
             try:
                 from gateway.run import _profile_runtime_scope
 
@@ -361,8 +472,62 @@ class GatewaySlashCommandsMixin:
             except Exception:
                 display = display_hermes_home()
 
-        # Shared executor resolves process-level fallbacks; the multiplexed
-        # per-source overrides (when any) ride in via options.
+        profile_name = profile_name or get_active_profile_name()
+
+        # Plain /profile is read-only, so the picker callback is the actual
+        # mutation boundary and rechecks admin authority at callback time.
+        if not sub and multiplexed:
+            try:
+                infos = list_profiles()
+            except Exception:
+                infos = []
+            if infos:
+                choices = []
+                for info in infos:
+                    name = getattr(info, "name", None) or getattr(info, "id", "?")
+                    choices.append(
+                        {"value": name, "label": name, "is_current": name == profile_name}
+                    )
+
+                async def _on_profile_selected(_chat_id: str, value: str) -> str:
+                    if not self._profile_mutation_allowed(source):
+                        return "Only gateway admins can change the persistent profile pin."
+                    canon = normalize_profile_name(value)
+                    try:
+                        validate_profile_name(canon)
+                    except ValueError as exc:
+                        return f"❌ Invalid profile name: {exc}"
+                    if not profile_exists(canon):
+                        return (
+                            f"❌ Profile '{canon}' does not exist. "
+                            f"Create it first: `hermes profile create {canon}`"
+                        )
+                    try:
+                        from gateway.profile_overrides import set_override
+
+                        await asyncio.to_thread(
+                            set_override, platform, chat_id, canon, thread_id
+                        )
+                    except Exception as exc:
+                        logger.exception("Failed to persist profile override")
+                        return f"❌ Could not save profile pin: {exc}"
+                    scope = "thread" if thread_id else "chat"
+                    return (
+                        f"✅ This {scope} now serves profile **{canon}** "
+                        "(live — no restart needed). Next message runs under it.\n"
+                        "To revert: `/profile clear`"
+                    )
+
+                picker_sent = await self._try_send_choice_picker(
+                    event,
+                    self._session_key_for_source(source),
+                    title=t("gateway.profile.picker_title", current=profile_name),
+                    choices=choices,
+                    on_choice_selected=_on_profile_selected,
+                )
+                if picker_sent:
+                    return None
+
         reply = execute_command(
             "profile",
             CommandContext(
@@ -370,12 +535,20 @@ class GatewaySlashCommandsMixin:
                 options={"profile_name": profile_name, "home_display": display},
             ),
         )
-
         lines = [
             t("gateway.profile.header", profile=reply.data["profile"]),
             t("gateway.profile.home", home=reply.data["home"]),
         ]
-
+        if pinned:
+            lines.append(f"pinned: {pinned} (live override)")
+        if not sub and not multiplexed:
+            lines.extend(
+                [
+                    "",
+                    "⚠️ Live profile switching requires `gateway.multiplex_profiles: true`.",
+                    "Set it with `hermes config set gateway.multiplex_profiles true` and restart the gateway.",
+                ]
+            )
         return "\n".join(lines)
 
     async def _handle_whoami_command(self, event: MessageEvent) -> str:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -186,7 +186,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("ctx",), args_hint="[all]", subcommands=("all",),
                busy_policy="dispatch"),
     CommandDef("whoami", "Show your slash command access (admin / user)", "Info"),
-    CommandDef("profile", "Show active profile name and home directory", "Info",
+    CommandDef("profile", "Show or switch the profile serving this chat", "Info",
                busy_policy="dispatch", execute="profile"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -168,7 +168,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("ctx",), args_hint="[all]", subcommands=("all",),
                busy_policy="dispatch"),
     CommandDef("whoami", "Show your slash command access (admin / user)", "Info"),
-    CommandDef("profile", "Show active profile name and home directory", "Info",
+    CommandDef("profile", "Show or switch the profile serving this chat", "Info",
                busy_policy="dispatch", execute="profile"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -186,6 +186,9 @@ gateway:
   profile:
     header:                "👤 **Profiel:** `{profile}`"
     home:                  "📂 **Tuiste:** `{home}`"
+    picker_title:           "👤 **Profiel:** `{current}`
+
+Kies die profiel vir hierdie geselsie/draad:"
 
   reasoning:
     level_default:             "medium (verstek)"

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -184,6 +184,9 @@ gateway:
   profile:
     header:                "👤 **Profiel:** `{profile}`"
     home:                  "📂 **Tuiste:** `{home}`"
+    picker_title:           "👤 **Profiel:** `{current}`
+
+Kies die profiel vir hierdie geselsie/draad:"
 
   reasoning:
     level_default:             "medium (verstek)"

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -209,6 +209,9 @@ gateway:
   profile:
     header:                "👤 **الملف الشخصي:** `{profile}`"
     home:                  "📂 **المجلد الرئيسي:** `{home}`"
+    picker_title:           "👤 **الملف الشخصي:** `{current}`
+
+اختر الملف الشخصي لهذه المحادثة/الموضوع:"
 
   reasoning:
     level_default:             "medium (افتراضي)"

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -207,6 +207,9 @@ gateway:
   profile:
     header:                "👤 **الملف الشخصي:** `{profile}`"
     home:                  "📂 **المجلد الرئيسي:** `{home}`"
+    picker_title:           "👤 **الملف الشخصي:** `{current}`
+
+اختر الملف الشخصي لهذه المحادثة/الموضوع:"
 
   reasoning:
     level_default:             "medium (افتراضي)"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -186,6 +186,9 @@ gateway:
   profile:
     header:                "👤 **Profil:** `{profile}`"
     home:                  "📂 **Stammverzeichnis:** `{home}`"
+    picker_title:           "👤 **Profil:** `{current}`
+
+Wählen Sie das Profil für diesen Chat/Thread:"
 
   reasoning:
     level_default:             "medium (Standard)"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -184,6 +184,9 @@ gateway:
   profile:
     header:                "👤 **Profil:** `{profile}`"
     home:                  "📂 **Stammverzeichnis:** `{home}`"
+    picker_title:           "👤 **Profil:** `{current}`
+
+Wählen Sie das Profil für diesen Chat/Thread:"
 
   reasoning:
     level_default:             "medium (Standard)"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -201,6 +201,7 @@ gateway:
   profile:
     header:                "👤 **Profile:** `{profile}`"
     home:                  "📂 **Home:** `{home}`"
+    picker_title:          "👤 **Profile:** `{current}`\n\nPick the profile for this chat/thread:"
 
   reasoning:
     level_default:             "medium (default)"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -199,6 +199,7 @@ gateway:
   profile:
     header:                "👤 **Profile:** `{profile}`"
     home:                  "📂 **Home:** `{home}`"
+    picker_title:          "👤 **Profile:** `{current}`\n\nPick the profile for this chat/thread:"
 
   reasoning:
     level_default:             "medium (default)"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -186,6 +186,9 @@ gateway:
   profile:
     header:                "👤 **Perfil:** `{profile}`"
     home:                  "📂 **Inicio:** `{home}`"
+    picker_title:           "👤 **Perfil:** `{current}`
+
+Elige el perfil para este chat/hilo:"
 
   reasoning:
     level_default:             "medium (predeterminado)"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -184,6 +184,9 @@ gateway:
   profile:
     header:                "👤 **Perfil:** `{profile}`"
     home:                  "📂 **Inicio:** `{home}`"
+    picker_title:           "👤 **Perfil:** `{current}`
+
+Elige el perfil para este chat/hilo:"
 
   reasoning:
     level_default:             "medium (predeterminado)"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -186,6 +186,9 @@ gateway:
   profile:
     header:                "👤 **Profil :** `{profile}`"
     home:                  "📂 **Dossier personnel :** `{home}`"
+    picker_title:           "👤 **Profil :** `{current}`
+
+Choisissez le profil pour ce chat/fil :"
 
   reasoning:
     level_default:             "medium (par défaut)"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -184,6 +184,9 @@ gateway:
   profile:
     header:                "👤 **Profil :** `{profile}`"
     home:                  "📂 **Dossier personnel :** `{home}`"
+    picker_title:           "👤 **Profil :** `{current}`
+
+Choisissez le profil pour ce chat/fil :"
 
   reasoning:
     level_default:             "medium (par défaut)"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -190,6 +190,9 @@ gateway:
   profile:
     header:                "👤 **Próifíl:** `{profile}`"
     home:                  "📂 **Baile:** `{home}`"
+    picker_title:           "👤 **Próifíl:** `{current}`
+
+Roghnaigh an próifíl don chomhrá/snáithe seo:"
 
   reasoning:
     level_default:             "medium (réamhshocraithe)"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -188,6 +188,9 @@ gateway:
   profile:
     header:                "👤 **Próifíl:** `{profile}`"
     home:                  "📂 **Baile:** `{home}`"
+    picker_title:           "👤 **Próifíl:** `{current}`
+
+Roghnaigh an próifíl don chomhrá/snáithe seo:"
 
   reasoning:
     level_default:             "medium (réamhshocraithe)"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -186,6 +186,9 @@ gateway:
   profile:
     header:                "👤 **Profil:** `{profile}`"
     home:                  "📂 **Kezdőkönyvtár:** `{home}`"
+    picker_title:           "👤 **Profil:** `{current}`
+
+Válassza ki a profilt ehhez a csevegéshez/szálhoz:"
 
   reasoning:
     level_default:             "medium (alapértelmezett)"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -184,6 +184,9 @@ gateway:
   profile:
     header:                "👤 **Profil:** `{profile}`"
     home:                  "📂 **Kezdőkönyvtár:** `{home}`"
+    picker_title:           "👤 **Profil:** `{current}`
+
+Válassza ki a profilt ehhez a csevegéshez/szálhoz:"
 
   reasoning:
     level_default:             "medium (alapértelmezett)"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -186,6 +186,9 @@ gateway:
   profile:
     header:                "👤 **Profilo:** `{profile}`"
     home:                  "📂 **Home:** `{home}`"
+    picker_title:           "👤 **Profilo:** `{current}`
+
+Scegli il profilo per questa chat/thread:"
 
   reasoning:
     level_default:             "medio (predefinito)"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -184,6 +184,9 @@ gateway:
   profile:
     header:                "👤 **Profilo:** `{profile}`"
     home:                  "📂 **Home:** `{home}`"
+    picker_title:           "👤 **Profilo:** `{current}`
+
+Scegli il profilo per questa chat/thread:"
 
   reasoning:
     level_default:             "medio (predefinito)"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -186,6 +186,9 @@ gateway:
   profile:
     header:                "👤 **プロファイル:** `{profile}`"
     home:                  "📂 **ホーム:** `{home}`"
+    picker_title:           "👤 **プロフィール:** `{current}`
+
+このチャット/スレッドのプロフィールを選択:"
 
   reasoning:
     level_default:             "medium (デフォルト)"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -184,6 +184,9 @@ gateway:
   profile:
     header:                "👤 **プロファイル:** `{profile}`"
     home:                  "📂 **ホーム:** `{home}`"
+    picker_title:           "👤 **プロフィール:** `{current}`
+
+このチャット/スレッドのプロフィールを選択:"
 
   reasoning:
     level_default:             "medium (デフォルト)"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -186,6 +186,9 @@ gateway:
   profile:
     header:                "👤 **프로필:** `{profile}`"
     home:                  "📂 **홈:** `{home}`"
+    picker_title:           "👤 **프로필:** `{current}`
+
+이 채팅/스레드의 프로필 선택:"
 
   reasoning:
     level_default:             "medium (기본값)"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -184,6 +184,9 @@ gateway:
   profile:
     header:                "👤 **프로필:** `{profile}`"
     home:                  "📂 **홈:** `{home}`"
+    picker_title:           "👤 **프로필:** `{current}`
+
+이 채팅/스레드의 프로필 선택:"
 
   reasoning:
     level_default:             "medium (기본값)"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -186,6 +186,7 @@ gateway:
   profile:
     header:                "👤 **Perfil:** `{profile}`"
     home:                  "📂 **Início:** `{home}`"
+    picker_title:          "👤 **Perfil:** `{current}`\n\nEscolhe o perfil para este chat/thread:"
 
   reasoning:
     level_default:             "medium (predefinido)"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -184,6 +184,7 @@ gateway:
   profile:
     header:                "👤 **Perfil:** `{profile}`"
     home:                  "📂 **Início:** `{home}`"
+    picker_title:          "👤 **Perfil:** `{current}`\n\nEscolhe o perfil para este chat/thread:"
 
   reasoning:
     level_default:             "medium (predefinido)"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -186,6 +186,9 @@ gateway:
   profile:
     header:                "👤 **Профиль:** `{profile}`"
     home:                  "📂 **Домашний каталог:** `{home}`"
+    picker_title:           "👤 **Профиль:** `{current}`
+
+Выберите профиль для этого чата/темы:"
 
   reasoning:
     level_default:             "medium (по умолчанию)"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -184,6 +184,9 @@ gateway:
   profile:
     header:                "👤 **Профиль:** `{profile}`"
     home:                  "📂 **Домашний каталог:** `{home}`"
+    picker_title:           "👤 **Профиль:** `{current}`
+
+Выберите профиль для этого чата/темы:"
 
   reasoning:
     level_default:             "medium (по умолчанию)"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -186,6 +186,9 @@ gateway:
   profile:
     header:                "👤 **Profil:** `{profile}`"
     home:                  "📂 **Ana dizin:** `{home}`"
+    picker_title:           "👤 **Profil:** `{current}`
+
+Bu sohbet/thread için profil seçin:"
 
   reasoning:
     level_default:             "medium (varsayılan)"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -184,6 +184,9 @@ gateway:
   profile:
     header:                "👤 **Profil:** `{profile}`"
     home:                  "📂 **Ana dizin:** `{home}`"
+    picker_title:           "👤 **Profil:** `{current}`
+
+Bu sohbet/thread için profil seçin:"
 
   reasoning:
     level_default:             "medium (varsayılan)"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -186,6 +186,9 @@ gateway:
   profile:
     header:                "👤 **Профіль:** `{profile}`"
     home:                  "📂 **Домашня тека:** `{home}`"
+    picker_title:           "👤 **Профіль:** `{current}`
+
+Оберіть профіль для цього чату/треду:"
 
   reasoning:
     level_default:             "medium (за замовчуванням)"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -184,6 +184,9 @@ gateway:
   profile:
     header:                "👤 **Профіль:** `{profile}`"
     home:                  "📂 **Домашня тека:** `{home}`"
+    picker_title:           "👤 **Профіль:** `{current}`
+
+Оберіть профіль для цього чату/треду:"
 
   reasoning:
     level_default:             "medium (за замовчуванням)"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -186,6 +186,9 @@ gateway:
   profile:
     header:                "👤 **設定檔：** `{profile}`"
     home:                  "📂 **主目錄：** `{home}`"
+    picker_title:           "👤 **設定檔：** `{current}`
+
+請選擇此聊天/話題的設定檔："
 
   reasoning:
     level_default:             "medium（預設）"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -184,6 +184,9 @@ gateway:
   profile:
     header:                "👤 **設定檔：** `{profile}`"
     home:                  "📂 **主目錄：** `{home}`"
+    picker_title:           "👤 **設定檔：** `{current}`
+
+請選擇此聊天/話題的設定檔："
 
   reasoning:
     level_default:             "medium（預設）"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -186,6 +186,9 @@ gateway:
   profile:
     header:                "👤 **配置文件：** `{profile}`"
     home:                  "📂 **主目录：** `{home}`"
+    picker_title:           "👤 **配置文件：** `{current}`
+
+为此聊天/话题选择配置文件："
 
   reasoning:
     level_default:             "medium（默认）"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -184,6 +184,9 @@ gateway:
   profile:
     header:                "👤 **配置文件：** `{profile}`"
     home:                  "📂 **主目录：** `{home}`"
+    picker_title:           "👤 **配置文件：** `{current}`
+
+为此聊天/话题选择配置文件："
 
   reasoning:
     level_default:             "medium（默认）"

--- a/tests/gateway/test_profile_overrides_live_switch.py
+++ b/tests/gateway/test_profile_overrides_live_switch.py
@@ -1,0 +1,393 @@
+"""Tests for live per-source profile switching (``/profile set``).
+
+Covers:
+  * gateway.profile_overrides — the persistent switch table (set/clear/
+    resolve/list, hierarchical thread > chat).
+  * build_source() honouring a live override before profile_routes.
+  * _handle_profile_command subcommands (set/status/clears, multiplex gate,
+    missing-profile error).
+
+Run under an isolated HERMES_HOME so the real overrides file is untouched.
+The isolated home also gets a couple of fake profile dirs (product/
+development) so profile_exists() behaves as it would on a real machine.
+"""
+
+from __future__ import annotations
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway import profile_overrides as po
+from gateway.config import Platform
+from gateway.platforms.base import BasePlatformAdapter
+
+
+# --------------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def isolated_hermes_home(tmp_path, monkeypatch):
+    """Point the override store + profile dirs at a throwaway home."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Create fake profile dirs so profile_exists() is realistic.
+    for name in ("product", "development"):
+        (tmp_path / "profiles" / name).mkdir(parents=True, exist_ok=True)
+    p = tmp_path / po._OVERRIDES_FILE
+    if p.exists():
+        p.unlink()
+    yield tmp_path
+    if p.exists():
+        p.unlink()
+
+
+@pytest.fixture
+def fake_adapter():
+    """A BasePlatformAdapter with platform + gateway_runner; real build_source."""
+    ad = MagicMock(spec=BasePlatformAdapter)
+    ad.platform = MagicMock(value="telegram")
+    ad.gateway_runner = None
+    # Bind the *real* build_source so the override hook actually runs.
+    ad.build_source = BasePlatformAdapter.build_source.__get__(ad)
+    return ad
+
+
+# --------------------------------------------------------------------------
+# gateway.profile_overrides unit tests
+# --------------------------------------------------------------------------
+
+class TestOverrideStore:
+    def test_set_and_resolve_chat(self, tmp_path):
+        po.set_override("telegram", "chatA", "product")
+        assert po.resolve_override("telegram", "chatA") == "product"
+
+    def test_set_and_resolve_thread_wins_over_chat(self, tmp_path):
+        po.set_override("telegram", "chatA", "product")
+        po.set_override("telegram", "chatA", "development", thread_id="t1")
+        assert po.resolve_override("telegram", "chatA", "t1") == "development"
+        assert po.resolve_override("telegram", "chatA") == "product"
+
+    def test_clear_chat(self, tmp_path):
+        po.set_override("telegram", "chatA", "product")
+        assert po.clear_override("telegram", "chatA") is True
+        assert po.resolve_override("telegram", "chatA") is None
+        assert po.clear_override("telegram", "chatA") is False
+
+    def test_clear_thread_only(self, tmp_path):
+        po.set_override("telegram", "chatA", "product")
+        po.set_override("telegram", "chatA", "development", thread_id="t1")
+        assert po.clear_override("telegram", "chatA", "t1") is True
+        assert po.resolve_override("telegram", "chatA") == "product"
+
+    def test_list_roundtrip(self, tmp_path):
+        po.set_override("telegram", "chatA", "product")
+        po.set_override("discord", "g1", "dev", thread_id="th")
+        data = po.list_overrides()
+        assert data["telegram:chatA"] == "product"
+        assert data["discord:g1:th"] == "dev"
+
+    def test_persists_to_disk(self, tmp_path):
+        po.set_override("telegram", "chatA", "product")
+        raw = (tmp_path / po._OVERRIDES_FILE).read_text()
+        assert "product" in raw and "telegram:chatA" in raw
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert po.resolve_override("telegram", "nope") is None
+        assert po.list_overrides() == {}
+
+    def test_concurrent_writes_preserve_all_pins(self):
+        def write(i):
+            po.set_override("telegram", f"chat-{i}", "product")
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(write, range(32)))
+
+        data = po.list_overrides()
+        assert len(data) == 32
+        assert all(data[f"telegram:chat-{i}"] == "product" for i in range(32))
+
+
+# --------------------------------------------------------------------------
+# build_source() honours the live override
+# --------------------------------------------------------------------------
+
+class TestBuildSourceOverride:
+    def _make_source(self, adapter, chat_id="chatA", thread_id=None):
+        return adapter.build_source(
+            chat_id=chat_id,
+            chat_type="dm",
+            user_id="u1",
+            thread_id=thread_id,
+        )
+
+    def test_override_wins_over_routes(self, fake_adapter, tmp_path):
+        runner = MagicMock()
+        runner._profile_name_for_source.return_value = "routed"
+        fake_adapter.gateway_runner = runner
+        po.set_override("telegram", "chatA", "product")
+
+        src = self._make_source(fake_adapter)
+        assert src.profile == "product"
+        # routing engine must NOT have been consulted when override exists
+        runner._profile_name_for_source.assert_not_called()
+
+    def test_falls_back_to_routes_when_no_override(self, fake_adapter, tmp_path):
+        runner = MagicMock()
+        runner._profile_name_for_source.return_value = "routed"
+        fake_adapter.gateway_runner = runner
+
+        src = self._make_source(fake_adapter)
+        assert src.profile == "routed"
+        runner._profile_name_for_source.assert_called_once()
+
+    def test_thread_override_scope(self, fake_adapter, tmp_path):
+        runner = MagicMock()
+        runner._profile_name_for_source.return_value = None
+        fake_adapter.gateway_runner = runner
+        po.set_override("telegram", "chatA", "development", thread_id="t9")
+
+        chat_only = self._make_source(fake_adapter, thread_id=None)
+        assert chat_only.profile is None  # no chat-level override
+        threaded = self._make_source(fake_adapter, thread_id="t9")
+        assert threaded.profile == "development"
+
+    def test_override_ignored_when_multiplex_disabled(self, fake_adapter):
+        runner = MagicMock()
+        runner.config = SimpleNamespace(multiplex_profiles=False)
+        runner._profile_name_for_source.return_value = None
+        fake_adapter.gateway_runner = runner
+        po.set_override("telegram", "chatA", "product")
+
+        src = self._make_source(fake_adapter)
+        assert src.profile is None
+        runner._profile_name_for_source.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# _handle_profile_command subcommands
+# --------------------------------------------------------------------------
+
+class TestProfileCommand:
+    def _make_event(self, args="", chat_id="chatA", thread_id=None):
+        ev = MagicMock()
+        ev.get_command_args.return_value = args
+        src = MagicMock()
+        src.platform = Platform.TELEGRAM
+        src.chat_id = chat_id
+        src.thread_id = thread_id
+        src.chat_type = "dm"
+        src.user_id = "user1"
+        src.profile = None
+        ev.source = src
+        return ev
+
+    def _runner(self, multiplex=True):
+        runner = MagicMock()
+        runner.config = MagicMock(multiplex_profiles=multiplex)
+        from gateway.run import GatewayRunner
+
+        runner._resolve_profile_home_for_source = (
+            GatewayRunner._resolve_profile_home_for_source.__get__(runner)
+        )
+        return runner
+
+    def _restricted_runner(self, event, multiplex=True):
+        runner = self._runner(multiplex=multiplex)
+        runner.config.platforms = {
+            event.source.platform: SimpleNamespace(
+                extra={
+                    "allow_admin_from": ["admin"],
+                    "user_allowed_commands": ["profile"],
+                }
+            )
+        }
+        return runner
+
+    @pytest.mark.asyncio
+    async def test_set_requires_multiplex(self):
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+
+        runner = self._runner(multiplex=False)
+        mixin = GatewaySlashCommandsMixin()
+        mixin.config = runner.config
+        out = await mixin._handle_profile_command(self._make_event("set product"))
+        assert "multiplex_profiles" in out
+
+    @pytest.mark.asyncio
+    async def test_set_unknown_profile(self):
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+
+        runner = self._runner(multiplex=True)
+        mixin = GatewaySlashCommandsMixin()
+        mixin.config = runner.config
+        out = await mixin._handle_profile_command(self._make_event("set ghost"))
+        assert "does not exist" in out
+
+    @pytest.mark.asyncio
+    async def test_set_writes_override(self, tmp_path):
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+
+        runner = self._runner(multiplex=True)
+        mixin = GatewaySlashCommandsMixin()
+        mixin.config = runner.config
+        out = await mixin._handle_profile_command(self._make_event("set product"))
+        assert "product" in out
+        assert po.resolve_override("telegram", "chatA") == "product"
+
+    @pytest.mark.asyncio
+    async def test_set_rechecks_admin_authority(self):
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+
+        event = self._make_event("set product")
+        event.source.user_id = "guest"
+        runner = self._restricted_runner(event)
+        mixin = GatewaySlashCommandsMixin()
+        mixin.config = runner.config
+
+        out = await mixin._handle_profile_command(event)
+        assert "admins" in out.lower()
+        assert po.resolve_override("telegram", "chatA") is None
+
+    @pytest.mark.asyncio
+    async def test_set_validation_rejects_bad_name(self):
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+
+        runner = self._runner(multiplex=True)
+        mixin = GatewaySlashCommandsMixin()
+        mixin.config = runner.config
+        out = await mixin._handle_profile_command(self._make_event("set .."))
+        assert "Invalid profile name" in out
+
+    @pytest.mark.asyncio
+    async def test_clear_removes_override(self, tmp_path):
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+
+        po.set_override("telegram", "chatA", "product")
+        runner = self._runner(multiplex=True)
+        mixin = GatewaySlashCommandsMixin()
+        mixin.config = runner.config
+        out = await mixin._handle_profile_command(self._make_event("clear"))
+        assert "cleared" in out.lower() or "no profile pin" in out.lower()
+        assert po.resolve_override("telegram", "chatA") is None
+
+    @pytest.mark.asyncio
+    async def test_clear_rechecks_admin_authority(self):
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+
+        po.set_override("telegram", "chatA", "product")
+        event = self._make_event("clear")
+        event.source.user_id = "guest"
+        runner = self._restricted_runner(event)
+        mixin = GatewaySlashCommandsMixin()
+        mixin.config = runner.config
+
+        out = await mixin._handle_profile_command(event)
+        assert "admins" in out.lower()
+        assert po.resolve_override("telegram", "chatA") == "product"
+
+    @pytest.mark.asyncio
+    async def test_status_reports_pinned(self, tmp_path):
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+
+        po.set_override("telegram", "chatA", "product")
+        runner = self._runner(multiplex=True)
+        mixin = GatewaySlashCommandsMixin()
+        mixin.config = runner.config
+        # No picker support -> falls back to the text status card, which
+        # must report the pinned profile.
+        mixin._session_key_for_source = lambda src: "k:chatA"
+        mixin._try_send_choice_picker = (
+            lambda *a, **k: __import__("asyncio").sleep(0, result=False)
+        )
+        out = await mixin._handle_profile_command(self._make_event(""))
+        assert "product" in out
+
+    @pytest.mark.asyncio
+    async def test_list_shows_profiles(self, monkeypatch):
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+        import hermes_cli.profiles as hp
+
+        monkeypatch.setattr(
+            hp, "list_profiles",
+            lambda: [SimpleNamespace(name="default"), SimpleNamespace(name="product")],
+        )
+        monkeypatch.setattr(hp, "get_active_profile_name", lambda: "default")
+
+        runner = self._runner(multiplex=True)
+        mixin = GatewaySlashCommandsMixin()
+        mixin.config = runner.config
+        out = await mixin._handle_profile_command(self._make_event("list"))
+        assert "default" in out
+
+    @pytest.mark.asyncio
+    async def test_no_args_opens_picker_and_set(self, tmp_path, monkeypatch):
+        """`/profile` (no args) opens the interactive picker; selecting a
+        profile performs the live set (parity with /model)."""
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+        import hermes_cli.profiles as hp
+
+        monkeypatch.setattr(
+            hp, "list_profiles",
+            lambda: [SimpleNamespace(name="default"), SimpleNamespace(name="product")],
+        )
+        monkeypatch.setattr(hp, "get_active_profile_name", lambda: "default")
+
+        runner = self._runner(multiplex=True)
+        mixin = GatewaySlashCommandsMixin()
+        mixin.config = runner.config
+        mixin._session_key_for_source = lambda src: "k:chatA"
+        captured = {}
+
+        async def fake_send_picker(event, session_key, title, choices, on_choice_selected, metadata=None):
+            captured["choices"] = choices
+            captured["on_choice_selected"] = on_choice_selected
+            captured["title"] = title
+            return SimpleNamespace(success=True)
+
+        mixin._try_send_choice_picker = fake_send_picker
+
+        out = await mixin._handle_profile_command(self._make_event(""))
+        assert out is None
+        names = [c["value"] for c in captured["choices"]]
+        assert names == ["default", "product"]
+        assert any(c["is_current"] for c in captured["choices"] if c["value"] == "default")
+
+        result = await captured["on_choice_selected"]("chatA", "product")
+        assert "product" in result
+        assert po.resolve_override("telegram", "chatA") == "product"
+
+    @pytest.mark.asyncio
+    async def test_picker_rechecks_admin_at_selection_time(self, monkeypatch):
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+        import hermes_cli.profiles as hp
+
+        monkeypatch.setattr(
+            hp,
+            "list_profiles",
+            lambda: [SimpleNamespace(name="default"), SimpleNamespace(name="product")],
+        )
+        monkeypatch.setattr(hp, "get_active_profile_name", lambda: "default")
+
+        event = self._make_event("")
+        runner = self._restricted_runner(event)
+        mixin = GatewaySlashCommandsMixin()
+        mixin.config = runner.config
+        mixin._session_key_for_source = lambda src: "k:chatA"
+        captured = {}
+
+        async def fake_send_picker(event, session_key, title, choices, on_choice_selected, metadata=None):
+            captured["on_choice_selected"] = on_choice_selected
+            return SimpleNamespace(success=True)
+
+        mixin._try_send_choice_picker = fake_send_picker
+        assert await mixin._handle_profile_command(event) is None
+
+        event.source.user_id = "guest"
+        result = await captured["on_choice_selected"]("chatA", "product")
+        assert "admins" in result.lower()
+        assert po.resolve_override("telegram", "chatA") is None

--- a/tests/gateway/test_profile_overrides_live_switch.py
+++ b/tests/gateway/test_profile_overrides_live_switch.py
@@ -354,7 +354,9 @@ class TestProfileCommand:
         out = await mixin._handle_profile_command(self._make_event(""))
         assert out is None
         names = [c["value"] for c in captured["choices"]]
-        assert names == ["default", "product"]
+        # Profiles come first, then the explicit Cancel escape hatch (parity
+        # with /model's cost-confirm cancel).
+        assert names == ["default", "product", "cancel"]
         assert any(c["is_current"] for c in captured["choices"] if c["value"] == "default")
 
         result = await captured["on_choice_selected"]("chatA", "product")

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -137,7 +137,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/image <path>` | Attach a local image file for your next prompt. |
 | `/debug` | Upload debug report (system info + logs) and get shareable links. Also available in messaging. |
 | `/update` | Update Hermes Agent to the latest version. |
-| `/profile` | Show active profile name and home directory |
+| `/profile` | Show or switch the profile serving this chat. With no args, opens a picker when multiplexing is enabled. Subcommands: `set NAME`, `clear`, and `list`; persistent changes require `gateway.multiplex_profiles: true` and admin access. |
 
 ### Exit
 

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -133,7 +133,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/image <path>` | Attach a local image file for your next prompt. |
 | `/debug` | Upload debug report (system info + logs) and get shareable links. Also available in messaging. |
 | `/update` | Update Hermes Agent to the latest version. |
-| `/profile` | Show active profile name and home directory |
+| `/profile` | Show or switch the profile serving this chat. With no args, opens a picker when multiplexing is enabled. Subcommands: `set NAME`, `clear`, and `list`; persistent changes require `gateway.multiplex_profiles: true` and admin access. |
 
 ### Exit
 


### PR DESCRIPTION
## Summary

Adds support for interactive profile switching in the gateway via the new `/profile` slash command (with picker support, parity with `/model`).

This allows changing which profile serves a specific chat or thread at runtime, without restarting the gateway.

## Motivation

Previously, to route a chat or thread to a different profile, users had to manually edit `profile_overrides.json` or restart everything. There was no first-class, user-friendly way to do live profile changes from within the chat.

## What the PR does

- New `/profile` command with subcommands:
  - `/profile` → shows the current profile serving this source (chat/thread)
  - `/profile set <name>` → pins the current chat/thread to the given profile (live)
  - `/profile set` (no name) → opens an interactive picker (same experience as `/model`)
  - `/profile clear` → removes the override for this chat/thread
  - `/profile list` → lists available profiles

- The picker is available on platforms that support rich interactions (Telegram, Discord, Matrix) and falls back gracefully on others.

- Thread-level overrides are supported (thread-specific overrides take precedence over chat-level).

- When `gateway.multiplex_profiles` is disabled (the default), plain `/profile` now shows a helpful message explaining the requirement instead of only showing the current profile.

## Requirements

Live profile switching requires `gateway.multiplex_profiles: true` in the gateway configuration.

When this setting is off, the command still works for viewing the current profile and listing profiles, but switching is blocked with clear guidance on how to enable it.

## Usage example

```
/profile set casa
```

From that point on, messages in that chat will be handled by the `casa` profile (no restart needed).

## Additional improvements in this PR

- Better UX and discoverability when `multiplex_profiles` is not enabled.
- Clear error messages guiding users to the correct configuration.
- Consistent behavior with other picker commands.

## Testing

- Tested on Telegram (primary platform used during development).
- Built using the free HY3 model available on the Nous Portal.

## Notes

Only @Teknium needs to review and merge.
