### PR TITLE
fix(models): allow reasoning effort for grok-composer-*

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -389,6 +389,12 @@ _GROK_EFFORT_CAPABLE_PREFIXES = (
     # "none" ("This model does not support `reasoning_effort` value `none`"),
     # unlike grok-4.3. models.dev agrees: effort values [low, medium, high].
     "grok-4.5",
+    # grok-composer-2.5-fast: OAuth-only slug via Grok Build CLI
+    # (xai-oauth). Without this prefix, grok_supports_reasoning_effort()
+    # is False and transports omit the reasoning key entirely (silent
+    # zero-effort). Effort value set is still model-side; if a level
+    # 400s, narrow accepted values rather than dropping the prefix.
+    "grok-composer",
 )
 
 


### PR DESCRIPTION
## Summary
- Add `grok-composer` to `_GROK_EFFORT_CAPABLE_PREFIXES` so `grok-composer-2.5-fast` receives a reasoning effort dial instead of silent omission.

## Symptom
For `grok-composer-2.5-fast` via xai-oauth, `grok_supports_reasoning_effort()` was False → transport sent no `reasoning` key (zero explicit effort), despite config `reasoning_overrides`.

## Test plan
- [x] `python -c "from agent.model_metadata import grok_supports_reasoning_effort as g; assert g('grok-composer-2.5-fast')"`
- [x] Live smoke: `hermes chat -q "reply with exactly: composer-effort-ok" -m grok-composer-2.5-fast --provider xai-oauth` → marker returned, no HTTP 400 on effort=high
- [ ] Maintainer: confirm xAI accepts effort high/medium/low for this slug (values may still be model-constrained)