### PR TITLE
fix(dashboard): improve password manager compatibility

### DIFF
--- a/hermes_cli/dashboard_auth/login_page.py
+++ b/hermes_cli/dashboard_auth/login_page.py
@@ -505,30 +505,43 @@ def _render_password_form(provider, next_path: str) -> str:
     submit handler) to POST JSON to ``/auth/password-login`` and navigate
     on success. ``next_path`` is carried in a hidden field; it has already
     been validated same-origin by the caller and is HTML-escaped here as
-    defence in depth. The provider ``name`` is emitted in a ``data-``
-    attribute (not a hidden input) so the script reads it without trusting
-    form-field ordering.
+    defence in depth. The provider's stable ``name`` supplies deterministic,
+    unique form-control IDs so password managers can recognize the same fields
+    across visits. Explicit labels keep those controls accessible.
+
+    ``method="post"`` is intentional even though JavaScript owns the JSON
+    request: if the handler does not run, the browser must not place credentials
+    in a GET URL. The provider ``name`` remains in a ``data-`` attribute rather
+    than a hidden input because the endpoint accepts JSON, not form data.
     """
     pname = html.escape(provider.name, quote=True)
     plabel = html.escape(provider.display_name)
     safe_next = html.escape(next_path, quote=True) if next_path else ""
     return (
         f'      <form class="provider-form" data-provider="{pname}" '
-        f'autocomplete="on">\n'
-        f'        <div class="form-title">Sign in with {plabel}</div>\n'
-        f'        <input type="hidden" name="next" value="{safe_next}">\n'
-        f'        <label class="field">\n'
-        f'          <span class="field-label">Username</span>\n'
-        f'          <input class="field-input" type="text" name="username" '
-        f'autocomplete="username" autocapitalize="none" '
-        f'autocorrect="off" spellcheck="false" required>\n'
-        f'        </label>\n'
-        f'        <label class="field">\n'
-        f'          <span class="field-label">Password</span>\n'
-        f'          <input class="field-input" type="password" name="password" '
-        f'autocomplete="current-password" required>\n'
-        f'        </label>\n'
-        f'        <div class="form-error" role="alert" hidden></div>\n'
+        f'id="dashboard-{pname}-login" method="post" autocomplete="on" '
+        f'aria-labelledby="dashboard-{pname}-title">\n'
+        f'        <div id="dashboard-{pname}-title" class="form-title">'
+        f'Sign in with {plabel}</div>\n'
+        f'        <input id="dashboard-{pname}-next" type="hidden" '
+        f'name="next" value="{safe_next}">\n'
+        f'        <div class="field">\n'
+        f'          <label class="field-label" for="dashboard-{pname}-username">'
+        f'Username</label>\n'
+        f'          <input id="dashboard-{pname}-username" class="field-input" '
+        f'type="text" name="username" autocomplete="username" autocapitalize="none" '
+        f'autocorrect="off" spellcheck="false" '
+        f'aria-describedby="dashboard-{pname}-error" required>\n'
+        f'        </div>\n'
+        f'        <div class="field">\n'
+        f'          <label class="field-label" for="dashboard-{pname}-password">'
+        f'Password</label>\n'
+        f'          <input id="dashboard-{pname}-password" class="field-input" '
+        f'type="password" name="password" autocomplete="current-password" '
+        f'aria-describedby="dashboard-{pname}-error" required>\n'
+        f'        </div>\n'
+        f'        <div id="dashboard-{pname}-error" class="form-error" '
+        f'role="alert" hidden></div>\n'
         f'        <button class="provider-btn" type="submit">Sign in</button>\n'
         f'      </form>'
     )

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -13,6 +13,7 @@ provider, flip ``app.state.auth_required = True``, drive a ``TestClient``.
 from __future__ import annotations
 
 import time
+from html.parser import HTMLParser
 
 import pytest
 
@@ -32,6 +33,23 @@ from hermes_cli.dashboard_auth.cookies import SESSION_AT_COOKIE, SESSION_RT_COOK
 from hermes_cli.dashboard_auth.login_page import render_login_html
 from hermes_cli.dashboard_auth.routes import _reset_password_rate_limit
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+
+class _LoginHTMLParser(HTMLParser):
+    """Collect rendered element attributes without depending on a DOM library."""
+
+    def __init__(self):
+        super().__init__()
+        self.elements: list[tuple[str, dict[str, str | None]]] = []
+
+    def handle_starttag(self, tag, attrs):
+        self.elements.append((tag, dict(attrs)))
+
+
+def _parse_login_html(markup: str) -> _LoginHTMLParser:
+    parser = _LoginHTMLParser()
+    parser.feed(markup)
+    return parser
 
 
 # ---------------------------------------------------------------------------
@@ -418,6 +436,90 @@ class TestRateLimit:
 
 
 class TestLoginPageRender:
+    def test_password_form_exposes_stable_autofill_semantics(self):
+        clear_providers()
+        register_provider(PasswordProvider())
+        try:
+            parsed = _parse_login_html(render_login_html(next_path="/sessions"))
+            forms = [attrs for tag, attrs in parsed.elements if tag == "form"]
+            assert len(forms) == 1
+            assert forms[0]["id"] == "dashboard-testpw-login"
+            assert forms[0]["method"] == "post"
+            assert forms[0]["autocomplete"] == "on"
+
+            inputs = {
+                attrs.get("name"): attrs
+                for tag, attrs in parsed.elements
+                if tag == "input"
+            }
+            assert inputs["username"]["id"] == "dashboard-testpw-username"
+            assert inputs["username"]["type"] == "text"
+            assert inputs["username"]["autocomplete"] == "username"
+            assert inputs["password"]["id"] == "dashboard-testpw-password"
+            assert inputs["password"]["type"] == "password"
+            assert inputs["password"]["autocomplete"] == "current-password"
+
+            element_ids = [
+                attrs["id"]
+                for _, attrs in parsed.elements
+                if attrs.get("id") is not None
+            ]
+            assert len(element_ids) == len(set(element_ids))
+        finally:
+            clear_providers()
+
+    def test_password_form_labels_and_error_are_programmatically_associated(self):
+        clear_providers()
+        register_provider(PasswordProvider())
+        try:
+            parsed = _parse_login_html(render_login_html())
+            attrs_by_id = {
+                attrs["id"]: attrs
+                for _, attrs in parsed.elements
+                if attrs.get("id") is not None
+            }
+            form = next(attrs for tag, attrs in parsed.elements if tag == "form")
+            assert form["aria-labelledby"] == "dashboard-testpw-title"
+            assert "dashboard-testpw-title" in attrs_by_id
+
+            labels = {
+                attrs["for"]
+                for tag, attrs in parsed.elements
+                if tag == "label"
+            }
+            assert labels == {
+                "dashboard-testpw-username",
+                "dashboard-testpw-password",
+            }
+
+            error_id = "dashboard-testpw-error"
+            assert attrs_by_id[error_id]["role"] == "alert"
+            assert attrs_by_id["dashboard-testpw-username"]["aria-describedby"] == error_id
+            assert attrs_by_id["dashboard-testpw-password"]["aria-describedby"] == error_id
+        finally:
+            clear_providers()
+
+    def test_multiple_password_forms_keep_all_ids_unique(self):
+        class OtherPasswordProvider(PasswordProvider):
+            name = "otherpw"
+            display_name = "Other Password"
+
+        clear_providers()
+        register_provider(PasswordProvider())
+        register_provider(OtherPasswordProvider())
+        try:
+            parsed = _parse_login_html(render_login_html(next_path="/sessions"))
+            element_ids = [
+                attrs["id"]
+                for _, attrs in parsed.elements
+                if attrs.get("id") is not None
+            ]
+            assert len(element_ids) == len(set(element_ids))
+            assert "dashboard-testpw-next" in element_ids
+            assert "dashboard-otherpw-next" in element_ids
+        finally:
+            clear_providers()
+
     def test_password_provider_renders_credential_form_and_script(self):
         clear_providers()
         register_provider(PasswordProvider())


### PR DESCRIPTION
## What does this PR do?

Improves dashboard username/password forms for password-manager autofill and assistive technology, following [1Password's compatible website design guidance](https://www.1password.dev/web/compatible-website-design).

Although the guide is published by 1Password, the recommendations applied here use standards-based HTML, autocomplete, and accessibility semantics that improve compatibility with password managers generally.

Each password-provider form now has stable, provider-derived IDs, explicit labels, standard `autocomplete` tokens, and accessible form/error associations. The form also declares `method="post"` so a missed JavaScript interception cannot place credentials in a GET URL. It intentionally does **not** declare a native action: `/auth/password-login` accepts JSON from the existing submit handler, not form-encoded data.

This is a focused alternative to #59900 that addresses its review feedback: it excludes the already-landed auto-SSO guard, avoids a broken native form-action contract, and does not add unrelated show-password UI.

## Related Issue

No issue exists for this narrowly scoped compatibility fix.

Related: #59900

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/dashboard_auth/login_page.py`
  - add stable, unique form and field IDs derived from the provider's stable name
  - declare `method="post"` and preserve the existing JSON submit flow
  - replace implicit wrapping labels with explicit `label[for]` associations
  - associate each form with its title and both credential fields with the existing alert region
- `tests/hermes_cli/test_dashboard_auth_password_login.py`
  - verify autofill metadata and POST semantics from rendered HTML
  - verify label, title, and error-region associations
  - verify IDs remain unique when multiple password providers are registered

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth*.py -q`.
2. Confirm the clean-environment result is `14 files, 293 tests passed, 0 failed`.
3. Render a password-provider login page and inspect the form: it should expose provider-stable IDs, `autocomplete="username"`, `autocomplete="current-password"`, explicit labels, and `method="post"`; submitting should still use the existing JSON fetch handler.

I also ran the literal `pytest tests/ -q` command in rootless Podman with Python 3.11, `_curses`, ACP, and the declared development/runtime dependency groups installed. Direct pytest terminated at 48% without a final summary on both this branch and its exact branch point (`15dc65eeda397a5d4d35edd6779141eeb8139944`), so I have left the all-tests-pass checkbox unchecked.

The repository's isolated full-suite runner did complete on both revisions. All 23 failing files on this branch also failed at the branch point; the one-test count difference was an unrelated, load-sensitive `sort` timeout that passed immediately when rerun on both revisions. The complete dashboard-auth test family passes in the runner's clean environment.

I also tested the updated rendered login flow manually with 1Password through a temporary HTTPS tunnel; autofill and submission worked as expected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: openSUSE MicroOS, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated the renderer docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — browser-native HTML semantics only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

Not applicable; this PR does not add or modify a skill.

## Screenshots / Logs

```text
=== Summary: 14 files, 293 tests passed, 0 failed (100% complete) in 2.9s (48 workers) ===
```

Two independent `codex review --base upstream/main` passes reported no actionable regressions.

## AI Disclosure

**AI Disclosure:** Code and tests were drafted and exercised with Hermes Agent using OpenAI Codex, under the contributor's direction. The agent ran the targeted dashboard-auth suite, repository linting, compilation checks, and two independent Codex review passes. AI assistance should be assumed throughout this contribution; the contributor is responsible for final review and follow-up with maintainers.
