### PR TITLE
fix: make preflight compression growth cumulative

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1804,7 +1804,10 @@ class ContextCompressor(ContextEngine):
         if growth > tolerated_growth:
             return False
 
-        self.last_rough_tokens_when_real_prompt_fit = max(baseline, rough_tokens)
+        # Keep the provider-proven baseline fixed until the next real usage
+        # update. Advancing it on every deferred preflight lets many small tool
+        # results ratchet rough pressure upward forever without ever crossing
+        # the cumulative-growth guard.
         return True
 
     def should_compress(self, prompt_tokens: int = None) -> bool:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -125,7 +125,15 @@ class TestPreflightDeferral:
         compressor.last_rough_tokens_when_real_prompt_fit = 90_000
 
         assert compressor.should_defer_preflight_to_real_usage(93_000) is True
-        assert compressor.last_rough_tokens_when_real_prompt_fit == 93_000
+
+    def test_incremental_growth_is_cumulative_from_provider_proven_baseline(self, compressor):
+        compressor.threshold_tokens = 85_000
+        compressor.last_real_prompt_tokens = 50_000
+        compressor.last_rough_tokens_when_real_prompt_fit = 90_000
+
+        assert compressor.should_defer_preflight_to_real_usage(93_000) is True
+        assert compressor.last_rough_tokens_when_real_prompt_fit == 90_000
+        assert compressor.should_defer_preflight_to_real_usage(96_000) is False
 
     def test_does_not_defer_when_rough_growth_is_large(self, compressor):
         compressor.threshold_tokens = 85_000


### PR DESCRIPTION
## What does this PR do?

Fixes delayed context compression during long, tool-heavy agent turns.

Hermes already checks request pressure before every model call. However, when the rough token estimate grew in several small increments, each deferred preflight check advanced the comparison baseline. This allowed the baseline to ratchet upward indefinitely, so cumulative growth could bypass the configured compression threshold and compression would only occur near the hard context limit.

This change keeps the rough-token baseline tied to the last provider-confirmed request. Small increments are therefore measured cumulatively and trigger regular compression once their combined growth exceeds the existing tolerance.

## Related Issue

No linked issue. Reproduced from a live tool-heavy session where a configured 40% threshold did not trigger until approximately 231k of a 272k context window.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Stop advancing `last_rough_tokens_when_real_prompt_fit` during deferred preflight checks.
- Preserve the provider-confirmed baseline until the next real usage update.
- Add a regression test proving that incremental rough-token growth is cumulative:
  - 93,000 tokens is initially deferred against a 90,000-token baseline.
  - The baseline remains 90,000.
  - 96,000 tokens then exceeds the cumulative-growth tolerance and is no longer deferred.
- Preserve the existing cooldown, anti-thrashing, real-usage refresh, and immediate post-compression deferral behavior.

## How to Test

Run:

python -m pytest tests/agent/test_context_compressor.py tests/run_agent/test_run_agent_codex_responses.py -q

Result on the final rebased commit:

302 passed

Additional verification:

- `git diff --check`: passed
- Added-line security scan: zero findings
- Two independent final reviews: PASS
- Reviewed diff SHA-256:
  `397a22ef822d5206ba94e4b1b94aafee9afd8abfaa3e1043b2d94becbae2e518`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant pytest suites and all tests pass
- [x] I've added a regression test for the bug
- [x] I've tested on Linux with Python 3.13

### Documentation & Housekeeping

- [x] Documentation update is not required; this is an internal compression-gate correction
- [x] No configuration keys were added or changed
- [x] No architecture or workflow documentation changes are required
- [x] The change is platform-independent Python logic
- [x] No tool descriptions or schemas were changed

## Screenshots / Logs

Observed before the fix in a live 272,000-token session:

- Configured regular compression threshold: approximately 108,800 tokens
- Actual pre-API compression events: approximately 231,399 and 231,718 tokens

The root cause was cumulative small growth being hidden by repeated baseline advancement.

