### PR TITLE
fix(browser): apply Camofox viewport config after tab creation

### DIFF
--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -395,6 +395,32 @@ def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
         return _adopt_existing_tab(session)
 
 
+def _apply_viewport_config(tab_id: str, user_id: str) -> None:
+    """Set viewport on a tab from ``browser.camofox.viewport`` config, if configured.
+
+    Camofox creates tabs at a default viewport (1280x720). When
+    ``browser.camofox.viewport: {width: N, height: M}`` is set in config.yaml,
+    this applies the user's preferred dimensions via ``POST /tabs/:tabId/viewport``.
+    """
+    camofox_cfg = _get_camofox_config()
+    viewport = camofox_cfg.get("viewport")
+    if not isinstance(viewport, dict):
+        return
+    width = viewport.get("width")
+    height = viewport.get("height")
+    if not isinstance(width, int) or not isinstance(height, int):
+        return
+    try:
+        _post(
+            f"/tabs/{tab_id}/viewport",
+            {"userId": user_id, "width": width, "height": height},
+            timeout=10,
+        )
+        logger.debug("Applied Camofox viewport %dx%d", width, height)
+    except Exception:
+        logger.warning("Failed to apply Camofox viewport %dx%d", width, height)
+
+
 def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, Any]:
     """Ensure a tab exists for the session, creating one if needed."""
     session = _get_session(task_id)
@@ -414,6 +440,8 @@ def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, A
     resp.raise_for_status()
     data = resp.json()
     session["tab_id"] = data.get("tabId")
+    # Apply configured viewport after tab creation
+    _apply_viewport_config(session["tab_id"], session["user_id"])
     return session
 
 


### PR DESCRIPTION
## Summary

- Adds a `_apply_viewport_config` helper that reads `browser.camofox.viewport` from config.yaml
- Calls it immediately after tab creation in `_ensure_tab`, so every new tab respects the user's preferred viewport dimensions
- Also covers stale-tab recovery paths since they delegate to `_ensure_tab`

## Motivation

When the browser provider is set to Camofox, screenshots use the server's default viewport (1280x720), regardless of user configuration. This causes screenshots to appear cropped or zoomed.

A prior attempt (PR #38526) tried to pass `viewport` in the `POST /tabs` creation body, but the Camofox server silently ignores unknown fields there. However, Camofox already exposes a dedicated `POST /tabs/:tabId/viewport` endpoint — this change uses that instead.

Closes #38478

## Changes

- `tools/browser_camofox.py`: Added `_apply_viewport_config()` + call site in `_ensure_tab()`

## Test Plan

- [ ] Existing tests pass (`pytest tests/tools/test_browser_camofox.py`)
- [ ] Manual: set `browser.camofox.viewport: {width: 1920, height: 1080}` and verify screenshots are at the configured size
- [ ] Manual: no viewport config → no extra POST (existing behavior unchanged)

## Config Example

```yaml
browser:
  camofox:
    viewport:
      width: 1920
      height: 1080
```

## 🤖 Model Attribution

| Role | Model | Tasks |
|------|-------|-------|
| **Implementer** | deepseek-v4-flash | Code change, PR authoring |

**Total subagent calls:** 0 · **CI:** TBD