### PR TITLE
fix(slack): media delivery — send_message MEDIA, DM targets, explicit post-stream uploads, workspace-scoped files

### DIFF
--- a/contributors/emails/rob@zolkos.com
+++ b/contributors/emails/rob@zolkos.com
@@ -1,0 +1,1 @@
+robzolkos

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14944,11 +14944,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         event: MessageEvent,
         adapter,
     ) -> None:
-        """Extract MEDIA: tags and local file paths from a response and deliver them.
+        """Extract explicit MEDIA: tags from a response and deliver them.
 
         Called after streaming has already sent the text to the user, so the
         text itself is already delivered — this only handles file attachments
         that the normal _process_message_background path would have caught.
+
+        Unlike the non-streaming path in ``gateway/platforms/base.py`` (which
+        also auto-detects bare local paths via ``extract_local_files``), this
+        post-stream rescan is EXPLICIT-ONLY. The visible reply has already
+        been streamed verbatim, so a bare path string here was either (a)
+        already shown to the user as text, or (b) stale tool/inspected
+        content that was never part of the intended visible reply. Promoting
+        such paths into uploads after the fact sent files the model never
+        asked to deliver (#20834). Only ``MEDIA:`` directives — the explicit
+        attachment contract — trigger post-stream uploads.
         """
         from pathlib import Path
         from urllib.parse import quote as _quote
@@ -14964,16 +14974,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             media_files, cleaned = adapter.extract_media(response)
             media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
-            # Chain the cleaned text through each extractor (extract_media →
-            # extract_images → extract_local_files) so MEDIA: tags and image URLs
-            # are removed before the bare-path auto-detect runs. Previously the
-            # cleaned text from extract_media was dropped (``_``) and
-            # extract_local_files scanned text that still contained MEDIA: tags,
-            # producing false-positive bare-path matches with the MEDIA: prefix
-            # glued on. This matches the chain order in gateway/platforms/base.py.
-            _, cleaned = adapter.extract_images(cleaned)
-            local_files, _ = adapter.extract_local_files(cleaned)
-            local_files = BasePlatformAdapter.filter_local_delivery_paths(local_files)
+            # Strip image URLs from the cleaned text for parity with the
+            # non-streaming chain, but do NOT run extract_local_files here:
+            # post-stream delivery is explicit-only (#20834). Bare local paths
+            # in an already-streamed reply are text the user has seen (or
+            # stale inspected content), not an attachment request.
+            adapter.extract_images(cleaned)
 
             _thread_meta = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event))
 
@@ -14994,14 +15000,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     image_paths.append(media_path)
                 else:
                     non_image_media.append((media_path, is_voice))
-
-            non_image_local: list = []
-            for file_path in local_files:
-                if (Path(file_path).suffix.lower() in _IMAGE_EXTS
-                        and not force_document_attachments):
-                    image_paths.append(file_path)
-                else:
-                    non_image_local.append(file_path)
 
             if image_paths:
                 try:
@@ -15037,24 +15035,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                 except Exception as e:
                     logger.warning("[%s] Post-stream media delivery failed: %s", adapter.name, e)
-
-            for file_path in non_image_local:
-                try:
-                    ext = Path(file_path).suffix.lower()
-                    if ext in _VIDEO_EXTS:
-                        await adapter.send_video(
-                            chat_id=event.source.chat_id,
-                            video_path=file_path,
-                            metadata=_thread_meta,
-                        )
-                    else:
-                        await adapter.send_document(
-                            chat_id=event.source.chat_id,
-                            file_path=file_path,
-                            metadata=_thread_meta,
-                        )
-                except Exception as e:
-                    logger.warning("[%s] Post-stream file delivery failed: %s", adapter.name, e)
 
         except Exception as e:
             logger.warning("Post-stream media extraction failed: %s", e)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -26,6 +26,7 @@ import time
 from collections import defaultdict
 from contextlib import suppress
 from typing import Callable, Dict, List, Optional, Any, Tuple
+from urllib.parse import urljoin
 
 from agent.async_utils import (
     consume_detached_task_result as _consume_background_task_result,
@@ -67,6 +68,8 @@ _DISCORD_NONCONVERSATIONAL_METADATA_KEYS = frozenset({
     "non_conversational",
     "non_conversational_history",
 })
+_DISCORD_IMAGE_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+_DISCORD_IMAGE_MAX_REDIRECTS = 10
 # Upgrade-bridge fallback only. The primary mechanism is the persisted
 # non-conversational message-ID set populated from explicitly marked sends
 # (metadata["non_conversational"]). These regexes exist solely to recognize
@@ -133,6 +136,43 @@ from gateway.platforms.base import (
     validate_inbound_media_size,
 )
 from tools.url_safety import is_safe_url
+
+
+async def _read_url_image_with_redirect_guard(
+    session: Any,
+    url: str,
+    *,
+    timeout: Any,
+    request_kwargs: Dict[str, Any],
+) -> Tuple[int, bytes, Dict[str, str]]:
+    """Read an image URL while re-checking every redirect target for SSRF."""
+    current_url = url
+    for _ in range(_DISCORD_IMAGE_MAX_REDIRECTS + 1):
+        if not is_safe_url(current_url):
+            raise ValueError("Blocked unsafe image URL redirect")
+
+        async with session.get(
+            current_url,
+            timeout=timeout,
+            allow_redirects=False,
+            **request_kwargs,
+        ) as resp:
+            raw_headers = getattr(resp, "headers", {}) or {}
+            headers = {str(key).lower(): value for key, value in dict(raw_headers).items()}
+            status = int(getattr(resp, "status", 0))
+            if status in _DISCORD_IMAGE_REDIRECT_STATUSES:
+                location = headers.get("location")
+                if not location:
+                    return status, b"", headers
+                next_url = urljoin(current_url, str(location))
+                if not is_safe_url(next_url):
+                    raise ValueError("Blocked redirect to private/internal address")
+                current_url = next_url
+                continue
+
+            return status, await resp.read(), headers
+
+    raise ValueError("Too many image URL redirects")
 
 
 def _truncate_discord_component_text(text: str, limit: int) -> str:
@@ -3396,25 +3436,27 @@ class DiscordAdapter(BasePlatformAdapter):
                             _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
                             if aiohttp_session is None:
                                 aiohttp_session = _aiohttp.ClientSession(**_sess_kw)
-                            async with aiohttp_session.get(
-                                image_url, timeout=_aiohttp.ClientTimeout(total=30), **_req_kw,
-                            ) as resp:
-                                if resp.status != 200:
-                                    logger.warning(
-                                        "[%s] Failed to download image (HTTP %d) in batch: %s",
-                                        self.name, resp.status, image_url[:80],
-                                    )
-                                    continue
-                                data = await resp.read()
-                                ct = resp.headers.get("content-type", "image/png")
-                                ext = "png"
-                                if "jpeg" in ct or "jpg" in ct:
-                                    ext = "jpg"
-                                elif "gif" in ct:
-                                    ext = "gif"
-                                elif "webp" in ct:
-                                    ext = "webp"
-                                files.append(_discord_mod.File(_io.BytesIO(data), filename=f"image_{len(files)}.{ext}"))
+                            status, data, headers = await _read_url_image_with_redirect_guard(
+                                aiohttp_session,
+                                image_url,
+                                timeout=_aiohttp.ClientTimeout(total=30),
+                                request_kwargs=_req_kw,
+                            )
+                            if status != 200:
+                                logger.warning(
+                                    "[%s] Failed to download image (HTTP %d) in batch: %s",
+                                    self.name, status, image_url[:80],
+                                )
+                                continue
+                            ct = headers.get("content-type", "image/png")
+                            ext = "png"
+                            if "jpeg" in ct or "jpg" in ct:
+                                ext = "jpg"
+                            elif "gif" in ct:
+                                ext = "gif"
+                            elif "webp" in ct:
+                                ext = "webp"
+                            files.append(_discord_mod.File(_io.BytesIO(data), filename=f"image_{len(files)}.{ext}"))
                         except Exception as dl_err:
                             logger.warning("[%s] Download failed for %s: %s", self.name, image_url[:80], dl_err)
                             continue
@@ -4531,37 +4573,40 @@ class DiscordAdapter(BasePlatformAdapter):
             _proxy = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
             _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
             async with aiohttp.ClientSession(**_sess_kw) as session:
-                async with session.get(image_url, timeout=aiohttp.ClientTimeout(total=30), **_req_kw) as resp:
-                    if resp.status != 200:
-                        raise Exception(f"Failed to download image: HTTP {resp.status}")
+                status, image_data, headers = await _read_url_image_with_redirect_guard(
+                    session,
+                    image_url,
+                    timeout=aiohttp.ClientTimeout(total=30),
+                    request_kwargs=_req_kw,
+                )
+                if status != 200:
+                    raise Exception(f"Failed to download image: HTTP {status}")
 
-                    image_data = await resp.read()
+                # Determine filename from URL or content type
+                content_type = headers.get("content-type", "image/png")
+                ext = "png"
+                if "jpeg" in content_type or "jpg" in content_type:
+                    ext = "jpg"
+                elif "gif" in content_type:
+                    ext = "gif"
+                elif "webp" in content_type:
+                    ext = "webp"
 
-                    # Determine filename from URL or content type
-                    content_type = resp.headers.get("content-type", "image/png")
-                    ext = "png"
-                    if "jpeg" in content_type or "jpg" in content_type:
-                        ext = "jpg"
-                    elif "gif" in content_type:
-                        ext = "gif"
-                    elif "webp" in content_type:
-                        ext = "webp"
+                import io
+                file = discord.File(io.BytesIO(image_data), filename=f"image.{ext}")
 
-                    import io
-                    file = discord.File(io.BytesIO(image_data), filename=f"image.{ext}")
-
-                    if self._is_forum_parent(channel):
-                        return await self._forum_post_file(
-                            channel,
-                            content=(caption or "").strip(),
-                            file=file,
-                        )
-
-                    msg = await channel.send(
-                        content=caption if caption else None,
+                if self._is_forum_parent(channel):
+                    return await self._forum_post_file(
+                        channel,
+                        content=(caption or "").strip(),
                         file=file,
                     )
-                    return SendResult(success=True, message_id=str(msg.id))
+
+                msg = await channel.send(
+                    content=caption if caption else None,
+                    file=file,
+                )
+                return SendResult(success=True, message_id=str(msg.id))
 
         except ImportError:
             logger.warning(
@@ -4610,27 +4655,30 @@ class DiscordAdapter(BasePlatformAdapter):
             _proxy = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
             _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
             async with aiohttp.ClientSession(**_sess_kw) as session:
-                async with session.get(animation_url, timeout=aiohttp.ClientTimeout(total=30), **_req_kw) as resp:
-                    if resp.status != 200:
-                        raise Exception(f"Failed to download animation: HTTP {resp.status}")
+                status, animation_data, _headers = await _read_url_image_with_redirect_guard(
+                    session,
+                    animation_url,
+                    timeout=aiohttp.ClientTimeout(total=30),
+                    request_kwargs=_req_kw,
+                )
+                if status != 200:
+                    raise Exception(f"Failed to download animation: HTTP {status}")
 
-                    animation_data = await resp.read()
+                import io
+                file = discord.File(io.BytesIO(animation_data), filename="animation.gif")
 
-                    import io
-                    file = discord.File(io.BytesIO(animation_data), filename="animation.gif")
-
-                    if self._is_forum_parent(channel):
-                        return await self._forum_post_file(
-                            channel,
-                            content=(caption or "").strip(),
-                            file=file,
-                        )
-
-                    msg = await channel.send(
-                        content=caption if caption else None,
+                if self._is_forum_parent(channel):
+                    return await self._forum_post_file(
+                        channel,
+                        content=(caption or "").strip(),
                         file=file,
                     )
-                    return SendResult(success=True, message_id=str(msg.id))
+
+                msg = await channel.send(
+                    content=caption if caption else None,
+                    file=file,
+                )
+                return SendResult(success=True, message_id=str(msg.id))
 
         except ImportError:
             logger.warning(

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -52,6 +52,7 @@ from gateway.platforms.base import (
     is_host_excluded_by_no_proxy,
     resolve_proxy_url,
     safe_url_for_log,
+    _ssrf_redirect_guard,
     cache_document_from_bytes,
     cache_video_from_bytes,
 )
@@ -2606,7 +2607,9 @@ class SlackAdapter(BasePlatformAdapter):
             initial_comment_parts: List[str] = []
             try:
                 async with _httpx.AsyncClient(
-                    timeout=30.0, follow_redirects=True
+                    timeout=30.0,
+                    follow_redirects=True,
+                    event_hooks={"response": [_ssrf_redirect_guard]},
                 ) as http_client:
                     for image_url, alt_text in chunk:
                         if alt_text:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4370,6 +4370,25 @@ class SlackAdapter(BasePlatformAdapter):
         # both as DM-style persistent conversations.
         is_one_to_one_dm = channel_type == "im"
 
+        # Early auth check: reject unauthorized users before any API calls
+        # (thread context fetch, user name resolution, file downloads).
+        # Pattern matches Telegram fix #54164 — gate at the adapter level
+        # BEFORE event construction consumes resources.
+        if user_id:
+            _source = self.build_source(
+                chat_id=channel_id, chat_name="",
+                chat_type="dm" if is_dm else "group",
+                user_id=user_id, user_name="",
+            )
+            _runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+            _auth_fn = getattr(_runner, "_is_user_authorized", None)
+            if callable(_auth_fn) and not _auth_fn(_source):
+                logger.warning(
+                    "[Slack] Early reject of unauthorized user %s in channel %s",
+                    user_id, channel_id,
+                )
+                return
+
         # Build thread_ts for session keying.
         # In channels: fall back to ts so each top-level @mention starts a
         #   new thread/session (the bot always replies in a thread).

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4338,6 +4338,12 @@ class SlackAdapter(BasePlatformAdapter):
         if not channel_id:
             channel_id = assistant_meta.get("channel_id", "")
         team_id = outer_team_id or assistant_meta.get("team_id", "")
+
+        # File-upload events sometimes omit team_id. Resolve from the channel
+        # workspace cache so multi-workspace token lookup uses the right bot.
+        if not team_id and channel_id in self._channel_team:
+            team_id = self._channel_team[channel_id]
+
         agent_context = self._agent_view_context_for_event(
             event, str(team_id or ""), str(user_id or "")
         )

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4370,22 +4370,25 @@ class SlackAdapter(BasePlatformAdapter):
         # both as DM-style persistent conversations.
         is_one_to_one_dm = channel_type == "im"
 
-        # Early auth check: reject unauthorized users before any API calls
-        # (thread context fetch, user name resolution, file downloads).
-        # Pattern matches Telegram fix #54164 — gate at the adapter level
-        # BEFORE event construction consumes resources.
-        if user_id:
+        # Reject unauthorized users before thread lookups, name resolution,
+        # or file downloads.  The final gateway runner auth check happens
+        # after MessageEvent construction, so adapter-side media fetches need
+        # the same auth chain up front.
+        _runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        _auth_fn = getattr(_runner, "_is_user_authorized", None)
+        if user_id and callable(_auth_fn):
             _source = self.build_source(
-                chat_id=channel_id, chat_name="",
+                chat_id=channel_id,
+                chat_name="",
                 chat_type="dm" if is_dm else "group",
-                user_id=user_id, user_name="",
+                user_id=user_id,
+                user_name="",
             )
-            _runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
-            _auth_fn = getattr(_runner, "_is_user_authorized", None)
-            if callable(_auth_fn) and not _auth_fn(_source):
+            if not _auth_fn(_source):
                 logger.warning(
                     "[Slack] Early reject of unauthorized user %s in channel %s",
-                    user_id, channel_id,
+                    user_id,
+                    channel_id,
                 )
                 return
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -19,11 +19,12 @@ import time
 from dataclasses import dataclass, field
 from typing import Callable, Dict, Optional, Any, Tuple, List
 
+import aiohttp
+
 try:
     from slack_bolt.async_app import AsyncApp
     from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
     from slack_sdk.web.async_client import AsyncWebClient
-    import aiohttp
 
     SLACK_AVAILABLE = True
 except ImportError:
@@ -746,6 +747,7 @@ class SlackAdapter(BasePlatformAdapter):
         self._CHANNEL_TEAM_MAX = 10000
         # user target (team_id:user_id) → opened DM conversation ID (D...)
         self._dm_conversation_cache: Dict[str, str] = {}
+        self._DM_CONVERSATION_CACHE_MAX = 5000
         # Dedup cache: prevents duplicate bot responses when Socket Mode
         # reconnects redeliver events (#4777). The TTL must outlast Slack's
         # worst-case reconnect-redelivery gap, not just a few seconds — the
@@ -2025,9 +2027,12 @@ class SlackAdapter(BasePlatformAdapter):
             dm_id = ((response or {}).get("channel") or {}).get("id")
             if dm_id:
                 self._dm_conversation_cache[cache_key] = dm_id
+                self._trim_oldest_dict_entries(
+                    self._dm_conversation_cache, self._DM_CONVERSATION_CACHE_MAX
+                )
                 # DM belongs to the same workspace as the user target.
                 if team_id:
-                    self._channel_team[dm_id] = team_id
+                    self._remember_channel_team(dm_id, team_id)
                 return dm_id
         except Exception as e:
             logger.warning(
@@ -3228,7 +3233,9 @@ class SlackAdapter(BasePlatformAdapter):
                 or (isinstance(profile, dict) and profile.get("bot_id"))
             )
             self._user_is_bot_cache[cache_key] = is_bot
-
+            self._trim_oldest_dict_entries(
+                self._user_is_bot_cache, self._USER_NAME_CACHE_MAX
+            )
             # Populate the name cache from the same users.info response so the
             # later source construction does not need a second API lookup.
             name = (
@@ -7089,6 +7096,13 @@ class SlackAdapter(BasePlatformAdapter):
 # Cache for Slack user ID -> DM conversation ID resolution in the standalone
 # send path.  Keyed by "{token}:{user_id}" to support multi-workspace setups.
 _slack_dm_cache: Dict[str, str] = {}
+_SLACK_DM_CACHE_MAX = 5000
+
+
+def _trim_slack_dm_cache() -> None:
+    """Bound the module-level DM cache, oldest-insertion-first (C16 policy)."""
+    while len(_slack_dm_cache) > _SLACK_DM_CACHE_MAX:
+        _slack_dm_cache.pop(next(iter(_slack_dm_cache)))
 
 
 async def _resolve_slack_user_dm(token: str, user_id: str) -> Optional[str]:
@@ -7128,6 +7142,7 @@ async def _resolve_slack_user_dm(token: str, user_id: str) -> Optional[str]:
                 if data.get("ok") and data.get("channel", {}).get("id"):
                     channel_id = data["channel"]["id"]
                     _slack_dm_cache[cache_key] = channel_id
+                    _trim_slack_dm_cache()
                     return channel_id
                 logger.warning(
                     "[Slack] conversations.open failed for %s: %s",
@@ -7249,6 +7264,9 @@ async def _standalone_send(
 
     # --- Media path: AsyncWebClient.files_upload_v2 (+ optional text) ---
     if media_files:
+        # Function-local import: tests inject a fake slack_sdk via
+        # sys.modules, and installs without slack_sdk get a clean error
+        # instead of an ImportError at module load.
         try:
             from slack_sdk.web.async_client import AsyncWebClient as _AsyncWebClient
         except ImportError:
@@ -7260,6 +7278,7 @@ async def _standalone_send(
             }
 
         client = _AsyncWebClient(token=token)
+        _apply_slack_proxy(client, resolve_proxy_url())
         last_message_id = None
 
         # Caption mode: skip a separate text post; comment rides the upload.

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7036,6 +7036,43 @@ async def _resolve_slack_user_dm(token: str, user_id: str) -> Optional[str]:
         return None
 
 
+async def _standalone_upload_file(
+    client,
+    chat_id: str,
+    media_path: str,
+    *,
+    initial_comment: str = "",
+    thread_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Upload one local file via ``files_upload_v2`` (same API as the live adapter)."""
+    kwargs: Dict[str, Any] = {
+        "channel": chat_id,
+        "file": media_path,
+        "filename": os.path.basename(media_path),
+        "initial_comment": initial_comment or "",
+    }
+    if thread_id:
+        kwargs["thread_ts"] = thread_id
+    result = await client.files_upload_v2(**kwargs)
+    if isinstance(result, dict) and result.get("ok") is False:
+        return {"error": f"Slack API error: {result.get('error', 'unknown')}"}
+    # files_upload_v2 responses vary by sdk version; prefer file timestamp when present.
+    message_id = None
+    if isinstance(result, dict):
+        file_obj = result.get("file") or {}
+        shares = file_obj.get("shares") or {}
+        for share_bucket in shares.values():
+            if isinstance(share_bucket, dict):
+                for entries in share_bucket.values():
+                    if isinstance(entries, list) and entries:
+                        message_id = entries[0].get("ts") or message_id
+                        break
+            if message_id:
+                break
+        message_id = message_id or file_obj.get("timestamp") or result.get("ts")
+    return {"success": True, "message_id": message_id, "raw": result}
+
+
 async def _standalone_send(
     pconfig,
     chat_id,
@@ -7044,18 +7081,28 @@ async def _standalone_send(
     thread_id=None,
     media_files=None,
     force_document=False,
+    caption=None,
 ):
-    """Out-of-process Slack delivery via the Web API ``chat.postMessage``.
+    """Out-of-process Slack delivery via the Web API.
 
     Implements the ``standalone_sender_fn`` contract so ``deliver=slack`` cron
-    jobs succeed when the cron process is not co-located with the gateway (the
-    in-process adapter weakref is ``None`` in that case). Replaces the legacy
-    ``_send_slack`` helper that used to live in ``tools/send_message_tool.py``.
+    jobs and ``send_message`` MEDIA attachments succeed when the cron/tool
+    process is not co-located with the gateway (the in-process adapter weakref
+    is ``None`` in that case). Replaces the legacy ``_send_slack`` helper that
+    used to live in ``tools/send_message_tool.py``.
 
-    mrkdwn formatting is applied exactly as the legacy core path did — via a
-    throwaway ``SlackAdapter`` instance's ``format_message`` — so cron-delivered
-    Slack messages render identically to gateway-delivered ones.
+    Text uses ``chat.postMessage`` (aiohttp). Media uses ``files_upload_v2`` via
+    ``AsyncWebClient`` — the same upload path as the live Slack adapter — so
+    PDFs/images/documents arrive as native Slack file shares.
+
+    ``force_document`` is accepted for signature parity but unused — Slack
+    treats every upload as a generic file share.
+
+    When ``caption`` is set (single captionable MEDIA:<path> + short text), the
+    text rides as ``initial_comment`` on the upload instead of a separate
+    ``chat.postMessage``.
     """
+    del force_document  # signature parity with other standalone senders
     token = getattr(pconfig, "token", None) or os.getenv("SLACK_BOT_TOKEN", "")
     if not token:
         return {"error": "Slack send failed: SLACK_BOT_TOKEN not configured"}
@@ -7076,69 +7123,128 @@ async def _standalone_send(
             }
         chat_id = resolved
 
-    formatted = message
-    if message:
+
+    media_files = media_files or []
+    warnings: List[str] = []
+
+    def _format_mrkdwn(text: str) -> str:
+        if not text:
+            return text
         try:
             _fmt_adapter = SlackAdapter.__new__(SlackAdapter)
-            formatted = _fmt_adapter.format_message(message)
+            return _fmt_adapter.format_message(text)
         except Exception:
             logger.debug(
                 "Failed to apply Slack mrkdwn formatting in _standalone_send",
                 exc_info=True,
             )
+            return text
 
-    # Out-of-process cron runs have no live SlackAdapter.  Upload MEDIA files
-    # here so the standalone path has feature parity with the live adapter
-    # instead of silently succeeding with text only.  This runs BEFORE the
-    # empty-text skip: a media delivery with a blank caption must still
-    # upload the files.
+    formatted = _format_mrkdwn(message) if message else message
+    formatted_caption = _format_mrkdwn(caption) if caption else caption
+
+    # --- Media path: AsyncWebClient.files_upload_v2 (+ optional text) ---
     if media_files:
-        if not check_slack_requirements():
-            return {"error": "Slack send failed: slack-sdk is not installed"}
-
-        paths = []
-        for media in media_files:
-            path = media[0] if isinstance(media, (tuple, list)) else media
-            path = str(path)
-            if not os.path.isfile(path):
-                return {"error": f"Slack media file not found: {os.path.basename(path)}"}
-            paths.append(path)
-
         try:
-            client = AsyncWebClient(token=token)  # pyright: ignore[reportCallIssue]
-            _apply_slack_proxy(client, resolve_proxy_url())
-            upload_result = None
-            for start in range(0, len(paths), 10):
-                batch = paths[start : start + 10]
-                kwargs = {
-                    "channel": chat_id,
-                    "initial_comment": formatted if start == 0 else "",
-                    "thread_ts": thread_id,
-                }
-                if len(batch) == 1:
-                    kwargs.update(
-                        file=batch[0],
-                        filename=os.path.basename(batch[0]),
-                    )
-                else:
-                    kwargs["file_uploads"] = [
-                        {"file": path, "filename": os.path.basename(path)}
-                        for path in batch
-                    ]
-                upload_result = await client.files_upload_v2(**kwargs)
+            from slack_sdk.web.async_client import AsyncWebClient as _AsyncWebClient
+        except ImportError:
             return {
-                "success": True,
-                "platform": "slack",
-                "chat_id": chat_id,
-                "message_id": (
-                    upload_result.get("ts")
-                    if upload_result is not None and hasattr(upload_result, "get")
-                    else None
-                ),
+                "error": (
+                    "slack_sdk not installed. Run: pip install 'slack-sdk' "
+                    "(required for Slack MEDIA delivery via send_message)"
+                )
             }
-        except Exception as e:
-            return {"error": f"Slack media upload failed: {e}"}
 
+        client = _AsyncWebClient(token=token)
+        last_message_id = None
+
+        # Caption mode: skip a separate text post; comment rides the upload.
+        text_to_send = "" if formatted_caption else (formatted or "")
+        if text_to_send.strip():
+            post_kwargs: Dict[str, Any] = {
+                "channel": chat_id,
+                "text": text_to_send,
+                "mrkdwn": True,
+            }
+            if thread_id:
+                post_kwargs["thread_ts"] = thread_id
+            try:
+                post_resp = await client.chat_postMessage(**post_kwargs)
+                if isinstance(post_resp, dict) and not post_resp.get("ok", True):
+                    return {
+                        "error": f"Slack API error: {post_resp.get('error', 'unknown')}"
+                    }
+                last_message_id = (
+                    post_resp.get("ts") if isinstance(post_resp, dict) else None
+                )
+            except Exception as e:
+                return {"error": f"Slack send failed: {e}"}
+
+        caption_pending = bool(formatted_caption)
+        uploaded_any = False
+        for media_path, _is_voice in media_files:
+            if not os.path.exists(media_path):
+                warning = f"Media file not found, skipping: {media_path}"
+                logger.warning("[Slack] %s", warning)
+                warnings.append(warning)
+                if caption_pending:
+                    # Keep caption deliverable even when the file is missing.
+                    try:
+                        fallback_kwargs: Dict[str, Any] = {
+                            "channel": chat_id,
+                            "text": formatted_caption,
+                            "mrkdwn": True,
+                        }
+                        if thread_id:
+                            fallback_kwargs["thread_ts"] = thread_id
+                        fb = await client.chat_postMessage(**fallback_kwargs)
+                        if isinstance(fb, dict) and fb.get("ok", True):
+                            last_message_id = fb.get("ts") or last_message_id
+                            caption_pending = False
+                    except Exception:
+                        logger.warning(
+                            "[Slack] Caption-fallback send failed for missing media",
+                            exc_info=True,
+                        )
+                continue
+            try:
+                upload_result = await _standalone_upload_file(
+                    client,
+                    chat_id,
+                    media_path,
+                    initial_comment=formatted_caption if caption_pending else "",
+                    thread_id=thread_id,
+                )
+                if upload_result.get("error"):
+                    warnings.append(
+                        f"Failed to send media {media_path}: {upload_result['error']}"
+                    )
+                    continue
+                uploaded_any = True
+                caption_pending = False
+                last_message_id = upload_result.get("message_id") or last_message_id
+            except Exception as e:
+                warning = f"Failed to send media {media_path}: {e}"
+                logger.error("[Slack] %s", warning, exc_info=True)
+                warnings.append(warning)
+
+        if last_message_id is None and not uploaded_any and not text_to_send.strip():
+            error = "No deliverable text or media remained after processing"
+            if warnings:
+                return {"error": error, "warnings": warnings}
+            return {"error": error}
+
+        result: Dict[str, Any] = {
+            "success": True,
+            "platform": "slack",
+            "chat_id": chat_id,
+            "message_id": last_message_id,
+        }
+        if warnings:
+            result["warnings"] = warnings
+        return result
+
+    # --- Text-only path (existing aiohttp chat.postMessage) ---
     if not formatted or not formatted.strip():
         logger.debug("[Slack] _standalone_send: skipping empty/whitespace message")
         return {

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -744,6 +744,8 @@ class SlackAdapter(BasePlatformAdapter):
         # the primary client meanwhile.
         self._channel_team: Dict[str, str] = {}
         self._CHANNEL_TEAM_MAX = 10000
+        # user target (team_id:user_id) → opened DM conversation ID (D...)
+        self._dm_conversation_cache: Dict[str, str] = {}
         # Dedup cache: prevents duplicate bot responses when Socket Mode
         # reconnects redeliver events (#4777). The TTL must outlast Slack's
         # worst-case reconnect-redelivery gap, not just a few seconds — the
@@ -1966,6 +1968,7 @@ class SlackAdapter(BasePlatformAdapter):
         self._team_clients = {}
         self._team_bot_user_ids = {}
         self._channel_team = {}
+        self._dm_conversation_cache = {}
 
         self._release_platform_lock()
 
@@ -1992,6 +1995,49 @@ class SlackAdapter(BasePlatformAdapter):
             return self._team_clients[team_id]
         return self._app.client  # fallback to primary
 
+    async def _ensure_dm_conversation(
+        self, chat_id: str, team_id: Optional[str] = None
+    ) -> str:
+        """Resolve a bare Slack user ID target to a DM conversation ID.
+
+        ``chat.postMessage`` and ``files_upload_v2`` reject user IDs (U.../W...)
+        — a DM must be opened first via ``conversations.open`` to obtain a D...
+        conversation ID (#19236 / #17261). Conversation IDs (C/G/D...) pass
+        through unchanged. Resolution goes through the workspace-scoped client
+        so multi-workspace installs open the DM with the right bot token, and
+        results are cached per (team, user) so repeated sends don't re-open.
+
+        Returns the resolved conversation ID, or the original ``chat_id`` when
+        resolution is not applicable or fails (the downstream API call then
+        surfaces the real Slack error).
+        """
+        cid = str(chat_id or "")
+        if not cid or cid[0] not in ("U", "W"):
+            return chat_id
+        cache_key = f"{team_id or ''}:{cid}"
+        cached = self._dm_conversation_cache.get(cache_key)
+        if cached:
+            return cached
+        try:
+            response = await self._get_client(cid, team_id=team_id).conversations_open(
+                users=cid
+            )
+            dm_id = ((response or {}).get("channel") or {}).get("id")
+            if dm_id:
+                self._dm_conversation_cache[cache_key] = dm_id
+                # DM belongs to the same workspace as the user target.
+                if team_id:
+                    self._channel_team[dm_id] = team_id
+                return dm_id
+        except Exception as e:
+            logger.warning(
+                "[Slack] conversations.open failed for user target %s: %s "
+                "(check the bot's im:write scope)",
+                cid,
+                e,
+            )
+        return chat_id
+
     async def send(
         self,
         chat_id: str,
@@ -2003,6 +2049,9 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Not connected")
 
+        chat_id = await self._ensure_dm_conversation(
+            chat_id, team_id=self._metadata_team_id(metadata)
+        )
         thread_ts = None
         try:
             # Check for a pending slash-command context.  When the user ran a
@@ -2536,6 +2585,9 @@ class SlackAdapter(BasePlatformAdapter):
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"File not found: {file_path}")
 
+        chat_id = await self._ensure_dm_conversation(
+            chat_id, team_id=self._metadata_team_id(metadata)
+        )
         thread_ts = self._resolve_thread_ts(reply_to, metadata)
         last_exc = None
         for attempt in range(3):
@@ -2586,6 +2638,9 @@ class SlackAdapter(BasePlatformAdapter):
         if not images:
             return
 
+        chat_id = await self._ensure_dm_conversation(
+            chat_id, team_id=self._metadata_team_id(metadata)
+        )
         try:
             import httpx as _httpx
             from urllib.parse import unquote as _unquote
@@ -3261,6 +3316,9 @@ class SlackAdapter(BasePlatformAdapter):
                 response.raise_for_status()
 
             thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            chat_id = await self._ensure_dm_conversation(
+                chat_id, team_id=self._metadata_team_id(metadata)
+            )
             result = await self._get_client(
                 chat_id, team_id=self._metadata_team_id(metadata)
             ).files_upload_v2(
@@ -3334,6 +3392,9 @@ class SlackAdapter(BasePlatformAdapter):
                 success=False, error=f"Video file not found: {video_path}"
             )
 
+        chat_id = await self._ensure_dm_conversation(
+            chat_id, team_id=self._metadata_team_id(metadata)
+        )
         try:
             thread_ts = self._resolve_thread_ts(reply_to, metadata)
             last_exc = None
@@ -3396,6 +3457,9 @@ class SlackAdapter(BasePlatformAdapter):
 
         display_name = file_name or os.path.basename(file_path)
         thread_ts = self._resolve_thread_ts(reply_to, metadata)
+        chat_id = await self._ensure_dm_conversation(
+            chat_id, team_id=self._metadata_team_id(metadata)
+        )
 
         try:
             last_exc = None
@@ -5176,6 +5240,9 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Not connected")
 
+        chat_id = await self._ensure_dm_conversation(
+            chat_id, team_id=self._metadata_team_id(metadata)
+        )
         try:
             thread_ts = self._resolve_thread_ts(None, metadata)
 
@@ -5270,6 +5337,9 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Not connected")
 
+        chat_id = await self._ensure_dm_conversation(
+            chat_id, team_id=self._metadata_team_id(metadata)
+        )
         try:
             thread_ts = self._resolve_thread_ts(None, metadata)
             # Same 3000-char section-block cap as send_exec_approval: budget
@@ -5374,6 +5444,9 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Not connected")
 
+        chat_id = await self._ensure_dm_conversation(
+            chat_id, team_id=self._metadata_team_id(metadata)
+        )
         try:
             thread_ts = self._resolve_thread_ts(None, metadata)
 

--- a/tests/gateway/test_post_stream_media_delivery.py
+++ b/tests/gateway/test_post_stream_media_delivery.py
@@ -1,0 +1,146 @@
+"""Post-stream media delivery is explicit-only (#20834).
+
+``GatewayRunner._deliver_media_from_response`` runs AFTER streaming has sent
+the visible reply. At that point a bare local filesystem path in the response
+text is either text the user already saw, or stale inspected/tool content —
+it is NOT an attachment request. Only explicit ``MEDIA:`` directives may
+trigger post-stream uploads.
+
+The non-streaming path (``gateway/platforms/base.py``) keeps its bare-path
+auto-detect (``extract_local_files``) — that path controls what text is sent
+and can strip the path from the visible reply, so auto-attach is intentional
+there. This file pins the asymmetry.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _event():
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123CHAN",
+        chat_type="group",
+        thread_id=None,
+    )
+    return MessageEvent(
+        text="hi",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="171.000001",
+    )
+
+
+def _fake_runner(thread_meta):
+    return SimpleNamespace(
+        _thread_metadata_for_source=lambda source, anchor=None: thread_meta,
+        _reply_anchor_for_event=lambda event: None,
+    )
+
+
+def _adapter():
+    return SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="imgs")),
+    )
+
+
+def _allowed_media_path(tmp_path, monkeypatch, name):
+    root = tmp_path / "media-cache"
+    media_file = root / name
+    media_file.parent.mkdir(parents=True, exist_ok=True)
+    media_file.write_bytes(b"media")
+    monkeypatch.setattr(
+        "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+        (root,),
+    )
+    return media_file.resolve()
+
+
+@pytest.mark.asyncio
+async def test_bare_local_path_in_streamed_reply_is_not_uploaded(tmp_path, monkeypatch):
+    """The #20834 shape: visible reply contains a bare path (from inspected
+    content), no MEDIA: directive — nothing may be uploaded post-stream."""
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "mockup.png")
+    adapter = _adapter()
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({}),
+        f"The design lives at {media_file} if you want to look later.",
+        _event(),
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_image_file.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+    adapter.send_video.assert_not_awaited()
+    adapter.send_voice.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_bare_document_path_in_streamed_reply_is_not_uploaded(tmp_path, monkeypatch):
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "report.pdf")
+    adapter = _adapter()
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({}),
+        f"I saved it to {media_file}.",
+        _event(),
+        adapter,
+    )
+
+    adapter.send_document.assert_not_awaited()
+    adapter.send_video.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_explicit_media_tag_still_delivers_post_stream(tmp_path, monkeypatch):
+    """Explicit MEDIA: directives keep working after the #20834 fix."""
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "chart.png")
+    adapter = _adapter()
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({}),
+        f"Here is the chart.\nMEDIA:{media_file}",
+        _event(),
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    images_kwargs = adapter.send_multiple_images.await_args.kwargs
+    assert images_kwargs["chat_id"] == "C123CHAN"
+    assert str(media_file) in images_kwargs["images"][0][0]
+
+
+@pytest.mark.asyncio
+async def test_explicit_media_document_still_delivers_post_stream(tmp_path, monkeypatch):
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "report.pdf")
+    adapter = _adapter()
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({}),
+        f"Report attached.\nMEDIA:{media_file}",
+        _event(),
+        adapter,
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="C123CHAN",
+        file_path=str(media_file),
+        metadata={},
+    )

