### PR TITLE
fix: electron-builder OOM in monorepos — correctly neutralize workspace root

### DIFF
--- a/apps/desktop/scripts/run-electron-builder.mjs
+++ b/apps/desktop/scripts/run-electron-builder.mjs
@@ -8,7 +8,7 @@ import fs from "node:fs"
 import path from "node:path"
 import { spawnSync } from "node:child_process"
 import { createRequire } from "node:module"
-import { fileURLToPath } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 const require = createRequire(import.meta.url)
 
@@ -26,8 +26,8 @@ const require = createRequire(import.meta.url)
 // workspace root from there, so that is what we must neutralize during the pack.
 // (Walking up from electron's install location lands in apps/desktop, which is
 // NOT the root — the root is one level higher.)
-function repoRootPkg() {
-  const scriptDir = path.dirname(fileURLToPath(import.meta.url)) // apps/desktop/scripts
+export function repoRootPkg(startDir) {
+  const scriptDir = startDir ?? path.dirname(fileURLToPath(import.meta.url)) // apps/desktop/scripts
   let dir = scriptDir
   for (let i = 0; i < 8; i++) {
     const cand = path.join(dir, "package.json")
@@ -41,8 +41,9 @@ function repoRootPkg() {
     if (parent === dir) break
     dir = parent
   }
-  // fallback: two levels up from apps/desktop/scripts
-  return path.resolve(scriptDir, "..", "..", "package.json")
+  // fallback: the monorepo root is three levels up from
+  // apps/desktop/scripts (scripts -> desktop -> apps -> root).
+  return path.resolve(scriptDir, "..", "..", "..", "package.json")
 }
 
 // electron-builder 26 detects the npm workspace root via BOTH the root
@@ -143,7 +144,13 @@ if (dist && fs.existsSync(distBinary(dist))) {
 }
 args.push(...process.argv.slice(2))
 
-// WORKAROUND: strip `workspaces` from the root package.json and replace the root
+// Only run the actual pack when invoked directly (e.g. `node
+// run-electron-builder.mjs`). When imported by a test, skip the
+// spawnSync/process.exit so the module can be loaded safely.
+const isMain =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+if (isMain) {
+// WORKAROND: strip `workspaces` from the root package.json and replace the root
 // package-lock.json with a minimal stub so electron-builder's node-module
 // collector only sees this app's context (not the whole monorepo), avoiding the
 // unbounded walk / OOM. Always restore, even on failure or if this process is
@@ -164,4 +171,5 @@ try {
   process.exit(result.status == null ? 1 : result.status)
 } finally {
   safeRestore()
+}
 }

--- a/apps/desktop/scripts/run-electron-builder.mjs
+++ b/apps/desktop/scripts/run-electron-builder.mjs
@@ -8,8 +8,103 @@ import fs from "node:fs"
 import path from "node:path"
 import { spawnSync } from "node:child_process"
 import { createRequire } from "node:module"
+import { fileURLToPath } from "node:url"
 
 const require = createRequire(import.meta.url)
+
+// WORKAROUND (desktop monorepo OOM): electron-builder 26's node-module collector
+// walks the ENTIRE hoisted monorepo node_modules when it detects an npm workspace
+// root, which explodes into millions of async proxy allocations and OOMs the
+// "searching for node modules" phase on this repo. The packaged desktop app does
+// not need the monorepo tree (its runtime deps are bundled by Vite/esbuild or
+// staged into dist/ by stage-native-deps.mjs), so we neutralize the workspace root
+// for the electron-builder child only: strip `workspaces` from the root
+// package.json, spawn, then always restore it in `finally`.
+
+// Resolve the MONOREPO ROOT package.json (the one carrying `workspaces`) by
+// walking UP from this script's directory. electron-builder detects the
+// workspace root from there, so that is what we must neutralize during the pack.
+// (Walking up from electron's install location lands in apps/desktop, which is
+// NOT the root — the root is one level higher.)
+function repoRootPkg() {
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url)) // apps/desktop/scripts
+  let dir = scriptDir
+  for (let i = 0; i < 8; i++) {
+    const cand = path.join(dir, "package.json")
+    if (fs.existsSync(cand)) {
+      try {
+        const json = JSON.parse(fs.readFileSync(cand, "utf8"))
+        if (json.workspaces) return cand
+      } catch { /* ignore, keep walking */ }
+    }
+    const parent = path.dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  // fallback: two levels up from apps/desktop/scripts
+  return path.resolve(scriptDir, "..", "..", "package.json")
+}
+
+// electron-builder 26 detects the npm workspace root via BOTH the root
+// package.json `workspaces` field AND the root package-lock.json (it walks up
+// from the app dir and reads the lock file to find the workspace root). Stripping
+// only `workspaces` is not enough — we must also hide the root package-lock.json
+// during the pack so electron-builder can't see the monorepo structure. Both are
+// restored in `finally`.
+// IMPORTANT: replacing the lock with a *minimal stub* (not just moving it aside)
+// is what makes detection fail. If we only move it aside, electron-builder falls
+// back to apps/desktop/pnpm-lock.yaml (still a workspace) and OOMs. The stub is a
+// valid non-workspace npm lock, so electron-builder treats the project as a plain
+// package and uses the app's own (pnpm) dependency tree only — no monorepo walk.
+const MINIMAL_LOCK = JSON.stringify({
+  name: "hermes-agent",
+  version: "1.0.0",
+  lockfileVersion: 3,
+  requires: true,
+  packages: { "": { name: "hermes-agent", version: "1.0.0" } },
+}, null, 2)
+
+function neutralizeWorkspaces() {
+  const pkgPath = repoRootPkg()
+  const lockPath = path.join(path.dirname(pkgPath), "package-lock.json")
+  let pkgBackup = null
+  let lockBackup = null
+  try {
+    const raw = fs.readFileSync(pkgPath, "utf8")
+    const json = JSON.parse(raw)
+    if (json.workspaces) {
+      pkgBackup = pkgPath + ".owlbak"
+      fs.writeFileSync(pkgBackup, raw)
+      delete json.workspaces
+      fs.writeFileSync(pkgPath, JSON.stringify(json, null, 2))
+    }
+    if (fs.existsSync(lockPath)) {
+      lockBackup = lockPath + ".owlbak"
+      fs.renameSync(lockPath, lockBackup)
+      fs.writeFileSync(lockPath, MINIMAL_LOCK)
+    }
+    console.warn("[run-electron-builder] neutralized workspace root for this pack (restored after).")
+  } catch (e) {
+    console.warn("[run-electron-builder] workspace neutralize skipped: " + e.message)
+  }
+  return { pkgPath, pkgBackup, lockPath, lockBackup }
+}
+
+function restoreWorkspaces(state) {
+  if (!state) return
+  try {
+    if (state.pkgBackup) {
+      fs.writeFileSync(state.pkgPath, fs.readFileSync(state.pkgBackup))
+      fs.unlinkSync(state.pkgBackup)
+    }
+    if (state.lockBackup && fs.existsSync(state.lockBackup)) {
+      fs.renameSync(state.lockBackup, state.lockPath)
+    }
+    console.warn("[run-electron-builder] restored workspace root.")
+  } catch (e) {
+    console.warn("[run-electron-builder] could not auto-restore workspace root; backups at " + state.pkgBackup + " / " + state.lockBackup)
+  }
+}
 
 function electronDistDir() {
   try {
@@ -48,11 +143,25 @@ if (dist && fs.existsSync(distBinary(dist))) {
 }
 args.push(...process.argv.slice(2))
 
-const result = spawnSync(process.execPath, [electronBuilderCli(), ...args], {
-  stdio: "inherit",
-})
-if (result.error) {
-  console.error(`[run-electron-builder] spawn failed: ${result.error.message}`)
-  process.exit(1)
+// WORKAROUND: strip `workspaces` from the root package.json and replace the root
+// package-lock.json with a minimal stub so electron-builder's node-module
+// collector only sees this app's context (not the whole monorepo), avoiding the
+// unbounded walk / OOM. Always restore, even on failure or if this process is
+// killed (SIGINT/SIGTERM) mid-pack.
+const wsState = neutralizeWorkspaces()
+function safeRestore() { try { restoreWorkspaces(wsState) } catch { /* best effort */ } }
+process.on("exit", safeRestore)
+process.on("SIGINT", () => { safeRestore(); process.exit(130) })
+process.on("SIGTERM", () => { safeRestore(); process.exit(143) })
+try {
+  const result = spawnSync(process.execPath, [electronBuilderCli(), ...args], {
+    stdio: "inherit",
+  })
+  if (result.error) {
+    console.error(`[run-electron-builder] spawn failed: ${result.error.message}`)
+    process.exit(1)
+  }
+  process.exit(result.status == null ? 1 : result.status)
+} finally {
+  safeRestore()
 }
-process.exit(result.status == null ? 1 : result.status)

--- a/apps/desktop/scripts/run-electron-builder.test.mjs
+++ b/apps/desktop/scripts/run-electron-builder.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, test } from 'vitest'
+
+import { repoRootPkg } from '../scripts/run-electron-builder.mjs'
+
+// PR #2: electron-builder OOM in monorepos. repoRootPkg() must walk
+// UP from a given start dir and resolve the MONOREPO ROOT package.json --
+// the one carrying `workspaces` -- not apps/desktop (which has no
+// `workspaces` field). If it resolved apps/desktop, the workspace
+// neutralize would be a no-op and the OOM would persist.
+
+const { tmpdir } = os
+let root
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(tmpdir(), 'eb-oom-'))
+})
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+test('resolves the monorepo root carrying workspaces, not apps/desktop', () => {
+  // monorepo root package.json WITH workspaces
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ name: 'hermes-agent', version: '1.0.0', workspaces: ['apps/*'] })
+  )
+  // apps/desktop has NO workspaces field
+  const appDir = path.join(root, 'apps', 'desktop')
+  fs.mkdirSync(path.join(appDir, 'scripts'), { recursive: true })
+  fs.writeFileSync(
+    path.join(appDir, 'package.json'),
+    JSON.stringify({ name: 'desktop', version: '1.0.0' })
+  )
+  // Start the walk from apps/desktop/scripts (what the real script does
+  // via its own import.meta.url).
+  const startDir = path.join(appDir, 'scripts')
+  const resolved = repoRootPkg(startDir)
+  // resolved path must be the monorepo root, not apps/desktop
+  assert.strictEqual(
+    path.dirname(resolved),
+    root,
+    `expected ${root}, got ${path.dirname(resolved)}`
+  )
+  const json = JSON.parse(fs.readFileSync(resolved, 'utf8'))
+  assert.ok(json.workspaces, 'resolved package.json must carry workspaces')
+})
+
+test('falls back to monorepo root when no workspaces root exists', () => {
+  // No workspaces anywhere: should not throw and should return a path.
+  fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: 'plain' }))
+  const startDir = path.join(root, 'apps', 'desktop', 'scripts')
+  fs.mkdirSync(startDir, { recursive: true })
+  // real repo has apps/desktop/package.json; fallback walks past it
+  fs.writeFileSync(path.join(root, 'apps', 'desktop', 'package.json'), JSON.stringify({ name: 'desktop' }))
+  const resolved = repoRootPkg(startDir)
+  assert.ok(resolved, 'repoRootPkg must return a path even without workspaces')
+  // fallback resolves to the monorepo root (3 levels up from scripts)
+  assert.strictEqual(path.dirname(resolved), root, `expected ${root}, got ${path.dirname(resolved)}`)
+  assert.ok(fs.existsSync(resolved), 'resolved path must exist')
+})


