### PR TITLE
fix(tui_gateway): preserve websocket batch order

### DIFF
--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent.futures
+import json
 import threading
 import time
 
@@ -222,3 +223,84 @@ def test_ws_transport_serializes_concurrent_sends():
         loop.call_soon_threadsafe(loop.stop)
         thread.join(timeout=2)
         loop.close()
+
+
+def test_ws_transport_preserves_cross_batch_order():
+    async def scenario():
+        entered = []
+        first_entered = asyncio.Event()
+        release_first = asyncio.Event()
+        second_started = asyncio.Event()
+
+        class FakeWS:
+            async def send_text(self, line):
+                entered.append(line)
+                if line == "A1":
+                    first_entered.set()
+                    await release_first.wait()
+
+        transport = ws_mod.WSTransport(
+            FakeWS(), asyncio.get_running_loop(), peer="batch-order-test"
+        )
+        first = asyncio.create_task(transport._safe_send_many(["A1", "A2"]))
+        await first_entered.wait()
+
+        async def send_second():
+            second_started.set()
+            await transport._safe_send_many(["B1", "B2"])
+
+        second = asyncio.create_task(send_second())
+        await second_started.wait()
+
+        # The second task has reached the transport. Without whole-batch
+        # serialization it runs B1/B2 before this task can resume.
+        assert entered == ["A1"]
+
+        release_first.set()
+        await asyncio.gather(first, second)
+        assert entered == ["A1", "A2", "B1", "B2"]
+
+    asyncio.run(scenario())
+
+
+def test_ws_write_async_keeps_drained_tokens_with_current_frame():
+    async def scenario():
+        entered = []
+        first_entered = asyncio.Event()
+        release_first = asyncio.Event()
+        current_started = asyncio.Event()
+
+        class FakeWS:
+            async def send_text(self, line):
+                entered.append(line)
+                if line == "A1":
+                    first_entered.set()
+                    await release_first.wait()
+
+        transport = ws_mod.WSTransport(
+            FakeWS(), asyncio.get_running_loop(), peer="async-order-test"
+        )
+        transport._pending_tokens.append("pending-token")
+
+        first = asyncio.create_task(transport._safe_send_many(["A1", "A2"]))
+        await first_entered.wait()
+
+        async def send_current():
+            current_started.set()
+            await transport.write_async({"id": "current"})
+
+        current = asyncio.create_task(send_current())
+        await current_started.wait()
+        later = asyncio.create_task(transport._safe_send_many(["later-batch"]))
+
+        release_first.set()
+        await asyncio.gather(first, current, later)
+        assert entered == [
+            "A1",
+            "A2",
+            "pending-token",
+            json.dumps({"id": "current"}),
+            "later-batch",
+        ]
+
+    asyncio.run(scenario())

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import threading
 import time
 
@@ -179,6 +180,43 @@ def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
         while len(sent) < 2 and time.time() < deadline:
             time.sleep(0.01)
         assert len(sent) == 2
+        assert transport._closed is False
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=2)
+        loop.close()
+
+
+def test_ws_transport_serializes_concurrent_sends():
+    active_sends = 0
+    max_active_sends = 0
+    sent = []
+
+    class FakeWS:
+        async def send_text(self, line):
+            nonlocal active_sends, max_active_sends
+            active_sends += 1
+            max_active_sends = max(max_active_sends, active_sends)
+            try:
+                await asyncio.sleep(0.05)
+                sent.append(line)
+            finally:
+                active_sends -= 1
+
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    try:
+        transport = ws_mod.WSTransport(FakeWS(), loop, peer="serialize-test")
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [
+                pool.submit(transport.write, {"idx": 1}),
+                pool.submit(transport.write, {"idx": 2}),
+            ]
+            assert [f.result(timeout=2) for f in futures] == [True, True]
+
+        assert len(sent) == 2
+        assert max_active_sends == 1
         assert transport._closed is False
     finally:
         loop.call_soon_threadsafe(loop.stop)

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -102,9 +102,9 @@ class WSTransport:
         self._pending_tokens: list[str] = []
         self._token_flush_handle: asyncio.TimerHandle | None = None
         self._token_flush_armed = False
-        # Serialize actual socket writes separately from buffer mutation. This
-        # commit predates token batching; the follow-up adapts the boundary to
-        # cover whole batches without dropping the current coalescing path.
+        # Buffer mutation is protected by the thread lock above; actual socket
+        # writes need an async boundary because several batches can be queued on
+        # the owning loop while it recovers from a stall.
         self._send_lock = asyncio.Lock()
 
     @staticmethod
@@ -215,39 +215,38 @@ class WSTransport:
         if self._closed:
             return False
         # Flush any buffered streamed tokens ahead of this frame (RPC response /
-        # control frame) so it can't overtake the tokens that preceded it.
+        # control frame) as ONE serialized batch. Sending them in two lock
+        # acquisitions would let a later batch slip between the pending tokens
+        # and the frame that drained them.
         with self._token_lock:
-            pending = self._pending_tokens
+            batch = self._pending_tokens
             self._pending_tokens = []
