### PR TITLE
fix(terminal): resolve shell init from effective home

### DIFF
--- a/tests/tools/test_local_shell_init.py
+++ b/tests/tools/test_local_shell_init.py
@@ -19,6 +19,26 @@ from tools.environments.local import (
 
 
 class TestResolveShellInitFiles:
+    def test_uses_effective_subprocess_home_instead_of_process_home(
+        self, tmp_path, monkeypatch
+    ):
+        process_home = tmp_path / "process-home"
+        subprocess_home = tmp_path / "subprocess-home"
+        process_home.mkdir()
+        subprocess_home.mkdir()
+        (process_home / ".profile").write_text("export WRONG_PROFILE=1\n")
+        expected = subprocess_home / ".profile"
+        expected.write_text("export EXPECTED_PROFILE=1\n")
+        monkeypatch.setenv("HOME", str(process_home))
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_init_config",
+            return_value=([], True),
+        ):
+            resolved = _resolve_shell_init_files({"HOME": str(subprocess_home)})
+
+        assert resolved == [str(expected)]
+
     def test_auto_sources_bashrc_when_present(self, tmp_path, monkeypatch):
         bashrc = tmp_path / ".bashrc"
         bashrc.write_text('export MARKER=seen\n')
@@ -255,6 +275,51 @@ class TestSnapshotEndToEnd:
         output = result.get("output", "")
         assert "PROBE=probe-ok" in output
         assert "/opt/shell-init-probe/bin" in output
+
+    def test_snapshot_sources_effective_profile_home_and_preserves_run_identity(
+        self, tmp_path, monkeypatch
+    ):
+        outer_home = tmp_path / "outer-home"
+        hermes_home = tmp_path / "profile"
+        profile_home = hermes_home / "home"
+        outer_home.mkdir()
+        profile_home.mkdir(parents=True)
+        (outer_home / ".profile").write_text(
+            "export WRONG_OUTER_PROFILE=1\n"
+            "export PAPERCLIP_API_KEY=wrong-parent-key\n"
+        )
+        (profile_home / ".profile").write_text(
+            "export EXPECTED_PROFILE=1\n"
+        )
+        monkeypatch.setenv("HOME", str(outer_home))
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_init_config",
+            return_value=([], True),
+        ):
+            env = LocalEnvironment(
+                cwd=str(tmp_path),
+                timeout=15,
+                env={
+                    "HOME": str(outer_home),
+                    "HERMES_HOME": str(hermes_home),
+                    "TERMINAL_HOME_MODE": "profile",
+                    "PAPERCLIP_API_KEY": "scoped-run-key",
+                },
+            )
+            try:
+                result = env.execute(
+                    'printf "EXPECTED=%s\\nWRONG=%s\\nKEY=%s\\n" '
+                    '"$EXPECTED_PROFILE" "$WRONG_OUTER_PROFILE" "$PAPERCLIP_API_KEY"'
+                )
+            finally:
+                env.cleanup()
+
+        output = result.get("output", "")
+        assert "EXPECTED=1" in output
+        assert "WRONG=" in output
+        assert "WRONG=1" not in output
+        assert "KEY=scoped-run-key" in output
 
     def test_profile_path_export_survives_bashrc_interactive_guard(
         self, tmp_path, monkeypatch

--- a/tests/tools/test_local_shell_init.py
+++ b/tests/tools/test_local_shell_init.py
@@ -357,6 +357,31 @@ class TestSnapshotEndToEnd:
         assert "WRONG=1" not in output
         assert "KEY=scoped-run-key" in output
 
+    def test_snapshot_respects_explicit_empty_home_without_outer_profile_fallback(
+        self, tmp_path, monkeypatch
+    ):
+        outer_home = tmp_path / "outer-home"
+        outer_home.mkdir()
+        (outer_home / ".profile").write_text("export WRONG_OUTER_PROFILE=1\n")
+        monkeypatch.setenv("HOME", str(outer_home))
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_init_config",
+            return_value=([], True),
+        ):
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=15, env={"HOME": ""})
+            try:
+                result = env.execute(
+                    'printf "HOME=%s\\nWRONG=%s\\n" "$HOME" "$WRONG_OUTER_PROFILE"'
+                )
+            finally:
+                env.cleanup()
+
+        output = result.get("output", "")
+        assert "HOME=\n" in output
+        assert "WRONG=\n" in output
+        assert "WRONG=1" not in output
+
     def test_profile_path_export_survives_bashrc_interactive_guard(
         self, tmp_path, monkeypatch
     ):

