### PR TITLE
fix(debug): redact PII from public debug shares

### DIFF
--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -197,7 +197,9 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        logger.info("[msgraph_webhook] Response for %s: %s", chat_id, content[:200])
+        logger.info(
+            "[msgraph_webhook] Response delivered (content_chars=%d)", len(content)
+        )
         return SendResult(success=True)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -376,7 +376,7 @@ class WebhookAdapter(BasePlatformAdapter):
         deliver_type = delivery.get("deliver", "log")
 
         if deliver_type == "log":
-            logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
+            logger.info("[webhook] Response delivered to log (content_chars=%d)", len(content))
             return SendResult(success=True)
 
         if deliver_type == "github_comment":
@@ -1306,7 +1306,7 @@ class WebhookAdapter(BasePlatformAdapter):
         if deliver_type == "log":
             # Shouldn't reach here — startup validation rejects deliver_only
             # with deliver=log — but guard defensively.
-            logger.info("[webhook] direct-deliver log-only: %s", content[:200])
+            logger.info("[webhook] direct-deliver log-only (content_chars=%d)", len(content))
             return SendResult(success=True)
 
         if deliver_type == "github_comment":

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -376,7 +376,7 @@ class WebhookAdapter(BasePlatformAdapter):
         deliver_type = delivery.get("deliver", "log")
 
         if deliver_type == "log":
-            logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
+            logger.info("[webhook] Response delivered to log (content_chars=%d)", len(content))
             return SendResult(success=True)
 
         if deliver_type == "github_comment":
@@ -1268,7 +1268,7 @@ class WebhookAdapter(BasePlatformAdapter):
         if deliver_type == "log":
             # Shouldn't reach here — startup validation rejects deliver_only
             # with deliver=log — but guard defensively.
-            logger.info("[webhook] direct-deliver log-only: %s", content[:200])
+            logger.info("[webhook] direct-deliver log-only (content_chars=%d)", len(content))
             return SendResult(success=True)
 
         if deliver_type == "github_comment":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21325,12 +21325,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
 
         if self._is_duplicate_voice_transcript(guild_id, user_id, transcript):
-            logger.info(
-                "Suppressing duplicate voice transcript for guild=%s user=%s: %s",
-                guild_id,
-                user_id,
-                transcript[:100],
-            )
+            logger.info("Suppressing duplicate voice transcript")
             return
 
         # Show transcript in text channel (after auth, with mention sanitization)
@@ -23324,7 +23319,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             session_key
                         ).persistent.update_prompt_pending = True
                         # .update_response to continue — it doesn't re-check
-                        logger.info("Forwarded update prompt to %s: %s", session_key, prompt_text[:80])
+                        logger.info(
+                            "Forwarded update prompt (prompt_chars=%d)", len(prompt_text)
+                        )
                 except (json.JSONDecodeError, OSError) as e:
                     logger.debug("Failed to read update prompt: %s", e)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18160,12 +18160,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
 
         if self._is_duplicate_voice_transcript(guild_id, user_id, transcript):
-            logger.info(
-                "Suppressing duplicate voice transcript for guild=%s user=%s: %s",
-                guild_id,
-                user_id,
-                transcript[:100],
-            )
+            logger.info("Suppressing duplicate voice transcript")
             return
 
         # Show transcript in text channel (after auth, with mention sanitization)
@@ -19924,7 +19919,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             session_key
                         ).persistent.update_prompt_pending = True
                         # .update_response to continue — it doesn't re-check
-                        logger.info("Forwarded update prompt to %s: %s", session_key, prompt_text[:80])
+                        logger.info(
+                            "Forwarded update prompt (prompt_chars=%d)", len(prompt_text)
+                        )
                 except (json.JSONDecodeError, OSError) as e:
                     logger.debug("Failed to read update prompt: %s", e)
 

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -48,6 +48,28 @@ _EMAIL_ADDRESS_RE = re.compile(
     r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"
     r"(?![A-Za-z0-9._%+-])"
 )
+_MESSAGE_FIELD_SINGLE_RE = re.compile(
+    r"\b(?P<key>msg|message|prompt|response|content)="
+    r"'(?:\\.|[^'\\])*'"
+)
+_MESSAGE_FIELD_DOUBLE_RE = re.compile(
+    r'\b(?P<key>msg|message|prompt|response|content)="'
+    r'(?:\\.|[^"\\])*"'
+)
+_MESSAGE_FIELD_BARE_RE = re.compile(
+    r"\b(?P<key>msg|message|prompt|response|content)=(?!['\"])[^\s]+"
+)
+_USER_FIELD_RE = re.compile(
+    r"\b(?P<key>user|user_id)="
+    r".*?"
+    r"(?=\s+(?:platform|user|user_id|chat|chat_id|session|session_id|thread|"
+    r"thread_id|msg|message|prompt|response|content)=|$)"
+)
+_IDENTITY_TOKEN_FIELD_RE = re.compile(
+    r"\b(?P<key>chat|chat_id|session|session_id|thread|thread_id)=[^\s]+"
+)
+_UNIX_HOME_COMPONENT_RE = re.compile(r"(?<![\w.-])/(?:home|Users)/[^/\s:'\"]+")
+_WINDOWS_HOME_COMPONENT_RE = re.compile(r"(?i)\b[A-Z]:\\Users\\[^\\\s:'\"]+")
 
 
 # ---------------------------------------------------------------------------
@@ -394,20 +416,65 @@ def _resolve_log_path(log_name: str) -> Optional[Path]:
 
 
 def _redact_log_text(text: str) -> str:
-    """Run ``redact_sensitive_text`` with ``force=True`` over upload-bound text.
+    """Run forced secret and privacy redaction over upload-bound text.
 
-    Uses ``force=True`` so redaction fires regardless of the operator's
-    ``security.redact_secrets`` setting. The local on-disk log file is
-    not modified; only the in-memory copy headed for the public paste
-    service is sanitized. Returns the redacted text (or the original
-    when empty / non-string).
+    Uses ``force=True`` so secret redaction fires regardless of the operator's
+    ``security.redact_secrets`` setting. A second debug-share-only pass removes
+    common PII-bearing log fields such as user/chat identifiers, message
+    snippets, and local home paths. The on-disk log file is never modified;
+    only the in-memory copy headed for the public paste service is sanitized.
     """
     if not text:
         return text
     from agent.redact import redact_sensitive_text
 
     text = redact_sensitive_text(text, force=True)
-    return _EMAIL_ADDRESS_RE.sub("[REDACTED_EMAIL]", text)
+    return _redact_debug_share_privacy(text)
+
+
+def _redact_debug_share_privacy(text: str) -> str:
+    """Remove personal context that is not covered by secret redaction."""
+    text = _EMAIL_ADDRESS_RE.sub("[REDACTED_EMAIL]", text)
+    text = _MESSAGE_FIELD_SINGLE_RE.sub(
+        lambda m: f"{m.group('key')}='[REDACTED_MESSAGE]'", text
+    )
+    text = _MESSAGE_FIELD_DOUBLE_RE.sub(
+        lambda m: f'{m.group("key")}="[REDACTED_MESSAGE]"', text
+    )
+    text = _MESSAGE_FIELD_BARE_RE.sub(
+        lambda m: f"{m.group('key')}=[REDACTED_MESSAGE]", text
+    )
+    text = _USER_FIELD_RE.sub(
+        lambda m: f"{m.group('key')}=[REDACTED_ID]", text
+    )
+    text = _IDENTITY_TOKEN_FIELD_RE.sub(
+        lambda m: f"{m.group('key')}=[REDACTED_ID]", text
+    )
+
+    for raw_path, replacement in _privacy_path_replacements():
+        text = text.replace(raw_path, replacement)
+        text = text.replace(raw_path.replace("\\", "/"), replacement.replace("\\", "/"))
+
+    text = _UNIX_HOME_COMPONENT_RE.sub("~", text)
+    return _WINDOWS_HOME_COMPONENT_RE.sub("~", text)
+
+
+def _privacy_path_replacements() -> list[tuple[str, str]]:
+    """Return local paths that should not be exposed in public debug pastes."""
+    replacements: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    candidates = [
+        (get_hermes_home(), "~/.hermes"),
+        (Path.home(), "~"),
+    ]
+
+    for path, replacement in candidates:
+        raw = str(path)
+        if raw and raw not in seen:
+            seen.add(raw)
+            replacements.append((raw, replacement))
+
+    return replacements
 
 
 def _capture_log_snapshot(

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -48,6 +48,28 @@ _EMAIL_ADDRESS_RE = re.compile(
     r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"
     r"(?![A-Za-z0-9._%+-])"
 )
+_MESSAGE_FIELD_SINGLE_RE = re.compile(
+    r"\b(?P<key>msg|message|prompt|response|content)="
+    r"'(?:\\.|[^'\\])*'"
+)
+_MESSAGE_FIELD_DOUBLE_RE = re.compile(
+    r'\b(?P<key>msg|message|prompt|response|content)="'
+    r'(?:\\.|[^"\\])*"'
+)
+_MESSAGE_FIELD_BARE_RE = re.compile(
+    r"\b(?P<key>msg|message|prompt|response|content)=(?!['\"])[^\s]+"
+)
+_USER_FIELD_RE = re.compile(
+    r"\b(?P<key>user|user_id)="
+    r".*?"
+    r"(?=\s+(?:platform|user|user_id|chat|chat_id|session|session_id|thread|"
+    r"thread_id|msg|message|prompt|response|content)=|$)"
+)
+_IDENTITY_TOKEN_FIELD_RE = re.compile(
+    r"\b(?P<key>chat|chat_id|session|session_id|thread|thread_id)=[^\s]+"
+)
+_UNIX_HOME_COMPONENT_RE = re.compile(r"(?<![\w.-])/(?:home|Users)/[^/\s:'\"]+")
+_WINDOWS_HOME_COMPONENT_RE = re.compile(r"(?i)\b[A-Z]:\\Users\\[^\\\s:'\"]+")
 
 
 # ---------------------------------------------------------------------------
@@ -423,20 +445,65 @@ def _resolve_log_path(log_name: str) -> Optional[Path]:
 
 
 def _redact_log_text(text: str) -> str:
-    """Run ``redact_sensitive_text`` with ``force=True`` over upload-bound text.
+    """Run forced secret and privacy redaction over upload-bound text.
 
-    Uses ``force=True`` so redaction fires regardless of the operator's
-    ``security.redact_secrets`` setting. The local on-disk log file is
-    not modified; only the in-memory copy headed for the public paste
-    service is sanitized. Returns the redacted text (or the original
-    when empty / non-string).
+    Uses ``force=True`` so secret redaction fires regardless of the operator's
+    ``security.redact_secrets`` setting. A second debug-share-only pass removes
+    common PII-bearing log fields such as user/chat identifiers, message
+    snippets, and local home paths. The on-disk log file is never modified;
+    only the in-memory copy headed for the public paste service is sanitized.
     """
     if not text:
         return text
     from agent.redact import redact_sensitive_text
 
     text = redact_sensitive_text(text, force=True)
-    return _EMAIL_ADDRESS_RE.sub("[REDACTED_EMAIL]", text)
+    return _redact_debug_share_privacy(text)
+
+
+def _redact_debug_share_privacy(text: str) -> str:
+    """Remove personal context that is not covered by secret redaction."""
+    text = _EMAIL_ADDRESS_RE.sub("[REDACTED_EMAIL]", text)
+    text = _MESSAGE_FIELD_SINGLE_RE.sub(
+        lambda m: f"{m.group('key')}='[REDACTED_MESSAGE]'", text
+    )
+    text = _MESSAGE_FIELD_DOUBLE_RE.sub(
+        lambda m: f'{m.group("key")}="[REDACTED_MESSAGE]"', text
+    )
+    text = _MESSAGE_FIELD_BARE_RE.sub(
+        lambda m: f"{m.group('key')}=[REDACTED_MESSAGE]", text
+    )
+    text = _USER_FIELD_RE.sub(
+        lambda m: f"{m.group('key')}=[REDACTED_ID]", text
+    )
+    text = _IDENTITY_TOKEN_FIELD_RE.sub(
+        lambda m: f"{m.group('key')}=[REDACTED_ID]", text
+    )
+
+    for raw_path, replacement in _privacy_path_replacements():
+        text = text.replace(raw_path, replacement)
+        text = text.replace(raw_path.replace("\\", "/"), replacement.replace("\\", "/"))
+
+    text = _UNIX_HOME_COMPONENT_RE.sub("~", text)
+    return _WINDOWS_HOME_COMPONENT_RE.sub("~", text)
+
+
+def _privacy_path_replacements() -> list[tuple[str, str]]:
+    """Return local paths that should not be exposed in public debug pastes."""
+    replacements: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    candidates = [
+        (get_hermes_home(), "~/.hermes"),
+        (Path.home(), "~"),
+    ]
+
+    for path, replacement in candidates:
+        raw = str(path)
+        if raw and raw not in seen:
+            seen.add(raw)
+            replacements.append((raw, replacement))
+
+    return replacements
 
 
 def _capture_log_snapshot(

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -20,6 +20,7 @@ Currently supports:
 import datetime
 import gzip
 import io
+import ipaddress
 import json
 import logging
 import re
@@ -39,7 +40,8 @@ logger = logging.getLogger(__name__)
 # Visible in the public paste so reviewers know the content was sanitized.
 # Kept short; the trailing newline guarantees the banner sits on its own line.
 _REDACTION_BANNER = (
-    "[hermes debug share: log content redacted at upload time. "
+    "[hermes debug share: best-effort secret and privacy redaction applied "
+    "at upload time; unrecognized personal data may remain. "
     "run with --no-redact to disable]\n"
 )
 
@@ -49,25 +51,122 @@ _EMAIL_ADDRESS_RE = re.compile(
     r"(?![A-Za-z0-9._%+-])"
 )
 _MESSAGE_FIELD_SINGLE_RE = re.compile(
-    r"\b(?P<key>msg|message|prompt|response|content)="
-    r"'(?:\\.|[^'\\])*'"
+    r"\b(?P<key>msg|message|prompt|response|content|text|answer|body|quote|root|"
+    r"target|title|url|reply_to_text|tool_output)="
+    r"'(?:\\[^\r\n]|[^'\\\r\n])*'"
 )
 _MESSAGE_FIELD_DOUBLE_RE = re.compile(
-    r'\b(?P<key>msg|message|prompt|response|content)="'
-    r'(?:\\.|[^"\\])*"'
+    r'\b(?P<key>msg|message|prompt|response|content|text|answer|body|quote|root|'
+    r'target|title|url|reply_to_text|tool_output)="'
+    r'(?:\\[^\r\n]|[^"\\\r\n])*"'
 )
 _MESSAGE_FIELD_BARE_RE = re.compile(
-    r"\b(?P<key>msg|message|prompt|response|content)=(?!['\"])[^\s]+"
+    r"\b(?P<key>msg|message|prompt|response|content|text|answer|body|quote|root|"
+    r"target|title|url|reply_to_text|tool_output)="
+    r"(?!['\"]).*?(?=\s+[A-Za-z_][\w.-]*=|$)",
+    re.MULTILINE,
+)
+_MESSAGE_FIELD_MALFORMED_SINGLE_RE = re.compile(
+    r"\b(?P<key>msg|message|prompt|response|content|text|answer|body|quote|root|"
+    r"target|title|url|reply_to_text|tool_output)="
+    r"'(?![^'\r\n]*')[^\r\n]*(?=\r?$)",
+    re.MULTILINE,
+)
+_MESSAGE_FIELD_MALFORMED_DOUBLE_RE = re.compile(
+    r'\b(?P<key>msg|message|prompt|response|content|text|answer|body|quote|root|'
+    r'target|title|url|reply_to_text|tool_output)='
+    r'"(?![^"\r\n]*")[^\r\n]*(?=\r?$)',
+    re.MULTILINE,
 )
 _USER_FIELD_RE = re.compile(
-    r"\b(?P<key>user|user_id)="
+    r"\b(?P<key>user|user_id|username|display_name|sender)="
     r".*?"
-    r"(?=\s+(?:platform|user|user_id|chat|chat_id|session|session_id|thread|"
-    r"thread_id|msg|message|prompt|response|content)=|$)"
+    r"(?=\s+[A-Za-z_][\w.-]*=|$)",
+    re.MULTILINE,
 )
 _IDENTITY_TOKEN_FIELD_RE = re.compile(
-    r"\b(?P<key>chat|chat_id|session|session_id|thread|thread_id)=[^\s]+"
+    r"\b(?P<key>chat|chat_id|room|room_id|peer|peer_id|session|session_id|"
+    r"thread|thread_id|reply_to_id|file_token|comment_id|reply_id|event_id|"
+    r"from_open_id|to_open_id|wiki_token|obj_token|file|comment|reply|from|to|"
+    r"token)=[^\s]+"
 )
+_UNAUTHORIZED_USER_RE = re.compile(
+    r"(?m)(?P<prefix>\bUnauthorized user:\s*)[^\s(]+"
+    r"(?:\s+\((?:[^\r\n)]|\)(?!\s+on\s+))*\))?"
+    r"(?P<suffix>\s+on\s+[^\s\r\n]+)"
+)
+_USER_PROMPT_RE = re.compile(r"(?im)(?P<prefix>\bUser prompt:\s*)[^\r\n]*")
+_WEBHOOK_RESPONSE_RE = re.compile(
+    r"(?im)(?P<prefix>\[(?:webhook|msgraph_webhook)\]\s+Response for\s*)[^\r\n]*?"
+    r"(?P<separator>:\s+)[^\r\n]*"
+)
+_WEBHOOK_DIRECT_DELIVER_RE = re.compile(
+    r"(?im)(?P<prefix>\[webhook\]\s+direct-deliver log-only:\s*)[^\r\n]*"
+)
+_TELEGRAM_BLOCKED_RE = re.compile(
+    r"(?im)(?P<prefix>\[Telegram\]\s+Blocked\s+(?:media from\s+)?"
+    r"unauthorized user\s+)[^\s\r\n]+(?P<middle>\s+in chat\s+)[^\s\r\n]+"
+)
+_VOICE_INPUT_RE = re.compile(
+    r"(?im)(?P<prefix>\bVoice input from user\s+)\d+(?P<separator>:\s*)[^\r\n]*"
+)
+_EMAIL_MESSAGE_RE = re.compile(
+    r"(?im)(?P<prefix>\[Email\]\s+New message from\s+)[^\s\r\n]+"
+    r"(?P<separator>:\s*)[^\r\n]*"
+)
+_EMAIL_SENT_REPLY_RE = re.compile(
+    r"(?im)(?P<prefix>\[Email\]\s+Sent reply to\s+)[^\s\r\n]+"
+    r"(?P<middle>\s+\(subject:\s*)[^\r\n)]*(?P<suffix>\))"
+)
+_TELEGRAM_UPDATE_ANSWER_RE = re.compile(
+    r"(?im)(?P<prefix>\bTelegram update prompt answered\s+)"
+    r"[^\r\n]*?(?P<middle>\s+by user\s+)[^\s\r\n]+"
+)
+_FEISHU_RAW_RESPONSE_RE = re.compile(
+    r"(?im)(?P<prefix>\[Feishu-Comment\]\s+API FAIL raw response:\s*)[^\r\n]*"
+)
+_FEISHU_API_REQUEST_RE = re.compile(
+    r"(?im)(?P<prefix>\[Feishu-Comment\]\s+API >>>\s+\S+\s+\S+)"
+    r"[^\r\n]*"
+)
+_FEISHU_META_VALUE_RE = re.compile(
+    r"(?im)(?P<prefix>\[Feishu-Comment\]\s+query_document_meta:"
+    r"[^\r\n]*?\svalue=)[^\r\n]*"
+)
+_FEISHU_FULL_PROMPT_RE = re.compile(
+    r"(?im)(?P<prefix>\[Feishu-Comment\]\s+Full prompt:\s*)[^\r\n]*"
+)
+_FEISHU_AGENT_RESPONSE_RE = re.compile(
+    r"(?im)(?P<prefix>\[Feishu-Comment\]\s+Agent response"
+    r"\s+\(\d+\s+chars\):\s*)[^\r\n]*"
+)
+_FEISHU_SESSION_RE = re.compile(
+    r"(?im)(?P<prefix>\[Feishu-Comment\]\s+Session\s+(?:expired|saved):\s*)"
+    r"[^\s\r\n]+"
+)
+_IMAGE_PROMPT_RE = re.compile(
+    r"(?im)(?P<prefix>\b(?:Editing|Generating) image[^\r\n]*?"
+    r"(?:prompt|prompt text):\s*)[^\r\n]*"
+)
+_FORWARDED_UPDATE_PROMPT_RE = re.compile(
+    r"(?im)(?P<prefix>\bForwarded update prompt to\s+)[^\s\r\n]+"
+    r"(?P<separator>:\s*)[^\r\n]*"
+)
+_DUPLICATE_VOICE_RE = re.compile(
+    r"(?im)(?P<prefix>\bSuppressing duplicate voice transcript for\s+)"
+    r"guild=[^\s\r\n]+\s+user=[^\s\r\n]+(?P<separator>:\s*)[^\r\n]*"
+)
+_LOG_RECORD_START_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}(?:[,.]\d+)?\s+[A-Z]+\b"
+)
+_IPV4_ADDRESS_RE = re.compile(
+    r"(?<![0-9A-Fa-f.])(?:\d{1,3}\.){3}\d{1,3}(?![0-9A-Fa-f.])"
+)
+_IPV6_ADDRESS_RE = re.compile(
+    r"(?<![0-9A-Fa-f:])(?:[0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4}"
+    r"(?:%[A-Za-z0-9_.-]+)?(?![0-9A-Fa-f:])"
+)
+_VERSION_VALUE_PREFIX_RE = re.compile(r"\b(?:version|ver)=\s*$", re.IGNORECASE)
 _UNIX_HOME_COMPONENT_RE = re.compile(r"(?<![\w.-])/(?:home|Users)/[^/\s:'\"]+")
 _WINDOWS_HOME_COMPONENT_RE = re.compile(r"(?i)\b[A-Z]:\\Users\\[^\\\s:'\"]+")
 
