### PR TITLE
fix(auth): read auth json stores as utf-8

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1112,7 +1112,7 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
         return {"version": AUTH_STORE_VERSION, "providers": {}}
 
     try:
-        raw = json.loads(auth_file.read_text())
+        raw = json.loads(auth_file.read_text(encoding="utf-8"))
     except Exception as exc:
         corrupt_path = auth_file.with_suffix(".json.corrupt")
         try:
@@ -3701,7 +3701,7 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
     if not auth_path.is_file():
         return None
     try:
-        payload = json.loads(auth_path.read_text())
+        payload = json.loads(auth_path.read_text(encoding="utf-8"))
         tokens = payload.get("tokens")
         if not isinstance(tokens, dict):
             return None
@@ -5136,7 +5136,7 @@ def _read_shared_nous_state() -> Optional[Dict[str, Any]]:
     if not path.is_file():
         return None
     try:
-        payload = json.loads(path.read_text())
+        payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
         logger.debug("Shared Nous auth store at %s is unreadable: %s", path, exc)
         return None

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -6,6 +6,7 @@ import base64
 import json
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -24,6 +25,43 @@ def _jwt_with_email(email: str) -> str:
         json.dumps({"email": email}).encode()
     ).rstrip(b"=").decode()
     return f"{header}.{payload}.signature"
+
+
+def test_auth_store_reads_utf8_json_under_legacy_windows_locale(tmp_path, monkeypatch):
+    """auth.json is UTF-8 even when Windows' preferred locale is GBK/cp936."""
+    from hermes_cli import auth
+
+    auth_path = tmp_path / "hermes" / "auth.json"
+    auth_path.parent.mkdir(parents=True)
+    auth_path.write_bytes(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {
+                    "custom": {
+                        "label": "测试-provider",
+                        "api_key": "sk-test",
+                    }
+                },
+            },
+            ensure_ascii=False,
+        ).encode("utf-8")
+    )
+
+    original_read_text = Path.read_text
+
+    def gbk_default_read_text(self, *args, **kwargs):
+        if kwargs.get("encoding") is None:
+            data = self.read_bytes()
+            return data.decode("gbk")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", gbk_default_read_text)
+
+    store = auth._load_auth_store(auth_path)
+
+    assert store["providers"]["custom"]["label"] == "测试-provider"
+    assert not auth_path.with_suffix(".json.corrupt").exists()
 
 
 def _codex_pool_only_store(*, exhausted: bool = False) -> dict:


### PR DESCRIPTION
Fixes #69706

`auth.json` is written as UTF-8, but the main auth-store read path was using `Path.read_text()` without an explicit encoding. On Windows systems with a legacy default locale such as GBK/cp936, UTF-8 auth metadata containing CJK characters could be decoded incorrectly or treated as corrupt.

This change makes the auth JSON read paths use `encoding="utf-8"` explicitly, matching the existing write path.

It also covers the Codex CLI auth import and shared Nous auth store reads for the same class of locale-dependent decoding issue.

Validation:
uv run --extra dev pytest tests/hermes_cli/test_auth_commands.py tests/hermes_cli/test_auth_codex_self_heal.py tests/hermes_cli/test_auth_nous_provider.py tests/hermes_cli/test_auth_qwen_provider.py -q

Result:
166 passed