### PR TITLE
fix(desktop): session-tab UX — ⌘W tab-shift, draft new-tab, unified status dot, stable lanes & optimistic delete

### DIFF
--- a/apps/desktop/src/app/chat/close-tab.ts
+++ b/apps/desktop/src/app/chat/close-tab.ts
@@ -2,17 +2,25 @@ import { closeActiveTerminal } from '@/app/right-sidebar/terminal/terminals'
 import { closeWorkspaceTab } from '@/components/pane-shell/tree/store'
 import { isFocusWithin } from '@/lib/keybinds/combo'
 import { $filePreviewTabs, $previewTarget, closeActiveRightRailTab } from '@/store/preview'
+import { closeSessionTile, nextSessionTileForWorkspace } from '@/store/session-states'
 
 /**
  * ⌘W — close the tab of the context you're in, by precedence:
  *   1. a focused terminal → its active terminal tab,
  *   2. right-rail tabs (live preview and/or file peeks),
  *   3. the MAIN zone → its active tab (a session tile stacked into the workspace).
+ *   4. the MAIN (workspace) tab itself, when session tabs are stacked with it:
+ *      the workspace can't close, so ⌘W shifts the NEXT session tab into main
+ *      (loads it as the primary + drops its now-redundant tile).
  * Returns false when nothing closes, so ⌘W is a no-op — it never closes the
  * window (a bare workspace stays put). Shared by the keyboard path (Win/Linux)
  * and the macOS menu-accelerator IPC.
+ *
+ * `loadSessionIntoWorkspace` carries the app's route-based "load this session
+ * into main" (the two call sites have router access); omitting it disables the
+ * step-4 promotion (⌘W stays the pre-existing no-op on the main tab).
  */
