### PR TITLE
fix(compress): allow manual /compress on every surface when auto-compaction is disabled

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1913,7 +1913,7 @@ class HermesACPAgent(acp.Agent):
         if getattr(agent, "compression_enabled", True) is False:
             lines.append(
                 "Auto-compaction is disabled (compression.enabled: false); "
-                "/compact still compresses manually."
+                "/compress still compresses manually."
             )
         else:
             lines.append("Tip: run /compress to compress manually before the threshold.")
@@ -1942,7 +1942,7 @@ class HermesACPAgent(acp.Agent):
         try:
             agent = state.agent
             # No compression_enabled gate: the flag disables *automatic*
-            # compaction only; manual /compact must keep working (matches
+            # compaction only; manual /compress must keep working (matches
             # the CLI /compress and gateway handlers).
             if not hasattr(agent, "_compress_context"):
                 return "Context compression not available for this agent."

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1911,7 +1911,10 @@ class HermesACPAgent(acp.Agent):
                 lines.append(f"Compression threshold: ~{threshold_tokens:,} tokens")
 
         if getattr(agent, "compression_enabled", True) is False:
-            lines.append("Compression is disabled for this agent.")
+            lines.append(
+                "Auto-compaction is disabled (compression.enabled: false); "
+                "/compact still compresses manually."
+            )
         else:
             lines.append("Tip: run /compress to compress manually before the threshold.")
 
@@ -1938,8 +1941,9 @@ class HermesACPAgent(acp.Agent):
             return "Nothing to compress — conversation is empty."
         try:
             agent = state.agent
-            if not getattr(agent, "compression_enabled", True):
-                return "Context compression is disabled for this agent."
+            # No compression_enabled gate: the flag disables *automatic*
+            # compaction only; manual /compact must keep working (matches
+            # the CLI /compress and gateway handlers).
             if not hasattr(agent, "_compress_context"):
                 return "Context compression not available for this agent."
 
@@ -1964,6 +1968,7 @@ class HermesACPAgent(acp.Agent):
                     getattr(agent, "_cached_system_prompt", "") or "",
                     approx_tokens=approx_tokens,
                     task_id=state.session_id,
+                    force=True,
                 )
             finally:
                 agent._session_db = original_session_db

--- a/cli.py
+++ b/cli.py
@@ -9927,9 +9927,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             print("(._.) No active agent -- send a message first.")
             return
 
-        if not self.agent.compression_enabled:
-            print("(._.) Compression is disabled in config.")
-            return
+        # No compression_enabled gate here: the config flag disables
+        # *automatic* compaction only. Manual /compress is an explicit user
+        # action — the context-overflow error path (conversation_loop.py)
+        # directs users here when auto-compaction is off, and the gateway's
+        # /compress handler has never gated on the flag.
 
         from hermes_cli.partial_compress import (
             extract_compress_flags,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1603,12 +1603,13 @@ class TestSlashCommands:
         original_session_db = object()
         state.agent._session_db = original_session_db
 
-        def _compress_context(messages, system_prompt, *, approx_tokens, task_id):
+        def _compress_context(messages, system_prompt, *, approx_tokens, task_id, force):
             assert state.agent._session_db is None
             assert messages == state.history
             assert system_prompt == "system"
             assert approx_tokens == 40
             assert task_id == state.session_id
+            assert force is True
             return [{"role": "user", "content": "summary"}], "new-system"
 
         state.agent._compress_context = MagicMock(side_effect=_compress_context)
@@ -1636,8 +1637,42 @@ class TestSlashCommands:
             "system",
             approx_tokens=40,
             task_id=state.session_id,
+            force=True,
         )
         mock_save.assert_called_once_with(state.session_id)
+
+    def test_compact_works_when_auto_compaction_disabled(self, agent, mock_manager):
+        """compression.enabled: false disables *automatic* compaction only —
+        manual /compact must still compress (matches CLI /compress and the
+        gateway handler)."""
+        state = self._make_state(mock_manager)
+        state.history = [
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+            {"role": "user", "content": "three"},
+            {"role": "assistant", "content": "four"},
+        ]
+        state.agent.compression_enabled = False
+        state.agent._cached_system_prompt = "system"
+        state.agent.tools = None
+        state.agent._session_db = None
+        state.agent._compress_context = MagicMock(
+            return_value=([{"role": "user", "content": "summary"}], "new-system")
+        )
+
+        with (
+            patch.object(agent.session_manager, "save_session"),
+            patch(
+                "agent.model_metadata.estimate_request_tokens_rough",
+                side_effect=[40, 12],
+            ),
+        ):
+            result = agent._handle_slash_command("/compact", state)
+
+        assert "disabled" not in result.lower()
+        assert "Context compressed: 4 -> 1 messages" in result
+        state.agent._compress_context.assert_called_once()
+        assert state.agent._compress_context.call_args.kwargs.get("force") is True
 
     def test_unknown_command_returns_none(self, agent, mock_manager):
         state = self._make_state(mock_manager)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1641,9 +1641,9 @@ class TestSlashCommands:
         )
         mock_save.assert_called_once_with(state.session_id)
 
