### PR TITLE
fix(mcp): prevent GeneratorExit RuntimeError during MCP server shutdown

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2335,13 +2335,20 @@ class MCPServerTask:
                 return_when=asyncio.FIRST_COMPLETED,
                 timeout=timeout,
             )
+        except GeneratorExit:
+            # Allow GeneratorExit to propagate cleanly during shutdown.
+            # Don't suppress it in the finally block.
+            raise
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
+                    try:
+                        t.cancel()
+                    except RuntimeError:
+                        pass  # event loop already closed during shutdown
                     try:
                         await t
-                    except (asyncio.CancelledError, Exception):
+                    except (asyncio.CancelledError, GeneratorExit):
                         pass
         if self._shutdown_event.is_set():
             return "shutdown"
@@ -3237,9 +3244,12 @@ class MCPServerTask:
                         self._was_parked = True
                         self._deregister_tools()
                         self._reconnect_event.clear()
-                        parked = await self._wait_for_reconnect_or_shutdown(
-                            timeout=_PARKED_RETRY_INTERVAL
-                        )
+                        try:
+                            parked = await self._wait_for_reconnect_or_shutdown(
+                                timeout=_PARKED_RETRY_INTERVAL
+                            )
+                        except GeneratorExit:
+                            return
                         if parked == "shutdown":
                             return
                         logger.debug(
@@ -3366,9 +3376,12 @@ class MCPServerTask:
                     self._was_parked = True
                     self._deregister_tools()
                     self._reconnect_event.clear()
-                    parked = await self._wait_for_reconnect_or_shutdown(
-                        timeout=_PARKED_RETRY_INTERVAL
-                    )
+                    try:
+                        parked = await self._wait_for_reconnect_or_shutdown(
+                            timeout=_PARKED_RETRY_INTERVAL
+                        )
+                    except GeneratorExit:
+                        return
                     if parked == "shutdown":
                         return
                     logger.debug(


### PR DESCRIPTION
## Summary

Fixes `RuntimeError: coroutine ignored GeneratorExit` exceptions during MCP server shutdown/cleanup. These manifest as noisy stderr warnings when MCP servers are parked during session teardown or `/reload-mcp`.

## Problem

When the event loop is being torn down during Hermes shutdown while `MCPServerTask` coroutines are parked in `_wait_for_reconnect_or_shutdown()`, Python sends `GeneratorExit` into the awaiting coroutines. Two issues prevent clean propagation:

1. The `finally` block in `_wait_for_reconnect_or_shutdown()` calls `t.cancel()` on already-closed event loops (raises `RuntimeError`) and catches `Exception` — not `GeneratorExit`, which is a `BaseException`.

2. The two call sites of `_wait_for_reconnect_or_shutdown()` in `MCPServerTask.run()` don't catch `GeneratorExit`, causing Python's `RuntimeError: coroutine ignored GeneratorExit`.

## Fix

1. **`_wait_for_reconnect_or_shutdown()`** — Guard `t.cancel()` with `except RuntimeError` (event loop already closed during shutdown). Change `except Exception` to `except GeneratorExit` so GeneratorExit isn't swallowed.

2. **Both `await` call sites** — Wrap in `try/except GeneratorExit: return` so the coroutine exits cleanly instead of ignoring the signal.

## Testing

- `test_mcp_parked_self_probe.py` — PASS (directly tests parked server revival)
- `test_mcp_reconnect_retry_reset.py` — 4/4 PASS
- `test_mcp_cancelled_error_propagation.py` — PASS
- `test_mcp_stability.py` — 27/29 PASS (2 pre-existing failures: missing `rich` module, `stdio_client` attr)