### PR TITLE
feat: per-function tool filtering via tools.disabled_functions config

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -422,6 +422,7 @@ def init_agent(
     tool_delay: float = 1.0,
     enabled_toolsets: List[str] = None,
     disabled_toolsets: List[str] = None,
+    disabled_functions: List[str] = None,
     save_trajectories: bool = False,
     verbose_logging: bool = False,
     quiet_mode: bool = False,
@@ -767,6 +768,7 @@ def init_agent(
     # Store toolset filtering options
     agent.enabled_toolsets = enabled_toolsets
     agent.disabled_toolsets = disabled_toolsets
+    agent.disabled_functions = disabled_functions
     
     # Model response configuration
     agent.max_tokens = max_tokens  # None = use model default
@@ -1363,6 +1365,7 @@ def init_agent(
     agent.tools = _ra().get_tool_definitions(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
+        disabled_functions=disabled_functions,
         quiet_mode=agent.quiet_mode,
     )
     

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1518,6 +1518,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     skip_tool_request_middleware=True,
                     enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                     disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                    disabled_functions=getattr(agent, "disabled_functions", None),
                     tool_request_middleware_trace=list(middleware_trace),
                 )
                 _spinner_result = function_result
@@ -1560,6 +1561,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     skip_tool_request_middleware=True,
                     enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                     disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                    disabled_functions=getattr(agent, "disabled_functions", None),
                     tool_request_middleware_trace=list(middleware_trace),
                 )
             except KeyboardInterrupt:

--- a/cli.py
+++ b/cli.py
@@ -3962,6 +3962,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Parse and validate toolsets
         self.enabled_toolsets = toolsets
         self.disabled_toolsets = CLI_CONFIG["agent"].get("disabled_toolsets") or []
+        self.disabled_functions = (CLI_CONFIG.get("tools") or {}).get("disabled_functions") or []
 
         if toolsets and "all" not in toolsets and "*" not in toolsets:
             # Validate each toolset — MCP server names are resolved via

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3357,6 +3357,7 @@ def run_job(
             openrouter_min_coding_score=(_cfg.get("openrouter") or {}).get("min_coding_score"),
             enabled_toolsets=_resolve_cron_enabled_toolsets(job, _cfg),
             disabled_toolsets=_resolve_cron_disabled_toolsets(_cfg),
+            disabled_functions=(_cfg.get("tools") or {}).get("disabled_functions") or None,
             quiet_mode=True,
             # Cron jobs should always inherit the user's SOUL.md identity from
             # HERMES_HOME. When a workdir is configured, also inject project

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1924,6 +1924,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        disabled_functions = (user_config.get("tools") or {}).get("disabled_functions") or None
 
         max_iterations = _current_max_iterations()
 
@@ -1940,6 +1941,7 @@ class APIServerAdapter(BasePlatformAdapter):
             verbose_logging=False,
             ephemeral_system_prompt=ephemeral_system_prompt or None,
             enabled_toolsets=enabled_toolsets,
+            disabled_functions=disabled_functions,
             session_id=session_id,
             platform="api_server",
             stream_delta_callback=stream_delta_callback,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15113,6 +15113,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
+            disabled_functions = (user_config.get("tools") or {}).get("disabled_functions") or None
 
             pr = self._provider_routing
             max_iterations = _current_max_iterations()
@@ -15150,6 +15151,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     verbose_logging=False,
                     enabled_toolsets=enabled_toolsets,
                     disabled_toolsets=disabled_toolsets,
+                    disabled_functions=disabled_functions,
                     reasoning_config=reasoning_config,
                     service_tier=self._service_tier,
                     request_overrides=turn_route.get("request_overrides"),
@@ -19410,6 +19412,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
+        disabled_functions = (user_config.get("tools") or {}).get("disabled_functions") or None
 
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):
@@ -20794,6 +20797,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     verbose_logging=False,
                     enabled_toolsets=enabled_toolsets,
                     disabled_toolsets=disabled_toolsets,
+                    disabled_functions=disabled_functions,
                     ephemeral_system_prompt=combined_ephemeral or None,
                     prefill_messages=self._prefill_messages or None,
                     reasoning_config=reasoning_config,

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -363,6 +363,7 @@ class CLIAgentSetupMixin:
                 max_iterations=self.max_turns,
                 enabled_toolsets=self.enabled_toolsets,
                 disabled_toolsets=self.disabled_toolsets,
+                disabled_functions=self.disabled_functions,
                 verbose_logging=self.verbose,
                 quiet_mode=not self.verbose,
                 tool_progress_mode=getattr(self, "tool_progress_mode", "all"),

--- a/model_tools.py
+++ b/model_tools.py
@@ -281,6 +281,7 @@ def get_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    disabled_functions: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -296,6 +297,9 @@ def get_tool_definitions(
             tool_search / tool_describe bridge handlers so they can read the
             real catalog, not the already-collapsed one. Public callers should
             leave this False.
+        disabled_functions: Per-function tool names to exclude from the result.
+            Applied after toolset resolution and check_fn filtering. Provides
+            finer-grained control than toolset-level enable/disable.
 
     Returns:
         Filtered list of OpenAI-format tool definitions.
@@ -319,6 +323,7 @@ def get_tool_definitions(
         cache_key = (
             frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
             frozenset(disabled_toolsets) if disabled_toolsets else None,
+            frozenset(disabled_functions) if disabled_functions else None,
             registry._generation,
             cfg_fp,
             bool(os.environ.get("HERMES_KANBAN_TASK")),
@@ -335,7 +340,8 @@ def get_tool_definitions(
             return list(cached)
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
+                                       skip_tool_search_assembly=skip_tool_search_assembly,
+                                       disabled_functions=disabled_functions)
     if quiet_mode:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
@@ -359,6 +365,7 @@ def _compute_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    disabled_functions: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
@@ -533,6 +540,20 @@ def _compute_tool_definitions(
         filtered_tools = sanitize_tool_schemas(filtered_tools)
     except Exception as e:  # pragma: no cover — defensive
         logger.warning("Schema sanitization skipped: %s", e)
+
+    # ── Per-function disabled list ─────────────────────────────────────
+    # Strip individual tools by name (e.g. ``skill_manage``) below toolset
+    # granularity.  Applied after sanitization so disabled tools never
+    # enter the bridge catalog, and before the Tool Search bridge so the
+    # deferred set doesn't include them.
+    if disabled_functions:
+        disabled_set = set(disabled_functions)
+        filtered_tools = [
+            t for t in filtered_tools
+            if t.get("function", {}).get("name") not in disabled_set
+        ]
+        if not quiet_mode:
+            print(f"🚫 Disabled functions: {', '.join(sorted(disabled_set))}")
 
     # ── Tool Search (progressive disclosure) ────────────────────────────
     # Conditionally replace MCP + plugin (non-core) tools with three bridge
@@ -1067,6 +1088,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    disabled_functions: Optional[List[str]] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1088,6 +1110,9 @@ def handle_function_call(
                        matching ``get_tool_definitions`` semantics.
         disabled_toolsets: The session's disabled toolsets, applied as a
                        subtraction when scoping the bridge catalog.
+        disabled_functions: Per-function tool names that are blocked from
+                       execution.  Defense-in-depth guard: even if a disabled
+                       tool's schema leaks into the prompt, dispatch rejects it.
 
     Returns:
         Function result as a JSON string.
@@ -1171,6 +1196,7 @@ def handle_function_call(
                 tool_request_middleware_trace=list(_tool_middleware_trace),
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
+                disabled_functions=disabled_functions,
             )
 
     _tool_original_args = dict(function_args)
@@ -1196,6 +1222,15 @@ def handle_function_call(
     try:
         if function_name in _AGENT_LOOP_TOOLS:
             return json.dumps({"error": f"{function_name} must be handled by the agent loop"})
+
+        # Defense-in-depth: reject disabled functions at dispatch time even
+        # if the schema filter above somehow didn't catch them (e.g. through
+        # the tool_search → tool_call bridge path).
+        if disabled_functions and function_name in disabled_functions:
+            return json.dumps(
+                {"error": f"Tool '{function_name}' is disabled by configuration"},
+                ensure_ascii=False,
+            )
 
         # Check plugin hooks for a block/approve directive (unless caller
         # already checked — e.g. run_agent._invoke_tool passes skip=True to

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -587,3 +587,94 @@ class TestDisabledToolsetsPostureToolset:
             )
         }
         assert "write_file" not in no_file
+
+
+class TestDisabledFunctions:
+    """Per-function filtering: ``disabled_functions`` strips individual tools
+    from schema and blocks them at dispatch time."""
+
+    def test_disabled_functions_strips_from_schema(self):
+        """Tools listed in disabled_functions are absent from the schema result."""
+        from model_tools import get_tool_definitions
+
+        baseline = get_tool_definitions(quiet_mode=True)
+        baseline_names = {t["function"]["name"] for t in baseline}
+        # Pick two tools that are almost certainly present in any install.
+        target = {"write_file", "read_file"} & baseline_names
+        if not target or len(target) < 2:
+            # Fallback: use any two tools present.
+            target = set(sorted(baseline_names)[:2])
+        target_list = sorted(target)
+
+        filtered = get_tool_definitions(
+            disabled_functions=target_list, quiet_mode=True,
+        )
+        filtered_names = {t["function"]["name"] for t in filtered}
+
+        for fn in target_list:
+            assert fn not in filtered_names, f"'{fn}' should be filtered out"
+
+    def test_disabled_function_not_present_not_crash(self):
+        """Passing a tool name that doesn't exist is harmless (no-op)."""
+        from model_tools import get_tool_definitions
+
+        baseline = get_tool_definitions(quiet_mode=True)
+        baseline_names = {t["function"]["name"] for t in baseline}
+        result = get_tool_definitions(
+            disabled_functions=["this_tool_does_not_exist_xyz123"],
+            quiet_mode=True,
+        )
+        result_names = {t["function"]["name"] for t in result}
+        assert result_names == baseline_names, (
+            "disabled_functions with unknown name must not alter the tool list"
+        )
+
+    def test_handle_function_call_blocks_disabled(self):
+        """Dispatch rejects tools listed in disabled_functions."""
+        result_str = handle_function_call(
+            "write_file",
+            {"path": "/tmp/test", "content": "hello"},
+            disabled_functions=["write_file"],
+        )
+        result = json.loads(result_str)
+        assert "error" in result
+        assert "write_file" in result["error"]
+        assert "disabled" in result["error"].lower()
+
+    def test_handle_function_call_not_disabled_passes(self):
+        """Tools NOT in disabled_functions dispatch normally (via registry)."""
+        with patch("model_tools.registry.dispatch", return_value='{"ok":true}'):
+            result = handle_function_call(
+                "web_search",
+                {"q": "test"},
+                disabled_functions=["write_file"],
+            )
+        assert result == '{"ok":true}'
+
+    def test_cache_key_varies_with_disabled_functions(self):
+        """Different disabled_functions lists produce different cache entries."""
+        from model_tools import get_tool_definitions, _clear_tool_defs_cache
+
+        _clear_tool_defs_cache()
+        tools_all = get_tool_definitions(quiet_mode=True)
+        all_names = {t["function"]["name"] for t in tools_all}
+        target = sorted(set(t for t in all_names if t in {"write_file", "read_file"}))
+        if len(target) < 2:
+            target = sorted(all_names)[:2]
+
+        tools_no_1 = get_tool_definitions(
+            disabled_functions=[target[0]], quiet_mode=True,
+        )
+        tools_no_both = get_tool_definitions(
+            disabled_functions=target, quiet_mode=True,
+        )
+
+        names_no_1 = {t["function"]["name"] for t in tools_no_1}
+        names_no_both = {t["function"]["name"] for t in tools_no_both}
+
+        assert target[0] not in names_no_1
+        assert target[0] not in names_no_both
+        assert target[1] not in names_no_both
+        assert target[1] in names_no_1, (
+            f"'{target[1]}' should still be present when only '{target[0]}' is disabled"
+        )


### PR DESCRIPTION
## Summary

Adds finer-grained tool control below toolset granularity. Users can now disable individual tools in `config.yaml`:

```yaml
tools:
  disabled_functions:
    - skill_manage
    - write_file
    - patch
```

## Design

The change plugs into the existing toolset filtering pipeline as a subtract stage:

1. **Schema filtering** (`model_tools.py:_compute_tool_definitions`): strips disabled function schemas after sanitization, before the Tool Search bridge — LLM never sees the tool name
2. **Dispatch guard** (`model_tools.py:handle_function_call`): defense-in-depth — rejects disabled tools at dispatch time even if the schema somehow leaks
3. **Cache-aware**: `disabled_functions` is part of the LRU cache key, so config changes automatically miss and recompute

## Changes

| File | Change |
|---|---|
| `model_tools.py` | `get_tool_definitions()` + `_compute_tool_definitions()` + `handle_function_call()` gain `disabled_functions` param |
| `agent/agent_init.py` | Store `agent.disabled_functions`, pass to `get_tool_definitions()` |
| `agent/tool_executor.py` | Pass `agent.disabled_functions` to both `handle_function_call()` sites |
| `cli.py` | Parse `tools.disabled_functions` from config |
| `gateway/run.py` | Parse + pass in 2 AIAgent creation sites |
| `gateway/platforms/api_server.py` | Parse + pass in `_create_agent()` |
| `cron/scheduler.py` | Parse + pass in cron agent creation |
| `hermes_cli/cli_agent_setup_mixin.py` | Pass `self.disabled_functions` to AIAgent |
| `tests/test_model_tools.py` | 5 new tests: schema filtering, dispatch blocking, cache isolation, no-op unknown |

## Related Issues

- Closes #68964
- Closes #31375