### PR TITLE
fix(auth): specify UTF-8 encoding for auth.json read_text() calls

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1112,7 +1112,7 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
         return {"version": AUTH_STORE_VERSION, "providers": {}}
 
     try:
-        raw = json.loads(auth_file.read_text())
+        raw = json.loads(auth_file.read_text(encoding="utf-8"))
     except Exception as exc:
         corrupt_path = auth_file.with_suffix(".json.corrupt")
         try:
@@ -3701,7 +3701,7 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
     if not auth_path.is_file():
         return None
     try:
-        payload = json.loads(auth_path.read_text())
+        payload = json.loads(auth_path.read_text(encoding="utf-8"))
         tokens = payload.get("tokens")
         if not isinstance(tokens, dict):
             return None
@@ -5136,7 +5136,7 @@ def _read_shared_nous_state() -> Optional[Dict[str, Any]]:
     if not path.is_file():
         return None
     try:
-        payload = json.loads(path.read_text())
+        payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
         logger.debug("Shared Nous auth store at %s is unreadable: %s", path, exc)
         return None


### PR DESCRIPTION
## Summary

On Windows with CJK usernames, `locale.getpreferredencoding()` returns GBK (or a similar multi-byte encoding). `Path.read_text()` without an explicit encoding argument uses the system default, so reading a UTF-8 encoded `auth.json` under a GBK locale raises `UnicodeDecodeError`, making auth completely broken for those users.

## Root Cause

Three `read_text()` calls in `hermes_cli/auth.py` parse JSON files without specifying `encoding="utf-8"`:
- `_load_auth_store()` (line 1115) — the main auth.json loader
- OAuth token reading (line 3704)
- Nous auth store reading (line 5139)

Meanwhile, `write_text()` calls and lock file operations already correctly specify `encoding="utf-8"`.

## Fix

Add `encoding="utf-8"` to all three `read_text()` calls, matching the pattern already used elsewhere in the same file.

## Fixes

Fixes #69706