### PR TITLE
Add PostFast to the optional MCP catalog (social media scheduling)

### DIFF
--- a/optional-mcps/postfast/manifest.yaml
+++ b/optional-mcps/postfast/manifest.yaml
@@ -1,0 +1,56 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: postfast
+description: Schedule and publish social media posts to 11 platforms (Instagram, TikTok, X, LinkedIn, YouTube, and more) via PostFast.
+source: https://github.com/peturgeorgievv-factory/postfast-mcp
+
+# postfast-mcp is the official stdio MCP server for PostFast (postfa.st), a
+# social media scheduling SaaS. npx resolves the package from npm, so there is
+# nothing to git-clone or build — no install block. Auth is a workspace API
+# key rather than OAuth: PostFast's hosted OAuth connector (mcp.postfa.st)
+# registers clients via CIMD, which targets the ChatGPT/Claude apps; for
+# self-hosted agents the API-key stdio server is the supported path.
+transport:
+  type: stdio
+  command: "npx"
+  # Pinned per catalog dependency policy: exact version, and the release must
+  # be at least 2 weeks old at pin time (supply-chain cooldown — the same rule
+  # the blender/n8n entries follow). 0.1.23 released 2026-07-07. The catalog
+  # never auto-updates; bumping the pin is a PR to this manifest.
+  args:
+    - "-y"
+    - "postfast-mcp@0.1.23"
+  version: "0.1.23"
+
+# Authentication: a workspace-scoped API key, prompted at install time and
+# written to ~/.hermes/.env (same api_key shape as the n8n entry). The stdio
+# server reads POSTFAST_API_KEY from its environment.
+auth:
+  type: api_key
+  env:
+    - name: POSTFAST_API_KEY
+      prompt: "PostFast workspace API key (app.postfa.st -> Workspace Settings -> API keys)"
+      required: true
+      secret: true
+
+# Tool selection at install time:
+# postfast-mcp@0.1.23 exposes 13 tools. Read/discovery tools (list_accounts,
+# list_posts, get_post_analytics, get_follower_history, list_pinterest_boards,
+# list_youtube_playlists, list_gbp_locations, search_places) are safe; the
+# mutating ones (create_posts, delete_post, upload_media, get_upload_urls,
+# generate_connect_link) publish or change real workspace state. Each tool
+# carries a thorough description and a typed input schema. We leave
+# default_enabled unset so the install-time checklist starts with everything
+# pre-checked; users prune with `hermes mcp configure postfast`. Happy to
+# encode a read-mostly default subset if reviewers prefer (as n8n does).
+
+post_install: |
+  Get an API key: sign up at https://app.postfa.st/register (7-day free
+  trial, no credit card), then Workspace Settings -> generate an API key.
+  Set it as POSTFAST_API_KEY. Regenerating the key invalidates the previous
+  one.
+
+  You can re-run the tool checklist any time with:
+    hermes mcp configure postfast

--- a/optional-mcps/postfast/manifest.yaml
+++ b/optional-mcps/postfast/manifest.yaml
@@ -36,15 +36,25 @@ auth:
       secret: true
 
 # Tool selection at install time:
-# postfast-mcp@0.1.23 exposes 13 tools. Read/discovery tools (list_accounts,
-# list_posts, get_post_analytics, get_follower_history, list_pinterest_boards,
-# list_youtube_playlists, list_gbp_locations, search_places) are safe; the
-# mutating ones (create_posts, delete_post, upload_media, get_upload_urls,
-# generate_connect_link) publish or change real workspace state. Each tool
-# carries a thorough description and a typed input schema. We leave
-# default_enabled unset so the install-time checklist starts with everything
-# pre-checked; users prune with `hermes mcp configure postfast`. Happy to
-# encode a read-mostly default subset if reviewers prefer (as n8n does).
+# postfast-mcp@0.1.23 exposes 13 tools. The five mutating ones (create_posts,
+# delete_post, upload_media, get_upload_urls, generate_connect_link) publish
+# to real social accounts, delete scheduled posts, or mint workspace connect
+# links — side effects that are public and mostly not reversible. They are
+# pruned from the default so a casual install gets a read-mostly surface, the
+# same posture as the n8n and blender entries. The eight below are
+# read/discovery calls. Users still see all 13 in the install-time checklist
+# and can opt into the mutating ones per their threat model; this list is
+# also what gets applied directly if the install-time probe fails.
+tools:
+  default_enabled:
+    - list_accounts
+    - list_posts
+    - get_post_analytics
+    - get_follower_history
+    - list_pinterest_boards
+    - list_youtube_playlists
+    - list_gbp_locations
+    - search_places
 
 post_install: |
   Get an API key: sign up at https://app.postfa.st/register (7-day free
