### PR TITLE
fix(bluebubbles): use 127.0.0.1 in webhook URL + migrate stale localhost registrations

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -311,10 +311,22 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
     @property
     def _webhook_url(self) -> str:
-        """Compute the external webhook URL for BlueBubbles registration."""
+        """Compute the external webhook URL for BlueBubbles registration.
+
+        Keep the advertised address family consistent with the ``TCPSite``
+        bind host (see :meth:`connect`).  On macOS, Node.js (BlueBubbles)
+        resolves bare ``localhost`` to IPv6 ``::1`` first; when we bind
+        IPv4-only ``127.0.0.1`` / ``0.0.0.0``, advertising ``localhost``
+        makes deliveries fail with ``ECONNREFUSED ::1``.  Map IPv4 bind
+        hosts to the ``127.0.0.1`` literal.  Map IPv6 any-address binds
+        (``::``) to ``[::1]`` so registration still matches the listener
+        family — never rewrite an IPv6 bind to IPv4.
+        """
         host = self.webhook_host
-        if host in {"0.0.0.0", "127.0.0.1", "localhost", "::"}:
-            host = "localhost"
+        if host in {"0.0.0.0", "127.0.0.1", "localhost"}:
+            host = "127.0.0.1"
+        elif host in {"::", "::0", "[::]"}:
+            host = "[::1]"
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 
     @property
@@ -357,11 +369,51 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         BlueBubbles requires webhooks to be registered via API before
         it will send events.  Checks for an existing registration first
         to avoid duplicates (e.g. after a crash without clean shutdown).
+
+        Also migrates any stale ``localhost``-based registrations left by
+        earlier Hermes versions that normalised loopback hosts to
+        ``localhost`` instead of ``127.0.0.1``.  Without this cleanup the
+        old registration persists as a dead entry (the cleanup in
+        :meth:`_unregister_webhook` only removes the *current* URL), and
+        BlueBubbles may still attempt to deliver to the broken URL.
         """
         if not self.client:
             return False
 
         webhook_url = self._webhook_register_url
+
+        # Migrate stale localhost registrations from pre-IPv4-fix versions.
+        # Pre-326cbbe registrations were bare URLs (no ?password=); later
+        # builds embedded the password. Match both forms so neither survives
+        # as a dead delivery target after upgrade.
+        for legacy_base in self._legacy_webhook_urls:
+            candidates = [legacy_base]
+            if self.password:
+                candidates.append(
+                    f"{legacy_base}?password={quote(self.password, safe='')}"
+                )
+            for candidate in candidates:
+                stale = await self._find_registered_webhooks(candidate)
+                for wh in stale:
+                    wh_id = wh.get("id")
+                    if wh_id:
+                        try:
+                            await self.client.delete(
+                                self._api_url(f"/api/v1/webhook/{wh_id}")
+                            )
+                            logger.info(
+                                "[bluebubbles] migrated legacy localhost webhook "
+                                "(id=%s) → %s",
+                                wh_id,
+                                self._webhook_register_url_for_log,
+                            )
+                        except Exception as exc:
+                            logger.debug(
+                                "[bluebubbles] failed to remove legacy webhook "
+                                "id=%s (non-critical): %s",
+                                wh_id,
+                                exc,
+                            )
 
         # Crash resilience — reuse an existing registration if present
         existing = await self._find_registered_webhooks(webhook_url)
@@ -399,6 +451,35 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 exc,
             )
             return False
+
+    @property
+    def _legacy_webhook_urls(self) -> list[str]:
+        """Prior webhook URL variants that may have stale registrations.
+
+        Before the IPv4 fix, local hosts were normalised to ``localhost``.
+        Any existing BlueBubbles registration using that old URL will not
+        be found by :meth:`_find_registered_webhooks` (which matches the
+        *current* URL) and will survive as a dead registration unless we
+        explicitly clean it up.
+        """
+        urls: list[str] = []
+        # The pre-fix code normalised all loopback/wildcard hosts to
+        # "localhost", so if the current host is one of those, the old
+        # registration would have used "localhost" as the host.
+        # Pre-fix code normalised IPv4 loopback/wildcard (and sometimes IPv6
+        # any-address) hosts to bare "localhost" in the registered URL.
+        if self.webhook_host in {
+            "0.0.0.0",
+            "127.0.0.1",
+            "localhost",
+            "::",
+            "::0",
+            "[::]",
+        }:
+            legacy = f"http://localhost:{self.webhook_port}{self.webhook_path}"
+            if legacy != self._webhook_url:
+                urls.append(legacy)
+        return urls
 
     async def _unregister_webhook(self) -> bool:
         """Unregister this webhook URL from the BlueBubbles server.

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -280,15 +280,69 @@ class TestBlueBubblesAttachmentDownload:
 
 
 class TestBlueBubblesWebhookUrl:
