### PR TITLE
fix(slack): route async/cron deliveries to the intended home channel/thread

### DIFF
--- a/contributors/emails/esther@feedmob.com
+++ b/contributors/emails/esther@feedmob.com
@@ -1,0 +1,1 @@
+Esther-Zhu023

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1612,6 +1612,31 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             )
             in_channel_surface = False
 
+        if in_channel_surface and mirror_this_target and runtime_adapter is not None:
+            # Force flat delivery (D2): the continuable-channel target must
+            # ignore any inherited origin/target thread_id, or the flat
+            # continuable session seeded below (thread_id=None, via
+            # _seed_cron_channel_session) never matches where the brief is
+            # actually delivered — route_thread_id further down in this loop
+            # reads `thread_id` and would otherwise route into the origin
+            # thread instead of flat into the channel.
+            #
+            # Scoped to EXACTLY the target that gets flat-seeded: the origin-
+            # continuable target (`mirror_this_target`) on a live, in_channel-
+            # capable adapter. The `runtime_adapter is not None` guard keeps
+            # this in lockstep with the D6 capability fail-safe (which only runs
+            # with a live adapter) and with the seed itself
+            # (`in_channel_surface and mirror_this_target`, inside the
+            # live-adapter block below): fan-out / broadcast / explicit-thread
+            # targets keep their thread_id (they are not continuable and are
+            # never seeded), and the standalone no-adapter path falls back to
+            # thread delivery — it can never seed the flat session, so
+            # flattening there would drop the brief out of any continuable lane
+            # while also bypassing the D6 capability check. Placed AFTER
+            # mirror_this_target / origin_user_id are computed above — those
+            # need the ORIGINAL thread_id to match the origin conversation.
+            thread_id = None
+
         # For an in_channel delivery the flat continuation session is created
         # explicitly below (the shipped mirror only APPENDS to an existing
         # session, and the flat channel row is otherwise absent for a

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1192,6 +1192,16 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
         except Exception:
             pass
 
+        if (
+            thread_id is None
+            and platform_key == "slack"
+            and origin
+            and str(origin.get("platform") or "").lower() == platform_key
+            and str(origin.get("chat_id")) == str(chat_id)
+            and origin.get("thread_id")
+        ):
+            thread_id = origin.get("thread_id")
+
         return {
             "platform": platform_name,
             "chat_id": chat_id,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1579,6 +1579,19 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # Prefer the live adapter when the gateway is running — this supports E2EE
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
         runtime_adapter = (adapters or {}).get(platform)
+        # The live-send path (which SEEDS the flat in_channel continuation
+        # session via _seed_cron_channel_session) needs not just a live adapter
+        # but a running event loop to schedule the async send onto. Compute that
+        # gate ONCE so the in_channel thread_id clear below stays in lockstep
+        # with the live-send/seed block further down (they used to drift): an
+        # adapter can be present while the loop is absent/not-running, in which
+        # case the live-send block is skipped and delivery falls through to the
+        # standalone path — which cannot seed the flat session (r3609147550).
+        live_adapter_ready = (
+            runtime_adapter is not None
+            and loop is not None
+            and getattr(loop, "is_running", lambda: False)()
+        )
         delivered = False
         target_errors = []
 
@@ -1612,7 +1625,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             )
             in_channel_surface = False
 
-        if in_channel_surface and mirror_this_target and runtime_adapter is not None:
+        if in_channel_surface and mirror_this_target and live_adapter_ready:
             # Force flat delivery (D2): the continuable-channel target must
             # ignore any inherited origin/target thread_id, or the flat
             # continuable session seeded below (thread_id=None, via
@@ -1621,18 +1634,20 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             # reads `thread_id` and would otherwise route into the origin
             # thread instead of flat into the channel.
             #
