### PR TITLE
fix(lazy-deps): skip ensurepip bootstrap on managed/package-manager installs

### DIFF
--- a/tests/tools/test_lazy_deps_managed.py
+++ b/tests/tools/test_lazy_deps_managed.py
@@ -1,0 +1,130 @@
+"""Managed-install coverage for lazy_deps (issue #48628)."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from tools import lazy_deps as ld
+
+
+class TestManagedPipBootstrap:
+    """Managed installs skip only ensurepip, while preserving useful errors."""
+
+    def test_managed_install_still_reaches_installer(self, monkeypatch):
+        checks = iter([("anthropic==0.87.0",), ()])
+        monkeypatch.setattr(ld, "feature_missing", lambda _feature: next(checks))
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        calls = []
+
+        def fake_install(specs, **kwargs):
+            calls.append((specs, kwargs))
+            return ld._InstallResult(True, "ok", "")
+
+        monkeypatch.setattr(ld, "_venv_pip_install", fake_install)
+        monkeypatch.setenv("HERMES_MANAGED", "nixos")
+
+        ld.ensure("provider.anthropic", prompt=False)
+
+        assert calls == [
+            (("anthropic==0.87.0",), {"feature": "provider.anthropic"})
+        ]
+
+    def test_nixos_skips_ensurepip_and_names_dependency_group(self, monkeypatch):
+        monkeypatch.setattr(ld.shutil, "which", lambda _name: None)
+        monkeypatch.setenv("HERMES_MANAGED", "nixos")
+        calls = []
+
+        def fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            if cmd[-1] == "--version":
+                return subprocess.CompletedProcess(cmd, 1, "", "No module named pip")
+            pytest.fail(f"managed install must not run bootstrap/install: {cmd}")
+
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+
+        result = ld._venv_pip_install(
+            ("anthropic==0.87.0",), feature="provider.anthropic"
+        )
+
+        assert not result.success
+        assert "ensurepip bootstrap was skipped" in result.stderr
+        assert 'extraDependencyGroups = [ "anthropic" ]' in result.remediation
+        assert len(calls) == 1
+
+    def test_ensure_surfaces_nix_remediation_without_pip_hint(self, monkeypatch):
+        monkeypatch.setattr(
+            ld,
+            "feature_missing",
+            lambda _feature: ("anthropic==0.87.0",),
+        )
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(ld.shutil, "which", lambda _name: None)
+        monkeypatch.setenv("HERMES_MANAGED", "true")
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[-1] == "--version":
+                return subprocess.CompletedProcess(cmd, 1, "", "No module named pip")
+            pytest.fail(f"managed install must not run bootstrap/install: {cmd}")
+
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+
+        with pytest.raises(ld.FeatureUnavailable) as exc_info:
+            ld.ensure("provider.anthropic", prompt=False)
+
+        message = str(exc_info.value)
+        assert 'extraDependencyGroups = [ "anthropic" ]' in message
+        assert "sudo nixos-rebuild switch" in message
+        assert "uv pip install" not in message
+
+    def test_readonly_nix_prefix_detected_without_managed_env(self, monkeypatch):
+        monkeypatch.delenv("HERMES_MANAGED", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.get_managed_system", lambda: None
+        )
+        monkeypatch.setattr(ld.sys, "prefix", "/nix/store/example-hermes-venv")
+        monkeypatch.setattr(ld.os, "access", lambda _path, _mode: False)
+
+        assert ld._managed_install_system() == "NixOS"
+
+    def test_writable_unmanaged_prefix_still_bootstraps(self, monkeypatch):
+        monkeypatch.setattr(ld.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(
+            "hermes_cli.config.get_managed_system", lambda: None
+        )
+        monkeypatch.setattr(ld.os, "access", lambda _path, _mode: True)
+        calls = []
+
+        def fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            if cmd[-1] == "--version":
+                return subprocess.CompletedProcess(cmd, 1, "", "No module named pip")
+            return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+
+        result = ld._venv_pip_install(("some-pkg==1.0",), feature="test.feature")
+
+        assert result.success
+        assert any("ensurepip" in cmd for cmd in calls)
+        assert any("install" in cmd and "some-pkg==1.0" in cmd for cmd in calls)
+
+    def test_homebrew_bootstrap_error_uses_package_manager(self, monkeypatch):
+        monkeypatch.setattr(ld.shutil, "which", lambda _name: None)
+        monkeypatch.setenv("HERMES_MANAGED", "homebrew")
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[-1] == "--version":
+                return subprocess.CompletedProcess(cmd, 1, "", "No module named pip")
+            pytest.fail(f"managed install must not run bootstrap/install: {cmd}")
+
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+
+        result = ld._venv_pip_install(
+            ("anthropic==0.87.0",), feature="provider.anthropic"
+        )
+
+        assert not result.success
+        assert "Homebrew" in result.stderr
+        assert "Homebrew package/formula" in result.remediation

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -261,14 +261,27 @@ class FeatureUnavailable(RuntimeError):
     installs, or the install attempt failed.
     """
 