@@ -52,5 +62,8 @@ post_install: |
   Set it as POSTFAST_API_KEY. Regenerating the key invalidates the previous
   one.
 
-  You can re-run the tool checklist any time with:
+  The publishing tools (create_posts, delete_post, upload_media,
+  get_upload_urls, generate_connect_link) are OFF by default — they post to
+  real social accounts and a deleted post is not recoverable. Opt into them,
+  or re-run the tool checklist any time, with:
     hermes mcp configure postfast


### PR DESCRIPTION
## What does this PR do?

Adds **PostFast** to the optional MCP catalog: schedule and publish social media posts to 11 platforms (Instagram, TikTok, X, LinkedIn, Facebook, YouTube, Threads, Pinterest, Bluesky, Telegram, Google Business Profile) from Hermes.

One new file — `optional-mcps/postfast/manifest.yaml` — mirroring the existing `blender`/`n8n` stdio entries: `stdio` transport via `npx -y postfast-mcp@<pinned>`, an `api_key` auth block, and an exact version pin per the catalog dependency policy. Nothing else in the diff.

**About the server**
- Official first-party MCP server from the vendor (I'm the founder of PostFast).
- npm: `postfast-mcp`, MIT, single runtime dependency (`@modelcontextprotocol/sdk`), Node >= 18, ~1.5k downloads/month.
- **13 tools**, each with a thorough natural-language description and a typed (zod) input schema — account/destination discovery, scheduling & cross-posting (batch up to 15 posts in one call), media upload, drafts, post analytics, follower history, and connect links. Read tools (`list_*` / `get_*` / `search_places`) are separate from the mutating ones (`create_posts`, `delete_post`, `upload_media`, `get_upload_urls`, `generate_connect_link`).
- Auth: workspace-scoped API key via env (`POSTFAST_API_KEY`), regenerable — modeled as an `api_key` auth block like the `n8n` entry.
- We chose the stdio server over our hosted OAuth endpoint (`mcp.postfa.st`) for the catalog because the hosted connector registers clients via CIMD (built for the ChatGPT/Claude apps), which self-hosted agents can't use.
- Version pinned per the catalog dependency policy (exact pin, release >= 2 weeks old): `postfast-mcp@0.1.23` (released 2026-07-07).
- Pairs well with the existing `n8n` entry — we also ship an official n8n node (`n8n-nodes-postfast`).
- Docs: https://postfa.st/docs and https://postfa.st/api-integrations/mcp — Hermes guide: https://postfa.st/api-integrations/hermes

Happy to provide a test workspace/API key for review, encode a read-mostly `tools.default_enabled` subset, or make any manifest changes you prefer.

## Related Issue

No related issue — new vendor catalog entry, following the same PR-only approval path as the existing `blender` / `linear` / `n8n` / `unreal-engine` entries.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Add `optional-mcps/postfast/manifest.yaml` (single file): `stdio` transport (`npx -y postfast-mcp@0.1.23`), `api_key` auth (`POSTFAST_API_KEY`), exact version pin.

## How to Test

1. `hermes mcp install postfast` and paste a PostFast workspace API key when prompted (get one at https://app.postfa.st/register — 7-day free trial, no card).
2. Start a new Hermes session and confirm the PostFast tools load; `list_accounts` returns the workspace's connected social accounts.
3. `hermes mcp configure postfast` to review/curate the tool checklist.

The entry is a single declarative manifest (no Python code paths). I validated locally that the YAML parses and that the structure mirrors the `blender` / `n8n` entries, and that `npx -y postfast-mcp@0.1.23` resolves on Node >= 18. I have not run the end-to-end catalog install (that path exists once the entry is merged) — happy to test against a review build or hand over a workspace key.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(mcp): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (one new file, no unrelated commits)
- [ ] `pytest tests/ -q` / added tests — **N/A**: manifest-only catalog entry, no Python code changed and the catalog has no per-entry tests
- [x] Tested on macOS to the extent an unmerged entry allows (YAML validated; `npx` resolution verified); full install verifiable post-merge

### Documentation & Housekeeping

- [x] Documentation — the entry is self-documenting via `post_install`; no README/`docs/` change needed
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact — stdio via `npx`, no platform-specific paths
- [x] Tool descriptions/schemas — N/A (the upstream server owns its tool schemas)
