### PR TITLE
feat(skills): evolve github-code-review via GEPA self-optimization (+16.7% holdout)

### DIFF
--- a/contributors/emails/270496070+A-KH17@users.noreply.github.com
+++ b/contributors/emails/270496070+A-KH17@users.noreply.github.com
@@ -1,0 +1,2 @@
+A-KH17
+# docs + skill PRs

--- a/skills/github/github-code-review/SKILL.md
+++ b/skills/github/github-code-review/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: github-code-review
 description: "Review PRs: diffs, inline comments via gh or REST."
-version: 1.1.0
-author: Hermes Agent
+version: 1.2.0
+author: "A-KH17, Hermes Agent"
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
@@ -11,471 +11,155 @@ metadata:
     related_skills: [github-auth, github-pr-workflow]
 ---
 
-# GitHub Code Review
+# GitHub Code Review Skill
 
-Perform code reviews on local changes before pushing, or review open PRs on GitHub. Most of this skill uses plain `git` — the `gh`/`curl` split only matters for PR-level interactions.
+Reviews local pre-push changes and GitHub pull requests, delivers a structured verdict,
+and posts inline comments or formal reviews to GitHub on request. It does not author PRs
+(`github-pr-workflow`) or triage issues (`github-issues`).
+
+## When to Use
+
+- "Review my changes before I push" — local `git diff BASE...HEAD` review, no GitHub API needed.
+- "Review PR #N" — fetch, inspect, test, and review a GitHub pull request.
+- "Post a comment / formal review on PR #N" — inline comments, `APPROVE` / `REQUEST_CHANGES` / `COMMENT`.
+- Advisory questions ("what should the review look like?") are action requests — deliver
+  the artifact plus staged commands, not just an explanation.
 
 ## Prerequisites
 
