### PR TITLE
fix(openai): route API endpoint by model family

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3557,6 +3557,32 @@ _AZURE_FOUNDRY_RESPONSES_PREFIXES = (
 )
 
 
+def _bare_model_id(model_name: Optional[str]) -> str:
+    raw = str(model_name or "").strip().lower()
+    if "/" in raw:
+        raw = raw.rsplit("/", 1)[-1]
+    return raw
+
+
+def openai_api_model_api_mode(model_name: Optional[str]) -> Optional[str]:
+    """Infer the official api.openai.com endpoint from the model name.
+
+    The official OpenAI API serves current GPT-5/Codex/o-series reasoning
+    models through the Responses API, while GPT-4-era chat models such as
+    ``gpt-4o`` still work through Chat Completions.  Return ``None`` for
+    unknown/non-OpenAI model names so explicit user configuration can still
+    handle forward-compatible cases.
+    """
+    raw = _bare_model_id(model_name)
+    if not raw:
+        return None
+    if raw.startswith(_AZURE_FOUNDRY_RESPONSES_PREFIXES):
+        return "codex_responses"
+    if raw.startswith(("gpt-4", "gpt-3.5")):
+        return "chat_completions"
+    return None
+
+
 def azure_foundry_model_api_mode(model_name: Optional[str]) -> Optional[str]:
     """Infer Azure Foundry api_mode from a deployment/model name.
 
@@ -3571,12 +3597,9 @@ def azure_foundry_model_api_mode(model_name: Optional[str]) -> Optional[str]:
     ``runtime_provider._detect_api_mode_for_url`` and by the user setting
     ``model.api_mode: anthropic_messages`` explicitly.
     """
-    raw = str(model_name or "").strip().lower()
+    raw = _bare_model_id(model_name)
     if not raw:
         return None
