### PR TITLE
feat(devshell): add terminal UI capture tools

### DIFF
--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -41,6 +41,11 @@
           # libglvnd provides libEGL.so.1 that cage needs on NixOS.
           cage
           libglvnd
+          # Graphical terminal + Wayland screenshot client for CLI/TUI UI
+          # evidence. `cage -- ghostty ...` keeps captures off the user's
+          # live compositor; grim runs inside that isolated client session.
+          ghostty
+          grim
         ]
         ++ self'.packages.default.passthru.devDeps;
         shellHook = ''

--- a/scripts/capture-cage-terminal.sh
+++ b/scripts/capture-cage-terminal.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+out=${1:?usage: $0 OUTPUT.png [command...]}
+shift
+mkdir -p "$(dirname "$out")"
+
+# This runs inside `cage --`, after Ghostty has already opened the isolated
+# Wayland display. Capture before this script exits so Cage keeps the surface
+# alive long enough for grim to see it.
+if (($#)); then
+  "$@"
+fi
+if ! command -v grim >/dev/null 2>&1; then
+  echo "grim is required inside the Cage client session" >&2
+  exit 127
+fi
+grim "$out"


### PR DESCRIPTION
## What does this PR do?

Adds the missing local tooling for real raster captures of the desktop app, Ink TUI, and classic curses CLI. The dev shell now includes Ghostty and grim alongside Cage; `scripts/capture-cage-terminal.sh` captures the isolated Wayland surface while the terminal client remains alive.

This supports UI review evidence without opening a window on the developer's live compositor.

## Related Issue

N/A

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Add `ghostty` and `grim` to `nix/devShell.nix`.
- Add `scripts/capture-cage-terminal.sh`, which writes a PNG from inside an active Cage client session.
- Keep the reusable screenshot workflow as a personal Hermes skill, not a bundled repository skill.

## How to Test

1. Run `nix develop -c bash -n scripts/capture-cage-terminal.sh`.
2. Run a fixed Ghostty command under `WLR_BACKENDS=headless cage` and invoke the helper inside that terminal session.
3. Confirm grim writes a PNG of the isolated terminal surface.

I ran the real Cage → Ghostty → grim path against PR #69579's interactive model picker. It produced separate 1280×720 before/after PNGs from clean detached worktrees; the after capture visibly included sale chrome absent from the base capture.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant syntax and real capture checks
- [x] I've tested on my platform: NixOS / Hyprland, with Cage headless Wayland

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: helper usage is documented inline and in the personal skill
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A: Cage, Ghostty, and grim are Linux-only dev-shell tooling
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

All three images below are GitHub PR attachments. They are not committed to the repository.

### Desktop app

Real Electron chat against the mock provider, with a rendered transcript and composer.

![Desktop chat](https://github.com/user-attachments/assets/fe1706d2-3ce0-4581-a6f5-4c6279159104)

### Ink TUI

The real Ink setup-required state, launched in Ghostty under headless Cage.

![Ink TUI setup required](https://github.com/user-attachments/assets/3f88bc34-503e-4596-bb03-a8e5fdde6edd)

### Classic CLI / curses

The real model picker under Ghostty and Cage. This is the PR #69579 after state, showing the sale-price marker, discount, and original price.

![Classic CLI model picker](https://github.com/user-attachments/assets/b1adb2b6-99cf-4a4d-8d52-3dfc4f4a5801)
