### PR TITLE
feat(cli): compare prompt size across profiles

### DIFF
--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -13,8 +13,12 @@ calls ``build_system_prompt_parts`` / inspects ``agent.tools`` offline.
 
 from __future__ import annotations
 
+import io
 import json
 import re
+import subprocess
+import sys
+from contextlib import redirect_stdout
 from typing import Any, Dict, List, Tuple
 
 # The skills index is wrapped in this tag pair inside the stable tier.
@@ -55,6 +59,101 @@ def _build_inspection_agent(platform: str) -> Any:
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
     )
+
+
+_CHILD_DIAGNOSTIC_LIMIT = 1000
+
+
+def _bounded_child_output(value: str) -> str:
+    """Return a compact single-line child diagnostic suitable for CLI errors."""
+    text = " ".join((value or "").strip().split())
+    if len(text) <= _CHILD_DIAGNOSTIC_LIMIT:
+        return text
+    return text[:_CHILD_DIAGNOSTIC_LIMIT] + "…"
+
+
+def _require_measurement(
+    data: Dict[str, Any], section: str, key: str, profile: str
+) -> int:
+    """Read one required non-negative integer from a child measurement."""
+    section_data = data.get(section)
+    value = section_data.get(key) if isinstance(section_data, dict) else None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise RuntimeError(
+            f"Invalid prompt-size output for profile '{profile}': "
+            f"{section}.{key} must be a non-negative integer"
+        )
+    return value
+
+
+def compute_all_profile_breakdowns(platform: str = "cli") -> List[Dict[str, Any]]:
+    """Measure every profile in a fresh isolated CLI process.
+
+    Profile selection must happen before Hermes modules import because many
+    paths cache ``HERMES_HOME`` at module scope. Spawning the normal CLI with an
+    explicit ``--profile`` preserves that contract and makes each result match
+    what the selected profile would actually send on a fresh session.
+    """
+    from hermes_cli.profiles import list_profiles
+
+    results: List[Dict[str, Any]] = []
+    for profile in list_profiles():
+        name = profile.name
+        command = [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "--profile",
+            name,
+            "prompt-size",
+            "--platform",
+            platform,
+            "--json",
+        ]
+        try:
+            completed = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=120,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Could not measure profile '{name}': child timed out after "
+                f"{exc.timeout} seconds"
+            ) from exc
+        except OSError as exc:
+            raise RuntimeError(
+                f"Could not start prompt-size child for profile '{name}': {exc}"
+            ) from exc
+        if completed.returncode != 0:
+            detail = _bounded_child_output(
+                completed.stderr or completed.stdout or "unknown error"
+            )
+            raise RuntimeError(f"Could not measure profile '{name}': {detail}")
+        try:
+            data = json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            detail = _bounded_child_output(completed.stdout) or "empty output"
+            raise RuntimeError(
+                f"Could not parse prompt-size output for profile '{name}': "
+                f"{exc}; child output: {detail}"
+            ) from exc
+        if not isinstance(data, dict):
+            raise RuntimeError(
+                f"Invalid prompt-size output for profile '{name}': expected a JSON object"
+            )
+        prompt_bytes = _require_measurement(data, "system_prompt", "bytes", name)
+        schema_bytes = _require_measurement(data, "tools", "json_bytes", name)
+        _require_measurement(data, "tools", "count", name)
+        data["profile"] = name
+        data["fixed_bytes"] = prompt_bytes + schema_bytes
+        results.append(data)
+    results.sort(key=lambda row: int(row["fixed_bytes"]), reverse=True)
+    return results
 
 
 def compute_prompt_breakdown(platform: str = "cli") -> Dict[str, Any]:
@@ -121,6 +220,42 @@ def _fmt_kb(n: int) -> str:
     return f"{n / 1024:.1f} KB"
 
 
