### PR TITLE
fix(mcp): clean up OAuth callback listener before connection retry

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -611,6 +611,253 @@ class TestCallbackPortReservation:
 
 
 # ---------------------------------------------------------------------------
+# Callback listener thread/socket cleanup
+#
+# mcp_tool.py's initial-connect retry ladder catches a bare asyncio.TimeoutError
+# from `asyncio.wait_for(session.initialize(), timeout=connect_timeout)` (not
+# classified as an OAuth error by _is_auth_error) and retries, reusing the SAME
+# cached OAuthClientProvider/callback port. Before this fix, the callback
+# HTTPServer's listener thread blocked forever in handle_request() (server.timeout
+# defaults to None), so server_close() from the cancelled coroutine did not free
+# the port — the retry's _wait() collided with OSError: Address already in use.
+# ---------------------------------------------------------------------------
+
+class TestCallbackListenerCleanup:
+    """A timed-out/cancelled callback waiter must release its thread and port
+    before returning, so a same-provider retry never hits 'address already
+    in use'."""
+
+    @staticmethod
+    def _port_is_free(port: int) -> bool:
+        """Can a *new* listener bind here the way production retries do?
+
+        SO_REUSEADDR (matching server.allow_reuse_address in mcp_oauth.py)
+        so an expected, harmless TIME_WAIT from the just-served client
+        connection of a successful callback doesn't register as "in use" —
+        only an actively bound/LISTENing socket should fail this probe.
+        """
+        import socket as sock
+        s = sock.socket(sock.AF_INET, sock.SOCK_STREAM)
+        s.setsockopt(sock.SOL_SOCKET, sock.SO_REUSEADDR, 1)
+        try:
+            s.bind(("127.0.0.1", port))
+            return True
+        except OSError:
+            return False
+        finally:
+            s.close()
+
+    @staticmethod
+    def _listener_threads():
+        import threading
+        return [t for t in threading.enumerate() if t.name.startswith("oauth-callback-")]
+
+    @staticmethod
+    def _nothing_listening(port: int) -> bool:
+        """True if no LISTENer accepts new connections on this port.
+
+        Unlike a bind() probe, this is unaffected by the harmless TIME_WAIT a
+        just-served client connection leaves behind on the same local port
+        (bind() with SO_REUSEADDR can still legitimately fail against that
+        TIME_WAIT on some kernels) — a connect() attempt only succeeds if
+        something is actively LISTENing, which is the invariant that
+        actually matters for "did the listener leak".
+        """
+        import socket as sock
+        s = sock.socket(sock.AF_INET, sock.SOCK_STREAM)
+        s.settimeout(0.2)
+        try:
+            s.connect(("127.0.0.1", port))
+            return False  # something accepted us — still listening
+        except (ConnectionRefusedError, OSError):
+            return True
+        finally:
+            s.close()
+
+    def _wait_for_listener_threads_to_exit(self, timeout: float = 3.0) -> None:
+        import time
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline and any(t.is_alive() for t in self._listener_threads()):
+            time.sleep(0.05)
+
+    def test_timeout_terminates_listener_thread(self, monkeypatch):
+        """Item 1: a timed-out waiter's HTTP listener thread must not outlive it."""
+        import tools.mcp_oauth as mod
+
+        monkeypatch.setattr(mod, "_is_interactive", lambda: True)
+        monkeypatch.setattr("sys.stdin", MagicMock(readline=lambda: ""))  # EOF, no paste
+
+        port = mod._reserve_callback_port()
+        waiter = mod._make_callback_waiter(port)
+
+        async def drive():
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(waiter(), timeout=0.6)
+
+        asyncio.run(drive())
+        self._wait_for_listener_threads_to_exit()
+
+        assert not any(t.is_alive() for t in self._listener_threads()), (
+            "OAuth callback listener thread leaked past cancellation"
+        )
+
+    def test_port_reusable_after_timeout(self, monkeypatch):
+        """Item 2: the port must be bindable again shortly after the waiter exits."""
+        import time
+        import tools.mcp_oauth as mod
+
+        monkeypatch.setattr(mod, "_is_interactive", lambda: True)
+        monkeypatch.setattr("sys.stdin", MagicMock(readline=lambda: ""))
+
+        port = mod._reserve_callback_port()
+        waiter = mod._make_callback_waiter(port)
+
+        async def drive():
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(waiter(), timeout=0.6)
+
+        asyncio.run(drive())
+
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline and not self._port_is_free(port):
+            time.sleep(0.05)
+
+        assert self._port_is_free(port), "callback port still bound after waiter exited"
+
+    def test_retry_reuses_same_port_without_collision(self, monkeypatch):
+        """Items 3 & 4: mirrors mcp_tool.py's initial-connect retry, which reuses
+        the SAME cached OAuthClientProvider (hence the same _make_callback_waiter
+        closure/port) after the outer connect_timeout fires. The second attempt
+        must not raise OSError('Address already in use')."""
+        import tools.mcp_oauth as mod
+
+        monkeypatch.setattr(mod, "_is_interactive", lambda: True)
+        monkeypatch.setattr("sys.stdin", MagicMock(readline=lambda: ""))
+
+        port = mod._reserve_callback_port()
+        waiter = mod._make_callback_waiter(port)  # one closure, like one cached provider
+
+        async def drive():
+            # Attempt 1 — simulates the outer 60s connect_timeout firing.
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(waiter(), timeout=0.6)
+            # Attempt 2 — the generic retry, same port/closure. Must NOT be an
+            # OSError/OAuthNonInteractiveError("already in use"); a further
+            # timeout is fine since no real callback is ever delivered here.
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(waiter(), timeout=0.6)
+
+        asyncio.run(drive())
+
+    def test_cached_token_does_not_create_callback_listener(self, tmp_path, monkeypatch):
+        """Item 5: building a provider with a valid cached token must not create
+        any oauth-callback listener thread as a side effect."""
+        pytest.importorskip("mcp.client.auth")
+        import tools.mcp_oauth as mod
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = False
+        monkeypatch.setattr(mod.sys, "stdin", mock_stdin)
+
+        d = tmp_path / "mcp-tokens"
+        d.mkdir(parents=True)
+        (d / "atlassian.json").write_text(json.dumps({
+            "access_token": "cached", "token_type": "Bearer",
+        }))
+
+        auth = build_oauth_auth("atlassian", "https://mcp.atlassian.com/v1/mcp")
+        assert auth is not None
+        assert self._listener_threads() == []
+
+    def test_successful_callback_still_works(self, monkeypatch):
+        """Item 6: a real callback hit still completes normally and still cleans
+        up its thread/port afterward."""
+        import threading
+        import time
+        import urllib.request
+        import tools.mcp_oauth as mod
+
+        monkeypatch.setattr(mod, "_is_interactive", lambda: False)
+        monkeypatch.setattr(mod, "_raise_if_non_interactive", lambda lead: None)
+
+        port = mod._reserve_callback_port()
+        waiter = mod._make_callback_waiter(port)
+
+        async def drive():
+            task = asyncio.create_task(waiter())
+            await asyncio.sleep(0.2)
+
+            def hit():
+                urllib.request.urlopen(
+                    f"http://127.0.0.1:{port}/callback?code=abc123&state=xyz", timeout=5,
+                )
+
+            threading.Thread(target=hit, daemon=True).start()
+            return await asyncio.wait_for(task, timeout=10)
+
+        code, state = asyncio.run(drive())
+        assert code == "abc123"
+        assert state == "xyz"
+
+        self._wait_for_listener_threads_to_exit()
+        assert not any(t.is_alive() for t in self._listener_threads())
+
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline and not self._nothing_listening(port):
+            time.sleep(0.05)
+        assert self._nothing_listening(port), "listener still accepting connections after success"
+
+    def test_pasted_callback_still_works(self, monkeypatch):
+        """Item 7: pasted redirect URL still resolves normally."""
+        import tools.mcp_oauth as mod
+
+        mod._oauth_port = mod._find_free_port()
+        monkeypatch.setattr(mod, "_is_interactive", lambda: True)
+        monkeypatch.setattr(
+            "sys.stdin",
+            MagicMock(readline=lambda: "http://127.0.0.1/callback?code=pasted42&state=st9\n"),
+        )
+
+        async def instant_sleep(_seconds):
+            pass
+
+        with patch.object(mod.asyncio, "sleep", instant_sleep):
+            code, state = asyncio.run(_wait_for_callback())
+        assert code == "pasted42"
+        assert state == "st9"
+
+    def test_cancellation_and_timeout_perform_same_cleanup(self, monkeypatch):
+        """Item 8: explicit task.cancel() must trigger identical thread/port
+        cleanup as the natural timeout path."""
+        import time
+        import tools.mcp_oauth as mod
+
+        monkeypatch.setattr(mod, "_is_interactive", lambda: True)
+        monkeypatch.setattr("sys.stdin", MagicMock(readline=lambda: ""))
+
+        port = mod._reserve_callback_port()
+        waiter = mod._make_callback_waiter(port)
+
+        async def drive():
+            task = asyncio.create_task(waiter())
+            await asyncio.sleep(0.3)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        asyncio.run(drive())
+        self._wait_for_listener_threads_to_exit()
+
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline and not self._port_is_free(port):
+            time.sleep(0.05)
+
+        assert not any(t.is_alive() for t in self._listener_threads())
+        assert self._port_is_free(port)
+
+
+# ---------------------------------------------------------------------------
 # remove_oauth_tokens
 # ---------------------------------------------------------------------------
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -2266,6 +2266,73 @@ class TestReconnection:
 # Configurable timeouts
 # ---------------------------------------------------------------------------
 
