### PR TITLE
fix: keep session approvals exact across legacy aliases

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9083,7 +9083,12 @@ def test_verification_status_outside_workspace_is_not_applicable(monkeypatch, tm
     finally:
         reset_hermes_home_override(token)
 
-    assert resp["result"]["verification"]["status"] == "not_applicable"
+    assert isinstance(resp, dict)
+    result = resp.get("result")
+    assert isinstance(result, dict)
+    verification = result.get("verification")
+    assert isinstance(verification, dict)
+    assert verification["status"] == "not_applicable"
 
 
 # ── browser.manage ───────────────────────────────────────────────────

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1063,6 +1063,15 @@ class TestPatternKeyUniqueness:
     patterns starting with the same word (e.g. find -exec rm and find -delete)
     produce the same key. Approving one silently approves the other."""
 
+    def setup_method(self):
+        # Earlier tests in this module exercise permanent allowlist loading.
+        # This class pins session-scoped approval isolation, so start from a
+        # clean module state to avoid a legacy permanent key (``find``)
+        # masking a session-key collision regression.
+        approval_module._session_approved.clear()
+        approval_module._pending.clear()
+        approval_module._permanent_approved.clear()
+
     def test_find_exec_rm_and_find_delete_have_different_keys(self):
         _, key_exec, _ = detect_dangerous_command("find . -exec rm {} \\;")
         _, key_delete, _ = detect_dangerous_command("find . -name '*.tmp' -delete")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2172,15 +2172,18 @@ def is_current_session_yolo_enabled() -> bool:
 def is_approved(session_key: str, pattern_key: str) -> bool:
     """Check if a pattern is approved (session-scoped or permanent).
 
-    Accept both the current canonical key and the legacy regex-derived key so
-    existing command_allowlist entries continue to work after key migrations.
+    Permanent approvals accept both the current canonical key and the legacy
+    regex-derived key so old ``command_allowlist`` entries continue to work
+    after key migrations. Session approvals are intentionally exact-match
+    only: a legacy colliding key such as ``find`` must not let approving
+    ``find -exec rm`` silently approve ``find -delete`` in the same session.
     """
     aliases = _approval_key_aliases(pattern_key)
     with _lock:
         if any(alias in _permanent_approved for alias in aliases):
             return True
         session_approvals = _session_approved.get(session_key, set())
-        return any(alias in session_approvals for alias in aliases)
+        return pattern_key in session_approvals
 
 
 def approve_permanent(pattern_key: str):


### PR DESCRIPTION
Isolated upstream contribution from a focused branch.