+def render_profile_comparison(
+    rows: List[Dict[str, Any]], *, platform: str = "cli"
+) -> str:
+    """Render a largest-first comparison of fixed prompt footprints."""
+    ordered = sorted(rows, key=lambda row: int(row.get("fixed_bytes", 0)), reverse=True)
+    profile_width = max(
+        18,
+        max((len(str(row.get("profile", ""))) for row in ordered), default=0),
+    )
+    lines = [
+        f"Profile prompt-size comparison (platform={platform})",
+        "",
+        f"  {'Profile':<{profile_width}} {'Model':<24} {'Prompt':>10} {'Schemas':>10} {'Tools':>7} {'Fixed':>10}",
+        f"  {'-' * profile_width} {'-' * 24} {'-' * 10} {'-' * 10} {'-' * 7} {'-' * 10}",
+    ]
+    for row in ordered:
+        prompt_bytes = int(row.get("system_prompt", {}).get("bytes", 0))
+        tools = row.get("tools", {})
+        schema_bytes = int(tools.get("json_bytes", 0))
+        tool_count = int(tools.get("count", 0))
+        fixed_bytes = int(row.get("fixed_bytes", prompt_bytes + schema_bytes))
+        model = str(row.get("model", "") or "unset")[:24]
+        lines.append(
+            f"  {str(row.get('profile', '')):<{profile_width}} {model:<24} "
+            f"{_fmt_kb(prompt_bytes):>10} {_fmt_kb(schema_bytes):>10} "
+            f"{tool_count:>7} {_fmt_kb(fixed_bytes):>10}"
+        )
+    lines.extend(
+        [
+            "",
+            "  Fixed payload = system prompt + tool-schema JSON (conversation history excluded).",
+        ]
+    )
+    return "\n".join(lines)
+
+
 def render_breakdown(data: Dict[str, Any]) -> str:
     """Render the breakdown as plain text suitable for a terminal."""
     lines: List[str] = []
