### PR TITLE
fix(gateway): treat API_SERVER_* as global env, not profile secrets

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -110,6 +110,7 @@ _GLOBAL_ENV_PREFIXES = (
     "HERMES_KANBAN_",
     "HERMES_TELEGRAM_",   # tuning knobs (batch delays, fallback toggles) — NOT the token
     "TERMINAL_",          # terminal/sandbox backend settings
+    "API_SERVER_",        # platform-enablement (Docker compose environment:) — NOT a secret (#69379)
 )
 
 

--- a/tests/agent/test_api_server_global_env.py
+++ b/tests/agent/test_api_server_global_env.py
@@ -1,0 +1,46 @@
+"""#69379: API_SERVER_* env vars must be treated as global (platform
+enablement), not profile secrets. Docker compose environment: must remain
+authoritative for platform enablement in multiplex mode."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from agent.secret_scope import _is_global_env, get_secret, set_secret_scope, _MULTIPLEX_ACTIVE
+
+
+class TestApiServerGlobalEnv:
+    def test_api_server_enabled_is_global(self):
+        assert _is_global_env("API_SERVER_ENABLED") is True
+
+    def test_api_server_host_is_global(self):
+        assert _is_global_env("API_SERVER_HOST") is True
+
+    def test_api_server_port_is_global(self):
+        assert _is_global_env("API_SERVER_PORT") is True
+
+    def test_api_server_cors_origins_is_global(self):
+        assert _is_global_env("API_SERVER_CORS_ORIGINS") is True
+
+    def test_api_server_var_reads_from_os_environ_under_scope(self, monkeypatch):
+        """When a secret scope is active, API_SERVER_* must still read
+        from os.environ, not the scope (it's platform enablement, not
+        a profile secret)."""
+        monkeypatch.setenv("API_SERVER_ENABLED", "true")
+        # Install a scope that does NOT contain API_SERVER_ENABLED
+        scope = {"TELEGRAM_BOT_TOKEN": "some-token"}
+        token = set_secret_scope(scope)
+        try:
+            val = get_secret("API_SERVER_ENABLED")
+            assert val == "true", (
+                "API_SERVER_ENABLED must read from os.environ even under "
+                "secret scope — it's platform enablement, not a profile "
+                "secret (#69379)"
+            )
+        finally:
+            _reset = set_secret_scope(None)  # clear
+            # Properly reset
+            from agent.secret_scope import _SECRET_SCOPE
+            _SECRET_SCOPE.reset(token)


### PR DESCRIPTION
## Summary

v2026.7.20 regression for Docker multiplex deployments: `load_gateway_config_for_runner` reloads config inside the default profile's `_profile_runtime_scope`, whose secret scope reads the profile's `.env` and never falls through to `os.environ`. Platform-enablement vars (`API_SERVER_ENABLED`, `API_SERVER_HOST`, `API_SERVER_PORT`, `API_SERVER_CORS_ORIGINS`) set via Docker compose `environment:` silently vanish — api_server no longer starts (#69379).

## Root cause

`_GLOBAL_ENV_PREFIXES` in `agent/secret_scope.py` did not include `API_SERVER_`. When `_MULTIPLEX_ACTIVE` is True and a secret scope is installed, `get_secret` returns `default` for any key not in the scope — it doesn't fall through to `os.environ`. So platform-enablement vars set via container environment are invisible.

## Fix

Add `"API_SERVER_"` to `_GLOBAL_ENV_PREFIXES` in `agent/secret_scope.py`. These are deployment/platform config (not credentials), so they always read from `os.environ` — the same treatment as `HERMES_TELEGRAM_*` tuning knobs and `TERMINAL_*` settings.

Credential vars (API keys, tokens) are NOT affected — they remain in the profile `.env` scope.

## Test plan

- [x] `API_SERVER_ENABLED` is classified as global env
- [x] `API_SERVER_HOST` is global
- [x] `API_SERVER_PORT` is global
- [x] `API_SERVER_CORS_ORIGINS` is global
- [x] Under active secret scope, `API_SERVER_ENABLED` reads from `os.environ` (not the scope)

Closes #69379