-- Authenticated with GitHub (see `github-auth` skill)
-- Inside a git repository
-
-### Setup (for PR interactions)
-
-```bash
-if command -v gh &>/dev/null && gh auth status &>/dev/null; then
-  AUTH="gh"
-else
-  AUTH="git"
-  if [ -z "$GITHUB_TOKEN" ]; then
-    if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
-      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
-    elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
-    fi
-  fi
-fi
-
-REMOTE_URL=$(git remote get-url origin)
-OWNER_REPO=$(echo "$REMOTE_URL" | sed -E 's|.*github\.com[:/]||; s|\.git$||')
-OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
-REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
-```
-
----
-
-## 1. Reviewing Local Changes (Pre-Push)
-
-This is pure `git` — works everywhere, no API needed.
-
-### Get the Diff
-
-```bash
-# Staged changes (what would be committed)
-git diff --staged
-
-# All changes vs main (what a PR would contain)
-git diff main...HEAD
-
-# File names only
-git diff main...HEAD --name-only
-
-# Stat summary (insertions/deletions per file)
-git diff main...HEAD --stat
-```
-
-### Review Strategy
-
-1. **Get the big picture first:**
-
-```bash
-git diff main...HEAD --stat
-git log main..HEAD --oneline
-```
-
-2. **Review file by file** — use `read_file` on changed files for full context, and the diff to see what changed:
-
-```bash
-git diff main...HEAD -- src/auth/login.py
-```
-
-3. **Check for common issues:**
-
-```bash
-# Debug statements, TODOs, console.logs left behind
-git diff main...HEAD | grep -n "print(\|console\.log\|TODO\|FIXME\|HACK\|XXX\|debugger"
-
-# Large files accidentally staged
-git diff main...HEAD --stat | sort -t'|' -k2 -rn | head -10
-
-# Secrets or credential patterns
-git diff main...HEAD | grep -in "password\|secret\|api_key\|token.*=\|private_key"
-
-# Merge conflict markers
-git diff main...HEAD | grep -n "<<<<<<\|>>>>>>\|======="
-```
-
-4. **Present structured feedback** to the user.
-
-### Review Output Format
-
-When reviewing local changes, present findings in this structure:
-
-```
-## Code Review Summary
-
-### Critical
-- **src/auth.py:45** — SQL injection: user input passed directly to query.
-  Suggestion: Use parameterized queries.
-
-### Warnings
-- **src/models/user.py:23** — Password stored in plaintext. Use bcrypt or argon2.
-- **src/api/routes.py:112** — No rate limiting on login endpoint.
-
-### Suggestions
-- **src/utils/helpers.py:8** — Duplicates logic in `src/core/utils.py:34`. Consolidate.
-- **tests/test_auth.py** — Missing edge case: expired token test.
-
-### Looks Good
-- Clean separation of concerns in the middleware layer
-- Good test coverage for the happy path
-```
-
----
-
-## 2. Reviewing a Pull Request on GitHub
-
-### View PR Details
-
-**With gh:**
-
-```bash
-gh pr view 123
-gh pr diff 123
-gh pr diff 123 --name-only
-```
-
-**With git + curl:**
-
-```bash
-PR_NUMBER=123
-
-# Get PR details
-curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python3 -c "
-import sys, json
-pr = json.load(sys.stdin)
-print(f\"Title: {pr['title']}\")
-print(f\"Author: {pr['user']['login']}\")
-print(f\"Branch: {pr['head']['ref']} -> {pr['base']['ref']}\")
-print(f\"State: {pr['state']}\")
-print(f\"Body:\n{pr['body']}\")"
-
-# List changed files
-curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/files \
-  | python3 -c "
-import sys, json
-for f in json.load(sys.stdin):
-    print(f\"{f['status']:10} +{f['additions']:-4} -{f['deletions']:-4}  {f['filename']}\")"
-```
-
-### Check Out PR Locally for Full Review
-
-This works with plain `git` — no `gh` needed:
-
-```bash
-# Fetch the PR branch and check it out
-git fetch origin pull/123/head:pr-123
-git checkout pr-123
-
-# Now you can use read_file, search_files, run tests, etc.
-
-# View diff against the base branch
-git diff main...pr-123
-```
-
-**With gh (shortcut):**
-
-```bash
-gh pr checkout 123
-```
-
-### Leave Comments on a PR
-
-**General PR comment — with gh:**
-
-```bash
-gh pr comment 123 --body "Overall looks good, a few suggestions below."
-```
-
-**General PR comment — with curl:**
-
-```bash
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/issues/$PR_NUMBER/comments \
-  -d '{"body": "Overall looks good, a few suggestions below."}'
-```
-
-### Leave Inline Review Comments
-
-**Single inline comment — with gh (via API):**
-
-```bash
-HEAD_SHA=$(gh pr view 123 --json headRefOid --jq '.headRefOid')
-
-gh api repos/$OWNER/$REPO/pulls/123/comments \
-  --method POST \
-  -f body="This could be simplified with a list comprehension." \
-  -f path="src/auth/login.py" \
-  -f commit_id="$HEAD_SHA" \
-  -f line=45 \
-  -f side="RIGHT"
-```
-
-**Single inline comment — with curl:**
-
-```bash
-# Get the head commit SHA
-HEAD_SHA=$(curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
-
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments \
-  -d "{
-    \"body\": \"This could be simplified with a list comprehension.\",
-    \"path\": \"src/auth/login.py\",
-    \"commit_id\": \"$HEAD_SHA\",
-    \"line\": 45,
-    \"side\": \"RIGHT\"
-  }"
-```
-
-### Submit a Formal Review (Approve / Request Changes)
-
-**With gh:**
-
-```bash
-gh pr review 123 --approve --body "LGTM!"
-gh pr review 123 --request-changes --body "See inline comments."
-gh pr review 123 --comment --body "Some suggestions, nothing blocking."
-```
-
-**With curl — multi-comment review submitted atomically:**
-
-```bash
-HEAD_SHA=$(curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
-
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews \
-  -d "{
-    \"commit_id\": \"$HEAD_SHA\",
-    \"event\": \"COMMENT\",
-    \"body\": \"Code review from Hermes Agent\",
-    \"comments\": [
-      {\"path\": \"src/auth.py\", \"line\": 45, \"body\": \"Use parameterized queries to prevent SQL injection.\"},
-      {\"path\": \"src/models/user.py\", \"line\": 23, \"body\": \"Hash passwords with bcrypt before storing.\"},
-      {\"path\": \"tests/test_auth.py\", \"line\": 1, \"body\": \"Add test for expired token edge case.\"}
-    ]
-  }"
-```
-
-Event values: `"APPROVE"`, `"REQUEST_CHANGES"`, `"COMMENT"`
-
-The `line` field refers to the line number in the *new* version of the file. For deleted lines, use `"side": "LEFT"`.
-
----
-
-## 3. Review Checklist
-
-When performing a code review (local or PR), systematically check:
-
-### Correctness
-- Does the code do what it claims?
-- Edge cases handled (empty inputs, nulls, large data, concurrent access)?
-- Error paths handled gracefully?
-
-### Security
-- No hardcoded secrets, credentials, or API keys
-- Input validation on user-facing inputs
-- No SQL injection, XSS, or path traversal
-- Auth/authz checks where needed
-
-### Code Quality
-- Clear naming (variables, functions, classes)
-- No unnecessary complexity or premature abstraction
-- DRY — no duplicated logic that should be extracted
-- Functions are focused (single responsibility)
-
-### Testing
-- New code paths tested?
-- Happy path and error cases covered?
-- Tests readable and maintainable?
-
-### Performance
-- No N+1 queries or unnecessary loops
-- Appropriate caching where beneficial
-- No blocking operations in async code paths
-
-### Documentation
-- Public APIs documented
-- Non-obvious logic has comments explaining "why"
-- README updated if behavior changed
-
----
-
-## 4. Pre-Push Review Workflow
-
-When the user asks you to "review the code" or "check before pushing":
-
-1. `git diff main...HEAD --stat` — see scope of changes
-2. `git diff main...HEAD` — read the full diff
-3. For each changed file, use `read_file` if you need more context
-4. Apply the checklist above
-5. Present findings in the structured format (Critical / Warnings / Suggestions / Looks Good)
-6. If critical issues found, offer to fix them before the user pushes
-
----
-
-## 5. PR Review Workflow (End-to-End)
-
-When the user asks you to "review PR #N", "look at this PR", or gives you a PR URL, follow this recipe:
-
-### Step 1: Set up environment
-
-```bash
-source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
-# Or run the inline setup block from the top of this skill
-```
-
-### Step 2: Gather PR context
-
-Get the PR metadata, description, and list of changed files to understand scope before diving into code.
-
-**With gh:**
-```bash
-gh pr view 123
-gh pr diff 123 --name-only
-gh pr checks 123
-```
-
-**With curl:**
-```bash
-PR_NUMBER=123
-
-# PR details (title, author, description, branch)
-curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER
-
-# Changed files with line counts
-curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER/files
-```
-
-### Step 3: Check out the PR locally
-
-This gives you full access to `read_file`, `search_files`, and the ability to run tests.
-
-```bash
-git fetch origin pull/$PR_NUMBER/head:pr-$PR_NUMBER
-git checkout pr-$PR_NUMBER
-```
-
-### Step 4: Read the diff and understand changes
-
-```bash
-# Full diff against the base branch
-git diff main...HEAD
-
-# Or file-by-file for large PRs
-git diff main...HEAD --name-only
-# Then for each file:
-git diff main...HEAD -- path/to/file.py
-```
-
-For each changed file, use `read_file` to see full context around the changes — diffs alone can miss issues visible only with surrounding code.
-
-### Step 5: Run automated checks locally (if applicable)
-
-```bash
-# Run tests if there's a test suite
-python -m pytest 2>&1 | tail -20
-# or: npm test, cargo test, go test ./..., etc.
-
-# Run linter if configured
-ruff check . 2>&1 | head -30
-# or: eslint, clippy, etc.
-```
-
-### Step 6: Apply the review checklist (Section 3)
-
-Go through each category: Correctness, Security, Code Quality, Testing, Performance, Documentation.
-
-### Step 7: Post the review to GitHub
-
-Collect your findings and submit them as a formal review with inline comments.
-
-**With gh:**
-```bash
-# If no issues — approve
-gh pr review $PR_NUMBER --approve --body "Reviewed by Hermes Agent. Code looks clean — good test coverage, no security concerns."
-
-# If issues found — request changes with inline comments
-gh pr review $PR_NUMBER --request-changes --body "Found a few issues — see inline comments."
-```
-
-**With curl — atomic review with multiple inline comments:**
-```bash
-HEAD_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
-
-# Build the review JSON — event is APPROVE, REQUEST_CHANGES, or COMMENT
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER/reviews \
-  -d "{
-    \"commit_id\": \"$HEAD_SHA\",
-    \"event\": \"REQUEST_CHANGES\",
-    \"body\": \"## Hermes Agent Review\n\nFound 2 issues, 1 suggestion. See inline comments.\",
-    \"comments\": [
-      {\"path\": \"src/auth.py\", \"line\": 45, \"body\": \"🔴 **Critical:** User input passed directly to SQL query — use parameterized queries.\"},
-      {\"path\": \"src/models.py\", \"line\": 23, \"body\": \"⚠️ **Warning:** Password stored without hashing.\"},
-      {\"path\": \"src/utils.py\", \"line\": 8, \"body\": \"💡 **Suggestion:** This duplicates logic in core/utils.py:34.\"}
-    ]
-  }"
-```
-
-### Step 8: Also post a summary comment
-
-In addition to inline comments, leave a top-level summary so the PR author gets the full picture at a glance. Use the review output format from `references/review-output-template.md`.
-
-**With gh:**
-```bash
-gh pr comment $PR_NUMBER --body "$(cat <<'EOF'
-## Code Review Summary
-
-**Verdict: Changes Requested** (2 issues, 1 suggestion)
-
-### 🔴 Critical
-- **src/auth.py:45** — SQL injection vulnerability
-
-### ⚠️ Warnings
-- **src/models.py:23** — Plaintext password storage
-
-### 💡 Suggestions
-- **src/utils.py:8** — Duplicated logic, consider consolidating
-
-### ✅ Looks Good
-- Clean API design
-- Good error handling in the middleware layer
-
----
-*Reviewed by Hermes Agent*
-EOF
-)"
-```
-
-### Step 9: Clean up
-
-```bash
-git checkout main
-git branch -D pr-$PR_NUMBER
-```
-
-### Decision: Approve vs Request Changes vs Comment
-
-- **Approve** — no critical or warning-level issues, only minor suggestions or all clear
-- **Request Changes** — any critical or warning-level issue that should be fixed before merge
-- **Comment** — observations and suggestions, but nothing blocking (use when you're unsure or the PR is a draft)
+- Inside a git repository; all shell commands run via `terminal`.
+- For PR interactions, resolve auth FIRST and CAPTURE the token for later steps — walk
+  the full fallback chain (`gh` → `$GITHUB_TOKEN` → `github-auth` credential helper →
+  hermes `.env` → unauthenticated API → plain-git fetch) documented in
+  [references/github-api-mechanics.md](references/github-api-mechanics.md). A user claim
+  of "no gh, no token" covers the first two rungs at most; never conclude "can't
+  authenticate" while a rung is untried. Only POSTing comments/reviews truly needs a token.
+
+## How to Run
+
+The first line of EVERY response is a mode line, phrased value-forward:
+
+- **Execution available:** "Executed below — real outputs, interpreted inline." Run the
+  commands via `terminal`, paste the real output (including empty output — an empty
+  result is itself a finding), and state what it means.
+- **No execution (or unknown):** "Your deliverable is fully staged below for a single
+  paste." Follow the No-Execution Playbook in
+  [references/playbooks.md](references/playbooks.md).
+
+Every response then follows the Deliverable Contract, in order:
+
+1. **Mode line** (above).
+2. **The deliverable** — the direct answer plus fully drafted artifacts (review text,
+   comment bodies, verbatim-pasteable) and/or one consolidated staged command block.
+3. **Interpretation guide** for every staged block: each plausible output → meaning →
+   next action, covering BOTH branches of any user claim being verified. This replaces
+   the fake transcript — a `$ cmd` block followed by invented output is the worst
+   possible failure; a labeled "run this" block plus guide is the correct form.
+4. **Failure triage** for each step (HTTP 422 / 401 / 403 / 404 / 429 — see the
+   mechanics reference).
+5. **One-line footnote** — the posting status, or the single minimal artifact still
+   needed. Never an open-ended offer, never a cliffhanger.
+
+Three standing rules override scenario habits:
+
+1. **Treat user claims as unverified hypotheses** ("the PR has no files", "auth is
+   missing"). The first commands settle the claim; the rest of the deliverable branches
+   on BOTH outcomes.
+2. **Advisory questions are action requests.** Give the direct answer AND the drafted
+   artifact AND the staged commands. Never end with "If you'd like me to verify…".
+3. **Probes must capture, not just detect.** Any probe for a value (token, owner/repo,
+   base branch, head SHA, PR number) stores it in a shell variable the rest of the block
+   uses — an existence-only probe is a half-deliverable.
+
+## Quick Reference
+
+| Task | Core command (run via `terminal`) |
+|------|-----------------------------------|
+| Local pre-push review | `git diff "$BASE"...HEAD` (+ `--stat`, `--oneline` log) |
+| Fetch a PR locally | `git fetch origin pull/N/head:pr-N && git checkout pr-N` |
+| PR metadata | `gh pr view N --json files,headRefOid,baseRefName` |
+| PR diff | `gh pr diff N` |
+| Find a PR by topic | `gh pr list --state open --search "<term>" --json number,title,headRefName` |
+| Post inline comment | `gh api repos/$OWNER_REPO/pulls/N/comments --method POST --input -` (JSON on stdin) |
+| Post formal review | `gh api repos/$OWNER_REPO/pulls/N/reviews --method POST --input -` (`event` + `comments` array) |
+| Top-level comment | `gh pr comment N --body "..."` (uses the **issues** endpoint) |
+| Tests on PR code | `git worktree add .wt-pr-N pr-N && (cd .wt-pr-N && <test cmd>); git worktree remove --force .wt-pr-N` |
+| Cleanup | `git checkout - && git branch -D pr-N` |
+
+## Procedure
+
+1. **Scope first:** `git diff BASE...HEAD --stat` and `git log BASE..HEAD --oneline`.
+   State the scope explicitly ("N commits, M files") so later "clean" results are
+   meaningful.
+2. **Read the full diff.** For each changed file, read surrounding context with
+   `read_file` and hunt related call sites with `search_files`.
+3. **Run the project's tests and linter against the PR code, not the user's working
+   tree** — use a worktree (Quick Reference). Detect the runner from `Makefile`,
+   `package.json`, `pyproject.toml`, `tox.ini`.
+4. **Apply the checklist:** correctness (edge cases, error paths), security (secrets,
+   injection, authz, input validation), quality (naming, DRY, complexity), tests (new
+   paths incl. failure cases), performance (N+1, blocking calls in async code), docs.
+5. **Leftover scan on ADDED lines only** (debug statements, conflict markers, secrets) —
+   pipeline in [references/github-api-mechanics.md](references/github-api-mechanics.md).
+   A scan over an EMPTY input is not a clean pass: establish scope, then report results.
+6. **Verdict mapping:** any Critical or Warning → Request Changes; only suggestions →
+   Approve or Comment; nothing found → Approve. Never Approve code you haven't read, and
+   never Approve/Request-Changes on an empty diff — a drafted top-level Comment is the
+   only vehicle there (playbooks reference).
+7. **If posting:** head SHA as `commit_id`; `side: "LEFT"` + old-file line numbers for
+   deletions; anchors must sit inside a diff hunk, with defined fallbacks (nearest
+   changed line → file-level `subject_type: "file"` → fold into the review body). Build
+   multi-comment review JSON via stdin heredoc or `jq -n`, never indexed `-f` flags.
+   Full mechanics in the reference.
+8. **Clean up:** restore the original branch, delete temporary `pr-N` branches, remove
+   temporary worktrees.
+
+Report a real review using the bundled
+[references/review-output-template.md](references/review-output-template.md): a
+`**Verdict: <Approve | Request Changes | Comment>**` line with a one-line rationale,
+then 🔴 Critical / ⚠️ Warnings / 💡 Suggestions / ✅ Looks Good as
+`file:line — issue — concrete fix` (omit empty sections), the reviewed scope stated, and
+the one-line footnote at the end.
+
+Scenario playbooks — the PR discovery ladder and two-block pattern for unidentified
+targets, the empty-diff package, the security-focused review checklist, on-demand
+comment posting, the pre-push gather block, and command-block standards — live in
+[references/playbooks.md](references/playbooks.md).
+
+## Pitfalls
+
+- Never end a turn with a cliffhanger, a progress report, a promise of future work, or
+  an offer ("If you'd like me to…, I can run…") where attaching the block was possible.
+- Never open with "I can't" while any tier is deliverable. Graceful degradation: posted
+  review → full review in chat with posting skipped (one-line reason) → partial review
+  with explicit gaps → blocker message (only if even the diff is unreachable; list what
+  was tried and the single minimal fix).
+- Never fabricate `$`-prompt transcripts, outputs, findings, file names, line numbers,
+  PR identifiers, auth state, or "clean" results. Real empty output is reported and
+  interpreted, never dressed up.
+- Never call a scan "clean" when its input was empty — distinguish "nothing to review"
+  from "reviewed, no findings", and state the scope either way.
+- Never stop at a blocker while an untried fallback rung exists — but when only POSTing
+  is blocked, still deliver the full review plus the minimal remediation
+  (`export GITHUB_TOKEN=...` or `gh auth login`) as a footnote.
+- Never ask the user for anything obtainable with one command (owner/repo, auth state,
+  tool existence, diff emptiness, which PR matches a description) — run or stage the
+  command. Ask only for the single minimal artifact, after concrete discovery attempts.
+- Never post placeholder body text. When the user supplies comment topics, drafting the
+  concrete professional body is REQUIRED — phrased as the user's finding, with no
+  invented specifics.
+- Paste blocks: no `set -e` / `set -euo pipefail` (one failing probe would kill the
+  fallback ladder), no interactive prompts, one consolidated block run from the repo
+  root, placeholders clearly labeled with the command that reveals valid values.
+- Run tests against the PR code (worktree or checkout), not the user's working tree —
+  and always clean up branches and worktrees afterward.
+
+## Verification
+
+Before delivering, confirm:
+- [ ] Scope stated (N commits, M files) and full diff read.
+- [ ] Tests/linter run against the PR code — or explicitly reported as not run, with the staged command.
+- [ ] Every posted item confirmed by the API response (URL or review ID).
+- [ ] No fabricated outputs, findings, or auth state; empty results reported and interpreted.
+- [ ] Verdict matches the findings and the verdict-mapping rule.
+- [ ] Cleanup done: original branch restored, `pr-N` branch and worktrees removed.

--- a/skills/github/github-code-review/references/github-api-mechanics.md
+++ b/skills/github/github-code-review/references/github-api-mechanics.md
@@ -1,0 +1,134 @@
+# GitHub API Mechanics — github-code-review
+
+Detailed shell mechanics for the `github-code-review` skill. Run everything via the
+`terminal` tool. Command-block standards (no `set -e`, one consolidated block, labeled
+placeholders) are in [playbooks.md](playbooks.md).
+
+## Authentication: the full fallback chain (try/stage in order)
+
+Never conclude "can't authenticate" until every rung fails — even when the user asserts
+credentials are missing. Their claim covers rungs 1–2 at most; rungs 3–6 remain.
+Capture the token into `TOKEN` for later rungs — do not stop at existence probes:
+
+```bash
+TOKEN=""
+command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1 && TOKEN=$(gh auth token 2>/dev/null)
+[ -n "$TOKEN" ] || TOKEN="$GITHUB_TOKEN"
+[ -n "$TOKEN" ] || TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py" 2>/dev/null)
+[ -n "$TOKEN" ] || TOKEN=$(grep '^GITHUB_TOKEN=' "${HERMES_HOME:-$HOME/.hermes}/.env" 2>/dev/null | cut -d= -f2-)
+[ -n "$TOKEN" ] && echo "auth: token captured (chain rungs 1-4)" || echo "auth: no token — read-only rungs 5-6 remain (unauth API / git fetch)"
+```
+
+1. `gh` installed and `gh auth status` succeeds → use `gh` (`gh auth token` yields a
+   curl-usable token).
+2. `$GITHUB_TOKEN` set → curl with `Authorization: token $GITHUB_TOKEN`.
+3. The `github-auth` skill's helper
+   (`${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py`)
+   safely extracts a stored credential from `~/.git-credentials` (percent-encoding and
+   `x-oauth-basic` forms handled — never extract credentials with sed).
+4. `${HERMES_HOME:-$HOME/.hermes}/.env` contains `GITHUB_TOKEN=` → extract it.
+5. **No token, public repo:** unauthenticated GETs work (60 req/hr): PR metadata,
+   `/pulls/N/files`, and the raw diff via
+   `curl -sS -H "Accept: application/vnd.github.v3.diff" https://api.github.com/repos/$OWNER_REPO/pulls/N`.
+6. **No token, any repo:** `git fetch origin pull/N/head:pr-N` uses the user's existing
+   git credentials (SSH key or credential helper).
+
+**Truly impossible without a token:** POSTing comments or reviews (needs `repo` scope on
+a classic token, or Pull requests: write on a fine-grained token). Everything else —
+fetching, diffing, reading files, running tests, producing the full structured review —
+is still possible. Deliver the review or staged block and give the minimal remediation
+(`export GITHUB_TOKEN=...` or `gh auth login`) as a footnote.
+
+## Deriving values inline
+
+```bash
+OWNER_REPO=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')
+BASE=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+[ -n "$BASE" ] || BASE=main
+git rev-parse --verify "$BASE" >/dev/null 2>&1 || BASE=master
+SHA=$(gh pr view N --json headRefOid -q .headRefOid)
+```
+
+## Posting review comments: prerequisites and mechanics
+
+Resolve and validate each — by command when possible, staged inline when not:
+
+1. **Owner/repo** — from the PR URL or `git remote get-url origin`.
+2. **Auth with write scope** — walk the full chain above, capturing the token.
+3. **PR head SHA** for `commit_id`:
+   `gh pr view N --json headRefOid -q .headRefOid`, or `GET /pulls/N` → `.head.sha`.
+   (The reviews endpoint defaults to head if omitted; the single-comment endpoint
+   requires it — always fetch and pass it.)
+4. **Anchor validity.** Inline comments attach only to lines inside the PR diff; GitHub
+   rejects off-diff anchors with HTTP 422. Confirm via `GET /pulls/N/files` (inspect
+   `patch` hunks) or `gh pr diff N` that the file is in the PR and the target line is in
+   a changed hunk.
+5. **Side and line semantics.** Deleted lines: `side: "LEFT"`, `line` = line number in
+   the OLD (pre-PR) file, computed from hunk headers
+   `@@ -old_start,old_count +new_start,new_count @@`. Added/context lines:
+   `side: "RIGHT"` (default), `line` = NEW-version number. Multi-line ranges use
+   `start_line`/`start_side` + `line`/`side`.
+6. **Impossible anchor fallbacks, in order:** (a) nearest changed line in that file,
+   (b) file-level comment via `subject_type: "file"` (no line/side), (c) fold the point
+   into the review `body` or a top-level comment. **"Add a missing test" comments:**
+   only anchor inline if the test file has changed lines in the PR; when the gap is the
+   *absence* of changes, inline anchoring always 422s — put that point in the review body.
+7. **Comment body.** Ask ONLY when no substance was given — after staging items 1–6 with
+   all resolved values filled in and one labeled body placeholder. When topics were
+   given, draft the bodies yourself. Never post placeholder body text.
+
+Single-comment post:
+
+```bash
+SHA=$(gh pr view N --json headRefOid -q .headRefOid)
+gh api repos/$OWNER_REPO/pulls/N/comments --method POST --input - <<EOF
+{"commit_id": "$SHA", "path": "path/to/file", "line": 88, "side": "LEFT", "body": "…"}
+EOF
+```
+
+Multi-comment reviews go atomically via `POST /repos/{owner}/{repo}/pulls/N/reviews`
+with `event` = `APPROVE` | `REQUEST_CHANGES` | `COMMENT` and a `comments` array.
+**Build nested JSON robustly** — pipe JSON on stdin, never fragile indexed flags like
+`-f "comments[0][path]=…"`:
+
+```bash
+gh api repos/$OWNER_REPO/pulls/N/reviews --method POST --input - <<EOF
+{
+  "commit_id": "$SHA",
+  "event": "REQUEST_CHANGES",
+  "body": "Requested changes: please resolve the inline issues before merging.",
+  "comments": [
+    {"path": "src/auth.py", "line": 45, "side": "RIGHT", "body": "…"}
+  ]
+}
+EOF
+```
+
+Unquoted `EOF` expands `$SHA`; if a body contains `$` or backticks, build with `jq -n`
+instead. The same JSON works with
+`curl -sS -X POST -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github+json" https://api.github.com/repos/$OWNER_REPO/pulls/N/reviews -d @-`.
+
+The review `body` IS the summary — a separate top-level `gh pr comment N -b "..."` /
+`POST /issues/N/comments` is redundant unless asked for (exception: the empty-diff
+scenario in the playbooks, where a top-level comment is the ONLY vehicle).
+
+## Failure triage
+
+- **HTTP 422** → anchor outside a diff hunk: recheck line/side against
+  `gh pr diff N -- path/to/file`, or fall back per item 6 above.
+- **401/403** → token absent or lacking write scope.
+- **404** → wrong owner/repo, or private repo without auth.
+- **429** → unauthenticated rate limit (60 req/hr) hit.
+
+## Leftover / secrets scan (ADDED lines only, scope-first)
+
+```bash
+git diff --cached --stat                       # scope first: is there anything staged?
+git diff --cached -U0 | grep -E '^\+' | grep -nEi 'TODO|FIXME|HACK|XXX|console\.(log|warn|error|debug)|debugger|print\(|import pdb|pdb\.set_trace|binding\.pry|puts |<<<<<<<|=======|>>>>>>>'
+git grep --cached -nEi 'AKIA[0-9A-Z]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----|(api[_-]?key|secret|password|token)\s*[:=]\s*["'"'"'][^"'"'"']+' -- .
+```
+
+Swap `--cached` for the appropriate diff target: `BASE...HEAD` for pre-push, `pr-N` for
+PR reviews. If the scope command shows an empty input, the answer is "there is nothing
+staged/in scope" — not "no leftovers found"; name the next scope explicitly
+(`git status --short`, `git diff` unstaged, `git diff BASE...HEAD`).

--- a/skills/github/github-code-review/references/playbooks.md
+++ b/skills/github/github-code-review/references/playbooks.md
@@ -1,0 +1,163 @@
+# Scenario Playbooks — github-code-review
+
+Behavioral playbooks for the `github-code-review` skill. All shell runs via the
+`terminal` tool; API mechanics (auth chain, posting, triage) are in
+[github-api-mechanics.md](github-api-mechanics.md).
+
+## Command-Block Standards
+
+- One block pasted top-to-bottom **from the repo root**. Never start with `cd /placeholder`.
+- **No `set -e` / `set -euo pipefail`**: one failing probe would kill the fallback
+  ladder. Run probes plainly, guard optional steps with `|| true`, branch with `if`.
+- **No interactive prompts** (`read -rp …`). Derive values inline; if truly
+  unobtainable, use a clearly labeled placeholder plus the exact command that reveals
+  valid values. Never fill a placeholder with an invented value that looks real.
+- Both `gh` and `curl` variants where applicable.
+- Resolve auth FIRST in the block and CAPTURE it for later rungs (see the mechanics
+  reference).
+
+## No-Execution Playbook
+
+When the session has no shell/API access, deliver in this order:
+
+1. ONE consolidated copy-paste command block (per the standards above) performing the
+   entire task, every derivable value resolved inline. For unidentified targets, the
+   two-block pattern below.
+2. An interpretation guide for each key command (each plausible output → meaning → next
+   action), covering BOTH branches of any user claim being verified.
+3. Fully drafted content: comment bodies, review text, applicable checklist/framework.
+4. Failure triage for each step (422 / 401 / 403 / 404 / 429).
+5. The single minimal artifact you still need — as a one-line footnote.
+
+## The two-block pattern for unidentified targets
+
+When a target (PR number, branch) must be discovered:
+
+- **Block 1 — discovery:** resolves owner/repo, base, auth (captured), and finds
+  candidates (full ladder below).
+- **Block 2 — follow-on:** the complete fetch + review + scan + test + cleanup pipeline,
+  parameterized on ONE clearly labeled placeholder (`N=<number printed by Block 1>`).
+
+The user makes one paste, reads one value, fills one placeholder — never a second
+round-trip for mechanics.
+
+## Resolving what to review
+
+- **PR number or URL given:** use it. Derive owner/repo from the URL or the remote.
+- **PR described but not identified** (e.g., "this PR adds /login"): run or stage this
+  FULL discovery ladder before asking:
+  1. `gh pr status` / `gh pr view` — PR attached to the current branch
+  2. `gh pr list --state open --search "login" --json number,title,headRefName,url` and
+     `gh pr list --state open --json number,title,headRefName`
+  3. curl fallback: `curl -sS "https://api.github.com/repos/$OWNER_REPO/pulls?state=open" | jq -r '.[] | "\(.number)\t\(.title)\t\(.head.ref)"'`
+  4. Inspect each candidate's file list for the feature:
+     `gh pr view N --json files -q '.files[].path'` (paths containing "login"/"auth")
+  5. Local fallback: `git branch --all --list '*login*'`,
+     `git log --all --oneline -i --grep='login'`; if the feature branch is checked out,
+     review `git diff BASE...HEAD` directly.
+  6. Only then ask — presenting the candidates found, plus the staged follow-on block
+     with the single labeled placeholder.
+- **"Review before pushing" / "check my changes":** local review of
+  `git diff BASE...HEAD` plus staged/unstaged diffs; no GitHub API needed.
+
+## Playbook: leftover / debug-statement scan
+
+- **With execution:** run the scope command and the added-lines scan (mechanics
+  reference); report real output. If `git diff --cached --stat` is empty, the answer is
+  **"there are no staged changes"** — not "no leftovers found". Offer the next scope
+  concretely: `git status --short`, `git diff` (unstaged), `git diff BASE...HEAD`.
+- **Without execution:** staged block + interpretation guide: `--stat` empty → nothing
+  staged → re-scan other scopes; `--stat` non-empty, greps silent → clean; greps hit →
+  each hit is file:line to fix.
+- One block, then results (executed) or interpretation (staged). Never both.
+
+## Playbook: user claims tools/credentials are missing
+
+Treat it as a claim about rungs 1–2 of the auth chain only. Stage or run the FULL
+ladder: capture-token auth block, then `git fetch origin pull/N/head:pr-N`, then — if
+fetch fails — the unauthenticated public-API diff. Include scope, full diff, test
+detection run against the PR code via worktree, and cleanup. Deliver the checklist and
+failure triage. Single minimal artifact if all rungs fail: pasted diff or PR URL.
+
+## Playbook: security-focused review of a login/auth endpoint
+
+If the PR isn't identified, use the TWO-BLOCK pattern — do not ask first. Block 1 is the
+discovery ladder looking for login/auth paths; Block 2 is the full review pipeline
+parameterized on `N`. Interpretation guide: each discovery hit → that's the PR, fill
+`N`; all empty → fork/merged/unpushed → paste URL or diff.
+
+Checklist — framed as "what the review will cover", report on each explicitly:
+passwords hashed with bcrypt/argon2/PBKDF2 (never plaintext/MD5/bare SHA), timing-safe
+comparison; parameterized queries/ORM (no string-built SQL); input validation with
+bounded lengths; rate limiting / lockout / backoff; generic "invalid credentials"
+errors (no user enumeration); session/JWT entropy, expiry, fixation prevention, cookies
+`HttpOnly; Secure; SameSite`; HTTPS only, CSRF protection, validated post-login
+redirects; no credentials/tokens logged, no hardcoded secrets, no leftover debug output;
+tests for wrong password, nonexistent user, expired/invalid token, lockout, injection
+payloads — not just the happy path.
+
+## Playbook: PR has no changed files (empty diff)
+
+Even when asked only *what the review should look like*, deliver the FULL package
+(mode line → artifact → verification → posting → footnote), not just an explanation:
+
+1. **Verdict: Comment** — Approve/Request-Changes on an empty diff is meaningless, and
+   inline comments are impossible (no diff lines to anchor). Never submit a formal
+   Approve/Request-Changes here.
+2. **Draft the verbatim top-level comment** (the actual deliverable): the finding (0
+   changed files / no diff against base); the likely causes — branch and base now
+   identical (commits already merged or branch reset/rebased to base), a later commit
+   reverted the changes, wrong base branch, intended commits never pushed, PR opened by
+   mistake; and the ask — push the missing commits, retarget the base branch, or close
+   the PR. Keep it short — NO four-section template of "None".
+3. **Stage (or run) independent verification FIRST**, with both branches covered:
+   ```bash
+   OWNER_REPO=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')
+   gh pr diff 9 --name-only
+   gh pr view 9 --json files -q '.files[].path'
+   curl -sS "https://api.github.com/repos/$OWNER_REPO/pulls/9/files" | jq length
+   # plain-git fallback:
+   git fetch origin pull/9/head:pr-9 && git diff "$BASE"...pr-9 --stat
+   ```
+   Interpretation: all empty / `0` → claim confirmed → post the drafted comment.
+   Anything non-empty → the claim was wrong → switch to the full review procedure
+   (scope, diff, tests, verdict) for the diff you just found.
+4. **Stage the posting command** (auth chain first, then `gh pr comment 9 --body "..."`
+   or the `POST /issues/9/comments` curl variant — top-level PR comments use the
+   **issues** comments endpoint; posting needs a token with `repo` / Pull requests:
+   write — without one, the comment text is the deliverable and the token is the
+   footnote).
+5. **Never end with "If you'd like me to verify…"** — the verification block IS
+   attached; that closes the turn.
+
+## Playbook: on-demand comment posting ("post a comment on the deleted line X of PR #N")
+
+- Immediately resolve (or stage): owner/repo, auth chain, head SHA, anchor validity —
+  file in `/pulls/N/files`, line inside a diff hunk, `side=LEFT` + old-file line number
+  for deletions. Verification inline: `gh pr diff N -- path/to/file`.
+- Body given → post/stage and confirm with the comment URL. Only topics given → draft
+  the body and post/stage. No substance → stage everything else, one labeled body
+  placeholder, ask for the body alone.
+- Include 422 triage (line not in a deletion hunk → recheck the old-file number from the
+  hunk header, or fall back per the mechanics reference).
+- Auth missing after the full chain → exact blocked step (POST needs a token with
+  `repo` / Pull requests: write) + minimal remediation. Don't also ask for derivables.
+
+## Playbook: local pre-push review ("review my changes before I push")
+
+- **With execution:** detect BASE (origin/HEAD symref, else `main`, else `master`), then
+  `git status --short --branch`, `git log BASE..HEAD --oneline`, `git diff BASE...HEAD`,
+  staged and unstaged diffs, tests/lint, full structured review.
+- **Without execution:** deliver this gather block plus the checklist, and ask the user
+  to paste the output:
+  ```bash
+  git status --short --branch
+  BASE=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||'); [ -n "$BASE" ] || BASE=main
+  git rev-parse --verify "$BASE" >/dev/null 2>&1 || BASE=master
+  echo "== commits ahead of $BASE =="; git log "$BASE"..HEAD --oneline
+  echo "== diffstat =="; git diff "$BASE"...HEAD --stat
+  echo "== full diff =="; git diff "$BASE"...HEAD
+  echo "== staged (uncommitted) =="; git diff --staged
+  echo "== unstaged =="; git diff
+  ls Makefile package.json pyproject.toml tox.ini setup.cfg 2>/dev/null
+  ```

--- a/tests/skills/test_github_code_review_skill.py
+++ b/tests/skills/test_github_code_review_skill.py
@@ -1,0 +1,73 @@
+"""Runtime loading tests for the bundled github-code-review skill.
+
+These exercise the production skill-loading/validation code paths in
+``tools.skill_manager_tool`` against the shipped skill bundle — the same gates
+a skill passes when Hermes creates, edits, and loads it — plus bundle
+consistency (every ``references/`` file the SKILL.md points at must ship).
+No source-shape assertions, no network; stdlib + pytest only.
+"""
+
+import re
+import shutil
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+from tools.skill_manager_tool import (
+    _find_skill,
+    _security_scan_skill,
+    _validate_category,
+    _validate_content_size,
+    _validate_frontmatter,
+    _validate_name,
+)
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2] / "skills" / "github" / "github-code-review"
+)
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+def _skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def test_skill_loads_through_production_validation():
+    """The skill must pass the same gates the skill manager applies on write/load."""
+    content = _skill_text()
+    assert _validate_name("github-code-review") is None
+    assert _validate_category("github") is None
+    assert _validate_frontmatter(content) is None
+    assert _validate_content_size(content) is None
+
+
+def test_description_fits_new_skill_prompt_budget():
+    """Create-path gate: description must fit the system-prompt char budget."""
+    assert _validate_frontmatter(_skill_text(), new_skill=True) is None
+
+
+def test_skill_dir_passes_security_scan():
+    assert _security_scan_skill(SKILL_DIR) is None
+
+
+def test_referenced_bundle_files_exist():
+    """Every references/ file the SKILL.md points at must ship in the bundle."""
+    refs = set(re.findall(r"references/[A-Za-z0-9._-]+\.md", _skill_text()))
+    assert refs, "expected the skill to reference at least one bundle file"
+    for ref in sorted(refs):
+        assert (SKILL_DIR / ref).is_file(), f"missing referenced file: {ref}"
+
+
+def test_skill_discoverable_and_loadable_after_install():
+    """Copied into a fresh HERMES_HOME, the skill is found by name through the
+    production discovery path and its content loads clean."""
+    import tools.skill_manager_tool as smt
+
+    # conftest points HERMES_HOME at a per-test tempdir; install the bundle there.
+    dest = get_hermes_home() / "skills" / "github" / "github-code-review"
+    shutil.copytree(SKILL_DIR, dest)
+
+    found = smt._find_skill("github-code-review")
+    assert found is not None, "skill not discoverable after install"
+    content = (found["path"] / "SKILL.md").read_text(encoding="utf-8")
+    assert smt._validate_frontmatter(content) is None
+    assert smt._validate_content_size(content) is None

