### PR TITLE
fix(skills): invalidate config caches on same-tick rewrites

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -5,6 +5,7 @@ heavy dependency chain.  It is safe to import at module level without triggering
 tool registration or provider resolution.
 """
 
+import hashlib
 import logging
 import os
 import re
@@ -323,7 +324,7 @@ def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
 # ── Disabled skills ───────────────────────────────────────────────────────
 
 
-_RAW_CONFIG_CACHE: Dict[Tuple[str, int, int], Dict[str, Any]] = {}
+_RAW_CONFIG_CACHE: Dict[Tuple[str, int, int, int, str], Dict[str, Any]] = {}
 
 
 def _raw_config_cache_clear() -> None:
@@ -331,38 +332,61 @@ def _raw_config_cache_clear() -> None:
     _RAW_CONFIG_CACHE.clear()
 
 
+def _read_config_snapshot(config_path: Path) -> Tuple[Tuple[str, int, int, int, str], str] | None:
+    """Return a cache key plus decoded config text.
+
+    Metadata alone is not enough on all filesystems: a rapid same-length
+    rewrite can keep both mtime and ctime tied. Hashing the already-read bytes
+    still avoids repeated YAML parsing while guaranteeing config edits are
+    visible immediately.
+    """
+    try:
+        stat = config_path.stat()
+        raw = config_path.read_bytes()
+        digest = hashlib.blake2b(raw, digest_size=16).hexdigest()
+        return (
+            str(config_path),
+            stat.st_mtime_ns,
+            stat.st_ctime_ns,
+            stat.st_size,
+            digest,
+        ), raw.decode("utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        logger.debug("Could not read skill config %s: %s", config_path, e)
+        return None
+
+
 def _load_raw_config() -> Dict[str, Any]:
-    """Read config.yaml with a shared mtime+size keyed cache.
+    """Read config.yaml with a shared content-signature keyed cache.
 
     This module intentionally avoids importing ``hermes_cli.config`` on the
     skill prompt/build path. A tiny local cache gives the same repeated-read
-    win without pulling the heavier CLI config stack into startup.
+    win without pulling the heavier CLI config stack into startup. The cache
+    key includes a content hash so same-tick, same-length edits invalidate
+    immediately while still avoiding repeated YAML parsing on hits.
     """
     config_path = get_config_path()
     if not config_path.exists():
         return {}
-    try:
-        stat = config_path.stat()
-        cache_key = (str(config_path), stat.st_mtime_ns, stat.st_size)
-    except OSError:
-        cache_key = None
+    snapshot = _read_config_snapshot(config_path)
+    if snapshot is None:
+        return {}
+    cache_key, content = snapshot
 
-    if cache_key is not None:
-        cached = _RAW_CONFIG_CACHE.get(cache_key)
-        if cached is not None:
-            return cached
+    cached = _RAW_CONFIG_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
 
     try:
-        parsed = yaml_load(config_path.read_text(encoding="utf-8"))
+        parsed = yaml_load(content)
     except Exception as e:
-        logger.debug("Could not read skill config %s: %s", config_path, e)
+        logger.debug("Could not parse skill config %s: %s", config_path, e)
         return {}
     if not isinstance(parsed, dict):
         return {}
 
-    if cache_key is not None:
-        _RAW_CONFIG_CACHE.clear()
-        _RAW_CONFIG_CACHE[cache_key] = parsed
+    _RAW_CONFIG_CACHE.clear()
+    _RAW_CONFIG_CACHE[cache_key] = parsed
     return parsed
 
 
@@ -414,13 +438,14 @@ def _normalize_string_set(values) -> Set[str]:
 
 # ── External skills directories ──────────────────────────────────────────
 
