### PR TITLE
fix(gateway): restore relay streaming and Slack command delivery

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -95,6 +95,19 @@ class GatewayAuthorizationMixin:
         transport_adapter = self._registered_transport_adapter(source)
         if transport_adapter is not None:
             return transport_adapter
+        # Relay ingress deliberately keeps the underlying platform on the
+        # source so session keys and display policy remain Slack/Discord/etc.
+        # Delivery still has to use the one live RelayAdapter that owns the
+        # authenticated connector socket. Looking up the underlying platform
+        # here silently disables streaming, typing, and tool progress when a
+        # managed gateway does not also run that platform's native adapter.
+        if getattr(source, "delivered_via_upstream_relay", False) is True:
+            # One process-level RelayAdapter owns the connector socket for all
+            # multiplexed profiles. Secondary profiles intentionally do not
+            # register their own relay adapters, so profile-aware lookup would
+            # fail and suppress streamed delivery for those profiles.
+            adapters = getattr(self, "adapters", None) or {}
+            return adapters.get(Platform.RELAY)
         # ``getattr`` guards test fixtures that build a bare source via
         # SimpleNamespace and omit ``profile`` (see AGENTS.md pitfall #17).
         return self._authorization_adapter(

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -513,6 +513,51 @@ class RelayAdapter(BasePlatformAdapter):
             error=result.get("error"),
         )
 
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Edit a relayed message through the connector-owned platform API."""
+        if self._transport is None:
+            return SendResult(success=False, error="no transport")
+        result = await self._transport.send_outbound(
+            {
+                "op": "edit",
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "metadata": self._with_scope(chat_id, metadata),
+            },
+            platform=self._platform_by_chat.get(str(chat_id)),
+        )
+        return SendResult(
+            success=bool(result.get("success")),
+            message_id=result.get("message_id") or message_id,
+            error=result.get("error"),
+        )
+
+    async def send_typing(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Forward a typing/status heartbeat to the connector."""
+        if self._transport is None:
+            return
+        await self._transport.send_outbound(
+            {
+                "op": "typing",
+                "chat_id": chat_id,
+                "metadata": self._with_scope(chat_id, metadata),
+            },
+            platform=self._platform_by_chat.get(str(chat_id)),
+        )
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         # Proxied to the connector (it owns the platform connection / cache).
         if self._transport is None:

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -558,6 +558,30 @@ class RelayAdapter(BasePlatformAdapter):
             platform=self._platform_by_chat.get(str(chat_id)),
         )
 
