### PR TITLE
fix(gateway): prevent restart resume fan-out after clean drain

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1877,21 +1877,28 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from hermes_constants import get_hermes_home, get_hermes_home_override
 from utils import atomic_json_write, is_truthy_value
 _hermes_home = get_hermes_home()
+_CLEAN_SHUTDOWN_MARKER_PAYLOAD = b"clean\n"
 
 
 def _consume_clean_shutdown_marker() -> bool:
-    """Atomically consume one clean-shutdown marker generation.
+    """Atomically claim one clean-shutdown marker generation.
 
-    Rename before inspection so any stat/read failure happens only after the
-    recognized marker name is gone. A failed startup can therefore never lend
-    an older process's clean proof to a later boot.
+    A valid claim remains at ``.clean_shutdown.cleanup_pending`` until startup durably
+    discards orphan active-turn markers. This makes receipt consumption and
+    marker cleanup one retryable transaction. The transaction runs immediately
+    after the gateway identity lock is acquired, before adapters or other
+    fallible startup work.
     """
     marker = _hermes_home / ".clean_shutdown"
-    consumed = _hermes_home / ".clean_shutdown.consumed"
+    consumed = _hermes_home / ".clean_shutdown.cleanup_pending"
     try:
         os.replace(marker, consumed)
     except FileNotFoundError:
-        return False
+        # A prior startup may have died after claiming the receipt but before
+        # committing orphan-marker cleanup. That attempt never started adapters,
+        # so retrying the claimed transaction is safe.
+        if not consumed.exists():
+            return False
     except Exception as exc:
         logger.warning("Failed to consume .clean_shutdown marker: %s", exc)
         # Never leave evidence that a later process could misattribute to its
@@ -1918,28 +1925,38 @@ def _consume_clean_shutdown_marker() -> bool:
                 ) from tombstone_exc
         return False
 
-    clean = False
     try:
-        clean = consumed.stat().st_size == 0
-        if not clean:
-            logger.debug("Ignoring non-empty .clean_shutdown invalidation tombstone")
+        clean = consumed.read_bytes() == _CLEAN_SHUTDOWN_MARKER_PAYLOAD
     except Exception as exc:
-        # The recognized name was already consumed, so inspection failure is
-        # safely one-shot and cannot be reused by a subsequent process.
         logger.warning("Failed to inspect consumed .clean_shutdown marker: %s", exc)
-    finally:
         try:
             consumed.unlink()
-        except Exception as exc:
-            # The recognized marker name is already gone; leftover cleanup is
-            # harmless and the next os.replace() overwrites this path atomically.
-            logger.warning("Failed to remove consumed shutdown marker: %s", exc)
-    return clean
+        except Exception:
+            try:
+                consumed.write_text("invalid\n", encoding="utf-8")
+            except Exception as tombstone_exc:
+                raise RuntimeError(
+                    "Cannot safely invalidate consumed shutdown marker"
+                ) from tombstone_exc
+        return False
+
+    if clean:
+        return True
+
+    logger.debug("Ignoring invalid .clean_shutdown marker payload")
+    try:
+        consumed.unlink()
+    except Exception as exc:
+        # Invalid bytes can remain safely: future claims will never trust them.
+        logger.warning("Failed to remove invalid consumed shutdown marker: %s", exc)
+    return False
 
 
 def _write_clean_shutdown_marker() -> None:
     """Record a clean drain, replacing any stale invalidation tombstone."""
-    (_hermes_home / ".clean_shutdown").write_bytes(b"")
+    (_hermes_home / ".clean_shutdown").write_bytes(
+        _CLEAN_SHUTDOWN_MARKER_PAYLOAD
+    )
 
 
 # Load environment variables from ~/.hermes/.env first.
@@ -6643,6 +6660,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # while gateway shutdown is draining or interrupting agents.
         self._shutdown_resume_pending_keys: set[str] = set()
         self._previous_shutdown_clean = False
+        self._clean_shutdown_marker_blocked = False
         # Per-SESSION_ID turn lease (#64934): serializes the
         # [load history → run → flush] region when two ROUTING KEYS resolve
         # to one session_id (switch_session's many-to-one mapping). The
@@ -11200,7 +11218,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # startup turn. ``restart_interrupted`` is a heuristic assigned to recent
     # sessions after an unclean exit; it is intentionally deferred until the
     # user's next real message so idle chats can never fan out blank turns.
-    _AUTO_RESUME_REASONS = frozenset({"restart_timeout", "shutdown_timeout"})
+    _AUTO_RESUME_REASONS = frozenset(
+        {"restart_timeout", "shutdown_timeout", "active_turn_interrupted"}
+    )
 
     async def _clear_resume_pending_after_success(self, session_key: str) -> None:
         """Clear recovery state unless shutdown has reserved it for restart.
@@ -11220,6 +11240,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 await self.async_session_store.clear_resume_pending(session_key)
             except Exception as _e:
+                self._clean_shutdown_marker_blocked = True
                 logger.debug(
                     "clear_resume_pending failed for %s: %s",
                     session_key,
@@ -11480,6 +11501,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 try:
                     await self.async_session_store.clear_resume_pending(session_key)
                 except Exception:
+                    self._clean_shutdown_marker_blocked = True
                     logger.debug(
                         "clear_resume_pending failed for %s", session_key,
                         exc_info=True,
@@ -11510,6 +11532,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         scheduled at startup is never resumed a second time.
         """
         window = _auto_continue_freshness_window()
+        allowed_reasons = self._AUTO_RESUME_REASONS
+        if not getattr(self, "_previous_shutdown_clean", False):
+            # On an unclean boot, only a durable active-turn marker is exact
+            # enough for synthetic dispatch. Planned-drain timeout receipts may
+            # be stale if their completion-time clear failed, while recency-only
+            # recovery is deliberately inbound-only.
+            allowed_reasons = frozenset({"active_turn_interrupted"})
         try:
             with self.session_store._lock:  # noqa: SLF001 — snapshot under lock
                 self.session_store._ensure_loaded_locked()  # noqa: SLF001
@@ -11518,7 +11547,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if entry.resume_pending
                     and not entry.suspended
                     and entry.origin is not None
-                    and entry.resume_reason in self._AUTO_RESUME_REASONS
+                    and entry.resume_reason in allowed_reasons
                     and (platform is None or entry.origin.platform == platform)
                 ]
         except Exception as exc:
@@ -11623,7 +11652,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             scheduled += 1
         if scheduled:
             logger.info(
-                "Scheduled auto-resume for %d restart-interrupted session(s)",
+                "Scheduled auto-resume for %d exactly marked session(s)",
                 scheduled,
             )
         return scheduled
@@ -12078,30 +12107,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # `hermes gateway restart`, or `/restart`.
         if getattr(self, "_previous_shutdown_clean", False):
             logger.info("Previous gateway exited cleanly — skipping session suspension")
-            try:
-                discarded = await self.async_session_store.discard_active_turn_markers()
-            except Exception as exc:
-                logger.error(
-                    "Clean-start marker cleanup failed; refusing startup so stale "
-                    "active-turn markers cannot survive trusted clean proof: %s",
-                    exc,
-                )
-                raise RuntimeError("clean-start recovery cleanup failed") from exc
-            if discarded:
-                logger.info(
-                    "Discarded %d orphan active-turn marker(s) after clean shutdown",
-                    discarded,
-                )
         else:
+            # Preserve current-main exact active-turn recovery before applying
+            # the PR's inbound-only downgrade to possibly stale planned-drain
+            # timeout receipts. Exact active-turn provenance is distinct from
+            # the 120-second legacy recency fallback.
             exact, fallback = await self._recover_unclean_sessions()
-            recovered = exact + fallback
-            if recovered:
+            if exact or fallback:
                 logger.info(
                     "Marked %d in-flight session(s) as resumable from previous run "
                     "(%d exact, %d legacy)",
-                    recovered,
+                    exact + fallback,
                     exact,
                     fallback,
+                )
+            try:
+                downgraded = await self.async_session_store.downgrade_untrusted_exact_resume_pending()
+                if downgraded:
+                    logger.info(
+                        "Deferred %d exact recovery marker(s) until real inbound "
+                        "because predecessor clean proof was absent",
+                        downgraded,
+                    )
+            except Exception as e:
+                # The current boot remains safe because synthetic restore admits
+                # only active_turn_interrupted on an unclean start. Prevent this
+                # lifecycle from writing new clean proof: otherwise a later boot
+                # could trust exact timeout markers whose downgrade failed.
+                self._clean_shutdown_marker_blocked = True
+                logger.error(
+                    "Failed to persist inbound-only recovery downgrade; "
+                    "clean shutdown proof is disabled for this lifecycle: %s",
+                    e,
                 )
 
         # Stuck-loop detection (#7536): if a session has been active across
@@ -14023,6 +14060,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # even when unrelated cron/API work keeps the overall drain waiting
             # until timeout. Clear its durable pre-drain recovery marker before
             # classifying the work that actually remains.
+            _resume_cleanup_failed = False
             for _sk in _reserved_pre_drain_keys:
                 if _sk not in self._running_agents:
                     _resume_lock = _resume_pending_lock_for(_sk)
@@ -14030,6 +14068,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         try:
                             await self.async_session_store.clear_resume_pending(_sk)
                         except Exception as _e:
+                            _resume_cleanup_failed = True
                             logger.debug(
                                 "clear_resume_pending after drain failed for %s: %s",
                                 _sk, _e,
@@ -14037,7 +14076,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         finally:
                             self._shutdown_resume_pending_keys.discard(_sk)
 
-            if not timed_out:
+            if (
+                not timed_out
+                and not _resume_cleanup_failed
+                and not getattr(self, "_clean_shutdown_marker_blocked", False)
+            ):
                 # Record the clean drain before slower teardown begins. Host
                 # shutdown can terminate the process while memory providers,
                 # adapters, or SQLite handles are still closing. Waiting until
@@ -14048,6 +14091,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _write_clean_shutdown_marker()
                 except Exception as _e:
                     logger.warning("Failed to write .clean_shutdown marker: %s", _e)
+            elif not timed_out:
+                logger.info(
+                    "Skipping .clean_shutdown marker — exact recovery state "
+                    "could not be made complete and unambiguous."
+                )
 
             if timed_out:
                 logger.warning(
@@ -14106,30 +14154,59 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 _sk, _e,
                             )
 
+                # A turn can finish while another session's timeout marker is
+                # being awaited. Re-snapshot until no newly completed marked
+                # sessions remain; the final empty pass has no await between
+                # the running-state check and interruption below.
+                _exact_interrupted_keys = {_sk for _sk, _agent in _interrupted_agents}
+                while True:
+                    _finished_during_mark = [
+                        _sk
+                        for _sk in _exact_interrupted_keys
+                        if _sk not in self._running_agents
+                    ]
+                    if not _finished_during_mark:
+                        break
+                    for _sk in _finished_during_mark:
+                        _resume_lock = _resume_pending_lock_for(_sk)
+                        async with _resume_lock:
+                            try:
+                                await self.async_session_store.clear_resume_pending(_sk)
+                            except Exception as _e:
+                                _resume_cleanup_failed = True
+                                logger.debug(
+                                    "clear_resume_pending after timeout mark failed for %s: %s",
+                                    _sk,
+                                    _e,
+                                )
+                            finally:
+                                self._shutdown_resume_pending_keys.discard(_sk)
+                                _exact_interrupted_keys.discard(_sk)
+
+                self._interrupt_running_agents(
+                    _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
+                )
+
                 # Every interrupted chat is now represented by an exact
                 # resume_pending marker. Record that broad crash inference is
                 # unnecessary before post-drain teardown: otherwise a timeout
                 # caused only by cron/API work marks unrelated recent chats as
                 # interrupted on the next boot. If an exact marker failed,
                 # retain the missing marker as the conservative fallback.
-                if not _resume_mark_failed and not _interrupted_agents:
+                if (
+                    not _resume_mark_failed
+                    and not _resume_cleanup_failed
+                    and not getattr(self, "_clean_shutdown_marker_blocked", False)
+                ):
                     try:
                         _write_clean_shutdown_marker()
                     except Exception as _e:
                         logger.warning("Failed to write .clean_shutdown marker: %s", _e)
-                elif _resume_mark_failed:
+                elif _resume_mark_failed or _resume_cleanup_failed:
                     logger.info(
-                        "Skipping .clean_shutdown marker — at least one "
-                        "interrupted session could not be marked for exact resume."
+                        "Skipping .clean_shutdown marker — exact recovery state "
+                        "could not be made complete and unambiguous."
                     )
-                else:
-                    logger.info(
-                        "Skipping .clean_shutdown marker — interrupted sessions "
-                        "were marked for exact resume."
-                    )
-                self._interrupt_running_agents(
-                    _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
-                )
                 interrupt_deadline = asyncio.get_running_loop().time() + 5.0
                 # Wait on API-server work too. The interrupt is cooperative:
                 # without this the settle window closes the instant
@@ -29501,12 +29578,22 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             "PID file race lost to another gateway instance. Exiting."
         )
         return False
-    # Consume the predecessor's one-shot clean proof immediately after this
-    # process owns both gateway identity guards.  Nothing fallible or awaitable
-    # may run first: if this startup crashes, a later boot must not reuse the
-    # old process's proof and misclassify this failed generation as clean.
+    # Consume the predecessor's clean proof and durably discard orphan active
+    # turns as one transaction immediately after this process owns both gateway
+    # identity guards. No adapter or other fallible startup work runs first.
+    # If cleanup fails (or this process dies mid-transaction), the claimed
+    # receipt remains retryable at .clean_shutdown.cleanup_pending on the next boot.
     try:
         runner._previous_shutdown_clean = _consume_clean_shutdown_marker()
+        if runner._previous_shutdown_clean:
+            discarded = await runner._consume_clean_shutdown_marker(
+                _hermes_home / ".clean_shutdown.cleanup_pending"
+            )
+            if discarded:
+                logger.info(
+                    "Discarded %d orphan active-turn marker(s) after clean shutdown",
+                    discarded,
+                )
     except BaseException:
         # Consumption failure is fatal when the recognized marker cannot be
         # invalidated. Release identity guards explicitly because the atexit

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1878,6 +1878,68 @@ from hermes_constants import get_hermes_home, get_hermes_home_override
 from utils import atomic_json_write, is_truthy_value
 _hermes_home = get_hermes_home()
 
+
+def _consume_clean_shutdown_marker() -> bool:
+    """Atomically consume one clean-shutdown marker generation.
+
+    Rename first so a cleanup failure cannot leave reusable evidence that
+    poisons a later startup after a genuinely interrupted shutdown.
+    """
+    marker = _hermes_home / ".clean_shutdown"
+    if not marker.exists():
+        return False
+    try:
+        if marker.stat().st_size != 0:
+            # Non-empty files are invalidation tombstones, never clean proof.
+            try:
+                marker.unlink()
+            except Exception:
+                pass
+            return False
+    except Exception as exc:
+        logger.warning("Failed to inspect .clean_shutdown marker: %s", exc)
+        return False
+    consumed = _hermes_home / ".clean_shutdown.consumed"
+    try:
+        os.replace(marker, consumed)
+    except FileNotFoundError:
+        return False
+    except Exception as exc:
+        logger.warning("Failed to consume .clean_shutdown marker: %s", exc)
+        # Never leave evidence that a later process could misattribute to its
+        # immediate predecessor. If atomic rename is unavailable, invalidate
+        # the marker in place before continuing as an unclean startup.
+        try:
+            marker.unlink()
+        except FileNotFoundError:
+            pass
+        except Exception as unlink_exc:
+            logger.error(
+                "Failed to invalidate unconsumed .clean_shutdown marker: %s",
+                unlink_exc,
+            )
+            try:
+                marker.write_text("invalid\n", encoding="utf-8")
+            except Exception as tombstone_exc:
+                logger.error(
+                    "Failed to tombstone .clean_shutdown marker: %s",
+                    tombstone_exc,
+                )
+        return False
+    try:
+        consumed.unlink()
+    except Exception as exc:
+        # The recognized marker name is already gone; leftover cleanup is
+        # harmless and the next os.replace() overwrites this path atomically.
+        logger.warning("Failed to remove consumed shutdown marker: %s", exc)
+    return True
+
+
+def _write_clean_shutdown_marker() -> None:
+    """Record a clean drain, replacing any stale invalidation tombstone."""
+    (_hermes_home / ".clean_shutdown").write_bytes(b"")
+
+
 # Load environment variables from ~/.hermes/.env first.
 # User-managed env files should override stale shell exports on restart.
 from dotenv import load_dotenv  # noqa: F401  # backward-compat for tests that monkeypatch this symbol
@@ -6575,6 +6637,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # self._session_state(key) (get-or-create) or
         # self._peek_session_state(key) (read-only).
         self._sessions: Dict[str, SessionState] = {}
+        # Session keys whose recovery markers must survive turn completion
+        # while gateway shutdown is draining or interrupting agents.
+        self._shutdown_resume_pending_keys: set[str] = set()
+        self._previous_shutdown_clean = False
         # Per-SESSION_ID turn lease (#64934): serializes the
         # [load history → run → flush] region when two ROUTING KEYS resolve
         # to one session_id (switch_session's many-to-one mapping). The
@@ -11128,14 +11194,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._restart_task = asyncio.create_task(_run_restart())
         return True
 
-    # Drain-timeout reasons set by _stop_impl() when a still-running turn is
-    # force-interrupted; "restart_interrupted" is set by
-    # SessionStore.suspend_recently_active() on crash recovery (no
-    # .clean_shutdown marker).  All three mean "the agent was mid-turn and
-    # we killed it" — eligible for startup auto-resume.
-    _AUTO_RESUME_REASONS = frozenset(
-        {"restart_timeout", "shutdown_timeout", "restart_interrupted"}
-    )
+    # Only exact per-session markers written by _stop_impl() may synthesize a
+    # startup turn. ``restart_interrupted`` is a heuristic assigned to recent
+    # sessions after an unclean exit; it is intentionally deferred until the
+    # user's next real message so idle chats can never fan out blank turns.
+    _AUTO_RESUME_REASONS = frozenset({"restart_timeout", "shutdown_timeout"})
+
+    async def _clear_resume_pending_after_success(self, session_key: str) -> None:
+        """Clear recovery state unless shutdown has reserved it for restart.
+
+        The reservation is installed before draining begins, closing the race
+        where a finishing turn could clear its exact marker while shutdown was
+        about to interrupt the still-registered agent.
+        """
+        if session_key in getattr(self, "_shutdown_resume_pending_keys", set()):
+            logger.debug(
+                "Preserving resume_pending for %s during gateway shutdown",
+                session_key,
+            )
+            return
+        try:
+            await self.async_session_store.clear_resume_pending(session_key)
+        except Exception as _e:
+            logger.debug(
+                "clear_resume_pending failed for %s: %s",
+                session_key,
+                _e,
+            )
 
     async def _run_startup_resume_event(
         self,
@@ -11262,8 +11347,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         exc_info=(type(exc), exc, exc.__traceback__),
                     )
         self._startup_restore_tasks = []
-        drained = await self._drain_startup_restore_queue()
-        self._startup_restore_in_progress = False
+        drained = 0
+        while True:
+            drained += await self._drain_startup_restore_queue()
+            # Keep the gate closed until the queue is observed empty after a
+            # drain. A message can be queued by the final awaited dispatch (or
+            # a test/platform wrapper) just before the drain coroutine returns;
+            # releasing the gate without re-checking would strand that event.
+            if not getattr(self, "_startup_restore_queue", None):
+                self._startup_restore_in_progress = False
+                break
         if drained:
             logger.info("Drained %d inbound message(s) queued during startup restore", drained)
 
@@ -11412,6 +11505,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         agent is already running are skipped regardless, so a session
         scheduled at startup is never resumed a second time.
         """
+        # A clean marker is authoritative: every conversational turn drained.
+        # Even if shutdown could not clear a stale exact flag from storage, do
+        # not synthesize it during this process lifetime.
+        if getattr(self, "_previous_shutdown_clean", False):
+            return 0
+
         window = _auto_continue_freshness_window()
         try:
             with self.session_store._lock:  # noqa: SLF001 — snapshot under lock
@@ -11979,15 +12078,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # process already drained active agents, so sessions aren't stuck.
         # This prevents unwanted auto-resets after `hermes update`,
         # `hermes gateway restart`, or `/restart`.
-        _clean_marker = _hermes_home / ".clean_shutdown"
-        if _clean_marker.exists():
+        self._previous_shutdown_clean = _consume_clean_shutdown_marker()
+        if self._previous_shutdown_clean:
             logger.info("Previous gateway exited cleanly — skipping session suspension")
             try:
-                discarded = await self._consume_clean_shutdown_marker(_clean_marker)
+                discarded = await self.async_session_store.discard_active_turn_markers()
             except Exception as exc:
                 logger.error(
-                    "Clean-start marker cleanup failed; refusing startup so the "
-                    "clean-exit receipt cannot mask a later unclean exit: %s",
+                    "Clean-start marker cleanup failed; refusing startup so stale "
+                    "active-turn markers cannot survive trusted clean proof: %s",
                     exc,
                 )
                 raise RuntimeError("clean-start recovery cleanup failed") from exc
@@ -13872,6 +13971,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # drain, the durable marker is already written so the next
             # gateway boot can recover in-flight sessions (#27856).
             _pre_drain_keys: list[str] = []
+            self._shutdown_resume_pending_keys = {
+                _sk
+                for _sk, _agent in list(self._running_agents.items())
+                if _agent is not _AGENT_PENDING_SENTINEL
+            }
             for _sk, _agent in list(self._running_agents.items()):
                 if _agent is _AGENT_PENDING_SENTINEL:
                     continue
@@ -13904,19 +14008,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._active_api_run_count(),
             )
 
+            # Any chat that finished during the drain window is not interrupted,
+            # even when unrelated cron/API work keeps the overall drain waiting
+            # until timeout. Clear its durable pre-drain recovery marker before
+            # classifying the work that actually remains.
+            for _sk in _pre_drain_keys:
+                if _sk not in self._running_agents:
+                    try:
+                        await self.async_session_store.clear_resume_pending(_sk)
+                    except Exception as _e:
+                        logger.debug(
+                            "clear_resume_pending after drain failed for %s: %s",
+                            _sk, _e,
+                        )
+
             if not timed_out:
-                # Drain completed gracefully — all running sessions finished.
-                # Clear the pre-drain resume_pending markers so sessions that
-                # completed during the drain window don't carry a stale flag.
-                for _sk in _pre_drain_keys:
-                    if _sk not in self._running_agents:
-                        try:
-                            await self.async_session_store.clear_resume_pending(_sk)
-                        except Exception as _e:
-                            logger.debug(
-                                "clear_resume_pending after drain failed for %s: %s",
-                                _sk, _e,
-                            )
+                # Record the clean drain before slower teardown begins. Host
+                # shutdown can terminate the process while memory providers,
+                # adapters, or SQLite handles are still closing. Waiting until
+                # the end made the next boot mistake recently used idle chats
+                # for interrupted turns and fan out synthetic auto-resume
+                # messages even though there was no work left to recover.
+                try:
+                    _write_clean_shutdown_marker()
+                except Exception as _e:
+                    logger.warning("Failed to write .clean_shutdown marker: %s", _e)
 
             if timed_out:
                 logger.warning(
@@ -13952,16 +14068,50 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _resume_reason = (
                     "restart_timeout" if self._restart_requested else "shutdown_timeout"
                 )
-                for _sk, _agent in list(self._running_agents.items()):
-                    if _agent is _AGENT_PENDING_SENTINEL:
-                        continue
+                _resume_mark_failed = False
+                _interrupted_agents = [
+                    (_sk, _agent)
+                    for _sk, _agent in list(self._running_agents.items())
+                    if _agent is not _AGENT_PENDING_SENTINEL
+                ]
+                self._shutdown_resume_pending_keys.update(
+                    _sk for _sk, _agent in _interrupted_agents
+                )
+                for _sk, _agent in _interrupted_agents:
                     try:
-                        await self.async_session_store.mark_resume_pending(_sk, _resume_reason)
+                        _marked = await self.async_session_store.mark_resume_pending(
+                            _sk, _resume_reason
+                        )
+                        if not _marked:
+                            _resume_mark_failed = True
                     except Exception as _e:
+                        _resume_mark_failed = True
                         logger.debug(
                             "mark_resume_pending failed for %s: %s",
                             _sk, _e,
                         )
+
+                # Every interrupted chat is now represented by an exact
+                # resume_pending marker. Record that broad crash inference is
+                # unnecessary before post-drain teardown: otherwise a timeout
+                # caused only by cron/API work marks unrelated recent chats as
+                # interrupted on the next boot. If an exact marker failed,
+                # retain the missing marker as the conservative fallback.
+                if not _resume_mark_failed and not _interrupted_agents:
+                    try:
+                        _write_clean_shutdown_marker()
+                    except Exception as _e:
+                        logger.warning("Failed to write .clean_shutdown marker: %s", _e)
+                elif _resume_mark_failed:
+                    logger.info(
+                        "Skipping .clean_shutdown marker — at least one "
+                        "interrupted session could not be marked for exact resume."
+                    )
+                else:
+                    logger.info(
+                        "Skipping .clean_shutdown marker — interrupted sessions "
+                        "were marked for exact resume."
+                    )
                 self._interrupt_running_agents(
                     _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
                 )
@@ -14157,26 +14307,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from gateway.status import remove_pid_file, release_gateway_runtime_lock
             remove_pid_file()
             release_gateway_runtime_lock()
-
-            # Write a clean-shutdown marker so the next startup knows this
-            # wasn't a crash.  suspend_recently_active() only needs to run
-            # after unexpected exits.  However, if the drain timed out and
-            # agents were force-interrupted, their sessions may be in an
-            # incomplete state (trailing tool response, no final assistant
-            # message).  Skip the marker in that case so the next startup
-            # suspends those sessions — giving users a clean slate instead
-            # of resuming a half-finished tool loop.
-            if not timed_out:
-                try:
-                    (_hermes_home / ".clean_shutdown").touch()
-                except Exception:
-                    pass
-            else:
-                logger.info(
-                    "Skipping .clean_shutdown marker — drain timed out with "
-                    "interrupted agents; next startup will suspend recently "
-                    "active sessions."
-                )
 
             # Track sessions that were active at shutdown for stuck-loop
             # detection (#7536).  On each restart, the counter increments
@@ -19325,13 +19455,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # the restart-interruption system note.
             if session_key and _should_clear_resume_pending_after_turn(agent_result):
                 await self._clear_restart_failure_count(session_key)
-                try:
-                    await self.async_session_store.clear_resume_pending(session_key)
-                except Exception as _e:
-                    logger.debug(
-                        "clear_resume_pending failed for %s: %s",
-                        session_key, _e,
-                    )
+                await self._clear_resume_pending_after_success(session_key)
 
             # Normalize empty responses: surface errors, partial failures, and
             # the case where agent did work but returned no text. Fix for #18765.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1882,23 +1882,11 @@ _hermes_home = get_hermes_home()
 def _consume_clean_shutdown_marker() -> bool:
     """Atomically consume one clean-shutdown marker generation.
 
-    Rename first so a cleanup failure cannot leave reusable evidence that
-    poisons a later startup after a genuinely interrupted shutdown.
+    Rename before inspection so any stat/read failure happens only after the
+    recognized marker name is gone. A failed startup can therefore never lend
+    an older process's clean proof to a later boot.
     """
     marker = _hermes_home / ".clean_shutdown"
-    if not marker.exists():
-        return False
-    try:
-        if marker.stat().st_size != 0:
-            # Non-empty files are invalidation tombstones, never clean proof.
-            try:
-                marker.unlink()
-            except Exception:
-                pass
-            return False
-    except Exception as exc:
-        logger.warning("Failed to inspect .clean_shutdown marker: %s", exc)
-        return False
     consumed = _hermes_home / ".clean_shutdown.consumed"
     try:
         os.replace(marker, consumed)
@@ -1925,14 +1913,28 @@ def _consume_clean_shutdown_marker() -> bool:
                     "Failed to tombstone .clean_shutdown marker: %s",
                     tombstone_exc,
                 )
+                raise RuntimeError(
+                    "Cannot safely invalidate unconsumed .clean_shutdown marker"
+                ) from tombstone_exc
         return False
+
+    clean = False
     try:
-        consumed.unlink()
+        clean = consumed.stat().st_size == 0
+        if not clean:
+            logger.debug("Ignoring non-empty .clean_shutdown invalidation tombstone")
     except Exception as exc:
-        # The recognized marker name is already gone; leftover cleanup is
-        # harmless and the next os.replace() overwrites this path atomically.
-        logger.warning("Failed to remove consumed shutdown marker: %s", exc)
-    return True
+        # The recognized name was already consumed, so inspection failure is
+        # safely one-shot and cannot be reused by a subsequent process.
+        logger.warning("Failed to inspect consumed .clean_shutdown marker: %s", exc)
+    finally:
+        try:
+            consumed.unlink()
+        except Exception as exc:
+            # The recognized marker name is already gone; leftover cleanup is
+            # harmless and the next os.replace() overwrites this path atomically.
+            logger.warning("Failed to remove consumed shutdown marker: %s", exc)
+    return clean
 
 
 def _write_clean_shutdown_marker() -> None:
@@ -11207,20 +11209,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         where a finishing turn could clear its exact marker while shutdown was
         about to interrupt the still-registered agent.
         """
-        if session_key in getattr(self, "_shutdown_resume_pending_keys", set()):
-            logger.debug(
-                "Preserving resume_pending for %s during gateway shutdown",
-                session_key,
-            )
-            return
-        try:
-            await self.async_session_store.clear_resume_pending(session_key)
-        except Exception as _e:
-            logger.debug(
-                "clear_resume_pending failed for %s: %s",
-                session_key,
-                _e,
-            )
+        state = self._session_state(session_key)
+        async with state.persistent.resume_pending_lock:
+            if session_key in getattr(self, "_shutdown_resume_pending_keys", set()):
+                logger.debug(
+                    "Preserving resume_pending for %s during gateway shutdown",
+                    session_key,
+                )
+                return
+            try:
+                await self.async_session_store.clear_resume_pending(session_key)
+            except Exception as _e:
+                logger.debug(
+                    "clear_resume_pending failed for %s: %s",
+                    session_key,
+                    _e,
+                )
 
     async def _run_startup_resume_event(
         self,
@@ -11505,12 +11509,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         agent is already running are skipped regardless, so a session
         scheduled at startup is never resumed a second time.
         """
-        # A clean marker is authoritative: every conversational turn drained.
-        # Even if shutdown could not clear a stale exact flag from storage, do
-        # not synthesize it during this process lifetime.
-        if getattr(self, "_previous_shutdown_clean", False):
-            return 0
-
         window = _auto_continue_freshness_window()
         try:
             with self.session_store._lock:  # noqa: SLF001 — snapshot under lock
@@ -12078,8 +12076,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # process already drained active agents, so sessions aren't stuck.
         # This prevents unwanted auto-resets after `hermes update`,
         # `hermes gateway restart`, or `/restart`.
-        self._previous_shutdown_clean = _consume_clean_shutdown_marker()
-        if self._previous_shutdown_clean:
+        if getattr(self, "_previous_shutdown_clean", False):
             logger.info("Previous gateway exited cleanly — skipping session suspension")
             try:
                 discarded = await self.async_session_store.discard_active_turn_markers()
@@ -13966,27 +13963,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             timeout = self._restart_drain_timeout
 
+            def _resume_pending_lock_for(session_key: str) -> asyncio.Lock:
+                """Return the SessionState lock, with a legacy-test fallback."""
+                state_getter = getattr(self, "_session_state", None)
+                if callable(state_getter):
+                    return state_getter(session_key).persistent.resume_pending_lock
+                locks = getattr(self, "_resume_pending_locks", None)
+                if locks is None:
+                    locks = {}
+                    self._resume_pending_locks = locks
+                return locks.setdefault(session_key, asyncio.Lock())
+
             # Pre-mark sessions as resume_pending BEFORE the drain wait.
             # If the process is killed by the service manager during the
             # drain, the durable marker is already written so the next
             # gateway boot can recover in-flight sessions (#27856).
-            _pre_drain_keys: list[str] = []
-            self._shutdown_resume_pending_keys = {
-                _sk
-                for _sk, _agent in list(self._running_agents.items())
-                if _agent is not _AGENT_PENDING_SENTINEL
-            }
+            _reserved_pre_drain_keys: list[str] = []
+            self._shutdown_resume_pending_keys = set()
             for _sk, _agent in list(self._running_agents.items()):
                 if _agent is _AGENT_PENDING_SENTINEL:
                     continue
-                try:
-                    await self.async_session_store.mark_resume_pending(
-                        _sk,
-                        "restart_timeout" if self._restart_requested else "shutdown_timeout",
-                    )
-                    _pre_drain_keys.append(_sk)
-                except Exception as _e:
-                    logger.debug("pre-drain mark_resume_pending failed for %s: %s", _sk, _e)
+                _resume_lock = _resume_pending_lock_for(_sk)
+                async with _resume_lock:
+                    # Reservation and durable mark are one serialized operation
+                    # with successful-turn clearing.  If an older clear already
+                    # owns the lock it finishes first and this newer mark wins;
+                    # otherwise the clear observes the reservation and yields.
+                    self._shutdown_resume_pending_keys.add(_sk)
+                    _reserved_pre_drain_keys.append(_sk)
+                    try:
+                        await self.async_session_store.mark_resume_pending(
+                            _sk,
+                            "restart_timeout" if self._restart_requested else "shutdown_timeout",
+                        )
+                    except Exception as _e:
+                        logger.debug("pre-drain mark_resume_pending failed for %s: %s", _sk, _e)
 
             _cron_at_start = self._active_cron_job_count()
             _api_at_start = self._active_api_run_count()
@@ -14012,15 +14023,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # even when unrelated cron/API work keeps the overall drain waiting
             # until timeout. Clear its durable pre-drain recovery marker before
             # classifying the work that actually remains.
-            for _sk in _pre_drain_keys:
+            for _sk in _reserved_pre_drain_keys:
                 if _sk not in self._running_agents:
-                    try:
-                        await self.async_session_store.clear_resume_pending(_sk)
-                    except Exception as _e:
-                        logger.debug(
-                            "clear_resume_pending after drain failed for %s: %s",
-                            _sk, _e,
-                        )
+                    _resume_lock = _resume_pending_lock_for(_sk)
+                    async with _resume_lock:
+                        try:
+                            await self.async_session_store.clear_resume_pending(_sk)
+                        except Exception as _e:
+                            logger.debug(
+                                "clear_resume_pending after drain failed for %s: %s",
+                                _sk, _e,
+                            )
+                        finally:
+                            self._shutdown_resume_pending_keys.discard(_sk)
 
             if not timed_out:
                 # Record the clean drain before slower teardown begins. Host
@@ -14074,22 +14089,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     for _sk, _agent in list(self._running_agents.items())
                     if _agent is not _AGENT_PENDING_SENTINEL
                 ]
