### PR TITLE
test(desktop): cover submit drift through e2e

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -318,6 +318,7 @@ export async function launchDesktop(
 export interface MockBackendFixture {
   app: ElectronApplication
   page: Page
+  mock: Awaited<ReturnType<typeof startMockServer>>
   mockUrl: string
   sandbox: Sandbox
   cleanup: () => Promise<void>
@@ -346,6 +347,7 @@ export async function setupMockBackend(): Promise<MockBackendFixture> {
   return {
     app,
     page,
+    mock,
     mockUrl: mock.url,
     sandbox,
     cleanup: async () => {

--- a/apps/desktop/e2e/mock-server.ts
+++ b/apps/desktop/e2e/mock-server.ts
@@ -22,10 +22,16 @@ const CANNED_REPLY = 'Hello from the mock inference server! The full boot chain 
 /**
  * Start the mock server on an ephemeral port.
  *
- * @returns a handle with `port`, `url`, and `close()`.
+ * @returns a handle with `port`, `url`, received user prompts, and `close()`.
  */
-export function startMockServer(): Promise<{ port: number; url: string; close: () => Promise<void> }> {
+export function startMockServer(): Promise<{
+  port: number
+  url: string
+  receivedPrompts: string[]
+  close: () => Promise<void>
+}> {
   return new Promise((resolve, reject) => {
+    const receivedPrompts: string[] = []
     const server = http.createServer((req, res) => {
       // CORS headers — the Electron renderer doesn't need them, but they
       // don't hurt and make the server usable from a browser context too.
@@ -73,6 +79,14 @@ export function startMockServer(): Promise<{ port: number; url: string; close: (
             parsed = JSON.parse(body)
           } catch {
             // malformed JSON — treat as non-streaming with defaults
+          }
+
+          const lastUserMessage = [...(parsed.messages ?? [])]
+            .reverse()
+            .find((message: { role?: unknown }) => message?.role === 'user')
+
+          if (typeof lastUserMessage?.content === 'string') {
+            receivedPrompts.push(lastUserMessage.content)
           }
 
           const stream = parsed.stream === true
@@ -187,6 +201,7 @@ export function startMockServer(): Promise<{ port: number; url: string; close: (
       resolve({
         port,
         url,
+        receivedPrompts,
         close: () =>
           new Promise((resolveClose, rejectClose) => {
             server.close((err) => {

--- a/apps/desktop/e2e/submit-drift.spec.ts
+++ b/apps/desktop/e2e/submit-drift.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression coverage for #69578: harmless route-token churn during a send
+ * must not make the desktop silently drop the prompt before prompt.submit.
+ */
+
+import { test, expect } from './test'
+
+import {
+  type MockBackendFixture,
+  setupMockBackend,
+  waitForAppReady,
+} from './fixtures'
+
+const PROMPT = 'E2E route token drift must still submit this prompt.'
+
+let fixture: MockBackendFixture | null = null
+
+test.beforeAll(async () => {
+  fixture = await setupMockBackend()
+  await waitForAppReady(fixture!, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+test('submits while same-chat search tokens churn during new-session creation', async ({}, testInfo) => {
+  const { page, mock } = fixture!
+  const composer = page.locator('[contenteditable="true"]').first()
+
+  await composer.click()
+  await composer.type(PROMPT, { delay: 10 })
+
+  // The submit pipeline snapshots the route synchronously, then awaits session
+  // creation. Keep changing only the query string of whichever chat route is
+  // current. Before #69578, comparing the raw route token treated this as a
+  // user chat switch and aborted before prompt.submit.
+  await page.evaluate(() => {
+    let revision = 0
+    const interval = window.setInterval(() => {
+      const pathname = window.location.hash.slice(1).split(/[?#]/, 1)[0] || '/new'
+      window.location.hash = `${pathname}?e2e-route-churn=${revision++}`
+    }, 1)
+
+    ;(window as typeof window & { __e2eStopRouteChurn?: () => void }).__e2eStopRouteChurn = () => {
+      window.clearInterval(interval)
+    }
+  })
+
+  try {
+    await page.keyboard.press('Enter')
+
+    await expect
+      .poll(() => mock.receivedPrompts.includes(PROMPT), { timeout: 60_000 })
+      .toBe(true)
+
+    await page.waitForFunction(
+      prompt => document.querySelector('[data-slot="aui_thread-viewport"]')?.textContent?.includes(prompt) ?? false,
+      PROMPT,
+      { timeout: 15_000 },
+    )
+    await page.waitForFunction(
+      () => document.querySelector('[data-slot="aui_thread-viewport"]')?.textContent?.includes('mock inference server') ?? false,
+      undefined,
+      { timeout: 60_000 },
+    )
+  } finally {
+    await page.evaluate(() => {
+      ;(window as typeof window & { __e2eStopRouteChurn?: () => void }).__e2eStopRouteChurn?.()
+    })
+  }
+
+  await page.screenshot({ path: testInfo.outputPath('same-chat-route-churn-submitted.png') })
+})


### PR DESCRIPTION
## What does this PR do?

Adds end-to-end coverage for the desktop submit-context drift fix in #69578. The test changes only the query string on the current HashRouter chat route while a new-session send is creating its backend session. That route-token churn must not be treated as a user switching chats and silently abort the send before `prompt.submit`.

## Related Issue

Fixes #64327

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added `apps/desktop/e2e/submit-drift.spec.ts`, which drives the real Electron → `hermes serve` → mock OpenAI provider path.
- Added prompt recording to `apps/desktop/e2e/mock-server.ts`, exposed through the shared mock-backend fixture.
- The test asserts the provider receives the exact prompt and its streaming reply renders in the chat transcript despite same-chat query churn.

## How to Test

1. Run `cd apps/desktop && npm run typecheck`.
2. Run `nix develop -c env WLR_BACKENDS=headless WLR_NO_HARDWARE_CURSORS=1 cage -- npm --prefix apps/desktop exec playwright test e2e/submit-drift.spec.ts --reporter=list`.
3. Confirm the spec passes and the mock provider receives the submitted prompt.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A; this changes Desktop TypeScript/E2E coverage.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / NixOS, headless Cage Electron E2E

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused E2E passed:

```text
1 passed (12.1s)
```

`npm run check` typechecked and completed 2,573 passing assertions (3 skipped), but exits nonzero due to an existing unhandled teardown timer from `src/store/coding-status.ts` after `approval-mode-event.test.tsx` (`ReferenceError: window is not defined`). This PR does not touch that path.
