### PR TITLE
feat(plugins): add pre_agent_dispatch plugin hook

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21397,7 +21397,52 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _conversation_kwargs["moa_config"] = moa_config
                 if _persist_user_timestamp_override is not None:
                     _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
-                result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
+
+                # ── pre_agent_dispatch plugin hook ──────────────────
+                from hermes_cli.plugins import dispatch_pre_agent as _dispatch_pre_agent
+
+                _hook_msg = (
+                    message if isinstance(message, str)
+                    else str(message)
+                )
+                _hook_kwargs: dict = dict(
+                    message=_hook_msg,
+                    session_key=session_key or "",
+                    source=source,
+                    gateway=self,
+                    history=list(agent_history),
+                )
+                # Pass the stream consumer's delta callback so router plugins
+                # can stream orchestrator output progressively instead of
+                # making the user wait in silence.
+                if _stream_consumer is not None:
+                    _hook_kwargs["stream_callback"] = _stream_consumer.on_delta
+                _hook_result = _dispatch_pre_agent(**_hook_kwargs)
+                _hook_action = _hook_result.get("action", "allow")
+
+                if _hook_action == "skip":
+                    result = {
+                        "final_response": "",
+                        "messages": list(agent_history),
+                        "interrupted": False,
+                    }
+                elif _hook_action == "route":
+                    result = {
+                        "final_response": _hook_result.get("result", ""),
+                        "messages": list(agent_history) + [
+                            {"role": "user", "content": _hook_msg},
+                            {"role": "assistant",
+                             "content": _hook_result.get("result", "")},
+                        ],
+                        "interrupted": False,
+                    }
+                else:
+                    if _hook_action == "rewrite":
+                        _api_run_message = _hook_result.get("text", _api_run_message)
+                    # ── Normal dispatch (allow, rewrite, or unrecognised) ─
+                    result = agent.run_conversation(
+                        _api_run_message, **_conversation_kwargs)
+                # ── End pre_agent_dispatch hook ──────────────────────
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 # Cancel any pending clarify entries so blocked agent

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2364,6 +2364,27 @@ DEFAULT_CONFIG = {
         "subagent_auto_approve": False,
     },
 
+    # Flash → Orchestrator gateway-level router.
+    # Pre-turn classifier that routes complex tasks to the orchestrator profile.
+    # Simple tasks stay on the default Flash model — fast and cheap.
+    "router": {
+        "enabled": False,          # master on/off switch (opt-in)
+        "classifier": {
+            "task": "triage_specifier",  # aux task for the classification call
+            "model": "",                 # explicit override (empty = use task default)
+        },
+        "orchestrator": {
+            "profile": "orchestrator",   # profile name for heavy tasks
+            "timeout": 600,              # subprocess timeout in seconds
+            "pass_history": True,        # whether to pass session history
+        },
+        "rules": {
+            "always_simple": [],         # regex patterns that always stay local
+            "always_complex": [],        # regex patterns that always escalate
+            "threshold": 0.5,            # minimum confidence to route to Pro
+        },
+    },
+
     # Ephemeral prefill messages file — JSON list of {role, content} dicts
     # injected at the start of every API call for few-shot priming.
     # Never saved to sessions, logs, or trajectories.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -171,6 +171,16 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Pre-agent-dispatch hook. Fired once per turn just BEFORE the agent
+    # processes a user message (CLI, gateway, or TUI). Plugins may return
+    # a dict to influence flow:
+    #   {"action": "allow"}  /  None              -> normal agent dispatch
+    #   {"action": "skip",    "reason": "..."}    -> drop message (no reply)
+    #   {"action": "rewrite", "text": "..."}      -> replace message text, continue
+    #   {"action": "route",   "result": "..."}    -> bypass agent, use this text as final response
+    # Kwargs: message: str, session_key: str, source: SessionSource | None,
+    #   history: list[dict] | None, gateway: GatewayRunner | None.
+    "pre_agent_dispatch",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.
@@ -2464,3 +2474,76 @@ def get_plugin_toolsets() -> List[tuple]:
         result.append((ts_key, label, desc))
 
     return result
+
+
+# ── Shared helper for pre_agent_dispatch hook ─────────────────────────
+
+def dispatch_pre_agent(
+    message: str,
+    session_key: str = "",
+    source=None,
+    gateway=None,
+    history: list | None = None,
+    stream_callback=None,
+) -> dict:
+    """Run pre_agent_dispatch hooks and return a result dict.
+
+    Callers should check the ``action`` key:
+
+    ``{"action": "skip"}``
+        Drop the message completely — no reply, no agent run.
+    ``{"action": "route", "result": str}``
+        Bypass the agent entirely; use ``result`` as the final response.
+    ``{"action": "rewrite", "text": str}``
+        Replace the message text with ``text``, then run the agent normally.
+    ``{"action": "allow"}``
+        Normal agent dispatch (hooks had no comment or chose not to intercept).
+
+    On error (hook failure, import error, etc.) the function returns
+    ``{"action": "allow"}`` — fail-closed to normal dispatch.
+
+    When ``stream_callback`` is provided, it is forwarded to every hook as a
+    ``stream_callback`` kwarg.  A hook that produces a ``route`` result may
+    call the callback repeatedly during the routing subprocess so the user
+    sees progressive output while the orchestrator works.
+    """
+    try:
+        discover_plugins()
+        _hook_kwargs: dict = dict(
+            message=message,
+            session_key=session_key,
+            source=source,
+            history=history or [],
+            gateway=gateway,
+        )
+        if stream_callback is not None:
+            _hook_kwargs["stream_callback"] = stream_callback
+        _hook_results = invoke_hook(
+            "pre_agent_dispatch",
+            **_hook_kwargs,
+        )
+        for _hr in (_hook_results or []):
+            if not isinstance(_hr, dict):
+                continue
+            action = _hr.get("action")
+            if action == "skip":
+                return {"action": "skip"}
+            if action == "route":
+                result_text = _hr.get("result", "") or ""
+                result: dict = {"action": "route", "result": result_text}
+                # Pass through streamed flag so callers can avoid duplicating
+                # output that was already shown via stream_callback.
+                if _hr.get("streamed"):
+                    result["streamed"] = True
+                return result
+            if action == "rewrite":
+                new_text = _hr.get("text", "")
+                if isinstance(new_text, str) and new_text:
+                    return {"action": "rewrite", "text": new_text}
+                continue  # empty rewrite is a no-op, check next hook
+        return {"action": "allow"}
+    except Exception:
+        logger = logging.getLogger(__name__)
+        logger.warning("pre_agent_dispatch hook failed, falling back to local agent")
+        logger.debug("pre_agent_dispatch hook traceback:", exc_info=True)
+        return {"action": "allow"}

