### PR TITLE
fix(slack): preserve legacy attachment URLs

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -384,19 +384,19 @@ def _serialize_slack_blocks_for_agent(blocks: list, max_chars: int = 6000) -> st
     return f"[Slack Block Kit payload for this message]\n```json\n{payload}\n```"
 
 
-def _extract_urls_from_slack_blocks(blocks: list) -> list[str]:
-    """Walk a Block Kit ``blocks`` tree and return URLs found on any element.
+def _extract_urls_from_slack_content(content: Any) -> list[str]:
+    """Walk Slack blocks or legacy attachments and return their URLs.
 
     Returns URLs preserving discovery order with duplicates removed. Used to
     surface the actionable links (``View graph``, ``View incident``, etc.)
-    embedded in bot-posted alerts so an agent reading the thread can fetch
-    or click them. The companion serializer
-    :func:`_serialize_slack_blocks_for_agent` deliberately strips ``url`` to
-    keep the JSON view compact and to avoid exposing arbitrary URLs through
-    the generic payload dump; this helper is the targeted opt-in for
+    embedded in bot-posted alerts, including legacy attachment URL fields, so
+    an agent reading the thread can fetch or click them. The companion
+    serializer :func:`_serialize_slack_blocks_for_agent` deliberately strips
+    ``url`` to keep the JSON view compact and to avoid exposing arbitrary URLs
+    through the generic payload dump; this helper is the targeted opt-in for
     use sites where URLs are the whole point of the message.
     """
-    if not blocks:
+    if not content:
         return []
 
     found: list[str] = []
@@ -410,9 +410,15 @@ def _extract_urls_from_slack_blocks(blocks: list) -> list[str]:
 
     def _walk(node: Any) -> None:
         if isinstance(node, dict):
-            # The common URL-bearing keys across Block Kit (buttons, link
-            # elements in rich_text, image accessories, etc.).
-            for key in ("url", "image_url", "external_url"):
+            # Common Block Kit URL keys plus legacy attachment link fields.
+            for key in (
+                "url",
+                "image_url",
+                "external_url",
+                "title_link",
+                "author_link",
+                "from_url",
+            ):
                 if key in node:
                     _maybe_add(node[key])
             for value in node.values():
@@ -421,7 +427,7 @@ def _extract_urls_from_slack_blocks(blocks: list) -> list[str]:
             for item in node:
                 _walk(item)
 
-    _walk(blocks)
+    _walk(content)
     return found
 
 
@@ -5303,12 +5309,12 @@ class SlackAdapter(BasePlatformAdapter):
         """Return bounded display text for a Slack message, surfacing Block Kit content.
 
         Starts with ``text``, strips bot mentions, then appends rich-text
