### PR TITLE
test(desktop): cover queued and steer turn boundaries

### DIFF
--- a/apps/desktop/e2e/queue-turn-boundary.spec.ts
+++ b/apps/desktop/e2e/queue-turn-boundary.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * A queued prompt must remain local until the current inference turn settles.
+ *
+ * Hold the first streamed reply open after its first token. This gives the
+ * composer a live, busy turn while the user queues a follow-up, then lets us
+ * assert against the mock provider's real request log before and after the
+ * held turn completes.
+ */
+
+import { expect, test, type Page } from './test'
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { MOCK_REPLY } from './mock-server'
+
+const ACTIVE_PROMPT = 'E2E_QUEUE_TURN_BOUNDARY_ACTIVE'
+const QUEUED_PROMPT = 'E2E_QUEUE_TURN_BOUNDARY_QUEUED'
+
+async function send(page: Page, text: string): Promise<void> {
+  const composer = page.locator('[contenteditable="true"]').first()
+  await composer.waitFor({ state: 'visible', timeout: 15_000 })
+  await composer.click()
+  await composer.type(text, { delay: 5 })
+  await page.keyboard.press('Enter')
+}
+
+test.describe('queued prompt turn boundary', () => {
+  let fixture: MockBackendFixture | null = null
+
+  test.beforeEach(async () => {
+    fixture = await setupMockBackend({
+      mockServer: { holdFirstStreamForPrompt: ACTIVE_PROMPT }
+    })
+    await waitForAppReady(fixture, 120_000)
+  })
+
+  test.afterEach(async () => {
+    await fixture?.cleanup()
+    fixture = null
+  })
+
+  test('submits a queued prompt only after the active turn completes', async () => {
+    const { mock, page } = fixture!
+    const composer = page.locator('[contenteditable="true"]').first()
+    const queue = page.locator('[data-slot="composer-root"] button[aria-label="Queue message"]')
+
+    await send(page, ACTIVE_PROMPT)
+    await mock.waitForHeldStream()
+
+    await composer.click()
+    await composer.type(QUEUED_PROMPT, { delay: 5 })
+    await queue.click()
+    await expect(page.getByText('1 Queued')).toBeVisible()
+
+    // The mock keeps the active SSE stream open, so a queued prompt has no
+    // completed-turn boundary that could legitimately drain it. Wait past the
+    // queue retry interval and assert the provider saw only the active turn.
+    await page.waitForTimeout(1_000)
+    expect(mock.receivedPrompts.filter(prompt => prompt === QUEUED_PROMPT)).toHaveLength(0)
+    await expect(page.locator('[data-slot="aui_thread-viewport"]')).not.toContainText(QUEUED_PROMPT)
+
+    mock.releaseHeldStream()
+    await page.waitForFunction(
+      expected => (document.querySelector('[data-slot="aui_thread-viewport"]')?.textContent ?? '').includes(expected),
+      MOCK_REPLY,
+      { timeout: 60_000 }
+    )
+    await expect.poll(() => mock.receivedPrompts.filter(prompt => prompt === QUEUED_PROMPT)).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Adds real Desktop E2E coverage for two mid-turn composer contracts:

- queued prompts stay out of the provider request log and transcript until the active turn settles;
- steer prompts appear before the assistant reply they redirect, rather than at the bottom of the transcript.

The steer regression reproduces the reported bug on the current branch.

## Related Issue

None.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `apps/desktop/e2e/queue-turn-boundary.spec.ts`, including a held SSE stream that reproduces the misplaced-steer transcript order.
- Strengthen `apps/desktop/e2e/correction-session-switch.spec.ts` to use the visible Steer action and preserve chronological message assertions across a tool boundary.

## How to Test

1. Run `cd apps/desktop && WLR_BACKENDS=headless WLR_NO_HARDWARE_CURSORS=1 cage -- npx playwright test e2e/queue-turn-boundary.spec.ts --reporter=list`.
2. Observe the steer placement test fail on current code: it receives `[original, assistant reply, steer]` instead of `[original, steer, assistant reply]`.
3. Run `cd apps/desktop && WLR_BACKENDS=headless WLR_NO_HARDWARE_CURSORS=1 cage -- npx playwright test e2e/correction-session-switch.spec.ts --reporter=list`; it passes.
4. Run `cd apps/desktop && npx tsc -p tsconfig.e2e.json --noEmit`; it passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this regression coverage
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (NixOS)

### Documentation & Housekeeping

- [x] Documentation/config/schema/architecture changes: N/A

## Screenshots / Logs

- Queue boundary E2E: first test passes; steer placement test intentionally fails and reproduces the transcript-order bug.
- Correction session-switch E2E: 1 passed.
- E2E TypeScript compilation: passed.
