### PR TITLE
fix(desktop): separate workspace defaults from live cwd

### DIFF
--- a/apps/desktop/e2e/worktree-branch-status.spec.ts
+++ b/apps/desktop/e2e/worktree-branch-status.spec.ts
@@ -73,7 +73,6 @@ test('creating a branch with ctrl-shift-b updates the composer git-status branch
   const codingRow = page.locator('.coding-status-bar')
   const composer = page.locator('[contenteditable="true"]').first()
 
-  await expect(codingRow).toContainText('main')
   await composer.click()
   await composer.type('create a repo-backed e2e session', { delay: 2 })
   await page.keyboard.press('Enter')
@@ -82,6 +81,7 @@ test('creating a branch with ctrl-shift-b updates the composer git-status branch
     'create a repo-backed e2e session',
     { timeout: 15_000 },
   )
+  await expect(codingRow).toContainText('main')
   await page.keyboard.press('Control+Shift+B')
 
   const branchInput = page.locator('input[placeholder="e.g. my-feature"]').first()

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -253,10 +253,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     requestGateway
   })
 
-  const { refreshHermesConfig, sttEnabled, voiceMaxRecordingSeconds } = useHermesConfig({
-    activeSessionIdRef,
-    refreshProjectBranch
-  })
+  const { refreshHermesConfig, sttEnabled, voiceMaxRecordingSeconds } = useHermesConfig({ activeSessionIdRef })
 
   const { refreshCurrentModel, selectModel, updateModelOptionsCache } = useModelControls({
     queryClient,

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
@@ -47,133 +47,38 @@ describe('useHermesConfig refreshHermesConfig', () => {
     persistString(WORKSPACE_CWD_KEY, null)
   })
 
-  it('applies terminal.cwd from config even when localStorage has a stale value', async () => {
-    // Simulate a stale remembered workspace cwd
-    persistString(WORKSPACE_CWD_KEY, '/Users/old/stale-project')
-    setCurrentCwd('/Users/old/stale-project')
+  it('does not let terminal.cwd replace an inactive selected workspace', async () => {
+    setCurrentCwd('/Users/example/repo/.worktrees/feature')
 
     mockConfig({ terminal: { cwd: '/Users/example/new-workspace' } })
-
-    const { result } = renderHook(() =>
-      useHermesConfig({
-        activeSessionIdRef: { current: null },
-        refreshProjectBranch: vi.fn().mockResolvedValue(undefined)
-      })
-    )
+    const { result } = renderHook(() => useHermesConfig({ activeSessionIdRef: { current: null } }))
 
     await act(async () => {
       await result.current.refreshHermesConfig()
     })
 
-    // The configured terminal.cwd must override the stale localStorage value
-    expect($currentCwd.get()).toBe('/Users/example/new-workspace')
+    expect($currentCwd.get()).toBe('/Users/example/repo/.worktrees/feature')
   })
 
-  it('keeps the active session workspace when a session is running', async () => {
-    setCurrentCwd('/workspace/attached-project')
+  it('does not let terminal.cwd replace an active session workspace', async () => {
+    setCurrentCwd('/Users/example/repo/.worktrees/attached')
 
     mockConfig({ terminal: { cwd: '/Users/example/new-workspace' } })
-
-    const { result } = renderHook(() =>
-      useHermesConfig({
-        activeSessionIdRef: { current: 'session-1' },
-        refreshProjectBranch: vi.fn().mockResolvedValue(undefined)
-      })
-    )
+    const { result } = renderHook(() => useHermesConfig({ activeSessionIdRef: { current: 'session-1' } }))
 
     await act(async () => {
       await result.current.refreshHermesConfig()
     })
 
-    // Config refreshes mid-session must not yank the workspace out from
-    // under the attached session.
-    expect($currentCwd.get()).toBe('/workspace/attached-project')
+    expect($currentCwd.get()).toBe('/Users/example/repo/.worktrees/attached')
   })
 
-  it('uses empty string when terminal.cwd is not set and localStorage is empty', async () => {
-    mockConfig({})
-
-    const { result } = renderHook(() =>
-      useHermesConfig({
-        activeSessionIdRef: { current: null },
-        refreshProjectBranch: vi.fn().mockResolvedValue(undefined)
-      })
-    )
-
-    await act(async () => {
-      await result.current.refreshHermesConfig()
-    })
-
-    expect($currentCwd.get()).toBe('')
-  })
-
-  it('ignores terminal.cwd when it is "."', async () => {
-    mockConfig({ terminal: { cwd: '.' } })
-
-    const { result } = renderHook(() =>
-      useHermesConfig({
-        activeSessionIdRef: { current: null },
-        refreshProjectBranch: vi.fn().mockResolvedValue(undefined)
-      })
-    )
-
-    await act(async () => {
-      await result.current.refreshHermesConfig()
-    })
-
-    expect($currentCwd.get()).toBe('')
-  })
-
-  it('calls refreshProjectBranch with the configured cwd', async () => {
-    const refreshProjectBranch = vi.fn().mockResolvedValue(undefined)
-    setCurrentCwd('')
-
-    mockConfig({ terminal: { cwd: '/workspace/project-a' } })
-
-    const { result } = renderHook(() =>
-      useHermesConfig({
-        activeSessionIdRef: { current: null },
-        refreshProjectBranch
-      })
-    )
-
-    await act(async () => {
-      await result.current.refreshHermesConfig()
-    })
-
-    expect(refreshProjectBranch).toHaveBeenCalledWith('/workspace/project-a')
-  })
-
-  it('refreshes the branch for the session cwd (not config) when a session is active', async () => {
-    const refreshProjectBranch = vi.fn().mockResolvedValue(undefined)
-    setCurrentCwd('/workspace/attached-project')
-
-    mockConfig({ terminal: { cwd: '/Users/example/new-workspace' } })
-
-    const { result } = renderHook(() =>
-      useHermesConfig({
-        activeSessionIdRef: { current: 'session-1' },
-        refreshProjectBranch
-      })
-    )
-
-    await act(async () => {
-      await result.current.refreshHermesConfig()
-    })
-
-    expect(refreshProjectBranch).toHaveBeenCalledWith('/workspace/attached-project')
-  })
 
   it('does not let a stale forced config refresh overwrite newer draft selector intent', async () => {
     const profileConfig = deferred<Awaited<ReturnType<typeof getHermesConfig>>>()
     vi.mocked(getHermesConfig).mockReturnValueOnce(profileConfig.promise)
 
-    const { result } = renderHook(() =>
-      useHermesConfig({
-        activeSessionIdRef: { current: null },
-        refreshProjectBranch: vi.fn().mockResolvedValue(undefined)
-      })
-    )
+    const { result } = renderHook(() => useHermesConfig({ activeSessionIdRef: { current: null } }))
 
     let pendingRefresh!: Promise<void>
     act(() => {
@@ -203,12 +108,7 @@ describe('useHermesConfig refreshHermesConfig', () => {
     const profileC = deferred<Awaited<ReturnType<typeof getHermesConfig>>>()
     vi.mocked(getHermesConfig).mockReturnValueOnce(profileB.promise).mockReturnValueOnce(profileC.promise)
 
-    const { result } = renderHook(() =>
-      useHermesConfig({
-        activeSessionIdRef: { current: null },
-        refreshProjectBranch: vi.fn().mockResolvedValue(undefined)
-      })
-    )
+    const { result } = renderHook(() => useHermesConfig({ activeSessionIdRef: { current: null } }))
 
     let refreshB!: Promise<void>
     let refreshC!: Promise<void>

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -4,11 +4,9 @@ import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
 import { BUILTIN_PERSONALITIES, normalizePersonalityValue, personalityNamesFromConfig } from '@/lib/chat-runtime'
 import { normalize } from '@/lib/text'
 import {
-  $currentCwd,
   getComposerSelectionGeneration,
   getCurrentModelSource,
   setAvailablePersonalities,
-  setCurrentCwd,
   setCurrentFastMode,
   setCurrentPersonality,
   setCurrentReasoningEffort,
@@ -43,10 +41,9 @@ function normalizeConfigEffort(value: unknown): string {
 
 interface HermesConfigOptions {
   activeSessionIdRef: MutableRefObject<string | null>
-  refreshProjectBranch: (cwd: string) => Promise<void>
 }
 
-export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: HermesConfigOptions) {
+export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
   const [voiceMaxRecordingSeconds, setVoiceMaxRecordingSeconds] = useState(DEFAULT_VOICE_SECONDS)
   const [sttEnabled, setSttEnabled] = useState(true)
   const profileRefreshEpochRef = useRef(0)
@@ -83,16 +80,6 @@ export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: He
           ])
         ])
 
-        const cwd = (config.terminal?.cwd ?? '').trim()
-
-        if (cwd && cwd !== '.') {
-          // Configured terminal.cwd beats a stale remembered workspace cwd
-          // (#38855) — but never yank the workspace out from under an active
-          // session; those keep their own cwd until the user detaches.
-          setCurrentCwd(prev => (activeSessionIdRef.current ? prev : cwd))
-          void refreshProjectBranch($currentCwd.get() || cwd)
-        }
-
         const reasoning = normalizeConfigEffort(config.agent?.reasoning_effort)
         const tier = (config.agent?.service_tier ?? '').trim()
 
@@ -115,7 +102,7 @@ export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: He
         // Config is nice-to-have; chat still works without it.
       }
     },
-    [activeSessionIdRef, refreshProjectBranch]
+    [activeSessionIdRef]
   )
 
   return { refreshHermesConfig, sttEnabled, voiceMaxRecordingSeconds }

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -222,6 +222,15 @@ describe('workspaceCwdForNewSession', () => {
     expect(workspaceCwdForNewSession()).toBe('/home/user/configured')
   })
 
+  it('keeps the configured default separate from a selected workspace', () => {
+    setCurrentCwd('/home/user/repo/.worktrees/feature')
+
+    applyConfiguredDefaultProjectDir('/home/user/configured')
+
+    expect(workspaceCwdForNewSession()).toBe('/home/user/configured')
+    expect($currentCwd.get()).toBe('/home/user/repo/.worktrees/feature')
+  })
+
   it('starts detached (no inherited cwd) when no default project dir is configured', () => {
     // A bare new chat must NOT inherit the sticky/remembered or live workspace —
     // that's the "why is my new session already on a branch" bug. Only an

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -113,12 +113,6 @@ export async function ensureDefaultWorkspaceCwd(): Promise<void> {
 
 export function applyConfiguredDefaultProjectDir(dir: null | string | undefined): void {
   configuredDefaultProjectDir = dir?.trim() || ''
-
-  // Cache only — new chats read this via workspaceCwdForNewSession(). Do not
-  // rewrite the live workspace (or localStorage) while a session is active.
-  if (configuredDefaultProjectDir && !$activeSessionId.get()) {
-    setCurrentCwd(configuredDefaultProjectDir)
-  }
 }
 
 interface AppAtom<T> {


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop workspace hand-off race by separating configured defaults from the renderer's live workspace selection.

`terminal.cwd` remains the backend default for a bare session. Config refresh no longer copies it into `$currentCwd`, so a refresh cannot redirect an inactive worktree draft. Desktop's configured default-project setting now also affects only future drafts rather than rewriting the current workspace.

The worktree E2E now waits for `session.create` runtime info to report the backend-selected default CWD before asserting `main`, then verifies the explicit branch/worktree update.

## Related Issue

No separate issue; follows the Desktop worktree branch-status flake investigation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Removed config-refresh CWD and branch-status side effects from `apps/desktop/src/app/session/hooks/use-hermes-config.ts`.
- Kept `$currentCwd` for actual renderer/session workspace selection; bare sessions let the backend apply `terminal.cwd` and return the resolved CWD via runtime info.
- Made `applyConfiguredDefaultProjectDir()` cache-only, with regression coverage that a configured default does not replace an explicitly selected worktree.
- Moved the E2E `main` assertion to after backend session creation and repeated the explicit worktree hand-off test.

## How to Test

1. `cd apps/desktop && nix develop -c npx vitest run src/store/session.test.ts src/app/session/hooks/use-hermes-config.test.ts` — 31 tests passed.
2. `cd apps/desktop && nix develop -c npm run typecheck && nix develop -c npm run lint` — typecheck passed; lint had 0 errors (18 existing warnings outside this change).
3. `cd apps/desktop && nix develop -c npm run build && nix develop -c env WLR_BACKENDS=headless cage -- npx playwright test e2e/worktree-branch-status.spec.ts --repeat-each=3 --workers=1` — production build passed; E2E passed 3/3.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux/NixOS, headless Cage Electron E2E

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused Electron worktree branch-status E2E: **3 passed** with `--repeat-each=3 --workers=1`.

