### PR TITLE
fix(telegram): prevent typing indicator stuck after response when connection blips (#69150)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -700,6 +700,12 @@ class TelegramAdapter(BasePlatformAdapter):
             min_value=1.0,
             max_value=300.0,
         )
+        # Chats where typing stop has been requested (e.g. after final response
+        # delivery).  send_typing() returns immediately when the chat is in this
+        # set, preventing the Telegram-side 5s typing timer from being re-armed
+        # after the response has been delivered.  Cleared when a new message
+        # arrives (resume_typing_for_chat).  See #69150.
+        self._telegram_typing_stopped: Set[str] = set()
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
         self._media_batch_delay_seconds = env_float("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", 0.8)
@@ -7058,6 +7064,13 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot or self._typing_in_cooldown(chat_id):
             return
 
+        # If typing has been explicitly stopped (e.g. after final response
+        # delivery), don't re-arm the Telegram-side 5s timer.  The response
+        # message itself already cleared the typing indicator; re-arming it
+        # here would leave it lingering with nothing to cancel it (#69150).
+        if hasattr(self, "_telegram_typing_stopped") and chat_id in self._telegram_typing_stopped:
+            return
+
         _is_dm_topic: bool = False
         message_thread_id: Optional[int] = None
         try:
@@ -7094,6 +7107,35 @@ class TelegramAdapter(BasePlatformAdapter):
                 _redact_telegram_error_text(e),
                 exc_info=True,
             )
+
+    async def stop_typing(self, chat_id: str) -> None:
+        """Stop the typing indicator for a chat.
+
+        Marks the chat so subsequent ``send_typing()`` calls return
+        immediately, preventing the Telegram-side ~5s typing timer from
+        being re-armed after the final response has been delivered.
+        The response message itself already cleared the indicator on
+        Telegram's side (Telegram exposes no sendChatAction(cancel) API);
+        this guard prevents any late ``send_typing()`` call (e.g. from
+        retry logic or a race in the keep-typing loop) from re-setting it.
+        Cleared by ``resume_typing_for_chat()`` when a new user message
+        starts a fresh turn.  See #69150.
+        """
+        if not hasattr(self, "_telegram_typing_stopped"):
+            self._telegram_typing_stopped = set()
+        self._telegram_typing_stopped.add(str(chat_id))
+
+    def resume_typing_for_chat(self, chat_id: str) -> None:
+        """Resume typing indicator for a chat after stop.
+
+        Clears the ``_telegram_typing_stopped`` flag set by
+        ``stop_typing()`` so subsequent ``send_typing()`` calls can
+        re-arm the indicator for the next turn.
+        """
+        if hasattr(self, "_telegram_typing_stopped"):
+            self._telegram_typing_stopped.discard(str(chat_id))
+        # Call super so _typing_paused is also cleared.
+        super().resume_typing_for_chat(chat_id)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Get information about a Telegram chat."""

--- a/tests/gateway/test_telegram_typing_backoff.py
+++ b/tests/gateway/test_telegram_typing_backoff.py
@@ -111,3 +111,54 @@ async def test_typing_bad_thread_failure_does_not_cool_down(monkeypatch):
 
     assert adapter._bot.send_chat_action.await_count == 2
     assert "123" not in adapter._telegram_typing_cooldown_until
+
+
+@pytest.mark.asyncio
+async def test_stop_typing_prevents_further_send():
+    """After stop_typing(), send_typing() must not re-arm the timer."""
+    adapter = _make_adapter()
+    adapter._bot.send_chat_action = AsyncMock(return_value=None)
+
+    # First call works normally
+    await adapter.send_typing("123")
+    assert adapter._bot.send_chat_action.await_count == 1
+
+    # Stop typing
+    await adapter.stop_typing("123")
+    assert "123" in adapter._telegram_typing_stopped
+
+    # Subsequent calls must be no-ops
+    await adapter.send_typing("123")
+    assert adapter._bot.send_chat_action.await_count == 1  # no new call
+
+
+@pytest.mark.asyncio
+async def test_stop_typing_cleared_by_resume():
+    """After resume_typing_for_chat(), send_typing() must work again."""
+    adapter = _make_adapter()
+    adapter._bot.send_chat_action = AsyncMock(return_value=None)
+
+    await adapter.stop_typing("123")
+    assert "123" in adapter._telegram_typing_stopped
+
+    # Resume clears the flag
+    adapter.resume_typing_for_chat("123")
+    assert "123" not in adapter._telegram_typing_stopped
+
+    # send_typing should work again
+    await adapter.send_typing("123")
+    assert adapter._bot.send_chat_action.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_typing_does_not_affect_other_chats():
+    """stop_typing for one chat must not affect others."""
+    adapter = _make_adapter()
+    adapter._bot.send_chat_action = AsyncMock(return_value=None)
+
+    await adapter.stop_typing("123")
+    assert "123" in adapter._telegram_typing_stopped
+    assert "456" not in adapter._telegram_typing_stopped
+
+    await adapter.send_typing("456")
+    assert adapter._bot.send_chat_action.await_count == 1


### PR DESCRIPTION
## Description

Fixes #69150 — Telegram typing indicator stuck after response when connection blips.

## Root Cause

The Telegram adapter has no `stop_typing()` method — the base `_keep_typing` loop's finally block calls `stop_typing()` via `_stop_typing_with_metadata()`, but since Telegram never implemented it, the call is a no-op. This means:

1. When the final response is delivered, Telegram's sendMessage API automatically clears the typing indicator on its side
2. However, a late `send_typing()` call (from a keep-typing loop tick or a post-send re-trigger in `send_message()`) can **re-arm** the Telegram-side ~5s timer **after** the response was delivered
3. With nothing to cancel the re-armed timer (Telegram exposes no `sendChatAction(cancel)` API), the "typing..." bubble lingers
4. During connection blips, this race is more likely because retries and fallback paths increase the window for late `send_typing()` calls

## Fix

1. **New `_telegram_typing_stopped: Set[str]`** — per-chat guard flag initialized in `__init__`
2. **New `stop_typing(chat_id)`** — adds the chat to the stopped set
3. **Guard in `send_typing()`** — returns immediately if the chat is in the stopped set, preventing any re-arm of the Telegram-side timer
4. **Override `resume_typing_for_chat()`** — clears the stopped flag when a new user message starts a fresh turn (also calls `super()` to clear `_typing_paused`)
5. **3 new tests** covering: stop prevents further sends, resume clears the flag, per-chat isolation

## Testing

```
tests/gateway/test_telegram_typing_backoff.py ✓✓✓✓✓✓ (6 passed)
```