### PR TITLE
feat(whatsapp): isolate shared-line tools by sender

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3,6 +3,7 @@ OpenAI-compatible API server platform adapter.
 
 Exposes an HTTP server with endpoints:
 - POST /v1/chat/completions        — OpenAI Chat Completions format (stateless; opt-in session continuity via X-Hermes-Session-Id header; opt-in long-term memory scoping via X-Hermes-Session-Key header)
+- POST /v1/chat/completions/restricted — same API with mandatory server-enforced enabled_toolsets
 - POST /v1/responses               — OpenAI Responses API format (stateful via previous_response_id; X-Hermes-Session-Key supported)
 - GET  /v1/responses/{response_id} — Retrieve a stored response
 - DELETE /v1/responses/{response_id} — Delete a stored response
@@ -57,6 +58,8 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
+
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None
 # (no prefix / multiplexing off → handle as the default profile).
@@ -93,6 +96,71 @@ from agent.redact import redact_sensitive_text
 from gateway.readiness import collect_runtime_readiness
 
 logger = logging.getLogger(__name__)
+
+_MAX_GATEWAY_SESSION_KEY_LEN = 256
+
+
+class _GatewaySource(BaseModel):
+    """Authenticated gateway origin carried only by restricted proxy calls."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    platform: str
+    chat_id: str
+    session_key: str
+    user_id: Optional[str] = None
+    user_id_alt: Optional[str] = None
+    thread_id: Optional[str] = None
+    message_id: Optional[str] = None
+    profile: str
+
+    @field_validator(
+        "platform",
+        "chat_id",
+        "session_key",
+        "user_id",
+        "user_id_alt",
+        "thread_id",
+        "message_id",
+        "profile",
+    )
+    @classmethod
+    def _validate_identifier(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        if not value or not value.strip():
+            raise ValueError("must not be empty")
+        if any(ord(char) < 32 or ord(char) == 127 for char in value):
+            raise ValueError("must not contain control characters")
+        return value
+
+    @field_validator("platform")
+    @classmethod
+    def _validate_platform(cls, value: str) -> str:
+        if not re.fullmatch(r"[a-z][a-z0-9_-]*", value):
+            raise ValueError("must be a canonical platform identifier")
+        try:
+            Platform(value)
+        except ValueError as exc:
+            raise ValueError("must be a registered platform") from exc
+        return value
+
+    @field_validator("session_key")
+    @classmethod
+    def _validate_session_key(cls, value: str) -> str:
+        if len(value) > _MAX_GATEWAY_SESSION_KEY_LEN:
+            raise ValueError("must not exceed 256 characters")
+        return value
+
+    @field_validator("profile")
+    @classmethod
+    def _validate_profile(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        from hermes_cli.profiles import validate_profile_name
+
+        validate_profile_name(value)
+        return value
 
 
 def _hermes_version() -> str:
@@ -1571,6 +1639,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("POST", "/api/sessions/{session_id}/chat", self._handle_session_chat),
             ("POST", "/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream),
             ("POST", "/v1/chat/completions", self._handle_chat_completions),
+            ("POST", "/v1/chat/completions/restricted", self._handle_chat_completions),
             ("POST", "/v1/responses", self._handle_responses),
             ("GET", "/v1/responses/{response_id}", self._handle_get_response),
             ("DELETE", "/v1/responses/{response_id}", self._handle_delete_response),
@@ -1609,7 +1678,7 @@ class APIServerAdapter(BasePlatformAdapter):
     # 256 chars is well above any realistic stable channel identifier
     # (e.g. ``agent:main:webui:dm:user-42``) while staying small enough
     # that the sanitized form is safe to pass into Honcho / state.db.
-    _MAX_SESSION_HEADER_LEN = 256
+    _MAX_SESSION_HEADER_LEN = _MAX_GATEWAY_SESSION_KEY_LEN
 
     def _parse_session_key_header(
         self, request: "web.Request"
@@ -1829,6 +1898,8 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        requested_toolsets: Optional[List[str]] = None,
+        gateway_source: Optional[Dict[str, str]] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1849,6 +1920,10 @@ class APIServerAdapter(BasePlatformAdapter):
         routing).  When set — and no session ``/model`` override exists for
         this session — its model/provider/api_key/base_url override the
         global defaults for this agent instance only.
+
+        ``gateway_source`` is validated origin metadata accepted only by the
+        restricted chat-completions endpoint. It changes agent/session identity,
+        never API-server toolset resolution.
         """
         from run_agent import AIAgent
         from gateway.run import (
@@ -1924,12 +1999,18 @@ class APIServerAdapter(BasePlatformAdapter):
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        if requested_toolsets is not None:
+            requested = set(requested_toolsets)
+            enabled_toolsets = [
+                toolset for toolset in enabled_toolsets if toolset in requested
+            ]
 
         max_iterations = _current_max_iterations()
 
         # Load fallback provider chain so the API server platform has the
         # same fallback behaviour as Telegram/Discord/Slack (fixes #4954).
         fallback_model = GatewayRunner._load_fallback_model()
+        source = gateway_source or {}
 
         agent = AIAgent(
             model=model,
@@ -1941,7 +2022,11 @@ class APIServerAdapter(BasePlatformAdapter):
             ephemeral_system_prompt=ephemeral_system_prompt or None,
             enabled_toolsets=enabled_toolsets,
             session_id=session_id,
-            platform="api_server",
+            platform=source.get("platform", "api_server"),
+            user_id=source.get("user_id"),
+            user_id_alt=source.get("user_id_alt"),
+            chat_id=source.get("chat_id"),
+            thread_id=source.get("thread_id"),
             stream_delta_callback=stream_delta_callback,
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
@@ -1949,7 +2034,7 @@ class APIServerAdapter(BasePlatformAdapter):
             session_db=self._ensure_session_db(),
             fallback_model=fallback_model,
             reasoning_config=reasoning_config,
-            gateway_session_key=gateway_session_key,
+            gateway_session_key=source.get("session_key", gateway_session_key),
         )
         return agent
 
@@ -2102,6 +2187,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "features": {
                 "chat_completions": True,
                 "chat_completions_streaming": True,
+                "chat_completions_enabled_toolsets": True,
                 "responses_api": True,
                 "responses_streaming": True,
                 "run_submission": True,
@@ -2130,6 +2216,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "health_detailed": {"method": "GET", "path": "/health/detailed"},
                 "models": {"method": "GET", "path": "/v1/models"},
                 "chat_completions": {"method": "POST", "path": "/v1/chat/completions"},
+                "chat_completions_restricted": {
+                    "method": "POST",
+                    "path": "/v1/chat/completions/restricted",
+                },
                 "responses": {"method": "POST", "path": "/v1/responses"},
                 "runs": {"method": "POST", "path": "/v1/runs"},
                 "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
@@ -2741,6 +2831,92 @@ class APIServerAdapter(BasePlatformAdapter):
         except (json.JSONDecodeError, Exception):
             return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
 
+        restricted = str(getattr(request, "path", "")).endswith(
+            "/v1/chat/completions/restricted"
+        )
+        if restricted and not self._api_key:
+            return web.json_response(
+                _openai_error(
+                    "The restricted endpoint requires API key authentication",
+                    code="api_key_required",
+                ),
+                status=403,
+            )
+        gateway_source = None
+        if not restricted and "gateway_source" in body:
+            return web.json_response(
+                _openai_error(
+                    "gateway_source is only accepted on the restricted endpoint",
+                    param="gateway_source",
+                ),
+                status=400,
+            )
+        if restricted:
+            if "gateway_source" not in body:
+                return web.json_response(
+                    _openai_error(
+                        "gateway_source is required on the restricted endpoint",
+                        param="gateway_source",
+                    ),
+                    status=400,
+                )
+            try:
+                gateway_source = _GatewaySource.model_validate(
+                    body["gateway_source"]
+                ).model_dump(exclude_none=True)
+            except ValidationError as exc:
+                issues = sorted(
+                    {
+                        f"{'.'.join(str(part) for part in error['loc']) or 'value'}: "
+                        f"{error['type']}"
+                        for error in exc.errors(include_input=False)
+                    }
+                )
+                return web.json_response(
+                    _openai_error(
+                        f"Invalid gateway_source ({'; '.join(issues)})",
+                        param="gateway_source",
+                    ),
+                    status=400,
+                )
+
+            source_profile = gateway_source.get("profile")
+            route_profile = (
+                str(request.match_info.get("profile") or "").strip() or None
+            )
+            scoped_profile = _api_request_profile.get()
+            if (
+                route_profile is not None and source_profile != route_profile
+            ) or (
+                scoped_profile is not None and source_profile != scoped_profile
+            ):
+                return web.json_response(
+                    _openai_error(
+                        "gateway_source.profile must match the URL profile scope",
+                        param="gateway_source.profile",
+                    ),
+                    status=400,
+                )
+            if source_profile is not None:
+                try:
+                    from hermes_cli.profiles import get_active_profile_name
+
+                    active_profile = get_active_profile_name()
+                except Exception:
+                    logger.warning(
+                        "Could not resolve the restricted request profile scope",
+                        exc_info=True,
+                    )
+                    active_profile = None
+                if source_profile != active_profile:
+                    return web.json_response(
+                        _openai_error(
+                            "gateway_source.profile does not match the active profile scope",
+                            param="gateway_source.profile",
+                        ),
+                        status=400,
+                    )
+
         messages = body.get("messages")
         if not messages or not isinstance(messages, list):
             return web.json_response(
@@ -2749,6 +2925,31 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
+
+        requested_toolsets = None
+        if "enabled_toolsets" in body:
+            raw_toolsets = body.get("enabled_toolsets")
+            if not isinstance(raw_toolsets, list) or not all(
+                isinstance(value, str) for value in raw_toolsets
+            ):
+                return web.json_response(
+                    _openai_error(
+                        "enabled_toolsets must be an array of strings",
+                        err_type="invalid_request_error",
+                    ),
+                    status=400,
+                )
+            requested_toolsets = [
+                value.strip() for value in raw_toolsets if value.strip()
+            ]
+        elif restricted:
+            return web.json_response(
+                _openai_error(
+                    "enabled_toolsets is required on the restricted endpoint",
+                    err_type="invalid_request_error",
+                ),
+                status=400,
+            )
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
@@ -2793,6 +2994,17 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        if gateway_source is not None:
+            source_session_key = gateway_source["session_key"]
+            if gateway_session_key and gateway_session_key != source_session_key:
+                return web.json_response(
+                    _openai_error(
+                        "X-Hermes-Session-Key must match gateway_source.session_key",
+                        param="gateway_source.session_key",
+                    ),
+                    status=400,
+                )
+            gateway_session_key = source_session_key
 
         # Allow caller to continue an existing session by passing X-Hermes-Session-Id.
         # When provided, history is loaded from state.db instead of from the request body.
@@ -2945,6 +3157,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
                 route=route,
+                requested_toolsets=requested_toolsets,
+                gateway_source=gateway_source,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -2965,11 +3179,24 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
                 route=route,
+                requested_toolsets=requested_toolsets,
+                gateway_source=gateway_source,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
-            fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "stream"])
+            fp = _make_request_fingerprint(
+                body,
+                keys=[
+                    "model",
+                    "messages",
+                    "tools",
+                    "tool_choice",
+                    "stream",
+                    "enabled_toolsets",
+                    "gateway_source",
+                ],
+            )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
             except Exception as e:
@@ -4709,16 +4936,15 @@ class APIServerAdapter(BasePlatformAdapter):
         chat_id: str = "",
         session_key: str = "",
         session_id: str = "",
+        gateway_source: Optional[Dict[str, str]] = None,
     ) -> list:
         """Bind session contextvars for an API-server agent run.
 
         This is the SINGLE structural chokepoint every API-server agent-entry
-        path must use to seed session context — it hardwires
-        ``platform="api_server"`` and ``async_delivery=False`` so a new route
-        physically cannot reintroduce the silent-no-op bug (#10760) by
-        forgetting to mark the channel as non-delivering. There is no
-        ``async_delivery`` parameter to get wrong; the stateless HTTP path can
-        never wake the agent after the turn ends, on ANY route.
+        path must use to seed session context. Normal API requests bind as
+        ``api_server``; restricted proxy calls bind their validated origin.
+        ``async_delivery=False`` is hardwired because every HTTP path is
+        stateless and cannot wake the agent after the turn ends.
 
         Returns reset tokens; pass them to ``clear_session_vars`` in a
         ``finally`` block (the binding is request-scoped and must not outlive
@@ -4727,11 +4953,17 @@ class APIServerAdapter(BasePlatformAdapter):
         """
         from gateway.session_context import set_session_vars
 
