### PR TITLE
fix: skip binary .ost/.pst files in search_files to prevent EDR alerts

### DIFF
--- a/tools/binary_extensions.py
+++ b/tools/binary_extensions.py
@@ -31,6 +31,8 @@ BINARY_EXTENSIONS = frozenset({
     ".swf", ".fla",
     # Lock/profiling data
     ".lockb", ".dat", ".data",
+    # Mail store
+    ".ost", ".pst",
 })
 
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2398,6 +2398,8 @@ class ShellFileOperations(FileOperations):
         # Exclude hidden directories (matching ripgrep's default behavior).
         # This prevents searching inside .hub/index-cache/, .git/, etc.
         cmd_parts.append("--exclude-dir='.*'")
+        # Skip binary files entirely — don't even open them to check.
+        cmd_parts.append("-I")
         
         # Add context if requested
         if context > 0:


### PR DESCRIPTION
## Summary

When `search_files` runs without a `file_glob` filter, it scans all files in the target path — including Outlook `.ost` / `.pst` mail store files. EDR (Endpoint Detection and Response) heuristics flag `grep`/`rg` accessing these files as *"possible theft of passwords and emails"*, producing false positive alerts.

## Changes

1. **`tools/binary_extensions.py`** — Added `.ost` and `.pst` to `BINARY_EXTENSIONS` so the Python-level code skips these files before invoking `rg`/`grep`.

2. **`tools/file_operations.py`** — Added `-I` (`--binary-files=without-match`) to the grep fallback command. BSD grep (macOS) does not support the long form, so `-I` is used for cross-platform compatibility.

## Root Cause

`.ost` (Outlook Offline Storage Table) and `.pst` (Personal Storage Table) are ESE database files containing cached email, calendar, and contact data. They were not in the binary extension skip list, and the grep fallback had no `--binary-files=without-match` flag, so `search_files` would open and read them.

## Verification

- `rg` (ripgrep) is the primary search engine and skips binary files by default — this fix covers the extension-based pre-filter and the grep fallback path.
- `-I` is supported by both GNU grep (Linux, Windows git-bash) and BSD grep (macOS).

Closes: N/A (found via local EDR alert)