### PR TITLE
fix: macOS API Keys page timeouts after cache clear (#69462)

### DIFF
--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -710,7 +710,14 @@ export function saveMemoryProviderConfig(provider: string, values: Record<string
 export function getEnvVars(): Promise<Record<string, EnvVarInfo>> {
   return window.hermesDesktop.api<Record<string, EnvVarInfo>>({
     ...profileScoped(),
-    path: '/api/env'
+    path: '/api/env',
+    // The backend's ``_catalog_provider_env_metadata()`` caches the result, but
+    // the first call triggers provider-plugin discovery which can perform
+    // expensive synchronous I/O (e.g. the Bedrock provider importing boto3 and
+    // scanning AWS credential files), stalling the async event loop.  Give it
+    // the same generous ceiling as the startup burst (60s) so a cold or
+    // overloaded backend doesn't surface a spurious timeout (issue #69462).
+    timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
 }
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7036,6 +7036,9 @@ async def update_config(body: ConfigUpdate, profile: Optional[str] = None):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+_catalog_provider_env_cache: dict | None = None
+
+
 def _catalog_provider_env_metadata() -> dict:
     """Map provider env vars → desktop card metadata, derived from the catalog.
 
@@ -7049,11 +7052,24 @@ def _catalog_provider_env_metadata() -> dict:
 
     Hand ``OPTIONAL_ENV_VARS`` prose is layered ON TOP of this in the endpoint;
     this only supplies membership + grouping + sensible fallbacks.
+
+    The result is cached after the first call because ``provider_catalog()``
+    triggers provider-plugin discovery which can perform expensive synchronous
+    I/O (e.g. the Bedrock provider importing boto3 and scanning AWS credential
+    files). Without caching, every ``GET /api/env`` request pays that cost,
+    which can stall the async event loop for tens of seconds and surface as
+    timeouts in the desktop API Keys page on macOS (issue #69462).
     """
+    global _catalog_provider_env_cache
+
+    if _catalog_provider_env_cache is not None:
+        return _catalog_provider_env_cache
+
     try:
         from hermes_cli.provider_catalog import provider_catalog
     except Exception:
-        return {}
+        _catalog_provider_env_cache = {}
+        return _catalog_provider_env_cache
 
     # Env vars already declared with a NON-provider category (e.g. the shared
     # GITHUB_TOKEN, which is a Skills-Hub "tool" credential) must not be
@@ -7140,6 +7156,7 @@ def _catalog_provider_env_metadata() -> dict:
                 "advanced": existing.get("advanced", True),
                 "category": "provider",
             }
+    _catalog_provider_env_cache = meta
     return meta
 
 


### PR DESCRIPTION
## Problem
After a clean install or cache clear on macOS, opening Settings - API Keys consistently shows:
> API keys failed to load. Timed out connecting to Hermes backend.

The backend starts normally and responds to curl, but the Desktop app API Keys page times out with the 15s default fetch timeout.

## Root Cause
The GET /api/env endpoint calls _catalog_provider_env_metadata() on EVERY request, which calls provider_catalog() - list_providers(). This triggers provider-plugin discovery including the Bedrock (aws_sdk) provider, which:
1. Lazy-installs boto3
2. Synchronously scans ~/.aws/credentials via botocore.credentials
3. Repeats this scan every ~15 seconds

On macOS, this synchronous I/O can stall the asyncio event loop for tens of seconds (observed: 171 seconds in the gui.log). The 15s DEFAULT_FETCH_TIMEOUT_MS fires before the response arrives.

## Fix (two-part)
1. Cache _catalog_provider_env_metadata() result so provider_catalog() is called only once per process.
2. Increase getEnvVars() timeout to 60s (matching STARTUP_REQUEST_TIMEOUT_MS) so even the first cold call completes.

Fixes #69462