### PR TITLE
fix: preserve named custom provider vision overrides

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -480,6 +480,7 @@ def init_agent(
     checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
+    requested_provider: str = None,
 ):
     """
     Initialize the AI Agent.
@@ -488,6 +489,7 @@ def init_agent(
         base_url (str): Base URL for the model API (optional)
         api_key (str): API key for authentication (optional, uses env var if not provided)
         provider (str): Provider identifier (optional; used for telemetry/routing hints)
+        requested_provider (str): Original provider identity before runtime canonicalization
         api_mode (str): API mode override: "chat_completions" or "codex_responses"
         model (str): Model name to use (default: "anthropic/claude-opus-4.6")
         max_iterations (int): Maximum number of tool calling iterations (default: 90)
@@ -568,6 +570,11 @@ def init_agent(
     agent.base_url = base_url or ""
     provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
     agent.provider = provider_name or ""
+    agent.requested_provider = (
+        requested_provider.strip().lower()
+        if isinstance(requested_provider, str) and requested_provider.strip()
+        else agent.provider
+    )
     agent._credential_pool = credential_pool
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
@@ -2569,6 +2576,7 @@ def init_agent(
     agent._primary_runtime = {
         "model": agent.model,
         "provider": agent.provider,
+        "requested_provider": agent.requested_provider,
         "base_url": agent.base_url,
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1178,6 +1178,7 @@ def try_recover_primary_transport(
         agent._client_kwargs = dict(rt["client_kwargs"])
         agent.model = rt["model"]
         agent.provider = rt["provider"]
+        agent.requested_provider = rt.get("requested_provider", agent.provider)
         agent.base_url = rt["base_url"]
         agent.api_mode = rt["api_mode"]
         if hasattr(agent, "_transport_cache"):
@@ -1341,6 +1342,7 @@ def restore_primary_runtime(agent) -> bool:
         # ── Core runtime state ──
         agent.model = rt["model"]
         agent.provider = rt["provider"]
+        agent.requested_provider = rt.get("requested_provider", agent.provider)
         agent.base_url = rt["base_url"]           # setter updates _base_url_lower
         agent.api_mode = rt["api_mode"]
         if hasattr(agent, "_transport_cache"):
@@ -2005,6 +2007,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         for name in (
             "model",
             "provider",
+            "requested_provider",
             "base_url",
             "api_mode",
             "api_key",
@@ -2033,6 +2036,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         # ── Swap core runtime fields ──
         agent.model = new_model
         agent.provider = new_provider
+        agent.requested_provider = new_provider
         # Use the new base_url when provided. When it's empty AND the
         # provider is actually changing, do NOT fall back to the current
         # (old provider's) URL — that silently pairs the new provider label
@@ -2282,6 +2286,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     agent._primary_runtime = {
         "model": agent.model,
         "provider": agent.provider,
+        "requested_provider": agent.requested_provider,
         "base_url": agent.base_url,
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2378,6 +2378,7 @@ def set_runtime_main(
     provider: str,
     model: str,
     *,
+    requested_provider: str = "",
     base_url: str = "",
     api_key: Any = "",
     api_mode: str = "",
@@ -2393,6 +2394,7 @@ def set_runtime_main(
     global _RUNTIME_MAIN_AUTH_MODE, _RUNTIME_MAIN_COMPAT_SNAPSHOT
     runtime = {
         "provider": (provider or "").strip().lower(),
+        "requested_provider": (requested_provider or "").strip().lower(),
         "model": (model or "").strip(),
         "base_url": (base_url or "").strip(),
         "api_key": (
@@ -2865,6 +2867,7 @@ _AUTO_PROVIDER_LABELS = {
 }
 
 _MAIN_RUNTIME_FIELDS = ("provider", "model", "base_url", "api_key", "api_mode", "auth_mode")
+_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + ("requested_provider",)
 
 
 def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str, Any]:
@@ -2887,7 +2890,7 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
     if not isinstance(main_runtime, dict):
         return {}
     normalized: Dict[str, Any] = {}
-    for field in _MAIN_RUNTIME_FIELDS:
+    for field in _MAIN_RUNTIME_CONTEXT_FIELDS:
         value = main_runtime.get(field)
         # Preserve a callable api_key (Entra ID bearer provider) unchanged.
         if field == "api_key" and callable(value) and not isinstance(value, str):
@@ -2895,9 +2898,10 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
             continue
         if isinstance(value, str) and value.strip():
             normalized[field] = value.strip()
-    provider = normalized.get("provider")
-    if isinstance(provider, str):
-        normalized["provider"] = provider.lower()
+    for identity_field in ("provider", "requested_provider"):
+        identity = normalized.get(identity_field)
+        if isinstance(identity, str):
+            normalized[identity_field] = identity.lower()
     return normalized
 
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1712,6 +1712,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         agent._config_context_length = None
         agent.model = fb_model
         agent.provider = fb_provider
+        agent.requested_provider = fb_provider
         agent.base_url = fb_base_url
         agent.api_mode = fb_api_mode
         if hasattr(agent, "_transport_cache"):

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -181,6 +181,8 @@ def _supports_vision_override(
     cfg: Optional[Dict[str, Any]],
     provider: str,
     model: str,
+    *,
+    requested_provider: str = "",
 ) -> Optional[bool]:
     """Resolve user-declared vision capability from config.yaml.
 