-                self._shutdown_resume_pending_keys.update(
-                    _sk for _sk, _agent in _interrupted_agents
-                )
                 for _sk, _agent in _interrupted_agents:
-                    try:
-                        _marked = await self.async_session_store.mark_resume_pending(
-                            _sk, _resume_reason
-                        )
-                        if not _marked:
+                    _resume_lock = _resume_pending_lock_for(_sk)
+                    async with _resume_lock:
+                        self._shutdown_resume_pending_keys.add(_sk)
+                        try:
+                            _marked = await self.async_session_store.mark_resume_pending(
+                                _sk, _resume_reason
+                            )
+                            if not _marked:
+                                _resume_mark_failed = True
+                        except Exception as _e:
                             _resume_mark_failed = True
-                    except Exception as _e:
-                        _resume_mark_failed = True
-                        logger.debug(
-                            "mark_resume_pending failed for %s: %s",
-                            _sk, _e,
-                        )
+                            logger.debug(
+                                "mark_resume_pending failed for %s: %s",
+                                _sk, _e,
+                            )
 
                 # Every interrupted chat is now represented by an exact
                 # resume_pending marker. Record that broad crash inference is
@@ -29486,6 +29501,20 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             "PID file race lost to another gateway instance. Exiting."
         )
         return False
+    # Consume the predecessor's one-shot clean proof immediately after this
+    # process owns both gateway identity guards.  Nothing fallible or awaitable
+    # may run first: if this startup crashes, a later boot must not reuse the
+    # old process's proof and misclassify this failed generation as clean.
+    try:
+        runner._previous_shutdown_clean = _consume_clean_shutdown_marker()
+    except BaseException:
+        # Consumption failure is fatal when the recognized marker cannot be
+        # invalidated. Release identity guards explicitly because the atexit
+        # handlers are intentionally not registered until after consumption.
+        remove_pid_file()
+        release_gateway_runtime_lock()
+        raise
+
     atexit.register(remove_pid_file)
     atexit.register(release_gateway_runtime_lock)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1661,6 +1661,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from hermes_constants import get_hermes_home, get_hermes_home_override
 from utils import atomic_json_write, is_truthy_value
 _hermes_home = get_hermes_home()
+_CLEAN_SHUTDOWN_MARKER_PAYLOAD = b"clean\n"
 
 
 def _consume_clean_shutdown_marker() -> bool:
@@ -1704,9 +1705,9 @@ def _consume_clean_shutdown_marker() -> bool:
 
     clean = False
     try:
-        clean = consumed.stat().st_size == 0
+        clean = consumed.read_bytes() == _CLEAN_SHUTDOWN_MARKER_PAYLOAD
         if not clean:
-            logger.debug("Ignoring non-empty .clean_shutdown invalidation tombstone")
+            logger.debug("Ignoring invalid .clean_shutdown marker payload")
     except Exception as exc:
         # The recognized name was already consumed, so inspection failure is
         # safely one-shot and cannot be reused by a subsequent process.
@@ -1723,7 +1724,9 @@ def _consume_clean_shutdown_marker() -> bool:
 
 def _write_clean_shutdown_marker() -> None:
     """Record a clean drain, replacing any stale invalidation tombstone."""
-    (_hermes_home / ".clean_shutdown").write_bytes(b"")
+    (_hermes_home / ".clean_shutdown").write_bytes(
+        _CLEAN_SHUTDOWN_MARKER_PAYLOAD
+    )
 
 
 # Load environment variables from ~/.hermes/.env first.
@@ -5698,6 +5701,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # while gateway shutdown is draining or interrupting agents.
         self._shutdown_resume_pending_keys: set[str] = set()
         self._previous_shutdown_clean = False
+        self._clean_shutdown_marker_blocked = False
         # Per-SESSION_ID turn lease (#64934): serializes the
         # [load history → run → flush] region when two ROUTING KEYS resolve
         # to one session_id (switch_session's many-to-one mapping). The
@@ -9807,6 +9811,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 await self.async_session_store.clear_resume_pending(session_key)
             except Exception as _e:
+                self._clean_shutdown_marker_blocked = True
                 logger.debug(
                     "clear_resume_pending failed for %s: %s",
                     session_key,
@@ -10066,6 +10071,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 try:
                     await self.async_session_store.clear_resume_pending(session_key)
                 except Exception:
+                    self._clean_shutdown_marker_blocked = True
                     logger.debug(
                         "clear_resume_pending failed for %s", session_key,
                         exc_info=True,
@@ -10095,6 +10101,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         agent is already running are skipped regardless, so a session
         scheduled at startup is never resumed a second time.
         """
+        # Exact timeout markers are auto-dispatchable only when the predecessor
+        # also left authoritative clean proof. Without that proof, a marker may
+        # be stale residue from a completed turn whose shutdown-time clear
+        # failed. Keep it pending for the next real inbound message instead of
+        # risking a synthetic replay.
+        if not getattr(self, "_previous_shutdown_clean", False):
+            return 0
+
         window = _auto_continue_freshness_window()
         try:
             with self.session_store._lock:  # noqa: SLF001 — snapshot under lock
@@ -10207,7 +10221,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             scheduled += 1
         if scheduled:
             logger.info(
-                "Scheduled auto-resume for %d restart-interrupted session(s)",
+                "Scheduled auto-resume for %d exactly marked session(s)",
                 scheduled,
             )
         return scheduled
@@ -10626,6 +10640,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if getattr(self, "_previous_shutdown_clean", False):
             logger.info("Previous gateway exited cleanly — skipping session suspension")
         else:
+            try:
+                downgraded = await self.async_session_store.downgrade_untrusted_exact_resume_pending()
+                if downgraded:
+                    logger.info(
+                        "Deferred %d exact recovery marker(s) until real inbound "
+                        "because predecessor clean proof was absent",
+                        downgraded,
+                    )
+            except Exception as e:
+                # The current boot remains safe because synthetic restore is
+                # gated on _previous_shutdown_clean. Prevent this lifecycle
+                # from writing new clean proof: otherwise a later boot could
+                # trust exact markers whose persistent downgrade failed.
+                self._clean_shutdown_marker_blocked = True
+                logger.error(
+                    "Failed to persist inbound-only recovery downgrade; "
+                    "clean shutdown proof is disabled for this lifecycle: %s",
+                    e,
+                )
             try:
                 suspended = await self.async_session_store.suspend_recently_active()
                 if suspended:
@@ -12216,6 +12249,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # even when unrelated cron/API work keeps the overall drain waiting
             # until timeout. Clear its durable pre-drain recovery marker before
             # classifying the work that actually remains.
+            _resume_cleanup_failed = False
             for _sk in _reserved_pre_drain_keys:
                 if _sk not in self._running_agents:
                     _resume_lock = _resume_pending_lock_for(_sk)
@@ -12223,6 +12257,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         try:
                             await self.async_session_store.clear_resume_pending(_sk)
                         except Exception as _e:
+                            _resume_cleanup_failed = True
                             logger.debug(
                                 "clear_resume_pending after drain failed for %s: %s",
                                 _sk, _e,
@@ -12230,7 +12265,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         finally:
                             self._shutdown_resume_pending_keys.discard(_sk)
 
-            if not timed_out:
+            if (
+                not timed_out
+                and not _resume_cleanup_failed
+                and not getattr(self, "_clean_shutdown_marker_blocked", False)
+            ):
                 # Record the clean drain before slower teardown begins. Host
                 # shutdown can terminate the process while memory providers,
                 # adapters, or SQLite handles are still closing. Waiting until
@@ -12241,6 +12280,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _write_clean_shutdown_marker()
                 except Exception as _e:
                     logger.warning("Failed to write .clean_shutdown marker: %s", _e)
+            elif not timed_out:
+                logger.info(
+                    "Skipping .clean_shutdown marker — exact recovery state "
+                    "could not be made complete and unambiguous."
+                )
 
             if timed_out:
                 logger.warning(
@@ -12299,30 +12343,59 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 _sk, _e,
                             )
 
+                # A turn can finish while another session's timeout marker is
+                # being awaited. Re-snapshot until no newly completed marked
+                # sessions remain; the final empty pass has no await between
+                # the running-state check and interruption below.
+                _exact_interrupted_keys = {_sk for _sk, _agent in _interrupted_agents}
+                while True:
+                    _finished_during_mark = [
+                        _sk
+                        for _sk in _exact_interrupted_keys
+                        if _sk not in self._running_agents
+                    ]
+                    if not _finished_during_mark:
+                        break
+                    for _sk in _finished_during_mark:
+                        _resume_lock = _resume_pending_lock_for(_sk)
+                        async with _resume_lock:
+                            try:
+                                await self.async_session_store.clear_resume_pending(_sk)
+                            except Exception as _e:
+                                _resume_cleanup_failed = True
+                                logger.debug(
+                                    "clear_resume_pending after timeout mark failed for %s: %s",
+                                    _sk,
+                                    _e,
+                                )
+                            finally:
+                                self._shutdown_resume_pending_keys.discard(_sk)
+                                _exact_interrupted_keys.discard(_sk)
+
+                self._interrupt_running_agents(
+                    _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
+                )
+
                 # Every interrupted chat is now represented by an exact
                 # resume_pending marker. Record that broad crash inference is
                 # unnecessary before post-drain teardown: otherwise a timeout
                 # caused only by cron/API work marks unrelated recent chats as
                 # interrupted on the next boot. If an exact marker failed,
                 # retain the missing marker as the conservative fallback.
-                if not _resume_mark_failed and not _interrupted_agents:
+                if (
+                    not _resume_mark_failed
+                    and not _resume_cleanup_failed
+                    and not getattr(self, "_clean_shutdown_marker_blocked", False)
+                ):
                     try:
                         _write_clean_shutdown_marker()
                     except Exception as _e:
                         logger.warning("Failed to write .clean_shutdown marker: %s", _e)
-                elif _resume_mark_failed:
+                elif _resume_mark_failed or _resume_cleanup_failed:
                     logger.info(
-                        "Skipping .clean_shutdown marker — at least one "
-                        "interrupted session could not be marked for exact resume."
+                        "Skipping .clean_shutdown marker — exact recovery state "
+                        "could not be made complete and unambiguous."
                     )
-                else:
-                    logger.info(
-                        "Skipping .clean_shutdown marker — interrupted sessions "
-                        "were marked for exact resume."
-                    )
-                self._interrupt_running_agents(
-                    _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
-                )
                 interrupt_deadline = asyncio.get_running_loop().time() + 5.0
                 while self._running_agents and asyncio.get_running_loop().time() < interrupt_deadline:
                     self._update_runtime_status("draining")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1662,6 +1662,68 @@ from hermes_constants import get_hermes_home, get_hermes_home_override
 from utils import atomic_json_write, is_truthy_value
 _hermes_home = get_hermes_home()
 
+
+def _consume_clean_shutdown_marker() -> bool:
+    """Atomically consume one clean-shutdown marker generation.
+
+    Rename first so a cleanup failure cannot leave reusable evidence that
+    poisons a later startup after a genuinely interrupted shutdown.
+    """
+    marker = _hermes_home / ".clean_shutdown"
+    if not marker.exists():
+        return False
+    try:
+        if marker.stat().st_size != 0:
+            # Non-empty files are invalidation tombstones, never clean proof.
+            try:
+                marker.unlink()
+            except Exception:
+                pass
+            return False
+    except Exception as exc:
+        logger.warning("Failed to inspect .clean_shutdown marker: %s", exc)
+        return False
+    consumed = _hermes_home / ".clean_shutdown.consumed"
+    try:
+        os.replace(marker, consumed)
+    except FileNotFoundError:
+        return False
+    except Exception as exc:
+        logger.warning("Failed to consume .clean_shutdown marker: %s", exc)
+        # Never leave evidence that a later process could misattribute to its
+        # immediate predecessor. If atomic rename is unavailable, invalidate
+        # the marker in place before continuing as an unclean startup.
+        try:
+            marker.unlink()
+        except FileNotFoundError:
+            pass
+        except Exception as unlink_exc:
+            logger.error(
+                "Failed to invalidate unconsumed .clean_shutdown marker: %s",
+                unlink_exc,
+            )
+            try:
+                marker.write_text("invalid\n", encoding="utf-8")
+            except Exception as tombstone_exc:
+                logger.error(
+                    "Failed to tombstone .clean_shutdown marker: %s",
+                    tombstone_exc,
+                )
+        return False
+    try:
+        consumed.unlink()
+    except Exception as exc:
+        # The recognized marker name is already gone; leftover cleanup is
+        # harmless and the next os.replace() overwrites this path atomically.
+        logger.warning("Failed to remove consumed shutdown marker: %s", exc)
+    return True
+
+
+def _write_clean_shutdown_marker() -> None:
+    """Record a clean drain, replacing any stale invalidation tombstone."""
+    (_hermes_home / ".clean_shutdown").write_bytes(b"")
+
+
 # Load environment variables from ~/.hermes/.env first.
 # User-managed env files should override stale shell exports on restart.
 from dotenv import load_dotenv  # noqa: F401  # backward-compat for tests that monkeypatch this symbol
@@ -5630,6 +5692,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # self._session_state(key) (get-or-create) or
         # self._peek_session_state(key) (read-only).
         self._sessions: Dict[str, SessionState] = {}
+        # Session keys whose recovery markers must survive turn completion
+        # while gateway shutdown is draining or interrupting agents.
+        self._shutdown_resume_pending_keys: set[str] = set()
+        self._previous_shutdown_clean = False
         # Per-SESSION_ID turn lease (#64934): serializes the
         # [load history → run → flush] region when two ROUTING KEYS resolve
         # to one session_id (switch_session's many-to-one mapping). The
@@ -9715,14 +9781,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._restart_task = asyncio.create_task(_run_restart())
         return True
 
-    # Drain-timeout reasons set by _stop_impl() when a still-running turn is
-    # force-interrupted; "restart_interrupted" is set by
-    # SessionStore.suspend_recently_active() on crash recovery (no
-    # .clean_shutdown marker).  All three mean "the agent was mid-turn and
-    # we killed it" — eligible for startup auto-resume.
-    _AUTO_RESUME_REASONS = frozenset(
-        {"restart_timeout", "shutdown_timeout", "restart_interrupted"}
-    )
+    # Only exact per-session markers written by _stop_impl() may synthesize a
+    # startup turn. ``restart_interrupted`` is a heuristic assigned to recent
+    # sessions after an unclean exit; it is intentionally deferred until the
+    # user's next real message so idle chats can never fan out blank turns.
+    _AUTO_RESUME_REASONS = frozenset({"restart_timeout", "shutdown_timeout"})
+
+    async def _clear_resume_pending_after_success(self, session_key: str) -> None:
+        """Clear recovery state unless shutdown has reserved it for restart.
+
+        The reservation is installed before draining begins, closing the race
+        where a finishing turn could clear its exact marker while shutdown was
+        about to interrupt the still-registered agent.
+        """
+        if session_key in getattr(self, "_shutdown_resume_pending_keys", set()):
+            logger.debug(
+                "Preserving resume_pending for %s during gateway shutdown",
+                session_key,
+            )
+            return
+        try:
+            await self.async_session_store.clear_resume_pending(session_key)
+        except Exception as _e:
+            logger.debug(
+                "clear_resume_pending failed for %s: %s",
+                session_key,
+                _e,
+            )
 
     async def _run_startup_resume_event(
         self,
@@ -9849,8 +9934,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         exc_info=(type(exc), exc, exc.__traceback__),
                     )
         self._startup_restore_tasks = []
-        drained = await self._drain_startup_restore_queue()
-        self._startup_restore_in_progress = False
+        drained = 0
+        while True:
+            drained += await self._drain_startup_restore_queue()
+            # Keep the gate closed until the queue is observed empty after a
+            # drain. A message can be queued by the final awaited dispatch (or
+            # a test/platform wrapper) just before the drain coroutine returns;
+            # releasing the gate without re-checking would strand that event.
+            if not getattr(self, "_startup_restore_queue", None):
+                self._startup_restore_in_progress = False
+                break
         if drained:
             logger.info("Drained %d inbound message(s) queued during startup restore", drained)
 
@@ -9998,6 +10091,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         agent is already running are skipped regardless, so a session
         scheduled at startup is never resumed a second time.
         """
+        # A clean marker is authoritative: every conversational turn drained.
+        # Even if shutdown could not clear a stale exact flag from storage, do
+        # not synthesize it during this process lifetime.
+        if getattr(self, "_previous_shutdown_clean", False):
+            return 0
+
         window = _auto_continue_freshness_window()
         try:
             with self.session_store._lock:  # noqa: SLF001 — snapshot under lock
@@ -10526,13 +10625,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # process already drained active agents, so sessions aren't stuck.
         # This prevents unwanted auto-resets after `hermes update`,
         # `hermes gateway restart`, or `/restart`.
-        _clean_marker = _hermes_home / ".clean_shutdown"
-        if _clean_marker.exists():
+        self._previous_shutdown_clean = _consume_clean_shutdown_marker()
+        if self._previous_shutdown_clean:
             logger.info("Previous gateway exited cleanly — skipping session suspension")
-            try:
-                _clean_marker.unlink()
-            except Exception:
-                pass
         else:
             try:
                 suspended = await self.async_session_store.suspend_recently_active()
@@ -12069,6 +12164,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # drain, the durable marker is already written so the next
             # gateway boot can recover in-flight sessions (#27856).
             _pre_drain_keys: list[str] = []
+            self._shutdown_resume_pending_keys = {
+                _sk
+                for _sk, _agent in list(self._running_agents.items())
+                if _agent is not _AGENT_PENDING_SENTINEL
+            }
             for _sk, _agent in list(self._running_agents.items()):
                 if _agent is _AGENT_PENDING_SENTINEL:
                     continue
@@ -12101,19 +12201,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._active_api_run_count(),
             )
 
+            # Any chat that finished during the drain window is not interrupted,
+            # even when unrelated cron/API work keeps the overall drain waiting
+            # until timeout. Clear its durable pre-drain recovery marker before
+            # classifying the work that actually remains.
+            for _sk in _pre_drain_keys:
+                if _sk not in self._running_agents:
+                    try:
+                        await self.async_session_store.clear_resume_pending(_sk)
+                    except Exception as _e:
+                        logger.debug(
+                            "clear_resume_pending after drain failed for %s: %s",
+                            _sk, _e,
+                        )
+
             if not timed_out:
-                # Drain completed gracefully — all running sessions finished.
-                # Clear the pre-drain resume_pending markers so sessions that
-                # completed during the drain window don't carry a stale flag.
-                for _sk in _pre_drain_keys:
-                    if _sk not in self._running_agents:
-                        try:
-                            await self.async_session_store.clear_resume_pending(_sk)
-                        except Exception as _e:
-                            logger.debug(
-                                "clear_resume_pending after drain failed for %s: %s",
-                                _sk, _e,
-                            )
+                # Record the clean drain before slower teardown begins. Host
+                # shutdown can terminate the process while memory providers,
+                # adapters, or SQLite handles are still closing. Waiting until
+                # the end made the next boot mistake recently used idle chats
+                # for interrupted turns and fan out synthetic auto-resume
+                # messages even though there was no work left to recover.
+                try:
+                    _write_clean_shutdown_marker()
+                except Exception as _e:
+                    logger.warning("Failed to write .clean_shutdown marker: %s", _e)
 
             if timed_out:
                 logger.warning(
@@ -12149,16 +12261,50 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _resume_reason = (
                     "restart_timeout" if self._restart_requested else "shutdown_timeout"
                 )
-                for _sk, _agent in list(self._running_agents.items()):
-                    if _agent is _AGENT_PENDING_SENTINEL:
-                        continue
+                _resume_mark_failed = False
+                _interrupted_agents = [
+                    (_sk, _agent)
+                    for _sk, _agent in list(self._running_agents.items())
+                    if _agent is not _AGENT_PENDING_SENTINEL
+                ]
+                self._shutdown_resume_pending_keys.update(
+                    _sk for _sk, _agent in _interrupted_agents
+                )
+                for _sk, _agent in _interrupted_agents:
                     try:
-                        await self.async_session_store.mark_resume_pending(_sk, _resume_reason)
+                        _marked = await self.async_session_store.mark_resume_pending(
+                            _sk, _resume_reason
+                        )
+                        if not _marked:
+                            _resume_mark_failed = True
                     except Exception as _e:
+                        _resume_mark_failed = True
                         logger.debug(
                             "mark_resume_pending failed for %s: %s",
                             _sk, _e,
                         )
+
+                # Every interrupted chat is now represented by an exact
+                # resume_pending marker. Record that broad crash inference is
+                # unnecessary before post-drain teardown: otherwise a timeout
+                # caused only by cron/API work marks unrelated recent chats as
+                # interrupted on the next boot. If an exact marker failed,
+                # retain the missing marker as the conservative fallback.
+                if not _resume_mark_failed and not _interrupted_agents:
+                    try:
+                        _write_clean_shutdown_marker()
+                    except Exception as _e:
+                        logger.warning("Failed to write .clean_shutdown marker: %s", _e)
+                elif _resume_mark_failed:
+                    logger.info(
+                        "Skipping .clean_shutdown marker — at least one "
+                        "interrupted session could not be marked for exact resume."
+                    )
+                else:
+                    logger.info(
+                        "Skipping .clean_shutdown marker — interrupted sessions "
+                        "were marked for exact resume."
+                    )
                 self._interrupt_running_agents(
                     _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
                 )
@@ -12317,26 +12463,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from gateway.status import remove_pid_file, release_gateway_runtime_lock
             remove_pid_file()
             release_gateway_runtime_lock()
-
-            # Write a clean-shutdown marker so the next startup knows this
-            # wasn't a crash.  suspend_recently_active() only needs to run
-            # after unexpected exits.  However, if the drain timed out and
-            # agents were force-interrupted, their sessions may be in an
-            # incomplete state (trailing tool response, no final assistant
-            # message).  Skip the marker in that case so the next startup
-            # suspends those sessions — giving users a clean slate instead
-            # of resuming a half-finished tool loop.
-            if not timed_out:
-                try:
-                    (_hermes_home / ".clean_shutdown").touch()
-                except Exception:
-                    pass
-            else:
-                logger.info(
-                    "Skipping .clean_shutdown marker — drain timed out with "
-                    "interrupted agents; next startup will suspend recently "
-                    "active sessions."
-                )
 
             # Track sessions that were active at shutdown for stuck-loop
             # detection (#7536).  On each restart, the counter increments
@@ -16762,13 +16888,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # the restart-interruption system note.
             if session_key and _should_clear_resume_pending_after_turn(agent_result):
                 self._clear_restart_failure_count(session_key)
-                try:
-                    await self.async_session_store.clear_resume_pending(session_key)
-                except Exception as _e:
-                    logger.debug(
-                        "clear_resume_pending failed for %s: %s",
-                        session_key, _e,
-                    )
+                await self._clear_resume_pending_after_success(session_key)
 
             # Normalize empty responses: surface errors, partial failures, and
             # the case where agent did work but returned no text. Fix for #18765.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1666,23 +1666,11 @@ _hermes_home = get_hermes_home()
 def _consume_clean_shutdown_marker() -> bool:
     """Atomically consume one clean-shutdown marker generation.
 
-    Rename first so a cleanup failure cannot leave reusable evidence that
-    poisons a later startup after a genuinely interrupted shutdown.
+    Rename before inspection so any stat/read failure happens only after the
+    recognized marker name is gone. A failed startup can therefore never lend
+    an older process's clean proof to a later boot.
     """
     marker = _hermes_home / ".clean_shutdown"
-    if not marker.exists():
-        return False
-    try:
-        if marker.stat().st_size != 0:
-            # Non-empty files are invalidation tombstones, never clean proof.
-            try:
-                marker.unlink()
-            except Exception:
-                pass
-            return False
-    except Exception as exc:
-        logger.warning("Failed to inspect .clean_shutdown marker: %s", exc)
-        return False
     consumed = _hermes_home / ".clean_shutdown.consumed"
     try:
         os.replace(marker, consumed)
@@ -1709,14 +1697,28 @@ def _consume_clean_shutdown_marker() -> bool:
                     "Failed to tombstone .clean_shutdown marker: %s",
                     tombstone_exc,
                 )
+                raise RuntimeError(
+                    "Cannot safely invalidate unconsumed .clean_shutdown marker"
+                ) from tombstone_exc
         return False
+
+    clean = False
     try:
-        consumed.unlink()
+        clean = consumed.stat().st_size == 0
+        if not clean:
+            logger.debug("Ignoring non-empty .clean_shutdown invalidation tombstone")
     except Exception as exc:
-        # The recognized marker name is already gone; leftover cleanup is
-        # harmless and the next os.replace() overwrites this path atomically.
-        logger.warning("Failed to remove consumed shutdown marker: %s", exc)
-    return True
+        # The recognized name was already consumed, so inspection failure is
+        # safely one-shot and cannot be reused by a subsequent process.
+        logger.warning("Failed to inspect consumed .clean_shutdown marker: %s", exc)
+    finally:
+        try:
+            consumed.unlink()
+        except Exception as exc:
+            # The recognized marker name is already gone; leftover cleanup is
+            # harmless and the next os.replace() overwrites this path atomically.
+            logger.warning("Failed to remove consumed shutdown marker: %s", exc)
+    return clean
 
 
 def _write_clean_shutdown_marker() -> None:
@@ -9794,20 +9796,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         where a finishing turn could clear its exact marker while shutdown was
         about to interrupt the still-registered agent.
         """
-        if session_key in getattr(self, "_shutdown_resume_pending_keys", set()):
-            logger.debug(
-                "Preserving resume_pending for %s during gateway shutdown",
-                session_key,
-            )
-            return
-        try:
-            await self.async_session_store.clear_resume_pending(session_key)
-        except Exception as _e:
-            logger.debug(
-                "clear_resume_pending failed for %s: %s",
-                session_key,
-                _e,
-            )
+        state = self._session_state(session_key)
+        async with state.persistent.resume_pending_lock:
+            if session_key in getattr(self, "_shutdown_resume_pending_keys", set()):
+                logger.debug(
+                    "Preserving resume_pending for %s during gateway shutdown",
+                    session_key,
+                )
+                return
+            try:
+                await self.async_session_store.clear_resume_pending(session_key)
+            except Exception as _e:
+                logger.debug(
+                    "clear_resume_pending failed for %s: %s",
+                    session_key,
+                    _e,
+                )
 
     async def _run_startup_resume_event(
         self,
@@ -10091,12 +10095,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         agent is already running are skipped regardless, so a session
         scheduled at startup is never resumed a second time.
         """
-        # A clean marker is authoritative: every conversational turn drained.
-        # Even if shutdown could not clear a stale exact flag from storage, do
-        # not synthesize it during this process lifetime.
-        if getattr(self, "_previous_shutdown_clean", False):
-            return 0
-
         window = _auto_continue_freshness_window()
         try:
             with self.session_store._lock:  # noqa: SLF001 — snapshot under lock
@@ -10625,8 +10623,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # process already drained active agents, so sessions aren't stuck.
         # This prevents unwanted auto-resets after `hermes update`,
         # `hermes gateway restart`, or `/restart`.
-        self._previous_shutdown_clean = _consume_clean_shutdown_marker()
-        if self._previous_shutdown_clean:
+        if getattr(self, "_previous_shutdown_clean", False):
             logger.info("Previous gateway exited cleanly — skipping session suspension")
         else:
             try:
@@ -12159,27 +12156,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             timeout = self._restart_drain_timeout
 
+            def _resume_pending_lock_for(session_key: str) -> asyncio.Lock:
+                """Return the SessionState lock, with a legacy-test fallback."""
+                state_getter = getattr(self, "_session_state", None)
+                if callable(state_getter):
+                    return state_getter(session_key).persistent.resume_pending_lock
+                locks = getattr(self, "_resume_pending_locks", None)
+                if locks is None:
+                    locks = {}
+                    self._resume_pending_locks = locks
+                return locks.setdefault(session_key, asyncio.Lock())
+
             # Pre-mark sessions as resume_pending BEFORE the drain wait.
             # If the process is killed by the service manager during the
             # drain, the durable marker is already written so the next
             # gateway boot can recover in-flight sessions (#27856).
-            _pre_drain_keys: list[str] = []
-            self._shutdown_resume_pending_keys = {
-                _sk
-                for _sk, _agent in list(self._running_agents.items())
-                if _agent is not _AGENT_PENDING_SENTINEL
-            }
+            _reserved_pre_drain_keys: list[str] = []
+            self._shutdown_resume_pending_keys = set()
             for _sk, _agent in list(self._running_agents.items()):
                 if _agent is _AGENT_PENDING_SENTINEL:
                     continue
-                try:
-                    await self.async_session_store.mark_resume_pending(
-                        _sk,
-                        "restart_timeout" if self._restart_requested else "shutdown_timeout",
-                    )
-                    _pre_drain_keys.append(_sk)
-                except Exception as _e:
-                    logger.debug("pre-drain mark_resume_pending failed for %s: %s", _sk, _e)
+                _resume_lock = _resume_pending_lock_for(_sk)
+                async with _resume_lock:
+                    # Reservation and durable mark are one serialized operation
+                    # with successful-turn clearing.  If an older clear already
+                    # owns the lock it finishes first and this newer mark wins;
+                    # otherwise the clear observes the reservation and yields.
+                    self._shutdown_resume_pending_keys.add(_sk)
+                    _reserved_pre_drain_keys.append(_sk)
+                    try:
+                        await self.async_session_store.mark_resume_pending(
+                            _sk,
+                            "restart_timeout" if self._restart_requested else "shutdown_timeout",
+                        )
+                    except Exception as _e:
+                        logger.debug("pre-drain mark_resume_pending failed for %s: %s", _sk, _e)
 
             _cron_at_start = self._active_cron_job_count()
             _api_at_start = self._active_api_run_count()
@@ -12205,15 +12216,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # even when unrelated cron/API work keeps the overall drain waiting
             # until timeout. Clear its durable pre-drain recovery marker before
             # classifying the work that actually remains.
-            for _sk in _pre_drain_keys:
+            for _sk in _reserved_pre_drain_keys:
                 if _sk not in self._running_agents:
-                    try:
-                        await self.async_session_store.clear_resume_pending(_sk)
-                    except Exception as _e:
-                        logger.debug(
-                            "clear_resume_pending after drain failed for %s: %s",
-                            _sk, _e,
-                        )
+                    _resume_lock = _resume_pending_lock_for(_sk)
+                    async with _resume_lock:
+                        try:
+                            await self.async_session_store.clear_resume_pending(_sk)
+                        except Exception as _e:
+                            logger.debug(
+                                "clear_resume_pending after drain failed for %s: %s",
+                                _sk, _e,
+                            )
+                        finally:
+                            self._shutdown_resume_pending_keys.discard(_sk)
 
             if not timed_out:
                 # Record the clean drain before slower teardown begins. Host
@@ -12267,22 +12282,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     for _sk, _agent in list(self._running_agents.items())
                     if _agent is not _AGENT_PENDING_SENTINEL
                 ]
-                self._shutdown_resume_pending_keys.update(
-                    _sk for _sk, _agent in _interrupted_agents
-                )
                 for _sk, _agent in _interrupted_agents:
-                    try:
-                        _marked = await self.async_session_store.mark_resume_pending(
-                            _sk, _resume_reason
-                        )
-                        if not _marked:
+                    _resume_lock = _resume_pending_lock_for(_sk)
+                    async with _resume_lock:
+                        self._shutdown_resume_pending_keys.add(_sk)
+                        try:
+                            _marked = await self.async_session_store.mark_resume_pending(
+                                _sk, _resume_reason
+                            )
+                            if not _marked:
+                                _resume_mark_failed = True
+                        except Exception as _e:
                             _resume_mark_failed = True
-                    except Exception as _e:
-                        _resume_mark_failed = True
-                        logger.debug(
-                            "mark_resume_pending failed for %s: %s",
-                            _sk, _e,
-                        )
+                            logger.debug(
+                                "mark_resume_pending failed for %s: %s",
+                                _sk, _e,
+                            )
 
                 # Every interrupted chat is now represented by an exact
                 # resume_pending marker. Record that broad crash inference is
@@ -25518,6 +25533,20 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             "PID file race lost to another gateway instance. Exiting."
         )
         return False
+    # Consume the predecessor's one-shot clean proof immediately after this
+    # process owns both gateway identity guards.  Nothing fallible or awaitable
+    # may run first: if this startup crashes, a later boot must not reuse the
+    # old process's proof and misclassify this failed generation as clean.
+    try:
+        runner._previous_shutdown_clean = _consume_clean_shutdown_marker()
+    except BaseException:
+        # Consumption failure is fatal when the recognized marker cannot be
+        # invalidated. Release identity guards explicitly because the atexit
+        # handlers are intentionally not registered until after consumption.
+        remove_pid_file()
+        release_gateway_runtime_lock()
+        raise
+
     atexit.register(remove_pid_file)
     atexit.register(release_gateway_runtime_lock)
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -13,6 +13,7 @@ import hashlib
 import logging
 import os
 import json
+import stat
 import threading
 import uuid
 from pathlib import Path
