### PR TITLE
fix(desktop): preserve terminal locale environment

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -186,6 +186,7 @@ import {
   SshConnection
 } from './ssh-connection'
 import { createStreamThrottle } from './stream-throttle'
+import { buildTerminalShellEnv } from './terminal-shell-env'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { waitForUpdateClearance } from './update-gate'
@@ -10958,39 +10959,6 @@ function safeTerminalCwd(cwd) {
   }
 }
 
-function terminalShellEnv() {
-  const env = { ...process.env }
-
-  // Electron is commonly launched through `npm run dev`; do not leak npm's
-  // managed prefix into a user's interactive shell (nvm/proto warn loudly).
-  for (const key of Object.keys(env)) {
-    if (key === 'npm_config_prefix' || key.startsWith('npm_config_') || key.startsWith('npm_package_')) {
-      delete env[key]
-    }
-  }
-
-  // Strip color/theme-detection vars that ride along when Electron is launched
-  // from a non-tty agent shell (Cursor's runner sets NO_COLOR/FORCE_COLOR=0
-  // /TERM=dumb; some terminals set COLORFGBG which would flip Hermes' TUI into
-  // light-mode). Our PTY is a real xterm-compat terminal — force truecolor.
-  delete env.NO_COLOR
-  delete env.FORCE_COLOR
-  delete env.COLORFGBG
-
-  env.COLORTERM = 'truecolor'
-  env.LC_CTYPE = env.LC_CTYPE || 'UTF-8'
-  env.TERM = 'xterm-256color'
-  env.TERM_PROGRAM = 'Hermes'
-  env.TERM_PROGRAM_VERSION = app.getVersion()
-
-  // Let a hermes/--tui launched in this pane know it's embedded in the desktop
-  // GUI (build_environment_hints surfaces this). Distinct from HERMES_DESKTOP,
-  // which marks the agent *backend* and gates cron/gateway behavior.
-  env.HERMES_DESKTOP_TERMINAL = '1'
-
-  return env
-}
-
 function terminalChannel(id, suffix) {
   return `hermes:terminal:${id}:${suffix}`
 }
@@ -11320,9 +11288,9 @@ ipcMain.handle('hermes:terminal:start', async (event, payload = {}) => {
           ? path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'OpenSSH', 'ssh.exe')
           : 'ssh',
         buildInteractiveSshArgs(sshTarget.ssh, String(payload?.cwd || '').trim(), undefined, remoteCommand),
-        { cols, cwd: app.getPath('home'), env: terminalShellEnv(), name: 'xterm-256color', rows }
+        { cols, cwd: app.getPath('home'), env: buildTerminalShellEnv({ appVersion: app.getVersion() }), name: 'xterm-256color', rows }
       )
