### PR TITLE
feat(skills): optional godot-quest-vr skill (Godot OpenXR → Meta Quest)

### DIFF
--- a/optional-skills/software-development/godot-quest-vr/SKILL.md
+++ b/optional-skills/software-development/godot-quest-vr/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: godot-quest-vr
+description: Build and ship Godot OpenXR apps to Meta Quest.
+version: 2.0.0
+author: Andre (buckster123) + Hermes Agent
+license: MIT
+platforms: [linux, macos]
+tags: [quest, vr, openxr, godot, android, meta-quest, adb]
+metadata:
+  hermes:
+    tags: [quest, vr, openxr, godot, android, meta-quest, adb, sideload]
+    category: software-development
+    related_skills: [blender-mcp]
+---
+
+# Godot Quest VR Skill
+
+Portable workflow for Godot 4.5+ OpenXR projects targeting Meta Quest 2/3/3S
+from a Linux (or macOS) host. Covers toolchain setup, XR scene setup, Android
+export, APK signing, ADB sideload, Godot-MCP editor control, and the hard-won
+manifest/export pitfalls that make apps launch as flat 2D panels instead of
+immersive VR.
+
+Does **not** teach Blender modeling — use the optional `blender-mcp` skill and
+`hermes mcp install blender` for DCC work, then import GLB into Godot here.
+
+## When to Use
+
+- New Godot VR project for Quest, or diagnosing a failed immersive launch
+- Headless / CI export, signing, and ADB install
+- OpenXR session, XROrigin locomotion, controller/hand setup
+- Godot-MCP setup (live editor tools) and WebSocket protocol fix
+- Android SDK / JDK / apksigner / gltfpack toolchain on a fresh machine
+
+Don't use for: native C++ OpenXR samples only (see Khronos samples), WebXR
+browser apps, or Unreal (`unreal-mcp`).
+
+## Prerequisites
+
+| Tool | Typical path / install | Notes |
+|------|------------------------|--------|
+| Godot 4.5+ | `${HOME}/bin/godot` or PATH | 4.5 fixed Vulkan issues seen on 4.4.1 |
+| JDK 17 | distro `openjdk-17-jdk` | Required by Gradle / apksigner |
+| Android SDK | `${HOME}/android-sdk` | platform-tools, build-tools 34+, platform 29+ |
+| Meta OpenXR Vendors | GodotVR `godot_openxr_vendors` **4.3.1-stable** | 5.0.x needs Godot 4.6+ |
+| ADB / apksigner | SDK platform-tools + build-tools | On PATH |
+| gltfpack (optional) | `${HOME}/bin/gltfpack` | Mesh/texture optimize before import |
+| Node 18+ (optional) | for Godot-MCP server | Only if using live editor MCP |
+
+Env (add to shell profile):
+
+```bash
+export ANDROID_HOME="${HOME}/android-sdk"
+export ANDROID_SDK_ROOT="${ANDROID_HOME}"
+export JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-17-openjdk-amd64}"
+export PATH="${HOME}/bin:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/build-tools/34.0.0:${PATH}"
+export GODOT="${GODOT:-${HOME}/bin/godot}"
+```
+
+On macOS, point `JAVA_HOME` at your Temurin/Homebrew JDK 17 instead.
+
+## How to Run
+
+```bash
+# Validate tools
+command -v "$GODOT" adb apksigner java
+
+# One-time per project
+cd /path/to/your-godot-project
+"$GODOT" --headless --install-android-build-template
+
+# Export unsigned → sign → install (see references/export-pipeline.md)
+"$GODOT" --headless --export-release "Android Quest" build/app-unsigned.apk
+apksigner sign --ks "${KEYSTORE:-${HOME}/.android/debug.keystore}" \
+  --ks-pass pass:android --key-pass pass:android \
+  --out build/app.apk build/app-unsigned.apk
+adb install -r build/app.apk
+```
+
+## Quick Reference
+
+### Export preset (Android Quest)
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| `xr_features/xr_mode` | OpenXR (`1`) | Immersive, not 2D |
+| `gradle_build/use_gradle_build` | `true` | Injects OpenXR loader |
+| `package/signed` | `false` | Headless ignores keystore for OpenXR |
+| `package/app_category` | **Game** (`1`) | Default Accessibility → flat panel |
+| Architectures | arm64 only | Quest is ARM64 |
+| Min SDK | 29+ | OpenXR |
+
+Renderer: **Mobile**. VSync: **Disabled** (XR runtime owns timing).
+
+### XR scene skeleton
+
+```
+Main (Node3D)
+└── XROrigin3D          # move this for locomotion, never the camera
+    ├── XRCamera3D
+    ├── XRController3D (left)
+    └── XRController3D (right)
+```
+
+```gdscript
+func _ready() -> void:
+    var xr := XRServer.find_interface("OpenXR")
+    if xr and xr.is_initialized():
+        get_viewport().use_xr = true
+    else:
+        push_error("OpenXR not available")
+```
+
+### Godot-MCP (optional live editor)
+
+```yaml
+# ~/.hermes/config.yaml — Hermes expands ${HOME}, not bare $HOME
+mcp_servers:
+  godot:
+    command: node
+    args: ["${HOME}/.local/share/godot-mcp/dist/index.js"]
+    connect_timeout: 30
+    timeout: 120
+```
+
+After every Godot-MCP build, strip the broken subprotocol (Godot 4.5
+`WebSocketPeer` does not negotiate `json`):
+
+```bash
+# From this skill directory:
+bash scripts/fix-godot-mcp-protocol.sh "${HOME}/.local/share/godot-mcp"
+```
+
+Full install steps: `references/godot-mcp.md`.
+
+### Blender assets
+
+Install/configure Blender MCP via the official optional skill — do not
+duplicate setup here:
+
+```bash
+hermes skills install official/creative/blender-mcp
+hermes mcp install blender
+```
+
+Export GLB (or gltfpack-compressed) → drop into Godot `res://` → import as
+raw GLB (avoid quantization extensions Godot rejects). Details:
+`references/glb-pipeline.md`.
+
+## Procedure
+
+1. **Toolchain** — `references/android-toolchain.md` until `adb devices` and
+   `"$GODOT" --version` work.
+2. **Project** — OpenXR enabled; Meta Vendors plugin installed (zip has an
+   `asset/` prefix — extract carefully); plugin enabled in Project Settings.
+3. **Scene** — XROrigin rig; locomotion on origin; Mobile renderer.
+4. **Export preset** — table above; `app_category=Game` is non-negotiable.
+5. **Build** — template install → headless unsigned export → `apksigner` →
+   `adb install -r`.
+6. **Verify immersive** — see checklist; if 2D panel, dump manifest
+   (`references/manifest.md`).
+7. **Optional MCP** — Godot editor + protocol fix; Blender via `blender-mcp`.
+
+## Pitfalls
+
+1. **`app_category` dropdown overrides manifests** — setting XML alone is not
+   enough if the export preset still says Accessibility.
+2. **Headless + `package/signed=true`** — keystore path is ignored for OpenXR
+   presets; always unsigned export + manual `apksigner`.
+3. **Manual `android_source.zip` extract** — ignored; must use
+   `--install-android-build-template`.
+4. **Vendors zip `asset/` prefix** — wrong depth breaks `libopenxr_loader.so`.
+5. **Godot-MCP `$HOME` in YAML** — use `${HOME}` or Hermes passes a literal
+   `$HOME/...` string to Node.
+6. **Godot-MCP `protocol: 'json'`** — remove or handshake fails on Godot 4.5.
+7. **Move camera for locomotion** — breaks tracking; move `XROrigin3D`.
+8. **Forward+ renderer** — not available on Quest Mobile.
+9. **After Godot upgrade** — delete `android/` and reinstall build template
+   (`.build_version` pin).
+
+## Verification
+
+- [ ] `adb devices` shows Quest authorized
+- [ ] Export preset: OpenXR + gradle build + **Game** category + unsigned
+- [ ] APK contains VR markers (`aapt dump xmltree … \| rg 'VR|headtracking|isGame'`)
+- [ ] App launches immersive (not a 2D floating panel)
+- [ ] Controllers tracked; stick locomotion moves origin
+- [ ] (Optional) `hermes mcp test godot` after editor + protocol fix
+- [ ] (Optional) Blender path uses `blender-mcp`, not a second setup doc
+
+## References
+
+| File | Contents |
+|------|----------|
+| `references/android-toolchain.md` | SDK/NDK/JDK/Godot/gltfpack install |
+| `references/export-pipeline.md` | Headless export, sign, install, launch |
+| `references/manifest.md` | Immersive VR manifest requirements |
+| `references/glb-pipeline.md` | GLB import + gltfpack; Blender handoff |
+| `references/xr-basics.md` | Origin rig, controllers, input notes |
+| `references/godot-mcp.md` | Godot-MCP build, config, protocol fix |
+| `scripts/fix-godot-mcp-protocol.sh` | Idempotent protocol strip helper |

