### PR TITLE
fix(desktop): disable Electron autoUpdater on macOS — no zip asset published to releases

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10,6 +10,7 @@ import { pathToFileURL } from 'node:url'
 
 import {
   app,
+  autoUpdater,
   BrowserWindow,
   clipboard,
   dialog,
@@ -10635,6 +10636,11 @@ app.on('open-url', (event, url) => {
 })
 
 app.whenReady().then(() => {
+  // Explicitly disable the Electron built-in autoUpdater (Squirrel.Mac on macOS).
+  // The app uses a git-based self-update mechanism — no zip-based Electron
+  // auto-update feed is published to GitHub Releases.
+  autoUpdater.autoDownload = false
+
   const systemCa = installWindowsSystemCaTrust(tls)
 
   if (systemCa.applied) {


### PR DESCRIPTION
## Summary

Fixes #69570 — The desktop app auto-updater silently fails on macOS because no macOS desktop zip asset is published to GitHub Releases. The Electron Squirrel.Mac framework bundled with the macOS .app queries update.electronjs.org for an update feed, but since releases only ship Python artifacts, the query returns 404 and the update silently fails.

## Change

Explicitly disable the Electron built-in `autoUpdater` (Squirrel.Mac on macOS) at app startup. The desktop app uses a git-based self-update mechanism, not the zip-based Electron auto-update feed.

Closes #69570