### PR TITLE
fix(desktop): split steer and queue keyboard shortcuts

### DIFF
--- a/apps/desktop/e2e/queue-turn-boundary.spec.ts
+++ b/apps/desktop/e2e/queue-turn-boundary.spec.ts
@@ -26,12 +26,18 @@ async function send(page: Page, text: string): Promise<void> {
 
 async function steer(page: Page, text: string): Promise<void> {
   const composer = page.locator('[contenteditable="true"]').first()
-  const primary = page.locator('[data-slot="composer-root"] button[type="submit"]')
 
   await composer.click()
   await composer.type(text, { delay: 5 })
-  await expect(primary).toHaveAttribute('aria-label', /Steer/)
-  await primary.click()
+  await page.keyboard.press('Enter')
+}
+
+async function queue(page: Page, text: string): Promise<void> {
+  const composer = page.locator('[contenteditable="true"]').first()
+
+  await composer.click()
+  await composer.type(text, { delay: 5 })
+  await page.keyboard.press('Control+Enter')
 }
 
 async function transcriptMessageOrder(page: Page): Promise<string[]> {
@@ -72,15 +78,10 @@ test.describe('queued prompt turn boundary', () => {
 
   test('submits a queued prompt only after the active turn completes', async () => {
     const { mock, page } = fixture!
-    const composer = page.locator('[contenteditable="true"]').first()
-    const queue = page.locator('[data-slot="composer-root"] button[aria-label="Queue message"]')
 
     await send(page, ACTIVE_PROMPT)
     await mock.waitForHeldStream()
-
-    await composer.click()
-    await composer.type(QUEUED_PROMPT, { delay: 5 })
-    await queue.click()
+    await queue(page, QUEUED_PROMPT)
     await expect(page.getByText('1 Queued')).toBeVisible()
 
     // The mock keeps the active SSE stream open, so a queued prompt has no

--- a/apps/desktop/src/app/chat/composer/controls.test.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.test.tsx
@@ -65,15 +65,15 @@ describe('ComposerControls shortcut tooltips', () => {
     await expectShortcutTooltip('Send', '↵')
   })
 
-  it('shows Ctrl+Enter for Steer', async () => {
+  it('shows Enter for Steer', async () => {
     renderControls({ busy: true, busyAction: 'steer' })
 
-    await expectShortcutTooltip('Steer the current run', 'Ctrl+↵')
+    await expectShortcutTooltip('Steer the current run', '↵')
   })
 
-  it('shows Enter for Queue', async () => {
+  it('shows Ctrl+Enter for Queue', async () => {
     renderControls({ busy: true, busyAction: 'queue' })
 
-    await expectShortcutTooltip('Queue message', '↵')
+    await expectShortcutTooltip('Queue message', 'Ctrl+↵')
   })
 })

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -81,7 +81,7 @@ export function ComposerControls({
       <DictationButton disabled={disabled} onToggle={onDictate} state={state.voice} status={voiceStatus} />
       <AutoSpeakButton active={autoSpeak} disabled={disabled} onToggle={onToggleAutoSpeak} />
       {busyAction === 'steer' ? (
-        <Tip label={<TipKeybindLabel actionId="composer.send" text={c.queueMessage} />}>
+        <Tip label={<TipKeybindLabel actionId="composer.queue" text={c.queueMessage} />}>
           <Button
             aria-label={c.queueMessage}
             className={GHOST_ICON_BTN}
@@ -116,7 +116,7 @@ export function ComposerControls({
           label={
             busy ? (
               <TipKeybindLabel
-                actionId={busyAction === 'steer' ? 'composer.steer' : 'composer.send'}
+                actionId={busyAction === 'steer' ? 'composer.steer' : busyAction === 'queue' ? 'composer.queue' : 'composer.send'}
                 text={busyLabel}
               />
             ) : (

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -587,14 +587,22 @@ export function ChatBar({
       return
     }
 
-    // Cmd/Ctrl+Enter is reserved for steering the live run — never a send.
-    // Steer when there's a steerable draft, otherwise swallow it so it can't
-    // surprise-send. (Plain Enter still queues while busy / sends when idle.)
+    // Cmd/Ctrl+Enter queues a follow-up while a turn runs. Plain Enter steers
+    // a text-only draft, so both live-turn actions stay reachable by keyboard.
     if (event.key === 'Enter' && (event.metaKey || event.ctrlKey) && !event.shiftKey) {
       event.preventDefault()
 
-      if (canSteer) {
-        steerDraft()
+      if (busy && !disabled) {
+        // As with plain Enter, source the just-typed content from the DOM so a
+        // fast keypress cannot queue a stale draft.
+        const editorText = editorRef.current ? composerPlainText(editorRef.current) : draftRef.current
+
+        if (editorText !== draftRef.current) {
+          draftRef.current = editorText
+          setComposerText(editorText)
+        }
+
+        queueDraft()
       }
 
       return

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -292,6 +292,7 @@ export const en: Translations = {
       'composer.send': 'Send message',
       'composer.newline': 'Insert newline',
       'composer.steer': 'Steer the running turn',
+      'composer.queue': 'Queue message',
       'composer.sendQueued': 'Send next queued turn',
       'composer.mention': 'Reference files, folders, URLs',
       'composer.slash': 'Slash command palette',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -283,6 +283,7 @@ export const zh: Translations = {
       'composer.send': '发送消息',
       'composer.newline': '插入换行',
       'composer.steer': '引导正在运行的回合',
+      'composer.queue': '消息排队',
       'composer.sendQueued': '发送下一条排队消息',
       'composer.mention': '引用文件、文件夹、网址',
       'composer.slash': '斜杠命令面板',

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -197,7 +197,8 @@ export interface KeybindReadonly {
 export const KEYBIND_READONLY: readonly KeybindReadonly[] = [
   { id: 'composer.send', category: 'composer', keys: ['enter'] },
   { id: 'composer.newline', category: 'composer', keys: ['shift+enter'] },
-  { id: 'composer.steer', category: 'composer', keys: ['mod+enter'] },
+  { id: 'composer.steer', category: 'composer', keys: ['enter'] },
+  { id: 'composer.queue', category: 'composer', keys: ['mod+enter'] },
   { id: 'composer.sendQueued', category: 'composer', keys: ['mod+shift+k'] },
   { id: 'composer.mention', category: 'composer', keys: ['@'] },
   { id: 'composer.slash', category: 'composer', keys: ['/'] },


### PR DESCRIPTION
## What does this PR do?

Restores a useful keyboard split for a live desktop turn: Enter keeps the Cursor-style steering behavior, while Ctrl+Enter on Linux and Cmd+Enter on macOS queues the current draft. The keybind settings and both composer tooltips now describe that behavior accurately.

## Related Issue

No tracked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Route Ctrl/Cmd+Enter to the existing busy-turn queue path in `apps/desktop/src/app/chat/composer/index.tsx`, including the live-DOM draft sync used by Enter.
- Register distinct readonly `composer.steer` (Enter) and `composer.queue` (Ctrl/Cmd+Enter) shortcuts in `apps/desktop/src/lib/keybinds/actions.ts`.
- Correct Queue and Steer tooltip labels, plus English and Chinese keybind labels.
- Exercise the real keyboard actions in `apps/desktop/e2e/queue-turn-boundary.spec.ts` and cover tooltip labels in `controls.test.tsx`.

## How to Test

1. Start a turn and type plain text in the composer.
2. Press Enter to steer the live turn, or Ctrl+Enter / Cmd+Enter to queue the draft.
3. Confirm the Queue and Steer tooltips display their matching shortcut.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: desktop TypeScript/Electron-only change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 7.1.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Ctrl/Cmd maps through the existing `mod` shortcut abstraction
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

`nix develop --command bash -lc 'cd apps/desktop && npm run check'` passed (typecheck, Vitest, desktop packaging checks).

The visual Electron suite also passed: `npm run test:e2e:visual -- e2e/queue-turn-boundary.spec.ts` reported 33 passed and 7 skipped.