--- a/website/docs/user-guide/skills/bundled/github/github-github-code-review.md
+++ b/website/docs/user-guide/skills/bundled/github/github-github-code-review.md
@@ -16,8 +16,8 @@ Review PRs: diffs, inline comments via gh or REST.
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/github/github-code-review` |
-| Version | `1.1.0` |
-| Author | Hermes Agent |
+| Version | `1.2.0` |
+| Author | A-KH17, Hermes Agent |
 | License | MIT |
 | Platforms | linux, macos, windows |
 | Tags | `GitHub`, `Code-Review`, `Pull-Requests`, `Git`, `Quality` |
@@ -29,471 +29,155 @@ Review PRs: diffs, inline comments via gh or REST.
 The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
 :::
 
-# GitHub Code Review
+# GitHub Code Review Skill
 
-Perform code reviews on local changes before pushing, or review open PRs on GitHub. Most of this skill uses plain `git` — the `gh`/`curl` split only matters for PR-level interactions.
+Reviews local pre-push changes and GitHub pull requests, delivers a structured verdict,
+and posts inline comments or formal reviews to GitHub on request. It does not author PRs
+(`github-pr-workflow`) or triage issues (`github-issues`).
+
+## When to Use
+
+- "Review my changes before I push" — local `git diff BASE...HEAD` review, no GitHub API needed.
+- "Review PR #N" — fetch, inspect, test, and review a GitHub pull request.
+- "Post a comment / formal review on PR #N" — inline comments, `APPROVE` / `REQUEST_CHANGES` / `COMMENT`.
+- Advisory questions ("what should the review look like?") are action requests — deliver
+  the artifact plus staged commands, not just an explanation.
 
 ## Prerequisites
 
-- Authenticated with GitHub (see `github-auth` skill)
-- Inside a git repository
-
-### Setup (for PR interactions)
-
-```bash
-if command -v gh &>/dev/null && gh auth status &>/dev/null; then
-  AUTH="gh"
-else
-  AUTH="git"
-  if [ -z "$GITHUB_TOKEN" ]; then
-    if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
-      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
-    elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
-    fi
-  fi
-fi
-
-REMOTE_URL=$(git remote get-url origin)
-OWNER_REPO=$(echo "$REMOTE_URL" | sed -E 's|.*github\.com[:/]||; s|\.git$||')
-OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
-REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
-```
-
----
-
-## 1. Reviewing Local Changes (Pre-Push)
-
-This is pure `git` — works everywhere, no API needed.
-
-### Get the Diff
-
-```bash
-# Staged changes (what would be committed)
-git diff --staged
-
-# All changes vs main (what a PR would contain)
-git diff main...HEAD
-
-# File names only
-git diff main...HEAD --name-only
-
-# Stat summary (insertions/deletions per file)
-git diff main...HEAD --stat
-```
-
-### Review Strategy
-
-1. **Get the big picture first:**
-
-```bash
-git diff main...HEAD --stat
-git log main..HEAD --oneline
-```
-
-2. **Review file by file** — use `read_file` on changed files for full context, and the diff to see what changed:
-
-```bash
-git diff main...HEAD -- src/auth/login.py
-```
-
-3. **Check for common issues:**
-
-```bash
-# Debug statements, TODOs, console.logs left behind
-git diff main...HEAD | grep -n "print(\|console\.log\|TODO\|FIXME\|HACK\|XXX\|debugger"
-
-# Large files accidentally staged
-git diff main...HEAD --stat | sort -t'|' -k2 -rn | head -10
-
-# Secrets or credential patterns
-git diff main...HEAD | grep -in "password\|secret\|api_key\|token.*=\|private_key"
-
-# Merge conflict markers
-git diff main...HEAD | grep -n "<<<<<<\|>>>>>>\|======="
-```
-
-4. **Present structured feedback** to the user.
-
-### Review Output Format
-
-When reviewing local changes, present findings in this structure:
-
-```
-## Code Review Summary
-
-### Critical
-- **src/auth.py:45** — SQL injection: user input passed directly to query.
-  Suggestion: Use parameterized queries.
-
-### Warnings
-- **src/models/user.py:23** — Password stored in plaintext. Use bcrypt or argon2.
-- **src/api/routes.py:112** — No rate limiting on login endpoint.
-
-### Suggestions
-- **src/utils/helpers.py:8** — Duplicates logic in `src/core/utils.py:34`. Consolidate.
-- **tests/test_auth.py** — Missing edge case: expired token test.
-
-### Looks Good
-- Clean separation of concerns in the middleware layer
-- Good test coverage for the happy path
-```
-
----
-
-## 2. Reviewing a Pull Request on GitHub
-
-### View PR Details
-
-**With gh:**
-
-```bash
-gh pr view 123
-gh pr diff 123
-gh pr diff 123 --name-only
-```
-
-**With git + curl:**
-
-```bash
-PR_NUMBER=123
-
-# Get PR details
-curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python3 -c "
-import sys, json
-pr = json.load(sys.stdin)
-print(f\"Title: {pr['title']}\")
-print(f\"Author: {pr['user']['login']}\")
-print(f\"Branch: {pr['head']['ref']} -> {pr['base']['ref']}\")
-print(f\"State: {pr['state']}\")
-print(f\"Body:\n{pr['body']}\")"
-
-# List changed files
-curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/files \
-  | python3 -c "
-import sys, json
-for f in json.load(sys.stdin):
-    print(f\"{f['status']:10} +{f['additions']:-4} -{f['deletions']:-4}  {f['filename']}\")"
-```
-
-### Check Out PR Locally for Full Review
-
-This works with plain `git` — no `gh` needed:
-
-```bash
-# Fetch the PR branch and check it out
-git fetch origin pull/123/head:pr-123
-git checkout pr-123
-
-# Now you can use read_file, search_files, run tests, etc.
-
-# View diff against the base branch
-git diff main...pr-123
-```
-
-**With gh (shortcut):**
-
-```bash
-gh pr checkout 123
-```
-
-### Leave Comments on a PR
-
-**General PR comment — with gh:**
-
-```bash
-gh pr comment 123 --body "Overall looks good, a few suggestions below."
-```
-
-**General PR comment — with curl:**
-
-```bash
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/issues/$PR_NUMBER/comments \
-  -d '{"body": "Overall looks good, a few suggestions below."}'
-```
-
-### Leave Inline Review Comments
-
-**Single inline comment — with gh (via API):**
-
-```bash
-HEAD_SHA=$(gh pr view 123 --json headRefOid --jq '.headRefOid')
-
-gh api repos/$OWNER/$REPO/pulls/123/comments \
-  --method POST \
-  -f body="This could be simplified with a list comprehension." \
-  -f path="src/auth/login.py" \
-  -f commit_id="$HEAD_SHA" \
-  -f line=45 \
-  -f side="RIGHT"
-```
-
-**Single inline comment — with curl:**
-
-```bash
-# Get the head commit SHA
-HEAD_SHA=$(curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
-
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments \
-  -d "{
-    \"body\": \"This could be simplified with a list comprehension.\",
-    \"path\": \"src/auth/login.py\",
-    \"commit_id\": \"$HEAD_SHA\",
-    \"line\": 45,
-    \"side\": \"RIGHT\"
-  }"
-```
-
-### Submit a Formal Review (Approve / Request Changes)
-
-**With gh:**
-
-```bash
-gh pr review 123 --approve --body "LGTM!"
-gh pr review 123 --request-changes --body "See inline comments."
-gh pr review 123 --comment --body "Some suggestions, nothing blocking."
-```
-
-**With curl — multi-comment review submitted atomically:**
-
-```bash
-HEAD_SHA=$(curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
-
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews \
-  -d "{
-    \"commit_id\": \"$HEAD_SHA\",
-    \"event\": \"COMMENT\",
-    \"body\": \"Code review from Hermes Agent\",
-    \"comments\": [
-      {\"path\": \"src/auth.py\", \"line\": 45, \"body\": \"Use parameterized queries to prevent SQL injection.\"},
-      {\"path\": \"src/models/user.py\", \"line\": 23, \"body\": \"Hash passwords with bcrypt before storing.\"},
-      {\"path\": \"tests/test_auth.py\", \"line\": 1, \"body\": \"Add test for expired token edge case.\"}
-    ]
-  }"
-```
-
-Event values: `"APPROVE"`, `"REQUEST_CHANGES"`, `"COMMENT"`
-
-The `line` field refers to the line number in the *new* version of the file. For deleted lines, use `"side": "LEFT"`.
-
----
-
-## 3. Review Checklist
-
-When performing a code review (local or PR), systematically check:
-
-### Correctness
-- Does the code do what it claims?
-- Edge cases handled (empty inputs, nulls, large data, concurrent access)?
-- Error paths handled gracefully?
-
-### Security
-- No hardcoded secrets, credentials, or API keys
-- Input validation on user-facing inputs
-- No SQL injection, XSS, or path traversal
-- Auth/authz checks where needed
-
-### Code Quality
-- Clear naming (variables, functions, classes)
-- No unnecessary complexity or premature abstraction
-- DRY — no duplicated logic that should be extracted
-- Functions are focused (single responsibility)
-
-### Testing
-- New code paths tested?
-- Happy path and error cases covered?
-- Tests readable and maintainable?
-
-### Performance
-- No N+1 queries or unnecessary loops
-- Appropriate caching where beneficial
-- No blocking operations in async code paths
-
-### Documentation
-- Public APIs documented
-- Non-obvious logic has comments explaining "why"
-- README updated if behavior changed
-
----
-
-## 4. Pre-Push Review Workflow
-
-When the user asks you to "review the code" or "check before pushing":
-
-1. `git diff main...HEAD --stat` — see scope of changes
-2. `git diff main...HEAD` — read the full diff
-3. For each changed file, use `read_file` if you need more context
-4. Apply the checklist above
-5. Present findings in the structured format (Critical / Warnings / Suggestions / Looks Good)
-6. If critical issues found, offer to fix them before the user pushes
-
----
-
-## 5. PR Review Workflow (End-to-End)
-
-When the user asks you to "review PR #N", "look at this PR", or gives you a PR URL, follow this recipe:
-
-### Step 1: Set up environment
-
-```bash
-source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
-# Or run the inline setup block from the top of this skill
-```
-
-### Step 2: Gather PR context
-
-Get the PR metadata, description, and list of changed files to understand scope before diving into code.
-
-**With gh:**
-```bash
-gh pr view 123
-gh pr diff 123 --name-only
-gh pr checks 123
-```
-
-**With curl:**
-```bash
-PR_NUMBER=123
-
-# PR details (title, author, description, branch)
-curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER
-
-# Changed files with line counts
-curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER/files
-```
-
-### Step 3: Check out the PR locally
-
-This gives you full access to `read_file`, `search_files`, and the ability to run tests.
-
-```bash
-git fetch origin pull/$PR_NUMBER/head:pr-$PR_NUMBER
-git checkout pr-$PR_NUMBER
-```
-
-### Step 4: Read the diff and understand changes
-
-```bash
-# Full diff against the base branch
-git diff main...HEAD
-
-# Or file-by-file for large PRs
-git diff main...HEAD --name-only
-# Then for each file:
-git diff main...HEAD -- path/to/file.py
-```
-
-For each changed file, use `read_file` to see full context around the changes — diffs alone can miss issues visible only with surrounding code.
-
-### Step 5: Run automated checks locally (if applicable)
-
-```bash
-# Run tests if there's a test suite
-python -m pytest 2>&1 | tail -20
-# or: npm test, cargo test, go test ./..., etc.
-
-# Run linter if configured
-ruff check . 2>&1 | head -30
-# or: eslint, clippy, etc.
-```
-
-### Step 6: Apply the review checklist (Section 3)
-
-Go through each category: Correctness, Security, Code Quality, Testing, Performance, Documentation.
-
-### Step 7: Post the review to GitHub
-
-Collect your findings and submit them as a formal review with inline comments.
-
-**With gh:**
-```bash
-# If no issues — approve
-gh pr review $PR_NUMBER --approve --body "Reviewed by Hermes Agent. Code looks clean — good test coverage, no security concerns."
-
-# If issues found — request changes with inline comments
-gh pr review $PR_NUMBER --request-changes --body "Found a few issues — see inline comments."
-```
-
-**With curl — atomic review with multiple inline comments:**
-```bash
-HEAD_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
-
-# Build the review JSON — event is APPROVE, REQUEST_CHANGES, or COMMENT
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER/reviews \
-  -d "{
-    \"commit_id\": \"$HEAD_SHA\",
-    \"event\": \"REQUEST_CHANGES\",
-    \"body\": \"## Hermes Agent Review\n\nFound 2 issues, 1 suggestion. See inline comments.\",
-    \"comments\": [
-      {\"path\": \"src/auth.py\", \"line\": 45, \"body\": \"🔴 **Critical:** User input passed directly to SQL query — use parameterized queries.\"},
-      {\"path\": \"src/models.py\", \"line\": 23, \"body\": \"⚠️ **Warning:** Password stored without hashing.\"},
-      {\"path\": \"src/utils.py\", \"line\": 8, \"body\": \"💡 **Suggestion:** This duplicates logic in core/utils.py:34.\"}
-    ]
-  }"
-```
-
-### Step 8: Also post a summary comment
-
-In addition to inline comments, leave a top-level summary so the PR author gets the full picture at a glance. Use the review output format from `references/review-output-template.md`.
-
-**With gh:**
-```bash
-gh pr comment $PR_NUMBER --body "$(cat <<'EOF'
-## Code Review Summary
-
-**Verdict: Changes Requested** (2 issues, 1 suggestion)
-
-### 🔴 Critical
-- **src/auth.py:45** — SQL injection vulnerability
-
-### ⚠️ Warnings
-- **src/models.py:23** — Plaintext password storage
-
-### 💡 Suggestions
-- **src/utils.py:8** — Duplicated logic, consider consolidating
-
-### ✅ Looks Good
-- Clean API design
-- Good error handling in the middleware layer
-
----
-*Reviewed by Hermes Agent*
-EOF
-)"
-```
-
-### Step 9: Clean up
-
-```bash
-git checkout main
-git branch -D pr-$PR_NUMBER
-```
-
-### Decision: Approve vs Request Changes vs Comment
-
-- **Approve** — no critical or warning-level issues, only minor suggestions or all clear
-- **Request Changes** — any critical or warning-level issue that should be fixed before merge
-- **Comment** — observations and suggestions, but nothing blocking (use when you're unsure or the PR is a draft)
+- Inside a git repository; all shell commands run via `terminal`.
+- For PR interactions, resolve auth FIRST and CAPTURE the token for later steps — walk
+  the full fallback chain (`gh` → `$GITHUB_TOKEN` → `github-auth` credential helper →
+  hermes `.env` → unauthenticated API → plain-git fetch) documented in
+  [references/github-api-mechanics.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/github/github-code-review/references/github-api-mechanics.md). A user claim
+  of "no gh, no token" covers the first two rungs at most; never conclude "can't
+  authenticate" while a rung is untried. Only POSTing comments/reviews truly needs a token.
+
+## How to Run
+
+The first line of EVERY response is a mode line, phrased value-forward:
+
+- **Execution available:** "Executed below — real outputs, interpreted inline." Run the
+  commands via `terminal`, paste the real output (including empty output — an empty
+  result is itself a finding), and state what it means.
+- **No execution (or unknown):** "Your deliverable is fully staged below for a single
+  paste." Follow the No-Execution Playbook in
+  [references/playbooks.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/github/github-code-review/references/playbooks.md).
+
+Every response then follows the Deliverable Contract, in order:
+
+1. **Mode line** (above).
+2. **The deliverable** — the direct answer plus fully drafted artifacts (review text,
+   comment bodies, verbatim-pasteable) and/or one consolidated staged command block.
+3. **Interpretation guide** for every staged block: each plausible output → meaning →
+   next action, covering BOTH branches of any user claim being verified. This replaces
+   the fake transcript — a `$ cmd` block followed by invented output is the worst
+   possible failure; a labeled "run this" block plus guide is the correct form.
+4. **Failure triage** for each step (HTTP 422 / 401 / 403 / 404 / 429 — see the
+   mechanics reference).
+5. **One-line footnote** — the posting status, or the single minimal artifact still
+   needed. Never an open-ended offer, never a cliffhanger.
+
+Three standing rules override scenario habits:
+
+1. **Treat user claims as unverified hypotheses** ("the PR has no files", "auth is
+   missing"). The first commands settle the claim; the rest of the deliverable branches
+   on BOTH outcomes.
+2. **Advisory questions are action requests.** Give the direct answer AND the drafted
+   artifact AND the staged commands. Never end with "If you'd like me to verify…".
+3. **Probes must capture, not just detect.** Any probe for a value (token, owner/repo,
+   base branch, head SHA, PR number) stores it in a shell variable the rest of the block
+   uses — an existence-only probe is a half-deliverable.
+
+## Quick Reference
+
+| Task | Core command (run via `terminal`) |
+|------|-----------------------------------|
+| Local pre-push review | `git diff "$BASE"...HEAD` (+ `--stat`, `--oneline` log) |
+| Fetch a PR locally | `git fetch origin pull/N/head:pr-N && git checkout pr-N` |
+| PR metadata | `gh pr view N --json files,headRefOid,baseRefName` |
+| PR diff | `gh pr diff N` |
+| Find a PR by topic | `gh pr list --state open --search "<term>" --json number,title,headRefName` |
+| Post inline comment | `gh api repos/$OWNER_REPO/pulls/N/comments --method POST --input -` (JSON on stdin) |
+| Post formal review | `gh api repos/$OWNER_REPO/pulls/N/reviews --method POST --input -` (`event` + `comments` array) |
+| Top-level comment | `gh pr comment N --body "..."` (uses the **issues** endpoint) |
+| Tests on PR code | `git worktree add .wt-pr-N pr-N && (cd .wt-pr-N && <test cmd>); git worktree remove --force .wt-pr-N` |
+| Cleanup | `git checkout - && git branch -D pr-N` |
+
+## Procedure
+
+1. **Scope first:** `git diff BASE...HEAD --stat` and `git log BASE..HEAD --oneline`.
+   State the scope explicitly ("N commits, M files") so later "clean" results are
+   meaningful.
+2. **Read the full diff.** For each changed file, read surrounding context with
+   `read_file` and hunt related call sites with `search_files`.
+3. **Run the project's tests and linter against the PR code, not the user's working
+   tree** — use a worktree (Quick Reference). Detect the runner from `Makefile`,
+   `package.json`, `pyproject.toml`, `tox.ini`.
+4. **Apply the checklist:** correctness (edge cases, error paths), security (secrets,
+   injection, authz, input validation), quality (naming, DRY, complexity), tests (new
+   paths incl. failure cases), performance (N+1, blocking calls in async code), docs.
+5. **Leftover scan on ADDED lines only** (debug statements, conflict markers, secrets) —
+   pipeline in [references/github-api-mechanics.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/github/github-code-review/references/github-api-mechanics.md).
+   A scan over an EMPTY input is not a clean pass: establish scope, then report results.
+6. **Verdict mapping:** any Critical or Warning → Request Changes; only suggestions →
+   Approve or Comment; nothing found → Approve. Never Approve code you haven't read, and
+   never Approve/Request-Changes on an empty diff — a drafted top-level Comment is the
+   only vehicle there (playbooks reference).
+7. **If posting:** head SHA as `commit_id`; `side: "LEFT"` + old-file line numbers for
+   deletions; anchors must sit inside a diff hunk, with defined fallbacks (nearest
+   changed line → file-level `subject_type: "file"` → fold into the review body). Build
+   multi-comment review JSON via stdin heredoc or `jq -n`, never indexed `-f` flags.
+   Full mechanics in the reference.
+8. **Clean up:** restore the original branch, delete temporary `pr-N` branches, remove
+   temporary worktrees.
+
+Report a real review using the bundled
+[references/review-output-template.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/github/github-code-review/references/review-output-template.md): a
+`**Verdict: <Approve | Request Changes | Comment>**` line with a one-line rationale,
+then 🔴 Critical / ⚠️ Warnings / 💡 Suggestions / ✅ Looks Good as
+`file:line — issue — concrete fix` (omit empty sections), the reviewed scope stated, and
+the one-line footnote at the end.
+
+Scenario playbooks — the PR discovery ladder and two-block pattern for unidentified
+targets, the empty-diff package, the security-focused review checklist, on-demand
+comment posting, the pre-push gather block, and command-block standards — live in
+[references/playbooks.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/github/github-code-review/references/playbooks.md).
+
+## Pitfalls
+
+- Never end a turn with a cliffhanger, a progress report, a promise of future work, or
+  an offer ("If you'd like me to…, I can run…") where attaching the block was possible.
+- Never open with "I can't" while any tier is deliverable. Graceful degradation: posted
+  review → full review in chat with posting skipped (one-line reason) → partial review
+  with explicit gaps → blocker message (only if even the diff is unreachable; list what
+  was tried and the single minimal fix).
+- Never fabricate `$`-prompt transcripts, outputs, findings, file names, line numbers,
+  PR identifiers, auth state, or "clean" results. Real empty output is reported and
+  interpreted, never dressed up.
+- Never call a scan "clean" when its input was empty — distinguish "nothing to review"
+  from "reviewed, no findings", and state the scope either way.
+- Never stop at a blocker while an untried fallback rung exists — but when only POSTing
+  is blocked, still deliver the full review plus the minimal remediation
+  (`export GITHUB_TOKEN=...` or `gh auth login`) as a footnote.
+- Never ask the user for anything obtainable with one command (owner/repo, auth state,
+  tool existence, diff emptiness, which PR matches a description) — run or stage the
+  command. Ask only for the single minimal artifact, after concrete discovery attempts.
+- Never post placeholder body text. When the user supplies comment topics, drafting the
+  concrete professional body is REQUIRED — phrased as the user's finding, with no
+  invented specifics.
+- Paste blocks: no `set -e` / `set -euo pipefail` (one failing probe would kill the
+  fallback ladder), no interactive prompts, one consolidated block run from the repo
+  root, placeholders clearly labeled with the command that reveals valid values.
+- Run tests against the PR code (worktree or checkout), not the user's working tree —
+  and always clean up branches and worktrees afterward.
+
+## Verification
+
+Before delivering, confirm:
+- [ ] Scope stated (N commits, M files) and full diff read.
+- [ ] Tests/linter run against the PR code — or explicitly reported as not run, with the staged command.
+- [ ] Every posted item confirmed by the API response (URL or review ID).
+- [ ] No fabricated outputs, findings, or auth state; empty results reported and interpreted.
+- [ ] Verdict matches the findings and the verdict-mapping rule.
+- [ ] Cleanup done: original branch restored, `pr-N` branch and worktrees removed.


### PR DESCRIPTION
## What does this PR do?

Replaces the bundled `github-code-review` SKILL.md (v1.1.0 → v1.2.0) with a version **evolved by the official [`hermes-agent-self-evolution`](https://github.com/NousResearch/hermes-agent-self-evolution) GEPA pipeline**, restructured to the modern skill-authoring standard (required section order, 163-line body, native-tool-first framing, detail moved to `references/`).

On the gym's holdout set (5 unseen scenarios, its own `skill_fitness_metric`, `kimi-k2.7-code` as the executing agent), the exact submitted text scores **0.580 vs 0.423 baseline (+37% relative), winning all 5 examples individually** (per-example: [0.387, 0.319, 0.494, 0.469, 0.444] → [0.679, 0.533, 0.553, 0.638, 0.497]).

What the evolution actually improved is mostly **behavioral discipline** the original lacks, learned from failure traces:

- **Never fabricate** command output / findings / auth state — staged commands are labeled, fake `$`-transcripts are called out as the worst failure.
- **Complete the turn** — no cliffhangers, no "If you'd like me to verify…" offers; every response is a finished deliverable or a staged paste-ready block.
- **Treat user claims as unverified hypotheses** ("no gh, no token", "PR has no files") — cheaply verify first, branch on both outcomes.
- **Probes must capture, not just detect** — a multi-rung auth fallback chain that stores values for later steps.
- **Verdict discipline** — never Approve/Request-Changes on an empty diff; never call an empty-input scan "clean"; verdict ↔ findings mapping.
- **Inline-comment mechanics** — head-SHA `commit_id`, `side: "LEFT"` + old-file line numbers for deletions, 422/401/403/404/429 triage, worktree test runs against the PR code (not the user's working tree).

## Method (fully reproducible)

1. Ran the official gym at `hermes-agent-self-evolution` against this repo at `9acc4b4` (`kimi-k3` optimizer, `kimi-k2.7-code` eval; valset improved 0.474 → 0.579 over 21 iterations / ~150 rollouts). **7 compatibility fixes were required to make the gym run GEPA at all on dspy 3.2.1** — including that the skill text was passed as an *input field*, which GEPA never optimizes, so the "evolved" output was previously byte-identical to baseline. Filed as NousResearch/hermes-agent-self-evolution#155.
2. Raw GEPA output tripped the gym's own 15K size gate; editorial pass for standards compliance.
3. **Restructured per review:** modern section order (`## How to Run` → `## Quick Reference` → `## Procedure`), body compressed 505 → 163 lines, native-tool-first prose, detailed recipes moved to `references/`, auth chain routed through the `github-auth` credential helper script (no legacy sed extraction).
4. **Re-measured on the exact submitted text** with the gym's `SkillModule` + metric on a freshly generated 20-scenario synthetic set (5 holdout), baseline = current `main` v1.1.0. Fresh scenarios, so not directly comparable to the pre-restructure measurement (0.515 → 0.601 on the original set); each run is internally consistent.

**Stated caveats:** the metric is the gym's own keyword-overlap heuristic (not an LLM judge); synthetic scenarios; single measurement run; one executing model. Results will vary across models/runs — but the direction is consistent with the GEPA valset trajectory.

## Related Issue

N/A — improvement proposal without a prior issue. Happy to file one if preferred.

## Type of Change

- [x] 🎯 New skill (bundled or hub) — *evolution of an existing bundled skill*

## Changes Made

- `skills/github/github-code-review/SKILL.md` — evolved rewrite, restructured (v1.1.0 → v1.2.0), 163-line body
- `skills/github/github-code-review/references/github-api-mechanics.md` — NEW: auth fallback chain, posting mechanics, failure triage, leftover/secrets scan
- `skills/github/github-code-review/references/playbooks.md` — NEW: PR discovery ladder, two-block pattern, empty-diff package, security-review checklist, pre-push gather block, command-block standards
- `tests/skills/test_github_code_review_skill.py` — runtime coverage through the production `tools.skill_manager_tool` gates (frontmatter incl. the 60-char create-path budget, content size, name/category, security scan), bundle-consistency checks for referenced files, and an install → discovery → load test via `_find_skill`. **No source-shape assertions.**
- `website/docs/user-guide/skills/bundled/github/github-github-code-review.md` — regenerated with `website/scripts/generate-skill-docs.py`
- `contributors/emails/` — email→login mapping for the commit author

## How to Test

1. `scripts/run_tests.sh tests/skills/test_github_code_review_skill.py -q` → 5 passed; full `tests/skills/` dir green (including the #22722 credential-regex regression test).
2. Behavioral: in a repo with an open PR, ask Hermes to "review PR #N and post inline comments" — the agent should complete end-to-end (scope → diff → worktree tests → verdict → posting with anchor validation), without deflecting or fabricating.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicate found for evolving this skill
- [x] My PR contains **only** changes related to this fix/feature
- [x] `scripts/run_tests.sh tests/skills/ -q` — the new skill tests pass (5/5); the rest of the change is markdown
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (tests) + Ubuntu 24.04 (original evolution run)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — bundled-skill docs page regenerated from SKILL.md
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — skill content is platform-agnostic; `platforms: [linux, macos, windows]` unchanged and audited