+        source = gateway_source or {}
+
         return set_session_vars(
-            platform="api_server",
-            chat_id=chat_id,
-            session_key=session_key,
+            platform=source.get("platform", "api_server"),
+            chat_id=source.get("chat_id", chat_id),
+            thread_id=source.get("thread_id", ""),
+            user_id=source.get("user_id", ""),
+            session_key=source.get("session_key", session_key),
             session_id=session_id,
+            message_id=source.get("message_id", ""),
+            profile=source.get("profile", ""),
             async_delivery=False,
         )
 
@@ -4748,6 +4980,8 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        requested_toolsets: Optional[List[str]] = None,
+        gateway_source: Optional[Dict[str, str]] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -4778,6 +5012,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     chat_id=session_id or "",
                     session_key=gateway_session_key or session_id or "",
                     session_id=session_id or "",
+                    gateway_source=gateway_source,
                 )
                 try:
                     agent = self._create_agent(
@@ -4789,6 +5024,8 @@ class APIServerAdapter(BasePlatformAdapter):
                         tool_complete_callback=tool_complete_callback,
                         gateway_session_key=gateway_session_key,
                         route=route,
+                        requested_toolsets=requested_toolsets,
+                        gateway_source=gateway_source,
                     )
                     if agent_ref is not None:
                         agent_ref[0] = agent

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2529,6 +2529,59 @@ def _check_unavailable_skill(command_name: str) -> str | None:
     return None
 
 
+def _whatsapp_owner_tool_gate(source, platform_key, user_config, disabled_toolsets):
+    """Optionally restrict the toolset for non-owner senders on a shared WhatsApp line.
+
+    When ``whatsapp.nonowner_disabled_toolsets`` is set (a list of tool names),
+    every sender that is NOT an owner has those tools disabled -- so a shared /
+    community WhatsApp number can answer friends and family without exposing
+    terminal / code execution / file / etc. to them. An owner is the configured
+    ``whatsapp.home_channel`` chat_id or any id in ``whatsapp.owner_users``.
+
+    No-op (returns ``disabled_toolsets`` unchanged) unless the platform is
+    WhatsApp *and* ``nonowner_disabled_toolsets`` is configured, so existing
+    deployments are unaffected. Once the feature is active it fails closed: any
+    error restricts rather than grants.
+    """
+    if platform_key != "whatsapp" or not isinstance(user_config, dict):
+        return disabled_toolsets
+    wa = user_config.get("whatsapp") or {}
+    drop = wa.get("nonowner_disabled_toolsets")
+    if not (isinstance(drop, list) and drop):
+        return disabled_toolsets  # feature disabled -> no behavior change
+
+    def _restrict():
+        base = list(disabled_toolsets or [])
+        for name in drop:
+            if name not in base:
+                base.append(name)
+        return base
+
+    try:
+        import re as _re
+
+        def _norm(value):
+            text = str(value or "").strip()
+            text = _re.sub(r":.*@", "@", text)
+            text = _re.sub(r"@.*", "", text)
+            return text.lstrip("+")
+
+        owners = set()
+        home = wa.get("home_channel") or {}
+        if isinstance(home, dict) and home.get("chat_id"):
+            owners.add(_norm(home.get("chat_id")))
+        for owner_id in (wa.get("owner_users") or []):
+            if owner_id:
+                owners.add(_norm(owner_id))
+
+        sender = getattr(source, "chat_id", None) or getattr(source, "sender_id", None) or ""
+        if sender and owners and _norm(sender) in owners:
+            return disabled_toolsets  # owner -> full toolset
+        return _restrict()
+    except Exception:
+        return _restrict()  # fail closed
+
+
 def _platform_config_key(platform: "Platform") -> str:
     """Map a Platform enum to its config.yaml key (LOCAL→"cli", rest→enum value)."""
     return "cli" if platform == Platform.LOCAL else platform.value
@@ -15113,6 +15166,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
+            disabled_toolsets = _whatsapp_owner_tool_gate(
+                source, platform_key, user_config, disabled_toolsets
+            )
 
             pr = self._provider_routing
             max_iterations = _current_max_iterations()
@@ -19410,6 +19466,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
+        disabled_toolsets = _whatsapp_owner_tool_gate(
+            source, platform_key, user_config, disabled_toolsets
+        )
 
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -40,6 +40,7 @@ import tempfile
 import threading
 import time
 import sqlite3
+from urllib.parse import quote, unquote, urlsplit
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
@@ -2529,62 +2530,125 @@ def _check_unavailable_skill(command_name: str) -> str | None:
     return None
 
 