-        content and actionable URLs from ``blocks`` when present.  Unlike
-        :func:`_serialize_slack_blocks_for_agent` (which can emit up to
+        content and actionable URLs from ``blocks`` and legacy attachments.
+        Unlike :func:`_serialize_slack_blocks_for_agent` (which can emit up to
         6 000 chars of JSON per message), this helper produces only the
-        readable text and URL list needed by thread-context and parent-
-        text rendering — bounded by what the blocks actually contain,
-        not a JSON dump.
+        readable text and URL list needed by thread-context and parent-text
+        rendering — bounded by what the message actually contains, not a JSON
+        dump.
         """
         msg_text = (msg.get("text") or "").strip()
         if bot_uid:
@@ -5331,15 +5337,16 @@ class SlackAdapter(BasePlatformAdapter):
         # Legacy ``attachments`` (Alertmanager, Grafana, PagerDuty, CI bots):
         # apps often post with an empty ``text`` and the real content in
         # attachment fields or attachment-nested blocks.
-        attachments_text = _extract_text_from_slack_attachments(
-            msg.get("attachments") or []
-        ).strip()
+        attachments = msg.get("attachments") or []
+        attachments_text = _extract_text_from_slack_attachments(attachments).strip()
         if attachments_text and attachments_text not in msg_text and all(
             attachments_text not in e for e in extras
         ):
             extras.append(attachments_text)
-        if blocks:
-            urls = _extract_urls_from_slack_blocks(blocks)
+        if blocks or attachments:
+            urls = _extract_urls_from_slack_content(
+                {"blocks": blocks, "attachments": attachments}
+            )
             new_urls = [u for u in urls if u not in msg_text and all(u not in e for e in extras)]
             if new_urls:
                 extras.append("URLs: " + ", ".join(new_urls))

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -678,6 +678,44 @@ class TestSlackThreadContext:
         # Marked as the thread parent.
         assert "[thread parent]" in context
 
+    def test_render_message_text_extracts_legacy_attachment_urls(self):
+        """Legacy attachment URL fields and nested Block Kit links survive."""
+        expected_urls = (
+            "https://alerts.example/incident/42",
+            "https://alerts.example/service",
+            "https://alerts.example/events/42",
+            "https://alerts.example/runbook/42",
+        )
+        rendered = SlackAdapter._render_message_text(
+            {
+                "text": "Incident triggered",
+                "attachments": [
+                    {
+                        "title": "Incident details",
+                        "title_link": expected_urls[0],
+                        "author_name": "Alert service",
+                        "author_link": expected_urls[1],
+                        "from_url": expected_urls[2],
+                        "text": "Threshold exceeded",
+                        "blocks": [
+                            {
+                                "type": "actions",
+                                "elements": [
+                                    {
+                                        "type": "button",
+                                        "url": expected_urls[3],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            }
+        )
+
+        for url in expected_urls:
+            assert url in rendered
+
     @pytest.mark.asyncio
     async def test_fetch_thread_context_includes_blocks_only_parent(self):
         """A parent message with empty ``text`` but non-empty ``blocks`` must


### PR DESCRIPTION
## What does this PR do?

Preserves HTTP(S) URLs carried by legacy Slack attachments when rendering fetched thread context and thread-parent reply context.

Current `main` already merges visible legacy attachment text and top-level Block Kit URLs. However, its URL walker only receives top-level `blocks`, so attachment fields such as `title_link`, `author_link`, and `from_url`—plus URLs in attachment-nested Block Kit—are omitted even though the attachment title/text remains visible.

This follows up on #69316 and keeps the same renderer, URL filtering, and discovery-order deduplication.

## Related Issue

Follow-up to #69316. Searches for the affected legacy attachment URL fields found no open issue or equivalent PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Generalize the existing Slack URL walker to cover both top-level Block Kit and legacy attachment URL fields.
- Feed the renderer's `blocks` and `attachments` through that single walker.
- Add a regression test for `title_link`, `author_link`, `from_url`, and attachment-nested Block Kit URLs.

## How to Test

1. Render a Slack message whose visible title/text is in a legacy attachment and whose links are only in attachment URL fields or nested Block Kit.
2. Confirm all attachment URLs appear in `_render_message_text` output alongside existing top-level Block Kit URLs.
3. Run the focused Slack suite below.

## Validation

- `scripts/run_tests.sh tests/gateway/test_slack*.py -q` — 544 passed
- `.venv/bin/ruff check .` — passed
- `.venv/bin/python scripts/check-windows-footguns.py --all` — passed
- `.venv/bin/python -m compileall -q plugins/platforms/slack/adapter.py tests/gateway/test_slack_approval_buttons.py` — passed
- `git diff upstream/main...HEAD --check` — passed

## Compatibility

- No configuration, dependency, session, or outbound Slack payload changes.
- URL collection remains limited to HTTP(S) and preserves first-seen order with duplicate removal.
- The change is platform-neutral dictionary traversal.

## Checklist

- [x] I've read the contribution guide and repository instructions.
- [x] My commit uses the repository's Conventional Commit format.
- [x] I searched open and closed issues/PRs for an equivalent fix.
- [x] The PR contains only this Slack thread-rendering fix and its regression test.
- [x] Documentation, configuration, architecture, and tool-schema updates are N/A.
- [x] Cross-platform impact was considered and the repository's Windows footgun check passes.
