### PR TITLE
fix(tui_gateway): expose is_running in session.resume response

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1820,6 +1820,18 @@ def _(rid, params: dict) -> dict:
         _init_session(sid, target, agent, history, cols=int(params.get("cols", 80)))
     except Exception as e:
         return _err(rid, 5000, f"resume failed: {e}")
+    # Check if the original session still has a turn running.
+    # session.resume creates a new gateway session with running=False, but the
+    # original session may still be executing a long tool call or generating
+    # text. Expose this so clients (mobile apps, dashboard sidebar) can
+    # restore busy/streaming UI state correctly after a reconnection.
+    is_running = any(
+        s.get("running") and s.get("session_key") == target
+        for s in _sessions.values()
+        if s is not _sessions.get(sid)
+    )
+    info = _session_info(agent)
+    info["is_running"] = is_running
     return _ok(
         rid,
         {
@@ -1827,7 +1839,7 @@ def _(rid, params: dict) -> dict:
             "resumed": target,
             "message_count": len(messages),
             "messages": messages,
-            "info": _session_info(agent),
+            "info": info,
         },
     )
 


### PR DESCRIPTION
## Problem

When a client reconnects after a WebSocket drop (common on iOS, which kills background connections), it calls `session.resume` to restore the conversation. But `session.resume` creates a **new gateway session** with `running: False` — it has no knowledge of whether the original session still has an active turn executing.

This means mobile clients and the desktop sidebar cannot determine whether to show a busy/streaming indicator after reconnection. They resort to fragile heuristics (checking last message content, waiting for stream deltas with timeouts) that fail when:
- The turn is mid-tool-call (no stream deltas for seconds/minutes)
- The turn completed server-side while disconnected (stale busy state)

## Fix

Before returning the `session.resume` response, check if any other session in `_sessions` shares the same `session_key` (stored session ID) and has `running=True`. Add this as `is_running` in the response `info` dict.

```python
is_running = any(
    s.get("running") and s.get("session_key") == target
    for s in _sessions.values()
    if s is not _sessions.get(sid)
)
info["is_running"] = is_running
```

Clients can use this field to authoritatively restore busy state. Older clients that don't read the field are unaffected.

## Testing

- Verified `_sessions` dict structure: `running` and `session_key` are set by `_init_session` and toggled by `prompt.submit`/thread completion
- `py_compile` passes
- The `is_running` check uses the same pattern as existing session lookups elsewhere in the codebase