### PR TITLE
fix(gateway): re-read kanban dispatch settings live each tick

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1226,6 +1226,36 @@ class GatewayKanbanWatchersMixin:
                 logger.exception("kanban dispatcher: zombie reaper failed")
 
             try:
+                # Re-read the kanban dispatch knobs live each tick (same policy
+                # as auto_decompose below) so edits to default_assignee, caps,
+                # and failure_limit apply on the next tick without a gateway
+                # restart. These are otherwise captured once at watcher startup;
+                # reassigning them here updates the closure vars that
+                # _tick_once_for_board reads. Invalid values keep the prior
+                # in-memory value.
+                _lk = (_load_config() or {})
+                _lk = _lk.get("kanban", {}) if isinstance(_lk, dict) else {}
+                if "default_assignee" in _lk:
+                    default_assignee = (_lk.get("default_assignee") or "").strip() or None
+                try:
+                    _v = _lk.get("max_in_progress", None)
+                    max_in_progress = int(_v) if _v is not None and int(_v) >= 1 else None
+                except (TypeError, ValueError):
+                    pass
+                try:
+                    _v = _lk.get("max_in_progress_per_profile", None)
+                    max_in_progress_per_profile = int(_v) if _v is not None and int(_v) >= 1 else None
+                except (TypeError, ValueError):
+                    pass
+                try:
+                    _v = int(_lk.get("failure_limit", failure_limit))
+                    failure_limit = _v if _v >= 1 else failure_limit
+                except (TypeError, ValueError):
+                    pass
+            except Exception:
+                logger.exception("kanban dispatcher: live kanban-config re-read failed; keeping prior values")
+
+            try:
                 # Re-read the auto-decompose toggle live each tick so a user
                 # flipping kanban.auto_decompose=false to STOP runaway fan-out
                 # takes effect on the next tick, not on gateway restart (#49638).


### PR DESCRIPTION
## Problem

The embedded kanban dispatcher reads most of its `kanban:` config once, at
`_kanban_dispatcher_watcher` startup — `default_assignee`, `max_in_progress`,
`max_in_progress_per_profile`, and `failure_limit` are captured into locals and
then reused for the lifetime of the gateway. Only `auto_decompose` is already
re-read live on every tick (via `_read_auto_decompose_settings()`).

The result is a surprising asymmetry: flipping `kanban.auto_decompose` takes
effect on the next tick, but editing `kanban.default_assignee` (or the
concurrency caps / failure limit) does nothing until the gateway is restarted.
Operators reasonably expect a config edit to a dispatch knob to apply the same
way the adjacent toggle does.

## Fix

Re-read those keys at the top of each dispatch tick, right beside the existing
`auto_decompose` re-read, and reassign the enclosing-scope variables that
`_tick_once_for_board` closes over. Python closures capture by reference, so the
per-board `dispatch_once(... default_assignee=default_assignee, ...)` call picks
up the new values on the next tick — no restart required.

- No new config keys; no behavior change when the config is unchanged.
- Invalid values keep the prior in-memory value (never crash the loop on a bad edit).
- The whole re-read is wrapped in `try/except` + `logger.exception`, so a
  transient config read can never stop the dispatcher.
- Mirrors the existing `auto_decompose` live-reload precedent exactly.

## Test plan

- `python -m py_compile gateway/kanban_watchers.py` passes.
- Manual: set `kanban.default_assignee` on a running gateway and confirm an
  unassigned `ready` task is auto-assigned on the next tick without a restart;
  set it back and confirm the change reverts live. Same for `max_in_progress`.
