### PR TITLE
fix(cron): forward require_parameters + data_collection to scheduled agents

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3354,6 +3354,8 @@ def run_job(
             providers_ignored=pr.get("ignore"),
             providers_order=pr.get("order"),
             provider_sort=pr.get("sort"),
+            provider_require_parameters=pr.get("require_parameters", False),
+            provider_data_collection=pr.get("data_collection"),
             openrouter_min_coding_score=(_cfg.get("openrouter") or {}).get("min_coding_score"),
             enabled_toolsets=_resolve_cron_enabled_toolsets(job, _cfg),
             disabled_toolsets=_resolve_cron_disabled_toolsets(_cfg),

--- a/tests/cron/test_cron_provider_routing.py
+++ b/tests/cron/test_cron_provider_routing.py
@@ -1,0 +1,104 @@
+"""Provider-routing parity for cron jobs.
+
+Scheduled jobs load the same ``provider_routing`` section of config.yaml as
+the CLI, messaging gateway and desktop/TUI, but the cron builder forwarded
+only ``only`` / ``ignore`` / ``order`` / ``sort`` — silently dropping
+``require_parameters`` and ``data_collection``.
+
+The ``data_collection`` drop is the one that bites: a user who sets
+``data_collection: "deny"`` had it honored on every interactive path and
+quietly ignored on every scheduled run, sending exactly the prompts they
+asked to protect to data-retaining providers.
+
+These tests pin the full forwarding set so cron cannot drift from the other
+construction paths again.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+# Ensure project root is importable.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron.scheduler import run_job
+
+
+def _job():
+    return {
+        "id": "routing-test",
+        "name": "routing test",
+        "prompt": "hello",
+        "model": None,
+        "provider": None,
+        "provider_snapshot": "openrouter",
+        "base_url": None,
+    }
+
+
+def _run_with_config(cfg, tmp_path):
+    """Drive run_job against a temp HERMES_HOME holding ``cfg``.
+
+    Returns the kwargs AIAgent was constructed with.
+    """
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    fake_db = MagicMock()
+    with patch("cron.scheduler._hermes_home", tmp_path), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+         patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+         patch("hermes_state.SessionDB", return_value=fake_db), \
+         patch(
+             "hermes_cli.runtime_provider.resolve_runtime_provider",
+             return_value={
+                 "api_key": "test-key",
+                 "base_url": "https://example.invalid/v1",
+                 "provider": "openrouter",
+                 "api_mode": "chat_completions",
+             },
+         ), \
+         patch("run_agent.AIAgent") as mock_agent_cls:
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent_cls.return_value = mock_agent
+
+        run_job(_job())
+
+        assert mock_agent_cls.called, "AIAgent was never constructed"
+        return mock_agent_cls.call_args.kwargs
+
+
+def test_cron_forwards_all_provider_routing_keys(tmp_path):
+    """Every provider_routing key reaches the scheduled agent."""
+    kwargs = _run_with_config({
+        "provider_routing": {
+            "only": ["anthropic", "google"],
+            "ignore": ["deepinfra"],
+            "order": ["anthropic", "together"],
+            "sort": "throughput",
+            "require_parameters": True,
+            "data_collection": "deny",
+        },
+    }, tmp_path)
+
+    assert kwargs["providers_allowed"] == ["anthropic", "google"]
+    assert kwargs["providers_ignored"] == ["deepinfra"]
+    assert kwargs["providers_order"] == ["anthropic", "together"]
+    assert kwargs["provider_sort"] == "throughput"
+    assert kwargs["provider_require_parameters"] is True
+    assert kwargs["provider_data_collection"] == "deny"
+
+
+def test_cron_provider_routing_defaults_when_unset(tmp_path):
+    """No provider_routing section → defaults, so behavior is unchanged for
+    users who never configured it."""
+    kwargs = _run_with_config({}, tmp_path)
+
+    assert kwargs["providers_allowed"] is None
+    assert kwargs["providers_ignored"] is None
+    assert kwargs["providers_order"] is None
+    assert kwargs["provider_sort"] is None
+    assert kwargs["provider_require_parameters"] is False
+    assert kwargs["provider_data_collection"] is None


### PR DESCRIPTION
## Summary

`cron/scheduler.py` reads the same `provider_routing` section of `config.yaml` as every other agent-construction path, but forwards only 4 of its 6 keys. `require_parameters` and `data_collection` are dropped silently.

| Reader | only | ignore | order | sort | require_parameters | data_collection |
|---|:-:|:-:|:-:|:-:|:-:|:-:|
| `cli.py` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `gateway/run.py` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `tui_gateway/server.py` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `cron/scheduler.py` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |

## Why it matters

`data_collection` is the one that bites. A user who sets `data_collection: "deny"` has it honored on every interactive path and ignored on every scheduled run — so the prompts they explicitly asked to keep away from data-retaining providers are the ones that go there, unattended, on a timer.

`require_parameters` is milder but the same class of surprise: silent parameter drops that occur on cron runs only, which is a genuinely unpleasant thing to debug.

This is the same parity gap that was previously fixed for the desktop/TUI backend, one layer further out.

## Changes

- `cron/scheduler.py` — forward `provider_require_parameters` and `provider_data_collection` (2 lines)
- `tests/cron/test_cron_provider_routing.py` — new; pins the full forwarding set plus the unset-defaults case

## Testing

- `tests/cron/` — 739 passed
- The new test was verified to fail before the fix. The kwargs are absent from the `AIAgent` call entirely, so the assertions raise `KeyError` rather than comparing wrong values — i.e. it genuinely catches the bug rather than passing vacuously.

Test harness reuses the established pattern from `tests/cron/test_cron_provider_pin.py` (real `run_job` path, mocked `AIAgent` + `resolve_runtime_provider` against a temp `HERMES_HOME`).

## Scope

Deliberately narrow — no new config keys, no behavior change for users who never set `provider_routing`. Both added kwargs default to the same values `AIAgent` already used when they were omitted, so this only takes effect when the user has actually configured them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)