### PR TITLE
fix(memory): resolve embedded provider credentials

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -42,6 +42,7 @@ import threading
 
 from datetime import datetime, timezone
 from typing import Any, Dict, List
+from urllib.parse import urlparse
 
 from agent.memory_provider import MemoryProvider
 from hermes_constants import get_hermes_home
@@ -504,15 +505,29 @@ def _load_simple_env(path) -> dict[str, str]:
     return values
 
 
+def _resolve_embedded_llm_api_key(config: dict[str, Any]) -> str:
+    """Resolve the embedded daemon key without duplicating provider credentials."""
+    explicit = (
+        config.get("llmApiKey")
+        or config.get("llm_api_key")
+        or os.environ.get("HINDSIGHT_LLM_API_KEY", "")
+    )
+    if explicit:
+        return str(explicit)
+    if config.get("llm_provider") == "openrouter":
+        return os.environ.get("OPENROUTER_API_KEY", "")
+    if config.get("llm_provider") == "openai_compatible":
+        hostname = urlparse(str(config.get("llm_base_url") or "")).hostname or ""
+        if hostname == "api.deepseek.com" or hostname.endswith(".api.deepseek.com"):
+            return os.environ.get("DEEPSEEK_API_KEY", "")
+    return ""
+
+
 def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None) -> dict[str, str]:
     """Build the profile-scoped env file that standalone hindsight-embed consumes."""
     current_key = llm_api_key
     if current_key is None:
-        current_key = (
-            config.get("llmApiKey")
-            or config.get("llm_api_key")
-            or os.environ.get("HINDSIGHT_LLM_API_KEY", "")
-        )
+        current_key = _resolve_embedded_llm_api_key(config)
 
     current_provider = config.get("llm_provider", "")
     current_model = config.get("llm_model", "")
@@ -553,10 +568,13 @@ def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: st
     profile_env = _embedded_profile_env_path(config)
     profile_env.parent.mkdir(parents=True, exist_ok=True)
     env_values = _build_embedded_profile_env(config, llm_api_key=llm_api_key)
+    profile_env.touch(mode=0o600, exist_ok=True)
+    profile_env.chmod(0o600)
     profile_env.write_text(
         "".join(f"{key}={value}\n" for key, value in env_values.items()),
         encoding="utf-8",
     )
+    profile_env.chmod(0o600)
     return profile_env
 
 def _sanitize_bank_segment(value: str) -> str:
@@ -1036,7 +1054,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 kwargs = dict(
                     profile=self._config.get("profile", "hermes"),
                     llm_provider=llm_provider,
-                    llm_api_key=self._config.get("llmApiKey") or self._config.get("llm_api_key") or os.environ.get("HINDSIGHT_LLM_API_KEY", ""),
+                    llm_api_key=_resolve_embedded_llm_api_key(self._config),
                     llm_model=self._config.get("llm_model", ""),
                 )
                 if self._llm_base_url:

--- a/tests/plugins/memory/test_hindsight_openrouter_fallback.py
+++ b/tests/plugins/memory/test_hindsight_openrouter_fallback.py
@@ -1,0 +1,87 @@
+"""Regression tests for embedded Hindsight OpenRouter credential handling."""
+
+import stat
+import sys
+from types import SimpleNamespace
+
+from plugins.memory.hindsight import (
+    HindsightMemoryProvider,
+    _build_embedded_profile_env,
+    _materialize_embedded_profile_env,
+)
+
+
+def test_embedded_profile_env_uses_openrouter_key_when_dedicated_key_is_missing(
+    monkeypatch,
+):
+    monkeypatch.delenv("HINDSIGHT_LLM_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-key")
+
+    env = _build_embedded_profile_env({
+        "llm_provider": "openrouter",
+        "llm_model": "deepseek/deepseek-v4-flash",
+    })
+
+    assert env["HINDSIGHT_API_LLM_API_KEY"] == "openrouter-test-key"
+
+
+def test_embedded_profile_env_uses_deepseek_key_for_deepseek_compatible_url(
+    monkeypatch,
+):
+    monkeypatch.delenv("HINDSIGHT_LLM_API_KEY", raising=False)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "deepseek-test-key")
+
+    env = _build_embedded_profile_env({
+        "llm_provider": "openai_compatible",
+        "llm_base_url": "https://api.deepseek.com/v1",
+        "llm_model": "deepseek-v4-flash",
+    })
+
+    assert env["HINDSIGHT_API_LLM_API_KEY"] == "deepseek-test-key"
+
+
+def test_materialized_embedded_profile_env_is_owner_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    profile_env = _materialize_embedded_profile_env({
+        "profile": "hermes-test",
+        "llm_provider": "openrouter",
+        "llm_api_key": "test-key",
+        "llm_model": "deepseek/deepseek-v4-flash",
+    })
+
+    assert stat.S_IMODE(profile_env.stat().st_mode) == 0o600
+
+
+def test_get_client_uses_openrouter_key_when_dedicated_key_is_missing(monkeypatch):
+    captured = {}
+
+    class FakeHindsightEmbedded:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hindsight",
+        SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded),
+    )
+    monkeypatch.setattr(
+        "plugins.memory.hindsight._check_local_runtime",
+        lambda: (True, ""),
+    )
+    monkeypatch.delenv("HINDSIGHT_LLM_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-key")
+
+    provider = HindsightMemoryProvider()
+    provider._mode = "local_embedded"
+    provider._config = {
+        "profile": "hermes",
+        "llm_provider": "openrouter",
+        "llm_model": "deepseek/deepseek-v4-flash",
+        "idle_timeout": 0,
+    }
+    provider._llm_base_url = "https://openrouter.ai/api/v1"
+
+    provider._get_client()
+
+    assert captured["llm_api_key"] == "openrouter-test-key"


### PR DESCRIPTION
## Summary
- Let embedded Hindsight reuse the selected OpenRouter credential when no dedicated key is configured.
- Support DeepSeek credentials for DeepSeek-compatible endpoints.
- Force generated profile environment files containing credentials to mode 0600.
- Add regression coverage for provider fallback and file permissions.

## Why
Local embedded Hindsight could report the plugin as available but fail daemon startup because `HINDSIGHT_API_LLM_API_KEY` was generated empty. Users already configured for OpenRouter or DeepSeek should not need to duplicate the same credential into another setting.

## Verification
- `pytest -q tests/plugins/memory/test_hindsight_openrouter_fallback.py tests/plugins/memory/test_hindsight_provider.py tests/plugins/test_hindsight_health_grace_timeout.py tests/plugins/test_hindsight_root_guard.py`
- Result: 127 passed.
- `pip check`: no broken requirements.
- Live embedded daemon: HTTP 200, database connected.
- Live recall operation completed successfully.
