### PR TITLE
fix(skills): expose context pressure to slash skills

### DIFF
--- a/agent/skill_bundles.py
+++ b/agent/skill_bundles.py
@@ -255,6 +255,7 @@ def build_bundle_invocation_message(
     user_instruction: str = "",
     task_id: str | None = None,
     platform: str | None = None,
+    runtime_note: str = "",
 ) -> Optional[Tuple[str, List[str], List[str]]]:
     """Build the user message content for a bundle slash command invocation.
 
@@ -363,6 +364,8 @@ def build_bundle_invocation_message(
         header_lines.extend(
             ["", f"User instruction: {user_instruction}"]
         )
+    if runtime_note:
+        header_lines.extend(["", f"[Runtime note: {runtime_note}]"])
 
     header = "\n".join(header_lines)
     return ("\n\n".join([header, *skill_blocks]), loaded_names, missing)

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -105,6 +105,9 @@ def _extract_bundle_user_instruction(message: str) -> Optional[str]:
         return None
 
     instruction = message[marker_idx + len(_BUNDLE_USER_INSTRUCTION):]
+    runtime_idx = instruction.find(_RUNTIME_NOTE)
+    if runtime_idx >= 0:
+        instruction = instruction[:runtime_idx]
     first_skill_idx = instruction.find(_BUNDLE_FIRST_SKILL_BLOCK)
     if first_skill_idx >= 0:
         instruction = instruction[:first_skill_idx]
@@ -512,6 +515,42 @@ def resolve_skill_command_key(command: str) -> Optional[str]:
     return cmd_key if cmd_key in get_skill_commands() else None
 
 
+def build_skill_runtime_note_from_usage(used: Any, total: Any) -> str:
+    """Format a truthful prior-request context occupancy note."""
+    try:
+        used = int(used or 0)
+        total = int(total or 0)
+    except (TypeError, ValueError):
+        return ""
+    if used <= 0 or total <= 0:
+        return ""
+
+    percent = max(0, min(100, round(used / total * 100)))
+    return (
+        f"Previous completed model request used {used:,} of {total:,} context "
+        f"tokens ({percent}%). This is measured prior-request occupancy; the "
+        "pending skill request may be larger."
+    )
+
+
+def build_skill_runtime_note(agent: Any) -> str:
+    """Describe measured context occupancy for a model-facing skill request.
+
+    ``last_prompt_tokens`` belongs to the previous completed model request.  It
+    is the newest measured occupancy available before the pending skill request
+    starts, so the note labels that timing explicitly instead of presenting it
+    as an exact current-turn value.  Missing, zero, and negative values are
+    intentionally omitted; ``-1`` is the post-compression transitional sentinel.
+    """
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is None:
+        return ""
+    return build_skill_runtime_note_from_usage(
+        getattr(compressor, "last_prompt_tokens", 0),
+        getattr(compressor, "context_length", 0),
+    )
+
+
 def build_skill_invocation_message(
     cmd_key: str,
     user_instruction: str = "",
@@ -612,6 +651,7 @@ def build_stacked_skill_invocation_message(
     cmd_keys: list[str],
     user_instruction: str = "",
     task_id: str | None = None,
+    runtime_note: str = "",
 ) -> Optional[tuple[str, list[str], list[str]]]:
     """Build the user message for a stacked multi-skill slash invocation.
 
