### PR TITLE
fix(browser): clear activity timestamp on failed open

### DIFF
--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -137,4 +137,131 @@ class TestBrowserCleanup:
         assert browser_tool._active_sessions == {}
         assert browser_tool._session_last_activity == {}
         assert browser_tool._recording_sessions == set()
-        assert browser_tool._cleanup_done is True
+
+
+class TestNavigateFailureClearsActivity:
+    """Regression for the activity-timestamp-on-failed-open bug.
+
+    `_get_session_info` calls `_update_session_activity(task_id)` *before*
+    the actual open command runs. If the open command then blows up
+    (timeout, refused connection, agent-browser daemon crash, etc.), the
+    session's last-activity timestamp gets refreshed anyway, so the
+    background inactivity-cleanup thread sees the session as "freshly
+    used" forever and never reaps it. On a long-running gateway that
+    leaves orphaned Chromium processes behind (see issue #32047).
+
+    The contract: after a failed browser_navigate, the session's
+    last-activity timestamp must NOT be present (or must be older than
+    the inactivity timeout), so the cleanup thread can reap it on its
+    next tick.
+    """
+
+    def setup_method(self):
+        from tools import browser_tool
+
+        self.browser_tool = browser_tool
+        self.orig_active_sessions = browser_tool._active_sessions.copy()
+        self.orig_session_last_activity = browser_tool._session_last_activity.copy()
+
+    def teardown_method(self):
+        self.browser_tool._active_sessions.clear()
+        self.browser_tool._active_sessions.update(self.orig_active_sessions)
+        self.browser_tool._session_last_activity.clear()
+        self.browser_tool._session_last_activity.update(self.orig_session_last_activity)
+
+    def test_navigate_timeout_clears_activity_timestamp(self):
+        """Open command raises -> _session_last_activity must be popped."""
+        browser_tool = self.browser_tool
+        nav_key = "default"  # bare task_id when no cloud provider
+
+        def fake_get_session_info(task_id):
+            # Simulate _get_session_info's documented side effect: it
+            # stamps the activity timestamp on the way in.
+            browser_tool._update_session_activity(task_id)
+            return {
+                "session_name": "fake-sess",
+                "_first_nav": True,
+            }
+
+        with (
+            patch(
+                "tools.browser_tool._get_session_info",
+                side_effect=fake_get_session_info,
+            ),
+            patch(
+                "tools.browser_tool._get_open_command_timeout",
+                return_value=120,
+            ),
+            patch(
+                "tools.browser_tool._maybe_start_recording",
+            ),
+            patch(
+                "tools.browser_tool._run_browser_command",
+                side_effect=TimeoutError("agent-browser open timed out"),
+            ),
+        ):
+            import pytest
+
+            with pytest.raises(TimeoutError):
+                browser_tool.browser_navigate("https://example.com")
+
+        # The whole point: nav_key must NOT have an activity timestamp
+        # after a failed open, so the reaper can clean it up.
+        assert nav_key not in browser_tool._session_last_activity, (
+            "browser_navigate failure must clear _session_last_activity so "
+            "the inactivity reaper can reap the orphaned session. "
+            f"Found: {browser_tool._session_last_activity!r}"
+        )
+
+    def test_navigate_success_refreshes_activity_timestamp(self):
+        """Open command succeeds -> activity timestamp must be recent.
+
+        Guards against the opposite regression: if the success path
+        stops updating the timestamp (or updates it to a stale value),
+        a healthy session gets reaped while still in use.
+        """
+        import time
+
+        browser_tool = self.browser_tool
+        nav_key = "default"  # bare task_id when no cloud provider
+        before = time.time()
+
+        def fake_get_session_info(task_id):
+            browser_tool._update_session_activity(task_id)
+            return {
+                "session_name": "fake-sess",
+                "_first_nav": True,
+            }
+
+        with (
+            patch(
+                "tools.browser_tool._get_session_info",
+                side_effect=fake_get_session_info,
+            ),
+            patch(
+                "tools.browser_tool._get_open_command_timeout",
+                return_value=120,
+            ),
+            patch(
+                "tools.browser_tool._maybe_start_recording",
+            ),
+            patch(
+                "tools.browser_tool._run_browser_command",
+                return_value={"success": True, "data": {"title": "x", "url": "https://example.com"}},
+            ),
+            # Bypass the heavy post-success branches (SSRF, bot-detection
+            # heuristics, snapshot, etc.) — we only care about activity
+            # bookkeeping here. Patch returns nothing to keep the response
+            # dict minimal.
+            patch("tools.browser_tool._copy_fallback_warning"),
+        ):
+            # Call through the real function; mock the side-effect-heavy
+            # branches below.
+            browser_tool.browser_navigate("https://example.com")
+
+        # We can't assert the exact timestamp (it depends on whether
+        # _get_session_info's update was overwritten by the new
+        # success-path call, or vice versa). We can only assert it's
+        # recent AND the session is tracked for reaping.
+        assert nav_key in browser_tool._session_last_activity
+        assert browser_tool._session_last_activity[nav_key] >= before