@@ -146,15 +281,58 @@ def render_breakdown(data: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _compute_for_output(compute: Any, platform: str, *, as_json: bool) -> Any:
+    """Keep machine-readable stdout pure while preserving incidental diagnostics."""
+    if not as_json:
+        return compute(platform)
+    captured = io.StringIO()
+    try:
+        with redirect_stdout(captured):
+            return compute(platform)
+    finally:
+        diagnostic = captured.getvalue()
+        if diagnostic:
+            print(diagnostic, file=sys.stderr, end="" if diagnostic.endswith("\n") else "\n")
+
+
 def cmd_prompt_size(args: Any) -> None:
     """Entry point for ``hermes prompt-size``."""
     platform = getattr(args, "platform", "cli") or "cli"
     as_json = getattr(args, "json", False)
-    try:
-        data = compute_prompt_breakdown(platform)
-    except Exception as e:
-        print(f"Could not compute prompt-size breakdown: {e}")
+    all_profiles = getattr(args, "all_profiles", False)
+    if all_profiles:
+        try:
+            rows = _compute_for_output(
+                compute_all_profile_breakdowns,
+                platform,
+                as_json=as_json,
+            )
+        except Exception as e:
+            print(
+                f"Could not compute all-profile prompt-size breakdown: {e}",
+                file=sys.stderr,
+            )
+            raise SystemExit(1) from e
+        if as_json:
+            print(
+                json.dumps(
+                    {"platform": platform, "profiles": rows},
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+        else:
+            print(render_profile_comparison(rows, platform=platform))
         return
+    try:
+        data = _compute_for_output(
+            compute_prompt_breakdown,
+            platform,
+            as_json=as_json,
+        )
+    except Exception as e:
+        print(f"Could not compute prompt-size breakdown: {e}", file=sys.stderr)
+        raise SystemExit(1) from e
     if as_json:
         print(json.dumps(data, ensure_ascii=False, indent=2))
     else:

--- a/hermes_cli/subcommands/prompt_size.py
+++ b/hermes_cli/subcommands/prompt_size.py
@@ -29,6 +29,14 @@ def build_prompt_size_parser(subparsers, *, cmd_prompt_size: Callable) -> None:
         help="Platform to simulate (cli, telegram, discord, ...). Default: cli",
     )
     prompt_size_parser.add_argument(
+        "--all-profiles",
+        action="store_true",
+        help=(
+            "Measure every profile in an isolated process and compare fixed "
+            "prompt + tool-schema footprints"
+        ),
+    )
+    prompt_size_parser.add_argument(
         "--json",
         action="store_true",
         help="Emit the breakdown as JSON",

--- a/tests/hermes_cli/test_prompt_size.py
+++ b/tests/hermes_cli/test_prompt_size.py
@@ -1,7 +1,11 @@
 """Tests for the ``hermes prompt-size`` diagnostic (issue #34667)."""
 
+import argparse
 import json
+import os
+import subprocess
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -9,8 +13,11 @@ import pytest
 from hermes_cli.prompt_size import (
     _SKILLS_BLOCK_RE,
     _build_inspection_agent,
+    cmd_prompt_size,
+    compute_all_profile_breakdowns,
     compute_prompt_breakdown,
     render_breakdown,
+    render_profile_comparison,
 )
 
 
@@ -28,6 +35,28 @@ def _seed_skill(hermes_home, name, description):
     skill_dir.mkdir(parents=True, exist_ok=True)
     (skill_dir / "SKILL.md").write_text(
         f"---\nname: {name}\ndescription: {description}\n---\n# {name}\nbody\n",
+        encoding="utf-8",
+    )
+
+
+def _seed_profile_config(hermes_root, name, model):
+    profile_dir = (
+        hermes_root if name == "default" else hermes_root / "profiles" / name
+    )
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "config.yaml").write_text(
+        "\n".join(
+            [
+                "model:",
+                f"  default: {model}",
+                "  provider: openrouter",
+                "toolsets:",
+                "  - file",
+                "agent:",
+                "  coding_context: off",
+                "",
+            ]
+        ),
         encoding="utf-8",
     )
 
@@ -71,6 +100,229 @@ def test_runs_offline_without_credentials(isolated_home, monkeypatch):
         monkeypatch.delenv(var, raising=False)
     data = compute_prompt_breakdown("cli")
     assert data["system_prompt"]["bytes"] > 0
+
+
+def test_all_profiles_are_measured_in_isolated_cli_processes(monkeypatch):
+    """Each profile is measured through normal CLI profile resolution."""
+    profiles = [SimpleNamespace(name="default"), SimpleNamespace(name="builder")]
+    monkeypatch.setattr("hermes_cli.profiles.list_profiles", lambda: profiles)
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        profile = command[command.index("--profile") + 1]
+        payload = {
+            "platform": "cli",
+            "model": f"model-{profile}",
+            "system_prompt": {"chars": 10, "bytes": 10},
+            "skills_index": {"chars": 0, "bytes": 0},
+            "memory": {"chars": 0, "bytes": 0},
+            "user_profile": {"chars": 0, "bytes": 0},
+            "tools": {"count": 2, "json_bytes": 20},
+            "sections": [],
+        }
+        return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = compute_all_profile_breakdowns("cli")
+
+    assert [item["profile"] for item in result] == ["default", "builder"]
+    assert [item["fixed_bytes"] for item in result] == [30, 30]
+    assert all("--json" in command for command, _ in calls)
+    assert [command[command.index("--profile") + 1] for command, _ in calls] == [
+        "default",
+        "builder",
+    ]
+
+
+def test_real_cli_subprocess_isolates_profile_models(tmp_path):
+    hermes_root = tmp_path / "hermes-root"
+    models = {
+        "default": "test/default-model",
+        "alpha": "test/alpha-model",
+        "beta": "test/beta-model",
+    }
+    for profile, model in models.items():
+        _seed_profile_config(hermes_root, profile, model)
+
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_root)
+    env["HOME"] = str(tmp_path / "home")
+    env["USERPROFILE"] = str(tmp_path / "home")
+    env["LOCALAPPDATA"] = str(tmp_path / "local-app-data")
+    env["PROGRAMDATA"] = str(tmp_path / "program-data")
+    env["ALLUSERSPROFILE"] = str(tmp_path / "program-data")
+    env["SystemDrive"] = tmp_path.drive or "C:"
+    env.pop("HERMES_PROFILE", None)
+    env.pop("HERMES_CONFIG", None)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "prompt-size",
+            "--all-profiles",
+            "--json",
+        ],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=180,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    rows = payload["profiles"]
+    assert {row["profile"] for row in rows} == set(models)
+    assert {row["profile"]: row["model"] for row in rows} == models
+    for row in rows:
+        assert row["fixed_bytes"] == (
+            row["system_prompt"]["bytes"] + row["tools"]["json_bytes"]
+        )
+
+
+def test_malformed_child_json_preserves_profile_and_output(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.profiles.list_profiles",
+        lambda: [SimpleNamespace(name="builder")],
+    )
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0,
+            stdout="not-json from builder",
+            stderr="",
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        compute_all_profile_breakdowns("cli")
+
+    message = str(exc_info.value)
+    assert "builder" in message
+    assert "not-json from builder" in message
+
+
+def test_all_profile_rows_are_sorted_largest_first(monkeypatch):
+    profiles = [SimpleNamespace(name="small"), SimpleNamespace(name="large")]
+    monkeypatch.setattr("hermes_cli.profiles.list_profiles", lambda: profiles)
+
+    def fake_run(command, **_kwargs):
+        profile = command[command.index("--profile") + 1]
+        prompt_bytes = 10 if profile == "small" else 100
+        payload = {
+            "platform": "cli",
+            "model": f"model-{profile}",
+            "system_prompt": {"chars": prompt_bytes, "bytes": prompt_bytes},
+            "skills_index": {"chars": 0, "bytes": 0},
+            "memory": {"chars": 0, "bytes": 0},
+            "user_profile": {"chars": 0, "bytes": 0},
+            "tools": {"count": 1, "json_bytes": 20},
+            "sections": [],
+        }
+        return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = compute_all_profile_breakdowns("cli")
+
+    assert [row["profile"] for row in result] == ["large", "small"]
+    assert [row["fixed_bytes"] for row in result] == [120, 30]
+
+
+def test_child_json_requires_numeric_prompt_and_tool_measurements(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.profiles.list_profiles",
+        lambda: [SimpleNamespace(name="builder")],
+    )
+    malformed = {
+        "platform": "cli",
+        "model": "gpt-test",
+        "system_prompt": {"bytes": 100},
+        "tools": {"count": 1},
+    }
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(malformed),
+            stderr="",
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        compute_all_profile_breakdowns("cli")
+
+    message = str(exc_info.value)
+    assert "builder" in message
+    assert "json_bytes" in message
+
+
+def test_child_timeout_preserves_profile_and_timeout(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.profiles.list_profiles",
+        lambda: [SimpleNamespace(name="builder")],
+    )
+
+    def time_out(command, **_kwargs):
+        raise subprocess.TimeoutExpired(command, timeout=120)
+
+    monkeypatch.setattr("subprocess.run", time_out)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        compute_all_profile_breakdowns("cli")
+
+    message = str(exc_info.value)
+    assert "builder" in message
+    assert "120" in message
+    assert "timed out" in message.lower()
+
+
+def test_nonzero_child_exit_preserves_profile_and_stderr(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.profiles.list_profiles",
+        lambda: [SimpleNamespace(name="builder")],
+    )
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=7,
+            stdout="",
+            stderr="provider exploded",
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        compute_all_profile_breakdowns("cli")
+
+    message = str(exc_info.value)
+    assert "builder" in message
+    assert "provider exploded" in message
+
+
+def test_child_spawn_error_preserves_profile(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.profiles.list_profiles",
+        lambda: [SimpleNamespace(name="builder")],
+    )
+
+    def fail_to_spawn(*_args, **_kwargs):
+        raise OSError("cannot spawn interpreter")
+
+    monkeypatch.setattr("subprocess.run", fail_to_spawn)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        compute_all_profile_breakdowns("cli")
+
+    message = str(exc_info.value)
+    assert "builder" in message
+    assert "cannot spawn interpreter" in message
 
 
 def test_inspection_agent_uses_resolved_platform_toolsets(monkeypatch):
