### PR TITLE
fix(skills): scan only newly introduced findings

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -689,6 +689,39 @@ class TestSecurityScanGate:
         assert result is not None
         assert "Security scan blocked" in result
 
+    def test_scan_failure_blocks_when_flag_on(self, tmp_path):
+        """A scanner exception must block the write instead of failing open."""
+        from tools.skill_manager_tool import _security_scan_skill
+
+        with patch("tools.skill_manager_tool._guard_agent_created_enabled", return_value=True), \
+             patch("tools.skill_manager_tool.scan_skill", side_effect=RuntimeError("boom")):
+            result = _security_scan_skill(tmp_path)
+
+        assert result == "Security scan failed; the skill write was not applied."
+
+    def test_scan_unavailable_blocks_when_flag_on(self, tmp_path):
+        """An enabled guard cannot silently allow writes without its scanner."""
+        from tools.skill_manager_tool import _security_scan_skill
+
+        with patch("tools.skill_manager_tool._guard_agent_created_enabled", return_value=True), \
+             patch("tools.skill_manager_tool._GUARD_AVAILABLE", False):
+            result = _security_scan_skill(tmp_path)
+
+        assert result == "Security scan unavailable; the skill write was not applied."
+
+    def test_captured_guard_decision_survives_concurrent_disable(self, tmp_path):
+        """A guard enabled before mutation must still scan after config changes."""
+        from tools.skill_manager_tool import _security_scan_skill
+
+        scan_result = object()
+        with patch("tools.skill_manager_tool._guard_agent_created_enabled", return_value=False), \
+             patch("tools.skill_manager_tool.scan_skill", return_value=scan_result) as scanner, \
+             patch("tools.skill_manager_tool.should_allow_install", return_value=(True, "safe")):
+            result = _security_scan_skill(tmp_path, guard_required=True)
+
+        assert result is None
+        scanner.assert_called_once_with(tmp_path, source="agent-created")
+
     def test_guard_flag_reads_config_default_false(self):
         """_guard_agent_created_enabled returns False when config doesn't set it."""
         from tools.skill_manager_tool import _guard_agent_created_enabled
@@ -705,11 +738,11 @@ class TestSecurityScanGate:
             assert _guard_agent_created_enabled() is True
 
     def test_guard_flag_handles_config_error(self):
-        """If load_config raises, _guard_agent_created_enabled defaults to False (fail-safe off)."""
+        """If config loading fails, the guard stays enabled (fail closed)."""
         from tools.skill_manager_tool import _guard_agent_created_enabled
 
         with patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
-            assert _guard_agent_created_enabled() is False
+            assert _guard_agent_created_enabled() is True
 
     def test_guard_flag_quoted_false_stays_disabled(self):
         """Quoted 'false' from YAML edits must not enable the guard."""

