### PR TITLE
feat(memory): make prefetch and query timeouts configurable

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1611,7 +1611,12 @@ def init_agent(
             if _mem_provider_name and _mem_provider_name.strip():
                 from agent.memory_manager import MemoryManager as _MemoryManager
                 from plugins.memory import load_memory_provider as _load_mem
-                agent._memory_manager = _MemoryManager()
+                _prefetch_timeout = mem_config.get("prefetch_timeout")
+                if _prefetch_timeout is not None:
+                    _prefetch_timeout = float(_prefetch_timeout)
+                agent._memory_manager = _MemoryManager(
+                    external_prefetch_timeout=_prefetch_timeout,
+                )
                 _mp = _load_mem(_mem_provider_name)
                 if _mp and _mp.is_available():
                     agent._memory_manager.add_provider(_mp)

--- a/plugins/memory/byterover/__init__.py
+++ b/plugins/memory/byterover/__init__.py
@@ -223,6 +223,8 @@ class ByteRoverMemoryProvider(MemoryProvider):
     def __init__(self, config: Optional[Dict[str, Any]] = None):
         self._config = dict(config) if config is not None else _load_plugin_config()
         self._auto_extract = _coerce_bool(self._config.get("auto_extract"), True)
+        _tq = self._config.get("timeout_query")
+        self._timeout_query = float(_tq) if _tq is not None else _QUERY_TIMEOUT
         self._cwd = ""
         self._session_id = ""
         self._turn_count = 0
@@ -251,6 +253,12 @@ class ByteRoverMemoryProvider(MemoryProvider):
                 "default": "true",
                 "choices": ["true", "false"],
             },
+            {
+                "key": "timeout_query",
+                "description": "Max seconds for brv query calls (prefetch + tool); increase if model cold-start exceeds default",
+                "default": str(_QUERY_TIMEOUT),
+                "type": "number",
+            },
         ]
 
     def initialize(self, session_id: str, **kwargs) -> None:
@@ -272,14 +280,15 @@ class ByteRoverMemoryProvider(MemoryProvider):
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         """Run brv query synchronously before the agent's first LLM call.
 
-        Blocks until the query completes (up to _QUERY_TIMEOUT seconds), ensuring
-        the result is available as context before the model is called.
-        """
+        Blocks until the query completes (up to the configured timeout_query
+        seconds, default %ds), ensuring the result is available as context
+        before the model is called.
+        """ % _QUERY_TIMEOUT
         if not query or len(query.strip()) < _MIN_QUERY_LEN:
             return ""
         result = _run_brv(
             ["query", "--", query.strip()[:5000]],
-            timeout=_QUERY_TIMEOUT, cwd=self._cwd,
+            timeout=self._timeout_query, cwd=self._cwd,
         )
         if result["success"] and result.get("output"):
             output = result["output"].strip()
@@ -402,7 +411,7 @@ class ByteRoverMemoryProvider(MemoryProvider):
 
         result = _run_brv(
             ["query", "--", query.strip()[:5000]],
-            timeout=_QUERY_TIMEOUT, cwd=self._cwd,
+            timeout=self._timeout_query, cwd=self._cwd,
         )
 
         if not result["success"]:


### PR DESCRIPTION
## Problem

Two hardcoded timeouts block ByteRover (and any memory provider backed by a local LLM) when the model is unloaded and must cold-start:

1. **Global prefetch timeout** (`_EXTERNAL_PREFETCH_TIMEOUT_S = 8.0`) in `agent/memory_manager.py` — the MemoryManager caps every external provider prefetch at 8 seconds. On timeout, it **permanently disables the provider for the rest of the session** (stuck-thread skip at line 558-564).

2. **ByteRover query timeout** (`_QUERY_TIMEOUT = 10`) in `plugins/memory/byterover/__init__.py` — brv query calls are capped at 10 seconds.

When the backing LLM is served via llama-swap (or any on-demand model loader), a cold start can take 10-30 seconds. Both timeouts fire, the provider is skipped for the entire session, and the user gets no memory injection.

## Solution

Make both timeouts configurable via `config.yaml`, following the precedent set by PR #43998 (configurable `prefetch_join_timeout` for Hindsight):

### `memory.prefetch_timeout` (global)
```yaml
memory:
  prefetch_timeout: 45  # seconds; default 8.0
```

### `memory.byterover.timeout_query` (per-provider)
```yaml
memory:
  byterover:
    timeout_query: 45  # seconds; default 10
```

## Changes

| File | Change |
|------|--------|
| `agent/agent_init.py` | Read `memory.prefetch_timeout` from config, pass to `MemoryManager(external_prefetch_timeout=...)` |
| `plugins/memory/byterover/__init__.py` | Read `memory.byterover.timeout_query` from plugin config, use in `prefetch()` and `_tool_query()` |

## Backward Compatibility

Both config keys are optional. When absent, the existing hardcoded defaults (8.0s / 10s) are used. No behavior change for existing users.

## Testing

Tested on a homelab setup:
- Hermes + ByteRover + llama-swap (Qwen3.5-9B on ROCm)
- Without config: cold start → prefetch timeout → provider skipped (existing behavior)
- With `prefetch_timeout: 45` + `timeout_query: 45`: cold start → model loads (~20s) → query completes → memory injected successfully