### PR TITLE
fix(gateway): wait for Telegram polling readiness before restart notification

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16509,6 +16509,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return True
 
+    async def _wait_adapter_send_ready(self, adapter: Any) -> None:
+        """Wait for platform-specific send readiness (e.g. Telegram polling).
+
+        On v0.19.0+ the faster cold-start path reaches restart-notification send
+        before Telegram's polling has made its first successful getUpdates
+        request, causing send_path_degraded failures (#69370).
+
+        Uses duck-typing: if the adapter exposes a ``_polling_progress_event``
+        (as the Telegram adapter does), we wait on it with a bounded timeout.
+        Other adapters have no-op.
+        """
+        progress_event = getattr(adapter, "_polling_progress_event", None)
+        if progress_event is not None and not progress_event.is_set():
+            try:
+                await asyncio.wait_for(progress_event.wait(), timeout=15.0)
+            except asyncio.TimeoutError:
+                logger.debug(
+                    "Timeout waiting for adapter send readiness "
+                    "(polling progress) — proceeding anyway"
+                )
+
     async def _send_restart_notification(self) -> Optional[tuple[str, str, Optional[str]]]:
         """Notify the chat that initiated /restart that the gateway is back."""
         notify_path = _hermes_home / ".restart_notify.json"
@@ -16542,6 +16563,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     platform_str,
                 )
                 return None
+
+            # Wait for the platform adapter's send path to be healthy before
+            # attempting delivery.  The generic 1 s settle in start() helps,
+            # but Telegram's polling-based adapters need their first successful
+            # getUpdates round to clear _send_path_degraded.
+            await self._wait_adapter_send_ready(adapter)
 
             metadata = self._thread_metadata_for_target(
                 platform,
@@ -16620,6 +16647,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     home.thread_id,
                     adapter=adapter,
                 )
+                # Wait for the platform adapter's send path to be healthy
+                # before attempting the startup notification broadcast.
+                # See _wait_adapter_send_ready docstring (#69370).
+                await self._wait_adapter_send_ready(adapter)
                 if metadata:
                     result = await adapter.send(
                         str(home.chat_id),


### PR DESCRIPTION
## Description

Fixes #69370 — Telegram post-restart notification lost on v0.19.0 (Quicksilver).

### Root Cause

The v0.19.0 faster cold-start reaches `_send_restart_notification()` before Telegram's polling path completes its first successful `getUpdates` request. At that point `_send_path_degraded` is still `True`, so `adapter.send()` returns `SendResult(success=False, error="send_path_degraded")` and the notification is lost. Normal messaging works moments later once polling makes progress.

### Fix

Introduces `_wait_adapter_send_ready()` on the gateway runner, which uses duck-typing to detect platform adapters exposing a `_polling_progress_event` (Telegram adapter) and awaits it with a 15-second bounded timeout before sending lifecycle notifications.

The wait is applied in two places:
1. **`_send_restart_notification()`** — the chat-originated /restart reply
2. **`_send_home_channel_startup_notifications()`** — the planned-restart home-channel broadcast

### Design Notes

- Uses **duck-typing** rather than `isinstance` checks, keeping the gateway runner platform-agnostic. Other adapters (Discord, WhatsApp, etc.) have no `_polling_progress_event` and are no-ops.
- The 15-second timeout prevents the readiness wait from *causing* a stall on a genuinely unhealthy adapter — it degrades to a debug log and the send proceeds anyway.
- Complements the existing 1-second settle in `start()` (line 8057) rather than replacing it.
- Tests pass without changes because `_wait_adapter_send_ready` is a no-op when no `_polling_progress_event` is set, and existing Telegram adapter tests already cover the `_polling_progress_event` lifecycle (`tests/gateway/test_telegram_polling_progress.py`).

### Testing

Validated by the reporter's local mitigation (commit 1f3aa26b53) which used the same mechanism. This upstream fix mirrors that approach with a bounded timeout and broader coverage.

Co-authored-by: Marcos (webtecnica) <marcos@webtecnica.com.br>