@@ -1242,6 +1243,14 @@ class SessionStore:
     Uses SQLite (via SessionDB) for session metadata and message transcripts.
     Falls back to legacy JSONL files if SQLite is unavailable.
     """
+
+    _JSON_EXACT_AUTHORITY_KEY = "_EXACT_STATE_AUTHORITY"
+    _JSON_EXACT_AUTHORITY_DB = "state.db"
+    _JSON_EXACT_AUTHORITY_JSON = "sessions.json"
+    _DB_EXACT_AUTHORITY_MARKER = ".sessions_json_exact_state_untrusted"
+    _EXACT_RESUME_REASONS = frozenset(
+        {"restart_timeout", "shutdown_timeout", "active_turn_interrupted"}
+    )
     
     def __init__(self, sessions_dir: Path, config: GatewayConfig,
                  has_active_processes_fn=None):
@@ -1284,6 +1293,9 @@ class SessionStore:
         self._write_sessions_json = bool(
             getattr(config, "write_sessions_json", True)
         )
+        # True only while sessions.json is the last known durable exact-state
+        # authority (genuinely DB-less operation or an uncompleted migration).
+        self._json_exact_state_is_authoritative = False
         
         # Initialize SQLite session database
         self._db = None
@@ -1300,6 +1312,104 @@ class SessionStore:
             print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
         except Exception as e:
             print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
+
+    def _db_exact_authority_marker_path(self) -> Path:
+        return self.sessions_dir / self._DB_EXACT_AUTHORITY_MARKER
+
+    def _ensure_db_exact_authority_marker(self) -> None:
+        """Durably prevent a legacy mirror from claiming exact-state authority."""
+        marker = self._db_exact_authority_marker_path()
+        try:
+            marker_fd = os.open(
+                marker,
+                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            )
+        except FileNotFoundError:
+            marker_fd = None
+        except OSError as exc:
+            raise OSError(
+                f"refusing unsafe exact-authority marker: {marker}"
+            ) from exc
+        if marker_fd is not None:
+            try:
+                opened = os.fstat(marker_fd)
+                if not stat.S_ISREG(opened.st_mode):
+                    raise OSError(
+                        f"refusing non-regular exact-authority marker: {marker}"
+                    )
+                if os.read(marker_fd, 64) != b"state.db\n":
+                    raise OSError(
+                        f"refusing invalid exact-authority marker: {marker}"
+                    )
+                current = os.lstat(marker)
+                if (current.st_dev, current.st_ino) != (
+                    opened.st_dev,
+                    opened.st_ino,
+                ):
+                    raise OSError(
+                        f"exact-authority marker changed during validation: {marker}"
+                    )
+            finally:
+                os.close(marker_fd)
+            self._fsync_sessions_dir()
+            self._json_exact_state_is_authoritative = False
+            return
+        self.sessions_dir.mkdir(parents=True, exist_ok=True)
+        import tempfile
+
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(self.sessions_dir), suffix=".tmp", prefix=".exact_authority_"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write("state.db\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            self._publish_routing_file_strict(tmp_path, marker)
+            self._json_exact_state_is_authoritative = False
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    def _fsync_sessions_dir(self) -> None:
+        """Persist an atomically replaced routing-file directory entry."""
+        if os.name != "posix":
+            return
+        directory_fd = os.open(self.sessions_dir, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+
+    def _publish_routing_file_strict(self, tmp_path: str, target: Path) -> None:
+        """Atomically publish an authoritative routing file and its directory.
+
+        ``utils.atomic_replace`` intentionally supports symlink targets and
+        non-atomic copy fallbacks.  Exact crash-recovery authority cannot use
+        those compatibility paths: a returned success must mean one same-
+        directory rename plus durable directory metadata.
+        """
+        if target.is_symlink():
+            raise OSError(
+                f"refusing symlink target for authoritative routing file: {target}"
+            )
+        os.replace(tmp_path, target)
+        self._fsync_sessions_dir()
+
+    def _routing_data_has_exact_state(self, data: Dict[str, Any]) -> bool:
+        """Return whether a snapshot still carries crash-replay authority."""
+        return any(
+            entry.get("active_turn_token")
+            or (
+                entry.get("resume_pending")
+                and entry.get("resume_reason") in self._EXACT_RESUME_REASONS
+            )
+            for entry in data.values()
+            if isinstance(entry, dict)
+        )
 
     def _has_active_processes_safe(self, session_key: str, *, context: str) -> bool:
         """Return whether a session has active work, failing closed on registry errors."""
@@ -1351,6 +1461,7 @@ class SessionStore:
         # partially-initialized stores without __init__ (same pattern as
         # _prune_stale_sessions_locked).
         db_had_entries = False
+        db_load_succeeded = False
         _db = getattr(self, "_db", None)
         if _db:
             loader = getattr(_db, "load_gateway_routing_entries", None)
@@ -1366,6 +1477,7 @@ class SessionStore:
                                 "Skipping invalid routing entry %r: %s", key, e
                             )
                     db_had_entries = bool(self._entries)
+                    db_load_succeeded = True
                 except Exception as e:
                     logger.warning(
                         "gateway.session: state.db routing load failed: %s", e
@@ -1375,18 +1487,37 @@ class SessionStore:
         # written by an older gateway after a downgrade). Only fills keys the
         # DB didn't provide — DB entries win.
         sessions_file = self.sessions_dir / "sessions.json"
+        trust_json_exact_state = False
         if sessions_file.exists():
             try:
                 with open(sessions_file, "r", encoding="utf-8") as f:
                     data = json.load(f)
                 imported = 0
+                # The mirror intentionally lags metadata written through the
+                # state.db single-row fast path. Exact crash-recovery fields
+                # are therefore trusted only when this file says it was the
+                # primary store (a genuinely DB-less installation). Missing
+                # metadata is treated as an old state.db mirror, not as proof
+                # of JSON authority.
+                marker_path = self._db_exact_authority_marker_path()
+                try:
+                    os.lstat(marker_path)
+                    marker_absent = False
+                except FileNotFoundError:
+                    marker_absent = True
+                trust_json_exact_state = (
+                    marker_absent
+                    and data.get(self._JSON_EXACT_AUTHORITY_KEY)
+                    == self._JSON_EXACT_AUTHORITY_JSON
+                )
+                self._json_exact_state_is_authoritative = trust_json_exact_state
                 for key, entry_data in data.items():
                     # Keys starting with "_" are documentation/metadata sentinels
                     # (e.g. the "_README" note written by _save), not session
                     # entries. Skip them so they never reach SessionEntry.from_dict.
                     if key.startswith("_"):
                         continue
-                    if key in self._entries:
+                    if key in self._entries and not trust_json_exact_state:
                         continue
                     # Skip non-dict entries (corrupted sessions.json, e.g. a
                     # bare bool or string where a dict is expected). Without
@@ -1401,6 +1532,10 @@ class SessionStore:
                         )
                         continue
                     try:
+                        if not trust_json_exact_state:
+                            entry_data = self._without_untrusted_exact_state(
+                                entry_data
+                            )
                         self._entries[key] = SessionEntry.from_dict(entry_data)
                         imported += 1
                     except (ValueError, KeyError, TypeError) as e:
@@ -1414,7 +1549,25 @@ class SessionStore:
             except Exception as e:
                 print(f"[gateway] Warning: Failed to load sessions: {e}")
 
-        self._loaded = True
+        if (
+            db_load_succeeded
+            and trust_json_exact_state
+            and not self._routing_data_has_exact_state(
+                {key: entry.to_dict() for key, entry in self._entries.items()}
+            )
+        ):
+            # Quiescent DB-less -> state.db migration: only hand authority to
+            # the new primary when no crash-replay state is live. Preserve the
+            # complete JSON snapshot in the DB first, then publish the sidecar.
+            data, generation = self._snapshot_routing_locked()
+            self._persist_routing_data(
+                data,
+                generation,
+                require_authoritative=True,
+                establish_exact_authority=False,
+                write_json=False,
+            )
+            self._ensure_db_exact_authority_marker()
 
         # Prune any sessions.json entries that point to sessions already ended
         # in state.db. A hard gateway crash (exit code 1) skips the graceful
@@ -1425,7 +1578,31 @@ class SessionStore:
         # live-gateway case; this startup prune still self-heals crash-left
         # entries before the first message arrives. Pruning here (lock already
         # held) is cheap: one lookup per routing key, once at startup.
-        self._prune_stale_sessions_locked()
+        if db_load_succeeded and not self._json_exact_state_is_authoritative:
+            self._prune_stale_sessions_locked()
+        # Do not publish a successfully loaded instance until migration,
+        # sidecar publication, and startup pruning have all completed. A
+        # caller that catches an initialization error can then retry safely.
+        self._loaded = True
+
+    def _without_untrusted_exact_state(
+        self, entry_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Downgrade exact fields from a legacy state.db mirror.
+
+        ``sessions.json`` remains useful for routing when SQLite is temporarily
+        unavailable, but a stale exact marker can duplicate a completed turn.
+        Preserve inbound-only continuity while refusing synthetic dispatch.
+        """
+        sanitized = dict(entry_data)
+        sanitized["active_turn_token"] = None
+        sanitized["active_turn_started_at"] = None
+        if (
+            sanitized.get("resume_pending")
+            and sanitized.get("resume_reason") in self._EXACT_RESUME_REASONS
+        ):
+            sanitized["resume_reason"] = "restart_interrupted"
+        return sanitized
 
     def _prune_stale_sessions_locked(self) -> None:
         """Remove sessions.json entries whose session has ended in state.db.
@@ -1511,10 +1688,15 @@ class SessionStore:
         if stale_keys or recovered_keys:
             self._save()
 
-    def _save(self) -> None:
+    def _save(self, *, require_authoritative: bool = False) -> None:
         """Persist the routing index while the caller holds ``_lock``."""
         data, generation = self._snapshot_routing_locked()
-        self._persist_routing_data(data, generation)
+        if require_authoritative:
+            self._persist_routing_data(
+                data, generation, require_authoritative=True
+            )
+        else:
+            self._persist_routing_data(data, generation)
 
     def _next_routing_generation_locked(self) -> int:
         """Bump and return the shared routing counter. Caller holds ``_lock``.
@@ -1535,7 +1717,15 @@ class SessionStore:
             self._next_routing_generation_locked(),
         )
 
-    def _persist_routing_data(self, data: Dict[str, Any], generation: int) -> None:
+    def _persist_routing_data(
+        self,
+        data: Dict[str, Any],
+        generation: int,
+        *,
+        require_authoritative: bool = False,
+        establish_exact_authority: bool = True,
+        write_json: bool = True,
+    ) -> None:
         """Serialize all whole-index writers through one durable write lock."""
         save_lock = getattr(self, "_save_lock", None)
         if save_lock is None:
@@ -1554,8 +1744,40 @@ class SessionStore:
                 for key, (revision, entry_json) in fast_persisted.items():
                     if revision > generation:
                         data[key] = json.loads(entry_json)
+            if (
+                require_authoritative
+                and establish_exact_authority
+                and getattr(
+                    self, "_json_exact_state_is_authoritative", False
+                )
+            ):
+                # Every exact transition—including the one that clears the last
+                # token—commits first to the current strict JSON authority. A
+                # later, separate quiescent transaction may hand authority to
+                # state.db; never combine the final exact mutation with that
+                # cross-resource handoff.
+                self._save_sessions_json(data)
+                self._persisted_routing_generation = generation
+                if fast_persisted:
+                    for key in [
+                        k
+                        for k, (rev, _) in fast_persisted.items()
+                        if rev <= generation
+                    ]:
+                        del fast_persisted[key]
+                return
             db_saved = False
+            db_error: Optional[Exception] = None
             _db = getattr(self, "_db", None)
+            if (
+                require_authoritative
+                and establish_exact_authority
+                and _db is not None
+            ):
+                # This small durable sidecar closes the window where a gateway
+                # first migrates from JSON-only operation to state.db but the
+                # large legacy mirror still advertises JSON authority.
+                self._ensure_db_exact_authority_marker()
             if _db:
                 replacer = getattr(_db, "replace_gateway_routing_entries", None)
                 if callable(replacer):
@@ -1566,10 +1788,21 @@ class SessionStore:
                         )
                         db_saved = True
                     except Exception as exc:
+                        db_error = exc
                         logger.warning(
                             "gateway.session: state.db routing save failed: %s", exc
                         )
-            if getattr(self, "_write_sessions_json", True) or not db_saved:
+            if require_authoritative and not db_saved:
+                # Do not publish an exact-transition candidate to the legacy
+                # mirror when the configured primary rejected it. A later boot
+                # that temporarily falls back to JSON must not revive state that
+                # was never authoritative.
+                raise RuntimeError(
+                    "authoritative state.db routing save failed"
+                ) from db_error
+            if write_json and (
+                getattr(self, "_write_sessions_json", True) or not db_saved
+            ):
                 try:
                     self._save_sessions_json(data)
                 except Exception as exc:
@@ -1614,6 +1847,16 @@ class SessionStore:
                 "Disable this file with `gateway.write_sessions_json: false` "
                 "in config.yaml."
             ),
+            self._JSON_EXACT_AUTHORITY_KEY: (
+                self._JSON_EXACT_AUTHORITY_JSON
+                if (
+                    getattr(self, "_db", None) is None
+                    or getattr(
+                        self, "_json_exact_state_is_authoritative", False
+                    )
+                )
+                else self._JSON_EXACT_AUTHORITY_DB
+            ),
             **data,
         }
         fd, tmp_path = tempfile.mkstemp(
@@ -1624,7 +1867,21 @@ class SessionStore:
                 json.dump(data, f, indent=2)
                 f.flush()
                 os.fsync(f.fileno())
-            atomic_replace(tmp_path, sessions_file)
+            if (
+                getattr(self, "_db", None) is None
+                or getattr(
+                    self, "_json_exact_state_is_authoritative", False
+                )
+            ):
+                # In DB-less or deferred-migration operation this file is the
+                # exact-state authority.
+                self._publish_routing_file_strict(tmp_path, sessions_file)
+            else:
+                # Preserve the established symlink/bind-mount compatibility
+                # for the non-authoritative legacy mirror. Exact state is safe
+                # because state.db and its strict sidecar are authoritative.
+                atomic_replace(tmp_path, sessions_file)
+                self._fsync_sessions_dir()
         except BaseException:
             try:
                 os.unlink(tmp_path)
@@ -1644,6 +1901,7 @@ class SessionStore:
         *,
         entry_data: Optional[Dict[str, Any]] = None,
         lock_held: bool = False,
+        require_authoritative: bool = False,
     ) -> None:
         """Persist ONE routing entry via UPSERT — the per-turn fast path.
 
@@ -1714,7 +1972,19 @@ class SessionStore:
             return
         entry_json, revision, candidate_entry = captured
         _db = getattr(self, "_db", None)
-        saver = getattr(_db, "save_gateway_routing_entry", None) if _db else None
+        json_exact_authority = bool(
+            require_authoritative
+            and getattr(
+                self, "_json_exact_state_is_authoritative", False
+            )
+        )
+        if require_authoritative and _db is not None and not json_exact_authority:
+            self._ensure_db_exact_authority_marker()
+        saver = (
+            getattr(_db, "save_gateway_routing_entry", None)
+            if _db and not json_exact_authority
+            else None
+        )
         if callable(saver):
             save_lock = getattr(self, "_save_lock", None)
             if save_lock is None:
@@ -1757,7 +2027,11 @@ class SessionStore:
                         for key, current in self._entries.items()
                     }
             fallback_data[session_key] = candidate_entry
-            self._persist_routing_data(fallback_data, revision)
+            self._persist_routing_data(
+                fallback_data,
+                revision,
+                require_authoritative=require_authoritative,
+            )
         else:
             self._save_entries()
 
@@ -2980,6 +3254,7 @@ class SessionStore:
                 session_key,
                 entry_data=candidate,
                 lock_held=True,
+                require_authoritative=self._db is not None,
             )
             entry.active_turn_token = token
             entry.active_turn_started_at = now
@@ -3006,6 +3281,7 @@ class SessionStore:
                 session_key,
                 entry_data=candidate,
                 lock_held=True,
+                require_authoritative=self._db is not None,
             )
             entry.active_turn_token = None
             entry.active_turn_started_at = None
@@ -3029,10 +3305,12 @@ class SessionStore:
         now = _now()
         max_age = timedelta(seconds=max(0, max_age_seconds))
         promoted = 0
-        changed = False
 
         with self._lock:
             self._ensure_loaded_locked()
+            transitions: list[
+                tuple[SessionEntry, Dict[str, Any], bool, Optional[str], Optional[datetime]]
+            ] = []
             for entry in self._entries.values():
                 if not entry.active_turn_token:
                     continue
@@ -3045,48 +3323,92 @@ class SessionStore:
                     )
                 except TypeError:
                     # Mixed aware/naive timestamps are invalid for this local
-                    # marker.  Clear rather than risking an unsafe old resume.
+                    # marker. Clear rather than risking an unsafe old resume.
                     marker_is_stale = True
 
+                resume_pending = entry.resume_pending
+                resume_reason = entry.resume_reason
+                marked_at = entry.last_resume_marked_at
                 if not marker_is_stale and not entry.suspended:
-                    if entry.resume_pending:
-                        # A drain-timeout marker is more specific than the
-                        # generic crash reason; preserve it and its freshness.
-                        if entry.last_resume_marked_at is None:
-                            entry.last_resume_marked_at = now
-                    else:
-                        entry.resume_pending = True
-                        entry.resume_reason = "restart_interrupted"
-                        # Freshness starts when recovery is discovered, not
-                        # when a potentially hours-long turn began.
-                        entry.last_resume_marked_at = now
-                        promoted += 1
+                    # A fresh durable active-turn token is exact evidence from
+                    # the crashed process. It supersedes both recency-only
+                    # recovery and any possibly stale planned-drain timeout
+                    # marker, and is the only unclean-start class eligible for
+                    # synthetic continuation.
+                    resume_pending = True
+                    resume_reason = "active_turn_interrupted"
+                    # Freshness starts when recovery is discovered, not when a
+                    # potentially hours-long turn began.
+                    marked_at = now
+                    promoted += 1
 
-                entry.active_turn_token = None
-                entry.active_turn_started_at = None
-                changed = True
+                candidate = entry.to_dict()
+                candidate["resume_pending"] = resume_pending
+                candidate["resume_reason"] = resume_reason
+                candidate["last_resume_marked_at"] = (
+                    marked_at.isoformat() if marked_at is not None else None
+                )
+                candidate["active_turn_token"] = None
+                candidate["active_turn_started_at"] = None
+                transitions.append(
+                    (entry, candidate, resume_pending, resume_reason, marked_at)
+                )
 
-            if changed:
-                # Cold-start batch: one durable rewrite is clearer and cheaper
-                # than an upsert per interrupted routing entry.
-                self._save()
+            if transitions:
+                data, generation = self._snapshot_routing_locked()
+                for entry, candidate, *_ in transitions:
+                    data[entry.session_key] = candidate
+                # Exact active-turn state lives in the authoritative routing
+                # store (state.db when configured, otherwise the legacy JSON
+                # store). Publish neither its promotion nor its clear until that
+                # rewrite lands; otherwise a failed startup could auto-dispatch
+                # from memory and replay the same durable marker on the next boot.
+                self._persist_routing_data(
+                    data,
+                    generation,
+                    require_authoritative=self._db is not None,
+                )
+                for entry, _candidate, resume_pending, resume_reason, marked_at in transitions:
+                    entry.resume_pending = resume_pending
+                    entry.resume_reason = resume_reason
+                    entry.last_resume_marked_at = marked_at
+                    entry.active_turn_token = None
+                    entry.active_turn_started_at = None
 
         return promoted
 
     def discard_active_turn_markers(self) -> int:
         """Clear orphan turn markers after a verified clean shutdown."""
-        cleared = 0
         with self._lock:
             self._ensure_loaded_locked()
-            for entry in self._entries.values():
-                if not entry.active_turn_token and entry.active_turn_started_at is None:
-                    continue
+            entries = [
+                entry
+                for entry in self._entries.values()
+                if entry.active_turn_token
+                or entry.active_turn_started_at is not None
+            ]
+            if not entries:
+                return 0
+
+            data, generation = self._snapshot_routing_locked()
+            for entry in entries:
+                candidate = entry.to_dict()
+                candidate["active_turn_token"] = None
+                candidate["active_turn_started_at"] = None
+                data[entry.session_key] = candidate
+
+            # A clean receipt may be committed only after the authoritative DB
+            # no longer carries orphan active-turn evidence. Keep the live state
+            # unchanged if persistence fails so this cleanup is retryable.
+            self._persist_routing_data(
+                data,
+                generation,
+                require_authoritative=self._db is not None,
+            )
+            for entry in entries:
                 entry.active_turn_token = None
                 entry.active_turn_started_at = None
-                cleared += 1
-            if cleared:
-                self._save()
-        return cleared
+            return len(entries)
 
     def mark_resume_pending(
         self,
@@ -3110,10 +3432,32 @@ class SessionStore:
                 # forced-wipe signal (from /stop or stuck-loop escalation).
                 if entry.suspended:
                     return False
+                marked_at = _now()
+                candidate = entry.to_dict()
+                candidate["resume_pending"] = True
+                candidate["resume_reason"] = reason
+                candidate["last_resume_marked_at"] = marked_at.isoformat()
+                data, generation = self._snapshot_routing_locked()
+                data[session_key] = candidate
+                self._persist_routing_data(
+                    data,
+                    generation,
+                    require_authoritative=(
+                        self._db is not None
+                        and reason
+                        in {
+                            "restart_timeout",
+                            "shutdown_timeout",
+                            "active_turn_interrupted",
+                        }
+                    ),
+                )
+                # Publish only after the required durable write succeeds. A
+                # failed authoritative save must leave live state retryable and
+                # must not leak through a later unrelated snapshot.
                 entry.resume_pending = True
                 entry.resume_reason = reason
-                entry.last_resume_marked_at = _now()
-                self._save()
+                entry.last_resume_marked_at = marked_at
                 return True
         return False
 
@@ -3131,11 +3475,67 @@ class SessionStore:
             entry = self._entries.get(session_key)
             if entry is None or not entry.resume_pending:
                 return False
+            require_authoritative = (
+                self._db is not None
+                and entry.resume_reason
+                in {
+                    "restart_timeout",
+                    "shutdown_timeout",
+                    "active_turn_interrupted",
+                }
+            )
+            candidate = entry.to_dict()
+            candidate["resume_pending"] = False
+            candidate["resume_reason"] = None
+            candidate["last_resume_marked_at"] = None
+            data, generation = self._snapshot_routing_locked()
+            data[session_key] = candidate
+            self._persist_routing_data(
+                data,
+                generation,
+                require_authoritative=require_authoritative,
+            )
+            # Preserve the live marker if persistence fails so the clear remains
+            # naturally retryable and cannot leak through another save.
             entry.resume_pending = False
             entry.resume_reason = None
             entry.last_resume_marked_at = None
-            self._save()
             return True
+
+    def downgrade_untrusted_exact_resume_pending(self) -> int:
+        """Make exact timeout markers inbound-only after an unclean boot.
+
+        A missing clean-shutdown proof means an exact marker could be residue
+        from a completed turn whose shutdown-time clear failed. Persistently
+        downgrade such markers so a later unrelated clean boot cannot make
+        them eligible for synthetic startup dispatch.
+        """
+        exact_reasons = {"restart_timeout", "shutdown_timeout"}
+        with self._lock:
+            self._ensure_loaded_locked()
+            entries = [
+                entry
+                for entry in self._entries.values()
+                if entry.resume_pending
+                and entry.resume_reason in exact_reasons
+                and not entry.suspended
+            ]
+            if not entries:
+                return 0
+
+            data, generation = self._snapshot_routing_locked()
+            for entry in entries:
+                candidate = entry.to_dict()
+                candidate["resume_reason"] = "restart_interrupted"
+                data[entry.session_key] = candidate
+            self._persist_routing_data(
+                data,
+                generation,
+                require_authoritative=self._db is not None,
+            )
+            for entry in entries:
+                entry.resume_reason = "restart_interrupted"
+            return len(entries)
 
     def prune_old_entries(self, max_age_days: int) -> int:
         """Drop SessionEntry records older than max_age_days.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1420,10 +1420,15 @@ class SessionStore:
         if stale_keys or recovered_keys:
             self._save()
 
-    def _save(self) -> None:
+    def _save(self, *, require_authoritative: bool = False) -> None:
         """Persist the routing index while the caller holds ``_lock``."""
         data, generation = self._snapshot_routing_locked()
-        self._persist_routing_data(data, generation)
+        if require_authoritative:
+            self._persist_routing_data(
+                data, generation, require_authoritative=True
+            )
+        else:
+            self._persist_routing_data(data, generation)
 
     def _snapshot_routing_locked(self) -> tuple[Dict[str, Any], int]:
         """Capture immutable routing data and a monotonic generation."""
@@ -1433,7 +1438,13 @@ class SessionStore:
             self._routing_generation,
         )
 
-    def _persist_routing_data(self, data: Dict[str, Any], generation: int) -> None:
+    def _persist_routing_data(
+        self,
+        data: Dict[str, Any],
+        generation: int,
+        *,
+        require_authoritative: bool = False,
+    ) -> None:
         """Serialize all whole-index writers through one durable write lock."""
         save_lock = getattr(self, "_save_lock", None)
         if save_lock is None:
@@ -1443,6 +1454,7 @@ class SessionStore:
             if generation <= getattr(self, "_persisted_routing_generation", 0):
                 return
             db_saved = False
+            db_error: Optional[Exception] = None
             _db = getattr(self, "_db", None)
             if _db:
                 replacer = getattr(_db, "replace_gateway_routing_entries", None)
@@ -1454,11 +1466,16 @@ class SessionStore:
                         )
                         db_saved = True
                     except Exception as exc:
+                        db_error = exc
                         logger.warning(
                             "gateway.session: state.db routing save failed: %s", exc
                         )
             if getattr(self, "_write_sessions_json", True) or not db_saved:
                 self._save_sessions_json(data)
+            if require_authoritative and not db_saved:
+                raise RuntimeError(
+                    "authoritative state.db routing save failed"
+                ) from db_error
             self._persisted_routing_generation = generation
 
     def _save_sessions_json(self, data: Dict[str, Any]) -> None:
@@ -2591,7 +2608,10 @@ class SessionStore:
                 entry.resume_pending = True
                 entry.resume_reason = reason
                 entry.last_resume_marked_at = _now()
-                self._save()
+                self._save(
+                    require_authoritative=reason
+                    in {"restart_timeout", "shutdown_timeout"}
+                )
                 return True
         return False
 
@@ -2609,11 +2629,39 @@ class SessionStore:
             entry = self._entries.get(session_key)
             if entry is None or not entry.resume_pending:
                 return False
+            require_authoritative = entry.resume_reason in {
+                "restart_timeout",
+                "shutdown_timeout",
+            }
             entry.resume_pending = False
             entry.resume_reason = None
             entry.last_resume_marked_at = None
-            self._save()
+            self._save(require_authoritative=require_authoritative)
             return True
