### PR TITLE
feat(skills): hermes-loop kanban software factory

### DIFF
--- a/contributors/emails/joelbrilliant@users.noreply.github.com
+++ b/contributors/emails/joelbrilliant@users.noreply.github.com
@@ -1,0 +1,1 @@
+joelbrilliant

--- a/skills/autonomous-ai-agents/hermes-loop/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-loop/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: hermes-loop
+description: "Kanban software factory loop: human freeze, scoped build, SHA-tied review, humans merge. Multi-hour/day trains as linked one-day units. Use for factory-spec, factory-build, factory-review workflows on Hermes kanban."
+version: 1.0.0
+author: Hermes Agent contributors
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [kanban, workflow, factory, review, build, long-running, software-factory]
+    related_skills: [hermes-agent]
+---
+
+# Hermes-loop
+
+Turn Hermes kanban into a software factory for multi-hour and multi-day work trains.
+
+**Roles (nouns, not people):**
+- **spec-orchestrator** — research, interview, file the packet, own the root card, spawn build/review tasks
+- **builder** — implement one unit inside the packet
+- **reviewer** — adversarial review of one handoff at one git SHA
+- **human** — freeze packets into `ready`, merge code
+
+Load the matching procedure under `references/` for the role you are playing. Shared invariants live in `references/protocol.md` only — do not fork them into three copies.
+
+## When to use
+
+- You want a queue that survives crashes and restarts (kanban + gateway dispatcher)
+- Work is larger than one chat turn but can be sliced into day-or-less units
+- You need human freeze before agents spend build tokens
+- You need SHA-tied review evidence before a human merges
+
+## Prerequisites (checked)
+
+1. Gateway running if you want automatic dispatch of `ready` tasks
+2. **`kanban.auto_decompose: false`** while using triage freeze (default true will fan-out packets before human approval)
+3. Profiles for builder and reviewer exist (names are yours; pin skills on each)
+4. Optional: a dedicated board (`hermes kanban boards create ...`)
+
+```bash
+hermes config set kanban.auto_decompose false
+hermes gateway status   # or start
+```
+
+## Quick cycle
+
+1. Spec-orchestrator files root packet in **`triage`** with full AC/NG/packet version/repo (template: `templates/packet.md`).
+2. **Human freezes** the unchanged packet: direct status move `triage` → `ready` (dashboard drag, or API status write). Do **not** run Specify or Decompose on the approved packet.
+3. Spec-orchestrator (or dispatcher) creates an ordinary **build** child task (worktree), not kernel status tricks.
+4. Builder implements only AC-N, preserves NG-N, returns `templates/build-handoff.md` with **full git SHA**.
+5. Spec-orchestrator creates a **separate ordinary review task** (reviewer profile). **Never use the kernel `review` column** for Hermes-loop v1.
+6. Reviewer returns `templates/review-verdict.md` tied to that full SHA. Fixer mode off — no push, no merge.
+7. Changes requested → new build-fix task → new review task.
+8. **Human merges** only when latest verdict full SHA equals PR head SHA (and CI policy is satisfied). Agents never merge.
+
+## Procedures
+
+| Role | File |
+|------|------|
+| Invariants | `references/protocol.md` |
+| Spec-orchestrator | `references/spec-orchestrate.md` |
+| Builder | `references/build.md` |
+| Reviewer | `references/review.md` |
+
+## Hard limits
+
+- No agent merge, auto-merge, deploy, credential changes, or destructive ops outside the packet
+- No kernel kanban `review` status for this loop
+- No Specify/Decompose on a frozen/approved packet
+- Missing required CI → human review path, never auto-approve
+- Forge labels (if used) are optional projections, never authority
+- Pre-freeze packets stay in **`triage`** (parent-free `todo` auto-readies)
+
+## Long trains
+
+A multi-day effort is a **graph of one-day-or-less worker units**, not one immortal chat session. Heartbeats and reclaim keep workers honest; the board is the memory.

