### PR TITLE
fix(api_server): call refresh_agent_mcp_tools() after agent creation

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1951,6 +1951,15 @@ class APIServerAdapter(BasePlatformAdapter):
             reasoning_config=reasoning_config,
             gateway_session_key=gateway_session_key,
         )
+        # Load custom MCP servers from config so /v1/chat/completions
+        # has the same MCP tools as interactive CLI / TUI sessions.
+        # Without this call, custom_mcp_servers entries in config.yaml
+        # are silently ignored for API server agents (fixes #69746).
+        try:
+            from tools.mcp_tool import refresh_agent_mcp_tools
+            refresh_agent_mcp_tools(agent, quiet_mode=True)
+        except Exception:
+            logger.debug("api_server: MCP tool refresh failed", exc_info=True)
         return agent
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The API server platform (`_create_agent`) never calls `refresh_agent_mcp_tools()`, so custom MCP servers configured in `config.yaml` under `custom_mcp_servers` are silently unavailable via `/v1/chat/completions`.

## Root Cause

The CLI (`cli.py:10661`) and gateway (`gateway/run.py:15884`) both call `refresh_agent_mcp_tools()` after constructing an `AIAgent`, but the API server's `_create_agent()` method skips this step entirely.

## Fix

Add the same `refresh_agent_mcp_tools()` call after `AIAgent` construction in `_create_agent()`, wrapped in try/except to match the existing error-handling pattern.

## Fixes

Fixes #69746