### PR TITLE
feat(gateway): gate sender-admitted LINE groups

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1783,6 +1783,22 @@ class MessageEvent:
     # ("Error while calling `get_updates` one more time to mark all fetched
     # updates" in gateway.log).
     platform_update_id: Optional[int] = None
+
+    # HMAC-authenticated platform event identity for ingress policies that
+    # need stable replay protection.  These fields remain optional because
+    # most platform adapters do not expose an equivalent event envelope.
+    platform_event_id: Optional[str] = None
+    platform_event_timestamp_ms: Optional[int] = None
+
+    # Adapter-scoped reply token for the exact inbound event. This is
+    # intentionally separate from chat-level reply-token caches so an
+    # immediate control flow can reply without consuming a different event.
+    platform_reply_token: Optional[str] = None
+
+    # A platform adapter may require an explicit gateway-dispatch approval
+    # before this user-originated event can enter either cold or busy routing.
+    # The gateway owns enforcement; adapters only mark events at intake.
+    required_dispatch_gate: Optional[str] = None
     
     # Media attachments
     # media_urls: local file paths (for vision tool access)
@@ -2131,7 +2147,10 @@ def merge_pending_message_event(
     event: MessageEvent,
     *,
     merge_text: bool = False,
-) -> None:
+    rebind: Optional[
+        Callable[[list[MessageEvent], MessageEvent, str], Optional[MessageEvent]]
+    ] = None,
+) -> Optional[MessageEvent]:
     """Store or merge a pending event for a session.
 
     Photo bursts/albums often arrive as multiple near-simultaneous PHOTO
@@ -2144,6 +2163,22 @@ def merge_pending_message_event(
     the last queued fragment.
     """
     existing = pending_messages.get(session_key)
+
+    def _commit(child: MessageEvent, parents: list[MessageEvent]) -> Optional[MessageEvent]:
+        if rebind is not None:
+            try:
+                rebound = rebind(parents, child, session_key)
+            except Exception:
+                logger.exception("Ingress rebinding failed while merging pending event")
+                rebound = None
+            if rebound is None:
+                # Keep an already-valid pending event; only the unprovable
+                # incoming transformation is rejected.
+                return existing
+            child = rebound
+        pending_messages[session_key] = child
+        return child
+
     if existing:
         existing_is_photo = getattr(existing, "message_type", None) == MessageType.PHOTO
         incoming_is_photo = event.message_type == MessageType.PHOTO
