### PR TITLE
fix(desktop): show composer action shortcuts

### DIFF
--- a/apps/desktop/src/app/chat/composer/controls.test.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ChatBarState } from '@/app/chat/composer/types'
+import { I18nProvider } from '@/i18n'
+
+import { ComposerControls } from './controls'
+
+vi.mock('./model-pill', () => ({ ModelPill: () => null }))
+
+const state: ChatBarState = {
+  model: { canSwitch: false, model: '', provider: '' },
+  tools: { enabled: false, label: '' },
+  voice: { active: false, enabled: false }
+}
+
+function renderControls(overrides: Partial<React.ComponentProps<typeof ComposerControls>> = {}) {
+  return render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <ComposerControls
+        autoSpeak={false}
+        busy={false}
+        busyAction="stop"
+        canSubmit={true}
+        conversation={{
+          active: false,
+          level: 0,
+          muted: false,
+          onEnd: vi.fn(),
+          onStart: vi.fn(),
+          onStopTurn: vi.fn(),
+          onToggleMute: vi.fn(),
+          status: 'idle'
+        }}
+        disabled={false}
+        hasComposerPayload={true}
+        onDictate={vi.fn()}
+        onQueue={vi.fn()}
+        onToggleAutoSpeak={vi.fn()}
+        state={state}
+        voiceStatus="idle"
+        {...overrides}
+      />
+    </I18nProvider>
+  )
+}
+
+async function expectShortcutTooltip(label: string, shortcut: string) {
+  fireEvent.pointerMove(screen.getByLabelText(label), { pointerType: 'mouse' })
+
+  const tooltip = await screen.findByRole('tooltip')
+
+  expect(tooltip.textContent).toContain(label)
+  expect(tooltip.textContent).toContain(shortcut)
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('ComposerControls shortcut tooltips', () => {
+  it('shows Enter for Send', async () => {
+    renderControls()
+
+    await expectShortcutTooltip('Send', '↵')
+  })
+
+  it('shows Ctrl+Enter for Steer', async () => {
+    renderControls({ busy: true, busyAction: 'steer' })
+
+    await expectShortcutTooltip('Steer the current run', 'Ctrl+↵')
+  })
+
+  it('shows Enter for Queue', async () => {
+    renderControls({ busy: true, busyAction: 'queue' })
+
+    await expectShortcutTooltip('Queue message', '↵')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
-import { Tip } from '@/components/ui/tooltip'
+import { Tip, TipKeybindLabel } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { AudioLines, iconSize, Layers3, Loader2, Square, SteeringWheel, Volume2, VolumeX } from '@/lib/icons'
@@ -81,7 +81,7 @@ export function ComposerControls({
       <DictationButton disabled={disabled} onToggle={onDictate} state={state.voice} status={voiceStatus} />
       <AutoSpeakButton active={autoSpeak} disabled={disabled} onToggle={onToggleAutoSpeak} />
       {busyAction === 'steer' ? (
-        <Tip label={c.queueMessage}>
+        <Tip label={<TipKeybindLabel actionId="composer.send" text={c.queueMessage} />}>
           <Button
             aria-label={c.queueMessage}
             className={GHOST_ICON_BTN}
@@ -112,7 +112,15 @@ export function ComposerControls({
           </Button>
         </Tip>
       ) : (
-        <Tip label={busy ? busyLabel : c.send}>
+        <Tip
+          label={
+            busy ? (
+              <TipKeybindLabel actionId={busyAction === 'steer' ? 'composer.steer' : 'composer.send'} text={busyLabel} />
+            ) : (
+              <TipKeybindLabel actionId="composer.send" text={c.send} />
+            )
+          }
+        >
           <Button
             aria-label={busy ? busyLabel : c.send}
             className={PRIMARY_ICON_BTN}


### PR DESCRIPTION
## What does this PR do?

Makes the desktop composer controls easier to discover by showing their existing platform-aware shortcuts in the Send, Steer, and Queue tooltips. It reuses `TipKeybindLabel`, so macOS shows Command while other platforms show Control without duplicating shortcut text.

## Related Issue

No issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `apps/desktop/src/app/chat/composer/controls.tsx` to use `TipKeybindLabel` for Send, Steer, and Queue action tooltips.
- Add `apps/desktop/src/app/chat/composer/controls.test.tsx` covering the displayed Send, Steer, and Queue shortcut hints.

## How to Test

1. Open the desktop composer with a draft and hover Send; confirm its tooltip shows `↵`.
2. During a running turn, enter a text-only follow-up and hover Steer; confirm its tooltip shows the platform modifier plus `↵`.
3. During a running turn, hover Queue; confirm its tooltip shows `↵`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A — desktop TypeScript-only change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS Linux; `npm run check` passed

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`npm run check` passed locally, including TypeScript checks, Vitest, and packaged desktop validation.
