### PR TITLE
test(desktop): cover correction resume without duplicate prompts

### DIFF
--- a/apps/desktop/e2e/correction-session-switch.spec.ts
+++ b/apps/desktop/e2e/correction-session-switch.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * Regression coverage for a correction sent during a live response, then a
+ * warm session switch away and back. The correction is an accepted user turn,
+ * not an optimistic duplicate of the original prompt, and its relative place
+ * in the transcript must survive the resume reconciliation.
+ */
+
+import { type TestInfo } from '@playwright/test'
+
+import { expect, test, type Page } from './test'
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { MOCK_REPLY } from './mock-server'
+
+const ORIGINAL_PROMPT = 'E2E original prompt must remain singular after a correction.'
+const CORRECTION = 'E2E correction must stay after the original prompt.'
+
+async function send(page: Page, text: string): Promise<void> {
+  const composer = page.locator('[contenteditable="true"]').first()
+  await composer.waitFor({ state: 'visible', timeout: 15_000 })
+  await composer.click()
+  await composer.type(text, { delay: 5 })
+  await page.keyboard.press('Enter')
+}
+
+async function waitForTranscriptText(page: Page, text: string): Promise<void> {
+  await page.waitForFunction(
+    (expected: string) => (document.querySelector('[data-slot="aui_thread-viewport"]')?.textContent ?? '').includes(expected),
+    text,
+    { timeout: 30_000 },
+  )
+}
+
+async function textNodeOccurrences(page: Page, text: string): Promise<number> {
+  return page.evaluate((expected: string) => {
+    const viewport = document.querySelector('[data-slot="aui_thread-viewport"]')
+    if (!viewport) return 0
+
+    const walker = document.createTreeWalker(viewport, NodeFilter.SHOW_TEXT)
+    let count = 0
+    while (walker.nextNode()) {
+      if (walker.currentNode.textContent?.includes(expected)) {
+        count += 1
+      }
+    }
+    return count
+  }, text)
+}
+
+async function transcriptTextOrder(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const viewport = document.querySelector('[data-slot="aui_thread-viewport"]')
+    if (!viewport) return []
+
+    return Array.from(viewport.querySelectorAll<HTMLElement>('[data-role="message"], [data-message-id]'))
+      .map(message => message.textContent?.trim() ?? '')
+      .filter(Boolean)
+  })
+}
+
+async function openFreshDraft(page: Page): Promise<void> {
+  await page.locator('[data-slot="sidebar"] button[aria-label="New session"]').first().click()
+  await page.waitForFunction(
+    (original: string) => !(document.querySelector('[data-slot="aui_thread-viewport"]')?.textContent ?? '').includes(original),
+    ORIGINAL_PROMPT,
+    { timeout: 15_000 },
+  )
+}
+
+async function reopenOriginalSession(page: Page): Promise<void> {
+  // The mock's first streamed token becomes the generated sidebar title, not
+  // the user's original prompt. It may still be only "Hello" when we switch.
+  const row = page.locator('[data-slot="sidebar"] button').filter({ hasText: MOCK_REPLY.split(' ')[0] }).first()
+  await row.waitFor({ state: 'visible', timeout: 30_000 })
+  await row.click()
+  await waitForTranscriptText(page, ORIGINAL_PROMPT)
+}
+
+function relevantOrder(messages: string[]): string[] {
+  return messages.filter(message => message.includes(ORIGINAL_PROMPT) || message.includes(CORRECTION))
+}
+
+test.describe('correction session switch', () => {
+  let fixture: MockBackendFixture | null = null
+
+  test.beforeEach(async () => {
+    fixture = await setupMockBackend({
+      mockServer: { holdFirstStreamForPrompt: ORIGINAL_PROMPT },
+    })
+    await waitForAppReady(fixture, 120_000)
+  })
+
+  test.afterEach(async () => {
+    await fixture?.cleanup()
+    fixture = null
+  })
+
+  test('keeps a live correction in place and does not duplicate its original prompt after switching sessions', async ({}, testInfo: TestInfo) => {
+    const { mock, page } = fixture!
+
+    await send(page, ORIGINAL_PROMPT)
+    await mock.waitForHeldStream()
+    await waitForTranscriptText(page, ORIGINAL_PROMPT)
+
+    // While the original response is live, Enter routes this through
+    // session.redirect. The renderer records the accepted correction once as a
+    // user message after the interrupted checkpoint.
+    await send(page, CORRECTION)
+    await waitForTranscriptText(page, CORRECTION)
+
+    const orderBeforeSwitch = relevantOrder(await transcriptTextOrder(page))
+    expect(orderBeforeSwitch).toEqual([ORIGINAL_PROMPT, CORRECTION])
+    expect(await textNodeOccurrences(page, ORIGINAL_PROMPT)).toBe(1)
+    expect(await textNodeOccurrences(page, CORRECTION)).toBe(1)
+    await page.screenshot({ path: testInfo.outputPath('correction-before-session-switch.png') })
+
+    // Reproduce the observed race: switch while the correction and original
+    // response are both still live, then return before the held stream settles.
+    await openFreshDraft(page)
+    await reopenOriginalSession(page)
+    await page.waitForTimeout(500)
+    await page.screenshot({ path: testInfo.outputPath('correction-after-warm-resume.png') })
+
+    expect(relevantOrder(await transcriptTextOrder(page))).toEqual(orderBeforeSwitch)
+    expect(await textNodeOccurrences(page, ORIGINAL_PROMPT)).toBe(1)
+    expect(await textNodeOccurrences(page, CORRECTION)).toBe(1)
+
+    mock.releaseHeldStream()
+    await waitForTranscriptText(page, MOCK_REPLY)
+  })
+})

