### PR TITLE
fix(cli): honor checkpoint config in oneshot mode

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -328,6 +328,11 @@ def _run_agent(
     from run_agent import AIAgent
 
     cfg = load_config()
+    checkpoint_cfg = cfg.get("checkpoints", {})
+    if isinstance(checkpoint_cfg, bool):
+        checkpoint_cfg = {"enabled": checkpoint_cfg}
+    elif not isinstance(checkpoint_cfg, dict):
+        checkpoint_cfg = {}
 
     # Resolve effective model: explicit arg → env var → config.
     model_cfg = cfg.get("model") or {}
@@ -419,6 +424,14 @@ def _run_agent(
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,
+            checkpoints_enabled=checkpoint_cfg.get("enabled", False),
+            checkpoint_max_snapshots=checkpoint_cfg.get("max_snapshots", 20),
+            checkpoint_max_total_size_mb=checkpoint_cfg.get(
+                "max_total_size_mb", 500,
+            ),
+            checkpoint_max_file_size_mb=checkpoint_cfg.get(
+                "max_file_size_mb", 10,
+            ),
             # Interactive callbacks are intentionally NOT wired beyond this
             # one.  In oneshot mode there's no user sitting at a terminal:
             #   - clarify  → returns a synthetic "pick a default" instruction

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -1635,6 +1635,84 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     assert captured["prompt"] == "recall this"
 
 
+def _run_oneshot_with_checkpoint_config(monkeypatch, tmp_path, checkpoint_config):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        textwrap.dedent(checkpoint_config),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import hermes_cli.oneshot as oneshot_mod
+    from run_agent import AIAgent
+
+    captured = {}
+
+    def fake_run_conversation(agent, _prompt, **_kwargs):
+        captured["manager"] = agent._checkpoint_mgr
+        return {"final_response": "ok"}
+
+    monkeypatch.setattr(AIAgent, "run_conversation", fake_run_conversation)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "api_key": "key",
+            "base_url": "https://example.invalid",
+            "provider": "openai",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr(oneshot_mod, "_create_session_db_for_oneshot", lambda: None)
+
+    text, _result = oneshot_mod._run_agent(
+        "hello",
+        model="gpt-test",
+        provider="openai",
+        toolsets=[],
+        use_config_toolsets=False,
+    )
+
+    return text, captured["manager"]
+
+
+def test_oneshot_honors_checkpoint_config(monkeypatch, tmp_path):
+    text, manager = _run_oneshot_with_checkpoint_config(
+        monkeypatch,
+        tmp_path,
+        """
+        checkpoints:
+          enabled: true
+          max_snapshots: 7
+          max_total_size_mb: 321
+          max_file_size_mb: 4
+        """,
+    )
+
+    assert text == "ok"
+    assert manager.enabled is True
+    assert manager.max_snapshots == 7
+    assert manager.max_total_size_mb == 321
+    assert manager.max_file_size_mb == 4
+
+
+def test_oneshot_tolerates_legacy_boolean_checkpoint_config(monkeypatch, tmp_path):
+    text, manager = _run_oneshot_with_checkpoint_config(
+        monkeypatch,
+        tmp_path,
+        """
+        checkpoints: true
+        """,
+    )
+
+    assert text == "ok"
+    assert manager.enabled is True
+    assert manager.max_snapshots == 20
+    assert manager.max_total_size_mb == 500
+    assert manager.max_file_size_mb == 10
+
+
 def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):
     captured = {}
     active_path_during_call = None


### PR DESCRIPTION
## What does this PR do?

Makes the one-shot `hermes -z` path honor the configured checkpoint settings when it constructs `AIAgent` directly.

The interactive `hermes chat` path already forwards these values through `CLIAgentSetupMixin`; one-shot mode bypasses `HermesCLI._init_agent()`, so it silently fell back to `AIAgent` defaults. This change reads the existing `checkpoints` mapping, preserves legacy boolean config compatibility, safely ignores malformed non-mapping values, and forwards all four checkpoint constructor settings.

## Related Issue

Fixes #69737

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Update `hermes_cli/oneshot.py` to pass `enabled`, `max_snapshots`, `max_total_size_mb`, and `max_file_size_mb` from the existing checkpoint config into `AIAgent`.
- Add an integration-style regression test using a temporary real `HERMES_HOME`, `load_config()`, `AIAgent`, and `CheckpointManager`; only model execution is replaced to avoid a network call.

## How to Test

1. Configure `checkpoints.enabled: true` and non-default checkpoint limits in `config.yaml`.
2. Run the one-shot path with `hermes -z "hello"`.
3. Verify the constructed checkpoint manager is enabled and uses the configured limits. The regression test covers this path with `scripts/run_tests.sh tests/hermes_cli/test_tui_resume_flow.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused suites below pass: 78 tests)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing behavior or config key changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; this wires existing keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - no platform-specific code added
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/hermes_cli/test_tui_resume_flow.py -q
72 passed

scripts/run_tests.sh tests/gateway/test_checkpoint_config.py -q
2 passed

scripts/run_tests.sh tests/run_agent/test_run_agent.py -k checkpoint -q
4 passed

.venv/bin/ruff check hermes_cli/oneshot.py tests/hermes_cli/test_tui_resume_flow.py
All checks passed!
```
