### PR TITLE
fix(codex): extend native Responses web_search to openai-codex provider

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -207,33 +207,33 @@ class ResponsesApiTransport(ProviderTransport):
         # Verified live against grok-composer-2.5-fast (2026-06).
         #
         # Fix: when the agent HAS a client-side ``web_search`` function (i.e.
-        # the user enabled the web toolset), declare xAI's native
-        # ``web_search`` built-in instead so the search actually runs to
-        # completion server-side and the model streams a real answer.  The
-        # Responses API rejects two tools sharing the name ``web_search``
-        # (HTTP 400 "Duplicate tool names"), so we drop the client-side
-        # ``web_search`` function for the xAI path and let the native tool
-        # satisfy it.  All other client-side tools (read_file, terminal,
-        # web_extract, MCP tools, …) are untouched and continue to dispatch
-        # through Hermes's agent loop.
+        # the user enabled the web toolset), declare the native
+        # ``web_search`` built-in for xAI and openai-codex providers so
+        # the search runs to completion server-side and the model streams
+        # a real answer.  The Responses API rejects two tools sharing the
+        # name ``web_search`` (HTTP 400 "Duplicate tool names"), so we
+        # drop the client-side function and let the native tool satisfy
+        # it.  All other client-side tools (read_file, terminal,
+        # web_extract, MCP tools, …) are untouched and continue to
+        # dispatch through Hermes's agent loop.
         #
         # Scope: we ONLY swap in the native built-in when the client
-        # ``web_search`` was actually present.  We do NOT force-enable Grok
-        # server-side search on turns where the user never had web enabled —
-        # that would silently route around Hermes's web-provider config and
-        # tool-trace/citation plumbing for every xai-oauth turn.  The swap is
-        # a 1:1 replacement of an already-requested capability, not an
-        # additive grant.
+        # ``web_search`` was actually present.  We do NOT force-enable
+        # server-side search on turns where the user never had web
+        # enabled — that would silently route around Hermes's
+        # web-provider config and tool-trace/citation plumbing.  The
+        # swap is a 1:1 replacement of an already-requested capability,
+        # not an additive grant.
         #
-        # NOTE: for the swapped case this routes ``web_search`` to Grok's
-        # native search engine for xAI sessions instead of Hermes's
-        # configured web provider (Tavily/etc.), and those results bypass
-        # Hermes's tool-trace / citation plumbing (they arrive baked into the
-        # model's answer rather than as a tool result the loop observes).
-        # Scoped to ``is_xai_responses`` deliberately; narrow to specific
-        # models if a future grok variant should keep the client-side
-        # function.
-        if is_xai_responses and response_tools:
+        # NOTE: for the swapped case this routes ``web_search`` to the
+        # provider's native search engine instead of Hermes's configured
+        # web provider (Tavily/etc.), and those results bypass Hermes's
+        # tool-trace / citation plumbing (they arrive baked into the
+        # model's answer rather than as a tool result the loop
+        # observes).  Scoped to ``is_xai_responses`` and
+        # ``is_codex_backend``; narrow to specific models if a future
+        # provider variant should keep the client-side function.
+        if (is_xai_responses or is_codex_backend) and response_tools:
             has_client_web_search = any(
                 isinstance(t, dict) and t.get("name") == "web_search"
                 for t in response_tools

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -590,8 +590,8 @@ class TestCodexBuildKwargs:
         )
 
     def test_non_xai_path_does_not_inject_native_web_search(self, transport):
-        """Native web_search injection is scoped to xAI — Codex/GitHub paths
-        keep the client-side web_search function untouched."""
+        """Native web_search injection is scoped to xAI and openai-codex —
+        other paths (plain OpenAI, …) keep the client-side function."""
         messages = [{"role": "user", "content": "Search."}]
         kw = transport.build_kwargs(
             model="gpt-5.4", messages=messages,
@@ -600,6 +600,7 @@ class TestCodexBuildKwargs:
                 "parameters": {"type": "object",
                                "properties": {"query": {"type": "string"}}}}}],
             is_xai_responses=False,
+            is_codex_backend=False,
         )
         tools = kw.get("tools", [])
         assert not any(t.get("type") == "web_search" for t in tools)
@@ -607,6 +608,38 @@ class TestCodexBuildKwargs:
             t.get("type") == "function" and t.get("name") == "web_search"
             for t in tools
         )
+
+    def test_codex_backend_injects_native_web_search(self, transport):
+        """openai-codex swaps a client-side ``web_search`` function for the
+        native ``{"type": "web_search"}`` built-in so server-side search
+        runs to completion.  Non-conflicting client tools are preserved."""
+        messages = [{"role": "user", "content": "Search the web."}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4", messages=messages,
+            tools=[
+                {"type": "function", "function": {
+                    "name": "read_file", "description": "Read a file.",
+                    "parameters": {"type": "object",
+                                   "properties": {"path": {"type": "string"}}}}},
+                {"type": "function", "function": {
+                    "name": "web_search", "description": "Search the web.",
+                    "parameters": {"type": "object",
+                                   "properties": {"query": {"type": "string"}}}}},
+            ],
+            is_xai_responses=False,
+            is_codex_backend=True,
+        )
+        tools = kw.get("tools", [])
+        # Native web_search built-in is present.
+        assert any(t.get("type") == "web_search" for t in tools), tools
+        # Client-side function form of web_search is dropped.
+        assert not any(
+            t.get("type") == "function" and t.get("name") == "web_search"
+            for t in tools
+        )
+        # Non-conflicting client-side tools are preserved.
+        names = [t.get("name") for t in tools if t.get("type") == "function"]
+        assert "read_file" in names
 
     def test_xai_reasoning_disabled_no_reasoning_key(self, transport):
         messages = [{"role": "user", "content": "Hi"}]


### PR DESCRIPTION
## Symptom

openai-codex backend sends a client-side web_search function to the Responses API, which returns HTTP 400 'Duplicate tool names' because the server already has a native web_search built-in. The xAI path already handles this correctly.

## Root Cause

The transport guard at `agent/transports/codex.py:236` only checks `is_xai_responses`. `is_codex_backend` was already computed and forwarded from `chat_completion_helpers.py:1028-1030` but was never used in the tool-swap logic.

## Changes

- Extend the guard from `is_xai_responses` to `(is_xai_responses or is_codex_backend)` — 1-line functional change
- Add regression test: `test_codex_backend_injects_native_web_search` verifies client `web_search` function is replaced by native `{"type": "web_search"}` while unrelated tools are preserved
- Update `test_non_xai_path_does_not_inject_native_web_search` to explicitly set `is_codex_backend=False`

Addresses teknium1 review on #64090: the original PR tried to read `provider` from `params` which is not forwarded to the transport layer — this version uses `is_codex_backend` which already arrives correctly.

## Validation

| Check | Result |
|---|---|
| `test_codex_backend_injects_native_web_search` | Pass ✅ |
| `test_non_xai_path_does_not_inject_native_web_search` | Pass ✅ |
| All 12 web_search tests | Pass ✅