-def _whatsapp_owner_tool_gate(source, platform_key, user_config, disabled_toolsets):
-    """Optionally restrict the toolset for non-owner senders on a shared WhatsApp line.
-
-    When ``whatsapp.nonowner_disabled_toolsets`` is set (a list of tool names),
-    every sender that is NOT an owner has those tools disabled -- so a shared /
-    community WhatsApp number can answer friends and family without exposing
-    terminal / code execution / file / etc. to them. An owner is the configured
-    ``whatsapp.home_channel`` chat_id or any id in ``whatsapp.owner_users``.
-
-    No-op (returns ``disabled_toolsets`` unchanged) unless the platform is
-    WhatsApp *and* ``nonowner_disabled_toolsets`` is configured, so existing
-    deployments are unaffected. Once the feature is active it fails closed: any
-    error restricts rather than grants.
-    """
-    if platform_key != "whatsapp" or not isinstance(user_config, dict):
-        return disabled_toolsets
-    wa = user_config.get("whatsapp") or {}
-    drop = wa.get("nonowner_disabled_toolsets")
-    if not (isinstance(drop, list) and drop):
-        return disabled_toolsets  # feature disabled -> no behavior change
-
-    def _restrict():
-        base = list(disabled_toolsets or [])
-        for name in drop:
-            if name not in base:
-                base.append(name)
-        return base
-
-    try:
-        import re as _re
-
-        def _norm(value):
-            text = str(value or "").strip()
-            text = _re.sub(r":.*@", "@", text)
-            text = _re.sub(r"@.*", "", text)
-            return text.lstrip("+")
-
-        owners = set()
-        home = wa.get("home_channel") or {}
-        if isinstance(home, dict) and home.get("chat_id"):
-            owners.add(_norm(home.get("chat_id")))
-        for owner_id in (wa.get("owner_users") or []):
-            if owner_id:
-                owners.add(_norm(owner_id))
-
-        sender = getattr(source, "chat_id", None) or getattr(source, "sender_id", None) or ""
-        if sender and owners and _norm(sender) in owners:
-            return disabled_toolsets  # owner -> full toolset
-        return _restrict()
-    except Exception:
-        return _restrict()  # fail closed
-
-
 def _platform_config_key(platform: "Platform") -> str:
     """Map a Platform enum to its config.yaml key (LOCAL→"cli", rest→enum value)."""
     return "cli" if platform == Platform.LOCAL else platform.value
+
+
+def _whatsapp_owner_tool_policy(
+    source: "SessionSource",
+    platform_key: str,
+    user_config: dict,
+    enabled_toolsets: list[str],
+) -> tuple[list[str], bool]:
+    """Limit non-owner WhatsApp senders to an explicit toolset allowlist.
+
+    ``whatsapp.nonowner_enabled_toolsets`` is opt-in. Owners are matched from
+    the configured WhatsApp ``home_channel``, ``WHATSAPP_HOME_CHANNEL``, or
+    ``whatsapp.owner_users`` using WhatsApp's phone/LID alias map. Group
+    ownership is always based on the sender, never the group chat ID.
+
+    Once configured, malformed identity/config data fails closed to no tools.
+    The boolean return value marks a non-owner restriction independently of
+    whether its list happens to equal the platform's configured toolsets.
+    """
+    if platform_key != "whatsapp" or not isinstance(user_config, dict):
+        return enabled_toolsets, False
+
+    whatsapp_config = user_config.get("whatsapp")
+    if not isinstance(whatsapp_config, dict):
+        return enabled_toolsets, False
+    if "nonowner_enabled_toolsets" not in whatsapp_config:
+        return enabled_toolsets, False
+
+    raw_nonowner_toolsets = whatsapp_config.get("nonowner_enabled_toolsets")
+    if not isinstance(raw_nonowner_toolsets, list):
+        return [], True
+    requested_nonowner_toolsets = {
+        value.strip()
+        for value in raw_nonowner_toolsets
+        if isinstance(value, str) and value.strip()
+    }
+    # This policy may only remove capabilities already enabled for WhatsApp.
+    # Preserve platform order so agent cache signatures remain deterministic.
+    nonowner_toolsets = [
+        value for value in enabled_toolsets if value in requested_nonowner_toolsets
+    ]
+
+    try:
+        configured_owners: list[str] = []
+        from agent.secret_scope import get_secret
+
+        env_home = str(get_secret("WHATSAPP_HOME_CHANNEL", "") or "").strip()
+        if env_home:
+            configured_owners.append(env_home)
+        else:
+            # Raw config keeps platform settings in one of three supported
+            # paths. Match load_gateway_config() precedence instead of unioning
+            # them: a stale lower-precedence home must never grant owner tools.
+            platform_blocks = [whatsapp_config]
+            platforms_config = user_config.get("platforms")
+            if isinstance(platforms_config, dict):
+                platform_blocks.append(platforms_config.get("whatsapp"))
+            gateway_config = user_config.get("gateway")
+            if isinstance(gateway_config, dict):
+                gateway_platforms = gateway_config.get("platforms")
+                if isinstance(gateway_platforms, dict):
+                    platform_blocks.append(gateway_platforms.get("whatsapp"))
+            for platform_block in platform_blocks:
+                if not isinstance(platform_block, dict):
+                    continue
+                if "home_channel" not in platform_block:
+                    continue
+                home_channel = platform_block.get("home_channel")
+                if not isinstance(home_channel, dict):
+                    return nonowner_toolsets, True
+                if home_channel.get("chat_id"):
+                    configured_owners.append(str(home_channel["chat_id"]))
+                break
+
+        owner_users = whatsapp_config.get("owner_users", [])
+        if not isinstance(owner_users, list):
+            return nonowner_toolsets, True
+        configured_owners.extend(
+            str(value) for value in owner_users if str(value or "").strip()
+        )
+
+        owner_aliases: set[str] = set()
+        for owner in configured_owners:
+            if str(owner).strip().lower().endswith("@g.us"):
+                continue
+            owner_aliases.update(_expand_whatsapp_auth_aliases(owner))
+
+        sender_ids = [
+            getattr(source, "user_id_alt", None),
+            getattr(source, "user_id", None),
+        ]
+        if not any(sender_ids) and getattr(source, "chat_type", "dm") == "dm":
+            sender_ids.append(getattr(source, "chat_id", None))
+
+        sender_aliases: set[str] = set()
+        for sender_id in sender_ids:
+            if sender_id:
+                sender_aliases.update(_expand_whatsapp_auth_aliases(str(sender_id)))
+
+        if owner_aliases and sender_aliases & owner_aliases:
+            return enabled_toolsets, False
+    except Exception:
+        logger.exception("WhatsApp owner tool gate failed; restricting sender")
+
+    return nonowner_toolsets, True
+
+
+def _whatsapp_owner_tool_gate(
+    source: "SessionSource",
+    platform_key: str,
+    user_config: dict,
+    enabled_toolsets: list[str],
+) -> list[str]:
+    return _whatsapp_owner_tool_policy(
+        source, platform_key, user_config, enabled_toolsets
+    )[0]
 
 
 def _teams_pipeline_plugin_enabled() -> bool:
@@ -15164,11 +15228,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             from hermes_cli.tools_config import _get_platform_tools
             enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+            enabled_toolsets = _whatsapp_owner_tool_gate(
+                source, platform_key, user_config, enabled_toolsets
+            )
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
-            disabled_toolsets = _whatsapp_owner_tool_gate(
-                source, platform_key, user_config, disabled_toolsets
-            )
 
             pr = self._provider_routing
             max_iterations = _current_max_iterations()
@@ -18971,6 +19035,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_key: str = None,
         run_generation: Optional[int] = None,
         event_message_id: Optional[str] = None,
+        enabled_toolsets: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Forward the message to a remote Hermes API server instead of
         running a local AIAgent.
@@ -19010,6 +19075,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return True
             return self._is_session_run_current(session_key, run_generation)
 
+        source_profile = str(getattr(source, "profile", None) or "").strip()
+        if not source_profile:
+            try:
+                from hermes_cli.profiles import get_active_profile_name
+
+                source_profile = get_active_profile_name()
+            except Exception:
+                logger.warning(
+                    "Could not resolve proxy source profile",
+                    exc_info=True,
+                )
+        if not source_profile:
+            return {
+                "final_response": "⚠️ Proxy request missing profile identity",
+                "messages": [],
+                "api_calls": 0,
+                "tools": [],
+            }
+        proxy_path_parts = [
+            unquote(part)
+            for part in urlsplit(proxy_url).path.rstrip("/").split("/")
+            if part
+        ]
+        proxy_url_profile = (
+            proxy_path_parts[-1]
+            if len(proxy_path_parts) >= 2 and proxy_path_parts[-2] == "p"
+            else None
+        )
+        if proxy_url_profile is not None and proxy_url_profile != source_profile:
+            logger.error(
+                "Refusing proxy request with mismatched URL profile scope"
+            )
+            return {
+                "final_response": "⚠️ Proxy URL profile mismatch",
+                "messages": [],
+                "api_calls": 0,
+                "tools": [],
+            }
+        if proxy_url_profile is None:
+            proxy_url = f"{proxy_url}/p/{quote(source_profile, safe='')}"
+
         # Build messages in OpenAI chat format --------------------------
         #
         # The remote api_server can maintain session continuity via
@@ -19046,6 +19152,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "messages": api_messages,
             "stream": True,
         }