+
+    def downgrade_untrusted_exact_resume_pending(self) -> int:
+        """Make exact timeout markers inbound-only after an unclean boot.
+
+        A missing clean-shutdown proof means an exact marker could be residue
+        from a completed turn whose shutdown-time clear failed. Persistently
+        downgrade such markers so a later unrelated clean boot cannot make
+        them eligible for synthetic startup dispatch.
+        """
+        exact_reasons = {"restart_timeout", "shutdown_timeout"}
+        count = 0
+        with self._lock:
+            self._ensure_loaded_locked()
+            for entry in self._entries.values():
+                if (
+                    entry.resume_pending
+                    and entry.resume_reason in exact_reasons
+                    and not entry.suspended
+                ):
+                    entry.resume_reason = "restart_interrupted"
+                    count += 1
+            if count:
+                self._save(require_authoritative=True)
+        return count
 
     def prune_old_entries(self, max_age_days: int) -> int:
         """Drop SessionEntry records older than max_age_days.

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -35,6 +35,7 @@ add eviction of fully-default SessionStates.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import MutableMapping
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
@@ -167,6 +168,10 @@ class PersistentState:
     # since they key on sid. Making this durable is tracked on #79624 as a
     # schema-level follow-up.
     hygiene_failure_streak: int = 0
+    # Serializes durable resume-marker writes/clears with shutdown's
+    # reservation decision.  A successful old turn must not clear a newer
+    # marker written while shutdown is preparing to interrupt that session.
+    resume_pending_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 @dataclass

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -35,6 +35,7 @@ add eviction of fully-default SessionStates.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import MutableMapping
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
@@ -148,6 +149,10 @@ class PersistentState:
     # Monotonic run-generation counter (#28686).  NEVER reset: clearing it
     # would break stale-run detection.
     run_generation: int = 0
+    # Serializes durable resume-marker writes/clears with shutdown's
+    # reservation decision.  A successful old turn must not clear a newer
+    # marker written while shutdown is preparing to interrupt that session.
+    resume_pending_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 @dataclass

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -73,6 +73,8 @@ def make_restart_runner(
     runner._restart_task_started = False
     runner._restart_detached = False
     runner._restart_via_service = False
+    runner._previous_shutdown_clean = True
+    runner._clean_shutdown_marker_blocked = False
     runner._detached_restart_helper_started = False
     runner._restart_command_source = None
     runner._restart_drain_timeout = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -70,6 +70,8 @@ def make_restart_runner(
     runner._restart_task_started = False
     runner._restart_detached = False
     runner._restart_via_service = False
+    runner._previous_shutdown_clean = True
+    runner._clean_shutdown_marker_blocked = False
     runner._detached_restart_helper_started = False
     runner._restart_command_source = None
     runner._restart_drain_timeout = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT

--- a/tests/gateway/test_active_turn_recovery.py
+++ b/tests/gateway/test_active_turn_recovery.py
@@ -6,6 +6,9 @@ marker, compare-and-swap cleanup, and promotion into the existing
 ``resume_pending`` recovery path after an unclean exit.
 """
 
+import asyncio
+import errno
+import json
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 from typing import Any, cast
@@ -13,7 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 
-from gateway.config import GatewayConfig, Platform
+from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.run import GatewayRunner
 from gateway.session import SessionEntry, SessionSource, SessionStore
 
@@ -36,6 +39,7 @@ def _make_store(tmp_path) -> SessionStore:
     # Exercise the legacy JSON fallback deterministically.  ``_save_entry``
     # must still persist correctly when state.db is unavailable.
     store._db = None
+    store._db_exact_authority_marker_path().unlink(missing_ok=True)
     return store
 
 
@@ -138,6 +142,7 @@ def test_mark_and_clear_use_single_entry_persistence(tmp_path):
         entry.session_key,
         entry_data=store._entries[entry.session_key].to_dict(),
         lock_held=True,
+        require_authoritative=False,
     )
 
     store._save_entry.reset_mock()
@@ -146,6 +151,7 @@ def test_mark_and_clear_use_single_entry_persistence(tmp_path):
         entry.session_key,
         entry_data=store._entries[entry.session_key].to_dict(),
         lock_held=True,
+        require_authoritative=False,
     )
 
 
@@ -204,32 +210,51 @@ def test_state_db_failure_atomic_marker_round_trip(tmp_path):
     store = _make_db_store(tmp_path)
     source = _make_source("state-db-active-turn")
     entry = store.get_or_create_session(source)
-    real_save_entry = store._save_entry
+    db = store._db
+    assert db is not None
+    db.save_gateway_routing_entry = MagicMock(
+        side_effect=OSError("fast state.db write blocked")
+    )
+    db.replace_gateway_routing_entries = MagicMock(
+        side_effect=OSError("full state.db write blocked")
+    )
 
-    store._save_entry = MagicMock(side_effect=OSError("state.db unavailable"))
-    with pytest.raises(OSError, match="state.db unavailable"):
+    with pytest.raises(
+        RuntimeError, match="authoritative state.db routing save failed"
+    ):
         store.mark_turn_active(entry.session_key)
     assert _entry_for(store, source).active_turn_token is None
-
-    store._save_entry = real_save_entry
-    token = store.mark_turn_active(entry.session_key)
-    assert token is not None
-
-    store._save_entry = MagicMock(side_effect=OSError("state.db unavailable"))
-    with pytest.raises(OSError, match="state.db unavailable"):
-        store.clear_turn_active(entry.session_key, token)
-    assert _entry_for(store, source).active_turn_token == token
-
-    store._save_entry = real_save_entry
-    assert store.clear_turn_active(entry.session_key, token) is True
     _close_store_db(store)
 
+    json_only = _make_store(tmp_path / "sessions")
+    assert _entry_for(json_only, source).active_turn_token is None
+
     reloaded = _make_db_store(tmp_path)
-    assert reloaded.recover_interrupted_turns() == 0
-    persisted = _entry_for(reloaded, source)
-    assert persisted.active_turn_token is None
-    assert persisted.active_turn_started_at is None
+    reloaded_entry = _entry_for(reloaded, source)
+    assert reloaded_entry.active_turn_token is None
+    token = reloaded.mark_turn_active(reloaded_entry.session_key)
+    assert token is not None
+
+    db = reloaded._db
+    assert db is not None
+    db.save_gateway_routing_entry = MagicMock(
+        side_effect=OSError("fast state.db write blocked")
+    )
+    db.replace_gateway_routing_entries = MagicMock(
+        side_effect=OSError("full state.db write blocked")
+    )
+    with pytest.raises(
+        RuntimeError, match="authoritative state.db routing save failed"
+    ):
+        reloaded.clear_turn_active(reloaded_entry.session_key, token)
+    assert _entry_for(reloaded, source).active_turn_token == token
     _close_store_db(reloaded)
+
+    final = _make_db_store(tmp_path)
+    persisted = _entry_for(final, source)
+    assert persisted.active_turn_token == token
+    assert final.clear_turn_active(persisted.session_key, token) is True
+    _close_store_db(final)
 
 
 def test_state_db_commit_survives_legacy_mirror_failure(tmp_path):
@@ -255,6 +280,395 @@ def test_state_db_commit_survives_legacy_mirror_failure(tmp_path):
     _close_store_db(reloaded)
 
 
