### PR TITLE
fix(tirith): add Windows support for auto-install

### DIFF
--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -29,6 +29,7 @@ import shutil
 import stat
 import subprocess
 import tarfile
+import zipfile
 import tempfile
 import threading
 import time
@@ -245,8 +246,7 @@ def _hermes_bin_dir() -> str:
 def _detect_target() -> str | None:
     """Return the Rust target triple for the current platform, or None.
 
-    Windows is intentionally unsupported — tirith does not ship a Windows
-    build. Callers should treat `None` as "this platform will never have
+    Callers should treat `None` as "this platform will never have
     tirith" and silently fall back to pattern-matching guards.
     """
     system = platform.system()
@@ -257,6 +257,8 @@ def _detect_target() -> str | None:
         plat = "apple-darwin"
     elif system in {"Linux", "Android"}:
         plat = "unknown-linux-gnu"
+    elif system == "Windows":
+        plat = "pc-windows-msvc"
     else:
         return None
 
@@ -357,7 +359,7 @@ def _verify_checksum(archive_path: str, checksums_path: str, archive_name: str) 
 
 
 def _extract_tirith_binary(tar: tarfile.TarFile, dest_dir: str, log) -> tuple[str | None, str]:
-    """Extract the tirith binary from a release archive into dest_dir."""
+    """Extract the tirith binary from a tar.gz release archive into dest_dir."""
     for member in tar.getmembers():
         if member.name == "tirith" or member.name.endswith("/tirith"):
             if ".." in member.name:
@@ -382,6 +384,29 @@ def _extract_tirith_binary(tar: tarfile.TarFile, dest_dir: str, log) -> tuple[st
     return None, "binary_not_in_archive"
 
 
+def _extract_tirith_binary_zip(zip_path: str, dest_dir: str, log) -> tuple[str | None, str]:
+    """Extract the tirith binary from a .zip release archive into dest_dir."""
+    binary_name = "tirith.exe" if platform.system() == "Windows" else "tirith"
+    try:
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            for member in zf.namelist():
+                basename = os.path.basename(member)
+                if basename == binary_name or basename == "tirith":
+                    if ".." in member:
+                        continue
+                    dest_path = os.path.join(dest_dir, binary_name)
+                    with zf.open(member) as src_file:
+                        with open(dest_path, "wb") as dst_file:
+                            dst_file.write(src_file.read())
+                    return dest_path, ""
+    except zipfile.BadZipFile as exc:
+        log("tirith archive is not a valid zip file: %s", exc)
+        return None, "binary_extract_failed"
+
+    log("tirith binary not found in archive")
+    return None, "binary_not_in_archive"
+
+
 def _install_tirith(*, log_failures: bool = True) -> tuple[str | None, str]:
     """Download and install tirith to $HERMES_HOME/bin/tirith.
 
@@ -398,7 +423,9 @@ def _install_tirith(*, log_failures: bool = True) -> tuple[str | None, str]:
                      platform.system(), platform.machine())
         return None, "unsupported_platform"
 
-    archive_name = f"tirith-{target}.tar.gz"
+    is_windows = platform.system() == "Windows"
+    ext = ".zip" if is_windows else ".tar.gz"
+    archive_name = f"tirith-{target}{ext}"
     base_url = f"https://github.com/{_REPO}/releases/latest/download"
 
     try:
@@ -453,12 +480,17 @@ def _install_tirith(*, log_failures: bool = True) -> tuple[str | None, str]:
         if not _verify_checksum(archive_path, checksums_path, archive_name):
             return None, "checksum_failed"
 
-        with tarfile.open(archive_path, "r:gz") as tar:
-            src, reason = _extract_tirith_binary(tar, tmpdir, log)
-            if src is None:
-                return None, reason
+        if is_windows:
+            src, reason = _extract_tirith_binary_zip(archive_path, tmpdir, log)
+        else:
+            with tarfile.open(archive_path, "r:gz") as tar:
+                src, reason = _extract_tirith_binary(tar, tmpdir, log)
 
-        dest = os.path.join(_hermes_bin_dir(), "tirith")
+        if src is None:
+            return None, reason
+
+        dest_name = "tirith.exe" if is_windows else "tirith"
+        dest = os.path.join(_hermes_bin_dir(), dest_name)
         try:
             shutil.move(src, dest)
         except OSError:
@@ -541,14 +573,15 @@ def _resolve_tirith_path(configured_path: str) -> str:
     # Default "tirith" — always re-run cheap local checks so a manual
     # install is picked up even after a previous network failure (P2 fix:
     # long-lived gateway/CLI recovers without restart).
-    found = shutil.which("tirith")
+    _bin_name = "tirith.exe" if platform.system() == "Windows" else "tirith"
+    found = shutil.which(_bin_name) or shutil.which("tirith")
     if found:
         _resolved_path = found
         _install_failure_reason = ""
         _clear_install_failed()
         return found
 
-    hermes_bin = os.path.join(_hermes_bin_dir(), "tirith")
+    hermes_bin = os.path.join(_hermes_bin_dir(), _bin_name)
     if os.path.isfile(hermes_bin) and os.access(hermes_bin, os.X_OK):
         _resolved_path = hermes_bin
         _install_failure_reason = ""
@@ -606,13 +639,14 @@ def _background_install(*, log_failures: bool = True):
             return
 
         # Re-check local paths (may have been installed by another process)
-        found = shutil.which("tirith")
+        _bin_name = "tirith.exe" if platform.system() == "Windows" else "tirith"
+        found = shutil.which(_bin_name) or shutil.which("tirith")
         if found:
             _resolved_path = found
             _install_failure_reason = ""
             return
 
-        hermes_bin = os.path.join(_hermes_bin_dir(), "tirith")
+        hermes_bin = os.path.join(_hermes_bin_dir(), _bin_name)
         if os.path.isfile(hermes_bin) and os.access(hermes_bin, os.X_OK):
             _resolved_path = hermes_bin
             _install_failure_reason = ""
@@ -675,14 +709,15 @@ def ensure_installed(*, log_failures: bool = True):
         return None
 
     # Default "tirith" — quick local checks first (no network)
-    found = shutil.which("tirith")
+    _bin_name = "tirith.exe" if platform.system() == "Windows" else "tirith"
+    found = shutil.which(_bin_name) or shutil.which("tirith")
     if found:
         _resolved_path = found
         _install_failure_reason = ""
         _clear_install_failed()
         return found
 
-    hermes_bin = os.path.join(_hermes_bin_dir(), "tirith")
+    hermes_bin = os.path.join(_hermes_bin_dir(), _bin_name)
     if os.path.isfile(hermes_bin) and os.access(hermes_bin, os.X_OK):
         _resolved_path = hermes_bin
         _install_failure_reason = ""


### PR DESCRIPTION
## What
Adds Windows platform detection to `tirith_security.py::_detect_target()` so the Tirith binary auto-installs on Windows.

## Why
Tirith v0.3.3 ([June 19, 2026](https://github.com/sheeki03/tirith/releases/tag/v0.3.3)) ships a Windows binary (`tirith-x86_64-pc-windows-msvc.zip`). The Hermes wrapper still returns `None` for Windows, silently disabling the security scanner on all Windows installations.

This means Windows users have **zero content-level injection protection** — commands and file contents are not scanned for threats like homograph URLs, pipe-to-interpreter, or prompt injection patterns.

## Why this PR exists (history of previous attempts)

This is the 5th attempt to fix #26044. Previous attempts failed to stick:

| PR | Author | Date | What happened |
|----|--------|------|---------------|
| [#23050](https://github.com/NousResearch/hermes-agent/pull/23050) | @fatinghenji | May 10 | Shows as MERGED, but the merge commit (`ae4b09ce`) contains unrelated code (plugin API auth tests). The tirith Windows fix is **not in the current codebase**. Likely reverted during a force-push or larger revert. |
| [#26069](https://github.com/NousResearch/hermes-agent/pull/26069) | @spranab | May 15 | Closed as duplicate of #23050 |
| [#26132](https://github.com/NousResearch/hermes-agent/pull/26132) | @ruguoba | May 15 | Closed as duplicate of #23050 |
| [#26068](https://github.com/NousResearch/hermes-agent/pull/26068) | @LeonSGP43 | May 15 | Still open — includes test coverage |

Meanwhile, [#26618](https://github.com/NousResearch/hermes-agent/pull/26618) and [#26718](https://github.com/NousResearch/hermes-agent/pull/26718) (both merged by @teknium1) **silence the warning messages** on Windows — suppressing the symptom without fixing the underlying installation.

On June 23, a comment on #26044 noted that Tirith v0.3.3 ships a Windows binary — no maintainer response.

## Changes
- `_detect_target()`: return `"x86_64-pc-windows-msvc"` when `platform.system() == "Windows"`
- New `_extract_tirith_binary_zip()`: handles `.zip` archive format (Windows releases ship as `.zip`, not `.tar.gz`)
- `_install_tirith()`: switches between `.zip`/`.tar.gz` and `tirith.exe`/`tirith` based on platform
- `_background_install()` and `ensure_installed()`: use platform-aware binary name for PATH and hermes_bin checks

## Related
- Closes #26044
- Tirith v0.3.3 release: https://github.com/sheeki03/tirith/releases/tag/v0.3.3