### PR TITLE
fix(desktop): scope TTS requests to active profile

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -19,6 +19,7 @@ import {
   listSessions,
   listSidebarSessions,
   resetSidebarBatchCapability,
+  setApiRequestProfile,
   speakText,
   transcribeAudio
 } from './hermes'
@@ -44,6 +45,7 @@ describe('Hermes REST helpers', () => {
   })
 
   afterEach(() => {
+    setApiRequestProfile(null)
     vi.restoreAllMocks()
     Reflect.deleteProperty(window, 'hermesDesktop')
   })
@@ -336,7 +338,8 @@ describe('Hermes REST helpers', () => {
     expect(audioSpeakRequestTimeoutMs('x'.repeat(100_000))).toBe(AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS)
   })
 
-  it('uses an extended timeout for blocking TTS synthesis', async () => {
+  it('routes blocking TTS synthesis through the active profile backend', async () => {
+    setApiRequestProfile('rhaegal')
     api.mockResolvedValueOnce({
       data_url: 'data:audio/mpeg;base64,AA==',
       mime_type: 'audio/mpeg',
@@ -355,6 +358,7 @@ describe('Hermes REST helpers', () => {
       body: { text: 'Read this aloud' },
       method: 'POST',
       path: '/api/audio/speak',
+      profile: 'rhaegal',
       timeoutMs: AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS
     })
   })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1388,6 +1388,7 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
 
 export function speakText(text: string): Promise<AudioSpeakResponse> {
   return window.hermesDesktop.api<AudioSpeakResponse>({
+    ...profileScoped(),
     path: '/api/audio/speak',
     method: 'POST',
     body: { text },


### PR DESCRIPTION
## Summary
- route Desktop `/api/audio/speak` requests through the active profile backend
- use the existing `profileScoped()` request mechanism
- add a regression test asserting that active-profile TTS includes the selected profile

## Problem
Desktop voice playback omitted the active profile from the TTS request. In a live profile swap, spoken replies were therefore synthesized by the primary/default backend, so profiles with distinct TTS configurations still played the default voice.

## Verification
- `npm exec vitest -- run --project ui src/hermes.test.ts src/hermes-profile-scope.test.ts` — 22 tests passed
- `npm run typecheck` — passed
- `npm exec eslint -- src/hermes.ts src/hermes.test.ts` — passed
- independently reviewed with no security or logic concerns
- manually validated end to end with separate default and `rhaegal` profile voices in Hermes Desktop