-# (config_path_str, mtime_ns) -> resolved external dirs list.  Keyed by
-# mtime_ns so a config.yaml edit mid-run is picked up automatically;
-# otherwise every call would re-read + re-YAML-parse the 15KB config,
-# which becomes the dominant cost of ``hermes`` startup when ~120 skills
-# each trigger a category lookup during banner construction (10+ seconds
-# of pure waste).
-_EXTERNAL_DIRS_CACHE: Dict[Tuple[str, int], List[Path]] = {}
+# (config_path_str, mtime_ns, ctime_ns, size, digest) -> resolved external
+# dirs list.  Keyed by content signature so a config.yaml edit mid-run is
+# picked up automatically; the digest handles same-tick/same-length rewrites
+# where metadata alone can tie on some filesystems. Otherwise every call would
+# re-YAML-parse the 15KB config, which becomes the dominant cost of ``hermes``
+# startup when ~120 skills each trigger a category lookup during banner
+# construction (10+ seconds of pure waste).
+_EXTERNAL_DIRS_CACHE: Dict[Tuple[str, int, int, int, str], List[Path]] = {}
 
 
 def _external_dirs_cache_clear() -> None:
@@ -436,28 +461,24 @@ def get_external_skills_dirs() -> List[Path]:
     path.  Only directories that actually exist are returned.  Duplicates and
     paths that resolve to the local ``~/.hermes/skills/`` are silently skipped.
 
-    Cached in-process, keyed on ``config.yaml`` mtime — the function is
-    called once per skill during banner / tool-registry scans, and YAML
-    parsing a non-trivial config dominates ``hermes`` cold-start time
-    when the cache is absent.
+    Cached in-process, keyed on the ``config.yaml`` content signature — the
+    function is called once per skill during banner / tool-registry scans,
+    and YAML parsing a non-trivial config dominates ``hermes`` cold-start
+    time when the cache is absent.
     """
     config_path = get_config_path()
     if not config_path.exists():
         return []
 
-    # Cache key: (absolute path, mtime_ns).  stat() is ~2us vs ~85ms for
-    # the full YAML parse, so the fast path is nearly free.
-    try:
-        stat = config_path.stat()
-        cache_key: Tuple[str, int] = (str(config_path), stat.st_mtime_ns)
-    except OSError:
-        cache_key = None  # type: ignore[assignment]
+    snapshot = _read_config_snapshot(config_path)
+    if snapshot is None:
+        return []
+    cache_key, _content = snapshot
 
-    if cache_key is not None:
-        cached = _EXTERNAL_DIRS_CACHE.get(cache_key)
-        if cached is not None:
-            # Return a copy so callers can't mutate the cached list.
-            return list(cached)
+    cached = _EXTERNAL_DIRS_CACHE.get(cache_key)
+    if cached is not None:
+        # Return a copy so callers can't mutate the cached list.
+        return list(cached)
 
     parsed = _load_raw_config()
     if not parsed:
@@ -470,8 +491,7 @@ def get_external_skills_dirs() -> List[Path]:
     raw_dirs = skills_cfg.get("external_dirs")
     if not raw_dirs:
         result: List[Path] = []
-        if cache_key is not None:
-            _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
+        _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
         return result
     if isinstance(raw_dirs, str):
         raw_dirs = [raw_dirs]
@@ -507,8 +527,7 @@ def get_external_skills_dirs() -> List[Path]:
         else:
             logger.debug("External skills dir does not exist, skipping: %s", p)
 
-    if cache_key is not None:
-        _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
+    _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
     return result
 
 

--- a/tests/agent/test_external_skills_dirs_cache.py
+++ b/tests/agent/test_external_skills_dirs_cache.py
@@ -1,11 +1,11 @@
-"""Guards for ``get_external_skills_dirs`` mtime-based memo.
+"""Guards for ``get_external_skills_dirs`` content-signature memo.
 
 ``get_external_skills_dirs()`` is called once per skill during banner
 construction and tool registration — on a typical install that's 120+
 calls.  Without caching, each call re-reads + YAML-parses the full
 config.yaml (~85ms each, 10+ seconds total).  This test pins the
-behavior: first call parses, subsequent calls return cached result,
-cache invalidates when config.yaml's mtime changes.
+behavior: first call parses, subsequent calls return cached result, and the
+cache invalidates on content changes even when filesystem metadata is tied.
 """
 
 from __future__ import annotations