@@ -685,6 +725,8 @@ def build_stacked_skill_invocation_message(
         header_lines.append(f"Skills missing (skipped): {', '.join(missing)}")
     if user_instruction:
         header_lines.extend(["", f"User instruction: {user_instruction}"])
+    if runtime_note:
+        header_lines.extend(["", f"[Runtime note: {runtime_note}]"])
 
     header = "\n".join(header_lines)
     return ("\n\n".join([header, *skill_blocks]), loaded_names, missing)

--- a/cli.py
+++ b/cli.py
@@ -9400,9 +9400,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # Skill bundles take precedence over individual skills — /<bundle>
             # loads multiple skills at once. Rescans cheaply when files change.
             elif base_cmd in skill_bundles:
+                from agent.skill_commands import build_skill_runtime_note
+
                 user_instruction = cmd_original[len(base_cmd):].strip()
                 bundle_result = build_bundle_invocation_message(
-                    base_cmd, user_instruction, task_id=self.session_id
+                    base_cmd,
+                    user_instruction,
+                    task_id=self.session_id,
+                    runtime_note=build_skill_runtime_note(self.agent),
                 )
                 if bundle_result:
                     msg, loaded_names, missing = bundle_result
@@ -9429,14 +9434,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # Inspired by Claude Code v2.1.199.
                 from agent.skill_commands import (
                     build_stacked_skill_invocation_message,
+                    build_skill_runtime_note,
                     split_stacked_skill_commands,
                 )
+                runtime_note = build_skill_runtime_note(self.agent)
                 extra_keys, user_instruction = split_stacked_skill_commands(rest)
                 if extra_keys:
                     stacked_result = build_stacked_skill_invocation_message(
                         [base_cmd, *extra_keys],
                         user_instruction,
                         task_id=self.session_id,
+                        runtime_note=runtime_note,
                     )
                     if stacked_result:
                         msg, loaded_names, missing = stacked_result
@@ -9457,7 +9465,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     return True
                 user_instruction = rest
                 msg = build_skill_invocation_message(
-                    base_cmd, user_instruction, task_id=self.session_id
+                    base_cmd,
+                    user_instruction,
+                    task_id=self.session_id,
+                    runtime_note=runtime_note,
                 )
                 if msg:
                     skill_name = skill_commands[base_cmd]["name"]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3932,6 +3932,49 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile=_profile,
         )
 
+    def _skill_runtime_note_for_session(self, session_key: str) -> str:
+        """Return prior-request context telemetry for a gateway skill turn."""
+        from agent.skill_commands import (
+            build_skill_runtime_note,
+            build_skill_runtime_note_from_usage,
+        )
+
+        runtime_agent = getattr(self, "_running_agents", {}).get(session_key)
+        if not runtime_agent or runtime_agent is _AGENT_PENDING_SENTINEL:
+            runtime_agent = None
+            cache_lock = getattr(self, "_agent_cache_lock", None)
+            agent_cache = getattr(self, "_agent_cache", None)
+            if cache_lock is not None and agent_cache is not None:
+                try:
+                    with cache_lock:
+                        cached_runtime = agent_cache.get(session_key)
+                    runtime_agent = cached_runtime[0] if cached_runtime else None
+                except Exception:
+                    runtime_agent = None
+
+        runtime_note = build_skill_runtime_note(runtime_agent)
+        if runtime_note:
+            return runtime_note
+
+        session_entry = None
+        session_store = getattr(self, "session_store", None)
+        if session_store is not None:
+            try:
+                peek_session_id = getattr(session_store, "peek_session_id", None)
+                lookup_by_session_id = getattr(
+                    session_store, "lookup_by_session_id", None
+                )
+                if callable(peek_session_id) and callable(lookup_by_session_id):
+                    session_id = peek_session_id(session_key)
+                    if isinstance(session_id, str) and session_id:
+                        session_entry = lookup_by_session_id(session_id)
+            except Exception:
+                session_entry = None
+
+        context_used = getattr(session_entry, "last_prompt_tokens", 0)
+        context_total = getattr(session_entry, "last_context_length", 0)
+        return build_skill_runtime_note_from_usage(context_used, context_total)
+
     def _telegram_topic_mode_enabled(self, source: SessionSource) -> bool:
         """Return whether Telegram DM topic mode is active for this chat."""
         if source.platform != Platform.TELEGRAM or source.chat_type != "dm":
@@ -11496,7 +11539,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # resolve_skill_command_key() handles the Telegram underscore/hyphen
         # round-trip so /claude_code from Telegram autocomplete still resolves
         # to the claude-code skill.
