### PR TITLE
fix(qwen-oauth): mock load_pool in runtime provider resolution tests (#69470)

### DIFF
--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -305,6 +305,11 @@ def test_resolve_runtime_provider_qwen_oauth(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "qwen-oauth")
     monkeypatch.setattr(
         rp,
+        "load_pool",
+        lambda provider: type("P", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.setattr(
+        rp,
         "resolve_qwen_runtime_credentials",
         lambda: {
             "provider": "qwen-oauth",
@@ -363,6 +368,11 @@ def test_qwen_oauth_auto_fallthrough_on_auth_failure(monkeypatch):
     from hermes_cli.auth import AuthError
 
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "qwen-oauth")
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("P", (), {"has_credentials": lambda self: False})(),
+    )
     monkeypatch.setattr(
         rp,
         "resolve_qwen_runtime_credentials",


### PR DESCRIPTION
## Summary

Fixes #69470 — Qwen OAuth: resolve_runtime_provider ignores resolve_qwen_runtime_credentials.

## Root cause

test_resolve_runtime_provider_qwen_oauth and test_qwen_oauth_auto_fallthrough_on_auth_failure did **not** mock load_pool, while load_pool("qwen-oauth") auto-seeds from ~/.qwen/oauth_creds.json via _seed_from_singletons. When the credential file exists, the pool path wins and bypasses the mocked resolve_qwen_runtime_credentials, causing:

- test_resolve_runtime_provider_qwen_oauth — gets the real pool token instead of the expected "qwen-token" from the mock.
- test_qwen_oauth_auto_fallthrough_on_auth_failure — the mocked AuthError never fires because the pool path returns first, so the fallthrough-to-OpenRouter branch never triggers. The resolver always returns "qwen-oauth" instead of falling through.

## Fix

Add monkeypatch.setattr(rp, "load_pool", ...) to both tests, matching the exact same pattern already used by test_resolve_runtime_provider_codex (line 274).

## Verification

The fix mirrors the established pattern for providers whose pool path can short-circuit the runtime credential resolver. Existing test test_resolve_runtime_provider_uses_qwen_pool_entry continues to exercise the pool path directly.