--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -22,6 +22,7 @@ def _can_symlink():
 from tools.skills_guard import (
     Finding,
     ScanResult,
+    scan_result_delta,
     scan_file,
     scan_skill,
     should_allow_install,
@@ -104,6 +105,39 @@ class TestDetermineVerdict:
     def test_low_finding_safe(self):
         f = Finding("x", "low", "obfuscation", "f.py", 1, "m", "d")
         assert _determine_verdict([f]) == "safe"
+
+
+class TestScanResultDelta:
+    @staticmethod
+    def _result(findings):
+        return ScanResult(
+            skill_name="test",
+            source="agent-created",
+            trust_level="agent-created",
+            verdict=_determine_verdict(findings),
+            findings=findings,
+        )
+
+    def test_ignores_line_number_changes_for_existing_finding(self):
+        before = Finding("secret", "critical", "exfil", "SKILL.md", 4, "token", "secret")
+        after = Finding("secret", "critical", "exfil", "SKILL.md", 9, "token", "secret")
+
+        delta = scan_result_delta(self._result([before]), self._result([after]))
+
+        assert delta.verdict == "safe"
+        assert delta.findings == []
+
+    def test_preserves_duplicate_counts(self):
+        existing = Finding("secret", "critical", "exfil", "SKILL.md", 4, "token", "secret")
+        duplicate = Finding("secret", "critical", "exfil", "SKILL.md", 9, "token", "secret")
+
+        delta = scan_result_delta(
+            self._result([existing]),
+            self._result([existing, duplicate]),
+        )
+
+        assert delta.verdict == "dangerous"
+        assert delta.findings == [duplicate]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -211,6 +211,123 @@ def test_skill_gate_on_then_apply_writes_file(hermes_home):
     assert smt._find_skill("applied-skill") is not None
 
 
+def _skill_security_context(name, content=_SKILL):
+    import importlib
+    import hermes_cli.config as cfg
+    import tools.skill_manager_tool as smt
+    importlib.reload(smt)
+    from tools import write_approval as wa
+
+    created = json.loads(smt.skill_manage("create", name, content=content))
+    assert created["success"] is True
+    config = cfg.load_config()
+    config.setdefault("skills", {})["write_approval"] = True
+    config["skills"]["guard_agent_created"] = True
+    cfg.save_config(config)
+    return smt, wa
+
+
+def _apply_staged(smt, wa, action, name, **kwargs):
+    staged = json.loads(smt.skill_manage(action, name, **kwargs))
+    rec = wa.get_pending("skills", staged["pending_id"])
+    assert rec is not None
+    return json.loads(smt.apply_skill_pending(rec["payload"]))
+
+
+def _content_with_dangerous_finding():
+    return _SKILL.replace(
+        "body",
+        'body\n\n```python\nos.environ.get("OPENAI_API_KEY")\n```',
+    )
+
+
+def test_approved_safe_patch_ignores_preexisting_dangerous_findings(hermes_home):
+    """A safe delta must not be blocked by unchanged findings elsewhere."""
+    smt, wa = _skill_security_context(
+        "existing-findings", _content_with_dangerous_finding()
+    )
+
+    applied = _apply_staged(
+        smt, wa, "patch", "existing-findings",
+        old_string="# Test", new_string="# Safer title\n\nExtra context",
+    )
+
+    assert applied["success"] is True
+    found = smt._find_skill("existing-findings")
+    assert found is not None
+    assert "# Safer title" in (found["path"] / "SKILL.md").read_text(encoding="utf-8")
+
+
+def test_approved_patch_blocks_and_rolls_back_new_dangerous_finding(hermes_home):
+    """Approval must not bypass a dangerous finding introduced by the delta."""
+    smt, wa = _skill_security_context("new-finding")
+
+    applied = _apply_staged(
+        smt, wa, "patch", "new-finding",
+        old_string="body",
+        new_string='body\n\n```python\nos.environ.get("OPENAI_API_KEY")\n```',
+    )
+
+    assert applied["success"] is False
+    assert "Security scan blocked" in applied["error"]
+    found = smt._find_skill("new-finding")
+    assert found is not None
+    assert "OPENAI_API_KEY" not in (found["path"] / "SKILL.md").read_text(encoding="utf-8")
+
+
+def test_approved_patch_rolls_back_when_scanner_fails(hermes_home):
+    """A post-mutation scanner failure must reject and restore the file."""
+    from unittest.mock import patch
+
+    smt, wa = _skill_security_context("scanner-failure")
+    with patch.object(smt, "_security_scan_snapshot", return_value=(True, None)), \
+         patch.object(smt, "scan_skill", side_effect=RuntimeError("boom")):
+        applied = _apply_staged(
+            smt, wa, "patch", "scanner-failure",
+            old_string="body", new_string="changed body",
+        )
+
+    assert applied["success"] is False
+    assert applied["error"] == "Security scan failed; the skill write was not applied."
+    found = smt._find_skill("scanner-failure")
+    assert found is not None
+    content = (found["path"] / "SKILL.md").read_text(encoding="utf-8")
+    assert "changed body" not in content
+    assert "body" in content
+
+
+def test_approved_safe_write_file_ignores_preexisting_dangerous_findings(hermes_home):
+    """Supporting-file writes evaluate only findings introduced by that write."""
+    smt, wa = _skill_security_context(
+        "safe-supporting-write", _content_with_dangerous_finding()
+    )
+
+    applied = _apply_staged(
+        smt, wa, "write_file", "safe-supporting-write",
+        file_path="references/notes.md", file_content="# Harmless notes\n",
+    )
+
+    assert applied["success"] is True
+    found = smt._find_skill("safe-supporting-write")
+    assert found is not None
+    assert (found["path"] / "references" / "notes.md").exists()
+
+
+def test_approved_edit_blocks_and_rolls_back_new_dangerous_finding(hermes_home):
+    """Full rewrites retain rollback when the new content adds a threat."""
+    smt, wa = _skill_security_context("dangerous-edit")
+
+    applied = _apply_staged(
+        smt, wa, "edit", "dangerous-edit", content=_content_with_dangerous_finding()
+    )
+
+    assert applied["success"] is False
+    assert "Security scan blocked" in applied["error"]
+    found = smt._find_skill("dangerous-edit")
+    assert found is not None
+    assert "OPENAI_API_KEY" not in (found["path"] / "SKILL.md").read_text(encoding="utf-8")
+
+
 def test_skill_create_diff_is_full_content(hermes_home):
     from tools.skill_manager_tool import skill_manage
     from tools import write_approval as wa

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -93,7 +93,12 @@ def _reset_background_review_read_marks() -> None:
 # Import security scanner — external hub installs always get scanned;
 # agent-created skills only get scanned when skills.guard_agent_created is on.
 try:
-    from tools.skills_guard import scan_skill, should_allow_install, format_scan_report
+    from tools.skills_guard import (
+        format_scan_report,
+        scan_result_delta,
+        scan_skill,
+        should_allow_install,
+    )
     _GUARD_AVAILABLE = True
 except ImportError:
     _GUARD_AVAILABLE = False
@@ -115,20 +120,60 @@ def _guard_agent_created_enabled() -> bool:
             default=False,
         )
     except Exception:
-        return False
+        # A broken or unreadable config must not silently disable a security
+        # control the user may have enabled.
+        return True
 
 
-def _security_scan_skill(skill_dir: Path) -> Optional[str]:
-    """Scan a skill directory after write. Returns error string if blocked, else None.
+def _security_scan_snapshot(skill_dir: Path):
+    """Capture the immutable guard decision and a pre-mutation scan.
 
-    No-op when skills.guard_agent_created is disabled (the default).
+    A failed snapshot returns no baseline so the post-mutation path performs a
+    full scan instead of subtracting an untrusted baseline. The captured guard
+    decision is reused after mutation to prevent a concurrent config change
+    from bypassing the scan.
     """
+    guard_required = _guard_agent_created_enabled()
+    if not guard_required:
+        return False, None
     if not _GUARD_AVAILABLE:
+        logger.warning("Pre-mutation security scanner is unavailable for %s", skill_dir)
+        return True, None
+    try:
+        return True, scan_skill(skill_dir, source="agent-created")
+    except Exception as e:
+        logger.warning(
+            "Pre-mutation security scan failed for %s: %s",
+            skill_dir,
+            e,
+            exc_info=True,
+        )
+        return True, None
+
+
+def _security_scan_skill(
+    skill_dir: Path,
+    previous_scan=None,
+    *,
+    guard_required: Optional[bool] = None,
+) -> Optional[str]:
+    """Scan a skill after write and return an error when policy blocks it.
+
+    When ``previous_scan`` is provided, only newly introduced findings are
+    evaluated. A create passes no snapshot and therefore evaluates every
+    finding in the new skill. Scanner failures block the write so callers can
+    roll it back rather than persisting unscanned content.
+    """
+    if guard_required is None:
+        guard_required = _guard_agent_created_enabled()
+    if not guard_required:
         return None
-    if not _guard_agent_created_enabled():
-        return None
+    if not _GUARD_AVAILABLE:
+        return "Security scan unavailable; the skill write was not applied."
     try:
         result = scan_skill(skill_dir, source="agent-created")
+        if previous_scan is not None:
+            result = scan_result_delta(previous_scan, result)
         allowed, reason = should_allow_install(result)
         if allowed is False:
             report = format_scan_report(result)
@@ -142,6 +187,7 @@ def _security_scan_skill(skill_dir: Path) -> Optional[str]:
             return f"Security scan blocked this skill ({reason}):\n{report}"
     except Exception as e:
         logger.warning("Security scan failed for %s: %s", skill_dir, e, exc_info=True)
+        return "Security scan failed; the skill write was not applied."
     return None
 
 import yaml
@@ -838,6 +884,11 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
             "error": f"A skill named '{name}' already exists at {existing['path']}."
         }
 
+    # Capture the guard decision before any filesystem mutation. Reusing the
+    # same decision after the write prevents a concurrent config change from
+    # disabling the post-mutation scan.
+    guard_required = _guard_agent_created_enabled()
+
     # Create the skill directory
     skill_dir = _resolve_skill_dir(name, category)
     skill_dir.mkdir(parents=True, exist_ok=True)
@@ -847,7 +898,7 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     _atomic_write_text(skill_md, content)
 
     # Security scan — roll back on block
-    scan_error = _security_scan_skill(skill_dir)
+    scan_error = _security_scan_skill(skill_dir, guard_required=guard_required)
     if scan_error:
         shutil.rmtree(skill_dir, ignore_errors=True)
         return {"success": False, "error": scan_error}
@@ -904,10 +955,13 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
 
     # Back up original content for rollback
     original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
+    guard_required, previous_scan = _security_scan_snapshot(existing["path"])
     _atomic_write_text(skill_md, content)
 
-    # Security scan — roll back on block
-    scan_error = _security_scan_skill(existing["path"])
+    # Security scan — roll back on newly introduced findings
+    scan_error = _security_scan_skill(
+        existing["path"], previous_scan, guard_required=guard_required
+    )
     if scan_error:
         if original_content is not None:
             _atomic_write_text(skill_md, original_content)
@@ -1024,10 +1078,13 @@ def _patch_skill(
             }
 
     original_content = content  # for rollback
+    guard_required, previous_scan = _security_scan_snapshot(skill_dir)
     _atomic_write_text(target, new_content)
 
-    # Security scan — roll back on block
-    scan_error = _security_scan_skill(skill_dir)
+    # Security scan — roll back on newly introduced findings
+    scan_error = _security_scan_skill(
+        skill_dir, previous_scan, guard_required=guard_required
+    )
     if scan_error:
         _atomic_write_text(target, original_content)
         return {"success": False, "error": scan_error}
@@ -1193,10 +1250,13 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     target.parent.mkdir(parents=True, exist_ok=True)
     # Back up for rollback
     original_content = target.read_text(encoding="utf-8") if target.exists() else None
+    guard_required, previous_scan = _security_scan_snapshot(existing["path"])
     _atomic_write_text(target, file_content)
 
-    # Security scan — roll back on block
-    scan_error = _security_scan_skill(existing["path"])
+    # Security scan — roll back on newly introduced findings
+    scan_error = _security_scan_skill(
+        existing["path"], previous_scan, guard_required=guard_required
+    )
     if scan_error:
         if original_content is not None:
             _atomic_write_text(target, original_content)

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -26,7 +26,8 @@ import re
 import fnmatch
 import hashlib
 import json
-from dataclasses import dataclass, field
+from collections import Counter
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Tuple
@@ -92,6 +93,54 @@ class ScanResult:
     scanned_at: str = ""
     summary: str = ""
     scan_provenance: dict = field(default_factory=dict)
+
+
+def _finding_identity(finding: Finding) -> tuple:
+    """Stable identity for comparing findings across a skill mutation.
+
+    Line numbers are intentionally excluded because an unrelated edit can move
+    unchanged suspicious text. The remaining fields preserve finding content,
+    and ``Counter`` in :func:`scan_result_delta` preserves duplicate counts.
+    """
+    return (
+        finding.pattern_id,
+        finding.severity,
+        finding.category,
+        finding.file,
+        finding.match,
+        finding.description,
+    )
+
+
+def scan_result_delta(previous: ScanResult, current: ScanResult) -> ScanResult:
+    """Return a result containing only findings introduced since ``previous``.
+
+    Mutation callers can enforce policy on changed content without allowing
+    unrelated pre-existing findings to deadlock a legitimate edit. Findings
+    are compared as a multiset, so adding an identical occurrence is detected.
+    """
+    remaining = Counter(_finding_identity(finding) for finding in previous.findings)
+    new_findings = []
+    for finding in current.findings:
+        identity = _finding_identity(finding)
+        if remaining[identity]:
+            remaining[identity] -= 1
+        else:
+            new_findings.append(finding)
+
+    verdict = _determine_verdict(new_findings)
+    return replace(
+        current,
+        verdict=verdict,
+        findings=new_findings,
+        summary=_build_summary(
+            current.skill_name,
+            current.source,
+            current.trust_level,
+            verdict,
+            new_findings,
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes the approval replay dead-end described in the discussion on #53491.

When `skills.write_approval` and `skills.guard_agent_created` are both enabled, an approved safe edit currently rescans the entire post-write skill. Any unchanged dangerous finding already present in that skill blocks the approved edit, so the user has no usable confirmation path.

This change captures a pre-mutation scan and evaluates only newly introduced findings after `edit`, `patch`, and `write_file`. Finding subtraction uses a multiset identity that excludes line numbers, so harmless line movement does not become a new finding while an additional identical finding is still detected. New skills continue to scan all findings.

The guard decision is captured before filesystem mutation and reused afterward, preventing a concurrent config change from disabling the post-write scan. Scanner/config failures also fail closed and trigger the existing rollback path.

This is complementary to #53492. That PR covers default-on behavior, finding disclosure, and additional scanner hardening. This PR is narrowly focused on mutation deltas and the approval replay lifecycle; it does not change the default guard setting or scanner classifier.

## Related Issue

Related to #53491

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skills_guard.py`
  - add multiset-based `scan_result_delta()`
  - ignore line-number-only movement while preserving duplicate counts
  - recalculate verdict and summary from only new findings
- `tools/skill_manager_tool.py`
  - snapshot enabled guard state and findings before mutations
  - delta-scan `edit`, `patch`, and `write_file`
  - retain full scans for `create`
  - fail closed when config/scanner evaluation fails
  - preserve rollback on blocks and scanner failures
- Tests
  - safe approved mutations with pre-existing findings
  - line-shift and duplicate-count behavior
  - new dangerous finding blocks and rolls back
  - scanner failure blocks and rolls back
  - supporting-file and full-edit mutation paths
  - immutable guard decision across a concurrent config disable

## How to Test

1. Run the targeted security and approval suites:
   ```bash
   uv run --extra dev pytest tests/tools/test_write_approval.py tests/tools/test_skill_manager_tool.py tests/tools/test_skills_guard.py -q
   ```
   Expected: `233 passed`.
2. Run static and cross-platform checks:
   ```bash
   uv run --extra dev ruff check tools/skill_manager_tool.py tools/skills_guard.py tests/tools/test_write_approval.py tests/tools/test_skill_manager_tool.py tests/tools/test_skills_guard.py
   uv run --extra dev python scripts/check-windows-footguns.py tools/skill_manager_tool.py tools/skills_guard.py tests/tools/test_write_approval.py tests/tools/test_skill_manager_tool.py tests/tools/test_skills_guard.py
   git diff --check HEAD^
   ```
3. Run the repository suite:
   ```bash
   scripts/run_tests.sh
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; internal behavior only, docstrings updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — standard-library Python only; Windows-footgun scan passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no schema change

## Screenshots / Logs

```text
Targeted affected suites:
233 passed in 3.88s
All checks passed!
✓ No Windows footguns found (5 file(s) scanned).

Full repository suite (`scripts/run_tests.sh`):
- Exit 1 with 29 failures across 15 unrelated files and 11 collection/timeout files.
- The sharded runner stranded `tests/tools/test_write_approval.py` before its final retry, reporting that path missing; the file was restored from the commit afterward.
- No changed production file appeared in the failure list.
- The three affected test files pass together in the targeted command above.
```
