### PR TITLE
fix(agent): keep assistant tool_calls in Copilot ACP prompt transcript

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -190,6 +190,15 @@ def _format_messages_as_prompt(
 
         content = message.get("content")
         rendered = _render_message_content(content)
+        tool_calls_text = ""
+        if role == "assistant":
+            tool_calls_text = _render_tool_calls_for_prompt(message.get("tool_calls"))
+        if tool_calls_text:
+            rendered = (
+                f"{rendered}\n{tool_calls_text}".strip()
+                if rendered
+                else tool_calls_text
+            )
         if not rendered:
             continue
 
@@ -231,6 +240,78 @@ def _render_message_content(content: Any) -> str:
                     parts.append(text.strip())
         return "\n".join(parts).strip()
     return str(content).strip()
+
+
+def _coerce_tool_call_arguments(arguments: Any) -> str:
+    if isinstance(arguments, str):
+        return arguments
+    if arguments is None:
+        return "{}"
+    try:
+        return json.dumps(arguments, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(arguments)
+
+
+def _normalize_tool_call_payload(tool_call: Any) -> dict[str, Any] | None:
+    """Normalize dict/object tool_calls into OpenAI function-call JSON shape."""
+    if isinstance(tool_call, dict):
+        raw_fn = tool_call.get("function") or {}
+        if not isinstance(raw_fn, dict):
+            raw_fn = {}
+        name = raw_fn.get("name") or tool_call.get("name")
+        if not isinstance(name, str) or not name.strip():
+            return None
+        call_id = tool_call.get("id") or tool_call.get("call_id") or ""
+        arguments = raw_fn.get("arguments")
+        if arguments is None:
+            arguments = tool_call.get("arguments")
+        return {
+            "id": str(call_id),
+            "type": tool_call.get("type") or "function",
+            "function": {
+                "name": name.strip(),
+                "arguments": _coerce_tool_call_arguments(arguments),
+            },
+        }
+
+    fn = getattr(tool_call, "function", None)
+    name = getattr(fn, "name", None) if fn is not None else getattr(tool_call, "name", None)
+    if not isinstance(name, str) or not name.strip():
+        return None
+    call_id = getattr(tool_call, "id", None) or getattr(tool_call, "call_id", None) or ""
+    arguments = getattr(fn, "arguments", None) if fn is not None else None
+    return {
+        "id": str(call_id),
+        "type": getattr(tool_call, "type", None) or "function",
+        "function": {
+            "name": name.strip(),
+            "arguments": _coerce_tool_call_arguments(arguments),
+        },
+    }
+
+
+def _render_tool_calls_for_prompt(tool_calls: Any) -> str:
+    """Serialize assistant tool_calls into transcript <tool_call> blocks.
+
+    Hermes conversation history often carries assistant turns with
+    ``content=None`` and a populated ``tool_calls`` array. The ACP prompt is
+    plain text, so those calls must be flattened or the next turn loses which
+    tool was requested and only keeps orphan Tool results.
+    """
+    if not isinstance(tool_calls, list) or not tool_calls:
+        return ""
+    blocks: list[str] = []
+    for tool_call in tool_calls:
+        payload = _normalize_tool_call_payload(tool_call)
+        if payload is None:
+            continue
+        blocks.append(
+            "<tool_call>"
+            + json.dumps(payload, ensure_ascii=False)
+            + "</tool_call>"
+        )
+    return "\n".join(blocks)
 
 
 def _build_openai_tool_call(

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -281,6 +281,8 @@ def _normalize_tool_call_payload(tool_call: Any) -> dict[str, Any] | None:
         return None
     call_id = getattr(tool_call, "id", None) or getattr(tool_call, "call_id", None) or ""
     arguments = getattr(fn, "arguments", None) if fn is not None else None
+    if arguments is None:
+        arguments = getattr(tool_call, "arguments", None)
     return {
         "id": str(call_id),
         "type": getattr(tool_call, "type", None) or "function",

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -10,7 +10,129 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from agent.copilot_acp_client import CopilotACPClient
+from agent.copilot_acp_client import CopilotACPClient, _format_messages_as_prompt
+
+
+class FormatMessagesAsPromptTests(unittest.TestCase):
+    @staticmethod
+    def _transcript_section(prompt: str) -> str:
+        marker = "Conversation transcript:\n\n"
+        start = prompt.index(marker) + len(marker)
+        end = prompt.index("\n\nContinue the conversation", start)
+        return prompt[start:end]
+
+    @staticmethod
+    def _first_tool_call_payload(prompt: str) -> dict:
+        transcript = FormatMessagesAsPromptTests._transcript_section(prompt)
+        start = transcript.index("<tool_call>") + len("<tool_call>")
+        end = transcript.index("</tool_call>", start)
+        return json.loads(transcript[start:end])
+
+    def test_assistant_tool_calls_with_null_content_appear_in_transcript(self) -> None:
+        prompt = _format_messages_as_prompt(
+            [
+                {"role": "user", "content": "do it"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {
+                                "name": "read_file",
+                                "arguments": '{"path":"x"}',
+                            },
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "c1", "content": "file contents here"},
+                {"role": "user", "content": "thanks"},
+            ]
+        )
+
+        transcript = self._transcript_section(prompt)
+        self.assertIn("Assistant:", transcript)
+        self.assertIn("Tool:", transcript)
+        self.assertIn("file contents here", transcript)
+        payload = self._first_tool_call_payload(prompt)
+        self.assertEqual(payload["id"], "c1")
+        self.assertEqual(payload["function"]["name"], "read_file")
+        self.assertIsInstance(payload["function"]["arguments"], str)
+        self.assertEqual(json.loads(payload["function"]["arguments"]), {"path": "x"})
+
+    def test_assistant_empty_string_content_with_tool_calls_is_kept(self) -> None:
+        prompt = _format_messages_as_prompt(
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "c3",
+                            "type": "function",
+                            "function": {
+                                "name": "read_file",
+                                "arguments": {"path": "y"},
+                            },
+                        }
+                    ],
+                }
+            ]
+        )
+        payload = self._first_tool_call_payload(prompt)
+        self.assertEqual(payload["id"], "c3")
+        self.assertIsInstance(payload["function"]["arguments"], str)
+        self.assertEqual(json.loads(payload["function"]["arguments"]), {"path": "y"})
+
+    def test_assistant_text_plus_tool_calls_keeps_both(self) -> None:
+        prompt = _format_messages_as_prompt(
+            [
+                {
+                    "role": "assistant",
+                    "content": "Inspecting the file.",
+                    "tool_calls": [
+                        {
+                            "id": "c2",
+                            "type": "function",
+                            "function": {
+                                "name": "search_files",
+                                "arguments": '{"query":"foo"}',
+                            },
+                        }
+                    ],
+                }
+            ]
+        )
+
+        transcript = self._transcript_section(prompt)
+        self.assertIn("Inspecting the file.", transcript)
+        self.assertIn("search_files", transcript)
+        self.assertLess(
+            transcript.index("Inspecting the file."),
+            transcript.index("<tool_call>"),
+        )
+
+    def test_non_assistant_tool_calls_are_ignored(self) -> None:
+        prompt = _format_messages_as_prompt(
+            [
+                {
+                    "role": "user",
+                    "content": "hi",
+                    "tool_calls": [
+                        {
+                            "id": "bad",
+                            "type": "function",
+                            "function": {"name": "read_file", "arguments": "{}"},
+                        }
+                    ],
+                }
+            ]
+        )
+        transcript = self._transcript_section(prompt)
+        self.assertEqual(transcript, "User:\nhi")
+        self.assertNotIn("<tool_call>", transcript)
+        self.assertNotIn("read_file", transcript)
 
 
 class _FakeProcess:

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -8,6 +8,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from agent.copilot_acp_client import CopilotACPClient, _format_messages_as_prompt
@@ -133,6 +134,123 @@ class FormatMessagesAsPromptTests(unittest.TestCase):
         self.assertEqual(transcript, "User:\nhi")
         self.assertNotIn("<tool_call>", transcript)
         self.assertNotIn("read_file", transcript)
