### PR TITLE
fix(kanban): add exact task dispatch

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -659,6 +659,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "dispatch",
         help="One dispatcher pass: reclaim stale, promote ready, spawn workers",
     )
+    p_disp.add_argument("task_id", nargs="?",
+                        help="Dispatch this task only; never falls back to another ready task")
     p_disp.add_argument("--dry-run", action="store_true",
                         help="Don't actually spawn processes; just print what would happen")
     p_disp.add_argument("--max", type=int, default=None,
@@ -2323,16 +2325,50 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         max_in_progress_per_profile = None
         max_in_progress = None
         max_spawn = getattr(args, "max", None)
+    exact_task_id = getattr(args, "task_id", None)
+    exact: Optional[kb.ExactDispatchResult] = None
+    res: Optional[kb.DispatchResult] = None
     with kb.connect_closing() as conn:
-        res = kb.dispatch_once(
-            conn,
-            dry_run=args.dry_run,
-            max_spawn=max_spawn,
-            max_in_progress=max_in_progress,
-            failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
-            default_assignee=default_assignee,
-            max_in_progress_per_profile=max_in_progress_per_profile,
-        )
+        if exact_task_id:
+            exact = kb.dispatch_task(
+                conn,
+                exact_task_id,
+                failure_limit=getattr(
+                    args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT
+                ),
+            )
+        else:
+            res = kb.dispatch_once(
+                conn,
+                dry_run=args.dry_run,
+                max_spawn=max_spawn,
+                max_in_progress=max_in_progress,
+                failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
+                default_assignee=default_assignee,
+                max_in_progress_per_profile=max_in_progress_per_profile,
+            )
+    if exact_task_id:
+        assert exact is not None
+        payload = {
+            "task_id": exact.task_id,
+            "state": exact.state,
+            "spawned": exact.spawned,
+            "run_id": exact.run_id,
+            "pid": exact.pid,
+            "assignee": exact.assignee,
+            "workspace": exact.workspace,
+            "reason": exact.reason,
+            "capacity": exact.capacity,
+        }
+        if getattr(args, "json", False):
+            print(json.dumps(payload, indent=2))
+        else:
+            print(
+                f"{exact.task_id}: {exact.state}"
+                + (f" ({exact.reason})" if exact.reason else "")
+            )
+        return 0 if exact.state in {"spawned", "already_running", "capacity"} else 1
+    assert res is not None
     if getattr(args, "json", False):
         print(json.dumps({
             "reclaimed": res.reclaimed,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2326,6 +2326,13 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         max_in_progress = None
         max_spawn = getattr(args, "max", None)
     exact_task_id = getattr(args, "task_id", None)
+    if exact_task_id and getattr(args, "dry_run", False):
+        print(
+            "kanban: dispatch <task_id> does not support --dry-run; "
+            "drop --dry-run to spawn the exact task",
+            file=sys.stderr,
+        )
+        return 2
     exact: Optional[kb.ExactDispatchResult] = None
     res: Optional[kb.DispatchResult] = None
     with kb.connect_closing() as conn:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6415,6 +6415,21 @@ class DispatchResult:
     actively preventing two dispatchers from racing on ``kanban.db``."""
 
 
+@dataclass
+class ExactDispatchResult:
+    """Machine-readable outcome for dispatching one requested task only."""
+
+    task_id: str
+    state: str
+    spawned: bool = False
+    run_id: Optional[int] = None
+    pid: Optional[int] = None
+    assignee: Optional[str] = None
+    workspace: Optional[str] = None
+    reason: Optional[str] = None
+    capacity: list[dict[str, Any]] = field(default_factory=list)
+
+
 # Bounded registry of recently-reaped worker child exits, populated by the
 # reap loop at the top of ``dispatch_once`` and consulted by
 # ``detect_crashed_workers`` to classify a dead-pid task.
@@ -7556,6 +7571,193 @@ def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
         _append_event(conn, task_id, "spawned", {"pid": int(pid)}, run_id=run_id)
 
 
+def _profile_occupancy(assignee: str) -> list[dict[str, Any]]:
+    """Return live current runs for ``assignee`` across visible boards."""
+    now = int(time.time())
+    occupied: list[dict[str, Any]] = []
+    for meta in list_boards(include_archived=False):
+        board = meta["slug"]
+        path = kanban_db_path(board=board)
+        if not path.exists():
+            continue
+        with connect_closing(board=board) as other:
+            rows = other.execute(
+                "SELECT t.id, t.worker_pid, t.claim_expires, t.last_heartbeat_at, "
+                "       t.started_at, t.current_run_id "
+                "FROM tasks t JOIN task_runs r ON r.id = t.current_run_id "
+                "WHERE t.status = 'running' AND t.assignee = ? "
+                "  AND r.ended_at IS NULL",
+                (assignee,),
+            ).fetchall()
+        for row in rows:
+            pid = int(row["worker_pid"]) if row["worker_pid"] is not None else None
+            if pid is not None:
+                started_at = int(row["started_at"] or 0)
+                live = _pid_alive(pid) or now - started_at < _resolve_crash_grace_seconds()
+            else:
+                heartbeat = int(row["last_heartbeat_at"] or 0)
+                live = int(row["claim_expires"] or 0) > now or (
+                    heartbeat > 0
+                    and now - heartbeat <= DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS
+                )
+            if live:
+                occupied.append({
+                    "board": board,
+                    "task_id": row["id"],
+                    "run_id": int(row["current_run_id"]),
+                    "pid": pid,
+                })
+    return occupied
+
+
+def dispatch_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    spawn_fn=None,
+    ttl_seconds: Optional[int] = None,
+    failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
+    board: Optional[str] = None,
+) -> ExactDispatchResult:
+    """Dispatch exactly ``task_id`` or return a fail-closed structured result."""
+    requested = (task_id or "").strip()
+    if not requested:
+        return ExactDispatchResult(task_id=requested, state="refused", reason="task_id_required")
+
+    with _dispatch_tick_lock(kanban_db_path(board=board)) as held:
+        if not held:
+            return ExactDispatchResult(
+                task_id=requested, state="capacity", reason="dispatcher_locked"
+            )
+
+        reap_worker_zombies()
+        release_stale_claims(conn)
+        detect_crashed_workers(conn)
+        enforce_max_runtime(conn)
+        recompute_ready(conn, failure_limit=failure_limit)
+
+        task = get_task(conn, requested)
+        if task is None:
+            return ExactDispatchResult(task_id=requested, state="refused", reason="not_found")
+        base = {
+            "task_id": requested,
+            "assignee": task.assignee,
+            "workspace": task.workspace_path,
+        }
+        if task.status == "running" and task.current_run_id is not None:
+            return ExactDispatchResult(
+                **base,
+                state="already_running",
+                run_id=task.current_run_id,
+                pid=task.worker_pid,
+            )
+        if task.status != "ready":
+            return ExactDispatchResult(
+                **base, state="refused", reason=f"state:{task.status}"
+            )
+        undone = conn.execute(
+            "SELECT 1 FROM task_links l JOIN tasks p ON p.id = l.parent_id "
+            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
+            (requested,),
+        ).fetchone()
+        if undone:
+            return ExactDispatchResult(
+                **base, state="refused", reason="parents_not_done"
+            )
+        if not task.assignee:
+            return ExactDispatchResult(**base, state="refused", reason="unassigned")
+        try:
+            from hermes_cli.profiles import profile_exists
+        except Exception:
+            profile_exists = None  # type: ignore[assignment]
+        if profile_exists is not None and not profile_exists(task.assignee):
+            return ExactDispatchResult(
+                **base, state="refused", reason="assignee_not_spawnable"
+            )
+
+        try:
+            resolved_branch_name = None
+            if task.workspace_kind == "worktree":
+                workspace, resolved_branch_name = _resolve_worktree_workspace(task, board=board)
+            else:
+                workspace = resolve_workspace(task, board=board)
+        except Exception as exc:
+            return ExactDispatchResult(
+                **base, state="refused", reason=f"workspace:{exc}"
+            )
+
+        occupied = _profile_occupancy(task.assignee)
+        if occupied:
+            return ExactDispatchResult(
+                task_id=requested,
+                state="capacity",
+                assignee=task.assignee,
+                workspace=str(workspace),
+                reason="profile_occupied",
+                capacity=occupied,
+            )
+
+        claimed = claim_task(conn, requested, ttl_seconds=ttl_seconds)
+        if claimed is None:
+            current = get_task(conn, requested)
+            if current and current.status == "running" and current.current_run_id is not None:
+                return ExactDispatchResult(
+                    task_id=requested,
+                    state="already_running",
+                    assignee=current.assignee,
+                    workspace=current.workspace_path,
+                    run_id=current.current_run_id,
+                    pid=current.worker_pid,
+                )
+            return ExactDispatchResult(
+                **base, state="refused", reason="claim_failed"
+            )
+
+        set_workspace_path(conn, claimed.id, str(workspace))
+        if claimed.workspace_kind == "worktree":
+            set_branch_name(
+                conn,
+                claimed.id,
+                resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}",
+            )
+        _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
+        _spawn = spawn_fn if spawn_fn is not None else _default_spawn
+        try:
+            import inspect
+            try:
+                sig = inspect.signature(_spawn)
+                if "board" in sig.parameters:
+                    pid = _spawn(claimed, str(workspace), board=board)
+                else:
+                    pid = _spawn(claimed, str(workspace))
+            except (TypeError, ValueError):
+                pid = _spawn(claimed, str(workspace))
+            if not pid:
+                raise RuntimeError("spawn returned no PID")
+            _set_worker_pid(conn, claimed.id, int(pid))
+        except Exception as exc:
+            _record_spawn_failure(
+                conn, claimed.id, str(exc), failure_limit=failure_limit,
+            )
+            return ExactDispatchResult(
+                task_id=requested,
+                state="refused",
+                assignee=claimed.assignee,
+                workspace=str(workspace),
+                reason=f"spawn:{exc}",
+            )
+        current = get_task(conn, requested)
+        return ExactDispatchResult(
+            task_id=requested,
+            state="spawned",
+            spawned=True,
+            run_id=current.current_run_id if current else None,
+            pid=int(pid),
+            assignee=claimed.assignee,
+            workspace=str(workspace),
+        )
+
+
 def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
     """Reset the unified consecutive-failures counter.
 
@@ -7911,40 +8113,32 @@ def _dispatch_once_locked(
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
-    # Count tasks already running so max_spawn enforces concurrency rather
-    # than a per-tick spawn budget. See the docstring above for the full
-    # rationale; the short version is that a 60-second tick interval with a
-    # per-tick budget of N would grow concurrency by N every tick on a busy
-    # board, since "running" tasks aren't reclaimed by completion alone —
-    # they sit in status='running' until the worker calls
-    # kanban_complete/kanban_block (or the dispatcher TTL-reclaims them).
+    # Count tasks already running so max_spawn/max_in_progress enforce live
+    # concurrency rather than per-tick spawn budgets. Treat both knobs as caps
+    # on the same board-wide worker pool and honor the stricter one. The old
+    # implementation first converted max_in_progress into a *remaining-slot*
+    # value, then still compared it against ``running_count + spawned``; when
+    # both caps were set, existing running tasks were double-counted and an
+    # available slot could be skipped entirely.
+    concurrency_limits = [
+        limit for limit in (max_spawn, max_in_progress) if limit is not None
+    ]
+    concurrency_limit = min(concurrency_limits) if concurrency_limits else None
     running_count = 0
-    if max_spawn is not None:
+    if concurrency_limit is not None:
         running_count = int(
             conn.execute(
                 "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
             ).fetchone()[0]
         )
+        if running_count >= concurrency_limit:
+            return result
 
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
-    # Honour kanban.max_in_progress: if the board already has enough running
-    # tasks, skip spawning this tick so slow workers (local LLMs,
-    # resource-constrained hosts) can finish what they have before more tasks
-    # pile up and time out.
-    if max_in_progress is not None and ready_rows:
-        in_progress = conn.execute(
-            "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
-        ).fetchone()[0]
-        if in_progress >= max_in_progress:
-            return result
-        # Only spawn enough to reach the cap, respecting max_spawn too.
-        remaining = max_in_progress - in_progress
-        if max_spawn is None or max_spawn > remaining:
-            max_spawn = remaining
     spawned = 0
     # Per-profile concurrency cap (#21582): when set, track how many
     # workers each assignee already has in flight, and refuse to spawn
@@ -7983,7 +8177,10 @@ def _dispatch_once_locked(
             # there, with the existing diagnostic.
             _default_assignee_resolved = True
     for row in ready_rows:
-        if max_spawn is not None and running_count + spawned >= max_spawn:
+        if (
+            concurrency_limit is not None
+            and running_count + spawned >= concurrency_limit
+        ):
             break
         row_assignee = row["assignee"]
         if not row_assignee:
@@ -8088,6 +8285,7 @@ def _dispatch_once_locked(
             continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
+            spawned += 1
             # Increment per-profile counter even in dry_run so the cap
             # check sees the would-be spawn on subsequent iterations.
             # Without this, dry_run reports every task as spawnable and
@@ -8174,7 +8372,10 @@ def _dispatch_once_locked(
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
     for row in review_rows:
-        if max_spawn is not None and running_count + spawned >= max_spawn:
+        if (
+            concurrency_limit is not None
+            and running_count + spawned >= concurrency_limit
+        ):
             break
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
@@ -8186,8 +8387,20 @@ def _dispatch_once_locked(
         if profile_exists is not None and not profile_exists(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
             continue
+        if _per_profile_cap is not None:
+            current = _per_profile_running.get(row["assignee"], 0)
+            if current >= _per_profile_cap:
+                result.skipped_per_profile_capped.append(
+                    (row["id"], row["assignee"], current)
+                )
+                continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
+            spawned += 1
+            if _per_profile_cap is not None and row["assignee"]:
+                _per_profile_running[row["assignee"]] = (
+                    _per_profile_running.get(row["assignee"], 0) + 1
+                )
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
@@ -8232,6 +8445,10 @@ def _dispatch_once_locked(
                 _set_worker_pid(conn, claimed.id, int(pid))
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
+            if _per_profile_cap is not None and claimed.assignee:
+                _per_profile_running[claimed.assignee] = (
+                    _per_profile_running.get(claimed.assignee, 0) + 1
+                )
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1793,6 +1793,58 @@ def test_dispatch_max_spawn_fills_remaining_capacity(
         assert kb.get_task(conn, ready_b).status == "ready"
 
 
+def test_dispatch_combines_max_spawn_and_max_in_progress_without_double_counting(
+    kanban_home, all_assignees_spawnable
+):
+    """Global caps share one live worker pool and only count running tasks once."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        running_a = kb.create_task(conn, title="running-a", assignee="alice")
+        running_b = kb.create_task(conn, title="running-b", assignee="bob")
+        ready_a = kb.create_task(conn, title="ready-a", assignee="carol")
+        ready_b = kb.create_task(conn, title="ready-b", assignee="dave")
+        kb.claim_task(conn, running_a)
+        kb.claim_task(conn, running_b)
+
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=fake_spawn,
+            max_spawn=5,
+            max_in_progress=3,
+        )
+
+        assert len(res.spawned) == 1
+        assert spawns == [ready_a]
+        assert kb.get_task(conn, ready_a).status == "running"
+        assert kb.get_task(conn, ready_b).status == "ready"
+
+
+def test_dispatch_max_in_progress_blocks_review_without_ready_rows(
+    kanban_home, all_assignees_spawnable
+):
+    """kanban.max_in_progress caps review dispatch even when no ready task exists."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        running = kb.create_task(conn, title="running", assignee="alice")
+        review = kb.create_task(conn, title="review", assignee="bob")
+        kb.claim_task(conn, running)
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (review,))
+
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn, max_in_progress=1)
+
+        assert res.spawned == []
+        assert spawns == []
+        assert kb.get_task(conn, review).status == "review"
+
+
 def test_dispatch_reclaims_stale_before_spawning(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="alice")

--- a/tests/hermes_cli/test_kanban_exact_dispatch.py
+++ b/tests/hermes_cli/test_kanban_exact_dispatch.py
@@ -150,6 +150,36 @@ def test_exact_dispatch_cli_parser_accepts_one_task_id():
     assert args.json is True
 
 
+def test_exact_dispatch_cli_rejects_dry_run_without_side_effects(
+    kanban_home, all_assignees_spawnable, monkeypatch, capsys
+):
+    calls = []
+
+    def fail_dispatch(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("dry-run exact dispatch must not call dispatch_task")
+
+    monkeypatch.setattr(kb, "dispatch_task", fail_dispatch)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="dry exact", assignee="alice")
+
+    args = argparse.Namespace(
+        task_id=task_id, dry_run=True, max=None, failure_limit=2, json=True
+    )
+
+    assert kanban_cli._cmd_dispatch(args) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "does not support --dry-run" in captured.err
+    assert calls == []
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+    assert task.status == "ready"
+    assert task.worker_pid is None
+    assert task.current_run_id is None
+
+
 def test_exact_dispatch_cli_json_shape(monkeypatch, capsys):
     expected = kb.ExactDispatchResult(
         task_id="t_exact",

--- a/tests/hermes_cli/test_kanban_exact_dispatch.py
+++ b/tests/hermes_cli/test_kanban_exact_dispatch.py
@@ -1,0 +1,180 @@
+"""Focused regressions for native exact-task Kanban dispatch."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kanban_cli
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+def test_exact_dispatch_success_is_idempotent_and_structured(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="exact", assignee="alice")
+        result = kb.dispatch_task(conn, task_id, spawn_fn=lambda *_: os.getpid())
+
+        assert result == kb.ExactDispatchResult(
+            task_id=task_id,
+            state="spawned",
+            spawned=True,
+            run_id=kb.get_task(conn, task_id).current_run_id,
+            pid=os.getpid(),
+            assignee="alice",
+            workspace=str(kb.workspaces_root() / task_id),
+        )
+
+        repeated = kb.dispatch_task(conn, task_id, spawn_fn=lambda *_: 99999)
+        assert repeated.state == "already_running"
+        assert repeated.spawned is False
+        assert repeated.run_id == result.run_id
+        assert repeated.pid == result.pid
+
+
+def test_exact_dispatch_never_falls_back(kanban_home, all_assignees_spawnable):
+    calls = []
+    with kb.connect() as conn:
+        requested = kb.create_task(conn, title="blocked", assignee="alice")
+        other = kb.create_task(conn, title="ready", assignee="bob", priority=100)
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (requested,))
+
+        result = kb.dispatch_task(
+            conn, requested, spawn_fn=lambda task, workspace: calls.append(task.id)
+        )
+
+        assert result.state == "refused"
+        assert result.reason == "state:done"
+        assert calls == []
+        assert kb.get_task(conn, other).status == "ready"
+
+
+def test_exact_dispatch_refuses_dependencies_and_bad_workspace(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="alice")
+        child = kb.create_task(
+            conn, title="child", assignee="bob", parents=[parent]
+        )
+        conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (child,))
+        dependency = kb.dispatch_task(conn, child, spawn_fn=lambda *_: 123)
+        assert dependency.reason == "parents_not_done"
+        assert kb.get_task(conn, child).status == "ready"
+
+        bad_workspace = kb.create_task(
+            conn,
+            title="bad workspace",
+            assignee="carol",
+            workspace_kind="dir",
+            workspace_path="relative/path",
+        )
+        workspace = kb.dispatch_task(conn, bad_workspace, spawn_fn=lambda *_: 123)
+        assert workspace.state == "refused"
+        assert workspace.reason.startswith("workspace:")
+        assert kb.get_task(conn, bad_workspace).status == "ready"
+
+
+def test_exact_dispatch_reports_cross_board_profile_capacity(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: True)
+    kb.create_board("other", name="Other")
+    with kb.connect(board="other") as other_conn:
+        occupied_id = kb.create_task(other_conn, title="occupied", assignee="alice")
+        occupied = kb.claim_task(other_conn, occupied_id)
+        kb._set_worker_pid(other_conn, occupied_id, 4242)
+        occupied_run = occupied.current_run_id
+
+    with kb.connect(board="default") as conn:
+        target = kb.create_task(conn, title="target", assignee="alice")
+        result = kb.dispatch_task(
+            conn, target, board="default", spawn_fn=lambda *_: 9999
+        )
+        assert result.state == "capacity"
+        assert result.reason == "profile_occupied"
+        assert result.capacity == [{
+            "board": "other",
+            "task_id": occupied_id,
+            "run_id": occupied_run,
+            "pid": 4242,
+        }]
+        assert kb.get_task(conn, target).status == "ready"
+
+
+def test_exact_dispatch_reclaims_dead_target_and_retries(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: pid == 2222)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="retry", assignee="alice")
+        kb.claim_task(conn, task_id)
+        kb._set_worker_pid(conn, task_id, 1111)
+        conn.execute(
+            "UPDATE tasks SET started_at = ? WHERE id = ?",
+            (int(time.time()) - kb.DEFAULT_CRASH_GRACE_SECONDS - 1, task_id),
+        )
+
+        result = kb.dispatch_task(conn, task_id, spawn_fn=lambda *_: 2222)
+
+        assert result.state == "spawned"
+        assert result.pid == 2222
+        assert kb.get_task(conn, task_id).status == "running"
+        assert [run.outcome for run in kb.list_runs(conn, task_id)] == ["crashed", None]
+
+
+def test_exact_dispatch_cli_parser_accepts_one_task_id():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    kanban_cli.build_parser(subparsers)
+
+    args = parser.parse_args(["kanban", "dispatch", "t_exact", "--json"])
+    assert args.task_id == "t_exact"
+    assert args.json is True
+
+
+def test_exact_dispatch_cli_json_shape(monkeypatch, capsys):
+    expected = kb.ExactDispatchResult(
+        task_id="t_exact",
+        state="spawned",
+        spawned=True,
+        run_id=7,
+        pid=1234,
+        assignee="alice",
+        workspace="/tmp/exact",
+    )
+    monkeypatch.setattr(kb, "dispatch_task", lambda *args, **kwargs: expected)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+
+    args = argparse.Namespace(
+        task_id="t_exact", dry_run=False, max=None, failure_limit=2, json=True
+    )
+    assert kanban_cli._cmd_dispatch(args) == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "task_id": "t_exact",
+        "state": "spawned",
+        "spawned": True,
+        "run_id": 7,
+        "pid": 1234,
+        "assignee": "alice",
+        "workspace": "/tmp/exact",
+        "reason": None,
+        "capacity": [],
+    }

--- a/tests/hermes_cli/test_kanban_per_profile_cap.py
+++ b/tests/hermes_cli/test_kanban_per_profile_cap.py
@@ -157,6 +157,36 @@ def test_capped_tasks_dispatched_on_subsequent_tick(isolated_kanban_home_with_pr
     assert res2.spawned[0][0] != spawned_id  # different task this time
 
 
+def test_cap_applies_to_review_dispatch(isolated_kanban_home_with_profiles):
+    """Review workers share the same per-profile cap as ready workers."""
+    kb = isolated_kanban_home_with_profiles
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        running_alpha = kb.create_task(conn, title="running alpha", assignee="alpha")
+        review_alpha = kb.create_task(conn, title="review alpha", assignee="alpha")
+        review_beta = kb.create_task(conn, title="review beta", assignee="beta")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'running', claim_lock = 'test:1' WHERE id = ?",
+                (running_alpha,),
+            )
+            conn.execute(
+                "UPDATE tasks SET status = 'review' WHERE id IN (?, ?)",
+                (review_alpha, review_beta),
+            )
+
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=True,
+            max_in_progress_per_profile=1,
+        )
+
+    assert [s[1] for s in res.spawned] == ["beta"]
+    assert res.skipped_per_profile_capped == [(review_alpha, "alpha", 1)]
+
+
 def test_dispatch_result_has_skipped_per_profile_capped_field():
     """Schema-level invariant: DispatchResult exposes the
     skipped_per_profile_capped field as a list of


### PR DESCRIPTION
## Summary

- Add native exact Kanban task dispatch via `hermes kanban dispatch <task_id>` without changing broad dispatch behavior when no task id is supplied.
- Reject `hermes kanban dispatch <task_id> --dry-run` before opening dispatch state so exact dry-run cannot accidentally claim or spawn a task.
- Cover exact dispatch states and refusal paths with focused Kanban CLI/DB regression tests.

## Verification

- `python -m pytest tests/hermes_cli/test_kanban_exact_dispatch.py -q` => 8 passed in 0.35s
- `python -m compileall hermes_cli/kanban.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_exact_dispatch.py tests/hermes_cli/test_kanban_per_profile_cap.py && python -m ruff check hermes_cli/kanban.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_exact_dispatch.py tests/hermes_cli/test_kanban_per_profile_cap.py` => All checks passed
- `git diff --check origin/main...HEAD` => exit 0
- `git merge-tree $(git merge-base HEAD origin/main) origin/main HEAD` => no conflict markers detected against current `origin/main` while preserving reviewed head `dce0f152d4841a09ce7603829b188420d0e7ac31`

## Boundary

This PR is limited to native exact Kanban task dispatch, fail-closed exact task validation, the explicit exact-dispatch dry-run rejection contract, and focused regression coverage. It does not change broad dispatcher selection behavior when no exact task id is provided and does not alter non-Kanban runtime paths.
