### PR TITLE
fix(browser): isolate headless Linux workers from desktop D-Bus

### DIFF
--- a/tests/tools/test_browser_chromium_autoinstall.py
+++ b/tests/tools/test_browser_chromium_autoinstall.py
@@ -104,3 +104,48 @@ class TestOneShot:
         assert bt._maybe_autoinstall_chromium() is True
         assert bt._maybe_autoinstall_chromium() is True
         assert len(runs) == 1
+
+
+class TestBrowserSubprocessEnvironment:
+    def test_linux_headless_browser_isolated_from_desktop_bus(self, monkeypatch):
+        monkeypatch.setattr(bt.sys, "platform", "linux")
+        monkeypatch.setattr(
+            "tools.environments.local.hermes_subprocess_env",
+            lambda **_: {
+                "DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/0/bus",
+                "XDG_RUNTIME_DIR": "/run/user/0",
+            },
+        )
+
+        env = bt._build_browser_env()
+
+        assert env["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/dev/null"
+        assert env["XDG_RUNTIME_DIR"] == "/run/user/0"
+
+    def test_linux_graphical_browser_keeps_real_desktop_bus(self, monkeypatch):
+        monkeypatch.setattr(bt.sys, "platform", "linux")
+        monkeypatch.setattr(
+            "tools.environments.local.hermes_subprocess_env",
+            lambda **_: {
+                "DISPLAY": ":1",
+                "DBUS_SESSION_BUS_ADDRESS": "unix:path=/tmp/dbus-real",
+            },
+        )
+
+        env = bt._build_browser_env()
+
+        assert env["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/tmp/dbus-real"
+
+    def test_linux_wayland_browser_keeps_real_desktop_bus(self, monkeypatch):
+        monkeypatch.setattr(bt.sys, "platform", "linux")
+        monkeypatch.setattr(
+            "tools.environments.local.hermes_subprocess_env",
+            lambda **_: {
+                "WAYLAND_DISPLAY": "wayland-0",
+                "DBUS_SESSION_BUS_ADDRESS": "unix:path=/tmp/dbus-real",
+            },
+        )
+
+        env = bt._build_browser_env()
+
+        assert env["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/tmp/dbus-real"

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -102,6 +102,15 @@ def _build_browser_env() -> dict:
     for _key in _BROWSER_PASSTHROUGH_KEYS:
         if _key in os.environ:
             env[_key] = os.environ[_key]
+    # A long-lived root systemd user manager exposes a session bus even on a
+    # headless Linux server. Chromium then asks that bus to activate desktop
+    # portals and notification daemons, which cannot open a display and flood
+    # the journal with failed user units. Keep real graphical sessions intact,
+    # but isolate headless browser workers from the unrelated desktop bus.
+    if sys.platform.startswith("linux") and not (
+        env.get("DISPLAY") or env.get("WAYLAND_DISPLAY")
+    ):
+        env["DBUS_SESSION_BUS_ADDRESS"] = "unix:path=/dev/null"
     return env
 
 try:


### PR DESCRIPTION
## What does this PR do?

Prevents local headless `agent-browser` workers on Linux from inheriting a desktop D-Bus session bus.

A long-lived `systemd --user` manager can expose `DBUS_SESSION_BUS_ADDRESS` even when Hermes runs without a graphical session. Chromium can then attempt desktop-portal and notification activation, producing failed user-unit noise in the journal.

The browser subprocess now receives an explicit inert D-Bus address only when Linux has neither `DISPLAY` nor `WAYLAND_DISPLAY`. X11 and pure-Wayland desktop sessions retain their real session bus.

## Changes

- Neutralize `DBUS_SESSION_BUS_ADDRESS` for truly headless Linux browser workers.
- Preserve the real session bus for X11 and Wayland environments.
- Add behavioral tests covering headless isolation and X11/Wayland preservation.

## How to test

```bash
python -m pytest tests/tools/test_browser_chromium_autoinstall.py -o 'addopts=' -q
ruff check tools/browser_tool.py tests/tools/test_browser_chromium_autoinstall.py
git diff --check origin/main...HEAD
```

Verified after rebasing onto current `main`:

```text
9 passed in 0.92s
All checks passed!
```

## Platform impact

- Linux headless workers: receive an inert D-Bus address.
- Linux X11/Wayland sessions: keep their existing session bus.
- macOS and Windows: unchanged.

## Related issues / PRs

No direct duplicate found after searching existing issues and PRs for D-Bus, Chromium, headless browser, and desktop portal reports.
