### PR TITLE
fix(agent): pass api_key_hint to mark_exhausted_and_rotate in credential pool recovery (#43755 salvage)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -922,6 +922,18 @@ def recover_with_credential_pool(
             )
             return False, has_retried_429
 
+    # Capture the current API key before any rotation — needed to
+    # identify which credential actually failed when
+    # mark_exhausted_and_rotate is called.  Without this hint the
+    # pool falls back to current() or _select_unlocked(), which may
+    # return the NEXT (healthy) entry after a prior rotation, marking
+    # the wrong credential as exhausted (#43747).
+    _api_key_hint = getattr(agent, "api_key", None) or None
+    if not _api_key_hint:
+        _cur = pool.current()
+        if _cur:
+            _api_key_hint = getattr(_cur, "runtime_api_key", None)
+
     effective_reason = classified_reason
     if effective_reason is None:
         if status_code == 402:
@@ -952,13 +964,13 @@ def recover_with_credential_pool(
 
     if effective_reason == FailoverReason.billing:
         rotate_status = status_code if status_code is not None else 402
+        # Runtime credentials can be resolved by a separate pool instance,
+        # leaving this recovery pool without ``current_id``. Match the key
+        # that actually failed instead of quarantining a different account.
         next_entry = pool.mark_exhausted_and_rotate(
             status_code=rotate_status,
             error_context=error_context,
-            # Runtime credentials can be resolved by a separate pool instance,
-            # leaving this recovery pool without ``current_id``. Match the key
-            # that actually failed instead of quarantining a different account.
-            api_key_hint=getattr(agent, "api_key", None),
+            api_key_hint=_api_key_hint,
         )
         if next_entry is not None:
             _ra().logger.info(
@@ -983,7 +995,7 @@ def recover_with_credential_pool(
                 current_last_status,
             )
             rotate_status = status_code if status_code is not None else 429
-            next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+            next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context, api_key_hint=_api_key_hint)
             if next_entry is not None:
                 _ra().logger.info(
                     "Credential %s (rate limit, pre-exhausted) — rotated to pool entry %s",
@@ -1007,7 +1019,7 @@ def recover_with_credential_pool(
         if not has_retried_429 and not usage_limit_reached:
             return False, True
         rotate_status = status_code if status_code is not None else 429
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context, api_key_hint=_api_key_hint)
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (rate limit) — rotated to pool entry %s",
@@ -1107,7 +1119,7 @@ def recover_with_credential_pool(
         # Refresh failed — rotate to next credential instead of giving up.
         # The failed entry is already marked exhausted by try_refresh_current().
         rotate_status = status_code if status_code is not None else 401
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context, api_key_hint=_api_key_hint)
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (auth refresh failed) — rotated to pool entry %s",

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -162,7 +162,7 @@ class TestPoolRotationCycle:
         # mark_exhausted_and_rotate returns next entry until exhausted
         self._rotation_index = 0
 
-        def rotate(status_code=None, error_context=None, api_key_hint=None):
+        def rotate(status_code=None, error_context=None, **_kwargs):
             self._rotation_index += 1
             if self._rotation_index < pool_entries:
                 return entries[self._rotation_index]
@@ -173,6 +173,9 @@ class TestPoolRotationCycle:
         agent._credential_pool = pool
         agent._swap_credential = MagicMock()
         agent.log_prefix = ""
+        agent.api_key = "test-api-key"
+        agent.provider = "test-provider"
+        pool.provider = "test-provider"
 
         return agent, pool, entries
 
@@ -194,7 +197,7 @@ class TestPoolRotationCycle:
         )
         assert recovered is True
         assert has_retried is False  # reset after rotation
-        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=429, error_context=None)
+        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=429, error_context=None, api_key_hint="test-api-key")
         agent._swap_credential.assert_called_once_with(entries[1])
 
     def test_pool_exhaustion_returns_false(self):
@@ -220,11 +223,7 @@ class TestPoolRotationCycle:
         )
         assert recovered is True
         assert has_retried is False
-        pool.mark_exhausted_and_rotate.assert_called_once_with(
-            status_code=402,
-            error_context=None,
-            api_key_hint=None,
-        )
+        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=402, error_context=None, api_key_hint="test-api-key")
 
     def test_no_pool_returns_false(self):
         """No pool should return (False, unchanged)."""