--- a/optional-skills/software-development/godot-quest-vr/references/android-toolchain.md
+++ b/optional-skills/software-development/godot-quest-vr/references/android-toolchain.md
@@ -1,0 +1,82 @@
+# Android / host toolchain
+
+Portable paths use `${HOME}`. Adjust if your distro or company image differs.
+
+## System packages (Debian/Ubuntu)
+
+```bash
+sudo apt update && sudo apt install -y \
+  git curl wget unzip \
+  openjdk-17-jdk \
+  libgl1-mesa-dev libvulkan-dev \
+  adb scrcpy ffmpeg
+```
+
+macOS: install JDK 17 (Temurin), Android command-line tools, and
+`brew install android-platform-tools scrcpy` (or SDK platform-tools).
+
+## Android SDK (command-line)
+
+```bash
+mkdir -p "${HOME}/android-sdk/cmdline-tools"
+cd "${HOME}/android-sdk/cmdline-tools"
+# Pick current commandlinetools zip from Google's Android studio downloads page
+wget https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip
+unzip -q commandlinetools-linux-*.zip
+mv cmdline-tools latest
+
+export ANDROID_HOME="${HOME}/android-sdk"
+yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses
+"${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" \
+  "platform-tools" \
+  "platforms;android-34" \
+  "build-tools;34.0.0" \
+  "ndk;25.2.9519653"
+```
+
+Ensure `adb` and `apksigner` resolve:
+
+```bash
+export PATH="${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/build-tools/34.0.0:${PATH}"
+command -v adb apksigner
+```
+
+## Godot binary
+
+```bash
+mkdir -p "${HOME}/bin"
+cd "${HOME}/bin"
+# Download Godot 4.5+ stable linux.x86_64 (or macOS universal) from godotengine.org
+# mv Godot_v4.5-stable_linux.x86_64 godot && chmod +x godot
+export GODOT="${HOME}/bin/godot"
+"$GODOT" --version
+```
+
+## gltfpack (optional)
+
+```bash
+# From zeux/meshoptimizer releases — place binary on PATH as gltfpack
+command -v gltfpack || echo "optional"
+```
+
+## Debug keystore
+
+```bash
+mkdir -p "${HOME}/.android"
+keytool -genkeypair -v -keystore "${HOME}/.android/debug.keystore" \
+  -storepass android -alias androiddebugkey -keypass android \
+  -keyalg RSA -keysize 2048 -validity 10000 \
+  -dname "CN=Android Debug,O=Android,C=US" 2>/dev/null || true
+```
+
+## Godot editor Android paths
+
+In Editor Settings → Export → Android, set SDK and Java paths to the same
+locations as `ANDROID_HOME` / `JAVA_HOME`. Without this, GUI export fails even
+when CLI tools work.
+
+## Quest device
+
+1. Developer Mode on the headset (Meta developer account).
+2. USB link; accept debugging prompt in headset.
+3. `adb devices` shows `device` (not `unauthorized`).

