### PR TITLE
fix(desktop): clear stale chat before profile switch

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-fresh-session-requests.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-fresh-session-requests.test.tsx
@@ -1,0 +1,47 @@
+import { act, renderHook } from '@testing-library/react'
+import { StrictMode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $freshSessionRequest, requestFreshSession } from '@/store/profile'
+
+import { useFreshSessionRequests } from './use-fresh-session-requests'
+
+describe('useFreshSessionRequests', () => {
+  beforeEach(() => {
+    $freshSessionRequest.set(0)
+  })
+
+  it('clears the old chat synchronously when a profile switch requests a fresh draft', () => {
+    const startFreshSessionDraft = vi.fn()
+
+    renderHook(() => useFreshSessionRequests(startFreshSessionDraft))
+
+    act(() => {
+      requestFreshSession()
+
+      // The clear must happen in the same stack as profile selection. Deferring
+      // it to a React effect leaves the old profile route live for a fast Enter.
+      expect(startFreshSessionDraft).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('keeps exactly one live listener through StrictMode effect replay', () => {
+    const startFreshSessionDraft = vi.fn()
+
+    renderHook(() => useFreshSessionRequests(startFreshSessionDraft), { wrapper: StrictMode })
+
+    act(() => requestFreshSession())
+
+    expect(startFreshSessionDraft).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes the synchronous listener on unmount', () => {
+    const startFreshSessionDraft = vi.fn()
+    const { unmount } = renderHook(() => useFreshSessionRequests(startFreshSessionDraft))
+
+    unmount()
+    requestFreshSession()
+
+    expect(startFreshSessionDraft).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-fresh-session-requests.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-fresh-session-requests.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+
+import { $freshSessionRequest } from '@/store/profile'
+
+/**
+ * Reset the primary chat when a profile/project action requests a fresh draft.
+ *
+ * Kept as a hook so the profile store remains router-agnostic while the chat
+ * controller owns the actual route/session reset. The nanostore listener is
+ * intentionally synchronous: profile selection must clear the old route and
+ * session refs before a same-stack Enter can submit through the previous
+ * profile's conversation.
+ */
+export function useFreshSessionRequests(startFreshSessionDraft: () => void): void {
+  useEffect(() => $freshSessionRequest.listen(() => startFreshSessionDraft()), [startFreshSessionDraft])
+}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -30,7 +30,7 @@ import { latestSessionTodos } from '@/lib/todos'
 import { setCronFocusJobId } from '@/store/cron'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { $filePreviewTarget, $previewTarget } from '@/store/preview'
-import { $activeGatewayProfile, $freshSessionRequest, $profileScope, refreshActiveProfile } from '@/store/profile'
+import { $activeGatewayProfile, $profileScope, refreshActiveProfile } from '@/store/profile'
 import { $startWorkSessionRequest, followActiveSessionCwd, resolveNewSessionCwd } from '@/store/projects'
 import {
   $activeSessionId,
@@ -98,6 +98,7 @@ import { UpdatesOverlay } from '../updates-overlay'
 import { ContribWiringContext } from './context'
 import { useBackgroundSync } from './hooks/use-background-sync'
 import { useDesktopIntegrations } from './hooks/use-desktop-integrations'
+import { useFreshSessionRequests } from './hooks/use-fresh-session-requests'
 import { usePetBridge } from './hooks/use-pet-bridge'
 import { useSessionTileDelegate } from './hooks/use-session-tile-delegate'
 import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
@@ -413,18 +414,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   })
 
   // A profile switch/create drops to a fresh new-session draft so the
-  // previously open session doesn't bleed across contexts. Skip initial value.
-  const freshSessionRequest = useStore($freshSessionRequest)
-  const lastFreshRef = useRef(freshSessionRequest)
-
-  useEffect(() => {
-    if (freshSessionRequest === lastFreshRef.current) {
-      return
-    }
-
-    lastFreshRef.current = freshSessionRequest
-    startFreshSessionDraft()
-  }, [freshSessionRequest, startFreshSessionDraft])
+  // previously open session doesn't bleed across contexts.
+  useFreshSessionRequests(startFreshSessionDraft)
 
   // Swapping the live gateway to another profile must re-pull that profile's
   // global model + active-profile pill (both are nanostores — the blanket


### PR DESCRIPTION
## Problem

Switching the primary Desktop window to another profile requests a fresh draft, but the chat reset was deferred through React state:

1. `selectProfile()` updated the intended profile and incremented `$freshSessionRequest`.
2. `ContribWiring` observed that atom through `useStore()`.
3. A later `useEffect()` called `startFreshSessionDraft()`.

That left the previous profile's routed session, active runtime ID, and selected stored-session ID usable until React flushed the effect. Pressing Enter during that gap could resume or send through the previous conversation, so a prompt composed after selecting Profile B could land in Profile A.

This is a live profile-switch race. It is separate from the cold-start remembered-navigation path addressed by #67823.

## Fix

Handle `$freshSessionRequest` with a direct Nano Stores `listen()` subscription:

- `listen()` runs synchronously inside the atom's `set()` call.
- `startFreshSessionDraft()` now clears routed intent and session refs before `selectProfile()` starts `ensureGatewayProfile()`.
- The hook returns Nano Stores' unsubscribe function, so React StrictMode setup/cleanup replay leaves one listener and real unmount removes it.
- `listen()`, unlike `subscribe()`, does not replay the current value on registration.

The profile store stays router-agnostic; the chat controller still owns navigation and session reset.

## Regression coverage

The new tests verify:

1. The old chat is cleared before `requestFreshSession()` returns (the assertion fails against the previous `useStore` + `useEffect` implementation).
2. StrictMode does not duplicate the reset.
3. Unmount removes the listener.

## Verification

On current `main` after rebase:

- Focused profile/switch/route/prompt suite: **101 passed**
- Desktop TypeScript: **passed**
- Modified-file ESLint: **passed**
- Production Desktop build and `assert-dist-built`: **passed**
- `git diff --check`: **passed**
- Independent review: **PASS, no required changes**

Full Desktop UI suite on the immediately preceding upstream base:

- **227/227 test files passed**
- **1,870 tests passed, 1 skipped**
- Vitest exited nonzero only because an existing post-teardown `coding-status` timer fired after jsdom removed `window`; the implicated tests pass **13/13** in isolation. This patch does not touch that timer or its modules.

## Related

- #67709
- #67823