+
+    def test_multiple_tool_calls_on_one_assistant_turn(self) -> None:
+        prompt = _format_messages_as_prompt(
+            [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {
+                                "name": "read_file",
+                                "arguments": '{"path":"a"}',
+                            },
+                        },
+                        {
+                            "id": "c2",
+                            "type": "function",
+                            "function": {
+                                "name": "search_files",
+                                "arguments": '{"query":"b"}',
+                            },
+                        },
+                    ],
+                }
+            ]
+        )
+        transcript = self._transcript_section(prompt)
+        self.assertEqual(transcript.count("<tool_call>"), 2)
+        self.assertLess(transcript.index('"c1"'), transcript.index('"c2"'))
+        first = self._first_tool_call_payload(prompt)
+        self.assertEqual(first["id"], "c1")
+        self.assertEqual(first["function"]["name"], "read_file")
+        self.assertIsInstance(first["function"]["arguments"], str)
+        self.assertEqual(json.loads(first["function"]["arguments"]), {"path": "a"})
+        second_start = transcript.index("</tool_call>") + len("</tool_call>")
+        second_block_start = transcript.index("<tool_call>", second_start) + len(
+            "<tool_call>"
+        )
+        second_block_end = transcript.index("</tool_call>", second_block_start)
+        second = json.loads(transcript[second_block_start:second_block_end])
+        self.assertEqual(second["id"], "c2")
+        self.assertEqual(second["function"]["name"], "search_files")
+        self.assertIsInstance(second["function"]["arguments"], str)
+        self.assertEqual(json.loads(second["function"]["arguments"]), {"query": "b"})
+
+    def test_nameless_tool_call_skipped_without_dropping_content(self) -> None:
+        prompt = _format_messages_as_prompt(
+            [
+                {
+                    "role": "assistant",
+                    "content": "Still here.",
+                    "tool_calls": [
+                        {"id": "bad", "type": "function", "function": {"arguments": "{}"}},
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {
+                                "name": "read_file",
+                                "arguments": '{"path":"x"}',
+                            },
+                        },
+                    ],
+                }
+            ]
+        )
+        transcript = self._transcript_section(prompt)
+        self.assertIn("Still here.", transcript)
+        self.assertEqual(transcript.count("<tool_call>"), 1)
+        payload = self._first_tool_call_payload(prompt)
+        self.assertEqual(payload["id"], "c1")
+        self.assertEqual(payload["function"]["name"], "read_file")
+
+    def test_flat_shape_tool_call_arguments_are_preserved(self) -> None:
+        prompt = _format_messages_as_prompt(
+            [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "flat1",
+                            "name": "read_file",
+                            "arguments": {"path": "z"},
+                        }
+                    ],
+                }
+            ]
+        )
+        payload = self._first_tool_call_payload(prompt)
+        self.assertEqual(payload["id"], "flat1")
+        self.assertEqual(payload["function"]["name"], "read_file")
+        self.assertIsInstance(payload["function"]["arguments"], str)
+        self.assertEqual(json.loads(payload["function"]["arguments"]), {"path": "z"})
+
+    def test_object_shape_tool_call_arguments_are_preserved(self) -> None:
+        prompt = _format_messages_as_prompt(
+            [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        SimpleNamespace(
+                            id="obj1",
+                            name="read_file",
+                            arguments={"path": "z"},
+                        )
+                    ],
+                }
+            ]
+        )
+        payload = self._first_tool_call_payload(prompt)
+        self.assertEqual(payload["id"], "obj1")
+        self.assertEqual(payload["function"]["name"], "read_file")
+        self.assertIsInstance(payload["function"]["arguments"], str)
+        self.assertEqual(json.loads(payload["function"]["arguments"]), {"path": "z"})
 
 
 class _FakeProcess:


