### PR TITLE
fix: honor cached secrets and disabled Telegram DM topics

### DIFF
--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -563,6 +563,20 @@ class OnePasswordSource(SecretSource):
                 result.error_kind = ErrorKind.NOT_CONFIGURED
             return result
 
+        # Honor override_existing before contacting 1Password. The registry
+        # applies precedence after fetch(), but fetching every mapped value
+        # first defeats the purpose of override_existing=False: a deleted or
+        # temporarily unavailable service account emits startup errors even
+        # when .env already contains every required value. Filter satisfied
+        # mappings here so local fallbacks can keep Hermes operational.
+        if not self.override_existing(cfg):
+            valid = {
+                name: ref for name, ref in valid.items()
+                if not os.environ.get(name)
+            }
+            if not valid:
+                return result
+
         binary_path = str(cfg.get("binary_path") or "")
         binary = find_op(binary_path)
         result.binary_path = binary

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4128,6 +4128,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         the original source unchanged.  Always derive the override storage key
         from the result so storage and read use an identical key.
         """
+        # /topic off promises that Telegram private topics stop acting as
+        # independent sessions. The adapter retains the inbound thread id for
+        # topic-mode routing, but once topic mode is off it must not remain a
+        # session-key discriminator. Collapse it to the root DM before deriving
+        # the key or delivery metadata.
+        if (
+            source.platform == Platform.TELEGRAM
+            and source.chat_type == "dm"
+            and source.thread_id is not None
+            and not self._telegram_topic_mode_enabled(source)
+        ):
+            return dataclasses.replace(source, thread_id=None)
+
         try:
             recovered = self._recover_telegram_topic_thread_id(source)
         except Exception:
@@ -12106,13 +12119,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Topic-mode DMs: rewrite a stale/foreign thread_id to the user's
         # last-active topic so a cross-topic Reply or stripped plain reply
         # doesn't fragment the conversation across sessions.
-        recovered = await asyncio.to_thread(self._recover_telegram_topic_thread_id, source)
-        if recovered is not None:
+        normalized_source = await asyncio.to_thread(
+            self._normalize_source_for_session_key, source
+        )
+        if normalized_source is not source:
             logger.info(
-                "telegram topic recovery: chat=%s user=%s %r -> %s",
-                source.chat_id, source.user_id, source.thread_id, recovered,
+                "telegram session source normalized: chat=%s user=%s %r -> %r",
+                source.chat_id, source.user_id, source.thread_id,
+                normalized_source.thread_id,
             )
-            source = dataclasses.replace(source, thread_id=recovered)
+            source = normalized_source
             try:
                 event.source = source
             except Exception:

--- a/tests/gateway/test_session_override_thread_recovery.py
+++ b/tests/gateway/test_session_override_thread_recovery.py
@@ -34,6 +34,7 @@ def _make_runner(recovered_thread_id=None):
     # Stub topic recovery: returns the bound topic id for a lobby message,
     # None otherwise (the real method's contract).
     runner._recover_telegram_topic_thread_id = MagicMock(return_value=recovered_thread_id)
+    runner._telegram_topic_mode_enabled = MagicMock(return_value=True)
     return runner
 
 
@@ -69,6 +70,18 @@ def test_normalize_passthrough_when_no_recovery():
     normalized = runner._normalize_source_for_session_key(src)
 
     assert normalized is src
+
+
+def test_normalize_collapses_private_topic_when_topic_mode_is_off():
+    """With /topic off, Telegram DM topics share the root-DM session key."""
+    runner = _make_runner(recovered_thread_id=None)
+    runner._telegram_topic_mode_enabled = MagicMock(return_value=False)
+    src = _topic_dm_source(thread_id="42")
+
+    normalized = runner._normalize_source_for_session_key(src)
+
+    assert normalized.thread_id is None
+    assert src.thread_id == "42"
 
 
 def test_normalize_swallows_recovery_exceptions():

--- a/tests/secret_sources/test_secret_source_registry.py
+++ b/tests/secret_sources/test_secret_source_registry.py
@@ -489,6 +489,30 @@ class TestOnePasswordSource:
         assert src.override_existing({}) is True
         assert src.override_existing({"override_existing": False}) is False
 
+    def test_fetch_skips_op_when_existing_values_win(self, monkeypatch, tmp_path):
+        import agent.secret_sources.onepassword as op
+
+        monkeypatch.setenv("EXISTING_SECRET", "local-fallback")
+        monkeypatch.setattr(
+            op,
+            "find_op",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("op must not be contacted")
+            ),
+        )
+
+        result = op.OnePasswordSource().fetch(
+            {
+                "enabled": True,
+                "override_existing": False,
+                "env": {"EXISTING_SECRET": "op://Vault/Item/password"},
+            },
+            tmp_path,
+        )
+
+        assert result.ok
+        assert result.secrets == {}
+
     def test_protected_vars_track_token_env(self):
         from agent.secret_sources.onepassword import OnePasswordSource
 


### PR DESCRIPTION
## Summary
- avoid fetching 1Password mappings that already have local values when `override_existing` is false
- normalize Telegram private-topic messages to the bare-DM session key when topic mode is disabled
- add regression coverage for both behaviors

## Why
A deleted 1Password service account caused startup errors even though valid cached values existed. Separately, `/topic off` still let Telegram private `message_thread_id` values split one DM into many sessions.

## Test plan
- `pytest -q tests/gateway/test_session_override_thread_recovery.py tests/gateway/test_telegram_topic_mode.py tests/gateway/test_dm_topics.py tests/secret_sources/test_secret_source_registry.py`
- Result: 156 passed
- Live `hermes doctor`: all checks passed; DeepSeek and Z.AI connectivity passed
- Live routing check: three private thread IDs normalize to one bare-DM session key
