### PR TITLE
fix(telegram): keep MarkdownV2 on flood finalize edits

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -430,6 +430,24 @@ def _escape_mdv2(text: str) -> str:
     return _MDV2_ESCAPE_RE.sub(r'\\\1', text)
 
 
+def _is_telegram_flood_error(exc: BaseException) -> bool:
+    """True when Telegram is rate-limiting (RetryAfter / flood control).
+
+    Flood is transient transport pressure, not a MarkdownV2 parse failure.
+    Callers must wait/retry with the original parse_mode instead of stripping
+    formatting to plain text (which is what made replies look unrendered).
+    """
+    retry_after = getattr(exc, "retry_after", None)
+    if retry_after is not None:
+        return True
+    err = str(exc).lower()
+    return (
+        "retry after" in err
+        or "flood control" in err
+        or "too many requests" in err
+    )
+
+
 def _strip_mdv2(text: str) -> str:
     """Strip MarkdownV2 escape backslashes to produce clean plain text.
 
@@ -4481,7 +4499,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 # "Message is not modified" is a no-op, not an error
                 if "not modified" in str(fmt_err).lower():
                     return SendResult(success=True, message_id=message_id)
-                # Fallback: strip MarkdownV2 escapes and retry as clean plain text
+                # Flood/rate-limit is NOT a parse failure. Re-raise so the outer
+                # handler can wait/retry (or escalate) while keeping MarkdownV2.
+                # Previously this branch stripped formatting on flood and users
+                # saw unrendered / plain final replies.
+                if _is_telegram_flood_error(fmt_err):
+                    raise
+                # Fallback: real MarkdownV2 parse failures only → clean plain text
                 safe_format_error = _redact_telegram_error_text(fmt_err)
                 logger.warning(
                     "[%s] MarkdownV2 edit failed, falling back to plain text: %s",
@@ -4528,8 +4552,8 @@ class TelegramAdapter(BasePlatformAdapter):
             # long waits return a failure immediately so streaming can fall back
             # to a normal final send instead of leaving a truncated partial.
             retry_after = getattr(e, "retry_after", None)
-            if retry_after is not None or "retry after" in err_str:
-                wait = retry_after if retry_after else 1.0
+            if retry_after is not None or "retry after" in err_str or "flood control" in err_str:
+                wait = float(retry_after) if retry_after is not None else 1.0
                 logger.warning(
                     "[%s] Telegram flood control, waiting %.1fs",
                     self.name, wait,
@@ -4542,11 +4566,22 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                 await asyncio.sleep(wait)
                 try:
-                    await self._bot.edit_message_text(
-                        chat_id=normalize_telegram_chat_id(chat_id),
-                        message_id=int(message_id),
-                        text=content,
-                    )
+                    # Preserve MarkdownV2 on finalize retries. Mid-stream
+                    # previews stay plain (no parse_mode) as before.
+                    if finalize:
+                        _retry_text = self.format_message(content)
+                        await self._bot.edit_message_text(
+                            chat_id=normalize_telegram_chat_id(chat_id),
+                            message_id=int(message_id),
+                            text=_retry_text,
+                            parse_mode=ParseMode.MARKDOWN_V2,
+                        )
+                    else:
+                        await self._bot.edit_message_text(
+                            chat_id=normalize_telegram_chat_id(chat_id),
+                            message_id=int(message_id),
+                            text=content,
+                        )
                     return SendResult(success=True, message_id=message_id)
                 except Exception as retry_err:
                     safe_retry_error = _redact_telegram_error_text(retry_err)
@@ -4656,6 +4691,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                 except Exception as fmt_err:
                     if "not modified" not in str(fmt_err).lower():
+                        # Flood is not a parse failure — bubble up so the caller
+                        # can retry with MarkdownV2 instead of stripping.
+                        if _is_telegram_flood_error(fmt_err):
+                            raise
                         logger.warning(
                             "[%s] Overflow split: MarkdownV2 first-chunk edit "
                             "failed, falling back to plain text: %s",

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -38,6 +38,7 @@ _ensure_telegram_mock()
 from plugins.platforms.telegram.adapter import (  # noqa: E402
     TelegramAdapter,
     _escape_mdv2,
+    _is_telegram_flood_error,
     _strip_mdv2,
     _wrap_markdown_tables,
 )
@@ -905,6 +906,83 @@ class TestEditMessageStreamingSafety:
             "message_id": 456,
             "text": "final bold",
         }
+
+    @pytest.mark.asyncio
+    async def test_final_edit_flood_does_not_plain_fallback(self):
+        """Flood control is not a MarkdownV2 parse failure.
+
+        Regression: finalize edits treated RetryAfter/flood like a parse error
+        and stripped formatting to plain text, so users saw unrendered replies.
+        """
+
+        class FloodError(Exception):
+            retry_after = 30.0
+
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+        adapter._bot = MagicMock()
+        adapter._bot.edit_message_text = AsyncMock(
+            side_effect=FloodError("Flood control exceeded. Retry in 30 seconds")
+        )
+
+        result = await adapter.edit_message(
+            "123", "456", "final **bold**", finalize=True
+        )
+
+        assert result.success is False
+        assert result.error == "flood_control:30.0"
+        assert result.retry_after == 30.0
+        # Single MarkdownV2 attempt only — never a stripped plain retry.
+        assert adapter._bot.edit_message_text.await_count == 1
+        only_call = adapter._bot.edit_message_text.await_args.kwargs
+        assert "parse_mode" in only_call
+        assert only_call["text"] == "final *bold*"
+
+    @pytest.mark.asyncio
+    async def test_final_edit_short_flood_retries_with_markdownv2(self, monkeypatch):
+        """Short flood waits retry the finalize edit still as MarkdownV2."""
+
+        class FloodError(Exception):
+            retry_after = 1.0
+
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+        adapter._bot = MagicMock()
+        adapter._bot.edit_message_text = AsyncMock(
+            side_effect=[
+                FloodError("Flood control exceeded. Retry in 1 seconds"),
+                None,
+            ]
+        )
+        sleep = AsyncMock()
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.asyncio.sleep", sleep
+        )
+
+        result = await adapter.edit_message(
+            "123", "456", "final **bold**", finalize=True
+        )
+
+        assert result.success is True
+        sleep.assert_awaited_once_with(1.0)
+        assert adapter._bot.edit_message_text.await_count == 2
+        first_call = adapter._bot.edit_message_text.await_args_list[0].kwargs
+        second_call = adapter._bot.edit_message_text.await_args_list[1].kwargs
+        assert "parse_mode" in first_call
+        assert "parse_mode" in second_call
+        assert second_call["text"] == "final *bold*"
+
+    def test_is_telegram_flood_error_detects_retry_after_shapes(self):
+        class WithAttr(Exception):
+            retry_after = 12
+
+        assert _is_telegram_flood_error(WithAttr("x"))
+        assert _is_telegram_flood_error(
+            Exception("Flood control exceeded. Retry in 221 seconds")
+        )
+        assert _is_telegram_flood_error(Exception("Too Many Requests: retry after 30"))
+        assert not _is_telegram_flood_error(
+            Exception("Can't parse entities: character '(' is reserved")
+        )
+        assert not _is_telegram_flood_error(Exception("bad markdown"))
 
     @pytest.mark.asyncio
     async def test_message_too_long_splits_into_continuations_not_silent_truncation(self):


### PR DESCRIPTION
## Summary
- Telegram finalize edits treated flood control / `RetryAfter` like a MarkdownV2 **parse** failure and fell back to plain text.
- That made final replies look unrendered after rate limits (common when streaming/progress spam trips flood control).
- Flood errors now re-raise into the existing wait/retry path; short floods retry still as MarkdownV2; plain fallback stays for real parse failures only.
- Added regression tests in `tests/gateway/test_telegram_format.py`.

## Root cause
In `TelegramAdapter.edit_message(finalize=True)`, the MarkdownV2 `edit_message_text` except-block stripped formatting on *any* error, including:
`Flood control exceeded. Retry in N seconds`

## Test plan
- [x] `pytest tests/gateway/test_telegram_format.py::TestEditMessageStreamingSafety -q`
- [x] `pytest tests/gateway/test_telegram_final_delivery.py::test_telegram_long_flood_result_keeps_retry_after -q`
- [ ] Manual: enable TG streaming, trip a short flood, confirm finalize still has bold/code (or clean flood fallback send with MarkdownV2), not stripped plain

## Notes
Operational mitigation still useful on busy bots: keep Telegram `tool_progress` / streaming quiet to avoid flooding the Bot API.