### PR TITLE
ci(nix): restore nix CI as trigger-only workflow with local entrypoint

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,42 @@
+name: Nix
+
+on:
+  workflow_dispatch:
+    inputs:
+      job:
+        description: Nix job to run
+        type: choice
+        options:
+          - check
+          - build
+        default: check
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nix:
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'ci/nix'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Nix
+        uses: ./.github/actions/nix-setup
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Run Nix job
+        run: scripts/nix-ci.sh "${{ github.event.inputs.job || 'check' }}"

--- a/scripts/nix-ci.sh
+++ b/scripts/nix-ci.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+case "${1:-check}" in
+  check)
+    nix flake check --print-build-logs
+    ;;
+  build)
+    nix build .#default .#tui .#web .#desktop \
+      --no-link --print-build-logs
+    ;;
+  *)
+    echo "Usage: $0 [check|build]" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary
Restores nix CI (ripped out in 9eb0bcd60 "to be re-added later when we have more stable ci flows") in a deliberately minimal, opt-in form:

- **Triggers only** on `workflow_dispatch` (job: check|build) or adding the `ci/nix` label to a PR — no push/PR auto-runs, so it costs nothing until asked.
- **`scripts/nix-ci.sh`** is the single entrypoint: `check` = `nix flake check -L` (16 checks on x86_64-linux), `build` = cold-builds `.#default .#tui .#web .#desktop`. Devs run exactly what CI runs.
- Reuses the orphaned-but-intact `.github/actions/nix-setup` composite (Determinate installer + Cachix `hermes-agent`, `CACHIX_AUTH_TOKEN` optional).
- The old workflow's stale-`npmDepsHash` diagnosis/auto-fix machinery is **not** restored: since #48883 (`importNpmLock`, hashless) that failure class is structurally gone, and `.#fix-lockfiles` no longer exists.

Note for merging: the `ci/nix` label needs to exist once (`gh label create ci/nix --description "run nix CI on this PR"`).

## Test plan
- YAML validated (PyYAML + yq), `bash -n scripts/nix-ci.sh`, mode 755
- `scripts/nix-ci.sh check` locally = the same `nix flake check -L` that passed green today at cbc1054e2
- Trigger gating: job-level `if` requires dispatch or exact label `ci/nix`