### PR TITLE
fix(acp): flag replayed compaction summaries via _meta

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -74,6 +74,10 @@ from acp_adapter.permissions import make_approval_callback
 from acp_adapter.provenance import session_provenance_meta
 from acp_adapter.session import SessionManager, SessionState, _expand_acp_enabled_toolsets
 from acp_adapter.tools import build_tool_complete, build_tool_start
+from agent.context_compressor import (
+    COMPRESSED_SUMMARY_METADATA_KEY,
+    ContextCompressor,
+)
 from tools.approval import (
     reset_hermes_interactive_context,
     set_hermes_interactive_context,
@@ -970,10 +974,48 @@ class HermesACPAgent(acp.Agent):
         return ""
 
     @staticmethod
+    def _history_summary_meta(message: dict[str, Any], text: str) -> dict[str, Any] | None:
+        """Build the ``_meta`` payload for a replayed compaction summary.
+
+        Compaction summaries are persisted as ordinary history messages —
+        standalone handoffs under ``role="user"`` OR ``role="assistant"``
+        (the compressor picks whichever role keeps alternation valid), and
+        merge-into-tail messages where the summary is appended after the
+        first preserved tail message's real content. Without a wire flag,
+        ACP frontends render all of these as ordinary turns.
+
+        Two distinct keys under ``_meta.hermes`` (ACP's extensibility
+        channel), so clients cannot accidentally hide real content:
+
+        * ``compactionSummary: true`` — the entire chunk is the handoff
+          summary. Safe to restyle or collapse wholesale.
+        * ``containsCompactionSummary: true`` — a merged-tail message: real
+          preserved turn content followed by the summary. Clients may style
+          it, but collapsing the whole chunk would hide the preserved
+          content, hence the separate key.
+
+        Detection honors the in-process ``_compressed_summary`` flag and
+        falls back to content classification, so it also works for a
+        DB-reloaded session that lost the in-memory flag.
+        """
+        kind = ContextCompressor.classify_summary_content(text)
+        if kind is None and message.get(COMPRESSED_SUMMARY_METADATA_KEY):
+            # Flagged in-process but content didn't classify (e.g. future
+            # prefix drift): treat as a standalone summary — the flag is only
+            # ever set on summary-bearing messages.
+            kind = "standalone"
+        if kind == "standalone":
+            return {"hermes": {"compactionSummary": True}}
+        if kind == "merged":
+            return {"hermes": {"containsCompactionSummary": True}}
+        return None
+
+    @staticmethod
     def _history_message_update(
         *,
         role: str,
         text: str,
+        field_meta: dict[str, Any] | None = None,
     ) -> UserMessageChunk | AgentMessageChunk | None:
         """Build an ACP history replay update for a user/assistant message."""
         block = TextContentBlock(type="text", text=text)
@@ -981,11 +1023,13 @@ class HermesACPAgent(acp.Agent):
             return UserMessageChunk(
                 session_update="user_message_chunk",
                 content=block,
+                field_meta=field_meta,
             )
         if role == "assistant":
             return AgentMessageChunk(
                 session_update="agent_message_chunk",
                 content=block,
+                field_meta=field_meta,
             )
         return None
 
@@ -1056,7 +1100,11 @@ class HermesACPAgent(acp.Agent):
             if role == "user":
                 text = self._history_message_text(message)
                 if text:
-                    update = self._history_message_update(role=role, text=text)
+                    update = self._history_message_update(
+                        role=role,
+                        text=text,
+                        field_meta=self._history_summary_meta(message, text),
+                    )
                     if update is not None and not await _send(update):
                         return
                 continue
@@ -1068,7 +1116,11 @@ class HermesACPAgent(acp.Agent):
 
                 text = self._history_message_text(message)
                 if text:
-                    update = self._history_message_update(role=role, text=text)
+                    update = self._history_message_update(
+                        role=role,
+                        text=text,
+                        field_meta=self._history_summary_meta(message, text),
+                    )
                     if update is not None and not await _send(update):
                         return
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3011,7 +3011,29 @@ This compaction should PRIORITISE preserving all information related to the focu
         return f"{SUMMARY_PREFIX}\n{text}" if text else SUMMARY_PREFIX
 
     @staticmethod
-    def _is_context_summary_content(content: Any) -> bool:
+    def _starts_with_summary_prefix(text: str) -> bool:
+        """Return True if *text* begins with any known handoff prefix."""
+        if text.startswith(SUMMARY_PREFIX) or text.startswith(LEGACY_SUMMARY_PREFIX):
+            return True
+        return any(text.startswith(p) for p in _HISTORICAL_SUMMARY_PREFIXES)
+
+    @classmethod
+    def classify_summary_content(cls, content: Any) -> Optional[str]:
+        """Classify how *content* relates to a compaction summary.
+
+        Returns:
+            ``"standalone"``: the entire message IS a compaction handoff
+            (current, legacy, or historical prefix at the start). Frontends
+            may restyle/collapse the whole message as a summary.
+
+            ``"merged"``: a merge-into-tail message — real preserved turn
+            content wrapped under ``_MERGED_PRIOR_CONTEXT_HEADER``, followed by
+            ``_MERGED_SUMMARY_DELIMITER`` and the summary body. The message
+            *contains* a summary but is not only a summary; collapsing the
+            whole message would hide the preserved content.
+
+            ``None``: no compaction summary detected.
+        """
         text = _content_text_for_contains(content).lstrip()
         # Merge-into-tail summaries wrap prior tail content before the summary,
         # so the handoff prefix lands after _MERGED_SUMMARY_DELIMITER rather than
@@ -3019,10 +3041,13 @@ This compaction should PRIORITISE preserving all information related to the focu
         # (auto-focus skip, carry-forward summary find, last-real-user anchor)
         # mistake a merged summary message for a real user turn.
         if _MERGED_SUMMARY_DELIMITER in text:
-            text = text.split(_MERGED_SUMMARY_DELIMITER, 1)[1].lstrip()
-        if text.startswith(SUMMARY_PREFIX) or text.startswith(LEGACY_SUMMARY_PREFIX):
-            return True
-        return any(text.startswith(p) for p in _HISTORICAL_SUMMARY_PREFIXES)
+            after = text.split(_MERGED_SUMMARY_DELIMITER, 1)[1].lstrip()
+            return "merged" if cls._starts_with_summary_prefix(after) else None
+        return "standalone" if cls._starts_with_summary_prefix(text) else None
+
+    @classmethod
+    def _is_context_summary_content(cls, content: Any) -> bool:
+        return cls.classify_summary_content(content) is not None
 
     @staticmethod
     def _has_compressed_summary_metadata(message: Any) -> bool:

--- a/contributors/emails/israel.lot@gmail.com
+++ b/contributors/emails/israel.lot@gmail.com
@@ -1,0 +1,1 @@
+israellot

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -423,6 +423,126 @@ class TestSessionOps:
         assert "cli.py:42" in tool_updates[1].content[0].content.text
 
     @pytest.mark.asyncio
+    async def test_load_session_flags_compaction_summary_on_replayed_user_chunk(self, agent):
+        """A replayed compaction summary must carry _meta.hermes.compactionSummary.
+
+        The handoff is stored role="user" but is not a real user turn; without
+        the flag on the wire, ACP frontends render the whole summary as a user
+        message. Detection falls back to content, so this holds even for a
+        DB-reloaded session that lost the in-process metadata flag.
+        """
+        from agent.context_compressor import SUMMARY_PREFIX
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        summary_text = SUMMARY_PREFIX + "\n\n## Active Task\nDo the thing."
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history = [
+            {"role": "user", "content": summary_text},
+            {"role": "user", "content": "wait 5s and reply ok"},
+        ]
+
+        mock_conn.session_update.reset_mock()
+        await agent.load_session(cwd="/tmp", session_id=new_resp.session_id)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        user_chunks = [
+            call.kwargs["update"]
+            for call in mock_conn.session_update.await_args_list
+            if isinstance(call.kwargs.get("update"), UserMessageChunk)
+        ]
+        assert len(user_chunks) == 2
+        # First user chunk is the summary → flagged; second is a real turn → not.
+        assert user_chunks[0].field_meta == {"hermes": {"compactionSummary": True}}
+        assert user_chunks[1].field_meta is None
+
+    @pytest.mark.asyncio
+    async def test_load_session_flags_compaction_summary_on_replayed_assistant_chunk(self, agent):
+        """The compressor can emit a standalone summary with role="assistant"
+        (whichever role keeps alternation valid), so the assistant replay
+        branch must flag it too — not just the user branch.
+        """
+        from agent.context_compressor import SUMMARY_PREFIX
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        summary_text = SUMMARY_PREFIX + "\n\n## Active Task\nDo the thing."
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history = [
+            {"role": "assistant", "content": summary_text},
+            {"role": "user", "content": "continue"},
+            {"role": "assistant", "content": "on it"},
+        ]
+
+        mock_conn.session_update.reset_mock()
+        await agent.load_session(cwd="/tmp", session_id=new_resp.session_id)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        agent_chunks = [
+            call.kwargs["update"]
+            for call in mock_conn.session_update.await_args_list
+            if isinstance(call.kwargs.get("update"), AgentMessageChunk)
+        ]
+        assert len(agent_chunks) == 2
+        assert agent_chunks[0].field_meta == {"hermes": {"compactionSummary": True}}
+        assert agent_chunks[1].field_meta is None
+
+    @pytest.mark.asyncio
+    async def test_load_session_flags_merged_tail_summary_as_contains_not_standalone(self, agent):
+        """A merge-into-tail message carries real preserved content plus the
+        summary. It must be flagged containsCompactionSummary — NOT
+        compactionSummary — so a client that collapses standalone summaries
+        cannot hide the preserved turn content.
+        """
+        from agent.context_compressor import (
+            _MERGED_PRIOR_CONTEXT_HEADER,
+            _MERGED_SUMMARY_DELIMITER,
+            _SUMMARY_END_MARKER,
+            SUMMARY_PREFIX,
+        )
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        merged_text = (
+            _MERGED_PRIOR_CONTEXT_HEADER
+            + "\nplease fix the login bug"
+            + "\n\n" + _MERGED_SUMMARY_DELIMITER + "\n\n"
+            + SUMMARY_PREFIX + "\n\n## Active Task\nFix login."
+            + "\n\n" + _SUMMARY_END_MARKER
+        )
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history = [
+            {"role": "user", "content": merged_text},
+            {"role": "assistant", "content": "looking at it"},
+        ]
+
+        mock_conn.session_update.reset_mock()
+        await agent.load_session(cwd="/tmp", session_id=new_resp.session_id)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        user_chunks = [
+            call.kwargs["update"]
+            for call in mock_conn.session_update.await_args_list
+            if isinstance(call.kwargs.get("update"), UserMessageChunk)
+        ]
+        assert len(user_chunks) == 1
+        assert user_chunks[0].field_meta == {
+            "hermes": {"containsCompactionSummary": True}
+        }
+
+    @pytest.mark.asyncio
     async def test_load_session_replays_native_plan_for_persisted_todo_tool(self, agent):
         """Persisted todo tool results should rebuild Zed's native plan panel."""
         mock_conn = MagicMock(spec=acp.Client)

--- a/tests/agent/test_compressed_summary_metadata.py
+++ b/tests/agent/test_compressed_summary_metadata.py
@@ -157,3 +157,92 @@ class TestClassifySummaryContent:
         content = "look at this:\n" + _MERGED_SUMMARY_DELIMITER + "\nnot a summary"
         assert ContextCompressor.classify_summary_content(content) is None
         assert ContextCompressor._is_context_summary_content(content) is False
+
+
+class TestClassifyAgreesWithPredicatesOnLiveEmissions:
+    """Behavior contract: classify_summary_content must agree with the
+    boolean summary predicates (``_is_context_summary_content`` and the
+    module-level ``is_compaction_summary_message``) on every handoff shape
+    the CURRENT compressor actually emits — not just hand-built fixtures.
+
+    If the emission format drifts (prefix rewording, new merge framing),
+    these tests fail on the real output rather than on a stale snapshot,
+    signalling that ACP replay flagging and the internal summary detectors
+    have diverged.
+    """
+
+    @staticmethod
+    def _live_compress(msgs):
+        # Match the emission-probe compressor shape (wide context, minimal
+        # protection) so the transcript geometry — not protection budgets —
+        # decides the merge-vs-standalone path deterministically.
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=100_000,
+        ):
+            cc = ContextCompressor(
+                model="test-model",
+                threshold_percent=0.85,
+                protect_first_n=1,
+                protect_last_n=1,
+                quiet_mode=True,
+            )
+        out = _compress(cc, msgs)
+        flagged = [
+            m for m in out
+            if isinstance(m, dict) and m.get(COMPRESSED_SUMMARY_METADATA_KEY)
+        ]
+        return flagged
+
+    @staticmethod
+    def _assert_agreement(message):
+        from agent.context_compressor import is_compaction_summary_message
+
+        kind = ContextCompressor.classify_summary_content(message.get("content"))
+        detected = ContextCompressor._is_context_summary_content(
+            message.get("content")
+        )
+        assert (kind is not None) == detected
+        # is_compaction_summary_message also honors the metadata flag, so it
+        # must detect every message classify flags — and on a flag-stripped
+        # copy (the DB-reload shape) content classification alone must carry.
+        assert is_compaction_summary_message(message) is True
+        stripped = {
+            k: v for k, v in message.items()
+            if k != COMPRESSED_SUMMARY_METADATA_KEY
+        }
+        assert is_compaction_summary_message(stripped) == (kind is not None)
+        return kind
+
+    def test_merged_emission_classifies_merged_and_predicates_agree(self):
+        """Alternating transcripts take the merge-into-tail path on current
+        main — the emitted handoff must classify 'merged'."""
+        flagged = self._live_compress(_make_messages())
+        assert len(flagged) == 1
+        kind = self._assert_agreement(flagged[0])
+        assert kind == "merged"
+
+    def test_standalone_emission_classifies_standalone_and_predicates_agree(self):
+        """A degenerate all-user transcript forces the standalone-insertion
+        path — the emitted handoff must classify 'standalone'."""
+        msgs = [{"role": "system", "content": "sys"}]
+        msgs.extend(
+            {"role": "user", "content": f"user only {i} " + "x" * 400}
+            for i in range(60)
+        )
+        flagged = self._live_compress(msgs)
+        assert len(flagged) == 1
+        kind = self._assert_agreement(flagged[0])
+        assert kind == "standalone"
+
+    def test_non_summary_messages_agree_on_none(self):
+        from agent.context_compressor import is_compaction_summary_message
+
+        for msg in (
+            {"role": "user", "content": "plain question"},
+            {"role": "assistant", "content": ""},
+            {"role": "assistant", "content": None},
+        ):
+            assert ContextCompressor.classify_summary_content(msg["content"]) is None
+            assert ContextCompressor._is_context_summary_content(msg["content"]) is False
+            assert is_compaction_summary_message(msg) is False