+        _skill_runtime_note = ""
         if command:
+            _skill_runtime_note = self._skill_runtime_note_for_session(_quick_key)
             # Skill bundles take precedence over individual skill commands —
             # /<bundle> loads multiple skills at once. Mirrors CLI dispatch.
             _bundle_handled = False
@@ -11517,6 +11562,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     bundle_result = build_bundle_invocation_message(
                         bundle_key, user_instruction, task_id=_quick_key,
                         platform=_bundle_plat,
+                        runtime_note=_skill_runtime_note,
                     )
                     if bundle_result:
                         msg, _loaded, missing = bundle_result
@@ -11595,6 +11641,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             [cmd_key, *extra_keys],
                             stacked_instruction,
                             task_id=_quick_key,
+                            runtime_note=_skill_runtime_note,
                         )
                         if stacked_result:
                             msg, _loaded, _missing = stacked_result
@@ -11604,7 +11651,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             return f"Failed to load stacked skills for /{command}."
                     else:
                         msg = build_skill_invocation_message(
-                            cmd_key, user_instruction, task_id=_quick_key
+                            cmd_key,
+                            user_instruction,
+                            task_id=_quick_key,
+                            runtime_note=_skill_runtime_note,
                         )
                         if msg:
                             event.text = msg
@@ -13741,6 +13791,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             await self.async_session_store.update_session(
                 session_entry.session_key,
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
+                last_context_length=agent_result.get("context_length", 0) or 0,
             )
 
             # Re-baseline the cached agent's message_count snapshot now that

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -715,6 +715,9 @@ class SessionEntry:
     
     # Last API-reported prompt tokens (for accurate compression pre-check)
     last_prompt_tokens: int = 0
+    # Context window paired with last_prompt_tokens for truthful persisted
+    # occupancy reporting after gateway restarts/cache eviction.
+    last_context_length: int = 0
     
     # Set when a session was created because the previous one expired;
     # consumed once by the message handler to inject a notice into context
@@ -779,6 +782,7 @@ class SessionEntry:
             "cache_write_tokens": self.cache_write_tokens,
             "total_tokens": self.total_tokens,
             "last_prompt_tokens": self.last_prompt_tokens,
+            "last_context_length": self.last_context_length,
             "estimated_cost_usd": self.estimated_cost_usd,
             "cost_status": self.cost_status,
             "expiry_finalized": self.expiry_finalized,
@@ -859,6 +863,7 @@ class SessionEntry:
             cache_write_tokens=data.get("cache_write_tokens", 0),
             total_tokens=data.get("total_tokens", 0),
             last_prompt_tokens=data.get("last_prompt_tokens", 0),
+            last_context_length=data.get("last_context_length", 0),
             estimated_cost_usd=data.get("estimated_cost_usd", 0.0),
             cost_status=data.get("cost_status", "unknown"),
             expiry_finalized=data.get("expiry_finalized", data.get("memory_flushed", False)),
@@ -2144,7 +2149,8 @@ class SessionStore:
     def update_session(
         self,
         session_key: str,
-        last_prompt_tokens: int = None,
+        last_prompt_tokens: Optional[int] = None,
+        last_context_length: Optional[int] = None,
     ) -> None:
         """Update lightweight session metadata after an interaction."""
         with self._lock:
@@ -2155,6 +2161,8 @@ class SessionStore:
                 entry.updated_at = _now()
                 if last_prompt_tokens is not None:
                     entry.last_prompt_tokens = last_prompt_tokens
