### PR TITLE
fix(ci): run trusted Docker publish directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,10 @@ jobs:
   docker:
     name: Build&Test Docker image
     needs: detect
-    if: needs.detect.outputs.python == 'true' || needs.detect.outputs.frontend == 'true' || needs.detect.outputs.docker_meta == 'true'
+    # Trusted main pushes run docker.yml directly so its container-publish
+    # environment secrets never cross this reusable-workflow call. PR runs
+    # remain build/test-only and secret-free.
+    if: needs.detect.outputs.event_name == 'pull_request' && (needs.detect.outputs.python == 'true' || needs.detect.outputs.frontend == 'true' || needs.detect.outputs.docker_meta == 'true')
     uses: ./.github/workflows/docker.yml
 
   supply-chain:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,15 @@
 name: Docker Build, Test, and Publish
 
 on:
+  # Trusted main pushes run this workflow directly so environment-scoped
+  # Docker Hub secrets are resolved by the top-level workflow, never across
+  # a reusable-workflow boundary.
+  push:
+    branches: [main]
   release:
     types: [published]
+  # CI calls this only for untrusted PR build/test coverage. Those runs never
+  # reach the protected publish or merge jobs below.
   workflow_call:
 
 permissions:


### PR DESCRIPTION
## What does this PR do?

Fixes Docker Hub publishing after the CI credential-boundary cleanup. The protected `container-publish` credentials were resolving as empty when Docker publishing ran through CI's reusable-workflow call.

The Docker workflow now runs directly for trusted pushes to `main`, where it resolves its own environment-scoped secrets. CI continues to call it only for untrusted PR build/test coverage, which remains secret-free.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- Add a direct `push: main` trigger to `.github/workflows/docker.yml` for the trusted Docker publish path.
- Restrict CI's reusable Docker workflow call to pull requests, keeping it build/test-only and secret-free.
- Preserve the `container-publish` environment as the sole Docker Hub credential boundary; no repository secrets or `secrets: inherit` were added.

## How to Test

1. Run `nix run nixpkgs#actionlint -- .github/workflows/ci.yml .github/workflows/docker.yml`.
2. Run `nix develop -c scripts/run_tests.sh tests/ci/test_classify_changes.py`.
3. Merge to `main` and confirm the direct Docker workflow logs into Docker Hub and publishes the multi-arch image.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A; this CI-only change was verified with the focused hermetic CI test below.
- [ ] I've added tests for my changes — N/A; GitHub Actions execution is the integration proof for this trigger/credential boundary.
- [x] I've tested on my platform: NixOS (actionlint and focused CI tests)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; workflow comments document the boundary.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A; GitHub-hosted Linux workflow only.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

- `nix run nixpkgs#actionlint -- .github/workflows/ci.yml .github/workflows/docker.yml` passed.
- `nix develop -c scripts/run_tests.sh tests/ci/test_classify_changes.py` passed: 33 tests.
