### PR TITLE
fix: disable SQLite mmap on all connections to prevent 2^30 FTS truncation

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -534,8 +534,13 @@ def pin_mmap_off(conn: sqlite3.Connection, *, db_label: str = "state.db") -> Non
     """
     try:
         conn.execute("PRAGMA mmap_size=0")
-        current = conn.execute("PRAGMA mmap_size").fetchone()[0]
-        if current != 0:
+        # Some SQLite builds return NO row (or a NULL cell) for
+        # ``PRAGMA mmap_size`` when the mmap capability is absent.
+        # Either case means the connection is not memory-mapped, which
+        # is the safe state we want -- not a failure to pin.
+        row = conn.execute("PRAGMA mmap_size").fetchone()
+        current = row[0] if row else None
+        if current not in (0, None):
             logger.warning(
                 "%s: mmap_size=%s after pin to 0 (unexpected) - review connection setup",
                 db_label, current,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -519,6 +519,32 @@ _repair_attempted_paths: set[str] = set()
 _repair_attempt_lock = threading.Lock()
 
 
+def pin_mmap_off(conn: sqlite3.Connection, *, db_label: str = "state.db") -> None:
+    """Explicitly disable SQLite mmap on this connection.
+
+    Local safety override (deliberate, not upstream). mmap is OFF by default
+    in SQLite, but a runtime ``PRAGMA mmap_size=...`` issued against state.db
+    in a past session historically enabled it, which (combined with a
+    long unattended FTS ``optimize`` on the multi-GB monolith) caused the
+    2026-07-03 DB truncation/corruption. Pinning mmap_size=0 on every
+    connection makes the safe state explicit and self-healing even if some
+    future code path or manual session attempts to raise it. mmap is never
+    needed here (search is already sub-5ms at 4.2GB); disabling it removes
+    the only code-path-independent way the 2^30 truncation hazard can recur.
+    """
+    try:
+        conn.execute("PRAGMA mmap_size=0")
+        current = conn.execute("PRAGMA mmap_size").fetchone()[0]
+        if current != 0:
+            logger.warning(
+                "%s: mmap_size=%s after pin to 0 (unexpected) - review connection setup",
+                db_label, current,
+            )
+    except sqlite3.OperationalError:
+        # Some read-only / attached connections reject the PRAGMA; non-fatal.
+        pass
+
+
 def is_malformed_db_error(exc: BaseException) -> bool:
     """True if *exc* is a SQLite 'malformed schema / disk image' error.
 
@@ -1460,6 +1486,7 @@ class SessionDB:
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
+                pin_mmap_off(self._conn, db_label="state.db")
                 return
 
             self.db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1478,6 +1505,7 @@ class SessionDB:
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
+                pin_mmap_off(self._conn, db_label="state.db")
                 apply_wal_with_fallback(self._conn, db_label="state.db")
                 self._conn.execute("PRAGMA foreign_keys=ON")
                 self._fts_cjk_loaded = load_fts5_cjk_extension(self._conn)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -7156,3 +7156,37 @@ class TestLoneSurrogatePersistence:
         assert db.set_session_title("s1", "title \ud835 bad") is True
         assert db.get_session("s1")["title"] == "title \ufffd bad"
 
+
+
+class TestMmapPin:
+    """PR: disable SQLite mmap on every connection (2^30 truncation guard)."""
+
+    def test_pin_mmap_off_sets_zero(self):
+        import sqlite3 as _sql
+        conn = _sql.connect(":memory:")
+        try:
+            from hermes_state import pin_mmap_off
+            pin_mmap_off(conn, db_label="test")
+            row = conn.execute("PRAGMA mmap_size").fetchone()
+            cur = row[0] if row else None
+            assert cur in (0, None), f"expected mmap_size in (0, None) after pin, got {cur}"
+        finally:
+            conn.close()
+
+    def test_session_db_connection_has_mmap_off(self, db):
+        # A freshly opened SessionDB must have mmap disabled on its live
+        # connection, regardless of any prior runtime PRAGMA.
+        row = db._conn.execute("PRAGMA mmap_size").fetchone()
+        cur = row[0] if row else None
+        assert cur == 0, f"SessionDB connection mmap_size={cur}, expected 0"
+
+    def test_pin_mmap_off_is_nonfatal_on_readonly(self):
+        import sqlite3 as _sql
+        # Some read-only / attached connections reject the PRAGMA; the
+        # helper must not raise.
+        conn = _sql.connect("file::memory:?mode=ro", uri=True)
+        try:
+            from hermes_state import pin_mmap_off
+            pin_mmap_off(conn, db_label="ro-test")  # must not raise
+        finally:
+            conn.close()


### PR DESCRIPTION
## What does this PR do?

Pins `PRAGMA mmap_size=0` on every `SessionDB` connection (read-only and read-write paths) so SQLite never memory-maps `state.db`.

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `hermes_state.py`: add `pin_mmap_off(conn)` helper that executes `PRAGMA mmap_size=0`, reads the value back, and logs a warning if it is not `0`/`NULL` (some SQLite builds / read-only connections report no mmap support — treated as the safe unmapped state, never fatal).
- Call `pin_mmap_off(self._conn)` on both `SessionDB` connection paths: the read-only `?mode=ro` attach and the read-write path (before `apply_wal_with_fallback`).
- `tests/test_hermes_state.py`: add `TestMmapPin` — asserts the helper sets `mmap_size=0` on a bare connection, that a freshly opened `SessionDB` connection reports `0`, and that the helper is non-fatal on a read-only connection.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `python -m pytest tests/test_hermes_state.py::TestMmapPin -q` → 3 passed.
2. `python -m pytest tests/test_hermes_state.py -q -k "MmapPin or corruption or fts or malformed or reindex or cjk" -q` → all upstream FTS/corruption probes still pass (no regression).
3. Manual: open any `state.db`; `PRAGMA mmap_size` returns `0` on every connection.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

`pytest tests/test_hermes_state.py::TestMmapPin` → 3 passed.
