### PR TITLE
fix(desktop): prevent cross-session leak in background queue drain

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -601,6 +601,62 @@ describe('usePromptActions submit / queue drain semantics', () => {
     expect($busy.get()).toBe(false)
   })
 
+  it('a fromQueue drain with null runtime id does NOT land in the foreground session (cross-session leak guard)', async () => {
+    // The cross-session leak: a background drain fires with sessionId=null
+    // (the stored session's runtime was reaped by the gateway). Without the
+    // guard, `null ?? activeSessionIdRef.current` falls back to whichever
+    // runtime id the foreground happens to hold — landing the queued prompt
+    // in the chat the user is currently viewing, NOT the session that owns
+    // the queue entry. The drain must instead go through session.resume to
+    // rebind the correct runtime before submitting.
+    const requestGateway = vi.fn(
+      async (method: string) =>
+        (method === 'session.resume' ? { session_id: 'rt-session-a-rebound' } : {}) as never
+    )
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={'rt-foreground'}
+        storedSessionId={'rt-foreground'}
+        getRuntimeIdForStoredSession={() => null}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    // Background drain: sessionId=null (binding reaped), storedSessionId
+    // points to a DIFFERENT session than the foreground.
+    const accepted = await handle!.submitText('queued for background session', {
+      fromQueue: true,
+      sessionId: null,
+      storedSessionId: 'stored-session-a'
+    })
+
+    expect(accepted).toBe(true)
+    // Must resume the correct stored session to get the right runtime id.
+    expect(requestGateway).toHaveBeenCalledWith('session.resume', {
+      session_id: 'stored-session-a',
+      source: 'desktop'
+    })
+    // The prompt must land in the resumed session, NOT the foreground.
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: 'rt-session-a-rebound',
+        text: 'queued for background session'
+      },
+      1_800_000
+    )
+    // The invariant: the foreground runtime never receives the prompt.
+    expect(
+      requestGateway.mock.calls.every(
+        ([method, params]) => method !== 'prompt.submit' || params?.session_id !== 'rt-foreground'
+      )
+    ).toBe(true)
+  })
+
   it('a rejected fromQueue drain returns false (entry stays queued) and a later retry sends it', async () => {
     // A stale-session 404 must not strand the queued entry: submitPrompt returns
     // false on failure so the composer keeps it, and the edge-independent

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -149,7 +149,19 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       const targetStartedInCurrentView =
         !targetStoredSessionId || targetStoredSessionId === selectedStoredSessionIdRef.current
 
-      let sessionId: null | string = options?.sessionId ?? activeSessionIdRef.current
+      // A queued/background drain whose runtime binding was reaped must NOT
+      // inherit the foreground runtime id when its storedSessionId targets a
+      // different session — that would land the queued prompt in whichever
+      // session the user happens to be viewing (cross-session leak). When the
+      // drain is for the current view (no storedSessionId, or it matches the
+      // foreground), the foreground runtime is correct and must be kept.
+      const isBackgroundQueueDrain = Boolean(
+        options?.fromQueue &&
+          options?.storedSessionId &&
+          options.storedSessionId !== selectedStoredSessionIdRef.current
+      )
+
+      let sessionId: null | string = options?.sessionId ?? (isBackgroundQueueDrain ? null : activeSessionIdRef.current)
 
       // Pin the foreground session context for the whole async submit pipeline.
       // Without this, a fast session switch during session.resume / file.attach


### PR DESCRIPTION
## Problem

Queued prompts leak across sessions when a background queue drain's runtime binding has been reaped by the gateway.

**Reproduction:**
1. User queues a message in Session A
2. User switches to Session B
3. Session A's runtime gets reaped by the gateway (idle timeout / resource pressure)
4. Background queue drain fires for Session A with `sessionId: null`
5. The expression `options?.sessionId ?? activeSessionIdRef.current` falls back to Session B's runtime id
6. **Session A's queued message is delivered to Session B** ← cross-session leak

## Root Cause

In `submit.ts:152`, the nullish coalescing operator unconditionally inherits the foreground runtime id when `options.sessionId` is null — regardless of whether the drain targets the foreground session or a different one.

## Fix

Guard the foreground-runtime fallback so it only applies when the drain targets the current view. A background drain (whose `storedSessionId` differs from `selectedStoredSessionIdRef.current`) is left with `sessionId: null`, letting the existing `session.resume` recovery path (submit.ts:367–407) rebind the correct runtime before `prompt.submit` fires.

```diff
-      let sessionId: null | string = options?.sessionId ?? activeSessionIdRef.current
+      const isBackgroundQueueDrain = Boolean(
+        options?.fromQueue &&
+          options?.storedSessionId &&
+          options.storedSessionId !== selectedStoredSessionIdRef.current
+      )
+
+      let sessionId: null | string = options?.sessionId ?? (isBackgroundQueueDrain ? null : activeSessionIdRef.current)
```

## Why This Is Safe

- **Foreground queue drains** (`storedSessionId` matches the current view, or no `storedSessionId`): behavior unchanged — still inherits the foreground runtime.
- **Background drains with a live explicit `sessionId`**: unaffected — `options.sessionId ?? ...` short-circuits before the new check.
- **Background drains with a stale explicit `sessionId`**: unaffected — the existing central-binding check (submit.ts:166–176) already handles these.
- **Only the bug path changes**: `fromQueue: true` + `sessionId: null` + `storedSessionId` ≠ foreground → now goes through `session.resume` instead of leaking.

## Testing

- **New regression test:** `"a fromQueue drain with null runtime id does NOT land in the foreground session (cross-session leak guard)"` — verifies the drain calls `session.resume` with the correct stored session id and that `prompt.submit` never fires against the foreground runtime.
- **All 53 existing tests pass** with zero regressions.

```
 ✓  ui  src/app/session/hooks/use-prompt-actions/index.test.tsx (53 tests) 569ms
 Test Files  1 passed (1)
      Tests  53 passed (53)
```

## Files Changed

| File | Change |
|------|--------|
| `apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts` | +14 lines (guard + comments) |
| `apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx` | +56 lines (regression test) |