-    def test_compact_works_when_auto_compaction_disabled(self, agent, mock_manager):
+    def test_compress_works_when_auto_compaction_disabled(self, agent, mock_manager):
         """compression.enabled: false disables *automatic* compaction only —
-        manual /compact must still compress (matches CLI /compress and the
+        manual /compress must still compress (matches CLI /compress and the
         gateway handler)."""
         state = self._make_state(mock_manager)
         state.history = [
@@ -1667,7 +1667,7 @@ class TestSlashCommands:
                 side_effect=[40, 12],
             ),
         ):
-            result = agent._handle_slash_command("/compact", state)
+            result = agent._handle_slash_command("/compress", state)
 
         assert "disabled" not in result.lower()
         assert "Context compressed: 4 -> 1 messages" in result

--- a/tests/cli/test_manual_compress.py
+++ b/tests/cli/test_manual_compress.py
@@ -188,6 +188,40 @@ def test_manual_compress_does_not_flush_full_history_when_session_id_unchanged()
     shell.agent._flush_messages_to_session_db.assert_not_called()
 
 
+def test_manual_compress_runs_when_auto_compaction_disabled(capsys):
+    """compression.enabled: false disables *automatic* compaction only.
+
+    Manual /compress must still work: the context-overflow error path
+    (agent/conversation_loop.py) explicitly directs users to /compress when
+    auto-compaction is off, and the gateway's /compress handler has never
+    gated on the flag. Regression for the CLI refusing with "Compression is
+    disabled in config."
+    """
+    shell = _make_cli()
+    history = _make_history()
+    compressed = [
+        {"role": "user", "content": "[summary]"},
+        history[-1],
+    ]
+    shell.conversation_history = history
+    shell.agent = MagicMock()
+    shell.agent.compression_enabled = False
+    shell.agent._cached_system_prompt = ""
+    shell.agent.tools = None
+    shell.agent.session_id = shell.session_id
+    shell.agent._compress_context.return_value = (compressed, "")
+
+    with patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100):
+        shell._manual_compress()
+
+    output = capsys.readouterr().out
+    assert "Compression is disabled" not in output
+    shell.agent._compress_context.assert_called_once()
+    # Manual compression bypasses the summary-failure cooldown.
+    assert shell.agent._compress_context.call_args.kwargs.get("force") is True
+    assert shell.conversation_history == compressed
+
+
 def test_manual_compress_no_sync_when_session_id_unchanged():
     """If compression is a no-op (agent.session_id didn't change), the CLI
     must NOT clear _pending_title or otherwise disturb session state.

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -91,6 +91,48 @@ async def test_compress_command_reports_noop_without_success_banner():
 
 
 @pytest.mark.asyncio
+async def test_compress_command_works_when_auto_compaction_disabled():
+    """compression.enabled: false disables *automatic* compaction only.
+
+    The gateway /compress handler has never gated on the flag — pin that
+    contract (every manual-compress surface must allow manual compression
+    regardless of the auto toggle, #64438) and the force=True cooldown
+    bypass that manual compression relies on."""
+    history = _make_history()
+    compressed = [
+        history[0],
+        {"role": "assistant", "content": "compressed summary"},
+        history[-1],
+    ]
+    runner = _make_runner(history)
+    agent_instance = MagicMock()
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+    agent_instance._cached_system_prompt = ""
+    agent_instance.tools = None
+    agent_instance.compression_enabled = False
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.session_id = "sess-1"
+    agent_instance._compress_context.return_value = (compressed, "")
+
+    def _estimate(messages, **_kwargs):
+        return 100 if messages == history else 60
+
+    with (
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=agent_instance),
+        patch("agent.model_metadata.estimate_request_tokens_rough", side_effect=_estimate),
+    ):
+        result = await runner._handle_compress_command(_make_event())
+
+    assert "disabled" not in result.lower()
+    assert "Compressed:" in result
+    agent_instance._compress_context.assert_called_once()
+    assert agent_instance._compress_context.call_args.kwargs.get("force") is True
+
+
+@pytest.mark.asyncio
 async def test_compress_command_explains_when_token_estimate_rises():
     history = _make_history()
     compressed = [

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5883,6 +5883,37 @@ def test_compress_session_history_passes_force():
     assert agent._compress_context.call_args.kwargs.get("force") is True
 
 
+def test_compress_session_history_works_when_auto_compaction_disabled():
+    """compression.enabled: false disables *automatic* compaction only —
+    manual /compress must still work on every TUI route (session.compress
+    RPC, slash compress/compact, slash-worker mirror), all of which converge
+    on _compress_session_history. Pin that the helper never gates on
+    agent.compression_enabled (#64438)."""
+    from unittest.mock import MagicMock
+
+    agent = MagicMock()
+    agent.compression_enabled = False
+    agent.context_compressor = None  # keep _get_usage on the simple path
+    compressed = [{"role": "user", "content": "summary"}]
+    agent._compress_context.return_value = (compressed, "")
+    session = _session(
+        agent=agent,
+        history=[
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+            {"role": "user", "content": "three"},
+            {"role": "assistant", "content": "four"},
+        ],
+    )
+
+    removed, _usage = server._compress_session_history(session)
+
+    assert removed == 3
+    assert session["history"] == compressed
+    agent._compress_context.assert_called_once()
+    assert agent._compress_context.call_args.kwargs.get("force") is True
+
+
 def test_session_compress_uses_compress_helper(monkeypatch):
     agent = types.SimpleNamespace()
     server._sessions["sid"] = _session(agent=agent)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5855,6 +5855,34 @@ def test_config_set_personality_preserves_history_and_returns_info(monkeypatch):
     assert ("session.info", "sid", {"model": "?"}) in emits
 
 
+def test_compress_session_history_passes_force():
+    """_compress_session_history is manual-only (session.compress RPC, slash
+    compress/compact, slash-worker mirror) — it must bypass the
+    summary-failure cooldown via force=True, matching the CLI and gateway
+    manual-compress handlers."""
+    from unittest.mock import MagicMock
+
+    agent = MagicMock()
+    agent.context_compressor = None  # keep _get_usage on the simple path
+    compressed = [{"role": "user", "content": "summary"}]
+    agent._compress_context.return_value = (compressed, "")
+    session = _session(
+        agent=agent,
+        history=[
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+            {"role": "user", "content": "three"},
+            {"role": "assistant", "content": "four"},
+        ],
+    )
+
+    removed, _usage = server._compress_session_history(session)
+
+    assert removed == 3
+    assert session["history"] == compressed
+    assert agent._compress_context.call_args.kwargs.get("force") is True
+
+
 def test_session_compress_uses_compress_helper(monkeypatch):
     agent = types.SimpleNamespace()
     server._sessions["sid"] = _session(agent=agent)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3592,12 +3592,18 @@ def _compress_session_history(
     # cached prompt (which already contains the agent identity block)
     # makes the rebuild append the identity a second time. Mirrors the
     # CLI's _manual_compress fix for issue #15281.
+    # force=True: every caller of this helper is a manual /compress path
+    # (session.compress RPC, slash compress/compact, slash-worker mirror) —
+    # auto-compaction runs inside the agent loop, not here. Manual
+    # compaction bypasses the summary-failure cooldown, matching the CLI
+    # and gateway handlers.
     try:
         compressed, _ = agent._compress_context(
             history,
             None,
             approx_tokens=approx_tokens,
             focus_topic=focus_topic or None,
+            force=True,
             defer_context_engine_notification=True,
         )
     except Exception:


### PR DESCRIPTION
## Summary
Manual `/compress` (and `/compact`) now works on every surface even when `compression.enabled: false` — the flag disables *automatic* compaction only. The context-overflow error path (`agent/conversation_loop.py`) explicitly tells users to "Run /compress to compact manually" when auto-compaction is off, but the classic CLI and the ACP adapter refused with "Compression is disabled", leaving those users at a full context with no escape hatch (#64438).

## Changes
- `cli.py`: remove the `compression_enabled` gate from `_manual_compress` (stale boilerplate from the original /compress commit; replaced with a comment documenting the contract).
- `acp_adapter/server.py`: remove the `compression_enabled` gate from the compress command, add `force=True` (manual compaction bypasses the summary-failure cooldown, matching CLI + gateway), and reword the `/context` status line so disabled auto-compaction no longer implies manual compress is unavailable.
- `tui_gateway/server.py`: add `force=True` to `_compress_session_history` — the shared choke point for all three TUI manual routes (session.compress RPC, command.dispatch compress branch, slash.exec mirror) plus the compute-host controls. Absorbs the residual fix from closed #57530.
- Surface audit (salvage hardening): `gateway/slash_commands.py` and the TUI routes never gated on the flag — new behavioral tests pin the manual-always-allowed contract per surface so a gate can't regress in:
  - `tests/cli/test_manual_compress.py` (contributor's test)
  - `tests/acp/test_server.py` (contributor's test, updated to current `/compress` command name — main renamed ACP's `/compact` after the PR was written)
  - `tests/gateway/test_compress_command.py` (new)
  - `tests/test_tui_gateway_server.py` (contributor's force=True test + new disabled-flag test)

## Validation
| | Before | After |
|---|---|---|
| CLI `/compress` with `compression.enabled: false` | "(._.) Compression is disabled in config." | compresses (force=True) |
| ACP compress command with flag off | "Context compression is disabled for this agent." | compresses (force=True) |
| TUI `_compress_session_history` cooldown bypass | no `force=True` (post-abort retries blocked) | force=True on all 3 routes |
| Gateway `/compress` with flag off | worked (never gated) | pinned by test |

Targeted tests: `tests/gateway/test_compress_command.py`, `tests/test_tui_gateway_server.py`, `tests/acp/test_server.py`, `tests/cli/test_manual_compress.py` — 502 passed, 0 failed.

## Credit
Salvaged from #63630 by @bnikanjam; gate removal extended to all manual-compress surfaces during salvage. Fixes #64438. Absorbs the force=True residual from #57530 by @gal064.

## Infographic
![manual-compress-every-surface](https://v3b.fal.media/files/b/0aa34de9/_nlwzZbYEW2hSp1iMojzc_Ae4S7b3f.png)