@@ -2151,42 +2186,68 @@ def merge_pending_message_event(
         incoming_has_media = bool(event.media_urls)
 
         if existing_is_photo and incoming_is_photo:
-            existing.media_urls.extend(event.media_urls)
-            existing.media_types.extend(event.media_types)
-            if event.text:
-                existing.text = BasePlatformAdapter._merge_caption(existing.text, event.text)
-            _invalidate_pending_stt_cache(existing)
-            return
+            child = dataclasses.replace(
+                existing,
+                media_urls=[*existing.media_urls, *event.media_urls],
+                media_types=[*existing.media_types, *event.media_types],
+                text=(
+                    BasePlatformAdapter._merge_caption(existing.text, event.text)
+                    if event.text
+                    else existing.text
+                ),
+            )
+            result = _commit(child, [existing, event])
+            if result is not None:
+                _invalidate_pending_stt_cache(result)
+            return result
 
         if existing_has_media or incoming_has_media:
-            if incoming_has_media:
-                existing.media_urls.extend(event.media_urls)
-                existing.media_types.extend(event.media_types)
+            text = existing.text
             if event.text:
-                if existing.text:
-                    existing.text = BasePlatformAdapter._merge_caption(existing.text, event.text)
-                else:
-                    existing.text = event.text
+                text = (
+                    BasePlatformAdapter._merge_caption(existing.text, event.text)
+                    if existing.text
+                    else event.text
+                )
+            message_type = existing.message_type
             if existing_is_photo or incoming_is_photo:
-                existing.message_type = MessageType.PHOTO
+                message_type = MessageType.PHOTO
             elif (
                 getattr(existing, "message_type", None) == MessageType.TEXT
                 and event.message_type != MessageType.TEXT
             ):
-                existing.message_type = event.message_type
-            _invalidate_pending_stt_cache(existing)
-            return
+                message_type = event.message_type
+            child = dataclasses.replace(
+                existing,
+                text=text,
+                message_type=message_type,
+                media_urls=[*existing.media_urls, *event.media_urls]
+                if incoming_has_media
+                else list(existing.media_urls),
+                media_types=[*existing.media_types, *event.media_types]
+                if incoming_has_media
+                else list(existing.media_types),
+            )
+            result = _commit(child, [existing, event])
+            if result is not None:
+                _invalidate_pending_stt_cache(result)
+            return result
 
         if (
             merge_text
             and getattr(existing, "message_type", None) == MessageType.TEXT
             and event.message_type == MessageType.TEXT
         ):
-            if event.text:
-                existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
-            return
+            child = dataclasses.replace(
+                existing,
+                text=(
+                    f"{existing.text}\n{event.text}" if existing.text else event.text
+                ) if event.text else existing.text,
+            )
+            return _commit(child, [existing, event])
 
     pending_messages[session_key] = event
+    return event
 
 
 # Error substrings that indicate a transient *connection* failure worth retrying.
@@ -2441,6 +2502,12 @@ class BasePlatformAdapter(ABC):
         self.config = config
         self.platform = platform
         self._message_handler: Optional[MessageHandler] = None
+        self._ingress_resolver: Optional[
+            Callable[[MessageEvent, str], Awaitable[Optional[MessageEvent]]]
+        ] = None
+        self._ingress_rebinder: Optional[
+            Callable[[list[MessageEvent], MessageEvent, str], Optional[MessageEvent]]
+        ] = None
         # Optional hook (e.g. Telegram DM topic recovery) that rewrites
         # ``event.source.thread_id`` before session keying. Returns the
         # corrected thread_id or None to leave the source untouched.
@@ -2947,6 +3014,39 @@ class BasePlatformAdapter(ABC):
         an optional response string.
         """
         self._message_handler = handler
+
+    def set_ingress_resolver(
+        self,
+        resolver: Optional[Callable[[MessageEvent, str], Awaitable[Optional[MessageEvent]]]],
+    ) -> None:
+        """Install the GatewayRunner-owned resolver before busy/cold routing."""
+        self._ingress_resolver = resolver
+
+    def set_ingress_rebinder(
+        self,
+        rebinder: Optional[Callable[[list[MessageEvent], MessageEvent, str], Optional[MessageEvent]]],
+    ) -> None:
+        """Install the core-only resolution rebinder for trusted transforms."""
+        self._ingress_rebinder = rebinder
+
+    def _rebind_pending_event(
+        self,
+        parents: list[MessageEvent],
+        child: MessageEvent,
+        session_key: str,
+    ) -> Optional[MessageEvent]:
+        """Rebind a queue/debounce reconstruction or drop a guarded one."""
+        rebinder = getattr(self, "_ingress_rebinder", None)
+        if rebinder is None:
+            if any(getattr(parent, "required_dispatch_gate", None) for parent in parents):
+                logger.warning("[%s] Dropping guarded event transform without a rebinder", self.name)
+                return None
+            return child
+        try:
+            return rebinder(parents, child, session_key)
+        except Exception:
+            logger.exception("[%s] Ingress rebinder failed", self.name)
+            return None
 
     def set_topic_recovery_fn(
         self,
@@ -4481,6 +4581,7 @@ class BasePlatformAdapter(ABC):
                         session_key,
                         event,
                         merge_text=True,
+                        rebind=self._rebind_pending_event,
                     )
                 return
 
@@ -4494,18 +4595,26 @@ class BasePlatformAdapter(ABC):
             )
             store[session_key] = state
         else:
-            if event.text:
-                state.event.text = (
+            latest_message_id = getattr(event, "message_id", None)
+            latest_anchor = latest_message_id or getattr(event, "reply_to_message_id", None)
+            child = dataclasses.replace(
+                state.event,
+                text=(
                     f"{state.event.text}\n{event.text}"
                     if state.event.text
                     else event.text
-                )
-            latest_message_id = getattr(event, "message_id", None)
-            latest_anchor = latest_message_id or getattr(event, "reply_to_message_id", None)
-            if latest_message_id is not None:
-                state.event.message_id = str(latest_message_id)
-            if latest_anchor is not None and hasattr(state.event, "reply_to_message_id"):
-                state.event.reply_to_message_id = str(latest_anchor)
+                ) if event.text else state.event.text,
+                message_id=(str(latest_message_id) if latest_message_id is not None else state.event.message_id),
+                reply_to_message_id=(
+                    str(latest_anchor)
+                    if latest_anchor is not None and hasattr(state.event, "reply_to_message_id")
+                    else state.event.reply_to_message_id
+                ),
+            )
+            rebound = self._rebind_pending_event([state.event, event], child, session_key)
+            if rebound is None:
+                return
+            state.event = rebound
             state.last_ts = now
 
         if state.task is not None and not state.task.done():
@@ -4554,6 +4663,7 @@ class BasePlatformAdapter(ABC):
             session_key,
             state.event,
             merge_text=True,
+            rebind=self._rebind_pending_event,
         )
         return True
 
@@ -4838,6 +4948,32 @@ class BasePlatformAdapter(ABC):
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
         )
 
+        resolver = getattr(self, "_ingress_resolver", None)
+        if resolver is None:
+            if event.required_dispatch_gate:
+                logger.warning(
+                    "[%s] Required ingress gate %s has no resolver; dropping event",
+                    self.name,
+                    event.required_dispatch_gate,
+                )
+                return
+        else:
+            try:
+                resolved_event = await resolver(event, session_key)
+            except Exception:
+                logger.exception("[%s] Ingress resolver failed", self.name)
+                if event.required_dispatch_gate:
+                    return
+                resolved_event = event
+            if resolved_event is None:
+                return
+            if not isinstance(resolved_event, MessageEvent):
+                logger.warning("[%s] Ingress resolver returned an invalid event", self.name)
+                if event.required_dispatch_gate:
+                    return
+            else:
+                event = resolved_event
+
         # On-entry self-heal: if the adapter still has an _active_sessions
         # entry for this key but the owner task has already exited (done or
         # cancelled), the lock is stale.  Clear it and fall through to
@@ -4973,7 +5109,12 @@ class BasePlatformAdapter(ABC):
             # then process them immediately after the current task finishes.
             if event.message_type == MessageType.PHOTO:
                 logger.debug("[%s] Queuing photo follow-up for session %s without interrupt", self.name, session_key)
-                merge_pending_message_event(self._pending_messages, session_key, event)
+                merge_pending_message_event(
+                    self._pending_messages,
+                    session_key,
+                    event,
+                    rebind=self._rebind_pending_event,
+                )
                 return  # Don't interrupt now - will run after current task completes
 
             if self._is_queue_text_debounce_candidate(event):
@@ -4997,6 +5138,7 @@ class BasePlatformAdapter(ABC):
                     session_key,
                     event,
                     merge_text=event.message_type == MessageType.TEXT,
+                    rebind=self._rebind_pending_event,
                 )
             return  # Don't process now - will be handled after current task finishes
         

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25,8 +25,10 @@ except ModuleNotFoundError:
     pass
 
 import asyncio
+import copy
 import concurrent.futures
 import dataclasses
+import hashlib
 import inspect
 import json
 import logging
@@ -40,6 +42,7 @@ import tempfile
 import threading
 import time
 import sqlite3
+import weakref
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
@@ -3931,6 +3934,317 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile=_profile,
         )
 
+    def _remember_ingress_resolution(
+        self,
+        event: MessageEvent,
+        session_key: str,
+    ) -> bool:
+        """Remember a core-issued ingress decision for one event object.
+
+        This deliberately does not use a public flag on ``MessageEvent``:
+        callers which construct an event directly must not be able to forge a
+        successful guarded resolution.  The mapping also makes the normal
+        adapter → runner handoff invoke hooks exactly once.
+        """
+        resolved = getattr(self, "_ingress_resolved_events", None)
+        if resolved is None:
+            resolved = {}
+            self._ingress_resolved_events = resolved
+        try:
+            payload_fingerprint = self._ingress_payload_fingerprint(event)
+        except Exception as exc:
+            logger.warning("Could not retain ingress resolution: %s", type(exc).__name__)
+            return False
+        # Keep only a weak reference plus a non-reversible fingerprint. A
+        # gateway can receive millions of events over its lifetime; retaining
+        # raw webhook payloads or media here would be a memory/privacy leak.
+        if len(resolved) >= 1024:
+            for event_id, entry in list(resolved.items()):
+                if entry[0]() is None:
+                    resolved.pop(event_id, None)
+        resolved[id(event)] = (weakref.ref(event), session_key, payload_fingerprint)
+        return True
+
+    @staticmethod
+    def _ingress_payload_fingerprint(event: MessageEvent) -> bytes:
+        """Return a non-reversible fingerprint of all dataclass event fields."""
+        values = {field.name: getattr(event, field.name) for field in dataclasses.fields(event)}
+        return hashlib.sha256(repr(values).encode("utf-8", errors="backslashreplace")).digest()
+
+    def _has_ingress_resolution(self, event: MessageEvent, session_key: str) -> bool:
+        """Return whether *event* has a valid core-issued decision for its lane."""
+        resolved = getattr(self, "_ingress_resolved_events", {})
+        entry = resolved.get(id(event))
+        if not (entry and entry[0]() is event and entry[1] == session_key):
+            return False
+        try:
+            return self._ingress_payload_fingerprint(event) == entry[2]
+        except Exception:
+            return False
+
+    @staticmethod
+    def _ingress_resolution_lane(event: MessageEvent, session_key: str) -> tuple[Any, ...]:
+        """Return the immutable routing/principal lane shared by safe merges."""
+        source = event.source
+        return (
+            session_key,
+            getattr(source, "platform", None),
+            getattr(source, "chat_type", None),
+            getattr(source, "chat_id", None),
+            getattr(source, "chat_id_alt", None),
+            getattr(source, "parent_chat_id", None),
+            getattr(source, "thread_id", None),
+            getattr(source, "scope_id", None),
+            getattr(source, "user_id", None),
+            getattr(source, "user_id_alt", None),
+            getattr(source, "profile", None),
+            getattr(source, "is_bot", None),
+            getattr(source, "role_authorized", None),
+            getattr(source, "delivered_via_upstream_relay", None),
+            bool(getattr(event, "internal", False)),
+            getattr(event, "required_dispatch_gate", None),
+        )
+
+    def _rebind_ingress_event(
+        self,
+        parents: list[MessageEvent],
+        child: MessageEvent,
+        session_key: str,
+    ) -> Optional[MessageEvent]:
+        """Mint one resolution for a trusted queue/command reconstruction.
+
+        The adapter owns routing transformations but not gate approvals.  This
+        core-only callback verifies every parent still has the exact resolution
+        issued by the resolver, checks that all guarded constituents share the
+        same authenticated lane and gate, invalidates the old entries, then
+        records the reconstructed event.  A guarded event is never allowed to
+        silently inherit a resolution after arbitrary mutation.
+        """
+        if not parents:
+            return None
+        parent_entries = []
+        guarded_lanes = []
+        for parent in parents:
+            entry = getattr(self, "_ingress_resolved_events", {}).get(id(parent))
+            if not (
+                entry
+                and entry[0]() is parent
+                and entry[1] == session_key
+                and self._has_ingress_resolution(parent, session_key)
+            ):
+                if getattr(parent, "required_dispatch_gate", None):
+                    logger.warning("Dropping guarded event reconstruction without a live resolution")
+                    return None
+                # Legacy/unresolved unguarded events retain their historic
+                # behavior; do not invent a resolution for them here.
+                continue
+            parent_entries.append((id(parent), entry))
+            if getattr(parent, "required_dispatch_gate", None):
+                guarded_lanes.append(self._ingress_resolution_lane(parent, session_key))
+
+        if guarded_lanes:
+            if any(lane != guarded_lanes[0] for lane in guarded_lanes[1:]) or (
+                self._ingress_resolution_lane(child, session_key) != guarded_lanes[0]
+            ):
+                logger.warning("Dropping guarded event reconstruction across incompatible lanes")
+                return None
+        elif getattr(child, "required_dispatch_gate", None):
+            # A reconstruction cannot create a required gate from an
+            # unguarded parent; only adapter intake + resolver may issue one.
+            return None
+
+        for parent_id, _entry in parent_entries:
+            getattr(self, "_ingress_resolved_events", {}).pop(parent_id, None)
+        if not self._remember_ingress_resolution(child, session_key):
+            return None
+        return child
+
+    @staticmethod
+    def _guarded_ingress_snapshot(event: MessageEvent, session_key: str) -> dict[str, Any]:
+        """Copy immutable fields before a guarded plugin callback runs.
+
+        Guarded plugins may only contribute a text rewrite, channel prompt, or
+        auto-skill selection.  Every other event field, including the complete
+        adapter-authenticated source/raw/metadata boundary, is compared after
+        each isolated callback.  A non-copyable authenticated boundary is a
+        fail-closed condition for guarded traffic.
+        """
+        mutable_enrichments = {"text", "channel_prompt", "auto_skill"}
+        immutable = {
+            field.name: getattr(event, field.name)
+            for field in dataclasses.fields(event)
+            if field.name not in mutable_enrichments
+        }
+        immutable["session_key"] = session_key
+        return copy.deepcopy(immutable)
+
+    @staticmethod
+    def _guarded_ingress_snapshot_matches(
+        event: MessageEvent,
+        snapshot: dict[str, Any],
+    ) -> bool:
+        """Return whether a callback left the authenticated boundary intact."""
+        try:
+            current = {
+                field.name: getattr(event, field.name)
+                for field in dataclasses.fields(event)
+                if field.name not in {"text", "channel_prompt", "auto_skill"}
+            }
+            return current == {
+                key: value for key, value in snapshot.items() if key != "session_key"
+            }
+        except Exception:
+            return False
+
+    @staticmethod
+    def _valid_ingress_enrichments(event: MessageEvent) -> bool:
+        """Validate the only callback-controlled fields accepted by core."""
+        if not isinstance(event.text, str):
+            return False
+        if event.channel_prompt is not None and not isinstance(event.channel_prompt, str):
+            return False
+        skills = event.auto_skill
+        return skills is None or isinstance(skills, str) or (
+            isinstance(skills, list) and all(isinstance(skill, str) for skill in skills)
+        )
+
+    async def _resolve_gateway_ingress(
+        self,
+        event: MessageEvent,
+        session_key: str,
+    ) -> Optional[MessageEvent]:
+        """Resolve plugin ingress before authorization or busy-session routing.
+
+        Unguarded events retain the historical hook contract.  A required gate
+        switches to a strict, isolated fail-closed contract: exactly one
+        declared gate owner must return ``{"action": "approve", "gate": ...}``.
+        """
+        gate = getattr(event, "required_dispatch_gate", None)
+        if not gate:
+            # Preserve the established internal-event bypass.  A required
+            # gate is handled below and is always rejected when internal.
+            if bool(getattr(event, "internal", False)):
+                return event if self._remember_ingress_resolution(event, session_key) else None
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+
+                results = _invoke_hook(
+                    "pre_gateway_dispatch",
+                    event=event,
+                    gateway=self,
+                    session_store=self.session_store,
+                )
+            except Exception as exc:
+                logger.warning("pre_gateway_dispatch invocation failed: %s", type(exc).__name__)
+                results = []
+
+            for result in results:
+                if not isinstance(result, dict):
+                    continue
+                action = result.get("action")
+                if action == "skip":
+                    logger.info("pre_gateway_dispatch skipped an unguarded event")
+                    return None
+                if action == "rewrite" and isinstance(result.get("text"), str):
+                    event = dataclasses.replace(event, text=result["text"])
+                    break
+                if action == "allow":
+                    break
+            return event if self._remember_ingress_resolution(event, session_key) else None
+
+        # An internal event cannot carry an approval gate.  In particular this
+        # prevents a synthetic startup/restore event from bypassing the LINE
+        # principal that the adapter authenticated at the webhook boundary.
+        if (
+            bool(getattr(event, "internal", False))
+            or not isinstance(gate, str)
+            or not gate.strip()
+            or not isinstance(getattr(event, "platform_event_id", None), str)
+            or not event.platform_event_id.strip()
+            or isinstance(getattr(event, "platform_event_timestamp_ms", None), bool)
+            or not isinstance(getattr(event, "platform_event_timestamp_ms", None), int)
+            or event.platform_event_timestamp_ms < 0
+            or getattr(event, "source", None) is None
+        ):
+            logger.warning("Dropping guarded ingress with invalid authenticated identity")
+            return None
+
+        try:
+            snapshot = self._guarded_ingress_snapshot(event, session_key)
+        except Exception as exc:
+            logger.warning("Dropping guarded ingress with unsnappable boundary: %s", type(exc).__name__)
+            return None
+
+        try:
+            from hermes_cli.plugins import get_plugin_manager
+
+            manager = get_plugin_manager()
+            callbacks = manager.list_hook_callbacks("pre_gateway_dispatch")
+            owners = [callback for callback in callbacks if callback.get("gate_owner") == gate]
+            if len(owners) != 1:
+                logger.warning("Dropping guarded ingress: expected one declared gate owner")
+                return None
+            invocations = manager.invoke_hook_isolated(
+                "pre_gateway_dispatch",
+                required_gate=gate,
+                event=event,
+                gateway=self,
+                session_store=self.session_store,
+            )
+        except Exception as exc:
+            logger.warning("Dropping guarded ingress after hook setup failure: %s", type(exc).__name__)
+            return None
+
+        approved = 0
+        enriched_event = event
+        for invocation in invocations:
+            callback_event = invocation.event
+            if invocation.error_type or not isinstance(callback_event, MessageEvent):
+                logger.warning("Dropping guarded ingress after isolated callback failure")
+                return None
+            if not self._guarded_ingress_snapshot_matches(callback_event, snapshot):
+                logger.warning("Dropping guarded ingress after immutable-boundary mutation")
+                return None
+            if not self._valid_ingress_enrichments(callback_event):
+                logger.warning("Dropping guarded ingress after invalid controlled enrichment")
+                return None
+
+            result = invocation.result
+            if result is None:
+                continue
+            if not isinstance(result, dict):
+                logger.warning("Dropping guarded ingress after malformed hook result")
+                return None
+            action = result.get("action")
+            if action == "skip":
+                return None
+            if action not in {"allow", "rewrite", "approve"}:
+                logger.warning("Dropping guarded ingress after unsupported hook action")
+                return None
+            if action == "rewrite" and not isinstance(result.get("text"), str):
+                logger.warning("Dropping guarded ingress after malformed rewrite")
+                return None
+            if action == "approve":
+                if invocation.gate_owner != gate or result.get("gate") != gate:
+                    logger.warning("Dropping guarded ingress after mismatched approval")
+                    return None
+                approved += 1
+            enriched_event = dataclasses.replace(
+                enriched_event,
+                text=callback_event.text,
+                channel_prompt=callback_event.channel_prompt,
+                auto_skill=copy.deepcopy(callback_event.auto_skill),
+            )
+
+        if approved != 1:
+            logger.warning("Dropping guarded ingress without one matching approval")
+            return None
+        return (
+            enriched_event
+            if self._remember_ingress_resolution(enriched_event, session_key)
+            else None
+        )
+
     def _telegram_topic_mode_enabled(self, source: SessionSource) -> bool:
         """Return whether Telegram DM topic mode is active for this chat."""
         if source.platform != Platform.TELEGRAM or source.chat_type != "dm":
@@ -7785,6 +8099,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_message_handler(self._handle_message)
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
+            adapter.set_ingress_resolver(self._resolve_gateway_ingress)
+            adapter.set_ingress_rebinder(self._rebind_ingress_event)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
             adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
@@ -8764,6 +9080,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter.set_message_handler(self._handle_message)
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
+                    adapter.set_ingress_resolver(self._resolve_gateway_ingress)
+                    adapter.set_ingress_rebinder(self._rebind_ingress_event)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
                     adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
                     adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
@@ -9638,6 +9956,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._make_profile_fatal_error_handler(profile_name, platform)
         )
         adapter.set_session_store(self.session_store)
+        adapter.set_ingress_resolver(self._resolve_gateway_ingress)
+        adapter.set_ingress_rebinder(self._rebind_ingress_event)
         adapter.set_busy_session_handler(self._handle_active_session_busy_message)
         adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
         adapter.set_authorization_check(
@@ -10247,8 +10567,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         6. Run agent conversation
         7. Return response
         """
-        source = event.source
-
         # 🔴 Cross-session leak guard. This handler runs inside a per-message
         # asyncio task created via create_task(), which snapshots the spawning
         # context with copy_context(). If a *concurrent* message had already
@@ -10265,6 +10583,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             reset_session_vars()
         except Exception:
             logger.debug("reset_session_vars failed at handler entry", exc_info=True)
+
+        # Normally BasePlatformAdapter has already resolved ingress after
+        # command/topic normalization and before its cold/busy split.  Direct
+        # callers (notably internal tests and a few legacy adapters) enter
+        # here without that handoff, so defensively perform the same decision
+        # before startup restore, authorization, commands, or agent routing.
+        source = event.source
+        ingress_session_key = self._session_key_for_source(source)
+        if not self._has_ingress_resolution(event, ingress_session_key):
+            event = await self._resolve_gateway_ingress(event, ingress_session_key)
+            if event is None:
+                return None
+            source = event.source
 
         if (
             getattr(self, "_startup_restore_in_progress", False)
@@ -10285,47 +10616,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # clock is what the idle predicate (gateway/scale_to_zero.is_idle) reads.
         if not is_internal:
             self._scale_to_zero_note_real_inbound()
-
-        # Fire pre_gateway_dispatch plugin hook for user-originated messages.
-        # Plugins receive the MessageEvent and may return a dict influencing flow:
-        #   {"action": "skip",    "reason": ...}    -> drop (no reply, plugin handled)
-        #   {"action": "rewrite", "text":  ...}     -> replace event.text, continue
-        #   {"action": "allow"}   /   None          -> normal dispatch
-        # Hook runs BEFORE auth so plugins can handle unauthorized senders
-        # (e.g. customer handover ingest) without triggering the pairing flow.
-        if not is_internal:
-            try:
-                from hermes_cli.plugins import invoke_hook as _invoke_hook
-                _hook_results = _invoke_hook(
-                    "pre_gateway_dispatch",
-                    event=event,
-                    gateway=self,
-                    session_store=self.session_store,
-                )
-            except Exception as _hook_exc:
-                logger.warning("pre_gateway_dispatch invocation failed: %s", _hook_exc)
-                _hook_results = []
-
-            for _result in _hook_results:
-                if not isinstance(_result, dict):
-                    continue
-                _action = _result.get("action")
-                if _action == "skip":
-                    logger.info(
-                        "pre_gateway_dispatch skip: reason=%s platform=%s chat=%s",
-                        _result.get("reason"),
-                        source.platform.value if source.platform else "unknown",
-                        source.chat_id or "unknown",
-                    )
-                    return None
-                if _action == "rewrite":
-                    _new_text = _result.get("text")
-                    if isinstance(_new_text, str):
-                        event = dataclasses.replace(event, text=_new_text)
-                        source = event.source
-                    break
-                if _action == "allow":
-                    break
 
         if is_internal:
             pass
@@ -10697,24 +10987,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return "Usage: /queue <prompt>"
                 adapter = self._adapter_for_source(source)
                 if adapter:
-                    queued_event = MessageEvent(
+                    queued_event = dataclasses.replace(
+                        event,
                         text=queued_text,
                         message_type=event.message_type if has_media else MessageType.TEXT,
-                        source=event.source,
-                        raw_message=event.raw_message,
-                        message_id=event.message_id,
                         media_urls=list(getattr(event, "media_urls", []) or []),
                         media_types=list(getattr(event, "media_types", []) or []),
-                        reply_to_message_id=event.reply_to_message_id,
-                        reply_to_text=event.reply_to_text,
-                        reply_to_author_id=event.reply_to_author_id,
-                        reply_to_author_name=event.reply_to_author_name,
-                        reply_to_is_own_message=event.reply_to_is_own_message,
-                        auto_skill=event.auto_skill,
-                        channel_prompt=event.channel_prompt,
-                        internal=event.internal,
-                        timestamp=event.timestamp,
                     )
+                    queued_event = self._rebind_ingress_event(
+                        [event], queued_event, _quick_key
+                    )
+                    if queued_event is None:
+                        return None
                     self._enqueue_fifo(_quick_key, queued_event, adapter)
                 depth = self._queue_depth(_quick_key, adapter=self._adapter_for_source(source))
                 if depth <= 1:
@@ -10735,13 +11019,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Agent hasn't started yet — queue as turn-boundary fallback.
                     adapter = self._adapter_for_source(source)
                     if adapter:
-                        queued_event = MessageEvent(
+                        queued_event = dataclasses.replace(
+                            event,
                             text=steer_text,
                             message_type=MessageType.TEXT,
-                            source=event.source,
-                            message_id=event.message_id,
-                            channel_prompt=event.channel_prompt,
                         )
+                        queued_event = self._rebind_ingress_event(
+                            [event], queued_event, _quick_key
+                        )
+                        if queued_event is None:
+                            return None
                         adapter._pending_messages[_quick_key] = queued_event
                     return "Agent still starting — /steer queued for the next turn."
                 if running_agent and hasattr(running_agent, "steer"):
@@ -10757,13 +11044,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Running agent is missing or lacks steer() — fall back to queue.
                 adapter = self._adapter_for_source(source)
                 if adapter:
-                    queued_event = MessageEvent(
+                    queued_event = dataclasses.replace(
+                        event,
                         text=steer_text,
                         message_type=MessageType.TEXT,
-                        source=event.source,
-                        message_id=event.message_id,
-                        channel_prompt=event.channel_prompt,
                     )
+                    queued_event = self._rebind_ingress_event(
+                        [event], queued_event, _quick_key
+                    )
+                    if queued_event is None:
+                        return None
                     adapter._pending_messages[_quick_key] = queued_event
                 return "No active agent — /steer queued for the next turn."
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4260,12 +4260,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     logger.warning("Dropping guarded ingress after mismatched approval")
                     return None
                 approved += 1
-            enriched_event = dataclasses.replace(
-                enriched_event,
-                text=callback_event.text,
-                channel_prompt=callback_event.channel_prompt,
-                auto_skill=copy.deepcopy(callback_event.auto_skill),
-            )
+            # Every callback receives its own copy of the original event so
+            # one plugin cannot observe or contaminate another.  Apply only
+            # fields a callback deliberately changed from that original
+            # baseline; otherwise a later ``allow`` would accidentally erase
+            # the gate owner's approved prompt/skill enrichment with its
+            # untouched copy.
+            enrichments: dict[str, Any] = {}
+            if callback_event.text != event.text:
+                enrichments["text"] = callback_event.text
+            if callback_event.channel_prompt != event.channel_prompt:
+                enrichments["channel_prompt"] = callback_event.channel_prompt
+            if callback_event.auto_skill != event.auto_skill:
+                enrichments["auto_skill"] = copy.deepcopy(callback_event.auto_skill)
+            if enrichments:
+                enriched_event = dataclasses.replace(enriched_event, **enrichments)
 
         if approved != 1:
             logger.warning("Dropping guarded ingress without one matching approval")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3962,7 +3962,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             for event_id, entry in list(resolved.items()):
                 if entry[0]() is None:
                     resolved.pop(event_id, None)
-        resolved[id(event)] = (weakref.ref(event), session_key, payload_fingerprint)
+        resolved[id(event)] = (weakref.ref(event), session_key, payload_fingerprint, "issued")
         return True
 
     @staticmethod
@@ -3981,6 +3981,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return self._ingress_payload_fingerprint(event) == entry[2]
         except Exception:
             return False
+
+    def _consume_guarded_ingress_resolution(
+        self,
+        event: MessageEvent,
+        session_key: str,
+    ) -> bool:
+        """Spend one guarded resolution immediately before core side effects.
+
+        A resolver-issued event can be transferred into queues and rebuilt by
+        trusted core code, but it cannot drive two terminal runner/busy-path
+        dispatches.  Unguarded events intentionally retain their historical
+        semantics and use the registry only as an exactly-once hook marker.
+        """
+        if not getattr(event, "required_dispatch_gate", None):
+            return True
+        resolved = getattr(self, "_ingress_resolved_events", {})
+        entry = resolved.get(id(event))
+        if not (
+            entry
+            and entry[0]() is event
+            and entry[1] == session_key
+            and self._has_ingress_resolution(event, session_key)
+            and entry[3] == "issued"
+        ):
+            logger.warning("Dropping guarded ingress after duplicate or invalid consumption")
+            return False
+        resolved[id(event)] = (entry[0], entry[1], entry[2], "consumed")
+        return True
 
     @staticmethod
     def _ingress_resolution_lane(event: MessageEvent, session_key: str) -> tuple[Any, ...]:
@@ -4119,6 +4147,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         switches to a strict, isolated fail-closed contract: exactly one
         declared gate owner must return ``{"action": "approve", "gate": ...}``.
         """
+        if self._has_ingress_resolution(event, session_key):
+            return event
+
         gate = getattr(event, "required_dispatch_gate", None)
         if not gate:
             # Preserve the established internal-event bypass.  A required
@@ -5192,6 +5223,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         pending_slot = getattr(adapter, "_pending_messages", None)
         if pending_slot is None:
             return
+        if getattr(queued_event, "required_dispatch_gate", None):
+            # The busy path may queue an event after consuming it to decide
+            # that queueing (rather than steering/interrupting) is safe. A
+            # pending slot owns a fresh child resolution, never the already
+            # consumed parent, even when the payload itself is unchanged.
+            queued_event = self._rebind_ingress_event(
+                [queued_event], dataclasses.replace(queued_event), session_key
+            )
+            if queued_event is None:
+                return
         queued_events = getattr(self, "_queued_events", None)
         if queued_events is None:
             queued_events = {}
@@ -5200,6 +5241,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             queued_events.setdefault(session_key, []).append(queued_event)
         else:
             pending_slot[session_key] = queued_event
+
+    def _merge_pending_ingress_event(
+        self,
+        adapter: Any,
+        session_key: str,
+        event: MessageEvent,
+        *,
+        merge_text: bool = False,
+    ) -> Optional[MessageEvent]:
+        """Merge a pending event while preserving a guarded resolution.
+
+        GatewayRunner has several busy-path fallbacks which are reached after
+        a cold adapter handoff races with a newly-running agent.  They must use
+        the same core-issued reconstruction operation as BasePlatformAdapter,
+        otherwise a merged guarded event would defensively invoke its hook a
+        second time when it drains.
+        """
+        if adapter is None or not hasattr(adapter, "_pending_messages"):
+            return None
+        return merge_pending_message_event(
+            adapter._pending_messages,
+            session_key,
+            event,
+            merge_text=merge_text,
+            rebind=self._rebind_ingress_event,
+        )
 
     def _promote_queued_event(
         self,
@@ -6140,8 +6207,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             or bool(getattr(event, "media_urls", None))
         ):
             # Preserve photo-burst / media-merge semantics for the head slot.
-            merge_pending_message_event(
-                adapter._pending_messages,
+            self._merge_pending_ingress_event(
+                adapter,
                 session_key,
                 event,
                 merge_text=event.message_type == MessageType.TEXT,
@@ -6159,6 +6226,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._enqueue_fifo(session_key, event, adapter)
 
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
+        if not self._consume_guarded_ingress_resolution(event, session_key):
+            return True
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
         # creating a session.  The busy path must enforce the same check;
@@ -10605,6 +10674,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._queue_startup_restore_event(event)
             return None
 
+        if not self._consume_guarded_ingress_resolution(event, ingress_session_key):
+            return None
+
         # Internal events (e.g. background-process completion notifications)
         # are system-generated and must skip user authorization.
         is_internal = bool(getattr(event, "internal", False))
@@ -11172,7 +11244,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
                 adapter = self._adapter_for_source(source)
                 if adapter:
-                    merge_pending_message_event(adapter._pending_messages, _quick_key, event)
+                    self._merge_pending_ingress_event(adapter, _quick_key, event)
                 return None
 
             _telegram_followup_grace = float(
@@ -11196,11 +11268,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if self._busy_input_mode == "queue":
                         self._enqueue_fifo(_quick_key, event, adapter)
                     else:
-                        merge_pending_message_event(
-                            adapter._pending_messages,
-                            _quick_key,
-                            event,
-                            merge_text=True,
+                        self._merge_pending_ingress_event(
+                            adapter, _quick_key, event, merge_text=True
                         )
                 return None
 
@@ -11216,11 +11285,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # agent starts.
                 adapter = self._adapter_for_source(source)
                 if adapter:
-                    merge_pending_message_event(
-                        adapter._pending_messages,
-                        _quick_key,
-                        event,
-                        merge_text=True,
+                    self._merge_pending_ingress_event(
+                        adapter, _quick_key, event, merge_text=True
                     )
                 return None
             if self._draining:
@@ -22515,7 +22581,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                     adapter = self._adapter_for_source(source)
                     if adapter and pending_event:
-                        merge_pending_message_event(adapter._pending_messages, session_key, pending_event)
+                        self._merge_pending_ingress_event(
+                            adapter, session_key, pending_event
+                        )
                     elif adapter and hasattr(adapter, 'queue_message'):
                         adapter.queue_message(session_key, pending)
                     return result_holder[0] or {"final_response": response, "messages": history}

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -34,6 +34,7 @@ so plugin-defined tools appear alongside the built-in tools.
 from __future__ import annotations
 
 import asyncio
+import copy
 import importlib.metadata
 import importlib.util
 import inspect
@@ -330,6 +331,33 @@ class LoadedPlugin:
     # imported) loader. The module loads on first real use via the
     # platform_registry; see PluginManager._register_deferred_platform.
     deferred: bool = False
+
+
+@dataclass(frozen=True)
+class HookRegistration:
+    """Stable, non-secret metadata for one plugin hook callback."""
+
+    callback: Callable
+    plugin_name: str
+    gate_owner: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class HookInvocation:
+    """Result of one isolated hook callback invocation."""
+
+    plugin_name: str
+    callback_name: str
+    gate_owner: Optional[str]
+    result: Any = None
+    error_type: Optional[str] = None
+    # The post-callback event copy is intentionally available only to the
+    # caller of ``invoke_hook_isolated``.  Gateway's guarded ingress resolver
+    # uses it to collect a tightly-controlled set of enrichments after it has
+    # verified that the callback did not alter the authenticated routing or
+    # trust boundary.  It is excluded from repr so diagnostics never render
+    # message text, tokens, or raw platform payloads.
+    event: Any = field(default=None, repr=False, compare=False)
 
 
 # ---------------------------------------------------------------------------
@@ -1155,7 +1183,13 @@ class PluginContext:
             display_name,
         )
 
-    def register_hook(self, hook_name: str, callback: Callable) -> None:
+    def register_hook(
+        self,
+        hook_name: str,
+        callback: Callable,
+        *,
+        gate_owner: Optional[str] = None,
+    ) -> None:
         """Register a lifecycle hook callback.
 
         Unknown hook names produce a warning but are still stored so
@@ -1169,8 +1203,26 @@ class PluginContext:
                 hook_name,
                 ", ".join(sorted(VALID_HOOKS)),
             )
+        if gate_owner is not None:
+            if hook_name != "pre_gateway_dispatch":
+                raise ValueError("gate_owner is only supported for pre_gateway_dispatch")
+            if not isinstance(gate_owner, str) or not gate_owner.strip():
+                raise ValueError("gate_owner must be a non-empty string")
+            gate_owner = gate_owner.strip()
         self._manager._hooks.setdefault(hook_name, []).append(callback)
-        logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
+        self._manager._hook_registrations.setdefault(hook_name, []).append(
+            HookRegistration(
+                callback=callback,
+                plugin_name=self.manifest.name,
+                gate_owner=gate_owner,
+            )
+        )
+        logger.debug(
+            "Plugin %s registered hook: %s%s",
+            self.manifest.name,
+            hook_name,
+            f" (gate owner: {gate_owner})" if gate_owner else "",
+        )
 
     # -- middleware registration -------------------------------------------
 
@@ -1251,6 +1303,7 @@ class PluginManager:
     def __init__(self) -> None:
         self._plugins: Dict[str, LoadedPlugin] = {}
         self._hooks: Dict[str, List[Callable]] = {}
+        self._hook_registrations: Dict[str, List[HookRegistration]] = {}
         self._middleware: Dict[str, List[Callable]] = {}
         self._plugin_tool_names: Set[str] = set()
         self._plugin_platform_names: Set[str] = set()
@@ -1292,6 +1345,7 @@ class PluginManager:
         if force:
             self._plugins.clear()
             self._hooks.clear()
+            self._hook_registrations.clear()
             self._middleware.clear()
             self._plugin_tool_names.clear()
             self._plugin_platform_names.clear()
@@ -1925,6 +1979,101 @@ class PluginManager:
                     exc,
                 )
         return results
+
+    def invoke_hook_isolated(
+        self,
+        hook_name: str,
+        *,
+        required_gate: Optional[str] = None,
+        **kwargs: Any,
+    ) -> List[HookInvocation]:
+        """Invoke hooks with a fresh event copy for every callback.
+
+        This is the guarded counterpart to :meth:`invoke_hook`. It records
+        callback identity and exceptions without exposing callback objects,
+        message bodies, tokens, or other secret-bearing values in diagnostics.
+        Existing hook callers keep the legacy ``invoke_hook`` behavior.
+        """
+        registrations = list(self._hook_registrations.get(hook_name, []))
+        if required_gate:
+            registrations.sort(
+                key=lambda registration: registration.gate_owner != required_gate
+            )
+        invocations: List[HookInvocation] = []
+        for registration in registrations:
+            callback_name = getattr(registration.callback, "__name__", "callback")
+            callback_kwargs = dict(kwargs)
+            if "event" in callback_kwargs:
+                try:
+                    callback_kwargs["event"] = copy.deepcopy(callback_kwargs["event"])
+                except Exception as exc:
+                    logger.warning(
+                        "Hook '%s' callback %s received an uncopyable event: %s",
+                        hook_name,
+                        callback_name,
+                        type(exc).__name__,
+                    )
+                    invocations.append(
+                        HookInvocation(
+                            plugin_name=registration.plugin_name,
+                            callback_name=callback_name,
+                            gate_owner=registration.gate_owner,
+                            error_type=type(exc).__name__,
+                        )
+                    )
+                    continue
+            callback_kwargs.setdefault(
+                "telemetry_schema_version", OBSERVER_SCHEMA_VERSION
+            )
+            try:
+                result = registration.callback(**callback_kwargs)
+            except Exception as exc:
+                logger.warning(
+                    "Hook '%s' callback %s raised: %s",
+                    hook_name,
+                    callback_name,
+                    type(exc).__name__,
+                )
+                invocations.append(
+                    HookInvocation(
+                        plugin_name=registration.plugin_name,
+                        callback_name=callback_name,
+                        gate_owner=registration.gate_owner,
+                        error_type=type(exc).__name__,
+                    )
+                )
+                continue
+            invocations.append(
+                HookInvocation(
+                    plugin_name=registration.plugin_name,
+                    callback_name=callback_name,
+                    gate_owner=registration.gate_owner,
+                    result=result,
+                    event=callback_kwargs.get("event"),
+                )
+            )
+            if required_gate:
+                action = result.get("action") if isinstance(result, dict) else None
+                is_owner = registration.gate_owner == required_gate
+                owner_approved = (
+                    is_owner
+                    and action == "approve"
+                    and result.get("gate") == required_gate
+                )
+                if (is_owner and not owner_approved) or action == "skip":
+                    break
+        return invocations
+
+    def list_hook_callbacks(self, hook_name: str) -> List[Dict[str, Optional[str]]]:
+        """Return stable callback metadata suitable for runtime diagnostics."""
+        return [
+            {
+                "plugin_name": registration.plugin_name,
+                "callback_name": getattr(registration.callback, "__name__", "callback"),
+                "gate_owner": registration.gate_owner,
+            }
+            for registration in self._hook_registrations.get(hook_name, [])
+        ]
 
     def has_hook(self, hook_name: str) -> bool:
         """Return True when at least one callback is registered for a hook."""

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -423,8 +423,9 @@ def _allowed_for_source(
     user_ids: Set[str],
     group_ids: Set[str],
     room_ids: Set[str],
+    allow_groups_from_allowed_users: bool = False,
 ) -> bool:
-    """Three-list gate — credit PR #18153."""
+    """Apply LINE allowlists, optionally admitting groups by allowed sender."""
     if allow_all:
         return True
     src_type = (source or {}).get("type", "")
@@ -433,7 +434,12 @@ def _allowed_for_source(
         return bool(uid) and uid in user_ids
     if src_type == "group":
         gid = source.get("groupId", "")
-        return bool(gid) and gid in group_ids
+        if bool(gid) and gid in group_ids:
+            return True
+        if allow_groups_from_allowed_users:
+            uid = source.get("userId", "")
+            return bool(gid and uid) and uid in user_ids
+        return False
     if src_type == "room":
         rid = source.get("roomId", "")
         return bool(rid) and rid in room_ids
@@ -690,6 +696,16 @@ class LineAdapter(BasePlatformAdapter):
         self.allowed_rooms = _csv_set(
             os.getenv("LINE_ALLOWED_ROOMS", "")
         ) | set(extra.get("allowed_rooms", []))
+        self.allow_groups_from_allowed_users = _truthy_env(
+            "LINE_ALLOW_GROUPS_FROM_ALLOWED_USERS",
+            bool(extra.get("allow_groups_from_allowed_users", False)),
+        )
+        self.group_sender_dispatch_gate = str(
+            extra.get("group_sender_dispatch_gate", "") or ""
+        ).strip()
+        self._sender_group_admission_enabled = bool(
+            self.allow_groups_from_allowed_users and self.group_sender_dispatch_gate
+        )
 
         # Slow-LLM postback button threshold
         try:
@@ -918,12 +934,25 @@ class LineAdapter(BasePlatformAdapter):
             user_ids=self.allowed_users,
             group_ids=self.allowed_groups,
             room_ids=self.allowed_rooms,
+            allow_groups_from_allowed_users=self._sender_group_admission_enabled,
         ):
             logger.info("LINE: rejecting unauthorized source %s", source)
             return
 
+        sender_admitted_group = bool(
+            not self.allow_all
+            and source.get("type") == "group"
+            and source.get("groupId")
+            and source.get("groupId") not in self.allowed_groups
+            and self._sender_group_admission_enabled
+            and source.get("userId") in self.allowed_users
+        )
+
         if event_type == "message":
-            await self._handle_message_event(event)
+            await self._handle_message_event(
+                event,
+                sender_admitted_group=sender_admitted_group,
+            )
         elif event_type == "postback":
             await self._handle_postback_event(event)
         elif event_type in {"follow", "unfollow", "join", "leave"}:
@@ -931,7 +960,12 @@ class LineAdapter(BasePlatformAdapter):
         else:
             logger.debug("LINE: ignoring event type %r", event_type)
 
-    async def _handle_message_event(self, event: Dict[str, Any]) -> None:
+    async def _handle_message_event(
+        self,
+        event: Dict[str, Any],
+        *,
+        sender_admitted_group: bool = False,
+    ) -> None:
         msg = event.get("message") or {}
         msg_type = msg.get("type", "")
         message_id = msg.get("id", "")
@@ -939,6 +973,14 @@ class LineAdapter(BasePlatformAdapter):
         source = event.get("source") or {}
         chat_id, chat_type = _resolve_chat(source)
         user_id = source.get("userId", "") or chat_id
+        webhook_event_id = event.get("webhookEventId")
+        event_timestamp = event.get("timestamp")
+        platform_event_id = webhook_event_id if isinstance(webhook_event_id, str) and webhook_event_id else None
+        platform_event_timestamp_ms = (
+            event_timestamp
+            if isinstance(event_timestamp, int) and not isinstance(event_timestamp, bool) and event_timestamp >= 0
+            else None
+        )
 
         # Stash the reply token for outbound use.
         if chat_id and reply_token:
@@ -989,6 +1031,14 @@ class LineAdapter(BasePlatformAdapter):
             source=source_obj,
             raw_message=event,
             message_id=message_id,
+            platform_event_id=platform_event_id,
+            platform_event_timestamp_ms=platform_event_timestamp_ms,
+            platform_reply_token=(
+                reply_token if isinstance(reply_token, str) and reply_token else None
+            ),
+            required_dispatch_gate=(
+                self.group_sender_dispatch_gate if sender_admitted_group else None
+            ),
             media_urls=media_urls,
             media_types=media_types,
         )
@@ -1077,6 +1127,34 @@ class LineAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # Outbound send (text)
     # ------------------------------------------------------------------
+
+    async def send_control_reply(self, event: MessageEvent, content: str) -> SendResult:
+        """Reply to one inbound LINE event without touching slow-response state."""
+        if not self._client or not event or not event.source:
+            return SendResult(success=False, error="LINE control reply is unavailable")
+        chat_id = str(event.source.chat_id or "")
+        if not chat_id:
+            return SendResult(success=False, error="LINE control reply requires a chat id")
+        chunks = split_for_line(strip_markdown_preserving_urls(str(content or "")))
+        if not chunks:
+            return SendResult(success=True, message_id=None)
+        messages = [_text_message(chunk) for chunk in chunks][:LINE_MAX_MESSAGES_PER_CALL]
+        reply_token = getattr(event, "platform_reply_token", None)
+        if isinstance(reply_token, str) and reply_token:
+            cached = self._reply_tokens.get(chat_id)
+            if cached is not None and cached[0] == reply_token:
+                self._reply_tokens.pop(chat_id, None)
+            try:
+                await self._client.reply(reply_token, messages)
+                return SendResult(success=True, message_id=reply_token)
+            except Exception as exc:
+                logger.info("LINE: control reply token rejected (%s); falling back to push", exc)
+        try:
+            await self._client.push(chat_id, messages)
+            return SendResult(success=True, message_id=None)
+        except Exception as exc:
+            logger.error("LINE: control-reply push failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
 
     async def send(
         self,
@@ -1500,7 +1578,12 @@ def validate_config(config) -> bool:
     has_secret = bool(
         os.getenv("LINE_CHANNEL_SECRET") or extra.get("channel_secret")
     )
-    return has_token and has_secret
+    allow_sender_groups = _truthy_env(
+        "LINE_ALLOW_GROUPS_FROM_ALLOWED_USERS",
+        bool(extra.get("allow_groups_from_allowed_users", False)),
+    )
+    dispatch_gate = str(extra.get("group_sender_dispatch_gate", "") or "").strip()
+    return has_token and has_secret and (not allow_sender_groups or bool(dispatch_gate))
 
 
 def is_connected(config) -> bool:

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -69,6 +69,29 @@ def _make_event(chat_id: str, thread_id: str, message_id: str = "1") -> MessageE
 
 class TestBasePlatformTopicSessions:
     @pytest.mark.asyncio
+    async def test_ingress_resolver_runs_before_an_active_session_can_queue(self):
+        """A required gate can drop an event before the busy-path branch."""
+        adapter = DummyTelegramAdapter()
+        adapter.set_message_handler(AsyncMock())
+        event = _make_event("-1001", "10", message_id="guarded")
+        event.required_dispatch_gate = "line-group-context"
+        session_key = build_session_key(event.source)
+        adapter._active_sessions[session_key] = asyncio.Event()
+        resolved = []
+
+        async def reject(inbound, inbound_session_key):
+            resolved.append((inbound, inbound_session_key))
+            return None
+
+        adapter.set_ingress_resolver(reject)
+
+        await adapter.handle_message(event)
+
+        assert resolved == [(event, session_key)]
+        assert adapter._pending_messages == {}
+        adapter._message_handler.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_handle_message_does_not_interrupt_different_topic(self, monkeypatch):
         adapter = DummyTelegramAdapter()
         adapter.set_message_handler(lambda event: asyncio.sleep(0, result=None))

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -141,6 +141,27 @@ class TestAllowlist:
         assert _allowed_for_source(src, allow_all=False, user_ids={"Uany"}, group_ids={"Cok"}, room_ids=set())
         assert not _allowed_for_source(src, allow_all=False, user_ids={"Uany"}, group_ids=set(), room_ids=set())
 
+    def test_group_sender_admission_requires_an_allowed_sender(self):
+        allowed_source = {"type": "group", "groupId": "Cnew", "userId": "Uok"}
+        denied_source = {"type": "group", "groupId": "Cnew", "userId": "Uother"}
+
+        assert _allowed_for_source(
+            allowed_source,
+            allow_all=False,
+            user_ids={"Uok"},
+            group_ids=set(),
+            room_ids=set(),
+            allow_groups_from_allowed_users=True,
+        )
+        assert not _allowed_for_source(
+            denied_source,
+            allow_all=False,
+            user_ids={"Uok"},
+            group_ids=set(),
+            room_ids=set(),
+            allow_groups_from_allowed_users=True,
+        )
+
     def test_room_uses_room_list(self):
         src = {"type": "room", "roomId": "Rok"}
         assert _allowed_for_source(src, allow_all=False, user_ids=set(), group_ids=set(), room_ids={"Rok"})
@@ -348,6 +369,63 @@ class TestSendRouting:
         assert result.success
         adapter._client.reply.assert_called_once()
         adapter._client.push.assert_called_once()
+
+    def test_control_reply_uses_its_own_event_token_and_bypasses_pending_cache(self, adapter):
+        import time as _time
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent
+        from gateway.session import SessionSource
+
+        pending_id = adapter._cache.register_pending("Cgroup")
+        adapter._pending_buttons["Cgroup"] = pending_id
+        adapter._reply_tokens["Cgroup"] = ("other-event-token", _time.time() + 30)
+        event = MessageEvent(
+            text="/onboarding",
+            source=SessionSource(
+                platform=Platform("line"),
+                chat_id="Cgroup",
+                chat_type="group",
+                user_id="Uowner",
+            ),
+            platform_reply_token="this-event-token",
+        )
+
+        result = asyncio.run(adapter.send_control_reply(event, "First question"))
+
+        assert result.success
+        adapter._client.reply.assert_called_once()
+        assert adapter._client.reply.call_args.args[0] == "this-event-token"
+        adapter._client.push.assert_not_called()
+        assert adapter._cache.get(pending_id).state is State.PENDING
+        assert adapter._reply_tokens["Cgroup"][0] == "other-event-token"
+
+    def test_control_reply_pushes_after_its_exact_token_fails(self, adapter):
+        """A failed control reply never consumes a different event's token."""
+        import time as _time
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent
+        from gateway.session import SessionSource
+
+        adapter._reply_tokens["Cgroup"] = ("this-event-token", _time.time() + 30)
+        adapter._client.reply.side_effect = RuntimeError("expired")
+        event = MessageEvent(
+            text="/onboarding",
+            source=SessionSource(
+                platform=Platform("line"),
+                chat_id="Cgroup",
+                chat_type="group",
+                user_id="Uowner",
+            ),
+            platform_reply_token="this-event-token",
+        )
+
+        result = asyncio.run(adapter.send_control_reply(event, "First question"))
+
+        assert result.success
+        adapter._client.reply.assert_called_once()
+        assert adapter._client.reply.call_args.args[0] == "this-event-token"
+        adapter._client.push.assert_called_once()
+        assert "Cgroup" not in adapter._reply_tokens
 
     def test_send_returns_failure_when_push_fails(self, adapter):
         adapter._client.push.side_effect = RuntimeError("network")
@@ -587,6 +665,30 @@ class TestValidateConfig:
         cfg = PlatformConfig(enabled=True, extra={})
         assert not validate_config(cfg)
 
+    def test_sender_group_admission_requires_a_dispatch_gate(self):
+        from gateway.config import PlatformConfig
+
+        missing_gate = PlatformConfig(
+            enabled=True,
+            extra={
+                "channel_access_token": "t",
+                "channel_secret": "s",
+                "allow_groups_from_allowed_users": True,
+            },
+        )
+        configured_gate = PlatformConfig(
+            enabled=True,
+            extra={
+                "channel_access_token": "t",
+                "channel_secret": "s",
+                "allow_groups_from_allowed_users": True,
+                "group_sender_dispatch_gate": "line-group-context",
+            },
+        )
+
+        assert not validate_config(missing_gate)
+        assert validate_config(configured_gate)
+
 
 class TestAdapterInit:
 
@@ -632,6 +734,47 @@ class TestAdapterInit:
         ad = LineAdapter(PlatformConfig(enabled=True))
         assert ad.allowed_users == {"U1", "U2", "U3"}
         assert ad.allowed_groups == {"C1"}
+
+
+@pytest.mark.asyncio
+async def test_sender_admitted_group_carries_a_required_gate_and_signed_event_identity():
+    from gateway.config import PlatformConfig
+
+    adapter = LineAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "channel_access_token": "token",
+                "channel_secret": "secret",
+                "allowed_users": ["Uowner"],
+                "allow_groups_from_allowed_users": True,
+                "group_sender_dispatch_gate": "line-group-context",
+            },
+        )
+    )
+    captured = []
+
+    async def capture(event):
+        captured.append(event)
+
+    adapter.handle_message = capture
+
+    await adapter._dispatch_event(
+        {
+            "type": "message",
+            "webhookEventId": "01JLINEEVENT",
+            "timestamp": 1_784_678_400_000,
+            "replyToken": "reply-token",
+            "source": {"type": "group", "groupId": "Cnew", "userId": "Uowner"},
+            "message": {"type": "text", "id": "message-1", "text": "hello"},
+        }
+    )
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event.required_dispatch_gate == "line-group-context"
+    assert event.platform_event_id == "01JLINEEVENT"
+    assert event.platform_event_timestamp_ms == 1_784_678_400_000
 
     def test_get_chat_info_infers_type_from_prefix(self, monkeypatch):
         monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -209,6 +209,51 @@ async def test_required_gate_accepts_only_matching_owner_and_keeps_enrichment(mo
 
 
 @pytest.mark.asyncio
+async def test_later_allow_callback_cannot_erase_gate_owner_enrichment(monkeypatch):
+    """Isolated later hooks preserve owner context when they make no edits."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+    manager = PluginManager()
+
+    def approve(event, **_kwargs):
+        event.channel_prompt = "approved context"
+        event.auto_skill = ["mochiwiz-bookkeeper"]
+        return {"action": "approve", "gate": "line-group-context"}
+
+    PluginContext(
+        manager=manager,
+        manifest=PluginManifest(name="context", source="user"),
+    ).register_hook("pre_gateway_dispatch", approve, gate_owner="line-group-context")
+    PluginContext(
+        manager=manager,
+        manifest=PluginManifest(name="unrelated", source="user"),
+    ).register_hook("pre_gateway_dispatch", lambda **_kwargs: {"action": "allow"})
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+    runner, _adapter = _make_runner(Platform.WHATSAPP)
+    observed = {}
+
+    async def capture(event, *_args):
+        observed["prompt"] = event.channel_prompt
+        observed["skills"] = event.auto_skill
+        return "ok"
+
+    runner._handle_message_with_agent = capture  # noqa: SLF001
+    event = _make_event("guarded")
+    event.required_dispatch_gate = "line-group-context"
+    event.platform_event_id = "signed-event-id"
+    event.platform_event_timestamp_ms = 1_784_678_400_000
+
+    assert await runner._handle_message(event) == "ok"
+    assert observed == {
+        "prompt": "approved context",
+        "skills": ["mochiwiz-bookkeeper"],
+    }
+
+
+@pytest.mark.asyncio
 async def test_required_gate_rejects_owner_source_mutation(monkeypatch):
     """A hook cannot replace the adapter-authenticated sender or routing lane."""
     _clear_auth_env(monkeypatch)

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -298,6 +298,133 @@ async def test_guarded_reconstruction_keeps_the_one_core_issued_resolution(monke
 
 
 @pytest.mark.asyncio
+async def test_guarded_busy_merge_does_not_resolve_a_third_time(monkeypatch):
+    """Gateway's own busy fallback rebinds a guarded merged pending event."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+    manager = PluginManager()
+    approvals = 0
+
+    def approve(**_kwargs):
+        nonlocal approvals
+        approvals += 1
+        return {"action": "approve", "gate": "line-group-context"}
+
+    PluginContext(
+        manager=manager,
+        manifest=PluginManifest(name="context", source="user"),
+    ).register_hook(
+        "pre_gateway_dispatch",
+        approve,
+        gate_owner="line-group-context",
+    )
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+    runner, adapter = _make_runner(Platform.WHATSAPP)
+    adapter._pending_messages = {}
+    first = _make_event("first")
+    second = _make_event("second")
+    for index, event in enumerate((first, second), start=1):
+        event.required_dispatch_gate = "line-group-context"
+        event.platform_event_id = f"signed-event-{index}"
+        event.platform_event_timestamp_ms = 1_784_678_400_000 + index
+    session_key = runner._session_key_for_source(first.source)
+    first_resolved = await runner._resolve_gateway_ingress(first, session_key)
+    second_resolved = await runner._resolve_gateway_ingress(second, session_key)
+    assert first_resolved is not None and second_resolved is not None
+    adapter._pending_messages[session_key] = first_resolved
+
+    merged = runner._merge_pending_ingress_event(
+        adapter, session_key, second_resolved, merge_text=True
+    )
+    assert merged is not None
+    assert merged.text == "first\nsecond"
+
+    async def capture(*_args):
+        return "ok"
+
+    runner._handle_message_with_agent = capture  # noqa: SLF001
+    assert await runner._handle_message(merged) == "ok"
+    assert approvals == 2
+
+
+@pytest.mark.asyncio
+async def test_guarded_resolution_is_consumed_before_a_second_runner_dispatch(monkeypatch):
+    """The same core-issued guarded event cannot invoke the agent twice."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+    manager = PluginManager()
+    PluginContext(
+        manager=manager,
+        manifest=PluginManifest(name="context", source="user"),
+    ).register_hook(
+        "pre_gateway_dispatch",
+        lambda **_kwargs: {"action": "approve", "gate": "line-group-context"},
+        gate_owner="line-group-context",
+    )
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+    runner, _adapter = _make_runner(Platform.WHATSAPP)
+    event = _make_event("guarded")
+    event.required_dispatch_gate = "line-group-context"
+    event.platform_event_id = "signed-event-id"
+    event.platform_event_timestamp_ms = 1_784_678_400_000
+    session_key = runner._session_key_for_source(event.source)
+    resolved = await runner._resolve_gateway_ingress(event, session_key)
+    assert resolved is not None
+    dispatches = 0
+
+    async def capture(*_args):
+        nonlocal dispatches
+        dispatches += 1
+        return "ok"
+
+    runner._handle_message_with_agent = capture  # noqa: SLF001
+    assert await runner._handle_message(resolved) == "ok"
+    assert await runner._handle_message(resolved) is None
+    assert dispatches == 1
+
+
+@pytest.mark.asyncio
+async def test_guarded_busy_queue_transfers_a_fresh_dispatchable_child(monkeypatch):
+    """Queueing a consumed busy event transfers—not reuses—its approval."""
+    _clear_auth_env(monkeypatch)
+    from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+    manager = PluginManager()
+    PluginContext(
+        manager=manager,
+        manifest=PluginManifest(name="context", source="user"),
+    ).register_hook(
+        "pre_gateway_dispatch",
+        lambda **_kwargs: {"action": "approve", "gate": "line-group-context"},
+        gate_owner="line-group-context",
+    )
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+    runner, adapter = _make_runner(Platform.WHATSAPP)
+    adapter._pending_messages = {}
+    event = _make_event("queued")
+    event.required_dispatch_gate = "line-group-context"
+    event.platform_event_id = "signed-event-id"
+    event.platform_event_timestamp_ms = 1_784_678_400_000
+    session_key = runner._session_key_for_source(event.source)
+    resolved = await runner._resolve_gateway_ingress(event, session_key)
+    assert resolved is not None
+    assert runner._consume_guarded_ingress_resolution(resolved, session_key)
+
+    runner._enqueue_fifo(session_key, resolved, adapter)
+
+    queued = adapter._pending_messages[session_key]
+    assert queued is not resolved
+    assert runner._consume_guarded_ingress_resolution(queued, session_key)
+    assert not runner._consume_guarded_ingress_resolution(queued, session_key)
+
+
+@pytest.mark.asyncio
 async def test_hook_exception_does_not_break_dispatch(monkeypatch):
     """A raising plugin hook does not break the gateway."""
     _clear_auth_env(monkeypatch)

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -5,6 +5,7 @@ agent dispatch. It runs in _handle_message and acts on returned action
 dicts: {"action": "skip"|"rewrite"|"allow"}.
 """
 
+import dataclasses
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -130,6 +131,170 @@ async def test_hook_allow_falls_through_to_auth(monkeypatch):
     # auth chain ran → pairing code was generated
     assert result is None
     runner.pairing_store.generate_code.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_required_gate_rejects_an_unrelated_allow_before_agent_dispatch(monkeypatch):
+    """Only the declared gate owner can approve a required ingress gate."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+    manager = PluginManager()
+    PluginContext(
+        manager=manager,
+        manifest=PluginManifest(name="unrelated", source="user"),
+    ).register_hook("pre_gateway_dispatch", lambda **_kwargs: {"action": "allow"})
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+    runner, _adapter = _make_runner(Platform.WHATSAPP)
+    reached_agent = False
+
+    async def capture(*_args):
+        nonlocal reached_agent
+        reached_agent = True
+        return "unexpected"
+
+    runner._handle_message_with_agent = capture  # noqa: SLF001
+    event = _make_event("guarded")
+    event.required_dispatch_gate = "line-group-context"
+
+    assert await runner._handle_message(event) is None
+    assert reached_agent is False
+
+
+@pytest.mark.asyncio
+async def test_required_gate_accepts_only_matching_owner_and_keeps_enrichment(monkeypatch):
+    """The declared owner may enrich only after an explicit gate approval."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+    manager = PluginManager()
+
+    def approve(event, **_kwargs):
+        event.channel_prompt = "approved context"
+        event.auto_skill = ["research", "calendar"]
+        return {"action": "approve", "gate": "line-group-context"}
+
+    PluginContext(
+        manager=manager,
+        manifest=PluginManifest(name="context", source="user"),
+    ).register_hook(
+        "pre_gateway_dispatch",
+        approve,
+        gate_owner="line-group-context",
+    )
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+    runner, _adapter = _make_runner(Platform.WHATSAPP)
+    observed = {}
+
+    async def capture(event, *_args):
+        observed["prompt"] = event.channel_prompt
+        observed["skills"] = event.auto_skill
+        return "ok"
+
+    runner._handle_message_with_agent = capture  # noqa: SLF001
+    event = _make_event("guarded")
+    event.required_dispatch_gate = "line-group-context"
+    event.platform_event_id = "signed-event-id"
+    event.platform_event_timestamp_ms = 1_784_678_400_000
+
+    assert await runner._handle_message(event) == "ok"
+    assert observed == {
+        "prompt": "approved context",
+        "skills": ["research", "calendar"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_required_gate_rejects_owner_source_mutation(monkeypatch):
+    """A hook cannot replace the adapter-authenticated sender or routing lane."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+    manager = PluginManager()
+
+    def mutate_source(event, **_kwargs):
+        event.source.user_id = "forged-user"
+        return {"action": "approve", "gate": "line-group-context"}
+
+    PluginContext(
+        manager=manager,
+        manifest=PluginManifest(name="context", source="user"),
+    ).register_hook(
+        "pre_gateway_dispatch",
+        mutate_source,
+        gate_owner="line-group-context",
+    )
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+    runner, _adapter = _make_runner(Platform.WHATSAPP)
+    reached_agent = False
+
+    async def capture(*_args):
+        nonlocal reached_agent
+        reached_agent = True
+        return "unexpected"
+
+    runner._handle_message_with_agent = capture  # noqa: SLF001
+    event = _make_event("guarded")
+    event.required_dispatch_gate = "line-group-context"
+    event.platform_event_id = "signed-event-id"
+    event.platform_event_timestamp_ms = 1_784_678_400_000
+
+    assert await runner._handle_message(event) is None
+    assert reached_agent is False
+
+
+@pytest.mark.asyncio
+async def test_guarded_reconstruction_keeps_the_one_core_issued_resolution(monkeypatch):
+    """A trusted queue-style reconstruction does not invoke onboarding twice."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+    manager = PluginManager()
+    approvals = 0
+
+    def approve(**_kwargs):
+        nonlocal approvals
+        approvals += 1
+        return {"action": "approve", "gate": "line-group-context"}
+
+    PluginContext(
+        manager=manager,
+        manifest=PluginManifest(name="context", source="user"),
+    ).register_hook(
+        "pre_gateway_dispatch",
+        approve,
+        gate_owner="line-group-context",
+    )
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+    runner, _adapter = _make_runner(Platform.WHATSAPP)
+    event = _make_event("/queue original")
+    event.required_dispatch_gate = "line-group-context"
+    event.platform_event_id = "signed-event-id"
+    event.platform_event_timestamp_ms = 1_784_678_400_000
+    session_key = runner._session_key_for_source(event.source)
+    resolved = await runner._resolve_gateway_ingress(event, session_key)
+    assert resolved is not None
+    reconstructed = runner._rebind_ingress_event(
+        [resolved],
+        dataclasses.replace(resolved, text="queued follow-up"),
+        session_key,
+    )
+    assert reconstructed is not None
+
+    async def capture(*_args):
+        return "ok"
+
+    runner._handle_message_with_agent = capture  # noqa: SLF001
+    assert await runner._handle_message(reconstructed) == "ok"
+    assert approvals == 1
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -659,6 +659,64 @@ class TestPluginHooks:
         assert len(results) == 1
         assert results[0] == {"action": "skip", "reason": "test"}
 
+    def test_isolated_gateway_dispatch_gives_each_callback_a_fresh_event_copy(self):
+        """A guarded dispatch hook cannot mutate another hook's event view."""
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent
+        from gateway.session import SessionSource
+
+        manager = PluginManager()
+        owner = PluginContext(
+            manager=manager,
+            manifest=PluginManifest(name="gate-owner", source="user"),
+        )
+        observer = PluginContext(
+            manager=manager,
+            manifest=PluginManifest(name="observer", source="user"),
+        )
+        observed = []
+
+        def mutate(event, **_kwargs):
+            event.source.user_id = "Umutated"
+            event.metadata["nested"]["value"] = "mutated"
+            return {"action": "approve", "gate": "line-group-context"}
+
+        def inspect(event, **_kwargs):
+            observed.append((event.source.user_id, event.metadata["nested"]["value"]))
+            return {"action": "allow"}
+
+        owner.register_hook(
+            "pre_gateway_dispatch",
+            mutate,
+            gate_owner="line-group-context",
+        )
+        observer.register_hook("pre_gateway_dispatch", inspect)
+        original = MessageEvent(
+            text="hello",
+            source=SessionSource(
+                platform=Platform("line"),
+                chat_id="Cgroup",
+                chat_type="group",
+                user_id="Uowner",
+            ),
+            metadata={"nested": {"value": "original"}},
+        )
+
+        invocations = manager.invoke_hook_isolated(
+            "pre_gateway_dispatch",
+            event=original,
+            gateway=object(),
+            session_store=object(),
+        )
+
+        assert observed == [("Uowner", "original")]
+        assert original.source.user_id == "Uowner"
+        assert original.metadata == {"nested": {"value": "original"}}
+        assert invocations[0].plugin_name == "gate-owner"
+        assert invocations[0].gate_owner == "line-group-context"
+        assert invocations[0].result == {"action": "approve", "gate": "line-group-context"}
+        assert invocations[1].plugin_name == "observer"
+
     def test_register_and_invoke_hook(self, tmp_path, monkeypatch):
         """Registered hooks are called on invoke_hook()."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"


### PR DESCRIPTION
## Summary

- add opt-in LINE group admission through existing allowed senders, requiring a YAML dispatch-gate name
- resolve guarded ingress before cold/busy routing using one declared plugin gate owner and isolated callback events
- preserve core-issued guarded decisions across active-session queue, media merge, debounce, `/queue`, `/steer`, and busy-path fallbacks; terminal dispatch consumes a decision once
- preserve a gate owner’s deliberate prompt/skill enrichment when later isolated hooks merely allow
- add exact-event LINE control replies that bypass the slow-response cache

## Safety

Guarded events fail closed for missing/duplicate owners, exceptions, malformed approvals, mutable security-boundary changes, internal events, invalid event identity, duplicate consumption, and unproven queue reconstruction. Existing unguarded hook behavior remains compatible.

## Verification

`scripts/run_tests.sh tests/gateway/test_line_plugin.py tests/gateway/test_pre_gateway_dispatch.py tests/gateway/test_busy_session_auth_bypass.py tests/gateway/test_session_race_guard.py tests/gateway/test_base_topic_sessions.py tests/gateway/test_queue_consumption.py tests/hermes_cli/test_plugins.py -q`

258 tests passed.