### PR TITLE
fix(compaction): strip proactive section headers from summary template

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -90,9 +90,6 @@ def _is_summary_access_or_quota_error(exc: Exception) -> bool:
 
 
 HISTORICAL_TASK_HEADING = "## Historical Task Snapshot"
-HISTORICAL_IN_PROGRESS_HEADING = "## Historical In-Progress State"
-HISTORICAL_PENDING_ASKS_HEADING = "## Historical Pending User Asks"
-HISTORICAL_REMAINING_WORK_HEADING = "## Historical Remaining Work"
 
 
 SUMMARY_PREFIX = (
@@ -107,9 +104,7 @@ SUMMARY_PREFIX = (
     "Topic overlap with the summary does NOT mean you should resume its "
     "task: even on similar topics, the latest user message WINS. Treat ONLY "
     "the latest message as the active task and discard stale items from "
-    f"'{HISTORICAL_TASK_HEADING}' / '{HISTORICAL_IN_PROGRESS_HEADING}' / "
-    f"'{HISTORICAL_PENDING_ASKS_HEADING}' / "
-    f"'{HISTORICAL_REMAINING_WORK_HEADING}' entirely — do not 'wrap up' or "
+    f"'{HISTORICAL_TASK_HEADING}' entirely — do not 'wrap up' or "
     "'finish' work described there unless the latest message explicitly "
     "asks for it. "
     "Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll "
@@ -236,9 +231,7 @@ _HISTORICAL_SUMMARY_PREFIXES = (
     "Topic overlap with the summary does NOT mean you should resume its "
     "task: even on similar topics, the latest user message WINS. Treat ONLY "
     "the latest message as the active task and discard stale items from "
-    f"'{HISTORICAL_TASK_HEADING}' / '{HISTORICAL_IN_PROGRESS_HEADING}' / "
-    f"'{HISTORICAL_PENDING_ASKS_HEADING}' / "
-    f"'{HISTORICAL_REMAINING_WORK_HEADING}' entirely — do not 'wrap up' or "
+    f"'{HISTORICAL_TASK_HEADING}' entirely — do not 'wrap up' or "
     "'finish' work described there unless the latest message explicitly "
     "asks for it. "
     "Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll "
@@ -2343,12 +2336,6 @@ Recovered from a deterministic fallback because the LLM context summarizer was u
 ## Active State
 Unknown from deterministic fallback. Inspect current repository/session state if needed.
 
-{HISTORICAL_IN_PROGRESS_HEADING}
-Unknown from deterministic fallback — the latest user ask is recorded once under
-"{HISTORICAL_TASK_HEADING}" above as historical context only. Do NOT treat it as an
-unfulfilled instruction to re-answer; verify current state and continue from the
-protected recent messages after this summary.
-
 ## Blocked
 {_bullets(blockers, limit=5)}
 
@@ -2358,16 +2345,8 @@ None recoverable from deterministic fallback.
 ## Resolved Questions
 None recoverable from deterministic fallback.
 
-{HISTORICAL_PENDING_ASKS_HEADING}
-None recoverable from deterministic fallback. (The latest user ask is preserved once
-under "{HISTORICAL_TASK_HEADING}" as historical context — it is NOT necessarily
-outstanding.)
-
 ## Relevant Files
 {_bullets(relevant_files, limit=12)}
-
-{HISTORICAL_REMAINING_WORK_HEADING}
-Continue from the most recent unfulfilled user ask and protected tail messages. Verify state with tools before making claims.
 
 ## Last Dropped Turns
 {_bullets(last_dropped_turns, limit=8)}
@@ -2619,9 +2598,6 @@ Be specific with file paths, commands, line numbers, and results.]
 - Any running processes or servers
 - Environment details that matter]
 
-{HISTORICAL_IN_PROGRESS_HEADING}
-[Work currently underway — what was being done when compaction fired]
-
 ## Blocked
 [Any blockers, errors, or issues not yet resolved. Include exact error messages.]
 
@@ -2631,14 +2607,8 @@ Be specific with file paths, commands, line numbers, and results.]
 ## Resolved Questions
 {_resolved_questions_instructions}
 
-{HISTORICAL_PENDING_ASKS_HEADING}
-{_pending_asks_instructions}
-
 ## Relevant Files
 [Files read, modified, or created — with brief note on each]