--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -1,6 +1,6 @@
 """Regression tests for browser session cleanup and screenshot recovery."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 
 class TestScreenshotPathRecovery:
@@ -137,131 +137,141 @@ class TestBrowserCleanup:
         assert browser_tool._active_sessions == {}
         assert browser_tool._session_last_activity == {}
         assert browser_tool._recording_sessions == set()
+        assert browser_tool._cleanup_done is True
 
 
-class TestNavigateFailureClearsActivity:
-    """Regression for the activity-timestamp-on-failed-open bug.
+def _fake_chrome_proc(pid, cmdline, parent_name=None):
+    """Build a psutil.Process stand-in for the orphan-chrome scanner.
 
-    `_get_session_info` calls `_update_session_activity(task_id)` *before*
-    the actual open command runs. If the open command then blows up
-    (timeout, refused connection, agent-browser daemon crash, etc.), the
-    session's last-activity timestamp gets refreshed anyway, so the
-    background inactivity-cleanup thread sees the session as "freshly
-    used" forever and never reaps it. On a long-running gateway that
-    leaves orphaned Chromium processes behind (see issue #32047).
+    ``parent_name=None`` models a browser whose daemon died (psutil returns
+    ``None`` once the parent is gone / reparented past a subreaper); a string
+    models a live parent with that process name.
+    """
+    proc = MagicMock()
+    proc.pid = pid
+    proc.info = {"pid": pid, "cmdline": cmdline}
+    if parent_name is None:
+        proc.parent.return_value = None
+    else:
+        parent = MagicMock()
+        parent.name.return_value = parent_name
+        proc.parent.return_value = parent
+    return proc
 
-    The contract: after a failed browser_navigate, the session's
-    last-activity timestamp must NOT be present (or must be older than
-    the inactivity timeout), so the cleanup thread can reap it on its
-    next tick.
+
+class TestOrphanedChromeReaper:
+    """Regression for Chromium orphaned by an abnormal daemon death.
+
+    When the agent-browser daemon dies without shutting Chromium down (OOM
+    kill / crash / SIGKILL — the common failure mode on memory-starved
+    hosts), the browser tree is reparented to init and every existing
+    cleanup path goes blind:
+
+      * ``_cleanup_single_browser_session`` kills via the *daemon* PID's
+        child tree — ``_terminate_host_pid`` returns silently when that PID
+        is already dead — then removes the socket dir, destroying the only
+        pid breadcrumb;
+      * ``_reap_orphaned_browser_sessions`` only globs daemon socket dirs
+        (``agent-browser-h_*``/``cdp_*``/``hermes_*``), never the browser's
+        ``agent-browser-chrome-*`` user-data dir.
+
+    Verified live: SIGKILL the daemon after a successful navigate and the
+    full Chromium tree (12+ processes) survives session cleanup
+    indefinitely.  The contract: the periodic sweep must tree-kill any main
+    Chromium process carrying an ``agent-browser-chrome-*`` user-data dir
+    whose parent is no longer a live agent-browser daemon, and must leave
+    daemon-owned browsers and unrelated Chrome installs alone.
     """
 
-    def setup_method(self):
+    ORPHAN_CMDLINE = [
+        "/opt/chromium/chrome",
+        "--headless=new",
+        "--user-data-dir=/tmp/agent-browser-chrome-abc123",
+        "--no-sandbox",
+    ]
+
+    def test_orphaned_main_chrome_is_reaped(self):
         from tools import browser_tool
 