-            # Scoped to EXACTLY the target that gets flat-seeded: the origin-
-            # continuable target (`mirror_this_target`) on a live, in_channel-
-            # capable adapter. The `runtime_adapter is not None` guard keeps
-            # this in lockstep with the D6 capability fail-safe (which only runs
-            # with a live adapter) and with the seed itself
-            # (`in_channel_surface and mirror_this_target`, inside the
-            # live-adapter block below): fan-out / broadcast / explicit-thread
-            # targets keep their thread_id (they are not continuable and are
-            # never seeded), and the standalone no-adapter path falls back to
-            # thread delivery — it can never seed the flat session, so
-            # flattening there would drop the brief out of any continuable lane
-            # while also bypassing the D6 capability check. Placed AFTER
+            # Gated on `live_adapter_ready` (adapter present AND a running loop)
+            # so the clear fires ONLY on the live-send path that actually seeds
+            # the flat session — the SAME condition as the live-send block
+            # below. `runtime_adapter is not None` alone is broader than that
+            # path: an adapter can be present while the event loop is absent or
+            # not running, in which case the live-send/seed block is skipped and
+            # delivery falls through to the standalone path. Clearing thread_id
+            # there would flatten a brief into a channel with NO seeded
+            # continuable session behind it (and bypass the D6 capability
+            # check), so the standalone fallback must keep the origin thread
+            # (review r3609147550).
+            #
+            # Fan-out / broadcast / explicit-thread targets keep their thread_id
+            # (they are not continuable and are never seeded). Placed AFTER
             # mirror_this_target / origin_user_id are computed above — those
             # need the ORIGINAL thread_id to match the origin conversation.
             thread_id = None
@@ -1689,7 +1704,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 thread_id = new_thread_id
                 opened_thread_id = new_thread_id
 
-        if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
+        if live_adapter_ready:
             # Telegram topic routing (#22773, regression fixed #52060): a
             # ``telegram:<positive_chat_id>:<numeric_thread_id>`` cron target is
             # ambiguous — a forum-style topic in a private chat and a genuine

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1200,6 +1200,13 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
 
     platform_name = deliver_value
     if origin and origin.get("platform") == platform_name:
+        chat_id = _get_home_target_chat_id(platform_name)
+        if chat_id:
+            return {
+                "platform": platform_name,
+                "chat_id": chat_id,
+                "thread_id": _get_home_target_thread_id(platform_name),
+            }
         return {
             "platform": platform_name,
             "chat_id": str(origin["chat_id"]),

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6259,6 +6259,58 @@ async def _standalone_send(
                 exc_info=True,
             )
 
+    # Out-of-process cron runs have no live SlackAdapter.  Upload MEDIA files
+    # here so the standalone path has feature parity with the live adapter
+    # instead of silently succeeding with text only.  This runs BEFORE the
+    # empty-text skip: a media delivery with a blank caption must still
+    # upload the files.
+    if media_files:
+        if not check_slack_requirements():
+            return {"error": "Slack send failed: slack-sdk is not installed"}
+
+        paths = []
+        for media in media_files:
+            path = media[0] if isinstance(media, (tuple, list)) else media
+            path = str(path)
+            if not os.path.isfile(path):
+                return {"error": f"Slack media file not found: {os.path.basename(path)}"}
+            paths.append(path)
+
+        try:
+            client = AsyncWebClient(token=token)  # pyright: ignore[reportCallIssue]
+            _apply_slack_proxy(client, resolve_proxy_url())
+            upload_result = None
+            for start in range(0, len(paths), 10):
+                batch = paths[start : start + 10]
+                kwargs = {
+                    "channel": chat_id,
+                    "initial_comment": formatted if start == 0 else "",
+                    "thread_ts": thread_id,
+                }
+                if len(batch) == 1:
+                    kwargs.update(
+                        file=batch[0],
+                        filename=os.path.basename(batch[0]),
+                    )
+                else:
+                    kwargs["file_uploads"] = [
+                        {"file": path, "filename": os.path.basename(path)}
+                        for path in batch
+                    ]
+                upload_result = await client.files_upload_v2(**kwargs)
+            return {
+                "success": True,
+                "platform": "slack",
+                "chat_id": chat_id,
+                "message_id": (
+                    upload_result.get("ts")
+                    if upload_result is not None and hasattr(upload_result, "get")
+                    else None
+                ),
+            }
+        except Exception as e:
+            return {"error": f"Slack media upload failed: {e}"}
+
     if not formatted or not formatted.strip():
         logger.debug("[Slack] _standalone_send: skipping empty/whitespace message")
         return {
@@ -6273,7 +6325,7 @@ async def _standalone_send(
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
 
     try:
-        from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+        from gateway.platforms.base import proxy_kwargs_for_aiohttp
 
         _proxy = resolve_proxy_url()
         _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2188,6 +2188,13 @@ class SlackAdapter(BasePlatformAdapter):
         thread replies.  Messages that originate inside an existing thread are
         always replied to in-thread to preserve conversation context.
         """
+        # Guard: async/cron deliveries (reply_to=None) should always go to
+        # the home/target channel, never to a stale thread context captured
+        # in metadata.  Only real replies to inbound messages preserve thread
+        # routing.
+        if reply_to is None:
+            return None
+
         # When reply_in_thread is disabled (default: True for backward compat),
         # only thread messages that are already part of an existing thread.
         # For top-level channel messages, the inbound handler sets

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6224,6 +6224,60 @@ class SlackAdapter(BasePlatformAdapter):
 # ──────────────────────────────────────────────────────────────────────────
 
 
+# Cache for Slack user ID -> DM conversation ID resolution in the standalone
+# send path.  Keyed by "{token}:{user_id}" to support multi-workspace setups.
+_slack_dm_cache: Dict[str, str] = {}
+
+
+async def _resolve_slack_user_dm(token: str, user_id: str) -> Optional[str]:
+    """Resolve a Slack user ID (U.../W...) to a DM conversation ID (D...).
+
+    ``chat.postMessage`` and ``files_upload_v2`` require a conversation ID; a
+    DM must be opened first via ``conversations.open``.  Results are cached
+    per (token, user_id) pair to avoid redundant API calls.  Returns None if
+    resolution fails (missing ``im:write`` scope, unknown user, etc.).
+    """
+    cache_key = f"{token}:{user_id}"
+    if cache_key in _slack_dm_cache:
+        return _slack_dm_cache[cache_key]
+
+    try:
+        import aiohttp
+    except ImportError:
+        return None
+    try:
+        from gateway.platforms.base import proxy_kwargs_for_aiohttp
+
+        _proxy = resolve_proxy_url()
+        _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
+        url = "https://slack.com/api/conversations.open"
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=15), **_sess_kw
+        ) as session:
+            payload = {"users": user_id}
+            async with session.post(
+                url, headers=headers, json=payload, **_req_kw
+            ) as resp:
+                data = await resp.json()
+                if data.get("ok") and data.get("channel", {}).get("id"):
+                    channel_id = data["channel"]["id"]
+                    _slack_dm_cache[cache_key] = channel_id
+                    return channel_id
+                logger.warning(
+                    "[Slack] conversations.open failed for %s: %s",
+                    user_id,
+                    data.get("error", "unknown"),
+                )
+                return None
+    except Exception as e:
+        logger.warning("[Slack] conversations.open exception for %s: %s", user_id, e)
+        return None
+
+
 async def _standalone_send(
     pconfig,
     chat_id,
@@ -6247,6 +6301,22 @@ async def _standalone_send(
     token = getattr(pconfig, "token", None) or os.getenv("SLACK_BOT_TOKEN", "")
     if not token:
         return {"error": "Slack send failed: SLACK_BOT_TOKEN not configured"}
+
+    # User-targeted delivery: chat.postMessage / files_upload_v2 reject bare
+    # user IDs (U.../W...) — resolve to a DM conversation ID (D...) first via
+    # conversations.open so `deliver=slack:U…` cron jobs reach the user's DM
+    # instead of failing with channel_not_found (#17444).
+    chat_id = str(chat_id or "")
+    if chat_id[:1] in ("U", "W"):
+        resolved = await _resolve_slack_user_dm(token, chat_id)
+        if resolved is None:
+            return {
+                "error": (
+                    f"Slack user ID resolution failed for {chat_id} "
+                    "(conversations.open — check the bot's im:write scope)"
+                )
+            }
+        chat_id = resolved
 
     formatted = message
     if message:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2188,13 +2188,6 @@ class SlackAdapter(BasePlatformAdapter):
         thread replies.  Messages that originate inside an existing thread are
         always replied to in-thread to preserve conversation context.
         """
-        # Guard: async/cron deliveries (reply_to=None) should always go to
-        # the home/target channel, never to a stale thread context captured
-        # in metadata.  Only real replies to inbound messages preserve thread
-        # routing.
-        if reply_to is None:
-            return None
-
         # When reply_in_thread is disabled (default: True for backward compat),
         # only thread messages that are already part of an existing thread.
         # For top-level channel messages, the inbound handler sets

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -4754,6 +4754,78 @@ class TestCronContinuableSurfaceInChannel:
         mirror_mock.assert_called_once()
         assert mirror_mock.call_args.kwargs.get("thread_id") is None
 
+    def test_in_channel_from_origin_thread_delivers_flat_not_to_thread(self):
+        """Regression: a job scheduled from INSIDE a Slack thread (origin carries
+        a thread_id) must still deliver FLAT when cron_continuable_surface is
+        in_channel — not into the origin thread. Without clearing the inherited
+        thread_id, the live-adapter route (DeliveryRouter._deliver_to_platform)
+        folds target.thread_id into send_metadata['thread_id'], so the brief
+        would land in the origin thread while the seeded continuable session
+        (thread_id=None, asserted above) never matches where it actually went."""
+        adapter = self._slack_adapter(supports_inchannel=True)
+        _, mirror_mock = self._run_inchannel_delivery(
+            {"cron_continuable_surface": "in_channel"}, adapter,
+            origin={
+                "platform": "slack", "chat_id": "C123", "user_id": "U_HUMAN",
+                "thread_id": "999.888",
+            },
+        )
+        # The thread-open branch must still be skipped (in_channel behavior).
+        adapter.send.assert_awaited_once()
+        _, send_kwargs = adapter.send.await_args
+        send_metadata = send_kwargs.get("metadata") or {}
+        assert "thread_id" not in send_metadata, (
+            "in_channel delivery must be flat — the origin's thread_id must "
+            "not be forwarded to the adapter, even though the job was "
+            "scheduled from inside that thread"
+        )
+        # The seeded continuable session must match where the brief actually
+        # landed: flat (thread_id=None), not the origin thread.
+        adapter._session_store.get_or_create_session.assert_called_once()
+        seeded = adapter._session_store.get_or_create_session.call_args[0][0]
+        assert seeded.thread_id is None
+        mirror_mock.assert_called_once()
+        assert mirror_mock.call_args.kwargs.get("thread_id") is None
+
+    def test_in_channel_standalone_no_adapter_preserves_origin_thread(self):
+        """Fail-safe (D6 bypass guard): with NO live adapter, an
+        in_channel-configured job must NOT be flattened. The flat continuable
+        session can only be seeded on the live-adapter path, and the D6
+        capability check can't run without an adapter — so the standalone send
+        must fall back to the origin thread rather than silently flattening
+        (which would bypass D6 and drop the brief out of any continuable lane).
+        Scoping the thread_id clear to `runtime_adapter is not None` keeps the
+        clear in lockstep with the seed and the D6 fail-safe."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        pconfig.extra = {"cron_continuable_surface": "in_channel"}
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.SLACK: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform",
+                   new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "brief-job",
+                "name": "Daily Brief",
+                "deliver": "origin",
+                "origin": {
+                    "platform": "slack", "chat_id": "C123",
+                    "user_id": "U_HUMAN", "thread_id": "999.888",
+                },
+            }
+            # No adapters/loop → standalone (no-live-adapter) delivery path.
+            _deliver_result(job, "Here is today's brief.")
+
+        send_mock.assert_called_once()
+        assert send_mock.call_args.kwargs.get("thread_id") == "999.888", (
+            "standalone in_channel delivery must fall back to the origin thread "
+            "(no live adapter can seed a flat continuable session), not flatten"
+        )
+
     def test_thread_mode_default_still_opens_thread(self):
         """G1 regression: the default (thread) mode is byte-identical — the
         thread-open branch still fires when no surface key is set."""

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -378,6 +378,54 @@ class TestResolveDeliveryTarget:
             "thread_id": None,
         }
 
+    def test_explicit_slack_same_channel_preserves_origin_thread_id(self):
+        job = {
+            "deliver": "slack:C0B3KEP3SD6",
+            "origin": {
+                "platform": "slack",
+                "chat_id": "C0B3KEP3SD6",
+                "thread_id": "1778485067.844139",
+            },
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "slack",
+            "chat_id": "C0B3KEP3SD6",
+            "thread_id": "1778485067.844139",
+        }
+
+    def test_explicit_slack_other_channel_does_not_inherit_origin_thread_id(self):
+        job = {
+            "deliver": "slack:COTHERCHAN",
+            "origin": {
+                "platform": "slack",
+                "chat_id": "C0B3KEP3SD6",
+                "thread_id": "1778485067.844139",
+            },
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "slack",
+            "chat_id": "COTHERCHAN",
+            "thread_id": None,
+        }
+
+    def test_explicit_slack_thread_target_overrides_origin_thread_id(self):
+        job = {
+            "deliver": "slack:C0B3KEP3SD6:1778500000.000001",
+            "origin": {
+                "platform": "slack",
+                "chat_id": "C0B3KEP3SD6",
+                "thread_id": "1778485067.844139",
+            },
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "slack",
+            "chat_id": "C0B3KEP3SD6",
+            "thread_id": "1778500000.000001",
+        }
+
     def test_bare_platform_uses_matching_origin_chat(self):
         job = {
             "deliver": "telegram",
@@ -1656,6 +1704,65 @@ class TestRunJobSessionPersistence:
             "platform": "telegram",
             "chat_id": "-2002",
             "thread_id": None,
+        }
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_PLATFORM") is None
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID") is None
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
+        fake_db.close.assert_called_once()
+
+    def test_run_job_preserves_slack_origin_thread_for_same_explicit_channel(self, tmp_path, monkeypatch):
+        job = {
+            "id": "slack-thread-job",
+            "name": "slack-thread",
+            "prompt": "hello",
+            "deliver": "slack:C0B3KEP3SD6",
+            "origin": {
+                "platform": "slack",
+                "chat_id": "C0B3KEP3SD6",
+                "thread_id": "1778485067.844139",
+            },
+        }
+        fake_db = MagicMock()
+        seen = {}
+
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID", raising=False)
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_conversation(self, *args, **kwargs):
+                from gateway.session_context import get_session_env
+
+                seen["platform"] = get_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM") or None
+                seen["chat_id"] = get_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID") or None
+                seen["thread_id"] = get_session_env("HERMES_CRON_AUTO_DELIVER_THREAD_ID") or None
+                return {"final_response": "ok"}
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent", FakeAgent):
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert "ok" in output
+        assert seen == {
+            "platform": "slack",
+            "chat_id": "C0B3KEP3SD6",
+            "thread_id": "1778485067.844139",
         }
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_PLATFORM") is None
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID") is None

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -4826,6 +4826,67 @@ class TestCronContinuableSurfaceInChannel:
             "(no live adapter can seed a flat continuable session), not flatten"
         )
 
+    def test_in_channel_adapter_present_but_loop_not_running_preserves_origin_thread(self):
+        """Regression (review r3609147550): the thread_id clear must be scoped to
+        the FULL live-send condition (adapter present AND a running loop), not
+        just ``runtime_adapter is not None``. An adapter can be present while the
+        event loop is absent/not-running — then the live-send block that seeds
+        the flat continuable session (``_seed_cron_channel_session``) is SKIPPED
+        and delivery falls through to the standalone path. Clearing thread_id in
+        that case would flatten an UNSEEDED brief (no continuable session behind
+        it) and bypass the D6 capability check, so the standalone fallback must
+        keep the origin thread. Bites an unscoped clear AND a partial fix that
+        adds ``loop is not None`` but omits ``loop.is_running()``."""
+        from gateway.config import Platform
+
+        adapter = self._slack_adapter(supports_inchannel=True)
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        pconfig.extra = {"cron_continuable_surface": "in_channel"}
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.SLACK: pconfig}
+
+        # Live adapter present, but the event loop is NOT running — the middle
+        # state between the live-send path and the no-adapter standalone path.
+        # ``runtime_adapter is not None`` is true here (so an unscoped clear
+        # would wrongly flatten); ``live_adapter_ready`` is false.
+        loop = MagicMock()
+        loop.is_running.return_value = False
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform",
+                   new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "brief-job",
+                "name": "Daily Brief",
+                "deliver": "origin",
+                # attach_to_session=True → mirror_this_target is True, so the
+                # (buggy) clear guard would actually fire without the loop gate.
+                "attach_to_session": True,
+                "origin": {
+                    "platform": "slack", "chat_id": "C123",
+                    "user_id": "U_HUMAN", "thread_id": "999.888",
+                },
+            }
+            _deliver_result(
+                job, "Here is today's brief.",
+                adapters={Platform.SLACK: adapter}, loop=loop,
+            )
+
+        # The live-send block never ran (loop not running): the flat session was
+        # never seeded and the adapter was never used to send.
+        adapter.send.assert_not_awaited()
+        adapter._session_store.get_or_create_session.assert_not_called()
+        # Standalone fallback must preserve the origin thread, not flatten.
+        send_mock.assert_called_once()
+        assert send_mock.call_args.kwargs.get("thread_id") == "999.888", (
+            "in_channel delivery with an adapter but no running loop must fall "
+            "back to the origin thread — the live-send block that seeds the flat "
+            "continuable session never ran, so flattening would leave an "
+            "unseeded brief"
+        )
+
     def test_thread_mode_default_still_opens_thread(self):
         """G1 regression: the default (thread) mode is byte-identical — the
         thread-open branch still fires when no surface key is set."""

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -217,6 +217,25 @@ class TestResolveDeliveryTarget:
             "thread_id": "topic-7",
         }
 
+    def test_bare_platform_delivery_uses_home_root_instead_of_origin_thread(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL", "home-parent")
+        monkeypatch.delenv("DISCORD_HOME_CHANNEL_THREAD_ID", raising=False)
+
+        job = {
+            "deliver": "discord",
+            "origin": {
+                "platform": "discord",
+                "chat_id": "origin-parent",
+                "thread_id": "origin-thread",
+            },
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "discord",
+            "chat_id": "home-parent",
+            "thread_id": None,
+        }
+
     def test_telegram_cron_thread_id_overrides_home_thread_id(self, monkeypatch):
         """TELEGRAM_CRON_THREAD_ID wins over TELEGRAM_HOME_CHANNEL_THREAD_ID for cron (#24409)."""
         monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-1001234567890")

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1224,6 +1224,140 @@ class TestStandaloneSendMedia:
 
 
 # ---------------------------------------------------------------------------
+# TestStandaloneSendUserDmResolution
+# ---------------------------------------------------------------------------
+
+
+class TestStandaloneSendUserDmResolution:
+    """_standalone_send resolves user IDs (U.../W...) to DM channels via
+    conversations.open before posting (#17444). Cron `deliver=slack:U…`
+    bypasses send_message()'s tool-level resolution, so the standalone
+    sender must resolve on its own."""
+
+    @staticmethod
+    def _mock_resp(payload):
+        resp = MagicMock()
+        resp.status = 200
+        resp.json = AsyncMock(return_value=payload)
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=None)
+        return resp
+
+    def _mock_session(self, *responses):
+        session = MagicMock()
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=None)
+        session.post = MagicMock(side_effect=list(responses))
+        return session
+
+    @pytest.mark.asyncio
+    async def test_user_id_target_resolves_dm_then_posts(self):
+        _slack_mod._slack_dm_cache.clear()
+        open_resp = self._mock_resp({"ok": True, "channel": {"id": "D999888777"}})
+        post_resp = self._mock_resp({"ok": True, "ts": "123.456"})
+        session = self._mock_session(open_resp, post_resp)
+        config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+
+        with patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session):
+            result = await _slack_mod._standalone_send(
+                config, "U1234567890", "hello via DM"
+            )
+
+        assert result["success"] is True
+        assert result["chat_id"] == "D999888777"
+        open_url = session.post.call_args_list[0].args[0]
+        assert "conversations.open" in open_url
+        assert session.post.call_args_list[0].kwargs["json"] == {"users": "U1234567890"}
+        post_url = session.post.call_args_list[1].args[0]
+        assert "chat.postMessage" in post_url
+        assert session.post.call_args_list[1].kwargs["json"]["channel"] == "D999888777"
+        _slack_mod._slack_dm_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_channel_id_skips_resolution(self):
+        _slack_mod._slack_dm_cache.clear()
+        post_resp = self._mock_resp({"ok": True, "ts": "123.456"})
+        session = self._mock_session(post_resp)
+        config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+
+        with patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session):
+            result = await _slack_mod._standalone_send(config, "C123", "hello channel")
+
+        assert result["success"] is True
+        assert session.post.call_count == 1
+        assert "chat.postMessage" in session.post.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_user_id_resolution_failure_returns_error(self):
+        _slack_mod._slack_dm_cache.clear()
+        open_resp = self._mock_resp({"ok": False, "error": "user_not_found"})
+        session = self._mock_session(open_resp)
+        config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+
+        with patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session):
+            result = await _slack_mod._standalone_send(config, "U9999999999", "hello")
+
+        assert "error" in result
+        assert "user ID resolution failed" in result["error"]
+        assert session.post.call_count == 1
+        assert "conversations.open" in session.post.call_args.args[0]
+        _slack_mod._slack_dm_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_user_id_resolution_cached_across_sends(self):
+        _slack_mod._slack_dm_cache.clear()
+        open_resp = self._mock_resp({"ok": True, "channel": {"id": "D555444333"}})
+        post_resp1 = self._mock_resp({"ok": True, "ts": "1.1"})
+        session1 = self._mock_session(open_resp, post_resp1)
+        config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+
+        with patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session1):
+            r1 = await _slack_mod._standalone_send(config, "U1112223334", "first")
+        assert r1["success"] is True
+        assert session1.post.call_count == 2
+
+        post_resp2 = self._mock_resp({"ok": True, "ts": "2.2"})
+        session2 = self._mock_session(post_resp2)
+        with patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session2):
+            r2 = await _slack_mod._standalone_send(config, "U1112223334", "second")
+        assert r2["success"] is True
+        assert r2["chat_id"] == "D555444333"
+        assert session2.post.call_count == 1  # cache hit — no conversations.open
+        _slack_mod._slack_dm_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_user_id_media_delivery_resolves_dm_before_upload(self, tmp_path):
+        """Media path composes with DM resolution: files_upload_v2 gets D…"""
+        _slack_mod._slack_dm_cache.clear()
+        image = tmp_path / "report.png"
+        image.write_bytes(b"\x89PNG\r\n\x1a\n")
+        open_resp = self._mock_resp({"ok": True, "channel": {"id": "D777666555"}})
+        session = self._mock_session(open_resp)
+        client = MagicMock()
+        client.files_upload_v2 = AsyncMock(return_value={"ok": True, "ts": "9.9"})
+        config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
+            patch.object(_slack_mod, "AsyncWebClient", return_value=client),
+            patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
+        ):
+            result = await _slack_mod._standalone_send(
+                config,
+                "U1234509876",
+                "daily report",
+                thread_id=None,
+                media_files=[(str(image), False)],
+            )
+
+        assert result["success"] is True
+        assert result["chat_id"] == "D777666555"
+        client.files_upload_v2.assert_awaited_once()
+        assert client.files_upload_v2.await_args.kwargs["channel"] == "D777666555"
+        _slack_mod._slack_dm_cache.clear()
+
+
+# ---------------------------------------------------------------------------
 # TestSendDocument
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1180,6 +1180,50 @@ class TestSlackProxyBehavior:
 
 
 # ---------------------------------------------------------------------------