+                if last_context_length is not None:
+                    entry.last_context_length = last_context_length
                 self._save()
                 self._record_gateway_session_peer(
                     entry.session_id,

--- a/tests/agent/test_skill_bundles.py
+++ b/tests/agent/test_skill_bundles.py
@@ -184,6 +184,31 @@ class TestResolveBundleCommandKey:
 
 
 class TestBuildBundleInvocationMessage:
+    def test_includes_runtime_note_without_polluting_user_instruction(
+        self, bundles_env
+    ):
+        from agent.skill_commands import extract_user_instruction_from_skill_message
+
+        bundles_dir, skills_dir = bundles_env
+        _make_skill(skills_dir, "skill-a")
+        _make_bundle_yaml(bundles_dir, "combo", ["skill-a"])
+        scan_bundles()
+
+        result = build_bundle_invocation_message(
+            "/combo",
+            user_instruction="finish cleanly",
+            runtime_note=(
+                "Previous completed model request used 57,344 of 114,688 "
+                "context tokens (50%)."
+            ),
+        )
+
+        assert result is not None
+        msg, _, _ = result
+        assert msg.count("[Runtime note:") == 1
+        assert "context tokens (50%)." in msg
+        assert extract_user_instruction_from_skill_message(msg) == "finish cleanly"
+
     def test_loads_all_skills(self, bundles_env):
         bundles_dir, skills_dir = bundles_env
         _make_skill(skills_dir, "skill-a", body="Skill A content.")

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -2,6 +2,7 @@
 
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -10,6 +11,7 @@ import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
     build_preloaded_skills_prompt,
     build_skill_invocation_message,
+    build_skill_runtime_note,
     resolve_skill_command_key,
     scan_skill_commands,
 )
@@ -48,6 +50,33 @@ def _symlink_category(skills_dir: Path, linked_root: Path, category: str) -> Pat
     except (OSError, NotImplementedError) as exc:
         pytest.skip(f"symlinks unavailable in test environment: {exc}")
     return external_category
+
+
+class TestSkillRuntimeNote:
+    def test_reports_previous_measured_context_occupancy(self):
+        agent = SimpleNamespace(
+            context_compressor=SimpleNamespace(
+                last_prompt_tokens=57_344,
+                context_length=114_688,
+            )
+        )
+
+        assert build_skill_runtime_note(agent) == (
+            "Previous completed model request used 57,344 of 114,688 context "
+            "tokens (50%). This is measured prior-request occupancy; the pending "
+            "skill request may be larger."
+        )
+
+    @pytest.mark.parametrize("last_prompt_tokens", [None, 0, -1])
+    def test_omits_unavailable_or_transitional_occupancy(self, last_prompt_tokens):
+        agent = SimpleNamespace(
+            context_compressor=SimpleNamespace(
+                last_prompt_tokens=last_prompt_tokens,
+                context_length=114_688,
+            )
+        )
+
+        assert build_skill_runtime_note(agent) == ""
 
 
 class TestScanSkillCommands:
@@ -1042,7 +1071,12 @@ class TestStackedSkillCommands:
             self._setup_three_skills(tmp_path)
             scan_skill_commands()
             result = build_stacked_skill_invocation_message(
-                ["/skill-a", "/skill-b"], "summarize the repo"
+                ["/skill-a", "/skill-b"],
+                "summarize the repo",
+                runtime_note=(
+                    "Previous completed model request used 50 of 100 context "
+                    "tokens (50%)."
+                ),
             )
         assert result is not None
         msg, _, _ = result

--- a/tests/cli/test_cli_prefix_matching.py
+++ b/tests/cli/test_cli_prefix_matching.py
@@ -1,4 +1,5 @@
 """Tests for slash command prefix matching in HermesCLI.process_command."""
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from cli import HermesCLI
 
@@ -15,6 +16,77 @@ def _make_cli():
 
 
 class TestSlashCommandPrefixMatching:
+    def test_bundle_command_receives_measured_context_runtime_note(self):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-1"
+        cli_obj.agent = SimpleNamespace(
+            context_compressor=SimpleNamespace(
+                last_prompt_tokens=57_344,
+                context_length=114_688,
+            )
+        )
+        fake_bundle = {
+            "/review-pack": {
+                "name": "review-pack",
+                "skills": ["phase-end"],
+            }
+        }
+
+        import cli as cli_mod
+        with (
+            patch.object(cli_mod, "_skill_bundles", fake_bundle),
+            patch.object(
+                cli_mod,
+                "build_bundle_invocation_message",
+                return_value=("loaded bundle", ["phase-end"], []),
+            ) as build_bundle,
+        ):
+            cli_obj.process_command("/review-pack finish cleanly")
+
+        build_bundle.assert_called_once_with(
+            "/review-pack",
+            "finish cleanly",
+            task_id="session-1",
+            runtime_note=(
+                "Previous completed model request used 57,344 of 114,688 context "
+                "tokens (50%). This is measured prior-request occupancy; the pending "
+                "skill request may be larger."
+            ),
+        )
+        cli_obj._pending_input.put.assert_called_once_with("loaded bundle")
+
+    def test_skill_command_receives_measured_context_runtime_note(self):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-1"
+        cli_obj.agent = SimpleNamespace(
+            context_compressor=SimpleNamespace(
+                last_prompt_tokens=57_344,
+                context_length=114_688,
+            )
+        )
+        fake_skill = {"/phase-end": {"name": "phase-end", "description": "test"}}
+
+        import cli as cli_mod
+        with (
+            patch.object(cli_mod, "_skill_commands", fake_skill),
+            patch(
+                "agent.skill_commands.build_skill_invocation_message",
+                return_value="loaded phase-end",
+            ) as build_message,
+        ):
+            cli_obj.process_command("/phase-end")
+
+        build_message.assert_called_once_with(
+            "/phase-end",
+            "",
+            task_id="session-1",
+            runtime_note=(
+                "Previous completed model request used 57,344 of 114,688 context "
+                "tokens (50%). This is measured prior-request occupancy; the pending "
+                "skill request may be larger."
+            ),
+        )
+
     def test_unique_prefix_dispatches_command(self):
         """/con should dispatch to /config when it uniquely matches."""
         cli_obj = _make_cli()

--- a/tests/gateway/test_max_concurrent_sessions.py
+++ b/tests/gateway/test_max_concurrent_sessions.py
@@ -1,7 +1,10 @@
 """Tests for the gateway max_concurrent_sessions active-session cap."""
 
 import asyncio
+from collections import OrderedDict
+import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -57,6 +60,8 @@ def _make_runner(max_concurrent_sessions: int | None = None) -> GatewayRunner:
     runner.adapters = {Platform.TELEGRAM: _FakeAdapter()}
     runner._running_agents = {}
     runner._running_agents_ts = {}
+    runner._agent_cache = OrderedDict()
+    runner._agent_cache_lock = threading.Lock()
     runner._active_session_leases = {}
     runner._session_run_generation = {}
     runner._pending_messages = {}
@@ -206,3 +211,103 @@ def test_skill_command_that_would_start_agent_is_blocked_at_limit(monkeypatch):
         "Hermes is at the active session limit (1/1). "
         "Try again when another session finishes."
     )