+class TestResolveConnectTimeout:
+    """_resolve_connect_timeout: the OAuth-aware connect_timeout floor (Fix A).
+
+    Mirrors hermes_cli/mcp_config.py's _reauth_oauth_server floor so the
+    generic MCPServerTask/_discover_and_register_server/probe_mcp_server_tools
+    connect paths don't time out mid-authorization and retry into the still-
+    open callback listener from the first attempt (tools/mcp_oauth.py).
+    """
+
+    def _write_cached_token(self, tmp_path, monkeypatch, server_name):
+        import json
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        d = tmp_path / "mcp-tokens"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{server_name}.json").write_text(json.dumps({
+            "access_token": "cached", "token_type": "Bearer",
+        }))
+
+    def test_non_oauth_server_never_gets_the_floor(self):
+        from tools.mcp_tool import _resolve_connect_timeout
+        assert _resolve_connect_timeout({"auth": "header"}, "srv") == 60
+        assert _resolve_connect_timeout({}, "srv") == 60
+        assert _resolve_connect_timeout({"auth": "header", "connect_timeout": 5}, "srv") == 5
+
+    def test_oauth_without_cached_token_gets_315_floor(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_tool import _resolve_connect_timeout
+        assert _resolve_connect_timeout({"auth": "oauth"}, "srv") == 315.0
+
+    def test_oauth_configured_timeout_greater_than_floor_is_respected(self, tmp_path, monkeypatch):
+        """A user-configured longer timeout must never be reduced."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_tool import _resolve_connect_timeout
+        assert _resolve_connect_timeout(
+            {"auth": "oauth", "connect_timeout": 500}, "srv"
+        ) == 500
+
+    def test_oauth_configured_timeout_below_floor_is_raised(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_tool import _resolve_connect_timeout
+        assert _resolve_connect_timeout(
+            {"auth": "oauth", "connect_timeout": 10}, "srv"
+        ) == 315.0
+
+    def test_oauth_with_valid_cached_token_is_not_floored(self, tmp_path, monkeypatch):
+        """A server that can reconnect without a browser round-trip doesn't
+        need the login-sized timeout — inflating it would only slow down
+        detecting a genuinely dead connection."""
+        self._write_cached_token(tmp_path, monkeypatch, "srv")
+        from tools.mcp_tool import _resolve_connect_timeout
+        assert _resolve_connect_timeout({"auth": "oauth"}, "srv") == 60
+        assert _resolve_connect_timeout(
+            {"auth": "oauth", "connect_timeout": 10}, "srv"
+        ) == 10
+
+    def test_malformed_connect_timeout_falls_back_to_default(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_tool import _resolve_connect_timeout
+        assert _resolve_connect_timeout(
+            {"auth": "header", "connect_timeout": "not-a-number"}, "srv"
+        ) == 60
+        # Still floored for OAuth once the bad value falls back to the default.
+        assert _resolve_connect_timeout(
+            {"auth": "oauth", "connect_timeout": "not-a-number"}, "srv"
+        ) == 315.0
+
+
 class TestConfigurableTimeouts:
     """Tests for configurable per-server timeouts."""
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -166,6 +166,12 @@ def _find_free_port() -> int:
 _reserved_sockets: "dict[int, socket.socket]" = {}
 _MAX_RESERVED_SOCKETS = 8
 
+# Bound on how long _wait()'s cleanup waits for the callback listener thread
+# to notice its stop signal and exit before giving up and logging a warning.
+# The thread itself checks in at most every poll_interval (0.5s), so this is
+# generous headroom, not the expected wait.
+_LISTENER_JOIN_TIMEOUT = 2.0
+
 
 def _reserve_callback_port() -> int:
     """Pick an ephemeral callback port and keep its socket bound.
@@ -803,6 +809,9 @@ def _make_callback_waiter(port: int):
 
         handler_cls, result = _make_callback_handler()
 
+        timeout = 300.0
+        poll_interval = 0.5
+
         # Start a temporary server on this flow's port, adopting the socket
         # reserved at port-selection time when one exists. Holding the bound
         # socket from _reserve_callback_port() until here closes the TOCTOU
@@ -815,6 +824,17 @@ def _make_callback_waiter(port: int):
             server = HTTPServer(
                 ("127.0.0.1", port), handler_cls, bind_and_activate=False
             )
+            # BaseServer.timeout defaults to None, so handle_request() blocks
+            # in an uninterruptible selector.select(timeout=None) forever if no
+            # request ever arrives. Bounding it to poll_interval lets the
+            # listener thread notice _stop_event on its own between requests —
+            # without this, closing the socket from the coroutine's cleanup does
+            # not wake a thread already blocked inside handle_request(), the
+            # port stays bound, and a same-provider retry (mcp_tool.py reusing
+            # the cached OAuthClientProvider/callback port after its outer
+            # connect_timeout fires) collides with OSError: address already in
+            # use. See the investigation behind this fix for the full trace.
+            server.timeout = poll_interval
             reserved = _reserved_sockets.pop(port, None)
             if reserved is not None:
                 # Adopt the reserved (already bound) socket and start listening.
@@ -832,13 +852,31 @@ def _make_callback_waiter(port: int):
             # collided. build_oauth_auth does not start its own callback server,
             # so there is nothing to poll here; surface a clear, actionable error
             # instead of a misleading "timed out".
+            try:
+                server.server_close()
+            except (NameError, OSError):
+                pass
             raise OAuthNonInteractiveError(
                 f"OAuth callback port {port} is already in use ({exc}). "
                 "Close any other in-progress login, or set a free `oauth.redirect_port` "
                 "in the server config, then retry."
             ) from exc
 
-        server_thread = threading.Thread(target=server.handle_request, daemon=True)
+        # stop_event lets the thread exit its own accord once this coroutine is
+        # done with it (success, error, timeout, or cancellation) instead of
+        # relying solely on server_close() to interrupt an in-flight
+        # handle_request() call from another thread (see server.timeout above).
+        stop_event = threading.Event()
+
+        def _serve_until_stopped() -> None:
+            while not stop_event.is_set():
+                if result["auth_code"] is not None or result["error"] is not None:
+                    return
+                server.handle_request()  # bounded by server.timeout, see above
+
+        server_thread = threading.Thread(
+            target=_serve_until_stopped, name=f"oauth-callback-{port}", daemon=True,
+        )
         server_thread.start()
 
         # Optional paste-fallback thread: only on interactive TTYs. Reads one
@@ -859,8 +897,6 @@ def _make_callback_waiter(port: int):
             )
             paste_thread.start()
 