--- a/optional-skills/software-development/godot-quest-vr/references/export-pipeline.md
+++ b/optional-skills/software-development/godot-quest-vr/references/export-pipeline.md
@@ -1,0 +1,81 @@
+# Export, sign, install
+
+## One-time per project
+
+```bash
+cd /path/to/your-godot-project
+"${GODOT}" --headless --install-android-build-template
+```
+
+Do **not** manually unzip `android_source.zip` into `android/`. Godot tracks
+internal state via `android/.build_version`. After upgrading Godot, delete
+`android/` and reinstall the template.
+
+## Meta OpenXR Vendors plugin
+
+Use GodotVR `godot_openxr_vendors` **4.3.1-stable** with Godot 4.5
+(5.0.x targets 4.6+).
+
+```bash
+wget https://github.com/GodotVR/godot_openxr_vendors/releases/download/4.3.1-stable/godotopenxrvendorsaddon.zip
+unzip -q godotopenxrvendorsaddon.zip
+# Zip nests under asset/ — wrong depth breaks libopenxr_loader.so
+mv asset/addons ./   # run from project root; merge with existing addons/
+rm -rf asset godotopenxrvendorsaddon.zip
+```
+
+In Godot: Project → Project Settings → Plugins → enable **Godot OpenXR Vendors**.
+
+## Export preset checklist
+
+Create **Project → Export → Add → Android** (name it e.g. `Android Quest`):
+
+- XR Mode: **OpenXR**
+- Use Gradle Build: **on**
+- Package → Signed: **off** for headless (sign with apksigner after)
+- Package → App Category: **Game** (not Accessibility)
+- Architectures: **arm64-v8a** only
+- Min SDK: **29+**
+
+Project Settings:
+
+- Rendering → Renderer → **Mobile**
+- Display → Window → VSync Mode → **Disabled**
+
+## Headless export + sign
+
+```bash
+mkdir -p build
+"${GODOT}" --headless --export-release "Android Quest" build/app-unsigned.apk
+
+KEYSTORE="${KEYSTORE:-${HOME}/.android/debug.keystore}"
+apksigner sign \
+  --ks "${KEYSTORE}" --ks-pass pass:android --key-pass pass:android \
+  --out build/app.apk build/app-unsigned.apk
+apksigner verify build/app.apk
+```
+
+Godot headless commonly **ignores keystore fields** on OpenXR presets. Treat
+unsigned export + `apksigner` as the supported path for CI.
+
+## Install and launch
+
+```bash
+adb install -r build/app.apk
+# Prefer launcher from Quest UI; for automation:
+adb shell am start -n com.yourcompany.yourapp/com.godot.game.GodotApp
+```
+
+Replace the package name with your export package/unique name.
+
+## Logs
+
+```bash
+adb logcat -c
+adb logcat | rg -i 'godot|openxr|xr_|vulkan|androidruntime'
+```
+
+## Release signing
+
+For store/sidequest release builds, use a real upload keystore and never
+commit it. Debug keystore is fine for local immersion testing only.

