### PR TITLE
fix(desktop): prevent stale worktree status

### DIFF
--- a/apps/desktop/src/store/coding-status.test.ts
+++ b/apps/desktop/src/store/coding-status.test.ts
@@ -76,6 +76,31 @@ describe('refreshRepoStatus', () => {
     expect($repoStatus.get()).toBeNull()
   })
 
+  it('never publishes an old worktree status after the active cwd moves', async () => {
+    let resolveOld!: (status: HermesRepoStatus | null) => void
+    stubProbe(
+      () =>
+        new Promise(resolve => {
+          resolveOld = resolve
+        })
+    )
+
+    $currentCwd.set('/repo-a')
+    vi.advanceTimersByTime(200)
+    await vi.runAllTicks()
+
+    // The first probe is still in flight when the user switches sessions. The
+    // new cwd's probe is intentionally debounced, so this is the exact window
+    // where Ctrl+Shift+B used to see the old branch in the coding rail.
+    $currentCwd.set('/repo-b')
+    expect($repoStatus.get()).toBeNull()
+
+    resolveOld(sampleStatus)
+    await vi.runAllTicks()
+
+    expect($repoStatus.get()).toBeNull()
+  })
+
   it('runs one probe at a time and coalesces overlap into one trailing refresh', async () => {
     const resolvers: Array<(status: HermesRepoStatus | null) => void> = []
     const calls: string[] = []

--- a/apps/desktop/src/store/coding-status.ts
+++ b/apps/desktop/src/store/coding-status.ts
@@ -56,11 +56,11 @@ async function loadWorktrees(target: string): Promise<void> {
   try {
     const worktrees = await list(target)
 
-    if (inflightCwd === target) {
+    if (inflightCwd === target && statusStillBelongsToActiveCwd(target)) {
       $repoWorktrees.set(worktrees)
     }
   } catch {
-    if (inflightCwd === target) {
+    if (inflightCwd === target && statusStillBelongsToActiveCwd(target)) {
       $repoWorktrees.set([])
     }
   }
@@ -84,6 +84,16 @@ let repoStatusRefreshTimer: ReturnType<typeof setTimeout> | null = null
 
 const normalizeCwd = (cwd?: null | string): null | string => cwd?.trim() || null
 
+// A result only belongs in the global rail while it still describes the active
+// workspace. The debounce below deliberately delays the next probe; without
+// this live check, an old probe can land during that gap and briefly make a new
+// session look like it is on the previous worktree's branch.
+const statusStillBelongsToActiveCwd = (target: string): boolean => {
+  const active = normalizeCwd($currentCwd.get())
+
+  return !active || active === target
+}
+
 /**
  * Re-probe the working tree for `cwd` (defaults to the active session's cwd).
  * Best-effort: a non-repo, a remote backend, or a missing probe clears the
@@ -95,7 +105,7 @@ async function runRepoStatusRefresh({ probe, seq, target }: RepoStatusRefreshReq
 
     // Drop the result if the cwd moved on while we were probing (a fast session
     // switch) — the newer probe owns the atom.
-    if (seq === repoStatusRefreshSeq && inflightCwd === target) {
+    if (seq === repoStatusRefreshSeq && inflightCwd === target && statusStillBelongsToActiveCwd(target)) {
       $repoStatus.set(status)
 
       // Worktrees only matter inside a repo; clear them otherwise.
@@ -106,7 +116,7 @@ async function runRepoStatusRefresh({ probe, seq, target }: RepoStatusRefreshReq
       }
     }
   } catch {
-    if (seq === repoStatusRefreshSeq && inflightCwd === target) {
+    if (seq === repoStatusRefreshSeq && inflightCwd === target && statusStillBelongsToActiveCwd(target)) {
       $repoStatus.set(null)
       $repoWorktrees.set([])
     }
@@ -169,8 +179,15 @@ function scheduleRepoStatusRefresh(cwd?: null | string): void {
 // Wired once at module load (mirrors projects.ts's module-scope subscriptions).
 // Each is a structural edge where the working tree may have changed under us.
 
-// The active session's cwd changed (session switch / new chat) → re-probe.
-$currentCwd.subscribe(cwd => scheduleRepoStatusRefresh(cwd))
+// The active session's cwd changed (session switch / new chat) → immediately
+// hide the old repo's facts, then re-probe after the small debounce. This makes
+// keyboard actions safe in the switch-to-probe gap: Ctrl+Shift+B cannot use a
+// still-painted branch label from the previous worktree.
+$currentCwd.subscribe(cwd => {
+  $repoStatus.set(null)
+  $repoWorktrees.set([])
+  scheduleRepoStatusRefresh(cwd)
+})
 
 // Switching sessions can land on the same cwd but a different checked-out
 // branch (the agent ran `git checkout` in another session's terminal). The cwd


### PR DESCRIPTION
## What does this PR do?

Fixes a desktop race where the global coding rail could briefly publish Git status from the previous session's worktree after the active workspace changed. During the status refresh debounce, `Ctrl+Shift+B` could then open the new-worktree flow against stale branch state.

The rail now clears immediately on a cwd change and refuses late Git-status/worktree-list results unless they still belong to the active cwd. A regression test covers the late-response window.

## Related Issue

No issue; reproduced from a desktop session/worktree switch.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/coding-status.ts`: clear stale rail state on cwd changes and gate asynchronous Git results on the live cwd.
- `apps/desktop/src/store/coding-status.test.ts`: cover an old worktree status response arriving after a workspace switch.

## How to Test

1. Start a Git-status probe for worktree A.
2. Switch to a fresh session/worktree B before that probe resolves.
3. Resolve A's probe and confirm the coding rail remains empty until B's own probe returns.
4. Run `cd apps/desktop && npm run check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A; desktop-only TypeScript change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS / Linux desktop build

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — cwd equality is platform-agnostic and covered by the existing desktop test layer
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

`cd apps/desktop && npm run check` passed:

- TypeScript typecheck
- 293 test files passed, 1 skipped (2,632 tests passed, 3 skipped)
- packaged Linux desktop smoke test completed successfully
