### PR TITLE
feat(codex): support plugin mentions over gateway

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -20,12 +20,49 @@ import json
 import logging
 import os
 import time
+from collections.abc import Mapping
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
 
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 
 logger = logging.getLogger(__name__)
+
+
+def list_codex_plugins(agent=None, *, cwd: str | None = None) -> list:
+    """List usable Codex plugins without running a turn.
+
+    Reuse an AIAgent's live app-server session when available. Otherwise own
+    and close a short-lived session so inventory probes cannot leak a Codex
+    subprocess. Codex being absent or unavailable is represented by an empty
+    inventory.
+    """
+    session = getattr(agent, "_codex_session", None) if agent is not None else None
+    if session is not None:
+        try:
+            return session.list_plugins()
+        except Exception:
+            logger.debug("unable to list Codex plugins from live session", exc_info=True)
+            return []
+
+    from agent.transports.codex_app_server_session import CodexAppServerSession
+
+    owned_session = CodexAppServerSession(cwd=cwd)
+    try:
+        return owned_session.list_plugins()
+    except Exception:
+        logger.debug("unable to list Codex plugins", exc_info=True)
+        return []
+    finally:
+        owned_session.close()
+
+
+def _transport_plugin_mentions(original_user_message: Any) -> list | None:
+    """Return well-shaped transport plugin metadata, if present."""
+    if not isinstance(original_user_message, Mapping):
+        return None
+    plugin_mentions = original_user_message.get("plugin_mentions")
+    return plugin_mentions if isinstance(plugin_mentions, list) else None
 
 
 def _coerce_usage_int(value: Any) -> int:
@@ -692,7 +729,11 @@ def run_codex_app_server_turn(
     # return reaches us. Do NOT append again — that would duplicate.
 
     try:
-        turn = agent._codex_session.run_turn(user_input=user_message)
+        run_turn_kwargs: dict[str, Any] = {"user_input": user_message}
+        plugin_mentions = _transport_plugin_mentions(original_user_message)
+        if plugin_mentions:
+            run_turn_kwargs["plugin_mentions"] = plugin_mentions
+        turn = agent._codex_session.run_turn(**run_turn_kwargs)
     except Exception as exc:
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn
@@ -1348,6 +1389,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
 
 
 __all__ = [
+    "list_codex_plugins",
     "run_codex_app_server_turn",
     "run_codex_stream",
     "run_codex_create_stream_fallback",

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -37,11 +37,30 @@ class CodexAppServerError(RuntimeError):
     """Raised on JSON-RPC errors from the app-server."""
 
     code: int
-    message: str
+    message: Any
     data: Optional[Any] = None
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         return f"codex app-server error {self.code}: {self.message}"
+
+
+@dataclass(frozen=True)
+class CodexPluginSummary:
+    id: str
+    name: str
+    display_name: str
+    description: str = ""
+    keywords: tuple[str, ...] = ()
+
+    @property
+    def path(self) -> str:
+        return f"plugin://{self.id}"
+
+
+@dataclass(frozen=True)
+class CodexPluginMention:
+    name: str
+    path: str
 
 
 @dataclass
@@ -238,6 +257,59 @@ class CodexAppServerClient:
     def notify(self, method: str, params: Optional[dict] = None) -> None:
         """Send a JSON-RPC notification (no id, no response expected)."""
         self._send({"method": method, "params": params or {}})
+
+    def list_plugins(self, timeout: float = 15.0) -> list[CodexPluginSummary]:
+        """Return usable installed plugins across current and older APIs."""
+        try:
+            result = self.request("plugin/installed", {}, timeout=timeout)
+        except CodexAppServerError as exc:
+            message = str(exc.message).lower().replace("_", "-")
+            if exc.code not in {-32601, -32600} and not any(
+                marker in message
+                for marker in ("method not found", "invalid method", "unknown method")
+            ):
+                raise
+            result = self.request("plugin/list", {}, timeout=timeout)
+
+        records: list[dict[str, Any]] = []
+
+        def collect(value: Any) -> None:
+            if isinstance(value, list):
+                for item in value:
+                    collect(item)
+            elif isinstance(value, dict):
+                if value.get("id") and ("interface" in value or "installed" in value):
+                    records.append(value)
+                else:
+                    for key in ("plugins", "items", "data", "marketplaces"):
+                        if key in value:
+                            collect(value[key])
+
+        collect(result)
+        summaries: list[CodexPluginSummary] = []
+        for plugin in records:
+            if plugin.get("installed") is not True or plugin.get("enabled") is not True:
+                continue
+            availability = plugin.get("availability")
+            if availability is not None and availability != "AVAILABLE":
+                continue
+            interface = plugin.get("interface") or {}
+            plugin_id = str(plugin["id"])
+            name = str(plugin.get("name") or plugin_id)
+            keywords = plugin.get("keywords") or interface.get("keywords") or ()
+            summaries.append(CodexPluginSummary(
+                id=plugin_id,
+                name=name,
+                display_name=str(interface.get("displayName") or name),
+                description=str(
+                    interface.get("shortDescription")
+                    or plugin.get("shortDescription")
+                    or plugin.get("description")
+                    or ""
+                ),
+                keywords=tuple(str(keyword) for keyword in keywords),
+            ))
+        return summaries
 
     def respond(self, request_id: Any, result: dict) -> None:
         """Reply to a server-initiated request (e.g. approval prompts)."""

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -36,6 +36,8 @@ from agent.redact import redact_sensitive_text
 from agent.transports.codex_app_server import (
     CodexAppServerClient,
     CodexAppServerError,
+    CodexPluginMention,
+    CodexPluginSummary,
 )
 from agent.transports.codex_event_projector import CodexEventProjector
 
@@ -310,6 +312,36 @@ class CodexAppServerSession:
         self._pending_file_changes: dict[str, str] = {}
         self._closed = False
 
+    def list_plugins(self) -> list[CodexPluginSummary]:
+        try:
+            self.ensure_started()
+            return self._client.list_plugins() if self._client is not None else []
+        except (CodexAppServerError, OSError, RuntimeError, TimeoutError):
+            logger.debug("unable to list Codex plugins", exc_info=True)
+            return []
+
+    def _validated_plugin_mentions(self, requested: Any) -> list[CodexPluginMention]:
+        if not isinstance(requested, (list, tuple)) or not requested:
+            return []
+        inventory = {plugin.path: plugin for plugin in self.list_plugins()}
+        mentions: list[CodexPluginMention] = []
+        seen: set[str] = set()
+        for item in requested:
+            if isinstance(item, CodexPluginMention):
+                name, path = item.name, item.path
+            elif isinstance(item, dict):
+                name, path = item.get("name"), item.get("path")
+            else:
+                continue
+            if not isinstance(name, str) or not isinstance(path, str) or path in seen:
+                continue
+            plugin = inventory.get(path)
+            if plugin is None or name not in {plugin.name, plugin.display_name}:
+                continue
+            seen.add(path)
+            mentions.append(CodexPluginMention(plugin.display_name, plugin.path))
+        return mentions
+
     # ---------- lifecycle ----------
 
     def ensure_started(self) -> str:
@@ -471,6 +503,7 @@ class CodexAppServerSession:
         self,
         user_input: Any,
         *,
+        plugin_mentions: Any = None,
         turn_timeout: float = 600.0,
         notification_poll_timeout: float = 0.25,
         post_tool_quiet_timeout: float = 90.0,
@@ -523,7 +556,13 @@ class CodexAppServerSession:
                 "turn/start",
                 {
                     "threadId": self._thread_id,
-                    "input": [{"type": "text", "text": user_input_text}],
+                    "input": [
+                        {"type": "text", "text": user_input_text},
+                        *[
+                            {"type": "mention", "name": mention.name, "path": mention.path}
+                            for mention in self._validated_plugin_mentions(plugin_mentions)
+                        ],
+                    ],
                 },
                 timeout=10,
             )

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -936,6 +936,28 @@ def _derive_chat_session_id(
     return f"api-{digest}"
 
 
+def _parse_original_user_message(body: Dict[str, Any]) -> tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Validate optional transport metadata without changing visible input text."""
+    if "original_user_message" not in body:
+        return None, None
+
+    value = body.get("original_user_message")
+    if not isinstance(value, dict):
+        return None, "'original_user_message' must be an object"
+
+    content = value.get("content")
+    if not isinstance(content, str):
+        return None, "'original_user_message.content' must be a string"
+
+    plugin_mentions = value.get("plugin_mentions")
+    if not isinstance(plugin_mentions, list):
+        return None, "'original_user_message.plugin_mentions' must be an array"
+
+    if not plugin_mentions:
+        return None, None
+    return {"content": content, "plugin_mentions": plugin_mentions}, None
+
+
 _CRON_AVAILABLE = False
 try:
     from cron.jobs import (
@@ -1960,7 +1982,12 @@ class APIServerAdapter(BasePlatformAdapter):
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
         return web.json_response(
-            {"status": "ok", "platform": "hermes-agent", "version": _hermes_version()}
+            {
+                "status": "ok",
+                "platform": "hermes-agent",
+                "version": _hermes_version(),
+                "features": {"plugin_mentions": True},
+            }
         )
 
     async def _handle_health_detailed(self, request: "web.Request") -> "web.Response":
@@ -2748,6 +2775,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
+        original_user_message, metadata_error = _parse_original_user_message(body)
+        if metadata_error is not None:
+            return web.json_response(_openai_error(metadata_error), status=400)
+
         stream = _coerce_request_bool(body.get("stream"), default=False)
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
@@ -2936,6 +2967,7 @@ class APIServerAdapter(BasePlatformAdapter):
             agent_ref = [None]
             agent_task = asyncio.ensure_future(self._run_agent(
                 user_message=user_message,
+                original_user_message=original_user_message,
                 conversation_history=history,
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
@@ -2960,6 +2992,7 @@ class APIServerAdapter(BasePlatformAdapter):
         async def _compute_completion():
             return await self._run_agent(
                 user_message=user_message,
+                original_user_message=original_user_message,
                 conversation_history=history,
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
@@ -4739,6 +4772,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self,
         user_message: str,
         conversation_history: List[Dict[str, str]],
+        original_user_message: Optional[Dict[str, Any]] = None,
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
@@ -4793,10 +4827,15 @@ class APIServerAdapter(BasePlatformAdapter):
                     if agent_ref is not None:
                         agent_ref[0] = agent
                     effective_task_id = session_id or str(uuid.uuid4())
+                    run_kwargs: Dict[str, Any] = {
+                        "user_message": user_message,
+                        "conversation_history": conversation_history,
+                        "task_id": effective_task_id,
+                    }
+                    if original_user_message is not None:
+                        run_kwargs["persist_user_message"] = original_user_message
                     result = agent.run_conversation(
-                        user_message=user_message,
-                        conversation_history=conversation_history,
-                        task_id=effective_task_id,
+                        **run_kwargs,
                     )
                     usage = {
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
@@ -4926,6 +4965,10 @@ class APIServerAdapter(BasePlatformAdapter):
         user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
         if not user_message:
             return web.json_response(_openai_error("No user message found in input"), status=400)
+
+        original_user_message, metadata_error = _parse_original_user_message(body)
+        if metadata_error is not None:
+            return web.json_response(_openai_error(metadata_error), status=400)
 
         instructions = body.get("instructions")
         previous_response_id = body.get("previous_response_id")
@@ -5104,11 +5147,14 @@ class APIServerAdapter(BasePlatformAdapter):
                                 session_key=approval_session_key,
                             )
                             register_gateway_notify(approval_session_key, _approval_notify)
-                            r = agent.run_conversation(
-                                user_message=user_message,
-                                conversation_history=conversation_history,
-                                task_id=effective_task_id,
-                            )
+                            run_kwargs: Dict[str, Any] = {
+                                "user_message": user_message,
+                                "conversation_history": conversation_history,
+                                "task_id": effective_task_id,
+                            }
+                            if original_user_message is not None:
+                                run_kwargs["persist_user_message"] = original_user_message
+                            r = agent.run_conversation(**run_kwargs)
                         finally:
                             try:
                                 unregister_gateway_notify(approval_session_key)

--- a/tests/agent/test_codex_runtime_plugin_mentions.py
+++ b/tests/agent/test_codex_runtime_plugin_mentions.py
@@ -1,0 +1,92 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from agent.codex_runtime import list_codex_plugins, run_codex_app_server_turn
+
+
+def _run_with_session(session, original_user_message):
+    agent = SimpleNamespace(
+        _codex_session=session,
+        _interrupt_requested=False,
+    )
+    return run_codex_app_server_turn(
+        agent,
+        user_message="display text",
+        original_user_message=original_user_message,
+        messages=[],
+        effective_task_id="task",
+    )
+
+
+def test_runtime_forwards_transport_plugin_mentions():
+    mentions = [{"name": "acme", "path": "plugin://acme/tools"}]
+    session = Mock()
+    session.run_turn.side_effect = RuntimeError("stop after call capture")
+
+    _run_with_session(
+        session,
+        {"content": "persisted text", "plugin_mentions": mentions},
+    )
+
+    session.run_turn.assert_called_once_with(
+        user_input="display text",
+        plugin_mentions=mentions,
+    )
+
+
+@pytest.mark.parametrize(
+    "original_user_message",
+    [
+        "plain persisted text",
+        {"content": "persisted text"},
+        {"content": "persisted text", "plugin_mentions": None},
+        {"content": "persisted text", "plugin_mentions": []},
+        {"content": "persisted text", "plugin_mentions": {"name": "acme"}},
+    ],
+)
+def test_runtime_omits_absent_or_malformed_plugin_mentions(
+    original_user_message,
+):
+    class LegacySession:
+        def __init__(self):
+            self.user_input = None
+            self.closed = False
+
+        def run_turn(self, *, user_input):
+            self.user_input = user_input
+            raise RuntimeError("stop after call capture")
+
+        def close(self):
+            self.closed = True
+
+    session = LegacySession()
+    _run_with_session(session, original_user_message)
+
+    assert session.user_input == "display text"
+    assert session.closed is True
+
+
+def test_list_codex_plugins_reuses_live_session():
+    inventory = [object()]
+    session = Mock()
+    session.list_plugins.return_value = inventory
+
+    assert list_codex_plugins(SimpleNamespace(_codex_session=session)) is inventory
+    session.list_plugins.assert_called_once_with()
+    session.close.assert_not_called()
+
+
+def test_list_codex_plugins_closes_owned_session_when_unavailable(monkeypatch):
+    session = Mock()
+    session.list_plugins.side_effect = OSError("codex unavailable")
+    factory = Mock(return_value=session)
+    monkeypatch.setattr(
+        "agent.transports.codex_app_server_session.CodexAppServerSession",
+        factory,
+    )
+
+    assert list_codex_plugins(cwd="/tmp/project") == []
+    factory.assert_called_once_with(cwd="/tmp/project")
+    session.close.assert_called_once_with()

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -704,6 +704,24 @@ def auth_adapter():
 
 class TestAgentExecution:
     @pytest.mark.asyncio
+    async def test_run_agent_hands_original_message_to_runtime(self, adapter):
+        metadata = {
+            "content": "visible text",
+            "plugin_mentions": [{"name": "acme", "path": "plugin://acme/tools"}],
+        }
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            await adapter._run_agent(
+                user_message="visible text",
+                conversation_history=[],
+                original_user_message=metadata,
+            )
+
+        assert mock_agent.run_conversation.call_args.kwargs["persist_user_message"] == metadata
+
+    @pytest.mark.asyncio
     async def test_run_agent_uses_session_id_as_task_id(self, adapter):
         mock_agent = MagicMock()
         mock_agent.run_conversation.return_value = {"final_response": "ok"}
@@ -762,6 +780,7 @@ class TestHealthEndpoint:
             data = await resp.json()
             assert data["status"] == "ok"
             assert data["platform"] == "hermes-agent"
+            assert data["features"]["plugin_mentions"] is True
 
     @pytest.mark.asyncio
     async def test_health_reports_version(self, adapter):
@@ -1217,6 +1236,71 @@ class TestToolsetsEndpoint:
 
 
 class TestChatCompletionsEndpoint:
+    @pytest.mark.asyncio
+    async def test_plugin_mentions_forward_structured_original_message(self, adapter):
+        metadata = {
+            "content": "Ask Acme to inspect this",
+            "plugin_mentions": [{"name": "acme", "path": "plugin://acme/tools"}],
+        }
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "done", "messages": []},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "messages": [{"role": "user", "content": metadata["content"]}],
+                        "original_user_message": metadata,
+                    },
+                )
+
+        assert resp.status == 200
+        assert mock_run.call_args.kwargs["user_message"] == metadata["content"]
+        assert mock_run.call_args.kwargs["original_user_message"] == metadata
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("plugin_mentions", [None, {}, "acme"])
+    async def test_plugin_mentions_reject_malformed_list(self, adapter, plugin_mentions):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "original_user_message": {
+                        "content": "hello",
+                        "plugin_mentions": plugin_mentions,
+                    },
+                },
+            )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            {},
+            {"original_user_message": {"content": "hello", "plugin_mentions": []}},
+        ],
+    )
+    async def test_plain_chat_request_has_no_metadata(self, adapter, extra):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "done", "messages": []},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"messages": [{"role": "user", "content": "hello"}], **extra},
+                )
+        assert resp.status == 200
+        assert mock_run.call_args.kwargs["original_user_message"] is None
+
     @pytest.mark.asyncio
     async def test_invalid_json_returns_400(self, adapter):
         app = _create_app(adapter)

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -121,6 +121,84 @@ def auth_adapter():
 
 class TestStartRun:
     @pytest.mark.asyncio
+    async def test_plugin_mentions_reach_run_conversation_without_changing_input(self, adapter):
+        metadata = {
+            "content": "Ask Acme to inspect this",
+            "plugin_mentions": [{"name": "acme", "path": "plugin://acme/tools"}],
+        }
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": metadata["content"], "original_user_message": metadata},
+                )
+                run_id = (await resp.json())["run_id"]
+                for _ in range(20):
+                    status = await (await cli.get(f"/v1/runs/{run_id}")).json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert status["status"] == "completed"
+        kwargs = mock_agent.run_conversation.call_args.kwargs
+        assert kwargs["user_message"] == metadata["content"]
+        assert kwargs["persist_user_message"] == metadata
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("plugin_mentions", [None, {}, "acme"])
+    async def test_plugin_mentions_reject_malformed_list(self, adapter, plugin_mentions):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs",
+                json={
+                    "input": "hello",
+                    "original_user_message": {
+                        "content": "hello",
+                        "plugin_mentions": plugin_mentions,
+                    },
+                },
+            )
+        assert resp.status == 400
+        assert adapter._run_streams == {}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            {},
+            {"original_user_message": {"content": "hello", "plugin_mentions": []}},
+        ],
+    )
+    async def test_plain_run_omits_original_message_handoff(self, adapter, extra):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+                resp = await cli.post("/v1/runs", json={"input": "hello", **extra})
+                run_id = (await resp.json())["run_id"]
+                for _ in range(20):
+                    status = await (await cli.get(f"/v1/runs/{run_id}")).json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert status["status"] == "completed"
+        assert "persist_user_message" not in mock_agent.run_conversation.call_args.kwargs
+
+    @pytest.mark.asyncio
     async def test_start_returns_202(self, adapter):
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:

--- a/tests/test_codex_app_server_plugin_mentions.py
+++ b/tests/test_codex_app_server_plugin_mentions.py
@@ -1,0 +1,143 @@
+from unittest.mock import Mock
+
+from agent.transports.codex_app_server import (
+    CodexAppServerClient,
+    CodexAppServerError,
+    CodexPluginMention,
+    CodexPluginSummary,
+)
+from agent.transports.codex_app_server_session import CodexAppServerSession
+
+
+def test_inventory_prefers_installed_then_falls_back_flattens_and_filters():
+    client = object.__new__(CodexAppServerClient)
+    client.request = Mock(
+        side_effect=[
+            CodexAppServerError(-32601, "Method not found"),
+            {
+                "marketplaces": [
+                    {
+                        "plugins": [
+                            {
+                                "id": "acme/tools",
+                                "name": "acme",
+                                "installed": True,
+                                "enabled": True,
+                                "availability": "AVAILABLE",
+                                "keywords": ["one", "two"],
+                                "interface": {
+                                    "displayName": "Acme Tools",
+                                    "shortDescription": "Useful",
+                                },
+                            },
+                            {
+                                "id": "disabled",
+                                "installed": True,
+                                "enabled": False,
+                                "interface": {},
+                            },
+                            {
+                                "id": "unavailable",
+                                "installed": True,
+                                "enabled": True,
+                                "availability": "UNAVAILABLE",
+                                "interface": {},
+                            },
+                        ]
+                    }
+                ]
+            },
+        ]
+    )
+    plugins = client.list_plugins()
+    assert [call.args[0] for call in client.request.call_args_list] == [
+        "plugin/installed",
+        "plugin/list",
+    ]
+    assert plugins == [
+        CodexPluginSummary("acme/tools", "acme", "Acme Tools", "Useful", ("one", "two"))
+    ]
+    assert plugins[0].path == "plugin://acme/tools"
+
+
+def test_inventory_fallback_accepts_structured_error_message():
+    client = object.__new__(CodexAppServerClient)
+    client.request = Mock(
+        side_effect=[
+            CodexAppServerError(-32000, {"error": "Unknown method"}),
+            [],
+        ]
+    )
+
+    assert client.list_plugins() == []
+    assert [call.args[0] for call in client.request.call_args_list] == [
+        "plugin/installed",
+        "plugin/list",
+    ]
+
+
+def test_mentions_validate_canonical_name_path_dedupe_and_wire_shape(monkeypatch):
+    session = CodexAppServerSession()
+    monkeypatch.setattr(
+        session,
+        "list_plugins",
+        Mock(return_value=[CodexPluginSummary("acme/tools", "acme", "Acme Tools")]),
+    )
+    assert session._validated_plugin_mentions([
+        {"name": "acme", "path": "plugin://acme/tools"},
+        {"name": "acme", "path": "plugin://acme/tools"},
+        {"name": "wrong", "path": "plugin://acme/tools"},
+        {"name": "acme", "path": "plugin://unknown"},
+        None,
+    ]) == [CodexPluginMention("Acme Tools", "plugin://acme/tools")]
+
+
+def test_mentions_are_idempotent_after_canonicalization(monkeypatch):
+    session = CodexAppServerSession()
+    monkeypatch.setattr(
+        session,
+        "list_plugins",
+        Mock(return_value=[CodexPluginSummary("acme/tools", "acme", "Acme Tools")]),
+    )
+
+    emitted = session._validated_plugin_mentions([
+        {"name": "acme", "path": "plugin://acme/tools"}
+    ])
+    replayed = session._validated_plugin_mentions([
+        {"name": mention.name, "path": mention.path} for mention in emitted
+    ])
+
+    assert (
+        replayed == emitted == [CodexPluginMention("Acme Tools", "plugin://acme/tools")]
+    )
+
+
+def test_turn_start_structured_input_and_plain_compatibility(monkeypatch):
+    client = Mock()
+    client.request.side_effect = [
+        {"turn": {"id": "one"}},
+        {"turn": {"id": "two"}},
+    ]
+    client.take_server_request.return_value = None
+    client.take_notification.side_effect = [
+        {"method": "turn/completed", "params": {"turn": {"id": "one"}}},
+        {"method": "turn/completed", "params": {"turn": {"id": "two"}}},
+    ]
+    session = CodexAppServerSession()
+    session._client = client
+    session._thread_id = "thread"
+    monkeypatch.setattr(
+        session,
+        "list_plugins",
+        lambda: [CodexPluginSummary("acme/tools", "acme", "Acme Tools")],
+    )
+    session.run_turn(
+        "hello", plugin_mentions=[{"name": "acme", "path": "plugin://acme/tools"}]
+    )
+    session.run_turn("plain")
+    starts = [call.args[1]["input"] for call in client.request.call_args_list]
+    assert starts[0] == [
+        {"type": "text", "text": "hello"},
+        {"type": "mention", "name": "Acme Tools", "path": "plugin://acme/tools"},
+    ]
+    assert starts[1] == [{"type": "text", "text": "plain"}]


### PR DESCRIPTION
## Motivation

Codex app-server supports plugin mentions, but Hermes had no plugin inventory or structured forwarding path. As a result, clients could not discover installed plugins safely or attach validated plugin mentions to Codex turns.

## Implementation

- Add plugin inventory with an installed-plugin fallback and optional filtering.
- Validate canonical plugin mentions and emit the Codex app-server `turn/start` mention shape.
- Add a safe listing helper that returns structured plugin metadata without exposing unrelated filesystem state.
- Advertise plugin-mention support through gateway capabilities.
- Forward mentions through both gateway request paths so behavior is consistent across clients.

## Compatibility and security

- Existing callers remain compatible when plugin mentions are absent.
- Unknown or malformed mentions are rejected instead of forwarded.
- Inventory discovery is bounded to installed plugin metadata and uses the existing fallback behavior; it does not broaden arbitrary file access.
- The gateway capability allows clients to feature-detect support before sending mentions.

## Tests

- Broad suite: **373 passed**
- Focused plugin/gateway coverage: **31 passed**
- Lint, Python compile checks, and diff validation passed
- Fable review: **APPROVE**, with no P0/P1 findings

A companion `hermes-webui` PR will follow to consume this capability.

## Companion WebUI PR

https://github.com/nesquena/hermes-webui/pull/6442