-        timeout = 300.0
-        poll_interval = 0.5
         elapsed = 0.0
         try:
             while elapsed < timeout:
@@ -869,7 +905,27 @@ def _make_callback_waiter(port: int):
                 await asyncio.sleep(poll_interval)
                 elapsed += poll_interval
         finally:
+            # Deterministic cleanup on every exit path (success, OAuth error,
+            # pasted callback, timeout, CancelledError, or any other
+            # exception): signal the listener thread to stop, close the
+            # server, then join with a bounded timeout so the port is
+            # verifiably free before this coroutine returns control to a
+            # caller that might immediately retry (mcp_tool.py's initial-
+            # connect ladder does exactly this after a connect_timeout).
+            stop_event.set()
             server.server_close()
+            # join() is a blocking call — run it off the event loop thread so a
+            # slow-to-notice listener thread (bounded by server.timeout, not
+            # instant) cannot stall every other coroutine sharing this loop
+            # (e.g. Hermes's other concurrent MCP server connections).
+            await asyncio.to_thread(server_thread.join, _LISTENER_JOIN_TIMEOUT)
+            if server_thread.is_alive():
+                logger.warning(
+                    "MCP OAuth callback listener thread for port %s did not "
+                    "terminate within %.1fs; the port may remain unavailable "
+                    "for a subsequent retry.",
+                    port, _LISTENER_JOIN_TIMEOUT,
+                )
 
         if result["error"] == _USER_SKIPPED_SENTINEL:
             raise OAuthNonInteractiveError("user_skipped")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -329,6 +329,12 @@ _MCP_LOG_LEVEL_MAP = {
 
 _DEFAULT_TOOL_TIMEOUT = 300      # seconds for tool calls
 _DEFAULT_CONNECT_TIMEOUT = 60    # seconds for initial connection per server
+# OAuth callback window (300s, see tools/mcp_oauth.py) plus headroom. Matches
+# the floor already applied to `hermes mcp login`/`reauth`
+# (hermes_cli/mcp_config.py's _reauth_oauth_server) and the GUI re-auth path
+# (web_server.py) so every entry point that might have to wait out a human's
+# browser authorization behaves the same way.
+_OAUTH_LOGIN_TIMEOUT_FLOOR = 315.0
 _MAX_RECONNECT_RETRIES = 5
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
 _MAX_BACKOFF_SECONDS = 60
@@ -348,6 +354,51 @@ def _jittered(seconds: float) -> float:
     """Return ``seconds`` with +/-20% uniform jitter, floored at 0."""
     return max(0.0, seconds * random.uniform(1.0 - _BACKOFF_JITTER,
                                              1.0 + _BACKOFF_JITTER))
+
+
+def _resolve_connect_timeout(config: dict, server_name: str) -> float:
+    """Resolve the initial-connection timeout for one MCP server.
+
+    An OAuth server with no valid cached token needs enough time for a human
+    to complete the browser authorization round-trip before the connection
+    attempt gives up — the plain connect_timeout default (60s,
+    _DEFAULT_CONNECT_TIMEOUT) is tuned for ordinary network handshakes, not a
+    login. Without this floor, the outer asyncio.wait_for(session.initialize(),
+    ...) times out mid-authorization, and MCPServerTask's initial-connect
+    ladder retries against the SAME cached OAuthClientProvider/callback port
+    (MCPOAuthManager.get_or_build_provider), racing the still-open callback
+    listener from the first attempt.
+
+    Mirrors the floor already applied to `hermes mcp login`/`reauth`
+    (hermes_cli/mcp_config.py's _reauth_oauth_server) and the GUI re-auth path
+    (web_server.py) — same _OAUTH_LOGIN_TIMEOUT_FLOOR, same "raise, never
+    lower, a user-configured longer timeout" behavior.
+
+    A server with a valid cached token is left at the configured/default
+    value: it doesn't need a browser round-trip on an ordinary reconnect, so
+    inflating its timeout would only slow down detecting a genuinely dead
+    connection.
+    """
+    configured = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+    try:
+        configured = float(configured)
+    except (TypeError, ValueError):
+        configured = float(_DEFAULT_CONNECT_TIMEOUT)
+
+    auth_type = (config.get("auth") or "").lower().strip()
+    if auth_type != "oauth":
+        return configured
+
+    try:
+        from tools.mcp_oauth import HermesTokenStorage
+        has_valid_token = HermesTokenStorage(server_name).has_cached_tokens()
+    except Exception:
+        has_valid_token = False
+
+    if has_valid_token:
+        return configured
+
+    return max(configured, _OAUTH_LOGIN_TIMEOUT_FLOOR)
 
 # Keepalive cadence for HTTP/SSE sessions. The MCP spec lets a server expire
 # idle sessions on any TTL it chooses (Streamable HTTP "Session Management"),
@@ -2728,7 +2779,7 @@ class MCPServerTask:
         # case-insensitive so conventional casing is preserved.
         if not any(key.lower() == "mcp-protocol-version" for key in headers):
             headers["mcp-protocol-version"] = LATEST_PROTOCOL_VERSION
-        connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+        connect_timeout = _resolve_connect_timeout(config, self.name)
         ssl_verify = config.get("ssl_verify", True)
         client_cert = _resolve_client_cert(self.name, config)
 
@@ -5566,7 +5617,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
 
     Returns list of registered tool names.
     """
-    connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+    connect_timeout = _resolve_connect_timeout(config, name)
     server = await asyncio.wait_for(
         _connect_server(name, config),
         timeout=connect_timeout,
@@ -5907,7 +5958,7 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
         names = list(enabled.keys())
         coros = []
         for name, cfg in enabled.items():
-            ct = cfg.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+            ct = _resolve_connect_timeout(cfg, name)
             coros.append(asyncio.wait_for(_connect_server(name, cfg), timeout=ct))
 
         outcomes = await asyncio.gather(*coros, return_exceptions=True)


### PR DESCRIPTION
## Summary

Fixes an MCP OAuth callback listener leak that caused a connection-timeout retry to reuse the same cached OAuth provider and callback port while the previous listener thread remained active.

The resulting failure was:

```text
OAuthNonInteractiveError:
OAuth callback port <redacted> is already in use
([Errno 98] Address already in use)
```

## Root cause

The MCP HTTP connection path used a 60-second outer timeout during interactive OAuth.

When that timeout expired:

1. The OAuth waiter coroutine was cancelled.
2. Its `finally` block called `server_close()`.
3. The listener thread remained blocked indefinitely inside `handle_request()` because `BaseServer.timeout` was `None`.
4. The generic MCP initial-connect retry reused the same cached `OAuthClientProvider`.
5. The reused provider invoked the same callback waiter closure and callback port.
6. The second bind failed with `Address already in use`.

This was reproduced using the installed Hermes callback-listener implementation with local synthetic sockets only. No external OAuth provider or browser was involved.

## Fix B — deterministic listener cleanup

Changes `tools/mcp_oauth.py` so that:

* the callback HTTP server uses a bounded polling timeout;
* the listener thread checks a stop event between bounded `handle_request()` calls;
* all exit paths signal the thread to stop;
* the server is closed;
* the listener thread is joined with a bounded timeout outside the asyncio event-loop thread;
* a warning is logged if the thread fails to terminate;
* partially created servers are closed on bind or activation failure.

This applies to:

* successful callbacks;
* OAuth errors;
* pasted callbacks;
* callback timeout;
* coroutine cancellation;
* unexpected exceptions.

## Fix A — OAuth-aware connection timeout

Changes `tools/mcp_tool.py` so OAuth servers without cached tokens receive a minimum initial connection timeout of 315 seconds.

Behavior:

* non-OAuth servers remain unchanged;
* OAuth servers with valid cached tokens remain unchanged;
* OAuth servers without valid cached tokens use:
  `max(configured_timeout, 315 seconds)`;
* user-configured timeouts greater than 315 seconds are preserved.

This mirrors the timeout treatment already used in Hermes's dedicated OAuth login and reauthentication paths.

## Tests

Added regression coverage for:

* callback timeout terminating the listener thread;
* callback port reuse after timeout;
* retrying with the same callback waiter and port;
* cached-token behavior bypassing callback listener creation;
* successful callback handling;
* pasted callback handling;
* explicit cancellation cleanup;
* timeout resolution for OAuth and non-OAuth servers.

Test results:

* `tests/tools/test_mcp_oauth.py`: 112 passed
* `tests/tools/test_mcp_tool.py`: 220 passed
* MCP-related test sweep: 784 passed
* Combined OAuth/tool/manager run: 352 passed
* Ruff checks: passed
* No new type-check diagnostics in edited regions

## Scope

Files changed:

* `tools/mcp_oauth.py`
* `tools/mcp_tool.py`
* `tests/tools/test_mcp_oauth.py`
* `tests/tools/test_mcp_tool.py`

No MCP SDK changes were required.

No credentials, configuration files, OAuth tokens, or service definitions were changed.

## Validation status

Validated with synthetic loopback tests only.

Not yet performed:

* deployment;
* Hermes restart;
* real MCP OAuth authorization;
* real TradeBook connection validation.

## Remaining risk

The listener-thread join uses a bounded timeout. Under extreme system load, the listener could theoretically fail to terminate within that bound; this condition is logged explicitly.

## Follow-up validation

After review and deployment approval:

1. deploy during a controlled maintenance window;
2. run one interactive `hermes mcp login tradebook`;
3. confirm exactly one authorization URL and callback listener;
4. confirm successful token storage;
5. confirm reconnect with the cached token does not create another callback listener.