+
+
+def test_skill_command_receives_cached_context_runtime_note(monkeypatch):
+    _silence_global_gateway_hooks(monkeypatch)
+    runner = _make_runner()
+    event = _make_event("/demo please", chat_id="context")
+    session_key = build_session_key(event.source)
+    agent = SimpleNamespace(
+        context_compressor=SimpleNamespace(
+            last_prompt_tokens=57_344,
+            context_length=114_688,
+        )
+    )
+    runner._agent_cache[session_key] = (agent, time.time())
+    captured = {}
+
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: {"demo": {"name": "demo-skill"}},
+    )
+    monkeypatch.setattr(
+        "agent.skill_commands.resolve_skill_command_key",
+        lambda command: "demo" if command == "demo" else None,
+    )
+
+    def build_message(*args, **kwargs):
+        captured.update(kwargs)
+        return "invoke demo skill"
+
+    monkeypatch.setattr(
+        "agent.skill_commands.build_skill_invocation_message",
+        build_message,
+    )
+    monkeypatch.setattr(
+        "agent.skill_utils.get_disabled_skill_names",
+        lambda *args, **kwargs: [],
+    )
+
+    async def mock_agent_run(self_inner, ev, src, qk, generation):
+        return ev.text
+
+    with patch.object(GatewayRunner, "_handle_message_with_agent", mock_agent_run):
+        result = asyncio.run(runner._handle_message(event))
+
+    assert result == "invoke demo skill"
+    assert captured["runtime_note"] == (
+        "Previous completed model request used 57,344 of 114,688 context "
+        "tokens (50%). This is measured prior-request occupancy; the pending "
+        "skill request may be larger."
+    )
+
+
+def test_gateway_skill_runtime_note_falls_back_to_persisted_session(monkeypatch):
+    runner = _make_runner()
+    source = _make_source()
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+    runner.session_store.peek_session_id.return_value = "sess-persisted"
+    runner.session_store.lookup_by_session_id.return_value = SimpleNamespace(
+        last_prompt_tokens=57_344,
+        last_context_length=114_688,
+    )
+
+    note = runner._skill_runtime_note_for_session(session_key)
+
+    assert "57,344 of 114,688 context tokens (50%)." in note
+
+
+def test_gateway_bundle_receives_persisted_context_runtime_note(monkeypatch):
+    _silence_global_gateway_hooks(monkeypatch)
+    runner = _make_runner()
+    event = _make_event("/review-pack finish cleanly", chat_id="bundle")
+    runner.session_store.peek_session_id.return_value = "sess-persisted"
+    runner.session_store.lookup_by_session_id.return_value = SimpleNamespace(
+        last_prompt_tokens=57_344,
+        last_context_length=114_688,
+    )
+    monkeypatch.setattr(
+        "agent.skill_bundles.resolve_bundle_command_key",
+        lambda command: "/review-pack" if command == "review-pack" else None,
+    )
+    captured = {}
+
+    def build_bundle(*args, **kwargs):
+        captured.update(kwargs)
+        return "invoke review bundle", ["phase-end"], []
+
+    monkeypatch.setattr(
+        "agent.skill_bundles.build_bundle_invocation_message",
+        build_bundle,
+    )
+
+    async def mock_agent_run(self_inner, ev, src, qk, generation):
+        return ev.text
+
+    with patch.object(GatewayRunner, "_handle_message_with_agent", mock_agent_run):
+        result = asyncio.run(runner._handle_message(event))
+
+    assert result == "invoke review bundle"
+    assert "57,344 of 114,688 context tokens (50%)." in captured["runtime_note"]

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1524,14 +1524,17 @@ class TestLastPromptTokens:
             created_at=datetime.now(),
             updated_at=datetime.now(),
             last_prompt_tokens=42000,
+            last_context_length=114688,
         )
         d = entry.to_dict()
         assert d["last_prompt_tokens"] == 42000
+        assert d["last_context_length"] == 114688
         restored = SessionEntry.from_dict(d)
         assert restored.last_prompt_tokens == 42000
+        assert restored.last_context_length == 114688
 
     def test_session_entry_from_old_data(self):
-        """Old session data without last_prompt_tokens should default to 0."""
+        """Old session data without context occupancy fields should default to 0."""
         from gateway.session import SessionEntry
         data = {
             "session_key": "test",
@@ -1545,6 +1548,7 @@ class TestLastPromptTokens:
         }
         entry = SessionEntry.from_dict(data)
         assert entry.last_prompt_tokens == 0
+        assert entry.last_context_length == 0
 
     def test_update_session_sets_last_prompt_tokens(self, tmp_path):
         """update_session should store the actual prompt token count."""
@@ -1565,8 +1569,13 @@ class TestLastPromptTokens:
         )
         store._entries = {"k1": entry}
 