--- a/optional-skills/software-development/godot-quest-vr/references/glb-pipeline.md
+++ b/optional-skills/software-development/godot-quest-vr/references/glb-pipeline.md
@@ -1,0 +1,55 @@
+# GLB pipeline (Godot side)
+
+Blender authoring is covered by the optional `blender-mcp` skill:
+
+```bash
+hermes skills install official/creative/blender-mcp
+hermes mcp install blender
+```
+
+This reference is only the handoff into Godot for Quest.
+
+## Export from DCC
+
+- Prefer **GLB** (binary glTF) over glTF+bin folders for simpler imports.
+- Apply transforms / freeze scale in the DCC before export when possible.
+- Keep real-world scale (1 unit = 1 meter) for comfortable XR.
+
+## Optional compression
+
+```bash
+gltfpack -i raw.glb -o optimized.glb -cc -tc
+```
+
+Avoid mesh quantization extensions that the Godot importer rejects. If import
+fails after gltfpack, retry with milder flags or raw GLB.
+
+## Godot import
+
+1. Copy GLB under `res://` (e.g. `res://models/`).
+2. Let Godot generate `.import` — open the Import dock and confirm.
+3. Instance as scene or load at runtime.
+
+### Stale import cache
+
+If geometry looks wrong after re-export:
+
+1. Delete `model.glb.import`
+2. Delete matching entries under `.godot/imported/`
+3. Reopen/reimport the project
+
+Deleting only one of the two can leave stale meshes.
+
+## Mobile renderer constraints
+
+Quest uses the **Mobile** renderer:
+
+- Prefer baked or simple lights; avoid heavy shadow cascades
+- Glow supported; SSAO generally not — design materials accordingly
+- Watch triangle count and overdraw; profile on-device
+
+## Materials
+
+- Keep PBR simple (base color, roughness, normal)
+- Huge 4K atlases waste VRAM; 1K–2K is usually enough for Quest 3
+- Emission for accents is fine; don't rely on expensive multi-bounce GI

