### PR TITLE
fix(kanban): enforce terminal handoff contract

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2115,18 +2115,24 @@ def _cmd_block(args: argparse.Namespace) -> int:
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
-            if reason:
-                kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
-            if not kb.block_task(
-                conn,
-                tid,
-                reason=reason,
-                kind=kind,
-                expected_run_id=_worker_run_id_for(tid),
-            ):
+            try:
+                ok = kb.block_task(
+                    conn,
+                    tid,
+                    reason=reason,
+                    kind=kind,
+                    expected_run_id=_worker_run_id_for(tid),
+                )
+            except kb.ReviewHandoffBlockError as exc:
+                failed.append(tid)
+                print(str(exc), file=sys.stderr)
+                continue
+            if not ok:
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
             else:
+                if reason:
+                    kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
                 # Report where the task actually landed — dependency blocks go
                 # to todo, and a tripped unblock-loop breaker routes to triage.
                 landed = kb.get_task(conn, tid)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -124,6 +124,84 @@ VALID_INITIAL_STATUSES = {"running", "blocked"}
 # ``None`` = legacy/un-typed block (treated as a generic human blocker).
 VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 
+_REVIEW_HANDOFF_KIND_TOKENS = {
+    "review-required",
+    "review_required",
+    "review required",
+    "review-only",
+    "review_only",
+    "needs-review",
+    "needs_review",
+    "needs review",
+}
+
+_REVIEW_HANDOFF_REASON_RE = re.compile(
+    r"\b("
+    r"review[-_ ]?required|"
+    r"review[-_ ]?only|"
+    r"needs[-_ ]?review|"
+    r"ready[-_ ]?for[-_ ]?review|"
+    r"awaiting[-_ ]?review|"
+    r"qa[-_ ]?review|"
+    r"eve[-_ ]?review"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+class ReviewHandoffBlockError(ValueError):
+    """Raised when a normal review handoff is attempted as a blocker."""
+
+    code = "review_handoff_not_blocker"
+
+    def __init__(self, *, task_id: str, reason: Optional[str], kind: Optional[str]):
+        self.task_id = task_id
+        self.reason = reason
+        self.kind = kind
+        super().__init__(review_handoff_block_message(task_id=task_id))
+
+
+def is_review_handoff_block(reason: Optional[str], kind: Optional[str] = None) -> bool:
+    """Return True for normal review/QA handoff language, not real blockers."""
+
+    kind_text = (kind or "").strip().casefold().replace("_", "-")
+    if kind_text in {token.replace("_", "-") for token in _REVIEW_HANDOFF_KIND_TOKENS}:
+        return True
+    reason_text = (reason or "").strip()
+    if not reason_text:
+        return False
+    return bool(_REVIEW_HANDOFF_REASON_RE.search(reason_text))
+
+
+def review_handoff_block_instruction(task_id: str) -> dict[str, Any]:
+    """Structured recovery instruction for rejected review-handoff blocks."""
+
+    return {
+        "code": ReviewHandoffBlockError.code,
+        "task_id": task_id,
+        "state_mutated": False,
+        "instruction": (
+            "Normal review-required/QA handoff is not a blocker. Create or "
+            "recover the exact artifact-bound successor first (use an "
+            "idempotency key derived from immutable artifact evidence), verify "
+            "the successor task id and status, then complete the producer with "
+            "structured artifact/test/successor/dispatch facts. If dispatch "
+            "capacity is unavailable, leave the successor Ready/Todo with a "
+            "capacity receipt; do not block the producer merely because review "
+            "is queued."
+        ),
+        "required_actions": [
+            "create_or_recover_artifact_bound_successor",
+            "verify_successor_id_and_status",
+            "complete_producer_with_structured_handoff",
+        ],
+    }
+
+
+def review_handoff_block_message(*, task_id: str) -> str:
+    payload = review_handoff_block_instruction(task_id)
+    return f"{payload['code']}: {payload['instruction']}"
+
 # After a task has been blocked, unblocked, and re-blocked this many times for
 # the same (truly-blocked) reason, the unblock-loop breaker stops trusting the
 # unblocker (usually a cron) and routes the task to ``triage`` instead of back
@@ -5242,6 +5320,20 @@ def block_task(
     Returns True on any successful transition (to ``blocked``, ``todo``, or
     ``triage``), False when the task wasn't in a blockable state.
     """
+    if is_review_handoff_block(reason, kind):
+        with write_txn(conn):
+            _append_event(
+                conn,
+                task_id,
+                "block_rejected_review_handoff",
+                {
+                    "reason": reason,
+                    "kind": kind,
+                    "contract": review_handoff_block_instruction(task_id),
+                },
+            )
+        raise ReviewHandoffBlockError(task_id=task_id, reason=reason, kind=kind)
+
     if kind is not None and kind not in VALID_BLOCK_KINDS:
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -192,6 +192,88 @@ def test_invalid_kind_rejected(kanban_home: Path) -> None:
             kb.block_task(conn, tid, reason="x", kind="bogus")
 
 
+def test_review_required_block_rejected_without_task_state_mutation(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        before = kb.get_task(conn, tid)
+        assert before is not None
+
+        with pytest.raises(kb.ReviewHandoffBlockError) as exc:
+            kb.block_task(
+                conn,
+                tid,
+                reason="review-required: implementation complete",
+                kind="needs_input",
+                expected_run_id=before.current_run_id,
+            )
+
+        after = kb.get_task(conn, tid)
+        assert after is not None
+        assert exc.value.task_id == tid
+        assert after.status == before.status == "running"
+        assert after.current_run_id == before.current_run_id
+        assert after.block_kind == before.block_kind
+        assert after.block_recurrences == before.block_recurrences
+
+
+def test_review_kind_alias_rejected_before_invalid_kind_error(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+
+        with pytest.raises(kb.ReviewHandoffBlockError):
+            kb.block_task(conn, tid, reason="done", kind="review_required")
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "running"
+
+
+def test_producer_handoff_successor_is_idempotent_and_not_parent_suppressed(
+    kanban_home: Path,
+) -> None:
+    with kb.connect_closing() as conn:
+        producer = _running_task(conn, title="producer")
+        key = "review:artifact:sha256:abc123"
+
+        successor_1 = kb.create_task(
+            conn,
+            title="EVE review exact artifact abc123",
+            assignee="eve",
+            body="Review immutable artifact sha256:abc123 from producer.",
+            idempotency_key=key,
+        )
+        successor_2 = kb.create_task(
+            conn,
+            title="duplicate EVE review exact artifact abc123",
+            assignee="eve",
+            idempotency_key=key,
+        )
+        assert successor_2 == successor_1
+
+        successor = kb.get_task(conn, successor_1)
+        assert successor is not None
+        assert successor.status == "ready"
+
+        assert kb.complete_task(
+            conn,
+            producer,
+            summary="Producer complete; exact artifact successor queued.",
+            metadata={
+                "artifact_sha256": "abc123",
+                "successor_task_id": successor_1,
+                "successor_status": successor.status,
+                "dispatch_receipt": {"status": "queued_capacity"},
+            },
+        )
+
+        producer_task = kb.get_task(conn, producer)
+        successor_task = kb.get_task(conn, successor_1)
+        assert producer_task is not None
+        assert successor_task is not None
+        assert producer_task.status == "done"
+        assert successor_task.status == "ready"
+
+
 def test_block_without_kind_is_backward_compatible(kanban_home: Path) -> None:
     """Existing callers that pass no kind keep the old single-block behaviour."""
     with kb.connect_closing() as conn:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -54,16 +54,17 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path) -> None:
-    """A standalone task that a worker explicitly blocks for review
+    """A standalone task that a worker explicitly blocks for human input
     must stay blocked across an arbitrary number of dispatcher ticks.
     Before #28712's fix, ``recompute_ready`` would silently flip it
     back to ``ready`` on the very next tick."""
     with kb.connect() as conn:
-        tid = kb.create_task(conn, title="needs human review")
+        tid = kb.create_task(conn, title="needs human approval")
         kb.claim_task(conn, tid)
         assert kb.block_task(
             conn, tid,
-            reason="review-required: please verify ACL change",
+            reason="auth-required: please approve ACL change",
+            kind="needs_input",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
         )
         assert kb.get_task(conn, tid).status == "blocked"
@@ -89,7 +90,8 @@ def test_worker_block_on_child_with_done_parents_is_still_sticky(kanban_home: Pa
         kb.claim_task(conn, child)
         kb.block_task(
             conn, child,
-            reason="review-required: child needs sign-off",
+            reason="auth-required: child needs sign-off",
+            kind="needs_input",
             expected_run_id=kb.get_task(conn, child).current_run_id,
         )
         assert kb.get_task(conn, child).status == "blocked"
@@ -185,7 +187,8 @@ def test_unblock_clears_sticky_state_and_lets_block_recover(kanban_home: Path) -
         kb.claim_task(conn, tid)
         kb.block_task(
             conn, tid,
-            reason="review-required: ...",
+            reason="auth-required: device consent needed",
+            kind="needs_input",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
         )
         assert kb.unblock_task(conn, tid)
@@ -236,7 +239,8 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
         kb.claim_task(conn, tid)
         kb.block_task(
             conn, tid,
-            reason="review-required: human eyes please",
+            reason="auth-required: human approval needed",
+            kind="needs_input",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
         )
         assert kb.get_task(conn, tid).status == "blocked"

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -742,6 +742,37 @@ def test_block_rejects_empty_reason(worker_env):
         assert json.loads(out).get("error")
 
 
+def test_block_rejects_review_required_handoff_without_state_change(worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        before = kb.get_task(conn, worker_env)
+        assert before is not None
+    finally:
+        conn.close()
+
+    out = kt._handle_block({
+        "reason": "review-required: implementation complete",
+        "kind": "needs_input",
+    })
+    d = json.loads(out)
+    assert d.get("code") == "review_handoff_not_blocker"
+    assert d.get("state_mutated") is False
+    assert "create_or_recover_artifact_bound_successor" in d.get("required_actions", [])
+
+    conn = kb.connect()
+    try:
+        after = kb.get_task(conn, worker_env)
+        assert after is not None
+        assert after.status == before.status == "running"
+        assert after.current_run_id == before.current_run_id
+        assert after.block_kind == before.block_kind
+    finally:
+        conn.close()
+
+
 def _make_goal_mode_worker_env(monkeypatch, tmp_path):
     """Set up an isolated HERMES_HOME with one claimed goal_mode task,
     matching the pattern used by the kanban_complete judge gate tests."""
@@ -1554,6 +1585,14 @@ def test_worker_complete_rejects_foreign_task_id(worker_env):
     d = json.loads(out)
     assert d.get("ok") is not True
     assert "refusing to mutate" in d.get("error", "")
+    assert d.get("code") == "cross_task_mutation_refused"
+    receipt = d.get("board_operator_request")
+    assert receipt["source_task_id"] == worker_env
+    assert receipt["target_task_ids"] == [other]
+    assert receipt["requested_terminal_actions"]
+    assert "kanban_complete your own evidence/reconciliation task" in d.get(
+        "worker_lifecycle_guidance", ""
+    )
 
     # Sibling task must be untouched.
     conn = kb.connect()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -157,9 +157,24 @@ def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
         return None
     if tid != env_tid:
         return tool_error(
-            f"worker is scoped to task {env_tid}; refusing to mutate "
-            f"{tid}. Use kanban_comment to hand off information to other "
-            f"tasks, or kanban_create to spawn follow-up work."
+            f"worker is scoped to task {env_tid}; refusing to mutate {tid}.",
+            code="cross_task_mutation_refused",
+            board_operator_request={
+                "source_task_id": env_tid,
+                "target_task_ids": [tid],
+                "requested_terminal_actions": [
+                    "review the source task's comment/run evidence",
+                    "apply the requested terminal state changes from an operator/orchestrator context",
+                ],
+                "evidence_references": [],
+            },
+            worker_lifecycle_guidance=(
+                "Do not block this task just because cross-task mutation was "
+                "refused. Add a kanban_comment with the target task ids, "
+                "requested terminal actions, and evidence references, then "
+                "kanban_complete your own evidence/reconciliation task with "
+                "that structured operator receipt."
+            ),
         )
     return None
 
@@ -695,6 +710,12 @@ def _handle_block(args: dict, **kw) -> str:
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
+        if kb.is_review_handoff_block(reason, kind):
+            conn.close()
+            return tool_error(
+                kb.review_handoff_block_message(task_id=tid),
+                **kb.review_handoff_block_instruction(tid),
+            )
         if kind is not None and kind not in kb.VALID_BLOCK_KINDS:
             conn.close()
             return tool_error(
@@ -725,12 +746,18 @@ def _handle_block(args: dict, **kw) -> str:
                 f"completion judge will evaluate it."
             )
         try:
-            ok = kb.block_task(
-                conn, tid,
-                reason=reason,
-                kind=kind,
-                expected_run_id=_worker_run_id(tid),
-            )
+            try:
+                ok = kb.block_task(
+                    conn, tid,
+                    reason=reason,
+                    kind=kind,
+                    expected_run_id=_worker_run_id(tid),
+                )
+            except kb.ReviewHandoffBlockError as review_err:
+                return tool_error(
+                    str(review_err),
+                    **kb.review_handoff_block_instruction(tid),
+                )
             if not ok:
                 return tool_error(
                     f"could not block {tid} (unknown id or not in "
@@ -1443,7 +1470,11 @@ KANBAN_COMPLETE_SCHEMA = {
         "in ``artifacts`` — the gateway notifier will upload them as "
         "native attachments to the human who subscribed to the task, "
         "so the deliverable lands in their chat alongside the summary "
-        "instead of being a path they have to fetch by hand."
+        "instead of being a path they have to fetch by hand. Normal "
+        "review-required producer handoff is a completion path, not a "
+        "blocker: create/recover the artifact-bound successor first, "
+        "verify its id/status, then include successor/dispatch/test facts "
+        "here."
     ),
     "parameters": {
         "type": "object",
@@ -1533,7 +1564,9 @@ KANBAN_BLOCK_SCHEMA = {
         "``reason`` is shown to the human on the board. If a task keeps "
         "getting unblocked and re-blocked for the same reason, it is "
         "auto-escalated to triage. Use for genuine blockers only — don't "
-        "block on things you can resolve yourself."
+        "block on things you can resolve yourself. Do not use this for "
+        "normal review-required/QA handoff; that is handled by creating "
+        "the review successor and completing the producer with evidence."
     ),
     "parameters": {
         "type": "object",


### PR DESCRIPTION
## Summary

- Reject normal review-required and QA handoff language from kanban block paths so producer agents route review/QA as successor gates instead of terminal blockers.
- Apply the handoff contract consistently through the kanban DB, CLI, and worker-facing tool layers while preserving typed blocker/dependency semantics.
- Add regression coverage for review-required rejection, sticky blocked behavior, and kanban tool recovery messaging.

## Verification

- git verify-commit 546287c0da9611407e71d12a2e4eef6148fd53b5
- git diff --check origin/main...HEAD
- git merge-tree --write-tree origin/main HEAD returned merge tree 8299bf36a8157bb9250d1895e3404a71cac6a70f for current origin/main 305a3c74246118e23ccaf42018dab60419c6683a.
- python -m pytest tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_blocked_sticky.py tests/tools/test_kanban_tools.py -q => 584 passed, 1 skipped in 32.64s.
- Maximus PASS recorded on kanban review task t_d64baec4 for exact head 546287c0da9611407e71d12a2e4eef6148fd53b5.

## Boundary

- Scope is limited to kanban handoff/blocking contract enforcement and associated tests.
- No public UI, credential, deployment, data migration, or destructive behavior changes.
- Merge owner must preserve the exact reviewed head 546287c0da9611407e71d12a2e4eef6148fd53b5.