--- a/tests/gateway/test_send_multiple_images.py
+++ b/tests/gateway/test_send_multiple_images.py
@@ -14,6 +14,7 @@ Signal's native implementation is covered by test_signal.py.
 
 import asyncio
 import sys
+import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -264,6 +265,221 @@ class TestDiscordMultiImage:
         adapter._client = MagicMock()
         _run(adapter.send_multiple_images("67890", []))
 
+    def test_url_batch_blocks_private_redirect_before_send(self, adapter, monkeypatch):
+        """A public image URL must not redirect into private metadata and then upload."""
+        import plugins.platforms.discord.adapter as discord_adapter
+
+        public_url = "https://cdn.example.test/image.png"
+        private_url = "http://169.254.169.254/latest/meta-data/"
+        safe_calls = []
+
+        def fake_is_safe_url(url):
+            safe_calls.append(url)
+            return not str(url).startswith("http://169.254.169.254")
+
+        class FakeResponse:
+            status = 302
+            headers = {"location": private_url}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def read(self):
+                return b"metadata-secret"
+
+        class FakeSession:
+            def get(self, url, **kwargs):
+                assert kwargs.get("allow_redirects") is False
+                return FakeResponse()
+
+            async def close(self):
+                return None
+
+        fake_aiohttp = types.SimpleNamespace(
+            ClientSession=lambda **kwargs: FakeSession(),
+            ClientTimeout=lambda **kwargs: kwargs,
+        )
+        monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+        monkeypatch.setattr(discord_adapter, "is_safe_url", fake_is_safe_url)
+
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock(return_value=MagicMock(id=1))
+        adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        adapter._is_forum_parent = MagicMock(return_value=False)
+
+        _run(adapter.send_multiple_images("67890", [(public_url, "caption")]))
+
+        mock_channel.send.assert_not_awaited()
+        assert private_url in safe_calls
+
+    def test_url_batch_follows_safe_redirect_location_header(self, adapter, monkeypatch):
+        """Redirect handling preserves aiohttp's case-insensitive Location behavior."""
+        import plugins.platforms.discord.adapter as discord_adapter
+
+        public_url = "https://cdn.example.test/image.png"
+        redirected_url = "https://assets.example.test/image.png"
+        requested_urls = []
+
+        class RedirectResponse:
+            status = 302
+            headers = {"Location": redirected_url}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def read(self):
+                raise AssertionError("redirect responses must not be read")
+
+        class ImageResponse:
+            status = 200
+            headers = {"Content-Type": "image/png"}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def read(self):
+                return b"\x89PNG"
+
+        class FakeSession:
+            def get(self, url, **kwargs):
+                assert kwargs.get("allow_redirects") is False
+                requested_urls.append(url)
+                if url == public_url:
+                    return RedirectResponse()
+                assert url == redirected_url
+                return ImageResponse()
+
+            async def close(self):
+                return None
+
+        fake_aiohttp = types.SimpleNamespace(
+            ClientSession=lambda **kwargs: FakeSession(),
+            ClientTimeout=lambda **kwargs: kwargs,
+        )
+        monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+        monkeypatch.setattr(discord_adapter, "is_safe_url", lambda url: True)
+
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock(return_value=MagicMock(id=1))
+        adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        adapter._is_forum_parent = MagicMock(return_value=False)
+
+        _run(adapter.send_multiple_images("67890", [(public_url, "caption")]))
+
+        assert requested_urls == [public_url, redirected_url]
+        mock_channel.send.assert_awaited_once()
+
+    def test_send_image_blocks_private_redirect_before_send(self, adapter, monkeypatch):
+        import plugins.platforms.discord.adapter as discord_adapter
+
+        public_url = "https://cdn.example.test/image.png"
+        private_url = "http://169.254.169.254/latest/meta-data/"
+
+        class FakeResponse:
+            status = 302
+            headers = {"Location": private_url}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def read(self):
+                return b"metadata-secret"
+
+        class FakeSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def get(self, url, **kwargs):
+                assert kwargs.get("allow_redirects") is False
+                return FakeResponse()
+
+        fake_aiohttp = types.SimpleNamespace(
+            ClientSession=lambda **kwargs: FakeSession(),
+            ClientTimeout=lambda **kwargs: kwargs,
+        )
+        monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+        monkeypatch.setattr(
+            discord_adapter,
+            "is_safe_url",
+            lambda url: not str(url).startswith("http://169.254.169.254"),
+        )
+        adapter._is_forum_parent = MagicMock(return_value=False)
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock(return_value=MagicMock(id=1))
+        adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        adapter._client.fetch_channel = AsyncMock(return_value=mock_channel)
+        adapter.send = AsyncMock()
+
+        _run(adapter.send_image("67890", public_url, "caption"))
+
+        mock_channel.send.assert_not_awaited()
+
+    def test_send_animation_blocks_private_redirect_before_send(self, adapter, monkeypatch):
+        import plugins.platforms.discord.adapter as discord_adapter
+
+        public_url = "https://cdn.example.test/animation.gif"
+        private_url = "http://169.254.169.254/latest/meta-data/"
+
+        class FakeResponse:
+            status = 302
+            headers = {"Location": private_url}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def read(self):
+                return b"metadata-secret"
+
+        class FakeSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def get(self, url, **kwargs):
+                assert kwargs.get("allow_redirects") is False
+                return FakeResponse()
+
+        fake_aiohttp = types.SimpleNamespace(
+            ClientSession=lambda **kwargs: FakeSession(),
+            ClientTimeout=lambda **kwargs: kwargs,
+        )
+        monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+        monkeypatch.setattr(
+            discord_adapter,
+            "is_safe_url",
+            lambda url: not str(url).startswith("http://169.254.169.254"),
+        )
+        adapter._is_forum_parent = MagicMock(return_value=False)
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock(return_value=MagicMock(id=1))
+        adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        adapter._client.fetch_channel = AsyncMock(return_value=mock_channel)
+        adapter.send = AsyncMock()
+
+        _run(adapter.send_animation("67890", public_url, "caption"))
+
+        mock_channel.send.assert_not_awaited()
+
 
 # ---------------------------------------------------------------------------
 # Slack
