### PR TITLE
fix(desktop): stop code-block expand button from covering the horizontal scrollbar

### DIFF
--- a/apps/desktop/src/components/chat/expandable-block.test.tsx
+++ b/apps/desktop/src/components/chat/expandable-block.test.tsx
@@ -1,0 +1,83 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ExpandableBlock } from './expandable-block'
+
+// jsdom has no ResizeObserver and reports scrollHeight === 0, so the block
+// never flips to `overflowing` on its own. Mirror the project's test pattern
+// (see approval-mode-menu.test.tsx): stub RO to fire immediately, then force a
+// tall scrollHeight on the observed node so the collapse button mounts.
+class TestResizeObserver {
+  constructor(private cb: ResizeObserverCallback) {}
+  observe(target: Element) {
+    Object.defineProperty(target, 'scrollHeight', { configurable: true, value: 400 })
+    this.cb([] as unknown as ResizeObserverEntry[], this as unknown as ResizeObserver)
+  }
+  unobserve() {}
+  disconnect() {}
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('ExpandableBlock', () => {
+  it('gives code cards (collapseAlign="end") a right-pinned button clear of the horizontal scrollbar', () => {
+    vi.stubGlobal('ResizeObserver', TestResizeObserver)
+
+    const { container } = render(
+      <ExpandableBlock collapseAlign="end">
+        <pre data-testid="content">{"const x = 1\n".repeat(20)}</pre>
+      </ExpandableBlock>
+    )
+
+    const inner = container.querySelector('[data-testid="content"]')!.parentElement!
+    const button = screen.getByRole('button', { name: /expand|collapse/i })
+
+    // Inner container must allow horizontal scroll and pad its right edge so
+    // the scrollbar stays draggable across the full width except the button.
+    expect(inner.className).toContain('overflow-x-auto')
+    expect(inner.className).toContain('pr-2')
+
+    // The button must NOT span the full bottom edge (the old bug) — it is
+    // pinned to the right so it cannot overlay the scrollbar.
+    expect(button.className).toContain('right-0')
+    expect(button.className).not.toContain('inset-x-0')
+  })
+
+  it('keeps the full-width centered button for the plain-text fallback (collapseAlign default)', () => {
+    vi.stubGlobal('ResizeObserver', TestResizeObserver)
+
+    const { container } = render(
+      <ExpandableBlock>
+        <pre data-testid="content">{"plain text\n".repeat(20)}</pre>
+      </ExpandableBlock>
+    )
+
+    const inner = container.querySelector('[data-testid="content"]')!.parentElement!
+    const button = screen.getByRole('button', { name: /expand|collapse/i })
+
+    // Fallback has no horizontal scroll, so it keeps the original full-width,
+    // centered button — and does not gain the end-aligned padding.
+    expect(button.className).toContain('inset-x-0')
+    expect(button.className).not.toContain('right-0')
+    expect(inner.className).not.toContain('pr-2')
+  })
+
+  it('toggles expanded state on button click without breaking the control', () => {
+    vi.stubGlobal('ResizeObserver', TestResizeObserver)
+
+    render(
+      <ExpandableBlock collapseAlign="end">
+        <pre data-testid="content">{"line\n".repeat(20)}</pre>
+      </ExpandableBlock>
+    )
+
+    const button = screen.getByRole('button', { name: /expand|collapse/i })
+
+    expect(button.getAttribute('aria-expanded')).toBe('false')
+    fireEvent.click(button)
+    expect(button.getAttribute('aria-expanded')).toBe('true')
+  })
+})

--- a/apps/desktop/src/components/chat/expandable-block.tsx
+++ b/apps/desktop/src/components/chat/expandable-block.tsx
@@ -9,9 +9,18 @@ import { cn } from '@/lib/utils'
 interface ExpandableBlockProps {
   children: ReactNode
   className?: string
+  // `full` (default) spans the collapse button across the whole bottom edge —
+  // used for plain text fallbacks. `end` pins it to the right edge so it never
+  // covers a horizontal scrollbar living along the bottom of the inner
+  // content (e.g. wide code blocks), leaving that scrollbar fully draggable.
+  collapseAlign?: 'full' | 'end'
 }
 
-export function ExpandableBlock({ children, className }: ExpandableBlockProps) {
+export function ExpandableBlock({
+  children,
+  className,
+  collapseAlign = 'full'
+}: ExpandableBlockProps) {
   const innerRef = useRef<HTMLDivElement>(null)
   const [expanded, setExpanded] = useState(false)
   const [overflowing, setOverflowing] = useState(false)
@@ -29,16 +38,30 @@ export function ExpandableBlock({ children, className }: ExpandableBlockProps) {
 
   useResizeObserver(measure, innerRef)
 
+  // `end` alignment needs horizontal scroll room so the scrollbar below the
+  // content stays clear of the button; pad the right edge to seat the button.
+  const innerClassName = cn(
+    'overflow-y-auto overflow-x-auto',
+    collapseAlign === 'end' && 'pr-2',
+    expanded ? 'max-h-[40dvh]' : 'max-h-[7.5rem]',
+    className
+  )
+
+  const buttonClassName = cn(
+    'absolute bottom-0 flex h-7 cursor-pointer items-end bg-linear-to-t from-(--ui-chat-surface-background) to-transparent pb-1 text-muted-foreground/70 transition-colors hover:text-foreground',
+    collapseAlign === 'end' ? 'right-0 justify-end pr-2' : 'inset-x-0 justify-center'
+  )
+
   return (
     <div className="relative">
-      <div className={cn('overflow-y-auto', expanded ? 'max-h-[40dvh]' : 'max-h-[7.5rem]', className)} ref={innerRef}>
+      <div className={innerClassName} ref={innerRef}>
         {children}
       </div>
       {overflowing && (
         <button
           aria-expanded={expanded}
           aria-label={expanded ? 'Collapse' : 'Expand'}
-          className="absolute inset-x-0 bottom-0 flex h-7 cursor-pointer items-end justify-center bg-linear-to-t from-(--ui-chat-surface-background) to-transparent pb-1 text-muted-foreground/70 transition-colors hover:text-foreground"
+          className={buttonClassName}
           onClick={() => setExpanded(v => !v)}
           type="button"
         >

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -156,7 +156,7 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
         />
       </CodeCardHeader>
       <CodeCardBody>
-        <ExpandableBlock>
+        <ExpandableBlock collapseAlign="end">
           <Pre className="aui-shiki m-0 overflow-hidden bg-transparent p-0">
             {plain ? (
               <PlainCode code={trimmed} />


### PR DESCRIPTION
## What does this PR do?

Fixes a UX bug where the **code-block collapse/expand button overlays the horizontal scrollbar** of a wide fenced code block, making that scrollbar non-functional.

**Root cause.** A fenced code block renders as `CodeCard → CodeCardBody → ExpandableBlock`. `CodeCardBody` sets `[&_pre]:overflow-x-auto`, so a wide code block gets a horizontal scrollbar along the bottom of the `<pre>`. The collapse control in `ExpandableBlock` was positioned `absolute inset-x-0 bottom-0` — i.e. it spanned the **entire width** of the bottom strip (28px tall) and sat *on top of* that scrollbar. Any click/pointer-down in the bottom strip hit the button (expand/collapse) instead of the scrollbar thumb, so the code could not be scrolled sideways at all while collapsed, and the horizontal scrollbar was effectively dead.

**The fix.** `ExpandableBlock` gains a `collapseAlign: 'full' | 'end'` prop:
- `'end'` (used by code cards via `shiki-highlighter.tsx`) pins the button to the **right edge** (`right-0`) instead of the full width, and the inner container gains `overflow-x-auto pr-2`. The horizontal scrollbar is now draggable across the full width **except** the narrow button zone on the right, so the two interactive elements no longer fight over the same click area.
- `'full'` (default) keeps the original centered, full-width button — used by the plain-text `HugeTextFallback`, which has no horizontal scroll, so its prior behavior is preserved unchanged.

This is a pure presentation fix: no data, no new dependencies, no behavior change outside the collapse control's placement. It improves UX directly — the bottom scrollbar becomes functional again and the expand/collapse control keeps working independently.

## Related Issue

Fixes # ...

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `apps/desktop/src/components/chat/expandable-block.tsx` — added the `collapseAlign` prop; the collapse button is now pinned to the right edge (`right-0`) when `collapseAlign="end"`, and the inner container gains `overflow-x-auto pr-2` so the horizontal scrollbar stays clear of the button. Default `'full'` keeps the old centered full-width button for non-scrolling fallbacks.
- `apps/desktop/src/components/chat/shiki-highlighter.tsx` — pass `collapseAlign="end"` to `<ExpandableBlock>` in the code-card body so the fix applies to fenced code blocks.
- `apps/desktop/src/components/chat/expandable-block.test.tsx` (new) — regression tests asserting: end-aligned code cards get `right-0` + `overflow-x-auto pr-2` and **not** `inset-x-0`; the plain-text fallback keeps `inset-x-0` and no `pr-2`; clicking the button still toggles `aria-expanded`. Verified the test fails without the fix.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. In the desktop app, narrow the window / open the right sidebar so the chat column is constrained, then render a fenced code block with a long single line (e.g. a wide `curl` command). A horizontal scrollbar appears at the bottom of the code block.
2. **Before the fix:** the expand/collapse button spanned the full bottom width and covered the scrollbar — clicking in the bottom strip collapsed/expanded the block instead of scrolling, so the code could not be scrolled sideways.
3. **After the fix:** the expand/collapse button sits at the **right edge** only. The horizontal scrollbar is draggable across the rest of the width (scroll the code sideways). Clicking the button (right side) still expands/collapses the block. Both controls are now independently usable.
4. Regression test: `cd apps/desktop && npx vitest run src/components/chat/expandable-block.test.tsx` → 3 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **N/A**: desktop change (TypeScript); verified instead via `npx vitest run` (3/3 pass).
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure CSS class placement, no platform-specific logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

**Before**: wide code block with the expand button spanning the full bottom width, covering the horizontal scrollbar (scrollbar non-functional).
<img width="879" height="404" alt="150 Code" src="https://github.com/user-attachments/assets/c2f35267-19fd-4435-8b2a-d60212fc688d" />


**After**: same block with the expand button pinned to the right edge; horizontal scrollbar draggable across the rest of the width; button still expands/collapses on click.
<img width="823" height="300" alt="150 Fix" src="https://github.com/user-attachments/assets/b7791aef-38a6-4c87-99d2-99a6ec42c629" />