@@ -221,24 +320,38 @@ _PRIVACY_NOTICE = """\
 ⚠️  This will upload system info + logs to a PUBLIC paste service.
 
 Cryptographic secrets (API keys, tokens, passwords) are redacted before
-upload, but the following personal data is NOT redacted and will be public:
-  • Your display name and persistent platform user ID
-  • Verbatim content of your recent messages (prompts, responses, tool output)
-  • Local filesystem paths
-  • Any other PII present in the logs
+upload. Best-effort privacy redaction also removes common email and IP
+addresses, user/chat/session identifiers, message-like fields, known
+positional log formats, and local home paths.
 
-The resulting URL is public to anyone who has the link. Pastes auto-delete
-after 6 hours, but may be archived by third parties in the meantime.
+Logs may still contain personal data in formats Hermes does not recognize.
+Review the report with --local before uploading when the logs are sensitive.
+
+The resulting URL is public to anyone who has the link. Hermes schedules
+best-effort deletion after 6 hours, but the paste may remain available or be
+archived by third parties.
 
 Use --local to view the report without uploading.
 """
 
+_NO_REDACTION_PRIVACY_NOTICE = """\
+⚠️  This will upload system info + logs to a PUBLIC paste service.
+
+--no-redact is set. Cryptographic secrets and personal data will be uploaded
+without upload-time redaction. Review the report with --local first.
+
+The resulting URL is public to anyone who has the link. Hermes schedules
+best-effort deletion after 6 hours, but the paste may remain available or be
+archived by third parties.
+"""
+
 _GATEWAY_PRIVACY_NOTICE = (
     "⚠️ **Privacy notice:** This uploads system info + recent log tails "
-    "(may contain conversation fragments) to a public paste service. "
+    "to a public paste service. Best-effort secret and privacy redaction is "
+    "applied, but unrecognized personal data may remain. "
     "Full logs are NOT included from the gateway — use `hermes debug share` "
     "from the CLI for full log uploads.\n"
-    "Pastes auto-delete after 6 hours."
+    "Hermes schedules best-effort deletion after 6 hours; availability may persist."
 )
 
 
@@ -464,6 +577,13 @@ def _redact_log_text(text: str) -> str:
 def _redact_debug_share_privacy(text: str) -> str:
     """Remove personal context that is not covered by secret redaction."""
     text = _EMAIL_ADDRESS_RE.sub("[REDACTED_EMAIL]", text)
+    text = _DUPLICATE_VOICE_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}guild=[REDACTED_ID] user=[REDACTED_ID]"
+            f"{m.group('separator')}[REDACTED_MESSAGE]"
+        ),
+        text,
+    )
     text = _MESSAGE_FIELD_SINGLE_RE.sub(
         lambda m: f"{m.group('key')}='[REDACTED_MESSAGE]'", text
     )
@@ -473,12 +593,106 @@ def _redact_debug_share_privacy(text: str) -> str:
     text = _MESSAGE_FIELD_BARE_RE.sub(
         lambda m: f"{m.group('key')}=[REDACTED_MESSAGE]", text
     )
+    text = _MESSAGE_FIELD_MALFORMED_SINGLE_RE.sub(
+        lambda m: f"{m.group('key')}='[REDACTED_MESSAGE]'",
+        text,
+    )
+    text = _MESSAGE_FIELD_MALFORMED_DOUBLE_RE.sub(
+        lambda m: f'{m.group("key")}="[REDACTED_MESSAGE]"',
+        text,
+    )
     text = _USER_FIELD_RE.sub(
         lambda m: f"{m.group('key')}=[REDACTED_ID]", text
     )
     text = _IDENTITY_TOKEN_FIELD_RE.sub(
         lambda m: f"{m.group('key')}=[REDACTED_ID]", text
     )
+    text = _UNAUTHORIZED_USER_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}[REDACTED_ID] ([REDACTED_NAME])"
+            f"{m.group('suffix')}"
+        ),
+        text,
+    )
+    text = _USER_PROMPT_RE.sub(
+        lambda m: f"{m.group('prefix')}[REDACTED_MESSAGE]", text
+    )
+    text = _WEBHOOK_RESPONSE_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}[REDACTED_ID]"
+            f"{m.group('separator')}[REDACTED_MESSAGE]"
+        ),
+        text,
+    )
+    text = _WEBHOOK_DIRECT_DELIVER_RE.sub(
+        lambda m: f"{m.group('prefix')}[REDACTED_MESSAGE]", text
+    )
+    text = _TELEGRAM_BLOCKED_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}[REDACTED_ID]"
+            f"{m.group('middle')}[REDACTED_ID]"
+        ),
+        text,
+    )
+    text = _VOICE_INPUT_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}[REDACTED_ID]"
+            f"{m.group('separator')}[REDACTED_MESSAGE]"
+        ),
+        text,
+    )
+    text = _EMAIL_MESSAGE_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}[REDACTED_EMAIL]"
+            f"{m.group('separator')}[REDACTED_MESSAGE]"
+        ),
+        text,
+    )
+    text = _EMAIL_SENT_REPLY_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}[REDACTED_EMAIL]"
+            f"{m.group('middle')}[REDACTED_MESSAGE]{m.group('suffix')}"
+        ),
+        text,
+    )
+    text = _TELEGRAM_UPDATE_ANSWER_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}[REDACTED_MESSAGE]"
+            f"{m.group('middle')}[REDACTED_ID]"
+        ),
+        text,
+    )
+    text = _FEISHU_RAW_RESPONSE_RE.sub(
+        lambda m: f"{m.group('prefix')}[REDACTED_MESSAGE]", text
+    )
+    text = _FEISHU_API_REQUEST_RE.sub(
+        lambda m: f"{m.group('prefix')} [REDACTED_REQUEST_METADATA]", text
+    )
+    text = _FEISHU_META_VALUE_RE.sub(
+        lambda m: f"{m.group('prefix')}[REDACTED_MESSAGE]", text
+    )
+    text = _FEISHU_FULL_PROMPT_RE.sub(
+        lambda m: f"{m.group('prefix')}[REDACTED_MESSAGE]", text
+    )
+    text = _FEISHU_AGENT_RESPONSE_RE.sub(
+        lambda m: f"{m.group('prefix')}[REDACTED_MESSAGE]", text
+    )
+    text = _FEISHU_SESSION_RE.sub(
+        lambda m: f"{m.group('prefix')}[REDACTED_ID]", text
+    )
+    text = _IMAGE_PROMPT_RE.sub(
+        lambda m: f"{m.group('prefix')}[REDACTED_MESSAGE]", text
+    )
+    text = _FORWARDED_UPDATE_PROMPT_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}[REDACTED_ID]"
+            f"{m.group('separator')}[REDACTED_MESSAGE]"
+        ),
+        text,
+    )
+    text = _redact_message_continuations(text)
+    text = _IPV4_ADDRESS_RE.sub(_redact_ipv4_address, text)
+    text = _IPV6_ADDRESS_RE.sub(_redact_ipv6_address, text)
 
     for raw_path, replacement in _privacy_path_replacements():
         text = text.replace(raw_path, replacement)
@@ -486,6 +700,44 @@ def _redact_debug_share_privacy(text: str) -> str:
 
     text = _UNIX_HOME_COMPONENT_RE.sub("~", text)
     return _WINDOWS_HOME_COMPONENT_RE.sub("~", text)
+
+
+def _redact_message_continuations(text: str) -> str:
+    """Redact newline continuations after a sensitive framed log record."""
+    lines = text.splitlines(keepends=True)
+    redact_continuation = False
+    for index, line in enumerate(lines):
+        is_record_start = bool(_LOG_RECORD_START_RE.match(line))
+        if is_record_start:
+            redact_continuation = "[REDACTED_MESSAGE]" in line
+            continue
+        if redact_continuation and line.strip():
+            newline = "\r\n" if line.endswith("\r\n") else "\n" if line.endswith("\n") else ""
+            lines[index] = f"[REDACTED_MESSAGE_CONTINUATION]{newline}"
+    return "".join(lines)
+
+
+def _redact_ipv4_address(match: re.Match[str]) -> str:
+    """Redact valid IPv4 addresses without treating version-like text as IP."""
+    prefix = match.string[max(0, match.start() - 24) : match.start()]
+    if _VERSION_VALUE_PREFIX_RE.search(prefix):
+        return match.group(0)
+    try:
+        ipaddress.ip_address(match.group(0))
+    except ValueError:
+        return match.group(0)
+    return "[REDACTED_IP]"
+
+
+def _redact_ipv6_address(match: re.Match[str]) -> str:
+    """Redact valid IPv6 addresses, including scoped link-local forms."""
+    candidate = match.group(0)
+    address = candidate.split("%", 1)[0]
+    try:
+        parsed = ipaddress.ip_address(address)
+    except ValueError:
+        return candidate
+    return "[REDACTED_IP]" if parsed.version == 6 else candidate
 
 
 def _privacy_path_replacements() -> list[tuple[str, str]]:
@@ -593,7 +845,10 @@ def _capture_log_snapshot(
 
         return LogSnapshot(path=log_path, tail_text=tail_text, full_text=full_text)
     except Exception as exc:
-        return LogSnapshot(path=log_path, tail_text=f"(error reading: {exc})", full_text=None)
+        error_text = f"(error reading: {exc})"
+        if redact:
+            error_text = _redact_log_text(error_text)
+        return LogSnapshot(path=log_path, tail_text=error_text, full_text=None)
 
 
 def _capture_default_log_snapshots(
@@ -754,17 +1009,20 @@ def collect_share_bundle(
     if desktop_log:
         desktop_log = dump_text + "\n\n--- full desktop.log ---\n" + desktop_log
 
-    # Visible banner so reviewers know redaction was applied at upload time.
+    # Apply the privacy boundary to every complete upload payload.  Log
+    # snapshots are already redacted above, but this final pass also covers
+    # diagnostic-dump output, snapshot error strings, and any future content
+    # added to the bundle outside the snapshot collector.
     if redact:
-        report = _REDACTION_BANNER + report
+        report = _REDACTION_BANNER + _redact_log_text(report)
         if agent_log:
-            agent_log = _REDACTION_BANNER + agent_log
+            agent_log = _REDACTION_BANNER + _redact_log_text(agent_log)
         if gateway_log:
-            gateway_log = _REDACTION_BANNER + gateway_log
+            gateway_log = _REDACTION_BANNER + _redact_log_text(gateway_log)
         if gui_log:
-            gui_log = _REDACTION_BANNER + gui_log
+            gui_log = _REDACTION_BANNER + _redact_log_text(gui_log)
         if desktop_log:
-            desktop_log = _REDACTION_BANNER + desktop_log
+            desktop_log = _REDACTION_BANNER + _redact_log_text(desktop_log)
 
     bundle: dict[str, str] = {"report": report}
     if agent_log:
@@ -944,7 +1202,7 @@ def run_debug_share(args):
         _run_debug_share_nous(args, log_lines=log_lines, redact=redact)
         return
 
-    print(_PRIVACY_NOTICE)
+    print(_PRIVACY_NOTICE if redact else _NO_REDACTION_PRIVACY_NOTICE)
     if not _confirm_upload(args):
         return
     print("Collecting debug report...")
@@ -971,7 +1229,7 @@ def run_debug_share(args):
         print(f"\n  (failed to upload: {', '.join(result.failures)})")
 
     hours = result.auto_delete_seconds // 3600
-    print(f"\n⏱  Pastes will auto-delete in {hours} hours.")
+    print(f"\n⏱  Hermes will attempt paste deletion in {hours} hours.")
 
     # Manual delete fallback
     print("To delete now:  hermes debug delete <url>")
@@ -1009,8 +1267,8 @@ def _run_debug_share_nous(args, *, log_lines: int, redact: bool) -> None:
         return
     if not redact:
         print(
-            "⚠️  --no-redact is set: secrets in your logs will NOT be redacted "
-            "before upload.\n"
+            "⚠️  --no-redact is set: secrets and personal data in your logs "
+            "will NOT be redacted before upload.\n"
         )
     print("Collecting debug report...")
     _best_effort_sweep_expired_pastes()
@@ -1107,7 +1365,7 @@ def run_debug(args):
         print("  --local      Print report locally instead of uploading")
         print("  --nous       Upload to Nous-internal storage (private, staff-only,")
         print("               auto-deletes in 14 days) instead of a public paste")
-        print("  --no-redact  Disable upload-time secret redaction (default: redact)")
+        print("  --no-redact  Disable upload-time secret and privacy redaction")
         print()
         print("Options (delete):")
         print("  <url> ...    One or more paste URLs to delete")

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -20,6 +20,7 @@ Currently supports:
 import datetime
 import gzip
 import io
+import ipaddress
 import json
 import logging
 import re
@@ -39,7 +40,8 @@ logger = logging.getLogger(__name__)
 # Visible in the public paste so reviewers know the content was sanitized.
 # Kept short; the trailing newline guarantees the banner sits on its own line.
 _REDACTION_BANNER = (
-    "[hermes debug share: log content redacted at upload time. "
+    "[hermes debug share: best-effort secret and privacy redaction applied "
+    "at upload time; unrecognized personal data may remain. "
     "run with --no-redact to disable]\n"
 )
 
@@ -49,25 +51,122 @@ _EMAIL_ADDRESS_RE = re.compile(
     r"(?![A-Za-z0-9._%+-])"
 )
 _MESSAGE_FIELD_SINGLE_RE = re.compile(
-    r"\b(?P<key>msg|message|prompt|response|content)="
-    r"'(?:\\.|[^'\\])*'"
+    r"\b(?P<key>msg|message|prompt|response|content|text|answer|body|quote|root|"
+    r"target|title|url|reply_to_text|tool_output)="
+    r"'(?:\\[^\r\n]|[^'\\\r\n])*'"
 )
 _MESSAGE_FIELD_DOUBLE_RE = re.compile(
-    r'\b(?P<key>msg|message|prompt|response|content)="'
-    r'(?:\\.|[^"\\])*"'
+    r'\b(?P<key>msg|message|prompt|response|content|text|answer|body|quote|root|'
+    r'target|title|url|reply_to_text|tool_output)="'
+    r'(?:\\[^\r\n]|[^"\\\r\n])*"'
 )
 _MESSAGE_FIELD_BARE_RE = re.compile(
-    r"\b(?P<key>msg|message|prompt|response|content)=(?!['\"])[^\s]+"
+    r"\b(?P<key>msg|message|prompt|response|content|text|answer|body|quote|root|"
+    r"target|title|url|reply_to_text|tool_output)="
+    r"(?!['\"]).*?(?=\s+[A-Za-z_][\w.-]*=|$)",
+    re.MULTILINE,
+)
+_MESSAGE_FIELD_MALFORMED_SINGLE_RE = re.compile(
+    r"\b(?P<key>msg|message|prompt|response|content|text|answer|body|quote|root|"
+    r"target|title|url|reply_to_text|tool_output)="
+    r"'(?![^'\r\n]*')[^\r\n]*(?=\r?$)",
+    re.MULTILINE,
+)
+_MESSAGE_FIELD_MALFORMED_DOUBLE_RE = re.compile(
+    r'\b(?P<key>msg|message|prompt|response|content|text|answer|body|quote|root|'
+    r'target|title|url|reply_to_text|tool_output)='
+    r'"(?![^"\r\n]*")[^\r\n]*(?=\r?$)',
+    re.MULTILINE,
 )
 _USER_FIELD_RE = re.compile(
-    r"\b(?P<key>user|user_id)="
+    r"\b(?P<key>user|user_id|username|display_name|sender)="
     r".*?"
-    r"(?=\s+(?:platform|user|user_id|chat|chat_id|session|session_id|thread|"
-    r"thread_id|msg|message|prompt|response|content)=|$)"
+    r"(?=\s+[A-Za-z_][\w.-]*=|$)",
+    re.MULTILINE,
 )
 _IDENTITY_TOKEN_FIELD_RE = re.compile(
-    r"\b(?P<key>chat|chat_id|session|session_id|thread|thread_id)=[^\s]+"
+    r"\b(?P<key>chat|chat_id|room|room_id|peer|peer_id|session|session_id|"
+    r"thread|thread_id|reply_to_id|file_token|comment_id|reply_id|event_id|"
+    r"from_open_id|to_open_id|wiki_token|obj_token|file|comment|reply|from|to|"
+    r"token)=[^\s]+"
 )
+_UNAUTHORIZED_USER_RE = re.compile(
+    r"(?m)(?P<prefix>\bUnauthorized user:\s*)[^\s(]+"
+    r"(?:\s+\((?:[^\r\n)]|\)(?!\s+on\s+))*\))?"
+    r"(?P<suffix>\s+on\s+[^\s\r\n]+)"
+)
+_USER_PROMPT_RE = re.compile(r"(?im)(?P<prefix>\bUser prompt:\s*)[^\r\n]*")
+_WEBHOOK_RESPONSE_RE = re.compile(
+    r"(?im)(?P<prefix>\[(?:webhook|msgraph_webhook)\]\s+Response for\s*)[^\r\n]*?"
+    r"(?P<separator>:\s+)[^\r\n]*"
+)
+_WEBHOOK_DIRECT_DELIVER_RE = re.compile(
+    r"(?im)(?P<prefix>\[webhook\]\s+direct-deliver log-only:\s*)[^\r\n]*"
+)
+_TELEGRAM_BLOCKED_RE = re.compile(
+    r"(?im)(?P<prefix>\[Telegram\]\s+Blocked\s+(?:media from\s+)?"
+    r"unauthorized user\s+)[^\s\r\n]+(?P<middle>\s+in chat\s+)[^\s\r\n]+"
+)
+_VOICE_INPUT_RE = re.compile(
+    r"(?im)(?P<prefix>\bVoice input from user\s+)\d+(?P<separator>:\s*)[^\r\n]*"
+)
+_EMAIL_MESSAGE_RE = re.compile(
+    r"(?im)(?P<prefix>\[Email\]\s+New message from\s+)[^\s\r\n]+"
+    r"(?P<separator>:\s*)[^\r\n]*"
+)
+_EMAIL_SENT_REPLY_RE = re.compile(
+    r"(?im)(?P<prefix>\[Email\]\s+Sent reply to\s+)[^\s\r\n]+"
+    r"(?P<middle>\s+\(subject:\s*)[^\r\n)]*(?P<suffix>\))"
+)
+_TELEGRAM_UPDATE_ANSWER_RE = re.compile(
+    r"(?im)(?P<prefix>\bTelegram update prompt answered\s+)"
+    r"[^\r\n]*?(?P<middle>\s+by user\s+)[^\s\r\n]+"
+)
+_FEISHU_RAW_RESPONSE_RE = re.compile(
+    r"(?im)(?P<prefix>\[Feishu-Comment\]\s+API FAIL raw response:\s*)[^\r\n]*"
+)
+_FEISHU_API_REQUEST_RE = re.compile(
+    r"(?im)(?P<prefix>\[Feishu-Comment\]\s+API >>>\s+\S+\s+\S+)"
+    r"[^\r\n]*"
+)
+_FEISHU_META_VALUE_RE = re.compile(
+    r"(?im)(?P<prefix>\[Feishu-Comment\]\s+query_document_meta:"
+    r"[^\r\n]*?\svalue=)[^\r\n]*"
+)
+_FEISHU_FULL_PROMPT_RE = re.compile(
+    r"(?im)(?P<prefix>\[Feishu-Comment\]\s+Full prompt:\s*)[^\r\n]*"
+)
+_FEISHU_AGENT_RESPONSE_RE = re.compile(
+    r"(?im)(?P<prefix>\[Feishu-Comment\]\s+Agent response"
+    r"\s+\(\d+\s+chars\):\s*)[^\r\n]*"
+)
+_FEISHU_SESSION_RE = re.compile(
+    r"(?im)(?P<prefix>\[Feishu-Comment\]\s+Session\s+(?:expired|saved):\s*)"
+    r"[^\s\r\n]+"
+)
+_IMAGE_PROMPT_RE = re.compile(
+    r"(?im)(?P<prefix>\b(?:Editing|Generating) image[^\r\n]*?"
+    r"(?:prompt|prompt text):\s*)[^\r\n]*"
+)
+_FORWARDED_UPDATE_PROMPT_RE = re.compile(
+    r"(?im)(?P<prefix>\bForwarded update prompt to\s+)[^\s\r\n]+"
+    r"(?P<separator>:\s*)[^\r\n]*"
+)
+_DUPLICATE_VOICE_RE = re.compile(
+    r"(?im)(?P<prefix>\bSuppressing duplicate voice transcript for\s+)"
+    r"guild=[^\s\r\n]+\s+user=[^\s\r\n]+(?P<separator>:\s*)[^\r\n]*"
+)
+_LOG_RECORD_START_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}(?:[,.]\d+)?\s+[A-Z]+\b"
+)
+_IPV4_ADDRESS_RE = re.compile(
+    r"(?<![0-9A-Fa-f.])(?:\d{1,3}\.){3}\d{1,3}(?![0-9A-Fa-f.])"
+)
+_IPV6_ADDRESS_RE = re.compile(
+    r"(?<![0-9A-Fa-f:])(?:[0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4}"
+    r"(?:%[A-Za-z0-9_.-]+)?(?![0-9A-Fa-f:])"
+)
+_VERSION_VALUE_PREFIX_RE = re.compile(r"\b(?:version|ver)=\s*$", re.IGNORECASE)
 _UNIX_HOME_COMPONENT_RE = re.compile(r"(?<![\w.-])/(?:home|Users)/[^/\s:'\"]+")
 _WINDOWS_HOME_COMPONENT_RE = re.compile(r"(?i)\b[A-Z]:\\Users\\[^\\\s:'\"]+")
 
@@ -221,24 +320,38 @@ _PRIVACY_NOTICE = """\
 ⚠️  This will upload system info + logs to a PUBLIC paste service.
 
 Cryptographic secrets (API keys, tokens, passwords) are redacted before
-upload, but the following personal data is NOT redacted and will be public:
-  • Your display name and persistent platform user ID
-  • Verbatim content of your recent messages (prompts, responses, tool output)
-  • Local filesystem paths
-  • Any other PII present in the logs
+upload. Best-effort privacy redaction also removes common email and IP
+addresses, user/chat/session identifiers, message-like fields, known
+positional log formats, and local home paths.
 
-The resulting URL is public to anyone who has the link. Pastes auto-delete
-after 6 hours, but may be archived by third parties in the meantime.
+Logs may still contain personal data in formats Hermes does not recognize.
+Review the report with --local before uploading when the logs are sensitive.
+
+The resulting URL is public to anyone who has the link. Hermes schedules
+best-effort deletion after 6 hours, but the paste may remain available or be
+archived by third parties.
 
 Use --local to view the report without uploading.
 """
 
+_NO_REDACTION_PRIVACY_NOTICE = """\
+⚠️  This will upload system info + logs to a PUBLIC paste service.
+
+--no-redact is set. Cryptographic secrets and personal data will be uploaded
+without upload-time redaction. Review the report with --local first.
+
+The resulting URL is public to anyone who has the link. Hermes schedules
+best-effort deletion after 6 hours, but the paste may remain available or be
+archived by third parties.
+"""
+
 _GATEWAY_PRIVACY_NOTICE = (
     "⚠️ **Privacy notice:** This uploads system info + recent log tails "
-    "(may contain conversation fragments) to a public paste service. "
+    "to a public paste service. Best-effort secret and privacy redaction is "
+    "applied, but unrecognized personal data may remain. "
     "Full logs are NOT included from the gateway — use `hermes debug share` "
     "from the CLI for full log uploads.\n"
-    "Pastes auto-delete after 6 hours."
+    "Hermes schedules best-effort deletion after 6 hours; availability may persist."
 )
 
 
@@ -435,6 +548,13 @@ def _redact_log_text(text: str) -> str:
 def _redact_debug_share_privacy(text: str) -> str:
     """Remove personal context that is not covered by secret redaction."""
     text = _EMAIL_ADDRESS_RE.sub("[REDACTED_EMAIL]", text)
+    text = _DUPLICATE_VOICE_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}guild=[REDACTED_ID] user=[REDACTED_ID]"
+            f"{m.group('separator')}[REDACTED_MESSAGE]"
+        ),
+        text,
+    )
     text = _MESSAGE_FIELD_SINGLE_RE.sub(
         lambda m: f"{m.group('key')}='[REDACTED_MESSAGE]'", text
     )
@@ -444,12 +564,106 @@ def _redact_debug_share_privacy(text: str) -> str:
     text = _MESSAGE_FIELD_BARE_RE.sub(
         lambda m: f"{m.group('key')}=[REDACTED_MESSAGE]", text
     )
+    text = _MESSAGE_FIELD_MALFORMED_SINGLE_RE.sub(
+        lambda m: f"{m.group('key')}='[REDACTED_MESSAGE]'",
+        text,
+    )
+    text = _MESSAGE_FIELD_MALFORMED_DOUBLE_RE.sub(
+        lambda m: f'{m.group("key")}="[REDACTED_MESSAGE]"',
+        text,
+    )
     text = _USER_FIELD_RE.sub(
         lambda m: f"{m.group('key')}=[REDACTED_ID]", text
     )
     text = _IDENTITY_TOKEN_FIELD_RE.sub(
         lambda m: f"{m.group('key')}=[REDACTED_ID]", text
     )
+    text = _UNAUTHORIZED_USER_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}[REDACTED_ID] ([REDACTED_NAME])"
+            f"{m.group('suffix')}"
+        ),
+        text,
+    )
+    text = _USER_PROMPT_RE.sub(
+        lambda m: f"{m.group('prefix')}[REDACTED_MESSAGE]", text
+    )
+    text = _WEBHOOK_RESPONSE_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}[REDACTED_ID]"
+            f"{m.group('separator')}[REDACTED_MESSAGE]"
+        ),
+        text,
+    )
+    text = _WEBHOOK_DIRECT_DELIVER_RE.sub(
+        lambda m: f"{m.group('prefix')}[REDACTED_MESSAGE]", text
+    )
+    text = _TELEGRAM_BLOCKED_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}[REDACTED_ID]"
+            f"{m.group('middle')}[REDACTED_ID]"
+        ),
+        text,
+    )
+    text = _VOICE_INPUT_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}[REDACTED_ID]"
+            f"{m.group('separator')}[REDACTED_MESSAGE]"
+        ),
+        text,
+    )
+    text = _EMAIL_MESSAGE_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}[REDACTED_EMAIL]"
+            f"{m.group('separator')}[REDACTED_MESSAGE]"
+        ),
+        text,
+    )
+    text = _EMAIL_SENT_REPLY_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}[REDACTED_EMAIL]"
+            f"{m.group('middle')}[REDACTED_MESSAGE]{m.group('suffix')}"
+        ),
+        text,
+    )
+    text = _TELEGRAM_UPDATE_ANSWER_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}[REDACTED_MESSAGE]"
+            f"{m.group('middle')}[REDACTED_ID]"
+        ),
+        text,
+    )
+    text = _FEISHU_RAW_RESPONSE_RE.sub(
+        lambda m: f"{m.group('prefix')}[REDACTED_MESSAGE]", text
+    )
+    text = _FEISHU_API_REQUEST_RE.sub(
+        lambda m: f"{m.group('prefix')} [REDACTED_REQUEST_METADATA]", text
+    )
+    text = _FEISHU_META_VALUE_RE.sub(
+        lambda m: f"{m.group('prefix')}[REDACTED_MESSAGE]", text
+    )
+    text = _FEISHU_FULL_PROMPT_RE.sub(
+        lambda m: f"{m.group('prefix')}[REDACTED_MESSAGE]", text
+    )
+    text = _FEISHU_AGENT_RESPONSE_RE.sub(
+        lambda m: f"{m.group('prefix')}[REDACTED_MESSAGE]", text
+    )
+    text = _FEISHU_SESSION_RE.sub(
+        lambda m: f"{m.group('prefix')}[REDACTED_ID]", text
+    )
+    text = _IMAGE_PROMPT_RE.sub(
+        lambda m: f"{m.group('prefix')}[REDACTED_MESSAGE]", text
+    )
+    text = _FORWARDED_UPDATE_PROMPT_RE.sub(
+        lambda m: (
+            f"{m.group('prefix')}[REDACTED_ID]"
+            f"{m.group('separator')}[REDACTED_MESSAGE]"
+        ),
+        text,
+    )
+    text = _redact_message_continuations(text)
+    text = _IPV4_ADDRESS_RE.sub(_redact_ipv4_address, text)
+    text = _IPV6_ADDRESS_RE.sub(_redact_ipv6_address, text)
 
     for raw_path, replacement in _privacy_path_replacements():
         text = text.replace(raw_path, replacement)
@@ -457,6 +671,44 @@ def _redact_debug_share_privacy(text: str) -> str:
 
     text = _UNIX_HOME_COMPONENT_RE.sub("~", text)
     return _WINDOWS_HOME_COMPONENT_RE.sub("~", text)
+
+
+def _redact_message_continuations(text: str) -> str:
+    """Redact newline continuations after a sensitive framed log record."""
+    lines = text.splitlines(keepends=True)
+    redact_continuation = False
+    for index, line in enumerate(lines):
+        is_record_start = bool(_LOG_RECORD_START_RE.match(line))
+        if is_record_start:
+            redact_continuation = "[REDACTED_MESSAGE]" in line
+            continue
+        if redact_continuation and line.strip():
+            newline = "\r\n" if line.endswith("\r\n") else "\n" if line.endswith("\n") else ""
+            lines[index] = f"[REDACTED_MESSAGE_CONTINUATION]{newline}"
+    return "".join(lines)
+
+
+def _redact_ipv4_address(match: re.Match[str]) -> str:
+    """Redact valid IPv4 addresses without treating version-like text as IP."""
+    prefix = match.string[max(0, match.start() - 24) : match.start()]
+    if _VERSION_VALUE_PREFIX_RE.search(prefix):
+        return match.group(0)
+    try:
+        ipaddress.ip_address(match.group(0))
+    except ValueError:
+        return match.group(0)
+    return "[REDACTED_IP]"
+
+
+def _redact_ipv6_address(match: re.Match[str]) -> str:
+    """Redact valid IPv6 addresses, including scoped link-local forms."""
+    candidate = match.group(0)
+    address = candidate.split("%", 1)[0]
+    try:
+        parsed = ipaddress.ip_address(address)
+    except ValueError:
+        return candidate
+    return "[REDACTED_IP]" if parsed.version == 6 else candidate
 
 
 def _privacy_path_replacements() -> list[tuple[str, str]]:
@@ -560,7 +812,10 @@ def _capture_log_snapshot(
 
         return LogSnapshot(path=log_path, tail_text=tail_text, full_text=full_text)
     except Exception as exc:
-        return LogSnapshot(path=log_path, tail_text=f"(error reading: {exc})", full_text=None)
+        error_text = f"(error reading: {exc})"
+        if redact:
+            error_text = _redact_log_text(error_text)
+        return LogSnapshot(path=log_path, tail_text=error_text, full_text=None)
 
 
 def _capture_default_log_snapshots(
@@ -721,17 +976,20 @@ def collect_share_bundle(
     if desktop_log:
         desktop_log = dump_text + "\n\n--- full desktop.log ---\n" + desktop_log
 
-    # Visible banner so reviewers know redaction was applied at upload time.
+    # Apply the privacy boundary to every complete upload payload.  Log
+    # snapshots are already redacted above, but this final pass also covers
+    # diagnostic-dump output, snapshot error strings, and any future content
+    # added to the bundle outside the snapshot collector.
     if redact:
-        report = _REDACTION_BANNER + report
+        report = _REDACTION_BANNER + _redact_log_text(report)
         if agent_log:
-            agent_log = _REDACTION_BANNER + agent_log
+            agent_log = _REDACTION_BANNER + _redact_log_text(agent_log)
         if gateway_log:
-            gateway_log = _REDACTION_BANNER + gateway_log
+            gateway_log = _REDACTION_BANNER + _redact_log_text(gateway_log)
         if gui_log:
-            gui_log = _REDACTION_BANNER + gui_log
+            gui_log = _REDACTION_BANNER + _redact_log_text(gui_log)
         if desktop_log:
-            desktop_log = _REDACTION_BANNER + desktop_log
+            desktop_log = _REDACTION_BANNER + _redact_log_text(desktop_log)
 
     bundle: dict[str, str] = {"report": report}
     if agent_log:
@@ -911,7 +1169,7 @@ def run_debug_share(args):
         _run_debug_share_nous(args, log_lines=log_lines, redact=redact)
         return
 
-    print(_PRIVACY_NOTICE)
+    print(_PRIVACY_NOTICE if redact else _NO_REDACTION_PRIVACY_NOTICE)
     if not _confirm_upload(args):
         return
     print("Collecting debug report...")
@@ -938,7 +1196,7 @@ def run_debug_share(args):
         print(f"\n  (failed to upload: {', '.join(result.failures)})")
 
     hours = result.auto_delete_seconds // 3600
-    print(f"\n⏱  Pastes will auto-delete in {hours} hours.")
+    print(f"\n⏱  Hermes will attempt paste deletion in {hours} hours.")
 
     # Manual delete fallback
     print("To delete now:  hermes debug delete <url>")
@@ -976,8 +1234,8 @@ def _run_debug_share_nous(args, *, log_lines: int, redact: bool) -> None:
         return
     if not redact:
         print(
-            "⚠️  --no-redact is set: secrets in your logs will NOT be redacted "
-            "before upload.\n"
+            "⚠️  --no-redact is set: secrets and personal data in your logs "
+            "will NOT be redacted before upload.\n"
         )
     print("Collecting debug report...")
     _best_effort_sweep_expired_pastes()
@@ -1074,7 +1332,7 @@ def run_debug(args):
         print("  --local      Print report locally instead of uploading")
         print("  --nous       Upload to Nous-internal storage (private, staff-only,")
         print("               auto-deletes in 14 days) instead of a public paste")
-        print("  --no-redact  Disable upload-time secret redaction (default: redact)")
+        print("  --no-redact  Disable upload-time secret and privacy redaction")
         print()
         print("Options (delete):")
         print("  <url> ...    One or more paste URLs to delete")

--- a/hermes_cli/subcommands/debug.py
+++ b/hermes_cli/subcommands/debug.py
@@ -29,7 +29,7 @@ Examples:
     hermes debug share --lines 500  Include more log lines
     hermes debug share --expire 30  Keep paste for 30 days
     hermes debug share --local      Print report locally (no upload)
-    hermes debug share --no-redact  Disable upload-time secret redaction
+    hermes debug share --no-redact  Disable best-effort secret and privacy redaction
     hermes debug share --nous       Upload to Nous-internal storage (private)
     hermes debug delete <url>       Delete a previously uploaded paste
 """,
@@ -70,10 +70,10 @@ Examples:
         "--no-redact",
         action="store_true",
         help=(
-            "Disable upload-time secret redaction (default: redact). Logs "
-            "are normally run through agent.redact.redact_sensitive_text "
-            "with force=True before upload so credentials are not leaked "
-            "into the public paste service."
+            "Disable upload-time best-effort secret and privacy redaction "
+            "(default: redact). The normal pass removes known credentials, "
+            "common personal identifiers, message-like fields, and local "
+            "home paths; unrecognized personal data may remain."
         ),
     )
     share_parser.add_argument(
@@ -83,8 +83,9 @@ Examples:
             "Upload the debug bundle to Nous-internal storage (AWS S3) instead "
             "of a public paste service. The bundle is private — viewable only "
             "by Nous staff (and allowlisted Discord mods) via a Google-login-"
-            "gated viewer — and auto-deletes after 14 days. Still force-redacts "
-            "secrets unless --no-redact is also passed."
+            "gated viewer — and auto-deletes after 14 days. Still applies "
+            "best-effort secret and privacy redaction unless --no-redact is "
+            "also passed."
         ),
     )
     delete_parser = debug_sub.add_parser(

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4910,7 +4910,7 @@ class DiscordAdapter(BasePlatformAdapter):
             if not transcript or is_whisper_hallucination(transcript):
                 return
 
-            logger.info("Voice input from user %d: %s", user_id, transcript[:100])
+            logger.info("Voice input transcribed (chars=%d)", len(transcript))
 
             if self._voice_input_callback:
                 await self._voice_input_callback(

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4395,7 +4395,7 @@ class DiscordAdapter(BasePlatformAdapter):
             if not transcript or is_whisper_hallucination(transcript):
                 return
 
-            logger.info("Voice input from user %d: %s", user_id, transcript[:100])
+            logger.info("Voice input transcribed (chars=%d)", len(transcript))
 
             if self._voice_input_callback:
                 await self._voice_input_callback(

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -605,7 +605,7 @@ class EmailAdapter(BasePlatformAdapter):
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
 
-        logger.info("[Email] Adapter initialized for %s", self._address)
+        logger.info("[Email] Adapter initialized")
 
     def _trim_seen_uids(self) -> None:
         """Keep only the most recent UIDs to prevent unbounded memory growth.
@@ -952,7 +952,7 @@ class EmailAdapter(BasePlatformAdapter):
         # Skip automated/noreply senders before any processing
         msg_headers = dict(msg.items())
         if _is_automated_sender(sender_addr, msg_headers):
-            logger.debug("[Email] Skipping automated sender: %s", sender_addr)
+            logger.debug("[Email] Skipping automated sender")
             return None
 
         # Verify the From: domain is authenticated (SPF/DKIM/DMARC)
@@ -1022,7 +1022,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         # Never reply to automated senders
         if _is_automated_sender(sender_addr, {}):
-            logger.debug("[Email] Dropping automated sender at dispatch: %s", sender_addr)
+            logger.debug("[Email] Dropping automated sender at dispatch")
             return
 
         # Skip senders not in EMAIL_ALLOWED_USERS — prevents the adapter
@@ -1037,14 +1037,13 @@ class EmailAdapter(BasePlatformAdapter):
             ):
                 logger.debug(
                     "[Email] Dropping sender at dispatch — EMAIL_ALLOWED_USERS is unset "
-                    "and open access is not opted in: %s",
-                    sender_addr,
+                    "and open access is not opted in"
                 )
                 return
         else:
             allowed = {addr.strip().lower() for addr in allowed_raw.split(",") if addr.strip()}
             if sender_addr.lower() not in allowed:
-                logger.debug("[Email] Dropping non-allowlisted sender at dispatch: %s", sender_addr)
+                logger.debug("[Email] Dropping non-allowlisted sender at dispatch")
                 return
 
         # Reject spoofed senders. The allowlist (and the gateway's own authz)
@@ -1064,12 +1063,10 @@ class EmailAdapter(BasePlatformAdapter):
             and not msg_data.get("sender_authenticated", False)
         ):
             logger.warning(
-                "[Email] Dropping sender with unauthenticated From: %s (%s). "
+                "[Email] Dropping sender with unauthenticated From. "
                 "If your mail server does not stamp Authentication-Results, set "
                 "platforms.email.require_authenticated_sender: false (or "
                 "EMAIL_TRUST_FROM_HEADER=true) to accept the risk.",
-                sender_addr,
-                msg_data.get("auth_reason", "no verdict"),
             )
             return
 
@@ -1124,7 +1121,7 @@ class EmailAdapter(BasePlatformAdapter):
             reply_to_message_id=msg_data["in_reply_to"] or None,
         )
 
