### PR TITLE
fix(desktop): add Apple Events automation entitlement for macOS

### DIFF
--- a/apps/desktop/electron/entitlements.mac.inherit.plist
+++ b/apps/desktop/electron/entitlements.mac.inherit.plist
@@ -12,5 +12,7 @@
   <true/>
   <key>com.apple.security.device.camera</key>
   <true/>
+  <key>com.apple.security.automation.apple-events</key>
+  <true/>
 </dict>
 </plist>

--- a/apps/desktop/electron/entitlements.mac.plist
+++ b/apps/desktop/electron/entitlements.mac.plist
@@ -12,5 +12,7 @@
   <true/>
   <key>com.apple.security.device.camera</key>
   <true/>
+  <key>com.apple.security.automation.apple-events</key>
+  <true/>
 </dict>
 </plist>

--- a/apps/desktop/electron/entitlements.mac.plist
+++ b/apps/desktop/electron/entitlements.mac.plist
@@ -12,6 +12,8 @@
   <true/>
   <key>com.apple.security.device.camera</key>
   <true/>
+  <key>com.apple.security.automation.apple-events</key>
+  <true/>
   <key>com.apple.security.personal-information.calendars</key>
   <true/>
   <key>com.apple.security.personal-information.reminders</key>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -223,7 +223,8 @@
         "CFBundleName": "Hermes",
         "NSAudioCaptureUsageDescription": "Hermes uses audio capture for voice conversations.",
         "NSCameraUsageDescription": "Hermes uses the camera when a plugin or feature you enable requests it.",
-        "NSMicrophoneUsageDescription": "Hermes uses the microphone for voice input and voice conversations."
+        "NSMicrophoneUsageDescription": "Hermes uses the microphone for voice input and voice conversations.",
+        "NSAppleEventsUsageDescription": "Hermes uses Apple Events to automate apps you explicitly ask it to control."
       },
       "gatekeeperAssess": false,
       "hardenedRuntime": true,

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -248,7 +248,8 @@
         "NSRemindersFullAccessUsageDescription": "Hermes needs full access to Reminders to read and manage reminders when explicitly requested.",
         "NSScreenCaptureUsageDescription": "Hermes captures the screen when you ask the agent to screenshot or record it.",
         "NSLocalNetworkUsageDescription": "Hermes connects to devices on your local network when a plugin or feature you enable requests it.",
-        "NSAppleMusicUsageDescription": "Hermes accesses your music library when a plugin or feature you enable requests it."
+        "NSAppleMusicUsageDescription": "Hermes accesses your music library when a plugin or feature you enable requests it.",
+        "NSAppleEventsUsageDescription": "Hermes uses Apple Events to automate apps you explicitly ask it to control."
       },
       "gatekeeperAssess": false,
       "hardenedRuntime": true,

--- a/tests-js/desktop-mac-entitlements.test.ts
+++ b/tests-js/desktop-mac-entitlements.test.ts
@@ -35,6 +35,7 @@ const REPO_ROOT = path.resolve(__dirname, '..')
 const ELECTRON_DIR = path.join(REPO_ROOT, 'apps', 'desktop', 'electron')
 const MAIN_PLIST = path.join(ELECTRON_DIR, 'entitlements.mac.plist')
 const INHERIT_PLIST = path.join(ELECTRON_DIR, 'entitlements.mac.inherit.plist')
+const DESKTOP_PKG = path.join(REPO_ROOT, 'apps', 'desktop', 'package.json')
 
 const DEVICE_PREFIX = 'com.apple.security.device.'
 
@@ -58,6 +59,41 @@ test('inherit plist grants microphone (regression #37718)', () => {
       '`com.apple.security.device.audio-input`; without it the ' +
       'hardened-runtime Helper process is denied the microphone and no ' +
       'TCC prompt appears (#37718).'
+  )
+})
+
+test('both plists grant Apple Events automation', () => {
+  const main = loadEntitlements(MAIN_PLIST)
+  const inherit = loadEntitlements(INHERIT_PLIST)
+
+  for (const [name, data] of [
+    ['entitlements.mac.plist', main],
+    ['entitlements.mac.inherit.plist', inherit],
+  ] as const) {
+    assert.equal(
+      data['com.apple.security.automation.apple-events'],
+      true,
+      `${name} must grant \`com.apple.security.automation.apple-events\`; ` +
+        'without it the hardened runtime denies sending Apple Events, so ' +
+        'AppleScript/osascript automation of other apps (e.g. Apple Notes, ' +
+        'which has no framework API) fails silently with no TCC prompt — ' +
+        'even when NSAppleEventsUsageDescription is present in Info.plist.'
+    )
+  }
+})
+
+test('Info.plist declares NSAppleEventsUsageDescription', () => {
+  const pkg = JSON.parse(fs.readFileSync(DESKTOP_PKG, 'utf-8'))
+  const value = pkg?.build?.mac?.extendInfo?.NSAppleEventsUsageDescription
+
+  assert.ok(
+    typeof value === 'string' && value.trim().length > 0,
+    'apps/desktop/package.json build.mac.extendInfo must declare ' +
+      '`NSAppleEventsUsageDescription`; the hardened runtime requires the ' +
+      'usage string in addition to the apple-events entitlement before the ' +
+      'Automation TCC prompt can fire — without it, AppleScript/osascript ' +
+      'from desktop-spawned runs is refused with errAEEventNotPermitted ' +
+      '(-1743) and no prompt ever appears (#69723).'
   )
 })
 

