### PR TITLE
fix(delegate): prevent fabricated results after background dispatch

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3560,16 +3560,24 @@ def delegate_task(
         if dispatch.get("status") == "dispatched":
             n = len(_goals)
             note = (
-                "Subagent is running in the background. You and the user can "
-                "keep working; its full result re-enters the conversation as a "
-                "new message when it finishes. Do not wait or poll — just "
-                "continue."
+                "The subagent is now running in the BACKGROUND. Its result is "
+                "NOT available to you yet — it re-enters the conversation as a "
+                "separate follow-up message when it finishes. You therefore have "
+                "NO result, output, or status for this task right now: do NOT "
+                "report, summarize, quote, or invent any outcome for it, and do "
+                "not claim it is done. Do not wait or poll. If you have other "
+                "independent work this turn, do it; otherwise tell the user "
+                "briefly that you've delegated it and END your turn. You will "
+                "report the real result only after its follow-up message arrives."
                 if n == 1 else
-                f"{n} subagents are running in parallel in the background. You "
-                f"and the user can keep working; they wait on each other and "
-                f"their consolidated results re-enter the conversation as a "
-                f"single message once ALL of them finish. Do not wait or poll "
-                f"— just continue."
+                f"{n} subagents are now running in parallel in the BACKGROUND. "
+                f"Their consolidated results are NOT available to you yet — they "
+                f"re-enter the conversation as a single follow-up message once "
+                f"ALL finish. You have NO results for these tasks right now: do "
+                f"NOT report, summarize, or invent any outcome, and do not claim "
+                f"they are done. Do not wait or poll. Do any other independent "
+                f"work this turn, or tell the user you've delegated it and END "
+                f"your turn. Report real results only after the follow-up arrives."
             )
             payload = {
                 "status": "dispatched",
@@ -4060,7 +4068,7 @@ DELEGATE_TASK_SCHEMA = {
                     "delegations run in the background automatically — you do "
                     "not need to (and cannot) opt in or out. A single result or "
                     "consolidated batch result re-enters the conversation when "
-                    "the work finishes; just continue working in the meantime. "
+                    "the work finishes; do not report or invent it before then. "
                     "Setting this has no effect; the parameter remains only for "
                     "backward compatibility."
                 ),


### PR DESCRIPTION
## What does this PR do?

Weak local models fabricate a result right after they delegate a task to run in the background. The dispatch guidance tells the model to "just continue," which they read as "produce your final answer now." With no result yet for the delegated task, they invent one. A local model here reported a live counter value for a stack whose sub-agent had not finished writing the files and which never ran.

This corrects the guidance in every model-facing place that carries it, so it states the result is not available yet and must not be reported or invented before the async follow-up arrives.

## Related Issue

Fixes #69776.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

All in `tools/delegate_tool.py`. Model-facing text only. No code paths, control flow, or return shapes change.

- The background-dispatch `note` (single and batch). It now states the result is not available yet, forbids reporting or inventing any outcome, and tells the model to do other independent work or end the turn.
- The `delegate_task` tool description, which sits in the model's context every turn. The line "just continue with other work after dispatching" now says the call returns with no result and the result must not be reported before its follow-up.
- The deprecated `background` param description. "just continue working in the meantime" becomes "do not report or invent it before then."

The note fires only on the background path (`dispatch.get("status") == "dispatched"`). The synchronous fallbacks (stateless channel, pool-at-capacity) return the real result inline with their own note and are left alone.

## How to Test

1. Run a local model. Force a delegation: "Use `delegate_task` to have a sub-agent write ~/x/hello.py that prints hello, then report when done."
2. Read the parent's message right after dispatch, before the follow-up arrives. Before this change it states a result that does not exist. After, it says the sub-agent was dispatched, ends the turn, and the real result arrives in the follow-up.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(delegate):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the seven delegation suites (all pass); I did not run the full suite, which has pre-existing unrelated failures on `main`
- [ ] I've added tests for my changes — this is a text-only prompt-guidance change; it is verified manually and against the existing delegation suites (no test asserts the exact strings)
- [x] I've tested on my platform: Fedora Linux 44, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no behavior or API change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (none)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (text only)

Tested on: Fedora Linux 44, Python 3.11.15, Hermes v0.18.2.
