### PR TITLE
skills(gaming): game 3D asset pipeline — TRELLIS.2 + SkinTokens via HF Spaces

### DIFF
--- a/contributors/emails/jpkorstad@gmail.com
+++ b/contributors/emails/jpkorstad@gmail.com
@@ -1,0 +1,1 @@
+Jpalmer95

--- a/skills/gaming/game-asset-pipeline/SKILL.md
+++ b/skills/gaming/game-asset-pipeline/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: game-asset-pipeline
+description: "Use when the user wants game-ready 3D characters/props from text descriptions or concept art in one go — orchestrates the full chain: concept prompts -> image generation -> alpha masking -> TRELLIS.2 image-to-3D -> SkinTokens auto-rigging -> engine-ready rigged GLBs, with quality gates, resume, and engine presets (Godot/Unity/Blender). Invoke for requests like 'make me 10 enemy characters for my game'."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [3d, game-dev, pipeline, orchestrator, trellis, skintokens, glb, rigging]
+    related_skills: [trellis-image-to-3d, skintokens-rigging, comfyui, segment-anything-model, blender-mcp, hermes-3d-mcp]
+---
+
+# Game Asset Pipeline — Concept to Rigged Characters
+
+## Overview
+
+Orchestrates the phase skills into a single end-to-end run. The agent drives the phases; each phase is independently usable via its own skill when the user only needs part of the chain.
+
+```
+prompts.txt -> [1 image gen] -> images/
+            -> [2 mask]      -> images_masked/
+            -> [3 3D gen]    -> assets/glb/ + manifest.csv      (trellis-image-to-3d)
+            -> [4 rig]       -> assets/rigged/ + rig_manifest   (skintokens-rigging)
+            -> [5 verify]    -> Blender/Godot import checks     (blender-mcp / hermes-3d-mcp)
+```
+
+## When to Use
+
+- "Make me N characters/enemies/props for my game" from text descriptions
+- "Turn this folder of concept art into rigged models"
+- Don't use for: single static prop (just call trellis-image-to-3d directly), re-rigging existing GLBs (just skintokens-rigging), 2D-only work
+
+## Phase Execution
+
+1. **Concepts.** Write/confirm `prompts.txt` — one line per asset, consistent anchors: `full body, T-pose front view, centered with margin, dark background, fantasy game asset`. Characters only for rigging; props skip phase 4.
+2. **Images.** Prefer local ComfyUI (`comfyui` skill) > HF image Space > `image_generate` tool. Name files `NN_slug.png` so sort order matches prompt lines. GATE: `vision_analyze` each image — subject fully visible, correct limb count/anatomy, plain dark background. Regenerate failures NOW (cheap) rather than after GPU phases. (Lesson: "ant" prompts can produce centipedes without "exactly six legs, three body segments, two antennae".)
+3. **Mask.** Use the rembg **Python API**, not its CLI (the CLI eagerly imports server deps — gradio/aiohttp/fastapi — and crashes without them):
+   ```python
+   from rembg import remove; from pathlib import Path
+   for f in Path("images").glob("*.png"):
+       (Path("images_masked")/f.name).write_bytes(remove(f.read_bytes()))
+   ```
+   Or rely on TRELLIS `--preprocess`. Local rembg preferred — inspectable before spending quota.
+4. **3D.** `python3 <trellis-skill>/scripts/trellis_gen.py --batch images_masked/ --out-root assets --prompts-file prompts.txt --keep-image --target godot --resume`. Runs sequential (ZeroGPU serializes), applies quality gates per asset (alpha coverage in, GLB geometry+texture out). Always run as a Hermes background task (`terminal(background=true, notify_on_complete=true)`) — expect 3-8 min per asset.
+5. **Rig (characters only).** `python3 <rig-skill>/scripts/skintokens_rig.py --batch assets/glb/ -o assets/rigged/ --preserve-texture-scale --resume`. Rig gate verifies joints + JOINTS_0/WEIGHTS_0. **For any asset that fails with "No output files were produced", retry that asset with `--voxel-postprocess` — confirmed to rescue all failures in the 10-ant dogfood batch (translucent/glossy/rocky textures trip the default path).**
+6. **Verify.** Import one output into Blender via `blender-mcp` (or headless `blender -b --python-expr`): check bone count, vertex groups match bones, pose 2-3 bones and screenshot. SkinTokens outputs include a stray `Icosphere` joint-viz mesh — hide/delete it before export. Consider renaming bones to readable names (keep vertex groups in sync) for hand animation work.
+
+## Script Flags Reference
+
+Both phase scripts support:
+- `--resume` — skip assets whose output already exists (crash-safe reruns)
+- `--skip-gates` — disable quality gates
+- trellis_gen.py additionally: `--target godot-mobile|godot|unity|blender|film` (sets decimation 30k/80k/80k/300k/500k + texture 1024/2048/2048/2048/4096), `--preprocess`, `--seed N`
+
+Quality gates live in `trellis-image-to-3d/scripts/pipeline_qgates.py`: alpha-mask coverage, GLB parse + vertex count + texture presence, rig joints + skin weights. `gate_failed` rows appear in the manifest instead of burning GPU.
+
+## Deliverables (completion criteria)
+
+- `assets/manifest.csv` — one row per asset: slug, prompt, image path, glb path, seed, status
+- `assets/rigged/rig_manifest.csv` — rig status per character
+- Every status `ok`; every GLB opens in the target engine
+- Verified sample posed in Blender without mesh tearing
+
+## Common Pitfalls
+
+1. **Anatomy drift at image gen.** Vision-gate every image before phase 3; specify limb counts explicitly in prompts for non-humanoid creatures.
+2. **Skipping --resume on reruns.** Without it, a crash at asset 8 of 10 restarts from 1.
+3. **Rigging props.** Only characters go to phase 5; split prompts.txt or filter assets/glb/ accordingly.
+4. **HF_TOKEN not visible to the shell.** Export in the same shell that launches the batch, or `set -a; . ~/.hermes/.env; set +a` first.
+5. **Forgetting the Icosphere.** SkinTokens adds joint-viz spheres to the GLB; strip in Blender before shipping to an engine.
+
+## Verification Checklist
+
+- [ ] All images vision-gated (anatomy, framing, background) before GPU phases
+- [ ] Batch run used `--resume` and appropriate `--target`
+- [ ] manifest.csv + rig_manifest.csv: all rows `ok` (or known/accepted failures)
+- [ ] One rigged sample pose-tested in Blender (bones deform mesh smoothly)
+- [ ] Icosphere joint-viz removed from shipped assets

