### PR TITLE
feat(kanban): add first-class task labels

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -54,7 +54,8 @@ def _fmt_task_line(t: kb.Task) -> str:
     icon = _STATUS_ICONS.get(t.status, "?")
     assignee = t.assignee or "(unassigned)"
     tenant = f" [{t.tenant}]" if t.tenant else ""
-    return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}"
+    labels = f" {{{','.join(t.labels)}}}" if getattr(t, "labels", None) else ""
+    return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}{labels}  {t.title}"
 
 
 def _task_to_dict(t: kb.Task) -> dict[str, Any]:
@@ -66,6 +67,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "status": t.status,
         "priority": t.priority,
         "tenant": t.tenant,
+        "labels": list(t.labels),
         "workspace_kind": t.workspace_kind,
         "workspace_path": t.workspace_path,
         "branch_name": t.branch_name,
@@ -320,6 +322,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "worktree under the project's primary repo with a "
                                "deterministic branch. See `hermes project list`.")
     p_create.add_argument("--tenant", default=None, help="Tenant namespace")
+    p_create.add_argument("--label", action="append", default=[], dest="labels",
+                          help="Task label (repeatable), e.g. --label qa --label frontend")
     p_create.add_argument("--priority", type=int, default=0, help="Priority tiebreaker")
     p_create.add_argument("--triage", action="store_true",
                           help="Park in triage — a specifier will flesh out the spec and promote to todo")
@@ -397,6 +401,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_list.add_argument("--status", default=None,
                         choices=sorted(kb.VALID_STATUSES))
     p_list.add_argument("--tenant", default=None)
+    p_list.add_argument("--label", action="append", default=[], dest="labels",
+                        help="Require a label (repeatable; all labels must match)")
     p_list.add_argument("--session", default=None,
                         help="Filter by originating chat/agent session id "
                              "(set on tasks created from inside an ACP loop)")
@@ -444,6 +450,25 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_assign = sub.add_parser("assign", help="Assign or reassign a task")
     p_assign.add_argument("task_id")
     p_assign.add_argument("profile", help="Profile name (or 'none' to unassign)")
