### PR TITLE
fix(desktop): clip overflowing notification detail so Copy button stays clear

### DIFF
--- a/apps/desktop/src/components/notifications.tsx
+++ b/apps/desktop/src/components/notifications.tsx
@@ -225,7 +225,7 @@ function NotificationDetail({ detail }: { detail: string }) {
       <summary className="select-none font-medium text-muted-foreground hover:text-foreground">{copy.details}</summary>
       <div className="mt-1 rounded-md bg-background/65 p-2">
         <pre
-          className="max-h-32 whitespace-pre-wrap wrap-break-word font-mono text-[0.6875rem] leading-relaxed"
+          className="max-h-32 overflow-y-auto whitespace-pre-wrap wrap-break-word font-mono text-[0.6875rem] leading-relaxed"
           data-selectable-text="true"
         >
           {detail}


### PR DESCRIPTION
## Summary

The `NotificationDetail` `<pre>` had `max-h-32` (128px) without an `overflow` property, so long error text visually overflowed downward and collided with the `CopyButton` rendered below it in normal flow. Adding `overflow-y-auto` turns the height cap into an actual scroll region instead of a hint the renderer is free to ignore.

## Root cause

CSS `overflow` defaults to `visible`. When text content exceeds the element's `max-height`, the browser allows the text to overflow the element's layout box and overlap following siblings in normal flow. Setting `overflow-y-auto` constrains the overflow to a scrollable region inside the element's box, keeping the `CopyButton` clear regardless of detail length.

Closes #69478

## Diff

Single Tailwind class addition to `<pre>`:

```diff
       <pre
-          className="max-h-32 whitespace-pre-wrap wrap-break-word font-mono text-[0.6875rem] leading-relaxed"
+          className="max-h-32 overflow-y-auto whitespace-pre-wrap wrap-break-word font-mono text-[0.6875rem] leading-relaxed"
           data-selectable-text="true"
         >
```

## Test plan

- Trigger the failing case (Ctrl+B in voice mode with no STT provider, expand the resulting error toast's "Details")
- Confirm the error text scrolls within the 128px cap rather than visually overflowing
- Confirm the "Copy detail" button remains visually separated from the text

## Environment note

Frontend type-check skipped — pnpm/vitest unavailable in this cron env. Diff is one attribute change on a `<pre>` element and was syntactically inspected end-to-end.
