### PR TITLE
fix(photon): register Photon as a low-verbosity display tier

### DIFF
--- a/contributors/emails/mattshapsss@gmail.com
+++ b/contributors/emails/mattshapsss@gmail.com
@@ -1,0 +1,1 @@
+mattshapsss

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -154,6 +154,13 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     # status update as a separate message. Promote to TIER_MEDIUM once
     # Cloud's edit_message lands.
     "whatsapp_cloud":  _TIER_LOW,
+    # Photon (managed iMessage over the gRPC sidecar) and BlueBubbles are both
+    # permanent-message iMessage inboxes with no message-edit support, so both
+    # stay TIER_LOW. This keeps tool progress, interim scratch commentary,
+    # "still working" heartbeats, and busy-ack iteration detail out of the
+    # user's iMessage thread. Without this entry Photon inherited the noisy
+    # global ("all") defaults and compacted/narrated on nearly every turn.
+    "photon":          _TIER_LOW,
     "bluebubbles":     _TIER_LOW,
     "weixin":          _TIER_LOW,
     "wecom":           _TIER_LOW,

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -259,6 +259,21 @@ class TestPlatformDefaults:
         for plat in ("signal", "bluebubbles", "weixin", "wecom", "dingtalk", "whatsapp_cloud"):
             assert resolve_display_setting({}, plat, "tool_progress") == "off", plat
 
+    def test_photon_defaults_to_low_tier(self):
+        """Photon (managed iMessage) is a permanent-message mobile inbox like
+        BlueBubbles, so it must default to TIER_LOW: tool progress off, no
+        interim scratch commentary, no heartbeats, no busy-ack iteration detail.
+        Regression guard for the Photon launch shipping without a
+        _PLATFORM_DEFAULTS entry, which left it inheriting the noisy global
+        ('all') defaults and spamming the iMessage thread."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "photon", "tool_progress") == "off"
+        assert resolve_display_setting({}, "photon", "interim_assistant_messages") is False
+        assert resolve_display_setting({}, "photon", "long_running_notifications") is False
+        assert resolve_display_setting({}, "photon", "busy_ack_detail") is False
+        assert resolve_display_setting({}, "photon", "streaming") is False
+
     def test_whatsapp_cloud_locked_to_low_tier_until_edit_message_lands(self):
         """Regression guard: ``whatsapp_cloud`` must stay TIER_LOW until the
         adapter implements edit_message. Without an edit endpoint, raising


### PR DESCRIPTION
## Summary
Photon (managed iMessage) now defaults to the TIER_LOW display tier, so tool progress, interim scratch commentary, heartbeats, and busy-ack iteration detail stay out of the user's permanent-message iMessage thread. Root cause: the Photon adapter launched without a `_PLATFORM_DEFAULTS` entry, so it inherited the noisy global ("all") defaults while its peers BlueBubbles and Signal were already TIER_LOW.

## Changes
- `gateway/display_config.py`: add `"photon": _TIER_LOW` to `_PLATFORM_DEFAULTS` (alongside BlueBubbles), with rationale comment.
- `tests/gateway/test_display_config.py`: regression test pinning Photon's low-tier defaults (tool_progress off, no interim messages, no heartbeats, no busy-ack detail, no streaming).
- `contributors/emails/mattshapsss@gmail.com`: contributor attribution mapping.

## Validation
| | Before | After |
|---|---|---|
| Photon display tier | inherits noisy global ("all") defaults — status/progress spam in iMessage | TIER_LOW like BlueBubbles/Signal — quiet thread |

Targeted tests: `bash scripts/run_tests.sh tests/gateway/ -q -k 'display_config or tier or photon'` → 66 passed, 0 failed.

## Credit
Salvaged from #50511 by @mattshapsss (sanitization-gating piece dropped as a regression against current main; retry piece evaluated separately).

**Why only the tier piece:** #50511 bundled three changes. (a) The Photon TIER_LOW entry lands here as-is. (b) Gating final-response sanitization on `_is_quiet_chat_platform` would *narrow* current main's sanitization and re-expose raw provider error bodies on non-quiet platforms — a regression, excluded entirely. (c) The bounded retry/backoff for transient summarizer connection errors duplicates coverage that already exists on current main: `call_llm` now has a unified same-provider transient-transport retry loop with exponential backoff (`auxiliary.transient_retries`, default 2 retries → 3 attempts, PR #16587) covering exactly the connection-blip class the PR targeted, including the aux==main case; `_generate_summary` additionally keeps its main-model fallback and streaming-closed abort-and-preserve handling. A second retry loop stacked in `_generate_summary` would multiply attempts (3×3) and wall-clock stall on the critical compression path, so it is dropped as duplicative.

## Infographic
![photon-low-tier](https://v3b.fal.media/files/b/0aa35b7c/CxEvu2oR54sqZUasA5sOu_9E2aUHkh.png)