@@ -188,9 +190,10 @@ def _supports_vision_override(
       1. ``model.supports_vision`` (top-level shortcut for the active model)
       2. ``providers.<provider>.models.<model>.supports_vision``
          (named custom providers — ``provider`` may be the runtime-resolved
-         value ``"custom"`` and/or the user-declared name under
-         ``model.provider``; both are tried. For ``custom:<name>`` syntax,
-         the stripped ``<name>`` is also tried as a provider key.)
+         value ``"custom"``, the runtime's originally requested provider,
+         and/or the user-declared name under ``model.provider``; all are
+         tried. For ``custom:<name>`` syntax, the stripped ``<name>`` is also
+         tried as a provider key.)
 
     Returns None when no override is set, so the caller falls through to
     models.dev. Returns False explicitly only when the user wrote a
@@ -214,7 +217,7 @@ def _supports_vision_override(
     # "custom:<name>" form while providers: is keyed by bare <name>.
     config_provider = str(model_cfg.get("provider") or "").strip()
     provider_candidates: List[str] = []
-    for candidate in (provider, config_provider):
+    for candidate in (requested_provider, provider, config_provider):
         if not candidate:
             continue
         provider_candidates.append(candidate)
@@ -240,28 +243,24 @@ def _supports_vision_override(
     # may appear as the raw name or "custom:<name>" at runtime).
     custom_providers = cfg.get("custom_providers")
     if isinstance(custom_providers, list):
-        # Build candidate names: the provider value and the config provider
-        # value, both raw and with "custom:" prefix stripped/added.
-        candidate_names: set = set()
-        for p in filter(None, (provider, config_provider)):
-            candidate_names.add(p)
-            if p.startswith("custom:"):
-                candidate_names.add(p[len("custom:"):])
-            else:
-                candidate_names.add(f"custom:{p}")
-        for entry_raw in custom_providers:
-            if not isinstance(entry_raw, dict):
-                continue
-            entry_name = str(entry_raw.get("name") or "").strip()
-            if entry_name not in candidate_names:
-                continue
-            models_raw = entry_raw.get("models")
-            models_cfg = models_raw if isinstance(models_raw, dict) else {}
-            per_model_raw = models_cfg.get(model)
-            per_model = per_model_raw if isinstance(per_model_raw, dict) else {}
-            coerced = _coerce_capability_bool(per_model.get("supports_vision"))
-            if coerced is not None:
-                return coerced
+        # Candidate priority matters when the CLI-selected provider differs
+        # from model.provider. Walk identities first, then config entries, so
+        # list order cannot let the persisted default shadow the live route.
+        for candidate in dict.fromkeys(provider_candidates):
+            candidate_name = candidate.strip().lower()
+            for entry_raw in custom_providers:
+                if not isinstance(entry_raw, dict):
+                    continue
+                entry_name = str(entry_raw.get("name") or "").strip().lower()
+                if entry_name != candidate_name:
+                    continue
+                models_raw = entry_raw.get("models")
+                models_cfg = models_raw if isinstance(models_raw, dict) else {}
+                per_model_raw = models_cfg.get(model)
+                per_model = per_model_raw if isinstance(per_model_raw, dict) else {}
+                coerced = _coerce_capability_bool(per_model.get("supports_vision"))
+                if coerced is not None:
+                    return coerced
 
     return None
 
@@ -381,6 +380,8 @@ def _lookup_supports_vision(
     provider: str,
     model: str,
     cfg: Optional[Dict[str, Any]] = None,
+    *,
+    requested_provider: str = "",
 ) -> Optional[bool]:
     """Return True/False if we can resolve caps, None if unknown.
 
@@ -388,7 +389,34 @@ def _lookup_supports_vision(
     (so custom/local models declared as vision-capable don't fall through to
     text routing in ``auto`` mode), then falls back to models.dev.
     """
-    override = _supports_vision_override(cfg, provider, model)
+    # Named custom providers are canonicalized to ``provider="custom"`` by
+    # runtime resolution.  The original CLI/config name is carried in the
+    # context-local main runtime so capability lookup can still select the
+    # exact custom_providers entry.  Require an exact provider+model match:
+    # background/auxiliary lookups must never borrow another turn's identity.
+    if not requested_provider:
+        try:
+            from agent.auxiliary_client import _runtime_main_value
+
+            runtime_provider = str(
+                _runtime_main_value("provider") or ""
+            ).strip().lower()
+            runtime_model = str(_runtime_main_value("model") or "").strip()
+            lookup_provider = str(provider or "").strip().lower()
+            lookup_model = str(model or "").strip()
+            if runtime_provider == lookup_provider and runtime_model == lookup_model:
+                requested_provider = str(
+                    _runtime_main_value("requested_provider") or ""
+                ).strip()
+        except Exception:
+            pass
+
+    override = _supports_vision_override(
+        cfg,
+        provider,
+        model,
+        requested_provider=requested_provider,
+    )
     if override is not None:
         return override
     if not provider or not model:
@@ -426,6 +454,8 @@ def decide_image_input_mode(
     provider: str,
     model: str,
     cfg: Optional[Dict[str, Any]],
+    *,
+    requested_provider: str = "",
 ) -> str:
     """Return ``"native"`` or ``"text"`` for the given turn.
 
@@ -433,6 +463,7 @@ def decide_image_input_mode(
       provider: active inference provider ID (e.g. ``"anthropic"``, ``"openrouter"``).
       model:    active model slug as it would be sent to the provider.
       cfg:      loaded config.yaml dict, or None. When None, behaves as auto.
+      requested_provider: provider identity before runtime canonicalization.
     """
     mode_cfg = "auto"
     if isinstance(cfg, dict):
@@ -449,7 +480,17 @@ def decide_image_input_mode(
     # explicit auxiliary.vision config acts as a *fallback* for text-only
     # main models — it should not preempt native vision on a model that
     # can natively inspect the pixels (issue #29135).
-    supports = _lookup_supports_vision(provider, model, cfg)
+    if requested_provider:
+        supports = _lookup_supports_vision(
+            provider,
+            model,
+            cfg,
+            requested_provider=requested_provider,
+        )
+    else:
+        # Keep the long-standing three-argument call contract for callers and
+        # tests that replace the capability lookup hook.
+        supports = _lookup_supports_vision(provider, model, cfg)
     if supports is True:
         return "native"
     if _explicit_aux_vision_override(cfg):

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -375,6 +375,7 @@ def build_turn_context(
         set_runtime_main(
             getattr(agent, "provider", "") or "",
             getattr(agent, "model", "") or "",
+            requested_provider=getattr(agent, "requested_provider", "") or "",
             base_url=getattr(agent, "base_url", "") or "",
             api_key=getattr(agent, "api_key", "") or "",
             api_mode=getattr(agent, "api_mode", "") or "",

--- a/cli.py
+++ b/cli.py
@@ -12106,6 +12106,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     (self.provider or "").strip(),
                     (self.model or "").strip(),
                     load_config(),
+                    requested_provider=(self.requested_provider or "").strip(),
                 )
             except Exception as _img_exc:
                 logging.debug("image_routing decision failed, defaulting to text: %s", _img_exc)
@@ -16278,6 +16279,9 @@ def main(
                                 (cli.provider or "").strip(),
                                 (cli.model or "").strip(),
                                 load_config(),
+                                requested_provider=(
+                                    cli.requested_provider or ""
+                                ).strip(),
                             )
                         except Exception:
                             _img_mode = "text"

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3399,6 +3399,7 @@ def run_job(
             api_key=runtime.get("api_key"),
             base_url=runtime.get("base_url"),
             provider=runtime.get("provider"),
+            requested_provider=runtime.get("requested_provider"),
             api_mode=runtime.get("api_mode"),
             acp_command=runtime.get("command"),
             acp_args=runtime.get("args"),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2142,6 +2142,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
         "provider": runtime.get("provider"),
+        "requested_provider": runtime.get("requested_provider"),
         "api_mode": runtime.get("api_mode"),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
@@ -2164,6 +2165,7 @@ def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
         "provider": runtime.get("provider"),
+        "requested_provider": runtime.get("requested_provider"),
         "api_mode": runtime.get("api_mode"),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
@@ -2223,6 +2225,7 @@ def _try_resolve_fallback_provider() -> dict | None:
                     "api_key": runtime.get("api_key"),
                     "base_url": runtime.get("base_url"),
                     "provider": runtime.get("provider"),
+                    "requested_provider": runtime.get("requested_provider"),
                     "api_mode": runtime.get("api_mode"),
                     "command": runtime.get("command"),
                     "args": list(runtime.get("args") or []),
@@ -4332,6 +4335,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "api_key": runtime_kwargs.get("api_key"),
             "base_url": runtime_kwargs.get("base_url"),
             "provider": runtime_kwargs.get("provider"),
+            "requested_provider": runtime_kwargs.get("requested_provider"),
             "api_mode": runtime_kwargs.get("api_mode"),
             "command": runtime_kwargs.get("command"),
             "args": list(runtime_kwargs.get("args") or []),
@@ -4344,6 +4348,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "signature": (
                 model,
                 runtime["provider"],
+                runtime["requested_provider"],
                 runtime["base_url"],
                 runtime["api_mode"],
                 runtime["command"],
@@ -16833,6 +16838,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             cfg = user_config if isinstance(user_config, dict) else load_config()
             resolved_provider = (provider or "").strip()
             resolved_model = (model or "").strip()
+            resolved_requested_provider = ""
 
             needs_session_runtime = not resolved_provider or not resolved_model
             has_session_identity = source is not None or session_key
@@ -16846,8 +16852,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if not resolved_model and isinstance(turn_model, str):
                         resolved_model = turn_model.strip()
                     runtime_provider = runtime_kwargs.get("provider") if isinstance(runtime_kwargs, dict) else None
+                    runtime_requested_provider = (
+                        runtime_kwargs.get("requested_provider")
+                        if isinstance(runtime_kwargs, dict)
+                        else None
+                    )
                     if not resolved_provider and isinstance(runtime_provider, str):
                         resolved_provider = runtime_provider.strip()
+                    if isinstance(runtime_requested_provider, str):
+                        resolved_requested_provider = runtime_requested_provider.strip()
                 except Exception as exc:
                     logger.debug(
                         "image_routing: session runtime resolution failed, falling back to config — %s",
@@ -16859,7 +16872,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not resolved_model:
                 resolved_model = _read_main_model()
 
-            return decide_image_input_mode(resolved_provider, resolved_model, cfg)
+            return decide_image_input_mode(
+                resolved_provider,
+                resolved_model,
+                cfg,
+                requested_provider=resolved_requested_provider,
+            )
         except Exception as exc:
             logger.debug("image_routing: decision failed, falling back to text — %s", exc)
             return "text"
@@ -17882,6 +17900,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _api_key_fingerprint,
                 runtime.get("base_url", ""),
                 runtime.get("provider", ""),
+                runtime.get("requested_provider", ""),
                 runtime.get("api_mode", ""),
                 sorted(enabled_toolsets) if enabled_toolsets else [],
                 # reasoning_config excluded — it's set per-message on the

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -193,6 +193,9 @@ class CLIAgentSetupMixin:
             "api_key": self.api_key,
             "base_url": self.base_url,
             "provider": self.provider,
+            "requested_provider": getattr(
+                self, "requested_provider", self.provider
+            ),
             "api_mode": self.api_mode,
             "command": self.acp_command,
             "args": list(self.acp_args or []),
@@ -204,6 +207,7 @@ class CLIAgentSetupMixin:
             "signature": (
                 self.model,
                 runtime["provider"],
+                runtime["requested_provider"],
                 runtime["base_url"],
                 runtime["api_mode"],
                 runtime["command"],
@@ -344,6 +348,9 @@ class CLIAgentSetupMixin:
                 "api_key": self.api_key,
                 "base_url": self.base_url,
                 "provider": self.provider,
+                "requested_provider": getattr(
+                    self, "requested_provider", self.provider
+                ),
                 "api_mode": self.api_mode,
                 "command": self.acp_command,
                 "args": list(self.acp_args or []),
@@ -355,6 +362,7 @@ class CLIAgentSetupMixin:
                 api_key=runtime.get("api_key"),
                 base_url=runtime.get("base_url"),
                 provider=runtime.get("provider"),
+                requested_provider=runtime.get("requested_provider"),
                 api_mode=runtime.get("api_mode"),
                 acp_command=runtime.get("command"),
                 acp_args=runtime.get("args"),
@@ -429,6 +437,7 @@ class CLIAgentSetupMixin:
             self._active_agent_route_signature = (
                 effective_model,
                 runtime.get("provider"),
+                runtime.get("requested_provider"),
                 runtime.get("base_url"),
                 runtime.get("api_mode"),
                 runtime.get("command"),

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -411,6 +411,7 @@ def _run_agent(
             api_key=runtime.get("api_key"),
             base_url=runtime.get("base_url"),
             provider=runtime.get("provider"),
+            requested_provider=runtime.get("requested_provider"),
             api_mode=runtime.get("api_mode"),
             model=effective_model,
             enabled_toolsets=toolsets_list,

--- a/run_agent.py
+++ b/run_agent.py
@@ -493,6 +493,7 @@ class AIAgent:
         checkpoint_max_total_size_mb: int = 500,
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
+        requested_provider: str = None,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         from agent.agent_init import init_agent
@@ -501,6 +502,7 @@ class AIAgent:
             base_url=base_url,
             api_key=api_key,
             provider=provider,
+            requested_provider=requested_provider,
             api_mode=api_mode,
             acp_command=acp_command,
             acp_args=acp_args,

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -25,6 +25,7 @@ class TestCliTurnRoutePool:
             api_key="sk-test",
             base_url=None,
             provider="openai-codex",
+            requested_provider="my-named-provider",
             api_mode="codex_responses",
             acp_command=None,
             acp_args=[],
@@ -37,6 +38,12 @@ class TestCliTurnRoutePool:
         route = bound("test message")
 
         assert route["runtime"]["credential_pool"] is fake_pool
+        assert route["runtime"]["requested_provider"] == "my-named-provider"
+        assert "my-named-provider" in route["signature"]
+
+        shell.requested_provider = "other-named-provider"
+        other_route = bound("test message")
+        assert other_route["signature"] != route["signature"]
 
 
 # ---------------------------------------------------------------------------
@@ -54,6 +61,7 @@ class TestGatewayTurnRoutePool:
             "api_key": "***",
             "base_url": None,
             "provider": "openai-codex",
+            "requested_provider": "openai-codex",
             "api_mode": "codex_responses",
             "command": None,
             "args": [],
@@ -64,6 +72,7 @@ class TestGatewayTurnRoutePool:
         route = bound("test message", "gpt-5.4", runtime_kwargs)
 
         assert route["runtime"]["credential_pool"] is fake_pool
+        assert route["runtime"]["requested_provider"] == "openai-codex"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_custom_providers_vision.py
+++ b/tests/agent/test_custom_providers_vision.py
@@ -261,3 +261,82 @@ class TestDecideImageInputMode:
         }
         result = decide_image_input_mode("my-provider", "my-model", cfg)
         assert result == "text"
+
+    def test_cli_named_provider_identity_survives_custom_runtime_resolution(self):
+        """The CLI-selected name must drive lookup after runtime canonicalizes it."""
+        from agent.image_routing import decide_image_input_mode
+
+        cfg = {
+            "model": {"provider": "default-proxy"},
+            "custom_providers": [
+                {
+                    "name": "custom",
+                    "models": {"shared-model": {"supports_vision": False}},
+                },
+                {
+                    "name": "default-proxy",
+                    "models": {"shared-model": {"supports_vision": False}},
+                },
+                {
+                    "name": "my-vision-provider",
+                    "models": {"shared-model": {"supports_vision": True}},
+                },
+            ],
+        }
+        assert decide_image_input_mode(
+            "custom",
+            "shared-model",
+            cfg,
+            requested_provider="my-vision-provider",
+        ) == "native"
+
+    def test_cli_named_provider_explicit_false_is_not_shadowed_by_default(self):
+        """A selected false override wins even when the configured default is true."""
+        from agent.image_routing import decide_image_input_mode
+
+        cfg = {
+            "model": {"provider": "default-proxy"},
+            "custom_providers": [
+                {
+                    "name": "default-proxy",
+                    "models": {"shared-model": {"supports_vision": True}},
+                },
+                {
+                    "name": "text-only-provider",
+                    "models": {"shared-model": {"supports_vision": False}},
+                },
+            ],
+        }
+        assert decide_image_input_mode(
+            "custom",
+            "shared-model",
+            cfg,
+            requested_provider="text-only-provider",
+        ) == "text"
+
+    def test_runtime_provider_identity_does_not_leak_to_another_model(self):
+        """Context identity is only evidence for its exact runtime provider/model."""
+        from agent.auxiliary_client import clear_runtime_main, set_runtime_main
+        from agent.image_routing import decide_image_input_mode
+
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "my-vision-provider",
+                    "models": {
+                        "selected-model": {"supports_vision": True},
+                        "other-model": {"supports_vision": True},
+                    },
+                }
+            ]
+        }
+        clear_runtime_main()
+        try:
+            set_runtime_main(
+                "custom",
+                "selected-model",
+                requested_provider="my-vision-provider",
+            )
+            assert decide_image_input_mode("custom", "other-model", cfg) == "text"
+        finally:
+            clear_runtime_main()

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -42,6 +42,7 @@ class _FakeAgent:
         self.session_id = "sess-1"
         self.model = "test/model"
         self.provider = "openrouter"
+        self.requested_provider = "openrouter"
         self.base_url = "https://openrouter.ai/api/v1"
         self.api_key = "sk-x"
         self.api_mode = "chat_completions"
@@ -273,6 +274,7 @@ def test_runtime_main_sync_happens_after_restore():
         agent.base_url = "https://api.anthropic.com"
         agent.api_key = "primary-key"
         agent.api_mode = "anthropic_messages"
+        agent.requested_provider = "anthropic"
 
     agent._restore_primary_runtime = restore_primary
     calls = []
@@ -289,6 +291,7 @@ def test_runtime_main_sync_happens_after_restore():
             "api_key": "primary-key",
             "api_mode": "anthropic_messages",
             "auth_mode": "",
+            "requested_provider": "anthropic",
         },
     )]
 
@@ -450,4 +453,3 @@ def test_expired_cooldown_allows_preflight(tmp_path):
     assert isinstance(ctx, TurnContext)
     agent._emit_status.assert_called_once()
     agent._compress_context.assert_called()
-

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -78,6 +78,23 @@ class TestAgentConfigSignature:
         sig2 = GatewayRunner._agent_config_signature("claude-sonnet-4", rt2, ["hermes-telegram"], "")
         assert sig1 != sig2
 
+    def test_requested_provider_change_different_signature(self):
+        """Named custom routes sharing one endpoint must not reuse an agent."""
+        from gateway.run import GatewayRunner
+
+        base = {
+            "api_key": "shared-key",
+            "base_url": "https://gateway.example.com/v1",
+            "provider": "custom",
+            "api_mode": "chat_completions",
+        }
+        rt1 = {**base, "requested_provider": "vision-provider"}
+        rt2 = {**base, "requested_provider": "text-provider"}
+
+        sig1 = GatewayRunner._agent_config_signature("shared-model", rt1, [], "")
+        sig2 = GatewayRunner._agent_config_signature("shared-model", rt2, [], "")
+        assert sig1 != sig2
+
     def test_toolset_change_different_signature(self):
         from gateway.run import GatewayRunner
 

--- a/tests/gateway/test_image_input_routing_runtime.py
+++ b/tests/gateway/test_image_input_routing_runtime.py
@@ -46,6 +46,41 @@ def _auto_config() -> dict:
     }
 
 
+def test_pre_turn_named_custom_provider_identity_selects_vision_override(monkeypatch):
+    """Gateway preprocessing must use the name retained by runtime resolution."""
+    runner = _make_runner()
+    cfg = {
+        "agent": {"image_input_mode": "auto"},
+        "model": {"provider": "default-proxy", "default": "shared-model"},
+        "custom_providers": [
+            {
+                "name": "default-proxy",
+                "models": {"shared-model": {"supports_vision": False}},
+            },
+            {
+                "name": "vision-provider",
+                "models": {"shared-model": {"supports_vision": True}},
+            },
+        ],
+    }
+    monkeypatch.setattr(
+        runner,
+        "_resolve_session_agent_runtime",
+        lambda **_: (
+            "shared-model",
+            {
+                "provider": "custom",
+                "requested_provider": "vision-provider",
+            },
+        ),
+    )
+
+    assert runner._decide_image_input_mode(
+        source=_source(),
+        user_config=cfg,
+    ) == "native"
+
+
 @pytest.mark.asyncio
 async def test_prepare_image_routing_uses_session_vision_model_override(monkeypatch):
     """Telegram /model overrides must affect native-vs-text image routing.

--- a/tests/hermes_cli/test_cli_custom_provider_vision.py
+++ b/tests/hermes_cli/test_cli_custom_provider_vision.py
@@ -1,0 +1,125 @@
+"""End-to-end CLI coverage for named custom-provider vision routing.
+
+Adapted from the independently reproduced CLI regression in #69896.  Unlike
+that PR, these tests keep the live transport canonical (``provider=custom``)
+and assert that the separate requested identity reaches each capability gate.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+
+MODEL = "qwen3.8-max-preview"
+REQUESTED_PROVIDER = "custom:qwen-token-plan"
+
+
+class _RuntimeCLI(CLIAgentSetupMixin):
+    def __init__(self, *, model: str, provider: str):
+        self.model = model
+        self.requested_provider = provider
+        self.provider = provider
+        self.api_key = None
+        self.base_url = None
+        self.api_mode = "chat_completions"
+        self.acp_command = None
+        self.acp_args = []
+        self.agent = None
+        self._fallback_model = []
+        self._explicit_api_key = None
+        self._explicit_base_url = None
+        self._credential_pool = None
+        self.service_tier = None
+
+    def _normalize_model_for_provider(self, _provider: str) -> bool:
+        return False
+
+
+def _write_profile_config(hermes_home) -> None:
+    (hermes_home / "config.yaml").write_text(
+        """
+model:
+  default: ollama-cloud/glm-5.2
+  provider: ollama-cloud
+providers:
+  qwen-token-plan:
+    base_url: https://qwen-token-plan.example/v1
+    api_key: test-key
+    models:
+      qwen3.8-max-preview:
+        supports_vision: true
+agent:
+  image_input_mode: auto
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _resolve_cli_route():
+    from hermes_cli._parser import build_top_level_parser
+    from hermes_constants import get_hermes_home
+
+    _write_profile_config(get_hermes_home())
+    parser, _subparsers, _chat = build_top_level_parser()
+    args, _unknown = parser.parse_known_args(
+        ["-m", MODEL, "--provider", REQUESTED_PROVIDER, "chat"]
+    )
+    cli = _RuntimeCLI(model=args.model, provider=args.provider)
+    assert cli._ensure_runtime_credentials() is True
+    return cli, cli._resolve_turn_agent_config("inspect the image")
+
+
+def test_real_cli_args_keep_transport_and_capability_identities_separate():
+    from agent.image_routing import decide_image_input_mode
+    from hermes_cli.config import load_config
+
+    cli, route = _resolve_cli_route()
+    runtime = route["runtime"]
+
+    assert cli.provider == "custom"
+    assert cli.requested_provider == REQUESTED_PROVIDER
+    assert runtime["provider"] == "custom"
+    assert runtime["requested_provider"] == REQUESTED_PROVIDER
+    assert decide_image_input_mode(
+        runtime["provider"],
+        route["model"],
+        load_config(),
+        requested_provider=runtime["requested_provider"],
+    ) == "native"
+
+    # A credential refresh with the same two identities must retain the live
+    # agent instead of treating canonicalization as a provider switch.
+    sentinel_agent = SimpleNamespace()
+    cli.agent = sentinel_agent
+    assert cli._ensure_runtime_credentials() is True
+    assert cli.agent is sentinel_agent
+
+
+def test_named_identity_reaches_agent_and_vision_tool_native_gates():
+    from agent.auxiliary_client import reset_runtime_main, set_runtime_main
+    from run_agent import AIAgent
+    from tools.vision_tools import _should_use_native_vision_fast_path
+
+    _cli, route = _resolve_cli_route()
+    runtime = route["runtime"]
+    token = set_runtime_main(
+        runtime["provider"],
+        route["model"],
+        requested_provider=runtime["requested_provider"],
+        base_url=runtime["base_url"],
+        api_key=runtime["api_key"],
+        api_mode=runtime["api_mode"],
+    )
+    try:
+        agent = AIAgent.__new__(AIAgent)
+        agent.provider = runtime["provider"]
+        agent.requested_provider = runtime["requested_provider"]
+        agent.model = route["model"]
+
+        assert agent._model_supports_vision() is True
+        assert _should_use_native_vision_fast_path() is True
+    finally:
+        reset_runtime_main(token)

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -3426,7 +3426,9 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
         },
     )
 
-    resolved = rp._resolve_named_custom_runtime(requested_provider="custom:lmstudio")
+    # Exercise the public resolver: it is responsible for preserving the
+    # original named identity after the pool path canonicalizes to "custom".
+    resolved = rp.resolve_runtime_provider(requested="custom:lmstudio")
 
     assert resolved is not None
     assert resolved["extra_headers"] == {
@@ -3435,3 +3437,5 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     }
     assert resolved["api_key"] == "pooled-key"
     assert resolved["source"] == "pool:lmstudio-pool"
+    assert resolved["provider"] == "custom"
+    assert resolved["requested_provider"] == "custom:lmstudio"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10519,6 +10519,9 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         _provider,
                         _model,
                         _cfg,
+                        requested_provider=getattr(
+                            agent, "requested_provider", ""
+                        ),
                     )
                     if getattr(agent, "api_mode", "") == "codex_app_server":
                         _mode = "text"


### PR DESCRIPTION
## Summary

- preserve the originally requested named custom provider alongside the canonical runtime provider
- use that identity during pre-turn and in-turn vision capability lookup, without changing provider="custom" transport routing
- include the identity in CLI/gateway route cache keys and keep it scoped across model/fallback transitions
- cover explicit true/false overrides, same-model isolation, direct and credential-pool resolution, and pre-turn gateway routing

## Upstream integration

- rebased onto current main after #69814 merged
- retained #69814’s provider_candidates handling for custom:<name>
- adds the requested named provider as capability evidence for the remaining bare provider="custom" rewrite path
- adapted #69896’s real CLI regression coverage to assert canonical transport plus separate requested identity

## Testing

- 476 focused routing/runtime tests passed on current main
- 464 broader agent, fallback, model-switch, and cron tests passed
- ruff passed on all modified files
- ty passed for the core image-routing and turn-context files

Fixes #69709