### PR TITLE
Protect inbox reads and advance Unbroker rechecks

### DIFF
--- a/optional-skills/security/unbroker/SKILL.md
+++ b/optional-skills/security/unbroker/SKILL.md
@@ -90,6 +90,9 @@ verifying re-scan.
       `EMAIL_IMAP_HOST` for non-mainstream providers; gmail/outlook/yahoo/icloud/fastmail inferred).
       The CLI sends via `send-email` and reads verify links via `poll-verification`. The `agentmail`
       skill (per-broker aliases) also counts.
+      Inbox polling is observation-only: IMAP message bodies must be fetched with
+      `BODY.PEEK[]`, never `RFC822`, so verification scans cannot mark the operator's
+      personal mail as read.
   - Google Sheets tracker: the `google-workspace` skill.
   - The `scrapling` skill for stealth/Cloudflare-protected pages.
 

--- a/optional-skills/security/unbroker/references/brokers/fastbackgroundcheck.json
+++ b/optional-skills/security/unbroker/references/brokers/fastbackgroundcheck.json
@@ -1,0 +1,46 @@
+{
+  "id": "fastbackgroundcheck",
+  "name": "FastBackgroundCheck",
+  "category": "people_search",
+  "priority": "crucial",
+  "jurisdictions": ["US"],
+  "search": {
+    "method": "url_pattern",
+    "url": "https://www.fastbackgroundcheck.com/",
+    "fetch": "web_extract",
+    "match_signal": "result",
+    "by": ["name", "phone", "address"],
+    "url_format_quirks": [
+      "Person records use /people/{first-last}/id/{opaque-id}. Search engines often expose the exact record URL even when the site's own search flow is JavaScript-heavy.",
+      "Confirm a match with the full name plus a phone number or address. Do not treat a same-name result alone as the subject."
+    ]
+  },
+  "optout": {
+    "tier": "T2",
+    "method": "web_form",
+    "url": "https://www.fastbackgroundcheck.com/optout",
+    "requires": {
+      "profile_url": false,
+      "email_verification": true,
+      "captcha": true,
+      "gov_id": false,
+      "account": false,
+      "phone_callback": false,
+      "payment": false
+    },
+    "inputs": ["full_name", "contact_email"],
+    "notes": "Official authorized-agent flow: enter agent and subject names/emails, accept the privacy-request certification, complete CAPTCHA, open the emailed link within 24 hours, and complete the matching form. The site states processing may take 3 days. It may request signed authorization or direct subject verification.",
+    "playbook": [
+      "Open the official opt-out form at https://www.fastbackgroundcheck.com/optout.",
+      "Choose the authorized-agent option when acting for another subject; provide only the fields the official form requires.",
+      "Complete the CAPTCHA manually if the configured browser cannot clear it; never bypass it.",
+      "Open the emailed link within 24 hours in the same browser, complete the matching form, and retain the confirmation.",
+      "Re-scan the exact listing after 3 days before marking confirmed_removed."
+    ],
+    "est_processing_days": 3,
+    "reappearance_risk": "high"
+  },
+  "last_verified": "2026-07-17",
+  "source": "official opt-out and privacy pages"
+}
+

--- a/optional-skills/security/unbroker/references/state-machine.md
+++ b/optional-skills/security/unbroker/references/state-machine.md
@@ -32,9 +32,9 @@ indirect_exposure    -> submitted | human_task_queued | not_found | found | bloc
 action_selected      -> submitted | human_task_queued | blocked
 submitted            -> verification_pending | awaiting_processing | human_task_queued | blocked
 verification_pending -> awaiting_processing | confirmed_removed | human_task_queued | blocked
-awaiting_processing  -> confirmed_removed | human_task_queued | blocked
+awaiting_processing  -> confirmed_removed | reappeared | human_task_queued | blocked
 confirmed_removed    -> reappeared | confirmed_removed   (recheck refreshes the date)
-reappeared           -> found | indirect_exposure
+reappeared           -> found | indirect_exposure | action_selected | submitted | human_task_queued | blocked
 human_task_queued    -> found | indirect_exposure | action_selected | submitted | verification_pending
                         | awaiting_processing | confirmed_removed | blocked
 blocked              -> searching | found | not_found | indirect_exposure | action_selected