### PR DESCRIPTION
## What does this PR do?

Copilot ACP flattens Hermes chat history into a plain-text prompt. Assistant turns that only carry `tool_calls` (with `content` null/empty) were skipped, so later turns kept orphan Tool results without the matching tool request. This PR serializes assistant `tool_calls` into `<tool_call>{...}</tool_call>` blocks in the transcript so multi-turn tool loops stay coherent.

### Bug Cause

`_format_messages_as_prompt` in `agent/copilot_acp_client.py` rendered only `content`, then did `if not rendered: continue`. OpenAI-style assistant messages with `content=None` and a populated `tool_calls` array were dropped entirely; `tool_calls` were never written into the ACP prompt.

### Reproduction Steps

1. Build messages: user -> assistant(`content=None`, `tool_calls=[read_file...]`) -> tool(result) -> user.
2. Call `_format_messages_as_prompt(messages)`.
3. Inspect the Conversation transcript section.

Expected: Assistant turn includes a `<tool_call>` for `read_file`, followed by the Tool result.
Before fix: transcript had Tool/User only; no Assistant tool request / no `read_file`.

### Fix

- For `role == "assistant"`, flatten `tool_calls` into OpenAI-shaped `<tool_call>` JSON blocks (same wire format this adapter already teaches / parses).
- Keep text + tool_calls turns with both parts; ignore `tool_calls` on non-assistant roles.
- Normalize dict/object tool_calls and coerce `arguments` to a JSON string.
- Tests in `tests/agent/test_copilot_acp_client.py` cover null/empty content, text+calls, dict arguments, and non-assistant ignore.

## Related Issue

No issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/copilot_acp_client.py` - render assistant `tool_calls` into ACP prompt transcript
- `tests/agent/test_copilot_acp_client.py` - regression coverage for tool-call retention

## How to Test

1. Manual: run the reproduction above; confirm transcript contains Assistant `<tool_call>` with `id` / `read_file` / stringified arguments, then Tool result.
2. Automated: `scripts/run_tests.sh tests/agent/test_copilot_acp_client.py -q` (15 passed locally)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (tests via bash/`scripts/run_tests.sh`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact - or N/A (pure Python prompt formatting)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A