+# TestStandaloneSendMedia
+# ---------------------------------------------------------------------------
+
+
+class TestStandaloneSendMedia:
+    @pytest.mark.asyncio
+    async def test_uploads_local_media_with_message_as_caption(self, tmp_path):
+        """Standalone cron sends should use files_upload_v2, not omit the image."""
+        image = tmp_path / "daily-report.png"
+        image.write_bytes(b"\x89PNG\r\n\x1a\n")
+        client = MagicMock()
+        client.files_upload_v2 = AsyncMock(
+            return_value={"ok": True, "files": [{"id": "F123"}]}
+        )
+        config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+
+        with (
+            patch.object(_slack_mod, "AsyncWebClient", return_value=client),
+            patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
+            patch.object(
+                _slack_mod.aiohttp,
+                "ClientSession",
+                side_effect=AssertionError("media delivery used text-only chat.postMessage"),
+            ),
+        ):
+            result = await _slack_mod._standalone_send(
+                config,
+                "C123",
+                "daily report",
+                thread_id=None,
+                media_files=[(str(image), False)],
+            )
+
+        assert result["success"] is True
+        client.files_upload_v2.assert_awaited_once_with(
+            channel="C123",
+            file=str(image),
+            filename="daily-report.png",
+            initial_comment="daily report",
+            thread_ts=None,
+        )
+
+
+# ---------------------------------------------------------------------------
 # TestSendDocument
 # ---------------------------------------------------------------------------
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -755,6 +755,44 @@ class TestSendToPlatformChunking:
             thread_ts=None,
         )
 