@@ -239,3 +238,40 @@ class TestPoolRotationCycle:
         )
         assert recovered is False
         assert has_retried is False
+
+    def test_api_key_hint_from_pool_current_when_agent_key_missing(self):
+        """api_key_hint should fall back to pool.current().runtime_api_key
+        when agent.api_key is not set (#43747)."""
+        from run_agent import AIAgent
+
+        with patch.object(AIAgent, "__init__", lambda self, **kw: None):
+            agent = AIAgent()
+
+        e0 = MagicMock(name="entry_0")
+        e0.id = "cred-0"
+        e1 = MagicMock(name="entry_1")
+        e1.id = "cred-1"
+
+        pool = MagicMock()
+        pool.has_credentials.return_value = True
+        pool.provider = "test-provider"
+        agent.provider = "test-provider"
+
+        # current entry has a runtime_api_key
+        cur_entry = MagicMock()
+        cur_entry.runtime_api_key = "pool-current-key"
+        pool.current.return_value = cur_entry
+
+        pool.mark_exhausted_and_rotate.return_value = e1
+        agent._credential_pool = pool
+        agent._swap_credential = MagicMock()
+        agent.log_prefix = ""
+        # No agent.api_key set — should fall back to pool.current().runtime_api_key
+
+        recovered, has_retried = agent._recover_with_credential_pool(
+            status_code=402, has_retried_429=False
+        )
+        assert recovered is True
+        pool.mark_exhausted_and_rotate.assert_called_once_with(
+            status_code=402, error_context=None, api_key_hint="pool-current-key"
+        )

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -275,3 +275,80 @@ class TestPoolRotationCycle:
         pool.mark_exhausted_and_rotate.assert_called_once_with(
             status_code=402, error_context=None, api_key_hint="pool-current-key"
         )
+
+
+# ---------------------------------------------------------------------------
+# 6. Real-pool regression: the hint routes exhaustion to the FAILED entry
+# ---------------------------------------------------------------------------
+
+class TestApiKeyHintRealPool:
+    """Prove the routing guarantee through the real CredentialPool selector:
+    when the failed key differs from the pool's current/first entry, only the
+    failed entry is marked exhausted (#43747, wrong-entry marking)."""
+
+    def _seed_pool(self, tmp_path, monkeypatch):
+        import json
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "auth.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "providers": {},
+                    "credential_pool": {
+                        "openrouter": [
+                            {
+                                "id": "cred-healthy",
+                                "label": "healthy",
+                                "auth_type": "api_key",
+                                "priority": 0,
+                                "source": "manual",
+                                "access_token": "sk-or-healthy",
+                            },
+                            {
+                                "id": "cred-failed",
+                                "label": "failed",
+                                "auth_type": "api_key",
+                                "priority": 1,
+                                "source": "manual",
+                                "access_token": "sk-or-failed",
+                            },
+                        ]
+                    },
+                }
+            )
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        from agent.credential_pool import load_pool
+
+        return load_pool("openrouter")
+
+    def test_hint_marks_failed_entry_not_current(self, tmp_path, monkeypatch):
+        pool = self._seed_pool(tmp_path, monkeypatch)
+        # Another process/pool instance issued sk-or-failed; THIS pool's
+        # current() would resolve to the first (healthy) entry.
+        assert pool.select().access_token == "sk-or-healthy"
+
+        next_entry = pool.mark_exhausted_and_rotate(
+            status_code=429,
+            error_context={"reason": "rate_limit_exceeded"},
+            api_key_hint="sk-or-failed",
+        )
+
+        statuses = {e.id: e.last_status for e in pool._entries}
+        assert statuses["cred-failed"] == "exhausted"
+        assert statuses["cred-healthy"] in (None, "ok")
+        assert next_entry is not None
+        assert next_entry.access_token == "sk-or-healthy"
+
+    def test_without_hint_current_entry_is_marked(self, tmp_path, monkeypatch):
+        """Baseline: no hint falls back to current() — the pre-fix behavior."""
+        pool = self._seed_pool(tmp_path, monkeypatch)
+        assert pool.select().access_token == "sk-or-healthy"
+
+        pool.mark_exhausted_and_rotate(status_code=429, error_context=None)
+
+        statuses = {e.id: e.last_status for e in pool._entries}
+        assert statuses["cred-healthy"] == "exhausted"
+        assert statuses["cred-failed"] in (None, "ok")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6282,9 +6282,12 @@ class TestCredentialPoolRecovery:
             def current(self):
                 return SimpleNamespace(label="primary")
 