+        proxy_path = "/v1/chat/completions"
+        if enabled_toolsets is not None:
+            if not session_key:
+                logger.error(
+                    "Refusing restricted proxy request without a gateway session key"
+                )
+                return {
+                    "final_response": "⚠️ Restricted proxy request missing session identity",
+                    "messages": [],
+                    "api_calls": 0,
+                    "tools": [],
+                }
+            body["enabled_toolsets"] = enabled_toolsets
+            body["gateway_source"] = {
+                "platform": source.platform.value,
+                "chat_id": str(source.chat_id),
+                "session_key": str(session_key),
+                "profile": source_profile,
+            }
+            for field in (
+                "user_id",
+                "user_id_alt",
+                "thread_id",
+            ):
+                value = getattr(source, field, None)
+                if value is not None and str(value):
+                    body["gateway_source"][field] = str(value)
+            if event_message_id is not None and str(event_message_id):
+                body["gateway_source"]["message_id"] = str(event_message_id)
+            # This endpoint does not exist on older servers.  A restricted
+            # request therefore fails atomically with 404 instead of reaching
+            # a worker that silently ignores the authorization field.
+            proxy_path = "/v1/chat/completions/restricted"
 
         # Set up platform streaming if available -------------------------
         _stream_consumer = None
@@ -19137,7 +19276,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _timeout = ClientTimeout(total=0, sock_read=1800)
             async with _AioClientSession(timeout=_timeout) as session:
                 async with session.post(
-                    f"{proxy_url}/v1/chat/completions",
+                    f"{proxy_url}{proxy_path}",
                     json=body,
                     headers=headers,
                 ) as resp:
@@ -19438,6 +19577,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         This is run in a thread pool to not block the event loop.
         Supports interruption via new messages.
         """
+        user_config = _load_gateway_config()
+        platform_key = _platform_config_key(source.platform)
+
+        from hermes_cli.tools_config import _get_platform_tools
+        enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+        gated_toolsets, restrict_proxy_toolsets = _whatsapp_owner_tool_policy(
+            source, platform_key, user_config, enabled_toolsets
+        )
+
         # ---- Proxy mode: delegate to remote API server ----
         if self._get_proxy_url():
             return await self._run_agent_via_proxy(
@@ -19449,7 +19597,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key=session_key,
                 run_generation=run_generation,
                 event_message_id=event_message_id,
+                enabled_toolsets=gated_toolsets if restrict_proxy_toolsets else None,
             )
+
+        enabled_toolsets = gated_toolsets
 
         from run_agent import AIAgent
         import queue
@@ -19459,16 +19610,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return True
             return self._is_session_run_current(session_key, run_generation)
         
-        user_config = _load_gateway_config()
-        platform_key = _platform_config_key(source.platform)
-
-        from hermes_cli.tools_config import _get_platform_tools
-        enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
-        disabled_toolsets = _whatsapp_owner_tool_gate(
-            source, platform_key, user_config, disabled_toolsets
-        )
 
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -29,6 +29,7 @@ from gateway.platforms.api_server import (
     APIServerAdapter,
     ResponseStore,
     _IdempotencyCache,
+    _api_request_profile,
     _derive_chat_session_id,
     _hermes_version,
     _redact_api_error_text,
@@ -333,6 +334,7 @@ class TestAdapterInit:
 
     def test_create_agent_forwards_runtime_config(self, monkeypatch):
         captured = {}
+        resolved_platforms = []
 
         class FakeAgent:
             def __init__(self, **kwargs):
@@ -365,12 +367,29 @@ class TestAdapterInit:
             staticmethod(lambda: {"enabled": True, "effort": "xhigh"}),
         )
         monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
-        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools",
+            lambda _config, platform: (
+                resolved_platforms.append(platform)
+                or {"context_engine", "terminal"}
+            ),
+        )
 
         adapter = APIServerAdapter(PlatformConfig(enabled=True))
         monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
 
-        agent = adapter._create_agent(session_id="api-session")
+        agent = adapter._create_agent(
+            session_id="api-session",
+            requested_toolsets=["context_engine", "whatsapp_admin"],
+            gateway_source={
+                "platform": "whatsapp",
+                "chat_id": "15551234567@s.whatsapp.net",
+                "user_id": "15551234567@s.whatsapp.net",
+                "user_id_alt": "15557654321@lid",
+                "thread_id": "thread-7",
+                "session_key": "agent:main:whatsapp:dm:15551234567",
+            },
+        )
 
         assert isinstance(agent, FakeAgent)
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
@@ -378,6 +397,16 @@ class TestAdapterInit:
         assert captured["checkpoint_max_snapshots"] == 7
         assert captured["checkpoint_max_total_size_mb"] == 321
         assert captured["checkpoint_max_file_size_mb"] == 4
+        assert resolved_platforms == ["api_server"]
+        assert captured["enabled_toolsets"] == ["context_engine"]
+        assert captured["platform"] == "whatsapp"
+        assert captured["chat_id"] == "15551234567@s.whatsapp.net"
+        assert captured["user_id"] == "15551234567@s.whatsapp.net"
+        assert captured["user_id_alt"] == "15557654321@lid"
+        assert captured["thread_id"] == "thread-7"
+        assert captured["gateway_session_key"] == (
+            "agent:main:whatsapp:dm:15551234567"
+        )
 
     def test_create_agent_refreshes_max_iterations_from_runtime_config(self, monkeypatch):
         captured = {}
@@ -649,6 +678,21 @@ def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
     return APIServerAdapter(config)
 
 
+def _valid_gateway_source(**overrides):
+    source = {
+        "platform": "whatsapp",
+        "chat_id": "15551234567@s.whatsapp.net",
+        "user_id": "15551234567@s.whatsapp.net",
+        "user_id_alt": "15557654321@lid",
+        "thread_id": "thread-7",
+        "message_id": "message-9",
+        "profile": "default",
+        "session_key": "agent:main:whatsapp:dm:15551234567",
+    }
+    source.update(overrides)
+    return source
+
+
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app from the adapter (without starting the full server)."""
     mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
@@ -662,6 +706,9 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/skills", adapter._handle_skills)
     app.router.add_get("/v1/toolsets", adapter._handle_toolsets)
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    app.router.add_post(
+        "/v1/chat/completions/restricted", adapter._handle_chat_completions
+    )
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
@@ -730,6 +777,78 @@ class TestAgentExecution:
             conversation_history=[],
             task_id="session-123",
         )
