### PR TITLE
docs(reference): sync slash-command tables with the command registry

### DIFF
--- a/contributors/emails/270496070+A-KH17@users.noreply.github.com
+++ b/contributors/emails/270496070+A-KH17@users.noreply.github.com
@@ -1,0 +1,2 @@
+A-KH17
+# docs + skill PRs

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/slash-commands.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/slash-commands.md
@@ -58,6 +58,7 @@ Hermes 有两个斜杠命令入口，均由 `hermes_cli/commands.py` 中的中�
 | `/agents`（别名：`/tasks`） | 显示当前会话中的活动 agent 和运行中的任务。 |
 | `/background <prompt>`（别名：`/bg`、`/btw`） | 在独立的后台会话中运行 prompt。agent 独立处理你的 prompt——当前会话保持空闲可继续其他工作。任务完成后结果以面板形式显示。见 [CLI 后台会话](/user-guide/cli#background-sessions)。 |
 | `/branch [name]`（别名：`/fork`） | 分支当前会话（探索不同路径） |
+| `/journey [list\|delete <id>\|edit <id>]`（别名：`/learning`、`/memory-graph`） | 打开已习得 skill 和 memory 的学习旅程时间线。可在经典 CLI、TUI 浮层以及桌面应用（Star Map 面板）中使用。在消息平台上不可用。见 [学习旅程](/user-guide/features/memory#learning-journey-journey)。 |
 | `/handoff <platform>` | **仅限 CLI。** 将当前会话移交给消息平台（Telegram、Discord、Slack、WhatsApp、Signal、Matrix）。gateway 立即接管，在支持线程的平台上创建新线程（Telegram 话题、Discord 文字频道线程、Slack 消息锚定线程），将目标重新绑定到你的 CLI session_id 以重放完整的角色感知转录，并伪造一条合成用户轮次让 agent 确认已在新位置工作。成功后 CLI 干净退出并提示 `/resume`；随时可用 `/resume <title>` 在本地恢复。轮次进行中拒绝执行。需要 gateway 正在运行且目标平台已配置 home 频道（从目标聊天中执行 `/sethome`）。见 [跨平台移交](/user-guide/sessions#cross-platform-handoff)。 |
 
 ### 配置
@@ -106,8 +107,8 @@ Hermes 有两个斜杠命令入口，均由 `hermes_cli/commands.py` 中的中�
 | `/help` | 显示帮助信息 |
 | `/version` | 显示 Hermes Agent 版本、构建及环境信息。 |
 | `/usage` | 显示 token 用量、费用明细、会话时长，以及——当活动提供商支持时——从提供商 API 实时拉取的**账户限额**部分，包含剩余配额/积分/套餐用量。 |
-| `/credits` | 显示你的 Nous 积分余额和充值跳转链接。 |
-| `/billing` | Nous 的 CLI 终端计费流程——查看余额、购买积分并管理自动充值 / 月度限额。 |
+| `/topup` | 显示你的 Nous 余额并在 portal 上管理计费（取代旧的 `/credits` 和 `/billing` 命令）。 |
+| `/subscription`（别名：`/upgrade`） | **仅限 CLI。** 查看你的 Nous 套餐并在浏览器中更改。 |
 | `/insights` | 显示用量洞察和分析（最近 30 天） |
 | `/platforms`（别名：`/gateway`） | 显示 gateway/消息平台状态（仅限 CLI 摘要视图）。 |
 | `/paste` | 附加剪贴板图片 |
@@ -215,7 +216,7 @@ hermes config set model.aliases.grok x-ai/grok-4
 | `/title [name]` | 设置或显示会话标题。 |
 | `/resume [name]` | 恢复之前命名的会话。 |
 | `/usage` | 显示 token 用量、估算费用明细（输入/输出）、上下文窗口状态、会话时长，以及——当活动提供商支持时——从提供商 API 实时拉取的**账户限额**部分，包含剩余配额/积分。 |
-| `/credits` | 显示你的 Nous 积分余额，以及会在浏览器中打开 portal 计费页的充值链接。 |
+| `/topup` | 显示你的 Nous 余额并在 portal 上管理计费。 |
 | `/insights [days]` | 显示用量分析。 |
 | `/reasoning [level\|show\|hide]` | 更改推理力度或切换推理显示。 |
 | `/voice [on\|off\|tts\|join\|channel\|leave\|status]` | 控制聊天中的语音回复。`join`/`channel`/`leave` 管理 Discord 语音频道模式。 |
@@ -245,11 +246,11 @@ hermes config set model.aliases.grok x-ai/grok-4
 
 ## 注意事项
 
-- `/skin`、`/snapshot`、`/reload`、`/tools`、`/toolsets`、`/browser`、`/config`、`/cron`、`/platforms`、`/paste`、`/image`、`/statusbar`、`/plugins`、`/busy`、`/indicator`、`/redraw`、`/clear`、`/history`、`/save`、`/copy`、`/handoff`、`/billing` 和 `/quit` 是**仅限 CLI** 的命令。
+- `/skin`、`/snapshot`、`/reload`、`/tools`、`/toolsets`、`/browser`、`/config`、`/cron`、`/platforms`、`/paste`、`/image`、`/statusbar`、`/plugins`、`/busy`、`/indicator`、`/redraw`、`/clear`、`/history`、`/save`、`/copy`、`/handoff`、`/journey`、`/subscription` 和 `/quit` 是**仅限 CLI** 的命令。
 - `/skills` **仅在搜索/浏览/安装时属于 CLI-only**；其写入审批子命令（`pending`、`approve`、`reject`、`diff`、`approval`）在 `skills.write_approval` 开启时也可在消息平台使用。`/memory` 可在**两个表面**使用。
 - `/verbose` **默认仅限 CLI**，但可通过在 `config.yaml` 中设置 `display.tool_progress_command: true` 为消息平台启用。启用后，它会循环切换 `display.tool_progress` 模式并保存到配置。
 - `/sethome`、`/update`、`/restart`、`/approve`、`/deny`、`/topic`、`/platform` 和 `/commands` 是**仅限消息平台**的命令。
-- `/status`、`/version`、`/background`、`/queue`、`/steer`、`/voice`、`/reload-mcp`、`/reload-skills`、`/rollback`、`/debug`、`/fast`、`/footer`、`/curator`、`/kanban`、`/credits`、`/suggestions`、`/blueprint`、`/sessions` 和 `/yolo` 在 **CLI 和消息 gateway 中均可使用**。
+- `/status`、`/version`、`/background`、`/queue`、`/steer`、`/voice`、`/reload-mcp`、`/reload-skills`、`/rollback`、`/debug`、`/fast`、`/footer`、`/curator`、`/kanban`、`/topup`、`/suggestions`、`/blueprint`、`/sessions` 和 `/yolo` 在 **CLI 和消息 gateway 中均可使用**。
 - `/voice join`、`/voice channel` 和 `/voice leave` 仅在 Discord 上有意义。
 
 ## 破坏性命令的确认提示


### PR DESCRIPTION
## What does this PR do?

Brings the **zh-Hans** slash-commands reference back in sync with the command registry in `hermes_cli/commands.py`:

- **Removes `/credits` and `/billing`** — neither command is registered anywhere at HEAD (CLI registry, gateway, or TUI). Billing was unified under `/topup` in v0.19.0, but the zh-Hans reference still tells users to type the retired commands.
- **Adds `/topup`** (CLI + messaging) and **`/subscription`** (alias `/upgrade`, CLI-only) — both previously undocumented in zh-Hans.
- **Adds `/journey`** (aliases `/learning`, `/memory-graph`) — available in the classic CLI, as a TUI overlay, and in the desktop app (Star Map panel); not available on messaging platforms.
- Updates the CLI-only / both-surfaces availability lists accordingly.

The English half of the original sync landed upstream in `43874d1a`; this PR now carries only the still-missing zh-Hans corrections.

## Related Issue

N/A — small, self-verifying docs correction; no issue filed. Happy to open one if preferred.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/slash-commands.md`: Info table (−`/credits`, −`/billing`, +`/topup`, +`/subscription`), Session table (+`/journey`), Messaging table (−`/credits`, +`/topup`), CLI-only list (−`/billing`, +`/journey`, +`/subscription`), both-surfaces list (−`/credits`, +`/topup`).
- `contributors/emails/`: email→login mapping for the commit author.

## How to Test

1. `grep -n 'CommandDef("topup"\|CommandDef("subscription"\|CommandDef("journey"' hermes_cli/commands.py` — all three registered.
2. `grep -nE 'credits|billing' website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/slash-commands.md` — only the `/topup` row's historical note remains.
3. `/journey` TUI registration: `ui-tui/src/app/slash/commands/ops.ts:329-334`.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicate found
- [x] My PR contains **only** changes related to this fix
- [x] `pytest` — N/A: docs-only change, no code paths touched
- [x] I've considered cross-platform impact — N/A (documentation only)
