### PR TITLE
fix(anthropic): coerce empty/whitespace-only text blocks on the request path (#69512)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1881,6 +1881,28 @@ def _content_parts_to_anthropic_blocks(parts: Any) -> List[Dict[str, Any]]:
     return out
 
 
+_EMPTY_TEXT_PLACEHOLDER = "(empty)"
+
+
+def _safe_text(text: Any) -> str:
+    """Return ``text`` if it's non-whitespace, else a non-whitespace placeholder.
+
+    The Anthropic Messages API rejects requests where a text content block is
+    empty or whitespace-only (HTTP 400 "text content blocks must contain
+    non-whitespace text"). When such a block gets stored in session history —
+    e.g. produced by context compression — it is replayed verbatim on every
+    subsequent turn, permanently wedging the session. Coercing to a
+    non-whitespace placeholder is self-healing: the next API call recovers.
+
+    Mirrors ``bedrock_adapter._safe_text`` (#9486); ref #69512.
+    """
+    if text is None:
+        return _EMPTY_TEXT_PLACEHOLDER
+    if not isinstance(text, str):
+        text = str(text)
+    return text if text.strip() else _EMPTY_TEXT_PLACEHOLDER
+
+
 def _sanitize_replay_block(b: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Strip output-only fields from a stored Anthropic content block so it is
     valid as REQUEST input on replay.
@@ -1898,7 +1920,10 @@ def _sanitize_replay_block(b: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         return None
     btype = b.get("type")
     if btype == "text":
-        out: Dict[str, Any] = {"type": "text", "text": b.get("text", "")}
+        # Coerce empty/whitespace-only text to a non-whitespace placeholder;
+        # the Messages input schema rejects blank text blocks (#69512), and a
+        # blank block stored in history replays on every turn → permanent 400.
+        out: Dict[str, Any] = {"type": "text", "text": _safe_text(b.get("text", ""))}
         # citations is input-valid ONLY when it's a non-empty list; the SDK
         # emits citations=None on responses, which the input schema rejects.
         cits = b.get("citations")
@@ -2058,7 +2083,16 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
     # Anthropic rejects empty assistant content
     effective = blocks or content
     if not effective or effective == "":
-        effective = [{"type": "text", "text": "(empty)"}]
+        effective = [{"type": "text", "text": _EMPTY_TEXT_PLACEHOLDER}]
+    elif isinstance(effective, list):
+        # The all-empty guard above misses a list that still contains a
+        # whitespace-only text block (e.g. from a content array of blank parts,
+        # or compression). Those also trip "text content blocks must contain
+        # non-whitespace text" (#69512). Coerce text blocks in place; other
+        # block types (thinking/tool_use/image) are left untouched.
+        for blk in effective:
+            if isinstance(blk, dict) and blk.get("type") == "text":
+                blk["text"] = _safe_text(blk.get("text", ""))
     return {"role": "assistant", "content": effective}
 
 

--- a/tests/agent/test_anthropic_whitespace_text_blocks.py
+++ b/tests/agent/test_anthropic_whitespace_text_blocks.py
@@ -1,0 +1,111 @@
+"""Regression: whitespace-only text blocks must be coerced, not sent verbatim.
+
+Reproduces HTTP 400 ``messages: text content blocks must contain non-whitespace
+text``. When context compression (or certain tool-call flows) produces an
+assistant message with an empty or whitespace-only text block, that block is
+stored in session history and replayed on every subsequent turn — permanently
+wedging the session behind the same 400.
+
+Fix (mirrors ``bedrock_adapter._safe_text``, ref #9486): coerce empty/whitespace
+text to a non-whitespace placeholder at two points on the Anthropic request path
+— ``_sanitize_replay_block`` (ordered-blocks replay) and the final content walk
+in ``_convert_assistant_message`` (main path). Ref #69512.
+"""
+import pytest
+from agent.anthropic_adapter import (
+    _EMPTY_TEXT_PLACEHOLDER,
+    _safe_text,
+    _sanitize_replay_block,
+    _convert_assistant_message,
+)
+
+
+def _text_blocks(msg):
+    return [b for b in msg["content"] if isinstance(b, dict) and b.get("type") == "text"]
+
+
+def _assert_no_blank_text(msg):
+    """No text content block in the converted message is empty/whitespace-only."""
+    assert isinstance(msg["content"], list)
+    for b in _text_blocks(msg):
+        assert b["text"].strip(), f"blank text block survived: {b!r}"
+
+
+class TestSafeText:
+    def test_none_becomes_placeholder(self):
+        assert _safe_text(None) == _EMPTY_TEXT_PLACEHOLDER
+
+    def test_empty_string_becomes_placeholder(self):
+        assert _safe_text("") == _EMPTY_TEXT_PLACEHOLDER
+
+    @pytest.mark.parametrize("blank", ["   ", "\n", "\t", " \n\t "])
+    def test_whitespace_only_becomes_placeholder(self, blank):
+        assert _safe_text(blank) == _EMPTY_TEXT_PLACEHOLDER
+
+    def test_real_text_is_kept_verbatim(self):
+        assert _safe_text("hello") == "hello"
+        assert _safe_text("  padded  ") == "  padded  "
+
+    def test_non_string_is_coerced_then_checked(self):
+        assert _safe_text(123) == "123"
+
+
+class TestSanitizeReplayBlockWhitespace:
+    def test_whitespace_text_block_coerced_to_placeholder(self):
+        out = _sanitize_replay_block({"type": "text", "text": "   \n"})
+        assert out == {"type": "text", "text": _EMPTY_TEXT_PLACEHOLDER}
+
+    def test_empty_text_block_coerced_to_placeholder(self):
+        out = _sanitize_replay_block({"type": "text", "text": ""})
+        assert out == {"type": "text", "text": _EMPTY_TEXT_PLACEHOLDER}
+
+    def test_real_text_block_unchanged(self):
+        out = _sanitize_replay_block({"type": "text", "text": "hi"})
+        assert out == {"type": "text", "text": "hi"}
+
+
+class TestConvertAssistantMessageWhitespace:
+    def test_ordered_blocks_replay_coerces_blank_text(self):
+        # The interleaved-thinking fast path replays anthropic_content_blocks
+        # through _sanitize_replay_block; a stored whitespace text block here is
+        # exactly the compression-produced poison that wedges the session.
+        msg = {
+            "role": "assistant",
+            "anthropic_content_blocks": [
+                {"type": "thinking", "thinking": "reasoning", "signature": "sig-A"},
+                {"type": "text", "text": "  "},
+            ],
+        }
+        out = _convert_assistant_message(msg)
+        _assert_no_blank_text(out)
+        assert _text_blocks(out) == [{"type": "text", "text": _EMPTY_TEXT_PLACEHOLDER}]
+
+    def test_main_path_coerces_whitespace_string_content(self):
+        # A whitespace-only string content becomes a whitespace text block that
+        # the all-empty guard does not catch; the final walk must coerce it.
+        out = _convert_assistant_message({"role": "assistant", "content": "   "})
+        _assert_no_blank_text(out)
+        assert _text_blocks(out) == [{"type": "text", "text": _EMPTY_TEXT_PLACEHOLDER}]
+
+    def test_fully_empty_content_still_gets_placeholder(self):
+        # Pre-existing behavior preserved.
+        out = _convert_assistant_message({"role": "assistant", "content": ""})
+        assert out["content"] == [{"type": "text", "text": _EMPTY_TEXT_PLACEHOLDER}]
+
+    def test_real_text_content_unchanged(self):
+        out = _convert_assistant_message({"role": "assistant", "content": "answer"})
+        assert out["content"] == [{"type": "text", "text": "answer"}]
+
+    def test_thinking_block_not_treated_as_text(self):
+        # Only text blocks are coerced; thinking blocks are left untouched even
+        # if their payload is whitespace (they obey a different schema rule).
+        msg = {
+            "role": "assistant",
+            "anthropic_content_blocks": [
+                {"type": "thinking", "thinking": "  ", "signature": "sig-B"},
+                {"type": "text", "text": "real"},
+            ],
+        }
+        out = _convert_assistant_message(msg)
+        thinking = [b for b in out["content"] if b.get("type") == "thinking"]
+        assert thinking == [{"type": "thinking", "thinking": "  ", "signature": "sig-B"}]


### PR DESCRIPTION
## What does this PR do?

Fixes #69512 — a permanently-wedged session when an assistant message carries an **empty or whitespace-only text content block**.

The Anthropic Messages API rejects such a request with:

```
HTTP 400: messages: text content blocks must contain non-whitespace text
```

Because the blank block is stored in session history and replayed verbatim on every subsequent turn, every following message produces the same 400 — the session never recovers on its own. This is the same class of bug as anthropics/claude-code#23390 / #23440.

## Root cause

- `_sanitize_replay_block()` rebuilt stored text blocks with the raw `b.get("text", "")`, so an empty/whitespace text block was replayed unchanged.
- The final guard in `_convert_assistant_message()` (`if not effective or effective == ""`) only caught a **fully empty** block list — not a list that still contained a whitespace-only text block.

The **Bedrock adapter** already guards this via `_safe_text()` (ref #9486); the native Anthropic path never got the same treatment.

## Fix

Adds a `_safe_text()` helper in `agent/anthropic_adapter.py` mirroring the Bedrock one, and applies it at the two request-construction points:

1. **`_sanitize_replay_block()`** — coerce empty/whitespace text to a `(empty)` placeholder on the interleaved-thinking ordered-blocks replay path.
2. **`_convert_assistant_message()`** — after the existing all-empty guard, walk the converted content list in place and coerce any surviving whitespace-only text block.

Both edits are **self-healing**: sessions that already stored a blank text block recover automatically on the next API call after deploy — no history surgery required. Only `text` blocks are touched; `thinking` / `tool_use` / `image` blocks are left untouched (they obey different schema rules).

## Tests

New `tests/agent/test_anthropic_whitespace_text_blocks.py` (16 cases):

- `_safe_text` unit coverage — `None`, `""`, whitespace variants (`"   "`, `"\n"`, `"\t"`), real text kept verbatim, non-str coercion.
- `_sanitize_replay_block` coerces empty/whitespace text blocks, leaves real text intact.
- `_convert_assistant_message` — ordered-blocks replay path, whitespace-string main path, fully-empty (pre-existing behavior preserved), real text unchanged, and thinking blocks left untouched.

```
16 passed
```

Ruff (incl. PLW1514) clean; Windows-footgun and subprocess-stdin checks clean; no `uv.lock` drift.

> The arm64 fork-Docker CI job is expected to fail on fork PRs and is unrelated to this change.

Fixes #69512