@@ -163,6 +415,109 @@ def test_render_breakdown_is_plain_text(isolated_home):
     assert "Tool schemas" in out
     # Plain text — no JSON braces leaking in.
     assert not out.strip().startswith("{")
+
+
+def test_render_profile_comparison_shows_ranked_fixed_footprint():
+    rows = [
+        {
+            "profile": "builder",
+            "model": "gpt-test",
+            "system_prompt": {"bytes": 1000},
+            "tools": {"count": 8, "json_bytes": 2000},
+            "fixed_bytes": 3000,
+        },
+        {
+            "profile": "skippy",
+            "model": "gpt-test",
+            "system_prompt": {"bytes": 2000},
+            "tools": {"count": 20, "json_bytes": 5000},
+            "fixed_bytes": 7000,
+        },
+    ]
+
+    out = render_profile_comparison(rows, platform="cli")
+
+    assert "Profile prompt-size comparison (platform=cli)" in out
+    assert "skippy" in out and "builder" in out
+    assert "20" in out and "8" in out
+    assert out.index("skippy") < out.index("builder")
+    assert "Fixed payload = system prompt + tool-schema JSON" in out
+
+
+def test_render_profile_comparison_aligns_long_profile_names():
+    profile = "long-specialist-profile-name"
+    rows = [
+        {
+            "profile": profile,
+            "model": "gpt-test",
+            "system_prompt": {"bytes": 1000},
+            "tools": {"count": 8, "json_bytes": 2000},
+            "fixed_bytes": 3000,
+        }
+    ]
+
+    lines = render_profile_comparison(rows, platform="cli").splitlines()
+    header = lines[2]
+    row = lines[4]
+
+    assert header.index("Model") == row.index("gpt-test")
+
+
+def test_command_all_profiles_outputs_comparison(monkeypatch, capsys):
+    rows = [
+        {
+            "profile": "builder",
+            "model": "gpt-test",
+            "system_prompt": {"bytes": 1000},
+            "tools": {"count": 8, "json_bytes": 2000},
+            "fixed_bytes": 3000,
+        }
+    ]
+    monkeypatch.setattr(
+        "hermes_cli.prompt_size.compute_all_profile_breakdowns",
+        lambda platform: rows,
+    )
+
+    cmd_prompt_size(SimpleNamespace(platform="cli", json=False, all_profiles=True))
+
+    out = capsys.readouterr().out
+    assert "Profile prompt-size comparison" in out
+    assert "builder" in out
+
+
+@pytest.mark.parametrize("all_profiles", [False, True])
+def test_command_failures_exit_nonzero_on_stderr(monkeypatch, capsys, all_profiles):
+    def fail(_platform):
+        raise RuntimeError("builder measurement failed")
+
+    target = (
+        "hermes_cli.prompt_size.compute_all_profile_breakdowns"
+        if all_profiles
+        else "hermes_cli.prompt_size.compute_prompt_breakdown"
+    )
+    monkeypatch.setattr(target, fail)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cmd_prompt_size(
+            SimpleNamespace(platform="cli", json=True, all_profiles=all_profiles)
+        )
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert captured.out == ""
+    assert "builder measurement failed" in captured.err
+
+
+def test_parser_accepts_all_profiles_flag():
+    from hermes_cli.subcommands.prompt_size import build_prompt_size_parser
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_prompt_size_parser(subparsers, cmd_prompt_size=lambda _args: None)
+
+    args = parser.parse_args(["prompt-size", "--all-profiles"])
+
+    assert args.all_profiles is True
 
 
 def test_json_serializable(isolated_home):