-            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+            def mark_exhausted_and_rotate(
+                self, *, status_code, error_context=None, api_key_hint=None
+            ):
                 assert status_code == 429
                 assert error_context is None
+                assert api_key_hint == agent.api_key
                 return next_entry
 
         agent._credential_pool = _Pool()
@@ -6387,9 +6390,12 @@ class TestCredentialPoolRecovery:
             def try_refresh_current(self):
                 return None  # refresh failed
 
-            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+            def mark_exhausted_and_rotate(
+                self, *, status_code, error_context=None, api_key_hint=None
+            ):
                 assert status_code == 401
                 assert error_context is None
+                assert api_key_hint == agent.api_key
                 return next_entry
 
         agent._credential_pool = _Pool()
@@ -6411,7 +6417,9 @@ class TestCredentialPoolRecovery:
             def try_refresh_current(self):
                 return None
 
-            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+            def mark_exhausted_and_rotate(
+                self, *, status_code, error_context=None, api_key_hint=None
+            ):
                 assert error_context is None
                 return None  # no more credentials
 
@@ -6488,9 +6496,12 @@ class TestCredentialPoolRecovery:
             def current(self):
                 return SimpleNamespace(label="primary")
 
-            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+            def mark_exhausted_and_rotate(
+                self, *, status_code, error_context=None, api_key_hint=None
+            ):
                 captured["status_code"] = status_code
                 captured["error_context"] = error_context
+                captured["api_key_hint"] = api_key_hint
                 return next_entry
 
         agent._credential_pool = _Pool()


### PR DESCRIPTION
## Summary

Salvage of #43755 by @liuhao1024: `recover_with_credential_pool()` now passes `api_key_hint` to every `mark_exhausted_and_rotate()` call, so a 429/402/401 quarantines the credential that actually issued the failed request instead of whatever `current()`/`_select_unlocked()` happens to return. This is the wrong-entry-marking half of #43747 ("pool marks healthy later account as usage_limit_reached; auth reset restores operation") — the externally-reset half landed in #69494.

Root cause: runtime credentials can be resolved by a separate pool instance, leaving the recovery pool without `current_id`; without a hint, the pool falls back to selection and can mark the NEXT (healthy) entry exhausted. The pool-side selector already supports `api_key_hint` — the billing site passed it, the three rate-limit/auth sites didn't.

## Changes

- `agent/agent_runtime_helpers.py` (contributor commit, cherry-picked): capture `_api_key_hint` from `agent.api_key` (fallback: `pool.current().runtime_api_key`) once, and pass it at all 4 rotation sites (billing, pre-exhausted rate-limit, rate-limit, auth-refresh-failed).
- `tests/run_agent/test_run_agent.py` (follow-up): strict `_Pool` doubles updated to accept `api_key_hint` and assert it carries the agent's failed key.
- `tests/agent/test_credential_pool_routing.py` (contributor + follow-up): hint-fallback test, plus a real-`CredentialPool` regression (no mocks) proving the hint routes exhaustion to the failed entry and the healthy entry keeps serving.

## Validation

| | Before | After |
|---|---|---|
| 429 on key B while pool `current()` is key A | Key A (healthy) marked exhausted, frozen for hours | Key B marked, key A keeps serving |
| Rotation after quarantine | May rotate away from a healthy key | Rotates to the healthy entry |

- `tests/agent/test_credential_pool_routing.py` + `tests/run_agent/test_run_agent.py`: 449 tests green.
- Adjacent suites green: `test_fallback_credential_isolation.py`, `test_credential_pool_interrupt.py`, `test_switch_model_pool_reload_52727.py`, `test_codex_xai_oauth_recovery.py` (510 total).
- Live E2E with a real two-entry pool in a temp `HERMES_HOME` through the real `_recover_with_credential_pool()`: failed key quarantined + persisted, healthy key swapped in.

Addresses the sweeper review on #43755 (strict doubles updated; real-selector regression added). Closes #43755's scope; fixes the remaining half of #43747.

## Credit

Core fix by @liuhao1024 (#43755), cherry-picked with authorship preserved. Test hardening added on top.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa34dfe/pao0PxC9HCQ9EYo1LvRLE_7qJD146w.png)
