### PR TITLE
fix(auxiliary): generic retry stripping reasoning param on 400 + gateway is_reconnect tolerance

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7196,6 +7196,53 @@ def call_llm(
                     raise
                 first_err = retry_err
 
+        # ── reasoning param compatibility retry (generic) ─────────────
+        # Many strict OpenAI-compatible endpoints (OpenAI Chat Completions,
+        # Azure, Meta's Llama API, custom proxies, etc.) reject the optional
+        # ``extra_body.reasoning`` control with 400 unknown/unsupported
+        # parameter. Title generation injects it to suppress thinking, but it
+        # is not required for correctness — stripping it and retrying once
+        # recovers a working title instead of falling back to the first-words
+        # heuristic. This generic retry is the safety net; the per-route
+        # allowlist in WebUI's _route_rejects_reasoning_extra is only an
+        # optimization to avoid the extra RTT for known-bad routes.
+        #
+        # Mirrors the existing temperature / max_tokens retry pattern above.
+        eb_for_reasoning_retry = kwargs.get("extra_body")
+        if (
+            isinstance(eb_for_reasoning_retry, dict)
+            and "reasoning" in eb_for_reasoning_retry
+            and _is_unsupported_parameter_error(first_err, "reasoning")
+        ):
+            retry_kwargs = dict(kwargs)
+            retry_eb = dict(eb_for_reasoning_retry)
+            retry_eb.pop("reasoning", None)
+            if retry_eb:
+                retry_kwargs["extra_body"] = retry_eb
+            else:
+                retry_kwargs.pop("extra_body", None)
+            logger.info(
+                "Auxiliary %s: provider rejected reasoning param; retrying without it",
+                task or "call",
+            )
+            try:
+                return _validate_llm_response(
+                    client.chat.completions.create(**retry_kwargs), task
+                )
+            except Exception as retry_err:
+                retry_err_str = str(retry_err)
+                if not (
+                    _is_payment_error(retry_err)
+                    or _is_connection_error(retry_err)
+                    or _is_auth_error(retry_err)
+                    or _is_rate_limit_error(retry_err)
+                    or "max_tokens" in retry_err_str
+                    or "unsupported_parameter" in retry_err_str
+                ):
+                    raise
+                first_err = retry_err
+                kwargs = retry_kwargs
+
         # ── Stale-model self-heal (Nous Portal recommendation drift) ───
         # A long-lived process can pin a Portal-recommended model that has
         # since been dropped from the Nous → OpenRouter catalog, so every
@@ -7759,6 +7806,44 @@ async def async_call_llm(
                 if not (_is_payment_error(retry_err) or _is_connection_error(retry_err) or _is_rate_limit_error(retry_err)):
                     raise
                 first_err = retry_err
+
+        # ── reasoning param compatibility retry (generic, async mirror) ─
+        # Same as sync path: strip extra_body.reasoning on 400. See sync
+        # block comment for rationale.
+        eb_for_reasoning_retry_async = kwargs.get("extra_body")
+        if (
+            isinstance(eb_for_reasoning_retry_async, dict)
+            and "reasoning" in eb_for_reasoning_retry_async
+            and _is_unsupported_parameter_error(first_err, "reasoning")
+        ):
+            retry_kwargs = dict(kwargs)
+            retry_eb = dict(eb_for_reasoning_retry_async)
+            retry_eb.pop("reasoning", None)
+            if retry_eb:
+                retry_kwargs["extra_body"] = retry_eb
+            else:
+                retry_kwargs.pop("extra_body", None)
+            logger.info(
+                "Auxiliary %s (async): provider rejected reasoning param; retrying without it",
+                task or "call",
+            )
+            try:
+                return _validate_llm_response(
+                    await client.chat.completions.create(**retry_kwargs), task
+                )
+            except Exception as retry_err:
+                retry_err_str = str(retry_err)
+                if not (
+                    _is_payment_error(retry_err)
+                    or _is_connection_error(retry_err)
+                    or _is_auth_error(retry_err)
+                    or _is_rate_limit_error(retry_err)
+                    or "max_tokens" in retry_err_str
+                    or "unsupported_parameter" in retry_err_str
+                ):
+                    raise
+                first_err = retry_err
+                kwargs = retry_kwargs
 
         # ── Stale-model self-heal (Nous Portal recommendation drift) ───
         # See the sync call_llm() path for the rationale: a long-lived process

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3857,14 +3857,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         server-side queue) from a watcher reconnect after a prolonged outage
         (preserve the queue so messages sent during the outage are delivered
         rather than silently dropped — #46621).
+
+        Third-party adapters (e.g. hermes-imessage 0.1.2) may not yet accept
+        ``is_reconnect``. We probe the signature first and fall back to a
+        bare ``connect()`` call so an older plugin never crashes the gateway
+        — the ``is_reconnect`` flag is an optimization, not a correctness
+        requirement for basic connectivity.
         """
         timeout = self._platform_connect_timeout_secs()
-        if timeout <= 0:
-            return await adapter.connect(is_reconnect=is_reconnect)
-        try:
-            return await asyncio.wait_for(
-                adapter.connect(is_reconnect=is_reconnect), timeout=timeout
+
+        def _connect_coro():
+            connect = adapter.connect
+            try:
+                sig = inspect.signature(connect)
+                params = sig.parameters.values()
+                accepts_reconnect = (
+                    "is_reconnect" in sig.parameters
+                    or any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params)
+                )
+            except (TypeError, ValueError):
+                # Builtins / Cython wrappers that don't expose a signature —
+                # assume they accept kwargs rather than crashing.
+                accepts_reconnect = True
+            if accepts_reconnect:
+                return connect(is_reconnect=is_reconnect)
+            logger.debug(
+                "%s adapter connect() does not accept is_reconnect; calling without it",
+                platform.value,
             )
+            return connect()
+
+        if timeout <= 0:
+            return await _connect_coro()
+        try:
+            return await asyncio.wait_for(_connect_coro(), timeout=timeout)
         except asyncio.TimeoutError as exc:
             raise TimeoutError(
                 f"{platform.value} connect timed out after {timeout:g}s"


### PR DESCRIPTION
### Problem

Title generation injects `extra_body={"reasoning": {"enabled": False}}` to suppress chain-of-thought on reasoning-capable models (#2083). Many strict OpenAI-compatible endpoints — OpenAI Chat Completions, Azure, Meta's Llama API `api.meta.ai`, custom proxies — reject unknown keys with `400 unknown parameter / unsupported_parameter`.

Without a generic retry, the call falls through to payment fallback chain and then to `_fallback_title_from_exchange()` heuristic, which looks like "first couple words of prompt" bug reported multiple times.

Separately, `gateway/run.py` `is_reconnect` arg was recently added but third-party adapters (e.g. `hermes-imessage 0.1.2`) don't accept it, crashing gateway with `unexpected keyword argument`.

### Fix — generic, not provider-specific

**1. `agent/auxiliary_client.py` — generic compatibility retry (correctness):**

After the existing `temperature` and `max_tokens` retries, add a generic safety net:

```python
eb = kwargs.get("extra_body")
if isinstance(eb, dict) and "reasoning" in eb and _is_unsupported_parameter_error(err, "reasoning"):
    retry once without reasoning, preserve other extra_body fields
```

Uses existing `_is_unsupported_parameter_error(exc, "reasoning")` detector which matches:
- `unknown parameter: reasoning`
- `unsupported_parameter: reasoning`
- `reasoning is not supported`
- `unrecognized request argument: reasoning`

Mirrors existing temperature/max_tokens pattern. Added to both `call_llm()` and `async_call_llm()`.

This fixes titles for **any** strict provider, not just Meta/OpenAI/Azure.

**2. `gateway/run.py` — signature tolerance (robustness):**

Probe `adapter.connect` via `inspect.signature` and fall back to bare `connect()` if `is_reconnect` not accepted. Third-party adapters shouldn't crash the gateway — `is_reconnect` is an optimization, not correctness requirement.

### Verification

```python
from agent.auxiliary_client import _is_unsupported_parameter_error
for msg in ["400 unknown parameter: reasoning", "unsupported_parameter: reasoning"]:
    assert _is_unsupported_parameter_error(Exception(msg), "reasoning")

# Mocked call_llm retries without reasoning, preserves other keys
# call count = 2, second extra_body has no reasoning, keeps 'other'
```

### Related

- #2083 reasoning injection
- #4161 OpenAI Chat Completions 400
- This makes the WebUI `_route_rejects_reasoning_extra` allowlist an optimization only, not correctness requirement (separate PR there clarifies docstring)