@@ -336,6 +552,49 @@ class TestSlackMultiImage:
         _run(adapter.send_multiple_images("C12345", []))
         client = adapter._get_client("C12345")
         client.files_upload_v2.assert_not_called()
+
+    def test_url_batch_blocks_private_redirect_before_upload(self, adapter, monkeypatch):
+        """HTTP redirects are rechecked before Slack batch uploads remote bytes."""
+        import httpx
+        import tools.url_safety as url_safety
+
+        public_url = "https://cdn.example.test/image.png"
+        private_url = "http://169.254.169.254/latest/meta-data/"
+        safe_calls = []
+
+        def fake_is_safe_url(url):
+            safe_calls.append(url)
+            return not str(url).startswith("http://169.254.169.254")
+
+        class RedirectResponse:
+            is_redirect = True
+            url = public_url
+            headers = {"location": private_url}
+            next_request = None
+
+        class FakeAsyncClient:
+            def __init__(self, **kwargs):
+                self.event_hooks = kwargs.get("event_hooks", {})
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def get(self, url):
+                for hook in self.event_hooks.get("response", []):
+                    await hook(RedirectResponse())
+                raise AssertionError("private redirect was not blocked before fetch")
+
+        monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+        monkeypatch.setattr(url_safety, "is_safe_url", fake_is_safe_url)
+
+        _run(adapter.send_multiple_images("C12345", [(public_url, "caption")]))
+
+        client = adapter._get_client("C12345")
+        client.files_upload_v2.assert_not_called()
+        assert private_url in safe_calls
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2104,6 +2104,33 @@ class TestIncomingDocumentHandling:
         assert msg_event.media_types == ["application/pdf"]
 
     @pytest.mark.asyncio
