### PR TITLE
fix(nix): set HERMES_BIN default in wrapped binaries

### DIFF
--- a/nix/hermes-agent.nix
+++ b/nix/hermes-agent.nix
@@ -194,6 +194,7 @@ stdenv.mkDerivation (finalAttrs: {
           --set HERMES_BUNDLED_LOCALES $out/share/hermes-agent/locales \
           --set HERMES_WEB_DIST $out/share/hermes-agent/web_dist \
           --set HERMES_TUI_DIR $out/ui-tui \
+          --set-default HERMES_BIN $out/bin/hermes \
           --set HERMES_PYTHON ${hermesVenv}/bin/python3 \
           --set HERMES_NODE ${lib.getExe nodejs}${
             # Fold the line continuation INTO the optionalString: a bare


### PR DESCRIPTION
## Summary
Fixes #14647 (`/provider` broken under nix).

The TUI shells out to the CLI via `HERMES_BIN` (`ui-tui/src/lib/externalCli.ts:8`) with a bare-`hermes` fallback that isn't resolvable under `nix run`/profile installs. The nix wrapper sets every other `HERMES_*` path var but never `HERMES_BIN`. This adds `--set-default HERMES_BIN $out/bin/hermes` — default, not force, so the operator-override contract in `hermes_cli/kanban_db.py` is preserved.

## Test plan
- `nix build .#default` green; wrapper now contains `HERMES_BIN=${HERMES_BIN-'/nix/store/…/bin/hermes'}`
- Override still wins: `HERMES_BIN=/custom/path hermes` leaves the env var untouched