### PR TITLE
fix(desktop): restore full-width chat composer

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -360,7 +360,7 @@
     --sticky-human-top: 0.23rem;
     --file-tree-row-height: 1.375rem;
 
-    --composer-width: 48.75rem;
+    --composer-width: 100%;
     --composer-control-size: 1.5rem;
     --composer-control-primary-size: 1.625rem;
     --composer-control-gap: 0.25rem;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1038,7 +1038,7 @@ text-* variant utilities. */ .btn-arc {
 }
 
 [data-slot='aui_intro'] > div {
-  max-width: min(var(--composer-width), 82vw);
+  max-width: var(--composer-width);
 }
 
 [data-slot='aui_intro'] p:last-child {


### PR DESCRIPTION
## Problem
- Desktop chat composer no longer spans the full chat pane width.
- The thread column and empty-state intro looked narrower than expected.

## Root Cause
- The desktop layout used a fixed --composer-width: 48.75rem, which hard-capped the chat column even when the pane had more room.

## Fix
- Set --composer-width to 100% so composer + thread can use the full available chat pane width.
- Align empty-state intro container to the same width behavior for consistency.

## Validation
- npm --workspace apps/desktop run test -- src/app/chat/composer/composer-utils.test.ts src/app/chat/composer/attachments.test.tsx
- npm --workspace apps/desktop run typecheck
- npm --workspace apps/desktop run test -- src/app/chat/composer/composer-utils.test.ts

## Scope
- Desktop UI only (no backend/auth changes).