+    async def test_uses_cached_channel_team_for_file_events_without_team_id(self, adapter):
+        """File events use the channel workspace cache when Slack omits team_id."""
+        content = b"Hello from workspace two"
+        adapter._channel_team["D123"] = "T_SECOND"
+
+        with patch.object(adapter, "_download_slack_file_bytes", new_callable=AsyncMock) as dl:
+            dl.return_value = content
+            event = self._make_event(
+                text="summarize this",
+                files=[{
+                    "mimetype": "text/plain",
+                    "name": "workspace-two.txt",
+                    "url_private_download": "https://files.slack.com/workspace-two.txt",
+                    "size": len(content),
+                }],
+            )
+            assert "team" not in event
+            assert "team_id" not in event
+
+            await adapter._handle_slack_message(event)
+
+        dl.assert_awaited_once()
+        assert dl.await_args.kwargs["team_id"] == "T_SECOND"
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert "Hello from workspace two" in msg_event.text
+
+    @pytest.mark.asyncio
     async def test_txt_document_injects_content(self, adapter):
         """A .txt file under 100KB should have its content injected into event text."""
         content = b"Hello from a text file"

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1221,25 +1221,63 @@ class TestSlackProxyBehavior:
 # ---------------------------------------------------------------------------
 
 
+
+from contextlib import contextmanager
+from types import ModuleType
+
+
+@contextmanager
+def _fake_slack_sdk_modules(client):
+    """Route ``from slack_sdk.web.async_client import AsyncWebClient`` to a mock."""
+    import sys as _sys
+
+    sdk = ModuleType("slack_sdk")
+    web = ModuleType("slack_sdk.web")
+    async_client = ModuleType("slack_sdk.web.async_client")
+    async_client.AsyncWebClient = MagicMock(return_value=client)
+    sdk.web = web
+    web.async_client = async_client
+    modules = {
+        "slack_sdk": sdk,
+        "slack_sdk.web": web,
+        "slack_sdk.web.async_client": async_client,
+    }
+    old = {name: _sys.modules.get(name) for name in modules}
+    _sys.modules.update(modules)
+    try:
+        yield
+    finally:
+        for name, prev in old.items():
+            if prev is None:
+                _sys.modules.pop(name, None)
+            else:
+                _sys.modules[name] = prev
+
+
 class TestStandaloneSendMedia:
     @pytest.mark.asyncio
     async def test_uploads_local_media_with_message_as_caption(self, tmp_path):
