### PR TITLE
feat(supermemory): throttle automatic recall

### DIFF
--- a/plugins/memory/supermemory/README.md
+++ b/plugins/memory/supermemory/README.md
@@ -52,6 +52,7 @@ Config file: `$HERMES_HOME/supermemory.json`
 | `auto_capture` | `true` | Store cleaned user-assistant turns after each response |
 | `max_recall_results` | `10` | Max recalled items to format into context |
 | `profile_frequency` | `50` | Include profile facts on first turn and every N turns |
+| `recall_frequency` | `1` | Run automatic Supermemory recall on first turn and every Nth turn. Raise this to reduce search/profile quota calls. |
 | `capture_mode` | `all` | Skip tiny or trivial turns by default |
 | `search_mode` | `hybrid` | Search mode: `hybrid` (profile + memories), `memories` (memories only), `documents` (documents only) |
 | `entity_context` | built-in default | Extraction guidance passed to Supermemory |

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_CONTAINER_TAG = "hermes"
 _DEFAULT_MAX_RECALL_RESULTS = 10
 _DEFAULT_PROFILE_FREQUENCY = 50
+_DEFAULT_RECALL_FREQUENCY = 1
 _DEFAULT_CAPTURE_MODE = "all"
 _DEFAULT_SEARCH_MODE = "hybrid"
 _VALID_SEARCH_MODES = ("hybrid", "memories", "documents")
@@ -61,6 +62,7 @@ def _default_config() -> dict:
         "auto_capture": True,
         "max_recall_results": _DEFAULT_MAX_RECALL_RESULTS,
         "profile_frequency": _DEFAULT_PROFILE_FREQUENCY,
+        "recall_frequency": _DEFAULT_RECALL_FREQUENCY,
         "capture_mode": _DEFAULT_CAPTURE_MODE,
         "search_mode": _DEFAULT_SEARCH_MODE,
         "entity_context": _DEFAULT_ENTITY_CONTEXT,
@@ -134,6 +136,10 @@ def _load_supermemory_config(hermes_home: str) -> dict:
         config["profile_frequency"] = max(1, min(500, int(config.get("profile_frequency", _DEFAULT_PROFILE_FREQUENCY))))
     except Exception:
         config["profile_frequency"] = _DEFAULT_PROFILE_FREQUENCY
+    try:
+        config["recall_frequency"] = max(1, min(500, int(config.get("recall_frequency", _DEFAULT_RECALL_FREQUENCY))))
+    except Exception:
+        config["recall_frequency"] = _DEFAULT_RECALL_FREQUENCY
     config["capture_mode"] = "everything" if config.get("capture_mode") == "everything" else "all"
     raw_search_mode = str(config.get("search_mode", _DEFAULT_SEARCH_MODE)).strip().lower()
     config["search_mode"] = raw_search_mode if raw_search_mode in _VALID_SEARCH_MODES else _DEFAULT_SEARCH_MODE
@@ -545,6 +551,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._auto_capture = True
         self._max_recall_results = _DEFAULT_MAX_RECALL_RESULTS
         self._profile_frequency = _DEFAULT_PROFILE_FREQUENCY
+        self._recall_frequency = _DEFAULT_RECALL_FREQUENCY
         self._capture_mode = _DEFAULT_CAPTURE_MODE
         self._search_mode = _DEFAULT_SEARCH_MODE
         self._entity_context = _DEFAULT_ENTITY_CONTEXT
@@ -660,6 +667,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._auto_capture = self._config["auto_capture"]
         self._max_recall_results = self._config["max_recall_results"]
         self._profile_frequency = self._config["profile_frequency"]
+        self._recall_frequency = self._config["recall_frequency"]
         self._capture_mode = self._config["capture_mode"]
         self._search_mode = self._config["search_mode"]
         self._entity_context = self._config["entity_context"]
@@ -713,6 +721,10 @@ class SupermemoryMemoryProvider(MemoryProvider):
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         if not self._active or not self._auto_recall or not self._client or not query.strip():
+            return ""
+        if _is_trivial_message(query):
+            return ""
+        if self._turn_count > 1 and (self._turn_count % self._recall_frequency != 0):
             return ""
         try:
             profile = self._client.get_profile(query=query[:200])

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -27,6 +27,7 @@ class FakeClient:
         self.add_calls = []
         self.search_results = []
         self.profile_response = {"static": [], "dynamic": [], "search_results": []}
+        self.profile_calls = []
         self.ingest_calls = []
         self.forgotten_ids = []
         self.forget_by_query_response = {"success": True, "message": "Forgot"}
@@ -46,6 +47,7 @@ class FakeClient:
         return self.search_results
 
     def get_profile(self, query=None, *, container_tag=None):
+        self.profile_calls.append({"query": query, "container_tag": container_tag})
         return self.profile_response
 
     def forget_memory(self, memory_id, *, container_tag=None):
@@ -151,6 +153,37 @@ def test_prefetch_skips_profile_between_frequency(provider):
     result = provider.prefetch("what am I working on?")
     assert "Relevant Memories" in result
     assert "User Profile (Persistent)" not in result
+
+
+def test_prefetch_respects_recall_frequency(monkeypatch, tmp_path):
+    monkeypatch.setenv("SUPERMEMORY_API_KEY", "test-key")
+    monkeypatch.setattr("plugins.memory.supermemory._SupermemoryClient", FakeClient)
+    _save_supermemory_config({"recall_frequency": 3}, str(tmp_path))
+    p = SupermemoryMemoryProvider()
+    p.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+    p._client.profile_response = {
+        "static": [],
+        "dynamic": [],
+        "search_results": [{"memory": "Working on Hermes memory quota warnings", "similarity": 0.9}],
+    }
+
+    p.on_turn_start(1, "first turn")
+    first = p.prefetch("first turn")
+    p.on_turn_start(2, "second turn")
+    second = p.prefetch("second turn")
+    p.on_turn_start(3, "third turn")
+    third = p.prefetch("third turn")
+
+    assert "Working on Hermes memory quota warnings" in first
+    assert second == ""
+    assert "Working on Hermes memory quota warnings" in third
+    assert len(p._client.profile_calls) == 2
+
+
+def test_prefetch_skips_trivial_messages(provider):
+    provider.on_turn_start(1, "thanks")
+    assert provider.prefetch("thanks") == ""
+    assert provider._client.profile_calls == []
 
 
 def test_sync_turn_buffers_short_messages(provider):


### PR DESCRIPTION
## Summary
- add a configurable Supermemory recall_frequency knob
- keep default behavior at recall_frequency=1 for compatibility
- skip automatic Supermemory recall for trivial short acknowledgements
- document the setting in the Supermemory memory provider README

## Test Plan
- python -m py_compile plugins/memory/supermemory/__init__.py tests/plugins/memory/test_supermemory_provider.py
- python -m pytest tests/plugins/memory/test_supermemory_provider.py::test_prefetch_respects_recall_frequency tests/plugins/memory/test_supermemory_provider.py::test_prefetch_skips_trivial_messages -q -o 'addopts='

Draft split from local Supermemory quota/waste hardening work.