--- a/tests/tools/test_local_shell_init.py
+++ b/tests/tools/test_local_shell_init.py
@@ -13,6 +13,7 @@ import pytest
 
 from tools.environments.local import (
     LocalEnvironment,
+    _make_run_env,
     _prepend_shell_init,
     _resolve_shell_init_files,
 )
@@ -74,6 +75,22 @@ class TestResolveShellInitFiles:
             r"C:\effective-home\rc.sh",
             r"C:\effective-init\profile.sh",
         ]
+
+    def test_windows_mixed_case_empty_home_override_wins_real_env_merge(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        monkeypatch.setenv("HOME", r"C:\inherited-home")
+        monkeypatch.setattr(
+            "tools.environments.local._read_terminal_shell_init_config",
+            lambda: ([r"~\profile.sh"], False),
+        )
+        monkeypatch.setattr(os.path, "isfile", lambda _path: True)
+
+        effective_env = _make_run_env({"home": ""})
+
+        assert [key for key in effective_env if key.upper() == "HOME"] == ["home"]
+        assert _resolve_shell_init_files(effective_env) == []
 
     def test_auto_sources_bashrc_when_present(self, tmp_path, monkeypatch):
         bashrc = tmp_path / ".bashrc"

--- a/tests/tools/test_local_shell_init.py
+++ b/tests/tools/test_local_shell_init.py
@@ -81,6 +81,11 @@ class TestResolveShellInitFiles:
     ):
         monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
         monkeypatch.setenv("HOME", r"C:\inherited-home")
+        monkeypatch.setenv("HERMES_REAL_HOME", r"C:\inherited-home")
+        monkeypatch.setattr(
+            "hermes_constants.apply_subprocess_home_env",
+            lambda effective_env: effective_env.__setitem__("HOME", r"C:\profile-home"),
+        )
         monkeypatch.setattr(
             "tools.environments.local._read_terminal_shell_init_config",
             lambda: ([r"~\profile.sh"], False),

--- a/tests/tools/test_local_shell_init.py
+++ b/tests/tools/test_local_shell_init.py
@@ -39,6 +39,22 @@ class TestResolveShellInitFiles:
 
         assert resolved == [str(expected)]
 
+    def test_explicit_empty_effective_home_never_falls_back_to_process_home(
+        self, tmp_path, monkeypatch
+    ):
+        process_home = tmp_path / "process-home"
+        process_home.mkdir()
+        (process_home / ".profile").write_text("export WRONG_PROFILE=1\n")
+        monkeypatch.setenv("HOME", str(process_home))
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_init_config",
+            return_value=([], True),
+        ):
+            resolved = _resolve_shell_init_files({"HOME": ""})
+
+        assert resolved == []
+
     def test_windows_expansion_uses_effective_home_and_case_insensitive_env(
         self, monkeypatch
     ):

--- a/tests/tools/test_local_shell_init.py
+++ b/tests/tools/test_local_shell_init.py
@@ -39,6 +39,26 @@ class TestResolveShellInitFiles:
 
         assert resolved == [str(expected)]
 
+    def test_windows_expansion_uses_effective_home_and_case_insensitive_env(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        monkeypatch.setattr(
+            "tools.environments.local._read_terminal_shell_init_config",
+            lambda: ([r"~\rc.sh", r"%INITDIR%\profile.sh"], False),
+        )
+        monkeypatch.setattr(os.path, "isfile", lambda _path: True)
+
+        effective_env = {
+            "HOME": r"C:\effective-home",
+            "InitDir": r"C:\effective-init",
+        }
+
+        assert _resolve_shell_init_files(effective_env) == [
+            r"C:\effective-home\rc.sh",
+            r"C:\effective-init\profile.sh",
+        ]
+
     def test_auto_sources_bashrc_when_present(self, tmp_path, monkeypatch):
         bashrc = tmp_path / ".bashrc"
         bashrc.write_text('export MARKER=seen\n')

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1255,10 +1255,17 @@ def _resolve_shell_init_files(effective_env: dict[str, str] | None = None) -> li
                     lambda match: env_value(match.group(1), match.group(0)),
                     path,
                 )
-            home = env_value("HOME", "") or os.path.expanduser("~")
+            # A missing HOME may fall back to the process account, but an
+            # explicitly empty HOME belongs to the effective subprocess
+            # environment and must not source the process user's profile.
+            home = env_value("HOME", os.path.expanduser("~"))
             if path == "~":
+                if not home:
+                    continue
                 path = home
             elif path.startswith("~/") or (_IS_WINDOWS and path.startswith("~\\")):
