### PR TITLE
feat(bluebubbles): approve commands with tapbacks

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -23,6 +23,7 @@ from urllib.parse import quote
 
 import httpx
 
+from agent.i18n import t
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -677,6 +678,16 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 approval_id=prompt.approval_id,
             )
             if count:
+                confirmation_key = (
+                    "gateway.approve.once_singular"
+                    if choice == "once"
+                    else "gateway.deny.denied_singular"
+                )
+                task = asyncio.create_task(
+                    self.send(prompt.chat_id, t(confirmation_key))
+                )
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
                 self.resume_typing_for_chat(prompt.chat_id)
             logger.info(
                 "[bluebubbles] Tapback resolved %d approval(s) (choice=%s, user=%s)",

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -13,8 +13,10 @@ import json
 import logging
 import os
 import re
+import time
 import uuid
 from collections import OrderedDict
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
@@ -100,6 +102,18 @@ _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
 _GUID_CACHE_SIZE = 500  # LRU cap for resolved chat-GUID lookups
 
 
+@dataclass
+class _BlueBubblesApprovalPrompt:
+    session_key: str
+    chat_id: str
+    message_id: str
+    approval_id: str
+    requester_user_id: Optional[str]
+    expires_at: float
+    expiry_handle: Optional[asyncio.TimerHandle] = None
+    resolved: bool = False
+
+
 def _redact(text: str) -> str:
     """Redact phone numbers and emails from log output."""
     text = _PHONE_RE.sub("[REDACTED]", text)
@@ -178,6 +192,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        self._approval_prompts_by_guid: Dict[str, _BlueBubblesApprovalPrompt] = {}
+        self._approval_prompt_by_approval_id: Dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # API helpers
@@ -300,6 +316,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         # Unregister webhook before cleaning up
         await self._unregister_webhook()
+
+        for guid, prompt in list(self._approval_prompts_by_guid.items()):
+            self._remove_approval_prompt(guid, prompt)
 
         if self.client:
             await self.client.aclose()
@@ -559,6 +578,194 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             except Exception as exc:
                 return SendResult(success=False, error=str(exc))
         return last
+
+    @staticmethod
+    def _normalize_message_guid(raw: Optional[str]) -> Optional[str]:
+        if not raw:
+            return None
+        value = raw.strip()
+        return re.sub(r"^p:\d+/", "", value) or None
+
+    def _remove_approval_prompt(
+        self, guid: str, prompt: _BlueBubblesApprovalPrompt
+    ) -> None:
+        self._approval_prompts_by_guid.pop(guid, None)
+        if self._approval_prompt_by_approval_id.get(prompt.approval_id) == guid:
+            self._approval_prompt_by_approval_id.pop(prompt.approval_id, None)
+        if prompt.expiry_handle is not None:
+            prompt.expiry_handle.cancel()
+            prompt.expiry_handle = None
+
+    def _expire_approval_prompt(self, guid: str, approval_id: str) -> None:
+        prompt = self._approval_prompts_by_guid.get(guid)
+        if prompt is None or prompt.approval_id != approval_id:
+            return
+        if time.monotonic() >= prompt.expires_at:
+            self._remove_approval_prompt(guid, prompt)
+
+    def _handle_approval_tapback(
+        self,
+        record: Dict[str, Any],
+        payload: Dict[str, Any],
+        assoc_type: int,
+    ) -> bool:
+        """Resolve a tracked approval Tapback and consume the webhook event."""
+        choice = {2001: "once", 2002: "deny"}.get(assoc_type)
+        target_guid = self._normalize_message_guid(
+            self._value(record.get("associatedMessageGuid"))
+        )
+        if not choice or not target_guid:
+            return False
+        prompt = self._approval_prompts_by_guid.get(target_guid)
+        if prompt is None:
+            return False
+
+        chat_guid = self._value(
+            record.get("chatGuid"),
+            payload.get("chatGuid"),
+            record.get("chat_guid"),
+            payload.get("chat_guid"),
+        )
+        if not chat_guid:
+            chats = record.get("chats") or []
+            if chats and isinstance(chats[0], dict):
+                chat_guid = chats[0].get("guid") or chats[0].get("chatGuid")
+        chat_identifier = self._value(
+            record.get("chatIdentifier"),
+            record.get("identifier"),
+            payload.get("chatIdentifier"),
+            payload.get("identifier"),
+        )
+        sender = (
+            self._value(
+                record.get("handle", {}).get("address")
+                if isinstance(record.get("handle"), dict)
+                else None,
+                record.get("sender"),
+                record.get("from"),
+                record.get("address"),
+            )
+            or chat_identifier
+        )
+        event_chat_id = chat_guid or chat_identifier
+        is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
+        chat_type = "group" if is_group else "dm"
+
+        if prompt.resolved or time.monotonic() > prompt.expires_at:
+            self._remove_approval_prompt(target_guid, prompt)
+            return True
+
+        if (
+            not sender
+            or event_chat_id != prompt.chat_id
+            or self._is_sender_authorized(sender, chat_type, event_chat_id) is not True
+            or not prompt.requester_user_id
+            or sender != prompt.requester_user_id
+        ):
+            return True
+
+        prompt.resolved = True
+        self._remove_approval_prompt(target_guid, prompt)
+
+        try:
+            from tools.approval import resolve_gateway_approval
+
+            count = resolve_gateway_approval(
+                prompt.session_key,
+                choice,
+                approval_id=prompt.approval_id,
+            )
+            if count:
+                self.resume_typing_for_chat(prompt.chat_id)
+            logger.info(
+                "[bluebubbles] Tapback resolved %d approval(s) (choice=%s, user=%s)",
+                count,
+                choice,
+                _redact(sender),
+            )
+        except Exception:
+            logger.exception("[bluebubbles] failed to resolve approval Tapback")
+        return True
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+        allow_permanent: bool = True,
+        allow_session: bool = True,
+        smart_denied: bool = False,
+    ) -> SendResult:
+        """Send and track a Tapback-enabled dangerous-command prompt."""
+        del allow_permanent, allow_session, smart_denied
+
+        prompt_metadata = metadata or {}
+        approval_id = str(prompt_metadata.get("approval_id") or "") or None
+        requester_user_id = (
+            str(prompt_metadata.get("requester_user_id") or "") or None
+        )
+        timeout_value = prompt_metadata.get("approval_timeout_seconds")
+        if not approval_id or not requester_user_id or timeout_value is None:
+            return SendResult(
+                success=False,
+                error="BlueBubbles approval prompt requires requester, approval ID, and timeout",
+            )
+        try:
+            timeout_seconds = max(float(timeout_value), 0.0)
+        except (TypeError, ValueError):
+            return SendResult(
+                success=False,
+                error="BlueBubbles approval prompt received an invalid timeout",
+            )
+
+        def _single_bubble_preview(value: str, limit: int) -> str:
+            normalized = re.sub(r"\n\s*\n+", "\n", value.strip())
+            return normalized[:limit] + ("..." if len(normalized) > limit else "")
+
+        command_preview = _single_bubble_preview(command, 2500)
+        description_preview = _single_bubble_preview(description, 800)
+        text = (
+            "⚠️ Dangerous command requires approval\n"
+            f"Command: {command_preview}\n"
+            f"Reason: {description_preview}\n"
+            "React 👍 to approve once or 👎 to deny.\n"
+            "You can also reply /approve or /deny."
+        )
+        result = await self.send(chat_id, text, metadata=metadata)
+        message_id = self._normalize_message_guid(result.message_id)
+        if not result.success:
+            return result
+        if not message_id or message_id == "ok":
+            return SendResult(
+                success=False,
+                error="BlueBubbles approval prompt did not return a message GUID",
+                raw_response=result.raw_response,
+            )
+
+        previous_guid = self._approval_prompt_by_approval_id.get(approval_id)
+        if previous_guid:
+            previous_prompt = self._approval_prompts_by_guid.get(previous_guid)
+            if previous_prompt is not None:
+                self._remove_approval_prompt(previous_guid, previous_prompt)
+        prompt = _BlueBubblesApprovalPrompt(
+            session_key=session_key,
+            chat_id=chat_id,
+            message_id=message_id,
+            approval_id=approval_id,
+            requester_user_id=requester_user_id,
+            expires_at=time.monotonic() + timeout_seconds,
+        )
+        self._approval_prompts_by_guid[message_id] = prompt
+        self._approval_prompt_by_approval_id[approval_id] = message_id
+        prompt.expiry_handle = asyncio.get_running_loop().call_later(
+            timeout_seconds,
+            self._expire_approval_prompt,
+            message_id,
+            approval_id,
+        )
+        return result
 
     # ------------------------------------------------------------------
     # Media sending (outbound)
