### PR TITLE
fix(cron): scope workdir to subprocess instead of os.chdir() global process

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2110,7 +2110,7 @@ def _windows_cron_python_invocation(python_exe: str) -> tuple[str, dict[str, str
     return str(interpreter), env_overlay
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _run_job_script(script_path: str, *, workdir: str | None = None) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
     Scripts must reside within HERMES_HOME/scripts/.  Both relative and
@@ -2211,7 +2211,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             capture_output=True,
             text=True,
             timeout=script_timeout,
-            cwd=str(path.parent),
+            cwd=workdir if workdir and Path(workdir).is_dir() else str(path.parent),
             env=env,
             **popen_kwargs,
         )
@@ -2245,7 +2245,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
 
 def _run_job_script_with_claim_heartbeat(
-    job: dict, script_path: str
+    job: dict, script_path: str, *, workdir: str | None = None
 ) -> tuple[bool, str]:
     """Run a cron script while keeping its owned one-shot claim fresh.
 
@@ -2707,22 +2707,16 @@ def run_job(
         # paths. For no_agent jobs this is just the subprocess cwd (not an
         # agent TERMINAL_CWD bridge).
         _job_workdir = (job.get("workdir") or "").strip() or None
-        _prior_cwd = None
-        if _job_workdir and Path(_job_workdir).is_dir():
-            _prior_cwd = os.getcwd()
-            try:
-                os.chdir(_job_workdir)
-            except OSError:
-                _prior_cwd = None
+        if _job_workdir and not Path(_job_workdir).is_dir():
+            logger.warning(
+                "Job '%s': configured workdir %r no longer exists — running without it",
+                job_id, _job_workdir,
+            )
+            _job_workdir = None
 
-        try:
-            ok, output = _run_job_script_with_claim_heartbeat(job, script_path)
-        finally:
-            if _prior_cwd is not None:
-                try:
-                    os.chdir(_prior_cwd)
-                except OSError:
-                    pass
+        ok, output = _run_job_script_with_claim_heartbeat(
+            job, script_path, workdir=_job_workdir
+        )
 
         now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
 


### PR DESCRIPTION
## Summary

The `no_agent` cron job path used `os.chdir()` to apply the job's `workdir`, which changed the global process cwd for **all threads**. Any gateway session (Telegram/Signal/etc.) created while the cron job was running inherited the cron job's `workdir`, causing `AGENTS.md` from an unrelated project to be injected into the interactive session's system prompt.

## Root Cause

In `_run_no_agent_job()`:
```python
os.chdir(_job_workdir)           # changes cwd for EVERY thread
ok, output = _run_job_script_with_claim_heartbeat(job, script_path)
os.chdir(_prior_cwd)             # restored after script ends
```

Between the `chdir` and the restore, any concurrent gateway session sees the wrong cwd.

## Fix

Remove `os.chdir()` and pass the workdir to `subprocess.run(cwd=)` instead, which scopes the directory change to the child process only. The agent path already correctly uses `TERMINAL_CWD` env var — this fix aligns the `no_agent` path.

## Changes

- `_run_job_script()` — new `workdir` kwarg, passed to `subprocess.run(cwd=)`
- `_run_job_script_with_claim_heartbeat()` — new `workdir` kwarg, forwarded
- `_run_no_agent_job()` — removed `os.chdir()`/restore block, passes workdir to runner

## Fixes

Fixes #69396