--- a/tests-js/desktop-mac-entitlements.test.ts
+++ b/tests-js/desktop-mac-entitlements.test.ts
@@ -35,6 +35,7 @@ const REPO_ROOT = path.resolve(__dirname, '..')
 const ELECTRON_DIR = path.join(REPO_ROOT, 'apps', 'desktop', 'electron')
 const MAIN_PLIST = path.join(ELECTRON_DIR, 'entitlements.mac.plist')
 const INHERIT_PLIST = path.join(ELECTRON_DIR, 'entitlements.mac.inherit.plist')
+const DESKTOP_PKG = path.join(REPO_ROOT, 'apps', 'desktop', 'package.json')
 const BOOTSTRAP_TAURI_DIR = path.join(REPO_ROOT, 'apps', 'bootstrap-installer', 'src-tauri')
 const BOOTSTRAP_TAURI_CONFIG = path.join(BOOTSTRAP_TAURI_DIR, 'tauri.conf.json')
 const BOOTSTRAP_ENTITLEMENTS = path.join(BOOTSTRAP_TAURI_DIR, 'entitlements.plist')
@@ -62,6 +63,41 @@ test('inherit plist grants microphone (regression #37718)', () => {
       '`com.apple.security.device.audio-input`; without it the ' +
       'hardened-runtime Helper process is denied the microphone and no ' +
       'TCC prompt appears (#37718).'
+  )
+})
+
+test('both plists grant Apple Events automation', () => {
+  const main = loadEntitlements(MAIN_PLIST)
+  const inherit = loadEntitlements(INHERIT_PLIST)
+
+  for (const [name, data] of [
+    ['entitlements.mac.plist', main],
+    ['entitlements.mac.inherit.plist', inherit],
+  ] as const) {
+    assert.equal(
+      data['com.apple.security.automation.apple-events'],
+      true,
+      `${name} must grant \`com.apple.security.automation.apple-events\`; ` +
+        'without it the hardened runtime denies sending Apple Events, so ' +
+        'AppleScript/osascript automation of other apps (e.g. Apple Notes, ' +
+        'which has no framework API) fails silently with no TCC prompt — ' +
+        'even when NSAppleEventsUsageDescription is present in Info.plist.'
+    )
+  }
+})
+
+test('Info.plist declares NSAppleEventsUsageDescription', () => {
+  const pkg = JSON.parse(fs.readFileSync(DESKTOP_PKG, 'utf-8'))
+  const value = pkg?.build?.mac?.extendInfo?.NSAppleEventsUsageDescription
+
+  assert.ok(
+    typeof value === 'string' && value.trim().length > 0,
+    'apps/desktop/package.json build.mac.extendInfo must declare ' +
+      '`NSAppleEventsUsageDescription`; the hardened runtime requires the ' +
+      'usage string in addition to the apple-events entitlement before the ' +
+      'Automation TCC prompt can fire — without it, AppleScript/osascript ' +
+      'from desktop-spawned runs is refused with errAEEventNotPermitted ' +
+      '(-1743) and no prompt ever appears (#69723).'
   )
 })
 


### PR DESCRIPTION
## Why

I want my Hermes agent to work with Apple Notes — read notes, update them, share notes with family through iCloud. Notes has no API; the only way in is AppleScript. That works fine when Hermes runs from a terminal, but anything spawned by the desktop app is silently blocked: no permission prompt, no way to allow it in System Settings, just `Not authorized to send Apple events (-1743)`.

The reason is that the app is signed with the hardened runtime but is missing the `com.apple.security.automation.apple-events` entitlement, so macOS refuses before it would ever ask the user. It also has no `NSAppleEventsUsageDescription`, which the hardened runtime requires in addition to the entitlement before the prompt can fire.

## What

- Add the entitlement to both macOS entitlement files (main app + helpers, same two-file lesson as the microphone fix in #37718).
- Add `NSAppleEventsUsageDescription` to `build.mac.extendInfo`.
- Pin both in the existing entitlement regression test.

This now carries both halves of the fix. The usage string is taken from #59486 (same wording), so the two PRs overlap on that one key — whichever merges second rebases trivially. The Contacts string stays with #59486.

Nothing is granted silently: with the entitlement in place, the user still gets the normal per-app Automation prompt and can decline.

## How to test

- `cd tests-js && npx vitest run desktop-mac-entitlements.test.ts` — fails without the changes, 6 passed with them (verified on macOS 26.5.2 arm64).
- On a signed build: automate any app from a desktop session, e.g. `osascript -e 'tell application "Notes" to get name of every folder'` — the Automation prompt should appear instead of the silent `-1743` denial.

Fixes #69723. Related: #59482.