-    def __init__(self, feature: str, missing: tuple[str, ...], reason: str):
+    def __init__(
+        self,
+        feature: str,
+        missing: tuple[str, ...],
+        reason: str,
+        *,
+        remediation: Optional[str] = None,
+    ):
         self.feature = feature
         self.missing = missing
         self.reason = reason
+        self.remediation = remediation
         super().__init__(self._format())
 
     def _format(self) -> str:
         spec_list = " ".join(repr(s) for s in self.missing)
+        if self.remediation is not None:
+            return (
+                f"Feature {self.feature!r} unavailable: {self.reason}. "
+                f"{self.remediation}"
+            )
         return (
             f"Feature {self.feature!r} unavailable: {self.reason}. "
             f"To enable manually: uv pip install {spec_list}  "
@@ -281,6 +294,7 @@ class _InstallResult:
     success: bool
     stdout: str
     stderr: str
+    remediation: Optional[str] = None
 
 
 # =============================================================================
@@ -295,6 +309,45 @@ class _InstallResult:
 # security.allow_lazy_installs in config.yaml. When unset, lazy installs go
 # into the active venv as before.
 _LAZY_TARGET_ENV = "HERMES_LAZY_INSTALL_TARGET"
+
+# Nix builds optional dependencies from pyproject groups into the sealed venv.
+# Keep this as a feature-to-remediation map rather than trying to infer group
+# names: several public feature names intentionally differ from their extras
+# (for example ``tts.elevenlabs`` -> ``tts-premium``).
+_NIX_DEPENDENCY_GROUPS: dict[str, str] = {
+    "provider.anthropic": "anthropic",
+    "provider.bedrock": "bedrock",
+    "provider.vertex": "vertex",
+    "provider.azure_identity": "azure-identity",
+    "search.exa": "exa",
+    "search.firecrawl": "firecrawl",
+    "search.parallel": "parallel-web",
+    "tts.mistral": "mistral",
+    "tts.edge": "edge-tts",
+    "tts.elevenlabs": "tts-premium",
+    "stt.mistral": "mistral",
+    "stt.faster_whisper": "voice",
+    "image.fal": "fal",
+    "memory.honcho": "honcho",
+    "memory.hindsight": "hindsight",
+    "memory.supermemory": "supermemory",
+    "memory.mem0": "mem0",
+    "platform.telegram": "messaging",
+    "platform.discord": "messaging",
+    "platform.slack": "slack",
+    "platform.matrix": "matrix",
+    "platform.dingtalk": "dingtalk",
+    "platform.feishu": "feishu",
+    "platform.wecom_callback": "wecom",
+    "platform.teams": "teams",
+    "terminal.modal": "modal",
+    "terminal.daytona": "daytona",
+    "skill.google_workspace": "google",
+    "skill.youtube": "youtube",
+    "tool.acp": "acp",
+    "tool.dashboard": "web",
+    "tool.computer_use": "computer-use",
+}
 
 # Name of the stamp file written into the target dir recording the Python
 # X.Y + ABI it was populated for. If a container rebuild bumps the
@@ -492,6 +545,67 @@ def _pkg_name_from_spec(spec: str) -> str:
     return m.group(1) if m else spec
 
 
+def _managed_install_system() -> Optional[str]:
+    """Return the package manager owning an immutable Python prefix.
+
+    ``get_managed_system`` is the canonical Hermes check and covers the
+    ``HERMES_MANAGED`` environment variable plus the legacy managed marker.
+    The prefix writability fallback also covers interactive Nix invocations,
+    where the service-provided environment variable may not be present.
+    """
+    try:
+        from hermes_cli.config import get_managed_system
+
+        managed_system = get_managed_system()
+        if managed_system:
+            return managed_system
+    except Exception:
+        pass
+
+    try:
+        if not os.access(sys.prefix, os.W_OK):
+            normalized = os.path.normpath(sys.prefix).replace(os.sep, "/")
+            if normalized == "/nix/store" or normalized.startswith("/nix/store/"):
+                return "NixOS"
+            return "managed"
+    except (OSError, TypeError, ValueError):
+        pass
+    return None
+
+
+def _managed_install_remediation(
+    system: str,
+    feature: Optional[str],
+    specs: tuple[str, ...],
+) -> str:
+    """Build package-manager guidance for a skipped pip bootstrap."""
+    if system == "NixOS":
+        group = _NIX_DEPENDENCY_GROUPS.get(feature or "")
+        if group:
+            return (
+                "Add the matching dependency group to configuration.nix: "
+                f'services.hermes-agent.extraDependencyGroups = [ "{group}" ]; '
+                "then run `sudo nixos-rebuild switch`."
+            )
+        packages = ", ".join(sorted({_pkg_name_from_spec(spec) for spec in specs}))
+        return (
+            "Add the Nix Python package(s) providing "
+            f"{packages} through services.hermes-agent.extraPythonPackages "
+            "and run `sudo nixos-rebuild switch`."
+        )
+
+    if system == "Homebrew":
+        return (
+            "Install a Homebrew package/formula that provides the missing "
+            "dependency, then reinstall or upgrade hermes-agent."
+        )
+
+    return (
+        "Install the missing dependency through the package manager that owns "
+        "this Hermes installation."
+    )
+
+
 def _specifier_from_spec(spec: str) -> str:
     """Extract just the version-specifier portion of a pip spec.
 
@@ -618,7 +732,12 @@ def _core_constraints_file() -> Optional[Path]:
         return None
 
 
-def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _InstallResult:
+def _venv_pip_install(
+    specs: tuple[str, ...],
+    *,
+    timeout: int = 300,
+    feature: Optional[str] = None,
+) -> _InstallResult:
     """Install ``specs`` using the uv → pip → ensurepip ladder.
 
     Two modes:
@@ -688,6 +807,15 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
             if probe.returncode != 0:
                 raise FileNotFoundError("pip not in venv")
         except (subprocess.TimeoutExpired, FileNotFoundError):
+            managed_system = _managed_install_system()
+            if managed_system:
+                return _InstallResult(
+                    False,
+                    "",
+                    "pip is unavailable and ensurepip bootstrap was skipped "
+                    f"because sys.prefix is managed by {managed_system}",
+                    _managed_install_remediation(managed_system, feature, specs),
+                )
             try:
                 subprocess.run(
                     [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
@@ -807,7 +935,7 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
             )
 
     logger.info("Lazy-installing %s for feature %r", " ".join(missing), feature)
-    result = _venv_pip_install(missing)
+    result = _venv_pip_install(missing, feature=feature)
     if not result.success:
         # Surface the actual pip error so the user can debug PyPI-side
         # issues (404 quarantine, network down, etc.).
@@ -817,7 +945,8 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
             snippet = snippet[-2000:]
         raise FeatureUnavailable(
             feature, missing,
-            f"pip install failed: {snippet or 'no error output'}"
+            f"pip install failed: {snippet or 'no error output'}",
+            remediation=result.remediation,
         )
 
     # Verify post-install. importlib.metadata caches per-process, so if we


### PR DESCRIPTION
## Summary
Salvage of #48637 by @liuhao1024; fixes #48628.

On managed installs (NixOS et al.) the sealed venv is read-only, yet `tools/lazy_deps.py` ran the ensurepip→pip bootstrap on **every launch** — ~20s of CPU that can never persist anything. The PR's branch head was a merge commit and the raw pick conflicted with current main, so this lands the contributor's change rebuilt on today's code (single commit, their authorship) with one behavioral refinement over the original: managed mode skips **only the ensurepip bootstrap** rather than raising `FeatureUnavailable` outright — a truly missing optional feature still produces an actionable error naming the dependency group to enable (e.g. the nix `.#messaging` variant), and legitimate installs still reach the installer when lazy installs are allowed.

## Test plan
- New `tests/tools/test_lazy_deps_managed.py`: 6 passed (managed skip, error wording names dependency group, installer still reachable)
- Wider lazy_deps selection + touched modules: 91 passed, 1 skipped (opt-in network test)
- `py_compile` clean