--- a/plugins/router/__init__.py
+++ b/plugins/router/__init__.py
@@ -1,0 +1,502 @@
+"""
+Router plugin — pre-turn classifier that routes complex tasks to the orchestrator.
+
+Architecture:
+  User message
+      │
+      ▼
+  pre_agent_dispatch hook fires
+      │
+      ▼
+  Classifier (cheap aux model via auxiliary_client)
+      │
+      ├── simple → allow normal agent dispatch (Flash handles it)
+      │
+      └── complex → call orchestrator subprocess
+                     → return routed result (bypass agent)
+
+The classifier uses the configured triage_specifier aux model (default:
+gemini-flash) — cheap and fast. The orchestrator subprocess runs
+``hermes -p <profile> chat -q "<prompt>"`` with full tool access.
+
+Configuration (in config.yaml):
+  router:
+    enabled: false              # master on/off (opt-in, default: false)
+    classifier:
+      task: "triage_specifier"  # aux task for classification
+      model: ""                 # override aux model
+    orchestrator:
+      profile: "orchestrator"   # profile name for heavy tasks
+      timeout: 600              # subprocess timeout (seconds)
+      pass_history: true        # pass session history to orchestrator
+    rules:
+      always_simple: []         # regex patterns → always stay on Flash
+      always_complex: []        # regex patterns → always go to Pro
+      threshold: 0.5            # confidence threshold for complex routing
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+import time
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+# ── Defaults ──────────────────────────────────────────────────────────
+_DEFAULT_CLASSIFIER_TASK = "triage_specifier"
+_DEFAULT_ORCHESTRATOR_PROFILE = "orchestrator"
+_DEFAULT_ORCHESTRATOR_TIMEOUT = 600
+
+# ── Classification prompt ─────────────────────────────────────────────
+_CLASSIFIER_SYSTEM_PROMPT = """You are a task complexity classifier for an AI agent routing system.
+Analyze the user's message and classify it as either "simple" or "complex".
+
+SIMPLE tasks (route to Flash — cheap/fast model):
+- Greetings, casual chat, small talk
+- Simple factual questions ("what is X", "when did Y happen")
+- Status checks, yes/no questions
+- Short translations, word definitions
+- Simple file operations (list files, read a small file)
+- Known-answer questions that don't need deep analysis
+- Formatting/conversion requests that are mechanical
+
+COMPLEX tasks (route to Pro — powerful model):
+- Code implementation, debugging, architecture design
+- System administration, configuration, deployment
+- Data analysis, SQL queries, pandas operations
+- Multi-step reasoning, planning, strategy
+- Research, investigation requiring web search
+- File editing, patching, refactoring
+- Infrastructure changes, Proxmox operations
+- Any task requiring tool use beyond basic read/search
+- Mathematical proofs, algorithm design
+- Contract/document generation or editing
+- Financial analysis, tax calculations
+- Real estate valuation or comparison
+
+Respond with ONLY a JSON object:
+{"classification": "simple"|"complex", "confidence": 0.0-1.0, "reason": "one-line reason"}"""
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+def _load_router_config() -> dict:
+    """Load router configuration from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return cfg.get("router", {})
+    except Exception:
+        return {}
+
+
+def _match_patterns(message: str, patterns: list[str]) -> bool:
+    """Check if the message matches any of the given regex patterns."""
+    if not patterns:
+        return False
+    for pattern in patterns:
+        try:
+            if re.search(pattern, message, re.IGNORECASE):
+                return True
+        except re.error:
+            logger.warning("Invalid router pattern: %s", pattern)
+    return False
+
+
+def _classify_with_llm(message: str, task: str, model_override: str) -> dict:
+    """Classify a message using the configured aux LLM."""
+    try:
+        from agent.auxiliary_client import call_llm
+    except ImportError:
+        logger.warning("auxiliary_client not available, defaulting to simple")
+        return {"classification": "simple", "confidence": 0.0,
+                "reason": "classifier unavailable"}
+
+    messages = [
+        {"role": "system", "content": _CLASSIFIER_SYSTEM_PROMPT},
+        {"role": "user", "content": message[:4000]},
+    ]
+
+    try:
+        call_kwargs: dict = {
+            "task": task,
+            "messages": messages,
+            "max_tokens": 256,
+            "temperature": 0.0,
+            "timeout": 30,
+        }
+        if model_override:
+            call_kwargs["model"] = model_override
+        response = call_llm(**call_kwargs)
+
+        content = ""
+        if hasattr(response, "choices") and response.choices:
+            content = response.choices[0].message.content or ""
+        elif isinstance(response, str):
+            content = response
+
+        content = content.strip()
+        if content.startswith("```"):
+            content = re.sub(r"^```(?:json)?\s*", "", content)
+            content = re.sub(r"\s*```$", "", content)
+
+        result = json.loads(content)
+        classification = str(result.get("classification", "simple")).lower()
+        if classification not in ("simple", "complex"):
+            classification = "simple"
+
+        return {
+            "classification": classification,
+            "confidence": float(result.get("confidence", 0.5)),
+            "reason": str(result.get("reason", "")),
+        }
+    except (json.JSONDecodeError, Exception) as exc:
+        logger.warning("Classifier failed: %s, defaulting to simple", exc)
+        return {"classification": "simple", "confidence": 0.0,
+                "reason": f"classifier error: {exc}"}
+
+
+def classify(message: str, router_cfg: dict | None = None) -> dict:
+    """Classify a user message as simple or complex.
+
+    Returns:
+        dict with keys: classification ("simple"|"complex"),
+        confidence (0-1), reason (str)
+    """
+    if router_cfg is None:
+        router_cfg = _load_router_config()
+
+    if not router_cfg.get("enabled", False):
+        return {"classification": "simple", "confidence": 0.0,
+                "reason": "router disabled"}
+
+    rules_cfg = router_cfg.get("rules", {})
+    threshold = float(rules_cfg.get("threshold", 0.5))
+
+    # Check always-simple patterns first
+    always_simple = list(rules_cfg.get("always_simple", []))
+    if _match_patterns(message, always_simple):
+        return {"classification": "simple", "confidence": 1.0,
+                "reason": "always_simple pattern match"}
+
+    # Check always-complex patterns
+    always_complex = list(rules_cfg.get("always_complex", []))
+    if _match_patterns(message, always_complex):
+        return {"classification": "complex", "confidence": 1.0,
+                "reason": "always_complex pattern match"}
+
+    # Run LLM classifier
+    classifier_cfg = router_cfg.get("classifier", {})
+    task = classifier_cfg.get("task", _DEFAULT_CLASSIFIER_TASK)
+    model_override = classifier_cfg.get("model", "")
+    result = _classify_with_llm(message, task, model_override)
+
+    # Apply threshold
+    if result["classification"] == "complex" and result["confidence"] < threshold:
+        result["classification"] = "simple"
+        result["reason"] = f"below threshold ({result['confidence']:.2f} < {threshold})"
+
+    return result
+
+
+def _build_orchestrator_prompt(
+    user_message: str,
+    history: list[dict] | None = None,
+    session_context: dict | None = None,
+) -> str:
+    """Build the prompt for the orchestrator subprocess."""
+    parts = []
+
+    if history:
+        recent = history[-6:]  # last 3 exchanges
+        if recent:
+            parts.append("=== Previous conversation ===")
+            for msg in recent:
+                role = msg.get("role", "unknown")
+                content = msg.get("content", "")
+                if isinstance(content, list):
+                    text_parts = [
+                        p.get("text", "")
+                        for p in content
+                        if isinstance(p, dict) and p.get("type") == "text"
+                    ]
+                    content = " ".join(text_parts)
+                content = str(content)[:2000]
+                parts.append(f"[{role}]: {content}")
+            parts.append("")
+
+    parts.append("=== Current user request ===")
+    parts.append(user_message)
+
+    if session_context:
+        cwd = session_context.get("cwd", "")
+        if cwd:
+            parts.insert(0, f"Working directory: {cwd}")
+
+    return "\n".join(parts)
+
+
+def _resolve_hermes_bin() -> str:
+    """Resolve the hermes binary path."""
+    hermes_bin = os.environ.get("HERMES_BIN", "")
+    if hermes_bin:
+        return hermes_bin
+    for candidate in [
+        "/usr/local/bin/hermes",
+        os.path.expanduser("~/.local/bin/hermes"),
+        "/usr/bin/hermes",
+    ]:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return "hermes"
+
+
+_NOISE_LINE_RE = re.compile(
+    r"^(Tokens|Cost|Model|Session|⏺|●|○|────|╭─|╰─|├─|│)"
+)
+
+
+def _is_noise_line(cleaned_line: str) -> bool:
+    """Return True if *cleaned_line* is a noise line from hermes output."""
+    stripped = cleaned_line.strip()
+    if not stripped:
+        return True
+    return bool(_NOISE_LINE_RE.match(stripped))
+
+
+def _extract_hermes_response(output: str) -> str:
+    """Extract the assistant's response from hermes chat output."""
+    lines = output.split("\n")
+    cleaned = []
+    for line in lines:
+        if _is_noise_line(line):
+            continue
+        cleaned.append(line)
+    result = "\n".join(cleaned).strip()
+    return result or output
+
+
+def route_to_orchestrator(
+    user_message: str,
+    history: list[dict] | None = None,
+    session_context: dict | None = None,
+    router_cfg: dict | None = None,
+    stream_callback: Callable[[str], Any] | None = None,
+) -> str:
+    """Route a complex task to the orchestrator profile.
+
+    Spawns ``hermes -p <profile> chat -q "<prompt>"`` and returns the full
+    response synchronously.
+
+    When ``stream_callback`` is provided, the orchestrator's stdout is read
+    line-by-line and each line (after filtering noise) is passed to the
+    callback so the user sees progressive output instead of waiting silently
+    for the entire subprocess to finish.  The callback receives one cleaned
+    line at a time.  Errors and noise lines are skipped.
+    """
+    if router_cfg is None:
+        router_cfg = _load_router_config()
+
+    orch_cfg = router_cfg.get("orchestrator", {})
+    profile = orch_cfg.get("profile", _DEFAULT_ORCHESTRATOR_PROFILE)
+    timeout_val = int(orch_cfg.get("timeout", _DEFAULT_ORCHESTRATOR_TIMEOUT))
+    pass_history = bool(orch_cfg.get("pass_history", True))
+
+    if pass_history:
+        prompt = _build_orchestrator_prompt(user_message, history, session_context)
+    else:
+        prompt = user_message
+
+    hermes_bin = _resolve_hermes_bin()
+
+    try:
+        logger.info(
+            "Router plugin: routing to orchestrator (profile=%s, timeout=%ds, prompt_len=%d)%s",
+            profile, timeout_val, len(prompt),
+            " [streaming]" if stream_callback else "",
+        )
+
+        cmd = [hermes_bin, "-p", profile, "chat", "-q", prompt, "-Q"]
+
+        env = os.environ.copy()
+        env.pop("HERMES_PROFILE", None)
+
+        if stream_callback:
+            # ── Streaming mode: Popen + line-by-line iteration ─────────
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+            )
+            all_lines: list[str] = []
+            try:
+                assert proc.stdout is not None
+                for line in iter(proc.stdout.readline, ""):
+                    if not line:
+                        break
+                    all_lines.append(line)
+                    cleaned = line.rstrip("\n")
+                    if _is_noise_line(cleaned):
+                        continue
+                    try:
+                        stream_callback(cleaned + "\n")
+                    except Exception:
+                        pass  # stream callback failures are non-fatal
+            finally:
+                proc.wait(timeout=timeout_val)
+
+            if proc.returncode != 0:
+                stderr_text = proc.stderr.read()[:500] if proc.stderr else ""
+                error_msg = (
+                    f"Orchestrator exited with code {proc.returncode}\n"
+                    f"stderr: {stderr_text}"
+                )
+                logger.error("Router plugin: orchestrator failed: %s", error_msg)
+                return f"[Orchestrator error] {error_msg}"
+
+            raw_output = "".join(all_lines).strip()
+            response = _extract_hermes_response(raw_output)
+            return response or raw_output
+
+        else:
+            # ── Batch mode (original behaviour) ────────────────────────
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout_val,
+                env=env,
+            )
+
+            if result.returncode != 0:
+                error_msg = (
+                    f"Orchestrator exited with code {result.returncode}\n"
+                    f"stderr: {result.stderr[:500]}"
+                )
+                logger.error("Router plugin: orchestrator failed: %s", error_msg)
+                return f"[Orchestrator error] {error_msg}"
+
+            raw_output = result.stdout.strip()
+            response = _extract_hermes_response(raw_output)
+            return response or raw_output
+
+    except FileNotFoundError:
+        logger.error("Router plugin: hermes binary not found at %s", hermes_bin)
+        return "[Orchestrator error] Hermes binary not found"
+    except subprocess.TimeoutExpired:
+        logger.error("Router plugin: orchestrator timed out after %ds", timeout_val)
+        return f"[Orchestrator error] Timed out after {timeout_val}s"
+    except Exception as exc:
+        logger.exception("Router plugin: orchestrator routing failed")
+        return f"[Orchestrator error] {exc}"
+
+
+# ── Session-level classification cache ────────────────────────────────
+_classification_cache: dict[str, tuple[float, dict]] = {}
+_CACHE_TTL = 300  # seconds
+
+
+def _get_cached_classification(session_key: str) -> dict | None:
+    """Get a cached classification for a session, if still valid."""
+    if session_key in _classification_cache:
+        timestamp, result = _classification_cache[session_key]
+        if time.time() - timestamp < _CACHE_TTL:
+            return result
+        del _classification_cache[session_key]
+    return None
+
+
+def _cache_classification(session_key: str, result: dict) -> None:
+    """Cache a classification result for a session."""
+    _classification_cache[session_key] = (time.time(), result)
+
+
+# ── Hook callback ─────────────────────────────────────────────────────
+
+def _on_pre_agent_dispatch(**kwargs: Any) -> dict | None:
+    """pre_agent_dispatch hook: classify and optionally route to orchestrator.
+
+    Called before the agent processes a user message. If the message is
+    classified as complex and the router is enabled, this function calls
+    the orchestrator subprocess and returns a ``route`` action with the
+    result, bypassing the normal agent dispatch.
+    """
+    message = kwargs.get("message", "")
+    if not message or not isinstance(message, str):
+        return None
+
+    session_key = kwargs.get("session_key", "") or ""
+    history = kwargs.get("history") or None
+    stream_callback = kwargs.get("stream_callback") or None
+
+    # Check config
+    router_cfg = _load_router_config()
+    if not router_cfg.get("enabled", False):
+        return None
+
+    # Check cache
+    if session_key:
+        cached = _get_cached_classification(session_key)
+        if cached is not None:
+            if cached.get("classification") == "complex":
+                logger.info(
+                    "Router plugin: cached complex → routing to orchestrator"
+                )
+            else:
+                return None
+        else:
+            # Classify
+            result = classify(message, router_cfg)
+            if session_key:
+                _cache_classification(session_key, result)
+
+            if result.get("classification") != "complex":
+                return None
+
+            logger.info(
+                "Router plugin: complex task (confidence=%.2f, reason=%s) → orchestrator",
+                result.get("confidence", 0),
+                result.get("reason", ""),
+            )
+
+    # Route to orchestrator
+    source = kwargs.get("source") or None
+    session_context: dict | None = None
+    if source is not None:
+        cwd = getattr(source, "cwd", None) or ""
+        if not cwd:
+            # Try getting session cwd from gateway
+            gateway = kwargs.get("gateway")
+            if gateway is not None and session_key:
+                session = getattr(gateway, "session_store", None)
+                if session is not None:
+                    sess_data = getattr(session, "get", lambda _: {})(session_key)
+                    cwd = sess_data.get("cwd", "") if isinstance(sess_data, dict) else ""
+        if cwd:
+            session_context = {"cwd": cwd}
+
+    orch_response = route_to_orchestrator(
+        user_message=message,
+        history=history,
+        session_context=session_context,
+        router_cfg=router_cfg,
+        stream_callback=stream_callback,
+    )
+
+    return {"action": "route", "result": orch_response,
+            "streamed": bool(stream_callback)}
+
+
+# ── Plugin entry point ────────────────────────────────────────────────
+
+def register(ctx: Any) -> None:
+    """Register the router plugin hooks."""
+    ctx.register_hook("pre_agent_dispatch", _on_pre_agent_dispatch)
+    logger.info("Router plugin registered: pre_agent_dispatch hook")