--- a/optional-skills/software-development/godot-quest-vr/references/godot-mcp.md
+++ b/optional-skills/software-development/godot-quest-vr/references/godot-mcp.md
@@ -1,0 +1,74 @@
+# Godot-MCP setup
+
+Live control of the Godot editor over MCP (create scenes/nodes, set
+properties, run editor scripts). Optional — the rest of this skill works
+without it.
+
+Upstream server: https://github.com/ee0pdt/Godot-MCP
+
+## Build and install server
+
+```bash
+git clone --depth 1 https://github.com/ee0pdt/Godot-MCP.git
+cd Godot-MCP/server
+npm install && npm run build
+
+mkdir -p "${HOME}/.local/share/godot-mcp"
+cp -r dist node_modules package.json "${HOME}/.local/share/godot-mcp/"
+```
+
+## Protocol fix (Godot 4.5)
+
+Godot 4.5 `WebSocketPeer` does **not** negotiate subprotocols. Upstream
+clients that pass `protocol: 'json'` fail the handshake ("socket hang up").
+
+From this skill directory:
+
+```bash
+bash scripts/fix-godot-mcp-protocol.sh "${HOME}/.local/share/godot-mcp"
+```
+
+Re-run after every `npm run build`. To survive rebuilds, also strip the line
+from the TypeScript source under `Godot-MCP/server/src/` and rebuild.
+
+## Project addon
+
+```bash
+mkdir -p /path/to/your-project/addons
+cp -r /path/to/Godot-MCP/addons/godot_mcp /path/to/your-project/addons/
+```
+
+Godot → Project → Project Settings → Plugins → enable **Godot MCP**.
+The editor listens on **ws://127.0.0.1:9080** by default.
+
+## Hermes config
+
+Hermes expands **`${VAR}`** placeholders in MCP config. Bare `$HOME` is **not**
+expanded and is passed literally to Node.
+
+```yaml
+mcp_servers:
+  godot:
+    command: node
+    args: ["${HOME}/.local/share/godot-mcp/dist/index.js"]
+    connect_timeout: 30
+    timeout: 120
+```
+
+Apply with a new session or `/reload-mcp`, then:
+
+```bash
+hermes mcp test godot
+```
+
+## Session order
+
+1. Open Godot with the project; plugin enabled (port 9080 listening).
+2. Ensure protocol fix applied on the Node server build.
+3. Start / reload Hermes so tools register (`mcp_godot_*` / server-prefixed names).
+
+## Tool pitfalls
+
+Some editor tools return generic success without payloads. Prefer
+property getters, explicit saves, and verifying on disk with `read_file`
+after mutations. Always save the scene after structural edits.

