### PR TITLE
fix(desktop): restore queue-on-plain-Enter when composer is busy

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -155,14 +155,7 @@ export function useComposerSubmit({
         triggerHaptic('submit')
         clearDraft()
         dispatchSubmit(text)
-      } else if (!compacting && !attachments.length && text.trim()) {
-        // Cursor-style stop-and-correct: interrupt the live turn and redirect
-        // it with this text. redirect() preserves the shown reasoning/work; if
-        // the turn already ended, steerDraft re-queues so nothing is lost.
-        steerDraft()
       } else if (payloadPresent) {
-        // Attachments can't ride a redirect (no tool-result image carriage) —
-        // queue the whole payload for the next turn.
         queueCurrentDraft()
       } else {
         // Stop button (the only way to reach here while busy with an empty

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -230,18 +230,12 @@ export function ChatBar({
   const hasComposerPayload = hasText || attachments.length > 0
   const canSubmit = busy || hasComposerPayload
 
+  const busyAction: 'queue' | 'stop' = busy && hasComposerPayload ? 'queue' : 'stop'
+
   // Steer only makes sense mid-turn, text-only (the gateway can't carry images
   // into a tool result) and never for a slash command (those execute inline).
+  // Still computed for Cmd+Enter steering in the key handler.
   const canSteer = busy && !compacting && !!onSteer && attachments.length === 0 && isSteerableText
-
-  // While busy: text redirects the live turn (Cursor-style stop-and-correct),
-  // attachments queue for the next turn, an empty composer stops.
-  const busyAction: 'steer' | 'queue' | 'stop' = canSteer
-    ? 'steer'
-    : compacting || hasComposerPayload
-      ? 'queue'
-      : 'stop'
-
   // The submit engine — the orchestration seam where draft + queue meet. Owns
   // the submit decision tree, the send-with-restore primitive, and steer.
   const { queueDraft, steerDraft, submitDraft } = useComposerSubmit({


### PR DESCRIPTION
## Summary

Restores the pre-`3d40a1cbf` composer behavior: plain Enter while the agent is busy now **queues** the typed message in the drawer above the composer, instead of immediately redirecting it into the thread history. Cmd+Enter steering is unaffected.

## The regression

Commit `3d40a1cbf` ("Cursor-style stop-and-correct on the composer", July 13) changed `submitDraft()` so that when the composer is busy and the user types text and hits Enter, it calls `steerDraft()` (immediate `session.redirect` RPC + thread message) instead of `queueCurrentDraft()` (queue in the `QueuePanel` drawer above the composer). Cmd+Enter was already the dedicated steering shortcut — making plain Enter also steer broke the expected queued-message UX:

- Messages appeared immediately in the thread history as user bubbles with a running elapsed timer
- The send button showed "Steer" instead of "Queue" while busy
- The collapsible queue drawer (status stack above composer) was bypassed entirely

Commit `34d0de80e` ("route busy-input corrections through active-turn redirect") also contributed: it changed the old system-note `appendSessionTextMessage(sid, 'system', ...)` to `appendSessionTextMessage(sid, 'user', text)` — turning what used to be a compact note into a full user bubble in the thread.

## This fix

- **`use-composer-submit.ts`**: Removes the `busy && text-only` branch that called `steerDraft()`. Now `busy && payloadPresent` always calls `queueCurrentDraft()`, matching pre-`3d40a1cbf` behavior.
- **`index.tsx`**: Reverts `busyAction` to `'queue' | 'stop'` (no `'steer'` default for plain Enter). `canSteer` is still computed and wired for Cmd+Enter in the key handler.
- **`controls.tsx`**: Unchanged; its `busyAction` type accepts `'steer'` as a widened parameter.

## Test Plan

- [x] `npx tsc -p . --noEmit` — passes
- [x] `npx vitest run src/store/composer-queue.test.ts src/app/chat/composer/hooks/use-composer-queue.test.tsx src/app/session/hooks/use-prompt-actions/index.test.tsx --environment jsdom` — **93 passed** (3 files)

Fixes #69660