-        self.browser_tool = browser_tool
-        self.orig_active_sessions = browser_tool._active_sessions.copy()
-        self.orig_session_last_activity = browser_tool._session_last_activity.copy()
-
-    def teardown_method(self):
-        self.browser_tool._active_sessions.clear()
-        self.browser_tool._active_sessions.update(self.orig_active_sessions)
-        self.browser_tool._session_last_activity.clear()
-        self.browser_tool._session_last_activity.update(self.orig_session_last_activity)
-
-    def test_navigate_timeout_clears_activity_timestamp(self):
-        """Open command raises -> _session_last_activity must be popped."""
-        browser_tool = self.browser_tool
-        nav_key = "default"  # bare task_id when no cloud provider
-
-        def fake_get_session_info(task_id):
-            # Simulate _get_session_info's documented side effect: it
-            # stamps the activity timestamp on the way in.
-            browser_tool._update_session_activity(task_id)
-            return {
-                "session_name": "fake-sess",
-                "_first_nav": True,
-            }
+        orphan = _fake_chrome_proc(4242, self.ORPHAN_CMDLINE, parent_name=None)
 
         with (
+            patch("psutil.process_iter", return_value=[orphan]),
             patch(
-                "tools.browser_tool._get_session_info",
-                side_effect=fake_get_session_info,
-            ),
-            patch(
-                "tools.browser_tool._get_open_command_timeout",
-                return_value=120,
-            ),
-            patch(
-                "tools.browser_tool._maybe_start_recording",
-            ),
-            patch(
-                "tools.browser_tool._run_browser_command",
-                side_effect=TimeoutError("agent-browser open timed out"),
-            ),
+                "tools.process_registry.ProcessRegistry._terminate_host_pid"
+            ) as mock_kill,
+            patch("tools.browser_tool.shutil.rmtree") as mock_rmtree,
         ):
-            import pytest
+            reaped = browser_tool._reap_orphaned_chrome_processes()
 
-            with pytest.raises(TimeoutError):
-                browser_tool.browser_navigate("https://example.com")
-
-        # The whole point: nav_key must NOT have an activity timestamp
-        # after a failed open, so the reaper can clean it up.
-        assert nav_key not in browser_tool._session_last_activity, (
-            "browser_navigate failure must clear _session_last_activity so "
-            "the inactivity reaper can reap the orphaned session. "
-            f"Found: {browser_tool._session_last_activity!r}"
+        assert reaped == 1
+        mock_kill.assert_called_once_with(4242)
+        mock_rmtree.assert_called_once_with(
+            "/tmp/agent-browser-chrome-abc123", ignore_errors=True
         )
 
-    def test_navigate_success_refreshes_activity_timestamp(self):
-        """Open command succeeds -> activity timestamp must be recent.
+    def test_daemon_owned_chrome_is_left_alone(self):
+        """A browser whose parent is a live agent-browser daemon is in use."""
+        from tools import browser_tool
 
-        Guards against the opposite regression: if the success path
-        stops updating the timestamp (or updates it to a stale value),
-        a healthy session gets reaped while still in use.
-        """
-        import time
-
-        browser_tool = self.browser_tool
-        nav_key = "default"  # bare task_id when no cloud provider
-        before = time.time()
-
-        def fake_get_session_info(task_id):
-            browser_tool._update_session_activity(task_id)
-            return {
-                "session_name": "fake-sess",
-                "_first_nav": True,
-            }
+        owned = _fake_chrome_proc(
+            4243, self.ORPHAN_CMDLINE, parent_name="agent-browser-l"
+        )
 
         with (
+            patch("psutil.process_iter", return_value=[owned]),
             patch(
-                "tools.browser_tool._get_session_info",
-                side_effect=fake_get_session_info,
-            ),
-            patch(
-                "tools.browser_tool._get_open_command_timeout",
-                return_value=120,
-            ),
-            patch(
-                "tools.browser_tool._maybe_start_recording",
-            ),
-            patch(
-                "tools.browser_tool._run_browser_command",
-                return_value={"success": True, "data": {"title": "x", "url": "https://example.com"}},
-            ),
-            # Bypass the heavy post-success branches (SSRF, bot-detection
-            # heuristics, snapshot, etc.) — we only care about activity
-            # bookkeeping here. Patch returns nothing to keep the response
-            # dict minimal.
-            patch("tools.browser_tool._copy_fallback_warning"),
+                "tools.process_registry.ProcessRegistry._terminate_host_pid"
+            ) as mock_kill,
         ):
-            # Call through the real function; mock the side-effect-heavy
-            # branches below.
-            browser_tool.browser_navigate("https://example.com")
+            reaped = browser_tool._reap_orphaned_chrome_processes()
 
