### PR TITLE
feat(mem0): add filter_by_agent_id option to scope memory reads per agent

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -88,6 +88,7 @@ def _load_config() -> dict:
         "api_key": os.environ.get("MEM0_API_KEY", ""),
         "host": os.environ.get("MEM0_HOST", ""),
         "agent_id": os.environ.get("MEM0_AGENT_ID", "hermes"),
+        "filter_by_agent_id": False,
         "oss": {},
     }
     # Only carry user_id when the operator explicitly configured one (env or
@@ -256,6 +257,7 @@ class Mem0MemoryProvider(MemoryProvider):
             {"key": "host", "description": "Self-hosted Mem0 server URL (leave blank for cloud)", "required": False, "env_var": "MEM0_HOST"},
             {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
             {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
+            {"key": "filter_by_agent_id", "description": "Scope memory search to this agent only (multi-profile isolation)", "default": False},
             {"key": "rerank", "description": "Enable reranking for recall", "default": "false", "choices": ["true", "false"]},
         ]
 
@@ -369,12 +371,19 @@ class Mem0MemoryProvider(MemoryProvider):
             self._atexit_registered = True
 
     def _read_filters(self) -> Dict[str, Any]:
-        # Scoped to user_id only — by design — so recall surfaces memories
+        # Scoped to user_id only by default — so recall surfaces memories
         # written from any gateway/agent under this principal. Writes attach
         # agent_id (and metadata.channel) so per-agent / per-channel views are
         # still possible at query time when needed; reads default to the wider
         # cross-agent recall.
-        return {"user_id": self._user_id}
+        #
+        # Set filter_by_agent_id: true in mem0.json to scope reads to a
+        # specific agent (useful for multi-profile deployments where each
+        # profile's memory should be isolated).
+        filters: Dict[str, Any] = {"user_id": self._user_id}
+        if self._config.get("filter_by_agent_id"):
+            filters["agent_id"] = self._agent_id
+        return filters
 
     def _write_metadata(self) -> Dict[str, Any]:
         # Tag every write with the gateway channel so the dashboard can offer

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -257,7 +257,7 @@ class Mem0MemoryProvider(MemoryProvider):
             {"key": "host", "description": "Self-hosted Mem0 server URL (leave blank for cloud)", "required": False, "env_var": "MEM0_HOST"},
             {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
             {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
-            {"key": "filter_by_agent_id", "description": "Scope memory search to this agent only (multi-profile isolation)", "default": False},
+            {"key": "filter_by_agent_id", "description": "Scope memory search to this agent only (multi-profile isolation)", "default": "false", "choices": ["true", "false"]},
             {"key": "rerank", "description": "Enable reranking for recall", "default": "false", "choices": ["true", "false"]},
         ]
 
@@ -364,6 +364,12 @@ class Mem0MemoryProvider(MemoryProvider):
         self._rerank_default = (
             _rr.lower() in ("true", "1", "yes") if isinstance(_rr, str) else bool(_rr)
         )
+        # Normalize filter_by_agent_id (setup wizard writes string "true"/"false"
+        # to mem0.json — same pattern as rerank above).
+        _fba = self._config.get("filter_by_agent_id", False)
+        self._filter_by_agent_id = (
+            _fba.lower() in ("true", "1", "yes") if isinstance(_fba, str) else bool(_fba)
+        )
         self._channel = kwargs.get("platform") or "cli"
         self._backend = self._create_backend()
         if self._backend and not self._atexit_registered:
@@ -381,7 +387,7 @@ class Mem0MemoryProvider(MemoryProvider):
         # specific agent (useful for multi-profile deployments where each
         # profile's memory should be isolated).
         filters: Dict[str, Any] = {"user_id": self._user_id}
-        if self._config.get("filter_by_agent_id"):
+        if self._filter_by_agent_id:
             filters["agent_id"] = self._agent_id
         return filters
 

--- a/tests/plugins/memory/test_mem0_agent_filter.py
+++ b/tests/plugins/memory/test_mem0_agent_filter.py
@@ -1,7 +1,6 @@
 """Tests for filter_by_agent_id option in _read_filters()."""
 
 import json
-from pathlib import Path
 
 import pytest
 
@@ -48,13 +47,13 @@ class TestReadFiltersDefault:
 class TestReadFiltersWithAgentId:
     """Behavior when filter_by_agent_id is True."""
 
-    def test_read_filters_includes_agent_id_when_true_direct(self, monkeypatch):
-        """Setting _config['filter_by_agent_id'] = True adds agent_id to filters."""
+    def test_read_filters_includes_agent_id_when_true(self, monkeypatch):
+        """Setting the normalized attribute adds agent_id to filters."""
         provider = Mem0MemoryProvider()
         monkeypatch.setenv("MEM0_USER_ID", "soji-client")
         monkeypatch.setenv("MEM0_AGENT_ID", "soji-hisyo")
         provider.initialize("test-session")
-        provider._config["filter_by_agent_id"] = True
+        provider._filter_by_agent_id = True
 
         filters = provider._read_filters()
 

--- a/tests/plugins/memory/test_mem0_agent_filter.py
+++ b/tests/plugins/memory/test_mem0_agent_filter.py
@@ -1,0 +1,105 @@
+"""Tests for filter_by_agent_id option in _read_filters()."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from plugins.memory.mem0 import Mem0MemoryProvider, _load_config
+
+
+class TestReadFiltersDefault:
+    """Default behavior when filter_by_agent_id is not set or False."""
+
+    def test_read_filters_user_id_only_by_default(self, monkeypatch):
+        """Without filter_by_agent_id, _read_filters() returns only user_id."""
+        provider = Mem0MemoryProvider()
+        monkeypatch.setenv("MEM0_USER_ID", "soji-client")
+        monkeypatch.setenv("MEM0_AGENT_ID", "soji-hisyo")
+        provider.initialize("test-session")
+
+        filters = provider._read_filters()
+
+        assert filters == {"user_id": "soji-client"}
+        assert "agent_id" not in filters
+
+    def test_read_filters_user_id_only_when_false(self, monkeypatch, tmp_path):
+        """filter_by_agent_id: false → user_id only."""
+        mem0_json = tmp_path / "mem0.json"
+        mem0_json.write_text(json.dumps({
+            "user_id": "soji-client",
+            "agent_id": "soji-hisyo",
+            "filter_by_agent_id": False,
+        }))
+
+        monkeypatch.setattr(
+            "plugins.memory.mem0._load_config",
+            lambda: json.loads(mem0_json.read_text()),
+        )
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+
+        filters = provider._read_filters()
+        assert filters == {"user_id": "soji-client"}
+        assert "agent_id" not in filters
+
+
+class TestReadFiltersWithAgentId:
+    """Behavior when filter_by_agent_id is True."""
+
+    def test_read_filters_includes_agent_id_when_true_direct(self, monkeypatch):
+        """Setting _config['filter_by_agent_id'] = True adds agent_id to filters."""
+        provider = Mem0MemoryProvider()
+        monkeypatch.setenv("MEM0_USER_ID", "soji-client")
+        monkeypatch.setenv("MEM0_AGENT_ID", "soji-hisyo")
+        provider.initialize("test-session")
+        provider._config["filter_by_agent_id"] = True
+
+        filters = provider._read_filters()
+
+        assert filters == {"user_id": "soji-client", "agent_id": "soji-hisyo"}
+
+    def test_agent_id_from_mem0_json(self, monkeypatch, tmp_path):
+        """mem0.json with filter_by_agent_id: true includes agent_id in filters."""
+        mem0_json = tmp_path / "mem0.json"
+        mem0_json.write_text(json.dumps({
+            "user_id": "soji-client",
+            "agent_id": "soji-eigyo",
+            "filter_by_agent_id": True,
+        }))
+
+        monkeypatch.setattr(
+            "plugins.memory.mem0._load_config",
+            lambda: json.loads(mem0_json.read_text()),
+        )
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+
+        filters = provider._read_filters()
+        assert filters == {"user_id": "soji-client", "agent_id": "soji-eigyo"}
+
+
+class TestConfigLoading:
+    """_load_config() correctly reads filter_by_agent_id."""
+
+    def test_load_config_defaults_filter_by_agent_id_false(self, monkeypatch):
+        """No mem0.json → filter_by_agent_id defaults to False."""
+        monkeypatch.setenv("MEM0_USER_ID", "u1")
+        config = _load_config()
+        assert config.get("filter_by_agent_id") is False
+
+    def test_load_config_reads_true_from_json(self, tmp_path, monkeypatch):
+        """mem0.json with filter_by_agent_id: true → True is read."""
+        mem0_json = tmp_path / "mem0.json"
+        mem0_json.write_text(json.dumps({
+            "user_id": "u1",
+            "filter_by_agent_id": True,
+        }))
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home",
+            lambda: tmp_path,
+        )
+        config = _load_config()
+        assert config.get("filter_by_agent_id") is True

--- a/tests/plugins/memory/test_mem0_agent_filter.py
+++ b/tests/plugins/memory/test_mem0_agent_filter.py
@@ -102,3 +102,43 @@ class TestConfigLoading:
         )
         config = _load_config()
         assert config.get("filter_by_agent_id") is True
+
+    def test_load_config_reads_string_false_from_json(self, tmp_path, monkeypatch):
+        """mem0.json with string "false" → normalized to False via initialize()."""
+        mem0_json = tmp_path / "mem0.json"
+        mem0_json.write_text(json.dumps({
+            "user_id": "u1",
+            "filter_by_agent_id": "false",
+        }))
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home",
+            lambda: tmp_path,
+        )
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+
+        # String "false" normalized to bool False → no agent_id in filters
+        filters = provider._read_filters()
+        assert filters == {"user_id": "u1"}
+        assert "agent_id" not in filters
+
+    def test_load_config_reads_string_true_from_json(self, tmp_path, monkeypatch):
+        """mem0.json with string "true" → normalized to bool True via initialize()."""
+        mem0_json = tmp_path / "mem0.json"
+        mem0_json.write_text(json.dumps({
+            "user_id": "u1",
+            "filter_by_agent_id": "true",
+        }))
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home",
+            lambda: tmp_path,
+        )
+
+        provider = Mem0MemoryProvider()
+        monkeypatch.setenv("MEM0_AGENT_ID", "test-agent")
+        provider.initialize("test-session")
+
+        # String "true" normalized to bool True → agent_id included in filters
+        filters = provider._read_filters()
+        assert filters == {"user_id": "u1", "agent_id": "test-agent"}

--- a/tests/plugins/memory/test_mem0_agent_filter.py
+++ b/tests/plugins/memory/test_mem0_agent_filter.py
@@ -13,21 +13,21 @@ class TestReadFiltersDefault:
     def test_read_filters_user_id_only_by_default(self, monkeypatch):
         """Without filter_by_agent_id, _read_filters() returns only user_id."""
         provider = Mem0MemoryProvider()
-        monkeypatch.setenv("MEM0_USER_ID", "soji-client")
-        monkeypatch.setenv("MEM0_AGENT_ID", "soji-hisyo")
+        monkeypatch.setenv("MEM0_USER_ID", "mameagent-client")
+        monkeypatch.setenv("MEM0_AGENT_ID", "mameagent-hisyo")
         provider.initialize("test-session")
 
         filters = provider._read_filters()
 
-        assert filters == {"user_id": "soji-client"}
+        assert filters == {"user_id": "mameagent-client"}
         assert "agent_id" not in filters
 
     def test_read_filters_user_id_only_when_false(self, monkeypatch, tmp_path):
         """filter_by_agent_id: false → user_id only."""
         mem0_json = tmp_path / "mem0.json"
         mem0_json.write_text(json.dumps({
-            "user_id": "soji-client",
-            "agent_id": "soji-hisyo",
+            "user_id": "mameagent-client",
+            "agent_id": "mameagent-hisyo",
             "filter_by_agent_id": False,
         }))
 
@@ -40,7 +40,7 @@ class TestReadFiltersDefault:
         provider.initialize("test-session")
 
         filters = provider._read_filters()
-        assert filters == {"user_id": "soji-client"}
+        assert filters == {"user_id": "mameagent-client"}
         assert "agent_id" not in filters
 
 
@@ -50,21 +50,21 @@ class TestReadFiltersWithAgentId:
     def test_read_filters_includes_agent_id_when_true(self, monkeypatch):
         """Setting the normalized attribute adds agent_id to filters."""
         provider = Mem0MemoryProvider()
-        monkeypatch.setenv("MEM0_USER_ID", "soji-client")
-        monkeypatch.setenv("MEM0_AGENT_ID", "soji-hisyo")
+        monkeypatch.setenv("MEM0_USER_ID", "mameagent-client")
+        monkeypatch.setenv("MEM0_AGENT_ID", "mameagent-hisyo")
         provider.initialize("test-session")
         provider._filter_by_agent_id = True
 
         filters = provider._read_filters()
 
-        assert filters == {"user_id": "soji-client", "agent_id": "soji-hisyo"}
+        assert filters == {"user_id": "mameagent-client", "agent_id": "mameagent-hisyo"}
 
     def test_agent_id_from_mem0_json(self, monkeypatch, tmp_path):
         """mem0.json with filter_by_agent_id: true includes agent_id in filters."""
         mem0_json = tmp_path / "mem0.json"
         mem0_json.write_text(json.dumps({
-            "user_id": "soji-client",
-            "agent_id": "soji-eigyo",
+            "user_id": "mameagent-client",
+            "agent_id": "mameagent-eigyo",
             "filter_by_agent_id": True,
         }))
 
@@ -77,7 +77,7 @@ class TestReadFiltersWithAgentId:
         provider.initialize("test-session")
 
         filters = provider._read_filters()
-        assert filters == {"user_id": "soji-client", "agent_id": "soji-eigyo"}
+        assert filters == {"user_id": "mameagent-client", "agent_id": "mameagent-eigyo"}
 
 
 class TestConfigLoading:


### PR DESCRIPTION
## What does this PR do?

Adds a `filter_by_agent_id` option to the Mem0 memory provider, allowing users to scope memory search results to a specific agent. This is useful for multi-profile deployments where each profile (e.g., secretary, sales, accounting) should have isolated memory search results.

Currently, `_read_filters()` only filters by `user_id`, which means all memories written by any agent under the same user are surfaced in search results. In multi-profile setups where different profiles represent different AI roles/employees, this causes memory leakage between agents.

The existing comment in `_read_filters()` already acknowledges that per-agent filtering is intended as an option: "per-agent views are still possible at query time when needed." This PR adds that opt-in.

## Related Issue

N/A (no existing issue; feature request from multi-profile deployment experience)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/memory/mem0/__init__.py`:
  - `_load_config()`: Added `filter_by_agent_id: False` default (L91)
  - `initialize()`: Added string/bool normalization for `filter_by_agent_id` matching `rerank` pattern (L367-372)
  - `_read_filters()`: Added conditional `agent_id` to filters when `filter_by_agent_id` is enabled (L389-391)
  - `get_config_schema()`: Added setup wizard field (L260)
- `tests/plugins/memory/test_mem0_agent_filter.py`: 8 tests covering defaults, JSON boolean opt-in, string normalization (setup wizard path), and config loading

## How to Test

1. Checkout `feat/mem0-agent-id-filter`
2. Run tests: `pytest tests/plugins/memory/ -v`
3. All tests pass (8 new + 55 existing, zero regressions)
4. Usage: Add `"filter_by_agent_id": true` to `mem0.json`, run `hermes`, verify only the current agent's memories appear in searches

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (inline docstring updated)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (config in mem0.json, not config.yaml)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure Python logic, no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema change)