### PR TITLE
fix(gateway): keep table fields whose value repeats the row heading

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -362,8 +362,19 @@ def _render_table_block(table_block: list[str]) -> str:
             data_cells = data_cells[: len(headers)]
 
         bullets: list[str] = []
+        # In the non-row-label case the first non-empty cell is promoted to the
+        # bold group heading, so its own bullet is redundant and skipped. Skip
+        # ONLY that one cell — matching on value alone dropped every later field
+        # that happened to repeat the heading's value (e.g. a row like
+        # ``| Open | Open | bob |`` silently lost "Priority: Open").
+        _heading_consumed = False
         for header, value in zip(headers, data_cells):
-            if not has_row_label_col and value == heading:
+            if (
+                not has_row_label_col
+                and not _heading_consumed
+                and value == heading
+            ):
+                _heading_consumed = True
                 continue
             bullets.append(f"• {header}: {value}")
 

--- a/tests/gateway/test_table_helpers.py
+++ b/tests/gateway/test_table_helpers.py
@@ -61,6 +61,27 @@ class TestConvertTableToBullets:
         assert "• City: NYC" in out
         assert "**Ada**\n• Age: 30\n• City: NYC" in out
 
+    def test_data_cell_repeating_heading_value_is_kept(self):
+        """Only the heading's own cell is dropped, not every cell equal to it.
+
+        The first non-empty cell becomes the bold heading and its redundant
+        bullet is skipped. A later column that happens to hold the same value
+        must still render — matching on value alone silently dropped real
+        fields (e.g. a status row where two columns are both "Open").
+        """
+        text = (
+            "| Status | Priority | Assignee |\n"
+            "|--------|----------|----------|\n"
+            "| Open   | Open     | bob      |"
+        )
+        out = convert_table_to_bullets(text)
+        assert "**Open**" in out
+        # The heading's own bullet is skipped...
+        assert "• Status: Open" not in out
+        # ...but the second column that repeats the value is NOT lost.
+        assert "• Priority: Open" in out
+        assert "• Assignee: bob" in out
+
     def test_row_label_column(self):
         text = (
             "|        | Score | Rank |\n"


### PR DESCRIPTION
## What does this PR do?

When a GFM table is rendered as bold-heading + bullet groups for platforms without table support (Discord, Telegram), `_render_table_block` promotes the first non-empty cell of each row to the bold heading and skips its redundant bullet. The skip matched on **value**:

```python
if not has_row_label_col and value == heading:
    continue
```

so it dropped **every** later column whose value happened to equal the heading — not just the heading's own cell. Any real field that repeats the first cell's value silently vanished from the rendered message.

Reproduced with a status row where two columns share a value:

```
| Status | Priority | Assignee |
|--------|----------|----------|
| Open   | Open     | bob      |

before:  **Open**
         • Assignee: bob            <-- "Priority: Open" lost
after:   **Open**
         • Priority: Open
         • Assignee: bob
```

Common enough to matter: status/state/enum tables routinely repeat a value across columns (`Open`/`Open`, `Yes`/`Yes`, `N/A`/`N/A`), and this is the live Discord and Telegram delivery path, so the user reads a table with a field silently missing.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/helpers.py` — in `_render_table_block`, skip only the heading's own bullet (the first cell equal to the heading, which is the promoted cell) via a one-shot flag, leaving every subsequent column intact. Matches the docstring's stated intent ("the bullet whose value duplicates the heading is skipped", singular).

## How to Test

1. Convert a table whose data row repeats the first cell's value in a later column (see the `Open / Open / bob` example).
2. **Before:** the repeated field is missing from the output. **After:** it renders, and the heading's own bullet is still skipped.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the suites: table helpers 19 passed (new test fails on `main`); telegram format/rich-message 181 passed
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] Docstrings — the intent is already documented; behavior now matches it — or N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure string logic)