+
+    @pytest.mark.asyncio
+    async def test_restricted_origin_reaches_contextvars_and_pre_tool_hook(
+        self, adapter, monkeypatch
+    ):
+        from gateway.session_context import async_delivery_supported, get_session_env
+        import hermes_cli.plugins as plugins
+
+        gateway_source = {
+            "platform": "whatsapp",
+            "chat_id": "15551234567@s.whatsapp.net",
+            "user_id": "15551234567@s.whatsapp.net",
+            "user_id_alt": "15557654321@lid",
+            "thread_id": "thread-7",
+            "message_id": "message-9",
+            "profile": "business",
+            "session_key": "agent:business:whatsapp:dm:15551234567",
+        }
+        observed = {}
+        create_kwargs = {}
+
+        def observe_hook(hook_name, **_kwargs):
+            if hook_name == "pre_tool_call":
+                for name in (
+                    "PLATFORM",
+                    "CHAT_ID",
+                    "USER_ID",
+                    "THREAD_ID",
+                    "MESSAGE_ID",
+                    "PROFILE",
+                    "KEY",
+                ):
+                    observed[name] = get_session_env(f"HERMES_SESSION_{name}")
+                observed["async_delivery"] = async_delivery_supported()
+            return []
+
+        monkeypatch.setattr(plugins, "invoke_hook", observe_hook)
+
+        class FakeAgent:
+            session_id = "request-session"
+            session_prompt_tokens = 0
+            session_completion_tokens = 0
+            session_total_tokens = 0
+
+            def run_conversation(self, **_kwargs):
+                plugins.get_pre_tool_call_block_message("memory", {})
+                return {"final_response": "ok"}
+
+        def fake_create_agent(**kwargs):
+            create_kwargs.update(kwargs)
+            return FakeAgent()
+
+        monkeypatch.setattr(adapter, "_create_agent", fake_create_agent)
+
+        await adapter._run_agent(
+            user_message="hello",
+            conversation_history=[],
+            session_id="request-session",
+            gateway_source=gateway_source,
+        )
+
+        assert create_kwargs["gateway_source"] == gateway_source
+        assert observed == {
+            "PLATFORM": "whatsapp",
+            "CHAT_ID": "15551234567@s.whatsapp.net",
+            "USER_ID": "15551234567@s.whatsapp.net",
+            "THREAD_ID": "thread-7",
+            "MESSAGE_ID": "message-9",
+            "PROFILE": "business",
+            "KEY": "agent:business:whatsapp:dm:15551234567",
+            "async_delivery": False,
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -1217,6 +1336,324 @@ class TestToolsetsEndpoint:
 
 
 class TestChatCompletionsEndpoint:
+    @pytest.fixture(autouse=True)
+    def _default_active_profile(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+        )
+
+    @pytest.mark.asyncio
+    async def test_restricted_endpoint_requires_enabled_toolsets(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions/restricted",
+                headers={"Authorization": "Bearer sk-secret"},
+                json={
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "gateway_source": _valid_gateway_source(),
+                },
+            )
+            assert resp.status == 400
+            data = await resp.json()
+            assert "enabled_toolsets is required" in data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_restricted_endpoint_requires_configured_api_key(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions/restricted",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "enabled_toolsets": ["context_engine"],
+                        "gateway_source": _valid_gateway_source(),
+                    },
+                )
+
+            assert resp.status == 403
+            assert "requires API key authentication" in (
+                await resp.json()
+            )["error"]["message"]
+            mock_run.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_restricted_endpoint_requires_gateway_source(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                auth_adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions/restricted",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "enabled_toolsets": ["context_engine"],
+                    },
+                )
+
+            assert resp.status == 400
+            assert "gateway_source is required" in (
+                await resp.json()
+            )["error"]["message"]
+            mock_run.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        "gateway_source",
+        [
+            None,
+            [],
+            {"platform": "whatsapp", "chat_id": "chat"},
+            _valid_gateway_source(user_id=7),
+            _valid_gateway_source(platform="WhatsApp"),
+            _valid_gateway_source(platform="unknown_gateway"),
+            _valid_gateway_source(chat_id="chat\nforged"),
+            _valid_gateway_source(profile="Bad Profile"),
+            _valid_gateway_source(session_key="x" * 257),
+            {**_valid_gateway_source(), "api_key": "must-not-leak"},
+            {
+                key: value
+                for key, value in _valid_gateway_source().items()
+                if key != "profile"
+            },
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_restricted_endpoint_rejects_malformed_gateway_source(
+        self, auth_adapter, gateway_source
+    ):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                auth_adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions/restricted",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "enabled_toolsets": ["context_engine"],
+                        "gateway_source": gateway_source,
+                    },
+                )
+
+            assert resp.status == 400
+            body = await resp.text()
+            assert "Invalid gateway_source" in body
+            assert "must-not-leak" not in body
+            mock_run.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_regular_endpoint_rejects_gateway_source(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                auth_adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "gateway_source": _valid_gateway_source(),
+                    },
+                )
+
+            assert resp.status == 400
+            assert "only accepted on the restricted endpoint" in (
+                await resp.json()
+            )["error"]["message"]
+            mock_run.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_restricted_stream_source_propagates_to_agent_run(
+        self, auth_adapter, monkeypatch
+    ):
+        source = _valid_gateway_source(profile="business")
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name",
+            lambda: "business",
+        )
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                auth_adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                async def run_with_delta(**kwargs):
+                    kwargs["stream_delta_callback"]("ok")
+                    return (
+                        mock_result,
+                        {
+                            "input_tokens": 0,
+                            "output_tokens": 0,
+                            "total_tokens": 0,
+                        },
+                    )
+
+                mock_run.side_effect = run_with_delta
+                resp = await cli.post(
+                    "/v1/chat/completions/restricted",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                        "enabled_toolsets": ["context_engine"],
+                        "gateway_source": source,
+                    },
+                )
+
+            assert resp.status == 200
+            assert "[DONE]" in await resp.text()
+            assert mock_run.call_args.kwargs["gateway_source"] == source
+            assert mock_run.call_args.kwargs["gateway_session_key"] == (
+                source["session_key"]
+            )
+            assert mock_run.call_args.kwargs["requested_toolsets"] == [
+                "context_engine"
+            ]
+
+    @pytest.mark.asyncio
+    async def test_restricted_profile_mismatch_fails_closed(
+        self, auth_adapter, monkeypatch, tmp_path
+    ):
+        class Runner:
+            config = GatewayConfig(multiplex_profiles=True)
+
+        auth_adapter.gateway_runner = Runner()
+        profile_home = tmp_path / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex: [("default", tmp_path), ("coder", profile_home)],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_profile_dir",
+            lambda _profile: profile_home,
+        )
+
+        def active_profile():
+            assert _api_request_profile.get() == "coder"
+            return "coder"
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", active_profile
+        )
+        app = web.Application(
+            middlewares=[auth_adapter._make_profile_prefix_middleware()]
+        )
+        app.router.add_post(
+            "/p/{profile}/v1/chat/completions/restricted",
+            auth_adapter._handle_chat_completions,
+        )
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                auth_adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mismatch = await cli.post(
+                    "/p/coder/v1/chat/completions/restricted",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "enabled_toolsets": ["context_engine"],
+                        "gateway_source": _valid_gateway_source(profile="default"),
+                    },
+                )
+                assert mismatch.status == 400
+                assert "must match the URL profile scope" in (
+                    await mismatch.json()
+                )["error"]["message"]
+                mock_run.assert_not_awaited()
+
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                matched = await cli.post(
+                    "/p/coder/v1/chat/completions/restricted",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "enabled_toolsets": ["context_engine"],
+                        "gateway_source": _valid_gateway_source(profile="coder"),
+                    },
+                )
+
+            assert matched.status == 200
+            assert mock_run.call_args.kwargs["gateway_source"]["profile"] == "coder"
+
+    @pytest.mark.asyncio
+    async def test_restricted_unprefixed_profile_must_match_active_profile(
+        self, auth_adapter, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+        )
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                auth_adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions/restricted",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "enabled_toolsets": ["context_engine"],
+                        "gateway_source": _valid_gateway_source(
+                            profile="business"
+                        ),
+                    },
+                )
+
+            assert resp.status == 400
+            assert "does not match the active profile scope" in (
+                await resp.json()
+            )["error"]["message"]
+            mock_run.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_restricted_source_rejects_conflicting_session_key(
+        self, auth_adapter
+    ):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                auth_adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions/restricted",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Key": "different-session",
+                    },
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "enabled_toolsets": ["context_engine"],
+                        "gateway_source": _valid_gateway_source(),
+                    },
+                )
+
+            assert resp.status == 400
+            assert "must match gateway_source.session_key" in (
+                await resp.json()
+            )["error"]["message"]
+            mock_run.assert_not_awaited()
+
     @pytest.mark.asyncio
     async def test_invalid_json_returns_400(self, adapter):
         app = _create_app(adapter)
@@ -4355,6 +4792,47 @@ class TestSessionKeyHeader:
             assert resp.status == 200
             # _create_agent must be called with gateway_session_key threaded through
             assert captured_kwargs.get("gateway_session_key") == "agent:main:webui:dm:user-7"
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_threads_requested_toolsets(self, auth_adapter):
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "enabled_toolsets": ["context_engine"],
+                    },
+                )
+
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["requested_toolsets"] == [
+                "context_engine"
+            ]
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_rejects_malformed_toolsets(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                headers={"Authorization": "Bearer sk-secret"},
+                json={
+                    "model": "hermes-agent",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "enabled_toolsets": "context_engine",
+                },
+            )
+
+            assert resp.status == 400
 
     @pytest.mark.asyncio
     async def test_responses_endpoint_accepts_session_key(self, auth_adapter):

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -176,3 +176,37 @@ class TestApiServerAdapterToolset:
             call_kwargs = mock_agent_cls.call_args
             toolsets = call_kwargs.kwargs.get("enabled_toolsets")
             assert sorted(toolsets) == ["terminal", "web"]
+
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_create_agent_only_narrows_caller_requested_toolsets(self):
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._resolve_gateway_model", return_value="test/model"), \
+             patch("gateway.run._load_gateway_config") as mock_config, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_kwargs.return_value = {
+                "api_key": "test-key",
+                "base_url": None,
+                "provider": None,
+                "api_mode": None,
+                "command": None,
+                "args": [],
+            }
+            mock_config.return_value = {
+                "platform_toolsets": {
+                    "api_server": ["context_engine", "file", "terminal"]
+                }
+            }
+            mock_agent_cls.return_value = MagicMock()
+
+            adapter._create_agent(
+                requested_toolsets=["context_engine", "not-server-enabled"]
+            )
+
+            assert mock_agent_cls.call_args.kwargs["enabled_toolsets"] == [
+                "context_engine"
+            ]

--- a/tests/gateway/test_multiplex_api_server_routing.py
+++ b/tests/gateway/test_multiplex_api_server_routing.py
@@ -64,10 +64,12 @@ class TestApiServerRouteTable:
         paths = {path for _method, path, _handler in adapter._http_route_table()}
         assert "/v1/models" in paths
         assert "/v1/chat/completions" in paths
+        assert "/v1/chat/completions/restricted" in paths
         # connect() mirrors every native path under /p/{profile}/…
         mirrored = {f"/p/{{profile}}{path}" for path in paths}
         assert "/p/{profile}/v1/models" in mirrored
         assert "/p/{profile}/v1/chat/completions" in mirrored
