### PR TITLE
fix(state): project multimodal text into FTS indexes

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7222,14 +7222,13 @@ def _print_curator_first_run_notice() -> None:
 
 
 def _print_fts_optimize_available_notice() -> None:
-    """Advertise the opt-in v23 search-index optimization after `hermes update`.
+    """Advertise an opt-in search-index upgrade after `hermes update`.
 
-    Only fires when the current profile's state.db is still on the legacy
-    (pre-v23) inline FTS layout. Leads with the reclaimable-space figure and
-    points at the exact command. Honors ``sessions.fts_optimize_notice``:
-    ``advise`` (default) prints an advisory notice, ``require`` prints a
-    firmer required-upgrade notice, ``off`` suppresses it. Silent for
-    fresh/already-optimized installs.
+    Fires for either the legacy pre-v23 inline layout or an external-content
+    index that still includes raw multimodal image payloads. Honors
+    ``sessions.fts_optimize_notice``: ``advise`` (default) prints an advisory
+    notice, ``require`` prints a firmer required-upgrade notice, ``off``
+    suppresses it. Silent for fresh/current installs.
     """
     mode = "advise"
     try:
@@ -7247,7 +7246,7 @@ def _print_fts_optimize_available_notice() -> None:
 
     try:
         from hermes_constants import get_hermes_home
-        from hermes_state import SessionDB
+        from hermes_state import FTS_STORAGE_VERSION, SessionDB
     except Exception:
         return
     db_path = get_hermes_home() / "state.db"
@@ -7262,6 +7261,7 @@ def _print_fts_optimize_available_notice() -> None:
         return
     db = None
     interrupted = False
+    multimodal_projection_upgrade = False
     try:
         db = SessionDB(db_path=db_path, read_only=True)
         # read_only opens skip schema init, so probe the layout directly.
@@ -7269,6 +7269,22 @@ def _print_fts_optimize_available_notice() -> None:
             "SELECT sql FROM sqlite_master "
             "WHERE type = 'table' AND name = 'messages_fts'"
         ).fetchone()
+        trigram_view = db._conn.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'view' AND name = 'messages_fts_trigram_src'"
+        ).fetchone()
+        layout_row = db._conn.execute(
+            "SELECT value FROM state_meta WHERE key = 'fts_storage_version'"
+        ).fetchone()
+        try:
+            layout_version = int(layout_row[0]) if layout_row else 0
+        except (TypeError, ValueError):
+            layout_version = 0
+        multimodal_projection_upgrade = (
+            layout_version < FTS_STORAGE_VERSION
+            and trigram_view is not None
+            and "fts_content" not in ((trigram_view[0] or "").lower())
+        )
         # An interrupted `optimize-storage` run: the table is already the
         # v23 shape, but backfill markers / demoted trash tables remain.
         # Offer the command again — re-running resumes and finishes it.
@@ -7295,8 +7311,12 @@ def _print_fts_optimize_available_notice() -> None:
             except Exception:
                 pass
     sql = (row[0] if row else "") or ""
-    if not sql or ("tool_name" in sql and not interrupted):
-        # v23 layout already present (fresh/optimized) — nothing to offer.
+    if not sql or (
+        "tool_name" in sql
+        and not interrupted
+        and not multimodal_projection_upgrade
+    ):
+        # Current layout already present — nothing to offer.
         return
 
     if interrupted:
@@ -7306,6 +7326,17 @@ def _print_fts_optimize_available_notice() -> None:
             "  A previous `hermes sessions optimize-storage` run was "
             "interrupted. Search still works; re-run the command to resume "
             "and finish reclaiming disk:"
+        )
+        print("    hermes sessions optimize-storage")
+        return
+
+    if multimodal_projection_upgrade:
+        print()
+        print("◆ Search index update available")
+        print(
+            "  Your trigram index includes multimodal image payloads. "
+            "Rebuilding it indexes only message text, which avoids "
+            "SQLite-version-dependent FTS checks and can reclaim space:"
         )
         print("    hermes sessions optimize-storage")
         return
@@ -16939,12 +16970,13 @@ def main():
 
     sessions_optimize_storage = sessions_subparsers.add_parser(
         "optimize-storage",
-        help="Migrate the search index to the compact v23 layout (reclaims disk on large DBs)",
+        help="Rebuild the compact search index and omit multimodal image payloads",
         description=(
-            "Rebuild the full-text search index in the compact v23 "
-            "external-content layout. On large databases this reclaims a "
-            "large fraction of state.db (the old layout stored duplicate "
-            "copies of every message and indexed tool output). Runs "
+            "Rebuild the full-text search index in the compact "
+            "external-content layout. On large databases this can reclaim a "
+            "large fraction of state.db: the old layout stored duplicate "
+            "copies of every message and the current projection omits "
+            "multimodal image payloads. Runs "
             "foreground with a progress bar, throttles so a running gateway "
             "stays responsive, and VACUUMs at the end. Safe to interrupt and "
             "re-run — it resumes where it left off. No conversation data is "

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -283,7 +283,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 23
+SCHEMA_VERSION = 24
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the
 # state_meta key ``fts_storage_version``. The main schema version advances
@@ -293,7 +293,9 @@ SCHEMA_VERSION = 23
 # layout 0 (marker absent) with a working inline index until the user opts in.
 #   1 = v23 external-content layout (content/tool_name/tool_calls,
 #       tool-row-excluded trigram)
-FTS_STORAGE_VERSION = 1
+#   2 = multimodal text projection for the trigram index (image payloads and
+#       the NUL JSON sentinel are excluded)
+FTS_STORAGE_VERSION = 2
 
 # Cap on user-controlled FTS5 query input before regex/sanitizer processing.
 # Search queries do not need to be arbitrarily large, and bounding them keeps
@@ -1295,6 +1297,7 @@ CREATE TABLE IF NOT EXISTS messages (
     session_id TEXT NOT NULL REFERENCES sessions(id),
     role TEXT NOT NULL,
     content TEXT,
+    fts_content TEXT,
     tool_call_id TEXT,
     tool_calls TEXT,
     tool_name TEXT,
@@ -1481,14 +1484,23 @@ END;
 # of the text it covers), and ``role='tool'`` rows are ~90% of message bytes
 # while being almost entirely machine noise (base64 payloads, file dumps,
 # delegation transcripts).  The index therefore reads through
-# ``messages_fts_trigram_src``, a view that excludes tool rows — they stay
+# ``messages_fts_trigram_src``, a view that excludes tool rows and reads their
+# SessionDB-maintained multimodal text projection — they stay
 # fully stored in ``messages`` and fully searchable via the standard
 # ``messages_fts`` index; they just don't get trigram (CJK substring)
-# treatment.  ``search_messages`` routes CJK queries that filter on
+# treatment. ``search_messages`` routes CJK queries that filter on
 # ``role='tool'`` to the LIKE fallback for the same reason.
-FTS_TRIGRAM_SQL = """
+def _fts_index_content_sql(content: str, projection: str) -> str:
+    """Return the FTS value for a trusted pair of message column expressions."""
+    return (
+        f"CASE WHEN substr(CAST({content} AS BLOB), 1, 6) = X'006A736F6E3A' "
+        f"THEN COALESCE({projection}, '') ELSE {content} END"
+    )
+
+
+FTS_TRIGRAM_SQL = f"""
 CREATE VIEW IF NOT EXISTS messages_fts_trigram_src AS
-    SELECT id, role, content, tool_name, tool_calls
+    SELECT id, role, {_fts_index_content_sql('content', 'fts_content')} AS content, tool_name, tool_calls
     FROM messages
     WHERE role <> 'tool';
 
@@ -1509,7 +1521,7 @@ WHEN new.role <> 'tool'
                             WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
-    VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+    VALUES (new.id, {_fts_index_content_sql('new.content', 'new.fts_content')}, new.tool_name, new.tool_calls);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_delete AFTER DELETE ON messages
@@ -1520,7 +1532,7 @@ WHEN old.role <> 'tool'
                             WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
-    VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+    VALUES ('delete', old.id, {_fts_index_content_sql('old.content', 'old.fts_content')}, old.tool_name, old.tool_calls);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update AFTER UPDATE ON messages
@@ -1534,10 +1546,10 @@ WHEN (old.content IS NOT new.content
                             WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
-    SELECT 'delete', old.id, old.content, old.tool_name, old.tool_calls
+    SELECT 'delete', old.id, {_fts_index_content_sql('old.content', 'old.fts_content')}, old.tool_name, old.tool_calls
     WHERE old.role <> 'tool';
     INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
-    SELECT new.id, new.content, new.tool_name, new.tool_calls
+    SELECT new.id, {_fts_index_content_sql('new.content', 'new.fts_content')}, new.tool_name, new.tool_calls
     WHERE new.role <> 'tool';
 END;
 """