-        """Standalone cron sends should use files_upload_v2, not omit the image."""
+        """Standalone cron sends must upload via files_upload_v2 — the text
+        posts as its own message and the file follows (caption-mode, where
+        text rides the upload as initial_comment, is chosen by the tool
+        layer via the ``caption=`` kwarg — covered in
+        tests/tools/test_slack_send_message_media.py)."""
         image = tmp_path / "daily-report.png"
         image.write_bytes(b"\x89PNG\r\n\x1a\n")
         client = MagicMock()
+        client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "1.0"})
         client.files_upload_v2 = AsyncMock(
             return_value={"ok": True, "files": [{"id": "F123"}]}
         )
         config = PlatformConfig(enabled=True, token="xoxb-fake-token")
 
         with (
-            patch.object(_slack_mod, "AsyncWebClient", return_value=client),
+            _fake_slack_sdk_modules(client),
             patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
             patch.object(
                 _slack_mod.aiohttp,
                 "ClientSession",
-                side_effect=AssertionError("media delivery used text-only chat.postMessage"),
+                side_effect=AssertionError("media delivery used text-only aiohttp path"),
             ),
         ):
             result = await _slack_mod._standalone_send(
@@ -1251,12 +1289,45 @@ class TestStandaloneSendMedia:
             )
 
         assert result["success"] is True
-        client.files_upload_v2.assert_awaited_once_with(
-            channel="C123",
-            file=str(image),
-            filename="daily-report.png",
-            initial_comment="daily report",
-            thread_ts=None,
+        client.chat_postMessage.assert_awaited_once()
+        assert client.chat_postMessage.await_args.kwargs["text"] == "daily report"
+        client.files_upload_v2.assert_awaited_once()
+        up_kwargs = client.files_upload_v2.await_args.kwargs
+        assert up_kwargs["channel"] == "C123"
+        assert up_kwargs["file"] == str(image)
+        assert up_kwargs["filename"] == "daily-report.png"
+        assert up_kwargs["initial_comment"] == ""
+
+    @pytest.mark.asyncio
+    async def test_caption_kwarg_rides_upload_as_initial_comment(self, tmp_path):
+        """When the tool layer passes caption=, it rides the upload and no
+        separate text message is posted (C8 caption-mode contract)."""
+        image = tmp_path / "chart.png"
+        image.write_bytes(b"\x89PNG\r\n\x1a\n")
+        client = MagicMock()
+        client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "1.0"})
+        client.files_upload_v2 = AsyncMock(
+            return_value={"ok": True, "files": [{"id": "F123"}]}
+        )
+        config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+
+        with (
+            _fake_slack_sdk_modules(client),
+            patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
+        ):
+            result = await _slack_mod._standalone_send(
+                config,
+                "C123",
+                "",
+                thread_id=None,
+                media_files=[(str(image), False)],
+                caption="Q3 chart",
+            )
+
+        assert result["success"] is True
+        client.chat_postMessage.assert_not_awaited()
+        assert (
+            client.files_upload_v2.await_args.kwargs["initial_comment"] == "Q3 chart"
         )
 
 
@@ -1371,12 +1442,13 @@ class TestStandaloneSendUserDmResolution:
         open_resp = self._mock_resp({"ok": True, "channel": {"id": "D777666555"}})
         session = self._mock_session(open_resp)
         client = MagicMock()
