### PR TITLE
feat(mcp-catalog): add Somvia Apple Health MCP

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -105,12 +105,15 @@ class ToolsSpec:
     """Manifest-side tool-selection hints.
 
     Drives the pre-checked state of the install-time tool checklist, and acts
-    as the fallback selection when probe fails. See install_entry() flow.
+    as the fallback selection when probe fails. An explicitly declared list
+    also keeps the confirmed selection pinned in ``tools.include`` so tools
+    added by the server later remain opt-in. See install_entry() flow.
     """
 
     # If declared, these tool names are pre-checked in the checklist (or
-    # applied directly when probe fails). If None, all probed tools are
-    # pre-checked (or no filter is written when probe fails).
+    # applied directly when probe fails), and the confirmed selection remains
+    # an explicit include list. If None, all probed tools are pre-checked (or
+    # no filter is written when probe fails).
     default_enabled: Optional[List[str]] = None
 
 
@@ -582,7 +585,10 @@ def _apply_tool_selection(
           1. *prior_selection* (reinstall: preserve what the user had)
           2. manifest's ``tools.default_enabled``
           3. all tools (default)
-      - All-on selection clears any filter (no ``tools.include`` written).
+      - When the manifest declares ``tools.default_enabled``, the confirmed
+        selection remains an explicit ``tools.include`` list, even if all
+        currently probed tools are selected. New server tools stay opt-in.
+      - Otherwise, an all-on selection clears any filter.
       - Sub-selection writes ``tools.include``.
 
     Probe-fail path:
@@ -597,7 +603,7 @@ def _apply_tool_selection(
     # Probe failure path
     if probed is None:
         manifest_default = entry.tools.default_enabled
-        if manifest_default:
+        if manifest_default is not None:
             _write_tools_include(entry.name, manifest_default)
             print(color(
                 f"  Couldn\'t probe server. Applied manifest default "
@@ -626,9 +632,9 @@ def _apply_tool_selection(
     tool_names = [t[0] for t in probed]
 
     # Build the pre-checked set in priority order
-    if prior_selection:
+    if prior_selection is not None:
         pre_set = {n for n in prior_selection if n in tool_names}
-    elif entry.tools.default_enabled:
+    elif entry.tools.default_enabled is not None:
         pre_set = {n for n in entry.tools.default_enabled if n in tool_names}
     else:
         pre_set = set(tool_names)
@@ -642,7 +648,7 @@ def _apply_tool_selection(
         if prior_selection is not None:
             include = [n for n in prior_selection if n in tool_names]
             _write_tools_include(entry.name, include)
-        elif entry.tools.default_enabled:
+        elif entry.tools.default_enabled is not None:
             include = [n for n in entry.tools.default_enabled if n in tool_names]
             _write_tools_include(entry.name, include)
         else:
@@ -678,7 +684,12 @@ def _apply_tool_selection(
         ))
         return
 
-    if len(chosen_indices) == len(probed):
+    chosen_names = [tool_names[i] for i in sorted(chosen_indices)]
+
+    if (
+        len(chosen_indices) == len(probed)
+        and entry.tools.default_enabled is None
+    ):
         # Everything selected — clear filter for the cleanest config shape.
         # NOTE: this means any tools the server adds later (e.g. a future MCP
         # version) will also be auto-enabled. To pin to the current set,
@@ -692,12 +703,18 @@ def _apply_tool_selection(
         ))
         return
 
-    chosen_names = [tool_names[i] for i in sorted(chosen_indices)]
     _write_tools_include(entry.name, chosen_names)
-    print(color(
-        f"  ✓ {len(chosen_names)}/{len(probed)} tools enabled.",
-        Colors.GREEN,
-    ))
+    if len(chosen_indices) == len(probed):
+        print(color(
+            f"  ✓ All {len(probed)} tools enabled and pinned to the current "
+            "set (new server tools remain opt-in).",
+            Colors.GREEN,
+        ))
+    else:
+        print(color(
+            f"  ✓ {len(chosen_names)}/{len(probed)} tools enabled.",
+            Colors.GREEN,
+        ))
 
 
 def install_entry(entry: CatalogEntry, *, enable: bool = True) -> None:

--- a/optional-mcps/somvia/manifest.yaml
+++ b/optional-mcps/somvia/manifest.yaml
@@ -1,0 +1,53 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: somvia
+description: Query selected Apple Health data, workouts, sleep, and time series through a read-only remote MCP server.
+source: https://somvia.app/hermes-apple-health
+
+# Somvia is a hosted Streamable HTTP MCP server. Its iOS app handles HealthKit
+# permissions and syncs only the categories and history window the user chose.
+# The MCP surface currently contains eight read-only health_* tools.
+transport:
+  type: http
+  url: https://somvia.app/mcp
+
+# The app issues a private som_ token for unattended agents. env_var identifies
+# the value used in the Bearer header while Hermes keeps the token in
+# ~/.hermes/.env rather than writing the secret into config.yaml.
+auth:
+  type: api_key
+  env_var: SOMVIA_ACCESS_TOKEN
+  env:
+    - name: SOMVIA_ACCESS_TOKEN
+      prompt: "Somvia access token (starts with som_; copy it from the app's Connect screen)"
+      required: true
+      secret: true
+
+# Keep new server tools opt-in until this manifest is reviewed again. Every
+# tool below is annotated read-only by the server.
+tools:
+  default_enabled:
+    - health_connection_status
+    - health_list_metric_types
+    - health_get_daily_summary
+    - health_get_metric_stats
+    - health_list_workouts
+    - health_get_workout
+    - health_get_workout_series
+    - health_get_sleep_stages
+
+post_install: |
+  Somvia requires an iPhone, Apple Health, and an active Somvia Pro plan.
+  Install the app from https://apps.apple.com/app/id6786936154, sign in with
+  Apple, choose the Health categories and history window you want, and let the
+  first sync finish. Then open the app's Connect screen and paste the private
+  som_ token when Hermes prompts for it.
+
+  Start a new Hermes session to load the Somvia tools. A useful first prompt is:
+    Use Somvia to summarize my sleep and resting heart rate for the last 7 days.
+
+  Treat the token like a password. If it is exposed, refresh it in Somvia
+  Settings and update Hermes; the previous token stops working. Deleting the
+  Somvia account deletes synced Health data and invalidates its access tokens.

--- a/optional-mcps/somvia/manifest.yaml
+++ b/optional-mcps/somvia/manifest.yaml
@@ -13,17 +13,12 @@ transport:
   type: http
   url: https://somvia.app/mcp
 
-# The app issues a private som_ token for unattended agents. env_var identifies
-# the value used in the Bearer header while Hermes keeps the token in
-# ~/.hermes/.env rather than writing the secret into config.yaml.
+# The Catalog uses native MCP OAuth so interactive Hermes clients can complete
+# browser authentication without handling a long-lived token. Somvia also
+# accepts an app-issued som_ Bearer token for manual headless/VPS setups; both
+# auth paths reach the same read-only tools.
 auth:
-  type: api_key
-  env_var: SOMVIA_ACCESS_TOKEN
-  env:
-    - name: SOMVIA_ACCESS_TOKEN
-      prompt: "Somvia access token (starts with som_; copy it from the app's Connect screen)"
-      required: true
-      secret: true
+  type: oauth
 
 # Keep new server tools opt-in until this manifest is reviewed again. Every
 # tool below is annotated read-only by the server.
@@ -42,12 +37,15 @@ post_install: |
   Somvia requires an iPhone, Apple Health, and an active Somvia Pro plan.
   Install the app from https://apps.apple.com/app/id6786936154, sign in with
   Apple, choose the Health categories and history window you want, and let the
-  first sync finish. Then open the app's Connect screen and paste the private
-  som_ token when Hermes prompts for it.
+  first sync finish.
 
-  Start a new Hermes session to load the Somvia tools. A useful first prompt is:
+  Hermes will open a browser on first connection. Sign in with the same Apple
+  account used in Somvia, then start a new Hermes session to load the tools.
+  A useful first prompt is:
     Use Somvia to summarize my sleep and resting heart rate for the last 7 days.
 
-  Treat the token like a password. If it is exposed, refresh it in Somvia
-  Settings and update Hermes; the previous token stops working. Deleting the
-  Somvia account deletes synced Health data and invalidates its access tokens.
+  For a headless or unattended host, use Somvia's app-issued som_ Bearer token
+  with the manual configuration at https://somvia.app/hermes-apple-health.
+  Treat that token like a password; refresh it in Somvia Settings if exposed.
+  Deleting the Somvia account deletes synced Health data and invalidates both
+  OAuth access and app-issued tokens.

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -264,6 +264,57 @@ class TestToolSelection:
         """Return a list of (tool_name, description) tuples for mocking."""
         return [(n, f"description of {n}") for n in names]
 
+    def test_successful_probe_pins_explicit_defaults_when_all_selected(
+        self, catalog_dir, monkeypatch
+    ):
+        body = _basic_manifest(
+            tools={"default_enabled": ["alpha", "beta"]},
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        import hermes_cli.mcp_catalog as mc
+        import sys as _sys
+
+        monkeypatch.setattr(
+            mc, "_probe_tools", lambda name: self._make_probed("alpha", "beta")
+        )
+        monkeypatch.setattr(_sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(
+            "hermes_cli.curses_ui.curses_checklist",
+            lambda title, labels, pre_selected: {0, 1},
+        )
+
+        from hermes_cli.config import load_config
+
+        mc.install_entry(_entry("demo"), enable=True)
+
+        server = load_config()["mcp_servers"]["demo"]
+        assert server["tools"]["include"] == ["alpha", "beta"]
+
+    def test_successful_probe_all_selected_without_defaults_keeps_no_filter(
+        self, catalog_dir, monkeypatch
+    ):
+        _write_manifest(catalog_dir, "demo", _basic_manifest())
+
+        import hermes_cli.mcp_catalog as mc
+        import sys as _sys
+
+        monkeypatch.setattr(
+            mc, "_probe_tools", lambda name: self._make_probed("alpha", "beta")
+        )
+        monkeypatch.setattr(_sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(
+            "hermes_cli.curses_ui.curses_checklist",
+            lambda title, labels, pre_selected: {0, 1},
+        )
+
+        from hermes_cli.config import load_config
+
+        mc.install_entry(_entry("demo"), enable=True)
+
+        server = load_config()["mcp_servers"]["demo"]
+        assert "tools" not in server
+
 
     def test_probe_fail_with_default_applies_directly(self, catalog_dir):
         body = _basic_manifest(

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -105,8 +105,11 @@ The pre-checked rows come from:
 3. **Everything** if neither applies
 
 Submit the checklist with ENTER. Only the checked tools end up in
-`mcp_servers.<name>.tools.include`. If you select everything, no filter is
-written (cleanest config shape, identical behavior).
+`mcp_servers.<name>.tools.include`. When a catalog manifest declares
+`tools.default_enabled`, Hermes retains that explicit include list even if it
+contains every tool currently reported by the server, so newly added server
+tools remain opt-in. For entries without manifest defaults, selecting everything
+still writes no filter.
 
 **If the probe fails** (server unreachable, OAuth not yet completed,
 backing service not running), the install still succeeds: the manifest's


### PR DESCRIPTION
## What does this PR do?

Adds Somvia to the Nous-reviewed MCP Catalog so Hermes users can discover and install its hosted Apple Health MCP from the built-in picker.

Somvia is a hosted, closed-source service: its iOS app handles HealthKit permission and sync, while `https://somvia.app/mcp` exposes eight read-only `health_*` tools for daily metrics, sleep stages, workout summaries, splits, and bounded time series. The manifest discloses the iPhone and Pro prerequisites, pins the current reviewed tool set, and documents both supported authentication paths.

This PR also tightens the existing Catalog installer contract for manifests that explicitly declare `tools.default_enabled`: after a successful probe, Hermes now retains the confirmed selection in `tools.include` even when it equals every tool currently reported by the server. That keeps tools added by the server later opt-in. Entries without manifest defaults retain the existing all-selected/no-filter behavior.

### Dual auth by design

Somvia's `/mcp` endpoint supports both:

- native MCP OAuth 2.1 for interactive clients; and
- an app-issued `som_` Bearer token for headless, VPS, or unattended agents.

A version 1 Hermes Catalog manifest selects one `auth.type` for its install flow rather than presenting an auth-method chooser. This entry uses `auth.type: oauth`, which current Hermes `main` already supports. On first connection Hermes can discover Somvia's authorization server, register a client, and open the browser flow.

Bearer support remains available through Hermes' existing manual MCP configuration with `Authorization: Bearer ${SOMVIA_ACCESS_TOKEN}`. The manifest's `post_install` links the headless guide. This PR does not depend on the separate Catalog API-key header changes in #59586 or #67682.

## Related Issue

No separate Somvia issue exists; I searched open and closed issues and PRs before submitting.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `optional-mcps/somvia/manifest.yaml`
  - registers the hosted Streamable HTTP endpoint;
  - uses native MCP OAuth for the built-in Catalog flow;
  - retains the app-issued Bearer path for manual headless configuration;
  - defaults to the eight currently exposed read-only tools;
  - documents setup, subscription, first-sync, rotation, and deletion behavior.
- `hermes_cli/mcp_catalog.py`
  - treats an explicitly declared `tools.default_enabled` list as a persistent opt-in boundary;
  - retains the current no-filter behavior when a manifest does not declare defaults.
- `tests/hermes_cli/test_mcp_catalog.py`
  - covers a successful interactive probe where all declared defaults are selected;
  - protects the existing no-default compatibility path.
- `website/docs/user-guide/features/mcp.md`
  - documents when an all-selected install remains pinned versus filter-free.

## How to Test

1. Run the focused Catalog suite:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py -q
   ```

   Local result on current `main`: **20 passed, 0 failed**.

2. Parse the shipped manifest with current `main`. `_build_server_config()` returns:

   ```python
   {"url": "https://somvia.app/mcp", "auth": "oauth"}
   ```

3. Verify OAuth discovery:

   - `GET https://somvia.app/.well-known/oauth-protected-resource/mcp`
     returns the protected resource and `authorization_servers: ["https://somvia.app"]`.
   - `GET https://somvia.app/.well-known/oauth-authorization-server`
     advertises `/authorize`, `/token`, `/register`, PKCE, authorization-code, and refresh-token support.

4. Run:

   ```bash
   hermes mcp install somvia
   ```

   Complete Sign in with Apple in the browser, restart the Hermes session, then call `health_connection_status` plus one data-returning read-only tool. Confirm that `mcp_servers.somvia.tools.include` contains the eight reviewed tools after accepting the pre-checked list.

5. For a headless verification, follow https://somvia.app/hermes-apple-health and configure the app-issued `som_` token as an explicit Bearer header.

The Somvia maintainer has verified the service's OAuth path with Claude and the manual Bearer path with Hermes. The Catalog OAuth config path is covered by Hermes' existing Catalog tests; this PR adds the successful-probe regression requested in review.

Public boundary checks performed while preparing this PR:

- `https://somvia.app/hermes-apple-health` → `200`
- `https://apps.apple.com/app/id6786936154` → `200`
- OAuth protected-resource metadata → `200 application/json`
- OAuth authorization-server metadata → `200 application/json`
- unauthenticated MCP `initialize` POST → `401 application/json`

No access token or personal health data is included in this PR or its test output.

## Security and privacy notes

- Every catalog-default tool is annotated read-only by the MCP server.
- The iOS app syncs only the Health categories and history window selected by the user.
- Interactive Catalog users authenticate through OAuth; Hermes manages the resulting credentials.
- For the optional headless path, the plaintext `som_` token is shown to the user for agent setup; Somvia stores only its SHA-256 hash server-side.
- Refreshing the app-issued token invalidates the previous token. Deleting the Somvia account deletes synced Health data and invalidates OAuth access and app-issued tokens.
- Somvia is not a medical device and does not provide diagnosis or treatment.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commits follow Conventional Commits.
- [x] I searched existing issues and PRs before submitting.
- [x] The PR contains the focused manifest plus the minimal installer semantics, tests, and docs required to preserve its reviewed tool boundary.
- [x] The focused Catalog suite passes: 20/20.
- [x] Added successful-probe regression coverage and protected the existing no-default behavior.
- [x] Tested on macOS 26.4.1; the manifest is platform-neutral remote HTTP configuration.

### Documentation & Housekeeping

- [x] Setup guidance is included in `post_install` and the linked public guide.
- [x] Catalog tool-selection semantics are documented in `website/docs/user-guide/features/mcp.md`.
- [x] `cli-config.yaml.example` — N/A; no config key was added or changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; contributor workflow is unchanged.
- [x] Cross-platform impact considered — remote URL, native MCP OAuth, optional manual Bearer header, and platform-neutral config persistence only.
- [x] Tool descriptions/schemas — N/A; this PR does not change the Somvia MCP tool schemas.

Prepared with Codex assistance. The manifest, live OAuth metadata, public boundaries, Catalog semantics, and focused tests were reviewed during preparation; the Somvia maintainer verified Claude OAuth and Hermes Bearer connectivity.
