### PR TITLE
fix(agent): drop the stale api_content sidecar when merging consecutive assistants

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -570,13 +570,26 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
             # blocks — fall back to keeping the existing content.
             prev_content = prev.get("content")
             new_content = msg.get("content")
+            _content_rewritten = False
             if isinstance(prev_content, str) and isinstance(new_content, str):
                 joined = "\n".join(
                     p for p in (prev_content.strip(), new_content.strip()) if p
                 )
                 prev["content"] = joined
+                _content_rewritten = True
             elif not prev_content and new_content is not None:
                 prev["content"] = new_content
+                _content_rewritten = True
+            if _content_rewritten:
+                # Folding new's content into prev invalidates prev's
+                # api_content sidecar (the exact bytes previously sent for the
+                # PRE-merge prev). The request-build replay substitutes that
+                # sidecar verbatim for a historical assistant row, so leaving
+                # it stale silently drops new's content from the wire while
+                # keeping the merged tool_call union — the model never sees the
+                # rationale for the second turn's calls. Drop it for the same
+                # reason the consecutive-user merge in Pass 2 does.
+                drop_stale_api_content(prev)
             # Carry reasoning_content from the later turn only if the
             # earlier turn lacks it (strict thinking providers require a
             # reasoning_content on the merged tool-call turn; the first

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -574,6 +574,78 @@ def test_repair_preserves_reasoning_content_on_merge():
     assert merged.get("reasoning_content") == "thinking A"
 
 
+def test_repair_drops_stale_api_content_on_assistant_merge():
+    """Merging assistants must drop the earlier one's api_content sidecar.
+
+    An assistant row whose stored content diverges from the exact bytes sent
+    (sanitize-divergence — e.g. it quotes a <memory-context> fence) carries an
+    ``api_content`` sidecar. The request-build replay substitutes that sidecar
+    verbatim for historical user/assistant rows. When Pass 0 folds a following
+    assistant's content into this one but leaves the sidecar in place, replay
+    resends only the pre-merge bytes and silently drops the second turn's
+    content from the wire (while keeping its tool_call in the union). Mirrors
+    the consecutive-user merge, which already drops the sidecar.
+    """
+    from agent.turn_context import substitute_api_content
+
+    agent = _bare_agent()
+    prev = {
+        "role": "assistant",
+        "content": "PREV",
+        "api_content": "PREV exact wire bytes",
+        "tool_calls": [{"id": "a", "type": "function",
+                        "function": {"name": "f", "arguments": "{}"}}],
+    }
+    messages = [
+        {"role": "user", "content": "go"},
+        prev,
+        {"role": "assistant", "content": "NEW real answer",
+         "tool_calls": [{"id": "b", "type": "function",
+                         "function": {"name": "g", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "a", "content": "ra"},
+        {"role": "tool", "tool_call_id": "b", "content": "rb"},
+    ]
+
+    AIAgent._repair_message_sequence(agent, messages)
+
+    merged = [m for m in messages if m.get("role") == "assistant"][0]
+    # Union of both tool_calls survives.
+    assert [tc["id"] for tc in merged["tool_calls"]] == ["a", "b"]
+    # The stale sidecar is gone, so replay composes from the merged content.
+    assert "api_content" not in merged
+    api_copy = dict(merged)
+    substitute_api_content(api_copy)
+    assert "NEW real answer" in api_copy["content"]
+
+
+def test_repair_drops_stale_api_content_when_prev_content_empty():
+    """The empty-prev branch (content fully replaced) also drops the sidecar."""
+    from agent.turn_context import substitute_api_content
+
+    agent = _bare_agent()
+    prev = {
+        "role": "assistant",
+        "content": "",
+        "api_content": "stale bytes",
+        "tool_calls": [{"id": "a", "type": "function",
+                        "function": {"name": "f", "arguments": "{}"}}],
+    }
+    messages = [
+        {"role": "user", "content": "go"},
+        prev,
+        {"role": "assistant", "content": "the answer"},
+    ]
+
+    AIAgent._repair_message_sequence(agent, messages)
+
+    merged = [m for m in messages if m.get("role") == "assistant"][0]
+    assert merged["content"] == "the answer"
+    assert "api_content" not in merged
+    api_copy = dict(merged)
+    substitute_api_content(api_copy)
+    assert api_copy["content"] == "the answer"
+
+
 def test_repair_noop_on_valid_parallel_format():
     """A correctly-formatted single assistant with multiple tool_calls is unchanged."""
     agent = _bare_agent()


### PR DESCRIPTION
## What does this PR do?

`repair_message_sequence` Pass 0 folds two adjacent assistant turns into one (MoA, verify-hook continuations, resume glitches), unioning their `tool_calls` and joining their content into `prev`. It rewrites `prev["content"]` but leaves `prev["api_content"]` in place.

That sidecar carries the exact bytes previously sent to the API for the **pre-merge** `prev` — captured whenever an assistant row's stored content diverges from what was actually sent (sanitize-divergence, e.g. content quoting a `<memory-context>` fence; see the capture in `_flush_messages_to_session_db`). The request-build replay substitutes that sidecar verbatim for any historical user/assistant row (`substitute_api_content` / the `api_messages` build in `conversation_loop`).

So after the merge, replay resends only `prev`'s original bytes and **silently drops the second turn's content from the wire** — while keeping the second turn's `tool_call` in the union. The model sees a tool call it never wrote a rationale for, on every subsequent turn, and the loss is durable: `repair_message_sequence` rewrites the list in place (`messages[:] = merged`) and it is flushed to `state.db`.

The consecutive-**user** merge in Pass 2 already drops the sidecar for exactly this reason; the consecutive-**assistant** merge in Pass 0 was the sibling that missed it. Assistant rows carry the same sidecar (`role in ("user", "assistant")` at the capture site), so the gap is real.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py` — in `repair_message_sequence` Pass 0, call `drop_stale_api_content(prev)` whenever the merge rewrites `prev["content"]` (both the joined-strings branch and the empty-prev branch), mirroring Pass 2.
- `tests/run_agent/test_message_sequence_repair.py` — two tests pinning the sidecar drop for both branches, each asserting the merged content survives a real `substitute_api_content` replay.

## How to Test

1. Build a message list with two adjacent assistant turns where the first carries an `api_content` sidecar differing from its content, plus their tool results.
2. Run `repair_message_sequence`, then `substitute_api_content` on the merged assistant row (what the request build does for historical rows).
3. **Before:** wire content = `"PREV exact wire bytes"`, the second turn's text is absent.
   **After:** wire content = `"PREV\nNEW real answer"`, both survive.

```
before fix — NEW assistant text present on wire: False
after  fix — NEW assistant text present on wire: True
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant suites and they pass (repair 39, alternation/flush 11, compressor merge/sidecar 33; the 2 new tests fail on `main`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — the new drop is commented inline; no external docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure in-memory list logic)