--- a/skills/autonomous-ai-agents/hermes-loop/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-loop/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: hermes-loop
-description: "Kanban software factory loop: human freeze, scoped build, SHA-tied review, humans merge. Multi-hour/day trains as linked one-day units. Use for factory-spec, factory-build, factory-review workflows on Hermes kanban."
+description: "Runs human-gated software work on Hermes kanban."
 version: 1.0.0
-author: Hermes Agent contributors
+author: Joel Brilliant (@joelbrilliant), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
@@ -11,26 +11,20 @@ metadata:
     related_skills: [hermes-agent]
 ---
 
-# Hermes-loop
+# Hermes-loop Skill
 
-Turn Hermes kanban into a software factory for multi-hour and multi-day work trains.
+Turn Hermes kanban into a software factory for multi-hour and multi-day
+work trains with human freeze and SHA-tied review. It does not merge code,
+replace human approval, or use the kernel review column.
 
-**Roles (nouns, not people):**
-- **spec-orchestrator** — research, interview, file the packet, own the root card, spawn build/review tasks
-- **builder** — implement one unit inside the packet
-- **reviewer** — adversarial review of one handoff at one git SHA
-- **human** — freeze packets into `ready`, merge code
-
-Load the matching procedure under `references/` for the role you are playing. Shared invariants live in `references/protocol.md` only — do not fork them into three copies.
-
-## When to use
+## When to Use
 
 - You want a queue that survives crashes and restarts (kanban + gateway dispatcher)
 - Work is larger than one chat turn but can be sliced into day-or-less units
 - You need human freeze before agents spend build tokens
 - You need SHA-tied review evidence before a human merges
 
-## Prerequisites (checked)
+## Prerequisites
 
 1. Gateway running if you want automatic dispatch of `ready` tasks
 2. **`kanban.auto_decompose: false`** while using triage freeze (default true will fan-out packets before human approval)