-        if pending:
-            await self._safe_send_many(pending)
-        await self._safe_send(json.dumps(obj, ensure_ascii=False))
+            batch.append(json.dumps(obj, ensure_ascii=False))
+        await self._safe_send_many(batch)
         return not self._closed
 
     async def _safe_send(self, line: str) -> None:
-        try:
-            async with self._send_lock:
-                if self._closed:
-                    return
-                await self._ws.send_text(line)
-        except Exception as exc:
-            self._closed = True
-            _log.warning(
-                "ws send failed peer=%s error_type=%s error=%s",
-                self._peer, type(exc).__name__, exc,
-            )
+        await self._safe_send_many([line])
 
     async def _safe_send_many(self, lines: list[str]) -> None:
-        """Send a batch of pre-serialized frames in order on the loop thread."""
-        try:
-            for line in lines:
-                await self._ws.send_text(line)
-        except Exception as exc:
-            self._closed = True
-            _log.warning(
-                "ws send failed peer=%s error_type=%s error=%s",
-                self._peer, type(exc).__name__, exc,
-            )
+        """Send one indivisible batch of pre-serialized frames in wire order."""
+        async with self._send_lock:
+            if self._closed:
+                return
+            try:
+                for line in lines:
+                    if self._closed:
+                        return
+                    await self._ws.send_text(line)
+            except Exception as exc:
+                # Latch while still holding the writer lock so queued batches
+                # observe the failure before they get a chance to touch the
+                # socket.
+                self._closed = True
+                _log.warning(
+                    "ws send failed peer=%s error_type=%s error=%s",
+                    self._peer, type(exc).__name__, exc,
+                )
 
     def close(self) -> None:
         self._closed = True

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -225,9 +225,6 @@ class WSTransport:
         await self._safe_send_many(batch)
         return not self._closed
 
-    async def _safe_send(self, line: str) -> None:
-        await self._safe_send_many([line])
-
     async def _safe_send_many(self, lines: list[str]) -> None:
         """Send one indivisible batch of pre-serialized frames in wire order."""
         async with self._send_lock:

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -102,6 +102,10 @@ class WSTransport:
         self._pending_tokens: list[str] = []
         self._token_flush_handle: asyncio.TimerHandle | None = None
         self._token_flush_armed = False
+        # Serialize actual socket writes separately from buffer mutation. This
+        # commit predates token batching; the follow-up adapts the boundary to
+        # cover whole batches without dropping the current coalescing path.
+        self._send_lock = asyncio.Lock()
 
     @staticmethod
     def _is_streaming_frame(obj: dict) -> bool:
@@ -222,7 +226,10 @@ class WSTransport:
 
     async def _safe_send(self, line: str) -> None:
         try:
-            await self._ws.send_text(line)
+            async with self._send_lock:
+                if self._closed:
+                    return
+                await self._ws.send_text(line)
         except Exception as exc:
             self._closed = True
             _log.warning(


### PR DESCRIPTION
## What does this PR do?

Serializes WebSocket writes per `WSTransport` across whole coalesced batches so streamed Desktop/dashboard frames cannot arrive out of order when the event loop recovers from a long stall.

The token buffer's `threading.Lock` currently preserves buffer-drain and task-creation order, but it does not serialize the asynchronous socket writes. Multiple `_safe_send_many()` tasks can therefore be in flight together, and each task yields at `await send_text()`. A later batch can enter the socket between two frames from an earlier batch. A deterministic reproduction produced `A1, B1, B2, A2` from logically ordered batches `[A1, A2]` and `[B1, B2]`.

This PR carries forward the per-socket serialization work from #48446 with the original contributor's authorship preserved, then adapts it to the token-batching implementation that landed afterward. It does not reopen the WebSocket-disconnect diagnosis resolved by #55545; this fixes the separate frame-ordering invariant.

## Related Issue

Related to #48446 and #55545.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/ws.py`: add a per-transport async writer lock and hold it for each complete `_safe_send_many()` batch.
- `tui_gateway/ws.py`: route single-frame sends through the same serialized writer path.
- `tui_gateway/ws.py`: send tokens drained by `write_async()` and its current control/RPC frame in one lock acquisition so another batch cannot overtake the current frame.
- `tests/test_tui_gateway_ws.py`: retain the original concurrent-send regression and add deterministic cross-batch and `write_async()` ordering coverage.

## How to Test

1. Run `tests/test_tui_gateway_ws.py` through the project test runner.
2. Confirm `test_ws_transport_preserves_cross_batch_order` blocks batch B until every frame in batch A has been sent.
3. Confirm `test_ws_write_async_keeps_drained_tokens_with_current_frame` keeps the current frame immediately behind the pending tokens it drains.

Focused local validation on Windows 11:

- `python -m py_compile tui_gateway/ws.py tests/test_tui_gateway_ws.py` passed.
- Direct isolated execution of the three serialization regressions passed.
- `git diff --check` passed.
- Full pytest coverage is left to GitHub CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the fix uses platform-neutral `asyncio.Lock`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no model tool changed

## Screenshots / Logs

Before the fix, the deterministic batch reproduction entered the socket as `A1, B1, B2, A2`. With the serialized batch boundary, it enters as `A1, A2, B1, B2`.