+    async def stop_typing(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Forward an explicit typing/status clear to the connector."""
+        if self._transport is None:
+            return
+        platform = self._platform_by_chat.get(str(chat_id))
+        # Slack Assistant status persists until explicitly cleared. Other relay
+        # senders expose only one-shot typing heartbeats; sending an empty
+        # heartbeat there would incorrectly re-trigger typing at completion.
+        if platform != Platform.SLACK.value:
+            return
+        await self._transport.send_outbound(
+            {
+                "op": "typing",
+                "chat_id": chat_id,
+                "content": "",
+                "metadata": self._with_scope(chat_id, metadata),
+            },
+            platform=platform,
+        )
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         # Proxied to the connector (it owns the platform connection / cache).
         if self._transport is None:

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -129,6 +129,42 @@ def _render_relay_context(context: Any) -> Optional[str]:
     return f"[Recent channel messages]\n{body}"
 
 
+def _normalize_slack_parent_command(
+    text: str,
+    message_type: MessageType,
+) -> tuple[str, MessageType]:
+    """Mirror native Slack ``/hermes`` routing for authenticated relay text."""
+    stripped = text.strip()
+    parent_parts = stripped.split(maxsplit=1)
+    if not parent_parts or parent_parts[0] != "/hermes":
+        return text, message_type
+
+    from hermes_cli.commands import slack_subcommand_map
+
+    payload = parent_parts[1].strip() if len(parent_parts) > 1 else ""
+    subcommand_map = slack_subcommand_map()
+    subcommand_map["compact"] = "/compress"
+    payload_parts = payload.split() if payload else []
+    first_word = payload_parts[0] if payload_parts else ""
+
+    if first_word in subcommand_map:
+        rest = payload[len(first_word) :].strip()
+        normalized = (
+            f"{subcommand_map[first_word]} {rest}".strip()
+            if rest
+            else subcommand_map[first_word]
+        )
+    elif payload:
+        normalized = payload
+    else:
+        normalized = "/help"
+
+    normalized_type = (
+        MessageType.COMMAND if normalized.startswith("/") else MessageType.TEXT
+    )
+    return normalized, normalized_type
+
+
 def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
     """Rebuild a MessageEvent from the connector's normalized inbound payload.
 
@@ -181,8 +217,16 @@ def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
     except ValueError:
         msg_type = MessageType.TEXT
 
+    text = raw.get("text", "")
+    if platform_enum == Platform.SLACK:
+        # Team Gateway carries Slack slash text over the authenticated message
+        # relay, bypassing Hermes' native Slack command callback. Normalize at
+        # the wire boundary so adapter-level active-session gates see the real
+        # gateway command rather than the legacy `hermes` parent name.
+        text, msg_type = _normalize_slack_parent_command(text, msg_type)
+
     return MessageEvent(
-        text=raw.get("text", ""),
+        text=text,
         message_type=msg_type,
         source=source,
         message_id=raw.get("message_id"),

--- a/tests/gateway/relay/test_relay_adapter.py
+++ b/tests/gateway/relay/test_relay_adapter.py
@@ -287,6 +287,56 @@ async def test_scoped_reply_without_inbound_author_carries_scope_only():
     assert "user_id" not in t.sent["metadata"]
 
 
+@pytest.mark.asyncio
+async def test_edit_message_forwards_relay_action_with_routing_context():
+    t = _CaptureTransport()
+    a = RelayAdapter(PlatformConfig(), make_desc(platform="slack"), transport=t)
+    event = _make_event(chat_id="channel-1", scope_id="workspace-1")
+    event.source.platform = Platform.SLACK
+    a._capture_scope(event)
+
+    result = await a.edit_message(
+        "channel-1",
+        "message-1",
+        "streamed answer",
+        metadata={"thread_id": "thread-1"},
+    )
+
+    assert result.success is True
+    assert t.sent == {
+        "op": "edit",
+        "chat_id": "channel-1",
+        "message_id": "message-1",
+        "content": "streamed answer",
+        "metadata": {
+            "thread_id": "thread-1",
+            "scope_id": "workspace-1",
+        },
+    }
+    assert t.sent_platform == "slack"
+
+
+@pytest.mark.asyncio
+async def test_send_typing_forwards_relay_action_with_routing_context():
+    t = _CaptureTransport()
+    a = RelayAdapter(PlatformConfig(), make_desc(platform="slack"), transport=t)
+    event = _make_event(chat_id="channel-1", scope_id="workspace-1")
+    event.source.platform = Platform.SLACK
+    a._capture_scope(event)
+
+    await a.send_typing("channel-1", metadata={"thread_id": "thread-1"})
+
+    assert t.sent == {
+        "op": "typing",
+        "chat_id": "channel-1",
+        "metadata": {
+            "thread_id": "thread-1",
+            "scope_id": "workspace-1",
+        },
+    }
+    assert t.sent_platform == "slack"
+
+
 # ── Phase 7 Unit 7d-B: terminal auth revocation → clean "relay disabled" ─────
 
 

--- a/tests/gateway/relay/test_relay_adapter.py
+++ b/tests/gateway/relay/test_relay_adapter.py
@@ -337,6 +337,40 @@ async def test_send_typing_forwards_relay_action_with_routing_context():
     assert t.sent_platform == "slack"
 
 
+@pytest.mark.asyncio
+async def test_stop_typing_forwards_explicit_clear_with_routing_context():
+    t = _CaptureTransport()
+    a = RelayAdapter(PlatformConfig(), make_desc(platform="slack"), transport=t)
+    event = _make_event(chat_id="channel-1", scope_id="workspace-1")
+    event.source.platform = Platform.SLACK
+    a._capture_scope(event)
+
+    await a.stop_typing("channel-1", metadata={"thread_id": "thread-1"})
+
+    assert t.sent == {
+        "op": "typing",
+        "chat_id": "channel-1",
+        "content": "",
+        "metadata": {
+            "thread_id": "thread-1",
+            "scope_id": "workspace-1",
+        },
+    }
+    assert t.sent_platform == "slack"
+
+
+@pytest.mark.asyncio
+async def test_stop_typing_is_noop_for_non_slack_relay_platforms():
+    t = _CaptureTransport()
+    a = RelayAdapter(PlatformConfig(), make_desc(platform="telegram"), transport=t)
+    event = _make_event(chat_id="channel-1", scope_id="workspace-1")
+    event.source.platform = Platform.TELEGRAM
+    a._capture_scope(event)
+
+    await a.stop_typing("channel-1", metadata={"thread_id": "thread-1"})
+
+    assert t.sent is None
+    assert t.sent_platform is None
 # ── Phase 7 Unit 7d-B: terminal auth revocation → clean "relay disabled" ─────
 
 

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -153,6 +153,54 @@ def test_chat_routed_source_keeps_receiving_shared_adapter(monkeypatch):
     assert runner._is_user_authorized(source) is True
 
 
+def test_adapter_for_relay_delivered_source_uses_relay_transport(monkeypatch):
+    """A relayed Slack event keeps Slack session semantics but replies over relay."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    slack_adapter = SimpleNamespace(send=AsyncMock())
+    relay_adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {
+        Platform.SLACK: slack_adapter,
+        Platform.RELAY: relay_adapter,
+    }
+    runner._profile_adapters = {}
+
+    source = SessionSource(
+        platform=Platform.SLACK,
+        user_id="U123",
+        chat_id="C123",
+        chat_type="channel",
+        profile="coder",
+        delivered_via_upstream_relay=True,
+    )
+
+    assert runner._adapter_for_source(source) is relay_adapter
+
+
+def test_adapter_for_direct_source_keeps_native_platform_adapter(monkeypatch):
+    """The relay routing rule must not affect direct Slack connector delivery."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    slack_adapter = SimpleNamespace(send=AsyncMock())
+    relay_adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {
+        Platform.SLACK: slack_adapter,
+        Platform.RELAY: relay_adapter,
+    }
+    runner._profile_adapters = {}
+
+    source = SessionSource(
+        platform=Platform.SLACK,
+        user_id="U123",
+        chat_id="C123",
+        chat_type="channel",
+    )
+
+    assert runner._adapter_for_source(source) is slack_adapter
+
+
 def test_secondary_allowlist_dm_behavior_ignores_unauthorized(monkeypatch):
     """Unauthorized-DM behavior must read the secondary adapter's dm_policy."""
     runner, _default_adapter, secondary_adapter = _make_multiplex_runner(monkeypatch)

--- a/tests/gateway/test_slack_relay_parent_command.py
+++ b/tests/gateway/test_slack_relay_parent_command.py
@@ -1,0 +1,53 @@
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageType
+from gateway.relay.ws_transport import _event_from_wire
+
+
+def _wire(text: str, *, platform: str = "slack") -> dict:
+    return {
+        "text": text,
+        "message_type": "command",
+        "source": {
+            "platform": platform,
+            "chat_id": "D123",
+            "chat_type": "dm",
+            "user_id": "U123",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("wire_text", "expected"),
+    [
+        ("/hermes sethome", "/sethome"),
+        ("/hermes\tsethome", "/sethome"),
+        (
+            "/hermes model gpt-5.6 --provider openai",
+            "/model gpt-5.6 --provider openai",
+        ),
+        ("/hermes", "/help"),
+    ],
+)
+def test_slack_relay_parent_becomes_gateway_command(wire_text: str, expected: str):
+    event = _event_from_wire(_wire(wire_text))
+
+    assert event.text == expected
+    assert event.message_type == MessageType.COMMAND
+    assert event.source.platform == Platform.SLACK
+    assert event.source.delivered_via_upstream_relay is True
+
+
+def test_slack_relay_parent_freeform_text_matches_native_adapter():
+    event = _event_from_wire(_wire("/hermes explain this"))
+
+    assert event.text == "explain this"
+    assert event.message_type == MessageType.TEXT
+
+
+def test_non_slack_relay_message_is_not_rewritten():
+    event = _event_from_wire(_wire("/hermes sethome", platform="discord"))
+
+    assert event.text == "/hermes sethome"
+    assert event.message_type == MessageType.COMMAND


### PR DESCRIPTION
## Summary

This PR restores the presentation and command behavior that Hermes users expect when Slack traffic is delivered through an authenticated relay instead of a native in-process Slack adapter.

It fixes three related failures:

- streamed edits, thinking state, interim commentary, and tool progress were suppressed even though the final response arrived;
- Slack `/hermes <subcommand>` input was parsed as an unknown `/hermes` gateway command;
- Slack Assistant thinking status could remain visible after a turn completed.

## Problem

Relay-delivered messages intentionally retain their concrete source platform. A Slack event therefore enters the gateway as `platform=slack`, with the original channel, thread, user, and connector routing metadata intact.

That identity is correct for authorization, session routing, command semantics, and platform-specific behavior. It was not sufficient for outbound presentation callbacks. The gateway selected the native Slack adapter from `source.platform`, but a relay deployment may not have a native Slack adapter or Slack credential in the Hermes process. The authenticated relay socket is the only valid delivery path.

This produced an asymmetric user experience: final responses were sent through the relay, while edits and status updates were silently discarded because Hermes could not resolve a delivery adapter for the concrete Slack source.

The same boundary affected Slack's parent command. Native Slack normalizes `/hermes sethome` and other known subcommands before gateway command dispatch. Relayed Slack input bypassed that adapter-level normalization, so `/hermes` reached active-session and command gates as the command name instead of mapping to the canonical gateway command.

Finally, the base platform lifecycle calls `stop_typing()` when command and turn processing exits. `RelayAdapter` inherited the no-op implementation, so Hermes had no way to clear Slack Assistant status over the connector.

## What changes

### Resolve delivery through the relay without changing source identity

`GatewayAuthzMixin._adapter_for_source()` now distinguishes event identity from delivery ownership:

1. preserve an explicitly registered transport adapter when one is attached to the source;
2. use the process relay adapter for authenticated events marked `delivered_via_upstream_relay`;
3. retain the existing concrete-platform lookup and scoped `user_id` fallback for native events.

This keeps Slack authorization and session semantics unchanged while ensuring presentation callbacks use the authenticated connector that delivered the event.

### Add relay presentation operations

`RelayAdapter` now emits scoped relay actions for:

- `edit`, used by streaming response updates;
- `typing`, used by thinking and status presentation;
- Slack status clear, represented as `op=typing` with empty content from `stop_typing()`.

Each action passes through `_with_scope()`, preserving the instance, tenant, owner, and connection metadata required to route it back through the correct connector session. Empty status content is emitted only for Slack. Other relay-backed platforms retain their existing one-shot typing behavior.

### Normalize Slack parent commands at the relay boundary

The WebSocket transport normalizes authenticated Slack `/hermes` input while converting the wire event into a `MessageEvent`, before active-session and command gates run.

Behavior matches the native Slack adapter:

- `/hermes` maps to `/help`;
- known subcommands map to canonical gateway commands;
- `compact` retains its compatibility mapping to `/compress`;
- free-form `/hermes <question>` text remains ordinary user input;
- non-Slack relay events are unchanged.

## Security and compatibility

- The change does not weaken source authorization. Relayed events must already have passed the authenticated upstream relay path before they can select `RelayAdapter` for delivery.
- Native Slack, Telegram, Discord, and other in-process adapters continue to resolve through their concrete platform.
- Registered transport-adapter provenance remains the highest-priority lookup, preserving current multiplexed-profile behavior from `main`.
- Relay actions retain connector scope metadata rather than reconstructing routing state from user-controlled message fields.
- Slack status clearing is explicitly platform-gated and does not change typing behavior for other relay-backed platforms.

## Scope

This PR is limited to Hermes relay delivery and command parity. It does not add connector-side Slack formatting, change Slack app manifests or command registration, alter DM threading policy, or introduce deployment-specific configuration.

## Verification

- 199 relay, authorization, multiplex-profile, and Slack parent-command tests passed.
- 275 stream-consumer, profile-routing, clarification, and interaction tests passed.
- Ruff passed on every changed Python file.
- Python compilation and `git diff --check` passed.
- An independent correctness and security review found no blockers or rebase regressions.

The affected flows were also exercised through a real shared Slack connector deployment:

- thinking/status, tool progress, streamed edits, and final delivery reached the correct linked Hermes instance;
- final responses were not duplicated;
- bare `/hermes sethome` executed as the canonical gateway command;
- thinking status cleared immediately after command and turn completion.
