### PR TITLE
fix(cron): verify fire tokens against job profile

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -33,7 +33,7 @@ except ImportError:  # pragma: no cover - non-Windows
     msvcrt = None
 from datetime import datetime, timedelta
 from pathlib import Path
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 from typing import Optional, Dict, List, Any, Set, Tuple, Union
 
 logger = logging.getLogger(__name__)
@@ -385,6 +385,66 @@ def _job_output_dir(job_id: str) -> Path:
     if Path(text).is_absolute() or Path(text).drive:
         raise ValueError(f"Invalid cron job id for output path: {job_id!r}")
     return _current_cron_store().output_dir / text
+
+
+def _cron_fire_profile_index_dir() -> Path:
+    """Shared per-job profile hints for public Chronos fire callbacks."""
+    return get_default_hermes_root() / "cron" / "fire_profile_index"
+
+
+def _cron_fire_profile_hint_path(job_id: str) -> Optional[Path]:
+    clean = str(job_id or "").strip()
+    if not clean:
+        return None
+    try:
+        _job_output_dir(clean)
+    except ValueError:
+        return None
+    return _cron_fire_profile_index_dir() / f"{clean}.profile"
+
+
+def resolve_cron_fire_profile_hint(job_id: str) -> Optional[str]:
+    """Return a bounded profile hint for a Chronos fire job, if known."""
+    path = _cron_fire_profile_hint_path(job_id)
+    if path is None or not path.is_file():
+        return None
+    try:
+        profile = path.read_text(encoding="utf-8").strip()
+    except Exception:
+        return None
+    return profile or None
+
+
+def record_cron_fire_profile_hint(job_id: str, profile: str) -> None:
+    """Persist a best-effort profile hint for a Chronos-armed job."""
+    clean_profile = str(profile or "").strip()
+    if not clean_profile or clean_profile == "custom":
+        return
+    path = _cron_fire_profile_hint_path(job_id)
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+    try:
+        tmp_path.write_text(f"{clean_profile}\n", encoding="utf-8")
+        atomic_replace(tmp_path, path)
+    finally:
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError:
+            pass
+
+
+def forget_cron_fire_profile_hint(job_id: str) -> None:
+    """Remove a Chronos fire profile hint when a job is cancelled or deleted."""
+    path = _cron_fire_profile_hint_path(job_id)
+    if path is None:
+        return
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
 
 
 def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:

--- a/hermes_cli/web_routers/cron.py
+++ b/hermes_cli/web_routers/cron.py
@@ -151,9 +151,10 @@ async def cron_fire_webhook(request: Request):
     except Exception:
         body = {}
     job_id = (body or {}).get("job_id") if isinstance(body, dict) else None
+    verifier = get_fire_verifier()
 
     def _verify_with_config(cfg):
