### PR TITLE
test(desktop): run visual E2E offscreen on macOS

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -33,6 +33,7 @@ import { installErrorBannerGuard } from './test'
 const DESKTOP_ROOT = path.resolve(import.meta.dirname, '..')
 const REPO_ROOT = path.resolve(DESKTOP_ROOT, '..', '..')
 const RELEASE_ROOT = path.join(DESKTOP_ROOT, 'release')
+const E2E_HEADLESS = process.env.HERMES_DESKTOP_E2E_HEADLESS === '1'
 
 // ─── Credential stripping (matches launch.spec.ts) ──────────────────────
 
@@ -609,7 +610,7 @@ export async function waitForAppReady(fixture: MockBackendFixture | NoProviderFi
   // window, but the DOM can be ready before that fires. Poll until the
   // window is actually visible so interactions (click, screenshot) don't
   // hit a hidden surface.
-  if (app) {
+  if (app && !E2E_HEADLESS) {
     const deadline = Date.now() + timeoutMs
 
     while (Date.now() < deadline) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -215,6 +215,10 @@ if (USER_DATA_OVERRIDE) {
 const DEV_SERVER = process.env.HERMES_DESKTOP_DEV_SERVER
 const IS_PACKAGED = app.isPackaged || Boolean(process.env.HERMES_DESKTOP_IS_PACKAGED)
 const IS_MAC = process.platform === 'darwin'
+// Linux E2E uses Cage. macOS has no equivalent isolated compositor, so the
+// visual runner opts into Electron's offscreen renderer instead. This is test
+// infrastructure only: normal desktop launches remain headed.
+const E2E_HEADLESS = process.env.HERMES_DESKTOP_E2E_HEADLESS === '1'
 const IS_WINDOWS = process.platform === 'win32'
 const IS_WSL = isWslEnvironment()
 // Truthful macOS kernel major (Tahoe = 25). Product version lies (16 vs 26) per
@@ -8093,7 +8097,7 @@ function focusWindow(win) {
     win.restore()
   }
 
-  if (!win.isVisible()) {
+  if (!E2E_HEADLESS && !win.isVisible()) {
     win.show()
   }
 
@@ -8123,7 +8127,7 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
     // themes/context.tsx, so the window appears already themed.
     show: false,
     backgroundColor: getWindowBackgroundColor(),
-    webPreferences: chatWindowWebPreferences(PRELOAD_PATH)
+    webPreferences: chatWindowWebPreferences(PRELOAD_PATH, { offscreen: E2E_HEADLESS })
   })
 
   if (IS_MAC) {
@@ -8131,7 +8135,7 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
   }
 
   win.once('ready-to-show', () => {
-    if (!win.isDestroyed()) {
+    if (!E2E_HEADLESS && !win.isDestroyed()) {
       win.show()
     }
   })
@@ -8200,7 +8204,7 @@ function createInstanceWindow() {
     icon,
     show: false,
     backgroundColor: getWindowBackgroundColor(),
-    webPreferences: chatWindowWebPreferences(PRELOAD_PATH)
+    webPreferences: chatWindowWebPreferences(PRELOAD_PATH, { offscreen: E2E_HEADLESS })
   })
 
   instanceWindows.add(win)
@@ -8210,7 +8214,7 @@ function createInstanceWindow() {
   }
 
   win.once('ready-to-show', () => {
-    if (!win.isDestroyed()) {
+    if (!E2E_HEADLESS && !win.isDestroyed()) {
       win.show()
     }
   })
@@ -8405,7 +8409,7 @@ function createWindow() {
     // both keep `backgroundThrottling: false` — the chat transcript streams via
     // a requestAnimationFrame-gated flush that Chromium pauses for blurred
     // windows, stalling the live answer until refocus. See session-windows.ts.
-    webPreferences: chatWindowWebPreferences(PRELOAD_PATH)
+    webPreferences: chatWindowWebPreferences(PRELOAD_PATH, { offscreen: E2E_HEADLESS })
   })
 
   if (IS_MAC) {
@@ -8432,7 +8436,7 @@ function createWindow() {
   }
 
   mainWindow.once('ready-to-show', () => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
+    if (!E2E_HEADLESS && mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.show()
     }
 
@@ -8462,7 +8466,7 @@ function createWindow() {
 
   // Under Playright testing, instantly show the window.
   // `ready-to-show` doesn't fire in some testing envs.
-  if (process.env.TEST_WORKER_INDEX !== undefined) {
+  if (!E2E_HEADLESS && process.env.TEST_WORKER_INDEX !== undefined) {
     if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isVisible()) {
       mainWindow.show()
     }

--- a/apps/desktop/electron/session-windows.test.ts
+++ b/apps/desktop/electron/session-windows.test.ts
@@ -208,3 +208,8 @@ test('chatWindowWebPreferences passes the preload path through and keeps the har
   assert.equal(prefs.sandbox, true)
   assert.equal(prefs.nodeIntegration, false)
 })
+
+test('chatWindowWebPreferences enables offscreen rendering only when requested', () => {
+  assert.equal(chatWindowWebPreferences('/tmp/preload.cjs').offscreen, false)
+  assert.equal(chatWindowWebPreferences('/tmp/preload.cjs', { offscreen: true }).offscreen, true)
+})

--- a/apps/desktop/electron/session-windows.ts
+++ b/apps/desktop/electron/session-windows.ts
@@ -21,7 +21,7 @@ const SESSION_WINDOW_MIN_HEIGHT = 620
 // blurred/occluded windows. A streaming chat app must keep painting in the
 // background, so every chat window opts out. The preload path is injected
 // because it depends on the Electron entry's __dirname.
-function chatWindowWebPreferences(preloadPath: string) {
+function chatWindowWebPreferences(preloadPath: string, { offscreen = false }: { offscreen?: boolean } = {}) {
   return {
     preload: preloadPath,
     contextIsolation: true,
@@ -29,7 +29,11 @@ function chatWindowWebPreferences(preloadPath: string) {
     sandbox: true,
     nodeIntegration: false,
     devTools: true,
-    backgroundThrottling: false
+    backgroundThrottling: false,
+    // macOS has no Cage-equivalent compositor. Playwright's offscreen renderer
+    // keeps desktop E2E windows out of the user's workspace while preserving a
+    // real Chromium surface for interaction and screenshots.
+    offscreen
   }
 }
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -56,8 +56,8 @@
     "preview": "node scripts/assert-root-install.mjs && vite preview --host 127.0.0.1 --port 4174",
     "check": "npm run typecheck && npm run test && npm run test:desktop:all",
     "test:e2e": "npm run clean:e2e && playwright test e2e/",
-    "test:e2e:visual": "npm run clean:e2e && WLR_BACKENDS=headless WLR_NO_HARDWARE_CURSORS=1 cage -- playwright test e2e/ --reporter=list",
-    "test:e2e:update-snapshots": "npm run clean:e2e && WLR_BACKENDS=headless WLR_NO_HARDWARE_CURSORS=1 cage -- playwright test e2e/ --reporter=list --update-snapshots"
+    "test:e2e:visual": "npm run build && node scripts/run-e2e-visual.mjs",
+    "test:e2e:update-snapshots": "npm run build && node scripts/run-e2e-visual.mjs --update-snapshots"
   },
   "dependencies": {
     "@assistant-ui/react": "^0.14.23",

--- a/apps/desktop/scripts/run-e2e-visual.mjs
+++ b/apps/desktop/scripts/run-e2e-visual.mjs
@@ -1,0 +1,32 @@
+import { spawnSync } from 'node:child_process'
+
+const env = { ...process.env }
+const extraArgs = process.argv.slice(2)
+const testPaths = extraArgs.filter(arg => !arg.startsWith('-'))
+const playwrightArgs = [
+  'test',
+  ...(testPaths.length > 0 ? testPaths : ['e2e/']),
+  '--reporter=list',
+  ...extraArgs.filter(arg => arg.startsWith('-')),
+]
+let command = 'playwright'
+let args = playwrightArgs
+
+if (process.platform === 'darwin') {
+  // macOS does not have a Cage-style headless Wayland compositor. Electron's
+  // offscreen renderer keeps the test BrowserWindow off the user's desktop.
+  env.HERMES_DESKTOP_E2E_HEADLESS = '1'
+} else {
+  command = 'cage'
+  args = ['--', 'playwright', ...playwrightArgs]
+  env.WLR_BACKENDS = 'headless'
+  env.WLR_NO_HARDWARE_CURSORS = '1'
+}
+
+const result = spawnSync(command, args, { env, stdio: 'inherit' })
+
+if (result.error) {
+  throw result.error
+}
+
+process.exitCode = result.status ?? 1


### PR DESCRIPTION
## What does this PR do?

Adds a no-visible-window visual E2E path for macOS. Linux continues to run visual Electron/Playwright tests inside Cage; macOS enables Electron offscreen rendering and suppresses window-show paths so the suite does not interrupt the user's desktop.

## Related Issue

N/A

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `apps/desktop/scripts/run-e2e-visual.mjs`, which selects Cage on Linux and Electron offscreen mode on macOS.
- Use the test-only `HERMES_DESKTOP_E2E_HEADLESS` flag to make chat windows offscreen and prevent them from being shown.
- Keep the normal headed `test:e2e` command unchanged.
- Build before visual E2E runs and add coverage for the offscreen web-preferences option.
- Invoke the project-local `playwright` binary directly; do not use `npx`.

## How to Test

1. Run `nix develop -c npm --prefix apps/desktop run check`.
2. Run `nix develop -c npm --prefix apps/desktop run test:e2e:visual -- e2e/boot.spec.ts`.
3. On macOS, run `npm --prefix apps/desktop run test:e2e:visual`; it uses offscreen Electron windows rather than opening them.

## Checklist

### Code

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Cage visual E2E)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validated locally:

- `npm run check`: 2,608 passed, 3 skipped; desktop package build passed.
- `npm run test:e2e:visual -- e2e/boot.spec.ts`: 4 passed.