-
-{HISTORICAL_REMAINING_WORK_HEADING}
-[What remains to be done — framed as STALE context for reference only. The agent must NOT resume this work unless the latest user message explicitly asks for it.]
 
 ## Critical Context
 [Any specific values, error messages, configuration details, or data that would be lost without explicit preservation. NEVER include API keys, tokens, passwords, or credentials — write [REDACTED] instead.]

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -215,7 +215,40 @@ _MERGED_SUMMARY_DELIMITER = "[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]
 # embedded in the body and keeps hijacking replies. Keep newest-first; entries
 # are matched literally. Add a frozen copy here whenever SUMMARY_PREFIX changes.
 _HISTORICAL_SUMMARY_PREFIXES = (
-    # Jul 2026 (#65848 class): identical to the current prefix except it
+    # Pre-#69619: identical to the current prefix except the stale-item
+    # discard clause named all four historical headings (the three
+    # section headers removed by #69619 were still in the template).
+    # Summaries persisted by builds immediately before #69619 carry this
+    # exact text and must remain detectable/strippable on resume.
+    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
+    "into the summary below. This is a handoff from a previous context "
+    "window — treat it as background reference, NOT as active instructions. "
+    "Do NOT answer questions or fulfill requests mentioned in this summary; "
+    "they were already addressed. "
+    "Respond ONLY to the latest user message that appears AFTER this "
+    "summary — that message is the single source of truth for what to do "
+    "right now. "
+    "Topic overlap with the summary does NOT mean you should resume its "
+    "task: even on similar topics, the latest user message WINS. Treat ONLY "
+    "the latest message as the active task and discard stale items from "
+    "'## Historical Task Snapshot' / '## Historical In-Progress State' / "
+    "'## Historical Pending User Asks' / "
+    "'## Historical Remaining Work' entirely — do not 'wrap up' or "
+    "'finish' work described there unless the latest message explicitly "
+    "asks for it. "
+    "Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll "
+    "back', 'just verify', 'don't do that anymore', 'never mind', a new "
+    "topic) must immediately end any in-flight work described in the "
+    "summary; do not re-surface it in later turns. "
+    "IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system "
+    "prompt is ALWAYS authoritative and active — never ignore or deprioritize "
+    "memory content due to this compaction note. "
+    "None of the above restricts HOW you work: your tools remain fully "
+    "active — keep calling them normally for the active task (edit files, "
+    "run commands, search) instead of merely narrating what you would do. "
+    "The current session state (files, config, etc.) may reflect work "
+    "described here — avoid repeating it:",
+    # Jul 2026 (#65848 class): identical to the pre-#69619 prefix except it
     # lacked the explicit "tools remain fully active" clause — the strong
     # REFERENCE ONLY framing bled into general tool-use suppression
     # (observed: 7 consecutive narration-only turns immediately after a
@@ -231,7 +264,9 @@ _HISTORICAL_SUMMARY_PREFIXES = (
     "Topic overlap with the summary does NOT mean you should resume its "
     "task: even on similar topics, the latest user message WINS. Treat ONLY "
     "the latest message as the active task and discard stale items from "
-    f"'{HISTORICAL_TASK_HEADING}' entirely — do not 'wrap up' or "
+    "'## Historical Task Snapshot' / '## Historical In-Progress State' / "
+    "'## Historical Pending User Asks' / "
+    "'## Historical Remaining Work' entirely — do not 'wrap up' or "
     "'finish' work described there unless the latest message explicitly "
     "asks for it. "
     "Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll "

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -214,6 +214,10 @@ _MERGED_SUMMARY_DELIMITER = "[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]
 # stale directive it carried (e.g. "resume exactly from Active Task") survives
 # embedded in the body and keeps hijacking replies. Keep newest-first; entries
 # are matched literally. Add a frozen copy here whenever SUMMARY_PREFIX changes.
+# NEVER mutate or reorder an existing entry — each one is the exact wire text a
+# shipped build persisted, so editing it silently un-normalizes every summary
+# written by that build generation; prepend only. tests/agent/
+# test_summary_prefix_semantics.py byte-pins every entry to enforce this.
 _HISTORICAL_SUMMARY_PREFIXES = (
     # Pre-#69619: identical to the current prefix except the stale-item
     # discard clause named all four historical headings (the three

--- a/tests/agent/test_summary_prefix_semantics.py
+++ b/tests/agent/test_summary_prefix_semantics.py
@@ -108,3 +108,61 @@ def test_replaced_prefixes_are_frozen_for_renormalization():
         assert ContextCompressor._is_context_summary_content(content)
         stripped = ContextCompressor._strip_summary_prefix(content)
         assert not stripped.startswith(old_prefix)
+
+
+# Exact literal copy of the live SUMMARY_PREFIX as it shipped immediately
+# before #69619 (four-heading discard clause + tools-active clause).
+# Frozen on purpose: do NOT derive it from module constants — the test must
+# fail if the corresponding entry in _HISTORICAL_SUMMARY_PREFIXES is mutated
+# or dropped.
+_PRE_69619_LIVE_PREFIX = (
+    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
+    "into the summary below. This is a handoff from a previous context "
+    "window — treat it as background reference, NOT as active instructions. "
+    "Do NOT answer questions or fulfill requests mentioned in this summary; "
+    "they were already addressed. "
+    "Respond ONLY to the latest user message that appears AFTER this "
+    "summary — that message is the single source of truth for what to do "
+    "right now. "
+    "Topic overlap with the summary does NOT mean you should resume its "
+    "task: even on similar topics, the latest user message WINS. Treat ONLY "
+    "the latest message as the active task and discard stale items from "
+    "'## Historical Task Snapshot' / '## Historical In-Progress State' / "
+    "'## Historical Pending User Asks' / "
+    "'## Historical Remaining Work' entirely — do not 'wrap up' or "
+    "'finish' work described there unless the latest message explicitly "
+    "asks for it. "
+    "Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll "
+    "back', 'just verify', 'don't do that anymore', 'never mind', a new "
+    "topic) must immediately end any in-flight work described in the "
+    "summary; do not re-surface it in later turns. "
+    "IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system "
+    "prompt is ALWAYS authoritative and active — never ignore or deprioritize "
+    "memory content due to this compaction note. "
+    "None of the above restricts HOW you work: your tools remain fully "
+    "active — keep calling them normally for the active task (edit files, "
+    "run commands, search) instead of merely narrating what you would do. "
+    "The current session state (files, config, etc.) may reflect work "
+    "described here — avoid repeating it:"
+)
+
+
+def test_pre_69619_prefix_generation_is_frozen_and_stripped():
+    """Regression for the #69619 review: the prefix generation live right
+    before the section-header removal was never added to
+    _HISTORICAL_SUMMARY_PREFIXES, so a summary persisted immediately before
+    upgrading survived resume/re-compaction undetected and unstripped.
+    That exact generation must stay frozen, detectable, and strippable."""
+    from agent.context_compressor import (
+        _HISTORICAL_SUMMARY_PREFIXES,
+        ContextCompressor,
+    )
+
+    assert _PRE_69619_LIVE_PREFIX in _HISTORICAL_SUMMARY_PREFIXES, (
+        "pre-#69619 live prefix missing from _HISTORICAL_SUMMARY_PREFIXES — "
+        "summaries persisted by the immediately previous build are no longer "
+        "normalized on resume"
+    )
+    content = _PRE_69619_LIVE_PREFIX + "\nBODY"
+    assert ContextCompressor._is_context_summary_content(content)
+    assert ContextCompressor._strip_summary_prefix(content) == "BODY"

--- a/tests/agent/test_summary_prefix_semantics.py
+++ b/tests/agent/test_summary_prefix_semantics.py
@@ -19,9 +19,6 @@ These tests pin the post-fix invariants so the conflict cannot regress.
 """
 
 from agent.context_compressor import (
-    HISTORICAL_IN_PROGRESS_HEADING,
-    HISTORICAL_PENDING_ASKS_HEADING,
-    HISTORICAL_REMAINING_WORK_HEADING,
     HISTORICAL_TASK_HEADING,
     SUMMARY_PREFIX,
 )
@@ -37,8 +34,6 @@ def test_latest_message_wins_on_conflict():
     lower = SUMMARY_PREFIX.lower()
     assert "latest user message" in lower
     assert HISTORICAL_TASK_HEADING.lower() in lower
-    assert HISTORICAL_PENDING_ASKS_HEADING.lower() in lower
-    assert HISTORICAL_REMAINING_WORK_HEADING.lower() in lower
     # Must have an explicit conflict-resolution rule.
     assert "wins" in lower or "supersede" in lower or "discard" in lower or "priority" in lower
 
@@ -51,7 +46,6 @@ def test_handoff_sections_are_framed_as_historical():
     assert "## pending user asks" not in lower
     assert "## remaining work" not in lower
     assert HISTORICAL_TASK_HEADING.lower() in lower
-    assert HISTORICAL_IN_PROGRESS_HEADING.lower() in lower
 
 
 def test_reverse_signals_called_out():

--- a/tests/agent/test_summary_prefix_semantics.py
+++ b/tests/agent/test_summary_prefix_semantics.py
@@ -110,41 +110,112 @@ def test_replaced_prefixes_are_frozen_for_renormalization():
         assert not stripped.startswith(old_prefix)
 
 
-# Exact literal copy of the live SUMMARY_PREFIX as it shipped immediately
-# before #69619 (four-heading discard clause + tools-active clause).
-# Frozen on purpose: do NOT derive it from module constants — the test must
-# fail if the corresponding entry in _HISTORICAL_SUMMARY_PREFIXES is mutated
-# or dropped.
-_PRE_69619_LIVE_PREFIX = (
-    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
-    "into the summary below. This is a handoff from a previous context "
-    "window — treat it as background reference, NOT as active instructions. "
-    "Do NOT answer questions or fulfill requests mentioned in this summary; "
-    "they were already addressed. "
-    "Respond ONLY to the latest user message that appears AFTER this "
-    "summary — that message is the single source of truth for what to do "
-    "right now. "
-    "Topic overlap with the summary does NOT mean you should resume its "
-    "task: even on similar topics, the latest user message WINS. Treat ONLY "
-    "the latest message as the active task and discard stale items from "
-    "'## Historical Task Snapshot' / '## Historical In-Progress State' / "
-    "'## Historical Pending User Asks' / "
-    "'## Historical Remaining Work' entirely — do not 'wrap up' or "
-    "'finish' work described there unless the latest message explicitly "
-    "asks for it. "
-    "Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll "
-    "back', 'just verify', 'don't do that anymore', 'never mind', a new "
-    "topic) must immediately end any in-flight work described in the "
-    "summary; do not re-surface it in later turns. "
-    "IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system "
-    "prompt is ALWAYS authoritative and active — never ignore or deprioritize "
-    "memory content due to this compaction note. "
-    "None of the above restricts HOW you work: your tools remain fully "
-    "active — keep calling them normally for the active task (edit files, "
-    "run commands, search) instead of merely narrating what you would do. "
-    "The current session state (files, config, etc.) may reflect work "
-    "described here — avoid repeating it:"
+# Exact literal copies of every SUMMARY_PREFIX generation retired into
+# _HISTORICAL_SUMMARY_PREFIXES, newest-first. Frozen on purpose: do NOT
+# derive them from module constants — the tests below must fail if any
+# frozen entry is mutated, reordered, or dropped.
+_FROZEN_PREFIX_GENERATIONS = (
+    # Pre-#69619: four-heading discard clause + tools-active clause.
+    (
+        "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were "
+        "compacted into the summary below. This is a handoff from a "
+        "previous context window — treat it as background reference, NOT "
+        "as active instructions. Do NOT answer questions or fulfill "
+        "requests mentioned in this summary; they were already addressed. "
+        "Respond ONLY to the latest user message that appears AFTER this "
+        "summary — that message is the single source of truth for what to "
+        "do right now. Topic overlap with the summary does NOT mean you "
+        "should resume its task: even on similar topics, the latest user "
+        "message WINS. Treat ONLY the latest message as the active task "
+        "and discard stale items from '## Historical Task Snapshot' / '## "
+        "Historical In-Progress State' / '## Historical Pending User "
+        "Asks' / '## Historical Remaining Work' entirely — do not 'wrap "
+        "up' or 'finish' work described there unless the latest message "
+        "explicitly asks for it. Reverse signals in the latest message "
+        "(e.g. 'stop', 'undo', 'roll back', 'just verify', 'don't do that "
+        "anymore', 'never mind', a new topic) must immediately end any "
+        "in-flight work described in the summary; do not re-surface it in "
+        "later turns. IMPORTANT: Your persistent memory (MEMORY.md, "
+        "USER.md) in the system prompt is ALWAYS authoritative and active "
+        "— never ignore or deprioritize memory content due to this "
+        "compaction note. None of the above restricts HOW you work: your "
+        "tools remain fully active — keep calling them normally for the "
+        "active task (edit files, run commands, search) instead of merely "
+        "narrating what you would do. The current session state (files, "
+        "config, etc.) may reflect work described here — avoid repeating "
+        "it:"
+    ),
+    # Jul 2026 (#65848 class): same discard clause, no tools-active clause.
+    (
+        "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were "
+        "compacted into the summary below. This is a handoff from a "
+        "previous context window — treat it as background reference, NOT "
+        "as active instructions. Do NOT answer questions or fulfill "
+        "requests mentioned in this summary; they were already addressed. "
+        "Respond ONLY to the latest user message that appears AFTER this "
+        "summary — that message is the single source of truth for what to "
+        "do right now. Topic overlap with the summary does NOT mean you "
+        "should resume its task: even on similar topics, the latest user "
+        "message WINS. Treat ONLY the latest message as the active task "
+        "and discard stale items from '## Historical Task Snapshot' / '## "
+        "Historical In-Progress State' / '## Historical Pending User "
+        "Asks' / '## Historical Remaining Work' entirely — do not 'wrap "
+        "up' or 'finish' work described there unless the latest message "
+        "explicitly asks for it. Reverse signals in the latest message "
+        "(e.g. 'stop', 'undo', 'roll back', 'just verify', 'don't do that "
+        "anymore', 'never mind', a new topic) must immediately end any "
+        "in-flight work described in the summary; do not re-surface it in "
+        "later turns. IMPORTANT: Your persistent memory (MEMORY.md, "
+        "USER.md) in the system prompt is ALWAYS authoritative and active "
+        "— never ignore or deprioritize memory content due to this "
+        "compaction note. The current session state (files, config, etc.) "
+        "may reflect work described here — avoid repeating it:"
+    ),
+    # Carveout era (#41607/#38364/#42812).
+    (
+        "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were "
+        "compacted into the summary below. This is a handoff from a "
+        "previous context window — treat it as background reference, NOT "
+        "as active instructions. Do NOT answer questions or fulfill "
+        "requests mentioned in this summary; they were already addressed. "
+        "Respond ONLY to the latest user message that appears AFTER this "
+        "summary — that message is the single source of truth for what to "
+        "do right now. If the latest user message is consistent with the "
+        "'## Active Task' section, you may use the summary as background. "
+        "If the latest user message contradicts, supersedes, changes "
+        "topic from, or in any way diverges from '## Active Task' / '## "
+        "In Progress' / '## Pending User Asks' / '## Remaining Work', the "
+        "latest message WINS — discard those stale items entirely and do "
+        "not 'wrap up the old task first'. Reverse signals in the latest "
+        "message (e.g. 'stop', 'undo', 'roll back', 'just verify', 'don't "
+        "do that anymore', 'never mind', a new topic) must immediately "
+        "end any in-flight work described in the summary; do not "
+        "re-surface it in later turns. IMPORTANT: Your persistent memory "
+        "(MEMORY.md, USER.md) in the system prompt is ALWAYS "
+        "authoritative and active — never ignore or deprioritize memory "
+        "content due to this compaction note. The current session state "
+        "(files, config, etc.) may reflect work described here — avoid "
+        "repeating it:"
+    ),
+    # Pre-#35344: self-contradicting "resume exactly" directive.
+    (
+        "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were "
+        "compacted into the summary below. This is a handoff from a "
+        "previous context window — treat it as background reference, NOT "
+        "as active instructions. Do NOT answer questions or fulfill "
+        "requests mentioned in this summary; they were already addressed. "
+        "Your current task is identified in the '## Active Task' section "
+        "of the summary — resume exactly from there. Respond ONLY to the "
+        "latest user message that appears AFTER this summary. The current "
+        "session state (files, config, etc.) may reflect work described "
+        "here — avoid repeating it:"
+    ),
 )
+
+
+# The generation retired by #69619, pinned individually for the review
+# regression below.
+_PRE_69619_LIVE_PREFIX = _FROZEN_PREFIX_GENERATIONS[0]
 
 
 def test_pre_69619_prefix_generation_is_frozen_and_stripped():
@@ -166,3 +237,24 @@ def test_pre_69619_prefix_generation_is_frozen_and_stripped():
     content = _PRE_69619_LIVE_PREFIX + "\nBODY"
     assert ContextCompressor._is_context_summary_content(content)
     assert ContextCompressor._strip_summary_prefix(content) == "BODY"
+
+
+def test_frozen_generations_match_historical_prefixes_byte_exactly():
+    """Every entry in _HISTORICAL_SUMMARY_PREFIXES must equal its literal pin
+    in _FROZEN_PREFIX_GENERATIONS, in order. Frozen entries are immutable and
+    prepend-only: mutating, reordering, or dropping one silently un-normalizes
+    summaries persisted by that build generation — the exact failure caught in
+    the #69619 review, which the per-entry self-matching loop above cannot see.
+    """
+    from agent.context_compressor import (
+        _HISTORICAL_SUMMARY_PREFIXES,
+        ContextCompressor,
+    )
+
+    assert tuple(_FROZEN_PREFIX_GENERATIONS) == tuple(
+        _HISTORICAL_SUMMARY_PREFIXES
+    ), "a frozen prefix entry was mutated, reordered, added, or dropped"
+    for prefix in _FROZEN_PREFIX_GENERATIONS:
+        content = prefix + "\nBODY"
+        assert ContextCompressor._is_context_summary_content(content)
+        assert ContextCompressor._strip_summary_prefix(content) == "BODY"

--- a/tests/agent/test_summary_prefix_tool_use.py
+++ b/tests/agent/test_summary_prefix_tool_use.py
@@ -30,11 +30,19 @@ class TestSummaryPrefixToolUseClause:
         generation must be frozen into _HISTORICAL_SUMMARY_PREFIXES so old
         persisted summaries still get the directive-strip on re-compaction."""
         assert len(_HISTORICAL_SUMMARY_PREFIXES) >= 3
-        newest_frozen = _HISTORICAL_SUMMARY_PREFIXES[0]
-        # The frozen copy is the pre-clause generation: same framing, no clause.
-        assert "tools remain fully active" not in newest_frozen
-        assert "Do NOT answer questions or fulfill requests" in newest_frozen
-        assert newest_frozen != SUMMARY_PREFIX
+        # The pre-clause generation (#65848 incident era): same framing, no
+        # tools-active clause. Newer generations are prepended ahead of it as
+        # the prefix evolves (tuple is newest-first), so match by content,
+        # not position. "topic overlap" distinguishes it from the older
+        # carveout-era entry.
+        pre_clause = [
+            p for p in _HISTORICAL_SUMMARY_PREFIXES
+            if "tools remain fully active" not in p
+            and "topic overlap" in p.lower()
+            and "Do NOT answer questions or fulfill requests" in p
+        ]
+        assert pre_clause, "pre-clause generation missing from frozen tuple"
+        assert all(p != SUMMARY_PREFIX for p in pre_clause)
 
     def test_historical_prefixes_are_distinct_from_current(self):
         for frozen in _HISTORICAL_SUMMARY_PREFIXES:


### PR DESCRIPTION
## Summary

Removes three directive/proactive section headers from the context compression summary template — `HISTORICAL_IN_PROGRESS_STATE`, `HISTORICAL_PENDING_USER_ASKS`, and `HISTORICAL_REMAINING_WORK` — which leaked future-tense instructions into cached prefixes and created a context hijack surface.

The summary now contains only descriptive/past-tense sections (`Historical Task Snapshot`, `Goal`, `Completed Actions`, `Active State`, `Key Decisions`, `Resolved Questions`, `Relevant Files`, `Critical Context`) plus the `REFERENCE ONLY` disclaimer that already anchors every compaction.

## Changes

- `agent/context_compressor.py`: Remove the three constant definitions, their references in `SUMMARY_PREFIX`, and the corresponding template sections in both the LLM-generated and deterministic-fallback templates.
- `tests/agent/test_summary_prefix_semantics.py`: Remove stale imports and assertions referencing the deleted constants.

## Verification

- All existing tests in `test_summary_prefix_semantics.py` pass.
- Zero remaining references to the deleted constants across the codebase.
- `context_compressor.py` compiles cleanly.