### PR DESCRIPTION
## What does this PR do?

Fixes electron-builder 26's out-of-memory crash during the "searching for node modules" phase in this monorepo, by correctly resolving the **monorepo root** (the `package.json` carrying `workspaces`) and neutralizing it for the electron-builder child only.

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `apps/desktop/scripts/run-electron-builder.mjs`:
  - `repoRootPkg()` now walks **up from this script's directory** (`apps/desktop/scripts`) to find the actual monorepo root `package.json` (the one with `workspaces`). The previous code walked up from electron's install location (`apps/desktop`), which lacks the `workspaces` field — so the neutralize was a no-op and the OOM persisted.
  - `neutralizeWorkspaces()` strips `workspaces` from the root `package.json` **and** replaces the root `package-lock.json` with a minimal stub (not just moved aside), so electron-builder's node-module collector falls back to the app's own dependency tree instead of walking the whole monorepo. Both are always restored (`finally` + `process.on('exit'|'SIGINT'|'SIGTERM')`).
  - Guard the top-level `spawnSync`/`process.exit` behind an `isMain` check so the module can be imported by tests without spawning a build.
  - Export `repoRootPkg(startDir?)` (optional start dir for testability); fix an off-by-one in the no-workspaces fallback (monorepo root is 3 levels up from `scripts`).
- `apps/desktop/scripts/run-electron-builder.test.mjs` (new): asserts `repoRootPkg` resolves the monorepo root carrying `workspaces` (not `apps/desktop`), and falls back to the monorepo root when none exists.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `cd apps/desktop && npx vitest run scripts/run-electron-builder.test.mjs` → 2 passed.
2. `npm run build:desktop` on the monorepo completes without OOM.
3. Verify root `package.json` / `package-lock.json` are restored after the build (the `*.owlbak` backups are removed).

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — _(N/A to this change; desktop build is `npm run build:desktop` + vitest; ran the desktop test suite for this file)_
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

`npx vitest run scripts/run-electron-builder.test.mjs`:
```
 ✓ resolves the monorepo root carrying workspaces, not apps/desktop
 ✓ falls back to monorepo root when no workspaces root exists
 Test Files  1 passed (1)
      Tests  2 passed (2)
```