### PR TITLE
fix(desktop): prevent stale optimistic tails after compression

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -327,6 +327,42 @@ describe('preserveLocalPendingTurnMessages', () => {
 
     expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
   })
+
+  it('drops stale optimistic history after compression and keeps only the live tail', () => {
+    const compressedAuthority = [
+      msg('stored-user', 'user', 'first turn that survived compression'),
+      msg('stored-assistant', 'assistant', 'latest authoritative reply')
+    ]
+
+    const pollutedWarmCache = [
+      msg('user-old-1', 'user', 'compressed-away prompt one'),
+      msg('assistant-old-1', 'assistant', 'compressed-away reply one'),
+      msg('user-old-2', 'user', 'compressed-away prompt two'),
+      msg('assistant-old-2', 'assistant', 'compressed-away reply two'),
+      msg('user-inflight', 'user', 'the one genuinely in-flight prompt')
+    ]
+
+    expect(preserveLocalPendingTurnMessages(compressedAuthority, pollutedWarmCache).map(message => message.id)).toEqual([
+      'stored-user',
+      'stored-assistant',
+      'user-inflight'
+    ])
+  })
+
+  it('drops the live tail once the latest authoritative user has persisted it after compression', () => {
+    const compressedAuthority = [
+      msg('stored-user', 'user', 'the one genuinely in-flight prompt'),
+      msg('stored-assistant', 'assistant', 'its authoritative reply')
+    ]
+
+    const pollutedWarmCache = [
+      msg('user-old-1', 'user', 'compressed-away prompt one'),
+      msg('assistant-old-1', 'assistant', 'compressed-away reply one'),
+      msg('user-inflight', 'user', 'the one genuinely in-flight prompt')
+    ]
+
+    expect(preserveLocalPendingTurnMessages(compressedAuthority, pollutedWarmCache)).toBe(compressedAuthority)
+  })
 })
 
 describe('appendLiveSessionProjection', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -234,9 +234,12 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
  * dropping either makes an accepted turn appear to vanish during transport
  * churn.
  *
- * Authoritative rows use different ids, so match by role ordinal. A matching
- * user row is considered committed only when its visible text also matches;
- * any authoritative assistant at the same ordinal supersedes the local stream.
+ * A lagging projection can be behind by one live turn, never a whole local
+ * history window. Preserve only the newest optimistic user row: compression
+ * rewrites past context, so older `user-*` rows in a warm cache are stale
+ * history, not in-flight work. The latest authoritative user confirms whether
+ * that tail has persisted; any authoritative assistant at the same ordinal
+ * supersedes the local stream.
  */
 export function preserveLocalPendingTurnMessages(
   nextMessages: ChatMessage[],
@@ -257,6 +260,10 @@ export function preserveLocalPendingTurnMessages(
 
   const nextIds = new Set(nextMessages.map(message => message.id))
   const previousRoleCounts = new Map<ChatMessage['role'], number>()
+  const newestOptimisticUser = [...previousMessages]
+    .reverse()
+    .find(message => message.role === 'user' && message.id.startsWith('user-'))
+  const latestAuthoritativeUser = [...nextMessages].reverse().find(message => message.role === 'user')
   const preserved: ChatMessage[] = []
 
   for (const message of previousMessages) {
@@ -269,6 +276,14 @@ export function preserveLocalPendingTurnMessages(
       message.role === 'assistant' && (message.pending === true || message.id.startsWith('assistant-stream-'))
 
     if ((!isOptimisticUser && !isPendingAssistant) || nextIds.has(message.id)) {
+      continue
+    }
+
+    if (isOptimisticUser && message !== newestOptimisticUser) {
+      continue
+    }
+
+    if (isOptimisticUser && latestAuthoritativeUser && chatMessageText(latestAuthoritativeUser).trim() === chatMessageText(message).trim()) {
       continue
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes a Desktop renderer bug after context compression. A warm session cache could re-append old user prompts at the bottom of the transcript, below newer assistant replies, even though the persisted session history was correct.

An **optimistic message** is a temporary local chat bubble shown immediately after the user presses Send, before the server returns its saved/authoritative version. It makes the UI feel instant during network and inference delay.

Keeping every cached optimistic row is wrong after compression: compression rewrites the authoritative transcript and shifts user ordinals, so old locally cached `user-*` rows can look uncommitted solely because their position no longer matches. They are already historical turns, not pending work; preserving them duplicates them at the bottom of the chat. The only optimistic user row that can genuinely still be in flight is the newest one, so this change retains only that tail. It drops the tail too once the latest authoritative user confirms the same prompt has persisted.

## Related Issue

Fixes #68979

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-session-actions/utils.ts`
  - Preserve only the newest optimistic user row during resume reconciliation.
  - Treat that tail as committed when it matches the latest authoritative user, even when compression shifted role ordinals.
- `apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts`
  - Add regression coverage for stale compressed-history rows and a persisted tail after ordinal shift.

## How to Test

1. Run `nix develop -c bash -lc 'cd apps/desktop && npx vitest run src/app/session/hooks/use-session-actions/utils.test.ts --environment jsdom --reporter=verbose'`.
2. Confirm the compressed-history regression retains only the genuine in-flight tail.
3. Confirm the persisted-tail regression removes the local bubble after the authoritative row arrives.
4. Run `nix develop -c bash -lc 'cd apps/desktop && npm run check'`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not applicable: Desktop TypeScript-only change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux/NixOS desktop build and package lane

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`nix develop -c bash -lc 'cd apps/desktop && npm run check'` passed after the amend:

- TypeScript checks passed for renderer, Electron, and E2E configs.
- Vitest: 2,609 passed, 3 skipped.
- Production renderer build and unpacked Linux Electron package completed successfully.

## Supersedes #68985

Closes #68985. Both fixes correctly bound optimistic-row preservation to the newest local user turn after compression. #68985 marks that tail committed when the same text appears anywhere in the authoritative transcript. That loses a genuinely new repeated prompt when an older turn has identical text. This PR instead requires the **latest** authoritative user to match, preserving repeat-prompt behavior established in #69649 while still draining stale compressed-history rows.