+                if not home:
+                    continue
                 path = (ntpath if _IS_WINDOWS else os.path).join(home, path[2:])
             else:
                 path = os.path.expanduser(path)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1132,7 +1132,20 @@ def _make_run_env(env: dict) -> dict:
     except Exception:
         _is_passthrough = lambda _: False  # noqa: E731
 
-    merged = dict(os.environ | env)
+    if _IS_WINDOWS:
+        # Python mappings are case-sensitive even though the Windows process
+        # environment is not. Apply caller overrides with Windows semantics so
+        # `home=""` replaces inherited `HOME` instead of creating two keys whose
+        # winner depends on the later subprocess implementation.
+        merged = dict(os.environ)
+        for key, value in env.items():
+            folded_key = key.upper()
+            for existing_key in list(merged):
+                if existing_key.upper() == folded_key:
+                    merged.pop(existing_key)
+            merged[key] = value
+    else:
+        merged = dict(os.environ | env)
     run_env = {}
     for k, v in merged.items():
         if k.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1207,6 +1207,15 @@ def _resolve_shell_init_files(effective_env: dict[str, str] | None = None) -> li
     """
     explicit, auto_bashrc = _read_terminal_shell_init_config()
     env = os.environ if effective_env is None else effective_env
+    casefolded_env = {key.upper(): value for key, value in env.items()} if _IS_WINDOWS else {}
+
+    def env_value(key: str, fallback: str) -> str:
+        value = env.get(key)
+        if value is not None:
+            return value
+        if _IS_WINDOWS:
+            return casefolded_env.get(key.upper(), fallback)
+        return fallback
 
     candidates: list[str] = []
     if explicit:
@@ -1234,7 +1243,7 @@ def _resolve_shell_init_files(effective_env: dict[str, str] | None = None) -> li
         try:
             path = re.sub(
                 r"\$(?:\{([^}]+)\}|([A-Za-z_][A-Za-z0-9_]*))",
-                lambda match: env.get(
+                lambda match: env_value(
                     match.group(1) or match.group(2) or "",
                     match.group(0),
                 ),
@@ -1243,14 +1252,14 @@ def _resolve_shell_init_files(effective_env: dict[str, str] | None = None) -> li
             if _IS_WINDOWS:
                 path = re.sub(
                     r"%([^%]+)%",
-                    lambda match: env.get(match.group(1), match.group(0)),
+                    lambda match: env_value(match.group(1), match.group(0)),
                     path,
                 )
-            home = env.get("HOME") or os.path.expanduser("~")
+            home = env_value("HOME", "") or os.path.expanduser("~")
             if path == "~":
                 path = home
-            elif path.startswith("~/"):
-                path = os.path.join(home, path[2:])
+            elif path.startswith("~/") or (_IS_WINDOWS and path.startswith("~\\")):
+                path = (ntpath if _IS_WINDOWS else os.path).join(home, path[2:])
             else:
                 path = os.path.expanduser(path)
         except Exception:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1132,6 +1132,16 @@ def _make_run_env(env: dict) -> dict:
     except Exception:
         _is_passthrough = lambda _: False  # noqa: E731
 
+    explicit_home = next(
+        (
+            (key, value)
+            for key, value in env.items()
+            if value == ""
+            and (key == "HOME" or (_IS_WINDOWS and key.upper() == "HOME"))
+        ),
+        None,
+    )
+
     if _IS_WINDOWS:
         # Python mappings are case-sensitive even though the Windows process
         # environment is not. Apply caller overrides with Windows semantics so
@@ -1176,6 +1186,14 @@ def _make_run_env(env: dict) -> dict:
 
     from hermes_constants import apply_subprocess_home_env
     apply_subprocess_home_env(run_env)
+    if explicit_home is not None:
+        home_key, home_value = explicit_home
+        for existing_key in list(run_env):
+            if existing_key == "HOME" or (
+                _IS_WINDOWS and existing_key.upper() == "HOME"
+            ):
+                run_env.pop(existing_key)
+        run_env[home_key] = home_value
 
     # Bridge ContextVar-based session vars into the subprocess env (with the
     # cross-session leak guard — strips _UNSET vars when a concurrent host is

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1197,7 +1197,7 @@ def _read_terminal_shell_init_config() -> tuple[list[str], bool]:
         return [], True
 
 
-def _resolve_shell_init_files() -> list[str]:
+def _resolve_shell_init_files(effective_env: dict[str, str] | None = None) -> list[str]:
     """Resolve the list of files to source before the login-shell snapshot.
 
     Expands ``~`` and ``${VAR}`` references and drops anything that doesn't
