### PR TITLE
fix(test): patch threading.Event class for CUA timeout tests

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -3786,7 +3786,7 @@ class TestStartupTimeoutPhaseDetail:
     def test_timeout_error_includes_startup_phase(self):
         import threading
         from typing import Any, cast
-        from unittest.mock import MagicMock
+        from unittest.mock import MagicMock, patch as _patch
         from tools.computer_use.cua_backend import _CuaDriverSession
 
         session = cast(Any, _CuaDriverSession.__new__(_CuaDriverSession))
@@ -3802,8 +3802,20 @@ class TestStartupTimeoutPhaseDetail:
         session._bridge = fake_bridge
 
         import asyncio
-        from unittest.mock import patch as _patch
-        with _patch.object(session._ready_event, "wait", return_value=False), \
+
+        class _FakeEvent:
+            """Event whose wait() always returns False (timeout path).
+
+            #69372: _start_lifecycle_locked reassigns a fresh threading.Event()
+            at line 786, so patching the pre-made instance's wait() is lost.
+            Patching threading.Event itself ensures the fresh instance also
+            has the mocked wait()."""
+            def set(self): pass
+            def is_set(self): return False
+            def clear(self): pass
+            def wait(self, timeout=None): return False
+
+        with _patch.object(threading, "Event", _FakeEvent), \
              _patch.object(asyncio, "run_coroutine_threadsafe", return_value=MagicMock()), \
              _patch.object(_CuaDriverSession, "_lifecycle_coro", lambda self: None):
             try:
@@ -3832,7 +3844,13 @@ class TestStartupTimeoutPhaseDetail:
         fake_bridge._loop = MagicMock()
         session._bridge = fake_bridge
 
-        with _patch.object(session._ready_event, "wait", return_value=False), \
+        class _FakeEvent:
+            def set(self): pass
+            def is_set(self): return False
+            def clear(self): pass
+            def wait(self, timeout=None): return False
+
+        with _patch.object(threading, "Event", _FakeEvent), \
              _patch.object(asyncio, "run_coroutine_threadsafe", return_value=MagicMock()), \
              _patch.object(_CuaDriverSession, "_lifecycle_coro", lambda self: None):
             try:


### PR DESCRIPTION
## Summary

`TestStartupTimeoutPhaseDetail` patched `wait` on a pre-made `threading.Event` instance, but `_start_lifecycle_locked` reassigns a **fresh** `threading.Event()` at line 786 before waiting. The patch never takes, so the real 30s wait races pytest-timeout and can kill the whole pytest process on Windows (#69372).

## Fix

Patch `threading.Event` itself with a `_FakeEvent` class whose `wait()` returns `False` immediately. This ensures the fresh Event created inside `_start_lifecycle_locked` also has the mocked `wait()`.

## Test plan

- [x] `test_timeout_error_includes_startup_phase` passes in ~1s (previously waited real 30s)
- [x] `test_timeout_error_defaults_to_unknown_phase` passes in ~1s

Closes #69372