@@ -95,6 +95,34 @@ def test_cache_invalidates_on_mtime_change(hermes_home_with_config):
 
     second = get_external_skills_dirs()
     assert second == [other.resolve()]
+
+
+def test_cache_invalidates_on_same_metadata_same_length_rewrite(
+    hermes_home_with_config, monkeypatch
+):
+    """A content digest catches rewrites even when stat metadata is tied."""
+    _home, external, config = hermes_home_with_config
+    other = external.parent / "othernal_skills"
+    other.mkdir()
+
+    first_text = f"skills:\n  external_dirs:\n    - {external}\n"
+    second_text = f"skills:\n  external_dirs:\n    - {other}\n"
+    assert len(first_text) == len(second_text)
+    config.write_text(first_text, encoding="utf-8")
+
+    real_stat = Path.stat
+    fixed = real_stat(config)
+
+    def tied_stat(path, *args, **kwargs):
+        if path == config:
+            return fixed
+        return real_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", tied_stat)
+    assert get_external_skills_dirs() == [external.resolve()]
+
+    config.write_text(second_text, encoding="utf-8")
+    assert get_external_skills_dirs() == [other.resolve()]
 
 
 def test_returns_empty_when_config_missing(tmp_path, monkeypatch):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -90,10 +90,12 @@ logger = logging.getLogger(__name__)
 # Per-session skill discovery cache.  _find_all_skills() re-reads every
 # SKILL.md on every call; with hundreds of skills this is wasteful.
 # Cache validation (mirrors hermes_cli/profiles.py::_count_skills, d5eee133e):
-#   - signature = per-dir max mtime of the dir AND its immediate children
-#     (one scandir per dir; catches skill add/remove inside categories,
-#     which does NOT bump the root dir's mtime), plus the disabled-set
-#     (config-driven — changes with no filesystem mtime bump at all)
+#   - signature = per-dir max mtime of the dir AND its immediate children,
+#     plus immediate child names below category dirs.  Some filesystems can
+#     coalesce rapid mkdir/write operations to the same mtime tick, so names
+#     make add/remove invalidation deterministic even when mtimes tie.
+#   - the disabled-set is part of the key too (config-driven — changes with
+#     no filesystem mtime bump at all)
 #   - a short TTL bounds staleness from in-place SKILL.md edits, which
 #     bump only the file's mtime, invisible to any directory signature.
 # skip_disabled True/False are cached separately.
@@ -117,22 +119,37 @@ def _skills_scan_signature(dirs_to_scan, disabled) -> tuple:
     sig = []
     for d in dirs_to_scan:
         try:
-            m = d.stat().st_mtime
+            root_mtime = d.stat().st_mtime
         except OSError:
             continue
+        child_sig = []
         try:
             with os.scandir(d) as it:
                 for entry in it:
                     try:
-                        if entry.is_dir(follow_symlinks=False):
-                            em = entry.stat(follow_symlinks=False).st_mtime
-                            if em > m:
-                                m = em
+                        if not entry.is_dir(follow_symlinks=False):
+                            continue
+                        entry_stat = entry.stat(follow_symlinks=False)
+                        entry_mtime = entry_stat.st_mtime
+                        if entry_mtime > root_mtime:
+                            root_mtime = entry_mtime
+                        nested_names = []
+                        try:
+                            with os.scandir(entry.path) as nested:
+                                for child in nested:
+                                    try:
+                                        if child.is_dir(follow_symlinks=False):
+                                            nested_names.append(child.name)
+                                    except OSError:
+                                        continue
+                        except OSError:
+                            pass
+                        child_sig.append((entry.name, entry_mtime, tuple(sorted(nested_names))))
                     except OSError:
                         continue
         except OSError:
             pass
-        sig.append((str(d), m))
+        sig.append((str(d), root_mtime, tuple(sorted(child_sig))))
     return (tuple(sig), frozenset(disabled), platform)
 
 


### PR DESCRIPTION
Isolated upstream contribution from a focused branch.