### PR TITLE
fix(terminal): keep profile home authoritative across snapshots

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -64,6 +64,7 @@ class TestWrapCommand:
         wrapped = env._wrap_command("echo hello", "/tmp")
 
         assert "source" in wrapped
+        assert "export HERMES_HOME=" not in wrapped
         assert "cd -- /tmp" in wrapped or "cd -- '/tmp'" in wrapped
         assert "eval 'echo hello'" in wrapped
         assert "__hermes_ec=$?" in wrapped

--- a/tests/tools/test_local_shell_init.py
+++ b/tests/tools/test_local_shell_init.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from tools.environments.local import (
     LocalEnvironment,
     _prepend_shell_init,
@@ -310,3 +311,33 @@ class TestSnapshotEndToEnd:
         assert str(fake_n_bin) in output
         # bashrc short-circuited on the interactive guard — its export never ran
         assert "FROM_BASHRC=bashrc-should-not-appear" not in output
+
+    def test_reused_local_environment_reasserts_profile_hermes_home(self, tmp_path):
+        profile_a = tmp_path / "profile-a"
+        profile_b = tmp_path / "profile-b"
+        profile_a.mkdir()
+        profile_b.mkdir()
+
+        token_a = set_hermes_home_override(str(profile_a))
+        env = None
+        token_b = None
+        try:
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+            first = env.execute(
+                'export SNAPSHOT_PIN="sticky"; echo "first=$HERMES_HOME"'
+            )
+            token_b = set_hermes_home_override(str(profile_b))
+            second = env.execute(
+                'echo "second=$HERMES_HOME SNAPSHOT_PIN=$SNAPSHOT_PIN"'
+            )
+            assert first["returncode"] == 0
+            assert second["returncode"] == 0
+            assert f"first={profile_a}" in first.get("output", "")
+            assert f"second={profile_b}" in second.get("output", "")
+            assert "SNAPSHOT_PIN=sticky" in second.get("output", "")
+        finally:
+            if token_b is not None:
+                reset_hermes_home_override(token_b)
+            reset_hermes_home_override(token_a)
+            if env is not None:
+                env.cleanup()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -21,7 +21,7 @@ from collections import deque
 from pathlib import Path
 from typing import IO, Callable, Protocol
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_hermes_home_override
 from hermes_cli._subprocess_compat import windows_hide_flags
 from tools.interrupt import is_interrupted
 
@@ -398,6 +398,9 @@ class BaseEnvironment(ABC):
     # Subclasses that embed stdin as a heredoc (Modal, Daytona) set this.
     _stdin_mode: str = "pipe"  # "pipe" or "heredoc"
 
+    # Local subprocesses receive the task-local host profile in their env.
+    _reassert_context_hermes_home: bool = False
+
     # Snapshot creation timeout (override for slow cold-starts).
     _snapshot_timeout: int = 30
 
@@ -624,6 +627,12 @@ class BaseEnvironment(ABC):
             parts.append(
                 f"source {_quoted_snap} >/dev/null 2>&1 || true"
             )
+            # A reused snapshot may belong to another profile. The current
+            # task's explicit profile remains authoritative.
+            if self._reassert_context_hermes_home and (
+                _hermes_home := get_hermes_home_override()
+            ):
+                parts.append(f"export HERMES_HOME={shlex.quote(_hermes_home)}")
 
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
         # ``$HOME`` so suffixes with spaces remain a single shell word.

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1268,6 +1268,8 @@ class LocalEnvironment(BaseEnvironment):
     CWD persists via file-based read after each command.
     """
 
+    _reassert_context_hermes_home = True
+
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         cwd = _resolve_local_initial_cwd(cwd)
         super().__init__(cwd=cwd, timeout=timeout, env=env)


### PR DESCRIPTION
## Summary

- reassert the current task-local `HERMES_HOME` after a local terminal snapshot is sourced
- preserve ordinary persistent shell exports
- keep remote terminal backends unchanged

## Root cause

`LocalEnvironment` builds each fresh subprocess with the current ContextVar-backed profile home. A persistent shell snapshot can outlive that context, and sourcing it before the user command replayed the previous profile's `HERMES_HOME` over the fresh value.

The regression test reuses one real local shell across profile A and profile B. It fails on the parent commit because the second command still sees A, then passes with this change while an unrelated exported variable remains persistent.

## Verification

- `pytest -q tests/tools/test_local_shell_init.py tests/tools/test_base_environment.py tests/tools/test_local_env_session_leak.py tests/test_profile_isolation_runtime.py` (`72 passed`)
- `python -m compileall -q tools/environments/base.py tools/environments/local.py tests/tools/test_base_environment.py tests/tools/test_local_shell_init.py`
- `ruff check tools/environments/base.py tools/environments/local.py tests/tools/test_base_environment.py tests/tools/test_local_shell_init.py`
- `git diff --check origin/main...HEAD`

## Risk and rollback

The reassertion is opt-in only for `LocalEnvironment`; remote backends keep the existing wrapper behavior. Reverting this commit restores the prior snapshot precedence.
