### PR TITLE
feat: add SuperTonic 3 as built-in local TTS provider

### DIFF
--- a/agent/tts_registry.py
+++ b/agent/tts_registry.py
@@ -56,6 +56,7 @@ _BUILTIN_NAMES = frozenset({
     "neutts",
     "kittentts",
     "piper",
+    "supertonic",
     "deepinfra",
 })
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2207,7 +2207,7 @@ DEFAULT_CONFIG = {
     # Gemini 32000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
     "tts": {
         # Set explicitly to pin a backend:
-        # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local)
+        # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local) | "supertonic" (local)
         "provider": "edge",
         "edge": {
             "voice": "en-US-AriaNeural",
@@ -2276,6 +2276,14 @@ DEFAULT_CONFIG = {
             # "noise_w_scale": 0.8,
             # "volume": 1.0,
             # "normalize_audio": True,
+        },
+        "supertonic": {
+            # SuperTonic 3 by Supertone — local CPU-only neural TTS (99M params).
+            # 31 languages, 44.1kHz output, expression tags (<laugh>, <breath>, <sigh>).
+            # Voices: M1-M5 (male), F1-F5 (female). M1 = default male, F1 = default female.
+            "voice": "M1",
+            "lang": "en",          # BCP-47-ish code; "na" for language-agnostic
+            "steps": 5,            # 5 = natural quality (4.2x RT), 2 = fast (8.3x RT, robotic)
         },
         "deepinfra": {
             "model": "",  # empty = first tts-tagged model from the live catalog

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -544,6 +544,15 @@ def _print_setup_summary(config: dict, hermes_home):
             tool_status.append(("Text-to-Speech (KittenTTS local)", True, None))
         else:
             tool_status.append(("Text-to-Speech (KittenTTS — not installed)", False, "run 'hermes setup tts'"))
+    elif tts_provider == "supertonic":
+        try:
+            supertonic_ok = importlib.util.find_spec("supertonic") is not None
+        except Exception:
+            supertonic_ok = False
+        if supertonic_ok:
+            tool_status.append(("Text-to-Speech (SuperTonic 3 local)", True, None))
+        else:
+            tool_status.append(("Text-to-Speech (SuperTonic 3 — not installed)", False, "run 'hermes setup tts'"))
     else:
         tool_status.append(("Text-to-Speech (Edge TTS)", True, None))
 
@@ -948,6 +957,7 @@ def _setup_tts_provider(config: dict):
         "gemini": "Google Gemini TTS",
         "neutts": "NeuTTS",
         "kittentts": "KittenTTS",
+        "supertonic": "SuperTonic 3",
     }
     current_label = provider_labels.get(current_provider, current_provider)
 
@@ -972,9 +982,10 @@ def _setup_tts_provider(config: dict):
             "Google Gemini TTS (30 prebuilt voices, prompt-controllable, needs API key)",
             "NeuTTS (local on-device, free, ~300MB model download)",
             "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)",
+            "SuperTonic 3 (local on-device, free, 31 languages, ~200MB ONNX)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
+    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "supertonic"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1158,6 +1169,38 @@ def _setup_tts_provider(config: dict):
                     selected = "edge"
             else:
                 print_info("Skipping install. Set tts.provider to 'kittentts' after installing manually.")
+                selected = "edge"
+
+    elif selected == "supertonic":
+        # Check if already installed
+        try:
+            already_installed = importlib.util.find_spec("supertonic") is not None
+        except Exception:
+            already_installed = False
+
+        if already_installed:
+            print_success("SuperTonic 3 is already installed")
+        else:
+            print()
+            print_info("SuperTonic 3 is a local neural TTS engine (99M params, CPU-only).")
+            print_info("31 languages, 44.1kHz output, expression tags. ~200MB model download on first use.")
+            print_info("Voices: M1-M5 (male), F1-F5 (female)")
+            print()
+            if prompt_yes_no("Install SuperTonic 3 now?", True):
+                print_info("Installing supertonic Python package...")
+                try:
+                    result = _pip_install(["supertonic", "--quiet"], timeout=300)
+                    if result:
+                        print_success("supertonic installed successfully")
+                    else:
+                        print_warning("SuperTonic installation incomplete. Falling back to Edge TTS.")
+                        selected = "edge"
+                except Exception as e:
+                    print_error(f"Failed to install supertonic: {e}")
+                    print_info("Try manually: pip install supertonic")
+                    selected = "edge"
+            else:
+                print_info("Skipping install. Set tts.provider to 'supertonic' after installing manually.")
                 selected = "edge"
 
     # Save the selection

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -374,6 +374,14 @@ TOOL_CATEGORIES = {
                 "post_setup": "piper",
             },
             {
+                "name": "SuperTonic 3",
+                "badge": "local · free",
+                "tag": "Local neural TTS, 31 languages, expression tags (~200MB)",
+                "env_vars": [],
+                "tts_provider": "supertonic",
+                "post_setup": "supertonic",
+            },
+            {
                 "name": "DeepInfra TTS",
                 "badge": "paid",
                 "tag": "Chatterbox, Qwen3-TTS, … — live catalog from api.deepinfra.com",
@@ -1415,6 +1423,28 @@ def _run_post_setup(post_setup_key: str):
         _print_info("    Default voice: en_US-lessac-medium (downloaded on first TTS call)")
         _print_info("    Full voice list: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md")
         _print_info("    Switch voices by setting tts.piper.voice in ~/.hermes/config.yaml")
+
+    elif post_setup_key == "supertonic":
+        try:
+            __import__("supertonic")
+            _print_success("    supertonic is already installed")
+        except ImportError:
+            _print_info("    Installing supertonic (~200MB model downloaded on first use)...")
+            try:
+                result = _pip_install(["-U", "supertonic", "--quiet"], timeout=300)
+                if result.returncode == 0:
+                    _print_success("    supertonic installed")
+                else:
+                    _print_warning("    supertonic install failed:")
+                    _print_info(f"      {(result.stderr or '').strip()[:300]}")
+                    _print_info("    Run manually: uv pip install -U supertonic")
+                    return
+            except subprocess.TimeoutExpired:
+                _print_warning("    supertonic install timed out (>5min)")
+                _print_info("    Run manually: uv pip install -U supertonic")
+                return
+        _print_info("    Default voice: M1 (male). Voices: M1-M5, F1-F5")
+        _print_info("    31 languages. Set tts.supertonic.voice / .lang in ~/.hermes/config.yaml")
 
     elif post_setup_key == "ddgs":
         try:

--- a/tests/tools/test_tts_supertonic.py
+++ b/tests/tools/test_tts_supertonic.py
@@ -1,0 +1,259 @@
+"""
+Tests for the native SuperTonic 3 TTS provider.
+
+These tests pin the resolution / caching / dispatch paths for SuperTonic
+without requiring the ``supertonic`` package to actually be installed
+(the synthesis step is monkey-patched to avoid needing the ONNX model).
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in ("HERMES_SESSION_PLATFORM",):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def clear_supertonic_cache():
+    """Reset the module-level model cache between tests."""
+    from tools import tts_tool as _tt
+    _tt._supertonic_model_cache.clear()
+    yield
+    _tt._supertonic_model_cache.clear()
+
+
+@pytest.fixture
+def mock_supertonic_module():
+    """Inject a fake supertonic + numpy + soundfile module that return stub objects."""
+    fake_tts_instance = MagicMock()
+    # synthesize() returns (wav, dur) where wav is (1, N) and dur is ndarray
+    fake_tts_instance.synthesize.return_value = (
+        [[0.0] * 44100],  # 1s of silence at 44100Hz, shape (1, N)
+        MagicMock(__getitem__=lambda self, idx: 1.0),  # dur[0] = 1.0
+    )
+    fake_tts_instance.get_voice_style.return_value = MagicMock()
+    fake_tts_cls = MagicMock(return_value=fake_tts_instance)
+    fake_supertonic = MagicMock()
+    fake_supertonic.TTS = fake_tts_cls
+
+    # Stub numpy — squeeze on (1, N) returns 1D
+    import numpy as np
+    fake_np = MagicMock(wraps=np)
+
+    # Stub soundfile
+    fake_sf = MagicMock()
+    def _fake_write(path, audio, samplerate):
+        Path(path).write_bytes(b"RIFF\x00\x00\x00\x00WAVEfmt fake")
+    fake_sf.write = _fake_write
+
+    with patch.dict(
+        "sys.modules",
+        {"supertonic": fake_supertonic, "soundfile": fake_sf},
+    ):
+        yield fake_tts_instance, fake_tts_cls
+
+
+# ---------------------------------------------------------------------------
+# Registry / constants
+# ---------------------------------------------------------------------------
+
+class TestSuperTonicRegistration:
+    def test_supertonic_is_a_builtin_provider(self):
+        from tools.tts_tool import BUILTIN_TTS_PROVIDERS
+        assert "supertonic" in BUILTIN_TTS_PROVIDERS
+
+    def test_supertonic_has_a_text_length_cap(self):
+        from tools.tts_tool import PROVIDER_MAX_TEXT_LENGTH
+        assert PROVIDER_MAX_TEXT_LENGTH.get("supertonic", 0) > 0
+
+
+# ---------------------------------------------------------------------------
+# _check_supertonic_available
+# ---------------------------------------------------------------------------
+
+class TestCheckSuperTonicAvailable:
+    def test_returns_bool_without_raising(self):
+        from tools.tts_tool import _check_supertonic_available
+        # We don't care about the current environment's answer — just that
+        # the probe never raises on a machine without supertonic installed.
+        assert isinstance(_check_supertonic_available(), bool)
+
+    def test_reports_available_when_package_present(self, monkeypatch):
+        import importlib.util
+        from tools.tts_tool import _check_supertonic_available
+
+        fake_spec = MagicMock()
+        monkeypatch.setattr(
+            importlib.util, "find_spec",
+            lambda name: fake_spec if name == "supertonic" else None,
+        )
+        assert _check_supertonic_available() is True
+
+    def test_reports_unavailable_when_package_missing(self, monkeypatch):
+        import importlib.util
+        from tools.tts_tool import _check_supertonic_available
+
+        monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+        assert _check_supertonic_available() is False
+
+
+# ---------------------------------------------------------------------------
+# _generate_supertonic_tts — stubbed so we don't need supertonic installed
+# ---------------------------------------------------------------------------
+
+class TestGenerateSuperTonicTts:
+    def test_successful_wav_generation(self, tmp_path, mock_supertonic_module):
+        from tools.tts_tool import _generate_supertonic_tts
+
+        fake_tts, fake_cls = mock_supertonic_module
+        output_path = str(tmp_path / "test.wav")
+        result = _generate_supertonic_tts("Hello world", output_path, {})
+
+        assert result == output_path
+        assert (tmp_path / "test.wav").exists()
+        fake_cls.assert_called_once_with(auto_download=True)
+        fake_tts.synthesize.assert_called_once()
+
+    def test_config_passes_voice_lang_steps(self, tmp_path, mock_supertonic_module):
+        from tools.tts_tool import _generate_supertonic_tts
+
+        fake_tts, _ = mock_supertonic_module
+        config = {
+            "supertonic": {
+                "voice": "F1",
+                "lang": "fr",
+                "steps": 2,
+            }
+        }
+        _generate_supertonic_tts("Bonjour", str(tmp_path / "out.wav"), config)
+
+        call_kwargs = fake_tts.synthesize.call_args.kwargs
+        assert call_kwargs["lang"] == "fr"
+        assert call_kwargs["steps"] == 2
+        # get_voice_style was called with the configured voice
+        fake_tts.get_voice_style.assert_called_once_with(voice_name="F1")
+
+    def test_default_voice_lang_steps(self, tmp_path, mock_supertonic_module):
+        from tools.tts_tool import (
+            DEFAULT_SUPERTONIC_VOICE,
+            DEFAULT_SUPERTONIC_LANG,
+            DEFAULT_SUPERTONIC_STEPS,
+            _generate_supertonic_tts,
+        )
+
+        fake_tts, _ = mock_supertonic_module
+        _generate_supertonic_tts("Hi", str(tmp_path / "out.wav"), {})
+
+        fake_tts.get_voice_style.assert_called_once_with(voice_name=DEFAULT_SUPERTONIC_VOICE)
+        call_kwargs = fake_tts.synthesize.call_args.kwargs
+        assert call_kwargs["lang"] == DEFAULT_SUPERTONIC_LANG
+        assert call_kwargs["steps"] == DEFAULT_SUPERTONIC_STEPS
+
+    def test_model_is_cached_across_calls(self, tmp_path, mock_supertonic_module):
+        from tools.tts_tool import _generate_supertonic_tts
+
+        _, fake_cls = mock_supertonic_module
+        _generate_supertonic_tts("One", str(tmp_path / "a.wav"), {})
+        _generate_supertonic_tts("Two", str(tmp_path / "b.wav"), {})
+
+        # Same cache key → TTS class instantiated exactly once
+        assert fake_cls.call_count == 1
+
+    def test_non_wav_extension_triggers_ffmpeg_conversion(
+        self, tmp_path, mock_supertonic_module, monkeypatch
+    ):
+        """Non-.wav output path causes WAV -> target ffmpeg conversion."""
+        from tools import tts_tool as _tt
+
+        calls = []
+
+        def fake_shutil_which(cmd):
+            return "/usr/bin/ffmpeg" if cmd == "ffmpeg" else None
+
+        def fake_run(cmd, check=False, timeout=None, **kw):
+            calls.append(cmd)
+            out_path = cmd[-1]
+            Path(out_path).write_bytes(b"fake-mp3-data")
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(_tt.shutil, "which", fake_shutil_which)
+        monkeypatch.setattr(_tt.subprocess, "run", fake_run)
+
+        output_path = str(tmp_path / "test.mp3")
+        result = _tt._generate_supertonic_tts("Hi", output_path, {})
+
+        assert result == output_path
+        assert len(calls) == 1
+        assert calls[0][0] == "/usr/bin/ffmpeg"
+
+    def test_missing_supertonic_raises_import_error(self, tmp_path, monkeypatch):
+        """When supertonic package is not installed, _import_supertonic raises."""
+        monkeypatch.setitem(sys.modules, "supertonic", None)
+        from tools.tts_tool import _generate_supertonic_tts
+
+        with pytest.raises((ImportError, TypeError)):
+            _generate_supertonic_tts("Hi", str(tmp_path / "out.wav"), {})
+
+
+# ---------------------------------------------------------------------------
+# text_to_speech_tool end-to-end (provider == "supertonic")
+# ---------------------------------------------------------------------------
+
+class TestTextToSpeechToolWithSuperTonic:
+    def test_dispatches_to_supertonic(self, tmp_path, monkeypatch, mock_supertonic_module):
+        from tools import tts_tool
+        from tools.tts_tool import text_to_speech_tool
+
+        monkeypatch.setattr(tts_tool, "_import_supertonic", lambda: mock_supertonic_module[1])
+
+        cfg = {"provider": "supertonic", "supertonic": {"voice": "M1"}}
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: cfg)
+
+        result = text_to_speech_tool(text="hi", output_path=str(tmp_path / "clip.wav"))
+        data = json.loads(result)
+
+        assert data["success"] is True, data
+        assert data["provider"] == "supertonic"
+        assert Path(data["file_path"]).exists()
+
+    def test_missing_package_surfaces_error(self, tmp_path, monkeypatch):
+        from tools import tts_tool
+        from tools.tts_tool import text_to_speech_tool
+
+        def raise_import():
+            raise ImportError("No module named 'supertonic'")
+
+        monkeypatch.setattr(tts_tool, "_import_supertonic", raise_import)
+
+        cfg = {"provider": "supertonic"}
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: cfg)
+
+        result = text_to_speech_tool(text="hi", output_path=str(tmp_path / "clip.wav"))
+        data = json.loads(result)
+
+        assert data["success"] is False
+        assert "supertonic" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# check_tts_requirements
+# ---------------------------------------------------------------------------
+
+class TestCheckTtsRequirementsSuperTonic:
+    def test_supertonic_install_satisfies_requirements(self, monkeypatch):
+        from tools import tts_tool
+        from tools.tts_tool import check_tts_requirements
+
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "supertonic"})
+        monkeypatch.setattr(tts_tool, "_check_supertonic_available", lambda: False)
+        assert check_tts_requirements() is False
+
+        monkeypatch.setattr(tts_tool, "_check_supertonic_available", lambda: True)
+        assert check_tts_requirements() is True

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -126,6 +126,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "tts.mistral": ("mistralai==2.4.8",),
     "tts.edge": ("edge-tts==7.2.7",),
     "tts.elevenlabs": ("elevenlabs==1.59.0",),
+    "tts.supertonic": ("supertonic>=1.3.1,<2",),
 
     # ─── Speech-to-text providers ──────────────────────────────────────────
     "stt.mistral": ("mistralai==2.4.8",),

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -163,6 +163,18 @@ def _import_piper():
     return PiperVoice
 
 
+def _import_supertonic():
+    """Lazy import SuperTonic 3. Returns the TTS class or raises ImportError.
+
+    SuperTonic 3 by Supertone is a local, CPU-only neural TTS engine (99M
+    params, flow-matching ONNX). 31 languages, 44.1kHz output, expression
+    tags. ``pip install supertonic`` provides the Python package; ONNX model
+    weights (~200MB) are auto-downloaded on first use.
+    """
+    from supertonic import TTS
+    return TTS
+
+
 # ===========================================================================
 # Defaults
 # ===========================================================================
@@ -180,6 +192,9 @@ MANAGED_OPENAI_TTS_MODELS = frozenset({"gpt-4o-mini-tts"})
 DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
 DEFAULT_PIPER_VOICE = "en_US-lessac-medium"  # balanced size/quality
+DEFAULT_SUPERTONIC_VOICE = "M1"  # default male voice; F1-F5, M1-M5 available
+DEFAULT_SUPERTONIC_LANG = "en"  # English; 31 languages supported
+DEFAULT_SUPERTONIC_STEPS = 5  # 5-step for natural quality (2-step = fast, robotic)
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_MINIMAX_MODEL = "speech-02-hd"
@@ -236,6 +251,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
     "piper": 5000,        # local VITS model, phoneme-based; practical cap
+    "supertonic": 5000,  # local 99M model; practical cap for single-pass synthesis
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -404,6 +420,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "neutts",
     "kittentts",
     "piper",
+    "supertonic",
     "deepinfra",
 })
 
@@ -2052,6 +2069,15 @@ def _check_piper_available() -> bool:
         return False
 
 
+def _check_supertonic_available() -> bool:
+    """Check whether the supertonic package is importable."""
+    try:
+        import importlib.util
+        return importlib.util.find_spec("supertonic") is not None
+    except Exception:
+        return False
+
+
 def _get_piper_voices_dir() -> Path:
     """Return the directory where Hermes caches Piper voice models.
 
@@ -2197,6 +2223,80 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
             voice.synthesize_wav(text, wav_file, syn_config=syn_config)
         else:
             voice.synthesize_wav(text, wav_file)
+
+    # Convert to desired format if caller requested mp3/ogg
+    if wav_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
+            subprocess.run(conv_cmd, check=True, timeout=30, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())
+            try:
+                os.remove(wav_path)
+            except OSError:
+                pass
+        else:
+            # No ffmpeg — keep WAV and return that path
+            os.rename(wav_path, output_path)
+
+    return output_path
+
+
+# ===========================================================================
+# Provider: SuperTonic 3 (local, multi-language, CPU)
+# ===========================================================================
+
+# Module-level cache for SuperTonic TTS instance
+_supertonic_model_cache: Dict[str, Any] = {}
+
+
+def _generate_supertonic_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using SuperTonic 3 local ONNX model.
+
+    SuperTonic 3 by Supertone is a flow-matching neural TTS engine (99M
+    params) that runs entirely on CPU. 31 languages, 44.1kHz output,
+    expression tags (<laugh>, <breath>, <sigh>). ONNX model weights
+    (~200MB) are auto-downloaded on first use.
+
+    Args:
+        text: Text to convert to speech.
+        output_path: Where to save the audio file.
+        tts_config: TTS config dict.
+
+    Returns:
+        Path to the saved audio file.
+    """
+    TTS = _import_supertonic()
+    import numpy as np
+
+    st_config = tts_config.get("supertonic", {}) if isinstance(tts_config, dict) else {}
+    voice_name = st_config.get("voice", DEFAULT_SUPERTONIC_VOICE)
+    lang = st_config.get("lang", DEFAULT_SUPERTONIC_LANG)
+    steps = st_config.get("steps", DEFAULT_SUPERTONIC_STEPS)
+
+    # Use cached TTS instance if available (model weights are ~200MB)
+    cache_key = "default"  # single model; auto_download handles weights
+    global _supertonic_model_cache
+    if cache_key not in _supertonic_model_cache:
+        logger.info("[SuperTonic] Loading model (auto-download on first use)...")
+        _supertonic_model_cache[cache_key] = TTS(auto_download=True)
+        logger.info("[SuperTonic] Model loaded")
+
+    tts = _supertonic_model_cache[cache_key]
+    voice_style = tts.get_voice_style(voice_name=voice_name)
+
+    # synthesize() returns (wav, dur) where wav is (1, N) float32 @ 44100Hz
+    # and dur is a numpy ndarray. Use .squeeze() for 1D and dur[0] for the
+    # float duration value.
+    wav, dur = tts.synthesize(text=text, lang=lang, voice_style=voice_style, steps=steps)
+    audio = np.squeeze(wav)
+
+    # Save as WAV at 44100Hz
+    import soundfile as sf
+    wav_path = output_path
+    if not output_path.endswith(".wav"):
+        wav_path = output_path.rsplit(".", 1)[0] + ".wav"
+
+    sf.write(wav_path, audio, 44100)
 
     # Convert to desired format if caller requested mp3/ogg
     if wav_path != output_path:
@@ -2496,6 +2596,19 @@ def text_to_speech_tool(
             logger.info("Generating speech with Piper (local)...")
             _generate_piper_tts(text, file_str, tts_config)
 
+        elif provider == "supertonic":
+            try:
+                _import_supertonic()
+            except ImportError:
+                return json.dumps({
+                    "success": False,
+                    "error": "SuperTonic provider selected but 'supertonic' package not installed. "
+                             "Run 'hermes setup tts' and choose SuperTonic, or install manually: "
+                             "pip install supertonic"
+                }, ensure_ascii=False)
+            logger.info("Generating speech with SuperTonic 3 (local, 31 languages)...")
+            _generate_supertonic_tts(text, file_str, tts_config)
+
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
             edge_available = True
@@ -2561,7 +2674,7 @@ def text_to_speech_tool(
                 voice_compatible = file_str.endswith(".ogg")
         elif (
             want_opus
-            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper"}
+            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper", "supertonic"}
             and not file_str.endswith(".ogg")
         ):
             opus_path = _convert_to_opus(file_str)
@@ -2667,6 +2780,8 @@ def check_tts_requirements() -> bool:
         return _check_kittentts_available()
     if provider == "piper":
         return _check_piper_available()
+    if provider == "supertonic":
+        return _check_supertonic_available()
 
     try:
         from agent.tts_registry import get_provider


### PR DESCRIPTION
## What does this PR do?

Adds **SuperTonic 3** by Supertone as a first-class built-in local TTS provider, following the same pattern as Piper and KittenTTS (lazy import, model cache, WAV output + ffmpeg conversion).

SuperTonic 3 is a local CPU-only neural TTS engine:
- 99M params, flow-matching ONNX
- 31 languages
- 44.1kHz output (studio grade)
- Expression tags (`<laugh>`, `<breath>`, `<sigh>`)
- 4.2x real-time on CPU (5-step), 8.3x (2-step)
- ~200MB model weights (auto-downloaded on first use)
- Apache 2.0 license (model + code)

## Related Issue

Refs #35396 #65373

Note: PR #35398 also addresses this feature. I opened this PR independently before discovering #35398. Happy to close this in favor of #35398 if the maintainers prefer, or collaborate on either.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

| File | Change |
|------|--------|
| `tools/tts_tool.py` | `_import_supertonic()`, `_generate_supertonic_tts()`, `_check_supertonic_available()`, constants, `BUILTIN_TTS_PROVIDERS` entry, dispatch branch, `check_tts_requirements` branch, Opus conversion list |
| `agent/tts_registry.py` | Add `supertonic` to `_BUILTIN_NAMES` (keeps in sync with `BUILTIN_TTS_PROVIDERS`) |
| `hermes_cli/config.py` | Default config block (`voice`, `lang`, `steps`) |
| `hermes_cli/setup.py` | Interactive TTS picker entry + install flow + status check |
| `hermes_cli/tools_config.py` | Picker row + `post_setup` install handler |
| `tools/lazy_deps.py` | Auto-install mapping for `tts.supertonic` (`>=1.3.1,<2`) |
| `tests/tools/test_tts_supertonic.py` | 14 tests (new file) |

## How to Test

1. `pip install supertonic`
2. `hermes config set tts.provider supertonic`
3. `hermes chat -q "Say hello"` with voice mode on, or use `text_to_speech` tool
4. Or run the unit tests: `pytest tests/tools/test_tts_supertonic.py -v`

Configuration:
```yaml
tts:
  provider: supertonic
  supertonic:
    voice: M1    # M1-M5 (male), F1-F5 (female)
    lang: en     # 31 languages; "na" for language-agnostic
    steps: 5     # 5 = natural (4.2x RT), 2 = fast (8.3x RT, robotic)
```

## Test Results

All 14 new tests pass. All 89 existing TTS + registry tests pass (no regressions):

```
tests/tools/test_tts_supertonic.py: 14 passed
tests/tools/test_tts_piper.py: 22 passed
tests/tools/test_tts_kittentts.py: 10 passed
tests/tools/test_tts_max_text_length.py: 23 passed
tests/hermes_cli/test_tts_picker.py: 8 passed
tests/agent/test_tts_registry.py: 26 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(tools):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate — found #35398 (open, same feature) and #23552 (closed, sweeper:implemented-on-main but not actually on main)
- [x] My PR contains only changes related to this feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (Python 3.13.2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (config defaults, setup wizard, tools picker)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (config defaults are in `hermes_cli/config.py` DEFAULT_CONFIG, which is the source of truth)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — uses same `shutil.which('ffmpeg')` + `windows_hide_flags()` pattern as Piper/KittenTTS
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## API Quirks Documented in Code

- `synthesize()` returns `(wav, dur)` where `wav` is `(1, N)` float32 — use `.squeeze()` for 1D
- `dur` is a `numpy.ndarray` — use `dur[0]` for the float duration value
- `voice_style_names` is an attribute, not a method
- Sample rate: 44100 Hz (fixed)