-    : nodePty.spawn(command, args, { cols, cwd, env: terminalShellEnv(), name: 'xterm-256color', rows })
+    : nodePty.spawn(command, args, { cols, cwd, env: buildTerminalShellEnv({ appVersion: app.getVersion() }), name: 'xterm-256color', rows })
 
   terminalSessions.set(id, {
     pty: ptyProcess,

--- a/apps/desktop/electron/terminal-ipc.ts
+++ b/apps/desktop/electron/terminal-ipc.ts
@@ -14,6 +14,7 @@ import { resolveTerminalConnectionForSender } from './connection-apply'
 import { ensureSpawnHelperExecutable } from './spawn-helper-perms'
 import { buildInteractiveSshArgs } from './ssh-connection'
 import { createTerminalOutputGate } from './terminal-output-gate'
+import { buildTerminalShellEnv } from './terminal-shell-env'
 import { buildWindowsInteractiveCommand } from './windows-remote-lifecycle'
 
 export interface TerminalIpcDeps {
@@ -134,39 +135,6 @@ export function registerTerminalIpc({
     } catch {
       return app.getPath('home')
     }
-  }
-
-  function terminalShellEnv() {
-    const env = { ...process.env }
-
-    // Electron is commonly launched through `npm run dev`; do not leak npm's
-    // managed prefix into a user's interactive shell (nvm/proto warn loudly).
-    for (const key of Object.keys(env)) {
-      if (key === 'npm_config_prefix' || key.startsWith('npm_config_') || key.startsWith('npm_package_')) {
-        delete env[key]
-      }
-    }
-
-    // Strip color/theme-detection vars that ride along when Electron is launched
-    // from a non-tty agent shell (Cursor's runner sets NO_COLOR/FORCE_COLOR=0
-    // /TERM=dumb; some terminals set COLORFGBG which would flip Hermes' TUI into
-    // light-mode). Our PTY is a real xterm-compat terminal — force truecolor.
-    delete env.NO_COLOR
-    delete env.FORCE_COLOR
-    delete env.COLORFGBG
-
-    env.COLORTERM = 'truecolor'
-    env.LC_CTYPE = env.LC_CTYPE || 'UTF-8'
-    env.TERM = 'xterm-256color'
-    env.TERM_PROGRAM = 'Hermes'
-    env.TERM_PROGRAM_VERSION = app.getVersion()
-
-    // Let a hermes/--tui launched in this pane know it's embedded in the desktop
-    // GUI (build_environment_hints surfaces this). Distinct from HERMES_DESKTOP,
-    // which marks the agent *backend* and gates cron/gateway behavior.
-    env.HERMES_DESKTOP_TERMINAL = '1'
-
-    return env
   }
 
   function terminalChannel(id, suffix) {
@@ -309,9 +277,21 @@ export function registerTerminalIpc({
             ? path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'OpenSSH', 'ssh.exe')
             : 'ssh',
           buildInteractiveSshArgs(sshTarget.ssh, String(payload?.cwd || '').trim(), undefined, remoteCommand),
-          { cols, cwd: app.getPath('home'), env: terminalShellEnv(), name: 'xterm-256color', rows }
+          {
+            cols,
+            cwd: app.getPath('home'),
+            env: buildTerminalShellEnv({ appVersion: app.getVersion() }),
+            name: 'xterm-256color',
+            rows
+          }
         )
-      : nodePty.spawn(command, args, { cols, cwd, env: terminalShellEnv(), name: 'xterm-256color', rows })
+      : nodePty.spawn(command, args, {
+          cols,
+          cwd,
+          env: buildTerminalShellEnv({ appVersion: app.getVersion() }),
+          name: 'xterm-256color',
+          rows
+        })
 
     const send = (suffix, payload) => {
       if (event.sender.isDestroyed()) {

--- a/apps/desktop/electron/terminal-shell-env.test.ts
+++ b/apps/desktop/electron/terminal-shell-env.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { buildTerminalShellEnv } from './terminal-shell-env'
+
+test('terminal shell environment preserves the inherited locale', () => {
+  const env = buildTerminalShellEnv({
+    appVersion: '0.17.0',
+    currentEnv: { LANG: 'en_US.UTF-8' }
+  })
+
+  assert.equal(env.LANG, 'en_US.UTF-8')
+  assert.equal(env.LC_CTYPE, undefined)
+})
+
+test('terminal shell environment keeps an explicitly inherited LC_CTYPE', () => {
+  const env = buildTerminalShellEnv({
+    appVersion: '0.17.0',
+    currentEnv: { LC_CTYPE: 'C.UTF-8' }
+  })
+
+  assert.equal(env.LC_CTYPE, 'C.UTF-8')
+})

--- a/apps/desktop/electron/terminal-shell-env.ts
+++ b/apps/desktop/electron/terminal-shell-env.ts
@@ -1,0 +1,38 @@
+type TerminalShellEnvOptions = {
+  appVersion: string
+  currentEnv?: NodeJS.ProcessEnv
+}
+
+function buildTerminalShellEnv({ appVersion, currentEnv = process.env }: TerminalShellEnvOptions) {
+  const env = { ...currentEnv }
+
+  // Electron is commonly launched through `npm run dev`; do not leak npm's
+  // managed prefix into a user's interactive shell (nvm/proto warn loudly).
+  for (const key of Object.keys(env)) {
+    if (key === 'npm_config_prefix' || key.startsWith('npm_config_') || key.startsWith('npm_package_')) {
+      delete env[key]
+    }
+  }
+
+  // Strip color/theme-detection vars that ride along when Electron is launched
+  // from a non-tty agent shell (Cursor's runner sets NO_COLOR/FORCE_COLOR=0
+  // /TERM=dumb; some terminals set COLORFGBG which would flip Hermes' TUI into
+  // light-mode). Our PTY is a real xterm-compat terminal — force truecolor.
+  delete env.NO_COLOR
+  delete env.FORCE_COLOR
+  delete env.COLORFGBG
+
+  env.COLORTERM = 'truecolor'
+  env.TERM = 'xterm-256color'
+  env.TERM_PROGRAM = 'Hermes'
+  env.TERM_PROGRAM_VERSION = appVersion
+
+  // Let a hermes/--tui launched in this pane know it's embedded in the desktop
+  // GUI (build_environment_hints surfaces this). Distinct from HERMES_DESKTOP,
+  // which marks the agent *backend* and gates cron/gateway behavior.
+  env.HERMES_DESKTOP_TERMINAL = '1'
+
+  return env
+}
+
+export { buildTerminalShellEnv }


### PR DESCRIPTION
## Summary
- stop injecting the invalid Linux locale value `LC_CTYPE=UTF-8` into desktop terminal sessions
- preserve an explicitly inherited `LC_CTYPE` and otherwise let `LANG` determine the locale
- extract the terminal environment builder into a focused helper with regression coverage

Fixes #69265

## Verification
- `npm run test:desktop:platforms -- --run electron/terminal-shell-env.test.ts`
- `npm run typecheck`
- `npm run test:desktop:platforms` (693 passed, 2 skipped)