### PR TITLE
fix(ci): authenticate gh-image installation

### DIFF
--- a/.github/workflows/publish-e2e-evidence.yml
+++ b/.github/workflows/publish-e2e-evidence.yml
@@ -33,6 +33,8 @@ jobs:
 
       # v1.2.0 resolves to 44f4b93ecbbe22de6c45fa2f62f519aee564ca8c.
       - name: Install gh-image
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: gh extension install drogers0/gh-image --pin v1.2.0
 
       - name: Download and attach evidence


### PR DESCRIPTION
## What does this PR do?

Fixes the trusted inline-E2E-evidence publisher failing before it can replace the CI review comment placeholder. The publisher installed `gh-image` without authentication, so GitHub-hosted runners could exhaust the shared anonymous API limit while resolving the extension release.

## Related Issue

N/A — diagnosed from the failed publisher run for #69781.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Add the publisher job's scoped `github.token` as `GH_TOKEN` to the `gh extension install` step in `.github/workflows/publish-e2e-evidence.yml`.
- Keep `GH_IMAGE_SESSION_TOKEN` restricted to the later attachment step; it is not exposed during extension installation.

## How to Test

1. Run `nix run nixpkgs#actionlint -- .github/workflows/publish-e2e-evidence.yml`.
2. Confirm `git diff --check` is clean.
3. On a PR with E2E evidence, verify the publisher installs `gh-image` without anonymous API rate-limit failure and replaces the inline-evidence marker.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: workflow-only change
- [ ] I've added tests for my changes — N/A: validated with actionlint; the failure requires a hosted runner's API limit state
- [x] I've tested on my platform: NixOS via `nix run nixpkgs#actionlint`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A: GitHub-hosted Linux workflow only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Failed publisher run before this change: https://github.com/NousResearch/hermes-agent/actions/runs/29976063522/job/89107939776

```text
could not check for binary extension: HTTP 403: API rate limit exceeded
```