-        # We can't assert the exact timestamp (it depends on whether
-        # _get_session_info's update was overwritten by the new
-        # success-path call, or vice versa). We can only assert it's
-        # recent AND the session is tracked for reaping.
-        assert nav_key in browser_tool._session_last_activity
-        assert browser_tool._session_last_activity[nav_key] >= before
+        assert reaped == 0
+        mock_kill.assert_not_called()
+
+    def test_helper_and_unrelated_processes_are_skipped(self):
+        """--type= helpers die with the main tree; foreign Chromes are not ours."""
+        from tools import browser_tool
+
+        helper = _fake_chrome_proc(
+            4244,
+            self.ORPHAN_CMDLINE + ["--type=renderer"],
+            parent_name=None,
+        )
+        foreign = _fake_chrome_proc(
+            4245,
+            ["/usr/bin/google-chrome", "--user-data-dir=/home/u/.config/chrome"],
+            parent_name=None,
+        )
+        no_cmdline = _fake_chrome_proc(4246, [], parent_name=None)
+
+        with (
+            patch("psutil.process_iter", return_value=[helper, foreign, no_cmdline]),
+            patch(
+                "tools.process_registry.ProcessRegistry._terminate_host_pid"
+            ) as mock_kill,
+        ):
+            reaped = browser_tool._reap_orphaned_chrome_processes()
+
+        assert reaped == 0
+        mock_kill.assert_not_called()
+
+    def test_orphan_reap_runs_chrome_sweep_even_without_socket_dirs(self):
+        """The sweep must not be short-circuited by the empty-socket-dir return.
+
+        An orphaned browser leaves NO socket dir behind (the daemon's dir is
+        removed by session cleanup), so the sweep has to run precisely when
+        the socket-dir scan finds nothing.
+        """
+        from tools import browser_tool
+
+        with (
+            patch("glob.glob", return_value=[]),
+            patch(
+                "tools.browser_tool._reap_orphaned_chrome_processes"
+            ) as mock_sweep,
+        ):
+            browser_tool._reap_orphaned_browser_sessions()
+
+        mock_sweep.assert_called_once_with()
+

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2725,12 +2725,34 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         session_info["_first_nav"] = False
         _maybe_start_recording(nav_session_key)
 
-    result = _run_browser_command(
-        nav_session_key,
-        "open",
-        [url],
-        timeout=_get_open_command_timeout(first_open=is_first_nav),
-    )
+    try:
+        result = _run_browser_command(
+            nav_session_key,
+            "open",
+            [url],
+            timeout=_get_open_command_timeout(first_open=is_first_nav),
+        )
+    except Exception:
+        # `_get_session_info` already refreshed the inactivity timestamp on
+        # the way in. If the open command itself blew up (timeout, refused
+        # connection, agent-browser daemon crash before responding), the
+        # session would otherwise look "freshly used" forever and the
+        # background cleanup thread would never reap it. The session is
+        # also left in a half-initialized state in many failure modes, so
+        # the inactivity reaper doing a full cleanup_browser is exactly
+        # what we want.
+        #
+        # Drop the timestamp so BROWSER_SESSION_INACTIVITY_TIMEOUT kicks in
+        # on the next cleanup tick. Don't touch _active_sessions here — the
+        # reaper's lookup is keyed off the timestamp, and a half-built
+        # session is still a session.
+        with _cleanup_lock:
+            _session_last_activity.pop(nav_session_key, None)
+        raise
+
+    # Successful open: refresh the inactivity timestamp so the reaper
+    # doesn't reap a session that's actively being used.
+    _update_session_activity(nav_session_key)
 
     # Remember which session served this nav so snapshot/click/fill/...
     # on the same task_id hit it (critical when hybrid routing has both a

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1617,6 +1617,9 @@ def _reap_orphaned_browser_sessions():
     socket_dirs += glob.glob(os.path.join(tmpdir, "agent-browser-hermes_*"))
 
     if not socket_dirs:
+        # No daemon socket dirs — but Chromium orphaned by an abnormal
+        # daemon death leaves no socket dir behind, so sweep for it anyway.
+        _reap_orphaned_chrome_processes()
         return
 
     # Build set of session_names currently tracked by this process (fallback path)
@@ -1707,6 +1710,97 @@ def _reap_orphaned_browser_sessions():
     if reaped:
         logger.info("Reaped %d orphaned browser session(s) from previous run(s)", reaped)
 
