### PR TITLE
feat(api-server): emit tool-call generation progress on SSE streams

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1827,6 +1827,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
+        tool_gen_callback=None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
     ) -> Any:
@@ -1946,6 +1947,7 @@ class APIServerAdapter(BasePlatformAdapter):
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
+            tool_gen_callback=tool_gen_callback,
             session_db=self._ensure_session_db(),
             fallback_model=fallback_model,
             reasoning_config=reasoning_config,
@@ -2925,6 +2927,29 @@ class APIServerAdapter(BasePlatformAdapter):
                     "status": "completed",
                 }))
 
+            def _on_tool_gen(tool_name):
+                """Emit ``hermes.tool.progress`` with ``status: preparing``.
+
+                Fires when the model begins generating tool-call arguments —
+                the gap between the last reasoning/content delta and
+                ``status: running`` where a large argument payload (e.g. a
+                45 KB write_file) previously left SSE clients with no
+                signal at all, looking like a hung connection.  No
+                ``toolCallId`` is included: the call id is not knowable
+                until argument generation finishes, so consumers must not
+                correlate this event to a later ``running``/``completed``
+                pair.  Internal tools (``_`` prefix) stay off the wire,
+                matching ``_on_tool_start``.
+                """
+                if not tool_name or tool_name.startswith("_"):
+                    return
+                from agent.display import get_tool_emoji
+                _stream_q.put(("__tool_progress__", {
+                    "tool": tool_name,
+                    "emoji": get_tool_emoji(tool_name),
+                    "status": "preparing",
+                }))
+
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.
             #
@@ -2942,6 +2967,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 stream_delta_callback=_on_delta,
                 tool_start_callback=_on_tool_start,
                 tool_complete_callback=_on_tool_complete,
+                tool_gen_callback=_on_tool_gen,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
                 route=route,
@@ -4745,6 +4771,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
+        tool_gen_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
@@ -4787,6 +4814,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         tool_progress_callback=tool_progress_callback,
                         tool_start_callback=tool_start_callback,
                         tool_complete_callback=tool_complete_callback,
+                        tool_gen_callback=tool_gen_callback,
                         gateway_session_key=gateway_session_key,
                         route=route,
                     )
@@ -5013,6 +5041,24 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
+        # Surface tool-call argument generation so clients can tell the
+        # difference between "model is writing a large tool payload" and a
+        # stalled run.  Fires before tool.started; carries no call id.
+        def _gen_cb(tool_name: str) -> None:
+            if not tool_name or tool_name.startswith("_"):
+                return
+            if run_id not in self._run_streams:
+                return
+            try:
+                loop.call_soon_threadsafe(_put_event_if_active, {
+                    "event": "tool.generating",
+                    "run_id": run_id,
+                    "timestamp": time.time(),
+                    "tool": tool_name,
+                })
+            except Exception:
+                pass
+
         self._set_run_status(
             run_id,
             "queued",
@@ -5048,6 +5094,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         session_id=session_id,
                         stream_delta_callback=_text_cb,
                         tool_progress_callback=event_cb,
+                        tool_gen_callback=_gen_cb,
                         gateway_session_key=gateway_session_key,
                         route=route,
                     )

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1677,6 +1677,71 @@ class TestChatCompletionsEndpoint:
             assert '"status": "completed"' not in body
 
     @pytest.mark.asyncio
