### PR TITLE
fix(mcp): silence Event loop is closed on reload parked teardown

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -736,3 +736,159 @@ class TestMCPInitialConnectionRetry:
                 await task
 
         asyncio.get_event_loop().run_until_complete(_run())
+
+
+# ---------------------------------------------------------------------------
+# Fix: parked wait helpers + reload must not raise "Event loop is closed"
+# ---------------------------------------------------------------------------
+
+class TestSafeCancelAwait:
+    """_safe_cancel_await must tolerate a closed event loop."""
+
+    def test_cancel_on_live_loop(self):
+        from tools.mcp_tool import _safe_cancel_await
+
+        async def _run():
+            blocker = asyncio.Event()
+            task = asyncio.create_task(blocker.wait())
+            await asyncio.sleep(0)  # let task start
+            await _safe_cancel_await(task)
+            assert task.cancelled() or task.done()
+
+        asyncio.run(_run())
+
+    def test_cancel_when_loop_already_closed(self):
+        """Simulates the reload race: cancel after the loop is gone."""
+        from tools.mcp_tool import _safe_cancel_await
+
+        async def _run():
+            # Create a dummy future on this loop, then hand it to a helper
+            # that will try cancel after we close a *different* scenario —
+            # we mock cancel() to raise RuntimeError like a closed loop.
+            fut = asyncio.get_running_loop().create_future()
+
+            class BoomFuture:
+                def done(self):
+                    return False
+
+                def cancel(self):
+                    raise RuntimeError("Event loop is closed")
+
+            # Must not raise
+            await _safe_cancel_await(BoomFuture())
+            fut.cancel()
+
+        asyncio.run(_run())
+
+    def test_done_task_is_noop(self):
+        from tools.mcp_tool import _safe_cancel_await
+
+        async def _run():
+            async def done_coro():
+                return 1
+
+            task = asyncio.create_task(done_coro())
+            await task
+            await _safe_cancel_await(task)  # no-op, no raise
+
+        asyncio.run(_run())
+
+
+class TestParkedFailedServerShutdown:
+    """Failed start that leaves run() parked must still be reaped on reload."""
+
+    def test_connect_server_tracks_parked_failed_start(self):
+        import tools.mcp_tool as mcp_mod
+        from tools.mcp_tool import MCPServerTask, _connect_server
+
+        async def _run():
+            with mcp_mod._lock:
+                mcp_mod._parked_failed_servers.clear()
+                mcp_mod._servers.clear()
+
+            server = MCPServerTask("parked-fail")
+
+            async def boom_start(self, config):
+                # Mimic start(): spawn run, signal ready with error, leave
+                # the task parked (alive) so the orphan race can fire.
+                async def parked_run():
+                    self._error = ConnectionError("permanent boom")
+                    self._ready.set()
+                    # Park like _wait_for_reconnect_or_shutdown
+                    await self._wait_for_reconnect_or_shutdown(timeout=60)
+
+                self._task = asyncio.ensure_future(parked_run())
+                await self._ready.wait()
+                if self._error:
+                    raise self._error
+
+            with patch.object(MCPServerTask, "start", boom_start):
+                try:
+                    await _connect_server("parked-fail", {"command": "fake"})
+                    raise AssertionError("expected connect failure")
+                except ConnectionError:
+                    pass
+
+            with mcp_mod._lock:
+                assert "parked-fail" in mcp_mod._parked_failed_servers
+                tracked = mcp_mod._parked_failed_servers["parked-fail"]
+                assert tracked._task is not None
+                assert not tracked._task.done()
+
+            # Shutdown must reap the parked task without raising.
+            await tracked.shutdown()
+            assert tracked._task.done()
+
+            with mcp_mod._lock:
+                mcp_mod._parked_failed_servers.clear()
+
+        asyncio.run(_run())
+
+    def test_shutdown_mcp_servers_includes_parked_failed(self):
+        import tools.mcp_tool as mcp_mod
+
+        try:
+            mcp_mod._ensure_mcp_loop()
+
+            mock_server = MagicMock()
+            mock_server.name = "orphan-park"
+
+            async def _shutdown_coro():
+                return None
+
+            mock_server.shutdown = _shutdown_coro
+
+            with mcp_mod._lock:
+                mcp_mod._servers.clear()
+                mcp_mod._parked_failed_servers.clear()
+                mcp_mod._parked_failed_servers["orphan-park"] = mock_server
+
+            # Should not raise; should clear parked map
+            mcp_mod.shutdown_mcp_servers()
+
+            with mcp_mod._lock:
+                assert mcp_mod._parked_failed_servers == {}
+        finally:
+            with mcp_mod._lock:
+                mcp_mod._servers.clear()
+                mcp_mod._parked_failed_servers.clear()
+            mcp_mod._stop_mcp_loop()
+
+    def test_wait_for_reconnect_finally_survives_closed_loop(self):
+        """_wait_for_reconnect_or_shutdown finally must not raise on closed loop."""
+        from tools.mcp_tool import MCPServerTask
+
+        async def _run():
+            server = MCPServerTask("closed-loop-park")
+            # Start the wait, then cancel the outer task while forcing the
+            # helper's cancel path through _safe_cancel_await.
+            wait_task = asyncio.create_task(
+                server._wait_for_reconnect_or_shutdown(timeout=30)
+            )
+            await asyncio.sleep(0)
+            # Trigger shutdown so wait returns cleanly
+            server._shutdown_event.set()
+            result = await wait_task
+            assert result == "shutdown"
+
+        asyncio.run(_run())

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1014,6 +1014,33 @@ def _contains_only_cancellation(exc: BaseException) -> bool:
     return isinstance(exc, asyncio.CancelledError)
 
 