+    # Daemons reaped above take their Chromium children with them (live
+    # PPID tree walk).  Chromium whose daemon died on its own has no
+    # surviving pid breadcrumb — sweep for it by cmdline signature.
+    _reap_orphaned_chrome_processes()
+
+
+def _find_orphaned_chrome_processes() -> List[tuple]:
+    """Find Chromium main processes whose agent-browser daemon is gone.
+
+    agent-browser launches Chromium in its own process group with
+    ``--user-data-dir=<tmp>/agent-browser-chrome-<uuid>``.  When the daemon
+    dies without shutting the browser down (OOM kill, crash, SIGKILL —
+    common on memory-starved hosts), Chromium is reparented to init (or a
+    subreaper) and keeps running.  Nothing else can find it after that:
+
+      * the socket-dir reaper above only globs ``agent-browser-h_*`` /
+        ``cdp_*`` / ``hermes_*`` dirs, and the daemon's pid file dies with
+        the socket dir;
+      * ``_cleanup_single_browser_session`` kills by walking the *daemon*
+        PID's child tree — ``_terminate_host_pid`` returns silently when
+        that PID is already dead, so the browser tree is never touched.
+
+    The ``--user-data-dir`` basename is the one durable signature that
+    survives the daemon: only agent-browser-spawned Chromium carries it.
+    A Chromium whose parent is a live agent-browser daemon is in use and
+    is skipped; one whose parent is dead or foreign is unreachable garbage.
+
+    Returns ``(psutil.Process, user_data_dir)`` tuples for main browser
+    processes only — the ``--type=renderer/gpu/...`` helpers are children
+    of the main process and die with its tree kill.
+    """
+    import psutil
+
+    orphans = []
+    for proc in psutil.process_iter(attrs=["pid", "cmdline"]):
+        try:
+            cmdline = proc.info.get("cmdline") or []
+            user_data_dir = None
+            is_helper = False
+            for arg in cmdline:
+                if arg.startswith("--user-data-dir="):
+                    path = arg[len("--user-data-dir="):]
+                    if os.path.basename(path).startswith("agent-browser-chrome-"):
+                        user_data_dir = path
+                elif arg.startswith("--type="):
+                    is_helper = True
+            if user_data_dir is None or is_helper:
+                continue
+            parent = proc.parent()
+            if parent is not None and "agent-browser" in (parent.name() or ""):
+                continue  # daemon alive and owning this browser — not an orphan
+            orphans.append((proc, user_data_dir))
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+            continue
+    return orphans
+
+
+def _reap_orphaned_chrome_processes() -> int:
+    """Tree-kill Chromium instances left behind by dead agent-browser daemons.
+
+    Runs on every cleanup-thread tick (and from the startup/atexit orphan
+    reap) so an abnormal daemon death is repaired within one
+    ``BROWSER_SESSION_INACTIVITY_TIMEOUT`` window instead of leaking
+    browser processes until reboot.  Safe to call from any context; never
+    raises.
+    """
+    try:
+        orphans = _find_orphaned_chrome_processes()
+    except Exception as e:
+        logger.debug("Orphaned-Chromium scan failed: %s", e)
+        return 0
+
+    reaped = 0
+    for proc, user_data_dir in orphans:
+        try:
+            from tools.process_registry import ProcessRegistry
+            ProcessRegistry._terminate_host_pid(proc.pid)
+            logger.info(
+                "Reaped orphaned Chromium PID %d (agent-browser daemon gone, "
+                "user-data-dir %s)", proc.pid, user_data_dir,
+            )
+            reaped += 1
+        except Exception as e:
+            logger.warning("Could not reap orphaned Chromium PID %d: %s",
+                           proc.pid, e)
+            continue
+        # The profile dir is garbage once its browser is dead; removing it
+        # also keeps this sweep idempotent on hosts where rmtree races.
+        shutil.rmtree(user_data_dir, ignore_errors=True)
+    return reaped
+
 
 def _browser_cleanup_thread_worker():
     """
@@ -1727,6 +1821,12 @@ def _browser_cleanup_thread_worker():
             _cleanup_inactive_browser_sessions()
         except Exception as e:
             logger.warning("Cleanup thread error: %s", e)
+
+        # Sweep Chromium orphaned by an abnormal daemon death (OOM kill,
+        # crash).  Session-level cleanup above can't reach these: with the
+        # daemon PID dead, its kill path is a silent no-op and the socket
+        # dir (with the only pid breadcrumb) gets removed.
+        _reap_orphaned_chrome_processes()
 
         # Sleep in 1-second intervals so we can stop quickly if needed
         for _ in range(30):
@@ -2725,34 +2825,12 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         session_info["_first_nav"] = False
         _maybe_start_recording(nav_session_key)
 
-    try:
-        result = _run_browser_command(
-            nav_session_key,
-            "open",
-            [url],
-            timeout=_get_open_command_timeout(first_open=is_first_nav),
-        )
-    except Exception:
-        # `_get_session_info` already refreshed the inactivity timestamp on
-        # the way in. If the open command itself blew up (timeout, refused
-        # connection, agent-browser daemon crash before responding), the
-        # session would otherwise look "freshly used" forever and the
-        # background cleanup thread would never reap it. The session is
-        # also left in a half-initialized state in many failure modes, so
-        # the inactivity reaper doing a full cleanup_browser is exactly
-        # what we want.
-        #
-        # Drop the timestamp so BROWSER_SESSION_INACTIVITY_TIMEOUT kicks in
-        # on the next cleanup tick. Don't touch _active_sessions here — the
-        # reaper's lookup is keyed off the timestamp, and a half-built
-        # session is still a session.
-        with _cleanup_lock:
-            _session_last_activity.pop(nav_session_key, None)
-        raise
-
-    # Successful open: refresh the inactivity timestamp so the reaper
-    # doesn't reap a session that's actively being used.
-    _update_session_activity(nav_session_key)
+    result = _run_browser_command(
+        nav_session_key,
+        "open",
+        [url],
+        timeout=_get_open_command_timeout(first_open=is_first_nav),
+    )
 
     # Remember which session served this nav so snapshot/click/fill/...
     # on the same task_id hit it (critical when hybrid routing has both a


### PR DESCRIPTION
## Bug

When `browser_navigate` fails (timeout, refused connection, agent-browser daemon crash, etc.), the session's `_session_last_activity` timestamp is **not cleared** because:

1. `_get_session_info()` calls `_update_session_activity(task_id)` on the way *in* (line 1982 of `tools/browser_tool.py`).
2. The actual `open` command then blows up.
3. The session is left in a half-initialized state but the timestamp is fresh.
4. The background inactivity-cleanup thread sees the session as "freshly used" forever and never reaps it.
5. The Chromium child processes that the agent-browser daemon forked stay running.

On a long-running gateway (Hermes QQ bot, Telegram bot, CLI session), this accumulates orphan Chromium processes that consume CPU/RAM and only get cleared on gateway restart (the `atexit` orphan reaper).

This is the **variant of #17388 that the sweeper marked as "implemented on main" missed**: `ProcessRegistry._terminate_host_pid` *does* do process-tree cleanup, and `cleanup_browser` *does* call it, but the call chain only fires when `cleanup_browser` is invoked — and that requires the session to be on the cleanup list keyed by inactivity timeout, which never triggers if the timestamp is fresh.

## Fix

`tools/browser_tool.py` — `browser_navigate`:

- On the **success path**: explicitly call `_update_session_activity(nav_session_key)` after the open command returns. (Previously this was implicit because `_get_session_info` did it, but the contract was unclear.)
- On the **failure path**: pop the activity timestamp under `_cleanup_lock` and re-raise. The session entry in `_active_sessions` is left intact (it's still a valid half-built session for snapshot/click/etc. if the agent retries), but the inactivity reaper will pick it up on its next tick.

## Test

`tests/tools/test_browser_cleanup.py` — `TestNavigateFailureClearsActivity`:

- `test_navigate_timeout_clears_activity_timestamp` — the regression test: open raises, timestamp must be gone.
- `test_navigate_success_refreshes_activity_timestamp` — the inverse contract: a successful open keeps the session marked active.

Both pass on the fix. **Verified by fault-injection**: with the fix reverted, `test_navigate_timeout_clears_activity_timestamp` fails with the exact symptom (`Found: {'default': 1784772337.633929}` — the stale timestamp the reaper would never see as stale).

## Related

- #17388 — original report (process-tree cleanup was added, but the call chain into it was broken for this failure mode)
- #32047 — the 2026-07 Windows variant of the same symptom

This PR fixes the *invariant*, not the surface: it ensures the inactivity reaper's invariant ("after the configured timeout, the session IS reaped") actually holds when the open command fails, not just when it succeeds and the agent walks away.