--- a/skills/gaming/skintokens-rigging/SKILL.md
+++ b/skills/gaming/skintokens-rigging/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: skintokens-rigging
+description: "Use when rigging static 3D meshes (GLB/OBJ/FBX) with automatic skeleton + skin weights via the VAST-AI/SkinTokens Hugging Face Space (user's HF_TOKEN ZeroGPU quota). Pairs with trellis-image-to-3d — TRELLIS.2 generates static GLBs, SkinTokens rigs them for animation in Godot/Blender. Covers single and batch rigging plus the full concept-to-rigged-asset pipeline."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [3d, rigging, skinning, game-dev, gradio, huggingface, glb, skeleton]
+    related_skills: [trellis-image-to-3d, blender-mcp, hermes-3d-mcp, hf-gradio-3d-rig]
+---
+
+# SkinTokens Auto-Rigging via Hugging Face Space
+
+## Overview
+
+`VAST-AI/SkinTokens` takes a static 3D mesh (.glb/.obj/.fbx) and predicts a skeleton + skin weights, returning a rigged GLB ready for animation retargeting in Godot 4 or Blender. It needs >=14GB VRAM, so the HF Space with the user's `HF_TOKEN` (ZeroGPU quota) is the practical way to run it. This skill ships `scripts/skintokens_rig.py`, a self-contained gradio_client wrapper.
+
+The Space exposes a single endpoint (verified against `/gradio_api/info`):
+
+`/run_gradio(models, top_k=5, top_p=0.95, temperature=1.0, repetition_penalty=2.0, num_beams=10, use_existing_skeleton=False, preserve_texture_scale=False, voxel_postprocess=False, checkpoint="experiments/articulation_xl_quantization_256_token_4/grpo_1400.ckpt", hf_path="None") -> (status, rigged_glb)`
+
+`models` accepts a list of files — you can rig a few per call, but sequential single calls are more debuggable and kinder to quota.
+
+## When to Use
+
+- After `trellis-image-to-3d` (or any other source) produced static GLBs that need skeletons/skin weights
+- User asks to "rig", "skin", or "make animatable" a 3D model
+- Don't use for: static props (rocks, houses — skip rigging), image-to-3D generation (that's trellis-image-to-3d), animation retargeting itself (do that in Godot/Blender)
+
+## Setup
+
+Same as trellis-image-to-3d: `export HF_TOKEN=***` and `pip install "gradio_client>=1.0"`. Hermes loads `.env` from the working directory — putting `HF_TOKEN=...` in the project `.env` (never committed) also works.
+
+## Usage
+
+Single asset:
+```bash
+python3 scripts/skintokens_rig.py goblin.glb -o rigged/goblin_rigged.glb
+```
+
+Batch (sequential; appends status to `<out-dir>/rig_manifest.csv`):
+```bash
+python3 scripts/skintokens_rig.py --batch assets/ants/glb/ -o assets/ants/rigged/
+```
+
+Useful flags (Space defaults shown):
+- `--top-k 5 --top-p 0.95 --temperature 1.0 --rep-penalty 2.0 --beams 10` — sampling knobs; leave alone unless output is degenerate, then lower temperature (e.g. 0.7) first.
+- `--preserve-texture-scale` — keeps original UV textures and world scale; usually WANT this on for TRELLIS.2 outputs (they're already textured and reasonably scaled).
+- `--use-existing-skeleton` — only when input already has a skeleton and you just need skin weights.
+- `--voxel-postprocess` — extra cleanup pass for skin weights. **CONFIRMED RULE from live batch: models that fail with "No output files were produced" (3/10 in the ant batch: translucent ice, glossy venom, granite stone textures) succeeded on the FIRST retry with this flag enabled. If a rig fails server-side, retry with `--voxel-postprocess` before anything else.**
+- Completion: output GLB exists, opens in Blender with an Armature modifier / in Godot with a Skeleton3D node.
+
+## Full Pipeline (concept -> rigged game asset)
+
+This is the combined trellis-image-to-3d + skintokens-rigging chain — the "10 elemental ant enemies" end-to-end recipe:
+
+1. **Concepts** — `prompts.txt`, one line per asset: `"fire ant warrior, glowing ember carapace, full body T-pose front view, centered, fantasy game asset, dark background"`. T-pose-ish, full-body, uncropped silhouettes matter for BOTH generation quality and rigging quality (SkinTokens finds joints much better on spread limbs).
+2. **Images** — generate one PNG per prompt (local ComfyUI preferred, else HF image Space / image_generate). Save `images/NN_slug.png`.
+3. **Alpha-mask** — `rembg i in.png out.png` per image, or rely on TRELLIS `--preprocess`. Verify masks before spending GPU.
+4. **3D meshes** — `python3 <trellis-skill>/scripts/trellis_gen.py --batch images/ --out-root assets/ants --preprocess --keep-image` (sequential; several min/asset; run with `terminal(background=true, notify_on_complete=true)`).
+5. **Rig** — `python3 <this-skill>/scripts/skintokens_rig.py --batch assets/ants/glb/ -o assets/ants/rigged/ --preserve-texture-scale`.
+6. **Verify + import** — open a rigged GLB in Blender (check armature bones sit inside the mesh, weights deform plausibly in pose mode) or drag into Godot 4. Completion: N rigged GLBs + manifest.csv + rig_manifest.csv all consistent.
+7. **Polish/animate** — retarget animations onto the generated skeleton in Blender (`blender-mcp`) or Godot (`hermes-3d-mcp`). Auto-rigs usually need weight cleanup around thin appendages; budget a manual pass for hero characters.
+
+## Common Pitfalls
+
+1. **No HF_TOKEN** — anonymous runs hit the public queue and frequently fail on this GPU-heavy Space. Export it first.
+2. **Rigging props.** Static scenery gains nothing; only rig characters/creatures.
+3. **Tangled input poses.** Characters holding weapons across the body or with limbs touching the torso confuse joint prediction. Prefer T-pose source images upstream in TRELLIS.
+4. **Cropped/waist-up source images will NOT rig.** Confirmed live: a waist-up wizard portrait produced a valid static GLB but SkinTokens failed with "No output files" even WITH voxel-postprocess — you can't skeletonize legs that don't exist. The retry auto-escalation rescues texture/material failures, NOT missing-geometry failures. Rule: if rigging is the goal, the source image MUST be full-body. (We tried gating this via bounding-box proportions — doesn't work, wide creatures like ants are legitimately squat. No cheap geometric test; enforce it at the image prompt/review stage.)
+4. **Expecting production weights.** Auto skinning is a starting point — thin geometry (antennae, fingers, lantern handles) often needs manual weight painting.
+5. **Parallel batch calls** — ZeroGPU serializes per account; loop sequentially.
+6. **Forgetting --preserve-texture-scale on TRELLIS outputs** — without it you may lose the texture TRELLIS baked.
+
+## Verification Checklist
+
+- [ ] `HF_TOKEN` exported (or in project `.env`)
+- [ ] Output GLB contains a skeleton (Blender: Armature; Godot: Skeleton3D)
+- [ ] Skin weights deform plausibly (test a few bone rotations)
+- [ ] Batch: `rig_manifest.csv` has one row per input with status
+- [ ] Textures survived (use `--preserve-texture-scale`)

--- a/skills/gaming/skintokens-rigging/scripts/skintokens_rig.py
+++ b/skills/gaming/skintokens-rigging/scripts/skintokens_rig.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""VAST-AI/SkinTokens (HF Space) auto-rigger: static mesh -> rigged GLB.
+
+Uses the caller's HF_TOKEN ZeroGPU quota. Single-file and batch modes.
+
+Usage:
+    python3 skintokens_rig.py model.glb -o rigged/model_rigged.glb
+    python3 skintokens_rig.py --batch assets/ants/glb/ -o assets/ants/rigged/ --preserve-texture-scale
+
+Requires: pip install "gradio_client>=1.0"
+Env: HF_TOKEN must be set.
+"""
+import argparse
+import csv
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from pipeline_qgates import gate_glb_rig
+except ImportError:
+    # standalone use outside the trellis skill dir: try sibling skill location
+    sys.path.insert(0, str(Path.home() / ".hermes/skills/gaming/trellis-image-to-3d/scripts"))
+    from pipeline_qgates import gate_glb_rig
+
+SPACE = "VAST-AI/SkinTokens"
+CHECKPOINT = "experiments/articulation_xl_quantization_256_token_4/grpo_1400.ckpt"
+MANIFEST_FIELDS = ["input", "output", "status", "error"]
+
+
+def get_client():
+    token = os.environ.get("HF_TOKEN")
+    if not token:
+        sys.exit("ERROR: HF_TOKEN is not set. Create one at https://huggingface.co/settings/tokens")
+    try:
+        from gradio_client import Client
+    except ImportError:
+        sys.exit("ERROR: gradio_client not installed. Run: pip install 'gradio_client>=1.0'")
+    return Client(SPACE, token=token)
+
+
+def download(url, dest):
+    import urllib.request
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {os.environ['HF_TOKEN']}"})
+    with urllib.request.urlopen(req) as r, open(dest, "wb") as f:
+        shutil.copyfileobj(r, f)
+
+
+def rig_one(client, model_path, out_glb, args):
+    """Rig a single mesh. Returns error string or None."""
+    from gradio_client import handle_file
+    payload = [
+        [handle_file(str(model_path))],  # models (list of files)
+        args.top_k,
+        args.top_p,
+        args.temperature,
+        args.rep_penalty,
+        args.beams,
+        args.use_existing_skeleton,
+        args.preserve_texture_scale,
+        args.voxel_postprocess,
+        CHECKPOINT,
+        "None",
+    ]
+    last_err = None
+    for attempt in range(3):
+        try:
+            # auto-escalate: repeated "No output files" failures are rescued by
+            # voxel post-processing (confirmed on translucent/glossy/rocky inputs)
+            if attempt >= 1 and not payload[8] and "No output files" in str(last_err or ""):
+                print(f"[{Path(model_path).stem}] auto-enabling voxel post-processing", flush=True)
+                payload[8] = True
+            print(f"[{Path(model_path).stem}] run_gradio (attempt {attempt + 1}) ...", flush=True)
+            res = client.predict(*payload, api_name="/run_gradio")
+            status, glb = (res if isinstance(res, (list, tuple)) else (None, res))[:2]
+            # output may be a single file or a list of files (one per input model)
+            if isinstance(glb, (list, tuple)):
+                glb = glb[0] if glb else None
+            if isinstance(glb, dict):
+                glb = glb.get("path") or glb.get("url") or glb.get("value")
+            if not (isinstance(glb, str) and glb.lower().endswith(".glb")):
+                raise RuntimeError(f"no rigged .glb in result (status={status!r}, out={glb!r})")
+            Path(out_glb).parent.mkdir(parents=True, exist_ok=True)
+            if glb.startswith("http"):
+                download(glb, out_glb)
+            else:
+                shutil.copyfile(glb, out_glb)
+            print(f"[{Path(model_path).stem}] OK -> {out_glb}", flush=True)
+            return None
+        except Exception as e:
+            last_err = e
+            wait = 20 * (attempt + 1)
+            print(f"[{Path(model_path).stem}] failed: {e}; retrying in {wait}s", flush=True)
+            time.sleep(wait)
+    return str(last_err)
+
+
+def append_manifest(out_dir, row):
+    path = Path(out_dir) / "rig_manifest.csv"
+    exists = path.exists()
+    with open(path, "a", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=MANIFEST_FIELDS)
+        if not exists:
+            w.writeheader()
+        w.writerow(row)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("input", nargs="?", help="input mesh (.glb/.obj/.fbx)")
+    ap.add_argument("-o", "--output", required=True, help="output .glb path (single) or directory (batch)")
+    ap.add_argument("--batch", help="directory of meshes to rig")
+    ap.add_argument("--top-k", type=float, default=5)
+    ap.add_argument("--top-p", type=float, default=0.95)
+    ap.add_argument("--temperature", type=float, default=1.0)
+    ap.add_argument("--rep-penalty", type=float, default=2.0)
+    ap.add_argument("--beams", type=float, default=10)
+    ap.add_argument("--use-existing-skeleton", action="store_true")
+    ap.add_argument("--preserve-texture-scale", action="store_true",
+                    help="keep original textures/scale (recommended for TRELLIS.2 outputs)")
+    ap.add_argument("--voxel-postprocess", action="store_true",
+                    help="extra skin-weight cleanup; try for thin limbs")
+    ap.add_argument("--resume", action="store_true",
+                    help="batch mode: skip meshes whose output .glb already exists")
+    ap.add_argument("--skip-gates", action="store_true", help="disable rig quality gate")
+    args = ap.parse_args()
+
+    client = get_client()
+
+    if args.batch:
+        out_dir = Path(args.output)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        meshes = sorted(p for p in Path(args.batch).iterdir()
+                        if p.suffix.lower() in (".glb", ".obj", ".fbx"))
+        if not meshes:
+            sys.exit(f"no meshes found in {args.batch}")
+        ok = 0
+        for m in meshes:
+            out_glb = out_dir / f"{m.stem}_rigged.glb"
+            if args.resume and out_glb.exists():
+                print(f"[{m.stem}] exists, skipping (--resume)", flush=True)
+                ok += 1
+                continue
+            err = rig_one(client, m, out_glb, args)
+            if not err and not args.skip_gates:
+                ok_g, msg = gate_glb_rig(out_glb)
+                print(f"[{m.stem}] gate(rig): {msg}", flush=True)
+                if not ok_g:
+                    err = f"rig_gate: {msg}"
+            append_manifest(out_dir, dict(input=str(m), output=str(out_glb) if not err else "",
+                                          status="ok" if not err else "error", error=err or ""))
+            ok += 0 if err else 1
+        print(f"done: {ok}/{len(meshes)} succeeded. Manifest: {out_dir / 'rig_manifest.csv'}")
+        sys.exit(0 if ok == len(meshes) else 1)
+
+    if not args.input:
+        ap.error("single mode requires INPUT (or use --batch)")
+    err = rig_one(client, args.input, args.output, args)
+    if err:
+        sys.exit(f"FAILED: {err}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/gaming/trellis-image-to-3d/SKILL.md
+++ b/skills/gaming/trellis-image-to-3d/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: trellis-image-to-3d
+description: Use when generating 3D GLB assets from images via the microsoft/TRELLIS.2 Hugging Face Space (uses the user's HF_TOKEN ZeroGPU quota). Covers single asset generation, preprocessing (alpha-masking/background removal), and batch character pipelines (concept -> image gen -> bg removal -> TRELLIS.2 -> GLB + manifest) for game dev workflows in Godot/Blender.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [3d, game-dev, gradio, huggingface, trellis, glb, asset-pipeline]
+    related_skills: [forgedna-comfyui-assets, blender-mcp, hermes-3d-mcp, comfyui]
+---
+
+# TRELLIS.2 Image-to-3D via Hugging Face Space
+
+## Overview
+
+`microsoft/TRELLIS.2` converts a 2D image into a textured 3D GLB asset. Running it through the HF Space with the user's `HF_TOKEN` spends THEIR ZeroGPU quota — no local GPU required. This skill ships `scripts/trellis_gen.py`, a self-contained client that handles the full call chain: upload -> preprocess -> generate -> extract GLB -> save locally.
+
+The Space's Gradio API (verified against `/gradio_api/info`):
+
+| Endpoint | Inputs | Outputs |
+|---|---|---|
+| `/start_session` | — | — |
+| `/preprocess_image` | image | alpha-masked RGBA image |
+| `/get_seed` | randomize_seed, seed | seed |
+| `/image_to_3d` | image, seed, resolution, then 3 stages x (guidance, guidance_rescale, steps, rescale_t) | 3D preview |
+| `/extract_glb` | decimation_target, texture_size | GLB path, download file |
+
+Defaults from the Space UI: resolution `512`, stage 1+2 params `7.5 / 0.7 / 12 / 5`, stage 3 params `1 / 0 / 12 / 3`, decimation `300000`, texture size `2048`.
+
+## When to Use
+
+- User asks to turn concept art / generated images into 3D GLB assets
+- Batch asset pipelines: "make me 10 elemental ant enemies as 3D models"
+- Any game-dev flow targeting Godot / Blender / HermesForge with GLB imports
+- Don't use for: rigging/skinning (roadmap: VAST-AI/SkinTokens, see Roadmap section), text-to-3D directly (generate an image first)
+
+## Setup
+
+1. `HF_TOKEN` must be set (read token at https://huggingface.co/settings/tokens). ZeroGPU quota is tied to the user's HF account; without a token the Space runs anonymously with no ZeroGPU priority and may fail.
+2. Install the client (once): `pip install "gradio_client>=1.0"` — that's the only dependency.
+3. Optional for background removal: `pip install rembg` (+ first run downloads the u2net model ~170MB).
+
+## Single Asset Generation
+
+```bash
+python3 scripts/trellis_gen.py input.png -o assets/goblin.glb \
+    --name goblin --preprocess --resolution 512 --texture-size 2048
+```
+
+Key flags (all optional, Space defaults shown):
+- `--preprocess` — call `/preprocess_image` first (alpha-mask the foreground). DO use this for raw images; skip if the image is already RGBA alpha-masked.
+- `--seed N` / `--randomize-seed` (default: randomize)
+- `--resolution {512,1024,1536}` (512 default; higher = slower, more quota)
+- `--decimation 300000` (face target at GLB extraction)
+- `--texture-size {1024,2048,4096}`
+- `--stage1 "7.5,0.7,12,5"` `--stage2 "7.5,0.7,12,5"` `--stage3 "1,0,12,3"`
+- `--keep-image` — also save the (preprocessed) image next to the GLB
+- Completion: the `.glb` file exists at `-o` and is non-trivial in size (>50KB for a real asset).
+
+GLB extraction server-side can take 30-60+ seconds and is the most likely step to hit queue timeouts — the script retries with backoff; if it still fails, re-run with the same `--seed` to retry extraction on the cached generation.
+
+## Batch Character Pipeline (the "10 elemental ants" recipe)
+
+End state per run: a working folder containing `images/NN_slug.png`, `glb/NN_slug.glb`, and `manifest.csv` (slug, prompt, image_path, glb_path, seed, resolution, status). Steps:
+
+1. **Concept list.** Write the N prompts to `prompts.txt` (one per line). Be specific and consistent: `"fire ant warrior character, glowing ember carapace, T-pose front view, full body, fantasy game asset, centered, dark background"`. Front/full-body shots with the whole silhouette visible produce drastically better 3D gens.
+2. **Image generation.** Generate one image per prompt with an open image Space or local tool — preferred order: local ComfyUI (see `comfyui`/`forgedna-comfyui-assets` skills, free, no quota) > HF image Space via `gradio_client` (e.g. FLUX.1-schnell Spaces) > `image_generate` tool. Save as `images/NN_slug.png`.
+3. **Background removal.** TRELLIS.2 wants an alpha-masked foreground. Either pass `--preprocess` (server-side masking, easiest) OR run locally for more control:
+   ```bash
+   rembg i input.png output_rgba.png
+   ```
+   Verify the alpha channel actually isolates the character (no floating props cut off, lantern/weapon intact). Bad masks = melted 3D models. Re-generate or hand-fix bad ones before burning ZeroGPU quota.
+4. **Batch convert.** Loop `trellis_gen.py` over the images. The script appends each result to `manifest.csv` in the output root. Run sequentially (ZeroGPU is single-queue per account) and expect several minutes per asset; for 10+ assets run it with `terminal(background=true, notify_on_complete=true)`.
+   ```bash
+   python3 scripts/trellis_gen.py --batch images/ --out-root assets/ants --preprocess --keep-image
+   ```
+5. **Verify + import.** Open a sample GLB (Blender: File > Import > glTF 2.0; Godot 4: drag into project, auto-imports). Check texture is applied and scale/orientation is sane. Completion: manifest has N rows with `status=ok` and every GLB opens.
+
+## Common Pitfalls
+
+1. **No HF_TOKEN passed.** The script reads `HF_TOKEN` from env; without it you get anonymous quota and frequent queue failures. Export it before batch runs or add it to `~/.hermes/.env` (source it with `set -a; . ~/.hermes/.env; set +a` — new Hermes sessions don't auto-inherit a token exported in another shell).
+2. **gradio_client 1.x renamed the auth kwarg to `token=`** (was `hf_token=` in 0.x). Scripts use `token=`; if you see `unexpected keyword argument 'hf_token'` you're reading old examples.
+2. **Skipping preprocessing on busy backgrounds.** TRELLIS.2 reconstructs whatever it sees — a background becomes geometry. Always alpha-mask first (flag or rembg).
+3. **Cropped silhouettes.** Characters with cut-off feet/weapons generate incomplete meshes. Prompt for "full body, centered, margin around subject".
+4. **Parallel batch calls.** ZeroGPU serializes per-account; parallel clients just queue-fight and time out. Sequential loop only.
+5. **Expecting rigged output.** TRELLIS.2 GLBs are static meshes. Rigging is the SkinTokens phase (below).
+6. **Giving up on extract_glb timeout.** Generation is cached server-side per session; re-running with the same seed often succeeds on retry.
+
+## Roadmap (planned companion skills / phases)
+
+- **Phase 2 — Rigging:** VAST-AI/SkinTokens Space (`https://vast-ai-skintokens.hf.space`, agents.md verified — needs >=14GB VRAM, runs on ZeroGPU with token) converts a static GLB into a skeleton+skin-weight rigged model. Same gradio_client pattern: upload -> `/gradio_api/queue/join` -> stream `/queue/data`. Planned as `scripts/skintokens_rig.py` in this skill or a sibling `skintokens-rigging` skill.
+- **Phase 3 — Engine import:** drop rigged GLBs into Blender (`blender-mcp`) for polish, or Godot/HermesForge (`hermes-3d-mcp`) for gameplay wiring.
+- **Phase 4 — Unified asset pipeline:** one orchestrating skill (concept -> image -> mask -> 3D -> rig -> engine) that invokes the phase skills only as needed for the user's current goal. Keep each phase independently usable.
+
+## Verification Checklist
+
+- [ ] `HF_TOKEN` exported and valid (script exits early with a clear error otherwise)
+- [ ] Input images are RGBA alpha-masked (or `--preprocess` used)
+- [ ] Output `.glb` exists, >50KB, opens in Blender/Godot with textures
+- [ ] Batch runs: `manifest.csv` row per asset with prompt, seed, paths, status
+- [ ] Sequential execution for batches (no parallel ZeroGPU calls)

--- a/skills/gaming/trellis-image-to-3d/scripts/pipeline_qgates.py
+++ b/skills/gaming/trellis-image-to-3d/scripts/pipeline_qgates.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Quality gates for the game-asset pipeline.
+
+Each gate is a function returning (ok: bool, message: str). Used by
+trellis_gen.py, skintokens_rig.py, and the game-asset-pipeline orchestrator.
+No third-party deps beyond what the pipeline already requires (Pillow optional
+for image gates; GLB parsing is done with stdlib struct/json).
+"""
+import json
+import struct
+from pathlib import Path
+
+
+def gate_alpha_mask(path, min_alpha_coverage=0.05, max_alpha_coverage=0.98):
+    """Image has a real alpha channel isolating a subject (not all opaque/transparent)."""
+    try:
+        from PIL import Image
+    except ImportError:
+        return True, "Pillow not installed; alpha gate skipped"
+    try:
+        im = Image.open(path).convert("RGBA")
+        a = im.getchannel("A")
+        hist = a.histogram()
+        total = im.width * im.height
+        # count pixels above half-alpha as subject: rembg/u2net produces
+        # semi-transparent masks where little is fully opaque
+        subject = sum(hist[128:]) / total
+        if subject < min_alpha_coverage:
+            return False, f"subject coverage {subject:.1%} too low — bad mask or empty image?"
+        if subject > max_alpha_coverage:
+            return False, f"opaque coverage {subject:.1%} — image is NOT alpha-masked (would bake background into 3D)"
+        return True, f"alpha mask ok ({subject:.0%} subject coverage)"
+    except Exception as e:
+        return False, f"alpha gate error: {e}"
+
+
+def _parse_glb_json(path):
+    with open(path, "rb") as f:
+        magic, version, _length = struct.unpack("<III", f.read(12))
+        if magic != 0x46546C67:
+            raise ValueError("not a GLB (bad magic)")
+        chunk_len, chunk_type = struct.unpack("<II", f.read(8))
+        if chunk_type != 0x4E4F534A:  # JSON
+            raise ValueError("first chunk is not JSON")
+        return json.loads(f.read(chunk_len))
+
+
+def gate_glb_geometry(path, min_verts=1000, max_verts=2_000_000):
+    """GLB parses, has meshes with a sane vertex count and at least one material/texture."""
+    try:
+        g = _parse_glb_json(path)
+        meshes = g.get("meshes", [])
+        if not meshes:
+            return False, "no meshes in GLB"
+        verts = 0
+        for m in meshes:
+            for prim in m.get("primitives", []):
+                idx = prim.get("attributes", {}).get("POSITION")
+                if idx is not None:
+                    verts += g["accessors"][idx].get("count", 0)
+        if verts < min_verts:
+            return False, f"only {verts} verts — generation likely failed"
+        if verts > max_verts:
+            return False, f"{verts} verts — decimation target not applied?"
+        has_tex = bool(g.get("images") or g.get("textures"))
+        note = "textured" if has_tex else "NO TEXTURES"
+        return (has_tex, f"{verts} verts, {note}") if not has_tex else (True, f"{verts} verts, textured")
+    except Exception as e:
+        return False, f"glb gate error: {e}"
+
+
+def gate_glb_rig(path, min_bones=5):
+    """GLB contains a skin with joints and skin weights (JOINTS_0/WEIGHTS_0)."""
+    try:
+        g = _parse_glb_json(path)
+        skins = g.get("skins", [])
+        if not skins:
+            return False, "no skins in GLB — not rigged"
+        joints = max(len(s.get("joints", [])) for s in skins)
+        if joints < min_bones:
+            return False, f"only {joints} joints — rig looks degenerate"
+        has_weights = any(
+            "JOINTS_0" in prim.get("attributes", {}) and "WEIGHTS_0" in prim.get("attributes", {})
+            for m in g.get("meshes", []) for prim in m.get("primitives", [])
+        )
+        if not has_weights:
+            return False, "skin exists but no JOINTS_0/WEIGHTS_0 attributes"
+        return True, f"rigged: {joints} joints, weights present"
+    except Exception as e:
+        return False, f"rig gate error: {e}"
+
+
+def gate_full_body_for_rig(path):
+    """DEPRECATED — bounding-box proportions cannot distinguish cropped humanoids
+    from legitimately wide creatures (ants/spiders). Verified: waist-up wizard
+    (fails rigging) and fire ant (rigs fine) have identical 1.0 ratios.
+    Kept as a no-op so existing callers don't break; rely on the auto-voxel
+    retry in skintokens_rig.py instead. Real defense: require full-body source
+    images when rigging is intended (documented in the skills)."""
+    return True, "proportion gate disabled (unreliable heuristic)"
+
+
+ENGINE_PRESETS = {
+    # target: (decimation, texture_size)
+    # NOTE: TRELLIS.2 /extract_glb enforces decimation >= 100000
+    "godot-mobile": (100000, 1024),
+    "godot": (100000, 2048),
+    "unity": (100000, 2048),
+    "blender": (300000, 2048),
+    "film": (500000, 4096),
+}
+
+
+def apply_engine_preset(args):
+    """Mutate an argparse namespace with --target presets, unless flags were explicitly set."""
+    target = getattr(args, "target", None)
+    if not target:
+        return args
+    if target not in ENGINE_PRESETS:
+        raise SystemExit(f"unknown --target '{target}'. Choices: {', '.join(ENGINE_PRESETS)}")
+    dec, tex = ENGINE_PRESETS[target]
+    if getattr(args, "decimation", None) in (None, 300000):
+        args.decimation = dec
+    if getattr(args, "texture_size", None) in (None, 2048):
+        args.texture_size = tex
+    return args

--- a/skills/gaming/trellis-image-to-3d/scripts/trellis_gen.py
+++ b/skills/gaming/trellis-image-to-3d/scripts/trellis_gen.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""TRELLIS.2 (microsoft/TRELLIS.2 HF Space) image-to-3D GLB generator.
+
+Uses the caller's HF_TOKEN ZeroGPU quota. Single-file and batch modes.
+
+Usage:
+    python3 trellis_gen.py input.png -o out.glb --name goblin --preprocess
+    python3 trellis_gen.py --batch images/ --out-root assets/ants --preprocess --keep-image
+
+Requires: pip install "gradio_client>=1.0"
+Env: HF_TOKEN must be set.
+"""
+import argparse
+import csv
+import os
+import random
+import shutil
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from pipeline_qgates import gate_alpha_mask, gate_glb_geometry, apply_engine_preset
+
+SPACE = "microsoft/TRELLIS.2"
+MANIFEST_FIELDS = ["slug", "prompt", "image_path", "glb_path", "seed", "resolution", "status", "error"]
+
+DEFAULTS = dict(
+    resolution="512",
+    decimation=300000,
+    texture_size="2048",
+    stage1=(7.5, 0.7, 12, 5),
+    stage2=(7.5, 0.7, 12, 5),
+    stage3=(1.0, 0.0, 12, 3),
+)
+
+
+def parse_stage(s):
+    parts = [float(x) for x in s.split(",")]
+    if len(parts) != 4:
+        raise argparse.ArgumentTypeError("stage params must be 'guidance,rescale,steps,rescale_t'")
+    # steps and rescale_t are ints
+    return (parts[0], parts[1], int(parts[2]), int(parts[3]))
+
+
+def get_client():
+    token = os.environ.get("HF_TOKEN")
+    if not token:
+        sys.exit("ERROR: HF_TOKEN is not set. Create a token at https://huggingface.co/settings/tokens")
+    try:
+        from gradio_client import Client
+    except ImportError:
+        sys.exit("ERROR: gradio_client not installed. Run: pip install 'gradio_client>=1.0'")
+    return Client(SPACE, token=token)
+
+
+def gen_one(client, image_path, out_glb, name, args):
+    """Full chain for one image. Returns (seed, error_or_none)."""
+    seed = args.seed if args.seed is not None else random.randint(0, 2**31 - 1)
+
+    from gradio_client import handle_file
+    img = handle_file(str(image_path))
+    if args.preprocess:
+        print(f"[{name}] preprocess_image ...", flush=True)
+        res = client.predict(img, api_name="/preprocess_image")
+        img = res[0] if isinstance(res, (list, tuple)) else res
+        if isinstance(img, dict):
+            img = img.get("path") or img.get("url")
+        img = handle_file(img)
+
+    flat = [v for st in (args.stage1, args.stage2, args.stage3) for v in st]
+    print(f"[{name}] image_to_3d seed={seed} res={args.resolution} ...", flush=True)
+    client.predict(img, seed, args.resolution, *flat, api_name="/image_to_3d")
+
+    # extract_glb is the slow step; retry with backoff (gen is cached per session)
+    last_err = None
+    for attempt in range(4):
+        try:
+            print(f"[{name}] extract_glb (attempt {attempt + 1}) ...", flush=True)
+            res = client.predict(args.decimation, args.texture_size, api_name="/extract_glb")
+            glb_src = None
+            for item in (res if isinstance(res, (list, tuple)) else [res]):
+                if isinstance(item, dict):
+                    item = item.get("path") or item.get("url")
+                if isinstance(item, str) and item.lower().endswith(".glb"):
+                    glb_src = item
+                    break
+            if not glb_src:
+                raise RuntimeError(f"no .glb in extract result: {res!r}")
+            Path(out_glb).parent.mkdir(parents=True, exist_ok=True)
+            if glb_src.startswith("http"):
+                import urllib.request
+                req = urllib.request.Request(glb_src, headers={"Authorization": f"Bearer {os.environ['HF_TOKEN']}"})
+                with urllib.request.urlopen(req) as r, open(out_glb, "wb") as f:
+                    shutil.copyfileobj(r, f)
+            else:
+                shutil.copyfile(glb_src, out_glb)
+            print(f"[{name}] OK -> {out_glb}", flush=True)
+            return seed, None
+        except Exception as e:
+            last_err = e
+            wait = 15 * (attempt + 1)
+            print(f"[{name}] extract failed: {e}; retrying in {wait}s", flush=True)
+            time.sleep(wait)
+    return seed, str(last_err)
+
+
+def append_manifest(root, row):
+    path = Path(root) / "manifest.csv"
+    exists = path.exists()
+    with open(path, "a", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=MANIFEST_FIELDS)
+        if not exists:
+            w.writeheader()
+        w.writerow(row)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("input", nargs="?", help="input image (single mode)")
+    ap.add_argument("-o", "--output", help="output .glb path (single mode)")
+    ap.add_argument("--name", default=None, help="asset slug (default: input filename stem)")
+    ap.add_argument("--batch", help="directory of images to convert (batch mode)")
+    ap.add_argument("--out-root", help="batch output root (creates glb/ and images/ + manifest.csv)")
+    ap.add_argument("--prompts-file", help="optional txt file (one prompt per line, order matches sorted images) recorded in manifest")
+    ap.add_argument("--preprocess", action="store_true", help="run /preprocess_image (alpha-mask) before generation")
+    ap.add_argument("--keep-image", action="store_true", help="copy the input image into out-root/images/ in batch mode")
+    ap.add_argument("--seed", type=int, default=None, help="fixed seed (default: random per asset)")
+    ap.add_argument("--resolution", default=DEFAULTS["resolution"], choices=["512", "1024", "1536"])
+    ap.add_argument("--decimation", type=int, default=DEFAULTS["decimation"])
+    ap.add_argument("--texture-size", type=int, default=2048, choices=[1024, 2048, 4096])
+    ap.add_argument("--stage1", type=parse_stage, default=DEFAULTS["stage1"])
+    ap.add_argument("--stage2", type=parse_stage, default=DEFAULTS["stage2"])
+    ap.add_argument("--stage3", type=parse_stage, default=DEFAULTS["stage3"])
+    ap.add_argument("--target", choices=["godot-mobile", "godot", "unity", "blender", "film"],
+                    help="engine preset: sets --decimation/--texture-size unless explicitly overridden")
+    ap.add_argument("--resume", action="store_true",
+                    help="batch mode: skip assets whose output .glb already exists")
+    ap.add_argument("--skip-gates", action="store_true", help="disable quality gates")
+    args = ap.parse_args()
+    apply_engine_preset(args)
+
+    client = get_client()
+
+    if args.batch:
+        out_root = Path(args.out_root or "assets_out")
+        glb_dir = out_root / "glb"
+        img_dir = out_root / "images"
+        glb_dir.mkdir(parents=True, exist_ok=True)
+        prompts = []
+        if args.prompts_file:
+            prompts = [l.strip() for l in open(args.prompts_file) if l.strip()]
+        images = sorted(p for p in Path(args.batch).iterdir()
+                        if p.suffix.lower() in (".png", ".jpg", ".jpeg", ".webp"))
+        if not images:
+            sys.exit(f"no images found in {args.batch}")
+        ok = 0
+        for i, img_path in enumerate(images):
+            stem = img_path.stem
+            # avoid double prefix when inputs are already NN_ named
+            slug = stem if stem[:2].isdigit() and stem[2:3] == "_" else f"{i + 1:02d}_{stem}"
+            prompt = prompts[i] if i < len(prompts) else ""
+            out_glb = glb_dir / f"{slug}.glb"
+            if args.resume and out_glb.exists():
+                print(f"[{slug}] exists, skipping (--resume)", flush=True)
+                ok += 1
+                continue
+            if not args.skip_gates and not args.preprocess:
+                # gate local masks only; --preprocess masks server-side instead
+                ok_g, msg = gate_alpha_mask(img_path)
+                print(f"[{slug}] gate(alpha): {msg}", flush=True)
+                if not ok_g:
+                    append_manifest(out_root, dict(slug=slug, prompt=prompt, image_path=str(img_path),
+                                                   glb_path="", seed="", resolution=args.resolution,
+                                                   status="gate_failed", error=f"alpha: {msg}"))
+                    continue
+            if args.keep_image:
+                img_dir.mkdir(exist_ok=True)
+                shutil.copyfile(img_path, img_dir / f"{slug}{img_path.suffix}")
+            seed, err = gen_one(client, img_path, out_glb, slug, args)
+            if not err and not args.skip_gates:
+                ok_g, msg = gate_glb_geometry(out_glb)
+                print(f"[{slug}] gate(glb): {msg}", flush=True)
+                if not ok_g:
+                    err = f"glb_gate: {msg}"
+            append_manifest(out_root, dict(
+                slug=slug, prompt=prompt,
+                image_path=str(img_path), glb_path=str(out_glb) if not err else "",
+                seed=seed, resolution=args.resolution,
+                status="ok" if not err else "error", error=err or ""))
+            ok += 0 if err else 1
+        print(f"done: {ok}/{len(images)} succeeded. Manifest: {out_root / 'manifest.csv'}")
+        sys.exit(0 if ok == len(images) else 1)
+
+    if not args.input or not args.output:
+        ap.error("single mode requires INPUT and -o OUTPUT (or use --batch)")
+    name = args.name or Path(args.input).stem
+    seed, err = gen_one(client, args.input, args.output, name, args)
+    if err:
+        sys.exit(f"FAILED: {err}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Three new skills under `skills/gaming/` (new category) for generating **game-ready rigged 3D characters** from text descriptions or concept art, running on Hugging Face ZeroGPU with the user's `HF_TOKEN` — no local GPU required:

| Skill | Role |
|---|---|
| `game-asset-pipeline` | Orchestrator: concept prompts → image gen → alpha masking → 3D → rigging → engine-ready GLBs. Quality gates, `--resume`, engine presets (`godot`/`godot-mobile`/`unity`/`blender`/`film`). |
| `trellis-image-to-3d` | [microsoft/TRELLIS.2](https://huggingface.co/spaces/microsoft/TRELLIS.2) image→3D batch client (`trellis_gen.py` + `pipeline_qgates.py`). |
| `skintokens-rigging` | [VAST-AI/SkinTokens](https://huggingface.co/spaces/VAST-AI/SkinTokens) auto-rigging client (`skintokens_rig.py`). Auto-escalates to voxel post-processing on server-side failures. |

## Battle-tested

Dogfooded end-to-end on **12 assets**: a 10-elemental-ant batch (10/10 rigged, 22–52 joints each) + 2 single-character paths (wizard, shiba). Real bugs found and fixed during live runs are encoded as pitfalls in the skills:

- gradio_client 1.x: `hf_token=` → `token=` kwarg rename
- File inputs must be `handle_file()`-wrapped (incl. preprocessed images)
- `/extract_glb`: decimation floor 100k; texture_size is numeric
- SkinTokens returns a **list** of GLBs; `rembg` CLI is broken (use Python API)
- Alpha gates must count half-alpha (u2net masks are semi-transparent)
- "No output files" rig failures are rescued by voxel post-processing (auto-escalation implemented); cropped/waist-up source images cannot rig (documented)

## Notes

- New `gaming` category — these are the first game-dev skills; more are expected (engine import, animation retargeting).
- Only dependency: `gradio_client>=1.0` (+ optional `rembg`, `pillow`).
- Companion public repo with guide + examples: https://github.com/Jpalmer95/game-3d-asset-skills
- TRELLIS.2/SkinTokens are research models; skills note license caveats for commercial use.

## Test plan

- [x] Frontmatter validated against `tools/skill_manager_tool.py` constraints (name, description ≤1024, ≤100k chars)
- [x] Scripts run end-to-end against the live Spaces (12/12 assets produced)
- [x] Quality gates verified on positive and negative cases