--- a/optional-skills/software-development/godot-quest-vr/references/manifest.md
+++ b/optional-skills/software-development/godot-quest-vr/references/manifest.md
@@ -1,0 +1,57 @@
+# Immersive VR manifest requirements
+
+Quest OS launches an APK as a **flat 2D panel** unless the merged manifest
+advertises VR correctly. The Meta OpenXR Vendors plugin injects most entries
+when enabled; the export preset still has one override that bites everyone.
+
+## Required markers
+
+Merged `AndroidManifest.xml` should include:
+
+- `uses-feature` `android.hardware.vr.headtracking` (required)
+- MAIN activity intent-filter category `com.oculus.intent.category.VR`
+- Activity meta-data `com.oculus.vr.focusaware` = `true`
+- Application `android:isGame="true"` and `android:appCategory="game"`
+
+## App Category dropdown override
+
+Godot's export preset **Package → App Category** defaults to
+**Accessibility**. That UI value **overrides** hand-edited
+`android:appCategory` in template manifests.
+
+**Always set App Category to Game** in the export preset (value `1` in
+`export_presets.cfg` as `package/app_category=1` on many versions).
+
+## Two manifests
+
+Gradle template may keep:
+
+1. `android/build/AndroidManifest.xml`
+2. `android/build/src/debug/AndroidManifest.xml` (debug overlay wins)
+
+Verify both after plugin install.
+
+## Inspect APK
+
+```bash
+aapt dump xmltree build/app.apk AndroidManifest.xml \
+  | rg -i 'headtracking|oculus|VR|isGame|appCategory|focusaware'
+```
+
+## Common logcat symptoms
+
+| Symptom | Likely cause |
+|---------|----------------|
+| `isVrApplication: false` | Missing VR category or focusaware |
+| `XR_ERROR_FORM_FACTOR_UNSUPPORTED` | Missing headtracking feature or OpenXR loader |
+| SurfaceView / 2D panel | `app_category` not Game |
+| `VK_ERROR_SURFACE_LOST_KHR` | Launched outside VR mode |
+
+## Last-resort apktool surgery
+
+Prefer fixing the export preset. If you must patch a built APK:
+
+1. `apktool d app.apk -o unpacked`
+2. Fix categories / isGame / VR intent in `AndroidManifest.xml`
+3. `apktool b unpacked -o app-rebuilt.apk`
+4. `apksigner sign ...` again

--- a/optional-skills/software-development/godot-quest-vr/references/xr-basics.md
+++ b/optional-skills/software-development/godot-quest-vr/references/xr-basics.md
@@ -1,0 +1,60 @@
+# XR basics (Godot OpenXR)
+
+## Session start
+
+```gdscript
+extends Node3D
+
+func _ready() -> void:
+    var xr_interface: XRInterface = XRServer.find_interface("OpenXR")
+    if xr_interface and xr_interface.is_initialized():
+        get_viewport().use_xr = true
+    else:
+        push_error("OpenXR not available — check Vendors plugin and export XR mode")
+```
+
+If `XRServer.primary_interface` is null at `_ready`, defer a frame and retry
+(plugin timing on device can lag first frame).
+
+## Origin rig
+
+```
+XROrigin3D          # tracking-space root — apply locomotion here
+├── XRCamera3D      # HMD
+├── XRController3D  # left (tracker: left_hand)
+└── XRController3D  # right (tracker: right_hand)
+```
+
+**Never** move `XRCamera3D` for thumbstick locomotion — you fight the
+tracking system. Move `XROrigin3D`.
+
+## Controllers
+
+- Assign `tracker` names expected by OpenXR (`left_hand` / `right_hand`)
+- Prefer an **action map** for inputs; `get_input` without actions can return
+  null — null-guard everything
+- Button indices vary by runtime; action maps beat magic numbers
+
+Optional: `OpenXRRenderModel` child nodes (Godot 4.5+) for platform controller
+meshes.
+
+## Hands / passthrough
+
+Enable the relevant OpenXR extensions via the Meta Vendors plugin settings and
+project OpenXR settings. Test on-device early — editor desktop preview is not
+a substitute for Quest hand tracking.
+
+## Performance floor
+
+| Target | Quest 2 | Quest 3 / 3S |
+|--------|---------|---------------|
+| Frame rate | 72 Hz | 90 Hz |
+| Renderer | Mobile | Mobile |
+
+Drop dynamic lights, huge real-time shadows, and dense transparent overdraw
+before chasing micro-optimizations.
+
+## Camera attributes
+
+On Mobile, physical camera attributes can underexpose dim scenes. Prefer a
+practical/simple environment exposure setup for dark VR levels.