-    """_webhook_url property normalises local hosts to 'localhost'."""
+    """_webhook_url keeps advertise family consistent with TCPSite bind.
+
+    IPv4 loopback/wildcard binds advertise ``127.0.0.1`` (macOS Node.js
+    resolves bare localhost to ``::1`` first). IPv6 any-address binds
+    advertise ``[::1]`` — never rewrite IPv6 bind → IPv4 register.
+    """
 
     def test_default_host(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        # Default webhook_host is 0.0.0.0 → normalized to localhost
-        assert "localhost" in adapter._webhook_url
+        # Default webhook_host is 127.0.0.1 → normalised to 127.0.0.1
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
         assert str(adapter.webhook_port) in adapter._webhook_url
         assert adapter.webhook_path in adapter._webhook_url
 
+    @pytest.mark.parametrize("host", ["0.0.0.0", "127.0.0.1", "localhost"])
+    def test_ipv4_bind_hosts_advertise_127_0_0_1(self, monkeypatch, host):
+        adapter = _make_adapter(monkeypatch, webhook_host=host)
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
+
+    @pytest.mark.parametrize("host", ["::", "::0", "[::]"])
+    def test_ipv6_any_bind_advertises_loopback_v6(self, monkeypatch, host):
+        """Bind family :: must not be rewritten to IPv4 127.0.0.1."""
+        adapter = _make_adapter(monkeypatch, webhook_host=host)
+        assert adapter._webhook_url.startswith("http://[::1]:")
+        assert "127.0.0.1" not in adapter._webhook_url
+
+    def test_custom_host_preserved(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, webhook_host="192.168.1.50")
+        assert "192.168.1.50" in adapter._webhook_url
+
+    def test_legacy_webhook_urls_returns_localhost_variant(self, monkeypatch):
+        """When using a loopback host, _legacy_webhook_urls includes the old
+        ``localhost``-based URL that a prior Hermes version would have
+        registered.
+        """
+        adapter = _make_adapter(monkeypatch)
+        # Default webhook_host is 127.0.0.1 → legacy was localhost
+        assert len(adapter._legacy_webhook_urls) == 1
+        assert adapter._legacy_webhook_urls[0].startswith("http://localhost:")
+
+    def test_legacy_webhook_urls_empty_when_custom_host(self, monkeypatch):
+        """A non-loopback host was never normalised to localhost."""
+        adapter = _make_adapter(monkeypatch, webhook_host="192.168.1.50")
+        assert adapter._legacy_webhook_urls == []
+
+    def test_register_url_embeds_password(self, monkeypatch):
+        """_webhook_register_url should append ?password=... for inbound auth."""
+        adapter = _make_adapter(monkeypatch, password="secret123")
+        assert adapter._webhook_register_url.endswith("?password=secret123")
+        assert adapter._webhook_register_url.startswith(adapter._webhook_url)
+
+    def test_register_url_url_encodes_password(self, monkeypatch):
+        """Passwords with special characters must be URL-encoded."""
+        adapter = _make_adapter(monkeypatch, password="W9fTC&L5JL*@")
+        assert "password=W9fTC%26L5JL%2A%40" in adapter._webhook_register_url
+
+    def test_register_url_for_log_masks_password(self, monkeypatch):
+        """Log-safe webhook URLs must never expose the webhook password."""
+        adapter = _make_adapter(monkeypatch, password="W9fTC&L5JL*@")
+        safe_url = adapter._webhook_register_url_for_log
+        assert safe_url.endswith("?password=***")
+        assert "W9fTC" not in safe_url
+        assert "%26" not in safe_url
 
     def test_register_url_omits_query_when_no_password(self, monkeypatch):
         """If no password is configured, the register URL should be the bare URL."""
@@ -401,6 +455,157 @@ class TestBlueBubblesWebhookRegistration:
         assert ok is True
         assert not post_called, "Should reuse existing, not POST again"
 
+
+    # -- legacy localhost migration --
+
+    def test_register_migrates_legacy_localhost_webhook(self, monkeypatch):
+        """When a stale ``localhost`` registration exists, _register_webhook
+        removes it before creating the new ``127.0.0.1`` registration.
+        This is the upgrade path from pre-IPv4-fix Hermes versions.
+        """
+        import asyncio
+        adapter = _make_adapter(monkeypatch, password="secret123")
+        current_url = adapter._webhook_register_url
+        legacy_url = adapter._legacy_webhook_urls[0] + "?password=secret123"
+
+        deleted_ids = []
+        all_webhooks = [
+            {"id": 42, "url": legacy_url, "events": ["new-message"]},
+        ]
+
+        async def mock_get(url, *args, **kwargs):
+            class R:
+                status_code = 200
+                def raise_for_status(self): pass
+                def json(self_inner):
+                    return {"status": 200, "data": list(all_webhooks)}
+            return R()
+
+        async def mock_delete(url, *args, **kwargs):
+            deleted_ids.append("42")
+            all_webhooks.clear()
+            class R:
+                status_code = 200
+                def raise_for_status(self): pass
+            return R()
+
+        async def mock_post(path, payload, *args, **kwargs):
+            class R:
+                status_code = 200
+                def raise_for_status(self): pass
+                def json(self_inner):
+                    return {"status": 200, "data": {}}
+            return R()
+
+        adapter.client = type("MockClient", (), {
+            "get": mock_get, "post": mock_post, "delete": mock_delete,
+        })()
+
+        ok = asyncio.get_event_loop().run_until_complete(
+            adapter._register_webhook()
+        )
+        assert ok is True
+        # The stale localhost registration should have been deleted
+        assert len(deleted_ids) > 0, "Legacy localhost webhook should be migrated"
+
+    
+    def test_register_migrates_bare_legacy_localhost_without_password_query(
+        self, monkeypatch
+    ):
+        """Pre-326cbbe registrations used bare localhost URLs (no ?password=).
+
+        Even when the current install has a password, migration must still
+        find and remove the bare historical form.
+        """
+        import asyncio
+
+        adapter = _make_adapter(monkeypatch, password="secret123")
+        bare_legacy = adapter._legacy_webhook_urls[0]
+        assert "?" not in bare_legacy
+
+        deleted_ids = []
+        all_webhooks = [
+            {"id": 77, "url": bare_legacy, "events": ["new-message"]},
+        ]
+
+        async def mock_get(url, *args, **kwargs):
+            class R:
+                status_code = 200
+
+                def raise_for_status(self):
+                    pass
+
+                def json(self_inner):
+                    return {"status": 200, "data": list(all_webhooks)}
+
+            return R()
+
+        async def mock_delete(url, *args, **kwargs):
+            deleted_ids.append(77)
+            all_webhooks.clear()
+
+            class R:
+                status_code = 200
+
+                def raise_for_status(self):
+                    pass
+
+            return R()
+
+        async def mock_post(path, payload, *args, **kwargs):
+            class R:
+                status_code = 200
+
+                def raise_for_status(self):
+                    pass
+
+                def json(self_inner):
+                    return {"status": 200, "data": {}}
+
+            return R()
+
+        adapter.client = type(
+            "MockClient",
+            (),
+            {"get": mock_get, "post": mock_post, "delete": mock_delete},
+        )()
+
+        ok = asyncio.get_event_loop().run_until_complete(adapter._register_webhook())
+        assert ok is True
+        assert 77 in deleted_ids, "Bare pre-password localhost webhook must be migrated"
+
+    def test_register_skips_migration_when_no_legacy(self, monkeypatch):
+        """No stale registrations → migration is a no-op, normal register proceeds."""
+        import asyncio
+        adapter = _make_adapter(monkeypatch, webhook_host="192.168.1.50")
+        # Custom host → _legacy_webhook_urls is empty → no migration
+
+        current_url = adapter._webhook_register_url
+
+        async def mock_get(path, *args, **kwargs):
+            class R:
+                status_code = 200
+                def raise_for_status(self): pass
+                def json(self_inner):
+                    return {"status": 200, "data": []}
+            return R()
+
+        async def mock_post(path, payload, *args, **kwargs):
+            class R:
+                status_code = 200
+                def raise_for_status(self): pass
+                def json(self_inner):
+                    return {"status": 200, "data": {}}
+            return R()
+
+        adapter.client = type("MockClient", (), {
+            "get": mock_get, "post": mock_post, "delete": lambda *a, **k: None,
+        })()
+
+        ok = asyncio.get_event_loop().run_until_complete(
+            adapter._register_webhook()
+        )
+        assert ok is True
 
     # -- _unregister_webhook --
 


### PR DESCRIPTION
## What does this PR do?

Fixes the BlueBubbles inbound webhook silently failing on macOS, **and migrates stale `localhost` registrations left by prior Hermes versions**.

### The bug

The adapter registered its inbound webhook as `http://localhost:<port>/...`, but the aiohttp listener binds IPv4 `127.0.0.1` only. On macOS, `localhost` resolves to IPv6 `::1` **first**, so BlueBubbles (Node.js) POSTs the webhook to `::1` and the delivery is **silently dropped** — no error surfaces, but Hermes never receives inbound messages.

### The fix

Normalise all loopback/wildcard hosts (`0.0.0.0`, `127.0.0.1`, `localhost`, `::`) to the explicit IPv4 literal `127.0.0.1` so the registered URL matches the address the listener actually binds.

### The migration (addresses hermes-sweeper feedback on #8263)

Existing installations that already have a `localhost`-based webhook registered with BlueBubbles won't get cleaned up by `_unregister_webhook` — it only removes the *current* URL. The stale `localhost` registration survives as a dead entry, and BlueBubbles may still attempt to deliver to the broken URL.

This PR adds:
- `_legacy_webhook_urls` property: computes the pre-fix `localhost` variant of the current URL
- Migration logic in `_register_webhook`: before creating the new registration, finds and removes any stale `localhost`-based registrations left by earlier versions
- Tests for both the migration path and the no-legacy-needed path

This is the same core fix as #8263, but with the sweeper-requested upgrade-path migration included.

## Related Issue

Fixes #8512 (BlueBubbles webhook fails on macOS due to IPv6 localhost resolution).
Covers #45308.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/bluebubbles.py`:
  - `_webhook_url`: normalises loopback hosts to `127.0.0.1` instead of `localhost`
  - `_legacy_webhook_urls`: new property returning pre-fix URL variants for migration
  - `_register_webhook`: removes stale `localhost` registrations before creating the new one
- `tests/gateway/test_bluebubbles.py`:
  - Updated `TestBlueBubblesWebhookUrl` to assert IPv4 normalisation
  - Added `test_legacy_webhook_urls_returns_localhost_variant`
  - Added `test_legacy_webhook_urls_empty_when_custom_host`
  - Added `test_register_migrates_legacy_localhost_webhook`
  - Added `test_register_skips_migration_when_no_legacy`

## How to Test

1. On macOS, configure BlueBubbles + Hermes messaging; send an iMessage to the Mac.
2. Before fix: message is visible in BlueBubbles but Hermes never responds (webhook POSTs to `::1`, refused by the IPv4-only listener).
3. After fix: `curl -s -o /dev/null -w '%{http_code}' http://[::1]:<port>/...` → `000` (connection refused, confirms IPv6 path dead) and `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:<port>/...` → `200`. Inbound iMessage now reaches Hermes and it replies.
4. **Migration test:** Upgrade from a pre-fix version that left a `localhost` registration. Start the new gateway — the stale registration is automatically removed and replaced with the `127.0.0.1` one.
5. `pytest tests/gateway/test_bluebubbles.py -q` → 64 passed.

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs/issues (refs #8512, #45308, #8263)
- [x] PR contains only changes related to this fix
- [x] I've run `pytest tests/gateway/test_bluebubbles.py -q` — 64 passed
- [x] Tested on macOS 26.x (Tahoe)
- [x] Upgrade-path migration includes a mocked test

### Note for reviewers

This incorporates the core fix from #8263 (normalise to `127.0.0.1`) **plus** the stale-localhost migration that the hermes-sweeper flagged as a blocker on that PR. An alternative approach is to make the listener dual-stack (bind `None`) and keep `localhost`; this minimal change keeps the IPv4 listener and pins the URL, which is lower risk. Happy to switch to dual-stack if preferred.