+    def test_slack_media_is_forwarded_to_standalone_plugin(self, monkeypatch, tmp_path):
+        """Out-of-process cron delivery must not silently drop Slack MEDIA files."""
+        _ensure_slack_mock(monkeypatch)
+        media_path = tmp_path / "daily-report.png"
+        media_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+        media_files = [(str(media_path), False)]
+        pconfig = SimpleNamespace(enabled=True, token="***", extra={})
+
+        entry = _slack_entry()
+        assert entry is not None
+        original = entry.standalone_sender_fn
+        send = AsyncMock(
+            return_value={"success": True, "platform": "slack", "message_id": "1"}
+        )
+        entry.standalone_sender_fn = send
+        try:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    pconfig,
+                    "C123",
+                    "daily report",
+                    media_files=media_files,
+                )
+            )
+        finally:
+            entry.standalone_sender_fn = original
+
+        assert result["success"] is True
+        send.assert_awaited_once_with(
+            pconfig,
+            "C123",
+            "daily report",
+            thread_id=None,
+            media_files=media_files,
+            force_document=False,
+        )
+
     def test_slack_bold_italic_formatted_before_send(self, monkeypatch):
         """Bold+italic ***text*** survives tool-layer formatting."""
         _ensure_slack_mock(monkeypatch)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1032,6 +1032,32 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Slack: route both text and native files through the plugin's