+        client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "1.0"})
         client.files_upload_v2 = AsyncMock(return_value={"ok": True, "ts": "9.9"})
         config = PlatformConfig(enabled=True, token="xoxb-fake-token")
 
         with (
             patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
-            patch.object(_slack_mod, "AsyncWebClient", return_value=client),
+            _fake_slack_sdk_modules(client),
             patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
         ):
             result = await _slack_mod._standalone_send(

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -7021,3 +7021,161 @@ class TestTrackingStructureBounds:
         # can never remove a newer entry while an older one remains).
         for i in range(450, 500):
             assert f"{2000 + i}.000000" in adapter._bot_message_ts
+
+
+# ---------------------------------------------------------------------------
+# TestEnsureDmConversation — bare user-ID targets resolve to DM channels
+# (#19236 / #17261: attachments and Block Kit prompts to U... targets)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureDmConversation:
+    @pytest.mark.asyncio
+    async def test_user_id_target_is_opened_as_dm(self, adapter):
+        adapter._app.client.conversations_open = AsyncMock(
+            return_value={"ok": True, "channel": {"id": "D999NEW"}}
+        )
+
+        resolved = await adapter._ensure_dm_conversation("U123ABCDEF")
+
+        assert resolved == "D999NEW"
+        adapter._app.client.conversations_open.assert_awaited_once_with(
+            users="U123ABCDEF"
+        )
+
+    @pytest.mark.asyncio
+    async def test_conversation_ids_pass_through(self, adapter):
+        adapter._app.client.conversations_open = AsyncMock()
+        for cid in ("C123CHAN", "G123GROUP", "D123DM"):
+            assert await adapter._ensure_dm_conversation(cid) == cid
+        adapter._app.client.conversations_open.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_resolution_is_cached_per_user(self, adapter):
+        adapter._app.client.conversations_open = AsyncMock(
+            return_value={"ok": True, "channel": {"id": "D999NEW"}}
+        )
+
+        first = await adapter._ensure_dm_conversation("U123ABCDEF")
+        second = await adapter._ensure_dm_conversation("U123ABCDEF")
+
+        assert first == second == "D999NEW"
+        adapter._app.client.conversations_open.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_failure_returns_original_target(self, adapter):
+        adapter._app.client.conversations_open = AsyncMock(
+            side_effect=Exception("missing_scope")
+        )
+
+        resolved = await adapter._ensure_dm_conversation("U123ABCDEF")
+
+        assert resolved == "U123ABCDEF"
+
+    @pytest.mark.asyncio
+    async def test_workspace_scoped_client_used_for_team_id(self, adapter):
+        team_client = AsyncMock()
+        team_client.conversations_open = AsyncMock(
+            return_value={"ok": True, "channel": {"id": "D_TEAM2"}}
+        )
+        adapter._team_clients["T_SECOND"] = team_client
+        adapter._app.client.conversations_open = AsyncMock()
+
+        resolved = await adapter._ensure_dm_conversation(
+            "U123ABCDEF", team_id="T_SECOND"
+        )
+
+        assert resolved == "D_TEAM2"
+        team_client.conversations_open.assert_awaited_once_with(users="U123ABCDEF")
+        adapter._app.client.conversations_open.assert_not_awaited()
+        # The opened DM is recorded as belonging to the same workspace.
+        assert adapter._channel_team["D_TEAM2"] == "T_SECOND"
+
+    @pytest.mark.asyncio
+    async def test_send_resolves_user_target_before_posting(self, adapter):
+        adapter._app.client.conversations_open = AsyncMock(
+            return_value={"ok": True, "channel": {"id": "D999NEW"}}
+        )
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "111.222"}
+        )
+
+        result = await adapter.send("U123ABCDEF", "hello there")
+
+        assert result.success is True
+        post_kwargs = adapter._app.client.chat_postMessage.await_args.kwargs
+        assert post_kwargs["channel"] == "D999NEW"
+
+    @pytest.mark.asyncio
+    async def test_upload_file_resolves_user_target(self, adapter, tmp_path):
+        media = tmp_path / "report.pdf"
+        media.write_bytes(b"%PDF-1.4 fake")
+        adapter._app.client.conversations_open = AsyncMock(
+            return_value={"ok": True, "channel": {"id": "D999NEW"}}
+        )
+        adapter._app.client.files_upload_v2 = AsyncMock(
+            return_value={"ok": True, "file": {"id": "F1"}}
+        )
+
+        result = await adapter._upload_file("U123ABCDEF", str(media))
+
+        assert result.success is True
+        upload_kwargs = adapter._app.client.files_upload_v2.await_args.kwargs
+        assert upload_kwargs["channel"] == "D999NEW"
+
+    @pytest.mark.asyncio
+    async def test_send_document_resolves_user_target(self, adapter, tmp_path):
+        media = tmp_path / "notes.md"
+        media.write_bytes(b"# notes")
+        adapter._app.client.conversations_open = AsyncMock(
+            return_value={"ok": True, "channel": {"id": "D999NEW"}}
+        )
+        adapter._app.client.files_upload_v2 = AsyncMock(
+            return_value={"ok": True, "file": {"id": "F1"}}
+        )
+
+        result = await adapter.send_document("U123ABCDEF", str(media))
+
+        assert result.success is True
+        upload_kwargs = adapter._app.client.files_upload_v2.await_args.kwargs
+        assert upload_kwargs["channel"] == "D999NEW"
+
+    @pytest.mark.asyncio
+    async def test_send_clarify_resolves_user_target(self, adapter):
+        adapter._app.client.conversations_open = AsyncMock(
+            return_value={"ok": True, "channel": {"id": "D999NEW"}}
+        )
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "111.222"}
+        )
+
+        result = await adapter.send_clarify(
+            chat_id="U123ABCDEF",
+            question="Which one?",
+            choices=["a", "b"],
+            clarify_id="cl-1",
+            session_key="sk-1",
+        )
+
+        assert result.success is True
+        post_kwargs = adapter._app.client.chat_postMessage.await_args.kwargs
+        assert post_kwargs["channel"] == "D999NEW"
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_resolves_user_target(self, adapter):
+        adapter._app.client.conversations_open = AsyncMock(
+            return_value={"ok": True, "channel": {"id": "D999NEW"}}
+        )
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "111.222"}
+        )
+
+        result = await adapter.send_exec_approval(
+            chat_id="U123ABCDEF",
+            command="rm -rf /tmp/x",
+            session_key="sk-1",
+        )
+
+        assert result.success is True
+        post_kwargs = adapter._app.client.chat_postMessage.await_args.kwargs
+        assert post_kwargs["channel"] == "D999NEW"

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2407,6 +2407,49 @@ class TestIncomingDocumentHandling:
         assert msg_event.media_types == [SUPPORTED_VIDEO_TYPES[".mp4"]]
 
     @pytest.mark.asyncio
