### PR TITLE
fix(desktop): clarify options defensive rendering and layout fix

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -15,7 +15,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
-import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
+import { clearClarifyRequest, normalizeChoices, setClarifyRequest } from '@/store/clarify'
 import { setSessionCompacting } from '@/store/compaction'
 import { refreshBackgroundProcesses } from '@/store/composer-status'
 import { $gateway } from '@/store/gateway'
@@ -621,12 +621,25 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // over; the inline ClarifyTool reads the active session's entry.
         const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
         const question = typeof payload?.question === 'string' ? payload.question : ''
+        const rawChoices = payload?.choices
+        const choices = normalizeChoices(rawChoices)
 
         if (requestId && question) {
+          // Diagnostic: log when gateway choices are malformed.
+          if (rawChoices !== undefined && rawChoices !== null && choices.length === 0) {
+            console.warn('[clarify] gateway choices dropped after normalization', {
+              source: 'gateway',
+              dropped_fields: ['choices'],
+              fallback_path: 'missing',
+              question_length: question.length,
+              choices_count: Array.isArray(rawChoices) ? rawChoices.length : 0
+            })
+          }
+
           setClarifyRequest({
             requestId,
             question,
-            choices: Array.isArray(payload?.choices) ? payload!.choices!.filter(c => typeof c === 'string') : null,
+            choices: choices.length > 0 ? choices : null,
             sessionId: sessionId ?? null
           })
 

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -22,7 +22,7 @@ import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { CircleLetterA, Loader2, MessageQuestion } from '@/lib/icons'
 import { cn } from '@/lib/utils'
-import { clearClarifyRequest, sessionClarifyRequest } from '@/store/clarify'
+import { clearClarifyRequest, normalizeChoices, sessionClarifyRequest } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 
@@ -32,6 +32,16 @@ import { parseMaybeObject } from './tool/fallback-model/format'
 interface ClarifyArgs {
   question?: string
   choices?: string[] | null
+}
+
+/** Structured diagnostic payload for malformed clarify tool data. */
+interface ClarifyDiagnostic {
+  tool_call_id?: string
+  source: 'gateway' | 'tool_args'
+  dropped_fields: string[]
+  fallback_path: 'markdown' | 'missing' | 'none'
+  question_length: number
+  choices_count: number
 }
 
 interface ClarifyResult {
@@ -52,11 +62,27 @@ function stringField(row: Record<string, unknown>, ...keys: string[]): string | 
 
 function readClarifyArgs(args: unknown): ClarifyArgs {
   const row = parseMaybeObject(args)
-  const choices = Array.isArray(row.choices) ? row.choices.filter((c): c is string => typeof c === 'string') : null
+  const rawChoices = row.choices
+  const choices = normalizeChoices(rawChoices)
+
+  const question = stringField(row, 'question')
+
+  // Diagnostic: log when choices are missing or malformed.
+  if (rawChoices !== undefined && rawChoices !== null && choices.length === 0 && question) {
+    const diag: ClarifyDiagnostic = {
+      source: 'tool_args',
+      dropped_fields: ['choices'],
+      fallback_path: 'missing',
+      question_length: question.length,
+      choices_count: Array.isArray(rawChoices) ? rawChoices.length : 0
+    }
+
+    console.warn('[clarify] choices dropped after normalization', diag)
+  }
 
   return {
-    question: stringField(row, 'question'),
-    choices: choices && choices.length > 0 ? choices : null
+    question,
+    choices: choices.length > 0 ? choices : null
   }
 }
 
@@ -398,7 +424,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
                 type="button"
               >
                 <KeyBadge char={letterFor(index)} selected={selectedChoice === choice} />
-                <span className="flex-1 wrap-anywhere">{choice}</span>
+                <span className="flex-1 [overflow-wrap:anywhere]">{choice}</span>
               </button>
             ))}
             <label className={cn(OPTION_ROW_CLASS, 'items-center')}>

--- a/apps/desktop/src/store/clarify.test.ts
+++ b/apps/desktop/src/store/clarify.test.ts
@@ -5,6 +5,7 @@ import {
   $clarifyRequests,
   type ClarifyRequest,
   clearClarifyRequest,
+  normalizeChoices,
   setClarifyRequest
 } from './clarify'
 import { $activeSessionId } from './session'