@@ -1206,6 +1206,7 @@ def _resolve_shell_init_files() -> list[str]:
     an explicit list — once they have, Hermes trusts them.
     """
     explicit, auto_bashrc = _read_terminal_shell_init_config()
+    env = os.environ if effective_env is None else effective_env
 
     candidates: list[str] = []
     if explicit:
@@ -1231,7 +1232,27 @@ def _resolve_shell_init_files() -> list[str]:
     resolved: list[str] = []
     for raw in candidates:
         try:
-            path = os.path.expandvars(os.path.expanduser(raw))
+            path = re.sub(
+                r"\$(?:\{([^}]+)\}|([A-Za-z_][A-Za-z0-9_]*))",
+                lambda match: env.get(
+                    match.group(1) or match.group(2) or "",
+                    match.group(0),
+                ),
+                raw,
+            )
+            if _IS_WINDOWS:
+                path = re.sub(
+                    r"%([^%]+)%",
+                    lambda match: env.get(match.group(1), match.group(0)),
+                    path,
+                )
+            home = env.get("HOME") or os.path.expanduser("~")
+            if path == "~":
+                path = home
+            elif path.startswith("~/"):
+                path = os.path.join(home, path[2:])
+            else:
+                path = os.path.expanduser(path)
         except Exception:
             continue
         if path and os.path.isfile(path):
@@ -1334,6 +1355,7 @@ class LocalEnvironment(BaseEnvironment):
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         bash = _find_bash()
+        run_env = _make_run_env(self.env)
         # For login-shell invocations (used by init_session to build the
         # environment snapshot), prepend sources for the user's bashrc /
         # custom init files so tools registered outside bash_profile
@@ -1341,11 +1363,10 @@ class LocalEnvironment(BaseEnvironment):
         # Non-login invocations are already sourcing the snapshot and
         # don't need this.
         if login:
-            init_files = _resolve_shell_init_files()
+            init_files = _resolve_shell_init_files(run_env)
             if init_files:
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
-        run_env = _make_run_env(self.env)
 
         # Recover when the cwd has been deleted out from under us — usually by
         # a previous tool call that ran ``rm -rf`` on its own working dir


### PR DESCRIPTION
## What does this PR do?

Hermes builds the login-shell snapshot from an effective subprocess environment, but shell init file discovery previously expanded `~` and `${VAR}` from the parent Python process environment. In profile-isolated runs those homes can differ: the child shell uses the selected profile's `HOME` while Hermes sources `.profile` from the outer process home.

This change resolves shell init files from the same effective environment passed to bash. That prevents an outer profile from mutating the first terminal invocation and preserves run-scoped environment values across snapshot creation.

## Related Issue

No public issue currently tracks this profile-isolation bug.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/local.py`: accept the effective subprocess environment when resolving shell init files; expand `$VAR`, `${VAR}`, Windows `%VAR%`, and `~` against that mapping; build `run_env` before login-shell init discovery.
- `tests/tools/test_local_shell_init.py`: verify effective `HOME` wins over process-global `HOME`, including Windows `~\\`, case-insensitive `%VAR%` expansion, and an explicitly empty effective `HOME` that must not fall back to the outer process.
- `tests/tools/test_local_shell_init.py`: add end-to-end snapshot regressions proving the selected profile is sourced, the outer profile is not sourced, a fake run-scoped identity value survives the first terminal call, and an explicitly empty effective `HOME` stays empty without sourcing the outer profile.

## How to Test

1. Run `uv run --extra dev pytest tests/tools/test_local_shell_init.py -o addopts='' -q` (20 passed locally).
2. Run the focused module together with the related local environment and subprocess-home modules (94 passed locally).
3. Run `uv run --extra dev ruff check tools/environments/local.py tests/tools/test_local_shell_init.py`.
4. Set process `HOME` to an outer directory, set `HERMES_HOME` and `TERMINAL_HOME_MODE=profile` for a different profile home, then create `LocalEnvironment`; the snapshot must source only the effective profile's init files and preserve the supplied run identity.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (the focused 20-test module and the 94-test combined focused/related slice pass; the full local suite reported 35 failures across 16 modules outside this change, so CI is authoritative)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian GNU/Linux 13 container on kernel 6.8

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); Windows `~\\` and case-insensitive `%VAR%` expansion use the effective subprocess environment
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused verification:

```text
20 passed in the focused module; 94 passed across the combined focused/related slice
All checks passed!
live_first_terminal=ok profile_home=ok scoped_identity=preserved
```