@@ -1576,9 +1588,9 @@ END;
 # an external-content 'delete' op for a rowid the index never held is the
 # canonical FTS5 index-corruption hazard the v23 marker gating exists to
 # prevent.
-FTS_CJK_TABLE_SQL = """
+FTS_CJK_TABLE_SQL = f"""
 CREATE VIEW IF NOT EXISTS messages_fts_cjk_src AS
-    SELECT id, role, content, tool_name, tool_calls
+    SELECT id, role, {_fts_index_content_sql('content', 'fts_content')} AS content, tool_name, tool_calls
     FROM messages
     WHERE role <> 'tool';
 
@@ -1592,7 +1604,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts_cjk USING fts5(
 );
 """
 
-FTS_CJK_TRIGGER_SQL = """
+FTS_CJK_TRIGGER_SQL = f"""
 CREATE TRIGGER IF NOT EXISTS messages_fts_cjk_insert AFTER INSERT ON messages
 WHEN new.role <> 'tool'
    AND (new.id > COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
@@ -1601,7 +1613,7 @@ WHEN new.role <> 'tool'
                             WHERE key = 'fts_cjk_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts_cjk(rowid, content, tool_name, tool_calls)
-    VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+    VALUES (new.id, {_fts_index_content_sql('new.content', 'new.fts_content')}, new.tool_name, new.tool_calls);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_cjk_delete AFTER DELETE ON messages
@@ -1612,7 +1624,7 @@ WHEN old.role <> 'tool'
                             WHERE key = 'fts_cjk_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts_cjk(messages_fts_cjk, rowid, content, tool_name, tool_calls)
-    VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+    VALUES ('delete', old.id, {_fts_index_content_sql('old.content', 'old.fts_content')}, old.tool_name, old.tool_calls);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_cjk_update AFTER UPDATE ON messages
@@ -1626,10 +1638,10 @@ WHEN (old.content IS NOT new.content
                             WHERE key = 'fts_cjk_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts_cjk(messages_fts_cjk, rowid, content, tool_name, tool_calls)
-    SELECT 'delete', old.id, old.content, old.tool_name, old.tool_calls
+    SELECT 'delete', old.id, {_fts_index_content_sql('old.content', 'old.fts_content')}, old.tool_name, old.tool_calls
     WHERE old.role <> 'tool';
     INSERT INTO messages_fts_cjk(rowid, content, tool_name, tool_calls)
-    SELECT new.id, new.content, new.tool_name, new.tool_calls
+    SELECT new.id, {_fts_index_content_sql('new.content', 'new.fts_content')}, new.tool_name, new.tool_calls
     WHERE new.role <> 'tool';
 END;
 """