### PR DESCRIPTION
## What does this PR do?

Adds `hermes prompt-size --all-profiles` so operators can compare the fixed prompt footprint of every configured profile before changing toolsets, skills, or profile policy.

Each profile is measured through a fresh `python -m hermes_cli.main --profile <name> prompt-size --json` subprocess. This is intentional: profile selection affects import-time configuration and module state, so switching profiles repeatedly inside one interpreter can contaminate results.

The command supports:

- a largest-first human-readable table;
- structured JSON for automation;
- validated `fixed_bytes = system_prompt.bytes + tools.json_bytes` measurements;
- fail-closed child handling for timeouts, spawn failures, nonzero exits, malformed JSON, and invalid numeric fields;
- clean JSON stdout even when prompt construction emits context warnings.

## Related Issue

Related to #34667 as a follow-up diagnostic enhancement. This PR does not claim to resolve or reopen that broader closed issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/prompt_size.py`
  - measures profiles in isolated subprocesses;
  - validates and ranks profile measurements;
  - preserves machine-readable stdout and nonzero failure semantics;
  - renders a dynamic-width comparison table.
- `hermes_cli/subcommands/prompt_size.py`
  - adds the opt-in `--all-profiles` flag.
- `tests/hermes_cli/test_prompt_size.py`
  - adds unit and real Windows subprocess coverage for isolation, output contracts, ordering, validation, and failure paths.