+async def _safe_cancel_await(task: "asyncio.Future") -> None:
+    """Cancel a wait-helper Future without exploding if the loop is closing.
+
+    During ``/reload-mcp`` / ``shutdown_mcp_servers`` the MCP event loop can
+    be stopped while a parked ``MCPServerTask.run`` is still inside
+    ``_wait_for_reconnect_or_shutdown`` (or the lifecycle / lazy-reconnect
+    wait helpers). Their ``finally`` blocks call ``task.cancel()``; if the
+    loop is already closed that raises ``RuntimeError: Event loop is closed``,
+    which then surfaces as the noisy::
+
+        Exception ignored in: <coroutine object MCPServerTask.run ...>
+        RuntimeError: Event loop is closed
+
+    Swallow the race — the connection is being torn down either way.
+    """
+    if task.done():
+        return
+    try:
+        task.cancel()
+    except RuntimeError:
+        return
+    try:
+        await task
+    except (asyncio.CancelledError, RuntimeError, Exception):
+        pass
+
+
 def _classify_mcp_failure(exc: BaseException) -> str:
     """Classify an MCP connection failure as ``'permanent'`` or ``'transient'``.
 
@@ -2293,12 +2320,7 @@ class MCPServerTask:
                     self._mark_session_proven()
         finally:
             for t in (shutdown_task, reconnect_task):
-                if not t.done():
-                    t.cancel()
-                    try:
-                        await t
-                    except (asyncio.CancelledError, Exception):
-                        pass
+                await _safe_cancel_await(t)
 
         if self._shutdown_event.is_set():
             return "shutdown"
@@ -2337,12 +2359,7 @@ class MCPServerTask:
             )
         finally:
             for t in (shutdown_task, reconnect_task):
-                if not t.done():
-                    t.cancel()
-                    try:
-                        await t
-                    except (asyncio.CancelledError, Exception):
-                        pass
+                await _safe_cancel_await(t)
         if self._shutdown_event.is_set():
             return "shutdown"
         self._reconnect_event.clear()
@@ -3480,12 +3497,7 @@ class MCPServerTask:
             )
         finally:
             for task in (shutdown_task, reconnect_task):
-                if not task.done():
-                    task.cancel()
-                    try:
-                        await task
-                    except (asyncio.CancelledError, Exception):
-                        pass
+                await _safe_cancel_await(task)
 
 
 # ---------------------------------------------------------------------------
@@ -3493,6 +3505,13 @@ class MCPServerTask:
 # ---------------------------------------------------------------------------
 
 _servers: Dict[str, MCPServerTask] = {}
+# Servers whose run() task is still alive after start() failed (parked for
+# revival after a permanent/initial connect error). Not counted as connected
+# and not tool-registered, but MUST be shut down on reload — otherwise
+# shutdown_mcp_servers closes the loop while the parked wait helpers still
+# try to cancel child tasks and Python prints "Exception ignored ... Event
+# loop is closed".
+_parked_failed_servers: Dict[str, MCPServerTask] = {}
 _server_connecting: set[str] = set()
 _server_connect_errors: Dict[str, str] = {}
 
@@ -4473,7 +4492,19 @@ async def _connect_server(name: str, config: dict) -> MCPServerTask:
         Exception: on connection or initialization failure.
     """
     server = MCPServerTask(name)