@@ -917,10 +1124,13 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         # Skip tapback reactions delivered as messages
         assoc_type = record.get("associatedMessageType")
+        if isinstance(assoc_type, str) and assoc_type.strip().isdigit():
+            assoc_type = int(assoc_type)
         if isinstance(assoc_type, int) and assoc_type in {
             **_TAPBACK_ADDED,
             **_TAPBACK_REMOVED,
         }:
+            self._handle_approval_tapback(record, payload, assoc_type)
             return web.Response(text="ok")
 
         text = (

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -91,6 +91,7 @@ _TAPBACK_REMOVED = {
     3000: "love", 3001: "like", 3002: "dislike",
     3003: "laugh", 3004: "emphasize", 3005: "question",
 }
+_TAPBACK_ADDED_BY_NAME = {name: code for code, name in _TAPBACK_ADDED.items()}
 
 # Webhook event types that carry user messages
 _MESSAGE_EVENTS = {"new-message", "message", "updated-message"}
@@ -1124,8 +1125,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         # Skip tapback reactions delivered as messages
         assoc_type = record.get("associatedMessageType")
-        if isinstance(assoc_type, str) and assoc_type.strip().isdigit():
-            assoc_type = int(assoc_type)
+        if isinstance(assoc_type, str):
+            normalized_assoc_type = assoc_type.strip().lower()
+            if normalized_assoc_type.isdigit():
+                assoc_type = int(normalized_assoc_type)
+            else:
+                assoc_type = _TAPBACK_ADDED_BY_NAME.get(normalized_assoc_type)
         if isinstance(assoc_type, int) and assoc_type in {
             **_TAPBACK_ADDED,
             **_TAPBACK_REMOVED,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -316,6 +316,23 @@ def _non_conversational_metadata(
     return merged
 
 
+def _approval_prompt_metadata(
+    metadata: Optional[Dict[str, Any]],
+    approval_data: Dict[str, Any],
+    *,
+    requester_user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Bind an interactive prompt to one exact approval queue entry."""
+    merged = dict(metadata or {})
+    if requester_user_id:
+        merged["requester_user_id"] = requester_user_id
+    for key in ("approval_id", "approval_timeout_seconds"):
+        value = approval_data.get(key)
+        if value is not None:
+            merged[key] = value
+    return merged
+
+
 def _seed_hygiene_system_prompt(
     agent: Any,
     session_row: Optional[Dict[str, Any]],
@@ -4835,7 +4852,16 @@ class TurnRunner:
                             command=cmd,
                             session_key=_approval_session_key,
                             description=desc,
-                            metadata=ctx._status_thread_metadata,
+                            metadata=_approval_prompt_metadata(
+                                ctx._status_thread_metadata,
+                                approval_data,
+                                requester_user_id=(
+                                    str(ctx.source.user_id)
+                                    if ctx.source.platform == Platform.BLUEBUBBLES
+                                    and ctx.source.user_id
+                                    else None
+                                ),
+                            ),
                             allow_permanent=approval_data.get("allow_permanent", True),
                             allow_session=approval_data.get("allow_session", True),
                             smart_denied=approval_data.get("smart_denied", False),

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -156,6 +156,29 @@ class TestBlockingGatewayApproval:
         assert not e2.event.is_set()
         assert len(_gateway_queues[session_key]) == 1
 
+    def test_resolve_by_approval_id_targets_exact_concurrent_entry(self):
+        """Interactive prompts must never resolve a different FIFO entry."""
+        from tools.approval import (
+            resolve_gateway_approval,
+            _ApprovalEntry, _gateway_queues,
+        )
+        session_key = "test-targeted"
+        e1 = _ApprovalEntry({"command": "first"})
+        e2 = _ApprovalEntry({"command": "second"})
+        _gateway_queues[session_key] = [e1, e2]
+
+        count = resolve_gateway_approval(
+            session_key,
+            "once",
+            approval_id=e2.approval_id,
+        )
+
+        assert count == 1
+        assert not e1.event.is_set()
+        assert e2.event.is_set()
+        assert e2.result == "once"
+        assert _gateway_queues[session_key] == [e1]
+        assert e1.data["approval_id"] == e1.approval_id
 
 # ------------------------------------------------------------------
 # /approve command

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -150,7 +150,10 @@ class TestBlueBubblesExecApproval:
         assert "\n\n" not in sent[0]
 
     @pytest.mark.asyncio
-    async def test_like_tapback_resolves_active_prompt_once(self, monkeypatch):
+    @pytest.mark.parametrize("assoc_type", [2001, "like"])
+    async def test_like_tapback_resolves_active_prompt_once(
+        self, monkeypatch, assoc_type
+    ):
         adapter = _make_adapter(monkeypatch, send_read_receipts=False)
 
         async def fake_send(chat_id, text, metadata=None):
@@ -188,7 +191,7 @@ class TestBlueBubblesExecApproval:
                 "isFromMe": False,
                 "chatGuid": "iMessage;-;user@example.com",
                 "chatIdentifier": "user@example.com",
-                "associatedMessageType": 2001,
+                "associatedMessageType": assoc_type,
                 "associatedMessageGuid": "p:0/APPROVAL-GUID",
             },
         }
@@ -424,7 +427,7 @@ class TestBlueBubblesExecApproval:
         assert resolved == []
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("assoc_type", [2002, "2002"])
+    @pytest.mark.parametrize("assoc_type", [2002, "2002", "dislike"])
     async def test_dislike_tapback_denies(self, monkeypatch, assoc_type):
         adapter = _make_adapter(monkeypatch, send_read_receipts=False)
 

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -155,10 +155,12 @@ class TestBlueBubblesExecApproval:
         self, monkeypatch, assoc_type
     ):
         adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        sent = []
 
         async def fake_send(chat_id, text, metadata=None):
             from gateway.platforms.base import SendResult
 
+            sent.append((chat_id, text))
             return SendResult(success=True, message_id="APPROVAL-GUID")
 
         monkeypatch.setattr(adapter, "send", fake_send)
@@ -198,6 +200,7 @@ class TestBlueBubblesExecApproval:
 
         first = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
         second = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
 
         assert first.status == 200
         assert second.status == 200
@@ -206,6 +209,12 @@ class TestBlueBubblesExecApproval:
         ]
         assert resumed == ["iMessage;-;user@example.com"]
         assert adapter._approval_prompts_by_guid == {}
+        assert sent[1:] == [
+            (
+                "iMessage;-;user@example.com",
+                "✅ Command approved. The agent is resuming...",
+            )
+        ]
 
     @pytest.mark.asyncio
     async def test_canonical_tapback_resolves_exact_concurrent_entry(self, monkeypatch):
@@ -260,6 +269,47 @@ class TestBlueBubblesExecApproval:
             assert _gateway_queues[session_key] == [entry_a]
         finally:
             _gateway_queues.pop(session_key, None)
+
+    @pytest.mark.asyncio
+    async def test_tapback_without_waiter_sends_no_confirmation(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        sent = []
+
+        async def fake_send(chat_id, text, metadata=None):
+            from gateway.platforms.base import SendResult
+
+            sent.append((chat_id, text))
+            return SendResult(success=True, message_id="STALE-GUID")
+
+        monkeypatch.setattr(adapter, "send", fake_send)
+        await adapter.send_exec_approval(
+            chat_id="iMessage;-;user@example.com",
+            command="touch protected-file",
+            session_key="bluebubbles:iMessage;-;user@example.com",
+            metadata=_approval_metadata(),
+        )
+        adapter.set_authorization_check(lambda *_args: True)
+        resumed = []
+        monkeypatch.setattr(adapter, "resume_typing_for_chat", resumed.append)
+        monkeypatch.setattr(
+            "tools.approval.resolve_gateway_approval", lambda *_args, **_kwargs: 0
+        )
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                "guid": "STALE-TAPBACK-GUID",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;user@example.com",
+                "associatedMessageType": "like",
+                "associatedMessageGuid": "p:0/STALE-GUID",
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert len(sent) == 1
+        assert resumed == []
 
     def test_gateway_approval_metadata_carries_requester_without_thread(self):
         from gateway.run import _approval_prompt_metadata
@@ -430,10 +480,12 @@ class TestBlueBubblesExecApproval:
     @pytest.mark.parametrize("assoc_type", [2002, "2002", "dislike"])
     async def test_dislike_tapback_denies(self, monkeypatch, assoc_type):
         adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        sent = []
 
         async def fake_send(chat_id, text, metadata=None):
             from gateway.platforms.base import SendResult
 
+            sent.append((chat_id, text))
             return SendResult(success=True, message_id="DENY-GUID")
 
         monkeypatch.setattr(adapter, "send", fake_send)
@@ -463,9 +515,13 @@ class TestBlueBubblesExecApproval:
                 "associatedMessageGuid": "p:0/DENY-GUID",
             },
         }))
+        await asyncio.sleep(0)
 
         assert resolved == [
             ("bluebubbles:iMessage;-;user@example.com", "deny", "approval-1")
+        ]
+        assert sent[1:] == [
+            ("iMessage;-;user@example.com", "❌ Command denied.")
         ]
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -23,6 +23,20 @@ def _make_adapter(monkeypatch, **extra):
     return BlueBubblesAdapter(cfg)
 
 
+def _approval_metadata(
+    requester_user_id: str | None = "user@example.com",
+    approval_id: str = "approval-1",
+    timeout_seconds: int = 300,
+):
+    metadata = {
+        "approval_id": approval_id,
+        "approval_timeout_seconds": timeout_seconds,
+    }
+    if requester_user_id is not None:
+        metadata["requester_user_id"] = requester_user_id
+    return metadata
+
+
 class TestBlueBubblesConfigLoading:
     def test_apply_env_overrides_bluebubbles(self, monkeypatch):
         monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
@@ -71,6 +85,530 @@ class TestBlueBubblesHelpers:
     def test_server_url_normalized(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, server_url="http://localhost:1234/")
         assert adapter.server_url == "http://localhost:1234"
+
+
+class TestBlueBubblesExecApproval:
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_records_prompt_by_returned_guid(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        sent = []
+
+        async def fake_send(chat_id, text, metadata=None):
+            from gateway.platforms.base import SendResult
+
+            sent.append((chat_id, text, metadata))
+            return SendResult(success=True, message_id="p:0/APPROVAL-GUID")
+
+        monkeypatch.setattr(adapter, "send", fake_send)
+
+        result = await adapter.send_exec_approval(
+            chat_id="iMessage;-;user@example.com",
+            command="rm protected-file",
+            session_key="bluebubbles:iMessage;-;user@example.com",
+            description="destructive command",
+            metadata=_approval_metadata(),
+            allow_permanent=False,
+            allow_session=False,
+            smart_denied=True,
+        )
+
+        assert result.success is True
+        assert result.message_id == "p:0/APPROVAL-GUID"
+        assert len(sent) == 1
+        assert "👍" in sent[0][1]
+        assert "👎" in sent[0][1]
+        assert "/approve" in sent[0][1]
+        assert "/deny" in sent[0][1]
+        prompt = adapter._approval_prompts_by_guid["APPROVAL-GUID"]
+        assert prompt.session_key == "bluebubbles:iMessage;-;user@example.com"
+        assert prompt.chat_id == "iMessage;-;user@example.com"
+        assert prompt.requester_user_id == "user@example.com"
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_always_fits_in_one_bubble(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        sent = []
+
+        async def fake_send(chat_id, text, metadata=None):
+            from gateway.platforms.base import SendResult
+
+            sent.append(text)
+            return SendResult(success=True, message_id="ONE-BUBBLE-GUID")
+
+        monkeypatch.setattr(adapter, "send", fake_send)
+
+        await adapter.send_exec_approval(
+            chat_id="iMessage;-;user@example.com",
+            command=("x" * 5000) + "\n\nnext command",
+            session_key="bluebubbles:iMessage;-;user@example.com",
+            description=("d" * 5000) + "\n\nmore context",
+            metadata=_approval_metadata(),
+        )
+
+        assert len(sent) == 1
+        assert len(sent[0]) <= adapter.MAX_MESSAGE_LENGTH
+        assert "\n\n" not in sent[0]
+
+    @pytest.mark.asyncio
+    async def test_like_tapback_resolves_active_prompt_once(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+
+        async def fake_send(chat_id, text, metadata=None):
+            from gateway.platforms.base import SendResult
+
+            return SendResult(success=True, message_id="APPROVAL-GUID")
+
+        monkeypatch.setattr(adapter, "send", fake_send)
+        await adapter.send_exec_approval(
+            chat_id="iMessage;-;user@example.com",
+            command="touch protected-file",
+            session_key="bluebubbles:iMessage;-;user@example.com",
+            metadata=_approval_metadata(),
+        )
+        adapter.set_authorization_check(
+            lambda user_id, chat_type, chat_id: user_id == "user@example.com"
+        )
+
+        resolved = []
+        resumed = []
+
+        def fake_resolve(session_key, choice, **kwargs):
+            resolved.append((session_key, choice, kwargs.get("approval_id")))
+            return 1
+
+        monkeypatch.setattr("tools.approval.resolve_gateway_approval", fake_resolve)
+        monkeypatch.setattr(adapter, "resume_typing_for_chat", resumed.append)
+
+        payload = {
+            "type": "updated-message",
+            "data": {
+                "guid": "TAPBACK-GUID",
+                "text": "Liked “touch protected-file”",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;user@example.com",
+                "chatIdentifier": "user@example.com",
+                "associatedMessageType": 2001,
+                "associatedMessageGuid": "p:0/APPROVAL-GUID",
+            },
+        }
+
+        first = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        second = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+
+        assert first.status == 200
+        assert second.status == 200
+        assert resolved == [
+            ("bluebubbles:iMessage;-;user@example.com", "once", "approval-1")
+        ]
+        assert resumed == ["iMessage;-;user@example.com"]
+        assert adapter._approval_prompts_by_guid == {}
+
+    @pytest.mark.asyncio
+    async def test_canonical_tapback_resolves_exact_concurrent_entry(self, monkeypatch):
+        from tools.approval import _ApprovalEntry, _gateway_queues
+
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        message_ids = iter(("PROMPT-A", "PROMPT-B"))
+
+        async def fake_send(chat_id, text, metadata=None):
+            from gateway.platforms.base import SendResult
+
+            return SendResult(success=True, message_id=next(message_ids))
+
+        monkeypatch.setattr(adapter, "send", fake_send)
+        monkeypatch.setattr(adapter, "resume_typing_for_chat", lambda _chat_id: None)
+        adapter.set_authorization_check(lambda *_args: True)
+
+        session_key = "bluebubbles:iMessage;-;user@example.com"
+        entry_a = _ApprovalEntry({"command": "COMMAND-A"})
+        entry_b = _ApprovalEntry({"command": "COMMAND-B"})
+        _gateway_queues[session_key] = [entry_a, entry_b]
+        try:
+            await adapter.send_exec_approval(
+                chat_id="iMessage;-;user@example.com",
+                command="COMMAND-A",
+                session_key=session_key,
+                metadata=_approval_metadata(approval_id=entry_a.approval_id),
+            )
+            await adapter.send_exec_approval(
+                chat_id="iMessage;-;user@example.com",
+                command="COMMAND-B",
+                session_key=session_key,
+                metadata=_approval_metadata(approval_id=entry_b.approval_id),
+            )
+
+            response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+                "type": "new-message",
+                "data": {
+                    "guid": "TAPBACK-B",
+                    "handle": {"address": "user@example.com"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "iMessage;-;user@example.com"}],
+                    "associatedMessageType": "2001",
+                    "associatedMessageGuid": "p:0/PROMPT-B",
+                },
+            }))
+
+            assert response.status == 200
+            assert not entry_a.event.is_set()
+            assert entry_b.event.is_set()
+            assert entry_b.result == "once"
+            assert _gateway_queues[session_key] == [entry_a]
+        finally:
+            _gateway_queues.pop(session_key, None)
+
+    def test_gateway_approval_metadata_carries_requester_without_thread(self):
+        from gateway.run import _approval_prompt_metadata
+
+        metadata = _approval_prompt_metadata(
+            None,
+            {
+                "approval_id": "approval-exact",
+                "approval_timeout_seconds": 42,
+            },
+            requester_user_id="user@example.com",
+        )
+
+        assert metadata == {
+            "requester_user_id": "user@example.com",
+            "approval_id": "approval-exact",
+            "approval_timeout_seconds": 42,
+        }
+
+    def test_gateway_approval_metadata_carries_exact_id_and_timeout(self):
+        from gateway.run import _approval_prompt_metadata
+
+        metadata = _approval_prompt_metadata(
+            {"requester_user_id": "user@example.com"},
+            {
+                "approval_id": "approval-exact",
+                "approval_timeout_seconds": 42,
+            },
+        )
+
+        assert metadata == {
+            "requester_user_id": "user@example.com",
+            "approval_id": "approval-exact",
+            "approval_timeout_seconds": 42,
+        }
+
+    @pytest.mark.asyncio
+    async def test_expired_tapback_cleans_prompt_without_resolving(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+
+        async def fake_send(chat_id, text, metadata=None):
+            from gateway.platforms.base import SendResult
+
+            return SendResult(success=True, message_id="EXPIRED-GUID")
+
+        monkeypatch.setattr(adapter, "send", fake_send)
+        await adapter.send_exec_approval(
+            chat_id="iMessage;-;user@example.com",
+            command="touch protected-file",
+            session_key="bluebubbles:iMessage;-;user@example.com",
+            metadata=_approval_metadata(),
+        )
+        adapter._approval_prompts_by_guid["EXPIRED-GUID"].expires_at = 0
+        adapter.set_authorization_check(lambda *_args: True)
+        resolved = []
+        monkeypatch.setattr(
+            "tools.approval.resolve_gateway_approval",
+            lambda *args, **kwargs: resolved.append((args, kwargs)),
+        )
+
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                "guid": "TAPBACK-GUID",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;user@example.com",
+                "associatedMessageType": 2001,
+                "associatedMessageGuid": "p:0/EXPIRED-GUID",
+            },
+        }))
+
+        assert response.status == 200
+        assert resolved == []
+        assert adapter._approval_prompts_by_guid == {}
+        assert adapter._approval_prompt_by_approval_id == {}
+
+    @pytest.mark.asyncio
+    async def test_timeout_automatically_purges_prompt_without_reaction(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_send(chat_id, text, metadata=None):
+            from gateway.platforms.base import SendResult
+
+            return SendResult(success=True, message_id="AUTO-EXPIRE-GUID")
+
+        monkeypatch.setattr(adapter, "send", fake_send)
+        result = await adapter.send_exec_approval(
+            chat_id="iMessage;-;user@example.com",
+            command="touch protected-file",
+            session_key="bluebubbles:iMessage;-;user@example.com",
+            metadata=_approval_metadata(timeout_seconds=0),
+        )
+
+        assert result.success is True
+        assert "AUTO-EXPIRE-GUID" in adapter._approval_prompts_by_guid
+        await asyncio.sleep(0.01)
+        assert adapter._approval_prompts_by_guid == {}
+        assert adapter._approval_prompt_by_approval_id == {}
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_without_real_guid_forces_text_fallback(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_send(chat_id, text, metadata=None):
+            from gateway.platforms.base import SendResult
+
+            return SendResult(success=True, message_id=None)
+
+        monkeypatch.setattr(adapter, "send", fake_send)
+
+        result = await adapter.send_exec_approval(
+            chat_id="iMessage;-;user@example.com",
+            command="touch protected-file",
+            session_key="bluebubbles:iMessage;-;user@example.com",
+            metadata=_approval_metadata(),
+        )
+
+        assert result.success is False
+        assert "message GUID" in (result.error or "")
+        assert adapter._approval_prompts_by_guid == {}
+
+    @pytest.mark.asyncio
+    async def test_tapback_without_requester_identity_fails_closed(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+
+        sent = []
+
+        async def fake_send(chat_id, text, metadata=None):
+            sent.append((chat_id, text, metadata))
+            from gateway.platforms.base import SendResult
+
+            return SendResult(success=True, message_id="NO-REQUESTER-GUID")
+
+        monkeypatch.setattr(adapter, "send", fake_send)
+        result = await adapter.send_exec_approval(
+            chat_id="iMessage;-;user@example.com",
+            command="touch protected-file",
+            session_key="bluebubbles:iMessage;-;user@example.com",
+            metadata=_approval_metadata(requester_user_id=None),
+        )
+        assert result.success is False
+        assert sent == []
+        assert adapter._approval_prompts_by_guid == {}
+        adapter.set_authorization_check(lambda *_args: True)
+        resolved = []
+        monkeypatch.setattr(
+            "tools.approval.resolve_gateway_approval",
+            lambda *args, **kwargs: resolved.append((args, kwargs)) or 1,
+        )
+
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                "guid": "TAPBACK-GUID",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;user@example.com",
+                "associatedMessageType": 2001,
+                "associatedMessageGuid": "p:0/NO-REQUESTER-GUID",
+            },
+        }))
+
+        assert response.status == 200
+        assert resolved == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("assoc_type", [2002, "2002"])
+    async def test_dislike_tapback_denies(self, monkeypatch, assoc_type):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+
+        async def fake_send(chat_id, text, metadata=None):
+            from gateway.platforms.base import SendResult
+
+            return SendResult(success=True, message_id="DENY-GUID")
+
+        monkeypatch.setattr(adapter, "send", fake_send)
+        await adapter.send_exec_approval(
+            chat_id="iMessage;-;user@example.com",
+            command="touch protected-file",
+            session_key="bluebubbles:iMessage;-;user@example.com",
+            metadata=_approval_metadata(),
+        )
+        adapter.set_authorization_check(lambda *_args: True)
+        resolved = []
+        monkeypatch.setattr(
+            "tools.approval.resolve_gateway_approval",
+            lambda session_key, choice, approval_id=None: resolved.append(
+                (session_key, choice, approval_id)
+            ) or 1,
+        )
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                "guid": "TAPBACK-GUID",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;user@example.com",
+                "associatedMessageType": assoc_type,
+                "associatedMessageGuid": "p:0/DENY-GUID",
+            },
+        }))
+
+        assert resolved == [
+            ("bluebubbles:iMessage;-;user@example.com", "deny", "approval-1")
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("auth_result", "sender", "chat_guid"),
+        [
+            (None, "user@example.com", "iMessage;-;user@example.com"),
+            (False, "user@example.com", "iMessage;-;user@example.com"),
+            (True, "other@example.com", "iMessage;-;user@example.com"),
+            (True, "user@example.com", "iMessage;-;other@example.com"),
+        ],
+    )
+    async def test_tapback_security_mismatch_never_resolves(
+        self, monkeypatch, auth_result, sender, chat_guid
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+
+        async def fake_send(chat_id, text, metadata=None):
+            from gateway.platforms.base import SendResult
+
+            return SendResult(success=True, message_id="SECURE-GUID")
+
+        monkeypatch.setattr(adapter, "send", fake_send)
+        await adapter.send_exec_approval(
+            chat_id="iMessage;-;user@example.com",
+            command="touch protected-file",
+            session_key="bluebubbles:iMessage;-;user@example.com",
+            metadata=_approval_metadata(),
+        )
+        if auth_result is not None:
+            adapter.set_authorization_check(lambda *_args: auth_result)
+        resolved = []
+        monkeypatch.setattr(
+            "tools.approval.resolve_gateway_approval",
+            lambda *args, **kwargs: resolved.append((args, kwargs)) or 1,
+        )
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                "guid": "TAPBACK-GUID",
+                "handle": {"address": sender},
+                "isFromMe": False,
+                "chatGuid": chat_guid,
+                "associatedMessageType": 2001,
+                "associatedMessageGuid": "p:0/SECURE-GUID",
+            },
+        }))
+
+        assert resolved == []
+        assert "SECURE-GUID" in adapter._approval_prompts_by_guid
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("assoc_type", "associated_guid"),
+        [
+            (3001, "p:0/IGNORED-GUID"),
+            (3002, "p:0/IGNORED-GUID"),
+            (2001, "p:0/OTHER-GUID"),
+        ],
+    )
+    async def test_removal_or_wrong_guid_never_resolves(
+        self, monkeypatch, assoc_type, associated_guid
+    ):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+
+        async def fake_send(chat_id, text, metadata=None):
+            from gateway.platforms.base import SendResult
+
+            return SendResult(success=True, message_id="IGNORED-GUID")
+
+        monkeypatch.setattr(adapter, "send", fake_send)
+        await adapter.send_exec_approval(
+            chat_id="iMessage;-;user@example.com",
+            command="touch protected-file",
+            session_key="bluebubbles:iMessage;-;user@example.com",
+            metadata=_approval_metadata(),
+        )
+        adapter.set_authorization_check(lambda *_args: True)
+        resolved = []
+        monkeypatch.setattr(
+            "tools.approval.resolve_gateway_approval",
+            lambda *args, **kwargs: resolved.append((args, kwargs)) or 1,
+        )
+
+        await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                "guid": "TAPBACK-GUID",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;user@example.com",
+                "associatedMessageType": assoc_type,
+                "associatedMessageGuid": associated_guid,
+            },
+        }))
+
+        assert resolved == []
+
+    @pytest.mark.asyncio
+    async def test_group_tapback_bypasses_mention_gate_for_exact_requester(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            require_mention=True,
+            send_read_receipts=False,
+        )
+
+        async def fake_send(chat_id, text, metadata=None):
+            from gateway.platforms.base import SendResult
+
+            return SendResult(success=True, message_id="GROUP-GUID")
+
+        monkeypatch.setattr(adapter, "send", fake_send)
+        await adapter.send_exec_approval(
+            chat_id="iMessage;+;family-group",
+            command="touch protected-file",
+            session_key="bluebubbles:iMessage;+;family-group",
+            metadata=_approval_metadata(),
+        )
+        adapter.set_authorization_check(lambda *_args: True)
+        resolved = []
+        monkeypatch.setattr(
+            "tools.approval.resolve_gateway_approval",
+            lambda session_key, choice, approval_id=None: resolved.append(
+                (session_key, choice, approval_id)
+            ) or 1,
+        )
+
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                "guid": "TAPBACK-GUID",
+                "text": "Liked “protected command”",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "isGroup": True,
+                "chats": [{"guid": "iMessage;+;family-group"}],
+                "associatedMessageType": 2001,
+                "associatedMessageGuid": "p:0/GROUP-GUID",
+            },
+        }))
+
+        assert response.status == 200
+        assert resolved == [
+            ("bluebubbles:iMessage;+;family-group", "once", "approval-1")
+        ]
 
 
 class _FakeBlueBubblesRequest:

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -409,6 +409,9 @@ class TestGatewayApprovalAllowPermanent:
         payload = self._capture_gateway_payload("rm -rf /important", "gw-allow-perm")
         assert payload["command"] == "rm -rf /important"
         assert payload["allow_permanent"] is True
+        assert payload["approval_id"]
+        from tools.approval import _get_approval_timeout
+        assert payload["approval_timeout_seconds"] == _get_approval_timeout()
 
     @patch(_TIRITH_PATCH,
            return_value=_tirith_result("warn",

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -21,6 +21,7 @@ import tempfile
 import threading
 import time
 import unicodedata
+import uuid
 from typing import Optional
 from hermes_cli.config import cfg_get
 
@@ -2154,11 +2155,13 @@ def _denial_breaker_addendum(session_key: str) -> str:
 
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result", "reason")
+    __slots__ = ("event", "data", "result", "reason", "approval_id")
 
     def __init__(self, data: dict):
         self.event = threading.Event()
         self.data = data          # command, description, pattern_keys, …
+        self.approval_id = str(data.get("approval_id") or uuid.uuid4().hex)
+        self.data["approval_id"] = self.approval_id
         self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
         # Optional free-text reason supplied with an explicit deny
         # (``/deny <reason>``) so the agent can adapt instead of only
@@ -2197,13 +2200,15 @@ def unregister_gateway_notify(session_key: str) -> None:
 
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
-                             reason: Optional[str] = None) -> int:
+                             reason: Optional[str] = None,
+                             approval_id: Optional[str] = None) -> int:
     """Called by the gateway's /approve or /deny handler to unblock
     waiting agent thread(s).
 
-    When *resolve_all* is True every pending approval in the session is
-    resolved at once (``/approve all``).  Otherwise only the oldest one
-    is resolved (FIFO).
+    When *approval_id* is provided, only that exact pending entry is resolved.
+    Otherwise, when *resolve_all* is True every pending approval in the session
+    is resolved at once (``/approve all``); the default resolves the oldest one
+    (FIFO).
 
     *reason* is an optional free-text explanation attached to an explicit
     deny (``/deny <reason>``).  It is relayed back to the agent in the
@@ -2215,7 +2220,16 @@ def resolve_gateway_approval(session_key: str, choice: str,
         queue = _gateway_queues.get(session_key)
         if not queue:
             return 0
-        if resolve_all:
+        if approval_id is not None:
+            target = next(
+                (entry for entry in queue if entry.approval_id == approval_id),
+                None,
+            )
+            if target is None:
+                return 0
+            queue.remove(target)
+            targets = [target]
+        elif resolve_all:
             targets = list(queue)
             queue.clear()
         else:
@@ -3262,6 +3276,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     notify callback raised.  Persistence of an approved choice and building
     the final tool-facing result dict remain the caller's responsibility.
     """
+    approval_data = dict(approval_data)
+    approval_data["approval_timeout_seconds"] = _get_approval_timeout()
     command = approval_data.get("command", "")
     description = approval_data.get("description", "")
     primary_key = approval_data.get("pattern_key", "")

--- a/website/docs/user-guide/messaging/bluebubbles.md
+++ b/website/docs/user-guide/messaging/bluebubbles.md
@@ -103,6 +103,15 @@ Hermes → BlueBubbles REST API → Messages.app → iMessage
 - **Outbound:** Hermes sends messages via the BlueBubbles REST API.
 - **Media:** Images, voice messages, videos, and documents are supported in both directions. Inbound attachments are downloaded and cached locally for the agent to process.
 
+### Dangerous command approvals
+
+When a command requires operator approval, Hermes sends a dedicated iMessage prompt. The user who requested the command can react directly to that exact prompt:
+
+- 👍 approves the pending operation once.
+- 👎 denies the pending operation.
+
+The reaction is accepted only from the authorized requester, in the same chat, on the exact active prompt, before it expires. Reaction removals, duplicate webhook deliveries, stale prompts, and reactions from other users are ignored. `/approve` and `/deny` remain available as text fallbacks. Session-wide and permanent approval are intentionally not available through Tapbacks.
+
 ## Environment Variables
 
 | Variable | Required | Default | Description |


### PR DESCRIPTION
## Summary

- let BlueBubbles users approve a pending dangerous command once with 👍 or deny it with 👎
- bind reactions to the exact approval prompt, approval ID, requester, and chat; fail closed on unauthorized, stale, duplicate, or ambiguous events
- support BlueBubbles numeric and named Tapback payloads (`2001`/`2002`, `like`/`dislike`)
- send the same localized confirmation messages as `/approve` and `/deny`
- document the iMessage Tapback workflow

## Validation

- 83 BlueBubbles adapter tests passed
- 354 approval-engine tests passed
- Python compilation and `git diff --check` passed
- independently reviewed with no security or logic findings
- real BlueBubbles/iMessage E2E passed on a disposable Git repo:
  - 👎 denied `git reset --hard`, preserved the uncommitted change, and sent `❌ Command denied.`
  - 👍 approved the same command, restored the clean baseline, and sent `✅ Command approved. The agent is resuming...`

Closes #69395