+    async def test_stream_emits_tool_preparing_event(self, adapter):
+        """``tool_gen_callback`` fires → ``status: preparing`` progress event.
+
+        While the model streams tool-call arguments (potentially tens of
+        KB for e.g. write_file), no content delta and no tool lifecycle
+        event is produced; without a ``preparing`` signal SSE clients
+        cannot distinguish generation from a stalled connection.  The
+        event intentionally carries no ``toolCallId`` (unknowable until
+        argument generation completes), and internal tools are filtered.
+        """
+        import asyncio
+        import json as _json
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                gen_cb = kwargs.get("tool_gen_callback")
+                ts_cb = kwargs.get("tool_start_callback")
+                cb = kwargs.get("stream_delta_callback")
+                if gen_cb:
+                    gen_cb("_thinking")      # internal — must be filtered
+                    gen_cb("write_file")     # real tool — must surface
+                if ts_cb:
+                    ts_cb("call_write_1", "write_file", {"path": "/tmp/a", "content": "..."})
+                if cb:
+                    await asyncio.sleep(0.05)
+                    cb("done.")
+                return (
+                    {"final_response": "done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "write"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+            events = []
+            lines = body.splitlines()
+            for i, line in enumerate(lines):
+                if line.strip() != "event: hermes.tool.progress":
+                    continue
+                for follow in lines[i + 1: i + 4]:
+                    if follow.startswith("data: "):
+                        events.append(_json.loads(follow[len("data: "):]))
+                        break
+
+            preparing = [e for e in events if e.get("status") == "preparing"]
+            assert len(preparing) == 1, f"expected exactly 1 preparing event, got {events}"
+            assert preparing[0]["tool"] == "write_file"
+            assert "emoji" in preparing[0]
+            # No call id exists during argument generation — clients must
+            # not be invited to correlate.
+            assert "toolCallId" not in preparing[0]
+            # Internal tool filtered at the source.
+            assert all(e.get("tool") != "_thinking" for e in events)
+
+    @pytest.mark.asyncio
     async def test_no_user_message_returns_400(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -325,6 +325,50 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+    @pytest.mark.asyncio
+    async def test_events_stream_includes_tool_generating(self, adapter):
+        """tool_gen_callback fires → ``tool.generating`` event on the run stream.
+
+        Large tool-call argument payloads (e.g. a 45 KB write_file) can
+        take tens of seconds to generate; without this event subscribers
+        see no activity between reasoning/message deltas and tool.started
+        and cannot tell generation apart from a stalled run.  Internal
+        tools (``_`` prefix) are filtered.
+        """
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            captured: dict = {}
+
+            def _fake_create(**kwargs):
+                captured.update(kwargs)
+                mock_agent = MagicMock()
+
+                def _run(user_message=None, conversation_history=None, task_id=None):
+                    cb = captured.get("tool_gen_callback")
+                    if cb:
+                        cb("_thinking")   # internal — must be filtered
+                        cb("write_file")  # real tool — must surface
+                    return {"final_response": "ok"}
+
+                mock_agent.run_conversation.side_effect = _run
+                mock_agent.session_prompt_tokens = 1
+                mock_agent.session_completion_tokens = 1
+                mock_agent.session_total_tokens = 2
+                return mock_agent
+
+            with patch.object(adapter, "_create_agent", side_effect=_fake_create):
+                resp = await cli.post("/v1/runs", json={"input": "write"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert events_resp.status == 200
+                body = await events_resp.text()
+
+            assert '"event": "tool.generating"' in body
+            assert '"tool": "write_file"' in body
+            assert "_thinking" not in body
+
 
 
     @pytest.mark.asyncio

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -109,7 +109,10 @@ Uploaded files (`file` / `input_file` / `file_id`) and non-image `data:` URLs re
 **Streaming** (`"stream": true`): Returns Server-Sent Events (SSE) with token-by-token response chunks. For **Chat Completions**, the stream uses standard `chat.completion.chunk` events plus Hermes' custom `hermes.tool.progress` event for tool-start UX. For **Responses**, the stream uses OpenAI Responses event types such as `response.created`, `response.output_text.delta`, `response.output_item.added`, `response.output_item.done`, and `response.completed`.
 
 **Tool progress in streams**:
-- **Chat Completions**: Hermes emits `event: hermes.tool.progress` for tool-start visibility without polluting persisted assistant text.
+- **Chat Completions**: Hermes emits `event: hermes.tool.progress` for tool-start visibility without polluting persisted assistant text. The payload's `status` field is one of:
+  - `preparing` — the model has started generating tool-call arguments. Large argument payloads (e.g. a multi-KB `write_file`) can stream for tens of seconds; this event lets clients show activity instead of an apparently stalled connection. Fires before `running` and carries no `toolCallId` (the call id is not knowable until argument generation completes), so do not correlate it to the lifecycle pair.
+  - `running` — arguments are complete and the tool is executing; carries `toolCallId` for correlation.
+  - `completed` — the tool finished; carries the matching `toolCallId`.
 - **Responses**: Hermes emits spec-native `function_call` and `function_call_output` output items during the SSE stream, so clients can render structured tool UI in real time.
 
 ### POST /v1/responses
@@ -275,6 +278,8 @@ Statuses are retained briefly after terminal states (`completed`, `failed`, or `
 ### GET /v1/runs/\{run_id\}/events
 
 Server-Sent Events stream of the run's tool-call progress, token deltas, and lifecycle events. Designed for dashboards and thick clients that want to attach/detach without losing state.
+
+Events are JSON objects on `data:` lines, distinguished by their `event` field: `message.delta` (token text), `reasoning.available`, `tool.generating` (the model has started generating a tool call's arguments — fires before `tool.started` and carries only `tool`, no call id), `tool.started`, `tool.completed`, and `run.completed` / `run.failed` / `run.cancelled`.
 
 Unconsumed event buffers expire after five minutes so a detached client cannot
 grow memory indefinitely. This expires transport state only: a run that is


### PR DESCRIPTION
When the model streams tool-call arguments, no content delta and no tool lifecycle event is produced — for large argument payloads (e.g. a 45 KB write_file) this gap lasts tens of seconds, and SSE clients cannot distinguish slow generation from a stalled connection. The TUI already covers this gap via tool_gen_callback ("preparing <tool>…"), but the callback was never wired into the API server.

Wire tool_gen_callback through _create_agent / _run_agent and surface it on both streaming surfaces:

- /v1/chat/completions (stream): emit event: hermes.tool.progress with status "preparing" alongside the existing running/completed pair. No toolCallId is included (unknowable until argument generation completes), so clients must not correlate it to the lifecycle pair.
- /v1/runs events: emit a tool.generating event before tool.started.

Internal tools ("_" prefix) are filtered, matching _on_tool_start.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