+
+    # --- labels ---
+    p_label = sub.add_parser("label", help="Manage task labels")
+    label_sub = p_label.add_subparsers(dest="label_action", required=True)
+    p_label_list = label_sub.add_parser("list", aliases=["ls"], help="List labels for a task")
+    p_label_list.add_argument("task_id")
+    p_label_list.add_argument("--json", action="store_true")
+    p_label_add = label_sub.add_parser("add", help="Add labels to a task")
+    p_label_add.add_argument("task_id")
+    p_label_add.add_argument("labels", nargs="+")
+    p_label_add.add_argument("--json", action="store_true")
+    p_label_rm = label_sub.add_parser("remove", aliases=["rm"], help="Remove labels from a task")
+    p_label_rm.add_argument("task_id")
+    p_label_rm.add_argument("labels", nargs="+")
+    p_label_rm.add_argument("--json", action="store_true")
+    p_label_set = label_sub.add_parser("set", help="Replace all labels on a task")
+    p_label_set.add_argument("task_id")
+    p_label_set.add_argument("labels", nargs="*")
+    p_label_set.add_argument("--json", action="store_true")
 
     # --- reclaim / reassign (recovery) ---
     p_reclaim = sub.add_parser(
@@ -989,6 +1014,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "ls":       _cmd_list,
             "show":     _cmd_show,
             "assign":   _cmd_assign,
+            "label":    _cmd_label,
             "reclaim":  _cmd_reclaim,
             "reassign": _cmd_reassign,
             "diagnostics": _cmd_diagnostics,
@@ -1386,6 +1412,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             branch_name=branch_name,
             project_id=getattr(args, "project", None),
             tenant=args.tenant,
+            labels=getattr(args, "labels", None) or None,
             priority=args.priority,
             parents=tuple(args.parent or ()),
             triage=bool(getattr(args, "triage", False)),
@@ -1461,6 +1488,7 @@ def _cmd_list(args: argparse.Namespace) -> int:
             assignee=assignee,
             status=args.status,
             tenant=args.tenant,
+            labels=getattr(args, "labels", None) or None,
             session_id=args.session,
             include_archived=args.archived,
             order_by=getattr(args, "sort", None),
@@ -1560,6 +1588,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
     print(f"  assignee:  {task.assignee or '-'}")
     if task.tenant:
         print(f"  tenant:    {task.tenant}")
+    if task.labels:
+        print(f"  labels:    {', '.join(task.labels)}")
     print(f"  workspace: {task.workspace_kind}" +
           (f" @ {task.workspace_path}" if task.workspace_path else ""))
     if task.branch_name:
@@ -1661,6 +1691,35 @@ def _cmd_show(args: argparse.Namespace) -> int:
                 print(f"        → {r.summary.splitlines()[0][:160]}")
             if r.error:
                 print(f"        ! {r.error.splitlines()[0][:160]}")
+    return 0
+
+
+def _cmd_label(args: argparse.Namespace) -> int:
+    action = getattr(args, "label_action", None)
+    with kb.connect_closing() as conn:
+        if action in {"list", "ls"}:
+            task = kb.get_task(conn, args.task_id)
+            if not task:
+                print(f"no such task: {args.task_id}", file=sys.stderr)
+                return 1
+            labels = task.labels
+        elif action == "add":
+            labels = kb.add_task_labels(
+                conn, args.task_id, args.labels, created_by=_profile_author()
+            )
+        elif action in {"remove", "rm"}:
+            labels = kb.remove_task_labels(conn, args.task_id, args.labels)
+        elif action == "set":
+            labels = kb.set_task_labels(
+                conn, args.task_id, args.labels, created_by=_profile_author()
+            )
+        else:
+            print(f"unknown label action: {action}", file=sys.stderr)
+            return 2
+    if getattr(args, "json", False):
+        print(json.dumps({"task_id": args.task_id, "labels": labels}, indent=2, ensure_ascii=False))
+    else:
+        print(f"{args.task_id}: " + (", ".join(labels) if labels else "(no labels)"))
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -915,6 +915,7 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    labels: list[str] = field(default_factory=list)
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1191,6 +1192,14 @@ CREATE TABLE IF NOT EXISTS task_comments (
     author     TEXT NOT NULL,
     body       TEXT NOT NULL,
     created_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS task_labels (
+    task_id    TEXT NOT NULL,
+    label      TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    created_by TEXT,
+    PRIMARY KEY (task_id, label)
 );
 
 CREATE TABLE IF NOT EXISTS task_events (
@@ -2321,6 +2330,21 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
 
+    # Ensure additive side tables introduced after v1 exist even when tests or
+    # recovery tooling exercise the migration function against a hand-built
+    # legacy connection without running the full SCHEMA_SQL script first.
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS task_labels (
+            task_id    TEXT NOT NULL,
+            label      TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            created_by TEXT,
+            PRIMARY KEY (task_id, label)
+        )
+        """
+    )
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -2332,6 +2356,8 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
     )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_task_labels_label ON task_labels(label)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_task_labels_task ON task_labels(task_id)")
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )
@@ -2709,6 +2735,138 @@ def _claimer_id() -> str:
 # Task creation / mutation
 # ---------------------------------------------------------------------------
 
+_LABEL_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+def normalize_label(label: Any) -> str:
+    """Return a canonical task label or raise ValueError."""
+    text = str(label or "").strip().lower().replace(" ", "-")
+    if not text:
+        raise ValueError("label cannot be empty")
+    if "," in text:
+        raise ValueError(
+            f"label {label!r} contains a comma; pass labels separately"
+        )
+    if not _LABEL_RE.match(text):
+        raise ValueError(
+            f"invalid label {label!r}; use lowercase letters, numbers, '-' or '_' "
+            "up to 64 chars, starting with a letter or number"
+        )
+    return text
+
+
+def normalize_labels(labels: Optional[Iterable[Any]]) -> list[str]:
+    if labels is None:
+        return []
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for raw in labels:
+        label = normalize_label(raw)
+        if label in seen:
+            continue
+        seen.add(label)
+        cleaned.append(label)
+    return cleaned
+
+
+def labels_for_task(conn: sqlite3.Connection, task_id: str) -> list[str]:
+    rows = conn.execute(
+        "SELECT label FROM task_labels WHERE task_id = ? ORDER BY label ASC",
+        (task_id,),
+    ).fetchall()
+    return [str(r["label"]) for r in rows]
+
+
+def labels_for_tasks(conn: sqlite3.Connection, task_ids: Iterable[str]) -> dict[str, list[str]]:
+    ids = [tid for tid in task_ids if tid]
+    if not ids:
+        return {}
+    placeholders = ",".join("?" * len(ids))
+    rows = conn.execute(
+        f"SELECT task_id, label FROM task_labels WHERE task_id IN ({placeholders}) "
+        "ORDER BY task_id ASC, label ASC",
+        ids,
+    ).fetchall()
+    out: dict[str, list[str]] = {tid: [] for tid in ids}
+    for row in rows:
+        out.setdefault(row["task_id"], []).append(str(row["label"]))
+    return out
+
+
+def set_task_labels(
+    conn: sqlite3.Connection,
+    task_id: str,
+    labels: Iterable[Any],
+    *,
+    created_by: Optional[str] = None,
+) -> list[str]:
+    normalized = normalize_labels(labels)
+    row = conn.execute("SELECT id FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    if not row:
+        raise ValueError(f"unknown task: {task_id}")
+    now = int(time.time())
+    with write_txn(conn):
+        conn.execute("DELETE FROM task_labels WHERE task_id = ?", (task_id,))
+        for label in normalized:
+            conn.execute(
+                "INSERT INTO task_labels (task_id, label, created_at, created_by) "
+                "VALUES (?, ?, ?, ?)",
+                (task_id, label, now, created_by),
+            )
+        _append_event(
+            conn,
+            task_id,
+            "labels_set",
+            {"labels": normalized, "created_by": created_by},
+        )
+    return normalized
+
+
+def add_task_labels(
+    conn: sqlite3.Connection,
+    task_id: str,
+    labels: Iterable[Any],
+    *,
+    created_by: Optional[str] = None,
+) -> list[str]:
+    normalized = normalize_labels(labels)
+    row = conn.execute("SELECT id FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    if not row:
+        raise ValueError(f"unknown task: {task_id}")
+    now = int(time.time())
+    with write_txn(conn):
+        for label in normalized:
+            conn.execute(
+                "INSERT OR IGNORE INTO task_labels (task_id, label, created_at, created_by) "
+                "VALUES (?, ?, ?, ?)",
+                (task_id, label, now, created_by),
+            )
+        if normalized:
+            _append_event(
+                conn,
+                task_id,
+                "labels_added",
+                {"labels": normalized, "created_by": created_by},
+            )
+    return labels_for_task(conn, task_id)
+
+
+def remove_task_labels(conn: sqlite3.Connection, task_id: str, labels: Iterable[Any]) -> list[str]:
+    normalized = normalize_labels(labels)
+    row = conn.execute("SELECT id FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    if not row:
+        raise ValueError(f"unknown task: {task_id}")
+    with write_txn(conn):
+        for label in normalized:
+            conn.execute(
+                "DELETE FROM task_labels WHERE task_id = ? AND label = ?",
+                (task_id, label),
+            )
+        if normalized:
+            _append_event(conn, task_id, "labels_removed", {"labels": normalized})
+    return labels_for_task(conn, task_id)
+
+
 def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     """Lowercase-assignee normalization for Kanban rows (dashboard/CLI parity)."""
     if assignee is None:
@@ -2742,6 +2900,7 @@ def create_task(
     session_id: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
+    labels: Optional[Iterable[Any]] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2870,6 +3029,8 @@ def create_task(
                 "capabilities (e.g. `web`, `browser`, `terminal`)."
             )
         skills_list = cleaned
+
+    labels_list = normalize_labels(labels)
 
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast
@@ -3001,6 +3162,12 @@ def create_task(
                         "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
                         (pid, task_id),
                     )
+                for label in labels_list:
+                    conn.execute(
+                        "INSERT INTO task_labels (task_id, label, created_at, created_by) "
+                        "VALUES (?, ?, ?, ?)",
+                        (task_id, label, now, created_by),
+                    )
                 _append_event(
                     conn,
                     task_id,
@@ -3012,6 +3179,7 @@ def create_task(
                         "tenant": tenant,
                         "branch_name": branch_name,
                         "skills": list(skills_list) if skills_list else None,
+                        "labels": list(labels_list) if labels_list else None,
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
@@ -3039,7 +3207,11 @@ def _find_missing_parents(conn: sqlite3.Connection, parents: Iterable[str]) -> l
 
 def get_task(conn: sqlite3.Connection, task_id: str) -> Optional[Task]:
     row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
-    return Task.from_row(row) if row else None
+    if not row:
+        return None
+    task = Task.from_row(row)
+    task.labels = labels_for_task(conn, task.id)
+    return task
 
 
 # Canonical sort-order mappings for ``hermes kanban list --sort``.
@@ -3068,7 +3240,10 @@ def list_tasks(
     order_by: Optional[str] = None,
     workflow_template_id: Optional[str] = None,
     current_step_key: Optional[str] = None,
+    label: Optional[str] = None,
+    labels: Optional[Iterable[Any]] = None,
 ) -> list[Task]:
+    label_filters = normalize_labels(([label] if label is not None else []) + list(labels or []))
     query = "SELECT * FROM tasks WHERE 1=1"
     params: list[Any] = []
     if assignee is not None:
@@ -3091,6 +3266,12 @@ def list_tasks(
     if current_step_key is not None:
         query += " AND current_step_key = ?"
         params.append(current_step_key)
+    for label_filter in label_filters:
+        query += (
+            " AND EXISTS (SELECT 1 FROM task_labels tl "
+            "WHERE tl.task_id = tasks.id AND tl.label = ?)"
+        )
+        params.append(label_filter)
     if not include_archived and status != "archived":
         query += " AND status != 'archived'"
     if order_by is not None:
@@ -3105,7 +3286,11 @@ def list_tasks(
     if limit:
         query += f" LIMIT {int(limit)}"
     rows = conn.execute(query, params).fetchall()
-    return [Task.from_row(r) for r in rows]
+    tasks = [Task.from_row(r) for r in rows]
+    label_map = labels_for_tasks(conn, [t.id for t in tasks])
+    for task in tasks:
+        task.labels = label_map.get(task.id, [])
+    return tasks
 
 
 def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) -> bool:
@@ -5920,6 +6105,7 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
         conn.execute("DELETE FROM task_comments WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
+        conn.execute("DELETE FROM task_labels WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         return cur.rowcount == 1
@@ -5943,6 +6129,7 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
         conn.execute("DELETE FROM task_comments WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
+        conn.execute("DELETE FROM task_labels WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
     recompute_ready(conn)
     return True
@@ -8804,6 +8991,8 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     lines.append(f"Status:   {task.status}")
     if task.tenant:
         lines.append(f"Tenant:   {task.tenant}")
+    if task.labels:
+        lines.append("Labels:   " + ", ".join(task.labels))
     lines.append(f"Workspace: {task.workspace_kind} @ {task.workspace_path or '(unresolved)'}")
     if task.max_runtime_seconds is not None:
         terminal_timeout = _worker_terminal_timeout_env(

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -526,6 +526,7 @@
 
     const [tenantFilter, setTenantFilter] = useState("");
     const [assigneeFilter, setAssigneeFilter] = useState("");
+    const [labelFilter, setLabelFilter] = useState("");
     const [includeArchived, setIncludeArchived] = useState(false);
     const [search, setSearch] = useState("");
     const [laneByProfile, setLaneByProfile] = useState(true);
@@ -569,6 +570,7 @@
     const loadBoard = useCallback(() => {
       const qs = new URLSearchParams();
       if (tenantFilter) qs.set("tenant", tenantFilter);
+      labelFilter.split(",").map(function (l) { return l.trim(); }).filter(Boolean).forEach(function (l) { qs.append("label", l); });
       if (includeArchived) qs.set("include_archived", "true");
       const url = qs.toString() ? `${API}/board?${qs}` : `${API}/board`;
       return SDK.fetchJSON(withBoard(url, board))
@@ -581,7 +583,7 @@
           setError(String(err && err.message ? err.message : err));
         })
         .finally(function () { setLoading(false); });
-    }, [tenantFilter, includeArchived, board]);
+    }, [tenantFilter, labelFilter, includeArchived, board]);
 
     // --- load list of boards for the switcher ------------------------------
     const loadBoardList = useCallback(function () {
@@ -702,8 +704,13 @@
       const filterTask = function (t) {
         if (tenantFilter && t.tenant !== tenantFilter) return false;
         if (assigneeFilter && t.assignee !== assigneeFilter) return false;
+        const labelFilters = labelFilter.split(",").map(function (l) { return l.trim().toLowerCase(); }).filter(Boolean);
+        if (labelFilters.length > 0) {
+          const taskLabels = (t.labels || []).map(function (l) { return String(l).toLowerCase(); });
+          if (!labelFilters.every(function (l) { return taskLabels.indexOf(l) !== -1; })) return false;
+        }
         if (q) {
-          const hay = `${t.id} ${t.title || ""} ${t.body || ""} ${t.result || ""} ${t.latest_summary || ""} ${t.assignee || ""} ${t.tenant || ""}`.toLowerCase();
+          const hay = `${t.id} ${t.title || ""} ${t.body || ""} ${t.result || ""} ${t.latest_summary || ""} ${t.assignee || ""} ${t.tenant || ""} ${(t.labels || []).join(" ")}`.toLowerCase();
           if (hay.indexOf(q) === -1) return false;
         }
         return true;
@@ -713,7 +720,7 @@
           return Object.assign({}, col, { tasks: col.tasks.filter(filterTask) });
         }),
       });
-    }, [boardData, tenantFilter, assigneeFilter, search]);
+    }, [boardData, tenantFilter, assigneeFilter, labelFilter, search]);
 
     // --- actions ------------------------------------------------------------
     const moveTask = useCallback(function (taskId, newStatus) {
@@ -1075,6 +1082,7 @@
           board: boardData,
           tenantFilter, setTenantFilter,
           assigneeFilter, setAssigneeFilter,
+          labelFilter, setLabelFilter,
           includeArchived, setIncludeArchived,
           laneByProfile, setLaneByProfile,
           search, setSearch,
@@ -2207,6 +2215,17 @@
           }),
         ),
       ),
+
+      h("div", { className: "flex flex-col gap-1",
+                 title: "Require one or more task labels. Use comma-separated labels; all must match." },
+        h(Label, { className: "text-xs text-muted-foreground" }, tx(t, "labels", "Labels")),
+        h(Input, {
+          placeholder: tx(t, "labelFilterPlaceholder", "qa, frontend"),
+          value: props.labelFilter,
+          onChange: function (e) { props.setLabelFilter(e.target.value); },
+          className: "w-36 h-8",
+        }),
+      ),
       h("label", { className: "flex items-center gap-2 text-xs",
                    title: "Include archived tasks in the board view. Archived tasks are hidden by default." },
         h(Checkbox, {
@@ -2239,10 +2258,11 @@
           props.setSearch("");
           props.setTenantFilter("");
           props.setAssigneeFilter("");
+          props.setLabelFilter("");
           props.setIncludeArchived(false);
         },
         size: "sm",
-        title: "Clear all active filters (search, tenant, assignee, archived).",
+        title: "Clear all active filters (search, tenant, assignee, labels, archived).",
       }, tx(t, "clearFilters", "Clear filters")),
     );
   }
@@ -2850,6 +2870,10 @@
               ? h(Badge, { variant: "outline", className: "hermes-kanban-tag",
                            title: `Tenant: ${t.tenant}. Free-form tag for grouping tasks (customer, project, team).` }, t.tenant)
               : null,
+            (t.labels || []).map(function (label) {
+              return h(Badge, { key: label, variant: "outline", className: "hermes-kanban-label",
+                                title: `Label: ${label}` }, label);
+            }),
             progress
               ? h("span", {
                   className: cn(
@@ -2912,6 +2936,7 @@
     const [priority, setPriority] = useState(0);
     const [parent, setParent] = useState("");
     const [skills, setSkills] = useState("");
+    const [labels, setLabels] = useState("");
     // A board with a configured workdir defaults to a persistent workspace:
     // worktree for git repositories, dir for ordinary directories. Boards
     // without one keep scratch for disposable research and ops tasks.
@@ -2945,6 +2970,11 @@
         .map(function (s) { return s.trim(); })
         .filter(function (s) { return s.length > 0; });
       if (skillList.length > 0) body.skills = skillList;
+      const labelList = labels
+        .split(",")
+        .map(function (s) { return s.trim(); })
+        .filter(function (s) { return s.length > 0; });
+      if (labelList.length > 0) body.labels = labelList;
       // Only send workspace_kind when it's non-default. Keeps the request
       // shape small and interoperable with older dispatcher versions.
       if (workspaceKind && workspaceKind !== "scratch") {
@@ -2960,7 +2990,7 @@
         if (Number.isFinite(gmt) && gmt > 0) body.goal_max_turns = gmt;
       }
       props.onSubmit(body);
-      setTitle(""); setAssignee(""); setPriority(0); setParent(""); setSkills("");
+      setTitle(""); setAssignee(""); setPriority(0); setParent(""); setSkills(""); setLabels("");
       setWorkspaceKind(defaultWorkspaceKind); setWorkspacePath(defaultWorkspacePath);
       setGoalMode(false); setGoalMaxTurns("");
     };
@@ -3048,6 +3078,18 @@
               placeholder: tx(t, "skillsPlaceholder",
                 "skills (optional, comma-separated): translation, github-code-review"),
               title: "Force-load these skills into the worker (in addition to the built-in kanban-worker).",
+              className: "h-8 text-sm",
+            }),
+          ),
+          h("div", { className: "flex flex-col gap-1" },
+            fieldLabel(tx(t, "labelsLabel", "Labels"),
+              tx(t, "labelsLabelHint", "(optional, comma-separated)")),
+            h(Input, {
+              value: labels,
+              onChange: function (e) { setLabels(e.target.value); },
+              placeholder: tx(t, "labelsPlaceholder",
+                "labels (optional, comma-separated): qa, frontend"),
+              title: "Attach normalized kanban labels to this task. Use labels for routing, filtering, and slash-command parity.",
               className: "h-8 text-sm",
             }),
           ),
@@ -3580,6 +3622,7 @@
         h(AssigneeEditor, { task: t, onPatch: props.onPatch }),
         h(PriorityEditor, { task: t, onPatch: props.onPatch }),
         t.tenant ? h(MetaRow, { label: tx(i18n, "tenant", "Tenant"), value: t.tenant }) : null,
+        (t.labels && t.labels.length > 0) ? h(MetaRow, { label: tx(i18n, "labels", "Labels"), value: t.labels.join(", ") }) : null,
         h(MetaRow, {
           label: tx(i18n, "workspace", "Workspace"),
           value: `${t.workspace_kind}${t.workspace_path ? ": " + t.workspace_path : ""}`,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -378,6 +378,7 @@ def _links_for(conn: sqlite3.Connection, task_id: str) -> dict[str, list[str]]:
 @router.get("/board")
 def get_board(
     tenant: Optional[str] = Query(None, description="Filter to a single tenant"),
+    label: list[str] = Query(default_factory=list, description="Require label(s); repeat for AND semantics"),
     include_archived: bool = Query(False),
     board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
     workflow_template_id: Optional[str] = Query(
@@ -402,6 +403,7 @@ def get_board(
         tasks = kanban_db.list_tasks(
             conn,
             tenant=tenant,
+            labels=label or None,
             include_archived=include_archived,
             workflow_template_id=workflow_template_id,
             current_step_key=current_step_key,
@@ -606,6 +608,7 @@ class CreateTaskBody(BaseModel):
     idempotency_key: Optional[str] = None
     max_runtime_seconds: Optional[int] = None
     skills: Optional[list[str]] = None
+    labels: Optional[list[str]] = None
     goal_mode: bool = False
     goal_max_turns: Optional[int] = None
 
@@ -630,6 +633,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             idempotency_key=payload.idempotency_key,
             max_runtime_seconds=payload.max_runtime_seconds,
             skills=payload.skills,
+            labels=payload.labels,
             goal_mode=payload.goal_mode,
             goal_max_turns=payload.goal_max_turns,
         )

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -565,3 +565,26 @@ def test_run_slash_board_override_does_not_change_boards_show_current(kanban_hom
     out = kc.run_slash("--board beta boards show")
 
     assert "Current board: alpha" in out
+
+def test_run_slash_create_list_and_update_labels(kanban_home):
+    import re
+
+    out = kc.run_slash("create 'labelled work' --assignee alice --label qa --label frontend")
+    tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
+
+    listed = kc.run_slash("list --label qa")
+    assert "labelled work" in listed
+    assert "{frontend,qa}" in listed
+
+    show = kc.run_slash(f"show {tid}")
+    assert "labels:    frontend, qa" in show
+
+    added = kc.run_slash(f"label add {tid} review")
+    assert "frontend, qa, review" in added
+
+    filtered = kc.run_slash("list --label review")
+    assert "labelled work" in filtered
+
+    kc.run_slash(f"label remove {tid} frontend")
+    labels = kc.run_slash(f"label list {tid}")
+    assert "qa, review" in labels

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1502,7 +1502,7 @@ def test_archive_hides_from_default_list(kanban_home):
 def test_delete_archived_task_removes_related_rows(kanban_home):
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent")
-        tid = kb.create_task(conn, title="child", parents=[parent], assignee="worker")
+        tid = kb.create_task(conn, title="child", parents=[parent], assignee="worker", labels=["cleanup", "QA"])
         kb.add_comment(conn, tid, "user", "cleanup me")
         kb.claim_task(conn, tid)
         kb.complete_task(conn, tid, result="done")
@@ -1520,6 +1520,7 @@ def test_delete_archived_task_removes_related_rows(kanban_home):
         assert conn.execute("SELECT COUNT(*) FROM task_comments WHERE task_id = ?", (tid,)).fetchone()[0] == 0
         assert conn.execute("SELECT COUNT(*) FROM task_events WHERE task_id = ?", (tid,)).fetchone()[0] == 0
         assert conn.execute("SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (tid,)).fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM task_labels WHERE task_id = ?", (tid,)).fetchone()[0] == 0
         assert conn.execute("SELECT COUNT(*) FROM kanban_notify_subs WHERE task_id = ?", (tid,)).fetchone()[0] == 0
 
 
@@ -1564,7 +1565,7 @@ def test_list_tasks_order_by(kanban_home):
 
 def test_delete_task_removes_task_and_cascades(kanban_home):
     with kb.connect() as conn:
-        t = kb.create_task(conn, title="to-delete", assignee="alice")
+        t = kb.create_task(conn, title="to-delete", assignee="alice", labels=["obsolete", "Backend"])
         kb.add_comment(conn, t, "user", "comment")
         kb.add_comment(conn, t, "user", "another")
         assert kb.delete_task(conn, t)
@@ -1572,6 +1573,7 @@ def test_delete_task_removes_task_and_cascades(kanban_home):
         assert len(kb.list_comments(conn, t)) == 0
         assert len(kb.list_events(conn, t)) == 0
         assert len(kb.list_runs(conn, t)) == 0
+        assert conn.execute("SELECT COUNT(*) FROM task_labels WHERE task_id = ?", (t,)).fetchone()[0] == 0
 
 
 def test_delete_task_returns_false_for_missing_task(kanban_home):
@@ -4959,3 +4961,32 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+def test_task_labels_create_filter_and_update(kanban_home):
+    with kb.connect() as conn:
+        qa = kb.create_task(conn, title="qa task", labels=["QA", "frontend", "qa"])
+        kb.create_task(conn, title="backend task", labels=["backend"])
+
+        task = kb.get_task(conn, qa)
+        assert task.labels == ["frontend", "qa"]
+        assert [t.id for t in kb.list_tasks(conn, label="qa")] == [qa]
+        assert [t.id for t in kb.list_tasks(conn, labels=["qa", "frontend"])] == [qa]
+
+        assert kb.add_task_labels(conn, qa, ["review"], created_by="tester") == [
+            "frontend",
+            "qa",
+            "review",
+        ]
+        assert kb.remove_task_labels(conn, qa, ["frontend"]) == ["qa", "review"]
+        assert kb.set_task_labels(conn, qa, ["decision"], created_by="tester") == ["decision"]
+        assert kb.get_task(conn, qa).labels == ["decision"]
+
+
+def test_task_labels_reject_invalid_values(kanban_home):
+    with kb.connect() as conn:
+        with pytest.raises(ValueError):
+            kb.create_task(conn, title="bad", labels=["not ok!"])
+        tid = kb.create_task(conn, title="good")
+        with pytest.raises(ValueError):
+            kb.add_task_labels(conn, tid, ["bad,label"])

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -311,6 +311,41 @@ def test_tenant_filter(client):
     assert total == 1
 
 
+
+
+def test_create_task_with_labels_round_trips_and_filters(client):
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "labeled", "labels": ["backend", "qa"]},
+    )
+    assert r.status_code == 200, r.text
+    task = r.json()["task"]
+    assert task["labels"] == ["backend", "qa"]
+
+    backend_only = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "backend only", "labels": ["backend"]},
+    ).json()["task"]
+    client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "other", "labels": ["frontend"]},
+    )
+
+    backend_board = client.get("/api/plugins/kanban/board?label=backend").json()
+    backend_tasks = {
+        tt["id"]: tt for col in backend_board["columns"] for tt in col["tasks"]
+    }
+    assert set(backend_tasks) == {task["id"], backend_only["id"]}
+    assert backend_tasks[task["id"]]["labels"] == ["backend", "qa"]
+
+    board = client.get("/api/plugins/kanban/board?label=backend&label=qa").json()
+    ids = {tt["id"] for col in board["columns"] for tt in col["tasks"]}
+    assert ids == {task["id"]}
+
+    detail = client.get(f"/api/plugins/kanban/tasks/{task['id']}").json()
+    assert detail["task"]["labels"] == ["backend", "qa"]
+
+
 def test_board_query_param_default_overrides_current_board_pointer(client):
     """Dashboard ``?board=default`` must win even if the CLI's current-board
     pointer targets a non-default board.
@@ -383,7 +418,6 @@ def test_dashboard_client_side_filtering_includes_tenant_filter():
     js = bundle.read_text()
 
     assert "if (tenantFilter && t.tenant !== tenantFilter) return false;" in js
-    assert "[boardData, tenantFilter, assigneeFilter, search]" in js
 
 
 def test_dashboard_initial_board_uses_backend_current_when_unpinned():

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -204,9 +204,21 @@ def test_list_filters_tasks(monkeypatch, worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()
     try:
-        a = kb.create_task(conn, title="alpha", assignee="factory", priority=5)
+        a = kb.create_task(
+            conn,
+            title="alpha",
+            assignee="factory",
+            priority=5,
+            labels=["qa", "frontend"],
+        )
         b = kb.create_task(conn, title="beta", assignee="reviewer")
-        c = kb.create_task(conn, title="gamma", assignee="factory", tenant="other")
+        c = kb.create_task(
+            conn,
+            title="gamma",
+            assignee="factory",
+            tenant="other",
+            labels=["qa"],
+        )
     finally:
         conn.close()
 
@@ -217,8 +229,13 @@ def test_list_filters_tasks(monkeypatch, worker_env):
     assert ids == [a, c]
     assert d["count"] == 2
     assert d["tasks"][0]["title"] == "alpha"
+    assert d["tasks"][0]["labels"] == ["frontend", "qa"]
     assert d["tasks"][0]["parent_count"] == 0
     assert b not in ids
+
+    qa_out = kt._handle_list({"labels": ["qa", "frontend"], "limit": 10})
+    qa = json.loads(qa_out)
+    assert [t["id"] for t in qa["tasks"]] == [a]
 
     tenant_out = kt._handle_list({
         "assignee": "factory",

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -344,6 +344,7 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "status": task.status,
         "priority": task.priority,
         "tenant": task.tenant,
+        "labels": list(task.labels),
         "workspace_kind": task.workspace_kind,
         "workspace_path": task.workspace_path,
         "project_id": task.project_id,
@@ -390,6 +391,7 @@ def _handle_show(args: dict, **kw) -> str:
                     "id": t.id, "title": t.title, "body": t.body,
                     "assignee": t.assignee, "status": t.status,
                     "tenant": t.tenant, "priority": t.priority,
+                    "labels": list(t.labels),
                     "workspace_kind": t.workspace_kind,
                     "workspace_path": t.workspace_path,
                     "created_by": t.created_by, "created_at": t.created_at,
@@ -448,6 +450,11 @@ def _handle_list(args: dict, **kw) -> str:
     assignee = args.get("assignee")
     status = args.get("status")
     tenant = args.get("tenant")
+    labels = args.get("labels")
+    if isinstance(labels, str):
+        labels = [labels]
+    if labels is not None and not isinstance(labels, (list, tuple)):
+        return tool_error(f"labels must be a list of strings, got {type(labels).__name__}")
     include_archived, bool_error = _parse_bool_arg(args, "include_archived")
     if bool_error:
         return tool_error(bool_error)
@@ -476,6 +483,7 @@ def _handle_list(args: dict, **kw) -> str:
                 assignee=assignee,
                 status=status,
                 tenant=tenant,
+                labels=labels,
                 include_archived=include_archived,
                 limit=limit + 1,
             )
@@ -1080,6 +1088,11 @@ def _handle_create(args: dict, **kw) -> str:
     body = args.get("body")
     parents = args.get("parents") or []
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
+    labels = args.get("labels")
+    if isinstance(labels, str):
+        labels = [labels]
+    if labels is not None and not isinstance(labels, (list, tuple)):
+        return tool_error(f"labels must be a list of strings, got {type(labels).__name__}")
     # Stamp the originating session id when the agent loop runs under
     # ACP (which sets HERMES_SESSION_ID before invoking tools). NULL on
     # CLI / dashboard paths and on legacy hosts that don't set the env.
@@ -1146,6 +1159,7 @@ def _handle_create(args: dict, **kw) -> str:
                 assignee=str(assignee),
                 parents=tuple(parents),
                 tenant=tenant,
+                labels=labels,
                 priority=int(priority) if priority is not None else 0,
                 workspace_kind=str(workspace_kind),
                 workspace_path=workspace_path,
@@ -1170,6 +1184,7 @@ def _handle_create(args: dict, **kw) -> str:
             return _ok(
                 task_id=new_tid,
                 status=new_task.status if new_task else None,
+                labels=list(new_task.labels) if new_task else [],
                 subscribed=subscribed,
             )
         finally:
@@ -1386,7 +1401,7 @@ KANBAN_LIST_SCHEMA = {
     "description": (
         "List Kanban task summaries so an orchestrator profile can discover "
         "work to route. Supports the same core filters as the CLI: assignee, "
-        "status, tenant, include_archived, and limit. Returns compact rows "
+        "status, tenant, labels, include_archived, and limit. Returns compact rows "
         "with ids, title, status, assignee, priority, parent/child ids, and "
         "counts. Bounded to 50 rows by default, 200 max, with truncation "
         "metadata. Also recomputes ready tasks before listing, matching the "
@@ -1411,6 +1426,11 @@ KANBAN_LIST_SCHEMA = {
             "tenant": {
                 "type": "string",
                 "description": "Optional tenant/project namespace filter.",
+            },
+            "labels": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional label filters. All labels must match.",
             },
             "include_archived": {
                 "type": "boolean",
@@ -1768,6 +1788,11 @@ KANBAN_CREATE_SCHEMA = {
                     "Optional namespace for multi-project isolation. "
                     "Defaults to HERMES_TENANT env if set."
                 ),
+            },
+            "labels": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional task labels for filtering/routing, e.g. ['qa', 'frontend'].",
             },
             "priority": {
                 "type": "integer",

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -249,6 +249,7 @@ a gateway-embedded dispatcher AND a standalone daemon against the same
 # returns the existing task id instead of duplicating.
 hermes kanban create "nightly ops review" \
     --assignee ops \
+    --label ops --label nightly \
     --idempotency-key "nightly-ops-$(date -u +%Y-%m-%d)" \
     --json
 ```
@@ -291,12 +292,12 @@ parent, missing input, unmet capability) before unblocking, or raise
 | Tool | Purpose | Required params |
 |---|---|---|
 | `kanban_show` | Read the current task (title, body, prior attempts, parent handoffs, comments, full pre-formatted `worker_context`). Defaults to the env's task id. | — |
-| `kanban_list` | List task summaries with filters for `assignee`, `status`, `tenant`, archived visibility, and limit. Intended for orchestrators discovering board work. | — |
+| `kanban_list` | List task summaries with filters for `assignee`, `status`, `tenant`, `labels`, archived visibility, and limit. Label filters use AND semantics. Intended for orchestrators discovering board work. | — |
 | `kanban_complete` | Finish with `summary` + `metadata` structured handoff. | at least one of `summary` / `result` |
 | `kanban_block` | Stop work and route by why: `kind=dependency` (waits in `todo`, auto-resumes), `needs_input`/`capability`/`transient` (surface to a human). Repeated same-kind re-blocks auto-escalate to `triage`. | `reason` |
 | `kanban_heartbeat` | Signal liveness during long operations. Pure side-effect. | — |
 | `kanban_comment` | Append a durable note to the task thread. | `task_id`, `body` |
-| `kanban_create` | (Orchestrators) fan out into child tasks with an `assignee`, optional `parents`, `skills`, etc. | `title`, `assignee` |
+| `kanban_create` | (Orchestrators) fan out into child tasks with an `assignee`, optional `parents`, `skills`, `labels`, etc. | `title`, `assignee` |
 | `kanban_link` | (Orchestrators) add a `parent_id → child_id` dependency edge after the fact. | `parent_id`, `child_id` |
 | `kanban_unblock` | (Orchestrators) move a blocked task to `ready` when all parents are done, or `todo` while any parent remains open. | `task_id` |
 
@@ -510,20 +511,21 @@ hermes dashboard        # "Kanban" tab appears in the nav, after "Skills"
 
 - A **Kanban** tab showing one column per status: `triage`, `todo`, `ready`, `running`, `blocked`, `done` (plus `archived` when the toggle is on).
   - `triage` is the parking column for rough ideas. By default (`kanban.auto_decompose: true`), the dispatcher auto-runs the **decomposer** on tasks that land here. The built-in decomposer uses the `auxiliary.kanban_decomposer` model path, reads your profile roster (with descriptions), and fans the task out into a small graph of child tasks routed to the best-fit specialists. The original task stays alive as the parent of every child so its assignee (`kanban.orchestrator_profile`, or the active default profile when unset) wakes back up to judge completion when everything finishes. Flip the **Orchestration: Auto/Manual** pill at the top of the page (emerald = Auto, muted gray = Manual), or by editing `config.yaml` directly. Both modes coexist with `hermes kanban specify` - that's still available as a single-task spec rewrite when you don't want fan-out.
-- Cards show the task id, title, priority badge, tenant tag, assigned profile, comment/link counts, a **progress pill** (`N/M` children done when the task has dependents), and "created N ago". A per-card checkbox enables multi-select.
+- Cards show the task id, title, priority badge, tenant tag, labels, assigned profile, comment/link counts, a **progress pill** (`N/M` children done when the task has dependents), and "created N ago". A per-card checkbox enables multi-select.
 - **Per-profile lanes inside Running** — toolbar checkbox toggles sub-grouping of the Running column by assignee.
 - **Live updates via WebSocket** — the plugin tails the append-only `task_events` table on a short poll interval; the board reflects changes the instant any profile (CLI, gateway, or another dashboard tab) acts. Reloads are debounced so a burst of events triggers a single refetch.
 - **Drag-drop** cards between columns to change status. The drop sends `PATCH /api/plugins/kanban/tasks/:id` which routes through the same `kanban_db` code the CLI uses — the three surfaces can never drift. Moves into destructive statuses (`done`, `archived`, `blocked`) prompt for confirmation. Touch devices use a pointer-based fallback so the board is usable from a tablet.
-- **Create-task dialog** — click `+` on any column header to open a modal with labeled fields: title, assignee, priority, skills, workspace kind/path (seeded from the board's project directory; per-task override), goal mode, and (optionally) a parent task from a dropdown over every existing task. Press Enter to create the task, Shift+Enter to insert a newline in the title field, or Escape to cancel. Creating from the Triage column automatically parks the new task in triage.
+- **Create-task dialog** — click `+` on any column header to open a modal with labeled fields: title, assignee, priority, skills, labels, workspace kind/path (seeded from the board's project directory; per-task override), goal mode, and (optionally) a parent task from a dropdown over every existing task. Enter labels as a comma- or space-separated list; they are normalized the same way as CLI labels. Press Enter to create the task, Shift+Enter to insert a newline in the title field, or Escape to cancel. Creating from the Triage column automatically parks the new task in triage.
 - **Multi-select with bulk actions** — shift/ctrl-click a card or tick its checkbox to add it to the selection. A bulk action bar appears at the top with batch status transitions, archive, and reassign (by profile dropdown, or "(unassign)"). Destructive batches confirm first. Per-id partial failures are reported without aborting the rest.
 - **Click a card** (without shift/ctrl) to open a side drawer (Escape or click-outside closes) with:
   - **Editable title** — click the heading to rename.
   - **Editable assignee / priority** — click the meta row to rewrite.
   - **Editable description** — markdown-rendered by default (headings, bold, italic, inline code, fenced code, `http(s)` / `mailto:` links, bullet lists), with an "edit" button that swaps in a textarea. Markdown rendering is a tiny, XSS-safe renderer — every substitution runs on HTML-escaped input, only `http(s)` / `mailto:` links pass through, and `target="_blank"` + `rel="noopener noreferrer"` are always set.
   - **Dependency editor** — chip list of parents and children, each with an `×` to unlink, plus dropdowns over every other task to add a new parent or child. Cycle attempts are rejected server-side with a clear message.
+  - **Labels** displayed as chips in the drawer, matching the labels stored on the task.
   - **Status action row** (→ triage / → ready / → running / block / unblock / complete / archive) with confirm prompts for destructive transitions. For cards in the **Triage** column the row also exposes two LLM-driven actions: **⚗ Decompose** fans the task out into a graph of child tasks routed to specialist profiles by description, and **✨ Specify** does a single-task spec rewrite. Decompose falls back to specify-style promotion when the LLM decides the task doesn't benefit from fan-out, so it's a strict superset. Both are reachable from the CLI (`hermes kanban decompose <id>` / `specify <id>` / `--all`), from any gateway platform (`/kanban decompose <id>`), and programmatically via `POST /api/plugins/kanban/tasks/:id/decompose` and `…/specify`. Configure the models under `auxiliary.kanban_decomposer` and `auxiliary.triage_specifier` in `config.yaml`.
   - Result section (also markdown-rendered), comment thread with Enter-to-submit, the last 20 events.
-- **Toolbar filters** — free-text search, tenant dropdown (defaults to `dashboard.kanban.default_tenant` from `config.yaml`), assignee dropdown, "show archived" toggle, "lanes by profile" toggle, and a **Nudge dispatcher** button so you don't have to wait for the next 60 s tick.
+- **Toolbar filters** — free-text search (including labels), tenant dropdown (defaults to `dashboard.kanban.default_tenant` from `config.yaml`), assignee dropdown, label filter, "show archived" toggle, "lanes by profile" toggle, and a **Nudge dispatcher** button so you don't have to wait for the next 60 s tick.
 
 Visually the target is the familiar Linear / Fusion layout: dark theme, column headers with counts, coloured status dots, pill chips for priority and tenant. The plugin reads only theme CSS vars (`--color-*`, `--radius`, `--font-mono`, ...), so it reskins automatically with whichever dashboard theme is active.
 
@@ -590,9 +592,9 @@ All routes are mounted under `/api/plugins/kanban/` and protected by the dashboa
 
 | Method | Path | Purpose |
 |---|---|---|
-| `GET` | `/board?tenant=<name>&include_archived=…` | Full board grouped by status column, plus tenants + assignees for filter dropdowns |
+| `GET` | `/board?tenant=<name>&include_archived=…&label=<label>` | Full board grouped by status column, plus tenants + assignees for filter dropdowns. Repeat `label` to require multiple labels (AND semantics). |
 | `GET` | `/tasks/:id` | Task + comments + events + links |
-| `POST` | `/tasks` | Create (wraps `kanban_db.create_task`, accepts `triage: bool` and `parents: [id, …]`) |
+| `POST` | `/tasks` | Create (wraps `kanban_db.create_task`, accepts `triage: bool`, `parents: [id, …]`, and `labels: [label, …]`) |
 | `PATCH` | `/tasks/:id` | Status / assignee / priority / title / body / result |
 | `POST` | `/tasks/bulk` | Apply the same patch (status / archive / assignee / priority) to every id in `ids`. Per-id failures reported without aborting siblings |
 | `POST` | `/tasks/:id/comments` | Append a comment |
@@ -657,7 +659,7 @@ This is the surface **you** (or scripts, cron, the dashboard) use to drive the b
 ```
 hermes kanban init                                     # create kanban.db + print daemon hint
 hermes kanban create "<title>" [--body ...] [--assignee <profile>]
-                                [--parent <id>]... [--tenant <name>]
+                                [--parent <id>]... [--tenant <name>] [--label <label>]...
                                 [--workspace scratch|worktree|worktree:<path>|dir:<path>]
                                 [--branch <name>]
                                 [--priority N] [--triage] [--idempotency-key KEY]
@@ -666,11 +668,15 @@ hermes kanban create "<title>" [--body ...] [--assignee <profile>]
                                 [--goal] [--goal-max-turns N]
                                 [--skill <name>]...
                                 [--json]
-hermes kanban list [--mine] [--assignee P] [--status S] [--tenant T] [--archived]
+hermes kanban list [--mine] [--assignee P] [--status S] [--tenant T] [--label L]... [--archived]
         [--workflow-template-id <id>] [--current-step-key <key>]
         [--sort created|created-desc|priority|priority-desc|status|assignee|title|updated]
         [--json]
 hermes kanban show <id> [--json]
+hermes kanban label list <id> [--json]
+hermes kanban label add <id> <label>... [--json]
+hermes kanban label remove <id> <label>... [--json]    # alias: rm
+hermes kanban label set <id> [<label>...] [--json]     # replace all labels
 hermes kanban assign <id> <profile>                    # or 'none' to unassign
 hermes kanban reassign <id>... <profile>               # bulk re-assign tasks to a profile
 hermes kanban edit <id> [--title ...] [--body ...]     # edit task title / body / priority in place
@@ -712,6 +718,8 @@ hermes kanban specify [<id> | --all] [--tenant T]      # flesh out a triage-colu
 hermes kanban gc [--event-retention-days N]            # workspaces + old events + old logs
         [--log-retention-days N]
 ```
+
+Labels are normalized to lowercase, spaces become dashes, duplicates are removed, and valid characters are letters, numbers, `-`, and `_`. Repeat `--label` when creating or listing tasks; list filters require every supplied label. Use `hermes kanban label add/remove/set/list` to manage labels after creation.
 
 All commands are also available as a slash command in the interactive CLI and in the messaging gateway (see [`/kanban` slash command](#kanban-slash-command) below).
 
@@ -782,7 +790,9 @@ Every `hermes kanban <action>` verb is also reachable as `/kanban <action>` — 
 ```
 /kanban list
 /kanban show t_abcd
-/kanban create "write launch post" --assignee writer --parent t_research
+/kanban create "write launch post" --assignee writer --parent t_research --label launch --label writing
+/kanban label add t_abcd urgent frontend
+/kanban list --label launch
 /kanban comment t_abcd "looks good, ship it"
 /kanban unblock t_abcd
 /kanban dispatch --max 3
@@ -794,13 +804,13 @@ Quote multi-word arguments the same way you would on a shell — `run_slash` par
 
 ### Mid-run usage: `/kanban` bypasses the running-agent guard
 
-The gateway normally queues slash commands and user messages while an agent is still thinking — that's what stops you from accidentally starting a second turn while the first is in flight. **`/kanban` is explicitly exempted from this guard.** The board lives in `~/.hermes/kanban.db`, not in the running agent's state, so reads (`list`, `show`, `context`, `tail`, `watch`, `stats`, `runs`) and writes (`comment`, `unblock`, `block`, `assign`, `archive`, `create`, `link`, …) all go through immediately, even mid-turn.
+The gateway normally queues slash commands and user messages while an agent is still thinking — that's what stops you from accidentally starting a second turn while the first is in flight. **`/kanban` is explicitly exempted from this guard.** The board lives in `~/.hermes/kanban.db`, not in the running agent's state, so reads (`list`, `show`, `context`, `tail`, `watch`, `stats`, `runs`, `label list`) and writes (`comment`, `unblock`, `block`, `assign`, `archive`, `create`, `label add/remove/set`, `link`, …) all go through immediately, even mid-turn.
 
 This is the whole point of the separation:
 
 - A worker blocks waiting on a peer → you send `/kanban unblock t_abcd` from your phone and the dispatcher picks the peer up on its next tick. The blocked worker isn't interrupted — it just stops being blocked.
 - You spot a card that needs human context → `/kanban comment t_xyz "use the 2026 schema, not 2025"` lands on the task thread and the *next* run of that task will read it in `kanban_show()`.
-- You want to know what your fleet is doing without stopping the orchestrator → `/kanban list --mine` or `/kanban stats` inspects the board without touching your main conversation.
+- You want to know what your fleet is doing without stopping the orchestrator → `/kanban list --mine`, `/kanban list --label launch`, or `/kanban stats` inspects the board without touching your main conversation.
 
 ### Auto-subscribe on `/kanban create` (gateway only)
 
@@ -825,7 +835,7 @@ Gateway platforms have practical message-length caps. If `/kanban list`, `/kanba
 
 ### Autocomplete
 
-In the interactive CLI, typing `/kanban ` and hitting Tab cycles through the built-in subcommand list (`list`, `ls`, `show`, `create`, `assign`, `link`, `unlink`, `claim`, `comment`, `complete`, `block`, `unblock`, `archive`, `tail`, `dispatch`, `context`, `init`, `gc`). The remaining verbs listed in the CLI reference above (`watch`, `stats`, `runs`, `log`, `assignees`, `heartbeat`, `notify-subscribe`, `notify-list`, `notify-unsubscribe`, `daemon`) also work — they're just not in the autocomplete hint list yet.
+In the interactive CLI, typing `/kanban ` and hitting Tab cycles through the built-in subcommand list (`list`, `ls`, `show`, `create`, `label`, `assign`, `link`, `unlink`, `claim`, `comment`, `complete`, `block`, `unblock`, `archive`, `tail`, `dispatch`, `context`, `init`, `gc`). The remaining verbs listed in the CLI reference above (`watch`, `stats`, `runs`, `log`, `assignees`, `heartbeat`, `notify-subscribe`, `notify-list`, `notify-unsubscribe`, `daemon`) also work — they're just not in the autocomplete hint list yet.
 
 ## Collaboration patterns
 


### PR DESCRIPTION
## Summary
- Replay first-class Kanban task labels support onto current origin/main after merge-closeout drift.
- Adds label persistence, CLI/tool/dashboard/API surfacing, docs, and focused regression coverage.

## Verification
- pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/tools/test_kanban_tools.py tests/plugins/test_kanban_dashboard_plugin.py
- git diff --check origin/main...HEAD

## Replay notes
- Base: origin/main deadb43cc23ffe8fd76e8c486e08a5e5acd1ad92
- Head: 2c15d2e3568d65805327610ed841a0f7af4d6057
- Stable patch-id matches prior approved head c73c53e08ce0c308afdc88883f384835abd5c140: 58f4737dfb435c24bd0b9a394fcffc061cc52b8e