### PR TITLE
fix(nix): use electron.headers instead of hardcoded headers hash in desktop.nix

### DIFF
--- a/contributors/emails/development@schmitthenner.eu
+++ b/contributors/emails/development@schmitthenner.eu
@@ -1,0 +1,2 @@
+fkz
+# PR #61824 salvage via #69458

--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -29,11 +29,6 @@ let
   packageJson = builtins.fromJSON (builtins.readFile (npm.src + "/apps/desktop/package.json"));
   version = packageJson.version;
 
-  electronHeaders = pkgs.fetchurl {
-    url = "https://artifacts.electronjs.org/headers/dist/v${electron.version}/node-v${electron.version}-headers.tar.gz";
-    sha256 = "sha256-zi/QMwRZ0+FwE9XTE+DiSIeJXAwxmLKEaBWD5W3pMOI=";
-  };
-
   # node-pty ships no Electron-tagged prebuild we can trust to match this
   # exact nixpkgs electron version, so it's always compiled from source
   # against Electron's own headers (not whatever Node ran `npm`).
@@ -80,18 +75,11 @@ let
           # build the electron bundle
           node scripts/bundle-electron-main.mjs
 
-          # Compile node-pty against Electron's actual ABI (the nixpkgs
-          # `electron` we ship). Headers come from a pinned fetchurl input
-          # since the sandbox has no network here, so node-gyp's
-          # normal --disturl download path can't run.
-          mkdir -p "$TMPDIR/electron-headers"
-          tar -xzf ${electronHeaders} -C "$TMPDIR/electron-headers" --strip-components=1
-
           npm rebuild node-pty \
             --build-from-source \
             --runtime=electron \
             --target=${electron.version} \
-            --nodedir="$TMPDIR/electron-headers" \
+            --nodedir="${electron.headers}" \
             --disturl="" \
             --offline
 


### PR DESCRIPTION
## Summary
Salvage of #61824 by @fkz (commit cherry-picked, authorship preserved). Prior art: #53202 by @ak2k contains the identical `electron.headers` change and predates #61824 — credit to both; #53202's separate CI-lane component is superseded by the trigger-only nix CI in #69463 (its offline-build guard scope is covered by `scripts/nix-ci.sh build`).

`nix/desktop.nix` pinned the Electron node-headers tarball via `fetchurl` with a hardcoded `sha256`. Because `electron.version` comes from nixpkgs, every nixpkgs Electron bump changes the URL and breaks `.#desktop` with a fixed-output hash mismatch (#61443). nixpkgs' `electron` already exposes the matching headers as `electron.headers`, so this deletes the fetchurl entirely and points `npm rebuild node-pty --nodedir` at it.

Verified today: bumping the flake's nixpkgs (2026-04-01 → 2026-07-19) moves Electron 41.0.2 → 41.9.1 and reproduces the hash mismatch on current main; with this change `.#desktop` builds green on both pins.

Closes #61443. Supersedes #61824 and the desktop.nix half of #53202.

## Test plan
- `nix build .#desktop` on current flake.lock (Electron 41.0.2) — passes
- `nix build .#desktop` with nixpkgs 241313f4 (Electron 41.9.1) — passes (was: hash mismatch)