### PR TITLE
fix(bluebubbles): preserve 127.0.0.1 in webhook URL on macOS

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -310,9 +310,16 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
     @property
     def _webhook_url(self) -> str:
-        """Compute the external webhook URL for BlueBubbles registration."""
+        """Compute the external webhook URL for BlueBubbles registration.
+
+        Keep ``127.0.0.1`` literal (do NOT rewrite to ``localhost``). On macOS
+        ``localhost`` resolves to IPv6 ``::1`` first, but the aiohttp listener
+        binds IPv4 ``127.0.0.1`` only — so a ``localhost`` URL makes BlueBubbles
+        POST to ``::1`` and the delivery silently fails. ``0.0.0.0``/``::`` still
+        become ``localhost`` so the server can reach the listener via loopback.
+        """
         host = self.webhook_host
-        if host in {"0.0.0.0", "127.0.0.1", "localhost", "::"}:
+        if host in {"0.0.0.0", "::"}:
             host = "localhost"
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -658,19 +658,31 @@ class TestBlueBubblesAttachmentDownload:
 
 
 class TestBlueBubblesWebhookUrl:
-    """_webhook_url property normalises local hosts to 'localhost'."""
+    """_webhook_url chooses a loopback host the listener actually binds.
+
+    The aiohttp webhook server binds IPv4 127.0.0.1 only. On macOS
+    'localhost' resolves to IPv6 ::1 first, so a 'localhost' URL makes
+    BlueBubbles POST to ::1 and the delivery silently fails. Keep 127.0.0.1
+    literal; only the wildcard binds (0.0.0.0 / ::) normalize to 'localhost'
+    so an external caller can still reach the listener via loopback.
+    """
 
     def test_default_host(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        # Default webhook_host is 0.0.0.0 → normalized to localhost
-        assert "localhost" in adapter._webhook_url
+        # Default webhook_host is 127.0.0.1 → kept literal (IPv4 listener)
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
         assert str(adapter.webhook_port) in adapter._webhook_url
         assert adapter.webhook_path in adapter._webhook_url
 
-    @pytest.mark.parametrize("host", ["0.0.0.0", "127.0.0.1", "localhost", "::"])
-    def test_local_hosts_normalized(self, monkeypatch, host):
+    @pytest.mark.parametrize("host", ["0.0.0.0", "::"])
+    def test_wildcard_hosts_normalized_to_localhost(self, monkeypatch, host):
         adapter = _make_adapter(monkeypatch, webhook_host=host)
         assert adapter._webhook_url.startswith("http://localhost:")
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "localhost"])
+    def test_loopback_hosts_preserved(self, monkeypatch, host):
+        adapter = _make_adapter(monkeypatch, webhook_host=host)
+        assert adapter._webhook_url.startswith(f"http://{host}:")
 
     def test_custom_host_preserved(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, webhook_host="192.168.1.50")


### PR DESCRIPTION
## What does this PR do?

Fixes the BlueBubbles inbound webhook silently failing on macOS.

The adapter registered its inbound webhook as `http://localhost:<port>/...`, but the
aiohttp listener binds IPv4 `127.0.0.1` only. On macOS, `localhost` resolves to IPv6
`::1` **first**, so BlueBubbles (Node.js) POSTs the webhook to `::1` and the delivery is
**silently dropped** — no error surfaces, but Hermes never receives inbound messages.

Keep `127.0.0.1` literal in the registered URL so it matches the IPv4 listener. Wildcard
binds (`0.0.0.0` / `::`) still normalize to `localhost` so an external caller can reach
the listener via loopback.

## Related Issue

Fixes #8512 (BlueBubbles webhook fails on macOS due to IPv6 localhost resolution).
Also covers the duplicate #45308.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/bluebubbles.py` — `_webhook_url` no longer rewrites `127.0.0.1`
  to `localhost`; only `0.0.0.0` / `::` normalize to `localhost`.
- `tests/gateway/test_bluebubbles.py` — updated `TestBlueBubblesWebhookUrl` to assert
  the corrected behavior (loopback hosts preserved, wildcard hosts → localhost).

## How to Test

1. On macOS, configure BlueBubbles + Hermes messaging; send an iMessage to the Mac.
2. Before fix: message is visible in BlueBubbles but Hermes never responds (webhook
   POSTs to `::1`, refused by the IPv4-only listener).
3. After fix: `curl -s -o /dev/null -w '%{http_code}' http://[::1]:<port>/...` → `000`
   (connection refused, confirms IPv6 path dead) and
   `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:<port>/...` → `200`.
   Inbound iMessage now reaches Hermes and it replies.
4. `pytest tests/gateway/test_bluebubbles.py -q` → 60 passed.

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs/issues (refs #8512, #45308)
- [x] PR contains only changes related to this fix
- [x] I've run `pytest tests/gateway/test_bluebubbles.py -q` — 60 passed
- [x] Tested on macOS 15.x (Sequoia)

### Note for reviewers

An alternative fix is to make the BlueBubbles listener dual-stack (bind `None`, like the
generic `gateway/platforms/webhook.py` already does) and keep `localhost` in the URL.
This minimal change keeps the IPv4 listener and pins the URL to `127.0.0.1`; it's lower
risk and clearly correct. Happy to switch to dual-stack if preferred.
