### PR TITLE
fix(kimi-coding): pass "max" reasoning_effort through for Kimi K3

### DIFF
--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -53,9 +53,7 @@ class KimiProfile(ProviderProfile):
             base_url=effective_base or None,
             timeout=timeout,
         )
-        if models is None or confirmed_coding_endpoint:
-            return models
-        return [model for model in models if model.strip().lower() != "k3"]
+        return models
 
     def build_api_kwargs_extras(
         self, *, reasoning_config: dict | None = None, **context
@@ -86,8 +84,10 @@ class KimiProfile(ProviderProfile):
 
         # Enabled: prefer an explicit effort; only fall back to extra_body
         # thinking when no recognized effort is requested.
+        # Kimi K3 accepts low|high|max (default: max; K3 always thinks), so
+        # pass "max" through instead of dropping it to the thinking toggle.
         effort = (reasoning_config.get("effort") or "").strip().lower()
-        if effort in {"low", "medium", "high"}:
+        if effort in {"low", "medium", "high", "max"}:
             top_level["reasoning_effort"] = effort
         else:
             extra_body["thinking"] = {"type": "enabled"}

--- a/tests/plugins/model_providers/test_kimi_profile.py
+++ b/tests/plugins/model_providers/test_kimi_profile.py
@@ -45,7 +45,7 @@ class TestKimiReasoningWireShape:
         assert extra_body == {"thinking": {"type": "enabled"}}
         assert top_level == {}
 
-    @pytest.mark.parametrize("effort", ["low", "medium", "high"])
+    @pytest.mark.parametrize("effort", ["low", "medium", "high", "max"])
     def test_explicit_effort_sends_effort_only(self, kimi_profile, effort):
         extra_body, top_level = kimi_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort}
@@ -60,10 +60,11 @@ class TestKimiReasoningWireShape:
         assert extra_body == {"thinking": {"type": "enabled"}}
         assert top_level == {}
 
-    @pytest.mark.parametrize("effort", ["", "garbage", "xhigh", "max"])
+    @pytest.mark.parametrize("effort", ["", "garbage", "xhigh", "ultra"])
     def test_unrecognized_effort_falls_back_to_thinking(self, kimi_profile, effort):
-        """Unknown/strong efforts aren't in Moonshot's low|medium|high set, so
-        we drop to the thinking toggle rather than sending an invalid effort."""
+        """Unknown/strong efforts outside Moonshot's set drop to the thinking
+        toggle rather than sending an invalid effort. K3's "max" is recognized
+        and passed through (covered above); xhigh/ultra are not."""
         extra_body, top_level = kimi_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort}
         )
@@ -120,7 +121,7 @@ class TestKimiModelDiscovery:
                 base_url="https://[api.kimi.com/coding",
             )
 
-        assert models == ["kimi-k2.6"]
+        assert models == ["k3", "kimi-k2.6"]
 
 
 class TestKimiFullKwargsIntegration:


### PR DESCRIPTION
## Problem

Kimi K3's API accepts `reasoning_effort` values `low`, `high`, and `max`, with `max` as the default (K3 always has thinking enabled). However, the `kimi-coding` provider profile whitelisted only `{low, medium, high}` as explicit effort values. When a user selected `/reasoning max` (or `xhigh` / `ultra`), the profile silently downgraded to the `extra_body.thinking` toggle instead of passing `reasoning_effort: "max"` through to the wire.

Additionally, `fetch_models()` filtered `k3` out of model discovery results. That filter predates K3 being a valid served model and now hides it from the `/model` picker on the Moonshot endpoints.

## Fix

- Added `"max"` to the recognized effort set in `plugins/model-providers/kimi-coding/__init__.py`, so it is sent as top-level `reasoning_effort` instead of falling back to `extra_body.thinking`.
- Removed the stale `k3` exclusion from `fetch_models()`.
- Updated `tests/plugins/model_providers/test_kimi_profile.py`: parametrized the pass-through test with `"max"`, moved `xhigh`/`ultra` (still unrecognized) into the fallback test, and asserted K3 survives model discovery.

## Test plan

```bash
uv run pytest -o addopts='' tests/plugins/model_providers/test_kimi_profile.py -q
# 21 passed

uv run pytest -o addopts='' tests/plugins/model_providers/ tests/providers/test_profile_wiring.py -q
# 242 passed

uv run --extra dev pytest -o addopts='' tests/run_agent/test_run_agent.py -q -k "kimi or moonshot"
# 10 passed
```

## Related

- Kimi K3 docs: thinking effort is configured with the top-level `reasoning_effort` request field and supports `low`, `high`, and `max` (default `max`).