-        logger.info("[Email] New message from %s: %s", sender_addr, subject)
+        logger.info("[Email] New message received (subject_chars=%d)", len(subject))
         await self.handle_message(event)
 
     async def send(
@@ -1142,7 +1139,7 @@ class EmailAdapter(BasePlatformAdapter):
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
-            logger.error("[Email] Send failed to %s: %s", chat_id, e)
+            logger.error("[Email] Send failed: %s", e)
             return SendResult(success=False, error=str(e))
 
     def _message_id_domain(self) -> str:
@@ -1195,7 +1192,7 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception:
                 smtp.close()
 
-        logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
+        logger.info("[Email] Sent reply (subject_chars=%d)", len(subject))
         return msg_id
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
@@ -1321,7 +1318,7 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception:
                 smtp.close()
 
-        logger.info("[Email] Sent multi-attachment email to %s (%d files)", to_addr, len(file_paths))
+        logger.info("[Email] Sent multi-attachment email (%d files)", len(file_paths))
         return msg_id
 
     async def send_document(

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -484,7 +484,7 @@ class EmailAdapter(BasePlatformAdapter):
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
 
-        logger.info("[Email] Adapter initialized for %s", self._address)
+        logger.info("[Email] Adapter initialized")
 
     def _trim_seen_uids(self) -> None:
         """Keep only the most recent UIDs to prevent unbounded memory growth.
@@ -707,7 +707,7 @@ class EmailAdapter(BasePlatformAdapter):
                     # Skip automated/noreply senders before any processing
                     msg_headers = dict(msg.items())
                     if _is_automated_sender(sender_addr, msg_headers):
-                        logger.debug("[Email] Skipping automated sender: %s", sender_addr)
+                        logger.debug("[Email] Skipping automated sender")
                         continue
 
                     # Verify the From: domain is authenticated (SPF/DKIM/DMARC)
@@ -785,7 +785,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         # Never reply to automated senders
         if _is_automated_sender(sender_addr, {}):
-            logger.debug("[Email] Dropping automated sender at dispatch: %s", sender_addr)
+            logger.debug("[Email] Dropping automated sender at dispatch")
             return
 
         # Skip senders not in EMAIL_ALLOWED_USERS — prevents the adapter
@@ -800,14 +800,13 @@ class EmailAdapter(BasePlatformAdapter):
             ):
                 logger.debug(
                     "[Email] Dropping sender at dispatch — EMAIL_ALLOWED_USERS is unset "
-                    "and open access is not opted in: %s",
-                    sender_addr,
+                    "and open access is not opted in"
                 )
                 return
         else:
             allowed = {addr.strip().lower() for addr in allowed_raw.split(",") if addr.strip()}
             if sender_addr.lower() not in allowed:
-                logger.debug("[Email] Dropping non-allowlisted sender at dispatch: %s", sender_addr)
+                logger.debug("[Email] Dropping non-allowlisted sender at dispatch")
                 return
 
         # Reject spoofed senders. The allowlist (and the gateway's own authz)
@@ -827,12 +826,10 @@ class EmailAdapter(BasePlatformAdapter):
             and not msg_data.get("sender_authenticated", False)
         ):
             logger.warning(
-                "[Email] Dropping sender with unauthenticated From: %s (%s). "
+                "[Email] Dropping sender with unauthenticated From. "
                 "If your mail server does not stamp Authentication-Results, set "
                 "platforms.email.require_authenticated_sender: false (or "
                 "EMAIL_TRUST_FROM_HEADER=true) to accept the risk.",
-                sender_addr,
-                msg_data.get("auth_reason", "no verdict"),
             )
             return
 
@@ -887,7 +884,7 @@ class EmailAdapter(BasePlatformAdapter):
             reply_to_message_id=msg_data["in_reply_to"] or None,
         )
 
-        logger.info("[Email] New message from %s: %s", sender_addr, subject)
+        logger.info("[Email] New message received (subject_chars=%d)", len(subject))
         await self.handle_message(event)
 
     async def send(
@@ -905,7 +902,7 @@ class EmailAdapter(BasePlatformAdapter):
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
-            logger.error("[Email] Send failed to %s: %s", chat_id, e)
+            logger.error("[Email] Send failed: %s", e)
             return SendResult(success=False, error=str(e))
 
     def _message_id_domain(self) -> str:
@@ -958,7 +955,7 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception:
                 smtp.close()
 
-        logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
+        logger.info("[Email] Sent reply (subject_chars=%d)", len(subject))
         return msg_id
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
@@ -1084,7 +1081,7 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception:
                 smtp.close()
 
-        logger.info("[Email] Sent multi-attachment email to %s (%d files)", to_addr, len(file_paths))
+        logger.info("[Email] Sent multi-attachment email (%d files)", len(file_paths))
         return msg_id
 
     async def send_document(

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2979,10 +2979,7 @@ class FeishuAdapter(BasePlatformAdapter):
             return
         try:
             self._write_update_prompt_response(answer)
-            logger.info(
-                "Feishu update prompt resolved for session %s (answer=%s, user=%s)",
-                state["session_key"], answer, user_name,
-            )
+            logger.info("Feishu update prompt resolved")
         except Exception as exc:
             logger.error("Failed to resolve Feishu update prompt: %s", exc)
 
@@ -3355,21 +3352,10 @@ class FeishuAdapter(BasePlatformAdapter):
         )
         reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
 
-        sender_primary = (
-            getattr(sender_id, "open_id", None)
-            or getattr(sender_id, "user_id", None)
-            or getattr(sender_id, "union_id", None)
-            or "<unknown>"
-        )
         logger.info(
-            "[Feishu] Inbound %s message received: id=%s type=%s chat_id=%s sender=%s:%s text=%r media=%d",
+            "[Feishu] Inbound %s message received: type=%s media=%d",
             "dm" if chat_type == "p2p" else "group",
-            message_id,
             inbound_type.value,
-            getattr(message, "chat_id", "") or "",
-            "bot" if is_bot else "user",
-            sender_primary,
-            text[:120],
             len(media_urls),
         )
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2931,10 +2931,7 @@ class FeishuAdapter(BasePlatformAdapter):
             return
         try:
             self._write_update_prompt_response(answer)
-            logger.info(
-                "Feishu update prompt resolved for session %s (answer=%s, user=%s)",
-                state["session_key"], answer, user_name,
-            )
+            logger.info("Feishu update prompt resolved")
         except Exception as exc:
             logger.error("Failed to resolve Feishu update prompt: %s", exc)
 
@@ -3307,21 +3304,10 @@ class FeishuAdapter(BasePlatformAdapter):
         )
         reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
 
-        sender_primary = (
-            getattr(sender_id, "open_id", None)
-            or getattr(sender_id, "user_id", None)
-            or getattr(sender_id, "union_id", None)
-            or "<unknown>"
-        )
         logger.info(
-            "[Feishu] Inbound %s message received: id=%s type=%s chat_id=%s sender=%s:%s text=%r media=%d",
+            "[Feishu] Inbound %s message received: type=%s media=%d",
             "dm" if chat_type == "p2p" else "group",
-            message_id,
             inbound_type.value,
-            getattr(message, "chat_id", "") or "",
-            "bot" if is_bot else "user",
-            sender_primary,
-            text[:120],
             len(media_urls),
         )
 

--- a/plugins/platforms/feishu/feishu_comment.py
+++ b/plugins/platforms/feishu/feishu_comment.py
@@ -59,9 +59,7 @@ def _build_request(method: str, uri: str, paths=None, queries=None, body=None):
 
 async def _exec_request(client, method, uri, paths=None, queries=None, body=None):
     """Execute a lark API request and return (code, msg, data_dict)."""
-    logger.info("[Feishu-Comment] API >>> %s %s paths=%s queries=%s body=%s",
-                 method, uri, paths, queries,
-                 json.dumps(body, ensure_ascii=False)[:500] if body else None)
+    logger.info("[Feishu-Comment] API >>> %s %s", method, uri)
     request = _build_request(method, uri, paths, queries, body)
     response = await asyncio.to_thread(client.request, request)
 
@@ -83,15 +81,15 @@ async def _exec_request(client, method, uri, paths=None, queries=None, body=None
         elif resp_data and hasattr(resp_data, "__dict__"):
             data = vars(resp_data)
 
-    logger.info("[Feishu-Comment] API <<< %s %s code=%s msg=%s data_keys=%s",
-                 method, uri, code, msg, list(data.keys()) if data else "empty")
+    logger.info(
+        "[Feishu-Comment] API <<< %s %s code=%s data_keys=%s",
+        method,
+        uri,
+        code,
+        list(data.keys()) if data else "empty",
+    )
     if code != 0:
-        # Log raw response for debugging failed API calls
-        raw = getattr(response, "raw", None)
-        raw_content = ""
-        if raw and hasattr(raw, "content"):
-            raw_content = raw.content[:500] if isinstance(raw.content, (str, bytes)) else str(raw.content)[:500]
-        logger.warning("[Feishu-Comment] API FAIL raw response: %s", raw_content)
+        logger.warning("[Feishu-Comment] API request failed: code=%s", code)
     return code, msg, data
 
 
@@ -181,7 +179,7 @@ async def add_comment_reaction(
         "reaction_type": reaction_type,
     }
 
-    code, msg, _ = await _exec_request(
+    code, _, _ = await _exec_request(
         client, "POST", _REACTION_URI,
         paths={"file_token": file_token},
         queries=[("file_type", file_type)],
@@ -190,15 +188,11 @@ async def add_comment_reaction(
 
     succeeded = code == 0
     if succeeded:
-        logger.info(
-            "[Feishu-Comment] Reaction '%s' added: file=%s:%s reply=%s",
-            reaction_type, file_type, file_token, reply_id,
-        )
+        logger.info("[Feishu-Comment] Reaction '%s' added", reaction_type)
     else:
         logger.warning(
-            "[Feishu-Comment] Reaction API failed: code=%s msg=%s "
-            "file=%s:%s reply=%s",
-            code, msg, file_type, file_token, reply_id,
+            "[Feishu-Comment] Reaction add failed: code=%s",
+            code,
         )
     return succeeded
 
@@ -221,7 +215,7 @@ async def delete_comment_reaction(
         "reaction_type": reaction_type,
     }
 
-    code, msg, _ = await _exec_request(
+    code, _, _ = await _exec_request(
         client, "POST", _REACTION_URI,
         paths={"file_token": file_token},
         queries=[("file_type", file_type)],
@@ -230,15 +224,11 @@ async def delete_comment_reaction(
 
     succeeded = code == 0
     if succeeded:
-        logger.info(
-            "[Feishu-Comment] Reaction '%s' deleted: file=%s:%s reply=%s",
-            reaction_type, file_type, file_token, reply_id,
-        )
+        logger.info("[Feishu-Comment] Reaction '%s' deleted", reaction_type)
     else:
         logger.warning(
-            "[Feishu-Comment] Reaction API failed: code=%s msg=%s "
-            "file=%s:%s reply=%s",
-            code, msg, file_type, file_token, reply_id,
+            "[Feishu-Comment] Reaction delete failed: code=%s",
+            code,
         )
     return succeeded
 
@@ -266,17 +256,20 @@ async def query_document_meta(
         "request_docs": [{"doc_token": file_token, "doc_type": file_type}],
         "with_url": True,
     }
-    logger.debug("[Feishu-Comment] query_document_meta: file_token=%s file_type=%s", file_token, file_type)
-    code, msg, data = await _exec_request(
+    logger.debug("[Feishu-Comment] query_document_meta: file_type=%s", file_type)
+    code, _, data = await _exec_request(
         client, "POST", _BATCH_QUERY_META_URI, body=body,
     )
     if code != 0:
-        logger.warning("[Feishu-Comment] Meta batch_query failed: code=%s msg=%s", code, msg)
+        logger.warning("[Feishu-Comment] Meta batch_query failed: code=%s", code)
         return {}
 
     metas = data.get("metas", [])
-    logger.debug("[Feishu-Comment] query_document_meta: raw metas type=%s value=%s",
-                 type(metas).__name__, str(metas)[:300])
+    logger.debug(
+        "[Feishu-Comment] query_document_meta: metas_type=%s count=%s",
+        type(metas).__name__,
+        len(metas) if isinstance(metas, (dict, list)) else "?",
+    )
     if not metas:
         # Try alternate response shape: metas may be a dict keyed by token
         if isinstance(data.get("metas"), dict):
@@ -292,8 +285,11 @@ async def query_document_meta(
         "url": meta.get("url", ""),
         "doc_type": meta.get("doc_type", file_type),
     }
-    logger.info("[Feishu-Comment] query_document_meta: title=%s url=%s",
-                result["title"], result["url"][:80] if result["url"] else "")
+    logger.info(
+        "[Feishu-Comment] query_document_meta: title_chars=%d has_url=%s",
+        len(result["title"]),
+        bool(result["url"]),
+    )
     return result
 
 
@@ -311,10 +307,10 @@ async def batch_query_comment(
     Returns the comment dict with fields like ``is_whole``, ``quote``,
     ``reply_list``, etc.  Empty dict on failure.
     """
-    logger.debug("[Feishu-Comment] batch_query_comment: file_token=%s comment_id=%s", file_token, comment_id)
+    logger.debug("[Feishu-Comment] batch_query_comment: start")
 
     for attempt in range(_COMMENT_RETRY_LIMIT):
-        code, msg, data = await _exec_request(
+        code, _, data = await _exec_request(
             client, "POST", _BATCH_QUERY_COMMENT_URI,
             paths={"file_token": file_token},
             queries=[
@@ -327,14 +323,14 @@ async def batch_query_comment(
             break
         if attempt < _COMMENT_RETRY_LIMIT - 1:
             logger.info(
-                "[Feishu-Comment] batch_query_comment retry %d/%d: code=%s msg=%s",
-                attempt + 1, _COMMENT_RETRY_LIMIT, code, msg,
+                "[Feishu-Comment] batch_query_comment retry %d/%d: code=%s",
+                attempt + 1, _COMMENT_RETRY_LIMIT, code,
             )
             await asyncio.sleep(_COMMENT_RETRY_DELAY_S)
         else:
             logger.warning(
-                "[Feishu-Comment] batch_query_comment failed after %d attempts: code=%s msg=%s",
-                _COMMENT_RETRY_LIMIT, code, msg,
+                "[Feishu-Comment] batch_query_comment failed after %d attempts: code=%s",
+                _COMMENT_RETRY_LIMIT, code,
             )
             return {}
 
@@ -343,10 +339,14 @@ async def batch_query_comment(
     logger.debug("[Feishu-Comment] batch_query_comment: got %d items", len(items) if isinstance(items, list) else 0)
     if items and isinstance(items, list):
         item = items[0]
-        logger.info("[Feishu-Comment] batch_query_comment: is_whole=%s quote=%s reply_count=%s",
-                    item.get("is_whole"),
-                    (item.get("quote", "") or "")[:60],
-                    len(item.get("reply_list", {}).get("replies", [])) if isinstance(item.get("reply_list"), dict) else "?")
+        logger.info(
+            "[Feishu-Comment] batch_query_comment: is_whole=%s quote_chars=%d reply_count=%s",
+            item.get("is_whole"),
+            len(item.get("quote", "") or ""),
+            len(item.get("reply_list", {}).get("replies", []))
+            if isinstance(item.get("reply_list"), dict)
+            else "?",
+        )
         return item
     logger.warning("[Feishu-Comment] batch_query_comment: empty items, raw data keys=%s", list(data.keys()))
     return {}
@@ -356,7 +356,7 @@ async def list_whole_comments(
     client: Any, file_token: str, file_type: str,
 ) -> List[Dict[str, Any]]:
     """List all whole-document comments (paginated, up to 500)."""
-    logger.debug("[Feishu-Comment] list_whole_comments: file_token=%s", file_token)
+    logger.debug("[Feishu-Comment] list_whole_comments: start")
     all_comments: List[Dict[str, Any]] = []
     page_token = ""
 
@@ -370,13 +370,13 @@ async def list_whole_comments(
         if page_token:
             queries.append(("page_token", page_token))
 
-        code, msg, data = await _exec_request(
+        code, _, data = await _exec_request(
             client, "GET", _LIST_COMMENTS_URI,
             paths={"file_token": file_token},
             queries=queries,
         )
         if code != 0:
-            logger.warning("[Feishu-Comment] List whole comments failed: code=%s msg=%s", code, msg)
+            logger.warning("[Feishu-Comment] List whole comments failed: code=%s", code)
             break
 
         items = data.get("items", [])
@@ -404,7 +404,7 @@ async def list_comment_replies(
     If *expect_reply_id* is set and not found in the first fetch,
     retries up to 6 times (handles eventual consistency).
     """
-    logger.debug("[Feishu-Comment] list_comment_replies: file_token=%s comment_id=%s", file_token, comment_id)
+    logger.debug("[Feishu-Comment] list_comment_replies: start")
 
     for attempt in range(_COMMENT_RETRY_LIMIT):
         all_replies: List[Dict[str, Any]] = []
@@ -420,13 +420,13 @@ async def list_comment_replies(
             if page_token:
                 queries.append(("page_token", page_token))
 
-            code, msg, data = await _exec_request(
+            code, _, data = await _exec_request(
                 client, "GET", _LIST_REPLIES_URI,
                 paths={"file_token": file_token, "comment_id": comment_id},
                 queries=queries,
             )
             if code != 0:
-                logger.warning("[Feishu-Comment] List replies failed: code=%s msg=%s", code, msg)
+                logger.warning("[Feishu-Comment] List replies failed: code=%s", code)
                 fetch_ok = False
                 break
 
@@ -448,14 +448,14 @@ async def list_comment_replies(
             break
         if attempt < _COMMENT_RETRY_LIMIT - 1:
             logger.info(
-                "[Feishu-Comment] list_comment_replies: reply_id=%s not found, retry %d/%d",
-                expect_reply_id, attempt + 1, _COMMENT_RETRY_LIMIT,
+                "[Feishu-Comment] expected reply not found, retry %d/%d",
+                attempt + 1, _COMMENT_RETRY_LIMIT,
             )
             await asyncio.sleep(_COMMENT_RETRY_DELAY_S)
         else:
             logger.warning(
-                "[Feishu-Comment] list_comment_replies: reply_id=%s not found after %d attempts",
-                expect_reply_id, _COMMENT_RETRY_LIMIT,
+                "[Feishu-Comment] expected reply not found after %d attempts",
+                _COMMENT_RETRY_LIMIT,
             )
 
     logger.info("[Feishu-Comment] list_comment_replies: total %d replies fetched", len(all_replies))
@@ -475,8 +475,7 @@ async def reply_to_comment(
     Returns ``(success, code)``.
     """
     text = _sanitize_comment_text(text)
-    logger.info("[Feishu-Comment] reply_to_comment: comment_id=%s text=%s",
-                comment_id, text[:100])
+    logger.info("[Feishu-Comment] reply_to_comment: text_chars=%d", len(text))
     body = {
         "content": {
             "elements": [
@@ -485,7 +484,7 @@ async def reply_to_comment(
         }
     }
 
-    code, msg, _ = await _exec_request(
+    code, _, _ = await _exec_request(
         client, "POST", _REPLY_COMMENT_URI,
         paths={"file_token": file_token, "comment_id": comment_id},
         queries=[("file_type", file_type)],
@@ -493,11 +492,11 @@ async def reply_to_comment(
     )
     if code != 0:
         logger.warning(
-            "[Feishu-Comment] reply_to_comment FAILED: code=%s msg=%s comment_id=%s",
-            code, msg, comment_id,
+            "[Feishu-Comment] reply_to_comment FAILED: code=%s",
+            code,
         )
     else:
-        logger.info("[Feishu-Comment] reply_to_comment OK: comment_id=%s", comment_id)
+        logger.info("[Feishu-Comment] reply_to_comment OK")
     return code == 0, code
 
 
@@ -509,8 +508,7 @@ async def add_whole_comment(
     Returns ``True`` on success.
     """
     text = _sanitize_comment_text(text)
-    logger.info("[Feishu-Comment] add_whole_comment: file_token=%s text=%s",
-                file_token, text[:100])
+    logger.info("[Feishu-Comment] add_whole_comment: text_chars=%d", len(text))
     body = {
         "file_type": file_type,
         "reply_elements": [
@@ -518,13 +516,13 @@ async def add_whole_comment(
         ],
     }
 
-    code, msg, _ = await _exec_request(
+    code, _, _ = await _exec_request(
         client, "POST", _ADD_COMMENT_URI,
         paths={"file_token": file_token},
         body=body,
     )
     if code != 0:
-        logger.warning("[Feishu-Comment] add_whole_comment FAILED: code=%s msg=%s", code, msg)
+        logger.warning("[Feishu-Comment] add_whole_comment FAILED: code=%s", code)
     else:
         logger.info("[Feishu-Comment] add_whole_comment OK")
     return code == 0
@@ -565,8 +563,12 @@ async def deliver_comment_reply(
     - Local comment -> reply_to_comment, fallback to add_whole_comment on 1069302
     """
     chunks = _chunk_text(text)
-    logger.info("[Feishu-Comment] deliver_comment_reply: is_whole=%s comment_id=%s text_len=%d chunks=%d",
-                is_whole, comment_id, len(text), len(chunks))
+    logger.info(
+        "[Feishu-Comment] deliver_comment_reply: is_whole=%s text_len=%d chunks=%d",
+        is_whole,
+        len(text),
+        len(chunks),
+    )
 
     all_ok = True
     for i, chunk in enumerate(chunks):
@@ -716,7 +718,7 @@ async def _reverse_lookup_wiki_token(
     Returns the wiki_token if the document belongs to a wiki space,
     or None if it doesn't or the API call fails.
     """
-    code, msg, data = await _exec_request(
+    code, _, data = await _exec_request(
         client, "GET", _WIKI_GET_NODE_URI,
         queries=[("token", obj_token), ("obj_type", obj_type)],
     )
@@ -725,7 +727,7 @@ async def _reverse_lookup_wiki_token(
         wiki_token = node.get("node_token", "")
         return wiki_token if wiki_token else None
     # code != 0: either not a wiki doc or service error — log and return None
-    logger.warning("[Feishu-Comment] Wiki reverse lookup failed: code=%s msg=%s obj=%s:%s", code, msg, obj_type, obj_token)
+    logger.warning("[Feishu-Comment] Wiki reverse lookup failed: code=%s", code)
     return None
 
 
@@ -744,7 +746,7 @@ async def _resolve_wiki_nodes(
 
     for link in wiki_links:
         wiki_token = link["token"]
-        code, msg, data = await _exec_request(
+        code, _, data = await _exec_request(
             client, "GET", _WIKI_GET_NODE_URI,
             queries=[("token", wiki_token)],
         )
@@ -754,15 +756,15 @@ async def _resolve_wiki_nodes(
             resolved_token = node.get("obj_token", "")
             if resolved_type and resolved_token:
                 logger.info(
-                    "[Feishu-Comment] Wiki resolved: %s -> %s:%s",
-                    wiki_token, resolved_type, resolved_token,
+                    "[Feishu-Comment] Wiki resolved: object_type=%s",
+                    resolved_type,
                 )
                 link["resolved_type"] = resolved_type
                 link["resolved_token"] = resolved_token
             else:
-                logger.warning("[Feishu-Comment] Wiki resolve returned empty: %s", wiki_token)
+                logger.warning("[Feishu-Comment] Wiki resolve returned empty")
         else:
-            logger.warning("[Feishu-Comment] Wiki resolve failed: code=%s msg=%s token=%s", code, msg, wiki_token)
+            logger.warning("[Feishu-Comment] Wiki resolve failed: code=%s", code)
 
     return links
 
@@ -1020,7 +1022,7 @@ def _load_session_history(key: str) -> List[Dict[str, Any]]:
         # Check TTL
         if _time.time() - entry["last_access"] > _SESSION_TTL_S:
             del _session_cache[key]
-            logger.info("[Feishu-Comment] Session expired: %s", key)
+            logger.info("[Feishu-Comment] Session expired")
             return []
         entry["last_access"] = _time.time()
         return list(entry["messages"])
@@ -1041,7 +1043,7 @@ def _save_session_history(key: str, messages: List[Dict[str, Any]]) -> None:
             "messages": cleaned,
             "last_access": _time.time(),
         }
-        logger.info("[Feishu-Comment] Session saved: %s (%d messages)", key, len(cleaned))
+        logger.info("[Feishu-Comment] Session saved (%d messages)", len(cleaned))
 
 
 def _run_comment_agent(prompt: str, client: Any, session_key: str = "") -> str:
@@ -1062,14 +1064,19 @@ def _run_comment_agent(prompt: str, client: Any, session_key: str = "") -> str:
 
     try:
         model, runtime_kwargs = _resolve_model_and_runtime()
-        logger.info("[Feishu-Comment] _run_comment_agent: model=%s provider=%s base_url=%s",
-                    model, runtime_kwargs.get("provider"), (runtime_kwargs.get("base_url") or "")[:50])
+        logger.info(
+            "[Feishu-Comment] _run_comment_agent: model=%s provider=%s",
+            model,
+            runtime_kwargs.get("provider"),
+        )
 
         # Load session history for cross-card memory
         history = _load_session_history(session_key) if session_key else []
         if history:
-            logger.info("[Feishu-Comment] _run_comment_agent: loaded %d history messages from session %s",
-                        len(history), session_key)
+            logger.info(
+                "[Feishu-Comment] _run_comment_agent: loaded %d history messages",
+                len(history),
+            )
 
         agent = AIAgent(
             model=model,
@@ -1089,8 +1096,11 @@ def _run_comment_agent(prompt: str, client: Any, session_key: str = "") -> str:
         result = agent.run_conversation(prompt, conversation_history=history or None)
         response = (result.get("final_response") or "").strip()
         api_calls = result.get("api_calls", 0)
-        logger.info("[Feishu-Comment] _run_comment_agent: done api_calls=%d response_len=%d response=%s",
-                    api_calls, len(response), response[:200])
+        logger.info(
+            "[Feishu-Comment] _run_comment_agent: done api_calls=%d response_len=%d",
+            api_calls,
+            len(response),
+        )
 
         # Save updated history
         if session_key:
@@ -1146,10 +1156,10 @@ async def handle_drive_comment_event(
 
     # Filter: self-reply, receiver check, notice_type
     if from_open_id and self_open_id and from_open_id == self_open_id:
-        logger.debug("[Feishu-Comment] Skipping self-authored event: from=%s", from_open_id)
+        logger.debug("[Feishu-Comment] Skipping self-authored event")
         return
     if not to_open_id or (self_open_id and to_open_id != self_open_id):
-        logger.debug("[Feishu-Comment] Skipping event not addressed to self: to=%s", to_open_id or "(empty)")
+        logger.debug("[Feishu-Comment] Skipping event not addressed to self")
         return
     if notice_type and notice_type not in _ALLOWED_NOTICE_TYPES:
         logger.debug("[Feishu-Comment] Skipping notice_type=%s", notice_type)
@@ -1159,8 +1169,9 @@ async def handle_drive_comment_event(
         return
 
     logger.info(
-        "[Feishu-Comment] Event: notice=%s file=%s:%s comment=%s from=%s",
-        notice_type, file_type, file_token, comment_id, from_open_id,
+        "[Feishu-Comment] Event accepted: notice=%s file_type=%s",
+        notice_type,
+        file_type,
     )
 
     # Access control
@@ -1176,13 +1187,21 @@ async def handle_drive_comment_event(
             rule = resolve_rule(comments_cfg, file_type, file_token, wiki_token=wiki_token)
 
     if not rule.enabled:
-        logger.info("[Feishu-Comment] Comments disabled for %s:%s, skipping", file_type, file_token)
+        logger.info("[Feishu-Comment] Comments disabled for file_type=%s, skipping", file_type)
         return
     if not is_user_allowed(rule, from_open_id):
-        logger.info("[Feishu-Comment] User %s denied (policy=%s, rule=%s)", from_open_id, rule.policy, rule.match_source)
+        logger.info(
+            "[Feishu-Comment] User denied (policy=%s, rule=%s)",
+            rule.policy,
+            rule.match_source,
+        )
         return
 
-    logger.info("[Feishu-Comment] Access granted: user=%s policy=%s rule=%s", from_open_id, rule.policy, rule.match_source)
+    logger.info(
+        "[Feishu-Comment] Access granted: policy=%s rule=%s",
+        rule.policy,
+        rule.match_source,
+    )
     if reply_id:
         asyncio.ensure_future(
             add_comment_reaction(
@@ -1209,8 +1228,9 @@ async def handle_drive_comment_event(
     is_whole = bool(comment_detail.get("is_whole"))
 
     logger.info(
-        "[Feishu-Comment] Comment context: title=%s is_whole=%s",
-        doc_title, is_whole,
+        "[Feishu-Comment] Comment context: title_chars=%d is_whole=%s",
+        len(doc_title),
+        is_whole,
     )
 
     # Step 3: Build timeline based on comment type
@@ -1251,9 +1271,14 @@ async def handle_drive_comment_event(
                     current_index = i
                     break
 
-        logger.info("[Feishu-Comment] Whole timeline: %d entries, current_idx=%d, self_idx=%d, text=%s",
-                    len(timeline), current_index, nearest_self_index,
-                    current_text[:80] if current_text else "(empty)")
+        logger.info(
+            "[Feishu-Comment] Whole timeline: %d entries, current_idx=%d, "
+            "self_idx=%d, text_chars=%d",
+            len(timeline),
+            current_index,
+            nearest_self_index,
+            len(current_text),
+        )
 
         # Extract and resolve document links from all replies
         all_raw_replies = []
@@ -1316,11 +1341,15 @@ async def handle_drive_comment_event(
                     target_index = i
                     break
 
-        logger.info("[Feishu-Comment] Local timeline: %d entries, target_idx=%d, quote=%s root=%s target=%s",
-                    len(timeline), target_index,
-                    quote_text[:60] if quote_text else "(empty)",
-                    root_text[:60] if root_text else "(empty)",
-                    target_text[:60] if target_text else "(empty)")
+        logger.info(
+            "[Feishu-Comment] Local timeline: %d entries, target_idx=%d, "
+            "quote_chars=%d root_chars=%d target_chars=%d",
+            len(timeline),
+            target_index,
+            len(quote_text),
+            len(root_text),
+            len(target_text),
+        )
 
         # Extract and resolve document links from replies
         doc_links = _extract_docs_links(replies)
@@ -1344,7 +1373,6 @@ async def handle_drive_comment_event(
         )
 
     logger.info("[Feishu-Comment] [Step 4/5] Prompt built (%d chars), running agent...", len(prompt))
-    logger.debug("[Feishu-Comment] Full prompt:\n%s", prompt)
 
     # Step 4: Run agent in a thread (run_conversation is synchronous)
     # Session key groups all comment cards on the same document
@@ -1357,10 +1385,13 @@ async def handle_drive_comment_event(
     if not response or _NO_REPLY_SENTINEL in response:
         logger.info("[Feishu-Comment] Agent returned NO_REPLY, skipping delivery")
     else:
-        logger.info("[Feishu-Comment] Agent response (%d chars): %s", len(response), response[:200])
+        logger.info("[Feishu-Comment] Agent response ready (%d chars)", len(response))
 
         # Step 5: Deliver reply
-        logger.info("[Feishu-Comment] [Step 5/5] Delivering reply (is_whole=%s, comment_id=%s)", is_whole, comment_id)
+        logger.info(
+            "[Feishu-Comment] [Step 5/5] Delivering reply (is_whole=%s)",
+            is_whole,
+        )
         success = await deliver_comment_reply(
             client, file_token, file_type, comment_id, response, is_whole,
         )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7345,8 +7345,7 @@ class TelegramAdapter(BasePlatformAdapter):
             tmp = response_path.with_suffix(".tmp")
             tmp.write_text(answer, encoding="utf-8")
             tmp.replace(response_path)
-            logger.info("Telegram update prompt answered '%s' by user %s",
-                        answer, getattr(query.from_user, "id", "unknown"))
+            logger.info("Telegram update prompt answered")
         except Exception as exc:
             logger.error("Failed to write update response from callback: %s", exc)
 
@@ -9471,11 +9470,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # generation. This prevents removed/blocked users from injecting prompts
         # into the agent path or the observed transcript context (#40863).
         if not self._is_user_authorized_from_message(msg):
-            logger.warning(
-                "[Telegram] Blocked unauthorized user %s in chat %s",
-                getattr(getattr(msg, "from_user", None), "id", None),
-                getattr(getattr(msg, "chat", None), "id", None),
-            )
+            logger.warning("[Telegram] Blocked unauthorized user")
             return
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
@@ -9497,11 +9492,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._should_process_message(msg, is_command=True):
             return
         if not self._is_user_authorized_from_message(msg):
-            logger.warning(
-                "[Telegram] Blocked unauthorized user %s in chat %s",
-                getattr(getattr(msg, "from_user", None), "id", None),
-                getattr(getattr(msg, "chat", None), "id", None),
-            )
+            logger.warning("[Telegram] Blocked unauthorized user")
             return
         await self._ensure_forum_commands(msg)
 
@@ -9529,11 +9520,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not msg:
             return
         if not self._is_user_authorized_from_message(msg):
-            logger.warning(
-                "[Telegram] Blocked unauthorized user %s in chat %s",
-                getattr(getattr(msg, "from_user", None), "id", None),
-                getattr(getattr(msg, "chat", None), "id", None),
-            )
+            logger.warning("[Telegram] Blocked unauthorized user")
             return
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
@@ -9748,11 +9735,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not update.message:
             return
         if not self._is_user_authorized_from_message(update.message):
-            logger.info(
-                "[Telegram] Blocked media from unauthorized user %s in chat %s",
-                getattr(getattr(update.message, "from_user", None), "id", None),
-                getattr(getattr(update.message, "chat", None), "id", None),
-            )
+            logger.info("[Telegram] Blocked media from unauthorized user")
             return
         if not self._should_process_message(update.message):
             if self._should_observe_unmentioned_group_message(update.message):

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6571,8 +6571,7 @@ class TelegramAdapter(BasePlatformAdapter):
             tmp = response_path.with_suffix(".tmp")
             tmp.write_text(answer, encoding="utf-8")
             tmp.replace(response_path)
-            logger.info("Telegram update prompt answered '%s' by user %s",
-                        answer, getattr(query.from_user, "id", "unknown"))
+            logger.info("Telegram update prompt answered")
         except Exception as exc:
             logger.error("Failed to write update response from callback: %s", exc)
 
@@ -8675,11 +8674,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # generation. This prevents removed/blocked users from injecting prompts
         # into the agent path or the observed transcript context (#40863).
         if not self._is_user_authorized_from_message(msg):
-            logger.warning(
-                "[Telegram] Blocked unauthorized user %s in chat %s",
-                getattr(getattr(msg, "from_user", None), "id", None),
-                getattr(getattr(msg, "chat", None), "id", None),
-            )
+            logger.warning("[Telegram] Blocked unauthorized user")
             return
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
@@ -8701,11 +8696,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._should_process_message(msg, is_command=True):
             return
         if not self._is_user_authorized_from_message(msg):
-            logger.warning(
-                "[Telegram] Blocked unauthorized user %s in chat %s",
-                getattr(getattr(msg, "from_user", None), "id", None),
-                getattr(getattr(msg, "chat", None), "id", None),
-            )
+            logger.warning("[Telegram] Blocked unauthorized user")
             return
         await self._ensure_forum_commands(msg)
 
@@ -8733,11 +8724,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not msg:
             return
         if not self._is_user_authorized_from_message(msg):
-            logger.warning(
-                "[Telegram] Blocked unauthorized user %s in chat %s",
-                getattr(getattr(msg, "from_user", None), "id", None),
-                getattr(getattr(msg, "chat", None), "id", None),
-            )
+            logger.warning("[Telegram] Blocked unauthorized user")
             return
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
@@ -8937,11 +8924,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not update.message:
             return
         if not self._is_user_authorized_from_message(update.message):
-            logger.info(
-                "[Telegram] Blocked media from unauthorized user %s in chat %s",
-                getattr(getattr(update.message, "from_user", None), "id", None),
-                getattr(getattr(update.message, "chat", None), "id", None),
-            )
+            logger.info("[Telegram] Blocked media from unauthorized user")
             return
         if not self._should_process_message(update.message):
             if self._should_observe_unmentioned_group_message(update.message):

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -293,15 +293,44 @@ class TestCaptureLogSnapshotRedaction:
         log_path.write_text(
             "2026-04-12 17:00:00 INFO gateway.run: "
             "inbound message: platform=bluebubbles "
-            "user=person@example.com chat=iMessage;-;person@example.com msg='hello'\n"
+            "user=person@example.com chat=iMessage;-;person@example.com "
+            "owner=person@example.com msg='hello'\n"
         )
 
         snap = _capture_log_snapshot("agent", tail_lines=10)
 
         assert "person@example.com" not in snap.tail_text
         assert "[REDACTED_EMAIL]" in snap.tail_text
+        assert "user=[REDACTED_ID]" in snap.tail_text
+        assert "chat=[REDACTED_ID]" in snap.tail_text
         assert snap.full_text is not None
         assert "person@example.com" not in snap.full_text
+
+    def test_default_redacts_identity_message_and_home_path(
+        self, hermes_home_with_secret
+    ):
+        from hermes_cli.debug import _capture_log_snapshot
+
+        log_path = hermes_home_with_secret / "logs" / "agent.log"
+        log_path.write_text(
+            "2026-04-12 17:00:00 INFO gateway.run: "
+            "inbound message: platform=telegram "
+            "user=Alice Smith chat=9876543210 "
+            "msg='private medical question' "
+            f"cwd={hermes_home_with_secret / 'sessions'}\n"
+        )
+
+        snap = _capture_log_snapshot("agent", tail_lines=10)
+
+        for text in (snap.tail_text, snap.full_text or ""):
+            assert "Alice Smith" not in text
+            assert "9876543210" not in text
+            assert "private medical question" not in text
+            assert str(hermes_home_with_secret) not in text
+            assert "user=[REDACTED_ID]" in text
+            assert "chat=[REDACTED_ID]" in text
+            assert "msg='[REDACTED_MESSAGE]'" in text
+            assert "~/.hermes" in text
 
     def test_no_redact_preserves_email_addresses(self, hermes_home_with_secret):
         from hermes_cli.debug import _capture_log_snapshot
@@ -317,6 +346,27 @@ class TestCaptureLogSnapshotRedaction:
 
         assert "person@example.com" in snap.tail_text
         assert "person@example.com" in (snap.full_text or "")
+
+    def test_no_redact_preserves_identity_message_and_home_path(
+        self, hermes_home_with_secret
+    ):
+        from hermes_cli.debug import _capture_log_snapshot
+
+        log_path = hermes_home_with_secret / "logs" / "agent.log"
+        log_path.write_text(
+            "2026-04-12 17:00:00 INFO gateway.run: "
+            "inbound message: platform=telegram "
+            "user=Alice Smith chat=9876543210 "
+            "msg='private medical question' "
+            f"cwd={hermes_home_with_secret / 'sessions'}\n"
+        )
+
+        snap = _capture_log_snapshot("agent", tail_lines=10, redact=False)
+
+        assert "Alice Smith" in snap.tail_text
+        assert "9876543210" in snap.tail_text
+        assert "private medical question" in snap.tail_text
+        assert str(hermes_home_with_secret) in snap.tail_text
 
     def test_capture_default_log_snapshots_threads_redact(
         self, hermes_home_with_secret

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -134,7 +134,9 @@ class TestCaptureLogSnapshot:
         # backward-reading loop so the truncation path actually fires.
         line = "A" * 99 + "\n"  # 100 bytes per line
         num_lines = 200  # 20000 bytes
-        (hermes_home / "logs" / "agent.log").write_text(line * num_lines)
+        (hermes_home / "logs" / "agent.log").write_text(
+            line * num_lines, newline="\n"
+        )
 
         # max_bytes = 1000 = 100 * 10 → cut at byte 20000 - 1000 = 19000,
         # and byte 19000 - 1 is '\n'.  Boundary hit → keep all 10 lines.
@@ -332,6 +334,141 @@ class TestCaptureLogSnapshotRedaction:
             assert "msg='[REDACTED_MESSAGE]'" in text
             assert "~/.hermes" in text
 
+    def test_default_redacts_positional_log_formats_and_ip_addresses(
+        self, hermes_home_with_secret
+    ):
+        from hermes_cli.debug import _capture_log_snapshot
+
+        log_path = hermes_home_with_secret / "logs" / "agent.log"
+        log_path.write_text(
+            "2026-04-12 WARNING gateway.run: "
+            "Unauthorized user: 123456 (Alice Example) on telegram\n"
+            "2026-04-12 INFO tools.vision_tools: "
+            "User prompt: private medical question\n"
+            "2026-04-12 INFO gateway.platforms.webhook: "
+            "[webhook] Response for github:owner/repo: internal answer\n"
+            "2026-04-12 INFO gateway.platforms.webhook: "
+            "[webhook] direct-deliver log-only: private fallback\n"
+            "2026-04-12 INFO service: backend=10.0.0.7:8080 "
+            "endpoint=[2001:db8::1]:443 scoped=fe80::1%eth0 version=1.2.3.4\n"
+            "2026-04-12 INFO service: user=alice\n"
+            "2026-04-12 INFO service: next=record\n"
+        )
+
+        snap = _capture_log_snapshot("agent", tail_lines=20)
+
+        for text in (snap.tail_text, snap.full_text or ""):
+            for sensitive in (
+                "123456",
+                "Alice Example",
+                "private medical question",
+                "github:owner/repo",
+                "internal answer",
+                "private fallback",
+                "10.0.0.7",
+                "2001:db8::1",
+                "fe80::1%eth0",
+                "user=alice",
+            ):
+                assert sensitive not in text
+            assert "Unauthorized user: [REDACTED_ID] ([REDACTED_NAME])" in text
+            assert "User prompt: [REDACTED_MESSAGE]" in text
+            assert "[webhook] Response for [REDACTED_ID]: [REDACTED_MESSAGE]" in text
+            assert "[webhook] direct-deliver log-only: [REDACTED_MESSAGE]" in text
+            assert "backend=[REDACTED_IP]:8080" in text
+            assert "version=1.2.3.4" in text
+            assert "endpoint=[[REDACTED_IP]]:443" in text
+            assert "scoped=[REDACTED_IP]" in text
+            assert "user=[REDACTED_ID]" in text
+
+    @pytest.mark.parametrize(
+        ("line", "sensitive"),
+        [
+            (
+                "[Telegram] Blocked unauthorized user 123 in chat -456",
+                ("123", "-456"),
+            ),
+            ("Voice input from user 123: medical transcript", ("123", "medical transcript")),
+            (
+                "[Email] New message from alice@example.test: payroll subject",
+                ("alice@example.test", "payroll subject"),
+            ),
+            (
+                "Generating image with flux (flux) — prompt: private portrait",
+                ("private portrait",),
+            ),
+            (
+                "Forwarded update prompt to discord:123: private question",
+                ("discord:123", "private question"),
+            ),
+            (
+                "Suppressing duplicate voice transcript for guild=12 user=34: secret words",
+                ("guild=12", "user=34", "secret words"),
+            ),
+            (
+                "api_calls=2 response=review confidential status=done",
+                ("review confidential",),
+            ),
+            (
+                "chat_id=oc_1 sender=user:ou_2 text='private feishu message' media=0",
+                ("oc_1", "user:ou_2", "private feishu message"),
+            ),
+            (
+                "session=abc answer=private choice user=Alice Example",
+                ("abc", "private choice", "Alice Example"),
+            ),
+        ],
+    )
+    def test_redacts_historical_sensitive_log_formats(self, line, sensitive):
+        from hermes_cli.debug import _redact_log_text
+
+        redacted = _redact_log_text(line)
+
+        assert all(value not in redacted for value in sensitive)
+
+    def test_redacts_nested_display_name_and_multiline_message_continuation(self):
+        from hermes_cli.debug import _redact_log_text
+
+        text = (
+            "2026-04-12 17:00:00 INFO gateway.run: "
+            "Unauthorized user: 123 (Alice (Admin)) on telegram\n"
+            "2026-04-12 17:00:01 INFO tools.vision_tools: User prompt: first line\n"
+            "private continuation\r\n"
+            "2026-04-12 17:00:02 INFO service: next record\n"
+        )
+
+        redacted = _redact_log_text(text)
+
+        for sensitive in ("123", "Alice (Admin)", "first line", "private continuation"):
+            assert sensitive not in redacted
+        assert "2026-04-12 17:00:02 INFO service: next record" in redacted
+        assert "[REDACTED_MESSAGE_CONTINUATION]\r\n" in redacted
+
+    def test_default_redacts_sensitive_snapshot_read_error_path(
+        self, hermes_home_with_secret
+    ):
+        from hermes_cli.debug import _capture_log_snapshot
+
+        log_path = hermes_home_with_secret / "logs" / "agent.log"
+        with patch(
+            "builtins.open",
+            side_effect=PermissionError(f"cannot read {log_path}"),
+        ):
+            snap = _capture_log_snapshot("agent", tail_lines=10)
+
+        assert str(hermes_home_with_secret) not in snap.tail_text
+        assert "~/.hermes/logs/agent.log" in snap.tail_text
+
+    def test_malformed_quoted_field_stays_on_its_physical_line(self):
+        from hermes_cli.debug import _redact_log_text
+
+        text = "msg='unterminated\r\n2026-04-12 17:00:01 INFO service: healthy\r\n"
+
+        redacted = _redact_log_text(text)
+
+        assert "unterminated" not in redacted
+        assert "2026-04-12 17:00:01 INFO service: healthy" in redacted
+
     def test_no_redact_preserves_email_addresses(self, hermes_home_with_secret):
         from hermes_cli.debug import _capture_log_snapshot
 
@@ -359,6 +496,9 @@ class TestCaptureLogSnapshotRedaction:
             "user=Alice Smith chat=9876543210 "
             "msg='private medical question' "
             f"cwd={hermes_home_with_secret / 'sessions'}\n"
+            "Unauthorized user: 123456 (Alice Smith) on telegram\n"
+            "User prompt: private medical question\n"
+            "[webhook] Response for room-987: internal answer from 10.0.0.7\n"
         )
 
         snap = _capture_log_snapshot("agent", tail_lines=10, redact=False)
@@ -367,6 +507,8 @@ class TestCaptureLogSnapshotRedaction:
         assert "9876543210" in snap.tail_text
         assert "private medical question" in snap.tail_text
         assert str(hermes_home_with_secret) in snap.tail_text
+        assert "123456 (Alice Smith)" in snap.tail_text
+        assert "room-987: internal answer from 10.0.0.7" in snap.tail_text
 
     def test_capture_default_log_snapshots_threads_redact(
         self, hermes_home_with_secret
@@ -426,6 +568,7 @@ class TestRunDebugShare:
         args.expire = 7
         args.local = False
         args.nous = False
+        args.no_redact = False
 
         with patch("hermes_cli.dump.run_dump"), \
              patch("hermes_cli.debug._sweep_expired_pastes", return_value=(0, 0)) as mock_sweep, \
@@ -574,7 +717,7 @@ class TestRunDebugShareRedaction:
             run_debug_share(args)
 
         for content in captured:
-            assert "redacted at upload time" in content, (
+            assert "redaction applied at upload time" in content, (
                 "redaction banner missing from upload-bound content"
             )
 
@@ -608,7 +751,7 @@ class TestRunDebugShareRedaction:
         )
         # No banner anywhere when redaction is disabled.
         for content in captured:
-            assert "redacted at upload time" not in content, (
+            assert "redaction applied at upload time" not in content, (
                 "banner present with --no-redact"
             )
 
@@ -844,8 +987,7 @@ class TestRunDebugDelete:
 class TestShareIncludesAutoDelete:
     """Verify that run_debug_share schedules auto-deletion and prints TTL."""
 
-
-    def test_share_shows_privacy_notice(self, hermes_home, capsys):
+    def test_share_schedules_auto_delete(self, hermes_home, capsys):
         from hermes_cli.debug import run_debug_share
 
         args = MagicMock()
@@ -856,13 +998,69 @@ class TestShareIncludesAutoDelete:
 
         with patch("hermes_cli.dump.run_dump"), \
              patch("hermes_cli.debug.upload_to_pastebin",
+                    return_value="https://paste.rs/test1"), \
+             patch("hermes_cli.debug._schedule_auto_delete") as mock_sched:
+            run_debug_share(args)
+
+        # auto-delete was scheduled with the uploaded URLs
+        mock_sched.assert_called_once()
+        urls_arg = mock_sched.call_args[0][0]
+        assert "https://paste.rs/test1" in urls_arg
+
+        out = capsys.readouterr().out
+        assert "attempt paste deletion" in out
+
+    def test_share_shows_privacy_notice(self, hermes_home, capsys):
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 7
+        args.local = False
+        args.nous = False
+        args.no_redact = False
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug.upload_to_pastebin",
                     return_value="https://paste.rs/test"), \
              patch("hermes_cli.debug._schedule_auto_delete"):
             run_debug_share(args)
 
         out = capsys.readouterr().out
         assert "PUBLIC paste service" in out
-        assert "NOT redacted" in out
+        assert "Best-effort privacy redaction" in out
+        assert "may still contain personal data" in out
+        assert "best-effort deletion" in out
+        assert "may remain available" in out
+        assert "--local" in out
+
+    def test_no_redact_share_shows_explicit_unredacted_notice(
+        self, hermes_home, capsys
+    ):
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock(
+            lines=50,
+            expire=7,
+            local=False,
+            nous=False,
+            no_redact=True,
+            yes=True,
+        )
+        with (
+            patch("hermes_cli.dump.run_dump"),
+            patch(
+                "hermes_cli.debug.upload_to_pastebin",
+                return_value="https://paste.rs/test",
+            ),
+            patch("hermes_cli.debug._schedule_auto_delete"),
+        ):
+            run_debug_share(args)
+
+        out = capsys.readouterr().out
+        assert "--no-redact is set" in out
+        assert "without upload-time redaction" in out
+        assert "Best-effort privacy redaction" not in out
 
 
 # ---------------------------------------------------------------------------
@@ -931,6 +1129,19 @@ class TestBuildDebugShare:
 # ---------------------------------------------------------------------------
 
 class TestCollectShareBundle:
+    def test_returns_report_and_logs(self, hermes_home):
+        from hermes_cli.debug import collect_share_bundle
+
+        with patch("hermes_cli.dump.run_dump"):
+            bundle = collect_share_bundle(log_lines=50, redact=True)
+
+        assert "report" in bundle
+        assert "agent.log" in bundle
+        assert "gateway.log" in bundle
+        assert "desktop.log" in bundle
+        # Banner is prepended under redact=True.
+        assert "redaction applied at upload time" in bundle["report"]
+        assert "session started" in bundle["agent.log"]
 
     def test_no_redact_omits_banner(self, hermes_home):
         from hermes_cli.debug import collect_share_bundle
@@ -938,7 +1149,7 @@ class TestCollectShareBundle:
         with patch("hermes_cli.dump.run_dump"):
             bundle = collect_share_bundle(log_lines=50, redact=False)
 
-        assert "redacted at upload time" not in bundle["report"]
+        assert "redaction applied at upload time" not in bundle["report"]
 
     def test_redaction_keeps_secrets_out(self, hermes_home):
         from hermes_cli.debug import collect_share_bundle
@@ -955,6 +1166,149 @@ class TestCollectShareBundle:
         assert secret in "\n".join(unredacted.values())
         # With redaction it must be scrubbed everywhere.
         assert secret not in "\n".join(redacted.values())
+
+    def test_redaction_covers_dump_text_in_every_bundle_payload(self, hermes_home):
+        from hermes_cli.debug import collect_share_bundle
+
+        dump_text = (
+            "terminal.docker_image: 10.0.0.7/private\n"
+            "operator_email: alice@example.test\n"
+        )
+        (hermes_home / "logs" / "agent.log").write_text("agent ready\n")
+
+        with (
+            patch("hermes_cli.debug._capture_dump", return_value=dump_text),
+            patch("hermes_cli.dump.run_dump"),
+        ):
+            redacted = collect_share_bundle(log_lines=50, redact=True)
+            unredacted = collect_share_bundle(log_lines=50, redact=False)
+
+        assert all("10.0.0.7" not in value for value in redacted.values())
+        assert all("alice@example.test" not in value for value in redacted.values())
+        assert any("10.0.0.7/private" in value for value in unredacted.values())
+        assert any("alice@example.test" in value for value in unredacted.values())
+
+    def test_redaction_sanitizes_positional_pii_across_full_bundle(
+        self, hermes_home
+    ):
+        from hermes_cli.debug import collect_share_bundle
+
+        sensitive = {
+            "123456",
+            "Alice Example",
+            "private medical question",
+            "room-987",
+            "internal answer",
+            "888",
+            "-999",
+            "777",
+            "private transcript",
+            "payroll@example.test",
+            "salary review",
+            "private portrait",
+            "discord:555",
+            "private decision",
+            "10.0.0.7",
+            "2001:db8::1",
+            "doc-secret",
+            "comment-secret",
+            "user-secret",
+            "private request body",
+            "private raw response",
+            "Confidential roadmap",
+            "https://tenant.example.test/private",
+            "private quote",
+            "private reply",
+            "private whole comment",
+            "private model response",
+            "private full prompt",
+            "private continuation",
+            "private agent response",
+            "comment-doc:docx:session-secret",
+            "alice@example.test",
+            "private subject",
+        }
+        fixture = (
+            "2026-04-12 17:00:00 INFO service: "
+            "Unauthorized user: 123456 (Alice Example) on telegram\n"
+            "2026-04-12 17:00:01 INFO service: "
+            "User prompt: private medical question\n"
+            "2026-04-12 17:00:02 INFO service: "
+            "[webhook] Response for room-987: internal answer\n"
+            "2026-04-12 17:00:03 INFO service: "
+            "[Telegram] Blocked unauthorized user 888 in chat -999\n"
+            "2026-04-12 17:00:04 INFO service: "
+            "Voice input from user 777: private transcript\n"
+            "2026-04-12 17:00:05 INFO service: "
+            "[Email] New message from payroll@example.test: salary review\n"
+            "2026-04-12 17:00:06 INFO service: "
+            "Generating image with flux (flux) — prompt: private portrait\n"
+            "2026-04-12 17:00:07 INFO service: "
+            "Forwarded update prompt to discord:555: private decision\n"
+            "2026-04-12 17:00:08 INFO service: "
+            "backend=10.0.0.7 peer=2001:db8::1\n"
+            "2026-04-12 17:00:09 INFO service: "
+            "[Feishu-Comment] API >>> POST /comments "
+            "paths={'file_token': 'doc-secret'} body=private request body\n"
+            "2026-04-12 17:00:10 WARNING service: "
+            "[Feishu-Comment] API FAIL raw response: private raw response\n"
+            "2026-04-12 17:00:11 DEBUG service: "
+            "[Feishu-Comment] query_document_meta: raw metas type=list "
+            "value=Confidential roadmap\n"
+            "2026-04-12 17:00:12 INFO service: "
+            "[Feishu-Comment] query_document_meta: title=Confidential roadmap "
+            "url=https://tenant.example.test/private\n"
+            "2026-04-12 17:00:13 INFO service: "
+            "[Feishu-Comment] batch_query_comment: is_whole=False "
+            "quote=private quote reply_count=1\n"
+            "2026-04-12 17:00:14 INFO service: "
+            "[Feishu-Comment] reply_to_comment: comment_id=comment-secret "
+            "text=private reply\n"
+            "2026-04-12 17:00:15 INFO service: "
+            "[Feishu-Comment] add_whole_comment: file_token=doc-secret "
+            "text=private whole comment\n"
+            "2026-04-12 17:00:16 INFO service: "
+            "[Feishu-Comment] _run_comment_agent: done api_calls=2 "
+            "response_len=22 response=private model response\n"
+            "2026-04-12 17:00:17 INFO service: "
+            "[Feishu-Comment] Event: notice=reply file=docx:doc-secret "
+            "comment=comment-secret from=user-secret\n"
+            "2026-04-12 17:00:18 INFO service: "
+            "[Feishu-Comment] Local timeline: 2 entries target_idx=1 "
+            "quote=private quote root=private reply target=private whole comment\n"
+            "2026-04-12 17:00:19 DEBUG service: "
+            "[Feishu-Comment] Full prompt: private full prompt\n"
+            "private continuation\n"
+            "2026-04-12 17:00:20 INFO service: "
+            "[Feishu-Comment] Agent response (22 chars): private agent response\n"
+            "2026-04-12 17:00:21 INFO service: "
+            "[Feishu-Comment] Session saved: comment-doc:docx:session-secret "
+            "(2 messages)\n"
+            "2026-04-12 17:00:22 INFO service: "
+            "Telegram update prompt answered 'y' by user user-secret\n"
+            "2026-04-12 17:00:23 INFO service: "
+            "[Email] Sent reply to alice@example.test (subject: private subject)\n"
+        )
+        for name in ("agent.log", "gateway.log", "gui.log", "desktop.log"):
+            (hermes_home / "logs" / name).write_text(fixture)
+
+        with patch("hermes_cli.dump.run_dump"):
+            redacted = collect_share_bundle(log_lines=50, redact=True)
+            unredacted = collect_share_bundle(log_lines=50, redact=False)
+
+        expected_outputs = {
+            "report",
+            "agent.log",
+            "gateway.log",
+            "gui.log",
+            "desktop.log",
+        }
+        assert set(redacted) == expected_outputs
+        assert set(unredacted) == expected_outputs
+        for output in expected_outputs:
+            assert all(value in unredacted[output] for value in sensitive), output
+            assert all(value not in redacted[output] for value in sensitive), output
+            assert "[REDACTED_MESSAGE]" in redacted[output]
 
 
 
@@ -1148,4 +1502,3 @@ class TestShareConsentGate:
 
         mock_upload.assert_not_called()
         assert "Aborted" not in capsys.readouterr().out
-

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -134,7 +134,9 @@ class TestCaptureLogSnapshot:
         # backward-reading loop so the truncation path actually fires.
         line = "A" * 99 + "\n"  # 100 bytes per line
         num_lines = 200  # 20000 bytes
-        (hermes_home / "logs" / "agent.log").write_text(line * num_lines)
+        (hermes_home / "logs" / "agent.log").write_text(
+            line * num_lines, newline="\n"
+        )
 
         # max_bytes = 1000 = 100 * 10 → cut at byte 20000 - 1000 = 19000,
         # and byte 19000 - 1 is '\n'.  Boundary hit → keep all 10 lines.
@@ -275,6 +277,141 @@ class TestCaptureLogSnapshotRedaction:
             assert "msg='[REDACTED_MESSAGE]'" in text
             assert "~/.hermes" in text
 
+    def test_default_redacts_positional_log_formats_and_ip_addresses(
+        self, hermes_home_with_secret
+    ):
+        from hermes_cli.debug import _capture_log_snapshot
+
+        log_path = hermes_home_with_secret / "logs" / "agent.log"
+        log_path.write_text(
+            "2026-04-12 WARNING gateway.run: "
+            "Unauthorized user: 123456 (Alice Example) on telegram\n"
+            "2026-04-12 INFO tools.vision_tools: "
+            "User prompt: private medical question\n"
+            "2026-04-12 INFO gateway.platforms.webhook: "
+            "[webhook] Response for github:owner/repo: internal answer\n"
+            "2026-04-12 INFO gateway.platforms.webhook: "
+            "[webhook] direct-deliver log-only: private fallback\n"
+            "2026-04-12 INFO service: backend=10.0.0.7:8080 "
+            "endpoint=[2001:db8::1]:443 scoped=fe80::1%eth0 version=1.2.3.4\n"
+            "2026-04-12 INFO service: user=alice\n"
+            "2026-04-12 INFO service: next=record\n"
+        )
+
+        snap = _capture_log_snapshot("agent", tail_lines=20)
+
+        for text in (snap.tail_text, snap.full_text or ""):
+            for sensitive in (
+                "123456",
+                "Alice Example",
+                "private medical question",
+                "github:owner/repo",
+                "internal answer",
+                "private fallback",
+                "10.0.0.7",
+                "2001:db8::1",
+                "fe80::1%eth0",
+                "user=alice",
+            ):
+                assert sensitive not in text
+            assert "Unauthorized user: [REDACTED_ID] ([REDACTED_NAME])" in text
+            assert "User prompt: [REDACTED_MESSAGE]" in text
+            assert "[webhook] Response for [REDACTED_ID]: [REDACTED_MESSAGE]" in text
+            assert "[webhook] direct-deliver log-only: [REDACTED_MESSAGE]" in text
+            assert "backend=[REDACTED_IP]:8080" in text
+            assert "version=1.2.3.4" in text
+            assert "endpoint=[[REDACTED_IP]]:443" in text
+            assert "scoped=[REDACTED_IP]" in text
+            assert "user=[REDACTED_ID]" in text
+
+    @pytest.mark.parametrize(
+        ("line", "sensitive"),
+        [
+            (
+                "[Telegram] Blocked unauthorized user 123 in chat -456",
+                ("123", "-456"),
+            ),
+            ("Voice input from user 123: medical transcript", ("123", "medical transcript")),
+            (
+                "[Email] New message from alice@example.test: payroll subject",
+                ("alice@example.test", "payroll subject"),
+            ),
+            (
+                "Generating image with flux (flux) — prompt: private portrait",
+                ("private portrait",),
+            ),
+            (
+                "Forwarded update prompt to discord:123: private question",
+                ("discord:123", "private question"),
+            ),
+            (
+                "Suppressing duplicate voice transcript for guild=12 user=34: secret words",
+                ("guild=12", "user=34", "secret words"),
+            ),
+            (
+                "api_calls=2 response=review confidential status=done",
+                ("review confidential",),
+            ),
+            (
+                "chat_id=oc_1 sender=user:ou_2 text='private feishu message' media=0",
+                ("oc_1", "user:ou_2", "private feishu message"),
+            ),
+            (
+                "session=abc answer=private choice user=Alice Example",
+                ("abc", "private choice", "Alice Example"),
+            ),
+        ],
+    )
+    def test_redacts_historical_sensitive_log_formats(self, line, sensitive):
+        from hermes_cli.debug import _redact_log_text
+
+        redacted = _redact_log_text(line)
+
+        assert all(value not in redacted for value in sensitive)
+
+    def test_redacts_nested_display_name_and_multiline_message_continuation(self):
+        from hermes_cli.debug import _redact_log_text
+
+        text = (
+            "2026-04-12 17:00:00 INFO gateway.run: "
+            "Unauthorized user: 123 (Alice (Admin)) on telegram\n"
+            "2026-04-12 17:00:01 INFO tools.vision_tools: User prompt: first line\n"
+            "private continuation\r\n"
+            "2026-04-12 17:00:02 INFO service: next record\n"
+        )
+
+        redacted = _redact_log_text(text)
+
+        for sensitive in ("123", "Alice (Admin)", "first line", "private continuation"):
+            assert sensitive not in redacted
+        assert "2026-04-12 17:00:02 INFO service: next record" in redacted
+        assert "[REDACTED_MESSAGE_CONTINUATION]\r\n" in redacted
+
+    def test_default_redacts_sensitive_snapshot_read_error_path(
+        self, hermes_home_with_secret
+    ):
+        from hermes_cli.debug import _capture_log_snapshot
+
+        log_path = hermes_home_with_secret / "logs" / "agent.log"
+        with patch(
+            "builtins.open",
+            side_effect=PermissionError(f"cannot read {log_path}"),
+        ):
+            snap = _capture_log_snapshot("agent", tail_lines=10)
+
+        assert str(hermes_home_with_secret) not in snap.tail_text
+        assert "~/.hermes/logs/agent.log" in snap.tail_text
+
+    def test_malformed_quoted_field_stays_on_its_physical_line(self):
+        from hermes_cli.debug import _redact_log_text
+
+        text = "msg='unterminated\r\n2026-04-12 17:00:01 INFO service: healthy\r\n"
+
+        redacted = _redact_log_text(text)
+
+        assert "unterminated" not in redacted
+        assert "2026-04-12 17:00:01 INFO service: healthy" in redacted
+
     def test_no_redact_preserves_email_addresses(self, hermes_home_with_secret):
         from hermes_cli.debug import _capture_log_snapshot
 
@@ -302,6 +439,9 @@ class TestCaptureLogSnapshotRedaction:
             "user=Alice Smith chat=9876543210 "
             "msg='private medical question' "
             f"cwd={hermes_home_with_secret / 'sessions'}\n"
+            "Unauthorized user: 123456 (Alice Smith) on telegram\n"
+            "User prompt: private medical question\n"
+            "[webhook] Response for room-987: internal answer from 10.0.0.7\n"
         )
 
         snap = _capture_log_snapshot("agent", tail_lines=10, redact=False)
@@ -310,6 +450,8 @@ class TestCaptureLogSnapshotRedaction:
         assert "9876543210" in snap.tail_text
         assert "private medical question" in snap.tail_text
         assert str(hermes_home_with_secret) in snap.tail_text
+        assert "123456 (Alice Smith)" in snap.tail_text
+        assert "room-987: internal answer from 10.0.0.7" in snap.tail_text
 
     def test_capture_default_log_snapshots_threads_redact(
         self, hermes_home_with_secret
@@ -369,6 +511,7 @@ class TestRunDebugShare:
         args.expire = 7
         args.local = False
         args.nous = False
+        args.no_redact = False
 
         with patch("hermes_cli.dump.run_dump"), \
              patch("hermes_cli.debug._sweep_expired_pastes", return_value=(0, 0)) as mock_sweep, \
@@ -517,7 +660,7 @@ class TestRunDebugShareRedaction:
             run_debug_share(args)
 
         for content in captured:
-            assert "redacted at upload time" in content, (
+            assert "redaction applied at upload time" in content, (
                 "redaction banner missing from upload-bound content"
             )
 
@@ -551,7 +694,7 @@ class TestRunDebugShareRedaction:
         )
         # No banner anywhere when redaction is disabled.
         for content in captured:
-            assert "redacted at upload time" not in content, (
+            assert "redaction applied at upload time" not in content, (
                 "banner present with --no-redact"
             )
 
@@ -787,8 +930,7 @@ class TestRunDebugDelete:
 class TestShareIncludesAutoDelete:
     """Verify that run_debug_share schedules auto-deletion and prints TTL."""
 
-
-    def test_share_shows_privacy_notice(self, hermes_home, capsys):
+    def test_share_schedules_auto_delete(self, hermes_home, capsys):
         from hermes_cli.debug import run_debug_share
 
         args = MagicMock()
@@ -799,13 +941,69 @@ class TestShareIncludesAutoDelete:
 
         with patch("hermes_cli.dump.run_dump"), \
              patch("hermes_cli.debug.upload_to_pastebin",
+                    return_value="https://paste.rs/test1"), \
+             patch("hermes_cli.debug._schedule_auto_delete") as mock_sched:
+            run_debug_share(args)
+
+        # auto-delete was scheduled with the uploaded URLs
+        mock_sched.assert_called_once()
+        urls_arg = mock_sched.call_args[0][0]
+        assert "https://paste.rs/test1" in urls_arg
+
+        out = capsys.readouterr().out
+        assert "attempt paste deletion" in out
+
+    def test_share_shows_privacy_notice(self, hermes_home, capsys):
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 7
+        args.local = False
+        args.nous = False
+        args.no_redact = False
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug.upload_to_pastebin",
                     return_value="https://paste.rs/test"), \
              patch("hermes_cli.debug._schedule_auto_delete"):
             run_debug_share(args)
 
         out = capsys.readouterr().out
         assert "PUBLIC paste service" in out
-        assert "NOT redacted" in out
+        assert "Best-effort privacy redaction" in out
+        assert "may still contain personal data" in out
+        assert "best-effort deletion" in out
+        assert "may remain available" in out
+        assert "--local" in out
+
+    def test_no_redact_share_shows_explicit_unredacted_notice(
+        self, hermes_home, capsys
+    ):
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock(
+            lines=50,
+            expire=7,
+            local=False,
+            nous=False,
+            no_redact=True,
+            yes=True,
+        )
+        with (
+            patch("hermes_cli.dump.run_dump"),
+            patch(
+                "hermes_cli.debug.upload_to_pastebin",
+                return_value="https://paste.rs/test",
+            ),
+            patch("hermes_cli.debug._schedule_auto_delete"),
+        ):
+            run_debug_share(args)
+
+        out = capsys.readouterr().out
+        assert "--no-redact is set" in out
+        assert "without upload-time redaction" in out
+        assert "Best-effort privacy redaction" not in out
 
 
 # ---------------------------------------------------------------------------
@@ -874,6 +1072,19 @@ class TestBuildDebugShare:
 # ---------------------------------------------------------------------------
 
 class TestCollectShareBundle:
+    def test_returns_report_and_logs(self, hermes_home):
+        from hermes_cli.debug import collect_share_bundle
+
+        with patch("hermes_cli.dump.run_dump"):
+            bundle = collect_share_bundle(log_lines=50, redact=True)
+
+        assert "report" in bundle
+        assert "agent.log" in bundle
+        assert "gateway.log" in bundle
+        assert "desktop.log" in bundle
+        # Banner is prepended under redact=True.
+        assert "redaction applied at upload time" in bundle["report"]
+        assert "session started" in bundle["agent.log"]
 
     def test_no_redact_omits_banner(self, hermes_home):
         from hermes_cli.debug import collect_share_bundle
@@ -881,7 +1092,7 @@ class TestCollectShareBundle:
         with patch("hermes_cli.dump.run_dump"):
             bundle = collect_share_bundle(log_lines=50, redact=False)
 
-        assert "redacted at upload time" not in bundle["report"]
+        assert "redaction applied at upload time" not in bundle["report"]
 
     def test_redaction_keeps_secrets_out(self, hermes_home):
         from hermes_cli.debug import collect_share_bundle
@@ -898,6 +1109,149 @@ class TestCollectShareBundle:
         assert secret in "\n".join(unredacted.values())
         # With redaction it must be scrubbed everywhere.
         assert secret not in "\n".join(redacted.values())
+
+    def test_redaction_covers_dump_text_in_every_bundle_payload(self, hermes_home):
+        from hermes_cli.debug import collect_share_bundle
+
+        dump_text = (
+            "terminal.docker_image: 10.0.0.7/private\n"
+            "operator_email: alice@example.test\n"
+        )
+        (hermes_home / "logs" / "agent.log").write_text("agent ready\n")
+
+        with (
+            patch("hermes_cli.debug._capture_dump", return_value=dump_text),
+            patch("hermes_cli.dump.run_dump"),
+        ):
+            redacted = collect_share_bundle(log_lines=50, redact=True)
+            unredacted = collect_share_bundle(log_lines=50, redact=False)
+
+        assert all("10.0.0.7" not in value for value in redacted.values())
+        assert all("alice@example.test" not in value for value in redacted.values())
+        assert any("10.0.0.7/private" in value for value in unredacted.values())
+        assert any("alice@example.test" in value for value in unredacted.values())
+
+    def test_redaction_sanitizes_positional_pii_across_full_bundle(
+        self, hermes_home
+    ):
+        from hermes_cli.debug import collect_share_bundle
+
+        sensitive = {
+            "123456",
+            "Alice Example",
+            "private medical question",
+            "room-987",
+            "internal answer",
+            "888",
+            "-999",
+            "777",
+            "private transcript",
+            "payroll@example.test",
+            "salary review",
+            "private portrait",
+            "discord:555",
+            "private decision",
+            "10.0.0.7",
+            "2001:db8::1",
+            "doc-secret",
+            "comment-secret",
+            "user-secret",
+            "private request body",
+            "private raw response",
+            "Confidential roadmap",
+            "https://tenant.example.test/private",
+            "private quote",
+            "private reply",
+            "private whole comment",
+            "private model response",
+            "private full prompt",
+            "private continuation",
+            "private agent response",
+            "comment-doc:docx:session-secret",
+            "alice@example.test",
+            "private subject",
+        }
+        fixture = (
+            "2026-04-12 17:00:00 INFO service: "
+            "Unauthorized user: 123456 (Alice Example) on telegram\n"
+            "2026-04-12 17:00:01 INFO service: "
+            "User prompt: private medical question\n"
+            "2026-04-12 17:00:02 INFO service: "
+            "[webhook] Response for room-987: internal answer\n"
+            "2026-04-12 17:00:03 INFO service: "
+            "[Telegram] Blocked unauthorized user 888 in chat -999\n"
+            "2026-04-12 17:00:04 INFO service: "
+            "Voice input from user 777: private transcript\n"
+            "2026-04-12 17:00:05 INFO service: "
+            "[Email] New message from payroll@example.test: salary review\n"
+            "2026-04-12 17:00:06 INFO service: "
+            "Generating image with flux (flux) — prompt: private portrait\n"
+            "2026-04-12 17:00:07 INFO service: "
+            "Forwarded update prompt to discord:555: private decision\n"
+            "2026-04-12 17:00:08 INFO service: "
+            "backend=10.0.0.7 peer=2001:db8::1\n"
+            "2026-04-12 17:00:09 INFO service: "
+            "[Feishu-Comment] API >>> POST /comments "
+            "paths={'file_token': 'doc-secret'} body=private request body\n"
+            "2026-04-12 17:00:10 WARNING service: "
+            "[Feishu-Comment] API FAIL raw response: private raw response\n"
+            "2026-04-12 17:00:11 DEBUG service: "
+            "[Feishu-Comment] query_document_meta: raw metas type=list "
+            "value=Confidential roadmap\n"
+            "2026-04-12 17:00:12 INFO service: "
+            "[Feishu-Comment] query_document_meta: title=Confidential roadmap "
+            "url=https://tenant.example.test/private\n"
+            "2026-04-12 17:00:13 INFO service: "
+            "[Feishu-Comment] batch_query_comment: is_whole=False "
+            "quote=private quote reply_count=1\n"
+            "2026-04-12 17:00:14 INFO service: "
+            "[Feishu-Comment] reply_to_comment: comment_id=comment-secret "
+            "text=private reply\n"
+            "2026-04-12 17:00:15 INFO service: "
+            "[Feishu-Comment] add_whole_comment: file_token=doc-secret "
+            "text=private whole comment\n"
+            "2026-04-12 17:00:16 INFO service: "
+            "[Feishu-Comment] _run_comment_agent: done api_calls=2 "
+            "response_len=22 response=private model response\n"
+            "2026-04-12 17:00:17 INFO service: "
+            "[Feishu-Comment] Event: notice=reply file=docx:doc-secret "
+            "comment=comment-secret from=user-secret\n"
+            "2026-04-12 17:00:18 INFO service: "
+            "[Feishu-Comment] Local timeline: 2 entries target_idx=1 "
+            "quote=private quote root=private reply target=private whole comment\n"
+            "2026-04-12 17:00:19 DEBUG service: "
+            "[Feishu-Comment] Full prompt: private full prompt\n"
+            "private continuation\n"
+            "2026-04-12 17:00:20 INFO service: "
+            "[Feishu-Comment] Agent response (22 chars): private agent response\n"
+            "2026-04-12 17:00:21 INFO service: "
+            "[Feishu-Comment] Session saved: comment-doc:docx:session-secret "
+            "(2 messages)\n"
+            "2026-04-12 17:00:22 INFO service: "
+            "Telegram update prompt answered 'y' by user user-secret\n"
+            "2026-04-12 17:00:23 INFO service: "
+            "[Email] Sent reply to alice@example.test (subject: private subject)\n"
+        )
+        for name in ("agent.log", "gateway.log", "gui.log", "desktop.log"):
+            (hermes_home / "logs" / name).write_text(fixture)
+
+        with patch("hermes_cli.dump.run_dump"):
+            redacted = collect_share_bundle(log_lines=50, redact=True)
+            unredacted = collect_share_bundle(log_lines=50, redact=False)
+
+        expected_outputs = {
+            "report",
+            "agent.log",
+            "gateway.log",
+            "gui.log",
+            "desktop.log",
+        }
+        assert set(redacted) == expected_outputs
+        assert set(unredacted) == expected_outputs
+        for output in expected_outputs:
+            assert all(value in unredacted[output] for value in sensitive), output
+            assert all(value not in redacted[output] for value in sensitive), output
+            assert "[REDACTED_MESSAGE]" in redacted[output]
 
 
 
@@ -1091,4 +1445,3 @@ class TestShareConsentGate:
 
         mock_upload.assert_not_called()
         assert "Aborted" not in capsys.readouterr().out
-

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -236,15 +236,44 @@ class TestCaptureLogSnapshotRedaction:
         log_path.write_text(
             "2026-04-12 17:00:00 INFO gateway.run: "
             "inbound message: platform=bluebubbles "
-            "user=person@example.com chat=iMessage;-;person@example.com msg='hello'\n"
+            "user=person@example.com chat=iMessage;-;person@example.com "
+            "owner=person@example.com msg='hello'\n"
         )
 
         snap = _capture_log_snapshot("agent", tail_lines=10)
 
         assert "person@example.com" not in snap.tail_text
         assert "[REDACTED_EMAIL]" in snap.tail_text
+        assert "user=[REDACTED_ID]" in snap.tail_text
+        assert "chat=[REDACTED_ID]" in snap.tail_text
         assert snap.full_text is not None
         assert "person@example.com" not in snap.full_text
+
+    def test_default_redacts_identity_message_and_home_path(
+        self, hermes_home_with_secret
+    ):
+        from hermes_cli.debug import _capture_log_snapshot
+
+        log_path = hermes_home_with_secret / "logs" / "agent.log"
+        log_path.write_text(
+            "2026-04-12 17:00:00 INFO gateway.run: "
+            "inbound message: platform=telegram "
+            "user=Alice Smith chat=9876543210 "
+            "msg='private medical question' "
+            f"cwd={hermes_home_with_secret / 'sessions'}\n"
+        )
+
+        snap = _capture_log_snapshot("agent", tail_lines=10)
+
+        for text in (snap.tail_text, snap.full_text or ""):
+            assert "Alice Smith" not in text
+            assert "9876543210" not in text
+            assert "private medical question" not in text
+            assert str(hermes_home_with_secret) not in text
+            assert "user=[REDACTED_ID]" in text
+            assert "chat=[REDACTED_ID]" in text
+            assert "msg='[REDACTED_MESSAGE]'" in text
+            assert "~/.hermes" in text
 
     def test_no_redact_preserves_email_addresses(self, hermes_home_with_secret):
         from hermes_cli.debug import _capture_log_snapshot
@@ -260,6 +289,27 @@ class TestCaptureLogSnapshotRedaction:
 
         assert "person@example.com" in snap.tail_text
         assert "person@example.com" in (snap.full_text or "")
+
+    def test_no_redact_preserves_identity_message_and_home_path(
+        self, hermes_home_with_secret
+    ):
+        from hermes_cli.debug import _capture_log_snapshot
+
+        log_path = hermes_home_with_secret / "logs" / "agent.log"
+        log_path.write_text(
+            "2026-04-12 17:00:00 INFO gateway.run: "
+            "inbound message: platform=telegram "
+            "user=Alice Smith chat=9876543210 "
+            "msg='private medical question' "
+            f"cwd={hermes_home_with_secret / 'sessions'}\n"
+        )
+
+        snap = _capture_log_snapshot("agent", tail_lines=10, redact=False)
+
+        assert "Alice Smith" in snap.tail_text
+        assert "9876543210" in snap.tail_text
+        assert "private medical question" in snap.tail_text
+        assert str(hermes_home_with_secret) in snap.tail_text
 
     def test_capture_default_log_snapshots_threads_redact(
         self, hermes_home_with_secret

--- a/tests/hermes_cli/test_subcommands_batch.py
+++ b/tests/hermes_cli/test_subcommands_batch.py
@@ -76,6 +76,21 @@ SINGLE_HANDLER_CASES = [
 ]
 
 
+def test_debug_share_help_describes_best_effort_privacy_redaction(capsys):
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_debug_parser(sub, cmd_debug=_h("debug"))
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["debug", "share", "--help"])
+
+    assert exc_info.value.code == 0
+    help_text = capsys.readouterr().out
+    normalized_help = " ".join(help_text.split())
+    assert "best-effort secret and privacy redaction" in normalized_help
+    assert "unrecognized personal data may remain" in normalized_help
+
+
 
 
 def test_config_get_unset_subcommands_parse():

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -943,9 +943,9 @@ def image_generate_tool(
             )
             endpoint = edit_endpoint
             logger.info(
-                "Editing image with %s (%s) — %d source image(s), prompt: %s",
+                "Editing image with %s (%s) — %d source image(s), prompt_chars=%d",
                 meta.get("display", model_id), endpoint, len(clamped_sources),
-                prompt[:80],
+                len(prompt),
             )
         else:
             arguments = _build_fal_payload(
@@ -953,8 +953,8 @@ def image_generate_tool(
             )
             endpoint = model_id
             logger.info(
-                "Generating image with %s (%s) — prompt: %s",
-                meta.get("display", model_id), model_id, prompt[:80],
+                "Generating image with %s (%s) — prompt_chars=%d",
+                meta.get("display", model_id), model_id, len(prompt),
             )
 
         handler = _submit_fal_request(endpoint, arguments=arguments)

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -1185,9 +1185,9 @@ def image_generate_tool(
             )
             endpoint = edit_endpoint
             logger.info(
-                "Editing image with %s (%s) — %d source image(s), prompt: %s",
+                "Editing image with %s (%s) — %d source image(s), prompt_chars=%d",
                 meta.get("display", model_id), endpoint, len(clamped_sources),
-                prompt[:80],
+                len(prompt),
             )
         else:
             arguments = _build_fal_payload(
@@ -1195,8 +1195,8 @@ def image_generate_tool(
             )
             endpoint = model_id
             logger.info(
-                "Generating image with %s (%s) — prompt: %s",
-                meta.get("display", model_id), model_id, prompt[:80],
+                "Generating image with %s (%s) — prompt_chars=%d",
+                meta.get("display", model_id), model_id, len(prompt),
             )
 
         handler = _submit_fal_request(endpoint, arguments=arguments)

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1362,7 +1362,7 @@ async def vision_analyze_tool(
             return tool_error("Interrupted", success=False)
 
         logger.info("Analyzing image: %s", image_url[:60])
-        logger.info("User prompt: %s", user_prompt[:100])
+        logger.info("Image-analysis prompt received (chars=%d)", len(user_prompt))
 
         # Resolve the source to raw bytes through the single resolver (unifies
         # data:/http/file/local/container and enforces terminal-backend
@@ -1978,7 +1978,7 @@ async def video_analyze_tool(
             return tool_error("Interrupted", success=False)
 
         logger.info("Analyzing video: %s", video_url[:60])
-        logger.info("User prompt: %s", user_prompt[:100])
+        logger.info("Video-analysis prompt received (chars=%d)", len(user_prompt))
 
         # Resolve local path vs remote URL
         resolved_url = video_url

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1149,7 +1149,7 @@ async def vision_analyze_tool(
             return tool_error("Interrupted", success=False)
 
         logger.info("Analyzing image: %s", image_url[:60])
-        logger.info("User prompt: %s", user_prompt[:100])
+        logger.info("Image-analysis prompt received (chars=%d)", len(user_prompt))
 
         # Resolve the source to raw bytes through the single resolver (unifies
         # data:/http/file/local/container and enforces terminal-backend
@@ -1684,7 +1684,7 @@ async def video_analyze_tool(
             return tool_error("Interrupted", success=False)
 
         logger.info("Analyzing video: %s", video_url[:60])
-        logger.info("User prompt: %s", user_prompt[:100])
+        logger.info("Video-analysis prompt received (chars=%d)", len(user_prompt))
 
         # Resolve local path vs remote URL
         resolved_url = video_url


### PR DESCRIPTION
Superseded by [#104577](https://github.com/NousResearch/hermes-agent/pull/104577) for conversation producer diagnostics and [#82556](https://github.com/NousResearch/hermes-agent/pull/82556) for the historical/local/private collector and scoped WhatsApp diagnostics. Both successors preserve the useful source contributions and have passed upstream CI. The collector remains compatible with #94911's proposed log-free public whitelist.

The description and test results below describe the historical combined branch.

Maintenance prepared with GPT-6 Astra, ultra reasoning, in Codex. The account owner loosely reviews these actions and receives the usual notifications from GitHub.

---

## Summary

- preserve PR #34818's public debug-share PII redaction patch as its own commit with zapabob's original authorship
- close the reviewed gaps for positional and multiline records, diagnostic dump and error content, structured identity/message fields, IPv4/IPv6 addresses, and complete upload bundles
- stop current platform and tool producers from logging the reviewed identities, prompts, subjects, transcripts, and webhook responses verbatim
- make default, opt-out, privacy, and client-side deletion notices describe their actual best-effort boundaries
- retain PR #37833's Windows-stable `newline="\n"` truncation fixture, with its concrete authorship credit explained in the correction commit

This replaces the incomplete PR #34818 and its duplicate PR #37833 while preserving their useful authored work and incorporating the public review feedback from both.

## Test plan

- 116 focused debug-share tests
- 911 related platform and producer tests
- 178 isolated reruns covering every failure from the broad suite after installing the declared optional dependencies
- Ruff, Python compilation, diff, ancestry, and merge-tree checks
- xhigh self-review and final CodeRabbit committed-diff review with no findings

Closes #46006
