### PR TITLE
fix(codex): keep consuming superseded streams

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1192,15 +1192,39 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     # Accumulate streamed text so callers / compat shims can read it.
     agent._codex_streamed_text_parts: list = []
 
+    _writer_token = 0
+    _superseded_logged = False
+
+    def _live_writer_is_current() -> bool:
+        nonlocal _superseded_logged
+        if stream_writer_is_current(agent, _writer_token):
+            return True
+        if not _superseded_logged:
+            logger.warning(
+                "Codex streaming attempt superseded by a newer stream; "
+                "suppressing live deltas while continuing consumption so "
+                "final delivery is not truncated (model=%s).",
+                api_kwargs.get("model", "unknown"),
+            )
+            _superseded_logged = True
+        return False
+
     def _on_text_delta(text: str) -> None:
         agent._codex_streamed_text_parts.append(text)
-        agent._fire_stream_delta(text)
+        if _live_writer_is_current():
+            agent._fire_stream_delta(text)
 
     def _on_reasoning_delta(text: str) -> None:
-        agent._fire_reasoning_delta(text)
+        if _live_writer_is_current():
+            agent._fire_reasoning_delta(text)
 
     def _on_commentary_message(text: str) -> None:
-        agent._fire_streamed_codex_commentary(text)
+        if _live_writer_is_current():
+            agent._fire_streamed_codex_commentary(text)
+
+    def _on_first_delta() -> None:
+        if on_first_delta is not None and _live_writer_is_current():
+            on_first_delta()
 
     def _on_event(event: Any) -> None:
         # TTFB watchdog and activity touch — runs once per SSE event.
@@ -1226,26 +1250,14 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 continue
             raise
 
-        # Claim the delta sink for THIS attempt (#65991) — parity with the
-        # chat_completions/anthropic/bedrock paths. If a prior attempt's
-        # stream is somehow still alive, this claim supersedes it so its
-        # late deltas are fenced out of the turn; conversely, a newer
-        # attempt supersedes us and the interrupt_check below stops our
-        # consumption immediately.
+        # Claim the live delta sink for THIS attempt (#65991). A newer attempt
+        # may supersede live display, but it must not abort provider stream
+        # consumption: gateway final delivery depends on the complete assembled
+        # response even when display streaming is disabled.
         _writer_token = claim_stream_writer(agent)
 
-        def _interrupt_or_superseded(_tok=_writer_token) -> bool:
-            if agent._interrupt_requested:
-                return True
-            if not stream_writer_is_current(agent, _tok):
-                logger.warning(
-                    "Codex streaming attempt superseded by a newer stream; "
-                    "stopping consumption to preserve the single-writer "
-                    "invariant (model=%s).",
-                    api_kwargs.get("model", "unknown"),
-                )
-                return True
-            return False
+        def _interrupt_requested() -> bool:
+            return bool(agent._interrupt_requested)
 
         try:
             # Compatibility: some mocks/providers return a concrete response
@@ -1267,9 +1279,9 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                         )
                         else None
                     ),
-                    on_first_delta=on_first_delta,
+                    on_first_delta=_on_first_delta,
                     on_event=_on_event,
-                    interrupt_check=_interrupt_or_superseded,
+                    interrupt_check=_interrupt_requested,
                 )
             except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
                 if attempt < max_stream_retries:

--- a/tests/agent/test_codex_runtime_live_events.py
+++ b/tests/agent/test_codex_runtime_live_events.py
@@ -180,3 +180,64 @@ def test_one_broken_callback_does_not_hide_other_live_events():
     bridge({"method": "item/started", "params": {"item": item}})
 
     assert starts == [("codex_dyn_search_d1", "search", {})]
+
+
+class _FakeResponsesClient:
+    def __init__(self, events):
+        self._events = events
+
+    def create(self, **kwargs):
+        assert kwargs["stream"] is True
+        return iter(self._events)
+
+
+class _FakeCodexClient:
+    def __init__(self, events):
+        self.responses = _FakeResponsesClient(events)
+
+
+def test_codex_stream_supersession_keeps_consuming_for_complete_final_response():
+    from agent.codex_runtime import run_codex_stream
+
+    events = [
+        {
+            "type": "response.output_item.added",
+            "item": {"type": "message", "role": "assistant"},
+        },
+        {"type": "response.output_text.delta", "delta": "I've added the live"},
+        {"type": "response.output_text.delta", "delta": " tail."},
+        {"type": "response.completed", "response": {"id": "resp_1", "status": "completed"}},
+    ]
+    live_deltas = []
+    current_checks = {"count": 0}
+
+    def is_current(_token):
+        current_checks["count"] += 1
+        # Simulate another stream claiming the live display sink after the
+        # first visible delta. The old turn must stop emitting live deltas, but
+        # it must keep consuming the provider stream so gateway final delivery
+        # receives the complete text instead of a silent partial.
+        return current_checks["count"] <= 1
+
+    agent = SimpleNamespace(
+        _interrupt_requested=False,
+        _codex_stream_last_event_ts=0,
+        _claim_stream_writer=lambda: 1,
+        _stream_writer_is_current=is_current,
+        _fire_stream_delta=lambda text: live_deltas.append(text),
+        _fire_reasoning_delta=lambda text: None,
+        _fire_streamed_codex_commentary=lambda text: None,
+        _touch_activity=lambda _message: None,
+        _client_log_context=lambda: "test-context",
+    )
+
+    final = run_codex_stream(
+        agent,
+        {"model": "gpt-5.6-terra"},
+        client=_FakeCodexClient(events),
+    )
+
+    assert final.output_text == "I've added the live tail."
+    assert final.status == "completed"
+    assert live_deltas == ["I've added the live"]
+    assert agent._codex_streamed_text_parts == ["I've added the live", " tail."]


### PR DESCRIPTION
Fixes #69486

## Summary
- keep consuming the Codex Responses stream after a newer writer supersedes the live display sink
- suppress live text/reasoning/commentary/first-delta callbacks after supersession so the single-writer invariant is preserved
- continue assembling the final response from provider deltas, preventing gateway final delivery from silently truncating mid-sentence
- add regression coverage for a superseded Codex stream where live deltas stop but final output remains complete

## Tests
- `python -m pytest tests/agent/test_codex_runtime_live_events.py::test_codex_stream_supersession_keeps_consuming_for_complete_final_response -q`
- `python -m pytest tests/agent/test_codex_runtime_live_events.py tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_codex_ttfb_watchdog.py -q`
- `git diff --check`
- `python -m py_compile agent/codex_runtime.py tests/agent/test_codex_runtime_live_events.py`

## Notes
- This keeps user-visible live streaming fenced to the current writer, but no longer treats live-display supersession as a provider-stream interrupt. Actual user interrupts still stop consumption.