--- a/tests/agent/test_compressed_summary_metadata.py
+++ b/tests/agent/test_compressed_summary_metadata.py
@@ -97,3 +97,63 @@ class TestMetadataFlagNeverReachesWire:
             isinstance(m, dict) and m.get(COMPRESSED_SUMMARY_METADATA_KEY)
             for m in out
         )
+
+
+class TestClassifySummaryContent:
+    """classify_summary_content distinguishes standalone handoffs from
+    merge-into-tail messages so wire consumers (ACP replay) can flag them
+    differently — collapsing a merged message would hide the preserved
+    tail content that precedes the summary."""
+
+    def test_standalone_summary(self):
+        from agent.context_compressor import SUMMARY_PREFIX
+
+        content = SUMMARY_PREFIX + "\n## Active Task\nstuff"
+        assert ContextCompressor.classify_summary_content(content) == "standalone"
+        assert ContextCompressor._is_context_summary_content(content) is True
+
+    def test_legacy_and_historical_prefixes_are_standalone(self):
+        from agent.context_compressor import (
+            LEGACY_SUMMARY_PREFIX,
+            _HISTORICAL_SUMMARY_PREFIXES,
+        )
+
+        assert ContextCompressor.classify_summary_content(
+            LEGACY_SUMMARY_PREFIX + " body"
+        ) == "standalone"
+        for prefix in _HISTORICAL_SUMMARY_PREFIXES:
+            assert ContextCompressor.classify_summary_content(
+                prefix + " body"
+            ) == "standalone"
+
+    def test_merged_tail_summary(self):
+        from agent.context_compressor import (
+            SUMMARY_PREFIX,
+            _MERGED_PRIOR_CONTEXT_HEADER,
+            _MERGED_SUMMARY_DELIMITER,
+            _SUMMARY_END_MARKER,
+        )
+
+        merged = (
+            _MERGED_PRIOR_CONTEXT_HEADER + "\n"
+            "old tail content\n\n"
+            + _MERGED_SUMMARY_DELIMITER + "\n\n"
+            + SUMMARY_PREFIX + "\nBODY\n\n"
+            + _SUMMARY_END_MARKER
+        )
+        assert ContextCompressor.classify_summary_content(merged) == "merged"
+        assert ContextCompressor._is_context_summary_content(merged) is True
+
+    def test_plain_messages_classify_none(self):
+        assert ContextCompressor.classify_summary_content("just a question") is None
+        assert ContextCompressor.classify_summary_content("") is None
+        assert ContextCompressor.classify_summary_content(None) is None
+
+    def test_delimiter_without_summary_prefix_is_none(self):
+        """A message merely quoting the merged delimiter (e.g. a user pasting
+        logs) is not a summary unless a handoff prefix follows it."""
+        from agent.context_compressor import _MERGED_SUMMARY_DELIMITER
+
+        content = "look at this:\n" + _MERGED_SUMMARY_DELIMITER + "\nnot a summary"
+        assert ContextCompressor.classify_summary_content(content) is None
+        assert ContextCompressor._is_context_summary_content(content) is False


