### PR TITLE
fix(cli): forward checkpoints config to the oneshot agent

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -407,6 +407,17 @@ def _run_agent(
         # gateway sessions.
         _fb = get_fallback_chain(cfg)
 
+        # Filesystem checkpoints: oneshot bypasses HermesCLI, so the
+        # ``checkpoints:`` config parsed there never reaches this
+        # construction — wire it from config.yaml directly, tolerating the
+        # legacy boolean form the same way the gateway's
+        # ``_checkpoint_agent_kwargs`` does (#69737).
+        cp_cfg = cfg.get("checkpoints", {})
+        if isinstance(cp_cfg, bool):
+            cp_cfg = {"enabled": cp_cfg}
+        elif not isinstance(cp_cfg, dict):
+            cp_cfg = {}
+
         agent = AIAgent(
             api_key=runtime.get("api_key"),
             base_url=runtime.get("base_url"),
@@ -419,6 +430,10 @@ def _run_agent(
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,
+            checkpoints_enabled=cp_cfg.get("enabled", False),
+            checkpoint_max_snapshots=cp_cfg.get("max_snapshots", 20),
+            checkpoint_max_total_size_mb=cp_cfg.get("max_total_size_mb", 500),
+            checkpoint_max_file_size_mb=cp_cfg.get("max_file_size_mb", 10),
             # Interactive callbacks are intentionally NOT wired beyond this
             # one.  In oneshot mode there's no user sitting at a terminal:
             #   - clarify  → returns a synthetic "pick a default" instruction

--- a/tests/hermes_cli/test_69737_oneshot_forwards_checkpoints.py
+++ b/tests/hermes_cli/test_69737_oneshot_forwards_checkpoints.py
@@ -1,0 +1,99 @@
+"""Regression tests for #69737: hermes -z must honor ``checkpoints:`` config.
+
+``cli.py`` parses the ``checkpoints:`` section into instance attributes and
+the interactive chat path forwards them to ``AIAgent``
+(``hermes_cli/cli_agent_setup_mixin.py``), but oneshot mode bypasses cli.py
+entirely — ``hermes_cli/oneshot.py::_run_agent`` builds its own agent — so
+``checkpoints.enabled: true`` silently produced zero snapshots for every
+``hermes -z`` run. Mirrors tests/gateway/test_checkpoint_config.py for the
+CLI oneshot construction path.
+"""
+
+import hermes_cli.config as config_mod
+import hermes_cli.runtime_provider as runtime_provider_mod
+import run_agent as run_agent_mod
+from hermes_cli import oneshot
+
+
+class _CapturingAgent:
+    """Stands in for AIAgent and records the constructor kwargs."""
+
+    captured: dict = {}
+
+    def __init__(self, **kwargs):
+        type(self).captured = dict(kwargs)
+        self.suppress_status_output = False
+        self.stream_delta_callback = None
+        self.tool_gen_callback = None
+
+    def run_conversation(self, prompt):
+        return {"final_response": "done"}
+
+    def shutdown_memory_provider(self, *args, **kwargs):
+        pass
+
+    def close(self):
+        pass
+
+
+def _wire_oneshot_stubs(monkeypatch, cfg):
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.setattr(config_mod, "load_config", lambda: cfg)
+    monkeypatch.setattr(
+        runtime_provider_mod,
+        "resolve_runtime_provider",
+        lambda **_kw: {
+            "api_key": "test-key",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "openrouter",
+            "api_mode": None,
+            "command": None,
+            "args": None,
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", lambda: None)
+    monkeypatch.setattr(oneshot, "get_fallback_chain", lambda _cfg: None)
+    _CapturingAgent.captured = {}
+    monkeypatch.setattr(run_agent_mod, "AIAgent", _CapturingAgent)
+
+
+def test_69737_oneshot_forwards_checkpoints_config_to_agent(monkeypatch):
+    """The four checkpoints.* settings must reach the AIAgent constructor."""
+    cfg = {
+        "model": {"default": "test/model", "provider": "openrouter"},
+        "checkpoints": {
+            "enabled": True,
+            "max_snapshots": 11,
+            "max_total_size_mb": 345,
+            "max_file_size_mb": 6,
+        },
+    }
+    _wire_oneshot_stubs(monkeypatch, cfg)
+
+    response, _result = oneshot._run_agent("hello", use_config_toolsets=False)
+
+    assert response == "done"
+    captured = _CapturingAgent.captured
+    assert captured["checkpoints_enabled"] is True
+    assert captured["checkpoint_max_snapshots"] == 11
+    assert captured["checkpoint_max_total_size_mb"] == 345
+    assert captured["checkpoint_max_file_size_mb"] == 6
+
+
+def test_69737_oneshot_tolerates_legacy_boolean_checkpoints_config(monkeypatch):
+    """Legacy ``checkpoints: true`` enables snapshots with default limits,
+    matching the gateway's ``_checkpoint_agent_kwargs`` semantics."""
+    cfg = {
+        "model": {"default": "test/model", "provider": "openrouter"},
+        "checkpoints": True,
+    }
+    _wire_oneshot_stubs(monkeypatch, cfg)
+
+    oneshot._run_agent("hello", use_config_toolsets=False)
+
+    captured = _CapturingAgent.captured
+    assert captured["checkpoints_enabled"] is True
+    assert captured["checkpoint_max_snapshots"] == 20
+    assert captured["checkpoint_max_total_size_mb"] == 500
+    assert captured["checkpoint_max_file_size_mb"] == 10


### PR DESCRIPTION
## What does this PR do?

Makes `checkpoints.enabled: true` actually take effect for one-shot sessions
(`hermes -z`). `hermes_cli/oneshot.py` builds its own `AIAgent` and omitted the
four checkpoint kwargs, so `checkpoints_enabled` always fell back to `False`
and file-mutating one-shot runs took zero snapshots. Interactive chat
(`cli_agent_setup_mixin.py#L389-L392`) and the gateway
(`gateway/run.py#L2630`, `_checkpoint_agent_kwargs`) already forward this
config -- one-shot was the remaining gap. The fix wires the four values from
the already-loaded config, tolerating the legacy boolean `checkpoints: true`
form the same way the gateway helper does.

Deliberately minimal: does not touch the `cli.py` parsing block (PR #68887
adds `checkpoint_scope` there) or the TUI launch path.

## Related Issue

Fixes #69737

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/oneshot.py` -- pass `checkpoints_enabled`,
  `checkpoint_max_snapshots`, `checkpoint_max_total_size_mb`,
  `checkpoint_max_file_size_mb` into the one-shot `AIAgent` construction,
  reading the `checkpoints:` config section (legacy bool form included).
- `tests/hermes_cli/test_69737_oneshot_forwards_checkpoints.py` -- regression
  tests mirroring `tests/gateway/test_checkpoint_config.py` for the one-shot
  construction path (dict form + legacy boolean form).

## How to Test

1. Red/green proof: with the fix stashed,
   `scripts/run_tests.sh tests/hermes_cli/test_69737_oneshot_forwards_checkpoints.py`
   fails (`KeyError: 'checkpoints_enabled'`); with the fix applied, both tests pass.
2. Targeted suites all green:
   `tests/gateway/test_checkpoint_config.py` +
   `tests/hermes_cli/test_oneshot_usage_file.py` +
   `tests/hermes_cli/test_web_server.py` -- 500 tests, 0 failures.
3. Live symptom (how this was found): on the official Docker image with
   `checkpoints.enabled: true`, `hermes -z "create hello.txt ..."` followed by
   `hermes checkpoints list` shows an empty store before the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(see note below)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux x86-64)

*Note on the full-suite box: targeted suites relevant to this change pass 100%
(500 tests). Running all of `tests/hermes_cli/` together surfaces two
pre-existing issues that reproduce identically at the parent commit
(`2a2474512`) without this diff: a test-order pollution failure in
`test_dashboard_auth_password_login.py::TestProviderListFlag` (passes in
isolation), and an early pytest termination (exit 0, no summary, ~1/3 through)
consistent with a stray `os._exit` in the suite. Happy to file these
separately.*

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(N/A: no user-facing docs describe the one-shot checkpoint gap)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(N/A: no new keys)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A *(N/A)*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(pure-Python config plumbing; no platform-specific paths)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016e12GP7EHU2KeCGGYcfvBo
