### PR TITLE
fix(ci): retain delayed and composite-action jobs in review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,9 +166,8 @@ jobs:
   # whatever results are available, and upserts it via the
   # ``<!-- hermes-ci-review-bot -->`` marker.
   #
-  # The poller exits when all non-infra jobs are completed (or on
-  # timeout). ci-timings' review_status is picked up automatically when
-  # its artifact becomes available — the poller downloads and merges it.
+  # When the visible job set goes quiet, the poller waits 10 seconds and polls
+  # once more so downstream jobs created by an aggregate gate get included.
   # ─────────────────────────────────────────────────────────────────────
   comment-live:
     name: CI review comment (live)
@@ -302,8 +301,8 @@ jobs:
   # report with a gantt chart + per-step breakdown. The report is uploaded
   # as an artifact and a markdown summary is written to $GITHUB_STEP_SUMMARY.
   #
-  # The live comment poller picks up ci-timings' completion automatically —
-  # it reads review-status.json from the artifact when the job finishes.
+  # The live comment poller can read the standalone review-status artifact
+  # after the HTML report is uploaded, so its link points straight at that report.
   # ─────────────────────────────────────────────────────────────────────
   ci-timings:
     name: CI timing report
@@ -334,27 +333,46 @@ jobs:
             --baseline ci-timings-baseline.json \
             --output ci-timings-report.html \
             --json-out ci-timings.json \
-            --summary-out ci-timings-summary.md \
-            --review-status-out review-status.json
+            --summary-out ci-timings-summary.md
 
-      - name: Upload HTML report + review status
+      - name: Upload HTML report
         # Advisory report — artifact-service blips must not fail the job.
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        id: ci-timings-artifact
+        id: ci-timings-html
         with:
           name: ci-timings-report
-          path: |
-            ci-timings-report.html
-            review-status.json
+          path: ci-timings-report.html
+          retention-days: 14
+
+      - name: Build linked review status
+        if: hashFiles('ci-timings.json') != ''
+        env:
+          CI_TIMINGS_REPORT_URL: ${{ steps.ci-timings-html.outputs.artifact-url }}
+        run: |
+          python3 scripts/ci/timings_report.py \
+            --from-json ci-timings.json \
+            --baseline ci-timings-baseline.json \
+            --review-status-out review-status.json \
+            --review-status-only
+
+      - name: Upload review status
+        if: hashFiles('review-status.json') != ''
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ci-timings-review-status
+          path: review-status.json
           retention-days: 14
 
       - name: Output summary
         env:
-          REPORT_URL: ${{ steps.ci-timings-artifact.outputs.artifact-url}}
+          REPORT_URL: ${{ steps.ci-timings-html.outputs.artifact-url}}
         run: |
-          echo "# CI Timing report" >> "$GITHUB_STEP_SUMMARY"
-          echo "[View the full interactive report]($REPORT_URL)" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "# CI Timing report"
+            echo "[View the full interactive report]($REPORT_URL)"
+          } >> "$GITHUB_STEP_SUMMARY"
           cat ci-timings-summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Save baseline cache (main only)

--- a/scripts/ci/live_comment.py
+++ b/scripts/ci/live_comment.py
@@ -25,7 +25,8 @@ Architecture:
     the status objects into the review statuses array.
 
   - :func:`run` — the polling loop. Calls the API, classifies, assembles,
-    upserts, sleeps, repeats. Exits when all jobs are completed.
+    upserts, sleeps, repeats. Before its final exit, it gives downstream jobs
+    a short grace period to appear.
 
 The orchestrator job names (detect, all-checks-pass, comment-live, etc.)
 are excluded from the comment — they're infrastructure, not review signal.
@@ -70,7 +71,6 @@ _CONCLUSION_MAP = {
     "timed_out": "failure",
     "action_required": "skipped",
 }