+def test_state_db_mirror_never_replays_stale_active_marker_on_json_fallback(
+    tmp_path,
+):
+    store = _make_db_store(tmp_path)
+    source = _make_source("stale-db-mirror")
+    entry = store.get_or_create_session(source)
+    token = store.mark_turn_active(entry.session_key)
+    assert token
+
+    # A structural save can capture the active marker in the legacy mirror.
+    # The later exact clear takes the state.db fast path, so the mirror is now
+    # deliberately stale but explicitly tagged as non-authoritative for exact
+    # recovery state.
+    with store._lock:
+        store._save()
+    assert store.clear_turn_active(entry.session_key, token) is True
+    _close_store_db(store)
+
+    fallback = SessionStore(
+        sessions_dir=tmp_path / "sessions",
+        config=GatewayConfig(),
+    )
+    fallback._db = None
+    fallback_entry = _entry_for(fallback, source)
+    assert fallback_entry.active_turn_token is None
+    assert fallback.recover_interrupted_turns(max_age_seconds=3600) == 0
+
+
+def test_exact_file_publication_fsyncs_parent_directory(tmp_path):
+    json_store = _make_store(tmp_path / "json-sessions")
+    json_entry = json_store.get_or_create_session(_make_source("json-dir-fsync"))
+    json_store._fsync_sessions_dir = MagicMock()
+    assert json_store.mark_turn_active(json_entry.session_key)
+    json_store._fsync_sessions_dir.assert_called_once_with()
+
+    db_store = _make_db_store(tmp_path / "db-case")
+    db_entry = db_store.get_or_create_session(_make_source("sidecar-dir-fsync"))
+    db_store._db_exact_authority_marker_path().unlink(missing_ok=True)
+    db_store._fsync_sessions_dir = MagicMock()
+    assert db_store.mark_turn_active(db_entry.session_key)
+    db_store._fsync_sessions_dir.assert_called_once_with()
+    _close_store_db(db_store)
+
+
+def test_exact_file_publication_rejects_non_atomic_replace_fallback(tmp_path):
+    store = _make_store(tmp_path / "json-sessions")
+    source = _make_source("strict-publication")
+    entry = store.get_or_create_session(source)
+
+    with patch(
+        "gateway.session.os.replace",
+        side_effect=OSError(errno.EXDEV, "cross-device rename"),
+    ):
+        with pytest.raises(OSError) as exc_info:
+            store.mark_turn_active(entry.session_key)
+
+    assert exc_info.value.errno == errno.EXDEV
+    assert _entry_for(store, source).active_turn_token is None
+
+
+def test_authority_sidecar_rejects_non_atomic_replace_fallback(tmp_path):
+    store = _make_db_store(tmp_path)
+    source = _make_source("strict-sidecar-publication")
+    entry = store.get_or_create_session(source)
+    store._db_exact_authority_marker_path().unlink(missing_ok=True)
+    db = store._db
+    assert db is not None
+    db.save_gateway_routing_entry = MagicMock()
+
+    with patch(
+        "gateway.session.os.replace",
+        side_effect=OSError(errno.EBUSY, "busy mount"),
+    ):
+        with pytest.raises(OSError) as exc_info:
+            store.mark_turn_active(entry.session_key)
+
+    assert exc_info.value.errno == errno.EBUSY
+    db.save_gateway_routing_entry.assert_not_called()
+    assert _entry_for(store, source).active_turn_token is None
+    _close_store_db(store)
+
+
+def test_exact_file_publication_rejects_symlink_target(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    store = _make_store(sessions_dir)
+    source = _make_source("strict-symlink-publication")
+    entry = store.get_or_create_session(source)
+    external = tmp_path / "external.json"
+    external.write_text("external remains unchanged", encoding="utf-8")
+    sessions_file = sessions_dir / "sessions.json"
+    sessions_file.unlink()
+    sessions_file.symlink_to(external)
+
+    with pytest.raises(OSError, match="refusing symlink target"):
+        store.mark_turn_active(entry.session_key)
+
+    assert external.read_text(encoding="utf-8") == "external remains unchanged"
+    assert _entry_for(store, source).active_turn_token is None
+
+
+def test_existing_sidecar_symlink_cannot_authorize_exact_db_transition(tmp_path):
+    store = _make_db_store(tmp_path)
+    source = _make_source("symlink-sidecar")
+    entry = store.get_or_create_session(source)
+    marker = store._db_exact_authority_marker_path()
+    marker.unlink(missing_ok=True)
+    external = tmp_path / "external-authority-marker"
+    external.write_text("state.db\n", encoding="utf-8")
+    marker.symlink_to(external)
+    db = store._db
+    assert db is not None
+    db.save_gateway_routing_entry = MagicMock()
+
+    with pytest.raises(OSError, match="refusing unsafe exact-authority marker"):
+        store.mark_turn_active(entry.session_key)
+
+    db.save_gateway_routing_entry.assert_not_called()
+    assert _entry_for(store, source).active_turn_token is None
+    assert marker.is_symlink()
+    _close_store_db(store)
+
+
+def test_dangling_sidecar_symlink_keeps_json_exact_state_untrusted(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    json_store = _make_store(sessions_dir)
+    source = _make_source("dangling-sidecar")
+    entry = json_store.get_or_create_session(source)
+    assert json_store.mark_turn_active(entry.session_key)
+
+    marker = json_store._db_exact_authority_marker_path()
+    external = tmp_path / "removed-authority-marker"
+    external.write_text("state.db\n", encoding="utf-8")
+    marker.symlink_to(external)
+    external.unlink()
+    assert marker.is_symlink() and not marker.exists()
+
+    fallback = SessionStore(sessions_dir=sessions_dir, config=GatewayConfig())
+    fallback._db = None
+    assert _entry_for(fallback, source).active_turn_token is None
+    assert fallback.recover_interrupted_turns(max_age_seconds=3600) == 0
+
+
+def test_sidecar_directory_fsync_failure_blocks_then_retries_exact_transition(
+    tmp_path,
+):
+    store = _make_db_store(tmp_path)
+    source = _make_source("authority-dir-fsync-retry")
+    entry = store.get_or_create_session(source)
+    store._db_exact_authority_marker_path().unlink(missing_ok=True)
+    store._fsync_sessions_dir = MagicMock(
+        side_effect=[OSError("directory fsync failed"), None]
+    )
+    db = store._db
+    assert db is not None
+    real_save = db.save_gateway_routing_entry
+    db.save_gateway_routing_entry = MagicMock(wraps=real_save)
+
+    with pytest.raises(OSError, match="directory fsync failed"):
+        store.mark_turn_active(entry.session_key)
+    db.save_gateway_routing_entry.assert_not_called()
+    assert _entry_for(store, source).active_turn_token is None
+
+    token = store.mark_turn_active(entry.session_key)
+    assert token
+    db.save_gateway_routing_entry.assert_called_once()
+    assert store._fsync_sessions_dir.call_count == 2
+    _close_store_db(store)
+
+
+def test_authority_sidecar_failure_prevents_exact_db_transition(tmp_path):
+    store = _make_db_store(tmp_path)
+    source = _make_source("authority-sidecar-failure")
+    entry = store.get_or_create_session(source)
+    store._db_exact_authority_marker_path().unlink(missing_ok=True)
+    db = store._db
+    assert db is not None
+    db.save_gateway_routing_entry = MagicMock()
+    store._ensure_db_exact_authority_marker = MagicMock(
+        side_effect=OSError("sidecar unavailable")
+    )
+
+    with pytest.raises(OSError, match="sidecar unavailable"):
+        store.mark_turn_active(entry.session_key)
+
+    db.save_gateway_routing_entry.assert_not_called()
+    assert _entry_for(store, source).active_turn_token is None
+    _close_store_db(store)
+
+
+def test_db_load_failure_cannot_prune_or_relabel_json_authority(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    json_store = _make_store(sessions_dir)
+    source = _make_source("json-db-load-failure")
+    entry = json_store.get_or_create_session(source)
+    token = json_store.mark_turn_active(entry.session_key)
+    assert token
+
+    db_store = _make_db_store(tmp_path)
+    db = db_store._db
+    assert db is not None
+    db.load_gateway_routing_entries = MagicMock(
+        side_effect=OSError("DB routing load failed")
+    )
+    db.get_session = MagicMock(return_value={"end_reason": "completed"})
+    db.replace_gateway_routing_entries = MagicMock(
+        side_effect=OSError("DB replacement failed")
+    )
+
+    loaded = _entry_for(db_store, source)
+    assert loaded.active_turn_token == token
+    assert db_store._loaded is True
+    db.get_session.assert_not_called()
+    db.replace_gateway_routing_entries.assert_not_called()
+    assert not db_store._db_exact_authority_marker_path().exists()
+
+    # Even a later ordinary save must preserve JSON authority if the DB still
+    # cannot accept the snapshot.
+    with db_store._lock:
+        db_store._save()
+    db.replace_gateway_routing_entries.assert_called_once()
+    persisted = json.loads((sessions_dir / "sessions.json").read_text())
+    assert (
+        persisted[SessionStore._JSON_EXACT_AUTHORITY_KEY]
+        == SessionStore._JSON_EXACT_AUTHORITY_JSON
+    )
+    assert persisted[entry.session_key]["active_turn_token"] == token
+
+    # A later exact transition remains on strict JSON authority instead of
+    # publishing a DB sidecar before a DB write that may fail.
+    db.save_gateway_routing_entry = MagicMock(
+        side_effect=OSError("DB upsert failed")
+    )
+    replacement_token = db_store.mark_turn_active(entry.session_key)
+    assert replacement_token and replacement_token != token
+    db.save_gateway_routing_entry.assert_not_called()
+    assert not db_store._db_exact_authority_marker_path().exists()
+    _close_store_db(db_store)
+
+    fallback = SessionStore(sessions_dir=sessions_dir, config=GatewayConfig())
+    fallback._db = None
+    assert _entry_for(fallback, source).active_turn_token == replacement_token
+    assert fallback.recover_interrupted_turns(max_age_seconds=3600) == 1
+
+
+def test_json_authoritative_final_clear_commits_before_any_db_handoff(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    json_store = _make_store(sessions_dir)
+    source = _make_source("json-final-clear")
+    entry = json_store.get_or_create_session(source)
+    token = json_store.mark_turn_active(entry.session_key)
+    assert token
+
+    db_store = _make_db_store(tmp_path)
+    loaded = _entry_for(db_store, source)
+    assert loaded.active_turn_token == token
+    assert db_store._json_exact_state_is_authoritative is True
+    db = db_store._db
+    assert db is not None
+    db.save_gateway_routing_entry = MagicMock(
+        side_effect=OSError("DB upsert failed")
+    )
+    db.replace_gateway_routing_entries = MagicMock(
+        side_effect=OSError("DB replacement failed")
+    )
+
+    assert db_store.clear_turn_active(entry.session_key, token) is True
+    db.save_gateway_routing_entry.assert_not_called()
+    db.replace_gateway_routing_entries.assert_not_called()
+    assert not db_store._db_exact_authority_marker_path().exists()
+    _close_store_db(db_store)
+
+    fallback = SessionStore(sessions_dir=sessions_dir, config=GatewayConfig())
+    fallback._db = None
+    assert _entry_for(fallback, source).active_turn_token is None
+    assert fallback.recover_interrupted_turns(max_age_seconds=3600) == 0
+
+
+def test_db_adoption_failure_preserves_json_exact_authority(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    json_store = _make_store(sessions_dir)
+    source = _make_source("json-to-db-failure")
+    entry = json_store.get_or_create_session(source)
+    token = json_store.mark_turn_active(entry.session_key)
+    assert token
+
+    db_store = _make_db_store(tmp_path)
+    db = db_store._db
+    assert db is not None
+    db.replace_gateway_routing_entries = MagicMock(
+        side_effect=OSError("DB adoption failed")
+    )
+    loaded = _entry_for(db_store, source)
+    assert loaded.active_turn_token == token
+    db.replace_gateway_routing_entries.assert_not_called()
+    assert db_store._json_exact_state_is_authoritative is True
+    assert not db_store._db_exact_authority_marker_path().exists()
+    _close_store_db(db_store)
+
+    fallback = SessionStore(sessions_dir=sessions_dir, config=GatewayConfig())
+    fallback._db = None
+    recovered = _entry_for(fallback, source)
+    assert recovered.active_turn_token == token
+    assert fallback.recover_interrupted_turns(max_age_seconds=3600) == 1
+
+
+def test_db_adoption_failure_cannot_prune_json_authority_first(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    json_store = _make_store(sessions_dir)
+    source = _make_source("json-to-db-stale-prune-failure")
+    entry = json_store.get_or_create_session(source)
+    token = json_store.mark_turn_active(entry.session_key)
+    assert token
+
+    db_store = _make_db_store(tmp_path)
+    db = db_store._db
+    assert db is not None
+    db.get_session = MagicMock(return_value={"end_reason": "completed"})
+    db.replace_gateway_routing_entries = MagicMock(
+        side_effect=OSError("DB adoption failed before prune")
+    )
+    loaded = _entry_for(db_store, source)
+    assert loaded.active_turn_token == token
+    db.replace_gateway_routing_entries.assert_not_called()
+    db.get_session.assert_not_called()
+    assert db_store._loaded is True
+    assert db_store._json_exact_state_is_authoritative is True
+    assert not db_store._db_exact_authority_marker_path().exists()
+    _close_store_db(db_store)
+
+    fallback = SessionStore(sessions_dir=sessions_dir, config=GatewayConfig())
+    fallback._db = None
+    recovered = _entry_for(fallback, source)
+    assert recovered.active_turn_token == token
+    assert fallback.recover_interrupted_turns(max_age_seconds=3600) == 1
+
+
+def test_db_adoption_sidecar_failure_retries_same_process(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    json_store = _make_store(sessions_dir)
+    source = _make_source("json-to-db-sidecar-retry")
+    entry = json_store.get_or_create_session(source)
+
+    db_store = _make_db_store(tmp_path)
+    real_ensure = db_store._ensure_db_exact_authority_marker
+    attempts = 0
+
+    def flaky_ensure():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OSError("sidecar unavailable")
+        real_ensure()
+
+    db_store._ensure_db_exact_authority_marker = flaky_ensure
+    with pytest.raises(OSError, match="sidecar unavailable"):
+        _entry_for(db_store, source)
+    assert db_store._loaded is False
+    assert not db_store._db_exact_authority_marker_path().exists()
+
+    migrated = _entry_for(db_store, source)
+    assert migrated.session_id == entry.session_id
+    assert migrated.active_turn_token is None
+    assert attempts == 2
+    assert db_store._loaded is True
+    assert db_store._db_exact_authority_marker_path().exists()
+    _close_store_db(db_store)
+
+
+def test_db_adoption_sidecar_invalidates_preexisting_json_exact_marker(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    json_store = _make_store(sessions_dir)
+    source = _make_source("json-to-db-migration")
+    entry = json_store.get_or_create_session(source)
+    token = json_store.mark_turn_active(entry.session_key)
+    assert token
+
+    db_store = _make_db_store(tmp_path)
+    migrated = _entry_for(db_store, source)
+    assert migrated.active_turn_token == token
+    assert db_store.clear_turn_active(migrated.session_key, token) is True
+    _close_store_db(db_store)
+
+    fallback = SessionStore(sessions_dir=sessions_dir, config=GatewayConfig())
+    fallback._db = None
+    recovered = _entry_for(fallback, source)
+    assert recovered.active_turn_token is None
+    assert fallback.recover_interrupted_turns(max_age_seconds=3600) == 0
+
+
 def test_exact_old_active_turn_recovers_even_when_updated_at_is_stale(tmp_path):
     store = _make_store(tmp_path)
     source = _make_source()
@@ -276,7 +690,7 @@ def test_exact_old_active_turn_recovers_even_when_updated_at_is_stale(tmp_path):
 
     recovered = _entry_for(reloaded, source)
     assert recovered.resume_pending is True
-    assert recovered.resume_reason == "restart_interrupted"
+    assert recovered.resume_reason == "active_turn_interrupted"
     assert recovered.last_resume_marked_at is not None
     assert recovered.last_resume_marked_at > datetime.now() - timedelta(seconds=5)
     assert recovered.active_turn_token is None
@@ -301,7 +715,7 @@ def test_suspended_active_turn_is_cleared_without_resume(tmp_path):
     assert recovered.active_turn_started_at is None
 
 
-def test_existing_resume_reason_and_freshness_are_preserved(tmp_path):
+def test_exact_active_marker_supersedes_existing_timeout_reason(tmp_path):
     store = _make_store(tmp_path)
     source = _make_source()
     entry = store.get_or_create_session(source)
@@ -314,11 +728,11 @@ def test_existing_resume_reason_and_freshness_are_preserved(tmp_path):
         current.resume_reason = "shutdown_timeout"
         current.last_resume_marked_at = original_mark
 
-    assert store.recover_interrupted_turns() == 0
+    assert store.recover_interrupted_turns() == 1
     recovered = _entry_for(store, source)
     assert recovered.resume_pending is True
-    assert recovered.resume_reason == "shutdown_timeout"
-    assert recovered.last_resume_marked_at == original_mark
+    assert recovered.resume_reason == "active_turn_interrupted"
+    assert recovered.last_resume_marked_at > original_mark
     assert recovered.active_turn_token is None
     assert recovered.active_turn_started_at is None
 
@@ -354,6 +768,42 @@ def test_clean_startup_discards_orphan_markers_without_resuming(tmp_path):
     assert recovered.resume_pending is False
     assert recovered.active_turn_token is None
     assert recovered.active_turn_started_at is None
+
+
+def test_recovery_db_failure_publishes_no_in_memory_resume(tmp_path):
+    store = _make_db_store(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    token = store.mark_turn_active(entry.session_key)
+    store._db.replace_gateway_routing_entries = MagicMock(
+        side_effect=OSError("db write blocked")
+    )
+
+    with pytest.raises(
+        RuntimeError, match="authoritative state.db routing save failed"
+    ):
+        store.recover_interrupted_turns()
+
+    assert entry.resume_pending is False
+    assert entry.resume_reason is None
+    assert entry.active_turn_token == token
+
+
+def test_clean_discard_db_failure_keeps_live_marker_retryable(tmp_path):
+    store = _make_db_store(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    token = store.mark_turn_active(entry.session_key)
+    store._db.replace_gateway_routing_entries = MagicMock(
+        side_effect=OSError("db write blocked")
+    )
+
+    with pytest.raises(
+        RuntimeError, match="authoritative state.db routing save failed"
+    ):
+        store.discard_active_turn_markers()
+
+    assert entry.active_turn_token == token
 
 
 @pytest.mark.asyncio
@@ -513,3 +963,98 @@ async def test_unclean_recovery_promotes_exact_markers_before_legacy_fallback(
 
     assert await runner._recover_unclean_sessions() == (1, 2)
     assert calls == ["exact", "fallback"]
+
+
+@pytest.mark.asyncio
+async def test_real_startup_promotes_and_dispatches_exact_active_turn_once(tmp_path):
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(enabled=True, token="test-token")
+        },
+        sessions_dir=tmp_path / "sessions",
+        loop_watchdog=False,
+    )
+    runner = GatewayRunner(config)
+    runner._previous_shutdown_clean = False
+    source = _make_source("startup-integration")
+    entry = runner.session_store.get_or_create_session(source)
+    runner.session_store.mark_turn_active(entry.session_key)
+    with runner.session_store._lock:
+        current = runner.session_store._entries[entry.session_key]
+        current.updated_at = datetime.now() - timedelta(hours=2)
+        current.active_turn_started_at = datetime.now() - timedelta(minutes=10)
+        runner.session_store._save()
+
+    from plugins.platforms.discord.adapter import DiscordAdapter
+
+    adapter = DiscordAdapter(config.platforms[Platform.DISCORD])
+    adapter.gateway_runner = runner
+    runner._create_adapter = MagicMock(return_value=adapter)
+    runner._connect_adapter_with_timeout = AsyncMock(return_value=True)
+    runner._is_user_authorized = MagicMock(return_value=True)
+    runner._suspend_stuck_loop_sessions = MagicMock(return_value=0)
+    runner._update_runtime_status = MagicMock()
+    runner._update_platform_runtime_status = MagicMock()
+    runner._sync_voice_mode_state_to_adapter = MagicMock()
+    runner._send_update_notification = AsyncMock(return_value=True)
+    runner._send_restart_notification = AsyncMock()
+    runner._redeliver_pending_obligations = AsyncMock(return_value=0)
+    runner.hooks = MagicMock(loaded_hooks=[])
+    runner.hooks.emit = AsyncMock()
+
+    agent_runs: list[str] = []
+
+    async def _fake_run(event, event_source, quick_key, run_generation):
+        agent_runs.append(quick_key)
+        return "RESUMED OK"
+
+    runner._handle_message_with_agent = _fake_run
+    runner._post_turn_goal_continuation = AsyncMock()
+    adapter.send = AsyncMock()
+    adapter._keep_typing = AsyncMock()
+    adapter._stop_typing_refresh = AsyncMock()
+    adapter._run_processing_hook = AsyncMock()
+
+    real_create_task = asyncio.create_task
+
+    def create_only_resume_task(coro, *args, **kwargs):
+        name = getattr(getattr(coro, "cr_code", None), "co_name", "")
+        if name in {
+            "_run_startup_resume_event",
+            "_process_message_background",
+            "_drain_pending_messages",
+        }:
+            return real_create_task(coro, *args, **kwargs)
+        coro.close()
+        task = MagicMock()
+        task.done.return_value = True
+        return task
+
+    with patch("gateway.status.write_runtime_status"), patch(
+        "hermes_cli.plugins.discover_plugins"
+    ), patch("hermes_cli.config.load_config", return_value={}), patch(
+        "agent.shell_hooks.register_from_config"
+    ), patch(
+        "tools.process_registry.process_registry.recover_from_checkpoint",
+        return_value=0,
+    ), patch(
+        "gateway.channel_directory.build_channel_directory",
+        new=AsyncMock(return_value={"platforms": {}}),
+    ), patch("gateway.run.asyncio.create_task", side_effect=create_only_resume_task):
+        assert await runner.start() is True
+
+    for _ in range(50):
+        if (
+            agent_runs
+            and entry.session_key not in runner._running_agents
+            and entry.session_key not in adapter._pending_messages
+        ):
+            break
+        await asyncio.sleep(0.02)
+
+    recovered = _entry_for(runner.session_store, source)
+    assert agent_runs == [entry.session_key]
+    assert recovered.resume_reason == "active_turn_interrupted"
+    assert recovered.active_turn_token is None
+    assert entry.session_key not in runner._running_agents
+    assert entry.session_key not in adapter._pending_messages

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -14,6 +14,7 @@ import pytest
 
 
 from gateway.config import GatewayConfig, Platform
+from gateway.run import start_gateway
 from gateway.session import SessionSource, SessionStore
 
 
@@ -121,6 +122,23 @@ class TestCleanShutdownMarker:
         assert (tmp_path / ".clean_shutdown.consumed").exists()
         assert _consume_clean_shutdown_marker() is False
 
+    def test_post_rename_inspection_failure_is_still_one_shot(
+        self, tmp_path, monkeypatch
+    ):
+        """Inspection failure after consume cannot preserve predecessor proof."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+        marker.touch()
+
+        from gateway.run import _consume_clean_shutdown_marker
+
+        with patch("pathlib.Path.stat", side_effect=OSError("stat blocked")):
+            assert _consume_clean_shutdown_marker() is False
+
+        assert not marker.exists()
+        assert not (tmp_path / ".clean_shutdown.consumed").exists()
+        assert _consume_clean_shutdown_marker() is False
+
     def test_failed_atomic_consume_invalidates_marker_for_next_boot(
         self, tmp_path, monkeypatch
     ):
@@ -139,6 +157,24 @@ class TestCleanShutdownMarker:
         assert _consume_clean_shutdown_marker() is False
         assert not marker.exists()
 
+    def test_failed_consume_and_invalidation_aborts_startup(
+        self, tmp_path, monkeypatch
+    ):
+        """Startup must fail closed if stale clean proof cannot be invalidated."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+        marker.touch()
+
+        from gateway.run import _consume_clean_shutdown_marker
+
+        with patch("gateway.run.os.replace", side_effect=OSError("rename blocked")), patch(
+            "pathlib.Path.unlink", side_effect=OSError("unlink blocked")
+        ), patch("pathlib.Path.write_text", side_effect=OSError("write blocked")):
+            with pytest.raises(RuntimeError, match="Cannot safely invalidate"):
+                _consume_clean_shutdown_marker()
+
+        assert marker.exists(), "the fatal path must not pretend invalidation succeeded"
+
     def test_later_clean_drain_replaces_invalid_tombstone(self, tmp_path, monkeypatch):
         """A stale consume tombstone must not suppress new clean-shutdown proof."""
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
@@ -152,6 +188,51 @@ class TestCleanShutdownMarker:
         assert marker.read_bytes() == b""
         assert _consume_clean_shutdown_marker() is True
         assert not marker.exists()
+
+    @pytest.mark.asyncio
+    async def test_startup_consumes_marker_before_fallible_post_lock_work(
+        self, tmp_path, monkeypatch
+    ):
+        """A startup crash cannot leave its predecessor's proof reusable."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+        marker.touch()
+        runner = MagicMock()
+
+        with patch("gateway.code_skew.record_boot_fingerprint"), patch(
+            "gateway.status.get_running_pid", return_value=None
+        ), patch(
+            "gateway.status.acquire_gateway_runtime_lock", return_value=True
+        ), patch(
+            "gateway.status.write_pid_file"
+        ), patch(
+            "gateway.status.release_gateway_runtime_lock"
+        ), patch(
+            "gateway.status.remove_pid_file"
+        ), patch(
+            "tools.skills_sync.sync_skills"
+        ), patch(
+            "hermes_logging.setup_logging"
+        ), patch(
+            "hermes_cli.security_audit_startup.log_startup_security_warnings"
+        ), patch(
+            "gateway.run.GatewayRunner", return_value=runner
+        ), patch(
+            "gateway.run.threading.current_thread", return_value=object()
+        ), patch(
+            "gateway.run.threading.Thread"
+        ), patch(
+            "gateway.run._ensure_windows_gateway_venv_imports",
+            side_effect=RuntimeError("post-lock startup crash"),
+        ):
+            with pytest.raises(RuntimeError, match="post-lock startup crash"):
+                await start_gateway(config=GatewayConfig(), verbosity=None)
+
+        assert runner._previous_shutdown_clean is True
+        assert not marker.exists()
+        from gateway.run import _consume_clean_shutdown_marker
+
+        assert _consume_clean_shutdown_marker() is False
 
     def test_no_marker_triggers_suspension(self, tmp_path, monkeypatch):
         """Without .clean_shutdown marker (crash), suspension should fire."""

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -105,13 +105,13 @@ class TestCleanShutdownMarker:
         assert marker.exists(), ".clean_shutdown marker should exist after graceful stop"
 
 
-    def test_marker_consumption_is_one_shot_even_if_cleanup_fails(
+    def test_claimed_marker_remains_retryable_until_cleanup_commits(
         self, tmp_path, monkeypatch
     ):
-        """A consumed marker must never survive under the recognized name."""
+        """A claimed receipt survives only for the immediate cleanup transaction."""
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
         marker = tmp_path / ".clean_shutdown"
-        marker.touch()
+        marker.write_bytes(b"clean\n")
 
         from gateway.run import _consume_clean_shutdown_marker
 
@@ -119,7 +119,16 @@ class TestCleanShutdownMarker:
             assert _consume_clean_shutdown_marker() is True
 
         assert not marker.exists()
-        assert (tmp_path / ".clean_shutdown.consumed").exists()
+        assert (tmp_path / ".clean_shutdown.cleanup_pending").exists()
+        assert _consume_clean_shutdown_marker() is True
+
+    def test_legacy_consumed_tombstone_is_never_trusted(self, tmp_path, monkeypatch):
+        """Old releases could leave this path after already starting adapters."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        (tmp_path / ".clean_shutdown.consumed").write_bytes(b"clean\n")
+
+        from gateway.run import _consume_clean_shutdown_marker
+
         assert _consume_clean_shutdown_marker() is False
 
     def test_post_rename_inspection_failure_is_still_one_shot(
@@ -128,15 +137,15 @@ class TestCleanShutdownMarker:
         """Inspection failure after consume cannot preserve predecessor proof."""
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
         marker = tmp_path / ".clean_shutdown"
-        marker.touch()
+        marker.write_bytes(b"clean\n")
 
         from gateway.run import _consume_clean_shutdown_marker
 
-        with patch("pathlib.Path.stat", side_effect=OSError("stat blocked")):
+        with patch("pathlib.Path.read_bytes", side_effect=OSError("read blocked")):
             assert _consume_clean_shutdown_marker() is False
 
         assert not marker.exists()
-        assert not (tmp_path / ".clean_shutdown.consumed").exists()
+        assert not (tmp_path / ".clean_shutdown.cleanup_pending").exists()
         assert _consume_clean_shutdown_marker() is False
 
     def test_failed_atomic_consume_invalidates_marker_for_next_boot(
@@ -144,7 +153,7 @@ class TestCleanShutdownMarker:
     ):
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
         marker = tmp_path / ".clean_shutdown"
-        marker.touch()
+        marker.write_bytes(b"clean\n")
 
         from gateway.run import _consume_clean_shutdown_marker
 
@@ -163,7 +172,7 @@ class TestCleanShutdownMarker:
         """Startup must fail closed if stale clean proof cannot be invalidated."""
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
         marker = tmp_path / ".clean_shutdown"
-        marker.touch()
+        marker.write_bytes(b"clean\n")
 
         from gateway.run import _consume_clean_shutdown_marker
 
@@ -175,6 +184,30 @@ class TestCleanShutdownMarker:
 
         assert marker.exists(), "the fatal path must not pretend invalidation succeeded"
 
+    def test_failed_tombstone_write_cannot_become_clean_proof(
+        self, tmp_path, monkeypatch
+    ):
+        """A truncate-then-fail invalidation leaves an invalid payload."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+        marker.write_bytes(b"clean\n")
+
+        from gateway.run import _consume_clean_shutdown_marker
+
+        def truncate_then_fail(*_args, **_kwargs):
+            marker.write_bytes(b"")
+            raise OSError("write blocked after truncate")
+
+        with patch("gateway.run.os.replace", side_effect=OSError("rename blocked")), patch(
+            "pathlib.Path.unlink", side_effect=OSError("unlink blocked")
+        ), patch("pathlib.Path.write_text", side_effect=truncate_then_fail):
+            with pytest.raises(RuntimeError, match="Cannot safely invalidate"):
+                _consume_clean_shutdown_marker()
+
+        assert marker.read_bytes() == b""
+        assert _consume_clean_shutdown_marker() is False
+        assert not marker.exists()
+
     def test_later_clean_drain_replaces_invalid_tombstone(self, tmp_path, monkeypatch):
         """A stale consume tombstone must not suppress new clean-shutdown proof."""
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
@@ -185,7 +218,7 @@ class TestCleanShutdownMarker:
 
         _write_clean_shutdown_marker()
 
-        assert marker.read_bytes() == b""
+        assert marker.read_bytes() == b"clean\n"
         assert _consume_clean_shutdown_marker() is True
         assert not marker.exists()
 
@@ -196,8 +229,16 @@ class TestCleanShutdownMarker:
         """A startup crash cannot leave its predecessor's proof reusable."""
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
         marker = tmp_path / ".clean_shutdown"
-        marker.touch()
+        marker.write_bytes(b"clean\n")
         runner = MagicMock()
+
+        async def commit_clean_receipt(path):
+            path.unlink()
+            return 0
+
+        runner._consume_clean_shutdown_marker = AsyncMock(
+            side_effect=commit_clean_receipt
+        )
 
         with patch("gateway.code_skew.record_boot_fingerprint"), patch(
             "gateway.status.get_running_pid", return_value=None
@@ -230,6 +271,10 @@ class TestCleanShutdownMarker:
 
         assert runner._previous_shutdown_clean is True
         assert not marker.exists()
+        assert not (tmp_path / ".clean_shutdown.cleanup_pending").exists()
+        runner._consume_clean_shutdown_marker.assert_awaited_once_with(
+            tmp_path / ".clean_shutdown.cleanup_pending"
+        )
         from gateway.run import _consume_clean_shutdown_marker
 
         assert _consume_clean_shutdown_marker() is False
@@ -302,6 +347,49 @@ class TestCleanShutdownMarker:
         assert marker.exists(), (
             "a successful drain must be recorded before slower teardown begins"
         )
+
+    def test_blocked_clean_proof_survives_graceful_stop(self, tmp_path, monkeypatch):
+        """A failed persistent downgrade must taint the whole lifecycle."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._restart_requested = False
+        runner._restart_detached = False
+        runner._restart_via_service = False
+        runner._restart_task_started = False
+        runner._running = True
+        runner._draining = False
+        runner._stop_task = None
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._background_tasks = set()
+        runner._shutdown_event = MagicMock()
+        runner._restart_drain_timeout = 5
+        runner._exit_code = None
+        runner._exit_reason = None
+        runner._clean_shutdown_marker_blocked = True
+        runner.adapters = {}
+        runner.config = GatewayConfig()
+
+        with patch(
+            "gateway.run.GatewayRunner._drain_active_agents",
+            new_callable=AsyncMock,
+            return_value=([], False),
+        ), patch(
+            "gateway.run.GatewayRunner._finalize_shutdown_agents",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("host teardown interrupted cleanup"),
+        ):
+            import asyncio
+
+            with pytest.raises(RuntimeError, match="host teardown interrupted cleanup"):
+                asyncio.get_event_loop().run_until_complete(runner.stop())
+
+        assert not marker.exists()
 
     def test_non_chat_timeout_does_not_trigger_broad_chat_recovery(
         self, tmp_path, monkeypatch

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -10,6 +10,8 @@ After a crash (no marker), suspension still fires as a safety net for stuck sess
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 
 from gateway.config import GatewayConfig, Platform
 from gateway.session import SessionSource, SessionStore
@@ -102,6 +104,55 @@ class TestCleanShutdownMarker:
         assert marker.exists(), ".clean_shutdown marker should exist after graceful stop"
 
 
+    def test_marker_consumption_is_one_shot_even_if_cleanup_fails(
+        self, tmp_path, monkeypatch
+    ):
+        """A consumed marker must never survive under the recognized name."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+        marker.touch()
+
+        from gateway.run import _consume_clean_shutdown_marker
+
+        with patch("pathlib.Path.unlink", side_effect=OSError("cleanup blocked")):
+            assert _consume_clean_shutdown_marker() is True
+
+        assert not marker.exists()
+        assert (tmp_path / ".clean_shutdown.consumed").exists()
+        assert _consume_clean_shutdown_marker() is False
+
+    def test_failed_atomic_consume_invalidates_marker_for_next_boot(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+        marker.touch()
+
+        from gateway.run import _consume_clean_shutdown_marker
+
+        with patch("gateway.run.os.replace", side_effect=OSError("rename blocked")), patch(
+            "pathlib.Path.unlink", side_effect=OSError("unlink blocked")
+        ):
+            assert _consume_clean_shutdown_marker() is False
+
+        assert marker.read_text(encoding="utf-8") == "invalid\n"
+        assert _consume_clean_shutdown_marker() is False
+        assert not marker.exists()
+
+    def test_later_clean_drain_replaces_invalid_tombstone(self, tmp_path, monkeypatch):
+        """A stale consume tombstone must not suppress new clean-shutdown proof."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+        marker.write_text("invalid\n", encoding="utf-8")
+
+        from gateway.run import _consume_clean_shutdown_marker, _write_clean_shutdown_marker
+
+        _write_clean_shutdown_marker()
+
+        assert marker.read_bytes() == b""
+        assert _consume_clean_shutdown_marker() is True
+        assert not marker.exists()
+
     def test_no_marker_triggers_suspension(self, tmp_path, monkeypatch):
         """Without .clean_shutdown marker (crash), suspension should fire."""
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
@@ -126,6 +177,209 @@ class TestCleanShutdownMarker:
             store._ensure_loaded_locked()
             resume_count = sum(1 for e in store._entries.values() if e.resume_pending)
         assert resume_count == 1, "Session should be resume_pending after crash (no marker)"
+
+
+    def test_marker_written_before_post_drain_cleanup(self, tmp_path, monkeypatch):
+        """A clean drain must survive teardown being cut short by host shutdown."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+
+        from gateway.run import GatewayRunner
+        runner = object.__new__(GatewayRunner)
+        runner._restart_requested = False
+        runner._restart_detached = False
+        runner._restart_via_service = False
+        runner._restart_task_started = False
+        runner._running = True
+        runner._draining = False
+        runner._stop_task = None
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._background_tasks = set()
+        runner._shutdown_event = MagicMock()
+        runner._restart_drain_timeout = 5
+        runner._exit_code = None
+        runner._exit_reason = None
+        runner.adapters = {}
+        runner.config = GatewayConfig()
+
+        with patch(
+            "gateway.run.GatewayRunner._drain_active_agents",
+            new_callable=AsyncMock,
+            return_value=([], False),
+        ), patch(
+            "gateway.run.GatewayRunner._finalize_shutdown_agents",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("host teardown interrupted cleanup"),
+        ):
+            import asyncio
+
+            with pytest.raises(RuntimeError, match="host teardown interrupted cleanup"):
+                asyncio.get_event_loop().run_until_complete(runner.stop())
+
+        assert marker.exists(), (
+            "a successful drain must be recorded before slower teardown begins"
+        )
+
+    def test_non_chat_timeout_does_not_trigger_broad_chat_recovery(
+        self, tmp_path, monkeypatch
+    ):
+        """Cron/API-only timeout must not make recent idle chats resumable."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+
+        from gateway.run import GatewayRunner
+        runner = object.__new__(GatewayRunner)
+        runner._restart_requested = False
+        runner._restart_detached = False
+        runner._restart_via_service = False
+        runner._restart_task_started = False
+        runner._running = True
+        runner._draining = False
+        runner._stop_task = None
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._background_tasks = set()
+        runner._shutdown_event = MagicMock()
+        runner._restart_drain_timeout = 5
+        runner._exit_code = None
+        runner._exit_reason = None
+        runner.adapters = {}
+        runner.config = GatewayConfig()
+
+        with patch(
+            "gateway.run.GatewayRunner._drain_active_agents",
+            new_callable=AsyncMock,
+            return_value=([], True),
+        ), patch(
+            "gateway.run.GatewayRunner._active_cron_job_count", return_value=1
+        ), patch(
+            "gateway.run.GatewayRunner._active_api_run_count", return_value=0
+        ), patch(
+            "gateway.run.GatewayRunner._finalize_shutdown_agents",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("host teardown interrupted cleanup"),
+        ):
+            import asyncio
+
+            with pytest.raises(RuntimeError, match="host teardown interrupted cleanup"):
+                asyncio.get_event_loop().run_until_complete(runner.stop())
+
+        assert marker.exists(), (
+            "a non-chat timeout must suppress broad recent-session inference"
+        )
+
+    def test_chat_finished_before_non_chat_timeout_clears_pre_drain_marker(
+        self, tmp_path, monkeypatch
+    ):
+        """A completed chat must not retain recovery state from a cron/API timeout."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._restart_requested = False
+        runner._restart_detached = False
+        runner._restart_via_service = False
+        runner._restart_task_started = False
+        runner._running = True
+        runner._draining = False
+        runner._stop_task = None
+        runner._running_agents = {"session-key": MagicMock()}
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._background_tasks = set()
+        runner._shutdown_event = MagicMock()
+        runner._restart_drain_timeout = 5
+        runner._exit_code = None
+        runner._exit_reason = None
+        runner.adapters = {}
+        runner.config = GatewayConfig()
+        runner.session_store = MagicMock()
+        runner._async_session_store = MagicMock()
+        runner._async_session_store._store = runner.session_store
+        runner._async_session_store.mark_resume_pending = AsyncMock(return_value=True)
+        runner._async_session_store.clear_resume_pending = AsyncMock(return_value=True)
+
+        async def _finish_chat_then_timeout(_timeout):
+            runner._running_agents.clear()
+            return [], True
+
+        with patch(
+            "gateway.run.GatewayRunner._notify_active_sessions_of_shutdown",
+            new_callable=AsyncMock,
+        ), patch(
+            "gateway.run.GatewayRunner._drain_active_agents",
+            new_callable=AsyncMock,
+            side_effect=_finish_chat_then_timeout,
+        ), patch(
+            "gateway.run.GatewayRunner._active_cron_job_count", return_value=1
+        ), patch(
+            "gateway.run.GatewayRunner._active_api_run_count", return_value=0
+        ), patch(
+            "gateway.run.GatewayRunner._finalize_shutdown_agents",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("host teardown interrupted cleanup"),
+        ):
+            import asyncio
+
+            with pytest.raises(RuntimeError, match="host teardown interrupted cleanup"):
+                asyncio.get_event_loop().run_until_complete(runner.stop())
+
+        runner._async_session_store.mark_resume_pending.assert_awaited_once_with(
+            "session-key", "shutdown_timeout"
+        )
+        runner._async_session_store.clear_resume_pending.assert_awaited_once_with(
+            "session-key"
+        )
+        assert marker.exists()
+
+    def test_marker_write_failure_is_visible(self, tmp_path, monkeypatch, caplog):
+        """A filesystem failure must be logged, not silently swallowed."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+
+        from gateway.run import GatewayRunner
+        runner = object.__new__(GatewayRunner)
+        runner._restart_requested = False
+        runner._restart_detached = False
+        runner._restart_via_service = False
+        runner._restart_task_started = False
+        runner._running = True
+        runner._draining = False
+        runner._stop_task = None
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._background_tasks = set()
+        runner._shutdown_event = MagicMock()
+        runner._restart_drain_timeout = 5
+        runner._exit_code = None
+        runner._exit_reason = None
+        runner.adapters = {}
+        runner.config = GatewayConfig()
+
+        with patch(
+            "gateway.run.GatewayRunner._drain_active_agents",
+            new_callable=AsyncMock,
+            return_value=([], True),
+        ), patch(
+            "gateway.run.GatewayRunner._active_cron_job_count", return_value=1
+        ), patch(
+            "gateway.run.GatewayRunner._active_api_run_count", return_value=0
+        ), patch("pathlib.Path.write_bytes", side_effect=OSError("read-only filesystem")), patch(
+            "gateway.run.GatewayRunner._finalize_shutdown_agents",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("host teardown interrupted cleanup"),
+        ):
+            import asyncio
+
+            with pytest.raises(RuntimeError, match="host teardown interrupted cleanup"):
+                asyncio.get_event_loop().run_until_complete(runner.stop())
+
+        assert "Failed to write .clean_shutdown marker: read-only filesystem" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -111,7 +111,7 @@ class TestCleanShutdownMarker:
         """A consumed marker must never survive under the recognized name."""
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
         marker = tmp_path / ".clean_shutdown"
-        marker.touch()
+        marker.write_bytes(b"clean\n")
 
         from gateway.run import _consume_clean_shutdown_marker
 
@@ -128,11 +128,11 @@ class TestCleanShutdownMarker:
         """Inspection failure after consume cannot preserve predecessor proof."""
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
         marker = tmp_path / ".clean_shutdown"
-        marker.touch()
+        marker.write_bytes(b"clean\n")
 
         from gateway.run import _consume_clean_shutdown_marker
 
-        with patch("pathlib.Path.stat", side_effect=OSError("stat blocked")):
+        with patch("pathlib.Path.read_bytes", side_effect=OSError("read blocked")):
             assert _consume_clean_shutdown_marker() is False
 
         assert not marker.exists()
@@ -144,7 +144,7 @@ class TestCleanShutdownMarker:
     ):
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
         marker = tmp_path / ".clean_shutdown"
-        marker.touch()
+        marker.write_bytes(b"clean\n")
 
         from gateway.run import _consume_clean_shutdown_marker
 
@@ -163,7 +163,7 @@ class TestCleanShutdownMarker:
         """Startup must fail closed if stale clean proof cannot be invalidated."""
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
         marker = tmp_path / ".clean_shutdown"
-        marker.touch()
+        marker.write_bytes(b"clean\n")
 
         from gateway.run import _consume_clean_shutdown_marker
 
@@ -175,6 +175,30 @@ class TestCleanShutdownMarker:
 
         assert marker.exists(), "the fatal path must not pretend invalidation succeeded"
 
+    def test_failed_tombstone_write_cannot_become_clean_proof(
+        self, tmp_path, monkeypatch
+    ):
+        """A truncate-then-fail invalidation leaves an invalid payload."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+        marker.write_bytes(b"clean\n")
+
+        from gateway.run import _consume_clean_shutdown_marker
+
+        def truncate_then_fail(*_args, **_kwargs):
+            marker.write_bytes(b"")
+            raise OSError("write blocked after truncate")
+
+        with patch("gateway.run.os.replace", side_effect=OSError("rename blocked")), patch(
+            "pathlib.Path.unlink", side_effect=OSError("unlink blocked")
+        ), patch("pathlib.Path.write_text", side_effect=truncate_then_fail):
+            with pytest.raises(RuntimeError, match="Cannot safely invalidate"):
+                _consume_clean_shutdown_marker()
+
+        assert marker.read_bytes() == b""
+        assert _consume_clean_shutdown_marker() is False
+        assert not marker.exists()
+
     def test_later_clean_drain_replaces_invalid_tombstone(self, tmp_path, monkeypatch):
         """A stale consume tombstone must not suppress new clean-shutdown proof."""
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
@@ -185,7 +209,7 @@ class TestCleanShutdownMarker:
 
         _write_clean_shutdown_marker()
 
-        assert marker.read_bytes() == b""
+        assert marker.read_bytes() == b"clean\n"
         assert _consume_clean_shutdown_marker() is True
         assert not marker.exists()
 
@@ -196,7 +220,7 @@ class TestCleanShutdownMarker:
         """A startup crash cannot leave its predecessor's proof reusable."""
         monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
         marker = tmp_path / ".clean_shutdown"
-        marker.touch()
+        marker.write_bytes(b"clean\n")
         runner = MagicMock()
 
         with patch("gateway.code_skew.record_boot_fingerprint"), patch(
@@ -302,6 +326,49 @@ class TestCleanShutdownMarker:
         assert marker.exists(), (
             "a successful drain must be recorded before slower teardown begins"
         )
+
+    def test_blocked_clean_proof_survives_graceful_stop(self, tmp_path, monkeypatch):
+        """A failed persistent downgrade must taint the whole lifecycle."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._restart_requested = False
+        runner._restart_detached = False
+        runner._restart_via_service = False
+        runner._restart_task_started = False
+        runner._running = True
+        runner._draining = False
+        runner._stop_task = None
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._background_tasks = set()
+        runner._shutdown_event = MagicMock()
+        runner._restart_drain_timeout = 5
+        runner._exit_code = None
+        runner._exit_reason = None
+        runner._clean_shutdown_marker_blocked = True
+        runner.adapters = {}
+        runner.config = GatewayConfig()
+
+        with patch(
+            "gateway.run.GatewayRunner._drain_active_agents",
+            new_callable=AsyncMock,
+            return_value=([], False),
+        ), patch(
+            "gateway.run.GatewayRunner._finalize_shutdown_agents",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("host teardown interrupted cleanup"),
+        ):
+            import asyncio
+
+            with pytest.raises(RuntimeError, match="host teardown interrupted cleanup"):
+                asyncio.get_event_loop().run_until_complete(runner.stop())
+
+        assert not marker.exists()
 
     def test_non_chat_timeout_does_not_trigger_broad_chat_recovery(
         self, tmp_path, monkeypatch

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -537,10 +537,11 @@ class TestFreshnessHelpers:
 
 
 @pytest.mark.asyncio
-async def test_drain_timeout_marks_resume_pending():
+async def test_drain_timeout_marks_resume_pending(tmp_path, monkeypatch):
     """End-to-end: a drain timeout during gateway stop should flag every
     active session as resume_pending BEFORE the interrupt fires, so the
     next startup's suspend_recently_active() does not destroy them."""
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
     runner, adapter = make_restart_runner()
     adapter.disconnect = AsyncMock()
     runner._restart_drain_timeout = 0.05
@@ -569,11 +570,118 @@ async def test_drain_timeout_marks_resume_pending():
     assert marked == {session_key_one, session_key_two}
     for args in calls:
         assert args[0][1] == "shutdown_timeout"
+    assert not (tmp_path / ".clean_shutdown").exists(), (
+        "interrupted chats rely on exact markers, not a clean-shutdown claim"
+    )
+
+
+@pytest.mark.asyncio
+async def test_drain_timeout_keeps_crash_fallback_when_exact_mark_fails(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner._restart_drain_timeout = 0.05
+    runner._running_agents = {"agent:main:telegram:dm:A": MagicMock()}
+
+    session_store = MagicMock()
+    session_store.mark_resume_pending = MagicMock(return_value=False)
+    runner.session_store = session_store
+
+    with patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop()
+
+    assert not (tmp_path / ".clean_shutdown").exists()
+    assert session_store.mark_resume_pending.call_count >= 2, (
+        "the timeout boundary must re-verify a pre-drain marker"
+    )
+
+
+@pytest.mark.asyncio
+async def test_turn_completion_cannot_clear_shutdown_reserved_resume_marker():
+    """Close the completion-clear vs timeout-boundary marking race."""
+    runner, _adapter = make_restart_runner()
+    session_key = "agent:main:telegram:dm:A"
+    session_store = MagicMock()
+    session_store.clear_resume_pending = MagicMock(return_value=True)
+    runner.session_store = session_store
+    runner._shutdown_resume_pending_keys = {session_key}
+
+    await runner._clear_resume_pending_after_success(session_key)
+    session_store.clear_resume_pending.assert_not_called()
+
+    runner._shutdown_resume_pending_keys.clear()
+    await runner._clear_resume_pending_after_success(session_key)
+    session_store.clear_resume_pending.assert_called_once_with(session_key)
 
 
 # ---------------------------------------------------------------------------
 # Gateway startup auto-resume
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clean_shutdown_suppresses_stale_exact_resume_marker():
+    """A failed centralized clear cannot replay a turn that drained cleanly."""
+    runner, adapter = make_restart_runner()
+    runner._previous_shutdown_clean = True
+    source = make_restart_source(chat_id="completed-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:completed-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="shutdown_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    adapter.handle_message = AsyncMock()
+
+    assert runner._schedule_resume_pending_sessions() == 0
+    await asyncio.sleep(0)
+    adapter.handle_message.assert_not_called()
+    assert pending_entry.resume_pending is True
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_defers_heuristic_crash_recovery():
+    """Heuristic crash recovery must wait for the next real user message.
+
+    ``suspend_recently_active()`` cannot distinguish an interrupted turn from
+    a recently idle chat. Synthesizing startup events for these entries caused
+    restart fan-out across unrelated topics; exact shutdown-time markers retain
+    auto-resume, while ``restart_interrupted`` remains pending for re-entry.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="crash-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:crash-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_interrupted",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+    assert pending_entry.resume_pending is True
 
 
 @pytest.mark.asyncio
@@ -634,7 +742,7 @@ async def test_reconnect_reschedule_is_platform_scoped():
         platform=Platform.TELEGRAM,
         chat_type="dm",
         resume_pending=True,
-        resume_reason="restart_interrupted",
+        resume_reason="restart_timeout",
         last_resume_marked_at=datetime.now(),
     )
     discord_entry = SessionEntry(
@@ -646,7 +754,7 @@ async def test_reconnect_reschedule_is_platform_scoped():
         platform=Platform.DISCORD,
         chat_type="dm",
         resume_pending=True,
-        resume_reason="restart_interrupted",
+        resume_reason="restart_timeout",
         last_resume_marked_at=datetime.now(),
     )
     runner.session_store._entries = {
@@ -685,7 +793,7 @@ async def test_startup_restore_waits_for_resume_before_draining_inbound():
         platform=Platform.TELEGRAM,
         chat_type="dm",
         resume_pending=True,
-        resume_reason="restart_interrupted",
+        resume_reason="restart_timeout",
         last_resume_marked_at=datetime.now(),
     )
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
@@ -724,6 +832,45 @@ async def test_startup_restore_waits_for_resume_before_draining_inbound():
     await finish_task
 
     assert seen == ["resume-start", "inbound:hello"]
+    assert runner._startup_restore_queue == []
+    assert runner._startup_restore_in_progress is False
+
+
+@pytest.mark.asyncio
+async def test_startup_restore_rechecks_queue_before_releasing_gate():
+    """An inbound event arriving at drain handoff must not be stranded."""
+    runner, adapter = make_restart_runner()
+    runner._startup_restore_in_progress = True
+    runner._startup_restore_queue = []
+    runner._startup_restore_tasks = []
+
+    late_inbound = MessageEvent(
+        text="late",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(chat_id="restore-chat"),
+    )
+    replayed: list[MessageEvent] = []
+
+    async def fake_handle_message(event: MessageEvent) -> None:
+        replayed.append(event)
+
+    adapter.handle_message = fake_handle_message
+    real_drain = runner._drain_startup_restore_queue
+    injected = False
+
+    async def drain_with_handoff_arrival() -> int:
+        nonlocal injected
+        drained = await real_drain()
+        if not injected:
+            injected = True
+            assert await runner._handle_message(late_inbound) is None
+        return drained
+
+    runner._drain_startup_restore_queue = drain_with_handoff_arrival
+
+    await runner._finish_startup_restore()
+
+    assert replayed == [late_inbound]
     assert runner._startup_restore_queue == []
     assert runner._startup_restore_in_progress is False
 
@@ -845,7 +992,7 @@ async def test_auto_resume_sets_sentinel_before_task_execution():
         platform=Platform.TELEGRAM,
         chat_type="dm",
         resume_pending=True,
-        resume_reason="restart_interrupted",
+        resume_reason="restart_timeout",
         last_resume_marked_at=datetime.now(),
     )
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
@@ -914,7 +1061,7 @@ async def test_auto_resume_runs_agent_exactly_once_through_full_path():
         platform=Platform.TELEGRAM,
         chat_type="dm",
         resume_pending=True,
-        resume_reason="restart_interrupted",
+        resume_reason="restart_timeout",
         last_resume_marked_at=datetime.now(),
     )
     runner.session_store._entries = {session_key: pending_entry}

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -601,21 +601,105 @@ async def test_drain_timeout_keeps_crash_fallback_when_exact_mark_fails(
 
 
 @pytest.mark.asyncio
-async def test_turn_completion_cannot_clear_shutdown_reserved_resume_marker():
-    """Close the completion-clear vs timeout-boundary marking race."""
-    runner, _adapter = make_restart_runner()
+async def test_completed_drain_clears_old_marker_when_pre_mark_raises(
+    tmp_path, monkeypatch
+):
+    """Every reserved session is cleaned after drain, even if pre-mark fails."""
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
     session_key = "agent:main:telegram:dm:A"
+    runner._running_agents = {session_key: MagicMock()}
+
+    async_store = MagicMock()
+    async_store._store = runner.session_store
+    async_store.mark_resume_pending = AsyncMock(side_effect=OSError("mark blocked"))
+    async_store.clear_resume_pending = AsyncMock(return_value=True)
+    runner._async_session_store = async_store
+
+    async def finish_during_drain(_timeout):
+        runner._running_agents.pop(session_key)
+        return {}, False
+
+    with patch(
+        "gateway.run.GatewayRunner._drain_active_agents",
+        side_effect=finish_during_drain,
+    ), patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop()
+
+    async_store.mark_resume_pending.assert_awaited_once_with(
+        session_key, "shutdown_timeout"
+    )
+    async_store.clear_resume_pending.assert_awaited_once_with(session_key)
+    assert session_key not in runner._shutdown_resume_pending_keys
+
+
+@pytest.mark.asyncio
+async def test_delayed_old_clear_cannot_delete_newer_shutdown_marker(
+    tmp_path, monkeypatch
+):
+    """Exercise the production completion-clear vs shutdown pre-mark race."""
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    session_key = "agent:main:telegram:dm:A"
+    runner._running_agents = {session_key: MagicMock()}
+
+    pending = False
+    ordering: list[str] = []
+    clear_entered = asyncio.Event()
+    release_clear = asyncio.Event()
+
     session_store = MagicMock()
-    session_store.clear_resume_pending = MagicMock(return_value=True)
     runner.session_store = session_store
-    runner._shutdown_resume_pending_keys = {session_key}
 
-    await runner._clear_resume_pending_after_success(session_key)
-    session_store.clear_resume_pending.assert_not_called()
+    async def delayed_old_clear(key: str) -> bool:
+        nonlocal pending
+        assert key == session_key
+        ordering.append("clear-enter")
+        clear_entered.set()
+        await release_clear.wait()
+        pending = False
+        ordering.append("clear-finish")
+        return True
 
-    runner._shutdown_resume_pending_keys.clear()
-    await runner._clear_resume_pending_after_success(session_key)
-    session_store.clear_resume_pending.assert_called_once_with(session_key)
+    async def mark_new_shutdown(key: str, reason: str) -> bool:
+        nonlocal pending
+        assert key == session_key
+        assert reason == "shutdown_timeout"
+        pending = True
+        ordering.append("mark")
+        return True
+
+    async_store = MagicMock()
+    async_store._store = session_store
+    async_store.clear_resume_pending = AsyncMock(side_effect=delayed_old_clear)
+    async_store.mark_resume_pending = AsyncMock(side_effect=mark_new_shutdown)
+    runner._async_session_store = async_store
+
+    old_clear = asyncio.create_task(
+        runner._clear_resume_pending_after_success(session_key)
+    )
+    await clear_entered.wait()
+
+    with patch(
+        "gateway.run.GatewayRunner._drain_active_agents",
+        new_callable=AsyncMock,
+        return_value=({session_key: runner._running_agents[session_key]}, True),
+    ), patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        stopping = asyncio.create_task(runner.stop())
+        await asyncio.sleep(0)
+        assert ordering == ["clear-enter"]
+        release_clear.set()
+        await old_clear
+        await stopping
+
+    assert pending is True
+    assert ordering == ["clear-enter", "clear-finish", "mark", "mark"]
 
 
 # ---------------------------------------------------------------------------
@@ -624,13 +708,13 @@ async def test_turn_completion_cannot_clear_shutdown_reserved_resume_marker():
 
 
 @pytest.mark.asyncio
-async def test_clean_shutdown_suppresses_stale_exact_resume_marker():
-    """A failed centralized clear cannot replay a turn that drained cleanly."""
+async def test_clean_shutdown_preserves_older_exact_marker_until_adapter_returns():
+    """Clean proof suppresses heuristics, not exact markers from older drains."""
     runner, adapter = make_restart_runner()
     runner._previous_shutdown_clean = True
-    source = make_restart_source(chat_id="completed-chat")
+    source = make_restart_source(chat_id="older-interrupted-chat")
     pending_entry = SessionEntry(
-        session_key="agent:main:telegram:dm:completed-chat",
+        session_key="agent:main:telegram:dm:older-interrupted-chat",
         session_id="sid",
         created_at=datetime.now(),
         updated_at=datetime.now(),
@@ -639,15 +723,23 @@ async def test_clean_shutdown_suppresses_stale_exact_resume_marker():
         chat_type="dm",
         resume_pending=True,
         resume_reason="shutdown_timeout",
-        last_resume_marked_at=datetime.now(),
+        last_resume_marked_at=datetime.now() - timedelta(minutes=5),
     )
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
     adapter.handle_message = AsyncMock()
+    runner.adapters = {}
+    runner._startup_restore_in_progress = True
+    runner._startup_restore_tasks = []
 
     assert runner._schedule_resume_pending_sessions() == 0
     await asyncio.sleep(0)
     adapter.handle_message.assert_not_called()
     assert pending_entry.resume_pending is True
+
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    assert runner._schedule_resume_pending_sessions(Platform.TELEGRAM) == 1
+    await asyncio.gather(*runner._startup_restore_tasks)
+    adapter.handle_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -232,6 +232,208 @@ class TestClearResumePending:
         # Not marked
         assert store.clear_resume_pending(entry.session_key) is False
 
+    def test_stale_db_mirror_exact_marker_is_inbound_only_on_json_fallback(
+        self, tmp_path
+    ):
+        store = _make_store(tmp_path)
+        source = _make_source(chat_id="stale-clear-mirror")
+        entry = store.get_or_create_session(source)
+        assert store.mark_resume_pending(entry.session_key, "shutdown_timeout") is True
+
+        store._save_sessions_json = MagicMock(
+            side_effect=OSError("legacy mirror unavailable")
+        )
+        assert store.clear_resume_pending(entry.session_key) is True
+        store._db.close()
+
+        fallback = SessionStore(
+            sessions_dir=tmp_path,
+            config=GatewayConfig(),
+        )
+        fallback._db = None
+        recovered = next(
+            candidate
+            for candidate in fallback.list_sessions()
+            if candidate.session_key == entry.session_key
+        )
+        assert recovered.resume_pending is True
+        assert recovered.resume_reason == "restart_interrupted"
+
+
+class TestDowngradeUntrustedExactResumePending:
+    @pytest.mark.asyncio
+    async def test_unclean_exact_marker_cannot_reenable_after_later_clean_boot(
+        self, tmp_path
+    ):
+        store = _make_store(tmp_path)
+        source = _make_source(chat_id="ambiguous")
+        entry = store.get_or_create_session(source)
+        assert store.mark_resume_pending(entry.session_key, "shutdown_timeout") is True
+
+        assert store.downgrade_untrusted_exact_resume_pending() == 1
+        assert entry.resume_reason == "restart_interrupted"
+
+        # Simulate a later, unrelated clean predecessor: the downgrade is
+        # persistent state, so clean proof cannot make this marker exact again.
+        runner, adapter = make_restart_runner()
+        runner._previous_shutdown_clean = True
+        runner.session_store = store
+        runner.adapters = {Platform.TELEGRAM: adapter}
+        adapter.handle_message = AsyncMock()
+
+        assert runner._schedule_resume_pending_sessions() == 0
+        await asyncio.sleep(0)
+        adapter.handle_message.assert_not_called()
+        assert entry.resume_pending is True
+        assert entry.resume_reason == "restart_interrupted"
+
+    def test_db_failure_propagates_even_when_json_mirror_succeeds(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source(chat_id="ambiguous-db")
+        entry = store.get_or_create_session(source)
+        assert store.mark_resume_pending(entry.session_key, "restart_timeout") is True
+
+        real_replace = store._db.replace_gateway_routing_entries
+        store._db.replace_gateway_routing_entries = MagicMock(
+            side_effect=OSError("db write blocked")
+        )
+
+        with pytest.raises(
+            RuntimeError, match="authoritative state.db routing save failed"
+        ):
+            store.downgrade_untrusted_exact_resume_pending()
+
+        assert entry.resume_reason == "restart_timeout"
+
+        # A reboot with state.db still loads the exact authoritative reason.
+        # If the next boot instead falls back to the legacy mirror, exact state
+        # is deliberately downgraded to inbound-only: the mirror is tagged as
+        # non-authoritative for exact crash recovery.
+        reloaded_store = _make_store(tmp_path)
+        reloaded = next(
+            candidate
+            for candidate in reloaded_store.list_sessions()
+            if candidate.session_key == entry.session_key
+        )
+        assert reloaded.resume_reason == "restart_timeout"
+
+        json_only_store = SessionStore(
+            sessions_dir=tmp_path,
+            config=GatewayConfig(),
+        )
+        json_only_store._db = None
+        json_only = next(
+            candidate
+            for candidate in json_only_store.list_sessions()
+            if candidate.session_key == entry.session_key
+        )
+        assert json_only.resume_reason == "restart_interrupted"
+
+        store._db.replace_gateway_routing_entries = real_replace
+        assert store.downgrade_untrusted_exact_resume_pending() == 1
+        assert entry.resume_reason == "restart_interrupted"
+
+    def test_json_only_store_is_authoritative_for_exact_downgrade(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source(chat_id="ambiguous-no-db")
+        entry = store.get_or_create_session(source)
+        assert store.mark_resume_pending(entry.session_key, "shutdown_timeout") is True
+        store._db = None
+
+        assert store.downgrade_untrusted_exact_resume_pending() == 1
+        assert entry.resume_reason == "restart_interrupted"
+
+        reloaded_store = SessionStore(
+            sessions_dir=tmp_path,
+            config=GatewayConfig(),
+        )
+        reloaded_store._db = None
+        reloaded = next(
+            candidate
+            for candidate in reloaded_store.list_sessions()
+            if candidate.session_key == entry.session_key
+        )
+        assert reloaded.resume_reason == "restart_interrupted"
+
+    def test_json_only_timeout_mark_and_clear_round_trip(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source(chat_id="json-only-timeout")
+        entry = store.get_or_create_session(source)
+        store._db = None
+
+        assert store.mark_resume_pending(entry.session_key, "shutdown_timeout") is True
+        assert entry.resume_pending is True
+        assert store.clear_resume_pending(entry.session_key) is True
+
+        reloaded_store = SessionStore(
+            sessions_dir=tmp_path,
+            config=GatewayConfig(),
+        )
+        reloaded_store._db = None
+        reloaded = next(
+            candidate
+            for candidate in reloaded_store.list_sessions()
+            if candidate.session_key == entry.session_key
+        )
+        assert reloaded.resume_pending is False
+        assert reloaded.resume_reason is None
+
+    def test_exact_mark_db_failure_propagates_and_db_remains_unmarked(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source(chat_id="exact-mark-db")
+        entry = store.get_or_create_session(source)
+        store._db.replace_gateway_routing_entries = MagicMock(
+            side_effect=OSError("db write blocked")
+        )
+
+        with pytest.raises(
+            RuntimeError, match="authoritative state.db routing save failed"
+        ):
+            store.mark_resume_pending(entry.session_key, "restart_timeout")
+
+        assert entry.resume_pending is False
+        assert entry.resume_reason is None
+
+        reloaded_store = _make_store(tmp_path)
+        reloaded = next(
+            candidate
+            for candidate in reloaded_store.list_sessions()
+            if candidate.session_key == entry.session_key
+        )
+        assert reloaded.resume_pending is False
+        assert reloaded.resume_reason is None
+
+    @pytest.mark.parametrize(
+        "reason", ["restart_timeout", "active_turn_interrupted"]
+    )
+    def test_exact_clear_db_failure_propagates_and_db_retains_marker(
+        self, tmp_path, reason
+    ):
+        store = _make_store(tmp_path)
+        source = _make_source(chat_id="exact-clear-db")
+        entry = store.get_or_create_session(source)
+        assert store.mark_resume_pending(entry.session_key, reason) is True
+        store._db.replace_gateway_routing_entries = MagicMock(
+            side_effect=OSError("db write blocked")
+        )
+
+        with pytest.raises(
+            RuntimeError, match="authoritative state.db routing save failed"
+        ):
+            store.clear_resume_pending(entry.session_key)
+
+        assert entry.resume_pending is True
+        assert entry.resume_reason == reason
+
+        reloaded_store = _make_store(tmp_path)
+        reloaded = next(
+            candidate
+            for candidate in reloaded_store.list_sessions()
+            if candidate.session_key == entry.session_key
+        )
+        assert reloaded.resume_pending is True
+        assert reloaded.resume_reason == reason
+
 
 # ---------------------------------------------------------------------------
 # SessionStore.get_or_create_session resume_pending behaviour
@@ -570,8 +772,8 @@ async def test_drain_timeout_marks_resume_pending(tmp_path, monkeypatch):
     assert marked == {session_key_one, session_key_two}
     for args in calls:
         assert args[0][1] == "shutdown_timeout"
-    assert not (tmp_path / ".clean_shutdown").exists(), (
-        "interrupted chats rely on exact markers, not a clean-shutdown claim"
+    assert (tmp_path / ".clean_shutdown").exists(), (
+        "complete exact markers must suppress broad recent-session inference"
     )
 
 
@@ -634,6 +836,126 @@ async def test_completed_drain_clears_old_marker_when_pre_mark_raises(
     )
     async_store.clear_resume_pending.assert_awaited_once_with(session_key)
     assert session_key not in runner._shutdown_resume_pending_keys
+
+
+@pytest.mark.asyncio
+async def test_completed_drain_clear_failure_keeps_crash_fallback(
+    tmp_path, monkeypatch
+):
+    """Uncertain cleanup must not make a stale exact marker auto-dispatchable."""
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    session_key = "agent:main:telegram:dm:A"
+    runner._running_agents = {session_key: MagicMock()}
+
+    async_store = MagicMock()
+    async_store._store = runner.session_store
+    async_store.mark_resume_pending = AsyncMock(return_value=True)
+    async_store.clear_resume_pending = AsyncMock(
+        side_effect=OSError("clear blocked")
+    )
+    runner._async_session_store = async_store
+
+    async def finish_during_drain(_timeout):
+        runner._running_agents.pop(session_key)
+        return {}, False
+
+    with patch(
+        "gateway.run.GatewayRunner._drain_active_agents",
+        side_effect=finish_during_drain,
+    ), patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop()
+
+    async_store.clear_resume_pending.assert_awaited_once_with(session_key)
+    assert not (tmp_path / ".clean_shutdown").exists(), (
+        "without clean proof, startup heuristics defer stale exact recovery "
+        "until a real inbound message"
+    )
+
+    source = make_restart_source(chat_id="A")
+    pending_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="shutdown_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {session_key: pending_entry}
+    runner._previous_shutdown_clean = False
+    adapter.handle_message = AsyncMock()
+
+    assert runner._schedule_resume_pending_sessions() == 0
+    await asyncio.sleep(0)
+    adapter.handle_message.assert_not_called()
+    assert pending_entry.resume_pending is True
+
+
+@pytest.mark.asyncio
+async def test_turn_finishing_during_timeout_remark_is_cleared(
+    tmp_path, monkeypatch
+):
+    """A turn finishing during the final mark must not retain exact recovery."""
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    session_key = "agent:main:telegram:dm:A"
+    running_agent = MagicMock()
+    runner._running_agents = {session_key: running_agent}
+
+    mark_calls = 0
+
+    async def mark_then_finish(key: str, reason: str) -> bool:
+        nonlocal mark_calls
+        assert key == session_key
+        assert reason == "shutdown_timeout"
+        mark_calls += 1
+        if mark_calls == 2:
+            runner._running_agents.pop(session_key)
+        return True
+
+    async_store = MagicMock()
+    async_store._store = runner.session_store
+    async_store.mark_resume_pending = AsyncMock(side_effect=mark_then_finish)
+    async_store.clear_resume_pending = AsyncMock(return_value=True)
+    runner._async_session_store = async_store
+
+    with patch(
+        "gateway.run.GatewayRunner._drain_active_agents",
+        new_callable=AsyncMock,
+        return_value=({session_key: running_agent}, True),
+    ), patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop()
+
+    assert mark_calls == 2
+    async_store.clear_resume_pending.assert_awaited_once_with(session_key)
+    assert session_key not in runner._shutdown_resume_pending_keys
+    assert (tmp_path / ".clean_shutdown").exists()
+
+
+@pytest.mark.asyncio
+async def test_runtime_exact_clear_failure_blocks_future_clean_proof():
+    runner, _adapter = make_restart_runner()
+    session_key = "agent:main:telegram:dm:A"
+    async_store = MagicMock()
+    async_store._store = runner.session_store
+    async_store.clear_resume_pending = AsyncMock(
+        side_effect=RuntimeError("authoritative state.db routing save failed")
+    )
+    runner._async_session_store = async_store
+
+    await runner._clear_resume_pending_after_success(session_key)
+
+    assert runner._clean_shutdown_marker_blocked is True
 
 
 @pytest.mark.asyncio
@@ -774,6 +1096,35 @@ async def test_startup_auto_resume_defers_heuristic_crash_recovery():
     assert scheduled == 0
     adapter.handle_message.assert_not_called()
     assert pending_entry.resume_pending is True
+
+
+@pytest.mark.asyncio
+async def test_unclean_start_auto_resumes_exact_active_turn_only():
+    """Exact durable crash evidence remains auto-dispatchable without clean proof."""
+    runner, adapter = make_restart_runner()
+    runner._previous_shutdown_clean = False
+    source = make_restart_source(chat_id="exact-crash-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:exact-crash-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="active_turn_interrupted",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    adapter.handle_message = AsyncMock()
+    runner._startup_restore_in_progress = True
+    runner._startup_restore_tasks = []
+
+    assert runner._schedule_resume_pending_sessions() == 1
+    await asyncio.gather(*runner._startup_restore_tasks)
+
+    adapter.handle_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -233,6 +233,119 @@ class TestClearResumePending:
         assert store.clear_resume_pending(entry.session_key) is False
 
 
+class TestDowngradeUntrustedExactResumePending:
+    @pytest.mark.asyncio
+    async def test_unclean_exact_marker_cannot_reenable_after_later_clean_boot(
+        self, tmp_path
+    ):
+        store = _make_store(tmp_path)
+        source = _make_source(chat_id="ambiguous")
+        entry = store.get_or_create_session(source)
+        assert store.mark_resume_pending(entry.session_key, "shutdown_timeout") is True
+
+        assert store.downgrade_untrusted_exact_resume_pending() == 1
+        assert entry.resume_reason == "restart_interrupted"
+
+        # Simulate a later, unrelated clean predecessor: the downgrade is
+        # persistent state, so clean proof cannot make this marker exact again.
+        runner, adapter = make_restart_runner()
+        runner._previous_shutdown_clean = True
+        runner.session_store = store
+        runner.adapters = {Platform.TELEGRAM: adapter}
+        adapter.handle_message = AsyncMock()
+
+        assert runner._schedule_resume_pending_sessions() == 0
+        await asyncio.sleep(0)
+        adapter.handle_message.assert_not_called()
+        assert entry.resume_pending is True
+        assert entry.resume_reason == "restart_interrupted"
+
+    def test_db_failure_propagates_even_when_json_mirror_succeeds(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source(chat_id="ambiguous-db")
+        entry = store.get_or_create_session(source)
+        assert store.mark_resume_pending(entry.session_key, "restart_timeout") is True
+
+        store._db.replace_gateway_routing_entries = MagicMock(
+            side_effect=OSError("db write blocked")
+        )
+
+        with pytest.raises(
+            RuntimeError, match="authoritative state.db routing save failed"
+        ):
+            store.downgrade_untrusted_exact_resume_pending()
+
+        assert entry.resume_reason == "restart_interrupted"
+
+        # A reboot still loads the stale exact reason from authoritative state.db,
+        # not the successfully updated JSON mirror. The propagated failure is what
+        # lets gateway startup taint this lifecycle and suppress new clean proof.
+        reloaded_store = _make_store(tmp_path)
+        reloaded = next(
+            candidate
+            for candidate in reloaded_store.list_sessions()
+            if candidate.session_key == entry.session_key
+        )
+        assert reloaded.resume_reason == "restart_timeout"
+
+    def test_missing_authoritative_db_fails_exact_downgrade(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source(chat_id="ambiguous-no-db")
+        entry = store.get_or_create_session(source)
+        assert store.mark_resume_pending(entry.session_key, "shutdown_timeout") is True
+        store._db = None
+
+        with pytest.raises(
+            RuntimeError, match="authoritative state.db routing save failed"
+        ):
+            store.downgrade_untrusted_exact_resume_pending()
+
+    def test_exact_mark_db_failure_propagates_and_db_remains_unmarked(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source(chat_id="exact-mark-db")
+        entry = store.get_or_create_session(source)
+        store._db.replace_gateway_routing_entries = MagicMock(
+            side_effect=OSError("db write blocked")
+        )
+
+        with pytest.raises(
+            RuntimeError, match="authoritative state.db routing save failed"
+        ):
+            store.mark_resume_pending(entry.session_key, "restart_timeout")
+
+        reloaded_store = _make_store(tmp_path)
+        reloaded = next(
+            candidate
+            for candidate in reloaded_store.list_sessions()
+            if candidate.session_key == entry.session_key
+        )
+        assert reloaded.resume_pending is False
+        assert reloaded.resume_reason is None
+
+    def test_exact_clear_db_failure_propagates_and_db_retains_marker(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source(chat_id="exact-clear-db")
+        entry = store.get_or_create_session(source)
+        assert store.mark_resume_pending(entry.session_key, "restart_timeout") is True
+        store._db.replace_gateway_routing_entries = MagicMock(
+            side_effect=OSError("db write blocked")
+        )
+
+        with pytest.raises(
+            RuntimeError, match="authoritative state.db routing save failed"
+        ):
+            store.clear_resume_pending(entry.session_key)
+
+        reloaded_store = _make_store(tmp_path)
+        reloaded = next(
+            candidate
+            for candidate in reloaded_store.list_sessions()
+            if candidate.session_key == entry.session_key
+        )
+        assert reloaded.resume_pending is True
+        assert reloaded.resume_reason == "restart_timeout"
+
+
 # ---------------------------------------------------------------------------
 # SessionStore.get_or_create_session resume_pending behaviour
 # ---------------------------------------------------------------------------
@@ -570,8 +683,8 @@ async def test_drain_timeout_marks_resume_pending(tmp_path, monkeypatch):
     assert marked == {session_key_one, session_key_two}
     for args in calls:
         assert args[0][1] == "shutdown_timeout"
-    assert not (tmp_path / ".clean_shutdown").exists(), (
-        "interrupted chats rely on exact markers, not a clean-shutdown claim"
+    assert (tmp_path / ".clean_shutdown").exists(), (
+        "complete exact markers must suppress broad recent-session inference"
     )
 
 
@@ -634,6 +747,126 @@ async def test_completed_drain_clears_old_marker_when_pre_mark_raises(
     )
     async_store.clear_resume_pending.assert_awaited_once_with(session_key)
     assert session_key not in runner._shutdown_resume_pending_keys
+
+
+@pytest.mark.asyncio
+async def test_completed_drain_clear_failure_keeps_crash_fallback(
+    tmp_path, monkeypatch
+):
+    """Uncertain cleanup must not make a stale exact marker auto-dispatchable."""
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    session_key = "agent:main:telegram:dm:A"
+    runner._running_agents = {session_key: MagicMock()}
+
+    async_store = MagicMock()
+    async_store._store = runner.session_store
+    async_store.mark_resume_pending = AsyncMock(return_value=True)
+    async_store.clear_resume_pending = AsyncMock(
+        side_effect=OSError("clear blocked")
+    )
+    runner._async_session_store = async_store
+
+    async def finish_during_drain(_timeout):
+        runner._running_agents.pop(session_key)
+        return {}, False
+
+    with patch(
+        "gateway.run.GatewayRunner._drain_active_agents",
+        side_effect=finish_during_drain,
+    ), patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop()
+
+    async_store.clear_resume_pending.assert_awaited_once_with(session_key)
+    assert not (tmp_path / ".clean_shutdown").exists(), (
+        "without clean proof, startup heuristics defer stale exact recovery "
+        "until a real inbound message"
+    )
+
+    source = make_restart_source(chat_id="A")
+    pending_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="shutdown_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {session_key: pending_entry}
+    runner._previous_shutdown_clean = False
+    adapter.handle_message = AsyncMock()
+
+    assert runner._schedule_resume_pending_sessions() == 0
+    await asyncio.sleep(0)
+    adapter.handle_message.assert_not_called()
+    assert pending_entry.resume_pending is True
+
+
+@pytest.mark.asyncio
+async def test_turn_finishing_during_timeout_remark_is_cleared(
+    tmp_path, monkeypatch
+):
+    """A turn finishing during the final mark must not retain exact recovery."""
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    session_key = "agent:main:telegram:dm:A"
+    running_agent = MagicMock()
+    runner._running_agents = {session_key: running_agent}
+
+    mark_calls = 0
+
+    async def mark_then_finish(key: str, reason: str) -> bool:
+        nonlocal mark_calls
+        assert key == session_key
+        assert reason == "shutdown_timeout"
+        mark_calls += 1
+        if mark_calls == 2:
+            runner._running_agents.pop(session_key)
+        return True
+
+    async_store = MagicMock()
+    async_store._store = runner.session_store
+    async_store.mark_resume_pending = AsyncMock(side_effect=mark_then_finish)
+    async_store.clear_resume_pending = AsyncMock(return_value=True)
+    runner._async_session_store = async_store
+
+    with patch(
+        "gateway.run.GatewayRunner._drain_active_agents",
+        new_callable=AsyncMock,
+        return_value=({session_key: running_agent}, True),
+    ), patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop()
+
+    assert mark_calls == 2
+    async_store.clear_resume_pending.assert_awaited_once_with(session_key)
+    assert session_key not in runner._shutdown_resume_pending_keys
+    assert (tmp_path / ".clean_shutdown").exists()
+
+
+@pytest.mark.asyncio
+async def test_runtime_exact_clear_failure_blocks_future_clean_proof():
+    runner, _adapter = make_restart_runner()
+    session_key = "agent:main:telegram:dm:A"
+    async_store = MagicMock()
+    async_store._store = runner.session_store
+    async_store.clear_resume_pending = AsyncMock(
+        side_effect=RuntimeError("authoritative state.db routing save failed")
+    )
+    runner._async_session_store = async_store
+
+    await runner._clear_resume_pending_after_success(session_key)
+
+    assert runner._clean_shutdown_marker_blocked is True
 
 
 @pytest.mark.asyncio

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -722,15 +722,17 @@ Set `typing_indicator: false` on any platform where the indicator is unwanted. S
 
 ### Session resume across gateway restarts
 
-When the gateway shuts down with an in-flight tool call or generation, the affected sessions are flagged as `restart_interrupted`. On the next startup, the gateway schedules an auto-resume for each one — the user gets a short heads-up in the chat ("Send any message after restart and I'll try to resume where you left off.") and the session picks up from the last committed turn when they reply.
+Before a planned gateway shutdown drains in-flight tool calls or generations, the gateway attempts to give each affected session an exact `restart_timeout` or `shutdown_timeout` marker. Markers for turns that finish during the drain are cleared, while markers for turns that are still interrupted remain. When that exact state and the predecessor's clean proof are both durable, the next startup schedules a synthetic recovery turn for each remaining exact marker. If clean proof is absent, exact markers are persistently downgraded and recovery conservatively waits for the user's next real inbound message; a later clean restart cannot re-enable synthetic dispatch for them.
 
-This behaviour is on by default and is logged at gateway start:
+After an unexpected exit, a fresh durable active-turn token is exact crash evidence and can schedule a synthetic recovery turn even without clean-shutdown proof. For older sessions without that token, the gateway may instead apply the heuristic `restart_interrupted` marker based on recent activity. Heuristic sessions are not auto-dispatched at startup; recovery waits for the user's next real inbound message. This avoids sending blank recovery turns to unrelated idle chats while preserving exact interrupted work.
+
+Exact-marker auto-resume is on by default and is logged at gateway start:
 
 ```
-Scheduled auto-resume for N restart-interrupted session(s)
+Scheduled auto-resume for N exactly marked session(s)
 ```
 
-No configuration is required. If you don't want the heads-up, set `gateway_restart_notification: false` on the platform.
+No configuration is required.
 
 ### Mobile-friendly progress defaults
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -721,15 +721,17 @@ Set `typing_indicator: false` on any platform where the indicator is unwanted. S
 
 ### Session resume across gateway restarts
 
-When the gateway shuts down with an in-flight tool call or generation, the affected sessions are flagged as `restart_interrupted`. On the next startup, the gateway schedules an auto-resume for each one — the user gets a short heads-up in the chat ("Send any message after restart and I'll try to resume where you left off.") and the session picks up from the last committed turn when they reply.
+Before a planned gateway shutdown drains in-flight tool calls or generations, the gateway attempts to give each affected session an exact `restart_timeout` or `shutdown_timeout` marker. Markers for turns that finish during the drain are cleared, while markers for turns that are still interrupted remain. When that exact state and the predecessor's clean proof are both durable, the next startup schedules a synthetic recovery turn for each remaining exact marker. If clean proof is absent, exact markers are persistently downgraded and recovery conservatively waits for the user's next real inbound message; a later clean restart cannot re-enable synthetic dispatch for them.
 
-This behaviour is on by default and is logged at gateway start:
+After an unexpected exit, the gateway may instead apply the heuristic `restart_interrupted` marker to recently active sessions. Those sessions are not auto-dispatched at startup; recovery waits for the user's next real inbound message. This avoids sending blank recovery turns to unrelated idle chats while still preserving the interrupted conversation.
+
+Exact-marker auto-resume is on by default and is logged at gateway start:
 
 ```
-Scheduled auto-resume for N restart-interrupted session(s)
+Scheduled auto-resume for N exactly marked session(s)
 ```
 
-No configuration is required. If you don't want the heads-up, set `gateway_restart_notification: false` on the platform.
+No configuration is required.
 
 ### Mobile-friendly progress defaults
 


### PR DESCRIPTION
## Summary

- persist the one-shot clean-shutdown marker immediately after a successful conversational drain, before slower teardown
- consume that proof immediately after PID/runtime-lock ownership so a failed startup cannot lend the previous process's clean status to a later boot
- preserve exact recovery for sessions interrupted by `restart_timeout` or `shutdown_timeout`, including older exact markers whose adapter was unavailable during an intervening clean process
- defer heuristic `restart_interrupted` recovery until genuine inbound user activity instead of emitting startup turns
- serialize successful-turn recovery clears with shutdown reservation/marking so an older clear cannot delete a newer interruption marker
- clear stale pre-drain recovery state when a chat finishes, including when unrelated cron/API work later times out
- add lifecycle and fan-out regressions for marker consumption, timeout classification, startup failure, mixed exact/heuristic recovery, and clear-versus-mark ordering

## Problem

A gateway could drain conversational work successfully and then be terminated during slower teardown before writing `.clean_shutdown`. The next startup treated the missing marker as evidence of a crash, heuristically marked recently active but idle sessions as `restart_interrupted`, and injected blank synthetic startup turns across unrelated topics.

Two adjacent lifecycle races mattered as well:

- startup previously consumed the marker only after substantial fallible initialization, allowing a failed startup to leave the predecessor's proof reusable;
- a successful turn's asynchronous recovery-state clear could race shutdown's durable interruption mark and delete the newer marker.

## Recovery policy

A known drain timeout identifies actual interrupted work and can justify intentional continuation. A generic crash heuristic cannot prove that a user turn was interrupted, so it preserves the session for the next real inbound message without automatically emitting user-visible startup output.

Clean proof applies only to the immediate predecessor's heuristic crash classification. It does not blanket-suppress older exact timeout evidence. Shutdown reservation and recovery-state persistence are serialized per session so successful completion and interruption marking have a defined order.

The marker remains one-shot. A later clean drain replaces any stale invalidation tombstone, and chats that finish during the drain window have their pre-drain recovery markers cleared even if only cron or API work remains at timeout.

## Testing

Fresh verification on the exact refreshed head:

- `.venv/bin/python -m py_compile gateway/run.py gateway/session_state.py tests/gateway/test_clean_shutdown_marker.py tests/gateway/test_restart_resume_pending.py`
- `.venv/bin/ruff check gateway/run.py gateway/session_state.py tests/gateway/test_clean_shutdown_marker.py tests/gateway/test_restart_resume_pending.py`
- focused/relevant startup, shutdown, restart, and SessionState cluster: **119 passed**
- `git diff --check upstream/main...HEAD`
- exact cumulative-head independent review: **PASS**

The focused cluster includes deterministic regressions for startup failure after lock ownership, post-rename marker inspection failure, fail-closed marker invalidation, mixed clean proof plus older exact recovery, failed pre-drain marking followed by successful completion, delayed successful-turn clear versus newer shutdown marking, generic-crash fan-out suppression, drain completion cleanup, and one-shot marker invalidation.

## Platform notes

Validated on Linux. Marker timing and startup recovery classification are supervisor-independent and do not introduce platform-specific APIs.

## AI Assistance

The implementation, regression tests, and analysis were prepared with AI agents.

Related to #25966