### PR TITLE
fix(cli): persist provider on global model switch

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8325,8 +8325,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if persist_global:
             HermesCLI._clear_persisted_context_for_model_switch(self, result)
             save_config_value("model.default", result.new_model)
-            if result.provider_changed:
-                save_config_value("model.provider", result.target_provider)
+            save_config_value("model.provider", result.target_provider)
             # base_url/api_mode were previously never persisted here, so a
             # global switch left the OLD provider's endpoint/wire-protocol in
             # config.yaml. result.base_url/api_mode are always freshly
@@ -8672,8 +8671,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if persist_global:
             HermesCLI._clear_persisted_context_for_model_switch(self, result)
             save_config_value("model.default", result.new_model)
-            if result.provider_changed:
-                save_config_value("model.provider", result.target_provider)
+            save_config_value("model.provider", result.target_provider)
             # See _apply_model_switch_result above for why base_url/api_mode
             # must be synced on every global switch (#25106).
             save_config_value("model.base_url", result.base_url or None)

--- a/tests/hermes_cli/test_25106_global_switch_persists_base_url_api_mode.py
+++ b/tests/hermes_cli/test_25106_global_switch_persists_base_url_api_mode.py
@@ -90,6 +90,12 @@ def test_global_switch_persists_base_url_and_api_mode(monkeypatch):
     assert saved["model.api_mode"] == "chat_completions"
 
 
+def test_global_switch_persists_provider_when_runtime_provider_is_unchanged(monkeypatch):
+    saved = _run_switch(monkeypatch, _make_result(provider_changed=False))
+
+    assert saved["model.provider"] == "custom:minimax"
+
+
 def test_global_switch_clears_base_url_and_api_mode_when_unresolved(monkeypatch):
     """When the resolver returns no base_url/api_mode for the new provider
     (e.g. a named provider needing neither), any previous value must be
@@ -149,6 +155,12 @@ def test_picker_global_switch_persists_base_url_and_api_mode(monkeypatch):
     assert saved["model.provider"] == "custom:minimax"
     assert saved["model.base_url"] == "https://api.minimax.io/v1"
     assert saved["model.api_mode"] == "chat_completions"
+
+
+def test_picker_global_switch_persists_provider_when_runtime_provider_is_unchanged(monkeypatch):
+    saved = _run_apply(monkeypatch, _make_result(provider_changed=False))
+
+    assert saved["model.provider"] == "custom:minimax"
 
 
 def test_picker_global_switch_clears_base_url_and_api_mode_when_unresolved(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Ensures classic CLI `/model ... --global` switches always persist the resolved provider together with the selected model.

The two classic CLI persistence paths used `result.provider_changed`, which compares the target provider with the current in-memory runtime provider, as a gate for writing `model.provider`. If the session already used the target provider while `config.yaml` still contained a stale provider, Hermes persisted the new model but left the stale provider on disk. The next launch then loaded a mismatched model/provider tuple.

Successful global switches now persist `result.target_provider` unconditionally, matching the existing gateway persistence behavior. Runtime transition behavior can still use `provider_changed`; durable configuration cannot.

## Related Issue

Related to #60903. That PR is conflicting and includes broader endpoint-helper and provider-alias changes. Current main already synchronizes `base_url` and `api_mode`; this PR isolates the remaining provider-persistence defect.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Always write `model.provider` for persisted picker-based model switches.
- Always write `model.provider` for persisted typed `/model` switches.
- Add regressions for both paths when `provider_changed` is `False`.

## How to Test

1. Start with a runtime already using the requested target provider while persisted `model.provider` is stale.
2. Perform a typed or picker-based global model switch.
3. Verify the persisted tuple includes both the new model and `result.target_provider`.
4. Run `scripts/run_tests.sh -j 4 tests/hermes_cli/test_25106_global_switch_persists_base_url_api_mode.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, direct single-process regression probes

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, this restores the existing global-persistence contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused local validation:

```text
cli provider persistence direct regressions: PASS
✓ No Windows footguns found (2 file(s) scanned).
git diff --check: PASS
python -m py_compile cli.py tests/hermes_cli/test_25106_global_switch_persists_base_url_api_mode.py: PASS
```

The full pytest suite was not run locally; GitHub CI owns full-suite coverage.
