### PR TITLE
fix(cli): honor custom_providers in preflight shrink warning

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8080,12 +8080,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         choice = self._normalize_slash_confirm_choice(raw, choices)
         return choice == "once"
 
-    def _confirm_and_apply_model_switch_result(self, result, persist_global: bool) -> None:
+    def _confirm_and_apply_model_switch_result(
+        self, result, persist_global: bool, custom_providers=None
+    ) -> None:
         try:
             if result.success and not self._confirm_expensive_model_switch(result):
                 _cprint("  Model switch cancelled.")
                 return
-            self._apply_model_switch_result(result, persist_global)
+            self._apply_model_switch_result(
+                result, persist_global, custom_providers=custom_providers
+            )
         except Exception as exc:
             _cprint(f"  ✗ Model selection failed: {exc}")
 
@@ -8205,7 +8209,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception:
             save_config_value("model.context_length", None)
 
-    def _apply_model_switch_result(self, result, persist_global: bool) -> None:
+    def _apply_model_switch_result(
+        self, result, persist_global: bool, custom_providers=None
+    ) -> None:
         if not result.success:
             _cprint(f"  ✗ {result.error_message}")
             return
@@ -8214,10 +8220,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             try:
                 from hermes_cli.context_switch_guard import merge_preflight_compression_warning
 
+                # Prefer the fresh inventory list (same source as switch_model /
+                # TUI); fall back to the agent-init snapshot.
+                _cp = (
+                    custom_providers
+                    if custom_providers is not None
+                    else getattr(self.agent, "_custom_providers", None)
+                )
                 merge_preflight_compression_warning(
                     result,
                     agent=self.agent,
                     messages=list(self.conversation_history or []),
+                    custom_providers=_cp,
                     config_context_length=getattr(self.agent, "_config_context_length", None),
                 )
             except Exception as exc:
@@ -8397,15 +8411,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     user_providers=state.get("user_provs"),
                     custom_providers=state.get("custom_provs"),
                 )
+                # Capture before close — picker state is cleared on close.
+                _picker_custom_provs = state.get("custom_provs")
                 self._close_model_picker()
                 if getattr(self, "_app", None):
                     threading.Thread(
                         target=self._confirm_and_apply_model_switch_result,
-                        args=(result, persist_global),
+                        args=(result, persist_global, _picker_custom_provs),
                         daemon=True,
                     ).start()
                 else:
-                    self._confirm_and_apply_model_switch_result(result, persist_global)
+                    self._confirm_and_apply_model_switch_result(
+                        result, persist_global, custom_providers=_picker_custom_provs
+                    )
                 return
             self._close_model_picker()
 
@@ -8550,6 +8568,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     result,
                     agent=self.agent,
                     messages=list(self.conversation_history or []),
+                    # Same fresh inventory list passed to switch_model above.
+                    custom_providers=custom_provs
+                    if custom_provs is not None
+                    else getattr(self.agent, "_custom_providers", None),
                     config_context_length=getattr(self.agent, "_config_context_length", None),
                 )
             except Exception as exc:

--- a/hermes_cli/context_switch_guard.py
+++ b/hermes_cli/context_switch_guard.py
@@ -83,6 +83,13 @@ def merge_preflight_compression_warning(
     if cc is None:
         return
 
+    # Classic CLI historically omitted custom_providers here while the /model
+    # confirmation display threaded agent._custom_providers — so the shrink
+    # warning fell through to the hardcoded catalog (e.g. "qwen" → 131072)
+    # even when custom_providers[].models.<id>.context_length was 1M.
+    if custom_providers is None:
+        custom_providers = getattr(agent, "_custom_providers", None)
+
     old_ctx = int(getattr(cc, "context_length", 0) or 0)
     new_ctx = resolve_display_context_length(
         result.new_model,

--- a/tests/hermes_cli/test_context_switch_guard.py
+++ b/tests/hermes_cli/test_context_switch_guard.py
@@ -136,3 +136,110 @@ def test_cross_route_switch_does_not_inherit_current_context_pin(monkeypatch):
     )
 
     assert "preflight compression" in result.warning_message
+
+
+def test_custom_provider_context_avoids_false_shrink_warning(monkeypatch):
+    """Classic CLI used to omit custom_providers from the shrink warning.
+
+    Repro: switch onto a custom endpoint with models.<id>.context_length=1M
+    while session ~147k. Probe fails → hardcoded catalog match on "qwen"
+    (131072) → false "Context window shrinks (... → 131,072)" warning, even
+    though /model confirmation and the status bar correctly show 1M.
+    """
+    custom_provs = [
+        {
+            "name": "qwen-token-plan",
+            "base_url": "https://token-plan.example/compatible-mode/v1",
+            "models": {
+                "qwen3.8-max-preview": {"context_length": 1_048_576},
+            },
+        }
+    ]
+    # Force the probe-down path that hit the "qwen" → 131072 catalog match
+    # when custom_providers was not threaded through.
+    monkeypatch.setattr(
+        "agent.model_metadata._resolve_endpoint_context_length",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata._query_ollama_api_show",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.context_switch_guard._estimate_tokens",
+        lambda *a, **k: 147_053,
+    )
+    cc = _compressor(monkeypatch, context_length=1_000_000)
+    agent = SimpleNamespace(
+        model="MiniMax-M3",
+        provider="minimax",
+        context_compressor=cc,
+        compression_enabled=True,
+        conversation_history=[],
+        base_url="https://api.minimax.example/v1",
+        api_key="",
+        _custom_providers=custom_provs,
+    )
+    result = ModelSwitchResult(
+        success=True,
+        new_model="qwen3.8-max-preview",
+        target_provider="qwen-token-plan",
+        provider_changed=True,
+        api_key="k",
+        base_url="https://token-plan.example/compatible-mode/v1",
+        api_mode="chat_completions",
+        provider_label="qwen-token-plan",
+        model_info=None,
+    )
+
+    # Explicit custom_providers — no false shrink warning (1M > 147k*2).
+    merge_preflight_compression_warning(
+        result,
+        agent=agent,
+        custom_providers=custom_provs,
+    )
+    assert not result.warning_message
+
+    # Agent snapshot alone (classic CLI historically forgot to pass the kwarg).
+    result2 = ModelSwitchResult(
+        success=True,
+        new_model="qwen3.8-max-preview",
+        target_provider="qwen-token-plan",
+        provider_changed=True,
+        api_key="k",
+        base_url="https://token-plan.example/compatible-mode/v1",
+        api_mode="chat_completions",
+        provider_label="qwen-token-plan",
+        model_info=None,
+    )
+    merge_preflight_compression_warning(result2, agent=agent)
+    assert not result2.warning_message
+
+    # Without any custom_providers source, catalog match still warns (131k).
+    agent_no_cp = SimpleNamespace(
+        model="MiniMax-M3",
+        provider="minimax",
+        context_compressor=cc,
+        compression_enabled=True,
+        conversation_history=[],
+        base_url="https://api.minimax.example/v1",
+        api_key="",
+        _custom_providers=None,
+    )
+    result3 = ModelSwitchResult(
+        success=True,
+        new_model="qwen3.8-max-preview",
+        target_provider="qwen-token-plan",
+        provider_changed=True,
+        api_key="k",
+        base_url="https://token-plan.example/compatible-mode/v1",
+        api_mode="chat_completions",
+        provider_label="qwen-token-plan",
+        model_info=None,
+    )
+    merge_preflight_compression_warning(result3, agent=agent_no_cp)
+    assert result3.warning_message
+    assert "preflight compression" in result3.warning_message
+    assert "shrinks" in result3.warning_message
+    # Must not honor the unused 1M custom override when no providers were passed.
+    assert "1,048,576" not in result3.warning_message

--- a/tests/hermes_cli/test_model_picker_expensive_confirm.py
+++ b/tests/hermes_cli/test_model_picker_expensive_confirm.py
@@ -62,5 +62,6 @@ def test_prompt_toolkit_model_picker_defers_confirmation_off_key_handler(monkeyp
     assert self_._model_picker_state is None
     assert captured["started"] is True
     assert captured["daemon"] is True
-    assert captured["args"] == (result, True)
+    # Third arg is the fresh picker custom_providers snapshot (None here).
+    assert captured["args"] == (result, True, None)
     assert "ran_inline" not in captured


### PR DESCRIPTION
## Summary
- Classic CLI `/model` confirmation already showed the correct custom-provider `context_length` (e.g. 1,048,576), but the preflight "Context window shrinks" warning resolved context without `custom_providers`, fell through to probe-down + hardcoded catalog match (`qwen` → 131,072), and falsely warned.
- Thread `agent._custom_providers` from both CLI call sites, and fall back to that snapshot inside `merge_preflight_compression_warning` when the kwarg is omitted (TUI/gateway already passed it).
- Add a regression test covering the false shrink warning for a 1M custom Qwen endpoint with ~147k session tokens.

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_context_switch_guard.py -q`
- [ ] Manually: configure a custom provider with `models.<id>.context_length: 1048576`, switch onto it from a ~1M session with ~147k tokens via classic CLI `/model`, confirm Context line + status bar stay at 1M and the shrink warning no longer claims 131,072.

## Infographic

![custom-provider-shrink-warning](https://v3b.fal.media/files/b/0aa35bcf/NW_C-ripUxY0xSilD2pzs_ZQPsHR27.png)