-
 
 def classify_jobs(api_jobs: list[dict]) -> tuple[dict[str, str], list[str], dict[str, str]]:
     """Classify raw API job dicts into completed + pending + job_urls.
@@ -197,7 +197,7 @@ def collect_run_jobs(token: str, repo: str, run_id: str) -> list[dict]:
     # queued jobs so the poller knows they're still running.
     for job in orch_jobs:
         steps = job.get("steps") or []
-        if any(s.get("name", "").startswith("Run ./.github/") for s in steps):
+        if any(s.get("name", "").startswith("Run ./.github/workflows/") for s in steps):
             continue
         all_jobs.append(job)
 
@@ -383,6 +383,7 @@ def run(
     asm = _import_assembler()
     start = time.time()
     last_body = ""
+    quiet_grace_used = False
 
     # Parse the base statuses once (from review-labels, lockfile-diff, etc.)
     try:
@@ -411,7 +412,7 @@ def run(
 
         # Try to fetch ci-timings artifact statuses (may not exist yet).
         artifact_statuses = _fetch_artifact_statuses(
-            token, repo, run_id, "ci-timings-report",
+            token, repo, run_id, "ci-timings-review-status",
         )
         if artifact_statuses:
             print(f"  Found ci-timings artifact with {len(artifact_statuses)} status entries")
@@ -440,6 +441,12 @@ def run(
         else:
             print("  No change since last poll.")
 
+        if not pending and not quiet_grace_used:
+            quiet_grace_used = True
+            print("  No visible jobs pending — waiting 10s for downstream jobs to appear.")
+            time.sleep(10)
+            continue
+
         if not pending:
             # Check if any dependency failed. If so, exit non-zero so the
             # run shows as failed — this lets ``gh run rerun --failed``
@@ -452,6 +459,7 @@ def run(
             print("  All jobs completed — done.")
             break
 
+        quiet_grace_used = False
         time.sleep(interval)
 
     return 0

--- a/scripts/ci/timings_report.py
+++ b/scripts/ci/timings_report.py
@@ -234,7 +234,8 @@ def collect_timings(token: str, repo: str, run_id: str, head_sha: str) -> dict:
     """Collect job/step timings from the GitHub API.
 
     1. Get orchestrator run's direct jobs (detect, all-checks-pass, etc.).
-       Skip workflow-call placeholder jobs (step name starts with "Run ./.github/").
+       Skip workflow-call placeholder jobs (step name starts with
+       "Run ./.github/workflows/").
     2. Find sub-workflow runs via head_sha + event=workflow_call.
     3. Get each sub-workflow run's jobs with full step timing.
     """
@@ -251,7 +252,7 @@ def collect_timings(token: str, repo: str, run_id: str, head_sha: str) -> dict:
     direct = []
     for job in orch_jobs:
         steps = job.get("steps") or []
-        if any(s.get("name", "").startswith("Run ./.github/") for s in steps):
+        if any(s.get("name", "").startswith("Run ./.github/workflows/") for s in steps):
             continue  # workflow-call placeholder
         if job.get("status") in ("in_progress", "queued"):
             continue  # skip self / unfinished
@@ -998,6 +999,8 @@ def main():
                         help="Markdown summary output path (default: ci-timings-summary.md)")
     parser.add_argument("--review-status-out", default="",
                         help="If set, write a review-status JSON for the unified PR comment.")
+    parser.add_argument("--review-status-only", action="store_true",
+                        help="Write review status from existing timings without regenerating the report.")
     args = parser.parse_args()
 
     # Collect or load timings
@@ -1043,6 +1046,16 @@ def main():
         print(f"Loaded baseline from {args.baseline}")
     else:
         print(f"No baseline file at {args.baseline} — generating current-only report")
+
+    if args.review_status_only:
+        if not args.review_status_out:
+            parser.error("--review-status-only requires --review-status-out")
+        report_url = os.environ.get("CI_TIMINGS_REPORT_URL", "")
+        statuses = generate_review_status(timings, baseline, report_url)
+        with open(args.review_status_out, "w", encoding="utf-8") as f:
+            f.write(f"review_status={json.dumps(statuses)}\n")
+        print(f"Wrote review status to {args.review_status_out}")
+        return
 
     # Generate HTML
     html = generate_html(timings, baseline)


### PR DESCRIPTION
## What does this PR do?

Fixes two gaps in the live CI review comment and timing report:

- The comment poller now waits 10 seconds and polls once more when its visible job set drains, allowing downstream jobs created by aggregate gates to appear.
- The job collectors now distinguish reusable-workflow placeholders (`Run ./.github/workflows/...`) from normal local composite actions. This keeps the JS/TS Typecheck & Test jobs—whose retry step is `Run ./.github/actions/retry`—in both the live comment and timing report.
- The HTML timing report and its review-status payload are uploaded as separate single-file artifacts. The status payload is generated after HTML upload, so its URL points directly to the report.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `.github/workflows/ci.yml`: split the timing HTML and review-status uploads; generate the link-bearing status after the HTML artifact upload.
- `scripts/ci/live_comment.py`: retain composite-action jobs and perform one 10-second final grace poll.
- `scripts/ci/timings_report.py`: retain composite-action jobs and add review-status-only generation from collected timing JSON.

## How to Test

1. Run `HERMES_PYTHON=<Nix dev-shell Python> scripts/run_tests.sh tests/ci/test_live_comment.py tests/ci/test_timings_report.py`.
2. Run `actionlint .github/workflows/ci.yml`.
3. Replay PR #69699's Actions job payload through the narrowed placeholder rule; it retains all seven `JS & TS checks / Typecheck & Test` jobs, including `apps/desktop`.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
28 passed, 0 failed
actionlint .github/workflows/ci.yml: passed
python3 -m py_compile scripts/ci/live_comment.py scripts/ci/timings_report.py: passed
git diff --check: passed
```
