### PR TITLE
fix(nix): load bundled platform plugins from HERMES_BUNDLED_PLUGINS

### DIFF
--- a/contributors/emails/dev@milanglacier.com
+++ b/contributors/emails/dev@milanglacier.com
@@ -1,0 +1,2 @@
+milanglacier
+# PR #27077 salvage via #69477

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -348,10 +348,22 @@ class Platform(Enum):
 
     @classmethod
     def _scan_bundled_plugin_platforms(cls) -> set:
-        """Return names of bundled platform plugins under ``plugins/platforms/``."""
+        """Return names of bundled platform plugins under ``plugins/platforms/``.
+
+        Packaged installs may relocate bundled plugins outside the source tree
+        and advertise that directory through ``HERMES_BUNDLED_PLUGINS``.
+        Keep this scanner aligned with the main plugin loader so dynamic
+        platform enum members are available before plugin adapters import.
+        """
         names: set = set()
         try:
-            platforms_dir = Path(__file__).parent.parent / "plugins" / "platforms"
+            bundled_plugins = os.getenv("HERMES_BUNDLED_PLUGINS")
+            plugins_dir = (
+                Path(bundled_plugins)
+                if bundled_plugins
+                else Path(__file__).parent.parent / "plugins"
+            )
+            platforms_dir = plugins_dir / "platforms"
             if platforms_dir.is_dir():
                 for child in platforms_dir.iterdir():
                     if (


### PR DESCRIPTION
## Summary
Salvage of #27077 by @milanglacier (authorship preserved).

Under nix installs, bundled plugins live in the store path advertised by `HERMES_BUNDLED_PLUGINS`. `hermes_cli/plugins.py` honors it, but the gateway's `_scan_bundled_plugin_platforms()` scanned only the source-tree path — so platforms shipped as bundled plugins (google_chat et al.) never got their dynamic enum members under nix. This aligns the gateway scanner with the sibling loader: env var wins, source tree is the fallback.

## Test plan
- `tests/gateway/test_config.py`: 135 passed
- E2E: `HERMES_BUNDLED_PLUGINS=<relocated copy>` → scan finds google_chat + 19 others; pointing it at an empty dir → empty set (env precedence over source-tree fallback confirmed)
- `py_compile` clean