--- a/optional-skills/software-development/godot-quest-vr/scripts/fix-godot-mcp-protocol.sh
+++ b/optional-skills/software-development/godot-quest-vr/scripts/fix-godot-mcp-protocol.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Strip Godot-MCP WebSocket subprotocol that breaks Godot 4.5 handshakes.
+# Usage: fix-godot-mcp-protocol.sh [godot-mcp-install-dir]
+# Default install dir: ${HOME}/.local/share/godot-mcp
+set -euo pipefail
+
+ROOT="${1:-${HOME}/.local/share/godot-mcp}"
+TARGET="${ROOT}/dist/utils/godot_connection.js"
+
+if [[ ! -f "${TARGET}" ]]; then
+  echo "error: missing ${TARGET}" >&2
+  echo "Build Godot-MCP and install dist/ to ${ROOT} first." >&2
+  exit 1
+fi
+
+if grep -q "protocol: 'json'" "${TARGET}" 2>/dev/null \
+  || grep -q 'protocol: "json"' "${TARGET}" 2>/dev/null; then
+  # portable in-place edit
+  tmp="$(mktemp)"
+  sed -e "/protocol: 'json',/d" -e '/protocol: "json",/d' "${TARGET}" > "${tmp}"
+  mv "${tmp}" "${TARGET}"
+  echo "patched: removed protocol json from ${TARGET}"
+else
+  echo "ok: no protocol json line in ${TARGET} (already patched or different build)"
+fi

