### PR TITLE
fix(gateway): make _getenv fall through to os.environ when var not in secret scope (#69379)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -239,10 +239,22 @@ def _getenv(name: str, default: Optional[str] = None) -> Optional[str]:
     secrets. In that scope we must prefer the scoped value; outside it we keep
     legacy ``os.getenv`` behavior for single-profile callers and unscoped
     gateway reads.
+
+    When a secret scope IS active but the requested var is NOT in it, we fall
+    through to ``os.environ`` so non-credential platform config (e.g.
+    ``API_SERVER_ENABLED``, ``API_SERVER_HOST``) set via container environment
+    (Docker compose, systemd) remains visible — preventing the v2026.7.20
+    regression where ``load_gateway_config_for_runner`` silently dropped
+    process-env-only platform config under multiplex (#69379).
     """
     if current_secret_scope() is not None:
         scope_val = _get_secret(name, None)
-        return scope_val if scope_val is not None else default
+        if scope_val is not None:
+            return scope_val
+        # Not a profile secret — fall through to process env so that
+        # non-credential platform config set via container environment
+        # (Docker compose ``environment:`` block, systemd ``Environment=``)
+        # is visible even when a profile secret scope is active (#69379).
     env_val = os.environ.get(name)
     if env_val is not None:
         return env_val

--- a/tests/gateway/test_64674_multiplex_primary_token_scope.py
+++ b/tests/gateway/test_64674_multiplex_primary_token_scope.py
@@ -78,6 +78,54 @@ class TestLoadGatewayConfigForRunner:
         assert tg.token == "default-profile-token-123"
         assert tg.enabled is True
 
+    def test_scoped_reload_still_gets_osenv_when_not_in_profile_env(self, tmp_path, monkeypatch):
+        """#69379 — process-env platform config visible inside scoped reload.
+
+        When a profile's ``.env`` has no ``API_SERVER_ENABLED`` but the
+        process ``os.environ`` does, the scoped reload must fall through so
+        container env vars (Docker compose ``environment:`` block) continue
+        to enable platforms like api_server.
+        """
+        from gateway import run as run_mod
+        import hermes_constants as hc
+
+        home = tmp_path / "home"
+        home.mkdir()
+        # Put a TELEGRAM token in the profile .env to exercise the
+        # scope mechanism, but do NOT put any API_SERVER_* var there.
+        (home / ".env").write_text(
+            "TELEGRAM_BOT_TOKEN=default-profile-token-123\n", encoding="utf-8"
+        )
+        (home / "config.yaml").write_text(
+            "gateway:\n  multiplex_profiles: true\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        # API_SERVER_ENABLED lives ONLY in os.environ, NOT in .env —
+        # this is the Docker compose use case.
+        monkeypatch.setenv("API_SERVER_ENABLED", "true")
+        monkeypatch.setenv("API_SERVER_HOST", "0.0.0.0")
+        monkeypatch.setenv("API_SERVER_PORT", "8642")
+        # Simulate a clean process env for TELEGRAM_BOT_TOKEN (not exported).
+        monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+        monkeypatch.setattr(hc, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(run_mod, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(run_mod, "_hermes_home", home)
+
+        cfg = run_mod.load_gateway_config_for_runner()
+        assert cfg.multiplex_profiles is True
+        # TELEGRAM token still from scope (profile .env)
+        tg = cfg.platforms.get(Platform.TELEGRAM)
+        assert tg is not None
+        assert tg.token == "default-profile-token-123"
+        assert tg.enabled is True
+        # API_SERVER enabled from os.environ fallthrough
+        api = cfg.platforms.get(Platform.API_SERVER)
+        assert api is not None, \
+            "api_server should be enabled from process env even inside scoped reload"
+        assert api.enabled is True
+        assert api.extra.get("host") == "0.0.0.0"
+        assert api.extra.get("port") == 8642
+
 
 class TestPlatformHasBotCredential:
     def test_telegram_empty_token_false(self):


### PR DESCRIPTION
## Summary

Fixes #69379 — v2026.7.20 regression for Docker multiplex deployments where `load_gateway_config_for_runner` silently drops platform config set via container environment vars.

## Root Cause

The #64674 fix (`load_gateway_config_for_runner`) introduced a scoped config reload under `_profile_runtime_scope` so profile `.env` tokens (e.g. `TELEGRAM_BOT_TOKEN`) resolve through the secret scope. However, `gateway/config._getenv`, when inside an active secret scope, returned **only** the scope value or the caller-supplied default — it never fell through to `os.environ`. Any platform configured exclusively via process env vars (`API_SERVER_ENABLED`, `API_SERVER_HOST`, `API_SERVER_PORT`, etc.) was therefore invisible to the scoped reload.

## Fix

In `gateway/config._getenv`: when `_get_secret` returns `None` (var not in the profile secret scope), fall through to `os.environ` instead of returning the default. Profile secrets (tokens, API keys) still take priority; non-credential platform config from the container environment is visible again.

**Before:** Secret scope active + var not in scope → return `default` (miss)
**After:** Secret scope active + var not in scope → fall through to `os.environ`

## Test

Added `test_scoped_reload_still_gets_osenv_when_not_in_profile_env` which:
- Puts `TELEGRAM_BOT_TOKEN` in profile `.env` only
- Sets `API_SERVER_ENABLED/HOST/PORT` in `os.environ` only
- Asserts both resolve correctly through `load_gateway_config_for_runner()`

## Verification

- All 9 tests in `test_64674_multiplex_primary_token_scope.py` pass (8 existing + 1 new)
- All 10 tests in `test_multiplex_credential_isolation.py` pass
- All 28 tests in `test_multiplex_phase0.py` pass (47 total)