### PR TITLE
fix(codex): dedupe app-server final previews

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -813,6 +813,19 @@ def run_codex_app_server_turn(
         except Exception:
             logger.debug("background review spawn raised", exc_info=True)
 
+    # The app-server bridge publishes every completed agentMessage through the
+    # interim callback so mid-turn commentary remains visible. The last such
+    # item is also Codex's final response, so tell host surfaces when that exact
+    # text was delivered successfully. TUI uses this to settle the preview onto
+    # the terminal message; messaging gateways use it to skip a duplicate send.
+    # Unrelated commentary and callback-free runs remain false.
+    interim_was_delivered = getattr(agent, "_interim_text_was_delivered", None)
+    response_previewed = bool(
+        turn.final_text
+        and callable(interim_was_delivered)
+        and interim_was_delivered(turn.final_text)
+    )
+
     return {
         "final_response": turn.final_text,
         "messages": messages,
@@ -820,6 +833,7 @@ def run_codex_app_server_turn(
         "completed": not turn.interrupted and turn.error is None,
         "partial": turn.interrupted or turn.error is not None,
         "error": turn.error,
+        "response_previewed": response_previewed,
         # The codex app-server runtime IS an early-return path that bypasses
         # conversation_loop, but we flush the projected assistant/tool messages
         # ourselves above (see the _flush_messages_to_session_db call after

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -85,6 +85,88 @@ class TestRunConversationCodexPath:
         assert result["api_calls"] == 1
         assert result["codex_thread_id"] == "thread-stub-1"
         assert result["codex_turn_id"] == "turn-stub-1"
+        assert result["response_previewed"] is False
+
+    def test_delivered_final_interim_is_marked_previewed(self, monkeypatch):
+        def fake_run_turn(self, user_input: str, **kwargs):
+            final_text = f"echo: {user_input}"
+            self._on_event({
+                "method": "item/completed",
+                "params": {
+                    "item": {
+                        "type": "agentMessage",
+                        "id": "final-message",
+                        "text": final_text,
+                    }
+                },
+            })
+            return TurnResult(
+                final_text=final_text,
+                projected_messages=[
+                    {"role": "assistant", "content": final_text}
+                ],
+                turn_id="turn-previewed-1",
+                thread_id="thread-previewed-1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession,
+            "ensure_started",
+            lambda self: "thread-previewed-1",
+        )
+        delivered = []
+        agent = _make_codex_agent(
+            interim_assistant_callback=lambda text, **kwargs: delivered.append(
+                (text, kwargs)
+            )
+        )
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello")
+
+        assert delivered == [("echo: hello", {"already_streamed": False})]
+        assert result["final_response"] == "echo: hello"
+        assert result["response_previewed"] is True
+
+    def test_distinct_interim_does_not_mark_final_previewed(self, monkeypatch):
+        def fake_run_turn(self, user_input: str, **kwargs):
+            self._on_event({
+                "method": "item/completed",
+                "params": {
+                    "item": {
+                        "type": "agentMessage",
+                        "id": "commentary-message",
+                        "text": "I'll inspect it first.",
+                    }
+                },
+            })
+            return TurnResult(
+                final_text="Done.",
+                projected_messages=[
+                    {"role": "assistant", "content": "Done."}
+                ],
+                turn_id="turn-distinct-1",
+                thread_id="thread-distinct-1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession,
+            "ensure_started",
+            lambda self: "thread-distinct-1",
+        )
+        delivered = []
+        agent = _make_codex_agent(
+            interim_assistant_callback=lambda text, **kwargs: delivered.append(text)
+        )
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello")
+
+        assert delivered == ["I'll inspect it first."]
+        assert result["final_response"] == "Done."
+        assert result["response_previewed"] is False
 
     def test_codex_app_server_token_usage_updates_session_accounting(self, monkeypatch):
         def fake_run_turn(self, user_input: str, **kwargs):
@@ -786,4 +868,3 @@ class TestCodexToolProgressBridge:
 
         assert "on_event" in captured_init and captured_init["on_event"] is not None
         assert ("tool.started", "exec_command", "pytest") in events
-

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -410,6 +410,12 @@ Known limitations:
 - **No inline patch preview in approval prompts when codex doesn't track the changeset.** Codex's `fileChange` approval params don't always carry the changeset. Hermes caches the data from the corresponding `item/started` notification when possible, but if approval arrives before the item has streamed, the prompt falls back to whatever `reason` codex provides.
 - **Sub-second cancellation isn't guaranteed.** Mid-stream interrupts (Ctrl+C while codex is responding) are sent via `turn/interrupt`, but if codex has already flushed the final message, you get the response anyway.
 
+Completed app-server messages are surfaced immediately as interim updates. When
+the last update exactly matches the final response, Hermes marks that response
+as already previewed so TUI and messaging clients settle it as one assistant
+message instead of rendering or sending it twice. Distinct mid-turn commentary
+remains separate.
+
 If you find a bug, [open an issue](https://github.com/NousResearch/hermes-agent/issues) with the output of `hermes logs --since 5m`. Mention `codex-runtime` in the title so it's easy to triage.
 
 ## Architecture


### PR DESCRIPTION
## What does this PR do?

Prevents Codex app-server final responses from rendering or sending twice when the exact final text was already delivered through the interim-assistant callback.

The app-server bridge intentionally surfaces every completed `agentMessage` as an interim update so real mid-turn commentary remains visible. The last completed item is also returned as `final_response`, but the app-server result did not set `response_previewed`. TUI therefore sealed that interim segment and appended the identical terminal response again; messaging gateways could likewise send the final twice.

This reuses AIAgent's existing delivered-interim registry and marks the response previewed only when the exact normalized final text was successfully delivered. Distinct commentary and callback-free runs retain normal final delivery.

## Related Issue

N/A — reproduced against current `main` through the Codex app-server TUI path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/codex_runtime.py`: set `response_previewed` only when the exact final app-server text was delivered as an interim update.
- `tests/run_agent/test_codex_app_server_integration.py`: cover exact-final deduplication, distinct commentary, and callback-free behavior.
- `website/docs/user-guide/features/codex-app-server-runtime.md`: document final-preview settlement across TUI and messaging clients.

## How to Test

1. Enable the Codex app-server runtime and start the TUI.
2. Send a prompt that returns a plain final answer, such as `hi`; confirm the assistant answer renders once.
3. Send a tool-using prompt that produces distinct progress commentary; confirm commentary remains separate and the final answer renders once.
4. Run `pytest -q tests/run_agent/test_codex_app_server_integration.py tests/agent/test_codex_app_server_event_bridge.py tests/agent/test_codex_runtime_live_events.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full Python suite passed in PR CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Linux x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated the Codex app-server runtime guide
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure response metadata; Windows-footgun CI passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool changes

## Screenshots / Logs

The focused regression suite passes with 83 tests. PR CI also passes the complete Python matrix, Ruff enforcement, Windows-footgun checks, docs checks, desktop E2E, and all required checks.
