### PR TITLE
fix(desktop): isolate New Window from remembered sessions

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -131,6 +131,7 @@ import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRoutePr
 import * as remoteLifecycle from './remote-lifecycle'
 import { RemoteLivenessTracker, RemoteRevalidationCoordinator, revalidateRemoteConnection } from './remote-liveness'
 import {
+  buildInstanceWindowUrl,
   buildSessionWindowUrl,
   chatWindowWebPreferences,
   createSessionWindowRegistry,
@@ -8230,11 +8231,12 @@ function createInstanceWindow() {
     instanceWindows.delete(win)
   })
 
-  if (DEV_SERVER) {
-    win.loadURL(DEV_SERVER)
-  } else {
-    win.loadURL(pathToFileURL(resolveRendererIndex()).toString())
-  }
+  win.loadURL(
+    buildInstanceWindowUrl({
+      devServer: DEV_SERVER,
+      rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex()
+    })
+  )
 
   return win
 }

--- a/apps/desktop/electron/session-windows.test.ts
+++ b/apps/desktop/electron/session-windows.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import {
+  buildInstanceWindowUrl,
   buildSessionWindowUrl,
   chatWindowWebPreferences,
   createSessionWindowRegistry,
@@ -86,6 +87,18 @@ test('buildSessionWindowUrl adds the watch flag for spectator windows, before th
   const url = buildSessionWindowUrl('abc', { devServer: 'http://localhost:5173', watch: true })
 
   assert.equal(url, 'http://localhost:5173/?win=secondary&watch=1#/abc')
+})
+
+test('buildInstanceWindowUrl marks a full peer as a fresh instance before the default hash route', () => {
+  const url = buildInstanceWindowUrl({ devServer: 'http://localhost:5173' })
+
+  assert.equal(url, 'http://localhost:5173/?win=instance#/')
+})
+
+test('buildInstanceWindowUrl marks packaged peer windows too', () => {
+  const url = buildInstanceWindowUrl({ rendererIndexPath: '/opt/app/index.html' })
+
+  assert.match(url, /^file:\/\/.*index\.html\?win=instance#\/$/)
 })
 
 test('instanceWindowBounds cascades a new window off its source bounds', () => {

--- a/apps/desktop/electron/session-windows.ts
+++ b/apps/desktop/electron/session-windows.ts
@@ -54,6 +54,24 @@ function buildSessionWindowUrl(sessionId: string, { devServer, rendererIndexPath
   return `${pathToFileURL(rendererIndexPath).toString()}${query}${route}`
 }
 
+// A full peer window must start as a new-chat draft. It shares Chromium local
+// storage with the primary window, so loading the plain root URL lets the
+// renderer's normal cold-start restore reopen the primary's remembered chat.
+// Mark the instance before HashRouter's hash route so the renderer can skip
+// that restore without changing its normal app-relaunch behavior.
+function buildInstanceWindowUrl({ devServer, rendererIndexPath }: any = {}) {
+  const query = '?win=instance'
+  const route = '#/'
+
+  if (devServer) {
+    const base = devServer.endsWith('/') ? devServer.slice(0, -1) : devServer
+
+    return `${base}/${query}${route}`
+  }
+
+  return `${pathToFileURL(rendererIndexPath).toString()}${query}${route}`
+}
+
 // Full "instance" windows (⌘⇧N / the "New Window" command) open a complete app
 // peer, not a compact chat. Cascade each one off its source window's bounds so a
 // new window doesn't land exactly on top of the one it was spawned from. Pure so
@@ -137,6 +155,7 @@ function createSessionWindowRegistry() {
 }
 
 export {
+  buildInstanceWindowUrl,
   buildSessionWindowUrl,
   chatWindowWebPreferences,
   createSessionWindowRegistry,

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldRestoreRememberedRoute } from './use-desktop-integrations'
+
+describe('shouldRestoreRememberedRoute', () => {
+  it('restores the remembered chat on a normal cold app launch', () => {
+    expect(shouldRestoreRememberedRoute({ freshInstanceWindow: false, locationPathname: '/', restored: false })).toBe(
+      true
+    )
+  })
+
+  it("never restores another window's remembered chat into a new peer instance", () => {
+    expect(shouldRestoreRememberedRoute({ freshInstanceWindow: true, locationPathname: '/', restored: false })).toBe(
+      false
+    )
+  })
+
+  it('does not restore after the cold-start decision has already run', () => {
+    expect(shouldRestoreRememberedRoute({ freshInstanceWindow: false, locationPathname: '/', restored: true })).toBe(
+      false
+    )
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -6,7 +6,7 @@ import { respondToApprovalAction } from '@/store/native-notifications'
 import { getRememberedRoute, getRememberedSessionId, setRememberedRoute, setRememberedSessionId } from '@/store/session'
 import { onSessionsChanged } from '@/store/session-sync'
 import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '@/store/updates'
-import { isSecondaryWindow } from '@/store/windows'
+import { isFreshInstanceWindow, isSecondaryWindow } from '@/store/windows'
 
 import { requestComposerFocus, requestComposerInsert } from '../../chat/composer/focus'
 import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, sessionRoute } from '../../routes'
@@ -20,6 +20,18 @@ interface DesktopIntegrationsParams {
   resumeExhaustedSessionId: null | string
   routedSessionId: null | string
   runtimeIdByStoredSessionId: { readonly current: Map<string, string> }
+}
+
+export function shouldRestoreRememberedRoute({
+  freshInstanceWindow,
+  locationPathname,
+  restored
+}: {
+  freshInstanceWindow: boolean
+  locationPathname: string
+  restored: boolean
+}): boolean {
+  return !freshInstanceWindow && !restored && locationPathname === NEW_CHAT_ROUTE
 }
 
 /**
@@ -37,6 +49,7 @@ export function useDesktopIntegrations({
   routedSessionId,
   runtimeIdByStoredSessionId
 }: DesktopIntegrationsParams): void {
+  const freshInstanceWindow = isFreshInstanceWindow()
   // Update polling — populates $desktopVersion/$updateStatus, which feed the
   // statusbar version pill and the update toasts. Also honors the main
   // process's "open updates" menu request.
@@ -62,6 +75,13 @@ export function useDesktopIntegrations({
   // lands where you were. Overlays (settings/command-center/…) aren't stored —
   // you don't want to boot into a modal.
   useEffect(() => {
+    // A new peer instance starts at `/` by design. Do not overwrite the
+    // primary's remembered route before the restore guard below gets to run;
+    // once this instance has a real routed chat it participates normally.
+    if (freshInstanceWindow && locationPathname === NEW_CHAT_ROUTE && !routedSessionId) {
+      return
+    }
+
     if (routedSessionId) {
       setRememberedSessionId(routedSessionId)
     }
@@ -69,7 +89,7 @@ export function useDesktopIntegrations({
     if (!isOverlayView(appViewForPath(locationPathname))) {
       setRememberedRoute(locationPathname)
     }
-  }, [locationPathname, routedSessionId])
+  }, [freshInstanceWindow, locationPathname, routedSessionId])
 
   const restoredRef = useRef(false)
 
@@ -77,7 +97,7 @@ export function useDesktopIntegrations({
   // route (a hidden-then-shown window keeps its own route). Prefer the full
   // remembered route (covers pages); fall back to the last session id.
   useEffect(() => {
-    if (restoredRef.current || locationPathname !== NEW_CHAT_ROUTE) {
+    if (!shouldRestoreRememberedRoute({ freshInstanceWindow, locationPathname, restored: restoredRef.current })) {
       restoredRef.current = true
 
       return
@@ -97,7 +117,7 @@ export function useDesktopIntegrations({
     if (last) {
       navigate(sessionRoute(last), { replace: true })
     }
-  }, [locationPathname, navigate])
+  }, [freshInstanceWindow, locationPathname, navigate])
 
   useEffect(() => {
     if (resumeExhaustedSessionId && getRememberedSessionId() === resumeExhaustedSessionId) {

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -6,6 +6,7 @@ import { notifyError } from './notifications'
 // never from the router. A "secondary" window renders a single chat without the
 // global session sidebar or the install / onboarding overlays.
 const SECONDARY_WINDOW_FLAG = 'secondary'
+const INSTANCE_WINDOW_FLAG = 'instance'
 
 let secondaryWindowCache: boolean | null = null
 
@@ -23,6 +24,29 @@ export function isSecondaryWindow(): boolean {
   }
 
   secondaryWindowCache = result
+
+  return result
+}
+
+let freshInstanceWindowCache: boolean | null = null
+
+// A full peer opened through New Window starts as an explicitly fresh draft.
+// Unlike a normal app relaunch, it must not restore the primary renderer's
+// remembered route from shared Chromium local storage.
+export function isFreshInstanceWindow(): boolean {
+  if (freshInstanceWindowCache !== null) {
+    return freshInstanceWindowCache
+  }
+
+  let result = false
+
+  try {
+    result = new URLSearchParams(window.location.search).get('win') === INSTANCE_WINDOW_FLAG
+  } catch {
+    result = false
+  }
+
+  freshInstanceWindowCache = result
 
   return result
 }


### PR DESCRIPTION
Fixes #65601.\n\nNew Window created a full peer renderer at the root route, but that renderer shares Chromium local storage with the primary window. Its cold-start restore therefore reopened the primary window's remembered route/session.\n\nThis marks peer New Window URLs as fresh instances and skips both the initial remembered-route write and cold-start restore only for that launch. Once the new window creates or opens a real chat, normal remembered-session behavior resumes.\n\nValidation run from apps/desktop:\n- npm run typecheck\n- npm run lint: 0 errors; 13 existing warnings\n- npm run test:desktop:platforms: 697 checks passed\n- npm run test:ui\n- focused Electron URL and Desktop restore regression tests