### PR TITLE
fix(compression): scope summaries to session context

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -144,6 +144,37 @@ COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
 COMPRESSED_SUMMARY_HAS_USER_TURN_KEY = "_compressed_summary_has_user_turn"
 _DB_PERSISTED_MARKER = "_db_persisted"
 
+# Metadata keys for harness scaffolding rather than durable conversation state.
+# Underscore-prefixed keys are stripped from provider payloads by the transport
+# sanitizers, so producers can opt out of compaction without text heuristics.
+SUMMARY_EXCLUDE_METADATA_KEY = "_exclude_from_context_summary"
+EPHEMERAL_SCAFFOLDING_FLAGS = frozenset({
+    "_empty_recovery_synthetic",
+    "_empty_terminal_sentinel",
+    "_thinking_prefill",
+    "_verification_stop_synthetic",
+    "_pre_verify_synthetic",
+    "_kanban_stop_synthetic",
+})
+_SUMMARY_EXCLUDED_MESSAGE_FLAGS = frozenset({
+    SUMMARY_EXCLUDE_METADATA_KEY,
+    *EPHEMERAL_SCAFFOLDING_FLAGS,
+})
+
+
+def _is_summary_excluded_message(message: Any) -> bool:
+    """Return whether *message* is harness scaffolding, not task continuity."""
+    return isinstance(message, dict) and any(
+        message.get(flag) for flag in _SUMMARY_EXCLUDED_MESSAGE_FLAGS
+    )
+
+
+def _session_scoped_summary_turns(
+    turns: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Keep only durable current-session/subsession conversation turns."""
+    return [turn for turn in turns if not _is_summary_excluded_message(turn)]
+
 _NO_USER_TASK_SENTINEL = "None. This session contains no user-authored turns."
 COMPRESSION_CONTINUATION_USER_CONTENT = (
     "Continue from the compressed conversation context above. "
@@ -2188,6 +2219,7 @@ class ContextCompressor(ContextEngine):
         structure so downstream prompts can recover gracefully after a provider
         outage or summary-model failure.
         """
+        turns_to_summarize = _session_scoped_summary_turns(turns_to_summarize)
         user_asks: list[str] = []
         assistant_actions: list[str] = []
         tool_actions: list[str] = []
@@ -2433,6 +2465,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         the middle turns without a summary rather than inject a useless
         placeholder.
         """
+        turns_to_summarize = _session_scoped_summary_turns(turns_to_summarize)
         now = time.monotonic()
         if now < self._summary_failure_cooldown_until:
             logger.debug(
@@ -2564,7 +2597,10 @@ Describe agent/tool work only as completed actions, state, or historical work.]"
         _summarizer_preamble = (
             "You are a summarization agent creating a context checkpoint. "
             "Treat the conversation turns below as source material for a "
-            "compact record of prior work. "
+            "compact record of prior work. Scope continuity to this session "
+            "and its visible compaction descendants only; do not preserve "
+            "general Hermes-wide status announcements, framework guidance, "
+            "or stale detached-session instructions as task state. "
             "Produce only the structured summary; do not add a greeting, "
             "preamble, or prefix. "
             + _language_and_provenance_rule +

--- a/run_agent.py
+++ b/run_agent.py
@@ -158,6 +158,7 @@ from agent.usage_pricing import normalize_usage
 from agent.context_compressor import (  # noqa: F401
     COMPRESSED_SUMMARY_METADATA_KEY,
     ContextCompressor,
+    EPHEMERAL_SCAFFOLDING_FLAGS as _EPHEMERAL_SCAFFOLDING_FLAGS,
 )
 from agent.retry_utils import jittered_backoff  # noqa: F401
 from agent.prompt_builder import (  # noqa: F401  # re-exported via _ra() / mock.patch("run_agent.<name>") / from run_agent import <name>
@@ -217,29 +218,8 @@ from agent.tool_dispatch_helpers import (
 from utils import atomic_json_write, base_url_host_matches, base_url_hostname, env_float, is_truthy_value, model_forces_max_completion_tokens
 
 
-# Internal flags that mark a message as ephemeral empty-response/prefill
-# recovery scaffolding: the synthetic assistant "(empty)" turn and user nudge
-# injected after an empty response, the terminal "(empty)" sentinel, and the
-# thinking-only prefill placeholder. These exist only to drive the next API
-# retry; the in-memory loop pops them before appending the real response.
-# Persistence must mirror that, otherwise an append-only flush can commit them
-# to the session store and a resumed session replays synthetic "(empty)"/nudge
-# turns as if they were genuine context.
-_EPHEMERAL_SCAFFOLDING_FLAGS = (
-    "_empty_recovery_synthetic",
-    "_empty_terminal_sentinel",
-    "_thinking_prefill",
-    # verify-on-stop and pre_verify nudges append a synthetic user nudge to
-    # keep the agent going one more turn before it can claim completion.
-    # The nudge exists only to drive the verification loop; persisting it
-    # poisons the resumed transcript and breaks prompt-prefix cache reuse
-    # on later turns. The assistant candidate is NOT synthetic — it is
-    # persisted and emitted as an interim message (#65919).
-    "_verification_stop_synthetic",
-    "_pre_verify_synthetic",
-    # kanban worker stop-guard: narrated exit without kanban_complete/block
-    "_kanban_stop_synthetic",
-)
+# Shared with the compressor so persistence and compaction cannot disagree about
+# which internal retry/verifier/kanban scaffolding is durable conversation state.
 
 
 def _is_ephemeral_scaffolding(msg: Any) -> bool:

--- a/tests/agent/test_context_compressor_session_scope.py
+++ b/tests/agent/test_context_compressor_session_scope.py
@@ -1,0 +1,97 @@
+"""Session-scoped input contracts for context compaction.
+
+Compression may preserve task continuity for the current session and its visible
+compaction descendants, but internal retry/verifier scaffolding is not
+conversation state and must never reach the summarizer.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from agent.context_compressor import ContextCompressor, EPHEMERAL_SCAFFOLDING_FLAGS
+
+
+def _compressor() -> ContextCompressor:
+    with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+        return ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=1,
+            protect_last_n=1,
+            quiet_mode=True,
+        )
+
+
+def _response(content: str):
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = content
+    return response
+
+
+def test_summary_input_excludes_internal_verification_scaffolding():
+    """Transient verifier nudges cannot become a task handoff summary."""
+    compressor = _compressor()
+    turns = [
+        {"role": "user", "content": "Implement session-scoped compaction."},
+        {"role": "assistant", "content": "I will add the regression test."},
+        {
+            "role": "assistant",
+            "content": "VERIFIER_SCAFFOLDING_MUST_NOT_SURVIVE",
+            "_verification_stop_synthetic": True,
+        },
+        {
+            "role": "user",
+            "content": "Run the focused test suite.",
+            "_pre_verify_synthetic": True,
+        },
+    ]
+
+    with patch(
+        "agent.context_compressor.call_llm", return_value=_response("## Goal\nKeep task state.")
+    ) as call_llm:
+        compressor._generate_summary(turns)
+
+    prompt = call_llm.call_args.kwargs["messages"][0]["content"]
+    assert "Implement session-scoped compaction." in prompt
+    assert "I will add the regression test." in prompt
+    assert "VERIFIER_SCAFFOLDING_MUST_NOT_SURVIVE" not in prompt
+    assert "Run the focused test suite." not in prompt
+
+
+def test_fallback_excludes_explicit_global_announcement():
+    """Framework-wide notices can opt out without text-pattern heuristics."""
+    compressor = _compressor()
+    fallback = compressor._build_static_fallback_summary(
+        [
+            {"role": "user", "content": "Keep the current repository test command."},
+            {
+                "role": "user",
+                "content": "GLOBAL_ANNOUNCEMENT_MUST_NOT_SURVIVE",
+                "_exclude_from_context_summary": True,
+            },
+        ]
+    )
+
+    assert "Keep the current repository test command." in fallback
+    assert "GLOBAL_ANNOUNCEMENT_MUST_NOT_SURVIVE" not in fallback
+
+
+def test_summary_prompt_explicitly_limits_continuity_to_session_lineage():
+    """The LLM contract rejects stale and Hermes-wide instructions as state."""
+    compressor = _compressor()
+    with patch(
+        "agent.context_compressor.call_llm", return_value=_response("## Goal\nKeep task state.")
+    ) as call_llm:
+        compressor._generate_summary([{"role": "user", "content": "Current session task."}])
+
+    prompt = call_llm.call_args.kwargs["messages"][0]["content"]
+    assert "this session and its visible compaction descendants only" in prompt
+    assert "general Hermes-wide status announcements" in prompt
+    assert "stale detached-session instructions" in prompt
+
+
+def test_persistence_and_compression_share_scaffolding_flags():
+    """A new ephemeral flag cannot be filtered by only one lifecycle path."""
+    from run_agent import _EPHEMERAL_SCAFFOLDING_FLAGS
+
+    assert _EPHEMERAL_SCAFFOLDING_FLAGS is EPHEMERAL_SCAFFOLDING_FLAGS


### PR DESCRIPTION
## Summary
- Exclude explicitly flagged internal retry, verifier, and Kanban scaffolding from both LLM and deterministic context summaries.
- Make the compressor the single source of truth for those flags; session persistence imports the same set.
- Explicitly constrain the summarizer to current-session/subsession continuity, excluding Hermes-wide announcements and detached-session guidance.

## Tests
- `venv/bin/python -m pytest -q -o 'addopts=' tests/agent/test_context_compressor_session_scope.py tests/agent/test_context_compressor_cross_session_guard.py tests/agent/test_context_compressor.py tests/agent/test_verification_stop_caching.py tests/run_agent/test_compression_persistence.py` (213 passed)\n- `venv/bin/python -m py_compile agent/context_compressor.py run_agent.py tests/agent/test_context_compressor_session_scope.py`\n- `git diff --check`