### PR TITLE
fix(desktop): show steer glyph in busy composer

### DIFF
--- a/apps/desktop/e2e/chat.spec.ts
+++ b/apps/desktop/e2e/chat.spec.ts
@@ -86,10 +86,11 @@ test.describe('chat interaction with mock backend', () => {
     await expectVisualSnapshot(fixture!.page, { name: 'chat-with-messages', app: fixture!.app })
   })
 
-  test('changes the busy composer action from stop to steer or queue', async ({}, testInfo) => {
+  test('offers stop, steer, and queue actions while busy', async ({}, testInfo) => {
     const page = fixture!.page
     const composer = page.locator('[contenteditable="true"]').first()
     const primary = page.locator('[data-slot="composer-root"] button[type="submit"]')
+    const queue = page.locator('[data-slot="composer-root"] button[aria-label="Queue message"]')
 
     await composer.click()
     await composer.type(BLOCKING_CLARIFY_TRIGGER)
@@ -102,27 +103,15 @@ test.describe('chat interaction with mock backend', () => {
     await composer.click()
     await composer.type('please answer tersely')
     await expect(primary).toHaveAttribute('aria-label', /Steer/)
+    await expect(queue).toBeVisible()
+    await expect(queue.locator('svg.tabler-icon-layers-intersect-2')).toBeVisible()
     await page.screenshot({ path: testInfo.outputPath('busy-composer-steer.png') })
     await expect(primary.locator('svg.tabler-icon-steering-wheel')).toBeVisible()
 
-    await page.evaluate(() => {
-      const composer = document.querySelector<HTMLElement>('[contenteditable="true"]')
-      const bytes = Uint8Array.from(
-        atob('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLqOQAAAABJRU5ErkJggg=='),
-        char => char.charCodeAt(0)
-      )
-      const image = new File([bytes], 'queued.png', { type: 'image/png' })
-      const transfer = new DataTransfer()
-
-      transfer.items.add(image)
-      composer?.dispatchEvent(new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: transfer }))
-    })
-    await page.locator('[data-slot="composer-attachments"]').waitFor({ state: 'visible' })
-    await expect(primary).toHaveAttribute('aria-label', /Queue/)
+    await queue.click()
+    await expect(primary).toHaveAttribute('aria-label', 'Stop')
+    await expect(queue).toHaveCount(0)
     await page.screenshot({ path: testInfo.outputPath('busy-composer-queue.png') })
-    await expect(primary.locator('svg.tabler-icon-layers-intersect-2')).toBeVisible()
-
-    await primary.click()
     await expect(page.getByText('1 Queued')).toBeVisible()
 
     await primary.click()

--- a/apps/desktop/e2e/chat.spec.ts
+++ b/apps/desktop/e2e/chat.spec.ts
@@ -8,13 +8,10 @@
  * Prerequisite: `npm run build` must have been run so dist/ exists.
  */
 
-import { test } from './test'
+import { expect, test } from './test'
 
-import {
-  type MockBackendFixture,
-  setupMockBackend,
-  waitForAppReady,
-} from './fixtures'
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { BLOCKING_CLARIFY_QUESTION, BLOCKING_CLARIFY_TRIGGER } from './mock-server'
 import { expectVisualSnapshot } from './visual-snapshot'
 
 let fixture: MockBackendFixture | null = null
@@ -61,7 +58,7 @@ test.describe('chat interaction with mock backend', () => {
         return (body.textContent ?? '').includes('Hello, can you hear me?')
       },
       undefined,
-      { timeout: 15_000 },
+      { timeout: 15_000 }
     )
 
     // Wait for the mock response to appear. The canned reply is:
@@ -81,11 +78,55 @@ test.describe('chat interaction with mock backend', () => {
         return text.includes('mock inference server') || text.includes('boot chain is working')
       },
       undefined,
-      { timeout: 60_000 },
+      { timeout: 60_000 }
     )
   })
 
   test('screenshot of chat with messages', async () => {
     await expectVisualSnapshot(fixture!.page, { name: 'chat-with-messages', app: fixture!.app })
+  })
+
+  test('changes the busy composer action from stop to steer or queue', async ({}, testInfo) => {
+    const page = fixture!.page
+    const composer = page.locator('[contenteditable="true"]').first()
+    const primary = page.locator('[data-slot="composer-root"] button[type="submit"]')
+
+    await composer.click()
+    await composer.type(BLOCKING_CLARIFY_TRIGGER)
+    await page.keyboard.press('Enter')
+    await page.getByText(BLOCKING_CLARIFY_QUESTION).waitFor({ state: 'visible', timeout: 30_000 })
+
+    await expect(primary).toHaveAttribute('aria-label', 'Stop')
+    await expect(primary.locator('span')).toHaveClass(/bg-current/)
+
+    await composer.click()
+    await composer.type('please answer tersely')
+    await expect(primary).toHaveAttribute('aria-label', /Steer/)
+    await page.screenshot({ path: testInfo.outputPath('busy-composer-steer.png') })
+    await expect(primary.locator('svg.tabler-icon-steering-wheel')).toBeVisible()
+
+    await page.evaluate(() => {
+      const composer = document.querySelector<HTMLElement>('[contenteditable="true"]')
+      const bytes = Uint8Array.from(
+        atob('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLqOQAAAABJRU5ErkJggg=='),
+        char => char.charCodeAt(0)
+      )
+      const image = new File([bytes], 'queued.png', { type: 'image/png' })
+      const transfer = new DataTransfer()
+
+      transfer.items.add(image)
+      composer?.dispatchEvent(new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: transfer }))
+    })
+    await page.locator('[data-slot="composer-attachments"]').waitFor({ state: 'visible' })
+    await expect(primary).toHaveAttribute('aria-label', /Queue/)
+    await page.screenshot({ path: testInfo.outputPath('busy-composer-queue.png') })
+    await expect(primary.locator('svg.tabler-icon-layers-intersect-2')).toBeVisible()
+
+    await primary.click()
+    await expect(page.getByText('1 Queued')).toBeVisible()
+
+    await primary.click()
+    await expect(page.getByText('1 Queued — paused')).toBeVisible()
+    await page.screenshot({ path: testInfo.outputPath('busy-composer-queue-paused.png') })
   })
 })