-    await server.start(config)
+    try:
+        await server.start(config)
+    except BaseException:
+        # start() raises when run() set _error (e.g. permanent initial
+        # failure) but run() may still be *parked* waiting for a reconnect
+        # signal. Track it so shutdown_mcp_servers /reload-mcp can reap the
+        # task instead of closing the loop under its feet.
+        if server._task is not None and not server._task.done():
+            with _lock:
+                _parked_failed_servers[name] = server
+        raise
+    with _lock:
+        _parked_failed_servers.pop(name, None)
     return server
 
 
@@ -6166,7 +6197,12 @@ def shutdown_mcp_servers():
     All servers are shut down in parallel via ``asyncio.gather``.
     """
     with _lock:
-        servers_snapshot = list(_servers.values())
+        # Include parked-but-failed starts so reload does not close the loop
+        # under orphaned MCPServerTask.run coroutines.
+        servers_snapshot = list(_servers.values()) + list(
+            _parked_failed_servers.values()
+        )
+        _parked_failed_servers.clear()
 
     # Fast path: nothing to shut down. The connect-cooldown maps can still
     # be populated here — a server that failed to connect is never recorded
@@ -6193,6 +6229,7 @@ def shutdown_mcp_servers():
                 )
         with _lock:
             _servers.clear()
+            _parked_failed_servers.clear()
             # Drop connect-retry cooldowns too: a full shutdown/restart
             # should re-attempt every server immediately, not honour a
             # stale per-server backoff from before the restart (#50394).
@@ -6221,6 +6258,7 @@ def shutdown_mcp_servers():
     with _lock:
         _server_connect_retry_after.clear()
         _server_connect_failures.clear()
+        _parked_failed_servers.clear()
 
     _stop_mcp_loop()
 
@@ -6369,7 +6407,7 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
     """Stop the background event loop and join its thread."""
     global _mcp_loop, _mcp_thread
     with _lock:
-        if only_if_idle and (_servers or _server_connecting):
+        if only_if_idle and (_servers or _server_connecting or _parked_failed_servers):
             logger.debug("Leaving MCP event loop running; active servers are registered or connecting")
             return False
         loop = _mcp_loop
@@ -6377,7 +6415,24 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
         _mcp_loop = None
         _mcp_thread = None
     if loop is not None:
-        loop.call_soon_threadsafe(loop.stop)
+        def _halt_loop() -> None:
+            # Cancel any leftover tasks (orphaned parked run() coroutines
+            # that never made it into _servers) *before* stopping the loop
+            # so their finally blocks still see a live loop.
+            try:
+                current = asyncio.current_task(loop)
+                for task in list(asyncio.all_tasks(loop)):
+                    if task is not current:
+                        task.cancel()
+            except Exception:
+                pass
+            loop.stop()
+
+        try:
+            loop.call_soon_threadsafe(_halt_loop)
+        except RuntimeError:
+            # Loop already closed — nothing left to stop.
+            pass
         if thread is not None:
             thread.join(timeout=5)
         try:


### PR DESCRIPTION
## Summary
- `/reload-mcp` (and any full MCP teardown path) could print a noisy ignored exception when tearing down parked MCP servers:

```
Exception ignored in: <coroutine object MCPServerTask.run ...>
  File tools/mcp_tool.py, in _wait_for_reconnect_or_shutdown
    t.cancel()
RuntimeError: Event loop is closed
```

- Happens when `run()` parks after a permanent/initial connect failure: `start()` raises, the server is **not** added to `_servers`, then reload closes the MCP loop while the parked wait helper's `finally` still calls `Future.cancel()`.

## Changes
1. **`_safe_cancel_await`** — cancel + await wait-helper futures without raising if the loop is already closed. Used by:
   - `_wait_for_lifecycle_event`
   - `_wait_for_reconnect_or_shutdown`
   - `_wait_for_lazy_reconnect`
2. **`_parked_failed_servers`** — if `start()` fails but leaves `run()` alive (parked for revival), track it so full MCP teardown still calls `server.shutdown()`.
3. **`_stop_mcp_loop`** — cancel leftover tasks on the loop *before* `loop.stop()`, so any remaining orphans exit while the loop is still alive.

## Test plan
- [x] `uv run --extra dev python -m pytest tests/tools/test_mcp_stability.py -q` → **30 passed**
- [ ] Manual: configure a failing MCP stdio server (bad command), let it park, run `/reload-mcp` — no `Event loop is closed` traceback; healthy servers reconnect.

## Context
Observed while hot-swapping Hermes MCP config (dropping failed servers + swapping Cerebro to a Rust binary). Reload still succeeded (`Reconnected: blender, cerebro, sonus`); the traceback was cosmetic but scary.
