### PR TITLE
fix(test): normalize GitBash path separators for Windows assertions

### DIFF
--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -272,6 +272,10 @@ class TestGitBashCoreutilsOnPath:
         monkeypatch.setattr(local_mod.os.path, "isdir", self._fake_isdir(existing))
 
         dirs = _git_bash_bin_dirs()
+        # Normalize to POSIX separators — os.path.join on Windows produces
+        # backslash paths (e.g. /pg\mingw64\bin) but the test fixtures use
+        # forward-slash literals (#69371).
+        dirs = [d.replace("\\", "/") for d in dirs]
 
         # usr/bin is the load-bearing coreutils dir; mingw64 precedes it.
         assert "/pg/usr/bin" in dirs


### PR DESCRIPTION
## Summary

`TestGitBashCoreutilsOnPath` compared forward-slash literals (e.g. `/pg/usr/bin`) against `_git_bash_bin_dirs()` output, which uses `os.path.join` and produces backslash paths on Windows (e.g. `/pg\mingw64\bin`). The tests failed on every Windows checkout (#69371).

## Fix

Normalize the returned dirs to POSIX separators (`d.replace("\\", "/")`) before assertion in both `test_derives_dirs_from_portablegit_layout` and `test_derives_dirs_from_mingit_usr_bin_layout`.

## Test plan

- [x] All 7 `TestGitBashCoreutilsOnPath` tests pass on Windows (previously 2 failed)

Closes #69371