### PR TITLE
fix(vision): resolve namespaced custom provider overrides

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -210,16 +210,21 @@ def _supports_vision_override(
     # get rewritten to provider="custom" at runtime
     # (hermes_cli/runtime_provider.py:_resolve_named_custom_runtime), so the
     # config still holds the user-declared name under model.provider. Try
-    # both as candidate provider keys, plus the stripped suffix from
-    # "custom:<name>" (where <name> is the key under providers:).
+    # both as candidate provider keys. Either identity may use the
+    # "custom:<name>" form while providers: is keyed by bare <name>.
     config_provider = str(model_cfg.get("provider") or "").strip()
-    # Extract the stripped name from "custom:<name>" if present
-    stripped_suffix = ""
-    if config_provider.startswith("custom:"):
-        stripped_suffix = config_provider[len("custom:"):]
+    provider_candidates: List[str] = []
+    for candidate in (provider, config_provider):
+        if not candidate:
+            continue
+        provider_candidates.append(candidate)
+        if candidate.startswith("custom:"):
+            stripped_candidate = candidate[len("custom:"):]
+            if stripped_candidate:
+                provider_candidates.append(stripped_candidate)
     providers_raw = cfg.get("providers")
     providers_cfg: Dict[str, Any] = providers_raw if isinstance(providers_raw, dict) else {}
-    for p in dict.fromkeys(filter(None, (provider, config_provider, stripped_suffix))):
+    for p in dict.fromkeys(provider_candidates):
         entry_raw = providers_cfg.get(p)
         entry: Dict[str, Any] = entry_raw if isinstance(entry_raw, dict) else {}
         models_raw = entry.get("models")

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -244,6 +244,14 @@ class TestSupportsVisionOverride:
         }
         assert _supports_vision_override(cfg, "custom", "gpt-5.5") is True
 
+    def test_custom_colon_runtime_name_stripped_suffix_lookup(self):
+        cfg = {
+            "providers": {
+                "my-proxy": {"models": {"gpt-5.5": {"supports_vision": True}}},
+            },
+        }
+        assert _supports_vision_override(cfg, "custom:my-proxy", "gpt-5.5") is True
+
     def test_custom_colon_name_stripped_suffix_false(self):
         # Explicitly disabled vision on the stripped key.
         cfg = {
@@ -324,6 +332,26 @@ class TestAutoModeRespectsOverride:
         cfg = {"model": {"supports_vision": True}}
         with patch("agent.models_dev.get_model_capabilities", return_value=None):
             assert decide_image_input_mode("custom", "qwen3.6-35b", cfg) == "native"
+
+    def test_auto_native_for_namespaced_runtime_custom_provider(self):
+        cfg = {
+            "providers": {
+                "my-proxy": {
+                    "models": {
+                        "qwen3.8-max-preview": {"supports_vision": True},
+                    },
+                },
+            },
+        }
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            assert (
+                decide_image_input_mode(
+                    "custom:my-proxy",
+                    "qwen3.8-max-preview",
+                    cfg,
+                )
+                == "native"
+            )
 
     def test_auto_text_for_custom_with_supports_vision_false(self):
         cfg = {"model": {"supports_vision": False}}


### PR DESCRIPTION
## What does this PR do?

Fixes native image routing for named custom providers when the effective runtime provider uses the `custom:<name>` form.

The new-style `providers:` capability lookup checked the runtime provider verbatim but only stripped `custom:` from `model.provider`. With a runtime identity such as `custom:my-proxy` and a configuration key such as `providers.my-proxy`, the explicit `supports_vision` value was missed and automatic image routing incorrectly selected the text or auxiliary-vision path.

This change builds lookup candidates from both the runtime and configured provider identities, using the raw value and its non-empty `custom:` suffix. Runtime candidates remain first so the effective session route keeps precedence.

## Related Issue

Related to #57649, which covered the configured-provider form but left the namespaced runtime-provider variant unresolved.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Normalize both runtime and configured provider identities in `agent/image_routing.py`.
- Preserve candidate precedence and ignore an empty suffix from malformed `custom:` input.
- Add direct capability-lookup and automatic native-routing regressions in `tests/agent/test_image_routing.py`.

## How to Test

1. Configure a named custom provider under `providers.my-proxy` with a model declaring `supports_vision: true`.
2. Resolve image routing with runtime provider `custom:my-proxy`.
3. Verify `_supports_vision_override(...)` returns `True` and `decide_image_input_mode(...)` returns `native`.
4. Run `scripts/run_tests.sh -j 4 tests/agent/test_image_routing.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, direct single-process regression probes

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure provider-string normalization
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused local validation:

```text
vision direct regressions: PASS
✓ No Windows footguns found (2 file(s) scanned).
git diff --check: PASS
python -m py_compile agent/image_routing.py tests/agent/test_image_routing.py: PASS
```

The full pytest suite was not run locally; GitHub CI owns full-suite coverage.
