### PR TITLE
feat(desktop): skipped clarify keeps its choices visible and answerable

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -1,8 +1,9 @@
 import type { ToolCallMessagePartProps } from '@assistant-ui/react'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { onComposerInsertRequest } from '@/app/chat/composer/focus'
 import { I18nProvider } from '@/i18n'
 
 import { ClarifyTool, readClarifyResult } from './clarify-tool'
@@ -113,5 +114,71 @@ describe('ClarifyTool settled view', () => {
 
     expect(screen.getByText('Anything else?')).toBeTruthy()
     expect(screen.getByText('Skipped')).toBeTruthy()
+  })
+
+  it('keeps the original choices visible and clickable after a skip', async () => {
+    const inserts: string[] = []
+
+    const stop = onComposerInsertRequest(detail => {
+      inserts.push(detail.text)
+    })
+
+    try {
+      renderClarify(
+        <ClarifyTool
+          {...settledClarifyProps(
+            { question: 'Which deployment target?', choices: ['staging', 'prod'] },
+            { question: 'Which deployment target?', user_response: '' },
+            'clarify-3'
+          )}
+        />
+      )
+
+      // The skip label renders AND the original options are still on screen.
+      expect(screen.getByText('Skipped')).toBeTruthy()
+      const group = document.querySelector('[data-clarify-late-choices]')
+      expect(group).toBeTruthy()
+      expect(screen.getByText('staging')).toBeTruthy()
+      expect(screen.getByText('prod')).toBeTruthy()
+
+      // Picking one drafts a quoted follow-up into the composer. The insert
+      // bus defers dispatch by a macrotask, so flush one tick.
+      fireEvent.click(screen.getByText('prod'))
+      await new Promise(resolve => window.setTimeout(resolve, 0))
+
+      expect(inserts).toHaveLength(1)
+      expect(inserts[0]).toContain('Which deployment target?')
+      expect(inserts[0]).toContain('prod')
+    } finally {
+      stop()
+    }
+  })
+
+  it('does not render late choices on an answered clarify', () => {
+    renderClarify(
+      <ClarifyTool
+        {...settledClarifyProps(
+          { question: 'Which deployment target?', choices: ['staging', 'prod'] },
+          { question: 'Which deployment target?', user_response: 'staging' },
+          'clarify-4'
+        )}
+      />
+    )
+
+    expect(document.querySelector('[data-clarify-late-choices]')).toBeNull()
+  })
+
+  it('does not render late choices for a free-text (no-choice) skip', () => {
+    renderClarify(
+      <ClarifyTool
+        {...settledClarifyProps(
+          { question: 'Anything else?' },
+          { question: 'Anything else?', user_response: '' },
+          'clarify-5'
+        )}
+      />
+    )
+
+    expect(document.querySelector('[data-clarify-late-choices]')).toBeNull()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -13,6 +13,7 @@ import {
   useState
 } from 'react'
 
+import { requestComposerFocus, requestComposerInsert } from '@/app/chat/composer/focus'
 import { useSessionView } from '@/app/chat/session-view'
 import { ToolFallback } from '@/components/assistant-ui/tool/fallback'
 import { Button } from '@/components/ui/button'
@@ -156,6 +157,22 @@ function ClarifyToolSettled({ args, result }: ToolCallMessagePartProps) {
   const error = fromResult.error
   const skipped = !error && answer !== undefined && !answer.trim()
   const answerText = error || (skipped ? copy.skipped : (answer ?? '').trim())
+  const choices = fromArgs.choices ?? []
+
+  // A skipped (timed-out) clarify keeps its choices on screen and actionable.
+  // The blocking request is long gone — the tool already returned empty — so a
+  // pick can't resolve it retroactively. Instead it drafts a quoted follow-up
+  // into the composer (Enter sends; if the agent is mid-turn it queues like
+  // any other prompt). Without this the card collapsed to just "Skipped" and
+  // the options were unrecoverable.
+  const followUp = useCallback(
+    (choice: string) => {
+      requestComposerInsert(copy.lateAnswer(question, choice), { mode: 'block' })
+      requestComposerFocus()
+      triggerHaptic('selection')
+    },
+    [copy, question]
+  )
 
   return (
     <ClarifyShell className="grid gap-1.5 px-2.5 py-2" data-clarify-settled="">
@@ -177,6 +194,27 @@ function ClarifyToolSettled({ args, result }: ToolCallMessagePartProps) {
             {answerText}
           </p>
         </ClarifyLine>
+      ) : null}
+      {skipped && choices.length > 0 ? (
+        <div className="grid gap-px" data-clarify-late-choices="" role="group">
+          {choices.map((choice, index) => (
+            <button
+              className={cn(
+                OPTION_ROW_CLASS,
+                'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-primary)'
+              )}
+              data-choice
+              key={`${index}-${choice}`}
+              onClick={() => followUp(choice)}
+              title={copy.lateAnswerTip}
+              type="button"
+            >
+              <KeyBadge char={letterFor(index)} selected={false} />
+              <span className="flex-1 wrap-anywhere">{choice}</span>
+            </button>
+          ))}
+          <p className="px-1.5 pt-0.5 text-[0.6875rem] leading-4 text-(--ui-text-tertiary)">{copy.lateAnswerHint}</p>
+        </div>
       ) : null}
     </ClarifyShell>
   )

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2515,7 +2515,10 @@ export const en: Translations = {
       placeholder: 'Type your answer…',
       skip: 'Skip',
       skipped: 'Skipped',
-      continueLabel: 'Continue'
+      continueLabel: 'Continue',
+      lateAnswer: (question, choice) => `Re: "${question}" — my answer: ${choice}`,
+      lateAnswerTip: 'Draft this answer as a follow-up message',
+      lateAnswerHint: 'This question timed out. Picking an option drafts it as a follow-up message.'
     },
     tool: {
       code: 'Code',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2445,7 +2445,10 @@ export const ja = defineLocale({
       placeholder: '回答を入力…',
       skip: 'スキップ',
       skipped: 'スキップ済み',
-      continueLabel: '続行'
+      continueLabel: '続行',
+      lateAnswer: (question, choice) => `「${question}」について — 私の回答: ${choice}`,
+      lateAnswerTip: 'この回答をフォローアップメッセージとして下書きします',
+      lateAnswerHint: 'この質問はタイムアウトしました。選択肢を選ぶとフォローアップメッセージとして下書きされます。'
     },
     tool: {
       code: 'コード',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2130,6 +2130,9 @@ export interface Translations {
       skip: string
       skipped: string
       continueLabel: string
+      lateAnswer: (question: string, choice: string) => string
+      lateAnswerTip: string
+      lateAnswerHint: string
     }
     tool: {
       code: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2371,7 +2371,10 @@ export const zhHant = defineLocale({
       placeholder: '輸入您的答案…',
       skip: '略過',
       skipped: '已略過',
-      continueLabel: '繼續'
+      continueLabel: '繼續',
+      lateAnswer: (question, choice) => `關於「${question}」 — 我的回答: ${choice}`,
+      lateAnswerTip: '將此回答起草為後續訊息',
+      lateAnswerHint: '此問題已逾時。選擇一個選項會將其起草為後續訊息。'
     },
     tool: {
       code: '程式碼',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2687,7 +2687,10 @@ export const zh: Translations = {
       placeholder: '输入你的答案…',
       skip: '跳过',
       skipped: '已跳过',
-      continueLabel: '继续'
+      continueLabel: '继续',
+      lateAnswer: (question, choice) => `关于"${question}" — 我的回答: ${choice}`,
+      lateAnswerTip: '将此回答起草为后续消息',
+      lateAnswerHint: '此问题已超时。选择一个选项会将其起草为后续消息。'
     },
     tool: {
       code: '代码',


### PR DESCRIPTION
## What does this PR do?

When a clarify prompt (multiple-choice question) times out, the settled card collapses to just the question and an italic "Skipped". The choices vanish — even though they're sitting right in the tool-call args — and there is no way to answer after the fact. If you stepped away and missed the window, you can't even see what the agent asked you to pick between.

This keeps the choices on the skipped card and makes them actionable:

- The original options render on the settled card, letter-badged like the live prompt.
- Clicking one drafts a quoted follow-up into the composer — `Re: "<question>" — my answer: <choice>` — and focuses it. Enter sends it as a normal user message; if the agent is mid-turn, it queues like any other prompt.
- A hint line under the options explains the question timed out and what picking does.

Deliberately NOT retroactive resolution of the expired request: by the time the card shows "Skipped", the tool has already returned empty and the turn has moved on. Injecting a late answer into past context would break the prompt-cache and role-alternation invariants, and `clarify.respond` against an expired request id hard-errors today (#56558). The follow-up-message path needs zero backend changes and behaves identically against older backends.

Answered clarifies and free-text (no-choice) skips render exactly as before.

Related: #44845 tracks the real long-term design (durable, ID-addressable clarify decisions instead of short blocking timers) — this is the interim UX until that lands. #12625 / #33567 (timeout controls) are adjacent but untouched.

## Related Issue

Interim UX for #44845.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/components/assistant-ui/clarify-tool.tsx`: `ClarifyToolSettled` reads `choices` from the tool args; when the result is a skip and choices exist, renders them as buttons that draft the follow-up via the composer insert bus (`requestComposerInsert` + `requestComposerFocus`).
- i18n: `lateAnswer` (template), `lateAnswerTip`, `lateAnswerHint` added to `types.ts` and all four locales (en, ja, zh, zh-hant).
- Tests (`clarify-tool.test.tsx`): skipped-with-choices renders the options and a click emits the drafted follow-up on the insert bus; answered clarifies and choice-less skips render no late-choice group.

## How to Test

1. Ask the agent something that triggers a multiple-choice clarify, then don't answer until it times out (default 5 min, or lower `approvals`/clarify timeout for a faster repro).
2. Before: the card shows the question + "Skipped" and nothing else. After: the original options are listed under the skip label.
3. Click an option: the composer fills with `Re: "<question>" — my answer: <choice>` and focuses. Enter sends; if the agent is busy the message queues and the queue panel shows it.
4. Answer a clarify normally: the settled card is unchanged (no options group).
5. Renderer checks: `cd apps/desktop && npx tsc -p . --noEmit && npx vitest run --project ui` (1930 passed, 210 files); eslint clean on touched files (5 pre-existing-style `document` warnings in the test file match the repo's existing test patterns).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the desktop renderer suite (`npx vitest run --project ui`) and all tests pass; `pytest` N/A, no Python changes
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no docs describe the skipped-clarify rendering)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (renderer-only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