-        return get_fire_verifier()(
+        return verifier(
             token=token,
             expected_audience=cfg_get(
                 cfg, "cron", "chronos", "expected_audience", default=""

--- a/hermes_cli/web_routers/cron.py
+++ b/hermes_cli/web_routers/cron.py
@@ -44,6 +44,7 @@ _delete_cron_job_sync = late("_delete_cron_job_sync")
 _find_cron_job_profile = late("_find_cron_job_profile")
 _fire_cron_job_for_profile = late("_fire_cron_job_for_profile")
 _call_cron_for_profile = late("_call_cron_for_profile")
+_load_cron_config_for_profile = late("_load_cron_config_for_profile")
 load_config = late("load_config")
 cfg_get = late("cfg_get")
 
@@ -145,28 +146,61 @@ async def cron_fire_webhook(request: Request):
     auth = request.headers.get("Authorization", "")
     token = auth[7:].strip() if auth.startswith("Bearer ") else ""
 
-    cfg = load_config()
-    claims = get_fire_verifier()(
-        token=token,
-        expected_audience=cfg_get(cfg, "cron", "chronos", "expected_audience", default=""),
-        jwks_or_key=cfg_get(cfg, "cron", "chronos", "nas_jwks_url", default="") or None,
-        issuer=cfg_get(cfg, "cron", "chronos", "portal_url", default="") or None,
-    )
-    if claims is None:
-        return JSONResponse({"error": "invalid fire token"}, status_code=401)
-
     try:
         body = await request.json()
     except Exception:
         body = {}
     job_id = (body or {}).get("job_id") if isinstance(body, dict) else None
+
+    def _verify_with_config(cfg):
+        return get_fire_verifier()(
+            token=token,
+            expected_audience=cfg_get(
+                cfg, "cron", "chronos", "expected_audience", default=""
+            ),
+            jwks_or_key=cfg_get(
+                cfg, "cron", "chronos", "nas_jwks_url", default=""
+            )
+            or None,
+            issuer=cfg_get(cfg, "cron", "chronos", "portal_url", default="")
+            or None,
+        )
+
+    profile = None
+    if job_id:
+        try:
+            from cron.jobs import resolve_cron_fire_profile_hint
+
+            profile = resolve_cron_fire_profile_hint(job_id)
+        except Exception:
+            profile = None
+
+    try:
+        cfg = _load_cron_config_for_profile(profile) if profile else load_config()
+    except Exception:
+        _log.exception("Ignoring stale Chronos fire profile hint for job %s", job_id)
+        profile = None
+        cfg = load_config()
+
+    claims = _verify_with_config(cfg)
+    if claims is None and profile:
+        # A persisted hint can go stale if a job is recreated or profiles are
+        # rearranged. Do not treat that hint as authoritative: fall back to the
+        # process Chronos verifier first, and only scan profiles after some
+        # configured verifier has accepted the bearer.
+        profile = None
+        claims = _verify_with_config(load_config())
+    if claims is None:
+        return JSONResponse({"error": "invalid fire token"}, status_code=401)
+
     if not job_id:
         return JSONResponse({"error": "missing job_id"}, status_code=400)
 
-    # _find_cron_job_profile walks every profile and lists its jobs (file
-    # I/O per profile) — run it off the event loop like the other cron
-    # dashboard endpoints.
-    profile = await _run_cron_dashboard_io(_find_cron_job_profile, job_id)
+    if not profile:
+        # _find_cron_job_profile walks every profile and lists its jobs (file
+        # I/O per profile). Keep it behind the bearer verifier because this
+        # endpoint is otherwise deliberately public.
+        profile = await _run_cron_dashboard_io(_find_cron_job_profile, job_id)
     if not profile:
         # Job is gone (cancelled / completed) — nothing to fire. 200 so NAS
         # does not retry a fire that is intentionally absent.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11441,6 +11441,24 @@ def _find_cron_job_profile(job_id: str) -> Optional[str]:
     return None
 
 
+def _load_cron_config_for_profile(profile: Optional[str]) -> Dict[str, Any]:
+    """Load Chronos settings from the resolved cron profile home."""
+    if not profile:
+        return load_config()
+
+    _profile_name, home = _cron_profile_home(profile)
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    token = set_hermes_home_override(str(home))
+    try:
+        return load_config()
+    finally:
+        reset_hermes_home_override(token)
+
+
 def _list_cron_jobs_sync(profile: str = "all"):
     requested = (profile or "all").strip()
     if requested.lower() != "all":

--- a/plugins/cron_providers/chronos/__init__.py
+++ b/plugins/cron_providers/chronos/__init__.py
@@ -147,6 +147,13 @@ class ChronosCronScheduler(CronScheduler):
             agent_callback_url=self._callback_url(),
             dedup_key=dedup_key,
         )
+        try:
+            from cron.jobs import record_cron_fire_profile_hint
+            from hermes_cli.profiles import get_active_profile_name
+
+            record_cron_fire_profile_hint(job_id, get_active_profile_name())
+        except Exception:
+            logger.debug("Chronos failed to record fire profile hint for %s", job_id, exc_info=True)
         with self._lock:
             self._armed[job_id] = fire_at
 
@@ -154,6 +161,12 @@ class ChronosCronScheduler(CronScheduler):
         try:
             self._get_client().cancel(job_id=job_id)
         finally:
+            try:
+                from cron.jobs import forget_cron_fire_profile_hint
+
+                forget_cron_fire_profile_hint(job_id)
+            except Exception:
+                logger.debug("Chronos failed to clear fire profile hint for %s", job_id, exc_info=True)
             with self._lock:
                 self._armed.pop(job_id, None)
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1068,12 +1068,6 @@ class TestJobsJsonUtf8Bom:
         loaded = load_jobs()
         assert [j["id"] for j in loaded] == ["plainjob01"]
 
-
-        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
-        JOBS_FILE.write_bytes(b'\xef\xbb\xbf{"jobs": []}')
-
-        assert load_jobs() == []
-
     def test_load_jobs_bom_plus_bare_list_auto_repairs(self, tmp_cron_dir):
         """BOM + bare list (hand-edited) must load and rewrap to dict envelope."""
         import json

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1069,3 +1069,73 @@ class TestJobsJsonUtf8Bom:
         assert [j["id"] for j in loaded] == ["plainjob01"]
 
 
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_bytes(b'\xef\xbb\xbf{"jobs": []}')
+
+        assert load_jobs() == []
+
+    def test_load_jobs_bom_plus_bare_list_auto_repairs(self, tmp_cron_dir):
+        """BOM + bare list (hand-edited) must load and rewrap to dict envelope."""
+        import json
+        from cron.jobs import JOBS_FILE, load_jobs
+
+        bare = [
+            {
+                "id": "barebom01",
+                "name": "bare",
+                "enabled": True,
+                "prompt": "x",
+                "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+            }
+        ]
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_bytes(b"\xef\xbb\xbf" + json.dumps(bare).encode("utf-8"))
+
+        loaded = load_jobs()
+        assert [j["id"] for j in loaded] == ["barebom01"]
+        # Auto-repair rewrites via save_jobs (plain utf-8) — heals the BOM.
+        on_disk = JOBS_FILE.read_bytes()
+        assert not on_disk.startswith(b"\xef\xbb\xbf"), "save_jobs should rewrite without BOM"
+        rewritten = json.loads(on_disk.decode("utf-8"))
+        assert isinstance(rewritten, dict)
+        assert [j["id"] for j in rewritten["jobs"]] == ["barebom01"]
+
+    def test_load_jobs_bom_plus_control_char_uses_strict_false_arm(self, tmp_cron_dir):
+        """BOM + bare control char in a string value exercises the strict=False arm.
+
+        json.load (strict) rejects unescaped control chars; the retry path must
+        also open with utf-8-sig so the BOM does not re-crash the repair.
+        """
+        from cron.jobs import JOBS_FILE, load_jobs
+
+        # Valid JSON structure but with a raw newline inside a string value
+        # (invalid under strict=True). Leading UTF-8 BOM.
+        raw = (
+            b'\xef\xbb\xbf{"jobs": [{"id": "ctrlbom01", "name": "has\nnewline",'
+            b' "enabled": true, "prompt": "x",'
+            b' "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"}}]}'
+        )
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_bytes(raw)
+
+        loaded = load_jobs()
+        assert [j["id"] for j in loaded] == ["ctrlbom01"]
+        assert "newline" in loaded[0]["name"]
+
+
+def test_cron_fire_profile_hints_are_per_job_files(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from cron import jobs as jobs_mod
+
+    jobs_mod.record_cron_fire_profile_hint("job-1", "work")
+
+    hint_path = tmp_path / "cron" / "fire_profile_index" / "job-1.profile"
+    assert hint_path.read_text(encoding="utf-8") == "work\n"
+    assert jobs_mod.resolve_cron_fire_profile_hint("job-1") == "work"
+
+    jobs_mod.record_cron_fire_profile_hint("../escape", "work")
+    assert not (tmp_path / "cron" / "fire_profile_index" / "../escape.profile").exists()
+
+    jobs_mod.forget_cron_fire_profile_hint("job-1")
+    assert jobs_mod.resolve_cron_fire_profile_hint("job-1") is None

--- a/tests/hermes_cli/test_cron_fire_dashboard.py
+++ b/tests/hermes_cli/test_cron_fire_dashboard.py
@@ -13,11 +13,69 @@ hosted agents don't expose). It must:
     background, returning 202.
 """
 
+import json
+
 import pytest
 from starlette.testclient import TestClient
 
 from hermes_cli import web_server
 from hermes_cli.dashboard_auth.public_paths import PUBLIC_API_PATHS
+
+
+def _write_profile_home(home, *, audience: str, job_id: str | None = None):
+    (home / "cron").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "\n".join(
+            [
+                "cron:",
+                "  chronos:",
+                f"    expected_audience: {audience}",
+                f"    nas_jwks_url: https://chronos.example/{audience}/jwks",
+                f"    portal_url: https://chronos.example/{audience}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    if job_id:
+        (home / "cron" / "jobs.json").write_text(
+            json.dumps(
+                {
+                    "jobs": [
+                        {
+                            "id": job_id,
+                            "name": job_id,
+                            "enabled": True,
+                            "prompt": "run",
+                            "schedule": {
+                                "kind": "once",
+                                "run_at": "2026-07-25T00:00:00+00:00",
+                            },
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+
+def _isolate_profiles(tmp_path, monkeypatch):
+    from hermes_cli import profiles
+
+    default_home = tmp_path / ".hermes"
+    profiles_root = default_home / "profiles"
+    old_home = profiles_root / "old"
+    work_home = profiles_root / "work"
+    for home in (default_home, old_home, work_home):
+        home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
+    monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profiles_root)
+    return {
+        "default": default_home,
+        "old": old_home,
+        "work": work_home,
+    }
 
 
 def _client(auth_required: bool):
@@ -208,3 +266,55 @@ def test_profile_chronos_config_is_used_before_token_verification(monkeypatch):
         "issuer": "https://chronos.example/work",
     }
     assert fired == [("work", "work-job")]
+
+
+def test_stale_existing_profile_hint_falls_back_after_process_auth(
+    tmp_path,
+    monkeypatch,
+):
+    """A stale hint may name a real profile, but it must not be authoritative."""
+    homes = _isolate_profiles(tmp_path, monkeypatch)
+    _write_profile_home(homes["default"], audience="agent:default", job_id="job-live")
+    _write_profile_home(homes["old"], audience="agent:old")
+    _write_profile_home(homes["work"], audience="agent:work")
+
+    from cron.jobs import record_cron_fire_profile_hint
+
+    record_cron_fire_profile_hint("job-live", "old")
+
+    events = []
+    fired = []
+
+    def verify(**kwargs):
+        events.append(("verify", kwargs["expected_audience"]))
+        if kwargs["expected_audience"] == "agent:default":
+            return {"purpose": "cron_fire", "aud": "agent:default"}
+        return None
+
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: verify,
+    )
+    monkeypatch.setattr(
+        web_server,
+        "_fire_cron_job_for_profile",
+        lambda profile, jid: fired.append((profile, jid)) or True,
+    )
+
+    client, pa, ph = _client(auth_required=False)
+    try:
+        resp = client.post(
+            "/api/cron/fire",
+            headers={"Authorization": "Bearer default-token"},
+            json={"job_id": "job-live"},
+        )
+        assert resp.status_code == 202
+    finally:
+        _restore(pa, ph)
+        client.close()
+
+    assert events == [
+        ("verify", "agent:old"),
+        ("verify", "agent:default"),
+    ]
+    assert fired == [("default", "job-live")]

--- a/tests/hermes_cli/test_cron_fire_dashboard.py
+++ b/tests/hermes_cli/test_cron_fire_dashboard.py
@@ -59,7 +59,16 @@ def test_bad_token_401(monkeypatch):
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: None),  # verification fails
     )
-    monkeypatch.setattr(web_server, "_find_cron_job_profile", lambda jid: "default")
+    monkeypatch.setattr(
+        web_server,
+        "_find_cron_job_profile",
+        lambda jid: pytest.fail("invalid fire tokens must not scan cron profiles"),
+    )
+    monkeypatch.setattr(
+        web_server,
+        "_call_cron_for_profile",
+        lambda *a, **k: pytest.fail("invalid fire tokens must not list profile jobs"),
+    )
     monkeypatch.setattr(web_server, "_fire_cron_job_for_profile",
                         lambda p, j: fired.append((p, j)))
 
@@ -111,3 +120,91 @@ def test_unknown_job_200_gone(monkeypatch):
         client.close()
 
 
+def test_valid_token_accepts_and_fires(monkeypatch):
+    """Valid token + known job -> 202 and fire_due invoked for the resolved
+    profile."""
+    fired = []
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **kw: {"purpose": "cron_fire", "aud": "agent:x"}),
+    )
+    monkeypatch.setattr(web_server, "_find_cron_job_profile", lambda jid: "default")
+    monkeypatch.setattr(web_server, "_fire_cron_job_for_profile",
+                        lambda p, j: fired.append((p, j)) or True)
+
+    client, pa, ph = _client(auth_required=False)
+    try:
+        resp = client.post("/api/cron/fire",
+                           headers={"Authorization": "Bearer good"},
+                           json={"job_id": "j1"})
+        assert resp.status_code == 202
+        assert resp.json()["job_id"] == "j1"
+    finally:
+        _restore(pa, ph)
+        client.close()
+    # background task ran the fire for the resolved profile
+    assert fired == [("default", "j1")]
+
+
+def test_profile_chronos_config_is_used_before_token_verification(monkeypatch):
+    """A managed fire token is verified against the job owner's profile."""
+    events = []
+    fired = []
+
+    monkeypatch.setattr(
+        web_server,
+        "_find_cron_job_profile",
+        lambda jid: pytest.fail("profile hint should avoid the pre-auth profile scan"),
+    )
+    monkeypatch.setattr(
+        "cron.jobs.resolve_cron_fire_profile_hint",
+        lambda jid: events.append(("hint", jid)) or "work",
+    )
+    monkeypatch.setattr(
+        web_server,
+        "_load_cron_config_for_profile",
+        lambda profile: events.append(("config", profile)) or {
+            "cron": {
+                "chronos": {
+                    "expected_audience": "agent:work",
+                    "nas_jwks_url": "https://chronos.example/work/jwks",
+                    "portal_url": "https://chronos.example/work",
+                }
+            }
+        },
+    )
+
+    def verify(**kwargs):
+        events.append(("verify", kwargs))
+        return {"purpose": "cron_fire", "aud": "agent:work"}
+
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: verify,
+    )
+    monkeypatch.setattr(
+        web_server,
+        "_fire_cron_job_for_profile",
+        lambda profile, jid: fired.append((profile, jid)) or True,
+    )
+
+    client, pa, ph = _client(auth_required=False)
+    try:
+        resp = client.post(
+            "/api/cron/fire",
+            headers={"Authorization": "Bearer work-token"},
+            json={"job_id": "work-job"},
+        )
+        assert resp.status_code == 202
+    finally:
+        _restore(pa, ph)
+        client.close()
+
+    assert [event[0] for event in events] == ["hint", "config", "verify"]
+    assert events[-1][1] == {
+        "token": "work-token",
+        "expected_audience": "agent:work",
+        "jwks_or_key": "https://chronos.example/work/jwks",
+        "issuer": "https://chronos.example/work",
+    }
+    assert fired == [("work", "work-job")]


### PR DESCRIPTION
Fixes #69715

The dashboard Chronos fire webhook validated NAS fire tokens using the default profile configuration before resolving the profile that owns job_id.

This rejected valid tokens for managed cron jobs in profiles with different Chronos audience, JWKS, or issuer settings.

This change:

- Resolves the owning profile before token verification.
- Loads Chronos settings from that profile's Hermes home.
- Verifies the token with the profile-specific audience, JWKS, and issuer.
- Preserves the existing behavior for missing and unknown jobs.

Added regression coverage that verifies profile lookup and profile configuration loading happen before token verification. The test also confirms that the verifier receives the work profile's Chronos settings.

Validation:

uv run --extra dev pytest tests/hermes_cli/test_cron_fire_dashboard.py tests/hermes_cli/test_cron_dashboard_off_loop.py tests/hermes_cli/test_web_server_cron_profiles.py tests/plugins/test_chronos_verify.py tests/plugins/test_chronos_cron.py -q

Result: 57 passed