--- a/plugins/router/plugin.yaml
+++ b/plugins/router/plugin.yaml
@@ -1,0 +1,7 @@
+name: router
+version: 1.1.0
+description: "Pre-turn classifier that routes complex tasks to the orchestrator profile with progressive streaming."
+author: "NousResearch"
+kind: standalone
+hooks:
+  - pre_agent_dispatch

--- a/tests/plugins/test_router_plugin.py
+++ b/tests/plugins/test_router_plugin.py
@@ -1,0 +1,532 @@
+"""Regression tests for the router plugin (plugins/router/).
+
+Covers the pure functions that don't require LLM mocking — pattern matching,
+noise filtering, prompt building, binary resolution, cache behaviour, and the
+classification pipeline up to (but not including) the LLM call itself.
+
+The actual LLM inference path and subprocess spawning are integration-tested
+via the pre_agent_dispatch hook dispatch tests, not here.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def _isolate_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME so router config lookups don't touch real config."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home
+
+
+def _load_module():
+    """Import the router plugin module directly."""
+    repo_root = Path(__file__).resolve().parents[2]
+    sys_path = str(repo_root)
+    import sys
+    if sys_path not in sys.path:
+        sys.path.insert(0, sys_path)
+    try:
+        return importlib.import_module("plugins.router")
+    finally:
+        if sys_path in sys.path:
+            # Don't leave the import path polluted
+            pass
+
+
+ROUTER = None  # cached module
+
+
+def _mod():
+    global ROUTER
+    if ROUTER is None:
+        ROUTER = _load_module()
+    return ROUTER
+
+
+# ── Pattern matching ──────────────────────────────────────────────────
+
+class TestMatchPatterns:
+    def test_empty_patterns(self):
+        """No patterns → no match regardless of message."""
+        mod = _mod()
+        assert mod._match_patterns("anything", []) is False
+        assert mod._match_patterns("", []) is False
+
+    def test_simple_literal_match(self):
+        mod = _mod()
+        assert mod._match_patterns("deploy to production", ["deploy"]) is True
+
+    def test_no_match(self):
+        mod = _mod()
+        assert mod._match_patterns("hello world", ["deploy", "restart"]) is False
+
+    def test_case_insensitive_match(self):
+        mod = _mod()
+        assert mod._match_patterns("DEPLOY NOW", ["deploy"]) is True
+
+    def test_regex_pattern(self):
+        mod = _mod()
+        assert mod._match_patterns("fix bug #1234", [r"#\d+"]) is True
+
+    def test_regex_word_boundary(self):
+        mod = _mod()
+        # "test" should not match "testing" when using word boundary
+        assert mod._match_patterns("testing", [r"\btest\b"]) is False
+        assert mod._match_patterns("run test now", [r"\btest\b"]) is True
+
+    def test_invalid_regex_warns_but_continues(self, caplog):
+        """Invalid regex patterns are logged and treated as no-match."""
+        mod = _mod()
+        result = mod._match_patterns("anything", [r"[invalid("])
+        assert result is False
+        # Should have logged a warning
+        assert any("Invalid router pattern" in r.message for r in caplog.records)
+
+    def test_multiple_patterns_first_match_wins(self):
+        mod = _mod()
+        # Second pattern would match but first already did
+        assert mod._match_patterns("hello", ["world", "hello"]) is True
+
+
+# ── Noise line detection ──────────────────────────────────────────────
+
+class TestIsNoiseLine:
+    def test_empty_line_is_noise(self):
+        mod = _mod()
+        assert mod._is_noise_line("") is True
+        assert mod._is_noise_line("   ") is True
+
+    def test_tokens_line_is_noise(self):
+        mod = _mod()
+        assert mod._is_noise_line("Tokens: 1.2k/200k") is True
+
+    def test_cost_line_is_noise(self):
+        mod = _mod()
+        assert mod._is_noise_line("Cost: $0.003") is True
+
+    def test_model_line_is_noise(self):
+        mod = _mod()
+        assert mod._is_noise_line("Model: deepseek-v4-pro") is True
+
+    def test_session_line_is_noise(self):
+        mod = _mod()
+        assert mod._is_noise_line("Session: abc123") is True
+
+    def test_box_drawing_characters_are_noise(self):
+        mod = _mod()
+        for line in ["──────", "╭─ Results", "╰─ done", "├─ step", "│ data"]:
+            assert mod._is_noise_line(line), f"should be noise: {line!r}"
+
+    def test_circle_symbols_are_noise(self):
+        mod = _mod()
+        assert mod._is_noise_line("⏺ Starting") is True
+        assert mod._is_noise_line("● Running") is True
+        assert mod._is_noise_line("○ Idle") is True
+
+    def test_real_content_is_not_noise(self):
+        mod = _mod()
+        assert mod._is_noise_line("Hello, this is a real response.") is False
+        assert mod._is_noise_line("   def foo(): pass") is False
+
+
+# ── Hermes response extraction ────────────────────────────────────────
+
+class TestExtractHermesResponse:
+    def test_removes_noise_lines(self):
+        mod = _mod()
+        output = "\n".join([
+            "Tokens: 100",
+            "Model: test",
+            "",
+            "The actual response content",
+            "",
+            "Cost: $0.001",
+        ])
+        result = mod._extract_hermes_response(output)
+        assert result == "The actual response content"
+
+    def test_fallback_to_raw_on_all_noise(self):
+        """When all lines are noise, returns the raw output."""
+        mod = _mod()
+        output = "Tokens: 100\nModel: test\nCost: $0.001"
+        result = mod._extract_hermes_response(output)
+        assert result == output
+
+    def test_empty_output(self):
+        mod = _mod()
+        assert mod._extract_hermes_response("") == ""
+
+    def test_preserves_content_structure(self):
+        mod = _mod()
+        output = "Line 1\nLine 2\nLine 3"
+        result = mod._extract_hermes_response(output)
+        assert result == "Line 1\nLine 2\nLine 3"
+
+
+# ── Orchestrator prompt building ──────────────────────────────────────
+
+class TestBuildOrchestratorPrompt:
+    def test_simple_message_no_history_no_context(self):
+        mod = _mod()
+        result = mod._build_orchestrator_prompt("do something")
+        assert "=== Current user request ===" in result
+        assert "do something" in result
+        assert "=== Previous conversation ===" not in result
+
+    def test_with_history(self):
+        mod = _mod()
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        result = mod._build_orchestrator_prompt("new task", history=history)
+        assert "=== Previous conversation ===" in result
+        assert "[user]: hello" in result
+        assert "[assistant]: hi there" in result
+        assert "=== Current user request ===" in result
+        assert "new task" in result
+
+    def test_history_truncated_to_last_6_messages(self):
+        mod = _mod()
+        history = [
+            {"role": "user", "content": f"msg{i}"} for i in range(20)
+        ]
+        result = mod._build_orchestrator_prompt("final", history=history)
+        # Only last 6 (3 exchanges) should appear
+        assert "msg0" not in result
+        assert "msg14" in result  # index 14 is in last 6
+        assert "msg19" in result
+
+    def test_history_content_truncated_at_2000_chars(self):
+        mod = _mod()
+        long_text = "x" * 3000
+        history = [{"role": "user", "content": long_text}]
+        result = mod._build_orchestrator_prompt("task", history=history)
+        # Content should be truncated
+        assert "x" * 2500 not in result
+
+    def test_history_with_multimodal_content(self):
+        """List-type content (from multimodal messages) is flattened."""
+        mod = _mod()
+        history = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "image description"},
+                {"type": "image_url", "image_url": {"url": "http://example.com/img.png"}},
+            ],
+        }]
+        result = mod._build_orchestrator_prompt("task", history=history)
+        assert "image description" in result
+
+    def test_with_session_context_cwd(self):
+        mod = _mod()
+        result = mod._build_orchestrator_prompt(
+            "task",
+            session_context={"cwd": "/home/user/project"},
+        )
+        assert "Working directory: /home/user/project" in result
+
+    def test_empty_session_context_no_cwd_line(self):
+        mod = _mod()
+        result = mod._build_orchestrator_prompt(
+            "task",
+            session_context={"cwd": ""},
+        )
+        assert "Working directory:" not in result
+
+
+# ── Hermes binary resolution ─────────────────────────────────────────
+
+class TestResolveHermesBin:
+    def test_env_var_takes_priority(self, monkeypatch):
+        mod = _mod()
+        monkeypatch.setenv("HERMES_BIN", "/custom/path/hermes")
+        assert mod._resolve_hermes_bin() == "/custom/path/hermes"
+
+    def test_env_var_even_if_file_missing(self, monkeypatch):
+        """Env var is returned regardless of file existence."""
+        mod = _mod()
+        monkeypatch.setenv("HERMES_BIN", "/nonexistent/path/hermes")
+        assert mod._resolve_hermes_bin() == "/nonexistent/path/hermes"
+
+    def test_fallback_to_hermes_when_no_candidates_found(self, monkeypatch):
+        """When no env var and no candidates exist, returns 'hermes'."""
+        mod = _mod()
+        monkeypatch.delenv("HERMES_BIN", raising=False)
+        with mock.patch.object(mod.os.path, "isfile", return_value=False):
+            assert mod._resolve_hermes_bin() == "hermes"
+
+
+# ── Classification cache ──────────────────────────────────────────────
+
+class TestClassificationCache:
+    def test_get_miss_when_empty(self):
+        mod = _mod()
+        # Clear cache so we start fresh
+        mod._classification_cache.clear()
+        assert mod._get_cached_classification("session-1") is None
+
+    def test_cache_hit_within_ttl(self):
+        mod = _mod()
+        mod._classification_cache.clear()
+        mod._cache_classification("session-1", {"classification": "complex"})
+        result = mod._get_cached_classification("session-1")
+        assert result == {"classification": "complex"}
+
+    def test_cache_expired_after_ttl(self, monkeypatch):
+        mod = _mod()
+        mod._classification_cache.clear()
+        # Cache with a timestamp far in the past
+        mod._classification_cache["session-old"] = (
+            0,  # epoch 0
+            {"classification": "complex"},
+        )
+        result = mod._get_cached_classification("session-old")
+        assert result is None
+        # Expired entry should be cleaned up
+        assert "session-old" not in mod._classification_cache
+
+    def test_cache_different_sessions_independent(self):
+        mod = _mod()
+        mod._classification_cache.clear()
+        mod._cache_classification("session-a", {"classification": "simple"})
+        mod._cache_classification("session-b", {"classification": "complex"})
+        assert mod._get_cached_classification("session-a") == \
+            {"classification": "simple"}
+        assert mod._get_cached_classification("session-b") == \
+            {"classification": "complex"}
+
+
+# ── Classify (without LLM) ───────────────────────────────────────────
+
+class TestClassify:
+    def test_disabled_returns_simple(self):
+        """When router.enabled is false, classify returns simple."""
+        mod = _mod()
+        cfg: dict = {"enabled": False}
+        result = mod.classify("complex task requiring deep analysis", cfg)
+        assert result["classification"] == "simple"
+
+    def test_disabled_without_config_key(self):
+        """Missing 'enabled' key → same as disabled."""
+        mod = _mod()
+        result = mod.classify("anything", {})
+        assert result["classification"] == "simple"
+
+    def test_always_simple_pattern_wins(self):
+        """always_simple patterns bypass everything → simple."""
+        mod = _mod()
+        cfg: dict = {
+            "enabled": True,
+            "rules": {
+                "always_simple": ["hello", "how are you"],
+                "always_complex": ["deploy"],
+            },
+        }
+        result = mod.classify("hello world", cfg)
+        assert result["classification"] == "simple"
+        assert result["confidence"] == 1.0
+        assert "always_simple" in result["reason"]
+
+    def test_always_complex_pattern_wins(self):
+        """always_complex patterns → complex regardless of LLM."""
+        mod = _mod()
+        cfg: dict = {
+            "enabled": True,
+            "rules": {
+                "always_simple": ["hello"],
+                "always_complex": ["deploy", "restart"],
+            },
+        }
+        result = mod.classify("please deploy now", cfg)
+        assert result["classification"] == "complex"
+        assert result["confidence"] == 1.0
+        assert "always_complex" in result["reason"]
+
+    def test_always_simple_beats_always_complex(self):
+        """Simple patterns are checked first — they beat complex patterns."""
+        mod = _mod()
+        cfg: dict = {
+            "enabled": True,
+            "rules": {
+                "always_simple": ["deploy safely"],
+                "always_complex": ["deploy"],
+            },
+        }
+        # "deploy safely" matches BOTH patterns
+        result = mod.classify("deploy safely", cfg)
+        assert result["classification"] == "simple"
+
+    def test_no_pattern_match_falls_through_to_llm(self):
+        """When neither pattern matches, LLM classifier is called.
+        We mock to avoid real inference."""
+        mod = _mod()
+        cfg: dict = {
+            "enabled": True,
+            "rules": {"always_simple": [], "always_complex": []},
+        }
+        with mock.patch.object(
+            mod, "_classify_with_llm",
+            return_value={"classification": "complex", "confidence": 0.9,
+                          "reason": "mock"},
+        ):
+            result = mod.classify("complex analysis request", cfg)
+        assert result["classification"] == "complex"
+        assert result["confidence"] == 0.9
+
+
+# ── Hook callback (_on_pre_agent_dispatch) ────────────────────────────
+
+class TestOnPreAgentDispatch:
+    def test_returns_none_when_disabled(self):
+        """When router is disabled, hook returns None (no-op)."""
+        mod = _mod()
+        with mock.patch.object(mod, "_load_router_config",
+                               return_value={"enabled": False}):
+            result = mod._on_pre_agent_dispatch(message="test")
+        assert result is None
+
+    def test_returns_none_for_empty_message(self):
+        """Empty messages are ignored."""
+        mod = _mod()
+        with mock.patch.object(mod, "_load_router_config",
+                               return_value={"enabled": True}):
+            result = mod._on_pre_agent_dispatch(message="")
+        assert result is None
+
+    def test_returns_none_for_non_string_message(self):
+        """Non-string messages are ignored."""
+        mod = _mod()
+        with mock.patch.object(mod, "_load_router_config",
+                               return_value={"enabled": True}):
+            result = mod._on_pre_agent_dispatch(message=123)
+        assert result is None
+
+    def test_cached_simple_returns_none(self):
+        """Cached 'simple' classification → no routing, returns None."""
+        mod = _mod()
+        mod._classification_cache.clear()
+        mod._cache_classification("sess", {"classification": "simple"})
+        with mock.patch.object(mod, "_load_router_config",
+                               return_value={"enabled": True}):
+            result = mod._on_pre_agent_dispatch(
+                message="hello",
+                session_key="sess",
+            )
+        assert result is None
+
+    def test_cached_complex_routes_to_orchestrator(self):
+        """Cached 'complex' classification → routes."""
+        mod = _mod()
+        mod._classification_cache.clear()
+        mod._cache_classification("sess", {"classification": "complex"})
+        with mock.patch.object(mod, "_load_router_config",
+                               return_value={
+                                   "enabled": True,
+                                   "orchestrator": {"profile": "test-profile"},
+                               }):
+            with mock.patch.object(
+                mod, "route_to_orchestrator",
+                return_value="orchestrator response",
+            ):
+                result = mod._on_pre_agent_dispatch(
+                    message="complex task",
+                    session_key="sess",
+                )
+        assert result is not None
+        assert result["action"] == "route"
+        assert result["result"] == "orchestrator response"
+
+    def test_classification_simple_returns_none(self):
+        """Fresh classification → simple → no routing."""
+        mod = _mod()
+        mod._classification_cache.clear()
+        with mock.patch.object(mod, "_load_router_config",
+                               return_value={"enabled": True}):
+            with mock.patch.object(
+                mod, "classify",
+                return_value={"classification": "simple", "confidence": 0.8,
+                              "reason": "looks easy"},
+            ):
+                result = mod._on_pre_agent_dispatch(
+                    message="what time is it",
+                    session_key="sess",
+                )
+        assert result is None
+
+    def test_streamed_flag_set_when_callback_provided(self):
+        """When stream_callback is provided, 'streamed' is True."""
+        mod = _mod()
+        mod._classification_cache.clear()
+        mod._cache_classification("sess", {"classification": "complex"})
+
+        def _noop(text: str) -> None:
+            pass
+
+        with mock.patch.object(mod, "_load_router_config",
+                               return_value={
+                                   "enabled": True,
+                                   "orchestrator": {"profile": "test-profile"},
+                               }):
+            with mock.patch.object(
+                mod, "route_to_orchestrator",
+                return_value="response",
+            ):
+                result = mod._on_pre_agent_dispatch(
+                    message="complex task",
+                    session_key="sess",
+                    stream_callback=_noop,
+                )
+        assert result["streamed"] is True
+
+    def test_streamed_false_when_no_callback(self):
+        """When no stream_callback, 'streamed' is False."""
+        mod = _mod()
+        mod._classification_cache.clear()
+        mod._cache_classification("sess", {"classification": "complex"})
+        with mock.patch.object(mod, "_load_router_config",
+                               return_value={
+                                   "enabled": True,
+                                   "orchestrator": {"profile": "test-profile"},
+                               }):
+            with mock.patch.object(
+                mod, "route_to_orchestrator",
+                return_value="response",
+            ):
+                result = mod._on_pre_agent_dispatch(
+                    message="complex task",
+                    session_key="sess",
+                )
+        assert result["streamed"] is False
+
+
+# ── Plugin registration ───────────────────────────────────────────────
+
+class TestPluginRegistration:
+    def test_register_calls_register_hook(self):
+        """register(ctx) registers the pre_agent_dispatch hook."""
+        mod = _mod()
+
+        class FakeCtx:
+            def __init__(self):
+                self.hooks: list = []
+
+            def register_hook(self, name, callback):
+                self.hooks.append((name, callback))
+
+        ctx = FakeCtx()
+        mod.register(ctx)
+        assert len(ctx.hooks) == 1
+        assert ctx.hooks[0][0] == "pre_agent_dispatch"
+        assert callable(ctx.hooks[0][1])

--- a/tests/test_pre_agent_dispatch_hook.py
+++ b/tests/test_pre_agent_dispatch_hook.py
@@ -201,3 +201,110 @@ def test_stream_callback_not_forwarded_when_none(monkeypatch):
 
     plugins_mod.dispatch_pre_agent(message="test", stream_callback=None)
     assert "stream_callback" not in captured
+
+
+# ── Priority / ordering ───────────────────────────────────────────────
+
+def test_route_wins_over_rewrite(monkeypatch):
+    """Route is checked before rewrite — first actionable wins."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[
+            {"action": "route", "result": "routed"},
+            {"action": "rewrite", "text": "ignored"},
+        ],
+    )
+    assert result == {"action": "route", "result": "routed"}
+
+
+def test_route_wins_over_skip(monkeypatch):
+    """Skip is checked before route — skip wins."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[
+            {"action": "skip"},
+            {"action": "route", "result": "never-reached"},
+        ],
+    )
+    assert result == {"action": "skip"}
+
+
+def test_two_route_hooks_first_wins(monkeypatch):
+    """Two route actions — first hook's result is used."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[
+            {"action": "route", "result": "first"},
+            {"action": "route", "result": "second-ignored"},
+        ],
+    )
+    assert result == {"action": "route", "result": "first"}
+
+
+def test_two_skip_hooks_first_wins(monkeypatch):
+    """Two skip actions — first one takes effect, second never reached."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[
+            {"action": "skip"},
+            {"action": "skip"},
+        ],
+    )
+    assert result == {"action": "skip"}
+
+
+# ── Unrecognised actions ──────────────────────────────────────────────
+
+def test_unrecognized_action_falls_through_to_allow(monkeypatch):
+    """A hook returning an unrecognised action is skipped; falls through."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[{"action": "unknown_action"}],
+    )
+    assert result == {"action": "allow"}
+
+
+def test_mixed_unknown_then_valid(monkeypatch):
+    """Unknown action is skipped; next valid action is used."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[
+            {"action": "unknown"},
+            {"action": "skip"},
+        ],
+    )
+    assert result == {"action": "skip"}
+
+
+# ── Route edge cases ──────────────────────────────────────────────────
+
+def test_route_with_explicit_none_result(monkeypatch):
+    """route with result=None returns empty string (None → '')."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[{"action": "route", "result": None}],
+    )
+    assert result == {"action": "route", "result": ""}
+
+
+# ── Rewrite edge cases ────────────────────────────────────────────────
+
+def test_rewrite_whitespace_only_text_is_truthy(monkeypatch):
+    """Whitespace-only rewrite text is truthy in Python — it is NOT a no-op.
+    This test documents current behaviour; if this becomes undesirable,
+    change the truthiness check in dispatch_pre_agent to strip first."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[{"action": "rewrite", "text": "   "}],
+    )
+    assert result == {"action": "rewrite", "text": "   "}
+
+
+# ── VALID_HOOKS registration ──────────────────────────────────────────
+
+def test_pre_agent_dispatch_in_valid_hooks():
+    """pre_agent_dispatch must be in VALID_HOOKS for plugins to register."""
+    assert "pre_agent_dispatch" in plugins_mod.VALID_HOOKS, (
+        "pre_agent_dispatch is missing from VALID_HOOKS — "
+        "plugins cannot register for this hook"
+    )

--- a/tests/test_pre_agent_dispatch_hook.py
+++ b/tests/test_pre_agent_dispatch_hook.py
@@ -1,0 +1,203 @@
+"""Tests for the ``pre_agent_dispatch`` plugin hook and ``dispatch_pre_agent`` helper."""
+
+import hermes_cli.plugins as plugins_mod
+
+
+# ── Helper ────────────────────────────────────────────────────────────
+
+_ACCEPTED_HOOK = "pre_agent_dispatch"
+
+
+def _call_dispatch(monkeypatch, *, hook_results=None):
+    """Call ``dispatch_pre_agent`` with a mocked hook pipeline.
+
+    ``hook_results`` is either a list that ``invoke_hook`` returns, or
+    ``None`` to use the real (empty) pipeline.
+    """
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", plugins_mod.PluginManager())
+    if hook_results is not None:
+        monkeypatch.setattr(plugins_mod, "invoke_hook", lambda _name, **_kw: hook_results)
+    return plugins_mod.dispatch_pre_agent(
+        message="test message",
+        session_key="test-session",
+    )
+
+
+# ── Baseline ──────────────────────────────────────────────────────────
+
+def test_allow_when_no_plugins(monkeypatch):
+    """With no plugins loaded, dispatch_pre_agent returns allow."""
+    result = _call_dispatch(monkeypatch, hook_results=[])
+    assert result == {"action": "allow"}
+
+
+def test_allow_when_hooks_return_none(monkeypatch):
+    """None returns from hooks are skipped."""
+    result = _call_dispatch(monkeypatch, hook_results=[None])
+    assert result == {"action": "allow"}
+
+
+def test_non_dict_returns_are_skipped(monkeypatch):
+    """Non-dict hook returns are ignored."""
+    result = _call_dispatch(monkeypatch, hook_results=[123, "string", {"action": "skip"}])
+    assert result == {"action": "skip"}
+
+
+# ── Action: skip ──────────────────────────────────────────────────────
+
+def test_skip_action(monkeypatch):
+    """A hook returning skip drops the message."""
+    result = _call_dispatch(monkeypatch, hook_results=[{"action": "skip"}])
+    assert result == {"action": "skip"}
+
+
+def test_skip_wins_over_allow(monkeypatch):
+    """First actionable result wins — skip before allow."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[{"action": "skip"}, {"action": "allow"}],
+    )
+    assert result == {"action": "skip"}
+
+
+# ── Action: route ─────────────────────────────────────────────────────
+
+def test_route_action(monkeypatch):
+    """A hook returning route bypasses the agent."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[{"action": "route", "result": "orchestrator says hi"}],
+    )
+    assert result == {"action": "route", "result": "orchestrator says hi"}
+
+
+def test_route_with_streamed_flag(monkeypatch):
+    """The streamed flag is passed through so callers can avoid double-streaming."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[{"action": "route", "result": "hi", "streamed": True}],
+    )
+    assert result == {"action": "route", "result": "hi", "streamed": True}
+
+
+def test_route_without_streamed_flag(monkeypatch):
+    """When streamed is not set, the result dict does not include it."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[{"action": "route", "result": "hi"}],
+    )
+    assert "streamed" not in result
+
+
+def test_route_result_empty_string_is_preserved(monkeypatch):
+    """An empty string result is kept (not coerced to '' redundantly)."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[{"action": "route", "result": ""}],
+    )
+    assert result == {"action": "route", "result": ""}
+
+
+def test_route_missing_result_defaults_to_empty(monkeypatch):
+    """A route action without a result key gets an empty string."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[{"action": "route"}],
+    )
+    assert result == {"action": "route", "result": ""}
+
+
+# ── Action: rewrite ───────────────────────────────────────────────────
+
+def test_rewrite_action(monkeypatch):
+    """A hook returning rewrite provides replacement text."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[{"action": "rewrite", "text": "rewritten message"}],
+    )
+    assert result == {"action": "rewrite", "text": "rewritten message"}
+
+
+def test_rewrite_empty_text_is_noop(monkeypatch):
+    """An empty rewrite text is treated as a no-op — falls through to allow."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[{"action": "rewrite", "text": ""}],
+    )
+    assert result == {"action": "allow"}
+
+
+def test_rewrite_non_string_text_is_noop(monkeypatch):
+    """A non-string rewrite text is treated as a no-op."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[{"action": "rewrite", "text": 123}],
+    )
+    assert result == {"action": "allow"}
+
+
+def test_rewrite_then_allow(monkeypatch):
+    """An empty rewrite is skipped; the next hook's result is used."""
+    result = _call_dispatch(
+        monkeypatch,
+        hook_results=[
+            {"action": "rewrite", "text": ""},
+            {"action": "allow"},
+        ],
+    )
+    assert result == {"action": "allow"}
+
+
+# ── Error handling ────────────────────────────────────────────────────
+
+def test_hook_exception_falls_back_to_allow(monkeypatch):
+    """If invoke_hook raises, dispatch_pre_agent returns allow (fail-closed)."""
+    def _raise(_name, **_kw):
+        raise RuntimeError("plugin crash")
+
+    monkeypatch.setattr(plugins_mod, "invoke_hook", _raise)
+    result = plugins_mod.dispatch_pre_agent(message="test")
+    assert result == {"action": "allow"}
+
+
+# ── Kwarg forwarding ──────────────────────────────────────────────────
+
+def test_kwargs_forwarded_to_hooks(monkeypatch):
+    """All expected kwargs are forwarded to invoke_hook."""
+    captured = {}
+
+    def _hook(_name, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(plugins_mod, "invoke_hook", _hook)
+
+    result = plugins_mod.dispatch_pre_agent(
+        message="hello",
+        session_key="sess-1",
+        source="test-source",
+        gateway="test-gateway",
+        history=[{"role": "user", "content": "prev"}],
+        stream_callback=lambda text: None,
+    )
+    assert result == {"action": "allow"}
+    assert captured["message"] == "hello"
+    assert captured["session_key"] == "sess-1"
+    assert captured["source"] == "test-source"
+    assert captured["gateway"] == "test-gateway"
+    assert captured["history"] == [{"role": "user", "content": "prev"}]
+    assert "stream_callback" in captured
+
+
+def test_stream_callback_not_forwarded_when_none(monkeypatch):
+    """When stream_callback is None, it is not forwarded to hooks."""
+    captured = {}
+
+    def _hook(_name, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(plugins_mod, "invoke_hook", _hook)
+
+    plugins_mod.dispatch_pre_agent(message="test", stream_callback=None)
+    assert "stream_callback" not in captured

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10524,7 +10524,45 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     run_kwargs["task_id"] = session["session_key"]
             except (TypeError, ValueError):
                 pass
-            result = agent.run_conversation(run_message, **run_kwargs)
+
+            # ── pre_agent_dispatch plugin hook ────────────────────────
+            from hermes_cli.plugins import dispatch_pre_agent as _dispatch_pre_agent
+
+            _hook_message = prompt if isinstance(prompt, str) else str(prompt)
+            _hook_result = _dispatch_pre_agent(
+                message=_hook_message,
+                session_key=session.get("session_key", ""),
+                history=list(history),
+                stream_callback=_stream,
+            )
+            _hook_action = _hook_result.get("action", "allow")
+
+            if _hook_action == "skip":
+                result = {
+                    "final_response": "",
+                    "messages": list(history),
+                    "interrupted": False,
+                }
+            elif _hook_action == "route":
+                _final_text = _hook_result.get("result", "") or "(empty response)"
+                # When a stream_callback was provided and the hook used it for
+                # incremental streaming, skip the bulk _stream call to avoid
+                # duplicating output that was already shown progressively.
+                _streamed = _hook_result.get("streamed", False)
+                if not _streamed:
+                    _stream(_final_text)
+                _user_msg = {"role": "user", "content": _hook_message}
+                _assistant_msg = {"role": "assistant", "content": _final_text}
+                result = {
+                    "final_response": _final_text,
+                    "messages": list(history) + [_user_msg, _assistant_msg],
+                    "interrupted": False,
+                }
+            else:
+                if _hook_action == "rewrite":
+                    run_message = _hook_result.get("text", run_message)
+                # ── Normal dispatch (allow, rewrite, or unrecognised) ──
+                result = agent.run_conversation(run_message, **run_kwargs)
             if "moa_one_shot_restore" in session:
                 _restore = session.pop("moa_one_shot_restore", None)
                 # Restore the model the user was on before the /moa one-shot.


### PR DESCRIPTION
## Summary

Add a new plugin lifecycle hook `pre_agent_dispatch` that fires once per turn just **before** the agent processes a user message. This allows plugins to intercept, rewrite, or bypass normal agent dispatch — useful for routing, content filtering, pre-processing, and multi-agent orchestration.

## Hook Protocol

A plugin's `pre_agent_dispatch` callback receives `message`, `session_key`, `source`, `gateway`, `history`, and optionally `stream_callback`. It returns a dict with an `action` key:

| Action | Effect |
|--------|--------|
| `allow` / `None` | Normal agent dispatch (default) |
| `skip` | Drop the message silently — no reply, no agent run |
| `route` | Bypass the agent entirely; supply a pre-computed `result` |
| `rewrite` | Replace the message `text`, then dispatch normally |

## Changes

- **`hermes_cli/plugins.py`**: Register `pre_agent_dispatch` in `VALID_HOOKS` (24 total); add `dispatch_pre_agent()` shared helper with fail-closed error handling
- **`gateway/run.py`**: Integrate hook into gateway dispatch (Telegram, Discord, etc.)
- **`tui_gateway/server.py`**: Integrate hook into TUI/WebUI prompt submission
- **`plugins/router/`**: Reference plugin — pre-turn classifier for Flash→Orchestrator routing
- **`tests/test_pre_agent_dispatch_hook.py`**: 17 tests covering all actions and edge cases

## Design Decisions

1. **Fail-closed**: Hook exceptions fall back to `allow` — never blocks the user
2. **First-wins**: First non-`allow` plugin return wins
3. **Streaming passthrough**: Optional `stream_callback` for progressive output during routing
4. **Two call sites**: Both tui_gateway and gateway use the shared `dispatch_pre_agent()` helper