### PR TITLE
perf(agent): precompile response and skill-scan regexes

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -52,6 +52,54 @@ logger = logging.getLogger(__name__)
 _MAX_AUTH_REFRESH_ATTEMPTS = 2
 
 
+_REASONING_BLOCK_PATTERNS = (
+    re.compile(r'<think>.*?</think>', re.DOTALL | re.IGNORECASE),
+    re.compile(r'<thinking>.*?</thinking>', re.DOTALL | re.IGNORECASE),
+    re.compile(r'<reasoning>.*?</reasoning>', re.DOTALL | re.IGNORECASE),
+    re.compile(
+        r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>',
+        re.DOTALL | re.IGNORECASE,
+    ),
+    re.compile(r'<thought>.*?</thought>', re.DOTALL | re.IGNORECASE),
+)
+
+_TOOL_CALL_BLOCK_PATTERNS = (
+    re.compile(r'<tool_call\b[^>]*>.*?</tool_call>', re.DOTALL | re.IGNORECASE),
+    re.compile(r'<tool_calls\b[^>]*>.*?</tool_calls>', re.DOTALL | re.IGNORECASE),
+    re.compile(r'<tool_result\b[^>]*>.*?</tool_result>', re.DOTALL | re.IGNORECASE),
+    re.compile(
+        r'<function_call\b[^>]*>.*?</function_call>',
+        re.DOTALL | re.IGNORECASE,
+    ),
+    re.compile(
+        r'<function_calls\b[^>]*>.*?</function_calls>',
+        re.DOTALL | re.IGNORECASE,
+    ),
+)
+
+_NAMED_FUNCTION_BLOCK_PATTERN = re.compile(
+    r'(?:(?<=^)|(?<=[\n\r.!?:]))[ \t]*'
+    r'<function\b[^>]*\bname\s*=[^>]*>'
+    r'(?:(?:(?!</function>).)*)</function>',
+    re.DOTALL | re.IGNORECASE,
+)
+
+_UNTERMINATED_REASONING_BLOCK_PATTERN = re.compile(
+    r'(?:^|\n)[ \t]*<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\b[^>]*>.*$',
+    re.DOTALL | re.IGNORECASE,
+)
+
+_ORPHAN_REASONING_TAG_PATTERN = re.compile(
+    r'</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>\s*',
+    re.IGNORECASE,
+)
+
+_STRAY_TOOL_CALL_CLOSER_PATTERN = re.compile(
+    r'</(?:tool_call|tool_calls|tool_result|function_call|function_calls|function)>\s*',
+    re.IGNORECASE,
+)
+
+
 def _ra():
     """Lazy ``run_agent`` reference for test-patch routing."""
     import run_agent
@@ -826,62 +874,31 @@ def strip_think_blocks(agent, content: str) -> str:
     # 1. Closed tag pairs — case-insensitive for all variants so
     #    mixed-case tags (<THINK>, <Thinking>) don't slip through to
     #    the unterminated-tag pass and take trailing content with them.
-    content = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<thinking>.*?</thinking>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<reasoning>.*?</reasoning>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<thought>.*?</thought>', '', content, flags=re.DOTALL | re.IGNORECASE)
+    for _pattern in _REASONING_BLOCK_PATTERNS:
+        content = _pattern.sub('', content)
     # 1b. Tool-call XML blocks (openclaw/openclaw#67318). Handle the
     #     generic tag names first — they have no attribute gating since
     #     a literal <tool_call> in prose is already vanishingly rare.
-    for _tc_name in ("tool_call", "tool_calls", "tool_result",
-                      "function_call", "function_calls"):
-        content = re.sub(
-            rf'<{_tc_name}\b[^>]*>.*?</{_tc_name}>',
-            '',
-            content,
-            flags=re.DOTALL | re.IGNORECASE,
-        )
+    for _pattern in _TOOL_CALL_BLOCK_PATTERNS:
+        content = _pattern.sub('', content)
     # 1c. <function name="...">...</function> — Gemma-style standalone
     #     tool call. Only strip when the tag sits at a block boundary
     #     (start of text, after a newline, or after sentence-ending
     #     punctuation) AND carries a name="..." attribute. This keeps
     #     prose mentions like "Use <function> to declare" safe.
-    content = re.sub(
-        r'(?:(?<=^)|(?<=[\n\r.!?:]))[ \t]*'
-        r'<function\b[^>]*\bname\s*=[^>]*>'
-        r'(?:(?:(?!</function>).)*)</function>',
-        '',
-        content,
-        flags=re.DOTALL | re.IGNORECASE,
-    )
+    content = _NAMED_FUNCTION_BLOCK_PATTERN.sub('', content)
     # 2. Unterminated reasoning block — open tag at a block boundary
     #    (start of text, or after a newline) with no matching close.
     #    Strip from the tag to end of string.  Fixes #8878 / #9568
     #    (MiniMax M2.7 leaking raw reasoning into assistant content).
-    content = re.sub(
-        r'(?:^|\n)[ \t]*<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\b[^>]*>.*$',
-        '',
-        content,
-        flags=re.DOTALL | re.IGNORECASE,
-    )
+    content = _UNTERMINATED_REASONING_BLOCK_PATTERN.sub('', content)
     # 3. Stray orphan open/close tags that slipped through.