@@ -2885,7 +2897,7 @@ class SessionDB:
                 )
                 conn.execute(
                     "INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls) "
-                    "SELECT m.id, m.content, m.tool_name, m.tool_calls "
+                    f"SELECT m.id, {_fts_index_content_sql('m.content', 'm.fts_content')}, m.tool_name, m.tool_calls "
                     "FROM messages m "
                     "WHERE m.id > ? AND m.id <= ? AND m.role <> 'tool' "
                     "AND NOT EXISTS (SELECT 1 FROM messages_fts_trigram_docsize d WHERE d.id = m.id)",
@@ -2990,7 +3002,7 @@ class SessionDB:
                 conn.execute(
                     "INSERT INTO messages_fts_trigram"
                     "(rowid, content, tool_name, tool_calls) "
-                    "SELECT id, content, tool_name, tool_calls FROM messages "
+                    f"SELECT id, {_fts_index_content_sql('content', 'fts_content')}, tool_name, tool_calls FROM messages "
                     "WHERE id > ? AND id <= ? AND role <> 'tool'",
                     (progress, upper),
                 )
@@ -3063,7 +3075,7 @@ class SessionDB:
             upper = min(progress + chunk, high_water)
             conn.execute(
                 "INSERT INTO messages_fts_cjk(rowid, content, tool_name, tool_calls) "
-                "SELECT id, content, tool_name, tool_calls FROM messages "
+                f"SELECT id, {_fts_index_content_sql('content', 'fts_content')}, tool_name, tool_calls FROM messages "
                 "WHERE id > ? AND id <= ? AND role <> 'tool'",
                 (progress, upper),
             )
@@ -3098,7 +3110,7 @@ class SessionDB:
                 lo, hi = hw - 1000, hw + 1000
                 conn.execute(
                     "INSERT INTO messages_fts_cjk(rowid, content, tool_name, tool_calls) "
-                    "SELECT m.id, m.content, m.tool_name, m.tool_calls "
+                    f"SELECT m.id, {_fts_index_content_sql('m.content', 'm.fts_content')}, m.tool_name, m.tool_calls "
                     "FROM messages m "
                     "WHERE m.id > ? AND m.id <= ? AND m.role <> 'tool' "
                     "AND NOT EXISTS (SELECT 1 FROM messages_fts_cjk_docsize d WHERE d.id = m.id)",
@@ -3151,20 +3163,116 @@ class SessionDB:
                 self._ensure_fts_cjk_schema(self._conn)
                 self._conn.commit()
 
-    # ── Opt-in v23 FTS storage optimization (`hermes sessions optimize-storage`) ──
+    # ── Opt-in FTS storage optimization (`hermes sessions optimize-storage`) ──
     #
     # This is the ONLY path that migrates an existing legacy (v22 inline) DB
-    # to the v23 external-content schema. It is deliberately foreground and
-    # user-invoked, never automatic, because it is disk-heavy and long. It
-    # runs the throttled/resumable chunk engine above to completion
-    # synchronously — demote → new schema → chunked backfill → chunked
-    # teardown — with progress callbacks, a disk preflight in the CLI
-    # wrapper, a VACUUM at the end, and a defensive schema_version bump.
+    # to the current external-content schema, or rebuilds an older FTS
+    # projection. It is deliberately foreground and user-invoked, never
+    # automatic, because it is disk-heavy and long. It runs the throttled /
+    # resumable chunk engine above to completion synchronously — demote → new
+    # schema → chunked backfill → chunked teardown — with progress callbacks,
+    # a disk preflight in the CLI wrapper, a VACUUM at the end, and a
+    # defensive schema_version bump.
+
+    @staticmethod
+    def _fts_storage_version(cursor) -> int:
+        """Read the independently-versioned FTS storage layout marker."""
+        row = cursor.execute(
+            "SELECT value FROM state_meta WHERE key = 'fts_storage_version'"
+        ).fetchone()
+        if row is None:
+            return 0
+        try:
+            return int(row[0])
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _fts_view_uses_multimodal_projection(cursor, view_name: str) -> bool:
+        row = cursor.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'view' AND name = ?",
+            (view_name,),
+        ).fetchone()
+        return row is None or "fts_content" in ((row[0] or "").lower())
+
+    def _fts_trigram_needs_multimodal_projection(self, cursor) -> bool:
+        """True when an existing trigram view still indexes raw JSON blobs."""
+        return (
+            self._fts_storage_version(cursor) < FTS_STORAGE_VERSION
+            and not self._fts_view_uses_multimodal_projection(
+                cursor, "messages_fts_trigram_src"
+            )
+        )
+
+    def _fts_cjk_needs_multimodal_projection(self, cursor) -> bool:
+        """True when a pre-projection CJK view needs an explicit rebuild."""
+        cjk_present = cursor.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+            "AND name = 'messages_fts_cjk'"
+        ).fetchone()
+        return bool(cjk_present) and not self._fts_view_uses_multimodal_projection(
+            cursor, "messages_fts_cjk_src"
+        )
+
+    def _upgrade_fts_trigram_projection(self) -> bool:
+        """Rebuild the trigram index against the portable text projection."""
+        with self._lock:
+            if not self._fts_trigram_needs_multimodal_projection(self._conn):
+                return False
+
+        def _do(conn):
+            for trigger in _FTS_TRIGGERS:
+                if trigger.startswith("messages_fts_trigram_"):
+                    conn.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+            conn.execute("DROP VIEW IF EXISTS messages_fts_trigram_src")
+            self._backfill_fts_content(conn)
+            if not self._ensure_fts_schema(
+                conn, "messages_fts_trigram", FTS_TRIGRAM_SQL
+            ):
+                return False
+            conn.execute(
+                "INSERT INTO messages_fts_trigram(messages_fts_trigram) "
+                "VALUES('rebuild')"
+            )
+            return True
+
+        return bool(self._execute_write(_do))
+
+    def _upgrade_fts_cjk_projection(self) -> bool:
+        """Rebuild the optional CJK index against the same text projection."""
+        if not self._fts_cjk_loaded:
+            return False
+        with self._lock:
+            if not self._fts_cjk_needs_multimodal_projection(self._conn):
+                return False
+
+        def _do(conn):
+            for trigger in _FTS_CJK_TRIGGERS:
+                conn.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+            conn.execute("DROP VIEW IF EXISTS messages_fts_cjk_src")
+            self._backfill_fts_content(conn)
+            conn.executescript(FTS_CJK_TABLE_SQL)
+            conn.executescript(FTS_CJK_TRIGGER_SQL)
+            conn.execute(
+                "INSERT INTO messages_fts_cjk(messages_fts_cjk) VALUES('rebuild')"
+            )
+            conn.execute(
+                "DELETE FROM state_meta WHERE key IN "
+                "('fts_cjk_rebuild_high_water', 'fts_cjk_rebuild_progress', ?) ",
+                (FTS_CJK_STALE_KEY,),
+            )
+            return True
+
+        upgraded = bool(self._execute_write(_do))
+        if upgraded:
+            self._fts_cjk_available = True
+        return upgraded
 
     def fts_optimize_available(self) -> bool:
         """True when `optimize_fts_storage()` has work to do: either this DB
-        is a legacy inline-FTS install that can be optimized to the v23
-        external-content schema, or a previous optimize run was interrupted
+        is a legacy inline-FTS install that can be optimized to the current
+        external-content schema, its trigram index still needs the multimodal
+        text projection, or a previous optimize run was interrupted
         (legacy vtables already demoted, but backfill markers and/or trash
         tables remain) and re-running would resume it, or the CJK-bigram
         index needs a backfill/rebuild on this tokenizer-capable host.
@@ -3174,6 +3282,8 @@ class SessionDB:
             return False
         with self._lock:
             if self._db_has_legacy_inline_fts(self._conn):
+                return True
+            if self._fts_trigram_needs_multimodal_projection(self._conn):
                 return True
             # Interrupted optimize: demotion already removed the legacy
             # vtables (so the check above is False), but the transition is
@@ -3192,6 +3302,10 @@ class SessionDB:
                 "SELECT 1 FROM state_meta WHERE key IN "
                 f"('fts_cjk_rebuild_high_water', '{FTS_CJK_STALE_KEY}') LIMIT 1"
             ).fetchone():
+                return True
+            if self._fts_cjk_loaded and self._fts_cjk_needs_multimodal_projection(
+                self._conn
+            ):
                 return True
             return self._has_fts_trash(self._conn)
 
@@ -3234,7 +3348,8 @@ class SessionDB:
                 ]
                 for sh in shadows:
                     conn.execute(f"ALTER TABLE {sh} RENAME TO fts_v22_trash_{sh}")
-            # Create the new v23 empty schema + set the backfill markers.
+            self._backfill_fts_content(conn)
+            # Create the current empty schema + set the backfill markers.
             self._ensure_fts_schema(conn, "messages_fts", FTS_SQL)
             self._ensure_fts_schema(conn, "messages_fts_trigram", FTS_TRIGRAM_SQL)
             hw = conn.execute("SELECT COALESCE(MAX(id), 0) FROM messages").fetchone()[0]
@@ -3257,9 +3372,12 @@ class SessionDB:
         progress_cb: Optional[Callable[[Dict[str, Any]], None]] = None,
         vacuum: bool = True,
     ) -> Dict[str, Any]:
-        """Migrate a legacy v22 inline-FTS DB to the v23 external-content
-        schema, foreground and to completion. Safe to re-run: if a previous
-        attempt was interrupted it resumes from the progress marker.
+        """Migrate or rebuild the FTS layout, foreground and to completion.
+
+        Safe to re-run: if a previous attempt was interrupted it resumes from
+        the progress marker. Older external-content indexes are rebuilt here
+        as well so their trigram and CJK indexes use the multimodal text
+        projection.
 
         ``progress_cb`` receives {"phase", "percent", "indexed", "total"}
         dicts for a CLI progress bar. Returns a summary dict.
@@ -3281,6 +3399,8 @@ class SessionDB:
         pending = self.get_meta("fts_rebuild_high_water") is not None
         if legacy and not pending:
             self._demote_legacy_fts_to_trash()
+        elif not legacy:
+            self._upgrade_fts_trigram_projection()
 
         # A stale CJK index (triggers dropped by a tokenizer-less process)
         # can only be recovered from scratch — reset it now so the cjk
@@ -3293,6 +3413,7 @@ class SessionDB:
             with self._lock:
                 self._ensure_fts_cjk_schema(self._conn)
                 self._conn.commit()
+            self._upgrade_fts_cjk_projection()
 
         def _emit(phase: str) -> None:
             if progress_cb is None:
@@ -3386,12 +3507,19 @@ class SessionDB:
         # DB opened only by pre-decoupling code still settles). The FTS-layout
         # marker is the source of truth for "is this DB optimized".
         def _settle(conn):
-            conn.execute(
-                "INSERT INTO state_meta (key, value) VALUES ('fts_storage_version', ?) "
-                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                (str(FTS_STORAGE_VERSION),),
-            )
-            conn.execute("DELETE FROM state_meta WHERE key = 'fts_optimize_available'")
+            if not self._fts_trigram_needs_multimodal_projection(conn):
+                conn.execute(
+                    "INSERT INTO state_meta (key, value) VALUES ('fts_storage_version', ?) "
+                    "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    (str(FTS_STORAGE_VERSION),),
+                )
+                conn.execute("DELETE FROM state_meta WHERE key = 'fts_optimize_available'")
+            else:
+                conn.execute(
+                    "INSERT INTO state_meta (key, value) VALUES "
+                    "('fts_optimize_available', '1') "
+                    "ON CONFLICT(key) DO UPDATE SET value = '1'"
+                )
             conn.execute(
                 "UPDATE schema_version SET version = ? WHERE version < ?",
                 (SCHEMA_VERSION, SCHEMA_VERSION),
@@ -3872,15 +4000,12 @@ class SessionDB:
                     self.set_meta("fts_optimize_available", "1", cursor=cursor)
 
             # The FTS storage layout is versioned independently of the main
-            # schema (see the v23 note above). Stamp the current layout so the
-            # main version can always advance: a fresh/optimized DB is at
-            # FTS_STORAGE_VERSION; a legacy DB is left at whatever it had
-            # (absent/0) until `optimize-storage` runs. An INTERRUPTED
-            # optimize (legacy vtables already demoted, but rebuild markers
-            # or demoted trash tables still present) is NOT stamped either —
-            # the marker is the source of truth for "fully optimized", and
-            # `fts_optimize_available()` keeps offering the resume until the
-            # transition actually completes.
+            # schema (see the v23 note above). Stamp a fresh/current layout so
+            # the main version can always advance. A legacy DB, an older
+            # trigram projection, or an interrupted optimize is left at its
+            # prior marker until the foreground `optimize-storage` rebuild
+            # completes — the marker is the source of truth for whether the
+            # index itself is current.
             if (
                 fts5_available
                 and not self._db_has_legacy_inline_fts(cursor)
@@ -3890,9 +4015,12 @@ class SessionDB:
                 ).fetchone() is None
                 and not self._has_fts_trash(cursor)
             ):
-                self.set_meta(
-                    "fts_storage_version", str(FTS_STORAGE_VERSION), cursor=cursor
-                )
+                if self._fts_trigram_needs_multimodal_projection(cursor):
+                    self.set_meta("fts_optimize_available", "1", cursor=cursor)
+                else:
+                    self.set_meta(
+                        "fts_storage_version", str(FTS_STORAGE_VERSION), cursor=cursor
+                    )
 
             # Advance schema_version to current for ALL non-FTS-layout
             # migrations. This is deliberately NOT gated on the FTS opt-in —
@@ -7010,6 +7138,42 @@ class SessionDB:
             return None
         return meta
 
+    @classmethod
+    def _fts_content(cls, content: Any) -> Optional[str]:
+        """Return the text worth indexing from stored message content.
+
+        Multimodal rows retain their sentinel-prefixed JSON verbatim for
+        replay, but only explicit text parts belong in substring indexes.
+        Image URLs frequently contain multi-megabyte base64 data and are not
+        meaningful search targets.
+        """
+        decoded = cls._decode_content(content)
+        if isinstance(decoded, list):
+            text_parts = [
+                part.get("text")
+                for part in decoded
+                if isinstance(part, dict)
+                and part.get("type") == "text"
+                and isinstance(part.get("text"), str)
+            ]
+            return " ".join(text_parts).replace("\x00", " ")
+        if isinstance(decoded, dict):
+            text = decoded.get("text") if decoded.get("type") == "text" else ""
+            return text.replace("\x00", " ") if isinstance(text, str) else ""
+        return None
+
+    def _backfill_fts_content(self, conn) -> None:
+        """Populate indexed text before rebuilding a projection-backed FTS view."""
+        rows = conn.execute(
+            "SELECT id, content FROM messages "
+            "WHERE substr(CAST(content AS BLOB), 1, 6) = X'006A736F6E3A'"
+        )
+        while batch := rows.fetchmany(500):
+            conn.executemany(
+                "UPDATE messages SET fts_content = ? WHERE id = ?",
+                [(self._fts_content(row[1]), row[0]) for row in batch],
+            )
+
     def append_message(
         self,
         session_id: str,
@@ -7082,6 +7246,7 @@ class SessionDB:
         # Multimodal content (list of parts) must be JSON-encoded: sqlite3
         # cannot bind list/dict parameters directly.
         stored_content = self._encode_content(content)
+        fts_content = self._fts_content(stored_content)
 
         message_timestamp = time.time()
         if timestamp is not None:
@@ -7122,15 +7287,16 @@ class SessionDB:
             ):
                 raise CompressionSessionClosedError(session_id)
             cursor = conn.execute(
-                """INSERT INTO messages (session_id, role, content, tool_call_id,
+                """INSERT INTO messages (session_id, role, content, fts_content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
                    codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
                     stored_content,
+                    fts_content,
                     tool_call_id,
                     tool_calls_json,
                     _scrub_surrogates(tool_name),
@@ -7261,17 +7427,19 @@ class SessionDB:
             )
 
             api_content = msg.get("api_content")
+            stored_content = self._encode_content(msg.get("content"))
 
             conn.execute(
-                """INSERT INTO messages (session_id, role, content, tool_call_id,
+                """INSERT INTO messages (session_id, role, content, fts_content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
                    codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
-                    self._encode_content(msg.get("content")),
+                    stored_content,
+                    self._fts_content(stored_content),
                     msg.get("tool_call_id"),
                     tool_calls_json,
                     _scrub_surrogates(msg.get("tool_name")),

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3504,8 +3504,8 @@ class TestBulkDeleteSessions:
         bulk-delete CLI / web flows don't leak files."""
         db.create_session(session_id="s1", source="cli")
         db.create_session(session_id="s2", source="cli")
-        (tmp_path / "s1.jsonl").write_text("")
-        (tmp_path / "s2.json").write_text("{}")
+        (tmp_path / "s1.jsonl").write_text("", encoding="utf-8")
+        (tmp_path / "s2.json").write_text("{}", encoding="utf-8")
 
         deleted = db.delete_sessions(["s1", "s2"], sessions_dir=tmp_path)
         assert deleted == 2
@@ -3619,9 +3619,9 @@ class TestDeleteEmptySessions:
         db.end_session("empty_with_dump", end_reason="done")
 
         dump = tmp_path / "request_dump_empty_with_dump_0.json"
-        dump.write_text("{}")
+        dump.write_text("{}", encoding="utf-8")
         transcript = tmp_path / "empty_with_dump.jsonl"
-        transcript.write_text("")
+        transcript.write_text("", encoding="utf-8")
 
         deleted = db.delete_empty_sessions(sessions_dir=tmp_path)
         assert deleted == 1
@@ -5602,10 +5602,10 @@ class TestAutoMaintenance:
         db.create_session(session_id="new", source="cli")  # active
 
         # Transcript files mimicking real gateway/CLI layout
-        (sessions_dir / "old1.json").write_text("{}")
-        (sessions_dir / "old1.jsonl").write_text("{}\n")
-        (sessions_dir / "old2.jsonl").write_text("{}\n")
-        (sessions_dir / "request_dump_old1_001.json").write_text("{}")
+        (sessions_dir / "old1.json").write_text("{}", encoding="utf-8")
+        (sessions_dir / "old1.jsonl").write_text("{}\n", encoding="utf-8")
+        (sessions_dir / "old2.jsonl").write_text("{}\n", encoding="utf-8")
+        (sessions_dir / "request_dump_old1_001.json").write_text("{}", encoding="utf-8")
         (sessions_dir / "new.jsonl").write_text("{}\n")  # active, must survive
 
         result = db.maybe_auto_prune_and_vacuum(
@@ -5639,7 +5639,7 @@ class TestAutoMaintenance:
         )
         db.end_session("long-lived", end_reason="agent_close")
         transcript = sessions_dir / "long-lived.jsonl"
-        transcript.write_text('{"role":"user","content":"recent"}\n')
+        transcript.write_text('{"role":"user","content":"recent"}\n', encoding="utf-8")
 
         result = db.maybe_auto_prune_and_vacuum(
             retention_days=90,
@@ -5659,7 +5659,7 @@ class TestAutoMaintenance:
         sessions_dir = tmp_path / "sessions"
         sessions_dir.mkdir()
         self._make_old_ended(db, "old", days_old=100)
-        (sessions_dir / "old.jsonl").write_text("{}\n")
+        (sessions_dir / "old.jsonl").write_text("{}\n", encoding="utf-8")
 
         result = db.maybe_auto_prune_and_vacuum(retention_days=90)
         assert result["pruned"] == 1
@@ -5672,8 +5672,8 @@ class TestAutoMaintenance:
         sessions_dir.mkdir()
         self._make_old_ended(db, "old", days_old=100)
         db.create_session(session_id="active", source="cli")  # not ended
-        (sessions_dir / "old.jsonl").write_text("{}\n")
-        (sessions_dir / "active.jsonl").write_text("{}\n")
+        (sessions_dir / "old.jsonl").write_text("{}\n", encoding="utf-8")
+        (sessions_dir / "active.jsonl").write_text("{}\n", encoding="utf-8")
 
         count = db.prune_sessions(older_than_days=90, sessions_dir=sessions_dir)
         assert count == 1
@@ -6253,6 +6253,130 @@ class TestFTSExternalContentMigration:
                 "INSERT INTO messages_fts_trigram(messages_fts_trigram, rank) "
                 "VALUES('integrity-check', 1)"
             )
+        finally:
+            db.close()
+
+    def test_multimodal_trigram_indexes_text_without_image_payload(self, tmp_path):
+        """The projection omits the sentinel and unsearchable image bytes."""
+        db = SessionDB(db_path=tmp_path / "fresh.db")
+        try:
+            db.create_session(session_id="s1", source="cli")
+            db.append_message(
+                "s1",
+                role="user",
+                content=[
+                    {"type": "text", "text": "searchable multimodal text"},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/png;base64,unsearchablebase64payload"
+                        },
+                    },
+                ],
+            )
+
+            projected = db._conn.execute(
+                "SELECT content FROM messages_fts_trigram_src"
+            ).fetchone()[0]
+            stored = db._conn.execute("SELECT content FROM messages").fetchone()[0]
+            assert stored.startswith("\x00json:")
+            assert projected == "searchable multimodal text"
+            assert "\x00" not in projected
+            assert "unsearchablebase64payload" not in projected
+            assert db._conn.execute(
+                "SELECT COUNT(*) FROM messages_fts_trigram "
+                "WHERE messages_fts_trigram MATCH 'searchable'"
+            ).fetchone()[0] == 1
+            assert db._conn.execute(
+                "SELECT COUNT(*) FROM messages_fts_trigram "
+                "WHERE messages_fts_trigram MATCH 'unsearchablebase64payload'"
+            ).fetchone()[0] == 0
+            db._conn.execute(
+                "INSERT INTO messages_fts_trigram(messages_fts_trigram, rank) "
+                "VALUES('integrity-check', 1)"
+            )
+            assert db._conn.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+        finally:
+            db.close()
+
+    def test_optimize_rebuilds_v1_trigram_with_multimodal_projection(self, tmp_path):
+        """An older external-content trigram index is rebuilt on demand."""
+        db = SessionDB(db_path=tmp_path / "v1.db")
+        try:
+            db.create_session(session_id="s1", source="cli")
+            db.append_message(
+                "s1",
+                role="user",
+                content=[
+                    {"type": "text", "text": "legacy searchable text"},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/png;base64,legacybase64payload"
+                        },
+                    },
+                ],
+            )
+
+            def _restore_v1_trigram(conn):
+                for trigger in (
+                    "messages_fts_trigram_insert",
+                    "messages_fts_trigram_delete",
+                    "messages_fts_trigram_update",
+                ):
+                    conn.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+                conn.execute("DROP VIEW messages_fts_trigram_src")
+                conn.executescript("""
+                    CREATE VIEW messages_fts_trigram_src AS
+                        SELECT id, role, content, tool_name, tool_calls
+                        FROM messages WHERE role <> 'tool';
+                    CREATE TRIGGER messages_fts_trigram_insert AFTER INSERT ON messages
+                    WHEN new.role <> 'tool' BEGIN
+                        INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
+                        VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+                    END;
+                    CREATE TRIGGER messages_fts_trigram_delete AFTER DELETE ON messages
+                    WHEN old.role <> 'tool' BEGIN
+                        INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
+                        VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+                    END;
+                    CREATE TRIGGER messages_fts_trigram_update AFTER UPDATE ON messages
+                    WHEN old.role <> 'tool' BEGIN
+                        INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
+                        VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+                        INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
+                        VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+                    END;
+                """)
+                conn.execute(
+                    "INSERT INTO state_meta (key, value) VALUES "
+                    "('fts_storage_version', '1') "
+                    "ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+                )
+                conn.execute(
+                    "INSERT INTO messages_fts_trigram(messages_fts_trigram) VALUES('rebuild')"
+                )
+
+            db._execute_write(_restore_v1_trigram)
+            assert db.fts_optimize_available() is True
+
+            result = db.optimize_fts_storage(vacuum=False)
+
+            assert result["ok"] is True
+            assert db.get_meta("fts_storage_version") == str(
+                hermes_state.FTS_STORAGE_VERSION
+            )
+            projected = db._conn.execute(
+                "SELECT content FROM messages_fts_trigram_src"
+            ).fetchone()[0]
+            assert projected == "legacy searchable text"
+            assert "\x00" not in projected
+            assert "legacybase64payload" not in projected
+            db._conn.execute(
+                "INSERT INTO messages_fts_trigram(messages_fts_trigram, rank) "
+                "VALUES('integrity-check', 1)"
+            )
+            assert db._conn.execute("PRAGMA quick_check").fetchone()[0] == "ok"
         finally:
             db.close()
 
@@ -7702,8 +7826,6 @@ class TestDisplayMetadataPersistence:
         switched = [m for m in reloaded if m.get("display_kind") == "model_switch"]
         assert len(switched) == 1
         assert switched[0]["display_metadata"] == meta
-
-
 class TestDisplayMetadataReadPaths:
     """Every message read path must hand back the decoded dict.
 
@@ -7809,9 +7931,6 @@ class TestDisplayMetadataReadPaths:
             }],
         )
         assert db.get_messages_as_conversation("s1")[0]["display_metadata"] == self.META
-
-
-
 class TestGatewayRoutingPkHeal:
     """Legacy gateway_routing tables (session_key-only PK) get rebuilt on open.
 


### PR DESCRIPTION
## What does this PR do?

Projects sentinel-prefixed multimodal message content into an FTS-only text field, so trigram and CJK indexes include text parts but exclude image URLs and base64 payloads. This removes the embedded NUL that makes trigram integrity checks SQLite-version-dependent, while preserving the original stored content for replay. Existing external-content indexes are upgraded deliberately by `hermes sessions optimize-storage`.

## Related Issue

Fixes #69672

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`: add a SessionDB-maintained multimodal text projection, use it in trigram/CJK FTS views, triggers, and rebuild paths, and version the opt-in FTS upgrade.
- `hermes_cli/main.py`: advertise the projection rebuild and describe the updated optimize-storage behavior.
- `tests/test_hermes_state.py`: cover text-only multimodal indexing, image-payload exclusion, FTS integrity, and rebuilding the prior external-content layout.

## How to Test

1. Activate the repository virtualenv and run `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`.
2. Run `/opt/homebrew/bin/timeout -k 30 480 $VIRTUAL_ENV/bin/python -m pytest tests/test_hermes_state.py tests/test_fts_cjk_bigram.py -q -x --timeout=60`.
3. Create a session with a text plus `image_url` multimodal message; confirm the text matches `messages_fts_trigram` but the base64 token does not, then run the FTS `integrity-check`.
4. For an existing affected database, run `hermes sessions optimize-storage` and verify `PRAGMA quick_check` succeeds.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.5.0, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — no skill is added.

## Screenshots / Logs

N/A — database/index behavior only.

<!-- autocontrib:worker-id=issue-new-ea36c45e kind=pr-open -->