--- a/apps/desktop/e2e/correction-session-switch.spec.ts
+++ b/apps/desktop/e2e/correction-session-switch.spec.ts
@@ -10,10 +10,13 @@ import { type TestInfo } from '@playwright/test'
 import { expect, test, type Page } from './test'
 
 import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
-import { MOCK_REPLY } from './mock-server'
+import { CORRECTION_SWITCH_TRIGGER, MOCK_REPLY } from './mock-server'
 
-const ORIGINAL_PROMPT = 'E2E original prompt must remain singular after a correction.'
+const OTHER_SESSION_PROMPT = 'E2E persisted session used for a warm resume.'
+const ORIGINAL_PROMPT = `${CORRECTION_SWITCH_TRIGGER}: original prompt must remain singular after a correction.`
 const CORRECTION = 'E2E correction must stay after the original prompt.'
+const TOOL_STARTED = 'Checking the long-running task before I continue.'
+const CORRECTED_REPLY = 'The corrected task finished.'
 
 async function send(page: Page, text: string): Promise<void> {
   const composer = page.locator('[contenteditable="true"]').first()
@@ -58,22 +61,26 @@ async function transcriptTextOrder(page: Page): Promise<string[]> {
   })
 }
 
-async function openFreshDraft(page: Page): Promise<void> {
+async function openFreshDraft(page: Page, priorSessionText: string): Promise<void> {
   await page.locator('[data-slot="sidebar"] button[aria-label="New session"]').first().click()
   await page.waitForFunction(
-    (original: string) => !(document.querySelector('[data-slot="aui_thread-viewport"]')?.textContent ?? '').includes(original),
-    ORIGINAL_PROMPT,
+    (priorText: string) => !(document.querySelector('[data-slot="aui_thread-viewport"]')?.textContent ?? '').includes(priorText),
+    priorSessionText,
     { timeout: 15_000 },
   )
 }
 
-async function reopenOriginalSession(page: Page): Promise<void> {
-  // The mock's first streamed token becomes the generated sidebar title, not
-  // the user's original prompt. It may still be only "Hello" when we switch.
-  const row = page.locator('[data-slot="sidebar"] button').filter({ hasText: MOCK_REPLY.split(' ')[0] }).first()
+async function openSidebarSession(page: Page, sidebarText: string, expectedTranscriptText: string): Promise<void> {
+  const row = page.locator('[data-slot="sidebar"] button').filter({ hasText: sidebarText }).first()
   await row.waitFor({ state: 'visible', timeout: 30_000 })
   await row.click()
-  await waitForTranscriptText(page, ORIGINAL_PROMPT)
+  await waitForTranscriptText(page, expectedTranscriptText)
+}
+
+async function reopenOriginalSession(page: Page): Promise<void> {
+  // A still-running tool has not generated a final title yet, so the sidebar
+  // retains the source prompt as its provisional session title.
+  await openSidebarSession(page, ORIGINAL_PROMPT, ORIGINAL_PROMPT)
 }
 
 function relevantOrder(messages: string[]): string[] {
@@ -84,9 +91,7 @@ test.describe('correction session switch', () => {
   let fixture: MockBackendFixture | null = null
 
   test.beforeEach(async () => {
-    fixture = await setupMockBackend({
-      mockServer: { holdFirstStreamForPrompt: ORIGINAL_PROMPT },
-    })
+    fixture = await setupMockBackend()
     await waitForAppReady(fixture, 120_000)
   })
 
@@ -96,15 +101,20 @@ test.describe('correction session switch', () => {
   })
 
   test('keeps a live correction in place and does not duplicate its original prompt after switching sessions', async ({}, testInfo: TestInfo) => {
-    const { mock, page } = fixture!
+    const { page } = fixture!
+
+    // A blank draft does not exercise session hydration. Seed a real second
+    // session first, matching the observed switch between two saved chats.
+    await send(page, OTHER_SESSION_PROMPT)
+    await waitForTranscriptText(page, MOCK_REPLY)
+    await openFreshDraft(page, OTHER_SESSION_PROMPT)
 
     await send(page, ORIGINAL_PROMPT)
-    await mock.waitForHeldStream()
+    await waitForTranscriptText(page, TOOL_STARTED)
     await waitForTranscriptText(page, ORIGINAL_PROMPT)
 
-    // While the original response is live, Enter routes this through
-    // session.redirect. The renderer records the accepted correction once as a
-    // user message after the interrupted checkpoint.
+    // The historical session redirected while a foreground terminal task was
+    // running. Enter records the accepted correction at the next tool boundary.
     await send(page, CORRECTION)
     await waitForTranscriptText(page, CORRECTION)
 
@@ -114,9 +124,9 @@ test.describe('correction session switch', () => {
     expect(await textNodeOccurrences(page, CORRECTION)).toBe(1)
     await page.screenshot({ path: testInfo.outputPath('correction-before-session-switch.png') })
 
-    // Reproduce the observed race: switch while the correction and original
-    // response are both still live, then return before the held stream settles.
-    await openFreshDraft(page)
+    // Reproduce the observed race: switch to another persisted session while
+    // the foreground tool is live, then return before its redirect settles.
+    await openSidebarSession(page, MOCK_REPLY, OTHER_SESSION_PROMPT)
     await reopenOriginalSession(page)
     await page.waitForTimeout(500)
     await page.screenshot({ path: testInfo.outputPath('correction-after-warm-resume.png') })
@@ -125,7 +135,6 @@ test.describe('correction session switch', () => {
     expect(await textNodeOccurrences(page, ORIGINAL_PROMPT)).toBe(1)
     expect(await textNodeOccurrences(page, CORRECTION)).toBe(1)
 
-    mock.releaseHeldStream()
-    await waitForTranscriptText(page, MOCK_REPLY)
+    await waitForTranscriptText(page, CORRECTED_REPLY)
   })
 })

--- a/apps/desktop/e2e/mock-server.ts
+++ b/apps/desktop/e2e/mock-server.ts
@@ -97,6 +97,9 @@ let _sidebarCrossIndex = 0
 /** Per-server counter for the queue-stop script. */
 let _queueStopIndex = 0
 
+/** Per-server counter for the correction/session-switch script. */
+let _correctionSwitchIndex = 0
+
 /** User messages received by the mock, for E2E assertions on real submits. */
 const _receivedUserTexts: string[] = []
 
@@ -106,6 +109,7 @@ function resetScriptIndex(): void {
   _sidebarScriptIndex = 0
   _sidebarCrossIndex = 0
   _queueStopIndex = 0
+  _correctionSwitchIndex = 0
   _receivedUserTexts.length = 0
 }
 
@@ -192,6 +196,19 @@ const QUEUE_STOP_SCRIPT: ScriptedTurn[] = [
   },
   { text: 'The paused task completed.' },
 ]
+
+// The reported correction arrived while a foreground tool was still running.
+// Keep that boundary open long enough for the renderer to redirect the turn,
+// then let the next model request complete normally.
+const CORRECTION_SWITCH_SCRIPT: ScriptedTurn[] = [
+  {
+    text: 'Checking the long-running task before I continue.',
+    toolCalls: [{ name: 'terminal', args: { command: 'sleep 5' } }],
+  },
+  { text: 'The corrected task finished.' },
+]
+
+export const CORRECTION_SWITCH_TRIGGER = 'E2E_CORRECTION_SWITCH_TRIGGER'
 
 /**
  * A marker that makes the mock emit a real blocking clarify tool call. Tests
@@ -313,6 +330,9 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
           const isSidebarTrigger = userText.includes('E2E_SIDEBAR_TRIGGER')
           const isSidebarCrossTrigger = userText.includes('E2E_SIDEBAR_CROSS')
           const isQueueStopTrigger = userText.includes('E2E_QUEUE_STOP_TRIGGER')
+          const isCorrectionSwitchTrigger = messages.some(
+            message => typeof message?.content === 'string' && message.content.includes(CORRECTION_SWITCH_TRIGGER),
+          )
 
           if (includesBlockingClarifyTrigger(parsed.messages)) {
             if (stream) {
@@ -326,6 +346,17 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
           if (isQueueStopTrigger) {
             const turn = QUEUE_STOP_SCRIPT[_queueStopIndex] ?? QUEUE_STOP_SCRIPT[QUEUE_STOP_SCRIPT.length - 1]
             _queueStopIndex++
+            if (stream) {
+              streamScriptedTurn(res, model, turn)
+            } else {
+              nonStreamingScriptedTurn(res, model, turn)
+            }
+            return
+          }
+
+          if (isCorrectionSwitchTrigger) {
+            const turn = CORRECTION_SWITCH_SCRIPT[_correctionSwitchIndex] ?? CORRECTION_SWITCH_SCRIPT[CORRECTION_SWITCH_SCRIPT.length - 1]
+            _correctionSwitchIndex++
             if (stream) {
               streamScriptedTurn(res, model, turn)
             } else {


### PR DESCRIPTION
## What does this PR do?

Adds Electron E2E coverage for the reported desktop race: a live composer correction accepted while a foreground tool runs, followed by switching through another persisted chat and warm-resuming back. The test proves the source prompt and correction retain their order and each render once.

## Related Issue

No tracker issue.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added `apps/desktop/e2e/correction-session-switch.spec.ts`.
- Extended `apps/desktop/e2e/mock-server.ts` with a scoped, scripted foreground-tool turn for this test.
- Seeded a second persisted session so the test exercises actual hydration instead of a blank-draft round trip.
- Asserted the original prompt and correction each appear once before and after warm resume, in the same order.
- Captured screenshots immediately before switching and after the resumed transcript settles.

## How to Test

1. Run `cd apps/desktop && npm run typecheck`.
2. Run `npm run build && WLR_BACKENDS=headless WLR_NO_HARDWARE_CURSORS=1 cage -- npx playwright test e2e/correction-session-switch.spec.ts --reporter=list`.
3. Confirm the live correction stays after the original prompt and neither appears twice after returning to the session.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A: desktop TypeScript/Electron-only change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS Linux (headless Cage + Electron)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Verified locally:

- `npm run typecheck` ✅
- focused packaged Electron E2E ✅ — `1 passed (17.8s)`

The test emits screenshots at the pre-switch and warm-resume assertions.