--- a/tests/skills/test_godot_quest_vr_skill.py
+++ b/tests/skills/test_godot_quest_vr_skill.py
@@ -1,0 +1,121 @@
+"""Hermetic checks for optional-skills/software-development/godot-quest-vr."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_ROOT = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "software-development"
+    / "godot-quest-vr"
+)
+SKILL_MD = SKILL_ROOT / "SKILL.md"
+FIX_SCRIPT = SKILL_ROOT / "scripts" / "fix-godot-mcp-protocol.sh"
+
+
+def _frontmatter(text: str) -> dict:
+    assert text.startswith("---"), "SKILL.md must start with ---"
+    m = re.search(r"\n---\s*\n", text[3:])
+    assert m, "closing frontmatter fence missing"
+    fm = yaml.safe_load(text[3 : m.start() + 3])
+    assert isinstance(fm, dict)
+    return fm
+
+
+def test_skill_md_exists():
+    assert SKILL_MD.is_file()
+
+
+def test_frontmatter_hardline():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    fm = _frontmatter(text)
+    assert fm.get("name") == "godot-quest-vr"
+    desc = fm.get("description") or ""
+    assert isinstance(desc, str)
+    assert len(desc) <= 60, len(desc)
+    assert desc.endswith(".")
+    assert "platforms" in fm
+    platforms = fm["platforms"]
+    assert "linux" in platforms
+    author = str(fm.get("author", ""))
+    assert "buckster123" in author or "Andre" in author
+    assert "Hermes Agent" in author
+
+
+def test_no_bare_dollar_home_in_mcp_examples():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    # Allow ${HOME} only — bare $HOME in yaml args is a known Hermes footgun
+    for i, line in enumerate(text.splitlines(), 1):
+        if "$HOME" in line and "${HOME}" not in line:
+            # allow prose like "not bare $HOME"
+            if "bare $HOME" in line or "not" in line.lower():
+                continue
+            if "args:" in line or "godot-mcp" in line:
+                pytest.fail(f"bare $HOME at line {i}: {line}")
+
+
+def test_defers_blender_to_optional_skill():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    assert "blender-mcp" in text
+    assert "hermes mcp install blender" in text
+    assert "uvx" not in text or "blender-mcp" in text  # no parallel uvx setup block required
+
+
+def test_references_present():
+    refs = SKILL_ROOT / "references"
+    expected = {
+        "android-toolchain.md",
+        "export-pipeline.md",
+        "manifest.md",
+        "glb-pipeline.md",
+        "xr-basics.md",
+        "godot-mcp.md",
+    }
+    found = {p.name for p in refs.glob("*.md")}
+    assert expected <= found
+
+
+def test_fix_protocol_script_idempotent():
+    assert FIX_SCRIPT.is_file()
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        target = root / "dist" / "utils" / "godot_connection.js"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            "const x = {\n  protocol: 'json',\n  foo: 1,\n};\n",
+            encoding="utf-8",
+        )
+        subprocess.run(
+            ["bash", str(FIX_SCRIPT), str(root)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        out = target.read_text(encoding="utf-8")
+        assert "protocol" not in out
+        assert "foo: 1" in out
+        # second run is no-op success
+        r2 = subprocess.run(
+            ["bash", str(FIX_SCRIPT), str(root)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert "ok:" in r2.stdout or "already" in r2.stdout.lower() or "patched" in r2.stdout.lower()
+
+
+def test_fix_protocol_script_missing_target_fails():
+    with tempfile.TemporaryDirectory() as td:
+        r = subprocess.run(
+            ["bash", str(FIX_SCRIPT), td],
+            capture_output=True,
+            text=True,
+        )
+        assert r.returncode != 0


### PR DESCRIPTION
## Summary

Reopens the Godot/Quest work from closed #27388 in the packaging shape maintainers asked for.

**Was:** 5 cross-linked bundled skills under `skills/software-development/` (no dependency system → partial installs break; heavy niche content in default skill lists).

**Now:** one **optional** skill:

```
optional-skills/software-development/godot-quest-vr/
```

Install after merge:

```bash
hermes skills install official/software-development/godot-quest-vr
```

## Addresses #27388 feedback

| Feedback | Fix |
|----------|-----|
| 5-skill bundle / no deps | Single self-contained optional skill |
| Bare `$HOME` in MCP args | `${HOME}/...` only |
| Missing `fix-protocol.sh` | `scripts/fix-godot-mcp-protocol.sh` (idempotent) |
| Blender setup duplicate | Defers to `blender-mcp` + `hermes mcp install blender` |
| description > 60 chars | `"Build and ship Godot OpenXR apps to Meta Quest."` (47) |
| author credit | `Andre (buckster123) + Hermes Agent` |
| `platforms:` | `[linux, macos]` |
| tests | `tests/skills/test_godot_quest_vr_skill.py` |
| Machine-specific paths | Portable `${HOME}` / placeholders only |

## Contents

- **SKILL.md** (~200 lines): export preset table, XROrigin rules, MCP config, pitfalls, verification
- **references/**: android-toolchain, export-pipeline, manifest, glb-pipeline, xr-basics, godot-mcp
- **scripts/fix-godot-mcp-protocol.sh**: Godot 4.5 WebSocket subprotocol strip

Hard-won Quest facts preserved: `app_category=Game`, headless unsigned + apksigner, Vendors zip `asset/` prefix, Mobile renderer, protocol fix.

## Test plan

- [x] `uv run --extra dev python -m pytest tests/skills/test_godot_quest_vr_skill.py -q` → **7 passed**
- [ ] Fresh clone path: install optional skill, open a Godot 4.5 Quest project, follow SKILL.md export checklist
- [ ] Confirm `hermes mcp test godot` docs with `${HOME}` work after protocol script

Closes the packaging discussion on #27388 (content path forward).