--- a/apps/desktop/e2e/chat.spec.ts
+++ b/apps/desktop/e2e/chat.spec.ts
@@ -91,6 +91,7 @@ test.describe('chat interaction with mock backend', () => {
     const composer = page.locator('[contenteditable="true"]').first()
     const primary = page.locator('[data-slot="composer-root"] button[type="submit"]')
     const queue = page.locator('[data-slot="composer-root"] button[aria-label="Queue message"]')
+    const dictation = page.locator('[data-slot="composer-root"] button[aria-label="Voice dictation"]')
 
     await composer.click()
     await composer.type(BLOCKING_CLARIFY_TRIGGER)
@@ -103,6 +104,7 @@ test.describe('chat interaction with mock backend', () => {
     await composer.click()
     await composer.type('please answer tersely')
     await expect(primary).toHaveAttribute('aria-label', /Steer/)
+    await expect(dictation).toBeVisible()
     await expect(queue).toBeVisible()
     await expect(queue.locator('svg.tabler-icon-layers-intersect-2')).toBeVisible()
     await page.screenshot({ path: testInfo.outputPath('busy-composer-steer.png') })

--- a/apps/desktop/e2e/chat.spec.ts
+++ b/apps/desktop/e2e/chat.spec.ts
@@ -92,6 +92,9 @@ test.describe('chat interaction with mock backend', () => {
     const primary = page.locator('[data-slot="composer-root"] button[type="submit"]')
     const queue = page.locator('[data-slot="composer-root"] button[aria-label="Queue message"]')
     const dictation = page.locator('[data-slot="composer-root"] button[aria-label="Voice dictation"]')
+    const speakReplies = page.locator(
+      '[data-slot="composer-root"] button[aria-label="Read replies aloud"], [data-slot="composer-root"] button[aria-label="Stop reading replies aloud"]'
+    )
 
     await composer.click()
     await composer.type(BLOCKING_CLARIFY_TRIGGER)
@@ -105,8 +108,20 @@ test.describe('chat interaction with mock backend', () => {
     await composer.type('please answer tersely')
     await expect(primary).toHaveAttribute('aria-label', /Steer/)
     await expect(dictation).toBeVisible()
+    await expect(speakReplies).toBeVisible()
     await expect(queue).toBeVisible()
     await expect(queue.locator('svg.tabler-icon-layers-intersect-2')).toBeVisible()
+    const controlLabels = await page
+      .locator('[data-slot="composer-root"] button')
+      .evaluateAll(buttons => buttons.map(button => button.getAttribute('aria-label')))
+    const speakRepliesIndex = controlLabels.findIndex(
+      label => label === 'Read replies aloud' || label === 'Stop reading replies aloud'
+    )
+    expect(controlLabels.indexOf('Voice dictation')).toBeLessThan(speakRepliesIndex)
+    expect(speakRepliesIndex).toBeLessThan(controlLabels.indexOf('Queue message'))
+    expect(controlLabels.indexOf('Queue message')).toBeLessThan(
+      controlLabels.findIndex(label => label?.startsWith('Steer'))
+    )
     await page.screenshot({ path: testInfo.outputPath('busy-composer-steer.png') })
     await expect(primary.locator('svg.tabler-icon-steering-wheel')).toBeVisible()
 

--- a/apps/desktop/e2e/mock-server.ts
+++ b/apps/desktop/e2e/mock-server.ts
@@ -194,6 +194,34 @@ const QUEUE_STOP_SCRIPT: ScriptedTurn[] = [
 ]
 
 /**
+ * A marker that makes the mock emit a real blocking clarify tool call. Tests
+ * use it to hold a turn open while exercising busy-composer interactions.
+ */
+export const BLOCKING_CLARIFY_TRIGGER = 'E2E_BLOCKING_CLARIFY_TRIGGER'
+export const BLOCKING_CLARIFY_QUESTION = 'Keep this test turn running?'
+
+const BLOCKING_CLARIFY_TURN: ScriptedTurn = {
+  text: '',
+  toolCalls: [{ name: 'clarify', args: { question: BLOCKING_CLARIFY_QUESTION, choices: ['Yes', 'No'] } }],
+}
+
+function includesBlockingClarifyTrigger(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return value.includes(BLOCKING_CLARIFY_TRIGGER)
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(includesBlockingClarifyTrigger)
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.values(value).some(includesBlockingClarifyTrigger)
+  }
+
+  return false
+}
+
+/**
  * Start the mock server on an ephemeral port.
  *
  * @returns a handle with `port`, `url`, received user prompts, and `close()`.
@@ -285,6 +313,15 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
           const isSidebarTrigger = userText.includes('E2E_SIDEBAR_TRIGGER')
           const isSidebarCrossTrigger = userText.includes('E2E_SIDEBAR_CROSS')
           const isQueueStopTrigger = userText.includes('E2E_QUEUE_STOP_TRIGGER')
+
+          if (includesBlockingClarifyTrigger(parsed.messages)) {
+            if (stream) {
+              streamScriptedTurn(res, model, BLOCKING_CLARIFY_TURN)
+            } else {
+              nonStreamingScriptedTurn(res, model, BLOCKING_CLARIFY_TURN)
+            }
+            return
+          }
 
           if (isQueueStopTrigger) {
             const turn = QUEUE_STOP_SCRIPT[_queueStopIndex] ?? QUEUE_STOP_SCRIPT[QUEUE_STOP_SCRIPT.length - 1]

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -48,6 +48,7 @@ export function ComposerControls({
   state,
   voiceStatus,
   onDictate,
+  onQueue,
   onToggleAutoSpeak
 }: {
   autoSpeak: boolean
@@ -61,6 +62,7 @@ export function ComposerControls({
   state: ChatBarState
   voiceStatus: VoiceStatus
   onDictate: () => void
+  onQueue: () => void
   onToggleAutoSpeak: () => void
 }) {
   const { t } = useI18n()
@@ -76,7 +78,23 @@ export function ComposerControls({
   return (
     <div className="ml-auto flex shrink-0 items-center gap-(--composer-control-gap)">
       <ModelPill compact={compactModelPill} disabled={disabled} model={state.model} />
-      <DictationButton disabled={disabled} onToggle={onDictate} state={state.voice} status={voiceStatus} />
+      {busyAction === 'steer' ? (
+        <Tip label={c.queueMessage}>
+          <Button
+            aria-label={c.queueMessage}
+            className={GHOST_ICON_BTN}
+            disabled={disabled}
+            onClick={onQueue}
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            <Layers3 className={iconSize.sm} />
+          </Button>
+        </Tip>
+      ) : (
+        <DictationButton disabled={disabled} onToggle={onDictate} state={state.voice} status={voiceStatus} />
+      )}
       <AutoSpeakButton active={autoSpeak} disabled={disabled} onToggle={onToggleAutoSpeak} />
       {showVoicePrimary ? (
         <Tip label={c.startVoice}>

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -3,7 +3,7 @@ import { Codicon } from '@/components/ui/codicon'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
-import { AudioLines, iconSize, Layers3, Loader2, Square, Volume2, VolumeX } from '@/lib/icons'
+import { AudioLines, iconSize, Layers3, Loader2, Square, SteeringWheel, Volume2, VolumeX } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 
 import type { ConversationStatus } from './hooks/use-voice-conversation'
@@ -71,8 +71,6 @@ export function ComposerControls({
   }
 
   const showVoicePrimary = !busy && !hasComposerPayload
-  // steer + stop both interrupt the live turn (the difference is whether a
-  // correction rides along), so they share the stop glyph; only queue differs.
   const busyLabel = busyAction === 'queue' ? c.queueMessage : busyAction === 'steer' ? c.steer : c.stop
 
   return (
@@ -107,6 +105,8 @@ export function ComposerControls({
             {busy ? (
               busyAction === 'queue' ? (
                 <Layers3 className={iconSize.sm} />
+              ) : busyAction === 'steer' ? (
+                <SteeringWheel className={iconSize.sm} />
               ) : (
                 <span className="block size-2.5 rounded-[0.1875rem] bg-current" />
               )

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -78,6 +78,7 @@ export function ComposerControls({
   return (
     <div className="ml-auto flex shrink-0 items-center gap-(--composer-control-gap)">
       <ModelPill compact={compactModelPill} disabled={disabled} model={state.model} />
+      <DictationButton disabled={disabled} onToggle={onDictate} state={state.voice} status={voiceStatus} />
       {busyAction === 'steer' ? (
         <Tip label={c.queueMessage}>
           <Button
@@ -92,9 +93,7 @@ export function ComposerControls({
             <Layers3 className={iconSize.sm} />
           </Button>
         </Tip>
-      ) : (
-        <DictationButton disabled={disabled} onToggle={onDictate} state={state.voice} status={voiceStatus} />
-      )}
+      ) : null}
       <AutoSpeakButton active={autoSpeak} disabled={disabled} onToggle={onToggleAutoSpeak} />
       {showVoicePrimary ? (
         <Tip label={c.startVoice}>

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -79,6 +79,7 @@ export function ComposerControls({
     <div className="ml-auto flex shrink-0 items-center gap-(--composer-control-gap)">
       <ModelPill compact={compactModelPill} disabled={disabled} model={state.model} />
       <DictationButton disabled={disabled} onToggle={onDictate} state={state.voice} status={voiceStatus} />
+      <AutoSpeakButton active={autoSpeak} disabled={disabled} onToggle={onToggleAutoSpeak} />
       {busyAction === 'steer' ? (
         <Tip label={c.queueMessage}>
           <Button
@@ -94,7 +95,6 @@ export function ComposerControls({
           </Button>
         </Tip>
       ) : null}
-      <AutoSpeakButton active={autoSpeak} disabled={disabled} onToggle={onToggleAutoSpeak} />
       {showVoicePrimary ? (
         <Tip label={c.startVoice}>
           <Button

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -200,5 +200,14 @@ export function useComposerSubmit({
     })
   }
 
-  return { dispatchSubmit, steerDraft, submitDraft }
+  const queueDraft = () => {
+    if (disabled || !busy) {
+      return
+    }
+
+    queueCurrentDraft()
+    focusInput()
+  }
+
+  return { dispatchSubmit, queueDraft, steerDraft, submitDraft }
 }

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -238,7 +238,7 @@ export function ChatBar({
 
   // The submit engine — the orchestration seam where draft + queue meet. Owns
   // the submit decision tree, the send-with-restore primitive, and steer.
-  const { steerDraft, submitDraft } = useComposerSubmit({
+  const { queueDraft, steerDraft, submitDraft } = useComposerSubmit({
     activeQueueSessionKey,
     activeQueueSessionKeyRef,
     attachments,
@@ -738,6 +738,7 @@ export function ChatBar({
       disabled={disabled}
       hasComposerPayload={hasComposerPayload}
       onDictate={dictate}
+      onQueue={queueDraft}
       onToggleAutoSpeak={handleToggleAutoSpeak}
       state={state}
       voiceStatus={voiceStatus}


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop busy composer when a turn is still running. It restores the steering-wheel glyph for a typed correction, and brings back a separate queue action in the former steer-control slot so users can either redirect the active turn or queue the draft behind it.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/app/chat/composer/controls.tsx`
  - Renders `SteeringWheel` for the busy **Steer** primary action instead of the old stop square.
  - Renders a separate sibling `Layers3` **Queue message** button whenever a typed text-only draft can steer the current turn, without replacing the dictation microphone; it sits after the read-aloud control and directly before the shared Stop/Steer action.
  - Keeps the stop square for Stop and layers glyph for attachment-driven queueing.
- `apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts`
  - Adds the explicit queue-draft route used by the sibling queue button.
- `apps/desktop/src/app/chat/composer/index.tsx`
  - Wires the queue action through the existing draft/queue lifecycle while keeping the live-turn action selection in sync with composer payload state.
- `apps/desktop/e2e/mock-server.ts`
  - Adds a deterministic mock `clarify` tool call that holds a real agent turn open.
- `apps/desktop/e2e/chat.spec.ts`
  - Runs the real Electron composer through Stop → typed Steer → explicit Queue → Stop/paused queue.
  - Asserts the square, steering-wheel, and layers glyphs in their respective live states.

## UI evidence

Same mock clarify block, 1220×800 window, reduced motion, and Cage headless Wayland on both refs.

**Typed correction during a blocked turn — `70d1b1309` before → `b48dc8fc9` after**

| Before: steering-wheel primary only | After: mic → speaker → queue → steering wheel |
| --- | --- |
| ![Before: steering primary only](https://github.com/user-attachments/assets/fe83b869-e45f-4d9f-af00-09157b9e2048) | ![After: dictation, speaker, queue, and steering primary](https://github.com/user-attachments/assets/97146d30-995b-4229-98af-1b3eb8c41cd6) |

**Queued draft after Stop**

![Queued draft paused after Stop](https://github.com/user-attachments/assets/b8cf0d0a-7190-4027-a524-95c6fc3b1b3c)

The queue panel remains visible as `1 Queued — paused`, with the typed draft available to resume.

## How to Test

```sh
cd apps/desktop
npm run build
env WLR_BACKENDS=headless WLR_NO_HARDWARE_CURSORS=1 \
  cage -- npx playwright test e2e/chat.spec.ts --reporter=list
```

- Before (`70d1b1309`): focused Electron spec passed — 3 passed.
- After (`b48dc8fc9`): focused Electron spec passed — 3 passed.
- Full visual suite previously passed at head: 16 passed, 4 skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS / Linux (Cage headless Wayland)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A: renderer-only controls; N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: N/A