+    async def test_unauthorized_message_does_not_fetch_file_info(
+        self,
+        adapter,
+        monkeypatch,
+    ):
+        """Global gateway auth must run before Slack file metadata fetches."""
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_ALLOWED")
+
+        class Runner:
+            def _is_user_authorized(self, source):
+                return source.user_id == "U_ALLOWED"
+
+            async def handle(self, _event):
+                raise AssertionError("gateway handler should not run")
+
+        adapter._message_handler = Runner().handle
+        adapter._app.client.files_info = AsyncMock()
+
+        await adapter._handle_slack_message(
+            {
+                "type": "message",
+                "channel": "D123",
+                "channel_type": "im",
+                "user": "U_INTRUDER",
+                "text": "please read this",
+                "ts": "1234567890.000001",
+                "files": [
+                    {
+                        "id": "FSECRET",
+                        "mimetype": "text/plain",
+                        "name": "secret.txt",
+                    }
+                ],
+            }
+        )
+
+        adapter._app.client.files_info.assert_not_awaited()
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_download_failure_is_surfaced_in_message_text(self, adapter):
         """Attachment download failures (401/403/HTML-body/etc.) should be
         translated into a user-facing `[Slack attachment notice]` block so

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -29,6 +29,7 @@ from gateway.config import Platform
 from tools.send_message_tool import (
     _is_telegram_thread_not_found,
     _parse_target_ref,
+    _resolve_slack_user_target,
     _send_matrix_via_adapter,
     _send_signal,
     _send_telegram,
@@ -1658,7 +1659,7 @@ class TestParseTargetRefWhatsAppJID:
 
 
 class TestParseTargetRefSlack:
-    """_parse_target_ref recognizes Slack channel/user IDs as explicit."""
+    """_parse_target_ref recognizes Slack conversation and user targets."""
 
     def test_thread_target_is_explicit(self):
         chat_id, thread_id, is_explicit = _parse_target_ref("slack", "C0B0QV5434G:171.000001")
@@ -1678,12 +1679,22 @@ class TestParseTargetRefSlack:
     def test_dm_id_is_explicit(self):
         assert _parse_target_ref("slack", "D123ABCDEF")[2] is True
 
-    def test_user_id_is_not_explicit(self):
-        """Slack user IDs (U...) and workspace IDs (W...) are NOT explicit send
-        targets. chat.postMessage rejects them — a DM must be opened first via
-        conversations.open to obtain a D... conversation ID.
-        """
-        assert _parse_target_ref("slack", "U123ABCDEF")[2] is False
+    def test_user_id_is_explicit_dm_target(self):
+        """Slack user IDs are explicit user targets that must be opened as DMs."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("slack", "U123ABCDEF")
+        assert chat_id == "user:U123ABCDEF"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_at_username_is_explicit_dm_target(self):
+        """slack:@username targets resolve to DMs through users.list + conversations.open."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("slack", "@alice")
+        assert chat_id == "user_name:alice"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_workspace_id_is_not_explicit(self):
+        """Slack workspace IDs (W...) are not sendable conversation/user targets."""
         assert _parse_target_ref("slack", "W123ABCDEF")[2] is False
 
     def test_whitespace_is_stripped(self):
@@ -1783,6 +1794,129 @@ class TestEmailHomeChannelErrorHint:
                 )
             )
         assert "TELEGRAM_HOME_CHANNEL" in result["error"]
+
+
+class TestResolveSlackUserTargets:
+    """_resolve_slack_user_target opens user targets as DMs before sending.
+
+    Adapted from #19237's ``_send_slack`` tests: main moved Slack delivery to
+    the plugin's ``_standalone_send`` (#41112), so the salvaged DM-open logic
+    lives in a resolution helper that runs before any send path.
+    """
+
+    @staticmethod
+    def _mock_response(data):
+        response = MagicMock()
+        response.json = AsyncMock(return_value=data)
+        response.__aenter__ = AsyncMock(return_value=response)
+        response.__aexit__ = AsyncMock(return_value=None)
+        return response
+
+    @staticmethod
+    def _mock_session(*responses):
+        session = MagicMock()
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=None)
+        session.post = MagicMock(side_effect=responses)
+        return session
+
+    def test_conversation_ids_pass_through_without_api_calls(self):
+        for cid in ("C0B0QV5434G", "G123ABCDEF", "D123ABCDEF"):
+            chat_id, err = asyncio.run(_resolve_slack_user_target("tok", cid))
+            assert chat_id == cid
+            assert err is None
+
+    def test_user_id_target_opens_dm(self):
+        session = self._mock_session(
+            self._mock_response({"ok": True, "channel": {"id": "D123ABCDEF"}}),
+        )
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            chat_id, err = asyncio.run(
+                _resolve_slack_user_target("tok", "user:U123ABCDEF")
+            )
+
+        assert err is None
+        assert chat_id == "D123ABCDEF"
+        open_payload = session.post.call_args_list[0].kwargs["json"]
+        assert open_payload == {"users": "U123ABCDEF"}
+
+    def test_username_target_resolves_user_then_opens_dm(self):
+        session = self._mock_session(
+            self._mock_response({
+                "ok": True,
+                "members": [
+                    {"id": "UOTHER123", "name": "someone", "profile": {"display_name": "Other", "real_name": "Other User"}},
+                    {"id": "U123ABCDEF", "name": "alice", "profile": {"display_name": "Alice", "real_name": "Alice Example"}},
+                ],
+                "response_metadata": {},
+            }),
+            self._mock_response({"ok": True, "channel": {"id": "D123ABCDEF"}}),
+        )
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            chat_id, err = asyncio.run(
+                _resolve_slack_user_target("tok", "user_name:alice")
+            )
+
+        assert err is None
+        assert chat_id == "D123ABCDEF"
+        assert session.post.call_args_list[1].kwargs["json"] == {"users": "U123ABCDEF"}
+
+    def test_username_target_does_not_match_display_or_real_name(self):
+        session = self._mock_session(
+            self._mock_response({
+                "ok": True,
+                "members": [
+                    {"id": "U123ABCDEF", "name": "notalice", "profile": {"display_name": "alice", "real_name": "alice"}},
+                ],
+                "response_metadata": {},
+            }),
+        )
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            chat_id, err = asyncio.run(
+                _resolve_slack_user_target("tok", "user_name:alice")
+            )
+
+        assert chat_id is None
+        assert "Could not resolve Slack user '@alice'" in err["error"]
+        assert session.post.call_count == 1
+
+    def test_ambiguous_username_returns_error_without_opening_dm(self):
+        session = self._mock_session(
+            self._mock_response({
+                "ok": True,
+                "members": [
+                    {"id": "U111AAAAA", "name": "alice", "profile": {}},
+                    {"id": "U222BBBBB", "name": "alice", "profile": {}},
+                ],
+                "response_metadata": {},
+            }),
+        )
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            chat_id, err = asyncio.run(
+                _resolve_slack_user_target("tok", "user_name:alice")
+            )
+
+        assert chat_id is None
+        assert "matched multiple Slack users" in err["error"]
+        assert session.post.call_count == 1
+
+    def test_conversations_open_failure_surfaces_error(self):
+        session = self._mock_session(
+            self._mock_response({"ok": False, "error": "missing_scope"}),
+        )
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            chat_id, err = asyncio.run(
+                _resolve_slack_user_target("tok", "user:U123ABCDEF")
+            )
+
+        assert chat_id is None
+        assert "missing_scope" in err["error"]
+        assert "im:write" in err["error"]
 
 
 class TestSendDiscordThreadId:

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -785,13 +785,15 @@ class TestSendToPlatformChunking:
             entry.standalone_sender_fn = original
 
         assert result["success"] is True
+        # C8 caption-mode: short text rides the upload as `caption=` and the
+        # message slot is emptied — one Slack bubble, not text + bare file.
         send.assert_awaited_once_with(
             pconfig,
             "C123",
-            "daily report",
+            "",
             thread_id=None,
             media_files=media_files,
-            force_document=False,
+            caption="daily report",
         )
 
     def test_slack_bold_italic_formatted_before_send(self, monkeypatch):

--- a/tests/tools/test_slack_send_message_media.py
+++ b/tests/tools/test_slack_send_message_media.py
@@ -1,0 +1,251 @@
+"""Slack media delivery for send_message.
+
+Covers ``plugins/platforms/slack/adapter.py::_standalone_send`` media path:
+text+file, media-only, caption-on-upload, missing-file warnings.
+
+``slack_sdk`` is optional in CI, so tests inject a fake module into
+``sys.modules`` (same pattern as ``tests/gateway/test_slack.py``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import sys
+import tempfile
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from plugins.platforms.slack.adapter import _standalone_send
+
+
+def _pconfig(token: str = "xoxb-test"):
+    return SimpleNamespace(token=token, extra={})
+
+
+def _tmpfile(suffix: str) -> str:
+    f = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+    f.write(b"%PDF-1.4 test")
+    f.close()
+    return f.name
+
+
+def _mock_client(*, post_ok=True, upload_ok=True):
+    client = MagicMock()
+    client.chat_postMessage = AsyncMock(
+        return_value={
+            "ok": post_ok,
+            "ts": "111.222",
+            "error": None if post_ok else "channel_not_found",
+        }
+    )
+    if upload_ok:
+        client.files_upload_v2 = AsyncMock(
+            return_value={
+                "ok": True,
+                "file": {
+                    "id": "F123",
+                    "timestamp": 1234567890,
+                    "shares": {"public": {"C012AB3CD": [{"ts": "333.444"}]}},
+                },
+            }
+        )
+    else:
+        client.files_upload_v2 = AsyncMock(
+            return_value={"ok": False, "error": "not_in_channel"}
+        )
+    return client
+
+
+@contextlib.contextmanager
+def _fake_slack_sdk(client):
+    """Make ``from slack_sdk.web.async_client import AsyncWebClient`` resolve to a factory."""
+    sdk = ModuleType("slack_sdk")
+    web = ModuleType("slack_sdk.web")
+    async_client = ModuleType("slack_sdk.web.async_client")
+    async_client.AsyncWebClient = MagicMock(return_value=client)
+    sdk.web = web
+    web.async_client = async_client
+
+    modules = {
+        "slack_sdk": sdk,
+        "slack_sdk.web": web,
+        "slack_sdk.web.async_client": async_client,
+    }
+    old = {name: sys.modules.get(name) for name in modules}
+    sys.modules.update(modules)
+    try:
+        yield
+    finally:
+        for name, prev in old.items():
+            if prev is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prev
+
+
+def test_text_plus_pdf_uploads_via_files_upload_v2():
+    pdf = _tmpfile(".pdf")
+    client = _mock_client()
+    try:
+        with _fake_slack_sdk(client):
+            result = asyncio.run(
+                _standalone_send(
+                    _pconfig(),
+                    "C012AB3CD",
+                    "Here is the report",
+                    media_files=[(pdf, False)],
+                )
+            )
+        assert result["success"] is True
+        assert result["platform"] == "slack"
+        client.chat_postMessage.assert_awaited_once()
+        client.files_upload_v2.assert_awaited_once()
+        upload_kwargs = client.files_upload_v2.await_args.kwargs
+        assert upload_kwargs["channel"] == "C012AB3CD"
+        assert upload_kwargs["file"] == pdf
+        assert upload_kwargs["filename"] == os.path.basename(pdf)
+        assert upload_kwargs["initial_comment"] == ""
+    finally:
+        os.unlink(pdf)
+
+
+def test_media_only_skips_text_post():
+    pdf = _tmpfile(".pdf")
+    client = _mock_client()
+    try:
+        with _fake_slack_sdk(client):
+            result = asyncio.run(
+                _standalone_send(
+                    _pconfig(),
+                    "C012AB3CD",
+                    "",
+                    media_files=[(pdf, False)],
+                )
+            )
+        assert result["success"] is True
+        client.chat_postMessage.assert_not_awaited()
+        client.files_upload_v2.assert_awaited_once()
+    finally:
+        os.unlink(pdf)
+
+
+def test_caption_rides_initial_comment_no_separate_text():
+    pdf = _tmpfile(".pdf")
+    client = _mock_client()
+    try:
+        with _fake_slack_sdk(client):
+            result = asyncio.run(
+                _standalone_send(
+                    _pconfig(),
+                    "C012AB3CD",
+                    "",
+                    media_files=[(pdf, False)],
+                    caption="Q3 summary PDF",
+                )
+            )
+        assert result["success"] is True
+        client.chat_postMessage.assert_not_awaited()
+        upload_kwargs = client.files_upload_v2.await_args.kwargs
+        assert upload_kwargs["initial_comment"] == "Q3 summary PDF"
+    finally:
+        os.unlink(pdf)
+
+
+def test_missing_media_file_warns_and_falls_back_caption():
+    client = _mock_client()
+    with _fake_slack_sdk(client):
+        result = asyncio.run(
+            _standalone_send(
+                _pconfig(),
+                "C012AB3CD",
+                "",
+                media_files=[("/no/such/file.pdf", False)],
+                caption="still deliver this",
+            )
+        )
+    assert result["success"] is True
+    assert result.get("warnings")
+    assert any("not found" in w.lower() for w in result["warnings"])
+    client.chat_postMessage.assert_awaited_once()
+    assert client.chat_postMessage.await_args.kwargs["text"] == "still deliver this"
+    client.files_upload_v2.assert_not_awaited()
+
+
+def test_missing_token_errors(monkeypatch):
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    result = asyncio.run(
+        _standalone_send(
+            _pconfig(token=""),
+            "C012AB3CD",
+            "hi",
+            media_files=[("/tmp/x.pdf", False)],
+        )
+    )
+    assert "error" in result
+    assert "SLACK_BOT_TOKEN" in result["error"]
+
+
+def test_thread_id_passed_to_upload():
+    pdf = _tmpfile(".pdf")
+    client = _mock_client()
+    try:
+        with _fake_slack_sdk(client):
+            asyncio.run(
+                _standalone_send(
+                    _pconfig(),
+                    "C012AB3CD",
+                    "",
+                    thread_id="999.000",
+                    media_files=[(pdf, False)],
+                )
+            )
+        assert client.files_upload_v2.await_args.kwargs["thread_ts"] == "999.000"
+    finally:
+        os.unlink(pdf)
+
+
+def test_send_to_platform_routes_slack_media():
+    """_send_to_platform must call Slack standalone_sender with media_files."""
+    import httpx
+
+    if not hasattr(httpx, "Proxy") or not hasattr(httpx, "URL"):
+        pytest.skip("httpx type annotations incompatible with telegram library")
+
+    from gateway.config import Platform
+    from hermes_cli.plugins import discover_plugins
+    from gateway.platform_registry import platform_registry
+    from tools.send_message_tool import _send_to_platform
+
+    pdf = _tmpfile(".pdf")
+    discover_plugins()
+    entry = platform_registry.get("slack")
+    assert entry is not None and entry.standalone_sender_fn is not None
+    original = entry.standalone_sender_fn
+    mock_sender = AsyncMock(
+        return_value={"success": True, "platform": "slack", "message_id": "1.2"}
+    )
+    entry.standalone_sender_fn = mock_sender
+    try:
+        result = asyncio.run(
+            _send_to_platform(
+                Platform.SLACK,
+                _pconfig(),
+                "C012AB3CD",
+                "Here is the report",
+                media_files=[(pdf, False)],
+            )
+        )
+        assert result["success"] is True
+        mock_sender.assert_awaited()
+        call_kwargs = mock_sender.await_args.kwargs
+        assert call_kwargs.get("media_files") == [(pdf, False)]
+        # Single captionable file + short text → caption rides the upload.
+        assert call_kwargs.get("caption") == "Here is the report"
+        assert not result.get("warnings")
+    finally:
+        entry.standalone_sender_fn = original
+        os.unlink(pdf)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -22,12 +22,15 @@ logger = logging.getLogger(__name__)
 _TELEGRAM_TOPIC_TARGET_RE = re.compile(r"^\s*(-?\d+)(?::(\d+))?\s*$")
 _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::([-A-Za-z0-9_]+))?\s*$")
 # Slack conversation IDs: C (public channel), G (private/group channel), D (DM).
-# Must be uppercase alphanumeric, 9+ chars. User IDs (U...) and workspace IDs
-# (W...) are NOT valid chat.postMessage channel values — posting to them fails
-# because the API requires a conversation ID. To DM a user you must first call
-# conversations.open to obtain a D... ID. Without this gate, Slack IDs fall
-# through to channel-name resolution, which only matches by name and fails.
-_SLACK_TARGET_RE = re.compile(r"^\s*([CGDU][A-Z0-9]{8,})\s*$")
+# Must be uppercase alphanumeric, 9+ chars. User IDs (U...) are parsed as
+# explicit user targets (``user:U...``) and are converted to D... conversations
+# via conversations.open before chat.postMessage — posting directly to a U/W
+# ID fails because the API requires a conversation ID. ``@handle`` targets are
+# resolved through users.list first (``user_name:...``).
+_SLACK_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,})\s*$")
+_SLACK_USER_ID_RE = re.compile(r"^\s*(U[A-Z0-9]{8,})\s*$")
+_SLACK_USER_NAME_RE = re.compile(r"^\s*@([A-Za-z0-9._-]{1,80})\s*$")
+_SLACK_MENTION_RE = re.compile(r"^\s*<@(U[A-Z0-9]{8,})(?:\|[^>]+)?>\s*$")
 # Session-derived Slack thread targets use "<conversation_id>:<thread_ts>".
 _SLACK_THREAD_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,}):([^\s:]+)\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