@@ -77,5 +78,45 @@ describe('clarify store', () => {
 
     expect($clarifyRequests.get()['session-a']).toBeUndefined()
     expect($clarifyRequests.get()['session-b']?.requestId).toBe('other')
+  })
+})
+
+describe('normalizeChoices', () => {
+  it('returns empty array for null/undefined', () => {
+    expect(normalizeChoices(null)).toEqual([])
+    expect(normalizeChoices(undefined)).toEqual([])
+  })
+
+  it('returns empty array for non-array input', () => {
+    expect(normalizeChoices('hello')).toEqual([])
+    expect(normalizeChoices(42)).toEqual([])
+    expect(normalizeChoices({})).toEqual([])
+  })
+
+  it('filters out non-string items', () => {
+    expect(normalizeChoices(['a', 42, 'b', null, 'c'])).toEqual(['a', 'b', 'c'])
+  })
+
+  it('drops blank and whitespace-only strings', () => {
+    expect(normalizeChoices(['a', '', 'b', '   ', 'c'])).toEqual(['a', 'b', 'c'])
+  })
+
+  it('drops strings with newlines', () => {
+    expect(normalizeChoices(['a', 'b\nc', 'd'])).toEqual(['a', 'd'])
+  })
+
+  it('drops strings over 200 chars', () => {
+    const long = 'x'.repeat(201)
+    const ok = 'y'.repeat(200)
+    expect(normalizeChoices(['a', long, ok])).toEqual(['a', ok])
+  })
+
+  it('drops empty items and keeps valid ones', () => {
+    expect(normalizeChoices(['valid', '  ', '', 'also valid'])).toEqual(['valid', 'also valid'])
+  })
+
+  it('returns empty array when nothing survives', () => {
+    expect(normalizeChoices(['', '  ', null, undefined])).toEqual([])
+    expect(normalizeChoices([])).toEqual([])
   })
 })

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -9,6 +9,28 @@ export interface ClarifyRequest {
   sessionId: string | null
 }
 
+/**
+ * Validate and normalize a choices array.
+ *
+ * Returns cleaned choices with non-blank, non-newline strings of length
+ * 1..200. Drops garbage items and returns an empty array when nothing
+ * usable survives — the caller should then fall back to a marker row.
+ */
+export function normalizeChoices(choices: unknown): string[] {
+  if (!Array.isArray(choices)) {
+    return []
+  }
+
+  return choices.filter(
+    (c): c is string =>
+      typeof c === 'string' &&
+      c.length >= 1 &&
+      c.length <= 200 &&
+      !c.includes('\n') &&
+      c.trim().length > 0
+  )
+}
+
 // Pending clarify requests keyed by the runtime session id that raised them.
 // Storing per-session (instead of one shared slot) lets a *background* session
 // park its clarify request while the user is looking at a different chat, then


### PR DESCRIPTION
## Summary

Fixes #69122 — clarify options rendering with wrong layout in the Desktop chat.

### Root cause

The clarify choices `<span>` used `wrap-anywhere`, an undefined CSS utility class with no effect. Long choice text would overflow the button container instead of wrapping, causing visible layout breakage.

Additionally, choices that did render could include garbage values (raw JSON arrays, nulls, multi-line strings) because there was no validation — they were only checked for `typeof === 'string'`.

### Changes

1. **Layout fix**: Replace the non-functional `wrap-anywhere` with Tailwind v4's `[overflow-wrap:anywhere]` so choice text wraps at any character boundary — preventing overflow on long options.

2. **Defensive choice normalization** (`normalizeChoices`): A new shared validation function in `store/clarify.ts` that:
   - Returns empty array for non-array input (null, undefined, string, number, object)
   - Strips non-string items (the raw JSON arrays from LLM edge-cases)
   - Drops blank/whitespace-only strings
   - Drops strings with newlines (preserve single-line button layout)
   - Caps at 200 characters

3. **Diagnostic logging**: `console.warn('[clarify] ...')` fires at both the gateway event handler and the tool-args parser when choices are present but none survive normalization — breaking the silent-failure pattern.

4. **Unit tests** for `normalizeChoices` covering null, non-array, mixed types, blanks, multi-line, and overlong inputs.

### Files changed

| File | Change |
|------|--------|
| apps/desktop/src/store/clarify.ts | Added `normalizeChoices()` validation function |
| apps/desktop/src/store/clarify.test.ts | 8 test cases for `normalizeChoices` |
| apps/desktop/src/components/assistant-ui/clarify-tool.tsx | Use `normalizeChoices` in `readClarifyArgs`; fix CSS class; add diagnostics |
| apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts | Use `normalizeChoices` in gateway handler; add diagnostics |

### Testing

- Unit tests added for `normalizeChoices` (8 cases)
- Existing clarify tests unaffected
- No regression to single-question clarify calls
- Text wrapping now works for long choices
- Malformed choices are filtered with a console warning
