### PR TITLE
fix(supermemory): show billing usage in runtime footer

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional
@@ -881,6 +882,62 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     )
 
 
+def _fetch_supermemory_account_usage() -> Optional[AccountUsageSnapshot]:
+    api_key = os.environ.get("SUPERMEMORY_API_KEY", "").strip()
+    if not api_key:
+        return AccountUsageSnapshot(
+            provider="supermemory",
+            source="billing_usage_api",
+            fetched_at=_utc_now(),
+            unavailable_reason="SUPERMEMORY_API_KEY not set",
+        )
+
+    with httpx.Client(timeout=10.0) as client:
+        response = client.get(
+            "https://api.supermemory.ai/v3/auth/billing/usage",
+            headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+    features = payload.get("features") if isinstance(payload, dict) else {}
+    credits = features.get("usd_credits") if isinstance(features, dict) else {}
+    if not isinstance(credits, dict):
+        credits = {}
+
+    used = credits.get("usage")
+    included = credits.get("included_usage")
+    balance = credits.get("balance")
+    reset = credits.get("next_reset_at")
+
+    windows: list[AccountUsageWindow] = []
+    details: list[str] = []
+    if isinstance(used, (int, float)) and isinstance(included, (int, float)) and float(included) > 0:
+        used_value = float(used)
+        included_value = float(included)
+        remaining = float(balance) if isinstance(balance, (int, float)) else max(0.0, included_value - used_value)
+        windows.append(
+            AccountUsageWindow(
+                label="Supermemory credits",
+                used_percent=(used_value / included_value) * 100,
+                reset_at=_parse_dt(float(reset) / 1000) if isinstance(reset, (int, float)) else _parse_dt(reset),
+                detail=f"${remaining:.2f} of ${included_value:.2f} remaining",
+            )
+        )
+        details.append(f"Supermemory credits used: ${used_value:.2f} of ${included_value:.2f}")
+    elif isinstance(balance, (int, float)):
+        details.append(f"Supermemory credits balance: ${float(balance):.2f}")
+
+    return AccountUsageSnapshot(
+        provider="supermemory",
+        source="billing_usage_api",
+        fetched_at=_utc_now(),
+        title="Supermemory limits",
+        windows=tuple(windows),
+        details=tuple(details),
+    )
+
+
 def fetch_account_usage(
     provider: Optional[str],
     *,
@@ -897,6 +954,8 @@ def fetch_account_usage(
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
+        if normalized == "supermemory":
+            return _fetch_supermemory_account_usage()
     except Exception:
         return None
     return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -147,6 +147,57 @@ _GATEWAY_RATE_LIMIT_RE = re.compile(
     re.IGNORECASE,
 )
 
+
+def _fetch_runtime_footer_quota_snapshot(provider: str | None, *, base_url: str | None = None, api_key: str | None = None):
+    """Best-effort quota snapshots for the final runtime footer.
+
+    This runs only after a normal model turn and never schedules background
+    polling. Keep it time-bounded and fail-open so quota metadata cannot block
+    the user's final answer.
+    """
+    normalized = str(provider or "").strip().lower()
+    try:
+        import concurrent.futures
+        from agent.account_usage import AccountUsageSnapshot, fetch_account_usage
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            futures = []
+            if normalized in {"anthropic", "openai-codex", "openrouter"}:
+                futures.append(pool.submit(
+                    fetch_account_usage,
+                    normalized,
+                    base_url=base_url,
+                    api_key=api_key,
+                ))
+            if os.environ.get("SUPERMEMORY_API_KEY", "").strip():
+                futures.append(pool.submit(fetch_account_usage, "supermemory"))
+
+            snapshots = []
+            for fut in futures:
+                snap = fut.result(timeout=5.0)
+                if snap and not getattr(snap, "unavailable_reason", None) and getattr(snap, "available", False):
+                    snapshots.append(snap)
+            if not snapshots:
+                return None
+            if len(snapshots) == 1:
+                return snapshots[0]
+            windows = []
+            details = []
+            for snap in snapshots:
+                windows.extend(list(getattr(snap, "windows", ()) or ()))
+                details.extend(list(getattr(snap, "details", ()) or ()))
+            return AccountUsageSnapshot(
+                provider="combined",
+                source="runtime_footer",
+                fetched_at=snapshots[0].fetched_at,
+                title="Account limits",
+                windows=tuple(windows),
+                details=tuple(details),
+            )
+    except Exception:
+        logger.debug("runtime footer quota fetch failed", exc_info=True)
+        return None
+
 _GATEWAY_SECRET_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}\b"),
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
@@ -13494,13 +13545,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # text, so we fire a separate trailing send below.
             _footer_line = ""
             try:
-                from gateway.runtime_footer import build_footer_line as _bfl
+                from gateway.runtime_footer import build_footer_line as _bfl, resolve_footer_config as _rfc
+                _gateway_config = _load_gateway_config()
+                _platform_key = _platform_config_key(source.platform)
+                _footer_cfg = _rfc(_gateway_config, _platform_key)
+                _quota_snapshot = None
+                if _footer_cfg.get("enabled") and "quota" in (_footer_cfg.get("fields") or ()):  # avoid quota API calls when footer/quota is hidden
+                    _quota_snapshot = _fetch_runtime_footer_quota_snapshot(
+                        agent_result.get("provider"),
+                        base_url=agent_result.get("base_url"),
+                        api_key=agent_result.get("api_key"),
+                    )
                 _footer_line = _bfl(
-                    user_config=_load_gateway_config(),
-                    platform_key=_platform_config_key(source.platform),
+                    user_config=_gateway_config,
+                    platform_key=_platform_key,
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
+                    quota_snapshot=_quota_snapshot,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
                 )
             except Exception as _footer_err:

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -9,7 +9,7 @@ Config (``~/.hermes/config.yaml``)::
     display:
       runtime_footer:
         enabled: true                       # off by default
-        fields: [model, context_pct, cwd]   # order shown; drop any to hide
+        fields: [model, context_pct, quota, cwd]   # order shown; drop any to hide
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
@@ -26,9 +26,15 @@ piecemeal, the footer is sent as a separate trailing message via
 from __future__ import annotations
 
 import os
+from datetime import datetime
 from typing import Any, Iterable, Optional
 
-_DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
+try:
+    from zoneinfo import ZoneInfo
+except Exception:  # pragma: no cover - Python without zoneinfo
+    ZoneInfo = None
+
+_DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "quota", "cwd")
 _SEP = " · "
 
 
@@ -51,6 +57,79 @@ def _model_short(model: Optional[str]) -> str:
     if not model:
         return ""
     return model.rsplit("/", 1)[-1]
+
+
+def _quota_window_label(label: str) -> str:
+    """Human-friendly quota-window labels for the multiline footer."""
+    text = str(label or "").strip()
+    lowered = text.lower()
+    if not lowered:
+        return ""
+    if lowered in {"current session", "session", "primary window"}:
+        return "5h"
+    if lowered in {"current week", "weekly", "secondary window"}:
+        return "7d"
+    if lowered.endswith(" week"):
+        prefix = lowered[:-5].replace("current", "").strip()
+        return f"{prefix.title()} 7d" if prefix else "7d"
+    return text[:24]
+
+
+def _quota_reset_short(value: Any) -> str:
+    """Compact Eastern reset timestamp for a quota window."""
+    if value is None:
+        return ""
+    try:
+        dt = value
+        if not isinstance(dt, datetime):
+            return ""
+        if ZoneInfo is not None:
+            dt = dt.astimezone(ZoneInfo("America/Toronto"))
+        else:
+            dt = dt.astimezone()
+        return dt.strftime("%b %-d %-I:%M %p %Z")
+    except Exception:
+        try:
+            return value.strftime("%b %d %I:%M %p %Z")
+        except Exception:
+            return ""
+
+
+def _quota_block(snapshot: Any) -> str:
+    """Render provider quota/limit windows as a readable multiline block."""
+    if not snapshot:
+        return ""
+    try:
+        if getattr(snapshot, "unavailable_reason", None):
+            return ""
+        windows = list(getattr(snapshot, "windows", ()) or ())
+    except Exception:
+        return ""
+    lines: list[str] = []
+    for window in windows:
+        try:
+            used = getattr(window, "used_percent", None)
+            if used is None:
+                continue
+            label = _quota_window_label(getattr(window, "label", ""))
+            if not label:
+                continue
+            pct = max(0, min(100, round(float(used))))
+            line = f"{label} - {pct}%"
+            detail = str(getattr(window, "detail", "") or "").strip()
+            if detail:
+                line += f" - {detail}"
+            reset = _quota_reset_short(getattr(window, "reset_at", None))
+            if reset:
+                line += f" - Reset {reset}"
+            lines.append(line)
+        except Exception:
+            continue
+        if len(lines) >= 3:
+            break
+    if not lines:
+        return ""
+    return "Quota Used:\n" + "\n".join(lines)
 
 
 def resolve_footer_config(
@@ -93,6 +172,7 @@ def format_runtime_footer(
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
+    quota_snapshot: Any = None,
     cwd: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
@@ -111,6 +191,10 @@ def format_runtime_footer(
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
                 parts.append(f"{pct}%")
+        elif field == "quota":
+            q = _quota_block(quota_snapshot)
+            if q:
+                parts.append(q)
         elif field == "cwd":
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
@@ -129,6 +213,7 @@ def build_footer_line(
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
+    quota_snapshot: Any = None,
     cwd: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
@@ -144,6 +229,7 @@ def build_footer_line(
         model=model,
         context_tokens=context_tokens,
         context_length=context_length,
+        quota_snapshot=quota_snapshot,
         cwd=cwd,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
     )

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -153,14 +153,14 @@ def test_format_footer_unknown_field_silently_ignored():
 
 def test_resolve_defaults_off_empty_config():
     cfg = resolve_footer_config({}, "telegram")
-    assert cfg == {"enabled": False, "fields": ["model", "context_pct", "cwd"]}
+    assert cfg == {"enabled": False, "fields": ["model", "context_pct", "quota", "cwd"]}
 
 
 def test_resolve_global_enable():
     user = {"display": {"runtime_footer": {"enabled": True}}}
     cfg = resolve_footer_config(user, "telegram")
     assert cfg["enabled"] is True
-    assert cfg["fields"] == ["model", "context_pct", "cwd"]
+    assert cfg["fields"] == ["model", "context_pct", "quota", "cwd"]
 
 
 def test_resolve_platform_override_wins():
@@ -189,7 +189,7 @@ def test_resolve_platform_can_add_fields_only():
     }
     tg = resolve_footer_config(user, "telegram")
     assert tg["enabled"] is True
-    assert tg["fields"] == ["model", "context_pct", "cwd"]
+    assert tg["fields"] == ["model", "context_pct", "quota", "cwd"]
     dc = resolve_footer_config(user, "discord")
     assert dc["enabled"] is True
     assert dc["fields"] == ["context_pct"]

--- a/tests/gateway/test_runtime_footer_quota_fetch.py
+++ b/tests/gateway/test_runtime_footer_quota_fetch.py
@@ -1,0 +1,96 @@
+from datetime import datetime, timezone
+
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+from gateway.run import _fetch_runtime_footer_quota_snapshot
+
+
+def test_runtime_footer_quota_fetch_combines_model_and_supermemory(monkeypatch):
+    fetched = []
+    now = datetime(2026, 7, 22, tzinfo=timezone.utc)
+
+    def fake_fetch(provider, *, base_url=None, api_key=None):
+        fetched.append((provider, base_url, api_key))
+        if provider == "openai-codex":
+            return AccountUsageSnapshot(
+                provider="openai-codex",
+                source="test",
+                fetched_at=now,
+                windows=(AccountUsageWindow(label="Session", used_percent=25),),
+            )
+        if provider == "supermemory":
+            return AccountUsageSnapshot(
+                provider="supermemory",
+                source="test",
+                fetched_at=now,
+                windows=(AccountUsageWindow(label="Supermemory credits", used_percent=80, detail="$10.00 of $55.00 remaining"),),
+            )
+        raise AssertionError(provider)
+
+    monkeypatch.setenv("SUPERMEMORY_API_KEY", "sm-test")
+    monkeypatch.setattr("agent.account_usage.fetch_account_usage", fake_fetch)
+
+    snapshot = _fetch_runtime_footer_quota_snapshot(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="codex-token",
+    )
+
+    assert snapshot is not None
+    assert snapshot.provider == "combined"
+    assert [(window.label, window.used_percent) for window in snapshot.windows] == [
+        ("Session", 25),
+        ("Supermemory credits", 80),
+    ]
+    assert fetched == [
+        ("openai-codex", "https://chatgpt.com/backend-api/codex", "codex-token"),
+        ("supermemory", None, None),
+    ]
+
+
+def test_runtime_footer_quota_fetch_allows_supermemory_without_model_provider(monkeypatch):
+    now = datetime(2026, 7, 22, tzinfo=timezone.utc)
+
+    def fake_fetch(provider, *, base_url=None, api_key=None):
+        assert provider == "supermemory"
+        return AccountUsageSnapshot(
+            provider="supermemory",
+            source="test",
+            fetched_at=now,
+            windows=(AccountUsageWindow(label="Supermemory credits", used_percent=81),),
+        )
+
+    monkeypatch.setenv("SUPERMEMORY_API_KEY", "sm-test")
+    monkeypatch.setattr("agent.account_usage.fetch_account_usage", fake_fetch)
+
+    snapshot = _fetch_runtime_footer_quota_snapshot("custom-local")
+
+    assert snapshot is not None
+    assert snapshot.provider == "supermemory"
+    assert snapshot.windows[0].label == "Supermemory credits"
+
+
+def test_gateway_footer_skips_quota_fetch_when_footer_disabled(monkeypatch):
+    from gateway.runtime_footer import build_footer_line, resolve_footer_config
+
+    cfg = {"display": {"runtime_footer": {"enabled": False}}}
+    resolved = resolve_footer_config(cfg, "telegram")
+    called = False
+
+    def fetch_quota():
+        nonlocal called
+        called = True
+        return None
+
+    quota_snapshot = fetch_quota() if resolved.get("enabled") and "quota" in (resolved.get("fields") or ()) else None
+    line = build_footer_line(
+        user_config=cfg,
+        platform_key="telegram",
+        model="openai/gpt-5.5",
+        context_tokens=1,
+        context_length=10,
+        quota_snapshot=quota_snapshot,
+        cwd="",
+    )
+
+    assert line == ""
+    assert called is False

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -201,3 +201,38 @@ def test_fetch_account_usage_openrouter_omits_quota_window_when_key_has_no_limit
     assert snapshot.windows == ()
     assert "Credits balance: $74.50" in snapshot.details
     assert "API key usage: $25.50 total • $1.25 today • $4.50 this week • $18.00 this month" in snapshot.details
+
+
+def test_fetch_account_usage_supermemory_uses_billing_usage_endpoint(monkeypatch):
+    monkeypatch.setenv("SUPERMEMORY_API_KEY", "sm-test")
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=10.0: _Client(
+            {
+                "features": {
+                    "usd_credits": {
+                        "usage": 44.25,
+                        "included_usage": 55,
+                        "balance": 10.75,
+                        "next_reset_at": 1785391522227,
+                    }
+                },
+                "periodStart": "2026-06-30T06:05:22.227Z",
+                "periodEnd": "2026-07-30T06:05:22.227Z",
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("supermemory")
+
+    assert snapshot is not None
+    assert snapshot.provider == "supermemory"
+    assert snapshot.windows == (
+        AccountUsageWindow(
+            label="Supermemory credits",
+            used_percent=80.45454545454545,
+            reset_at=datetime.fromtimestamp(1785391522227 / 1000, tz=timezone.utc),
+            detail="$10.75 of $55.00 remaining",
+        ),
+    )
+    assert "Supermemory credits used: $44.25 of $55.00" in snapshot.details


### PR DESCRIPTION
## Summary
- add Supermemory billing usage snapshots via the existing account usage path
- render Supermemory credit usage in the runtime footer alongside model/provider quota windows
- include remaining credit detail and reset time in the quota footer block

## Test Plan
- python -m py_compile agent/account_usage.py gateway/runtime_footer.py gateway/run.py tests/test_account_usage.py tests/gateway/test_runtime_footer_quota_fetch.py
- python -m pytest tests/gateway/test_runtime_footer.py tests/test_account_usage.py::test_fetch_account_usage_supermemory_uses_billing_usage_endpoint tests/gateway/test_runtime_footer_quota_fetch.py -q -o 'addopts='

Draft split from local Supermemory quota/waste hardening work.