-export function closeActiveTab(): boolean {
+export function closeActiveTab(loadSessionIntoWorkspace?: (storedSessionId: string) => void): boolean {
   if (isFocusWithin('[data-terminal]')) {
     closeActiveTerminal()
 
@@ -28,5 +36,27 @@ export function closeActiveTab(): boolean {
     return closeActiveRightRailTab()
   }
 
-  return closeWorkspaceTab()
+  // A closeable main-zone tab (a session tile that's the active tab) closes
+  // outright; the uncloseable workspace tab returns false and falls through.
+  if (closeWorkspaceTab()) {
+    return true
+  }
+
+  // The main (workspace) tab is active and can't be closed — but if session
+  // tabs are stacked with it, ⌘W shifts the next one into the main tab: drop
+  // its tile (the session stays alive, no busy-close prompt) and load it into
+  // main. Order matters — close the tile FIRST so the selection homes to the
+  // workspace instead of re-fronting the tile.
+  if (loadSessionIntoWorkspace) {
+    const next = nextSessionTileForWorkspace()
+
+    if (next) {
+      closeSessionTile(next)
+      loadSessionIntoWorkspace(next)
+
+      return true
+    }
+  }
+
+  return false
 }

--- a/apps/desktop/src/app/chat/pane-mirror.ts
+++ b/apps/desktop/src/app/chat/pane-mirror.ts
@@ -31,9 +31,10 @@ export interface PaneMirror<T> {
   before?: (tile: T) => null | string | undefined
   minWidth: string
   title: (key: string) => string
-  /** Lead-dot color for the tile's tab (e.g. a session's project color). Re-read
-   *  on every `also` change, so pass the color source in `also` to keep it live. */
-  accent?: (key: string) => string | undefined
+  /** Custom lead NODE for the tile's tab (rendered before the label). A live,
+   *  self-subscribing component (e.g. a session's status dot) so the strip needn't
+   *  re-sync on status/color change — only `title` drives re-registration. */
+  tabLead?: (key: string) => ReactNode
   render: (key: string) => ReactNode
   /** Wrap the tile's TAB (domain context menu — session verbs). */
   tabWrap?: (key: string, tab: ReactElement) => ReactNode
@@ -52,7 +53,7 @@ export interface PaneMirror<T> {
 /** Build a `watch*` fn: syncs once, then re-syncs on every source/also change.
  *  Module-level state lives in the returned closure, so call it once per app. */
 export function paneMirror<T>(cfg: PaneMirror<T>): () => void {
-  const registered = new Map<string, { dispose: () => void; title: string; accent?: string }>()
+  const registered = new Map<string, { dispose: () => void; title: string }>()
   const paneId = (key: string) => `${cfg.prefix}:${key}`
 
   const sync = () => {
@@ -62,11 +63,10 @@ export function paneMirror<T>(cfg: PaneMirror<T>): () => void {
     for (const tile of tiles) {
       const key = cfg.key(tile)
       const title = cfg.title(key)
-      const accent = cfg.accent?.(key)
       const current = registered.get(key)
 
-      // register() replaces same-id in place — safe for live title/accent refreshes.
-      if (current && current.title === title && current.accent === accent) {
+      // register() replaces same-id in place — safe for live title refreshes.
+      if (current && current.title === title) {
         continue
       }
 
@@ -75,7 +75,7 @@ export function paneMirror<T>(cfg: PaneMirror<T>): () => void {
         area: 'panes',
         title,
         data: {
-          accent,
+          tabLead: cfg.tabLead ? () => cfg.tabLead!(key) : undefined,
           dock: {
             before: cfg.before?.(tile),
             pane: cfg.anchor?.(tile) ?? 'workspace',
@@ -92,7 +92,7 @@ export function paneMirror<T>(cfg: PaneMirror<T>): () => void {
         render: () => cfg.render(key)
       })
 
-      registered.set(key, { dispose, title, accent })
+      registered.set(key, { dispose, title })
 
       if (!current) {
         registerPaneCloser(paneId(key), () => cfg.close(key))

--- a/apps/desktop/src/app/chat/session-status-dot.tsx
+++ b/apps/desktop/src/app/chat/session-status-dot.tsx
@@ -1,0 +1,141 @@
+import { useStore } from '@nanostores/react'
+
+import { type Translations, useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+import { $backgroundRunningSessionIds } from '@/store/composer-status'
+import { $unreadFinishedSessionIds } from '@/store/session'
+import { $sessionColorById, sessionColorFor } from '@/store/session-color'
+import { $attentionSessionIds, $stalledSessionIds, $workingSessionIds } from '@/store/session-states'
+import type { SessionInfo } from '@/types/hermes'
+
+import { type SessionDotState, sessionDotState } from './sidebar/session-row-state'
+
+// A pure lookup table: each state maps to its className, aria-label, and title.
+// No priority resolution here — sessionDotState already picked one. Label/title
+// resolve from sidebar.row translations, keyed by name.
+type DotVariant = {
+  ariaLabel?: (r: Translations['sidebar']['row']) => string
+  className: string
+  role?: 'status'
+  title?: (r: Translations['sidebar']['row']) => string
+}
+
+// Shared base for every active dot; idle is smaller and uses its own class.
+const DOT_BASE = 'relative size-1.5 rounded-full'
+
+// Pseudo-element ping ring that scales outward and fades — shared scaffold for
+// the two pulsing dots. The `before:bg-*` color is written inline per variant
+// (NOT interpolated here): Tailwind only generates utilities it can see as
+// complete static strings, so a `before:bg-${color}` template never emits.
+const PING = "before:absolute before:inset-0 before:animate-ping before:rounded-full before:content-['']"
+
+const DOT_VARIANTS: Record<SessionDotState, DotVariant> = {
+  // Amber steady — a clarify/approval is blocking the turn. Steady (not
+  // pulsing) reads as "your turn", distinct from the accent pulse of a turn.
+  'needs-input': {
+    ariaLabel: r => r.needsInput,
+    className: `${DOT_BASE} quest-glow bg-amber-500`,
+    role: 'status',
+    title: r => r.waitingForAnswer
+  },
+  // Accent pulse — the LLM turn is actively running.
+  working: {
+    ariaLabel: r => r.sessionRunning,
+    className: `${DOT_BASE} bg-(--ui-accent) shadow-[0_0_0.625rem_color-mix(in_srgb,var(--ui-accent)_55%,transparent)] ${PING} before:bg-(--ui-accent) before:opacity-70`,
+    role: 'status'
+  },
+  // Quiet accent pulse — the turn is still authoritative-running, but no
+  // stream activity has arrived for the watchdog window.
+  stalled: {
+    ariaLabel: r => r.sessionRunning,
+    className: `${DOT_BASE} bg-(--ui-accent) opacity-70 ${PING} before:bg-(--ui-accent) before:opacity-40`,
+    role: 'status',
+    title: r => r.sessionRunning
+  },
+  // Pulsing gray — a terminal(background=true) process is alive while the LLM
+  // is idle. Gray (not accent) reads as "something chugging along". Brighter
+  // than muted-foreground so it's visible against the surface.
+  background: {
+    ariaLabel: r => r.backgroundRunning,
+    className: `${DOT_BASE} bg-muted-foreground/80 ${PING} before:bg-muted-foreground/80 before:opacity-60`,
+    role: 'status',
+    title: r => r.backgroundRunning
+  },
+  // Steady green — a background session's turn completed and the user hasn't
+  // opened it since. "Something new here, go look."
+  unread: {
+    ariaLabel: r => r.finishedUnread,
+    className: `${DOT_BASE} bg-emerald-500`,
+    role: 'status',
+    title: r => r.finishedUnread
+  },
+  idle: {
+    className: 'size-1 rounded-full bg-(--ui-text-quaternary) opacity-80'
+  }
+}
+
+export interface SessionStatusDotProps {
+  /** The STORED session id — the key every live-state atom (working /
+   *  attention / stalled / unread / background) is keyed by, on BOTH surfaces:
+   *  the sidebar row's `session.id` and a pane tile's `storedSessionId` are the
+   *  same stored id (`$workingSessionIds` et al. map `storedSessionId`). */
+  storedSessionId: string
+  /** The session row for color resolution — recents OR the project tree. Both
+   *  call sites already hold it; passing it lets the idle dot inherit the
+   *  project color even for a session older than the paginated recents page
+   *  (which has no `$sessionColorById` entry). */
+  session?: null | SessionInfo
+  /** TUI-style tree stem for a branched session (`└─ ` / `├─ `). */
+  branchStem?: string
+  /** Applied to the OUTER wrapper (stem + dot) — e.g. hover-fade on the
+   *  reorder handle. */
+  className?: string
+}
+
+/**
+ * SESSION STATUS DOT — the ONE primitive both the sidebar row and the pane tab
+ * render, so a session's status/color can never disagree between the two
+ * surfaces. It reads every signal itself from the shared stores keyed by the
+ * stored session id: live state (working / needs-input / stalled / unread /
+ * background, mutually exclusive via `sessionDotState`) and the resolved color
+ * (override → project color, via `sessionColorFor`). An idle session shows its
+ * project color; the active states own the dot with their semantic color so an
+ * attention cue is never masked by the inherited tint.
+ */
+export function SessionStatusDot({ storedSessionId, session, branchStem, className }: SessionStatusDotProps) {
+  const { t } = useI18n()
+  const r = t.sidebar.row
+
+  // Subscribe to the shared color map for reactivity; sessionColorFor falls
+  // back to the resolver for a session outside the recents page.
+  useStore($sessionColorById)
+  const color = sessionColorFor(session) ?? null
+
+  const needsInput = useStore($attentionSessionIds).includes(storedSessionId)
+  const isWorking = useStore($workingSessionIds).includes(storedSessionId)
+  const isStalled = useStore($stalledSessionIds).includes(storedSessionId)
+  const isUnread = useStore($unreadFinishedSessionIds).includes(storedSessionId)
+  const hasBackground = useStore($backgroundRunningSessionIds).includes(storedSessionId)
+
+  const dotState = sessionDotState({ hasBackground, isStalled, isUnread, isWorking, needsInput })
+
+  return (
+    <span className={cn('flex items-center gap-0.5', className)}>
+      {branchStem ? (
+        <span aria-hidden className="shrink-0 font-mono text-[0.625rem] leading-none text-(--ui-text-quaternary)">
+          {branchStem}
+        </span>
+      ) : null}
+      {dotState === 'idle' && color ? (
+        <span aria-hidden="true" className="size-1 rounded-full" style={{ backgroundColor: color }} />
+      ) : (
+        <span
+          aria-label={DOT_VARIANTS[dotState].ariaLabel?.(r)}
+          className={DOT_VARIANTS[dotState].className}
+          role={DOT_VARIANTS[dotState].role}
+          title={DOT_VARIANTS[dotState].title?.(r)}
+        />
+      )}
+    </span>
+  )
+}

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -46,7 +46,6 @@ import {
   sessionMatchesStoredId,
   sessionPinId
 } from '@/store/session'
-import { $sessionColorById, sessionColorFor } from '@/store/session-color'
 import {
   $sessionStates,
   $sessionTiles,
@@ -63,6 +62,7 @@ import { type ComposerScope, ComposerScopeProvider } from './composer/scope'
 import { useComposerActions } from './hooks/use-composer-actions'
 import { paneMirror } from './pane-mirror'
 import { startSessionDrag } from './session-drag'
+import { SessionStatusDot } from './session-status-dot'
 import { useSessionTileActions } from './session-tile-actions'
 import { type SessionView, SessionViewProvider } from './session-view'
 import { SessionContextMenu } from './sidebar/session-actions-menu'
@@ -353,12 +353,6 @@ function tileTitle(storedSessionId: string): string {
   return stored ? sessionTitle(stored) : 'New session'
 }
 
-/** The tab's lead-dot color — the tile's session resolved through the SAME
- *  shared map the sidebar reads, so a row and its tab always agree. */
-function tileAccent(storedSessionId: string): string | undefined {
-  return sessionColorFor(tileStoredRow(storedSessionId))
-}
-
 /** The `@session` link payload for a tile tab drag — id + owning profile + title. */
 function tileDragPayload(storedSessionId: string): SessionDragPayload {
   const stored = tileStoredRow(storedSessionId)
@@ -513,8 +507,9 @@ export function WorkspaceTabMenu({ children }: { children: React.ReactElement })
 export const watchSessionTiles = paneMirror<SessionTile>({
   source: $sessionTiles,
   // $projectTree: a tile whose session is older than the recents page resolves
-  // its title/accent through the tree, which loads after the tiles register.
-  also: [$sessions, $sessionColorById, $projectTree],
+  // its title through the tree, which loads after the tiles register. (The tab's
+  // status dot subscribes to color/state itself, so it needs no `also` entry.)
+  also: [$sessions, $projectTree],
   key: t => t.storedSessionId,
   prefix: 'session-tile',
   dir: t => t.dir,
@@ -522,7 +517,13 @@ export const watchSessionTiles = paneMirror<SessionTile>({
   before: t => t.before,
   minWidth: '20rem',
   title: tileTitle,
-  accent: tileAccent,
+  // The tab's status dot — the SAME primitive the sidebar row renders, keyed by
+  // the stored id, so a session's status/color can never disagree between the
+  // two surfaces. Self-subscribing (live state + resolved color), so the strip
+  // needn't re-sync when it changes.
+  tabLead: storedSessionId => (
+    <SessionStatusDot session={tileStoredRow(storedSessionId)} storedSessionId={storedSessionId} />
+  ),
   render: storedSessionId => <SessionTilePane storedSessionId={storedSessionId} />,
   tabWrap: (storedSessionId, tab) => (
     <SessionTabMenu

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -21,6 +21,7 @@ import { useEffect, useMemo, useRef } from 'react'
 
 import { useGatewayRequest } from '@/app/gateway/hooks/use-gateway-request'
 import { useModelControls } from '@/app/session/hooks/use-model-controls'
+import { resolveStoredSession } from '@/app/session/hooks/use-session-actions/utils'
 import { blobToDataUrl } from '@/app/session/hooks/use-prompt-actions/utils'
 import { ModelMenuPanel } from '@/app/shell/model-menu-panel'
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
@@ -201,6 +202,53 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
   const resumingRef = useRef(false)
   const view = useMemo(() => buildTileView(storedSessionId), [storedSessionId])
 
+  // A tab-strip "+"/⌘T tab is created UNLISTED — its session stays out of
+  // $sessions (no sidebar clutter) until it's actually used, so the tab shows
+  // "New session". The moment this tile has a message, pull its row into
+  // $sessions via the lightweight by-id lookup so the tab (and a sidebar row)
+  // resolve the real title. `resolveStoredSession` no-ops when it's already
+  // listed, and 404s harmlessly for an in-memory draft that hasn't persisted a
+  // turn yet — so we retry across that brief persist lag and stop as soon as it
+  // lands (a global turn-complete refresh may beat us to it).
+  const hasMessages = useStore(view.$messagesEmpty) === false
+
+  useEffect(() => {
+    const alreadyListed = () => $sessions.get().some(s => sessionMatchesStoredId(s, storedSessionId))
+
+    if (!runtimeId || !hasMessages || alreadyListed()) {
+      return
+    }
+
+    let cancelled = false
+    let timer: number | undefined
+
+    const attempt = (remaining: number) => {
+      if (cancelled || alreadyListed()) {
+        return
+      }
+
+      void resolveStoredSession(storedSessionId)
+        .then(resolved => {
+          if (cancelled || resolved || remaining <= 0) {
+            return
+          }
+
+          timer = window.setTimeout(() => attempt(remaining - 1), 500)
+        })
+        .catch(() => undefined)
+    }
+
+    attempt(6)
+
+    return () => {
+      cancelled = true
+
+      if (timer !== undefined) {
+        window.clearTimeout(timer)
+      }
+    }
+  }, [hasMessages, runtimeId, storedSessionId])
+
   // Same gating as the primary's route resume (use-route-resume): never fire
   // session.resume before the gateway is OPEN. Persisted tiles mount at boot
   // while it's still connecting — an ungated resume rejected there and
@@ -300,7 +348,9 @@ export function tileStoredRow(storedSessionId: string): SessionInfo | undefined 
 function tileTitle(storedSessionId: string): string {
   const stored = tileStoredRow(storedSessionId)
 
-  return stored ? sessionTitle(stored) : 'Session'
+  // A tab-strip "+" tab is unlisted until its first turn persists, so it isn't
+  // in $sessions yet — label it "New session" rather than a bare "Session".
+  return stored ? sessionTitle(stored) : 'New session'
 }
 
 /** The tab's lead-dot color — the tile's session resolved through the SAME

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -15,7 +15,7 @@ import {
 import type { HermesGitWorktree } from '@/global'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { $dismissedWorktreeIds, dismissWorktree } from '@/store/layout'
+import { $dismissedWorktreeIds, dismissWorktree, setWorkspaceNodeOpen } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { removeWorktreePath } from '@/store/projects'
 
@@ -257,7 +257,15 @@ function RepoFlatSection({
       <WorkspaceHeader
         action={
           onNewSession && (
-            <WorkspaceAddButton label={s.newSessionIn(repo.label)} onClick={() => onNewSession(repo.path)} />
+            <WorkspaceAddButton
+              label={s.newSessionIn(repo.label)}
+              onClick={() => {
+                // Reveal the repo the new session targets if the user had it
+                // collapsed — the session lands in one of its lanes.
+                setWorkspaceNodeOpen(repo.id, true)
+                onNewSession(repo.path)
+              }}
+            />
           )
         }
         count={repoCount}

--- a/apps/desktop/src/app/chat/sidebar/projects/model.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/model.ts
@@ -5,7 +5,7 @@ import type { HermesGitWorktree } from '@/global'
 import type { SessionInfo } from '@/hermes'
 import { desktopGit } from '@/lib/desktop-git'
 import { mapPool } from '@/lib/pool'
-import { $sidebarWorkspaceCollapsedIds, toggleWorkspaceNodeCollapsed } from '@/store/layout'
+import { $sidebarWorkspaceNodeOpen, toggleWorkspaceNodeCollapsed } from '@/store/layout'
 import { $worktreeRefreshToken } from '@/store/projects'
 
 import { sessionRecency, type SidebarProjectTree } from './workspace-groups'
@@ -123,14 +123,13 @@ export function useRepoWorktreeMap(
 // Persisted open/collapse for a repo/worktree node. Lets a project's folder
 // layout auto-restore when you enter it, and survive reloads.
 //
-// The persisted set is an OVERRIDE of `defaultOpen`, not an absolute "collapsed"
-// list: XOR lets one store serve both polarities. A default-open node (repo,
-// populated lane) lists collapses; a default-collapsed node (an EMPTY lane — no
-// sessions yet) instead records an explicit expand. So empty worktree/branch
-// lanes start collapsed and only open when the user clicks in.
+// State is stored as the RESOLVED boolean per node (see `$sidebarWorkspaceNodeOpen`),
+// so a node whose `defaultOpen` flips — an empty worktree/branch lane defaults
+// collapsed, then defaults open once it holds a session — keeps whatever the
+// user explicitly chose instead of having it silently reinterpreted. An absent
+// id follows `defaultOpen`, so empty lanes still start collapsed until opened.
 export function useWorkspaceNodeOpen(id: string, defaultOpen = true): [boolean, () => void] {
-  const collapsed = useStore($sidebarWorkspaceCollapsedIds)
-  const overridden = collapsed.includes(id)
+  const state = useStore($sidebarWorkspaceNodeOpen)
 
-  return [defaultOpen ? !overridden : overridden, () => toggleWorkspaceNodeCollapsed(id)]
+  return [state[id] ?? defaultOpen, () => toggleWorkspaceNodeCollapsed(id, defaultOpen)]
 }

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { Codicon } from '@/components/ui/codicon'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { setWorkspaceNodeOpen } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { newSessionInProfile } from '@/store/profile'
 import { switchBranchInRepo } from '@/store/projects'
@@ -68,6 +69,11 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
   }
 
   const handleNewSession = async () => {
+    // Reveal the lane the new session targets — an empty worktree/branch lane
+    // starts collapsed, so without this the session lands in a folder the user
+    // can't see. Stable across the lane's default flipping open once populated.
+    setWorkspaceNodeOpen(group.id, true)
+
     if (isProfileGroup) {
       newSessionInProfile(group.id)
 

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -14,15 +14,14 @@ import { triggerHaptic } from '@/lib/haptics'
 import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
 import { coarseElapsed } from '@/lib/time'
 import { cn } from '@/lib/utils'
-import { $backgroundRunningSessionIds } from '@/store/composer-status'
-import { $unreadFinishedSessionIds } from '@/store/session'
-import { $sessionColorById } from '@/store/session-color'
-import { $attentionSessionIds, $stalledSessionIds, openSessionTile } from '@/store/session-states'
+import { $attentionSessionIds, openSessionTile } from '@/store/session-states'
 import { canOpenSessionWindow, openSessionInNewWindow } from '@/store/windows'
+
+import { SessionStatusDot } from '../session-status-dot'
 
 import { SidebarRowBody, SidebarRowGrab, SidebarRowLabel, SidebarRowLead, SidebarRowShell } from './chrome'
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
-import { type SessionDotState, sessionDotState, sessionShowsRunningArc } from './session-row-state'
+import { sessionShowsRunningArc } from './session-row-state'
 import { useProfilePrewarm } from './use-profile-prewarm'
 
 interface SidebarSessionRowProps extends React.ComponentProps<'div'> {
@@ -88,22 +87,6 @@ export function SidebarSessionRow({
   const handoffLabel = handoffSource ? (sessionSourceLabel(handoffSource) ?? handoffSource) : null
   // True when a clarify prompt in this session is waiting on the user.
   const needsInput = useStore($attentionSessionIds).includes(session.id)
-  // True when the session's most recent turn finished in the background (while
-  // the user was viewing a different session) and hasn't been opened since.
-  const isUnread = useStore($unreadFinishedSessionIds).includes(session.id)
-  // True when the turn is still running but the stream has been quiet long
-  // enough to soften the animation. This must never look like an idle row.
-  const isStalled = useStore($stalledSessionIds).includes(session.id)
-  // True when a terminal(background=true) process is alive in this session.
-  const hasBackground = useStore($backgroundRunningSessionIds).includes(session.id)
-  // The session's resolved color (idle dot tint), read from the ONE shared map
-  // the pane tabs also read — an O(1) lookup, never re-derived per render.
-  const projectColor = useStore($sessionColorById)[session.id] ?? null
-
-  // Resolve the dot's display state once — the four signals are mutually
-  // exclusive by priority, so threading them as booleans through wrappers just
-  // to collapse them at the leaf is backwards.
-  const dotState = sessionDotState({ hasBackground, isStalled, isUnread, isWorking, needsInput })
 
   return (
     <SessionContextMenu
@@ -237,16 +220,16 @@ export function SidebarSessionRow({
               dragHandleProps={dragHandleProps}
               leadClassName={needsInput ? 'overflow-visible' : undefined}
             >
-              <SessionRowLeadDot
+              <SessionStatusDot
                 branchStem={branchStem}
                 className="transition-opacity group-hover/handle:opacity-0 group-focus-within/handle:opacity-0"
-                dotState={dotState}
-                projectColor={projectColor}
+                session={session}
+                storedSessionId={session.id}
               />
             </SidebarRowGrab>
           ) : (
             <SidebarRowLead className={needsInput ? 'overflow-visible' : 'overflow-hidden'}>
-              <SessionRowLeadDot branchStem={branchStem} dotState={dotState} projectColor={projectColor} />
+              <SessionStatusDot branchStem={branchStem} session={session} storedSessionId={session.id} />
             </SidebarRowLead>
           )}
           {handoffSource && handoffLabel ? (
@@ -265,130 +248,5 @@ export function SidebarSessionRow({
         </SidebarRowBody>
       </SidebarRowShell>
     </SessionContextMenu>
-  )
-}
-
-function SessionRowLeadDot({
-  branchStem,
-  dotState = 'idle',
-  className,
-  projectColor
-}: {
-  branchStem?: string
-  dotState?: SessionDotState
-  className?: string
-  projectColor?: null | string
-}) {
-  return (
-    <span className={cn('flex items-center gap-0.5', className)}>
-      {branchStem ? (
-        <span aria-hidden className="shrink-0 font-mono text-[0.625rem] leading-none text-(--ui-text-quaternary)">
-          {branchStem}
-        </span>
-      ) : null}
-      <SidebarRowDot dotState={dotState} projectColor={projectColor} />
-    </span>
-  )
-}
-
-// A pure lookup table: each state maps to its className, aria-label, and
-// title. No priority resolution here — the call site already picked one.
-// Label/title are resolved from sidebar.row translations, keyed by name.
-type DotVariant = {
-  ariaLabel?: (r: Translations['sidebar']['row']) => string
-  className: string
-  role?: 'status'
-  title?: (r: Translations['sidebar']['row']) => string
-}
-
-// Shared base for every active dot; idle is smaller and uses its own class.
-const DOT_BASE = 'relative size-1.5 rounded-full'
-
-// Pseudo-element ping ring that scales outward and fades — shared scaffold for
-// the two pulsing dots. The `before:bg-*` color is written inline per variant
-// (NOT interpolated here): Tailwind only generates utilities it can see as
-// complete static strings, so a `before:bg-${color}` template never emits.
-const PING = "before:absolute before:inset-0 before:animate-ping before:rounded-full before:content-['']"
-
-const DOT_VARIANTS: Record<SessionDotState, DotVariant> = {
-  // Amber steady — a clarify/approval is blocking the turn. Steady (not
-  // pulsing) reads as "your turn", distinct from the accent pulse of a turn.
-  'needs-input': {
-    ariaLabel: r => r.needsInput,
-    className: `${DOT_BASE} quest-glow bg-amber-500`,
-    role: 'status',
-    title: r => r.waitingForAnswer
-  },
-  // Accent pulse — the LLM turn is actively running.
-  working: {
-    ariaLabel: r => r.sessionRunning,
-    className: `${DOT_BASE} bg-(--ui-accent) shadow-[0_0_0.625rem_color-mix(in_srgb,var(--ui-accent)_55%,transparent)] ${PING} before:bg-(--ui-accent) before:opacity-70`,
-    role: 'status'
-  },
-  // Quiet accent pulse — the turn is still authoritative-running, but no
-  // stream activity has arrived for the watchdog window.
-  stalled: {
-    ariaLabel: r => r.sessionRunning,
-    className: `${DOT_BASE} bg-(--ui-accent) opacity-70 ${PING} before:bg-(--ui-accent) before:opacity-40`,
-    role: 'status',
-    title: r => r.sessionRunning
-  },
-  // Pulsing gray — a terminal(background=true) process is alive while the LLM
-  // is idle. Gray (not accent) reads as "something chugging along". Brighter
-  // than muted-foreground so it's visible against the sidebar surface.
-  background: {
-    ariaLabel: r => r.backgroundRunning,
-    className: `${DOT_BASE} bg-muted-foreground/80 ${PING} before:bg-muted-foreground/80 before:opacity-60`,
-    role: 'status',
-    title: r => r.backgroundRunning
-  },
-  // Steady green — a background session's turn completed and the user hasn't
-  // opened it since. "Something new here, go look."
-  unread: {
-    ariaLabel: r => r.finishedUnread,
-    className: `${DOT_BASE} bg-emerald-500`,
-    role: 'status',
-    title: r => r.finishedUnread
-  },
-  idle: {
-    className: 'size-1 rounded-full bg-(--ui-text-quaternary) opacity-80'
-  }
-}
-
-function SidebarRowDot({
-  dotState,
-  className,
-  projectColor
-}: {
-  dotState: SessionDotState
-  className?: string
-  projectColor?: null | string
-}) {
-  const { t } = useI18n()
-  const r = t.sidebar.row
-
-  // An idle session inherits its project's color (a quiet marker matching the
-  // project row's own color dot). The active states (working / needs-input /
-  // background / unread) own the dot and keep their semantic color, so the
-  // inherited tint never competes with an attention cue.
-  if (dotState === 'idle' && projectColor) {
-    return (
-      <span
-        aria-hidden="true"
-        className={cn('size-1 rounded-full', className)}
-        style={{ backgroundColor: projectColor }}
-      />
-    )
-  }
-
-  const variant = DOT_VARIANTS[dotState]
-
-  return (
-    <span
-      aria-label={variant.ariaLabel?.(r)}
-      className={cn(variant.className, className)}
-      role={variant.role}
-      title={variant.title?.(r)}
-    />
   )
 }

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -3,6 +3,7 @@ import { computed } from 'nanostores'
 import type { CSSProperties, ReactElement, PointerEvent as ReactPointerEvent } from 'react'
 
 import { PREVIEW_RAIL_MAX_WIDTH, PREVIEW_RAIL_MIN_WIDTH } from '@/app/chat/right-rail'
+import { SessionStatusDot } from '@/app/chat/session-status-dot'
 import { PALETTE_AREA, type PaletteContribution } from '@/app/command-palette/contrib'
 import { type StatusbarItem } from '@/app/shell/statusbar-controls'
 import { IdleMount } from '@/components/idle-mount'
@@ -53,7 +54,6 @@ import {
 import { $filePreviewTarget, $previewTarget, closeRightRail } from '@/store/preview'
 import { $reviewOpen, closeReview, REVIEW_PANE_ID } from '@/store/review'
 import { $currentCwd, $selectedStoredSessionId, $sessions, sessionMatchesStoredId } from '@/store/session'
-import { $sessionColorById, sessionColorFor } from '@/store/session-color'
 
 import type { SessionDragPayload } from '../chat/composer/inline-refs'
 import { watchRouteTiles } from '../chat/route-tile'
@@ -410,9 +410,10 @@ const syncWorkspaceTitle = () => {
     area: 'panes',
     title: stored ? storedSessionTitle(stored) : 'New session',
     data: {
-      // The tab's lead dot — same shared map the sidebar row reads, so the
-      // main tab and its sidebar row always show the same color.
-      accent: sessionColorFor(stored),
+      // The tab's status dot — the SAME primitive the sidebar row and session
+      // tiles render, so the main tab never disagrees with its sidebar row. No
+      // dot on a fresh draft (no session yet).
+      tabLead: selected ? () => <SessionStatusDot session={stored} storedSessionId={selected} /> : undefined,
       // Pages aren't tab-able: the main zone's bar stands down while one shows.
       headerVeto: $workspaceIsPage.get(),
       placement: 'main',
@@ -427,7 +428,6 @@ const syncWorkspaceTitle = () => {
 
 $selectedStoredSessionId.listen(syncWorkspaceTitle)
 $sessions.listen(syncWorkspaceTitle)
-$sessionColorById.listen(syncWorkspaceTitle)
 $workspaceIsPage.listen(syncWorkspaceTitle)
 
 // Layout reset collapses every session tile into main as a tab (after the

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -155,10 +155,12 @@ export function useDesktopIntegrations({
   // OS-standard window close, esp. secondary windows). The Win/Linux keyboard
   // path is the `view.closeTab` keybind (use-keybinds), sharing closeActiveTab.
   useEffect(() => {
-    const unsubscribe = window.hermesDesktop?.onClosePreviewRequested?.(() => void closeActiveTab())
+    const unsubscribe = window.hermesDesktop?.onClosePreviewRequested?.(() =>
+      void closeActiveTab(id => navigate(sessionRoute(id)))
+    )
 
     return () => unsubscribe?.()
-  }, [])
+  }, [navigate])
 
   // Another window mutated the shared session list -> re-pull the sidebar.
   useEffect(() => {

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -14,6 +14,7 @@ import { type CSSProperties, lazy, type ReactNode, Suspense, useCallback, useEff
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
+import { $newSessionTabAction } from '@/components/pane-shell/tree/store'
 import { BootFailureOverlay } from '@/components/boot-failure-overlay'
 import { DesktopInstallOverlay } from '@/components/desktop-install-overlay'
 import { GatewayConnectingOverlay } from '@/components/gateway-connecting-overlay'
@@ -709,14 +710,32 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     }
   }, [])
 
+  // The tab-strip "+" and ⌘T share one action: open a new session as its own
+  // tab (stacked into the workspace zone) WITHOUT polluting the session list.
+  // Created `listed: false`, so each new tab's in-memory session stays out of
+  // the sidebar until its first message persists a turn and a refresh surfaces
+  // it — Cursor-style. Every click opens a fresh "New session" tab (multiple
+  // empty tabs are fine since none touch the session list).
+  const openNewSessionTab = useCallback(() => {
+    void openNewSessionTile('center', { listed: false })
+  }, [openNewSessionTile])
+
   // Single global listener for every rebindable hotkey plus the on-screen
   // keybind editor's capture mode (same as DesktopController).
   useKeybinds({
-    openNewSessionTab: () => void openNewSessionTile('center'),
+    openNewSessionTab,
     startFreshSession: startFreshSessionDraft,
     toggleCommandCenter,
     toggleSelectedPin
   })
+
+  // Register the tab-strip "+" action (the generic renderer stays
+  // session-agnostic; null until wired hides the glyph).
+  useEffect(() => {
+    $newSessionTabAction.set(openNewSessionTab)
+
+    return () => $newSessionTabAction.set(null)
+  }, [openNewSessionTab])
 
   // The controller's entire callback surface, gathered into the stable
   // `actions` bag. `nextActions` is TS-checked against WiringActions each

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -181,10 +181,12 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     'view.closeTerminal': () => $terminalTakeover.get() && closeActiveTerminal(),
     'view.flipPanes': togglePanesFlipped,
     // ⌘W: close the focused tab (terminal / preview target / zone tree tab).
-    // On macOS the menu accelerator owns ⌘W and routes through the same
+    // On the main tab with session tabs stacked, it shifts the next one in —
+    // the loader navigates to that session's route (loads it into main). On
+    // macOS the menu accelerator owns ⌘W and routes through the same
     // closeActiveTab via IPC (see use-desktop-integrations); this binding is
     // the Win/Linux path where ⌘W reaches the renderer directly.
-    'view.closeTab': () => void closeActiveTab(),
+    'view.closeTab': () => void closeActiveTab(id => navigate(sessionRoute(id))),
     'view.reopenTab': reopenLastClosedTile,
 
     'appearance.toggleMode': () => setMode(resolvedMode === 'dark' ? 'light' : 'dark'),

--- a/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
@@ -19,7 +19,7 @@ import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { cn } from '@/lib/utils'
 import { $renamingPath, copyFilePath, revealFile, toRelativePath } from '@/store/file-actions'
-import { $sidebarWorkspaceCollapsedIds, revealFileInTree, toggleWorkspaceNodeCollapsed } from '@/store/layout'
+import { $sidebarWorkspaceNodeOpen, revealFileInTree, toggleWorkspaceNodeCollapsed } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { setCurrentSessionPreviewTarget } from '@/store/preview'
 import {
@@ -198,9 +198,9 @@ function ReviewDirRow({
   motion: boolean
   node: ReviewTreeNode
 }) {
-  const collapsed = useStore($sidebarWorkspaceCollapsedIds)
+  const nodeOpen = useStore($sidebarWorkspaceNodeOpen)
   const id = `review:${node.id}`
-  const open = !collapsed.includes(id)
+  const open = nodeOpen[id] ?? true
   const toggle = () => toggleWorkspaceNodeCollapsed(id)
 
   return (

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -13,7 +13,13 @@ import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
-import { resolveNewSessionCwd, tombstoneSessions, untombstoneSessions } from '@/store/projects'
+import {
+  beginSessionMutation,
+  endSessionMutation,
+  resolveNewSessionCwd,
+  tombstoneSessions,
+  untombstoneSessions
+} from '@/store/projects'
 import {
   $activeSessionStoredIdRotation,
   $currentCwd,
@@ -1207,12 +1213,15 @@ export function useSessionActions({
       // Pins are keyed on the durable lineage-root id; the stored id may be the
       // live tip after compression. Drop both so the pin can't linger.
       const removedPinId = removed ? sessionPinId(removed) : storedSessionId
+      const removedIds = [storedSessionId, removed?.id, removed?._lineage_root_id]
 
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
       // Evict from the project tree's optimistic layer too (the backend snapshot
       // still lists it until its next refresh), so grouped + flat views drop the
-      // row in lockstep.
-      tombstoneSessions([storedSessionId, removed?.id, removed?._lineage_root_id])
+      // row in lockstep. Pin the tombstone against the projects.tree prune while
+      // the delete RPC is in flight, so a racing refresh can't flash it back.
+      tombstoneSessions(removedIds)
+      beginSessionMutation(removedIds)
       // Keep $sessionsTotal in sync so the sidebar's "Load N more" footer
       // doesn't keep claiming the removed row is still on the server.
       setSessionsTotal(prev => Math.max(0, prev - 1))
@@ -1253,7 +1262,7 @@ export function useSessionActions({
           setSessionsTotal(prev => prev + 1)
         }
 
-        untombstoneSessions([storedSessionId, removed?.id, removed?._lineage_root_id])
+        untombstoneSessions(removedIds)
         $pinnedSessionIds.set(previousPinned)
 
         if (wasSelected) {
@@ -1276,6 +1285,11 @@ export function useSessionActions({
         }
 
         notifyError(err, copy.deleteFailed)
+      } finally {
+        // Release the tombstone to the normal projects.tree prune now the RPC has
+        // settled (kept on success — the backend has deleted it; cleared on the
+        // rollback above on failure).
+        endSessionMutation(removedIds)
       }
     },
     [
@@ -1302,10 +1316,12 @@ export function useSessionActions({
       // Pins are keyed on the durable lineage-root id; the stored id may be the
       // live tip after compression. Drop both so the pin can't linger.
       const archivedPinId = archived ? sessionPinId(archived) : storedSessionId
+      const archivedIds = [storedSessionId, archived?.id, archived?._lineage_root_id]
 
       // Soft-hide: drop from the sidebar immediately, keep the data.
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
-      tombstoneSessions([storedSessionId, archived?.id, archived?._lineage_root_id])
+      tombstoneSessions(archivedIds)
+      beginSessionMutation(archivedIds)
       // Archived sessions are hidden by the listSessions(min_messages=1) query
       // on the next refresh, so they count as "removed" for the load-more
       // footer math.
@@ -1318,12 +1334,6 @@ export function useSessionActions({
 
       try {
         await setSessionArchived(storedSessionId, true, archived?.profile)
-        // A sidebar refresh can race the optimistic removal while the PATCH is
-        // in flight and briefly reinsert the still-unarchived backend row. Win
-        // that race after the mutation succeeds so right-click → Archive does
-        // not appear to do nothing until the next full refresh.
-        setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
-        $pinnedSessionIds.set($pinnedSessionIds.get().filter(id => id !== storedSessionId && id !== archivedPinId))
         // An archived session is hidden from the sidebar; its tile must go too.
         const tiledRuntimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
         closeSessionTile(storedSessionId)
@@ -1341,9 +1351,11 @@ export function useSessionActions({
           setSessionsTotal(prev => prev + 1)
         }
 
-        untombstoneSessions([storedSessionId, archived?.id, archived?._lineage_root_id])
+        untombstoneSessions(archivedIds)
         $pinnedSessionIds.set(previousPinned)
         notifyError(err, copy.archiveFailed)
+      } finally {
+        endSessionMutation(archivedIds)
       }
     },
     [copy, runtimeIdByStoredSessionIdRef, selectedStoredSessionId, sessionStateByRuntimeIdRef, startFreshSessionDraft]

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -457,10 +457,19 @@ export function useSessionActions({
   )
 
   /** Create a fresh session and open it as a tile — leaves the primary chat alone.
-   *  Used by the New session row's "Open in split" menu (and any future
-   *  "new chat beside" affordance). */
+   *  Used by the New session row's "Open in split" menu and the tab-strip "+".
+   *
+   *  `listed` (default true) controls sidebar visibility. A brand-new backend
+   *  session is IN-MEMORY only until its first turn persists a row, so
+   *  `listSessions(min_messages=1)` already hides an unused one — the sidebar
+   *  pollution comes solely from the optimistic upsert here. The tab-strip "+"
+   *  passes `listed: false` so an unused new tab never clutters the session
+   *  list (Cursor-style draft tab); it surfaces on the next refresh once the
+   *  first message persists a turn. "Open in split" keeps the listed behavior. */
   const openNewSessionTile = useCallback(
-    async (dir: TileDock = 'right') => {
+    async (dir: TileDock = 'right', options?: { listed?: boolean }) => {
+      const listed = options?.listed ?? true
+
       try {
         // Fresh tile → the resolved new-session cwd (project/default), not the
         // primary composer's live cwd.
@@ -476,17 +485,25 @@ export function useSessionActions({
         }
 
         createdThisRun.add(stored)
-        // Seed the sidebar + per-runtime cache, but DON'T steal the primary
-        // selection — this session lives in the tile. Prime it with the create
-        // runtime so the tile skips a redundant resume.
-        upsertOptimisticSession(created, stored, null, null)
+
+        // Seed the per-runtime cache so the tile renders immediately without a
+        // redundant resume. Only add the row to the SIDEBAR when `listed` — an
+        // unlisted (draft) tab stays out of the session list until its first
+        // turn persists and a refresh surfaces it.
+        if (listed) {
+          upsertOptimisticSession(created, stored, null, null)
+        }
+
         const runtimeInfo = applyRuntimeInfo(created.info)
         updateSessionState(created.session_id, state => (runtimeInfo ? { ...state, ...runtimeInfo } : state), stored)
 
         openSessionTile(stored, dir)
         patchSessionTile(stored, { runtimeId: created.session_id })
         revealTreePane(`session-tile:${stored}`)
-        broadcastSessionsChanged()
+
+        if (listed) {
+          broadcastSessionsChanged()
+        }
       } catch (error) {
         notifyError(error, copy.createSessionFailed)
       }

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -62,9 +62,18 @@ vi.mock('@/hermes', async importOriginal => ({
   listSidebarSessions: (...args: unknown[]) => listSidebarSessions(...args)
 }))
 
+// The refresh only reads the optimistic tombstone set; stub it so we don't pull
+// the whole projects store (gateway / fs / git) into this hook's test.
+const removed = vi.hoisted(() => ({ ids: new Set<string>() }))
+
+vi.mock('@/store/projects', () => ({
+  $removedSessionIds: { get: () => removed.ids }
+}))
+
 beforeEach(() => {
   listSidebarSessions.mockReset()
   listAllProfileSessions.mockReset()
+  removed.ids = new Set()
   setSessions([])
   setCronSessions([])
   setMessagingSessions([])
@@ -144,6 +153,28 @@ describe('refreshSessions identity + loading hygiene', () => {
     off()
     // Only the initial subscribe emission — no true/false churn per refresh.
     expect(loadingStates).toEqual([false])
+  })
+
+  it('drops rows the user just deleted, even when the backend page still lists them', async () => {
+    // A delete RPC is in flight: the row is tombstoned optimistically but the
+    // batched refresh still carries it (and a lineage-tip variant). Both must be
+    // filtered so the optimistic removal never flashes back.
+    removed.ids = new Set(['b', 'root-c'])
+    listSidebarSessions.mockResolvedValue(
+      sidebar({
+        sessions: [row('a'), row('b'), row('c', { _lineage_root_id: 'root-c' } as Partial<SessionInfo>)],
+        total: 3,
+        profile_totals: {}
+      })
+    )
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect($sessions.get().map(s => s.id)).toEqual(['a'])
   })
 
   it('still shows loading for the initial (empty-list) fetch', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -11,6 +11,7 @@ import {
 import { setCronJobs } from '@/store/cron'
 import { $pinnedSessionIds, $sessionsLimit, bumpSessionsLimit, SIDEBAR_SESSIONS_PAGE_SIZE } from '@/store/layout'
 import { ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
+import { $removedSessionIds } from '@/store/projects'
 import {
   $messagingSessions,
   $selectedStoredSessionId,
@@ -180,12 +181,22 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       if (refreshSessionsRequestRef.current === requestId) {
         const recents = result.recents
 
+        // Drop rows the user just deleted/archived: a refresh can race an
+        // in-flight mutation and the backend page still carries the doomed row.
+        // Honoring the optimistic tombstone keeps the removal from flashing back
+        // (the tombstone self-clears once projects.tree confirms the delete).
+        const tombstones = $removedSessionIds.get()
+
+        const incoming = tombstones.size
+          ? recents.sessions.filter(s => !tombstones.has(s.id) && !(s._lineage_root_id && tombstones.has(s._lineage_root_id)))
+          : recents.sessions
+
         // Signature-gate the swap (same pattern as cron/messaging): a refresh
         // that returns content-identical rows must keep the previous array
         // identity, or every sidebar memo keyed on $sessions recomputes and the
         // whole list re-renders once per turn/broadcast for nothing.
         setSessions(prev => {
-          const next = mergeSessionPage(prev, recents.sessions, sessionsToKeep())
+          const next = mergeSessionPage(prev, incoming, sessionsToKeep())
 
           return sameCronSignature(prev, next) ? prev : next
         })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
@@ -58,11 +58,11 @@ interface PaneChrome {
    *  (artifacts/skills/plugin pages) are not tab-able surfaces. The flag is
    *  live: the workspace contribution re-registers it on route changes. */
   headerVeto?: boolean
-  /** A lead-dot color for this pane's TAB (a session tab inheriting its
-   *  project color). Generic — any pane may contribute one; the strip just
-   *  renders a tinted dot before the label. Live: the owning contribution
-   *  re-registers it when the resolved color changes. */
-  accent?: string
+  /** A lead NODE for this pane's TAB, rendered before the label. A session
+   *  pane (main workspace + tiles) passes its live `SessionStatusDot` here so
+   *  the tab and the sidebar row render status/color from the ONE primitive
+   *  (self-subscribing — it updates without the strip re-registering). */
+  tabLead?: () => React.ReactNode
 }
 
 export const paneChrome = (c: Contribution | undefined) => (c?.data ?? {}) as PaneChrome

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -472,12 +472,8 @@ export function TreeGroup({
                     role="tab"
                     style={{ cursor: 'grab' }}
                   >
-                    {chrome.accent ? (
-                      <span
-                        aria-hidden="true"
-                        className="ml-2 -mr-1 size-1 shrink-0 rounded-full"
-                        style={{ backgroundColor: chrome.accent }}
-                      />
+                    {chrome.tabLead ? (
+                      <span className="ml-2 -mr-1 flex shrink-0 items-center">{chrome.tabLead()}</span>
                     ) : null}
                     <PaneTabLabel>{title}</PaneTabLabel>
                   </PaneTab>

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -37,6 +37,7 @@ import {
   $hiddenTreePanes,
   $layoutTree,
   $narrowViewport,
+  $newSessionTabAction,
   $treeDragging,
   activateTreePane,
   closeTreePane,
@@ -162,6 +163,7 @@ export function TreeGroup({
 
   const hiddenPanes = useStore($hiddenTreePanes)
   const narrow = useStore($narrowViewport)
+  const newSessionTabAction = useStore($newSessionTabAction)
 
   const paneFor = (id: string) => panes.find(p => p.id === id)
 
@@ -485,6 +487,23 @@ export function TreeGroup({
                 // tile tab); the wrapper needs the key since it's the root.
                 return <Fragment key={paneId}>{chrome.tabWrap ? chrome.tabWrap(tab) : tab}</Fragment>
               })}
+
+              {/* Plain "+" after the last tab of the MAIN strip (the workspace
+                  zone) — always shown, no tab/button chrome, just the glyph.
+                  Creates a new session tab (mirrors ⌘T) via the app-registered
+                  action; hidden when unwired or the zone is minimized. */}
+              {node.panes.includes('workspace') && newSessionTabAction && !node.minimized && (
+                <button
+                  aria-label={t.zones.newSessionTab}
+                  className="grid size-7 shrink-0 place-items-center self-center bg-transparent text-(--ui-text-quaternary) transition-colors hover:text-foreground [-webkit-app-region:no-drag]"
+                  onClick={() => newSessionTabAction()}
+                  onPointerDown={e => e.stopPropagation()}
+                  title={t.zones.newSessionTab}
+                  type="button"
+                >
+                  <Codicon name="add" size="0.8125rem" />
+                </button>
+              )}
             </div>
             {minimizable && (
               <button

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -343,6 +343,13 @@ export function treePanesWithPrefix(prefix: string): string[] {
   return tree ? allPaneIds(tree).filter(id => id.startsWith(prefix)) : []
 }
 
+/** The main tab strip's "+": open a new session as its own tab (reusing an
+ *  already-open unused tab when one exists, so repeated clicks don't pile up
+ *  empty sessions). The app wiring registers the concrete action so this
+ *  generic renderer stays session-agnostic; null until wired (the "+" hides).
+ *  An atom so the strip re-renders when the action becomes available. */
+export const $newSessionTabAction = atom<(() => void) | null>(null)
+
 /** ⌘1…⌘9: activate the Nth tab of the FOCUSED zone (the interaction tracker's
  *  group), but only when it's a real tab strip (≥2 panes). Returns false so the
  *  caller falls back to its default (profile switch) — the number keys mean

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2429,6 +2429,7 @@ export const en: Translations = {
     closeOthers: 'Close others',
     closeToRight: 'Close to the right',
     closeAll: 'Close all',
+    newSessionTab: 'New session tab',
     split: dir => `Split ${dir}`,
     move: dir => `Move ${dir}`,
     dirUp: 'up',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2362,6 +2362,7 @@ export const ja = defineLocale({
     closeOthers: '他を閉じる',
     closeToRight: '右側を閉じる',
     closeAll: 'すべて閉じる',
+    newSessionTab: '新しいセッションタブ',
     split: dir => `${dir}に分割`,
     move: dir => `${dir}へ移動`,
     dirUp: '上',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2048,6 +2048,7 @@ export interface Translations {
     closeOthers: string
     closeToRight: string
     closeAll: string
+    newSessionTab: string
     split: (dir: string) => string
     move: (dir: string) => string
     dirUp: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2290,6 +2290,7 @@ export const zhHant = defineLocale({
     closeOthers: '關閉其他',
     closeToRight: '關閉右側',
     closeAll: '全部關閉',
+    newSessionTab: '新增工作階段分頁',
     split: dir => `向${dir}分割`,
     move: dir => `向${dir}移動`,
     dirUp: '上',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2604,6 +2604,7 @@ export const zh: Translations = {
     closeOthers: '关闭其他',
     closeToRight: '关闭右侧',
     closeAll: '全部关闭',
+    newSessionTab: '新建会话标签',
     split: dir => `向${dir}拆分`,
     move: dir => `向${dir}移动`,
     dirUp: '上',

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -4,7 +4,7 @@ import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '@/app/layout-constants'
 import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
 import { matchesQuery } from '@/hooks/use-media-query'
 import { Codecs, persistentAtom } from '@/lib/persisted'
-import { arraysEqual, insertUniqueId } from '@/lib/storage'
+import { arraysEqual, insertUniqueId, readKey } from '@/lib/storage'
 
 import { $paneStates, ensurePaneRegistered, setPaneOpen, setPaneWidthOverride, togglePane } from './panes'
 
@@ -29,6 +29,7 @@ const SIDEBAR_WORKSPACE_ORDER_STORAGE_KEY = 'hermes.desktop.workspaceOrder'
 const SIDEBAR_WORKSPACE_PARENT_ORDER_STORAGE_KEY = 'hermes.desktop.workspaceParentOrder'
 const SIDEBAR_PROJECT_ORDER_STORAGE_KEY = 'hermes.desktop.projectOrder'
 const SIDEBAR_WORKSPACE_COLLAPSED_STORAGE_KEY = 'hermes.desktop.workspaceCollapsed'
+const SIDEBAR_WORKSPACE_NODE_OPEN_STORAGE_KEY = 'hermes.desktop.workspaceNodeOpen'
 const SIDEBAR_DISMISSED_AUTO_PROJECTS_STORAGE_KEY = 'hermes.desktop.dismissedAutoProjects'
 const SIDEBAR_DISMISSED_WORKTREES_STORAGE_KEY = 'hermes.desktop.dismissedWorktrees'
 const PANES_FLIPPED_STORAGE_KEY = 'hermes.desktop.panesFlipped'
@@ -96,14 +97,61 @@ export const $sidebarProjectOrderIds = persistentAtom(
   [] as string[],
   Codecs.stringArray
 )
-// Repo/worktree nodes that the user has explicitly COLLAPSED. Absent = open, so
-// a project's folders auto-open when you enter it (and persist your collapses
-// across reloads). Keyed by stable node id (repo root / worktree path).
-export const $sidebarWorkspaceCollapsedIds = persistentAtom(
-  SIDEBAR_WORKSPACE_COLLAPSED_STORAGE_KEY,
-  [] as string[],
-  Codecs.stringArray
+// Explicit open/collapse state for sidebar workspace nodes AND review file-tree
+// folders, keyed by stable node id (repo root / worktree path / `review:<path>`).
+// A stored value is the user's EXPLICIT choice (true = open, false = collapsed);
+// an absent id falls back to the caller's `defaultOpen`.
+//
+// We store the RESOLVED boolean, NOT an XOR against the default (the old
+// `workspaceCollapsed` set did the latter). The XOR was buggy for any node
+// whose default *flips*: a worktree lane defaults collapsed while empty and
+// open once it holds a session, so an explicit expand of an empty lane silently
+// re-read as a "collapse" the moment the lane gained a row — collapsing the very
+// lane the user had just opened to work in. An absolute value survives that flip.
+export const $sidebarWorkspaceNodeOpen = persistentAtom<Record<string, boolean>>(
+  SIDEBAR_WORKSPACE_NODE_OPEN_STORAGE_KEY,
+  migrateWorkspaceCollapsedIds(),
+  Codecs.json<Record<string, boolean>>(raw => {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return {}
+    }
+
+    return Object.fromEntries(
+      Object.entries(raw).filter((entry): entry is [string, boolean] => typeof entry[1] === 'boolean')
+    )
+  })
 )
+
+// One-time migration off the old XOR `workspaceCollapsed` string[]. Every id in
+// it was a deviation from a DEFAULT-OPEN node (repos + file-tree folders, whose
+// default never flips), so it maps cleanly to `collapsed` (false). The rare
+// empty-worktree-lane "expand" record maps to `false` too, which just returns
+// that lane to its default-collapsed state — self-healing, not a regression.
+function migrateWorkspaceCollapsedIds(): Record<string, boolean> {
+  if (readKey(SIDEBAR_WORKSPACE_NODE_OPEN_STORAGE_KEY) !== null) {
+    return {}
+  }
+
+  const raw = readKey(SIDEBAR_WORKSPACE_COLLAPSED_STORAGE_KEY)
+
+  if (raw === null) {
+    return {}
+  }
+
+  try {
+    const ids = JSON.parse(raw) as unknown
+
+    if (!Array.isArray(ids)) {
+      return {}
+    }
+
+    return Object.fromEntries(
+      ids.filter((id): id is string => typeof id === 'string' && id.length > 0).map(id => [id, false])
+    )
+  } catch {
+    return {}
+  }
+}
 // Auto-derived (git-repo) projects the user has dismissed ("deleted") from the
 // overview. Keyed by repo-root path; persisted so they stay hidden. Explicit
 // projects are deleted for real instead — this only declutters the auto tier.
@@ -141,11 +189,26 @@ export const $panesFlipped = persistentAtom(PANES_FLIPPED_STORAGE_KEY, false, Co
 export const $isSidebarResizing = atom(false)
 export const $sessionsLimit = atom(SIDEBAR_SESSIONS_PAGE_SIZE)
 
-// Toggle a repo/worktree node's persisted collapse state (absent = open).
-export function toggleWorkspaceNodeCollapsed(id: string): void {
-  const current = $sidebarWorkspaceCollapsedIds.get()
+// Resolve a node's open state against its default (absent = follow default).
+export function workspaceNodeOpen(id: string, defaultOpen = true): boolean {
+  return $sidebarWorkspaceNodeOpen.get()[id] ?? defaultOpen
+}
 
-  $sidebarWorkspaceCollapsedIds.set(current.includes(id) ? current.filter(nodeId => nodeId !== id) : [...current, id])
+// Force a node open/collapsed. Stable across a default flip — used by "+ new
+// session" to reveal the lane it targets and keep it open once it's populated.
+export function setWorkspaceNodeOpen(id: string, open: boolean): void {
+  const current = $sidebarWorkspaceNodeOpen.get()
+
+  if (current[id] === open) {
+    return
+  }
+
+  $sidebarWorkspaceNodeOpen.set({ ...current, [id]: open })
+}
+
+// Toggle a repo/worktree/file-tree node relative to its current resolved state.
+export function toggleWorkspaceNodeCollapsed(id: string, defaultOpen = true): void {
+  setWorkspaceNodeOpen(id, !workspaceNodeOpen(id, defaultOpen))
 }
 
 // Dismiss ("delete") an auto-derived project from the overview.

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -10,9 +10,13 @@ import {
   $projectScope,
   $projectsRpcAvailable,
   $projectTree,
+  $removedSessionIds,
+  $sessionMutationsInFlight,
   $worktreeRefreshToken,
   ALL_PROJECTS,
+  beginSessionMutation,
   createProject,
+  endSessionMutation,
   enterProject,
   exitProjectScope,
   openProjectCreate,
@@ -21,7 +25,8 @@ import {
   refreshProjects,
   refreshProjectTree,
   refreshWorktrees,
-  scanAndRecordRepos
+  scanAndRecordRepos,
+  tombstoneSessions
 } from './projects'
 
 vi.mock('@/i18n', () => ({
@@ -406,5 +411,51 @@ describe('project tree profile isolation', () => {
     await pendingA
 
     expect($projectTree.get().map(project => project.id)).toEqual(['profile-b'])
+  })
+})
+
+describe('tombstone pruning', () => {
+  const openGatewayReturning = (scopedIds: string[]) => {
+    const gateway = {
+      connectionState: 'open',
+      request: vi.fn().mockResolvedValue({ active_id: null, projects: [], scoped_session_ids: scopedIds })
+    }
+
+    activeGateway.mockImplementation(() => gateway as never)
+    gatewayAtom.set(gateway as never)
+
+    return gateway
+  }
+
+  beforeEach(() => {
+    $removedSessionIds.set(new Set())
+    $sessionMutationsInFlight.set(new Set())
+  })
+
+  it('keeps an in-flight delete tombstone even when the backend snapshot omits it', async () => {
+    // Optimistic delete: hide the row, mark the RPC as in flight.
+    tombstoneSessions(['sess-1'])
+    beginSessionMutation(['sess-1'])
+
+    // A projects.tree refresh races the pending delete: the id is already gone
+    // from scope, but the RPC hasn't landed — the tombstone must survive so the
+    // row doesn't flash back.
+    openGatewayReturning([])
+    await refreshProjectTree()
+
+    expect($removedSessionIds.get().has('sess-1')).toBe(true)
+  })
+
+  it('prunes the tombstone once the mutation settles and scope no longer lists it', async () => {
+    tombstoneSessions(['sess-1'])
+    beginSessionMutation(['sess-1'])
+    openGatewayReturning([])
+    await refreshProjectTree()
+
+    // Delete RPC settled; the next refresh with the id absent from scope drops it.
+    endSessionMutation(['sess-1'])
+    await refreshProjectTree()
+
+    expect($removedSessionIds.get().has('sess-1')).toBe(false)
   })
 })

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -94,6 +94,32 @@ export function untombstoneSessions(ids: Array<null | string | undefined>): void
   }
 }
 
+// Ids whose delete/archive RPC is still in flight. Their tombstones are pinned
+// against the projects.tree prune below: a refresh whose snapshot predates the
+// mutation completing must NOT drop the tombstone, or the row flashes back until
+// the backend catches up. Keyed by id, so concurrent deletes stay independent.
+export const $sessionMutationsInFlight = atom<Set<string>>(new Set())
+
+function mutateInFlight(ids: Array<null | string | undefined>, add: boolean): void {
+  const current = $sessionMutationsInFlight.get()
+  const next = new Set(current)
+
+  for (const id of ids) {
+    const trimmed = id?.trim()
+
+    if (trimmed) {
+      add ? next.add(trimmed) : next.delete(trimmed)
+    }
+  }
+
+  if (next.size !== current.size) {
+    $sessionMutationsInFlight.set(next)
+  }
+}
+
+export const beginSessionMutation = (ids: Array<null | string | undefined>): void => mutateInFlight(ids, true)
+export const endSessionMutation = (ids: Array<null | string | undefined>): void => mutateInFlight(ids, false)
+
 // True while the disk scan is in flight (drives the "finding repos" hint).
 export const $reposScanning = atom(false)
 
@@ -341,7 +367,11 @@ async function refreshProjectTreeOn(gateway: HermesGateway): Promise<void> {
     const tombstones = $removedSessionIds.get()
 
     if (tombstones.size) {
-      const pending = new Set([...tombstones].filter(id => scoped.has(id)))
+      // Keep a tombstone while the backend still lists the id (delete pending on
+      // its side) OR while its mutation is still in flight locally — dropping it
+      // early flashes the row back until the RPC lands.
+      const inFlight = $sessionMutationsInFlight.get()
+      const pending = new Set([...tombstones].filter(id => scoped.has(id) || inFlight.has(id)))
 
       if (pending.size !== tombstones.size) {
         $removedSessionIds.set(pending)

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -540,6 +540,37 @@ export function openSessionTile(
   }
 }
 
+/** ⌘W on the MAIN tab: the next session tab stacked WITH the workspace, to
+ *  shift into main. Walks the workspace group's strip from the workspace tab
+ *  outward (the tab after it first, then wrapping to the ones before), and
+ *  returns the first session tile's stored id. Null when the workspace has no
+ *  session tab stacked beside it (⌘W then stays the no-op it was). */
+export function nextSessionTileForWorkspace(): null | string {
+  const tree = $layoutTree.get()
+  const group = tree ? findGroupOfPane(tree, 'workspace') : null
+
+  if (!group) {
+    return null
+  }
+
+  const tiles = $sessionTiles.get()
+  const idx = group.panes.indexOf('workspace')
+  // After the workspace tab first, then the ones before it (nearest-out).
+  const ordered = [...group.panes.slice(idx + 1), ...group.panes.slice(0, idx).reverse()]
+
+  for (const paneId of ordered) {
+    if (paneId.startsWith(TILE_PANE_PREFIX)) {
+      const storedSessionId = paneId.slice(TILE_PANE_PREFIX.length)
+
+      if (tiles.some(t => t.storedSessionId === storedSessionId)) {
+        return storedSessionId
+      }
+    }
+  }
+
+  return null
+}
+
 /** If a session is already ON SCREEN — an open tile OR the one loaded in main —
  *  front its tab (and focus its zone) and return true. A sidebar click on an
  *  already-open chat JUMPS to its tab instead of reloading it; `false` means the


### PR DESCRIPTION
Desktop session-tab UX: a cluster of fixes around the multi-tab strip, session status rendering, and sidebar lane state.

## ⌘W shifts the next tab into main
Closing the main workspace tab with `⌘W` while session tabs are stacked beside it was a no-op (the workspace tab is `uncloseable`). It now promotes the next session tab into the main position instead of doing nothing.

## Always-shown "+" new-session tab (draft, no pollution)
A plain `+` sits after the last tab (and `⌘T`) to open a new session tab. New tabs are created **unlisted** — the backend session stays in-memory and out of the sidebar until its first turn persists, so spinning up tabs never litters the session list with untitled entries (Cursor-style draft tabs). You can open several at once; each resolves its real title once you send a message.

## One session-status-dot primitive — zero duplication
The sidebar row and the pane tabs each painted their own dot from **different data**: the sidebar read color from the `$sessionColorById` map (no resolver fallback) layered with live state, while a tab painted a flat color via `sessionColorFor` (map + fallback). A session older than the recents page missed the map, so the *same session* showed **grey in the sidebar and its project color in the tab**.

Now a single `SessionStatusDot`, keyed by the stored session id (the key every live-state atom already uses), resolves color (override → project, with fallback) and live state (working / needs-input / stalled / unread / background) itself. The **sidebar row, session tiles, and the main workspace tab** all render it — status/color can no longer disagree across surfaces, and tabs gain the full live status (pulse etc.), not just a static color. The orphaned generic `accent` tab-dot path is collapsed into this one primitive.

## Auto-expand the target lane on "+", and stable collapse state
Clicking `+` on a collapsed worktree/branch lane (or repo) created a session in a folder you couldn't see — it now force-expands the target node.

Root cause: sidebar collapse state was stored as an **XOR override of `defaultOpen`**, and `defaultOpen` flips for a worktree lane (collapsed while empty, open once it holds a session). So an explicit expand of an empty lane silently re-read as a *collapse* the moment the lane gained its first row — collapsing the very lane you'd just opened to work in. State is now stored as the **resolved** open/collapsed boolean per node (`$sidebarWorkspaceNodeOpen`), which survives the default flip, with a one-time migration off the old set. The review file-tree shares this store and was updated to match.

## Optimistic delete/archive no longer flashes back
Deleting a session — worse when it was open in a tab — sometimes left the row in the sidebar until a later refresh. A refresh racing the in-flight RPC resurrected it: `refreshSessions` repopulated recents straight from the backend page **ignoring tombstones**, and the `projects.tree` prune dropped the tombstone the moment its id left `scoped_session_ids`, so the grouped lane un-filtered it too.

Refreshes now honor the optimistic tombstone (and its lineage tip), and delete/archive **pin** their tombstone via `$sessionMutationsInFlight` until the RPC settles — keyed per id, so concurrent deletes across worktrees stay independent with no shared lock. This also retires the old archive-only post-success re-filter band-aid.

## Testing
- `npm run typecheck` (tsc + electron + e2e projects) — clean
- `npx vitest run` for `store/layout`, `chat/sidebar`, `store/session*`, `store/projects`, `session/hooks`, `pane-shell` — all green (incl. new tombstone-prune + refresh-honors-tombstone invariants)