-    content = re.sub(
-        r'</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>\s*',
-        '',
-        content,
-        flags=re.IGNORECASE,
-    )
+    content = _ORPHAN_REASONING_TAG_PATTERN.sub('', content)
     # 3b. Stray tool-call closers. (We do NOT strip bare <function> or
     #     unterminated <function name="..."> because a truncated tail
     #     during streaming may still be valuable to the user; matches
     #     OpenClaw's intentional asymmetry.)
-    content = re.sub(
-        r'</(?:tool_call|tool_calls|tool_result|function_call|function_calls|function)>\s*',
-        '',
-        content,
-        flags=re.IGNORECASE,
-    )
+    content = _STRAY_TOOL_CALL_CLOSER_PATTERN.sub('', content)
     return content
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -418,6 +418,25 @@ class TestStripThinkBlocks:
 
 
 
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            (
+                "before <tool_call>{x}</function_call> after",
+                "before <tool_call>{x}after",
+            ),
+            (
+                "before <function_calls>{x}</tool_calls> after",
+                "before <function_calls>{x}after",
+            ),
+        ],
+    )
+    def test_mismatched_generic_tool_tags_preserve_opener_and_payload(
+        self, agent, text, expected
+    ):
+        assert agent._strip_think_blocks(text) == expected
+
+
 class TestExtractReasoning:
     def test_reasoning_field(self, agent):
         msg = _mock_assistant_msg(reasoning="thinking hard")
@@ -5712,5 +5731,4 @@ class TestMemoryContextSanitization:
         assert "memory-context" not in result.lower()
         assert "stale observation" not in result
         assert "how is the honcho working" in result
-
 

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -520,6 +520,11 @@ THREAT_PATTERNS = [
      "instructs agent to send data to a URL"),
 ]
 
+_COMPILED_THREAT_PATTERNS = [
+    (re.compile(pattern, re.IGNORECASE), pid, severity, category, description)
+    for pattern, pid, severity, category, description in THREAT_PATTERNS
+]
+
 # Structural limits for skill directories
 MAX_FILE_COUNT = 50       # skills shouldn't have 50+ files
 MAX_TOTAL_SIZE_KB = 1024  # 1MB total is suspicious for a skill
@@ -591,11 +596,11 @@ def scan_file(file_path: Path, rel_path: str = "") -> List[Finding]:
     seen = set()  # (pattern_id, line_number) for deduplication
 
     # Regex pattern matching
-    for pattern, pid, severity, category, description in THREAT_PATTERNS:
+    for pattern, pid, severity, category, description in _COMPILED_THREAT_PATTERNS:
         for i, line in enumerate(lines, start=1):
             if (pid, i) in seen:
                 continue
-            if re.search(pattern, line, re.IGNORECASE):
+            if pattern.search(line):
                 seen.add((pid, i))
                 matched_text = line.strip()
                 if len(matched_text) > 120:


### PR DESCRIPTION
## What does this PR do?

Precompiles two sets of hot-path regular expressions without changing their matching behavior:

- `strip_think_blocks()` now reuses module-level compiled response-scrubbing patterns.
- Skills Guard now compiles its 121 threat patterns once rather than dispatching string patterns through `re.search()` for every scanned line.
- Generic tool-call tags remain separate paired expressions, preserving the existing requirement that opener and closer tags match. Regression tests cover mismatched tags and existing stray-closer cleanup.

This salvages the still-valid regex-precompilation subset of #32713 by @ErnestHysa. The gateway watcher hunks are intentionally excluded because that work was superseded by the safe detached-batch implementation associated with #32708; #32712 is a duplicate of #32713.

## Related Issue

Part of #33208

Source and attribution: #32713 by @ErnestHysa.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added module-level compiled response scrubber patterns in `agent/agent_runtime_helpers.py`.
- Added compiled threat-pattern reuse in `tools/skills_guard.py`.
- Added mismatched generic tool-call tag regressions in `tests/run_agent/test_run_agent.py`.

## Root Cause / Invariant

Both call sites repeatedly supplied unchanged regex strings to Python's regex dispatcher in nested hot paths. The change makes compilation explicit and one-time while retaining pattern order, flags, replacement behavior, and same-tag opener/closer pairing.

## How to Test

1. Run `scripts/run_tests.sh tests/run_agent/test_run_agent.py tests/tools/test_skills_guard.py`.
2. Run `scripts/run_tests.sh`.
3. Exercise mismatched generic tags such as `<tool>payload</function>` and confirm the payload remains while matching pairs are stripped.

## Validation

- `scripts/run_tests.sh`: 44,672 passed across 2,180 files, 0 failed (Python 3.13.14, Linux).
- Touched test files: 521 passed.
- Focused post-base validation: 80 response-scrubber tests and 31 Skills Guard tests passed.
- `git diff --check`: clean.
- `git merge-tree --write-tree origin/main HEAD`: clean against `origin/main` at `15dc65eeda397a5d4d35edd6779141eeb8139944`.
- Benchmark medians: response scrubber 1.042018s → 0.345333s (3.017x); Skills Guard 0.596s → 0.175s.
- CodeRabbit CLI was attempted against the final committed diff and retried after its stated cooldown; the free review limit remained unavailable, so no fresh CodeRabbit verdict was produced.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, Python 3.13.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior and public interfaces are unchanged
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A; this is an internal, behavior-preserving performance change.

## Agent Disclosure

- Created by: GPT-5.6-sol-xhigh in Codex
- Human looked at and manually signed the commit