-    # Strip any vendor/ prefix a user may have copied from OpenRouter / Copilot.
-    if "/" in raw:
-        raw = raw.rsplit("/", 1)[-1]
     # gpt-5-mini speaks chat completions on Copilot but Azure Foundry deploys
     # the full gpt-5 family uniformly on Responses API — don't carve an
     # exception here.

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -445,6 +445,25 @@ def _resolve_runtime_from_pool_entry(
         base_url = base_url or OPENROUTER_BASE_URL
     elif provider == "xai":
         api_mode = "codex_responses"
+    elif provider == "openai-api" and base_url_host_matches(base_url, "openai.com"):
+        effective_model = str(target_model or model_cfg.get("default") or "").strip()
+        try:
+            from hermes_cli.models import openai_api_model_api_mode
+
+            inferred = openai_api_model_api_mode(effective_model)
+        except Exception:
+            inferred = None
+        if inferred:
+            api_mode = inferred
+        else:
+            configured_provider = str(model_cfg.get("provider") or "").strip().lower()
+            configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
+            if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
+                api_mode = configured_mode
+            else:
+                detected = _detect_api_mode_for_url(base_url)
+                if detected:
+                    api_mode = detected
     elif provider == "nous":
         api_mode = "chat_completions"
         base_url = _nous_inference_base_url_override() or base_url
@@ -1371,6 +1390,7 @@ def _resolve_explicit_runtime(
     model_cfg: Dict[str, Any],
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     explicit_api_key = str(explicit_api_key or "").strip()
     explicit_base_url = str(explicit_base_url or "").strip().rstrip("/")
@@ -1496,6 +1516,24 @@ def _resolve_explicit_runtime(
             api_mode = _copilot_runtime_api_mode(model_cfg, api_key)
         elif provider == "xai":
             api_mode = "codex_responses"
+        elif provider == "openai-api" and base_url_host_matches(base_url, "openai.com"):
+            effective_model = str(target_model or model_cfg.get("default") or "").strip()
+            try:
+                from hermes_cli.models import openai_api_model_api_mode
+
+                inferred = openai_api_model_api_mode(effective_model)
+            except Exception:
+                inferred = None
+            if inferred:
+                api_mode = inferred
+            else:
+                configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
+                if configured_mode:
+                    api_mode = configured_mode
+                else:
+                    detected = _detect_api_mode_for_url(base_url)
+                    if detected:
+                        api_mode = detected
         else:
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
             if configured_mode:
@@ -1695,6 +1733,7 @@ def resolve_runtime_provider(
         model_cfg=model_cfg,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        target_model=target_model,
     )
     if explicit_runtime:
         return explicit_runtime
@@ -2070,6 +2109,25 @@ def resolve_runtime_provider(
             api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
         elif provider == "xai":
             api_mode = "codex_responses"
+        elif provider == "openai-api" and base_url_host_matches(base_url, "openai.com"):
+            _effective = target_model or model_cfg.get("default", "")
+            try:
+                from hermes_cli.models import openai_api_model_api_mode
+
+                inferred = openai_api_model_api_mode(_effective)
+            except Exception:
+                inferred = None
+            if inferred:
+                api_mode = inferred
+            else:
+                configured_provider = str(model_cfg.get("provider") or "").strip().lower()
+                configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
+                if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
+                    api_mode = configured_mode
+                else:
+                    detected = _detect_api_mode_for_url(base_url)
+                    if detected:
+                        api_mode = detected
         else:
             configured_provider = str(model_cfg.get("provider") or "").strip().lower()
             # Only honor persisted api_mode when it belongs to the same provider family.

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1387,6 +1387,115 @@ def test_model_config_codex_api_mode_still_applies_to_direct_openai_url(monkeypa
     assert resolved["base_url"] == "https://api.openai.com/v1"
 
 
+def test_openai_api_gpt53_codex_overrides_stale_chat_completions(monkeypatch):
+    """Official OpenAI API must route Responses-only models to /v1/responses."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-api")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openai-api",
+            "base_url": "https://api.openai.com/v1",
+            "default": "gpt-5.3-codex",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+
+    resolved = rp.resolve_runtime_provider(requested="openai-api")
+
+    assert resolved["provider"] == "openai-api"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://api.openai.com/v1"
+
+
+def test_openai_api_gpt4o_uses_chat_completions_despite_stale_responses(monkeypatch):
+    """Official OpenAI API should not force chat models through Responses only by URL."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-api")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openai-api",
+            "base_url": "https://api.openai.com/v1",
+            "default": "gpt-4o",
+            "api_mode": "codex_responses",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+
+    resolved = rp.resolve_runtime_provider(requested="openai-api")
+
+    assert resolved["provider"] == "openai-api"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://api.openai.com/v1"
+
+
+def test_openai_api_target_model_switch_recomputes_api_mode(monkeypatch):
+    """/model switches should route by target model, not persisted default/api_mode."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-api")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openai-api",
+            "base_url": "https://api.openai.com/v1",
+            "default": "gpt-4o",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="openai-api",
+        target_model="gpt-5.3-codex",
+    )
+
+    assert resolved["api_mode"] == "codex_responses"
+
+
+def test_openai_api_pool_entry_routes_by_target_model(monkeypatch):
+    """Credential-pool OpenAI API entries must still use model-specific routing."""
+    entry = SimpleNamespace(
+        provider="openai-api",
+        runtime_api_key="pool-key",
+        runtime_base_url="https://api.openai.com/v1",
+        source="pool",
+    )
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return entry
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-api")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openai-api",
+            "base_url": "https://api.openai.com/v1",
+            "default": "gpt-4o",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(rp, "credential_pool_matches_provider", lambda *a, **k: True)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="openai-api",
+        target_model="gpt-5.3-codex",
+    )
+
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["api_key"] == "pool-key"
+
+
 def test_model_config_api_mode_ignored_when_provider_differs(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "zai")
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- Route official OpenAI API calls by model family instead of a stale global `api_mode`.
- Send GPT-5, Codex, and o-series models to the Responses API.
- Keep GPT-4-era chat models on Chat Completions.
- Cover direct credentials, credential-pool entries, and model-switch routing.

## Verification
- `uv run --with pytest python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q -o 'addopts='`
- Result: `155 passed`