-        store.update_session("k1", last_prompt_tokens=85000)
+        store.update_session(
+            "k1",
+            last_prompt_tokens=85000,
+            last_context_length=114688,
+        )
         assert entry.last_prompt_tokens == 85000
+        assert entry.last_context_length == 114688
 
     def test_update_session_none_does_not_change(self, tmp_path):
         """update_session with default (None) should not change last_prompt_tokens."""

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -366,6 +366,7 @@ async def test_handle_message_persists_agent_token_counts(monkeypatch):
             "tools": [],
             "history_offset": 0,
             "last_prompt_tokens": 80,
+            "context_length": 100000,
             "input_tokens": 120,
             "output_tokens": 45,
             "model": "openai/test-model",
@@ -384,6 +385,7 @@ async def test_handle_message_persists_agent_token_counts(monkeypatch):
     runner.session_store.update_session.assert_called_once_with(
         session_entry.session_key,
         last_prompt_tokens=80,
+        last_context_length=100000,
     )
 
 

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1492,6 +1492,13 @@ def test_slash_exec_routes_custom_skill_bundle_away_from_worker(server):
         "session_key": sid,
         "agent": None,
         "slash_worker": worker,
+        "_compute_host_active": True,
+        "_metadata_mirror": {
+            "usage": {
+                "context_used": 57_344,
+                "context_max": 114_688,
+            }
+        },
     }
     fake_bundles = {
         "/analysis-pack": {
@@ -1508,7 +1515,7 @@ def test_slash_exec_routes_custom_skill_bundle_away_from_worker(server):
          patch(
              "agent.skill_bundles.build_bundle_invocation_message",
              return_value=(fake_msg, ["source-check", "claim-audit"], []),
-         ):
+         ) as build_bundle:
         resp = server.handle_request({
             "id": "r-bundle-slash",
             "method": "slash.exec",
@@ -1525,6 +1532,7 @@ def test_slash_exec_routes_custom_skill_bundle_away_from_worker(server):
         "notice": "⚡ Loading bundle: analysis-pack (2 skills)",
     }
     assert worker.calls == []
+    assert "context tokens (50%)." in build_bundle.call_args.kwargs["runtime_note"]
 
 
 def test_slash_exec_handles_plugin_commands_in_live_gateway(server):
@@ -1891,13 +1899,23 @@ def test_command_dispatch_retry_handles_multipart_content(server):
 def test_command_dispatch_returns_skill_payload(server):
     """command.dispatch returns structured skill payload for the TUI to send()."""
     sid = "test-session"
-    server._sessions[sid] = {"session_key": sid}
+    server._sessions[sid] = {
+        "session_key": sid,
+        "agent": None,
+        "_compute_host_active": True,
+        "_metadata_mirror": {
+            "usage": {
+                "context_used": 57_344,
+                "context_max": 114_688,
+            }
+        },
+    }
 
     fake_skills = {"/hermes-agent-dev": {"name": "hermes-agent-dev", "description": "Dev workflow"}}
     fake_msg = "Loaded skill content here"
 
     with patch("agent.skill_commands.scan_skill_commands", return_value=fake_skills), \
-         patch("agent.skill_commands.build_skill_invocation_message", return_value=fake_msg):
+         patch("agent.skill_commands.build_skill_invocation_message", return_value=fake_msg) as build_message:
         resp = server.handle_request({
             "id": "r2",
             "method": "command.dispatch",
@@ -1909,6 +1927,16 @@ def test_command_dispatch_returns_skill_payload(server):
     assert result["type"] == "skill"
     assert result["message"] == fake_msg
     assert result["name"] == "hermes-agent-dev"
+    build_message.assert_called_once_with(
+        "/hermes-agent-dev",
+        "",
+        task_id=sid,
+        runtime_note=(
+            "Previous completed model request used 57,344 of 114,688 context "
+            "tokens (50%). This is measured prior-request occupancy; the pending "
+            "skill request may be larger."
+        ),
+    )
 
 
 def test_command_dispatch_returns_custom_bundle_payload(server):
@@ -1955,6 +1983,7 @@ def test_command_dispatch_returns_custom_bundle_payload(server):
         arg,
         task_id=sid,
         platform="tui",
+        runtime_note="",
     )
     build_skill.assert_not_called()
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13626,11 +13626,18 @@ def _(rid, params: dict) -> dict:
 
     if bundle_key is not None:
         try:
+            from agent.skill_commands import build_skill_runtime_note_from_usage
+
+            usage = _session_usage_snapshot(session)
             bundle_result = build_bundle_invocation_message(
                 bundle_key,
                 arg,
                 task_id=session.get("session_key", "") if session else "",
                 platform=_resolve_session_platform(),
+                runtime_note=build_skill_runtime_note_from_usage(
+                    usage.get("context_used"),
+                    usage.get("context_max"),
+                ),
             )
         except Exception as exc:
             return _err(rid, 4018, f"bundle dispatch failed: {exc}")
@@ -13657,13 +13664,21 @@ def _(rid, params: dict) -> dict:
         from agent.skill_commands import (
             scan_skill_commands,
             build_skill_invocation_message,
+            build_skill_runtime_note_from_usage,
         )
 
         cmds = scan_skill_commands()
         key = f"/{name}"
         if key in cmds:
+            usage = _session_usage_snapshot(session)
             msg = build_skill_invocation_message(
-                key, arg, task_id=session.get("session_key", "") if session else ""
+                key,
+                arg,
+                task_id=session.get("session_key", "") if session else "",
+                runtime_note=build_skill_runtime_note_from_usage(
+                    usage.get("context_used"),
+                    usage.get("context_max"),
+                ),
             )
             if msg:
                 return _ok(


### PR DESCRIPTION
## What changed

Dynamic slash-skill invocations now receive the previous completed request's measured context occupancy when that telemetry is available.

- Thread runtime notes through direct skill and configured bundle invocations in CLI, gateway, and TUI/dashboard paths.
- Use dashboard compute-host mirrored usage when no local agent exists.
- Persist the exact gateway `last_prompt_tokens` / `context_length` pair so restart and cache-eviction paths remain truthful without re-resolving model metadata.
- Keep the existing `UNKNOWN` behavior when either side of the measured pair is unavailable.
- Strip runtime notes when recovering stacked-skill user instructions so telemetry is not stored as user memory.

## Why

Hermes already tracks context occupancy, but `/phase-end` and other dynamic slash skills did not receive it. They therefore reported `CONTEXT_PRESSURE: UNKNOWN` even when authoritative runtime telemetry existed.

## How to test

```bash
scripts/run_tests.sh \
  tests/agent/test_skill_commands.py \
  tests/agent/test_skill_bundles.py \
  tests/cli/test_cli_prefix_matching.py \
  tests/gateway/test_max_concurrent_sessions.py \
  tests/gateway/test_session.py \
  tests/gateway/test_status_command.py \
  tests/gateway/test_stacked_skill_platform_disabled.py \
  tests/tui_gateway/test_protocol.py \
  tests/openviking_plugin/test_openviking.py -q
```

Result: 399 passed, 0 failed.

Also verified:

- `python -m py_compile` on changed runtime modules
- `python -m ruff check` on changed implementation and tests
- `python scripts/check-windows-footguns.py` on 13 changed Python files
- model-facing `/phase-end` runtime-note/extraction probe
- bounded read-only adversarial review: PASS

A full repository run was also attempted. It reported 54 failures across 15 unrelated files. A detached `origin/main` control reproduced all 14 failures in three representative files (`test_verification_evidence.py`, `test_agent_cache.py`, and `test_tui_gateway_server.py`), confirming those failures pre-exist this change.

## Platforms tested

- Linux, Python 3.11

## Related issues

No matching open or merged issue/PR was found for `phase-end context pressure`, `runtime note`, or `context telemetry`.