## How to Test

1. Run the focused hermetic suite:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_prompt_size.py -q -k "not blank_slate_prompt_size_counts_only_minimal_tools"
   ```
   Result on native Windows: **22 passed, 0 failed**.
2. Exercise human output:
   ```bash
   python -m hermes_cli.main prompt-size --all-profiles
   ```
3. Exercise and parse JSON output:
   ```bash
   python -m hermes_cli.main prompt-size --all-profiles --json
   ```
   Verified against 11 local profiles: unique profile names, largest-first ordering, and every fixed-byte invariant passed.
4. Run static checks:
   ```bash
   uvx --from ruff==0.15.10 ruff check hermes_cli/prompt_size.py hermes_cli/subcommands/prompt_size.py tests/hermes_cli/test_prompt_size.py
   python -m py_compile hermes_cli/prompt_size.py hermes_cli/subcommands/prompt_size.py tests/hermes_cli/test_prompt_size.py
   python scripts/check-windows-footguns.py --diff origin/main
   git diff --check origin/main...HEAD
   ```
   All passed.

### Known baseline

The full prompt-size test file still contains the pre-existing `test_blank_slate_prompt_size_counts_only_minimal_tools` assertion failure. It reproduces unchanged on `origin/main` and is not introduced by this branch. The focused command above excludes only that known baseline failure.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted hermetic tests passed; full repository suite was not run locally
- [x] I've added tests for my changes
- [x] I've tested on my platform: native Windows 10, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; CLI `--help` documents the opt-in flag
- [x] I've updated `cli-config.yaml.example` — N/A; no config keys added
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A; no architecture/workflow contract changed
- [x] I've considered cross-platform impact; subprocesses use `sys.executable`, argv lists, explicit UTF-8 decoding, and no shell
- [x] I've updated tool descriptions/schemas — N/A; no model tool changed

## Screenshots / Logs

Example output shape:

```text
Profile prompt-size comparison (platform=cli)

  Profile             Model                        Prompt    Schemas   Tools      Fixed
  ------------------  ------------------------  ---------- ---------- ------- ----------
  <profile>            <model>                      ... KB     ... KB      ...     ... KB

  Fixed payload = system prompt + tool-schema JSON (conversation history excluded).
```

## Risks / Notes

- Measurement is intentionally sequential and process-isolated. This diagnostic command favors correctness over speed.
- Exact byte counts legitimately vary with profile config, installed skills, toolsets, platform, and project context.
- The command does not mutate profiles or configuration.
