### PR TITLE
fix(agent): stop mid-line reasoning leaking when the close tag lands in a later delta

### DIFF
--- a/agent/think_scrubber.py
+++ b/agent/think_scrubber.py
@@ -176,6 +176,35 @@ class StreamingThinkScrubber:
                     buf = buf[open_idx + open_len:]
                     continue
 
+                # A COMPLETE open tag mid-line (any boundary-legal opener
+                # was already handled above, so an opener found here is NOT
+                # at a block boundary) with no close yet in buf is ambiguous:
+                # prose that merely mentions the tag, OR a real reasoning
+                # block whose closing tag lands in a LATER delta. Emitting the
+                # content now leaks the reasoning whenever the close is split
+                # across deltas — the exact failure this scrubber exists to
+                # prevent, and the reason a mid-line closed pair only got
+                # stripped when the whole pair happened to fall in one delta.
+                # Hold from the open tag to end-of-buf and re-decide on the
+                # next feed (close arrives -> the Priority-1 closed-pair strip
+                # above discards it) or at flush (no close ever -> emitted
+                # verbatim as prose). Only the tail after a mid-line opener is
+                # buffered, so ordinary streaming is untouched.
+                mid_open_idx, _mid_open_len = self._find_first_tag(
+                    buf, self._OPEN_TAGS,
+                )
+                if mid_open_idx != -1:
+                    preceding = buf[:mid_open_idx]
+                    if preceding:
+                        preceding = self._strip_orphan_close_tags(preceding)
+                        if preceding:
+                            out.append(preceding)
+                            self._last_emitted_ended_newline = (
+                                preceding.endswith("\n")
+                            )
+                    self._buf = buf[mid_open_idx:]
+                    return "".join(out)
+
                 # No resolvable tag structure in buf.  Hold back any
                 # partial-tag prefix at the tail so a split tag
                 # across deltas isn't missed, then emit the rest.

--- a/tests/agent/test_think_scrubber.py
+++ b/tests/agent/test_think_scrubber.py
@@ -156,6 +156,64 @@ class TestTheMiniMaxScenario:
         assert out == ""
 
 
+class TestMidLineBlockAcrossDeltas:
+    """A mid-line closed pair must be stripped even when its close tag lands
+    in a LATER delta than the reasoning content.
+
+    A closed ``<think>...</think>`` pair is always stripped (TestClosedPairs),
+    including mid-line. The streaming scrubber only detected that when the
+    whole pair fell inside one delta; when the close arrived in a later delta
+    the open was treated as prose and the reasoning content streamed out
+    verbatim — a reasoning leak, the exact thing this scrubber prevents. These
+    lock the guarantee under realistic delta splits.
+    """
+
+    def test_midline_pair_close_in_later_delta(self) -> None:
+        s = StreamingThinkScrubber()
+        out = _drive(s, ["Hello ", "<think>", "secret reasoning", "</think>", " done"])
+        assert out == "Hello  done"
+        assert "secret reasoning" not in out
+        assert "<think>" not in out
+
+    def test_midline_pair_char_by_char(self) -> None:
+        text = "Answer: <think>internal chain of thought</think> 42"
+        s = StreamingThinkScrubber()
+        out = "".join(s.feed(c) for c in text) + s.flush()
+        assert out == "Answer:  42"
+        assert "internal chain of thought" not in out
+
+    def test_two_midline_blocks_split(self) -> None:
+        s = StreamingThinkScrubber()
+        out = _drive(s, ["A ", "<think>r1", "</think> B ", "<think>r2", "</think> C"])
+        assert out == "A  B  C"
+
+    def test_midline_reasoning_variant_tag_split(self) -> None:
+        s = StreamingThinkScrubber()
+        out = _drive(s, ["Pre ", "<reasoning>deep", "</reasoning>", " Post"])
+        assert out == "Pre  Post"
+
+    def test_midline_unterminated_is_still_preserved(self) -> None:
+        """No close ever: it was prose, emit verbatim (don't over-strip)."""
+        s = StreamingThinkScrubber()
+        out = _drive(s, ["Answer: ", "<think>", "no close arrives"])
+        assert out == "Answer: <think>no close arrives"
+
+    def test_chunk_independence(self) -> None:
+        """Output must not depend on where delta boundaries fall."""
+        text = "Lead <think>hidden</think> tail <reasoning>more</reasoning> end"
+
+        def scrub(size: int) -> str:
+            s = StreamingThinkScrubber()
+            parts = [s.feed(text[i:i + size]) for i in range(0, len(text), size)]
+            parts.append(s.flush())
+            return "".join(parts)
+
+        whole = scrub(len(text))
+        assert "hidden" not in whole and "more" not in whole
+        for size in (1, 2, 3, 5, 9):
+            assert scrub(size) == whole
+
+
 class TestResetAndReentry:
     def test_reset_clears_in_block_state(self) -> None:
         s = StreamingThinkScrubber()


### PR DESCRIPTION
## What does this PR do?

`StreamingThinkScrubber` exists so downstream consumers (ACP, api_server, TTS, CLI, gateway) never see `<think>` reasoning blocks in the visible stream. Closed `<tag>...</tag>` pairs are always stripped, mid-line included — the module's own contract, pinned by `test_closed_pair_surrounded_by_content` and `test_split_open_tag_not_at_boundary`.

But that only held when the whole pair fell inside **one** delta. The closed-pair detector scans a single `feed()` buffer; when a mid-line `<think>` opens and its `</think>` arrives in a **later** delta (the normal case for any multi-token reasoning block), the pair is never recognized. The open is treated as prose (boundary-gated), the reasoning content streams out verbatim, and only the trailing `</think>` is later removed. **The model's internal reasoning leaks to the user** — exactly what the scrubber prevents — and it's non-deterministic: the same response scrubs cleanly or leaks depending purely on where the provider's SSE deltas split.

Reproduced (reasoning at a block boundary is unaffected; the leak is mid-line):

```
"Hello <think>secret reasoning</think> World"
  one delta                       -> "Hello  World"                        (stripped)
  close in a later delta / char   -> "Hello <think>secret reasoning World" (LEAKED)
```

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/think_scrubber.py` — when a complete open tag is found mid-line (boundary openers are already handled, so any opener reaching this point is not at a boundary) with no close yet in the buffer, hold from the open tag to end-of-buffer instead of emitting it. The next delta re-decides: close arrives → the existing Priority-1 closed-pair strip discards the block; end-of-stream with no close → it was prose, emitted verbatim by `flush()`. Only the tail after a mid-line opener is buffered, so ordinary streaming (and reasoning that opens at a line boundary — the dominant model pattern) is untouched. Output is now identical regardless of chunking.

## How to Test

1. Feed `"Hello "`, `"<think>"`, `"secret reasoning"`, `"</think>"`, `" done"` as separate deltas (or char-by-char).
2. **Before:** `"Hello <think>secret reasoning World"` — reasoning leaked. **After:** `"Hello  done"`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the suites: scrubber 39 passed (5 new tests fail on `main`), turn_context/api_content 51, stream_consumer 173, streaming_context_scrubber 21
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] Docstrings — the new branch is documented inline; contract unchanged — or N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure string/state logic)