### PR TITLE
fix(update): handle protected SYSTEM gateway tasks on Windows (#63743)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -333,6 +333,39 @@ def _append_unique_pid(
     pids.append(pid)
 
 
+def _is_install_venv_python_exe(exe: str | None) -> bool:
+    """Return True when ``exe`` is this install's ``venv\\Scripts\\python(w).exe``."""
+    if not exe:
+        return False
+    try:
+        exe_path = Path(exe).resolve()
+    except (OSError, ValueError):
+        exe_path = Path(str(exe))
+    if exe_path.name.lower() not in {"python.exe", "pythonw.exe"}:
+        return False
+    try:
+        venv_scripts = (PROJECT_ROOT / "venv" / "Scripts").resolve()
+    except OSError:
+        venv_scripts = PROJECT_ROOT / "venv" / "Scripts"
+    try:
+        return exe_path.parent == venv_scripts or venv_scripts in exe_path.parents
+    except Exception:
+        return str(exe_path).lower().startswith(str(venv_scripts).lower() + os.sep)
+
+
+def _psutil_username_is_system(username: str | None) -> bool:
+    """True for Windows SYSTEM / LocalSystem process owners."""
+    if not username:
+        return False
+    normalized = username.strip().upper().replace("/", "\\")
+    return (
+        normalized == "SYSTEM"
+        or normalized.endswith("\\SYSTEM")
+        or normalized == "NT AUTHORITY\\SYSTEM"
+        or normalized.endswith("\\LOCALSYSTEM")
+    )
+
+
 def _scan_gateway_pids_windows_psutil(
     pids: list[int],
     exclude_pids: set[int],
@@ -340,15 +373,21 @@ def _scan_gateway_pids_windows_psutil(
     all_profiles: bool,
     matches_gateway_runtime,
     matches_current_profile,
+    known_pids: set[int] | None = None,
 ) -> None:
     """Supplement wmic/CIM with psutil for cross-session gateways (#63743).
 
     ``Get-CimInstance Win32_Process`` often returns an empty ``CommandLine``
     for processes in another session (e.g. a Scheduled Task gateway running as
-    SYSTEM) when queried from a non-elevated user. psutil can still read their
-    argv — the same API ``_detect_venv_python_processes`` uses to block
-    ``hermes update``. Without this pass the update flow fails to pause the
+    SYSTEM) when queried from a non-elevated user. psutil can still often read
+    ``exe`` across that boundary even when ``cmdline`` is empty or
+    ``AccessDenied``. Without this pass the update flow fails to pause the
     gateway but still refuses with "Other Hermes processes are running".
+
+    Strict identity when cmdline is unavailable:
+    - install ``venv\\Scripts\\python(w).exe`` **and** SYSTEM owner, or
+    - install venv python whose parent/child is already a known gateway PID
+      (PID-file / prior scan hit) so launcher stubs join the tree.
     """
     try:
         import psutil  # type: ignore
@@ -356,9 +395,13 @@ def _scan_gateway_pids_windows_psutil(
         return
 
     try:
-        proc_iter = psutil.process_iter(["pid", "cmdline"])
+        proc_iter = psutil.process_iter(["pid", "cmdline", "exe", "username", "ppid"])
     except Exception:
         return
+
+    known = {int(pid) for pid in pids}
+    if known_pids:
+        known.update(int(pid) for pid in known_pids)
 
     try:
         for proc in proc_iter:
@@ -369,19 +412,65 @@ def _scan_gateway_pids_windows_psutil(
             pid = info.get("pid")
             if pid is None:
                 continue
+            pid_i = int(pid)
+
             cmdline_parts = info.get("cmdline") or []
             if not cmdline_parts:
                 try:
                     cmdline_parts = list(proc.cmdline() or [])
                 except Exception:
-                    continue
-            if not cmdline_parts:
+                    # AccessDenied / empty across the SYSTEM session boundary.
+                    cmdline_parts = []
+
+            if cmdline_parts:
+                command = " ".join(str(part) for part in cmdline_parts)
+                if matches_gateway_runtime(command) and (
+                    all_profiles or matches_current_profile(command)
+                ):
+                    _append_unique_pid(pids, pid_i, exclude_pids)
+                    known.add(pid_i)
                 continue
-            command = " ".join(str(part) for part in cmdline_parts)
-            if matches_gateway_runtime(command) and (
-                all_profiles or matches_current_profile(command)
-            ):
-                _append_unique_pid(pids, int(pid), exclude_pids)
+
+            # No readable cmdline: require exe + a strict corroborating signal.
+            exe = info.get("exe")
+            if not exe:
+                try:
+                    exe = proc.exe()
+                except Exception:
+                    continue
+            if not _is_install_venv_python_exe(exe):
+                continue
+
+            username = info.get("username")
+            if not username:
+                try:
+                    username = proc.username()
+                except Exception:
+                    username = None
+
+            ppid = info.get("ppid")
+            if ppid is None:
+                try:
+                    ppid = proc.ppid()
+                except Exception:
+                    ppid = None
+            try:
+                ppid_i = int(ppid) if ppid is not None else None
+            except (TypeError, ValueError):
+                ppid_i = None
+
+            system_owned = _psutil_username_is_system(username)
+            tree_hit = pid_i in known or (ppid_i is not None and ppid_i in known)
+            if not system_owned and not tree_hit:
+                continue
+            # SYSTEM-owned install python is only safe as a gateway candidate
+            # for the update-wide (all_profiles) sweep — profile scoping needs
+            # cmdline or a PID-file hit collected elsewhere.
+            if system_owned and not all_profiles and not tree_hit:
+                continue
+
+            _append_unique_pid(pids, pid_i, exclude_pids)
+            known.add(pid_i)
     except Exception:
         return
 
@@ -390,18 +479,25 @@ def _scan_gateway_pids(
     exclude_pids: set[int],
     all_profiles: bool = False,
     include_restart_managers: bool = False,
+    seed_pids: list[int] | None = None,
 ) -> list[int]:
     """Best-effort process-table scan for gateway PIDs.
 
     This supplements the profile-scoped PID file so status views can still spot
     a live gateway when the PID file is stale/missing, and ``--all`` sweeps can
     discover gateways outside the current profile.
+
+    ``seed_pids`` carries PIDs already established by PID-file / service
+    discovery so the Windows psutil pass can attach launcher-stub parents when
+    cmdline is unreadable across the SYSTEM session boundary. Seeds are not
+    re-emitted in the return value — callers already hold them.
     """
     # Exclude the entire ancestor chain so the CLI process that invoked this
     # scan (e.g. ``hermes gateway status``) is never mistaken for a running
     # gateway.  See #13242.
     exclude_pids = exclude_pids | _get_ancestor_pids()
     pids: list[int] = []
+    known_seeds = {int(pid) for pid in (seed_pids or ()) if pid is not None}
     # Strict command-line matcher shared with gateway.status: requires the
     # actual ``gateway run`` subcommand (or the dedicated entrypoints), so this
     # scan no longer false-matches ``gateway status``/``dashboard`` siblings or
@@ -532,6 +628,7 @@ def _scan_gateway_pids(
                 all_profiles=all_profiles,
                 matches_gateway_runtime=_matches_gateway_runtime,
                 matches_current_profile=_matches_current_profile,
+                known_pids=known_seeds,
             )
         else:
             # Try /proc first (works in Docker without procps installed),
@@ -661,6 +758,11 @@ def find_gateway_pids(
             needs this because a code update affects every profile.
             When ``False`` (default), only PIDs belonging to the current
             Hermes profile are returned.
+
+    When ``all_profiles`` is set, profile ``gateway.pid`` records are included
+    first. Cross-session SYSTEM gateways often have an empty CIM command line
+    and a denied psutil cmdline, but the PID file + lock still identify them
+    (#63743) — process-table scans alone are not enough.
     """
     _exclude = set(exclude_pids or set())
     pids: list[int] = []
@@ -669,6 +771,13 @@ def find_gateway_pids(
             from gateway.status import get_running_pid
 
             _append_unique_pid(pids, get_running_pid(), _exclude)
+        except Exception:
+            pass
+    else:
+        # PID-file-aware discovery for update / multi-profile sweeps.
+        try:
+            for proc in find_profile_gateway_processes(exclude_pids=_exclude):
+                _append_unique_pid(pids, proc.pid, _exclude)
         except Exception:
             pass
     for pid in _get_service_pids():
@@ -681,6 +790,7 @@ def find_gateway_pids(
         _exclude,
         all_profiles=all_profiles,
         include_restart_managers=include_restart_managers,
+        seed_pids=pids,
     ):
         _append_unique_pid(pids, pid, _exclude)
     return pids

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -333,6 +333,59 @@ def _append_unique_pid(
     pids.append(pid)
 
 
+def _scan_gateway_pids_windows_psutil(
+    pids: list[int],
+    exclude_pids: set[int],
+    *,
+    all_profiles: bool,
+    matches_gateway_runtime,
+    matches_current_profile,
+) -> None:
+    """Supplement wmic/CIM with psutil for cross-session gateways (#63743).
+
+    ``Get-CimInstance Win32_Process`` often returns an empty ``CommandLine``
+    for processes in another session (e.g. a Scheduled Task gateway running as
+    SYSTEM) when queried from a non-elevated user. psutil can still read their
+    argv — the same API ``_detect_venv_python_processes`` uses to block
+    ``hermes update``. Without this pass the update flow fails to pause the
+    gateway but still refuses with "Other Hermes processes are running".
+    """
+    try:
+        import psutil  # type: ignore
+    except ImportError:
+        return
+
+    try:
+        proc_iter = psutil.process_iter(["pid", "cmdline"])
+    except Exception:
+        return
+
+    try:
+        for proc in proc_iter:
+            try:
+                info = proc.info
+            except Exception:
+                continue
+            pid = info.get("pid")
+            if pid is None:
+                continue
+            cmdline_parts = info.get("cmdline") or []
+            if not cmdline_parts:
+                try:
+                    cmdline_parts = list(proc.cmdline() or [])
+                except Exception:
+                    continue
+            if not cmdline_parts:
+                continue
+            command = " ".join(str(part) for part in cmdline_parts)
+            if matches_gateway_runtime(command) and (
+                all_profiles or matches_current_profile(command)
+            ):
+                _append_unique_pid(pids, int(pid), exclude_pids)
+    except Exception:
+        return
+
+
 def _scan_gateway_pids(
     exclude_pids: set[int],
     all_profiles: bool = False,
@@ -408,7 +461,6 @@ def _scan_gateway_pids(
 
             _no_window = {"creationflags": windows_hide_flags()}
             wmic_path = shutil.which("wmic")
-            used_fallback = False
             result = None
             if wmic_path is not None:
                 try:
@@ -433,46 +485,54 @@ def _scan_gateway_pids(
                 # Fallback: PowerShell Get-CimInstance, emit LIST-style output
                 # so the downstream parser below doesn't need to branch.
                 powershell = shutil.which("powershell") or shutil.which("pwsh")
-                if powershell is None:
-                    return []
-                ps_cmd = (
-                    "Get-CimInstance Win32_Process | "
-                    "ForEach-Object { "
-                    "  'CommandLine=' + ($_.CommandLine -replace \"`r`n\",' ' -replace \"`n\",' '); "
-                    "  'ProcessId=' + $_.ProcessId; "
-                    "  '' "
-                    "}"
-                )
-                try:
-                    result = subprocess.run(
-                        [powershell, "-NoProfile", "-Command", ps_cmd],
-                        capture_output=True,
-                        text=True,
-                        encoding="utf-8",
-                        errors="ignore",
-                        timeout=15,
-                        **_no_window,
+                if powershell is not None:
+                    ps_cmd = (
+                        "Get-CimInstance Win32_Process | "
+                        "ForEach-Object { "
+                        "  'CommandLine=' + ($_.CommandLine -replace \"`r`n\",' ' -replace \"`n\",' '); "
+                        "  'ProcessId=' + $_.ProcessId; "
+                        "  '' "
+                        "}"
                     )
-                except (OSError, subprocess.TimeoutExpired):
-                    return []
-                used_fallback = True
-            if result.returncode != 0 or result.stdout is None:
-                return []
-            current_cmd = ""
-            for line in result.stdout.split("\n"):
-                line = line.strip()
-                if line.startswith("CommandLine="):
-                    current_cmd = line[len("CommandLine=") :]
-                elif line.startswith("ProcessId="):
-                    pid_str = line[len("ProcessId=") :]
-                    if _matches_gateway_runtime(current_cmd) and (
-                        all_profiles or _matches_current_profile(current_cmd)
-                    ):
-                        try:
-                            _append_unique_pid(pids, int(pid_str), exclude_pids)
-                        except ValueError:
-                            pass
-                    current_cmd = ""
+                    try:
+                        result = subprocess.run(
+                            [powershell, "-NoProfile", "-Command", ps_cmd],
+                            capture_output=True,
+                            text=True,
+                            encoding="utf-8",
+                            errors="ignore",
+                            timeout=15,
+                            **_no_window,
+                        )
+                    except (OSError, subprocess.TimeoutExpired):
+                        result = None
+            if (
+                result is not None
+                and result.returncode == 0
+                and result.stdout is not None
+            ):
+                current_cmd = ""
+                for line in result.stdout.split("\n"):
+                    line = line.strip()
+                    if line.startswith("CommandLine="):
+                        current_cmd = line[len("CommandLine=") :]
+                    elif line.startswith("ProcessId="):
+                        pid_str = line[len("ProcessId=") :]
+                        if _matches_gateway_runtime(current_cmd) and (
+                            all_profiles or _matches_current_profile(current_cmd)
+                        ):
+                            try:
+                                _append_unique_pid(pids, int(pid_str), exclude_pids)
+                            except ValueError:
+                                pass
+                        current_cmd = ""
+            _scan_gateway_pids_windows_psutil(
+                pids,
+                exclude_pids,
+                all_profiles=all_profiles,
+                matches_gateway_runtime=_matches_gateway_runtime,
+                matches_current_profile=_matches_current_profile,
+            )
         else:
             # Try /proc first (works in Docker without procps installed),
             # fall back to ps -A eww.
@@ -538,7 +598,8 @@ def _scan_gateway_pids(
                     ):
                         _append_unique_pid(pids, pid, exclude_pids)
     except (OSError, subprocess.TimeoutExpired):
-        return []
+        if not pids:
+            return []
 
     # Windows-specific: collapse venv launcher stubs.  A venv-built
     # ``pythonw.exe`` in ``<venv>/Scripts/`` is a ~100 KB launcher exe

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -53,7 +53,9 @@ _FALLBACK_PATTERNS = re.compile(
     r"(access is denied|acceso denegado|přístup byl odepřen|schtasks timed out|schtasks produced no output)",
     re.IGNORECASE,
 )
-_ACCESS_DENIED_PATTERN = re.compile(r"(access is denied|acceso denegado)", re.IGNORECASE)
+_ACCESS_DENIED_PATTERN = re.compile(
+    r"(access is denied|acceso denegado|přístup byl odepřen)", re.IGNORECASE
+)
 
 _TASK_NAME_DEFAULT = "Hermes_Gateway"
 _TASK_DESCRIPTION = "Hermes Agent Gateway - Messaging Platform Integration"
@@ -197,6 +199,112 @@ def _is_running_as_admin() -> bool:
         return False
 
 
+def _shell_execute_elevated_and_wait(
+    executable: str,
+    parameters: str,
+    *,
+    cwd: str,
+    timeout_s: float,
+) -> tuple[int, str]:
+    """Run one executable through UAC, wait, and return its exit code.
+
+    ``ShellExecuteW`` only reports whether the handoff started. Update-time
+    Scheduled Task control needs a stronger contract: the parent must know
+    that ``schtasks`` finished before it mutates the checkout or venv. Use
+    ``ShellExecuteExW`` with a process handle so cancellation, timeout, and a
+    nonzero child exit all remain visible to the caller.
+    """
+    _assert_windows()
+    from ctypes import wintypes
+
+    class _ShellExecuteInfoW(ctypes.Structure):
+        _fields_ = [
+            ("cbSize", wintypes.DWORD),
+            ("fMask", wintypes.ULONG),
+            ("hwnd", wintypes.HWND),
+            ("lpVerb", wintypes.LPCWSTR),
+            ("lpFile", wintypes.LPCWSTR),
+            ("lpParameters", wintypes.LPCWSTR),
+            ("lpDirectory", wintypes.LPCWSTR),
+            ("nShow", ctypes.c_int),
+            ("hInstApp", wintypes.HINSTANCE),
+            ("lpIDList", wintypes.LPVOID),
+            ("lpClass", wintypes.LPCWSTR),
+            ("hkeyClass", wintypes.HKEY),
+            ("dwHotKey", wintypes.DWORD),
+            ("hIconOrMonitor", wintypes.HANDLE),
+            ("hProcess", wintypes.HANDLE),
+        ]
+
+    shell32 = ctypes.windll.shell32
+    kernel32 = ctypes.windll.kernel32
+    execute = shell32.ShellExecuteExW
+    execute.argtypes = [ctypes.POINTER(_ShellExecuteInfoW)]
+    execute.restype = wintypes.BOOL
+    wait_for_process = kernel32.WaitForSingleObject
+    wait_for_process.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    wait_for_process.restype = wintypes.DWORD
+    terminate_process = kernel32.TerminateProcess
+    terminate_process.argtypes = [wintypes.HANDLE, wintypes.UINT]
+    terminate_process.restype = wintypes.BOOL
+    get_exit_code = kernel32.GetExitCodeProcess
+    get_exit_code.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+    get_exit_code.restype = wintypes.BOOL
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+
+    info = _ShellExecuteInfoW()
+    info.cbSize = ctypes.sizeof(info)
+    info.fMask = 0x00000040  # SEE_MASK_NOCLOSEPROCESS
+    info.lpVerb = "runas"
+    info.lpFile = executable
+    info.lpParameters = parameters
+    info.lpDirectory = cwd
+    info.nShow = 0  # SW_HIDE
+
+    if not execute(ctypes.byref(info)):
+        error_code = int(kernel32.GetLastError())
+        if error_code == 1223:  # ERROR_CANCELLED
+            return (1223, "UAC prompt was cancelled")
+        return (error_code or 1, f"ShellExecuteExW failed with error {error_code}")
+    if not info.hProcess:
+        return (1, "ShellExecuteExW returned no process handle")
+
+    try:
+        timeout_ms = max(1, int(max(timeout_s, 0.001) * 1000))
+        wait_result = int(wait_for_process(info.hProcess, timeout_ms))
+        if wait_result == 0x00000102:  # WAIT_TIMEOUT
+            # A stuck schtasks child must not outlive the update attempt.
+            terminate_process(info.hProcess, 124)
+            wait_for_process(info.hProcess, 1000)
+            return (124, f"elevated process timed out after {timeout_s:g}s")
+        if wait_result != 0x00000000:  # WAIT_OBJECT_0
+            return (1, f"WaitForSingleObject failed with result {wait_result}")
+
+        exit_code = wintypes.DWORD()
+        if not get_exit_code(info.hProcess, ctypes.byref(exit_code)):
+            error_code = int(kernel32.GetLastError())
+            return (error_code or 1, f"GetExitCodeProcess failed with error {error_code}")
+        return (int(exit_code.value), "")
+    finally:
+        close_handle(info.hProcess)
+
+
+def _exec_schtasks_elevated(args: list[str]) -> tuple[int, str]:
+    """Run ``schtasks.exe`` through UAC and wait for the exact result."""
+    _assert_windows()
+    schtasks = shutil.which("schtasks")
+    if schtasks is None:
+        return (1, "schtasks.exe not found on PATH")
+    return _shell_execute_elevated_and_wait(
+        schtasks,
+        subprocess.list2cmdline(args),
+        cwd=str(Path(__file__).resolve().parent.parent),
+        timeout_s=_SCHTASKS_TIMEOUT_S,
+    )
+
+
 def _current_profile_cli_args() -> list[str]:
     """Return CLI args that preserve the current Hermes profile."""
     from hermes_cli.gateway import _profile_arg
@@ -287,6 +395,13 @@ def _launch_elevated_uninstall() -> bool:
 # Paths: where we stash our task script and where Startup lives
 # ---------------------------------------------------------------------------
 
+def task_name_for_profile(profile: str) -> str:
+    """Return the Scheduled Task name for one validated profile name."""
+    if profile == "default":
+        return _TASK_NAME_DEFAULT
+    return f"{_TASK_NAME_DEFAULT}_{profile}"
+
+
 def get_task_name() -> str:
     """Scheduled Task name, scoped per profile.
 
@@ -299,8 +414,8 @@ def get_task_name() -> str:
 
     suffix = _profile_suffix()
     if not suffix:
-        return _TASK_NAME_DEFAULT
-    return f"{_TASK_NAME_DEFAULT}_{suffix}"
+        return task_name_for_profile("default")
+    return task_name_for_profile(suffix)
 
 
 def _sanitize_filename(value: str) -> str:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10431,18 +10431,57 @@ def _pause_windows_gateways_for_update() -> dict | None:
             logger.debug("Could not capture argv for unmapped gateway %s: %s", pid, exc)
         unmapped.append({"pid": int(pid), "argv": argv})
 
+    # Task-aware stop first (#63743): a non-elevated ``taskkill`` against a
+    # SYSTEM-owned Scheduled Task gateway is often Access Denied. ``schtasks
+    # /End`` uses the task ACL the installer created and can stop Session-0
+    # gateways the raw PID kill cannot.
+    task_ended = False
+    try:
+        from hermes_cli import gateway_windows
+
+        if gateway_windows.is_task_registered():
+            code, _out, err = gateway_windows._exec_schtasks(
+                ["/End", "/TN", gateway_windows.get_task_name()]
+            )
+            if code == 0:
+                task_ended = True
+            elif "not running" not in (err or "").lower():
+                logger.debug(
+                    "schtasks /End before update returned %s: %s", code, (err or "").strip()
+                )
+    except Exception as exc:
+        logger.debug("Could not end Windows gateway Scheduled Task before update: %s", exc)
+
     force_killed = []
+    kill_denied = []
     for pid in sorted(set(survivors).union(unmapped_pids)):
         try:
             terminate_pid(int(pid), force=True)
             force_killed.append(int(pid))
-        except (ProcessLookupError, PermissionError, OSError):
+        except ProcessLookupError:
             pass
+        except PermissionError:
+            kill_denied.append(int(pid))
+        except OSError as exc:
+            # taskkill surfaces access-denied as OSError with stderr text.
+            details = str(exc).lower()
+            if "access is denied" in details or "denied" in details:
+                kill_denied.append(int(pid))
+            else:
+                logger.debug("taskkill failed for gateway PID %s: %s", pid, exc)
 
     if profiles:
         print(f"  ✓ Paused gateway profile(s): {', '.join(sorted(profiles))}")
+    if task_ended:
+        print("  → Ended Windows gateway Scheduled Task")
     if force_killed:
         print(f"  → Force-stopped {len(force_killed)} gateway process(es)")
+    if kill_denied:
+        print(
+            f"  ⚠ Could not force-stop gateway PID(s) {', '.join(str(p) for p in kill_denied)} "
+            "(access denied — SYSTEM session?). If update still blocks, run an elevated "
+            "`hermes gateway stop` or end the Hermes_Gateway Scheduled Task, then retry."
+        )
 
     if unmapped_pids:
         respawnable = sum(1 for u in unmapped if u.get("argv"))

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10431,30 +10431,109 @@ def _pause_windows_gateways_for_update() -> dict | None:
             logger.debug("Could not capture argv for unmapped gateway %s: %s", pid, exc)
         unmapped.append({"pid": int(pid), "argv": argv})
 
-    # Task-aware stop first (#63743): a non-elevated ``taskkill`` against a
-    # SYSTEM-owned Scheduled Task gateway is often Access Denied. ``schtasks
-    # /End`` uses the task ACL the installer created and can stop Session-0
-    # gateways the raw PID kill cannot.
-    task_ended = False
+    # Preserve Task Scheduler ownership across the update. A legacy gateway
+    # task may run as SYSTEM and deny Query/End/Run to a non-elevated updater.
+    # Query every task that can own one of the discovered PIDs, elevate only
+    # when its ACL requires it, and remember the exact task for resume.
+    scheduled_tasks: list[dict] = []
+    task_control_failures: list[str] = []
+    task_candidates: dict[str, dict] = {}
     try:
         from hermes_cli import gateway_windows
 
-        if gateway_windows.is_task_registered():
-            code, _out, err = gateway_windows._exec_schtasks(
-                ["/End", "/TN", gateway_windows.get_task_name()]
+        for profile, pid in profiles.items():
+            name = gateway_windows.task_name_for_profile(str(profile))
+            entry = task_candidates.setdefault(
+                name, {"name": name, "profiles": set(), "pids": set()}
             )
-            if code == 0:
-                task_ended = True
-            elif "not running" not in (err or "").lower():
-                logger.debug(
-                    "schtasks /End before update returned %s: %s", code, (err or "").strip()
+            entry["profiles"].add(str(profile))
+            entry["pids"].add(int(pid))
+        if unmapped_pids:
+            name = gateway_windows.get_task_name()
+            entry = task_candidates.setdefault(
+                name, {"name": name, "profiles": set(), "pids": set()}
+            )
+            entry["pids"].update(int(pid) for pid in unmapped_pids)
+
+        alive_before_task_control = set(survivors).union(unmapped_pids)
+        for candidate in task_candidates.values():
+            task_name = str(candidate["name"])
+            task_pids = {int(pid) for pid in candidate["pids"]}
+            task_alive = bool(task_pids.intersection(alive_before_task_control))
+            query_code, query_out, query_err = gateway_windows._exec_schtasks(
+                ["/Query", "/TN", task_name]
+            )
+            query_detail = "\n".join(part for part in (query_out, query_err) if part)
+            protected = gateway_windows._is_access_denied(query_detail)
+            if query_code != 0 and not protected:
+                continue
+
+            managed = False
+            elevated = False
+            control_code = 0
+            control_detail = ""
+            if protected:
+                # An ACL-denied query is the signal the old SYSTEM task still
+                # owns this profile. Record it even when the planned-stop
+                # marker already drained the PID, so resume uses /Run under
+                # the original task identity instead of a current-user spawn.
+                managed = True
+                if task_alive:
+                    elevated = True
+                    control_code, control_detail = (
+                        gateway_windows._exec_schtasks_elevated(
+                            ["/End", "/TN", task_name]
+                        )
+                    )
+            elif task_alive:
+                control_code, _end_out, end_err = gateway_windows._exec_schtasks(
+                    ["/End", "/TN", task_name]
                 )
+                if control_code == 0:
+                    managed = True
+                elif gateway_windows._is_access_denied(end_err):
+                    managed = True
+                    elevated = True
+                    control_code, control_detail = (
+                        gateway_windows._exec_schtasks_elevated(
+                            ["/End", "/TN", task_name]
+                        )
+                    )
+                elif "not running" not in (end_err or "").lower():
+                    logger.debug(
+                        "schtasks /End before update returned %s for %s: %s",
+                        control_code,
+                        task_name,
+                        (end_err or "").strip(),
+                    )
+
+            if not managed:
+                continue
+            scheduled_tasks.append(
+                {
+                    "name": task_name,
+                    "profiles": sorted(candidate["profiles"]),
+                    "pids": sorted(task_pids),
+                    "elevated": elevated or protected,
+                }
+            )
+            if control_code != 0:
+                detail = control_detail or f"schtasks exited with code {control_code}"
+                task_control_failures.append(f"{task_name}: {detail}")
     except Exception as exc:
-        logger.debug("Could not end Windows gateway Scheduled Task before update: %s", exc)
+        logger.debug("Could not control Windows gateway Scheduled Task before update: %s", exc)
+
+    kill_targets = set(survivors).union(unmapped_pids)
+    if scheduled_tasks:
+        # /End is asynchronous. Give Task Scheduler time to reap the process
+        # before falling back to taskkill, which cannot cross a SYSTEM ACL.
+        kill_targets = _wait_for_windows_update_gateway_exit(
+            sorted(kill_targets), timeout=5.0
+        )
 
     force_killed = []
     kill_denied = []
-    for pid in sorted(set(survivors).union(unmapped_pids)):
+    for pid in sorted(kill_targets):
         try:
             terminate_pid(int(pid), force=True)
             force_killed.append(int(pid))
@@ -10470,35 +10549,57 @@ def _pause_windows_gateways_for_update() -> dict | None:
             else:
                 logger.debug("taskkill failed for gateway PID %s: %s", pid, exc)
 
+    remaining_pids = _wait_for_windows_update_gateway_exit(
+        sorted(kill_targets), timeout=5.0
+    )
+    for task in scheduled_tasks:
+        task_pids = {int(pid) for pid in task.get("pids", [])}
+        task["restart_after_update"] = not bool(task_pids.intersection(remaining_pids))
+
     if profiles:
         print(f"  ✓ Paused gateway profile(s): {', '.join(sorted(profiles))}")
-    if task_ended:
-        print("  → Ended Windows gateway Scheduled Task")
+    if scheduled_tasks:
+        names = ", ".join(entry["name"] for entry in scheduled_tasks)
+        print(f"  → Paused Windows gateway Scheduled Task(s): {names}")
     if force_killed:
         print(f"  → Force-stopped {len(force_killed)} gateway process(es)")
-    if kill_denied:
-        print(
-            f"  ⚠ Could not force-stop gateway PID(s) {', '.join(str(p) for p in kill_denied)} "
-            "(access denied — SYSTEM session?). If update still blocks, run an elevated "
-            "`hermes gateway stop` or end the Hermes_Gateway Scheduled Task, then retry."
+    pause_errors = list(task_control_failures)
+    if remaining_pids:
+        pause_errors.append(
+            "gateway PID(s) still running: "
+            + ", ".join(str(pid) for pid in sorted(remaining_pids))
         )
+    elif kill_denied:
+        # Access denied is harmless only when the task stop already removed
+        # the process before the final liveness check.
+        logger.debug("taskkill access denied after gateway already exited: %s", kill_denied)
 
     if unmapped_pids:
-        respawnable = sum(1 for u in unmapped if u.get("argv"))
+        scheduled_pids = {
+            int(pid)
+            for task in scheduled_tasks
+            for pid in task.get("pids", [])
+        }
+        unmanaged = [u for u in unmapped if int(u.get("pid", 0)) not in scheduled_pids]
+        respawnable = sum(1 for u in unmanaged if u.get("argv"))
         print(
             f"  → Stopped {len(unmapped_pids)} gateway process(es) without profile mapping"
         )
-        if respawnable < len(unmapped_pids):
+        if respawnable < len(unmanaged):
             # Some had no recoverable command line (psutil missing, access
             # denied, already gone): those still need a manual restart.
             print("    Restart manually after update: hermes gateway run")
 
-    return {
+    token = {
         "resume_needed": True,
         "profiles": profiles,
         "unmapped_pids": unmapped_pids,
         "unmapped": unmapped,
+        "scheduled_tasks": scheduled_tasks,
     }
+    if pause_errors:
+        token["pause_error"] = "; ".join(pause_errors)
+    return token
 
 
 def _cold_start_windows_gateway_after_update() -> None:
@@ -10608,9 +10709,76 @@ def _resume_windows_gateways_after_update(token: dict | None) -> None:
     if not _is_windows():
         return
 
-    profiles = token.get("profiles") or {}
-    unmapped = token.get("unmapped") or []
+    profiles = dict(token.get("profiles") or {})
+    unmapped = list(token.get("unmapped") or [])
+    scheduled_tasks = list(token.get("scheduled_tasks") or [])
+    tasks_to_restart = [
+        task
+        for task in scheduled_tasks
+        if task.get("restart_after_update", True)
+    ]
     cold_start = bool(token.get("cold_start_if_installed"))
+
+    task_profiles = {
+        str(profile)
+        for task in scheduled_tasks
+        for profile in task.get("profiles", [])
+    }
+    task_pids = {
+        int(pid)
+        for task in scheduled_tasks
+        for pid in task.get("pids", [])
+    }
+    profiles = {
+        profile: pid
+        for profile, pid in profiles.items()
+        if str(profile) not in task_profiles
+    }
+    unmapped = [
+        entry for entry in unmapped if int(entry.get("pid", 0)) not in task_pids
+    ]
+
+    restarted_tasks = []
+    failed_tasks = []
+    if tasks_to_restart:
+        try:
+            from hermes_cli import gateway_windows
+
+            for task in tasks_to_restart:
+                task_name = str(task.get("name") or "")
+                if not task_name:
+                    continue
+                code, out, err = gateway_windows._exec_schtasks(
+                    ["/Run", "/TN", task_name]
+                )
+                detail = "\n".join(part for part in (out, err) if part)
+                if code != 0 and gateway_windows._is_access_denied(detail):
+                    code, detail = gateway_windows._exec_schtasks_elevated(
+                        ["/Run", "/TN", task_name]
+                    )
+                if code == 0:
+                    restarted_tasks.append(task_name)
+                else:
+                    failed_tasks.append((task_name, detail or f"exit code {code}"))
+        except Exception as exc:
+            logger.debug("Could not restart Windows Scheduled Task after update: %s", exc)
+            failed_tasks.extend(
+                (str(task.get("name") or "unknown"), str(exc))
+                for task in tasks_to_restart
+            )
+
+    if restarted_tasks:
+        print()
+        print(
+            "  ✓ Restarted Windows gateway Scheduled Task(s): "
+            + ", ".join(restarted_tasks)
+        )
+    if failed_tasks:
+        print()
+        print("  ⚠ Could not restart Windows gateway Scheduled Task(s):")
+        for task_name, detail in failed_tasks:
+            print(f"    - {task_name}: {detail}")
+
     if not profiles and not any(u.get("argv") for u in unmapped):
         if cold_start:
             _cold_start_windows_gateway_after_update()
@@ -10829,6 +10997,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _resume_windows_gateways_after_update,
             _windows_gateway_resume,
         )
+        if _windows_gateway_resume.get("pause_error"):
+            print("✗ Cannot safely update while a Windows gateway is still active.")
+            print(f"  {_windows_gateway_resume['pause_error']}")
+            _resume_windows_gateways_after_update(_windows_gateway_resume)
+            sys.exit(2)
 
     # With gateways paused, anything still running from the venv interpreter
     # (most commonly the Desktop app's `hermes serve` backend) will keep .pyd

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1142,6 +1142,90 @@ def test_scan_gateway_pids_detects_windows_hermes_exe_case_variants(monkeypatch)
     assert gateway._scan_gateway_pids(set(), all_profiles=True) == [2468]
 
 
+def _fake_psutil_process_iter(records):
+    """Build a minimal psutil.process_iter stand-in for gateway scan tests."""
+
+    class _Proc:
+        def __init__(self, info):
+            self.info = info
+
+        def cmdline(self):
+            return self.info.get("cmdline") or []
+
+    class _Psutil:
+        @staticmethod
+        def process_iter(attrs):
+            for record in records:
+                yield _Proc(record)
+
+    return _Psutil()
+
+
+def test_scan_gateway_pids_windows_psutil_when_cim_hides_cmdline(monkeypatch):
+    """CIM often returns empty CommandLine for SYSTEM gateways (#63743)."""
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    monkeypatch.setattr(
+        gateway.shutil,
+        "which",
+        lambda name: "powershell.exe" if name == "powershell" else None,
+    )
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "powershell.exe":
+            return SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    "CommandLine=\n"
+                    "ProcessId=4242\n\n"
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+    fake_psutil = _fake_psutil_process_iter(
+        [
+            {
+                "pid": 4242,
+                "cmdline": [
+                    "pythonw.exe",
+                    "-m",
+                    "hermes_cli.main",
+                    "gateway",
+                    "run",
+                ],
+            }
+        ]
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+    assert gateway._scan_gateway_pids(set(), all_profiles=True) == [4242]
+
+
+def test_scan_gateway_pids_windows_psutil_only_when_no_wmic_or_powershell(monkeypatch):
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    monkeypatch.setattr(gateway.shutil, "which", lambda _name: None)
+    fake_psutil = _fake_psutil_process_iter(
+        [
+            {
+                "pid": 5150,
+                "cmdline": [
+                    "C:\\Hermes\\venv\\Scripts\\pythonw.exe",
+                    "-m",
+                    "hermes_cli.main",
+                    "gateway",
+                    "run",
+                ],
+            }
+        ]
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+    assert gateway._scan_gateway_pids(set(), all_profiles=True) == [5150]
+
+
 # ---------------------------------------------------------------------------
 # _wait_for_gateway_exit
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1062,15 +1062,23 @@ def test_find_gateway_pids_includes_restart_managers_without_systemd(monkeypatch
     monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
     monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
     monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "find_profile_gateway_processes", lambda **_k: [])
 
-    def fake_scan(exclude_pids, all_profiles=False, include_restart_managers=False):
-        calls.append((set(exclude_pids), all_profiles, include_restart_managers))
+    def fake_scan(
+        exclude_pids,
+        all_profiles=False,
+        include_restart_managers=False,
+        seed_pids=None,
+    ):
+        calls.append(
+            (set(exclude_pids), all_profiles, include_restart_managers, list(seed_pids or []))
+        )
         return [708] if include_restart_managers else []
 
     monkeypatch.setattr(gateway, "_scan_gateway_pids", fake_scan)
 
     assert gateway.find_gateway_pids(all_profiles=True) == [708]
-    assert calls == [(set(), True, True)]
+    assert calls == [(set(), True, True, [])]
 
 
 def test_reap_unsupervised_orphans_noop_on_systemd_hosts(monkeypatch):
@@ -1145,14 +1153,34 @@ def test_scan_gateway_pids_detects_windows_hermes_exe_case_variants(monkeypatch)
 def _fake_psutil_process_iter(records):
     """Build a minimal psutil.process_iter stand-in for gateway scan tests."""
 
+    class _AccessDenied(Exception):
+        pass
+
     class _Proc:
         def __init__(self, info):
             self.info = info
 
         def cmdline(self):
-            return self.info.get("cmdline") or []
+            if self.info.get("cmdline_raises"):
+                raise _AccessDenied("AccessDenied")
+            return list(self.info.get("cmdline") or [])
+
+        def exe(self):
+            if self.info.get("exe_raises"):
+                raise _AccessDenied("AccessDenied")
+            return self.info.get("exe")
+
+        def username(self):
+            if self.info.get("username_raises"):
+                raise _AccessDenied("AccessDenied")
+            return self.info.get("username")
+
+        def ppid(self):
+            return self.info.get("ppid")
 
     class _Psutil:
+        AccessDenied = _AccessDenied
+
         @staticmethod
         def process_iter(attrs):
             for record in records:
@@ -1224,6 +1252,84 @@ def test_scan_gateway_pids_windows_psutil_only_when_no_wmic_or_powershell(monkey
     monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
 
     assert gateway._scan_gateway_pids(set(), all_profiles=True) == [5150]
+
+
+def test_scan_gateway_pids_windows_psutil_exe_when_cmdline_access_denied(monkeypatch, tmp_path):
+    """SYSTEM boundary: cmdline denied, but exe under install venv is readable."""
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    monkeypatch.setattr(gateway.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(gateway, "PROJECT_ROOT", tmp_path)
+
+    scripts = tmp_path / "venv" / "Scripts"
+    scripts.mkdir(parents=True)
+    exe = scripts / "pythonw.exe"
+    exe.write_bytes(b"")
+
+    fake_psutil = _fake_psutil_process_iter(
+        [
+            {
+                "pid": 7777,
+                "cmdline": [],
+                "cmdline_raises": True,
+                "exe": str(exe),
+                "username": r"NT AUTHORITY\SYSTEM",
+                "ppid": 4,
+            }
+        ]
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+    assert gateway._scan_gateway_pids(set(), all_profiles=True) == [7777]
+
+
+def test_scan_gateway_pids_windows_psutil_empty_cmdline_needs_system_or_seed(
+    monkeypatch, tmp_path
+):
+    """User-owned venv python with empty cmdline must not match without a seed."""
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    monkeypatch.setattr(gateway.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(gateway, "PROJECT_ROOT", tmp_path)
+
+    scripts = tmp_path / "venv" / "Scripts"
+    scripts.mkdir(parents=True)
+    exe = scripts / "python.exe"
+    exe.write_bytes(b"")
+
+    fake_psutil = _fake_psutil_process_iter(
+        [
+            {
+                "pid": 8888,
+                "cmdline": [],
+                "exe": str(exe),
+                "username": "Alice",
+                "ppid": 1,
+            }
+        ]
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+    assert gateway._scan_gateway_pids(set(), all_profiles=True) == []
+    # Parent already known via PID file → attach the launcher stub.
+    assert gateway._scan_gateway_pids(set(), all_profiles=True, seed_pids=[1]) == [8888]
+
+
+def test_find_gateway_pids_all_profiles_includes_pid_files(monkeypatch, tmp_path):
+    """Update sweep must see SYSTEM gateways via gateway.pid when scan is blind."""
+    monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+    monkeypatch.setattr(gateway, "_scan_gateway_pids", lambda *a, **k: [])
+    monkeypatch.setattr(
+        gateway,
+        "find_profile_gateway_processes",
+        lambda exclude_pids=None: [
+            gateway.ProfileGatewayProcess(
+                profile="default", path=tmp_path, pid=4242
+            )
+        ],
+    )
+
+    assert gateway.find_gateway_pids(all_profiles=True) == [4242]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -72,6 +72,44 @@ def test_exec_schtasks_decodes_with_replace_errors(monkeypatch):
     assert captured["text"] is True
 
 
+def test_exec_schtasks_elevated_waits_for_exact_child_result(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(
+        gateway_windows.shutil,
+        "which",
+        lambda name: r"C:\Windows\System32\schtasks.exe",
+    )
+
+    def fake_elevated(executable, parameters, *, cwd, timeout_s):
+        captured.update(
+            executable=executable,
+            parameters=parameters,
+            cwd=cwd,
+            timeout_s=timeout_s,
+        )
+        return (1223, "UAC prompt was cancelled")
+
+    monkeypatch.setattr(
+        gateway_windows, "_shell_execute_elevated_and_wait", fake_elevated
+    )
+
+    result = gateway_windows._exec_schtasks_elevated(
+        ["/End", "/TN", "Hermes Gateway"]
+    )
+
+    assert result == (1223, "UAC prompt was cancelled")
+    assert captured["executable"].endswith("schtasks.exe")
+    assert captured["parameters"] == '/End /TN "Hermes Gateway"'
+    assert captured["timeout_s"] == gateway_windows._SCHTASKS_TIMEOUT_S
+
+
+def test_task_name_for_profile_matches_default_and_named_tasks():
+    assert gateway_windows.task_name_for_profile("default") == "Hermes_Gateway"
+    assert gateway_windows.task_name_for_profile("work") == "Hermes_Gateway_work"
+
+
 def test_build_gateway_argv_keeps_venv_console_python_for_uv_venv(monkeypatch, tmp_path):
     """No pythonw / base-interpreter detour: the venv console python.exe is
     launched hidden (CREATE_NO_WINDOW) so descendants inherit its hidden

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -494,6 +494,9 @@ def test_pause_windows_gateways_for_update_stops_profile_and_unmapped_pids(
         "terminate_pid",
         lambda pid, force=False: terminated.append((pid, force)),
     )
+    from hermes_cli import gateway_windows
+
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: False)
 
     token = cli_main._pause_windows_gateways_for_update()
 
@@ -521,6 +524,50 @@ def test_pause_windows_gateways_for_update_stops_profile_and_unmapped_pids(
     # An unmapped PID whose argv we captured is respawnable, so we must NOT
     # tell the user to restart it manually.
     assert "Restart manually after update" not in captured
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_pause_windows_gateways_ends_scheduled_task_before_taskkill(
+    _winp,
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    """SYSTEM Scheduled Task gateways need schtasks /End; taskkill often denies."""
+    import gateway.status as status_mod
+    import hermes_cli.gateway as gateway_mod
+    from hermes_cli import gateway_windows
+
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda **_k: [303])
+    monkeypatch.setattr(gateway_mod, "find_profile_gateway_processes", lambda **_k: [])
+    monkeypatch.setattr(gateway_mod, "_get_restart_drain_timeout", lambda: 0.1)
+    monkeypatch.setattr(
+        cli_main, "_wait_for_windows_update_gateway_exit", lambda pids, *, timeout: set()
+    )
+    monkeypatch.setattr(gateway_mod, "_capture_gateway_argv", lambda pid: None)
+
+    schtasks_calls = []
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway")
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks",
+        lambda args: schtasks_calls.append(list(args)) or (0, "", ""),
+    )
+
+    terminated = []
+    monkeypatch.setattr(
+        status_mod,
+        "terminate_pid",
+        lambda pid, force=False: terminated.append((pid, force)),
+    )
+
+    token = cli_main._pause_windows_gateways_for_update()
+
+    assert token["unmapped_pids"] == [303]
+    assert schtasks_calls == [["/End", "/TN", "Hermes_Gateway"]]
+    assert terminated == [(303, True)]
+    assert "Ended Windows gateway Scheduled Task" in capsys.readouterr().out
 
 
 @patch.object(cli_main, "_is_windows", return_value=True)

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -496,7 +496,11 @@ def test_pause_windows_gateways_for_update_stops_profile_and_unmapped_pids(
     )
     from hermes_cli import gateway_windows
 
-    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: False)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks",
+        lambda args: (1, "", "ERROR: The system cannot find the file specified."),
+    )
 
     token = cli_main._pause_windows_gateways_for_update()
 
@@ -510,8 +514,9 @@ def test_pause_windows_gateways_for_update_stops_profile_and_unmapped_pids(
                 "argv": ["pythonw.exe", "-m", "hermes_cli.main", "gateway", "run"],
             }
         ],
+        "scheduled_tasks": [],
     }
-    assert waited_for == [101]
+    assert waited_for == [101, 202]
     assert terminated == [(202, True)]
 
     marker = json.loads((profile_home / ".gateway-planned-stop.json").read_text())
@@ -547,13 +552,13 @@ def test_pause_windows_gateways_ends_scheduled_task_before_taskkill(
     monkeypatch.setattr(gateway_mod, "_capture_gateway_argv", lambda pid: None)
 
     schtasks_calls = []
-    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
     monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway")
-    monkeypatch.setattr(
-        gateway_windows,
-        "_exec_schtasks",
-        lambda args: schtasks_calls.append(list(args)) or (0, "", ""),
-    )
+
+    def fake_schtasks(args):
+        schtasks_calls.append(list(args))
+        return (0, "", "")
+
+    monkeypatch.setattr(gateway_windows, "_exec_schtasks", fake_schtasks)
 
     terminated = []
     monkeypatch.setattr(
@@ -565,9 +570,118 @@ def test_pause_windows_gateways_ends_scheduled_task_before_taskkill(
     token = cli_main._pause_windows_gateways_for_update()
 
     assert token["unmapped_pids"] == [303]
-    assert schtasks_calls == [["/End", "/TN", "Hermes_Gateway"]]
-    assert terminated == [(303, True)]
-    assert "Ended Windows gateway Scheduled Task" in capsys.readouterr().out
+    assert schtasks_calls == [
+        ["/Query", "/TN", "Hermes_Gateway"],
+        ["/End", "/TN", "Hermes_Gateway"],
+    ]
+    assert terminated == []
+    assert token["scheduled_tasks"] == [
+        {
+            "name": "Hermes_Gateway",
+            "profiles": [],
+            "pids": [303],
+            "elevated": False,
+            "restart_after_update": True,
+        }
+    ]
+    assert "Paused Windows gateway Scheduled Task(s)" in capsys.readouterr().out
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_pause_windows_gateways_elevates_protected_system_task(
+    _winp,
+    monkeypatch,
+):
+    import gateway.status as status_mod
+    import hermes_cli.gateway as gateway_mod
+    from hermes_cli import gateway_windows
+
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda **_k: [404])
+    monkeypatch.setattr(gateway_mod, "find_profile_gateway_processes", lambda **_k: [])
+    monkeypatch.setattr(gateway_mod, "_get_restart_drain_timeout", lambda: 0.1)
+    monkeypatch.setattr(gateway_mod, "_capture_gateway_argv", lambda pid: None)
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway")
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks",
+        lambda args: (1, "", "ERROR: Access is denied."),
+    )
+    elevated = []
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks_elevated",
+        lambda args: elevated.append(list(args)) or (0, ""),
+    )
+    monkeypatch.setattr(
+        cli_main,
+        "_wait_for_windows_update_gateway_exit",
+        lambda pids, *, timeout: set(),
+    )
+    terminated = []
+    monkeypatch.setattr(
+        status_mod,
+        "terminate_pid",
+        lambda pid, force=False: terminated.append((pid, force)),
+    )
+
+    token = cli_main._pause_windows_gateways_for_update()
+
+    assert elevated == [["/End", "/TN", "Hermes_Gateway"]]
+    assert terminated == []
+    assert token["scheduled_tasks"] == [
+        {
+            "name": "Hermes_Gateway",
+            "profiles": [],
+            "pids": [404],
+            "elevated": True,
+            "restart_after_update": True,
+        }
+    ]
+    assert "pause_error" not in token
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_pause_windows_gateways_fails_closed_when_uac_cannot_stop_system_task(
+    _winp,
+    monkeypatch,
+):
+    import gateway.status as status_mod
+    import hermes_cli.gateway as gateway_mod
+    from hermes_cli import gateway_windows
+
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda **_k: [505])
+    monkeypatch.setattr(gateway_mod, "find_profile_gateway_processes", lambda **_k: [])
+    monkeypatch.setattr(gateway_mod, "_get_restart_drain_timeout", lambda: 0.1)
+    monkeypatch.setattr(gateway_mod, "_capture_gateway_argv", lambda pid: None)
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway")
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks",
+        lambda args: (1, "", "ERROR: Access is denied."),
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks_elevated",
+        lambda args: (1223, "UAC prompt was cancelled"),
+    )
+
+    waits = iter([set(), {505}, {505}])
+    monkeypatch.setattr(
+        cli_main,
+        "_wait_for_windows_update_gateway_exit",
+        lambda pids, *, timeout: next(waits),
+    )
+
+    def deny_terminate(pid, force=False):
+        raise PermissionError("Access is denied")
+
+    monkeypatch.setattr(status_mod, "terminate_pid", deny_terminate)
+
+    token = cli_main._pause_windows_gateways_for_update()
+
+    assert "UAC prompt was cancelled" in token["pause_error"]
+    assert "gateway PID(s) still running: 505" in token["pause_error"]
+    assert token["scheduled_tasks"][0]["restart_after_update"] is False
 
 
 @patch.object(cli_main, "_is_windows", return_value=True)
@@ -642,6 +756,99 @@ def test_resume_windows_gateways_after_update_respawns_unmapped_by_cmdline(
     assert by_cmdline == [(7560, scheduled_argv)]
     out = capsys.readouterr().out
     assert "Restarting 1 unmapped Windows gateway process(es)" in out
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_resume_windows_gateways_runs_protected_task_without_user_respawn(
+    _winp,
+    monkeypatch,
+    capsys,
+):
+    import hermes_cli.gateway as gateway_mod
+    from hermes_cli import gateway_windows
+
+    normal_calls = []
+    elevated_calls = []
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks",
+        lambda args: normal_calls.append(list(args))
+        or (1, "", "ERROR: Access is denied."),
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks_elevated",
+        lambda args: elevated_calls.append(list(args)) or (0, ""),
+    )
+    profile_restarts = []
+    cmdline_restarts = []
+    monkeypatch.setattr(
+        gateway_mod,
+        "launch_detached_profile_gateway_restart",
+        lambda profile, old_pid: profile_restarts.append((profile, old_pid)) or True,
+    )
+    monkeypatch.setattr(
+        gateway_mod,
+        "launch_detached_gateway_restart_by_cmdline",
+        lambda old_pid, argv: cmdline_restarts.append((old_pid, argv)) or True,
+    )
+
+    token = {
+        "resume_needed": True,
+        "profiles": {"default": 606},
+        "unmapped_pids": [606],
+        "unmapped": [
+            {
+                "pid": 606,
+                "argv": ["pythonw.exe", "-m", "hermes_cli.main", "gateway", "run"],
+            }
+        ],
+        "scheduled_tasks": [
+            {
+                "name": "Hermes_Gateway",
+                "profiles": ["default"],
+                "pids": [606],
+                "elevated": True,
+            }
+        ],
+    }
+
+    cli_main._resume_windows_gateways_after_update(token)
+
+    assert normal_calls == [["/Run", "/TN", "Hermes_Gateway"]]
+    assert elevated_calls == [["/Run", "/TN", "Hermes_Gateway"]]
+    assert profile_restarts == []
+    assert cmdline_restarts == []
+    assert "Restarted Windows gateway Scheduled Task(s): Hermes_Gateway" in capsys.readouterr().out
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_resume_skips_task_that_never_stopped(_winp, monkeypatch):
+    from hermes_cli import gateway_windows
+
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks",
+        lambda args: pytest.fail("still-running task must not be started again"),
+    )
+    token = {
+        "resume_needed": True,
+        "profiles": {},
+        "unmapped": [],
+        "scheduled_tasks": [
+            {
+                "name": "Hermes_Gateway",
+                "profiles": [],
+                "pids": [707],
+                "elevated": True,
+                "restart_after_update": False,
+            }
+        ],
+    }
+
+    cli_main._resume_windows_gateways_after_update(token)
+
+    assert token["resume_needed"] is False
 
 
 @patch.object(cli_main, "_is_windows", return_value=True)
@@ -761,6 +968,58 @@ def test_resume_cold_start_skips_when_gateway_already_running(
 # ---------------------------------------------------------------------------
 # cmd_update integration — concurrent-instance gate
 # ---------------------------------------------------------------------------
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_cmd_update_aborts_before_mutation_when_gateway_pause_fails(
+    _winp,
+    monkeypatch,
+):
+    import atexit
+
+    token = {
+        "resume_needed": True,
+        "profiles": {},
+        "unmapped": [],
+        "scheduled_tasks": [],
+        "pause_error": "gateway PID(s) still running: 707",
+    }
+    resumed = []
+    registered = []
+    monkeypatch.setattr(cli_main, "_run_pre_update_backup", lambda args: None)
+    monkeypatch.setattr(
+        cli_main, "_pause_windows_gateways_for_update", lambda: token
+    )
+    monkeypatch.setattr(
+        cli_main,
+        "_resume_windows_gateways_after_update",
+        lambda value: resumed.append(value),
+    )
+    monkeypatch.setattr(
+        atexit,
+        "register",
+        lambda func, value: registered.append((func, value)),
+    )
+    monkeypatch.setattr(
+        cli_main.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("update mutation started"),
+    )
+
+    args = SimpleNamespace(
+        yes=True,
+        force=True,
+        force_venv=True,
+        backup=False,
+        no_backup=True,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main._cmd_update_impl(args, gateway_mode=False)
+
+    assert exc_info.value.code == 2
+    assert resumed == [token]
+    assert registered == [(cli_main._resume_windows_gateways_after_update, token)]
 
 
 @patch.object(cli_main, "_is_windows", return_value=True)


### PR DESCRIPTION
## What does this PR do?

Salvages and completes #63838 for #63743 while preserving HexLab98's original commits and authorship.

The original change correctly extends Windows gateway discovery to PID files and psutil, but its update stop path still assumes a non-elevated `schtasks /Query` and `/End` can control a legacy task running as SYSTEM. Windows applies the same protected task ACL to those commands, so the updater can discover the gateway and still fail to stop it.

This adds a synchronous, narrowly scoped UAC path for protected Scheduled Task control. The updater waits for the elevated command, verifies the discovered gateway PIDs actually exited, and aborts before git or venv mutation if they remain alive. Resume retains the exact Scheduled Task identity and uses `/Run` instead of replaying argv under the current user.

## Related Issue

Fixes #63743

Related PR: #63838

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Preserve #63838's PID-file and psutil discovery changes, including denied or empty command-line coverage.
- Add synchronous `ShellExecuteExW` task control that returns UAC cancellation, timeout, and child exit status to the updater.
- Map discovered profile gateways to their exact `Hermes_Gateway[_profile]` task names.
- Elevate protected `/End` and `/Run` operations, verify PID exit before update mutation, and fail closed when a gateway remains alive.
- Record task-owned profiles and PIDs in the update resume token so Scheduled Task gateways are not relaunched by command line under a different user.
- Avoid a redundant resume/UAC attempt when an aborted pause never stopped the task.
- Add focused behavioral coverage for protected task stop, cancellation, pre-mutation abort, exact-task resume, and the never-stopped path.

## How to Test

1. Run `scripts/run_tests.sh -j 4 tests/hermes_cli/test_gateway_windows.py tests/hermes_cli/test_update_concurrent_quarantine.py`.
2. Register a disposable Windows Scheduled Task as `NT AUTHORITY\SYSTEM` whose process holds the Hermes venv, then run the pause path from a non-elevated shell.
3. Verify non-elevated task query is denied, the UAC-backed `/End` removes the original PID, and resume starts the same task under a new live PID.

Local result: 72 focused tests passed. A real Windows SYSTEM Scheduled Task smoke also passed end to end, including protected query denial, elevated stop, PID-exit verification, exact-task restart, and fixture cleanup.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, non-elevated updater against a real SYSTEM Scheduled Task

Full-suite coverage is left to GitHub CI. Local validation used the focused four-worker test command above.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused tests: 72 passed, 0 failed, 4 workers.

SYSTEM-task smoke:

```text
Non-elevated task query was denied as expected
Pause stopped the protected task and retained exact task identity
Resume restarted the same SYSTEM task under a new PID
SYSTEM Scheduled Task smoke passed and fixture was removed
```
