### PR TITLE
feat(skills): optional PromptGuard prompt-contract auditor

### DIFF
--- a/optional-skills/devops/promptguard/SKILL.md
+++ b/optional-skills/devops/promptguard/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: promptguard
+description: >
+  Offline prompt-contract auditor for agent workflows. Use before writing or
+  seeding system prompts, agent instructions, or vague coding tasks ("fix this
+  and write code"). Checks ownership, verification, safety, and tool schema;
+  returns findings with approval criteria and a grounded fix draft. No model API.
+version: 0.4.2
+author: mturac
+license: MIT
+metadata:
+  hermes:
+    tags: [prompt, guardrails, safety, coding, contracts, pre-write, devops]
+    category: devops
+    related_skills: []
+---
+
+# PromptGuard
+
+Audit prompts as **executable contracts** — offline, deterministic, zero dependencies.
+
+Upstream project: [mturac/promptguard](https://github.com/mturac/promptguard)
+
+## When to Use
+
+- User asks to write, seed, or edit a system / agent / router / evaluator prompt
+- Coding task is vague (missing owner, surface, tests, acceptance criteria)
+- Pre-write review of `AGENTS.md`, `SKILL.md`, `CLAUDE.md`, or prompt configs
+- CI or agent hook should fail closed on incomplete instruction contracts
+
+## Install
+
+```bash
+# CLI
+pipx install "git+https://github.com/mturac/promptguard.git"
+
+# Hermes skill + pre_tool_call plugin (from the repo)
+git clone --depth 1 https://github.com/mturac/promptguard.git /tmp/promptguard
+/tmp/promptguard/install-agent-adapters.sh hermes
+```
+
+Or install the skill bundle from GitHub (may require `--force` under community scan):
+
+```bash
+hermes skills install mturac/promptguard/skills/promptguard --force
+```
+
+Restart Hermes after adapter install. Recommended env:
+
+```bash
+export PROMPTGUARD_PROFILE=coding-agent
+export PROMPTGUARD_FAIL_ON=high
+```
+
+## Procedure
+
+1. Prefer package CLI when available:
+   ```bash
+   promptguard audit <file> --profile coding-agent --fail-on high --format markdown
+   printf '%s' '<prompt>' | promptguard audit - --profile coding-agent --fail-on high
+   ```
+2. For a whole repo:
+   ```bash
+   promptguard audit-repo . --profile coding-agent --fail-on high
+   ```
+3. If high/critical findings appear before a write: **do not write yet**. Show findings, ask for approval, or apply a grounded fix draft.
+4. Optional interactive review:
+   ```bash
+   promptguard tui <file> --profile coding-agent
+   ```
+
+## Profiles
+
+| Profile | Use |
+|---------|-----|
+| `coding-agent` | Implementation prompts (responsibility, risk, verification) |
+| `system` | System / router / policy prompts |
+| `security` | Instruction-override and exfil patterns (PG016–018) |
+| `general` | Full core catalog |
+
+## Report shape
+
+`Severity | Evidence | Impact | Missing Contract | Questions | Approval | Fix Draft`
+
+## Pitfalls
+
+- Community hub install may flag scripts as dangerous (false positives on instruction filenames). Prefer `install-agent-adapters.sh hermes` or package CLI.
+- Plugin hard-block uses `PROMPTGUARD_PROFILE` / `PROMPTGUARD_FAIL_ON`. Disable with `PROMPTGUARD_HERMES_DISABLE=1`.
+- Product is intentionally offline — no remote model judge.
+
+## Verification
+
+```bash
+promptguard audit - --profile coding-agent --fail-on high <<'EOF'
+Fix this bug and write code.
+EOF
+# expect non-zero exit and PG012 / related findings
+```

--- a/optional-skills/devops/promptguard/SKILL.md
+++ b/optional-skills/devops/promptguard/SKILL.md
@@ -1,13 +1,10 @@
 ---
 name: promptguard
-description: >
-  Offline prompt-contract auditor for agent workflows. Use before writing or
-  seeding system prompts, agent instructions, or vague coding tasks ("fix this
-  and write code"). Checks ownership, verification, safety, and tool schema;
-  returns findings with approval criteria and a grounded fix draft. No model API.
+description: Audit prompt contracts before agent execution.
 version: 0.4.2
-author: mturac
+author: Mehmet Turac (@mturac), Hermes Agent
 license: MIT
+platforms: [linux, macos]
 metadata:
   hermes:
     tags: [prompt, guardrails, safety, coding, contracts, pre-write, devops]
@@ -15,84 +12,121 @@ metadata:
     related_skills: []
 ---
 
-# PromptGuard
+# PromptGuard Skill
 
-Audit prompts as **executable contracts** — offline, deterministic, zero dependencies.
-
-Upstream project: [mturac/promptguard](https://github.com/mturac/promptguard)
+PromptGuard audits prompts as executable contracts before an agent acts on
+them. It runs offline, reports missing ownership, verification, safety, and tool
+schema requirements, and does not call model APIs or modify audited files.
 
 ## When to Use
 
-- User asks to write, seed, or edit a system / agent / router / evaluator prompt
-- Coding task is vague (missing owner, surface, tests, acceptance criteria)
-- Pre-write review of `AGENTS.md`, `SKILL.md`, `CLAUDE.md`, or prompt configs
-- CI or agent hook should fail closed on incomplete instruction contracts
+- Before writing or changing a system, agent, router, or evaluator prompt.
+- When a coding task omits ownership, tests, acceptance criteria, or safety
+  boundaries.
+- Before publishing changes to `AGENTS.md`, `SKILL.md`, `CLAUDE.md`, or prompt
+  configuration.
+- When CI or an agent hook should reject incomplete instruction contracts.
 
-## Install
+## Prerequisites
+
+- Linux or macOS with Python and `pipx`.
+- The Hermes `terminal` tool for running PromptGuard commands.
+- Install the CLI once:
+
+  ```bash
+  pipx install "git+https://github.com/mturac/promptguard.git"
+  ```
+
+- Optional Hermes adapter installation:
+
+  ```bash
+  work_dir="$(mktemp -d)"
+  git clone --depth 1 https://github.com/mturac/promptguard.git \
+    "$work_dir/promptguard"
+  "$work_dir/promptguard/install-agent-adapters.sh" hermes
+  ```
+
+  Restart Hermes after installing an adapter.
+
+## How to Run
+
+Use `terminal` to audit a file, standard input, or an entire repository:
 
 ```bash
-# CLI
-pipx install "git+https://github.com/mturac/promptguard.git"
+promptguard audit path/to/prompt.md \
+  --profile coding-agent \
+  --fail-on high \
+  --format markdown
 
-# Hermes skill + pre_tool_call plugin (from the repo)
-git clone --depth 1 https://github.com/mturac/promptguard.git /tmp/promptguard
-/tmp/promptguard/install-agent-adapters.sh hermes
+printf '%s\n' 'Fix this bug and write code.' |
+  promptguard audit - --profile coding-agent --fail-on high
+
+promptguard audit-repo . --profile coding-agent --fail-on high
 ```
 
-Or install the skill bundle from GitHub (may require `--force` under community scan):
+## Quick Reference
 
-```bash
-hermes skills install mturac/promptguard/skills/promptguard --force
-```
+| Profile | Use |
+|---|---|
+| `coding-agent` | Implementation ownership, risk, and verification |
+| `system` | System, router, and policy prompts |
+| `security` | Instruction override and exfiltration patterns |
+| `general` | Full core rule catalog |
 
-Restart Hermes after adapter install. Recommended env:
+| Command | Purpose |
+|---|---|
+| `promptguard audit <file>` | Audit one prompt file |
+| `promptguard audit -` | Audit text from standard input |
+| `promptguard audit-repo .` | Audit prompt-bearing files in a repository |
+| `promptguard tui <file>` | Open an optional interactive review |
 
-```bash
-export PROMPTGUARD_PROFILE=coding-agent
-export PROMPTGUARD_FAIL_ON=high
+The report shape is:
+
+```text
+Severity | Evidence | Impact | Missing Contract | Questions | Approval | Fix Draft
 ```
 
 ## Procedure
 
-1. Prefer package CLI when available:
-   ```bash
-   promptguard audit <file> --profile coding-agent --fail-on high --format markdown
-   printf '%s' '<prompt>' | promptguard audit - --profile coding-agent --fail-on high
-   ```
-2. For a whole repo:
-   ```bash
-   promptguard audit-repo . --profile coding-agent --fail-on high
-   ```
-3. If high/critical findings appear before a write: **do not write yet**. Show findings, ask for approval, or apply a grounded fix draft.
-4. Optional interactive review:
-   ```bash
-   promptguard tui <file> --profile coding-agent
-   ```
-
-## Profiles
-
-| Profile | Use |
-|---------|-----|
-| `coding-agent` | Implementation prompts (responsibility, risk, verification) |
-| `system` | System / router / policy prompts |
-| `security` | Instruction-override and exfil patterns (PG016–018) |
-| `general` | Full core catalog |
-
-## Report shape
-
-`Severity | Evidence | Impact | Missing Contract | Questions | Approval | Fix Draft`
+1. Identify the prompt-bearing file or text and choose the narrowest matching
+   profile.
+2. Run the audit through `terminal` with an explicit `--fail-on` threshold.
+3. Preserve the command exit status and report every high or critical finding
+   with its evidence.
+4. Do not perform the requested write while blocking findings remain. Present
+   the approval criteria or a grounded fix draft first.
+5. Re-run the same command after revising the prompt. A clean rerun is the
+   completion signal.
+6. Use `promptguard tui <file>` only when an interactive review adds value; it
+   is not required for deterministic validation.
 
 ## Pitfalls
 
-- Community hub install may flag scripts as dangerous (false positives on instruction filenames). Prefer `install-agent-adapters.sh hermes` or package CLI.
-- Plugin hard-block uses `PROMPTGUARD_PROFILE` / `PROMPTGUARD_FAIL_ON`. Disable with `PROMPTGUARD_HERMES_DISABLE=1`.
-- Product is intentionally offline — no remote model judge.
+- PromptGuard is intentionally offline; do not describe its output as a remote
+  model review.
+- Community installation can flag instruction-related filenames. Inspect the
+  repository before using an override such as `--force`.
+- Adapter settings use `PROMPTGUARD_PROFILE` and `PROMPTGUARD_FAIL_ON`.
+  `PROMPTGUARD_HERMES_DISABLE=1` disables adapter blocking for recovery.
+- A successful process launch is not a clean audit. Use the exit status and
+  finding severity to determine the result.
+- Do not broaden a task merely because the audit supplies a possible fix draft.
+  Keep changes within the user's approved scope.
 
 ## Verification
 
+Run a deliberately incomplete prompt and confirm that the configured threshold
+rejects it:
+
 ```bash
-promptguard audit - --profile coding-agent --fail-on high <<'EOF'
-Fix this bug and write code.
-EOF
-# expect non-zero exit and PG012 / related findings
+set +e
+printf '%s\n' 'Fix this bug and write code.' |
+  promptguard audit - --profile coding-agent --fail-on high
+status=$?
+set -e
+test "$status" -ne 0
 ```
+
+Expected result: a non-zero exit status with `PG012` or another relevant
+contract finding. Then audit a complete prompt and confirm the same command
+returns zero before treating the workflow as verified.

--- a/tests/skills/test_promptguard_skill.py
+++ b/tests/skills/test_promptguard_skill.py
@@ -1,0 +1,72 @@
+"""Contract tests for the optional PromptGuard skill."""
+
+from pathlib import Path
+import re
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = ROOT / "optional-skills" / "devops" / "promptguard" / "SKILL.md"
+REQUIRED_HEADINGS = [
+    "# PromptGuard Skill",
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+]
+
+
+@pytest.fixture(scope="module")
+def content() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(content: str) -> str:
+    match = re.match(r"^---\n(.*?)\n---\n", content, re.DOTALL)
+    assert match, "SKILL.md missing YAML frontmatter"
+    return match.group(1)
+
+
+def _scalar(frontmatter: str, field: str) -> str:
+    match = re.search(rf"^{re.escape(field)}:\s*(.+)$", frontmatter, re.MULTILINE)
+    assert match, f"frontmatter missing {field}"
+    return match.group(1).strip()
+
+
+def test_description_is_compact_sentence(frontmatter: str) -> None:
+    description = _scalar(frontmatter, "description")
+    assert description not in {">", "|"}, "description must be one line"
+    assert len(description) <= 60
+    assert description.endswith(".")
+
+
+def test_author_credits_human_first(frontmatter: str) -> None:
+    author = _scalar(frontmatter, "author")
+    contributors = [part.strip() for part in author.split(",")]
+    assert re.fullmatch(r".+\s+\(@[A-Za-z0-9-]+\)", contributors[0])
+    assert "Hermes Agent" in contributors[1:]
+
+
+def test_platforms_match_posix_workflow(frontmatter: str) -> None:
+    platforms = _scalar(frontmatter, "platforms")
+    declared = set(re.findall(r"[A-Za-z0-9_-]+", platforms))
+    assert {"linux", "macos"} <= declared
+
+
+def test_modern_section_order(content: str) -> None:
+    positions = [content.find(heading) for heading in REQUIRED_HEADINGS]
+    assert all(position >= 0 for position in positions)
+    assert positions == sorted(positions)
+
+
+def test_uses_native_terminal_surface(content: str) -> None:
+    assert "`terminal`" in content
+
+
+def test_avoids_ungated_temp_path(content: str) -> None:
+    assert "/tmp" not in content


### PR DESCRIPTION
## Summary

Adds an **optional official skill** for [PromptGuard](https://github.com/mturac/promptguard) under `optional-skills/devops/promptguard`.

PromptGuard is an offline, zero-dependency prompt **contract** auditor for agent workflows (coding-agent ownership/verification, system-prompt safety, static security pack). Hermes already has a first-class adapter in the upstream project (`install-agent-adapters.sh hermes` + `pre_tool_call` plugin).

This skill teaches Hermes when to audit and how to install/use the tool without bloating the default skill set.

## Test plan

- [ ] `hermes skills browse --source official` lists promptguard (after merge/sync)
- [ ] `hermes skills install official/devops/promptguard` (or path used by optional skills) succeeds
- [ ] Skill body matches install paths in https://github.com/mturac/promptguard