### PR TITLE
fix(code-exec): derive child session env from request context

### DIFF
--- a/tests/tools/test_execute_code_session_context.py
+++ b/tests/tools/test_execute_code_session_context.py
@@ -1,0 +1,97 @@
+"""Regression tests for request-local session context in execute_code."""
+
+import json
+import os
+import queue
+import threading
+from contextvars import Context
+from unittest.mock import patch
+
+from gateway.session_context import get_session_env, set_current_session_id
+from tools.code_execution_tool import execute_code
+from tools.env_passthrough import register_env_passthrough
+
+
+def test_execute_code_prefers_request_context_over_global_session_mirror():
+    """A concurrent session must not replace the caller's child session ID.
+
+    ``AIAgent`` initialization calls ``set_current_session_id()``, which binds
+    a request-local ContextVar and also updates a process-global compatibility
+    mirror. This test controls that same interleaving without constructing
+    full agents or requiring model credentials.
+    """
+    let_request_b_run = threading.Event()
+    request_b_finished = threading.Event()
+    results = queue.Queue()
+    errors = queue.Queue()
+
+    def request_b():
+        try:
+            if not let_request_b_run.wait(timeout=5):
+                raise AssertionError("request B was not released")
+            set_current_session_id("session-B")
+        except BaseException as exc:
+            errors.put(exc)
+        finally:
+            request_b_finished.set()
+
+    def request_a():
+        try:
+            set_current_session_id("session-A")
+            register_env_passthrough(["HERMES_SESSION_ID"])
+
+            let_request_b_run.set()
+            if not request_b_finished.wait(timeout=5):
+                raise AssertionError("request B did not update the global mirror")
+
+            assert os.environ["HERMES_SESSION_ID"] == "session-B"
+            assert get_session_env("HERMES_SESSION_ID") == "session-A"
+
+            raw_result = execute_code(
+                'import os\nprint(os.environ.get("HERMES_SESSION_ID", "MISSING"))',
+                task_id="session-context-regression",
+                enabled_tools=[],
+            )
+            results.put(json.loads(raw_result))
+        except BaseException as exc:
+            errors.put(exc)
+
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch(
+            "tools.approval.check_execute_code_guard",
+            return_value={"approved": True},
+        ),
+        patch("tools.terminal_tool._docker_has_host_access", return_value=False),
+        patch(
+            "tools.terminal_tool._get_env_config",
+            return_value={"env_type": "local"},
+        ),
+        patch(
+            "tools.code_execution_tool._load_config",
+            return_value={"timeout": 15, "max_tool_calls": 50},
+        ),
+    ):
+        thread_b = threading.Thread(
+            target=lambda: Context().run(request_b),
+            name="session-context-request-b",
+        )
+        thread_a = threading.Thread(
+            target=lambda: Context().run(request_a),
+            name="session-context-request-a",
+        )
+
+        thread_b.start()
+        thread_a.start()
+        thread_a.join(timeout=30)
+        thread_b.join(timeout=30)
+
+        assert not thread_a.is_alive(), "request A did not finish"
+        assert not thread_b.is_alive(), "request B did not finish"
+
+    if not errors.empty():
+        raise errors.get()
+
+    result = results.get_nowait()
+    assert result["status"] == "success", result
+    assert result["output"].strip() == "session-A"

--- a/tests/tools/test_execute_code_session_context.py
+++ b/tests/tools/test_execute_code_session_context.py
@@ -7,6 +7,7 @@ import threading
 from contextvars import Context
 from unittest.mock import patch
 
+import gateway.session_context as session_context
 from gateway.session_context import get_session_env, set_current_session_id
 from tools.code_execution_tool import execute_code
 from tools.env_passthrough import register_env_passthrough
@@ -95,3 +96,40 @@ def test_execute_code_prefers_request_context_over_global_session_mirror():
     result = results.get_nowait()
     assert result["status"] == "success", result
     assert result["output"].strip() == "session-A"
