### PR TITLE
fix(skills): validate name at skill_manage entry to prevent empty-name loops

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -341,6 +341,67 @@ class TestRemoveFile:
 
 
 class TestSkillManageDispatcher:
+    # --- empty / malformed name validation through the dispatcher ---
+
+    @pytest.mark.parametrize("action", [
+        "create", "edit", "patch", "delete", "write_file", "remove_file",
+    ])
+    def test_empty_name_rejected_for_all_actions(self, tmp_path, action):
+        """Empty name must be rejected before the action dispatcher runs."""
+        with _skill_dir(tmp_path):
+            raw = skill_manage(action=action, name="")
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "name" in result["error"].lower()
+        # Must NOT reach action-specific error (which would be "Skill '' not found"
+        # or "content is required")
+        assert "not found" not in result["error"]
+
+    @pytest.mark.parametrize("name,expected_substr", [
+        ("", "required"),
+        ("   ", "Invalid skill name"),
+        ("MySkill", "Invalid skill name"),
+        ("skill/name", "Invalid skill name"),
+        ("skill name", "Invalid skill name"),
+        ("-invalid", "Invalid skill name"),
+    ])
+    def test_malformed_name_rejected_by_dispatcher(self, tmp_path, name, expected_substr):
+        """The dispatcher validates names before any action-specific logic."""
+        with _skill_dir(tmp_path):
+            raw = skill_manage(action="create", name=name, content=VALID_SKILL_CONTENT)
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert expected_substr in result["error"]
+
+    def test_empty_name_rejected_before_preflight_and_write_gate(self, tmp_path):
+        """An empty name must never reach the background-review preflight or the
+        write gate — both must be skipped for invalid names.
+
+        Uses an action ('edit') that _background_review_preflight is active
+        for, so a future reordering that validates after preflight fails here.
+        """
+        with (
+            _skill_dir(tmp_path),
+            patch("tools.skill_manager_tool._background_review_preflight", return_value=None) as mock_preflight,
+            patch("tools.skill_manager_tool._apply_skill_write_gate", return_value=None) as mock_gate,
+        ):
+            raw = skill_manage(action="edit", name="")
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "name" in result["error"].lower()
+        mock_preflight.assert_not_called()
+        mock_gate.assert_not_called()
+
+    def test_none_name_rejected(self, tmp_path):
+        """name=None must be handled gracefully, not crash."""
+        with _skill_dir(tmp_path):
+            raw = skill_manage(action="create", name=None, content=VALID_SKILL_CONTENT)
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "name" in result["error"].lower()
+
+    # --- end name validation tests ---
+
     def test_full_create_via_dispatcher(self, tmp_path):
         """Foreground create does NOT mark the skill as agent-created.
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1529,6 +1529,10 @@ def skill_manage(
 
     Returns JSON string with results.
     """
+    err = _validate_name(name)
+    if err:
+        return tool_error(err, success=False)
+
     preflight = _background_review_preflight(action, name)
     if preflight is not None:
         return json.dumps(preflight, ensure_ascii=False)


### PR DESCRIPTION
Fixes #46216, #46217.

## Root cause

When a background review fork (or any automated caller) passes `name=""` to `skill_manage()`, the empty string bypasses the preflight and gate checks. It falls through to action dispatch where `_find_skill("")` returns `None` and produces `"Skill '' not found"`. The background review fork interprets this as a transient lookup failure and retries, creating an infinite loop at ~18-19s intervals.

The existing `_validate_name()` helper (`tools/skill_manager_tool.py:527`) already handles empty/malformed names, but was only called inside `_create_skill()` — never at the top-level dispatcher.

## Fix

Add a `_validate_name(name)` guard at the very beginning of `skill_manage()` (line 1532), **before** both `_background_review_preflight()` and `_apply_skill_write_gate()`. This:

- Rejects all invalid names (empty, whitespace-only, uppercase, special chars, leading hyphen) with a clear error message
- Prevents empty names from being staged in the write-gate queue (previous PR #46219 placed the guard after the gate)
- Covers all six actions (`create`, `edit`, `patch`, `delete`, `write_file`, `remove_file`)
- Uses the existing validated helper rather than a bare `if not name` check

## Tests

14 new test cases across 4 test functions in `TestSkillManageDispatcher`:
- `test_empty_name_rejected_for_all_actions` — parametrized across all 6 actions
- `test_malformed_name_rejected_by_dispatcher` — parametrized across 6 edge cases (empty, whitespace, uppercase, special chars)
- `test_empty_name_rejected_before_preflight_and_write_gate` — mocks both `_background_review_preflight` and `_apply_skill_write_gate`, uses `action="edit"`, and asserts neither is called for invalid names. Strengthened per review feedback: the earlier version used `action="create"` (a no-op action for preflight) and only asserted the gate, so it could not catch a reordering that validates after preflight
- `test_none_name_rejected` — `name=None` handled gracefully

All 61 tests pass (47 pre-existing + 14 new — zero regressions).

## Verification

```
$ python -m pytest tests/tools/test_skill_manager_tool.py -q
61 passed in 1.08s
```

Branch rebased onto current `main` (the PR was previously marked CONFLICTING).

## Notes

The `_background_review_preflight` function also calls `_find_skill(name)` internally but opts to return `None` (no-op) when the skill isn't found. It has exactly one caller (`skill_manage`, line 1536), which now validates the name first, and the ordering test pins the guard before preflight — so an additional internal validation would be redundant defensive layering.
