### PR TITLE
fix(terminal): include Linuxbrew in fallback PATH

### DIFF
--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -514,7 +514,7 @@ class TestBlocklistCoverage:
 
 
 class TestSanePathIncludesHomebrew:
-    """Verify _SANE_PATH includes macOS Homebrew directories."""
+    """Verify _SANE_PATH includes macOS Homebrew and Linuxbrew directories."""
 
     @pytest.fixture(autouse=True)
     def _disable_hermes_bin_injection(self):
@@ -532,6 +532,14 @@ class TestSanePathIncludesHomebrew:
         from tools.environments.local import _SANE_PATH
         assert "/opt/homebrew/bin" in _SANE_PATH
 
+
+    def test_sane_path_includes_linuxbrew_bin(self):
+        from tools.environments.local import _SANE_PATH
+        assert "/home/linuxbrew/.linuxbrew/bin" in _SANE_PATH
+
+    def test_sane_path_includes_linuxbrew_sbin(self):
+        from tools.environments.local import _SANE_PATH
+        assert "/home/linuxbrew/.linuxbrew/sbin" in _SANE_PATH
 
     def test_make_run_env_appends_homebrew_on_minimal_path(self):
         """When PATH is minimal, _make_run_env appends missing sane entries."""

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -472,7 +472,7 @@ class TestBlocklistCoverage:
 
 
 class TestSanePathIncludesHomebrew:
-    """Verify _SANE_PATH includes macOS Homebrew directories."""
+    """Verify _SANE_PATH includes macOS Homebrew and Linuxbrew directories."""
 
     @pytest.fixture(autouse=True)
     def _disable_hermes_bin_injection(self):
@@ -490,6 +490,14 @@ class TestSanePathIncludesHomebrew:
         from tools.environments.local import _SANE_PATH
         assert "/opt/homebrew/bin" in _SANE_PATH
 
+
+    def test_sane_path_includes_linuxbrew_bin(self):
+        from tools.environments.local import _SANE_PATH
+        assert "/home/linuxbrew/.linuxbrew/bin" in _SANE_PATH
+
+    def test_sane_path_includes_linuxbrew_sbin(self):
+        from tools.environments.local import _SANE_PATH
+        assert "/home/linuxbrew/.linuxbrew/sbin" in _SANE_PATH
 
     def test_make_run_env_appends_homebrew_on_minimal_path(self):
         """When PATH is minimal, _make_run_env appends missing sane entries."""

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1057,6 +1057,7 @@ def _find_shell() -> str:
 # Standard PATH entries for environments with minimal PATH.
 _SANE_PATH = (
     "/opt/homebrew/bin:/opt/homebrew/sbin:"
+    "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:"
     "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 )
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1044,6 +1044,7 @@ def _find_shell() -> str:
 # Standard PATH entries for environments with minimal PATH.
 _SANE_PATH = (
     "/opt/homebrew/bin:/opt/homebrew/sbin:"
+    "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:"
     "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 )
 


### PR DESCRIPTION
## Summary
- add the canonical Linuxbrew `bin` and `sbin` directories to the local terminal fallback PATH
- cover both directories with regression tests

## Why
Service-managed Hermes processes can start with a minimal PATH. The fallback included macOS Homebrew paths but omitted Linuxbrew, so CLIs installed under `/home/linuxbrew/.linuxbrew` were unavailable unless the parent process already inherited `brew shellenv`.

## Testing
- `venv/bin/python -m pytest tests/tools/test_local_env_blocklist.py tests/tools/test_local_env_relative_cwd.py tests/tools/test_local_env_windows_msys.py tests/tools/test_local_env_cwd_recovery.py tests/tools/test_local_env_session_leak.py -o 'addopts=' -q`
- 118 passed

Closes #69625
