### PR TITLE
fix(relay): declare explicit relevance policy when require_mention is configured false

### DIFF
--- a/gateway/relay/__init__.py
+++ b/gateway/relay/__init__.py
@@ -309,7 +309,9 @@ def relay_relevance_policy(platform: Optional[str] = None) -> Optional[dict]:
     the ``{PLATFORM}_*`` env. ``platform`` defaults to the PRIMARY fronted
     platform (back-compat). Returns the generic dict, or None when relay isn't
     configured or the platform exposes no relevance knobs (⇒ the connector's
-    quiet default already matches, so there's nothing to declare).
+    default — mention-gated — applies unchallenged; an EXPLICIT
+    ``require_mention: false`` IS a knob and is declared so the connector
+    doesn't mention-gate an agent configured to free-respond).
     """
     if platform is None:
         platform, _bot_id = relay_platform_identity()
@@ -351,12 +353,17 @@ def relay_relevance_policy(platform: Optional[str] = None) -> Optional[dict]:
     allow_bots_env = os.environ.get(f"{platform.upper()}_ALLOW_BOTS", "").lower().strip()
     allow_other_bots = allow_bots_env in {"mentions", "all"}
 
-    require_address = bool(require_mention) if require_mention is not None else False
-
-    # Nothing non-default to declare ⇒ let the connector keep its quiet default
-    # (matches absence-of-row semantics on the connector side).
-    if not require_address and not free_response and not allow_other_bots:
+    # Nothing CONFIGURED to declare ⇒ let the connector keep its default policy
+    # (mention-gated with agent-thread continuation — matches absence-of-row
+    # semantics on the connector side). NOTE the condition is "require_mention
+    # is unset", NOT "require_mention is falsy": the connector's default is now
+    # requireAddress=true, so an EXPLICIT `require_mention: false` is a
+    # non-default choice that MUST be declared or the connector would
+    # mention-gate an agent configured to free-respond.
+    if require_mention is None and not free_response and not allow_other_bots:
         return None
+
+    require_address = bool(require_mention) if require_mention is not None else False
 
     return {
         "platform": platform,

--- a/tests/gateway/relay/test_relay_policy_send.py
+++ b/tests/gateway/relay/test_relay_policy_send.py
@@ -87,10 +87,42 @@ def test_projection_falls_back_to_top_level_require_mention(monkeypatch):
 
 def test_projection_none_when_all_default(monkeypatch):
     # No require_mention, no free-response, no allow-bots ⇒ nothing to declare
-    # (the connector's quiet default already matches).
+    # (the connector's default — mention-gated — applies).
     monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "discord")
     monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {"discord": {}}, raising=False)
     assert relay.relay_relevance_policy() is None
+
+
+def test_projection_declares_explicit_require_mention_false(monkeypatch):
+    # An EXPLICIT `require_mention: false` is a configured (non-default) choice
+    # and MUST be declared: the connector's absent-row default is now
+    # requireAddress=true, so staying silent would mention-gate an agent the
+    # operator configured to free-respond.
+    monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "discord")
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"discord": {"require_mention": False}},
+        raising=False,
+    )
+    pol = relay.relay_relevance_policy()
+    assert pol == {
+        "platform": "discord",
+        "requireAddress": False,
+        "freeResponseScopes": [],
+        "allowOtherBots": False,
+    }
+
+
+def test_projection_declares_explicit_top_level_require_mention_false(monkeypatch):
+    # Same as above via the bridged top-level key.
+    monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "discord")
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"require_mention": False},
+        raising=False,
+    )
+    pol = relay.relay_relevance_policy()
+    assert pol is not None and pol["requireAddress"] is False
 
 
 def test_projection_none_when_platform_unresolved(monkeypatch):


### PR DESCRIPTION
Companion to NousResearch/gateway-gateway#160, which flips the Team Gateway connector's absent-row relevance default to mention-gated (`requireAddress=true`).

## The bug this preempts

`relay_relevance_policy()` returns `None` when there's "nothing non-default to declare", and `send_relay_policy()` skips the POST — sound while the connector's quiet default was `requireAddress=false`. After the connector flip, that logic has one inverted case: an agent **explicitly configured** with `require_mention: false` projects an all-falsy policy, stays silent, and gets mention-gated by the connector's new default anyway — with no way to opt out.

## The fix

The nothing-to-declare check now keys on **`require_mention` is unset**, not "is falsy":

- `require_mention: false` (per-platform block or bridged top-level key) ⇒ declares an explicit `requireAddress: false` policy to `/relay/policy`.
- No relevance knobs configured at all ⇒ still declares nothing; the connector's default governs (previous behaviour, new meaning).

No wire or contract change — same `/relay/policy` POST shape, same boot-time full-replace semantics. Because relay gateways re-declare on every boot, any stale old-gateway + explicit-false combination self-heals on the next restart.

## Verification

- `pytest tests/gateway/relay/` — **186 passed** (includes 2 new projection tests: explicit per-platform `require_mention: false` and the bridged top-level key both produce a declared policy).
- Cross-repo live E2E from the connector repo (`test/e2e/run_all.sh`, real socket + real Redis, this gateway code against the flipped connector): **22/22 drivers `VERDICT: ALL PASS`**, including the per-platform tenant-leakage matrices.

Deploy order: connector PR first (this change is a no-op against the current connector — declaring `requireAddress:false` writes a row identical to today's absent-row default).

## Infographic

![relay-declare-explicit-no-mention](https://v3b.fal.media/files/b/0aa35b1a/xcPmU2fZVYOfrKRCR8QDx_brp3Kjg6.png)