### PR DESCRIPTION
## Summary
ACP history replay now tags replayed compaction-summary messages under `_meta.hermes`, so ACP frontends (Zed, vscode-hermes) can restyle/collapse them instead of rendering the whole handoff as an ordinary user/assistant turn. Root cause: the compressor's in-process `_compressed_summary` marker never reached the wire — replay streamed handoffs as bare message chunks.

## Changes
- `acp_adapter/server.py`: `_history_summary_meta()` builds the `_meta` payload for replayed chunks — `compactionSummary: true` for standalone handoffs (user OR assistant role), `containsCompactionSummary: true` for merge-into-tail messages (distinct key so clients that collapse standalone summaries can't hide preserved real content). Wired into both the user and assistant replay branches; detection honors the in-process metadata flag and falls back to content classification for DB-reloaded sessions.
- `agent/context_compressor.py`: new `ContextCompressor.classify_summary_content()` (standalone/merged/None); `_is_context_summary_content` is now a thin wrapper, existing callers unchanged.
- `tests/acp/test_server.py`: replay flagging tests for all three persistence shapes.
- `tests/agent/test_compressed_summary_metadata.py`: classifier unit tests (PR) + salvage hardening: live-emission behavior contract asserting `classify_summary_content` agrees with `_is_context_summary_content` / `is_compaction_summary_message` on real compressor output for both emission paths, including the flag-stripped DB-reload shape.

## Validation
| | Before | After |
|---|---|---|
| Replayed compaction handoff on ACP wire | Bare user/agent chunk, rendered as a real turn | `_meta.hermes.compactionSummary: true` |
| Merged-tail message (real content + summary) | Indistinguishable from the summary | Distinct `containsCompactionSummary: true` key |
| DB-reloaded session (in-memory flag lost) | No detection possible | Content classifier fallback still flags it |

Targeted tests: tests/acp/ 315 passed; tests/agent/ -k 'classify or summary_metadata' 176 passed; test_context_compressor.py + summary_continuity 219 passed. Live emission probe verified the classifier against real compress() output on current main (merged path on alternating transcripts, standalone on degenerate all-user transcripts).

## Credit
Salvaged from #59114 by @israellot.

## Infographic
![acp-compaction-summary-meta](https://v3b.fal.media/files/b/0aa34d7d/QpMKL85W9nEVGFn_PlBbT_tk9RksDW.png)
