### PR TITLE
fix(desktop): add overflow clipping to notification detail pre block

### DIFF
--- a/apps/desktop/src/components/notifications.tsx
+++ b/apps/desktop/src/components/notifications.tsx
@@ -225,7 +225,7 @@ function NotificationDetail({ detail }: { detail: string }) {
       <summary className="select-none font-medium text-muted-foreground hover:text-foreground">{copy.details}</summary>
       <div className="mt-1 rounded-md bg-background/65 p-2">
         <pre
-          className="max-h-32 whitespace-pre-wrap wrap-break-word font-mono text-[0.6875rem] leading-relaxed"
+          className="max-h-32 overflow-y-auto pe-1 whitespace-pre-wrap wrap-break-word font-mono text-[0.6875rem] leading-relaxed"
           data-selectable-text="true"
         >
           {detail}


### PR DESCRIPTION
## Summary

Fixes a CSS overflow bug in the notification toast's detail panel where long error text (like the STT provider-not-found message) overflows its `max-h-32` container and overlaps the "Copy detail" button.

The `<pre>` element had `max-h-32` but no `overflow` property, so when text exceeded the max height, it visually overflowed the box and bled into the button below.

## Fix

One line — add `overflow-y-auto pe-1` to the `<pre>` className in `NotificationDetail`:

```diff
-          className="max-h-32 whitespace-pre-wrap wrap-break-word font-mono text-[0.6875rem] leading-relaxed"
+          className="max-h-32 overflow-y-auto pe-1 whitespace-pre-wrap wrap-break-word font-mono text-[0.6875rem] leading-relaxed"
```

- `overflow-y-auto` — clips content at `max-h-32`, shows vertical scrollbar only when content exceeds
- `pe-1` (`padding-inline-end`) — keeps monospace text clear of the scrollbar track, RTL-safe

## Verification

- `NotificationDetail` has a single caller (`NotificationItem` line 188) — no other consumers affected
- `overflow-y-auto` only renders a scrollbar when content exceeds `max-h-32`; short messages are unaffected
- Cross-vendor reviewed by Gemini 3.6 Flash + GPT-OSS 120B — both confirm the fix is safe

Fixes #69478