@@ -465,27 +468,22 @@ def _handle_send(args):
     if duplicate_skip:
         return json.dumps(duplicate_skip)
 
-    # Slack: resolve user IDs (U...) to DM channel IDs via conversations.open
-    if platform_name == "slack" and chat_id and chat_id.startswith("U"):
-        try:
-            import aiohttp
-            async def _open_slack_dm(token, user_id):
-                url = "https://slack.com/api/conversations.open"
-                headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-                async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
-                    async with session.post(url, headers=headers, json={"users": [user_id]}) as resp:
-                        data = await resp.json()
-                        if data.get("ok"):
-                            return data["channel"]["id"]
-                        return None
+    # Slack: resolve user targets to DM channel IDs before sending.
+    # _parse_target_ref emits internal ``user:U...`` / ``user_name:@handle``
+    # targets; a bare U... id can also arrive from session metadata or the
+    # home-channel config. All are opened via conversations.open (fixes #19236).
+    if platform_name == "slack" and chat_id:
+        _slack_dm_target = chat_id
+        if _slack_dm_target.startswith("U") and _SLACK_USER_ID_RE.fullmatch(_slack_dm_target):
+            _slack_dm_target = f"user:{_slack_dm_target}"
+        if _slack_dm_target.startswith(("user:", "user_name:")):
             from model_tools import _run_async
-            dm_channel = _run_async(_open_slack_dm(pconfig.token, chat_id))
-            if dm_channel:
-                chat_id = dm_channel
-            else:
-                return json.dumps({"error": f"Could not open DM with Slack user {chat_id}. Check bot permissions (im:write)."})
-        except Exception as e:
-            return json.dumps({"error": f"Failed to open Slack DM: {e}"})
+            _resolved, _resolve_err = _run_async(
+                _resolve_slack_user_target(pconfig.token, _slack_dm_target)
+            )
+            if _resolve_err:
+                return json.dumps(_resolve_err)
+            chat_id = _resolved
 
     try:
         from model_tools import _run_async
@@ -556,14 +554,13 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             return match.group(1), match.group(2), True
         match = _SLACK_TARGET_RE.fullmatch(target_ref)
         if match:
-            chat_id = match.group(1)
-            # Slack user IDs (U...) and workspace IDs (W...) are NOT valid
-            # explicit send targets — chat.postMessage rejects them. A DM
-            # must be opened first via conversations.open to get a D...
-            # conversation ID. Caller still gets the chat_id so the U→D
-            # resolution path in send_message() can run.
-            is_explicit = chat_id[0] not in {"U", "W"}
-            return chat_id, None, is_explicit
+            return match.group(1), None, True
+        match = _SLACK_USER_ID_RE.fullmatch(target_ref) or _SLACK_MENTION_RE.fullmatch(target_ref)
+        if match:
+            return f"user:{match.group(1)}", None, True
+        match = _SLACK_USER_NAME_RE.fullmatch(target_ref)
+        if match:
+            return f"user_name:{match.group(1)}", None, True
     if platform_name == "matrix":
         trimmed = target_ref.strip()
         split_idx = trimmed.rfind(":$")
@@ -1512,6 +1509,84 @@ async def _registry_standalone_send(platform_name, pconfig, chat_id, message, th
 
 # _send_whatsapp moved to plugins/platforms/whatsapp/adapter.py::_standalone_send,
 # wired via standalone_sender_fn and reached through _registry_standalone_send. #41112.
+
+
+async def _resolve_slack_user_target(token, chat_id):
+    """Resolve a Slack user target to a D... DM conversation ID.
+
+    ``chat_id`` may be a Slack conversation ID (C/G/D...) — returned unchanged —
+    or an internal user target (``user:U...`` / ``user_name:<handle>``). User
+    targets are opened as DMs via conversations.open because Slack
+    chat.postMessage requires a conversation ID. ``user_name:`` targets are
+    first resolved to a user ID through users.list (stable handle match only).
+
+    Returns ``(chat_id, None)`` on success or ``(None, error_dict)`` on failure.
+    """
+    if not (chat_id.startswith("user:") or chat_id.startswith("user_name:")):
+        return chat_id, None
+    try:
+        import aiohttp
+    except ImportError:
+        return None, {"error": "aiohttp not installed. Run: pip install aiohttp"}
+    try:
+        from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+        _proxy = resolve_proxy_url()
+        _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
+        base_url = "https://slack.com/api"
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+        async def post_api(session, method, payload):
+            async with session.post(f"{base_url}/{method}", headers=headers, json=payload, **_req_kw) as resp:
+                return await resp.json()
+
+        async def resolve_user_name(session, name):
+            query = name.strip().lstrip("@").lower()
+            matches = []
+            cursor = None
+            for _page in range(20):
+                payload = {"limit": 200}
+                if cursor:
+                    payload["cursor"] = cursor
+                data = await post_api(session, "users.list", payload)
+                if not data.get("ok"):
+                    return None, f"Slack users.list error: {data.get('error', 'unknown')}"
+                for member in data.get("members", []):
+                    if member.get("deleted") or member.get("is_bot"):
+                        continue
+                    # ``@name`` should match the stable Slack handle only. Display
+                    # and real names are mutable/non-unique enough that using them
+                    # could DM the wrong person with sensitive content.
+                    if str(member.get("name", "")).strip().lower() == query:
+                        matches.append(member)
+                cursor = (data.get("response_metadata") or {}).get("next_cursor")
+                if not cursor:
+                    break
+            if not matches:
+                return None, f"Could not resolve Slack user '@{name}'."
+            if len(matches) > 1:
+                return None, f"Slack user '@{name}' matched multiple Slack users. Use a Slack user ID instead."
+            return matches[0].get("id"), None
+
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
+            if chat_id.startswith("user_name:"):
+                user_id, error = await resolve_user_name(session, chat_id[len("user_name:"):])
+                if error:
+                    return None, _error(error)
+                chat_id = f"user:{user_id}"
+
+            user_id = chat_id[len("user:"):]
+            opened = await post_api(session, "conversations.open", {"users": user_id})
+            if not opened.get("ok"):
+                return None, _error(
+                    f"Slack conversations.open error: {opened.get('error', 'unknown')}. "
+                    "Check bot permissions (im:write)."
+                )
+            dm_id = (opened.get("channel") or {}).get("id")
+            if not dm_id:
+                return None, _error("Slack conversations.open did not return a DM channel ID")
+            return dm_id, None
+    except Exception as e:
+        return None, _error(f"Slack DM resolution failed: {e}")
 
 
 async def _send_signal(extra, chat_id, message, media_files=None):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -982,6 +982,48 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Slack: native media via files_upload_v2 in the plugin's
+    # standalone_sender_fn (plugins/platforms/slack/adapter.py::_standalone_send).
+    # Gateway in-channel MEDIA: delivery already worked; send_message previously
+    # omitted Slack attachments and told the model media was unsupported.
+    if platform == Platform.SLACK and media_files:
+        from gateway.platform_registry import platform_registry as _pr_slack
+        from hermes_cli.plugins import discover_plugins as _dp_slack
+        _dp_slack()
+        _slack_entry = _pr_slack.get("slack")
+        if _slack_entry is None or _slack_entry.standalone_sender_fn is None:
+            return {"error": "Slack plugin not registered or missing standalone_sender_fn"}
+        _sl_caption, _ = _media_caption_split(
+            message, media_files,
+            max_caption_len=(max_len or _DEFAULT_CAPTION_LIMIT),
+        )
+        if _sl_caption is not None:
+            result = await _slack_entry.standalone_sender_fn(
+                pconfig,
+                chat_id,
+                "",
+                thread_id=thread_id,
+                media_files=media_files,
+                caption=_sl_caption,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            return result
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _slack_entry.standalone_sender_fn(
+                pconfig,
+                chat_id,
+                chunk,
+                thread_id=thread_id,
+                media_files=media_files if is_last else [],
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- WhatsApp: native media attachment support via the registry's
     # standalone_sender_fn (plugins/platforms/whatsapp/adapter.py::_standalone_send).
     # The plugin uploads each file through the local Baileys bridge /send-media
@@ -1062,7 +1104,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and whatsapp; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -1070,7 +1112,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and whatsapp"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack"
         )
 
     last_result = None


### PR DESCRIPTION
## Summary
Slack media delivery now works everywhere: `send_message` uploads MEDIA attachments, bare user targets (`slack:U…`, `slack:@handle`) open DMs across every send path (including clarify/approval prompts), post-stream delivery uploads only explicitly-tagged files, and file events resolve against the owning workspace.

Fixes #51198, #19236, #17261, #20834.

## Changes
- `send_message` MEDIA: routed through the plugin's standalone sender → `files_upload_v2`, caption-on-upload, per-file warnings with caption fallback, media-on-last-chunk for chunked text (#67219).
- DM targets: `users.list` handle resolution + `conversations.open` ported into `_resolve_slack_user_target` (#19237); widening: `_ensure_dm_conversation` (workspace-scoped, cached, fail-open) wired into send, uploads, images/video/document, approval, slash-confirm, and clarify paths — attachments AND prompts now reach bare user targets (#17261).
- Post-stream media: `_deliver_media_from_response` no longer auto-detects local paths — explicit `MEDIA:` tags only (#20834; non-streaming path intentionally keeps auto-detect, asymmetry documented).
- Multi-workspace: file events without team_id resolve via the `_channel_team` cache (#30456).
- Security-adjacent, composing cleanly: redirect re-validation on image downloads + SSRF redirect guard on batch uploads — no filetype blocklists (#62932); unauthorized users gated before file metadata fetch (#55272).

## Credits
Salvaged with authorship preserved: #67219 (@HexLab98), #19237 (@davesecops), #30456 (@robzolkos), #62932 + #55272 (@necoweb3).
Supersedes #51199 (@greptile — verified human account; hard-fails on missing files), #21800 (@tony88331 — EARLIEST implementation of MEDIA-in-send_message, credited as originator; targeted the pre-plugin architecture).
Deferred: #69185/#32315 (inbound image-context plumbing, 2,400+ lines cross-cutting — own cluster).

## Validation
| Check | Result |
|---|---|
| `tests/gateway/ -q -k slack` | 617 passed, 0 failed |
| send_message tool suites + new media/post-stream test files | 1,170 passed in combined sweep |
| Re-verified post-rebase by parent session | green |

Note for merge sequencing: touches `_standalone_send` — C7 (#cron delivery PR) touches the same function; whichever merges second will be rebased and reconciled manually.

## Infographic

![slack-media-delivery](https://v3b.fal.media/files/b/0aa34a3f/3ZdtwqNh_pNjHNN6hWe_3_Gv1JZuwc.png)