--- a/optional-skills/security/unbroker/scripts/emailer.py
+++ b/optional-skills/security/unbroker/scripts/emailer.py
@@ -295,7 +295,10 @@ def fetch_recent(env: dict | None = None, since_days: int = 3, limit: int = 30,
         ids = (data[0].split() if data and data[0] else [])[-limit:]
         out: list[dict] = []
         for mid in reversed(ids):  # newest first
-            _typ, msg_data = conn.fetch(mid, "(RFC822)")
+            # RFC822 implicitly sets the IMAP \Seen flag on Gmail even when the
+            # mailbox was selected readonly. BODY.PEEK[] retrieves the same
+            # complete message without changing the operator's read state.
+            _typ, msg_data = conn.fetch(mid, "(BODY.PEEK[])")
             raw = next((p[1] for p in msg_data or [] if isinstance(p, tuple)), None)
             if not raw:
                 continue

--- a/optional-skills/security/unbroker/scripts/ledger.py
+++ b/optional-skills/security/unbroker/scripts/ledger.py
@@ -36,9 +36,11 @@ TRANSITIONS: dict[str, set[str]] = {
     # broker is now processing the removal (their stated window). confirmed_removed still requires a
     # verifying re-scan, never the submission flow's own say-so.
     "verification_pending": {"awaiting_processing", "confirmed_removed", "human_task_queued", "blocked"},
-    "awaiting_processing": {"confirmed_removed", "human_task_queued", "blocked"},
+    # A verification scan after the processing window may prove the listing is still live.
+    # Requeue that result through `reappeared` so the opt-out can be submitted again.
+    "awaiting_processing": {"confirmed_removed", "reappeared", "human_task_queued", "blocked"},
     "confirmed_removed": {"reappeared", "confirmed_removed"},
-    "reappeared": {"found", "indirect_exposure"},
+    "reappeared": {"found", "indirect_exposure", "action_selected", "submitted", "human_task_queued", "blocked"},
     "human_task_queued": {
         "found", "indirect_exposure", "action_selected", "submitted", "verification_pending",
         "awaiting_processing", "confirmed_removed", "blocked",

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -586,7 +586,10 @@ class EmailAdapter(BasePlatformAdapter):
             imap.login(self._address, self._password)
             _send_imap_id(imap)
             # Mark all existing messages as seen so we only process new ones
-            imap.select("INBOX")
+            # EXAMINE the mailbox instead of opening it read-write.  The gateway
+            # only needs to discover UIDs here; it must never change a user's
+            # Gmail flags as a side effect of startup.
+            imap.select("INBOX", readonly=True)
             status, data = imap.uid("search", None, "ALL")
             if status == "OK" and data and data[0]:
                 for uid in data[0].split():
@@ -655,7 +658,10 @@ class EmailAdapter(BasePlatformAdapter):
             try:
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)
-                imap.select("INBOX")
+                # Keep the mailbox read-only and use BODY.PEEK below.  A normal
+                # RFC822 fetch implicitly sets the IMAP \\Seen flag, which caused
+                # the legacy gateway to mark every inspected Gmail message read.
+                imap.select("INBOX", readonly=True)
 
                 status, data = imap.uid("search", None, "UNSEEN")
                 if status != "OK" or not data or not data[0]:
@@ -669,7 +675,7 @@ class EmailAdapter(BasePlatformAdapter):
                     if len(self._seen_uids) > self._seen_uids_max:
                         self._trim_seen_uids()
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    status, msg_data = imap.uid("fetch", uid, "(BODY.PEEK[])")
                     if status != "OK":
                         continue
 

--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -142,11 +142,15 @@ himalaya envelope list from john@example.com subject meeting
 
 ### Read an Email
 
-Read email by ID (shows plain text):
+Preview email by ID without changing its read state:
 
 ```bash
-himalaya message read 42
+himalaya message read --preview 42
 ```
+
+`himalaya message read 42` without `--preview` automatically applies the
+`\Seen` flag. Never use the non-preview form while triaging the operator's
+personal inbox unless they explicitly asked to mark that message read.
 
 Export raw MIME:
 

--- a/tests/gateway/test_email_robustness.py
+++ b/tests/gateway/test_email_robustness.py
@@ -46,7 +46,10 @@ class TestImapResponseGuard(unittest.TestCase):
         )
         fetch_iter = iter(fetch_responses)
 
+        commands = []
+
         def uid_handler(command, *args):
+            commands.append((command, args))
             if command == "search":
                 return ("OK", [uids])
             if command == "fetch":
@@ -56,7 +59,19 @@ class TestImapResponseGuard(unittest.TestCase):
         mock_imap = MagicMock()
         mock_imap.uid.side_effect = uid_handler
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
-            return adapter._fetch_new_messages()
+            results = adapter._fetch_new_messages()
+        self.last_imap = mock_imap
+        self.last_commands = commands
+        return results
+
+    def test_mailbox_is_examined_read_only(self):
+        self._fetch_with([("OK", [(b"1 (BODY[] {123}", _raw_email())])])
+        self.last_imap.select.assert_called_once_with("INBOX", readonly=True)
+
+    def test_message_fetch_uses_body_peek(self):
+        self._fetch_with([("OK", [(b"1 (BODY[] {123}", _raw_email())])])
+        fetches = [args for command, args in self.last_commands if command == "fetch"]
+        self.assertEqual(fetches, [(b"1", "(BODY.PEEK[])")])
 
     def test_normal_response_parses(self):
         results = self._fetch_with([("OK", [(b"1 (RFC822 {123}", _raw_email())])])

--- a/tests/skills/test_unbroker_skill.py
+++ b/tests/skills/test_unbroker_skill.py
@@ -354,6 +354,24 @@ def test_ledger_valid_transition_and_audit():
         assert any(e["to"] == "found" for e in audit)
 
 
+def test_processing_window_can_requeue_a_listing_that_is_still_live():
+    with temp_env():
+        sid = "sub_test01"
+        ledger.transition(sid, "spokeo", "found", found=True)
+        ledger.transition(sid, "spokeo", "submitted")
+        ledger.transition(sid, "spokeo", "awaiting_processing")
+        case = ledger.transition(
+            sid,
+            "spokeo",
+            "reappeared",
+            found=True,
+            evidence={"verification": "listing still live after processing window"},
+        )
+        assert case["state"] == "reappeared"
+        assert case["found"] is True
+        assert ledger.transition(sid, "spokeo", "submitted")["state"] == "submitted"
+
+
 def test_new_can_record_scan_outcome_directly():
     with temp_env():
         assert ledger.transition("sub_test01", "thatsthem", "found", found=True)["state"] == "found"
@@ -794,6 +812,50 @@ def test_emailer_send_requires_config_and_broker_address():
         pass
     else:
         raise AssertionError("broker without a declared address must raise")
+
+
+class _FakeIMAP:
+    fetch_queries: list[str] = []
+
+    def __init__(self, host, port):
+        self.host, self.port = host, port
+
+    def login(self, user, password):
+        self.user = user
+
+    def select(self, folder, readonly=False):
+        assert folder == "INBOX"
+        assert readonly is True
+        return "OK", [b""]
+
+    def search(self, charset, *criteria):
+        return "OK", [b"1"]
+
+    def fetch(self, message_id, query):
+        _FakeIMAP.fetch_queries.append(query)
+        raw = (
+            b"From: no-reply@spokeo.com\r\n"
+            b"Subject: Confirm your opt out\r\n"
+            b"Date: Thu, 16 Jul 2026 09:00:00 -0400\r\n"
+            b"Content-Type: text/plain; charset=utf-8\r\n"
+            b"\r\n"
+            b"Confirm here."
+        )
+        return "OK", [(b"1 (BODY[] {123}", raw), b")"]
+
+    def logout(self):
+        return "BYE", [b""]
+
+
+def test_emailer_imap_fetch_does_not_mark_messages_seen():
+    env = {"EMAIL_ADDRESS": "agent@gmail.com", "EMAIL_PASSWORD": "p"}
+    _FakeIMAP.fetch_queries = []
+
+    messages = emailer.fetch_recent(env=env, _imap_factory=_FakeIMAP)
+
+    assert messages[0]["subject"] == "Confirm your opt out"
+    assert _FakeIMAP.fetch_queries == ["(BODY.PEEK[])"]
+    assert all("RFC822" not in query for query in _FakeIMAP.fetch_queries)
 
 
 def test_browser_send_payload_is_recipient_locked():


### PR DESCRIPTION
## What changed

- Open IMAP mailboxes read-only and fetch messages with `BODY.PEEK[]` so gateway and Unbroker polling cannot mark personal mail as read.
- Document the same read-state rule in the Himalaya and Unbroker skills.
- Allow Unbroker records that remain live after a processing window to re-enter the removal workflow.
- Add a reviewed FastBackgroundCheck broker definition and regression coverage.

## Why

Mailbox inspection must be observational, and a still-live listing must be eligible for another supervised removal attempt instead of becoming stuck in a terminal state.

## Validation

- `pytest -q tests/gateway/test_email_robustness.py tests/skills/test_unbroker_skill.py`
- 110 passed
- `git diff --check`