+        assert "/p/{profile}/v1/chat/completions/restricted" in mirrored
 
 
 class TestApiServerModelsUnderProfile:

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -69,8 +69,10 @@ class _FakeSession:
         self.captured_url = None
         self.captured_json = None
         self.captured_headers = None
+        self.post_calls = 0
 
     def post(self, url, json=None, headers=None, **kwargs):
+        self.post_calls += 1
         self.captured_url = url
         self.captured_json = json
         self.captured_headers = headers
@@ -188,19 +190,54 @@ class TestRunAgentProxyDispatch:
 
         runner._run_agent_via_proxy = AsyncMock(return_value=expected_result)
 
-        result = await runner._run_agent(
-            message="hi",
-            context_prompt="",
-            history=[],
-            source=source,
-            session_id="test-session-123",
-            session_key="test-key",
-            run_generation=7,
-        )
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            result = await runner._run_agent(
+                message="hi",
+                context_prompt="",
+                history=[],
+                source=source,
+                session_id="test-session-123",
+                session_key="test-key",
+                run_generation=7,
+            )
 
         assert result["final_response"] == "Hello from remote!"
         runner._run_agent_via_proxy.assert_called_once()
         assert runner._run_agent_via_proxy.call_args.kwargs["run_generation"] == 7
+        assert runner._run_agent_via_proxy.call_args.kwargs["enabled_toolsets"] is None
+
+    @pytest.mark.asyncio
+    async def test_whatsapp_nonowner_toolsets_are_forwarded_to_proxy(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.setenv("WHATSAPP_HOME_CHANNEL", "owner")
+        runner = _make_runner()
+        runner._run_agent_via_proxy = AsyncMock(
+            return_value={"final_response": "ok", "messages": [], "api_calls": 1}
+        )
+        source = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="guest@s.whatsapp.net",
+            chat_type="dm",
+            user_id="guest@s.whatsapp.net",
+        )
+        config = {
+            "platform_toolsets": {"whatsapp": ["context_engine"]},
+            "whatsapp": {"nonowner_enabled_toolsets": ["context_engine"]}
+        }
+
+        with patch("gateway.run._load_gateway_config", return_value=config):
+            await runner._run_agent(
+                message="hi",
+                context_prompt="",
+                history=[],
+                source=source,
+                session_id="test-session",
+                session_key="agent:main:whatsapp:dm:guest",
+            )
+
+        assert runner._run_agent_via_proxy.call_args.kwargs["enabled_toolsets"] == [
+            "context_engine"
+        ]
 
     @pytest.mark.asyncio
     async def test_run_agent_skips_proxy_when_not_configured(self, monkeypatch):
@@ -227,12 +264,29 @@ class TestRunAgentProxyDispatch:
 class TestRunAgentViaProxy:
     """Test the actual proxy HTTP forwarding logic."""
 