+
+
+def test_execute_code_strips_foreign_global_when_engaged_session_id_is_unset():
+    """Strip a foreign global session ID from an unbound task's child process.
+
+    A fresh ``Context`` keeps ``_SESSION_ID`` at ``_UNSET`` while the process
+    is marked engaged and ``os.environ`` carries another session's ID.
+    Explicit passthrough makes that value eligible for the child, so this
+    exercises the ``_inject_session_context_env`` guard: the real local
+    ``execute_code`` child must receive no session ID and print ``MISSING``.
+    """
+    context = Context()
+
+    with (
+        patch.dict(os.environ, {"HERMES_SESSION_ID": "foreign-session"}),
+        patch.object(session_context, "_session_context_engaged", True),
+        patch("tools.approval.check_execute_code_guard", return_value={"approved": True}),
+        patch("tools.terminal_tool._docker_has_host_access", return_value=False),
+        patch("tools.terminal_tool._get_env_config", return_value={"env_type": "local"}),
+        patch(
+            "tools.code_execution_tool._load_config",
+            return_value={"timeout": 15, "max_tool_calls": 50},
+        ),
+    ):
+        assert context.run(session_context.session_context_engaged) is True
+        assert context.run(session_context._SESSION_ID.get) is session_context._UNSET
+        context.run(register_env_passthrough, ["HERMES_SESSION_ID"])
+        raw_result = context.run(
+            execute_code,
+            'import os\nprint(os.environ.get("HERMES_SESSION_ID", "MISSING"))',
+            task_id="session-context-unset-regression",
+            enabled_tools=[],
+        )
+
+    result = json.loads(raw_result)
+    assert result["status"] == "success", result
+    assert result["output"].strip() == "MISSING"

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1340,7 +1340,15 @@ def execute_code(
         # OS-essential allowlist (SYSTEMROOT, WINDIR, COMSPEC, ...) is also
         # passed through — without those, the child can't create a socket
         # or spawn a subprocess.  See ``_scrub_child_env`` for the rules.
-        child_env = _scrub_child_env(os.environ)
+        # Start from a private snapshot, then make the current request's
+        # ContextVars authoritative over the process-global compatibility
+        # mirror before applying the existing passthrough/scrubbing policy.
+        # This prevents a concurrent request's HERMES_SESSION_* values from
+        # leaking into this execute_code child.
+        source_env = dict(os.environ)
+        from tools.environments.local import _inject_session_context_env
+        _inject_session_context_env(source_env)
+        child_env = _scrub_child_env(source_env)
         child_env["HERMES_RPC_SOCKET"] = rpc_endpoint
         child_env["HERMES_RPC_TOKEN"] = rpc_token
         child_env["PYTHONDONTWRITEBYTECODE"] = "1"

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1446,7 +1446,13 @@ def _build_child_env(*, rpc_endpoint: str, rpc_token: str, tmpdir: str,
     PYTHONPATH hygiene for external interpreters.
     """
     from hermes_constants import apply_subprocess_home_env
-    child_env = _scrub_child_env(os.environ)
+    from tools.environments.local import _inject_session_context_env
+
+    # Make this request's ContextVars authoritative over the process-global
+    # compatibility mirror before applying the existing scrub policy.
+    source_env = dict(os.environ)
+    _inject_session_context_env(source_env)
+    child_env = _scrub_child_env(source_env)
     child_env["HERMES_RPC_SOCKET"] = rpc_endpoint
     child_env["HERMES_RPC_TOKEN"] = rpc_token
     child_env["PYTHONDONTWRITEBYTECODE"] = "1"
@@ -1742,7 +1748,6 @@ def execute_code(
         # OS-essential allowlist (SYSTEMROOT, WINDIR, COMSPEC, ...) is also
         # passed through — without those, the child can't create a socket
         # or spawn a subprocess.  See ``_scrub_child_env`` for the rules.
-
         # Resolve interpreter + CWD based on execute_code mode.
         #   - strict : today's behavior (sys.executable + tmpdir CWD).
         #   - project: user's venv python + session's working directory, so


### PR DESCRIPTION
## What does this PR do?

This PR prevents the local `execute_code` child process from inheriting a session ID written to the process-global environment by another concurrent request.

Before applying the existing environment scrubber, the child environment is now copied from `os.environ` and overlaid with the current request's session ContextVars using the existing `_inject_session_context_env()` bridge.

This preserves the existing environment allowlist and scrubbing behavior while making the invoking request's session context authoritative.



## Related Issue

Fixes #69820

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `tools/code_execution_tool.py`: overlay the current request's session ContextVars onto a private copy of `os.environ` before applying the existing child-environment scrubber.
- `tests/tools/test_execute_code_session_context.py`: add deterministic regression coverage verifying that the local execute_code child receives the invoking request’s session ID during concurrent updates and does not inherit a foreign process-global session ID when the current task is unbound in an engaged process.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

Run:
    
```shell
python -m pytest tests/tools/test_execute_code_session_context.py -vv
```
The concurrent-session regression test deterministically:

- calls `set_current_session_id("session-A")` in request A and explicitly allows `HERMES_SESSION_ID` through environment passthrough;
- calls `set_current_session_id("session-B")` in request B, overwriting the process-global session ID mirror while request A's ContextVar remains `session-A`; and
- invokes the real local `execute_code` path from request A and verifies that the child process receives `session-A`.

The unbound-context regression test:

- creates a fresh `Context` where the session ID is unset while the process is engaged;
- places a foreign `HERMES_SESSION_ID` in `os.environ` and explicitly allows it through environment passthrough; and
- invokes the real local `execute_code` path and verifies that the child does not inherit the foreign ID.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows (Python 3.11.15)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
N/A — no UI changes. Verification is covered by the regression test described in the How to Test section.
