### PR TITLE
feat: add CoinMarketCap MCP catalog entry

### DIFF
--- a/optional-mcps/coinmarketcap/manifest.yaml
+++ b/optional-mcps/coinmarketcap/manifest.yaml
@@ -1,0 +1,39 @@
+manifest_version: 1
+
+name: coinmarketcap
+description: Real-time crypto market data, technical analysis, and on-chain metrics from CoinMarketCap.
+source: https://coinmarketcap.com/api/mcp/
+
+transport:
+  type: http
+  url: "https://mcp.coinmarketcap.com/mcp"
+  headers:
+    X-CMC-MCP-API-KEY: "${COINMARKETCAP_API_KEY}"
+
+auth:
+  type: api_key
+  env:
+    - name: COINMARKETCAP_API_KEY
+      prompt: "CoinMarketCap API key (free Basic key at pro.coinmarketcap.com)"
+      required: true
+      secret: true
+
+tools:
+  default_enabled:
+    - get_crypto_quotes_latest
+    - search_cryptos
+    - get_crypto_info
+    - get_crypto_technical_analysis
+    - get_crypto_marketcap_technical_analysis
+    - get_crypto_metrics
+    - get_global_metrics_latest
+    - get_global_crypto_derivatives_metrics
+    - trending_crypto_narratives
+    - get_upcoming_macro_events
+    - get_crypto_latest_news
+    - search_crypto_info
+
+post_install: |
+  CoinMarketCap market data is now available in Hermes.
+  Get a free API key at pro.coinmarketcap.com if you do not have one.
+  Start a new Hermes session to load the CMC tools.


### PR DESCRIPTION
## What does this PR do?

Adds a catalog entry for CoinMarketCap's hosted MCP server under `optional-mcps/coinmarketcap/` so Hermes users can install real-time crypto market data in one step (`hermes mcp install coinmarketcap`). There is currently no crypto market-data source in the catalog. CMC runs a hosted MCP at mcp.coinmarketcap.com/mcp, so the entry is a remote HTTP server (streamable HTTP) with nothing to clone or build.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎇 New skill (bundled or hub)

## Changes Made

- Added `optional-mcps/coinmarketcap/manifest.yaml` (39 lines): remote HTTP transport to mcp.coinmarketcap.com/mcp, API key auth via the `X-CMC-MCP-API-KEY` header, all 12 read-only tools enabled by default.
- Auth and tool names taken from CMC's public docs: https://coinmarketcap.com/api/documentation/ai-agent-hub/mcp

## How to Test

1. Run `hermes mcp install coinmarketcap`
2. Provide a CoinMarketCap API key when prompted (free Basic key at pro.coinmarketcap.com)
3. Start a session and ask "What is the current price of Bitcoin and Ethereum?"

## Notes

I work on CoinMarketCap's API. Happy to adjust the tool defaults, header name, or auth shape to match your catalog conventions. There is also an x402 no-auth endpoint (mcp.coinmarketcap.com/x402/mcp) if a keyless default is preferred.