+    # standalone sender.  This path is used by out-of-process cron runs where
+    # no live gateway adapter is available; dropping ``media_files`` here made
+    # MEDIA directives disappear while the text delivery still reported
+    # success.
+    if platform == Platform.SLACK:
+        from gateway.platform_registry import platform_registry
+        entry = platform_registry.get("slack")
+        if entry is None or entry.standalone_sender_fn is None:
+            return {"error": "Slack plugin not registered or missing standalone_sender_fn"}
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = i == len(chunks) - 1
+            result = await entry.standalone_sender_fn(
+                pconfig,
+                chat_id,
+                chunk,
+                thread_id=thread_id,
+                media_files=media_files if is_last else [],
+                force_document=force_document,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
@@ -1049,19 +1075,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
 
     last_result = None
     for chunk in chunks:
-        if platform == Platform.SLACK:
-            # Slack migrated to a bundled plugin (#41112); delivery flows
-            # through the registry's standalone_sender_fn, which applies
-            # mrkdwn formatting and posts via the Slack Web API.
-            from gateway.platform_registry import platform_registry
-            _slack_entry = platform_registry.get("slack")
-            if _slack_entry is None or _slack_entry.standalone_sender_fn is None:
-                result = {"error": "Slack plugin not registered or missing standalone_sender_fn"}
-            else:
-                result = await _slack_entry.standalone_sender_fn(
-                    pconfig, chat_id, chunk, thread_id=thread_id
-                )
-        elif platform == Platform.WHATSAPP:
+        if platform == Platform.WHATSAPP:
             result = await _registry_standalone_send("whatsapp", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.SIGNAL:
             result = await _send_signal(pconfig.extra, chat_id, chunk)


### PR DESCRIPTION
## Summary
Async/cron deliveries to Slack now land where intended: bare `deliver=slack` targets the home channel instead of a stale origin thread, `in_channel` deliveries clear inherited thread state, explicit same-channel targets keep their origin thread, user-ID targets open DMs, and media survives standalone delivery.

Fixes #59097.

## Changes
- cron: bare-platform `deliver=slack` prefers home channel over stale origin thread (#59194 — note its adapter-side guard self-reverted in favor of the cron-side fix; net adapter diff zero); `in_channel` clears inherited thread_id, scoped to the live-send/seed gate so the standalone fallback keeps origin (#65790).
- adapter: explicit `slack:<same-channel>` targets re-inherit origin thread (#36680); `slack:U…`/`W…` user targets resolve to DM channels via `conversations.open`, per-token cached (#17444, reimplemented onto the plugin architecture with author attribution); MEDIA uploads via `files_upload_v2` on the standalone path, placed before the empty-text skip so blank-caption media still sends (#68616).
- Design rule respected: no cron→session mirroring introduced.

## Credits
Salvaged with authorship preserved: #65790 (@vb3), #59194 (@wesleysimplicio), #36680 (@jakelongvu-bot — verified human git identity), #68616 (@kandotrun), #17444 (@Esther-Zhu023, reimplemented with `--author`).
Deferred: #54598 (@RxChi1d) — different bug class (undeliverable-target redirect at fire time, 980-line cross-platform feature); complements this cluster, recommend separate salvage.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/gateway/ -q -k 'slack or cron'` | 656 passed, 0 failed |
| scheduler + slack + send_message_tool targeted suites | 661 passed |
| Re-verified post-rebase by parent session | green |

## Infographic

![slack-cron-delivery](https://v3b.fal.media/files/b/0aa34a28/CzKdu2TPc_HM8g-3xynD2_Gi375nrP.png)
