### PR TITLE
fix(cron): preserve pre-advanced minute slots

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1569,8 +1569,20 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         save_jobs(jobs)
                         return
                 
-                # Compute next run
-                job["next_run_at"] = compute_next_run(job["schedule"], now)
+                # ``advance_next_run()`` reserves the next recurring slot
+                # before execution for at-most-once crash safety.  Keep that
+                # reservation when this completion crosses a cron boundary:
+                # recomputing from completion would skip the reserved slot
+                # (for example, a :54 tick that finishes at :01 turns a
+                # one-minute job into a two-minute job).  The marker is only
+                # written by pre-dispatch paths and is cleared immediately so
+                # direct mark_job_run() callers retain their completion-based
+                # scheduling semantics.
+                pre_advanced_next = job.pop("_pre_run_next_run_at", None)
+                if pre_advanced_next and job.get("next_run_at") == pre_advanced_next:
+                    job["next_run_at"] = pre_advanced_next
+                else:
+                    job["next_run_at"] = compute_next_run(job["schedule"], now)
 
                 # If no next run, decide whether this is terminal completion
                 # (one-shot) or a transient failure (recurring schedule couldn't
@@ -1723,10 +1735,15 @@ def advance_next_run(job_id: str) -> bool:
                     return False
                 now = _hermes_now().isoformat()
                 new_next = compute_next_run(job["schedule"], now)
-                if new_next and new_next != job.get("next_run_at"):
+                if new_next:
+                    changed = new_next != job.get("next_run_at")
                     job["next_run_at"] = new_next
+                    # Retain the exact slot selected before execution so
+                    # mark_job_run() does not re-anchor a late completion and
+                    # silently skip an eligible cron occurrence.
+                    job["_pre_run_next_run_at"] = new_next
                     save_jobs(jobs)
-                    return True
+                    return changed
                 return False
         return False
 
@@ -1798,6 +1815,9 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
                 nxt = compute_next_run(job["schedule"], now.isoformat())
                 if nxt:
                     job["next_run_at"] = nxt
+                    # External providers claim and advance before dispatch as
+                    # well; preserve the reserved occurrence at completion.
+                    job["_pre_run_next_run_at"] = nxt
             save_jobs(jobs)
             return True
         return False

--- a/docs/changes/2026-07-23-cron-minute-cadence.md
+++ b/docs/changes/2026-07-23-cron-minute-cadence.md
@@ -1,0 +1,27 @@
+# Preserve pre-advanced cron slots across late completion
+
+## Problem
+
+The in-process scheduler advances a recurring job before dispatch for
+at-most-once crash safety. `mark_job_run()` then recomputed `next_run_at` from
+the completion timestamp. For a `* * * * *` job claimed at `:54` and completed
+after the next `:00` boundary, the recomputation skipped the already reserved
+minute. A one-minute watchdog therefore ran every two minutes.
+
+## Change
+
+Pre-dispatch paths record the exact recurring slot they reserve.
+`mark_job_run()` retains that slot only when it still matches the job's current
+`next_run_at`, then clears the marker. Direct completion calls and changed
+schedules continue to compute from completion time.
+
+## Safety
+
+The change preserves existing at-most-once crash protection. It does not add
+or invoke any order-submission path.
+
+## Verification
+
+- Focused regression reproduces a `:54` dispatch that completes at `:01` and
+  asserts the `:00` slot is retained.
+- Focused test passes after the fix.

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -563,6 +563,32 @@ class TestResolveJobRef:
 
 
 class TestMarkJobRun:
+    def test_preserves_preadvanced_cron_slot_when_run_crosses_minute_boundary(self, tmp_cron_dir, monkeypatch):
+        """A late tick must not skip the following cron minute on completion.
+
+        The scheduler advances recurring jobs before execution for crash safety.
+        If a tick starts at :54 and finishes after the next :00 boundary,
+        recomputing from completion would replace the pre-advanced :00 slot
+        with the following minute and turn a one-minute job into a two-minute
+        job.  Completion must retain the slot selected before execution.
+        """
+        pytest.importorskip("croniter")
+        dispatch_at = datetime(2026, 7, 23, 4, 10, 54, tzinfo=timezone.utc)
+        completion_at = datetime(2026, 7, 23, 4, 11, 2, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: dispatch_at)
+        job = create_job(prompt="minute watchdog", schedule="* * * * *")
+
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = "2026-07-23T04:10:00+00:00"
+        save_jobs(jobs)
+        assert advance_next_run(job["id"]) is True
+        assert get_job(job["id"])["next_run_at"] == "2026-07-23T04:11:00+00:00"
+
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: completion_at)
+        mark_job_run(job["id"], success=True)
+
+        assert get_job(job["id"])["next_run_at"] == "2026-07-23T04:11:00+00:00"
+
     def test_increments_completed(self, tmp_cron_dir):
         job = create_job(prompt="Test", schedule="every 1h")
         mark_job_run(job["id"], success=True)


### PR DESCRIPTION
## Summary
- Preserve the recurring slot reserved before execution when a completion crosses a cron boundary.
- Prevent one-minute no-agent watchdogs from silently degrading to a two-minute cadence.
- Cover the :54 -> :01 regression and document the safety scope.

## Safety
No exchange or trading code is changed. The patch preserves existing recurring-job at-most-once pre-advance behavior.

## Verification
- RED: focused regression failed with next_run_at advancing from 04:11 to 04:12.
- GREEN: focused regression passed.
- Focused cron job tests: 145 passed.
- Full cron suite: 712 passed, 11 skipped; 7 known Windows baseline failures reproduced unchanged on clean HEAD (POSIX permission assertions and HOME tilde expansion).
- compileall and git diff --check passed.