+    @pytest.mark.parametrize(
+        ("proxy_url", "expected_url"),
+        [
+            (
+                "http://host:8642",
+                "http://host:8642/p/business/v1/chat/completions/restricted",
+            ),
+            (
+                "http://host:8642/p/business/",
+                "http://host:8642/p/business/v1/chat/completions/restricted",
+            ),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_builds_correct_request(self, monkeypatch):
-        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+    async def test_builds_correct_request(self, monkeypatch, proxy_url, expected_url):
+        monkeypatch.setenv("GATEWAY_PROXY_URL", proxy_url)
         monkeypatch.setenv("GATEWAY_PROXY_KEY", "test-key-123")
         runner = _make_runner()
         source = _make_source()
+        source.user_id_alt = "user-alt-7"
+        source.thread_id = "thread-9"
+        source.profile = "business"
+        source.api_key = "must-not-cross-proxy-boundary"
 
         resp = _FakeSSEResponse(
             status=200,
@@ -256,10 +310,13 @@ class TestRunAgentViaProxy:
                         ],
                         source=source,
                         session_id="session-abc",
+                        session_key="agent:business:matrix:thread:room:thread-9",
+                        event_message_id="message-11",
+                        enabled_toolsets=["context_engine"],
                     )
 
         # Verify request URL
-        assert session.captured_url == "http://host:8642/v1/chat/completions"
+        assert session.captured_url == expected_url
 
         # Verify auth header
         assert session.captured_headers["Authorization"] == "Bearer test-key-123"
@@ -276,9 +333,48 @@ class TestRunAgentViaProxy:
 
         # Verify streaming is requested
         assert session.captured_json["stream"] is True
+        assert session.captured_json["enabled_toolsets"] == ["context_engine"]
+        assert session.captured_json["gateway_source"] == {
+            "platform": "matrix",
+            "chat_id": "!room:server.org",
+            "session_key": "agent:business:matrix:thread:room:thread-9",
+            "user_id": "@user:server.org",
+            "user_id_alt": "user-alt-7",
+            "thread_id": "thread-9",
+            "message_id": "message-11",
+            "profile": "business",
+        }
+        assert "api_key" not in session.captured_json["gateway_source"]
+        assert "user_name" not in session.captured_json["gateway_source"]
+        assert "chat_name" not in session.captured_json["gateway_source"]
 
         # Verify response was assembled
         assert result["final_response"] == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_restricted_request_fails_closed_on_older_remote(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        runner = _make_runner()
+        session = _FakeSession(_FakeSSEResponse(status=404, error_text="Not Found"))
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    result = await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=_make_source(Platform.WHATSAPP),
+                        session_id="test",
+                        session_key="agent:main:whatsapp:dm:user",
+                        enabled_toolsets=["context_engine"],
+                    )
+
+        assert "Proxy error (404)" in result["final_response"]
+        assert session.captured_url == (
+            "http://host:8642/p/default/v1/chat/completions/restricted"
+        )
+        assert session.post_calls == 1
 
     @pytest.mark.asyncio
     async def test_handles_http_error(self, monkeypatch):
@@ -303,6 +399,60 @@ class TestRunAgentViaProxy:
 
         assert "Proxy error (401)" in result["final_response"]
         assert result["api_calls"] == 0
+        assert session.captured_url == (
+            "http://host:8642/p/default/v1/chat/completions"
+        )
+        assert "gateway_source" not in session.captured_json
+
+    @pytest.mark.asyncio
+    async def test_restricted_request_without_session_identity_fails_before_http(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        runner = _make_runner()
+        session = _FakeSession(_FakeSSEResponse(status=200))
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                result = await runner._run_agent_via_proxy(
+                    message="hi",
+                    context_prompt="",
+                    history=[],
+                    source=_make_source(Platform.WHATSAPP),
+                    session_id="test",
+                    enabled_toolsets=["context_engine"],
+                )
+
+        assert "missing session identity" in result["final_response"]
+        assert session.post_calls == 0
+
+    @pytest.mark.parametrize(
+        "enabled_toolsets", [None, ["context_engine"]]
+    )
+    @pytest.mark.asyncio
+    async def test_scoped_proxy_url_profile_mismatch_fails_before_http(
+        self, monkeypatch, enabled_toolsets
+    ):
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642/p/default")
+        runner = _make_runner()
+        source = _make_source(Platform.WHATSAPP)
+        source.profile = "coder"
+        session = _FakeSession(_FakeSSEResponse(status=200))
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                result = await runner._run_agent_via_proxy(
+                    message="hi",
+                    context_prompt="",
+                    history=[],
+                    source=source,
+                    session_id="test",
+                    session_key="agent:coder:whatsapp:dm:user",
+                    enabled_toolsets=enabled_toolsets,
+                )
+
+        assert "profile mismatch" in result["final_response"]
+        assert session.post_calls == 0
 
     @pytest.mark.asyncio
     async def test_handles_connection_error(self, monkeypatch):

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -64,6 +64,7 @@ async def test_capabilities_advertises_session_control_surface(adapter):
     assert features["session_chat"] is True
     assert features["session_chat_streaming"] is True
     assert features["session_fork"] is True
+    assert features["chat_completions_enabled_toolsets"] is True
     assert features["admin_config_rw"] is False
     assert features["memory_write_api"] is False
     assert features["skills_api"] is True
@@ -72,6 +73,10 @@ async def test_capabilities_advertises_session_control_surface(adapter):
     assert data["endpoints"]["session_chat_stream"] == {
         "method": "POST",
         "path": "/api/sessions/{session_id}/chat/stream",
+    }
+    assert data["endpoints"]["chat_completions_restricted"] == {
+        "method": "POST",
+        "path": "/v1/chat/completions/restricted",
     }
 
 

--- a/tests/gateway/test_whatsapp_owner_tool_gate.py
+++ b/tests/gateway/test_whatsapp_owner_tool_gate.py
@@ -1,0 +1,61 @@
+"""Owner-aware WhatsApp toolset gating (``_whatsapp_owner_tool_gate``).
+
+A shared / community WhatsApp line otherwise exposes the full agent toolset
+(terminal, code execution, file, ...) to every allowlisted sender. When
+``whatsapp.nonowner_disabled_toolsets`` is configured, only owners -- the
+``whatsapp.home_channel`` chat_id or ids in ``whatsapp.owner_users`` -- keep the
+full toolset; everyone else has the configured tools disabled. The feature is
+opt-in (no config -> no behavior change) and fails closed.
+"""
+
+from types import SimpleNamespace
+
+from gateway.run import _whatsapp_owner_tool_gate
+
+OWNER = "178172540747977"
+DROP = ["terminal", "code_execution", "file"]
+CFG = {
+    "whatsapp": {
+        "home_channel": {"platform": "whatsapp", "chat_id": f"{OWNER}@lid"},
+        "owner_users": ["15551234567"],
+        "nonowner_disabled_toolsets": DROP,
+    }
+}
+
+
+def _src(chat_id):
+    return SimpleNamespace(chat_id=chat_id)
+
+
+def test_noop_when_feature_unconfigured():
+    cfg = {"whatsapp": {"home_channel": {"chat_id": f"{OWNER}@lid"}}}
+    assert _whatsapp_owner_tool_gate(_src("99999@lid"), "whatsapp", cfg, None) is None
+
+
+def test_noop_on_other_platforms():
+    assert _whatsapp_owner_tool_gate(_src("99999"), "telegram", CFG, None) is None
+
+
+def test_owner_keeps_full_toolset():
+    # home_channel owner, including a device-suffixed LID variant
+    assert _whatsapp_owner_tool_gate(_src(f"{OWNER}@lid"), "whatsapp", CFG, None) is None
+    assert _whatsapp_owner_tool_gate(_src(f"{OWNER}:12@lid"), "whatsapp", CFG, None) is None
+    # explicit owner_users entry (configured as a bare number, sender arrives as a jid)
+    assert _whatsapp_owner_tool_gate(_src("15551234567@s.whatsapp.net"), "whatsapp", CFG, None) is None
+
+
+def test_non_owner_is_restricted():
+    out = _whatsapp_owner_tool_gate(_src("19998887777@s.whatsapp.net"), "whatsapp", CFG, None)
+    assert set(DROP).issubset(set(out))
+
+
+def test_non_owner_preserves_existing_disabled():
+    out = _whatsapp_owner_tool_gate(_src("19998887777@lid"), "whatsapp", CFG, ["moa"])
+    assert "moa" in out
+    assert set(DROP).issubset(set(out))
+
+
+def test_fails_closed_when_sender_unknown():
+    # feature active but sender id missing -> restrict, never grant
+    out = _whatsapp_owner_tool_gate(SimpleNamespace(), "whatsapp", CFG, None)
+    assert set(DROP).issubset(set(out))

--- a/tests/gateway/test_whatsapp_owner_tool_gate.py
+++ b/tests/gateway/test_whatsapp_owner_tool_gate.py
@@ -1,61 +1,240 @@
-"""Owner-aware WhatsApp toolset gating (``_whatsapp_owner_tool_gate``).
-
-A shared / community WhatsApp line otherwise exposes the full agent toolset
-(terminal, code execution, file, ...) to every allowlisted sender. When
-``whatsapp.nonowner_disabled_toolsets`` is configured, only owners -- the
-``whatsapp.home_channel`` chat_id or ids in ``whatsapp.owner_users`` -- keep the
-full toolset; everyone else has the configured tools disabled. The feature is
-opt-in (no config -> no behavior change) and fails closed.
-"""
+"""Per-sender WhatsApp toolset isolation for shared business lines."""
 
 from types import SimpleNamespace
 
-from gateway.run import _whatsapp_owner_tool_gate
+import gateway.run as gateway_run
+import pytest
 
-OWNER = "178172540747977"
-DROP = ["terminal", "code_execution", "file"]
-CFG = {
-    "whatsapp": {
-        "home_channel": {"platform": "whatsapp", "chat_id": f"{OWNER}@lid"},
-        "owner_users": ["15551234567"],
-        "nonowner_disabled_toolsets": DROP,
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+FULL_TOOLSETS = ["context_engine", "file", "terminal", "web"]
+EXTERNAL_TOOLSETS = ["context_engine"]
+
+
+@pytest.fixture(autouse=True)
+def _clear_home_channel_env(monkeypatch):
+    monkeypatch.delenv("WHATSAPP_HOME_CHANNEL", raising=False)
+
+
+def _config(**whatsapp):
+    return {
+        "whatsapp": {
+            "nonowner_enabled_toolsets": EXTERNAL_TOOLSETS,
+            **whatsapp,
+        }
     }
-}
 
 
-def _src(chat_id):
-    return SimpleNamespace(chat_id=chat_id)
+def _source(*, chat_id="contact@s.whatsapp.net", user_id=None, chat_type="dm"):
+    return SimpleNamespace(
+        chat_id=chat_id,
+        chat_type=chat_type,
+        user_id=user_id,
+        user_id_alt=None,
+    )
 
 
-def test_noop_when_feature_unconfigured():
-    cfg = {"whatsapp": {"home_channel": {"chat_id": f"{OWNER}@lid"}}}
-    assert _whatsapp_owner_tool_gate(_src("99999@lid"), "whatsapp", cfg, None) is None
+def test_unconfigured_and_other_platform_are_unchanged():
+    source = _source()
+    assert gateway_run._whatsapp_owner_tool_gate(
+        source, "whatsapp", {"whatsapp": {}}, FULL_TOOLSETS
+    ) is FULL_TOOLSETS
+    assert gateway_run._whatsapp_owner_tool_gate(
+        source, "telegram", _config(), FULL_TOOLSETS
+    ) is FULL_TOOLSETS
 
 
-def test_noop_on_other_platforms():
-    assert _whatsapp_owner_tool_gate(_src("99999"), "telegram", CFG, None) is None
+def test_nonowner_gets_only_explicit_allowlist():
+    assert gateway_run._whatsapp_owner_tool_gate(
+        _source(user_id="contact@s.whatsapp.net"),
+        "whatsapp",
+        _config(owner_users=["owner"]),
+        FULL_TOOLSETS,
+    ) == EXTERNAL_TOOLSETS
 
 
-def test_owner_keeps_full_toolset():
-    # home_channel owner, including a device-suffixed LID variant
-    assert _whatsapp_owner_tool_gate(_src(f"{OWNER}@lid"), "whatsapp", CFG, None) is None
-    assert _whatsapp_owner_tool_gate(_src(f"{OWNER}:12@lid"), "whatsapp", CFG, None) is None
-    # explicit owner_users entry (configured as a bare number, sender arrives as a jid)
-    assert _whatsapp_owner_tool_gate(_src("15551234567@s.whatsapp.net"), "whatsapp", CFG, None) is None
+def test_nonowner_allowlist_only_reduces_enabled_toolsets_in_platform_order():
+    enabled = ["web", "context_engine", "file"]
+    assert gateway_run._whatsapp_owner_tool_gate(
+        _source(user_id="contact@s.whatsapp.net"),
+        "whatsapp",
+        _config(
+            owner_users=["owner"],
+            nonowner_enabled_toolsets=["terminal", "context_engine", "web"],
+        ),
+        enabled,
+    ) == ["web", "context_engine"]
 
 
-def test_non_owner_is_restricted():
-    out = _whatsapp_owner_tool_gate(_src("19998887777@s.whatsapp.net"), "whatsapp", CFG, None)
-    assert set(DROP).issubset(set(out))
+def test_nonowner_policy_stays_explicit_when_allowlist_matches_platform_tools():
+    toolsets = ["context_engine"]
+    gated, restricted = gateway_run._whatsapp_owner_tool_policy(
+        _source(user_id="contact@s.whatsapp.net"),
+        "whatsapp",
+        _config(owner_users=["owner"]),
+        toolsets,
+    )
+    assert gated == toolsets
+    assert restricted is True
 
 
-def test_non_owner_preserves_existing_disabled():
-    out = _whatsapp_owner_tool_gate(_src("19998887777@lid"), "whatsapp", CFG, ["moa"])
-    assert "moa" in out
-    assert set(DROP).issubset(set(out))
+def test_owner_matches_phone_lid_aliases(monkeypatch):
+    aliases = {
+        "owner-phone": {"owner-phone", "owner-lid"},
+        "owner-lid": {"owner-phone", "owner-lid"},
+    }
+    monkeypatch.setattr(
+        gateway_run,
+        "_expand_whatsapp_auth_aliases",
+        lambda value: aliases.get(value, {value}),
+    )
+
+    result = gateway_run._whatsapp_owner_tool_gate(
+        _source(user_id="owner-lid"),
+        "whatsapp",
+        _config(owner_users=["owner-phone"]),
+        FULL_TOOLSETS,
+    )
+    assert result is FULL_TOOLSETS
 
 
-def test_fails_closed_when_sender_unknown():
-    # feature active but sender id missing -> restrict, never grant
-    out = _whatsapp_owner_tool_gate(SimpleNamespace(), "whatsapp", CFG, None)
-    assert set(DROP).issubset(set(out))
+def test_standard_home_channel_env_identifies_owner(monkeypatch):
+    monkeypatch.setenv("WHATSAPP_HOME_CHANNEL", "owner")
+    assert gateway_run._whatsapp_owner_tool_gate(
+        _source(user_id="owner@s.whatsapp.net"),
+        "whatsapp",
+        _config(),
+        FULL_TOOLSETS,
+    ) is FULL_TOOLSETS
+
+
+def test_home_channel_env_overrides_stale_yaml(monkeypatch):
+    monkeypatch.setenv("WHATSAPP_HOME_CHANNEL", "current-owner")
+    config = _config(home_channel={"chat_id": "stale-owner"})
+
+    assert gateway_run._whatsapp_owner_tool_gate(
+        _source(user_id="stale-owner@s.whatsapp.net"),
+        "whatsapp",
+        config,
+        FULL_TOOLSETS,
+    ) == EXTERNAL_TOOLSETS
+
+
+def test_group_chat_id_never_grants_owner_tools():
+    config = _config(home_channel={"chat_id": "home-group@g.us"})
+    result = gateway_run._whatsapp_owner_tool_gate(
+        _source(
+            chat_id="home-group@g.us",
+            user_id="home-group@s.whatsapp.net",
+            chat_type="group",
+        ),
+        "whatsapp",
+        config,
+        FULL_TOOLSETS,
+    )
+    assert result == EXTERNAL_TOOLSETS
+
+
+def test_group_owner_is_matched_from_sender():
+    config = _config(owner_users=["owner"])
+    result = gateway_run._whatsapp_owner_tool_gate(
+        _source(
+            chat_id="group@g.us",
+            user_id="owner@s.whatsapp.net",
+            chat_type="group",
+        ),
+        "whatsapp",
+        config,
+        FULL_TOOLSETS,
+    )
+    assert result is FULL_TOOLSETS
+
+
+def test_home_channel_env_is_profile_scoped(monkeypatch):
+    from agent.secret_scope import (
+        reset_secret_scope,
+        set_multiplex_active,
+        set_secret_scope,
+    )
+
+    monkeypatch.setenv("WHATSAPP_HOME_CHANNEL", "default-owner")
+    set_multiplex_active(True)
+    token = set_secret_scope({"WHATSAPP_HOME_CHANNEL": "profile-owner"})
+    try:
+        assert gateway_run._whatsapp_owner_tool_gate(
+            _source(user_id="profile-owner@s.whatsapp.net"),
+            "whatsapp",
+            _config(),
+            FULL_TOOLSETS,
+        ) is FULL_TOOLSETS
+        assert gateway_run._whatsapp_owner_tool_gate(
+            _source(user_id="default-owner@s.whatsapp.net"),
+            "whatsapp",
+            _config(),
+            FULL_TOOLSETS,
+        ) == EXTERNAL_TOOLSETS
+    finally:
+        reset_secret_scope(token)
+        set_multiplex_active(False)
+
+
+def test_missing_dm_sender_falls_back_to_chat_id():
+    config = _config(home_channel={"chat_id": "owner"})
+    assert gateway_run._whatsapp_owner_tool_gate(
+        _source(chat_id="owner@s.whatsapp.net"),
+        "whatsapp",
+        config,
+        FULL_TOOLSETS,
+    ) is FULL_TOOLSETS
+
+
+@pytest.mark.parametrize(
+    "config_path",
+    [("platforms",), ("gateway", "platforms")],
+)
+def test_nested_platform_home_channel_identifies_owner(config_path):
+    config = _config()
+    target = config
+    for key in config_path:
+        target = target.setdefault(key, {})
+    target["whatsapp"] = {"home_channel": {"chat_id": "owner"}}
+
+    assert gateway_run._whatsapp_owner_tool_gate(
+        _source(user_id="owner@s.whatsapp.net"),
+        "whatsapp",
+        config,
+        FULL_TOOLSETS,
+    ) is FULL_TOOLSETS
+
+
+def test_invalid_config_or_identity_resolution_fails_closed(monkeypatch):
+    assert gateway_run._whatsapp_owner_tool_gate(
+        _source(user_id="owner"),
+        "whatsapp",
+        {"whatsapp": {"nonowner_enabled_toolsets": "context_engine"}},
+        FULL_TOOLSETS,
+    ) == []
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_expand_whatsapp_auth_aliases",
+        lambda _value: (_ for _ in ()).throw(OSError("broken alias map")),
+    )
+    assert gateway_run._whatsapp_owner_tool_gate(
+        _source(user_id="owner"),
+        "whatsapp",
+        _config(owner_users=["owner"]),
+        FULL_TOOLSETS,
+    ) == EXTERNAL_TOOLSETS
+
+
+def test_toolset_change_alters_agent_cache_signature():
+    owner_signature = gateway_run.GatewayRunner._agent_config_signature(
+        "model", {}, FULL_TOOLSETS, ""
+    )
+    external_signature = gateway_run.GatewayRunner._agent_config_signature(
+        "model", {}, EXTERNAL_TOOLSETS, ""
+    )
+    assert owner_signature != external_signature

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -87,6 +87,43 @@ Standard OpenAI Chat Completions format. Stateless — the full conversation is 
 }
 ```
 
+### POST /v1/chat/completions/restricted
+
+Authenticated gateway-proxy endpoint. It requires a configured API server key,
+an `enabled_toolsets` array, and a `gateway_source` object. Hermes intersects
+requested toolsets with toolsets enabled for the API server, so callers can
+reduce capabilities but cannot grant new ones.
+
+```json
+{
+  "model": "hermes-agent",
+  "messages": [{"role": "user", "content": "Summarize this conversation"}],
+  "enabled_toolsets": ["context_engine"],
+  "gateway_source": {
+    "platform": "whatsapp",
+    "chat_id": "15551234567@s.whatsapp.net",
+    "user_id": "15551234567@s.whatsapp.net",
+    "profile": "default",
+    "session_key": "agent:main:whatsapp:dm:15551234567"
+  }
+}
+```
+
+Use this versioned endpoint when a gateway or other trusted proxy must enforce
+a narrower tool surface. Older servers return 404 instead of silently running
+the request with their full configured toolset. `gateway_source` accepts only
+`platform`, `chat_id`, `session_key`, `profile`, and optional `user_id`,
+`user_id_alt`, `thread_id`, and `message_id` string fields. Missing required
+fields, malformed values, and extra fields are rejected; `session_key` has the same
+256-character limit as `X-Hermes-Session-Key`. `profile` must match both the URL
+profile prefix and the active server profile. Proxy mode appends the URL-quoted
+`/p/<profile>` scope to every regular and restricted proxy request when
+`gateway.proxy_url` is unscoped, and preserves an existing matching scope
+without adding a second one. Mismatches fail before HTTP locally or with 400
+before agent execution remotely. The regular chat-completions endpoint rejects
+`gateway_source`; it still accepts `enabled_toolsets` as an optional capability
+reduction.
+
 **Inline image input:** user messages may send `content` as an array of `text` and `image_url` parts. Both remote `http(s)` URLs and `data:image/...` URLs are supported:
 
 ```json

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -130,6 +130,29 @@ whatsapp:
 - `unauthorized_dm_behavior: pair` is the global default. Unknown DM senders get a pairing code.
 - `whatsapp.unauthorized_dm_behavior: ignore` makes WhatsApp stay silent for unauthorized DMs, which is usually the better choice for a private number.
 
+### Shared-line tool isolation
+
+On a WhatsApp number shared with customers or a community, give non-owner
+senders only an explicit toolset allowlist:
+
+```yaml
+whatsapp:
+  owner_users:
+    - "15551234567"
+  nonowner_enabled_toolsets:
+    - context_engine
+```
+
+The `WHATSAPP_HOME_CHANNEL` user and entries in `owner_users` keep the normal
+WhatsApp toolsets. Every other sender receives the configured subset of the
+currently enabled WhatsApp toolsets; entries disabled for WhatsApp are ignored,
+so this list can only reduce capabilities. Use an empty list for no tools. Phone
+and LID forms are resolved as aliases, and group ownership is based on the
+message sender, not the group ID. Omitting `nonowner_enabled_toolsets` preserves
+default behavior. In gateway proxy mode, restricted turns use the versioned
+`/v1/chat/completions/restricted` endpoint so older remote servers fail closed;
+upgrade both gateway and API server before enabling this policy.
+
 Then start the gateway:
 
 ```bash


### PR DESCRIPTION
## Summary\n- preserve Marcelo Paniza's owner-aware WhatsApp gate from #53742\n- restrict non-owner senders to an explicit subset of toolsets already enabled for WhatsApp\n- enforce same restriction across local, background, and proxy execution\n- add authenticated fail-closed restricted proxy routing with platform, session, and profile validation\n- handle group sender identity plus phone/LID aliases without granting from group chat IDs\n\nSupersedes #53742 while preserving Marcelo's original commit and authorship.\n\n## Verification\n- 315 focused tests passed\n- Ruff passed\n- py_compile and git diff --check passed