@@ -42,18 +36,14 @@ hermes config set kanban.auto_decompose false
 hermes gateway status   # or start
 ```
 
-## Quick cycle
+## How to Run
 
-1. Spec-orchestrator files root packet in **`triage`** with full AC/NG/packet version/repo (template: `templates/packet.md`).
-2. **Human freezes** the unchanged packet: direct status move `triage` → `ready` (dashboard drag, or API status write). Do **not** run Specify or Decompose on the approved packet.
-3. Spec-orchestrator (or dispatcher) creates an ordinary **build** child task (worktree), not kernel status tricks.
-4. Builder implements only AC-N, preserves NG-N, returns `templates/build-handoff.md` with **full git SHA**.
-5. Spec-orchestrator creates a **separate ordinary review task** (reviewer profile). **Never use the kernel `review` column** for Hermes-loop v1.
-6. Reviewer returns `templates/review-verdict.md` tied to that full SHA. Fixer mode off — no push, no merge.
-7. Changes requested → new build-fix task → new review task.
-8. **Human merges** only when latest verdict full SHA equals PR head SHA (and CI policy is satisfied). Agents never merge.
+1. Read `references/protocol.md` for the shared invariants.
+2. Load the reference for your current role.
+3. Use the matching template for the packet, build handoff, or review verdict.
+4. Keep every worker unit to one day or less and link it to the root packet.
 
-## Procedures
+## Quick Reference
 
 | Role | File |
 |------|------|
@@ -62,7 +52,41 @@ hermes gateway status   # or start
 | Builder | `references/build.md` |
 | Reviewer | `references/review.md` |
 
-## Hard limits
+| Artifact | Template |
+|----------|----------|
+| Frozen packet | `templates/packet.md` |
+| Build evidence | `templates/build-handoff.md` |
+| Review verdict | `templates/review-verdict.md` |
+
+Roles are nouns, not people:
+
+- **spec-orchestrator** researches, files the packet, owns the root card, and creates build and review tasks
+- **builder** implements one unit inside the packet
+- **reviewer** adversarially reviews one handoff at one git SHA
+- **human** freezes packets into `ready` and merges code
+
+## Procedure
+
+1. Spec-orchestrator files the root packet in **`triage`** with full AC,
+   NG, packet version, and repository using `templates/packet.md`.
+2. **Human freezes** the unchanged packet with a direct status move from
+   `triage` to `ready`. Do **not** run Specify or Decompose on the approved
+   packet.
+3. Spec-orchestrator or dispatcher creates an ordinary **build** child task
+   in a worktree, not a kernel status shortcut.
+4. Builder implements only AC-N, preserves NG-N, and returns
+   `templates/build-handoff.md` with the **full git SHA**.
+5. Spec-orchestrator creates a **separate ordinary review task** with the
+   reviewer profile. **Never use the kernel `review` column** for
+   Hermes-loop v1.
+6. Reviewer returns `templates/review-verdict.md` tied to that full SHA.
+   Fixer mode stays off, with no push and no merge.
+7. If changes are requested, create a new build-fix task followed by a new
+   review task.
+8. **Human merges** only when the latest verdict SHA equals the PR head SHA
+   and CI policy is satisfied. Agents never merge.
+
+## Pitfalls
 
 - No agent merge, auto-merge, deploy, credential changes, or destructive ops outside the packet
 - No kernel kanban `review` status for this loop
@@ -70,7 +94,18 @@ hermes gateway status   # or start
 - Missing required CI → human review path, never auto-approve
 - Forge labels (if used) are optional projections, never authority
 - Pre-freeze packets stay in **`triage`** (parent-free `todo` auto-readies)
+- Do not copy shared invariants into each role file. Keep them in
+  `references/protocol.md`.
+- A multi-day effort is a graph of one-day-or-less worker units, not one
+  immortal chat session. Heartbeats and reclaim keep workers honest, while
+  the board remains the memory.
 
-## Long trains
+## Verification
 
-A multi-day effort is a **graph of one-day-or-less worker units**, not one immortal chat session. Heartbeats and reclaim keep workers honest; the board is the memory.
+- Confirm `kanban.auto_decompose` is `false` before moving a packet to
+  `ready`.
+- Confirm the frozen packet version is unchanged before creating build
+  tasks.
+- Confirm every build handoff and review verdict names the full commit SHA.
+- Confirm the latest verdict SHA equals the PR head SHA.
+- Confirm required CI passes before the human merge path.

--- a/skills/autonomous-ai-agents/hermes-loop/references/build.md
+++ b/skills/autonomous-ai-agents/hermes-loop/references/build.md
@@ -1,0 +1,26 @@
+# Builder procedure
+
+Load `references/protocol.md` first.
+
+## Job
+
+Implement exactly one unit: the acceptance criteria on your task card / parent packet. Return a structured handoff with a full git SHA.
+
+## Steps
+
+1. Preflight: correct repo from packet, clean or isolated worktree, default branch detected (never assumed).
+2. Prefer fixing open `changes-requested` units for this packet before starting new AC work when both exist.
+3. Read packet version and every AC-N / NG-N. If ambiguous or conflicting, block with one concrete question — do not guess.
+4. Implement only AC-N. Preserve NG-N. No opportunistic refactors.
+5. Run the narrowest useful lint/typecheck/tests for the change. Disclose pre-existing failures separately.
+6. Before opening/updating a PR: re-check packet version unchanged and freeze still valid.
+7. Open or update PR if that is the delivery mode. Description includes scope ledger (AC evidence, NG preservation, Other behaviour changes: None).
+8. Complete the kanban task with `templates/build-handoff.md` filled, including **full commit SHA**.
+9. If you push new commits after a prior review, say so explicitly — prior verdicts are invalid.
+
+## Never
+
+- Merge or enable auto-merge
+- Expand scope
+- Change packet AC/NG yourself (ask orchestrator/human)
+- Use kernel `review` status

--- a/skills/autonomous-ai-agents/hermes-loop/references/protocol.md
+++ b/skills/autonomous-ai-agents/hermes-loop/references/protocol.md
@@ -1,0 +1,103 @@
+# Hermes-loop protocol (upstream)
+
+Shared invariants for all roles. Skills point here; do not duplicate.
+
+## Purpose
+
+Kanban-backed software factory: human freeze, scoped build units, SHA-tied review, humans merge. Designed for multi-hour and multi-day trains as linked short units.
+
+## Mode requirement
+
+While packets use triage freeze:
+
+```yaml
+kanban:
+  auto_decompose: false
+```
+
+Otherwise the default decomposer can rewrite and fan-out triage cards before a human approves them.
+
+## Packet (root card)
+
+Starts in **`triage`**. Body must include:
+
+- Goal (one verifiable sentence)
+- Repo (`org/name` or absolute path) and base branch if not default
+- Acceptance Criteria as stable `AC-N` observable outcomes
+- Non-goals as binding `NG-N`
+- Packet version `vN` (integer, starts at 1)
+- Risk / authority notes (what agents may not do)
+- How to verify (covers every AC)
+- Factory role on worker cards: `spec-orchestrator` | `builder` | `reviewer`
+
+Template: `templates/packet.md`
+
+## Freeze
+
+Human moves the **unchanged** packet from `triage` → `ready`.
+
+- Do not run Specify or Decompose on the approved packet
+- Spec-orchestrator never self-freezes
+- Editing AC/NG/constraints/repo/risk after freeze: bump packet version and return to human freeze path
+
+## Task graph (v1)
+
+Do **not** walk a single card through the kernel `review` status. That status forces `sdlc-review` and keeps the current assignee.
+
+Correct graph:
+
+1. Root packet (orchestrator) owns the immutable contract
+2. Ordinary **build** task (builder profile, prefer `worktree`)
+3. Build completes with structured handoff + full git SHA
+4. Ordinary **review** task (reviewer profile), separate card
+5. Changes requested → new **build-fix** task → new **review** task
+
+## Evidence contract
+
+Canonical evidence is **kanban handoff text + git**, not forge labels.
+
+Build handoff must include:
+
+- Packet version
+- Full commit SHA
+- Changed files summary
+- Commands run + results
+- PR URL or branch name if any
+- `Other behaviour changes: None` (or stop and amend packet)
+
+Review verdict must include:
+
+- Packet version reviewed
+- Full commit SHA reviewed
+- CI: passed | failed | pending | not configured
+- Findings (must-fix / should-fix)
+- Verdict: approve-evidence | changes-requested | needs-human-review
+- Residual risk
+
+Rules:
+
+- New commit after a green verdict **invalidates** that verdict
+- Human merge only when latest verdict SHA equals current head SHA
+- Required CI missing or not configured → `needs-human-review`, never treat as approved evidence
+- Optional GitHub labels (`loop-approved`, `loop-changes-requested`, `needs-human-review`) may project state; they never grant merge authority
+
+## Agent hard bans
+
+Agents never:
+
+- merge or enable auto-merge
+- deploy
+- change credentials/permissions/security settings
+- expand scope outside AC-N / against NG-N
+- use kernel `review` status for this loop
+
+## Recovery
+
+- Heartbeat on long builder/reviewer runs
+- Reclaim reuses the same worktree and prior attempt history when possible
+- Gateway down pauses dispatch; board state remains
+- Idempotent re-entry: do not open a duplicate PR for the same packet unit without cause
+
+## UI (v1)
+
+Hermes Agent CLI + **web dashboard** Kanban tab. Electron Desktop is out of scope for v1.

--- a/skills/autonomous-ai-agents/hermes-loop/references/review.md
+++ b/skills/autonomous-ai-agents/hermes-loop/references/review.md
@@ -1,0 +1,27 @@
+# Reviewer procedure
+
+Load `references/protocol.md` first.
+
+## Job
+
+Review one build handoff against the packet at one full git SHA. Produce a verdict. Do not fix code in this role for Hermes-loop v1.
+
+## Steps
+
+1. Read the linked packet (root) and build handoff. Confirm packet version match.
+2. Check out or diff the exact full SHA named in the handoff. If HEAD moved, review the named SHA or demand a fresh handoff — never rubber-stamp a moving target.
+3. Review only against the packet: AC gaps, defects, security, scope expansion, missing states, maintainability for future agents.
+4. Check CI: required checks passed/failed/pending/not configured. Pending → no terminal verdict yet. Not configured → needs-human-review, never approve-evidence.
+5. Post `templates/review-verdict.md` on the review task (and optionally as a PR comment first line: `Hermes-loop review of <full SHA>`).
+6. Complete the review task with the verdict summary.
+
+Must-fix tags when useful: `[AC-N]`, `[DEFECT]`, `[SECURITY]`, `[CI]`, `[SCOPE-CONFLICT]`.
+
+`[SCOPE-CONFLICT]` is halt → needs-human-review (not a builder nit). Out-of-scope defects become new packets, not silent PR expansion.
+
+## Never
+
+- Push commits or apply fixes (fixer mode off)
+- Merge or formal self-approve as merge authority
+- Approve when required CI is absent
+- Approve when SHA does not match the handoff/head policy

--- a/skills/autonomous-ai-agents/hermes-loop/references/spec-orchestrate.md
+++ b/skills/autonomous-ai-agents/hermes-loop/references/spec-orchestrate.md
@@ -1,0 +1,35 @@
+# Spec-orchestrator procedure
+
+Load `references/protocol.md` first.
+
+## Job
+
+Turn a raw idea into a frozen-ready packet and run the task graph until a human can merge with SHA-tied evidence.
+
+## Steps
+
+1. Research the repo before asking product questions. Never ask what the code can answer.
+2. Interview in short rounds (1-4 questions, options + recommendation first) until two engineers would ship the same observable behaviour.
+3. Draft the packet with `templates/packet.md`. Size to one day of agent work or less; larger work becomes a chain of packets/units.
+4. Create the root kanban card in **`triage`** with the full body. Do not assign a spawnable builder yet if that would land the card in `ready` before freeze. Prefer `--triage`.
+5. Show the human the packet. They freeze `triage` → `ready` on the unchanged body.
+6. After freeze, create an ordinary **build** child task:
+   - body includes Factory role: builder, packet version, AC/NG summary or pointer to root
+   - workspace: `worktree` for code
+   - assignee: builder profile
+   - parent: root (or prior unit)
+7. When build completes with handoff, create an ordinary **review** child task:
+   - Factory role: reviewer
+   - pin packet version + full SHA from build handoff
+   - assignee: reviewer profile
+   - **do not** set kernel status `review`
+8. On `changes-requested`, create a new build-fix task then a new review task. Do not ask the reviewer to push fixes.
+9. When review returns approve-evidence, present the human merge checklist: verdict SHA == head SHA, CI policy, residual risk.
+10. After human merge, complete/close the graph with PR URL + packet version.
+
+## Never
+
+- Self-freeze
+- Specify/Decompose the approved packet
+- Put factory review on kernel `review` status
+- Merge

--- a/skills/autonomous-ai-agents/hermes-loop/templates/build-handoff.md
+++ b/skills/autonomous-ai-agents/hermes-loop/templates/build-handoff.md
@@ -1,0 +1,15 @@
+## Build handoff
+
+- Packet version: vN
+- Full commit SHA: 
+- Branch / PR: 
+- Changed files: 
+- Commands run and results: 
+- AC evidence:
+  - AC-1: 
+  - AC-2: 
+- NG preserved:
+  - NG-1: 
+- Other behaviour changes: None
+- Residual risk: 
+- Ready for review: yes/no

--- a/skills/autonomous-ai-agents/hermes-loop/templates/packet.md
+++ b/skills/autonomous-ai-agents/hermes-loop/templates/packet.md
@@ -1,0 +1,32 @@
+## Goal
+
+One verifiable sentence.
+
+## Repo
+
+- Repo: `org/name`
+- Base branch: `main`
+
+## Problem
+
+What this solves (1-2 sentences).
+
+## Acceptance Criteria
+
+- [ ] AC-1 — Observable outcome
+- [ ] AC-2 — Observable outcome
+
+## Non-goals
+
+- NG-1 — Must not change
+- NG-2 — Explicitly out of scope
+
+## Packet
+
+- Packet version: v1
+- Risk / authority: agents must not merge, deploy, or change credentials
+- Factory role (root): spec-orchestrator
+
+## How to verify
+
+1. Steps covering every AC.

--- a/skills/autonomous-ai-agents/hermes-loop/templates/review-verdict.md
+++ b/skills/autonomous-ai-agents/hermes-loop/templates/review-verdict.md
@@ -1,0 +1,26 @@
+## Hermes-loop review of FULL_SHA
+
+- Packet version reviewed: vN
+- Full commit SHA reviewed: 
+- CI: passed | failed | pending | not configured
+- Mergeability notes: 
+
+### Must fix before merge
+
+None.
+
+### Should fix soon
+
+None.
+
+### Verdict
+
+approve-evidence | changes-requested | needs-human-review
+
+### Residual risk
+
+-
+
+### Human merge reminder
+
+Merge only if this full SHA equals current head SHA and your CI policy is satisfied. Agents never merge.

--- a/tests/skills/test_hermes_loop_skill.py
+++ b/tests/skills/test_hermes_loop_skill.py
@@ -1,0 +1,89 @@
+"""Hermetic contract tests for the bundled hermes-loop skill."""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "skills" / "autonomous-ai-agents" / "hermes-loop"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+PROTOCOL = SKILL_DIR / "references" / "protocol.md"
+SPEC = SKILL_DIR / "references" / "spec-orchestrate.md"
+BUILD = SKILL_DIR / "references" / "build.md"
+REVIEW = SKILL_DIR / "references" / "review.md"
+TEMPLATES = SKILL_DIR / "templates"
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"missing {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def test_skill_layout_and_frontmatter():
+    text = _read(SKILL_MD)
+    assert text.startswith("---")
+    assert "name: hermes-loop" in text
+    assert "description:" in text
+    assert (SKILL_DIR / "references").is_dir()
+    assert (SKILL_DIR / "templates").is_dir()
+    for name in ("packet.md", "build-handoff.md", "review-verdict.md"):
+        assert (TEMPLATES / name).is_file()
+
+
+def test_manual_freeze_and_triage_rules():
+    proto = _read(PROTOCOL)
+    skill = _read(SKILL_MD)
+    blob = "\n".join([proto, skill, _read(SPEC)])
+    assert "auto_decompose: false" in blob
+    assert "triage" in proto.lower()
+    assert "specify" in blob.lower()
+    assert "decompose" in blob.lower()
+    assert (
+        "never self-freeze" in blob.lower()
+        or "never self-freezes" in blob.lower()
+        or "self-freeze" in blob.lower()
+    )
+
+
+def test_no_kernel_review_status_for_factory_graph():
+    blob = "\n".join(_read(p) for p in (PROTOCOL, SPEC, BUILD, REVIEW, SKILL_MD))
+    assert "kernel" in blob.lower() and "review" in blob.lower()
+    assert "ordinary" in blob.lower()
+    assert "set status to `review`" not in blob.lower()
+    assert "status: review" not in blob.lower()
+
+
+def test_no_agent_merge():
+    blob = "\n".join(_read(p) for p in (PROTOCOL, BUILD, REVIEW, SKILL_MD))
+    assert "never" in blob.lower() and "merge" in blob.lower()
+    assert (
+        "auto-merge" in blob.lower()
+        or "auto merge" in blob.lower()
+        or "enable auto-merge" in blob.lower()
+    )
+
+
+def test_sha_and_packet_evidence_fields():
+    proto = _read(PROTOCOL)
+    handoff = _read(TEMPLATES / "build-handoff.md")
+    verdict = _read(TEMPLATES / "review-verdict.md")
+    assert "packet version" in handoff.lower()
+    assert "full commit sha" in handoff.lower()
+    assert "FULL_SHA" in verdict or "full commit sha" in verdict.lower()
+    assert "invalidat" in proto.lower()
+    assert "not configured" in proto.lower() or "not configured" in verdict.lower()
+
+
+def test_optional_labels_are_not_authority():
+    proto = _read(PROTOCOL)
+    assert "optional" in proto.lower()
+    assert "label" in proto.lower()
+    assert "authority" in proto.lower() or "never grant" in proto.lower()
+
+
+def test_reviewer_fixer_mode_off():
+    rev = _read(REVIEW)
+    assert (
+        "fixer mode off" in rev.lower()
+        or "do not fix" in rev.lower()
+    )
+    assert "push" in rev.lower()

--- a/tests/skills/test_hermes_loop_skill.py
+++ b/tests/skills/test_hermes_loop_skill.py
@@ -1,6 +1,7 @@
 """Hermetic contract tests for the bundled hermes-loop skill."""
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -27,6 +28,26 @@ def test_skill_layout_and_frontmatter():
     assert (SKILL_DIR / "templates").is_dir()
     for name in ("packet.md", "build-handoff.md", "review-verdict.md"):
         assert (TEMPLATES / name).is_file()
+
+
+def test_frontmatter_description_contract():
+    text = _read(SKILL_MD)
+    match = re.search(r'^description: "(.*)"$', text, re.MULTILINE)
+    assert match is not None
+    description = match.group(1)
+    assert len(description) <= 60
+    assert description.endswith(".")
+    assert description.count(".") == 1
+    assert "?" not in description and "!" not in description
+
+
+def test_human_contributor_is_credited_first():
+    text = _read(SKILL_MD)
+    match = re.search(r"^author: (.*)$", text, re.MULTILINE)
+    assert match is not None
+    author = match.group(1)
+    assert author.startswith("Joel Brilliant (@joelbrilliant)")
+    assert author.endswith("Hermes Agent")
 
 
 def test_manual_freeze_and_triage_rules():


### PR DESCRIPTION
## Summary

Adds a bundled **hermes-loop** skill: a kanban-backed software factory for multi-hour and multi-day build trains.

One skill with shared protocol + role procedures (spec-orchestrator, builder, reviewer), packet/build/review templates, and hermetic contract tests.

## Why

Default Hermes installs already have kanban + dispatcher, but lack a clear freeze → build → SHA-tied review → human-merge loop. This makes long trains a graph of short units instead of one immortal chat.

Inspired by Finn-loop-style queue discipline; Hermes-native (kanban, no Linear required, role nouns not private agent names).

## Design locks (from dual design review)

1. **No kernel `review` status** for this loop (that column forces `sdlc-review` and keeps the same assignee). Use a separate ordinary review task.
2. **`kanban.auto_decompose: false`** while using triage freeze (default true can fan out pre-approval).
3. **Canonical evidence** = kanban handoff + full git SHA. Optional forge labels are projections only, never merge authority.
4. **Agents never merge.** Humans merge when verdict SHA equals head SHA.
5. **V1 UI claim** = CLI + web dashboard Kanban. Electron Desktop out of scope.

## Files

- `skills/autonomous-ai-agents/hermes-loop/SKILL.md`
- `skills/autonomous-ai-agents/hermes-loop/references/{protocol,spec-orchestrate,build,review}.md`
- `skills/autonomous-ai-agents/hermes-loop/templates/{packet,build-handoff,review-verdict}.md`
- `tests/skills/test_hermes_loop_skill.py`

## Test plan

- [x] `PYTHONPATH=. pytest tests/skills/test_hermes_loop_skill.py -q` (7 passed)
- [x] ruff clean on new paths
- [ ] Docs PR (follow-up): user-guide page + kanban callouts

## Non-goals (this PR)

- Electron Desktop surface
- Core kanban behaviour changes
- Linear integration
- Model defaults / dispatcher rewrites

## Checklist

- [x] Skill frontmatter + modern layout
- [x] Tests under `tests/skills/`
- [x] No secrets
- [x] No agent-merge instructions
